### PR TITLE
Silly text changes

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.jsx
@@ -53,7 +53,7 @@ class SunshineNewCommentsItem extends Component {
               <Components.SidebarAction title="Mark as Reviewed" onClick={this.handleReview}>
                 done
               </Components.SidebarAction>
-              <Components.SidebarAction title="Spam/Eugin (delete immediately)" onClick={this.handleDelete} warningHighlight>
+              <Components.SidebarAction title="Spam (delete immediately)" onClick={this.handleDelete} warningHighlight>
                 clear
               </Components.SidebarAction>
             </Components.SidebarActionMenu>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.jsx
@@ -90,7 +90,7 @@ class SunshineReportedItem extends Component {
           <SidebarAction title="Mark as Reviewed" onClick={this.handleReview}>
             done
           </SidebarAction>
-          <SidebarAction title="Spam/Eugin (delete immediately)" onClick={this.handleDelete} warningHighlight>
+          <SidebarAction title="Spam (delete immediately)" onClick={this.handleDelete} warningHighlight>
             delete
           </SidebarAction>
         </SidebarActionMenu>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -81,7 +81,7 @@ class SunshineSidebar extends Component {
             <KeyboardArrowDownIcon
               className={classes.toggle}
               onClick={this.toggleUnderbelly}/>
-            <SunshineListTitle>Hide the Underbelly</SunshineListTitle>
+            <SunshineListTitle>Hide Low Priority</SunshineListTitle>
           </div>
           :
           <div>
@@ -89,7 +89,7 @@ class SunshineSidebar extends Component {
               className={classes.toggle}
               onClick={this.toggleUnderbelly}
             />
-            <SunshineListTitle>Show the Underbelly</SunshineListTitle>
+            <SunshineListTitle>Show Low Priority</SunshineListTitle>
           </div>}
         { showUnderbelly && <div>
           <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true, includeBioOnlyUsers: true}} allowContentPreview={false}/>


### PR DESCRIPTION
I want to be able to show the admin sidebar to EA Forum moderators without them being confused. Rather than have this be a fork diff or dynamically changed based on the forumType setting, I think it makes sense to update LW to be a bit more professional. Feel free to push back with a "stop oppressing me with your blandness" if you want. I'm estimating this as the best option for global utility, but I'm biased by it being the easiest option for me.