### PR TITLE
Turn on eslint no-mixed-operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,8 @@
     "react/prop-types": 0,
     "meteor/audit-argument-checks": 0,
     "no-case-declarations": 0,
-    "react/no-unescaped-entities": 0
+    "react/no-unescaped-entities": 0,
+    "no-mixed-operators": 1
   },
   "env": {
     "browser": true,

--- a/packages/lesswrong/components/comments/CommentsListSection.jsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.jsx
@@ -76,16 +76,15 @@ const styles = theme => ({
 class CommentsListSection extends Component {
   constructor(props) {
     super(props);
+    const {lastEvent, post} = this.props;
+    
     this.state = {
-      highlightDate: this.props.lastEvent &&
-        this.props.lastEvent.properties &&
-        this.props.lastEvent.properties.createdAt &&
-        new Date(this.props.lastEvent.properties.createdAt)
-        ||
-        this.props.post &&
-        this.props.post.lastVisitedAt &&
-        new Date(this.props.post.lastVisitedAt) ||
-        new Date(),
+      highlightDate:
+        (lastEvent && lastEvent.properties && lastEvent.properties.createdAt
+          && new Date(lastEvent.properties.createdAt))
+        || (post && post.lastVisitedAt &&
+          new Date(post.lastVisitedAt))
+        || new Date(),
     }
   }
 

--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -221,7 +221,7 @@ class CommentsNode extends Component {
                 postPage={postPage}
                 nestingLevel={nestingLevel}
                 showPostTitle={showPostTitle}
-                parentAnswerId={parentAnswerId || comment.answer && comment._id}
+                parentAnswerId={parentAnswerId || (comment.answer && comment._id)}
               />
             </div>
             {!collapsed && <div className="comments-children">
@@ -241,7 +241,7 @@ class CommentsNode extends Component {
                   editMutation={editMutation}
                   post={post}
                   postPage={postPage}
-                  parentAnswerId={parentAnswerId || comment.answer && comment._id}
+                  parentAnswerId={parentAnswerId || (comment.answer && comment._id)}
                 />)}
             </div>}
           </div>

--- a/packages/lesswrong/components/form-components/LocationFormComponent.jsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.jsx
@@ -8,14 +8,14 @@ class LocationFormComponent extends Component {
   constructor(props, context) {
     super(props,context);
     this.state = {
-      location: props.document && props.document.location || ""
+      location: (props.document && props.document.location) || ""
     }
   }
 
   componentDidMount() {
     const { document } = this.props;
     this.context.updateCurrentValues({
-      location: document && document.location || "",
+      location: (document && document.location) || "",
       googleLocation: document && document.googleLocation,
       mongoLocation: document && document.mongoLocation
     })

--- a/packages/lesswrong/components/form-components/MuiInput.jsx
+++ b/packages/lesswrong/components/form-components/MuiInput.jsx
@@ -16,14 +16,14 @@ class MuiInput extends Component {
   constructor(props, context) {
     super(props,context);
     this.state = {
-      content: props.document && props.document[props.path] || props.defaultValue || ""
+      content: (props.document && props.document[props.path]) || props.defaultValue || ""
     }
   }
 
   componentDidMount() {
     this.context.addToSuccessForm(() => this.setState({content: ""}))
     this.context.updateCurrentValues({
-      [this.props.path]: this.props.document && this.props.document[this.props.path] || ""
+      [this.props.path]: (this.props.document && this.props.document[this.props.path]) || ""
     })
   }
 

--- a/packages/lesswrong/components/form-components/SequencesListEditorItem.jsx
+++ b/packages/lesswrong/components/form-components/SequencesListEditorItem.jsx
@@ -15,7 +15,7 @@ const SequencesListEditorItem = ({document, loading, documentId, ...props}) => {
         </div>
         <div className="sequences-list-edit-item-meta">
           <div className="sequences-list-edit-item-author">
-            {document.user && document.user.displayName || "Undefined Author"}
+            {(document.user && document.user.displayName) || "Undefined Author"}
           </div>
           <div className="sequences-list-edit-item-karma">
             {document.karma || "undefined"} points

--- a/packages/lesswrong/components/localGroups/CommunityHome.jsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.jsx
@@ -53,26 +53,28 @@ class CommunityHome extends Component {
   }
 
   render() {
-    const router = this.props.router;
+    const {router} = this.props;
+    const filters = (router.location.query && router.location.query.filters) || [];
+    
     const postsListTerms = {
       view: 'nearbyEvents',
       lat: this.state.currentUserLocation.lat,
       lng: this.state.currentUserLocation.lng,
       limit: 5,
-      filters: router.location.query && router.location.query.filters || [],
+      filters: filters,
     }
     const groupsListTerms = {
       view: 'nearby',
       lat: this.state.currentUserLocation.lat,
       lng: this.state.currentUserLocation.lng,
       limit: 3,
-      filters: router.location.query && router.location.query.filters || [],
+      filters: filters,
     }
     const mapEventTerms = {
       view: 'nearbyEvents',
       lat: this.state.currentUserLocation.lat,
       lng: this.state.currentUserLocation.lng,
-      filters: router.location.query && router.location.query.filters || [],
+      filters: filters,
     }
     return (
       <div className="community-home">

--- a/packages/lesswrong/components/localGroups/CommunityMapWrapper.jsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapWrapper.jsx
@@ -3,20 +3,21 @@ import { Components, registerComponent, getSetting, withList} from 'meteor/vulca
 import { Posts } from '../../lib/collections/posts';
 import { withRouter } from 'react-router';
 
-const CommunityMapWrapper = (props) => {
+const CommunityMapWrapper = ({router, groupQueryTerms, results, currentUserLocation, mapOptions}) => {
   const mapsAPIKey = getSetting('googleMaps.apiKey', null);
-    return (
-      <Components.CommunityMap
-        terms={props.groupQueryTerms || {view: "all", filters: props.router.location.query && props.router.location.query.filters || []}}
-        loadingElement= {<div style={{ height: `100%` }} />}
-        events={props.results}
-        containerElement= {<div style={{height: "500px"}} className="community-map"/>}
-        mapElement= {<div style={{ height: `100%` }} />}
-        googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&v=3.exp&libraries=geometry,drawing,places`}
-        center={props.currentUserLocation}
-        {...props.mapOptions}
-      />
-    )
+  
+  return (
+    <Components.CommunityMap
+      terms={groupQueryTerms || {view: "all", filters: (router.location.query && router.location.query.filters) || []}}
+      loadingElement= {<div style={{ height: `100%` }} />}
+      events={results}
+      containerElement= {<div style={{height: "500px"}} className="community-map"/>}
+      mapElement= {<div style={{ height: `100%` }} />}
+      googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&v=3.exp&libraries=geometry,drawing,places`}
+      center={currentUserLocation}
+      {...mapOptions}
+    />
+  )
 }
 const listOptions = {
   collection: Posts,

--- a/packages/lesswrong/components/localGroups/SmallMapPreview.jsx
+++ b/packages/lesswrong/components/localGroups/SmallMapPreview.jsx
@@ -20,11 +20,11 @@ class SmallMapPreview extends Component {
   }
 
   render() {
-    const { post, group } = this.props;
+    const { post, group, center, zoom } = this.props;
     return (
       <GoogleMap
-        defaultCenter={this.props.center}
-        defaultZoom={this.props.zoom}
+        defaultCenter={center}
+        defaultZoom={zoom}
         options={{
           styles: mapStyle,
           keyboardShortcuts: false,

--- a/packages/lesswrong/components/localGroups/SmallMapPreviewWrapper.jsx
+++ b/packages/lesswrong/components/localGroups/SmallMapPreviewWrapper.jsx
@@ -8,7 +8,9 @@ import { Components, registerComponent, getSetting} from 'meteor/vulcan:core';
 const SmallMapPreviewWrapper = (props) => {
   const mapsAPIKey = getSetting('googleMaps.apiKey', null);
   let document = props.post || props.group;
-  let location = document.googleLocation && document.googleLocation.geometry && document.googleLocation.geometry.location || {lat: 37.871853, lng: -122.258423};
+  const googleLocation = document.googleLocation;
+  const defaultLocation = {lat: 37.871853, lng: -122.258423};
+  let location = (googleLocation && googleLocation.geometry && googleLocation.geometry.location) || defaultLocation;
   return <div className="small-map-preview-wrapper">
     <Components.SmallMapPreview
       {...props}

--- a/packages/lesswrong/components/posts/PostsViews.jsx
+++ b/packages/lesswrong/components/posts/PostsViews.jsx
@@ -36,8 +36,8 @@ class PostsViews extends Component {
     const query = props.router.location.query
     this.state = {
       anchorEl: null,
-      view: query && query.view || "new",
-      filter: query && query.filter || "all"
+      view: (query && query.view) || "new",
+      filter: (query && query.filter) || "all"
     }
   }
 
@@ -89,7 +89,7 @@ class PostsViews extends Component {
       views = views.concat(adminViews);
     }
     const query = _.clone(router.location.query);
-    const currentView = query && query.view || "new"
+    const currentView = (query && query.view) || "new"
 
     return (
       <div>

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
@@ -30,7 +30,7 @@ class TableOfContentsList extends Component {
 
     const sections = sectionData ? sectionData.sections : []
 
-    const title = document && document.title || sectionData && sectionData.document && sectionData.document.title
+    const title = (document && document.title) || (sectionData && sectionData.document && sectionData.document.title);
     
     return <div>
       <div>
@@ -71,7 +71,7 @@ class TableOfContentsList extends Component {
     let anchor = document.getElementById(anchorName);
     if (anchor) {
       let anchorBounds = anchor.getBoundingClientRect();
-      return anchorBounds.top + anchorBounds.height/2;
+      return anchorBounds.top + (anchorBounds.height/2);
     } else {
       return null
     }

--- a/packages/lesswrong/components/questions/AnswerCommentsList.jsx
+++ b/packages/lesswrong/components/questions/AnswerCommentsList.jsx
@@ -52,18 +52,18 @@ class AnswerCommentsList extends PureComponent {
 
   constructor(props) {
     super(props);
+    
+    const { lastEvent, post } = this.props;
+    
     this.state = {
       commenting: false,
       loadedMore: false,
-      highlightDate: this.props.lastEvent &&
-        this.props.lastEvent.properties &&
-        this.props.lastEvent.properties.createdAt &&
-        new Date(this.props.lastEvent.properties.createdAt)
-        ||
-        this.props.post &&
-        this.props.post.lastVisitedAt &&
-        new Date(this.props.post.lastVisitedAt) ||
-        new Date(),
+      highlightDate: 
+        (lastEvent && lastEvent.properties && lastEvent.properties.createdAt
+          && new Date(lastEvent.properties.createdAt))
+        || (post && post.lastVisitedAt
+          && new Date(post.lastVisitedAt))
+        || new Date(),
     }
   }
 

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -141,9 +141,9 @@ const UsersProfile = (props) => {
 
     const displaySequenceSection = (canEdit, user)  => {
       if (getSetting('AlignmentForum', false)) {
-          return (canEdit && user.afSequenceDraftCount || user.afSequenceCount) || (!canEdit && user.afSequenceCount)
+          return ((canEdit && user.afSequenceDraftCount) || user.afSequenceCount) || (!canEdit && user.afSequenceCount)
       } else {
-          return (canEdit && user.sequenceDraftCount || user.sequenceCount) || (!canEdit && user.sequenceCount)
+          return ((canEdit && user.sequenceDraftCount) || user.sequenceCount) || (!canEdit && user.sequenceCount)
       }
     }
 

--- a/packages/lesswrong/lib/collections/users/validate_login.js
+++ b/packages/lesswrong/lib/collections/users/validate_login.js
@@ -2,7 +2,7 @@ import { Accounts } from 'meteor/accounts-base';
 import Users from 'meteor/vulcan:users';
 
 Accounts.validateLoginAttempt((attempt) => {
-  const userStub = attempt.user || attempt.methodArguments && attempt.methodArguments[0] && attempt.methodArguments[0].user;
+  const userStub = attempt.user || (attempt.methodArguments && attempt.methodArguments[0] && attempt.methodArguments[0].user);
   const user = userStub && Users.findOne({username: userStub.username});
   if (user && user.legacy && user.legacyData && user.legacyData.password && user.services && user.services.password && !attempt.allowed) {
     throw new Meteor.Error('legacy-account', 'LessWrong 1.0 detected, legacy password salt attached ', {salt: user.legacyData.password.substring(0,3), username: user.username})

--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -40,7 +40,7 @@ export const commentExcerptFromHTML = (html, truncationCharCount) => {
     // We want the amount comments get truncated to to be less than the threshold at which they are truncated, so that users don't have the experience of expanding a comment only to see a couple more words (which just feels silly).
 
     // This varies by the size of the comment or truncation amount, and reducing it by 1/4th seems about right.
-    TruncateLength: Math.floor(truncationCharCount - truncationCharCount/4) || excerptMaxChars,
+    TruncateLength: Math.floor(truncationCharCount - (truncationCharCount/4)) || excerptMaxChars,
     TruncateBy: "characters",
     Suffix: `... <span class="read-more"><a class="read-more-default">(Read more)</a><a class="read-more-tooltip">(Click to expand thread)</a><span class="read-more-f-tooltip">Cmd/Ctrl F to expand all comments on this post</span></span>${styles}`,
   }));

--- a/packages/lesswrong/lib/editor/utils.js
+++ b/packages/lesswrong/lib/editor/utils.js
@@ -30,7 +30,7 @@ export const htmlToDraft = convertFromHTML({
     // }
   },
   htmlToBlock: (nodeName, node, lastList, inBlock) => {
-    if (nodeName === 'figure' && node.firstChild.nodeName === 'IMG' || (nodeName === 'img' && inBlock !== 'atomic')) {
+    if ((nodeName === 'figure' && node.firstChild.nodeName === 'IMG') || (nodeName === 'img' && inBlock !== 'atomic')) {
         return 'atomic';
     }
     // if (nodeName === 'blockquote') {

--- a/packages/lesswrong/lib/modules/utils/componentUtils.js
+++ b/packages/lesswrong/lib/modules/utils/componentUtils.js
@@ -25,7 +25,7 @@ export function debugShouldComponentUpdate(description, log, oldProps, oldState,
 // every key k, and both objects have the same set of keys.
 export function shallowEqual(a,b) {
   if (!a && !b) { return true; }
-  if (!a && b || a && !b) { return false; }
+  if ((!a && b) || (a && !b)) { return false; }
 
   let numKeysA = 0, numKeysB = 0, key;
   for (key in b) {
@@ -46,7 +46,7 @@ export function shallowEqual(a,b) {
 // same set of keys.
 export function shallowEqualExcept(a,b, ignoredKeys) {
   if (!a && !b) { return true; }
-  if (!a && b || a && !b) { return false; }
+  if ((!a && b) || (a && !b)) { return false; }
 
   let numKeysA = 0, numKeysB = 0, key;
   for (key in b) {

--- a/packages/lesswrong/lib/modules/utils/getHeaderSubtitleData.js
+++ b/packages/lesswrong/lib/modules/utils/getHeaderSubtitleData.js
@@ -26,7 +26,7 @@ export default function getHeaderSubtitleData(routeName, query, params, client) 
     return communitySubtitle()
   } else if (routeName == "groups.post") {
     return communitySubtitle()
-  } else if (!getSetting('AlignmentForum', false) && routeName == "alignment.forum" || (query && query.af)) {
+  } else if ((!getSetting('AlignmentForum', false) && routeName == "alignment.forum") || (query && query.af)) {
     return alignmentSubtitle()
   }
 }

--- a/packages/lesswrong/lib/modules/vote.js
+++ b/packages/lesswrong/lib/modules/vote.js
@@ -201,7 +201,7 @@ If power is a function, call it on user
 
 */
 const getVotePower = ({ user, voteType, document }) => {
-  const power = voteTypes[voteType] && voteTypes[voteType].power || 1;
+  const power = (voteTypes[voteType] && voteTypes[voteType].power) || 1;
   return typeof power === 'function' ? power(user, document) : power;
 };
 

--- a/packages/lesswrong/server/posts/out.js
+++ b/packages/lesswrong/server/posts/out.js
@@ -17,7 +17,7 @@ Picker.route('/out', ({ query}, req, res, next) => {
       const post = Posts.findOne({url: {$regex: escapeStringRegexp(query.url)}}, {sort: {postedAt: -1, createdAt: -1}});
 
       if (post) {
-        const ip = req.headers && req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+        const ip = (req.headers && req.headers['x-forwarded-for']) || req.connection.remoteAddress;
 
         runCallbacksAsync('posts.click.async', post, ip);
 

--- a/packages/lesswrong/server/scripts/fixKarmaField.js
+++ b/packages/lesswrong/server/scripts/fixKarmaField.js
@@ -14,16 +14,22 @@ if (fixKarma) {
     if (user.legacy) {
       // Function to deal with fields sometimes being undefined. Casts undefined to 0;
       const f = (number) => number || 0;
-      const mainPostKarma = upvoteWeight * f(user.legacyData.karma_ups_link_lesswrong) - downvoteWeight * f(user.legacyData.karma_downs_link_lesswrong);
+      const mainPostKarma = (upvoteWeight * f(user.legacyData.karma_ups_link_lesswrong))
+        - (downvoteWeight * f(user.legacyData.karma_downs_link_lesswrong));
 
-      const mainCommentKarma = upvoteWeight *  f(user.legacyData.karma_ups_comment_lesswrong) -
-      downvoteWeight * f(user.legacyData.karma_downs_comment_lesswrong)
+      const mainCommentKarma = (upvoteWeight * f(user.legacyData.karma_ups_comment_lesswrong))
+        - (downvoteWeight * f(user.legacyData.karma_downs_comment_lesswrong))
 
-      const discussionPostKarma = upvoteWeight * f(user.legacyData.karma_ups_link_discussion) - downvoteWeight * f(user.legacyData.karma_downs_link_discussion)
+      const discussionPostKarma = (upvoteWeight * f(user.legacyData.karma_ups_link_discussion))
+        - (downvoteWeight * f(user.legacyData.karma_downs_link_discussion))
 
-      const discussionCommentKarma = upvoteWeight * f(user.legacyData.karma_ups_comment_discussion) - downvoteWeight  * f(user.legacyData.karma_downs_comment_discussion)
+      const discussionCommentKarma = (upvoteWeight * f(user.legacyData.karma_ups_comment_discussion))
+        - (downvoteWeight * f(user.legacyData.karma_downs_comment_discussion))
 
-      const karma = mainPostKarmaWeight * mainPostKarma + mainCommentKarmaWeight * mainCommentKarma + discussionPostKarmaWeight * discussionPostKarma + discussionCommentKarmaWeight * discussionCommentKarma
+      const karma = (mainPostKarmaWeight*mainPostKarma)
+        + (mainCommentKarmaWeight*mainCommentKarma)
+        + (discussionPostKarmaWeight*discussionPostKarma)
+        + (discussionCommentKarmaWeight*discussionCommentKarma)
 
       Users.update({_id: user._id}, {$set :{karma: karma}});
       usersCount++;

--- a/packages/lesswrong/server/updateScores.js
+++ b/packages/lesswrong/server/updateScores.js
@@ -32,7 +32,7 @@ export const updateScore = async ({collection, item, forceUpdate}) => {
   //      and posts can become inactive
   const n = 30;
   // x = score increase amount of a single vote after n days (for n=100, x=0.000040295)
-  const x = 1/Math.pow(n*24+2,1.3);
+  const x = 1/Math.pow((n*24)+2, 1.3);
 
   // HN algorithm
   const newScore = recalculateScore(item);
@@ -70,7 +70,7 @@ export const batchUpdateScore = async ({collection, inactive = false, forceUpdat
   const FRONTPAGE_BONUS = 10;
   const FEATURED_BONUS = 10;
   // x = score increase amount of a single vote after n days (for n=100, x=0.000040295)
-  const x = 1/Math.pow(INACTIVITY_THRESHOLD_DAYS*24+2,TIME_DECAY_FACTOR);
+  const x = 1 / Math.pow((INACTIVITY_THRESHOLD_DAYS*24) + 2, TIME_DECAY_FACTOR);
 
   const itemsPromise = collection.rawCollection().aggregate([
     {


### PR DESCRIPTION
Turns on an eslint warning that would have catched the comment-expander bug. Adds a bunch of parentheses to satisfy that warning.