### PR TITLE
Add specificity to posts page settings styles

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -18,9 +18,9 @@ const styles = theme => ({
   },
   title: {
     cursor: "pointer",
-    // '&:hover $settingsIcon, &:hover $sortedBy': {
-    //   color: theme.palette.grey[800]
-    // }
+    '&:hover $settingsIcon, &:hover $sortedBy': {
+      color: theme.palette.grey[800]
+    }
   }
 });
 


### PR DESCRIPTION
I think this bug was caused by the recent change in import-architecture that utilizes proxys. If I am not confused, the import-order of CSS sheets now depends on your traversal-order of different pages, which seems like a pretty big problem, since making all CSS we write completely import-order independent is quite difficult. 

We could change the import-order algorithm, but that also doesn't seem great. Like, if we make it alphabetical or something then that's at least transparent. 