### PR TITLE
Fix query link handling

### DIFF
--- a/packages/lesswrong/lib/reactRouterWrapper.js
+++ b/packages/lesswrong/lib/reactRouterWrapper.js
@@ -37,6 +37,6 @@ export const QueryLink = reactRouter.withRouter(({query, location, staticContext
   const newSearchString = merge ? qs.stringify({...parseQuery(location), ...query}) : qs.stringify(query)
   return <reactRouterDom.Link
     {...rest}
-    to={{search: newSearchString}}
+    to={{...location, search: newSearchString}}
   />
 })


### PR DESCRIPTION
Fixes bug reported in Intercom: 

So I was reading a comment on a post (https://www.lesswrong.com/posts/6hfGNLf4Hg5DXqJCF/a-fable-of-science-and-politics#vAfLJXAY7EoFxSs68), and that comment had an automatic note, with a link, in the upper right that said the comment was a response to an earlier version. But the link just went to (https://www.lesswrong.com/?revision=1.0.0).

So I took the suffix and went back and added to the end of the post's URL and it seemed* to work. (Before, after, and without the the "#comments").