### PR TITLE
Add ability for admins to disable posting and commenting

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -45,6 +45,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
+export const commentingDisabledWarning = <div>
+  <p>You can't make new comments right now.</p>
+</div>
+
 const CommentsNewForm = ({prefilledProps = {}, post, tag, parentComment, successCallback, type, cancelCallback, classes, removeFields, fragment = "CommentsList", formProps, enableGuidelines=true, padding=true}:
 {
   prefilledProps?: any,
@@ -70,6 +74,8 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, parentComment, success
   const [showGuidelines, setShowGuidelines] = useState(false)
   const [loading, setLoading] = useState(false)
   const { ModerationGuidelinesBox, WrappedSmartForm, RecaptchaWarning, Loading } = Components
+
+  if (currentUser?.commentingDisabled) return commentingDisabledWarning
 
   const wrappedSuccessCallback = (...args) => {
     if (successCallback) {
@@ -194,4 +200,3 @@ declare global {
     CommentsNewForm: typeof CommentsNewFormComponent,
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -84,6 +84,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+export const postingDisabledWarning = <div>
+  <p>You can't make new posts right now.</p>
+</div>
+
 const PostsNewForm = ({classes}: {
   classes: ClassesType,
 }) => {
@@ -108,6 +112,9 @@ const PostsNewForm = ({classes}: {
 
   if (!Posts.options.mutations.new.check(currentUser)) {
     return (<WrappedLoginForm />);
+  }
+  if (currentUser?.postingDisabled) {
+    return postingDisabledWarning
   }
   const NewPostsSubmit = (props) => {
     return <div className={classes.formSubmit}>
@@ -147,4 +154,3 @@ declare global {
     PostsNewForm: typeof PostsNewFormComponent
   }
 }
-

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -12,7 +12,9 @@ import SnoozeIcon from '@material-ui/icons/Snooze';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
 import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
-import DescriptionIcon from '@material-ui/icons/Description'
+import DescriptionIcon from '@material-ui/icons/Description';
+import SpeakerNotesOffOutlinedIcon from '@material-ui/icons/SpeakerNotesOffOutlined';
+import ChatIcon from '@material-ui/icons/Chat';
 import { useMulti } from '../../lib/crud/withMulti';
 import MessageIcon from '@material-ui/icons/Message'
 import Button from '@material-ui/core/Button';
@@ -182,6 +184,21 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
     setNotes( signatureWithNote("Snooze")+notes )
   }
 
+  const handleCommentingDisabled = () => {
+    updateUser({
+      selector: {_id: user._id},
+      data: {
+        reviewedAt: new Date(),
+        reviewedByUserId: currentUser!._id,
+        sunshineNotes: notes,
+        commentingDisabled: !user?.commentingDisabled
+      }
+    })
+
+    const commentingDisabledStatus = user?.commentingDisabled ? "Re-enable commenting" : "Disable commenting"
+    setNotes( signatureWithNote(commentingDisabledStatus)+notes )
+  }
+
   const banMonths = 3
 
   const handleBan = async () => {
@@ -323,6 +340,11 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
                 <LWTooltip title="Snooze (approve all posts)">
                   <Button title="Snooze" onClick={handleSnooze}>
                     <SnoozeIcon />
+                  </Button>
+                </LWTooltip>
+                <LWTooltip title={user?.commentingDisabled ? "Reenable commenting" : "Disable commenting"}>
+                  <Button onClick={handleCommentingDisabled}>
+                    {user?.commentingDisabled ?  <ChatIcon /> : <SpeakerNotesOffOutlinedIcon />}
                   </Button>
                 </LWTooltip>
                 <LWTooltip title="Ban for 3 months">

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -78,6 +78,8 @@ const UsersMenu = ({color="rgba(0, 0, 0, 0.6)", classes}: {
   const showNewButtons = (forumTypeSetting.get() !== 'AlignmentForum' || userCanDo(currentUser, 'posts.alignment.new')) && !currentUser.deleted
   const isAfMember = currentUser.groups && currentUser.groups.includes('alignmentForum')
 
+  const userCanPost = userCanDo(currentUser, 'posts.new') //!currentUser.postingDisabled
+
   return (
       <div className={classes.root} {...eventHandlers}>
         <Link to={`/users/${currentUser.slug}`}>
@@ -103,12 +105,12 @@ const UsersMenu = ({color="rgba(0, 0, 0, 0.6)", classes}: {
           placement="bottom-start"
         >
           <Paper>
-            {showNewButtons &&
+            {showNewButtons && userCanPost && 
               <MenuItem onClick={()=>openDialog({componentName:"NewQuestionDialog"})}>
                 New Question
               </MenuItem>
             }
-            {showNewButtons && <Link to={`/newPost`}>
+            {showNewButtons && userCanPost &&  <Link to={`/newPost`}>
                 <MenuItem>New Post</MenuItem>
               </Link>
             }
@@ -118,7 +120,7 @@ const UsersMenu = ({color="rgba(0, 0, 0, 0.6)", classes}: {
               </MenuItem>
             }
             {showNewButtons && <Divider/>}
-            {showNewButtons && forumTypeSetting.get() !== 'EAForum' &&
+            {showNewButtons && forumTypeSetting.get() !== 'EAForum' && userCanPost && 
               <Link to={`/newPost?eventForm=true`}>
                 <MenuItem>New Event</MenuItem>
               </Link>

--- a/packages/lesswrong/lib/collections/comments/collection.ts
+++ b/packages/lesswrong/lib/collections/comments/collection.ts
@@ -10,6 +10,8 @@ export const commentMutationOptions: MutationOptions<DbComment> = {
   newCheck: async (user: DbUser|null, document: DbComment|null) => {
     if (!user) return false;
 
+    if (user.commentingDisabled) return false
+
     if (!document || !document.postId) return userCanDo(user, 'comments.new')
     const post = await mongoFindOne("Posts", document.postId)
     if (!post) return true

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -8,6 +8,7 @@ import { postCanEdit } from './helpers';
 const options: MutationOptions<DbPost> = {
   newCheck: (user: DbUser|null) => {
     if (!user) return false;
+    if (user.postingDisabled) return false
     return userCanDo(user, 'posts.new')
   },
 

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -56,6 +56,8 @@ registerFragment(`
     reenableDraftJs
     ...SunshineUsersList
     ...SharedUserBooleans
+    postingDisabled
+    commentingDisabled
   }
 `);
 

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -20,6 +20,8 @@ registerFragment(`
     afCommentCount
     spamRiskScore
     tagRevisionCount
+    postingDisabled
+    commentingDisabled
   }
 `);
 
@@ -56,8 +58,6 @@ registerFragment(`
     reenableDraftJs
     ...SunshineUsersList
     ...SharedUserBooleans
-    postingDisabled
-    commentingDisabled
   }
 `);
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -5,6 +5,7 @@ import { userGetEditUrl } from '../../vulcan-users/helpers';
 import { userGroups, userOwns, userIsAdmin } from '../../vulcan-users/permissions';
 import { formGroups } from './formGroups';
 import * as _ from 'underscore';
+import {schemaDefaultValue} from '../../collectionUtils';
 
 ///////////////////////////////////////
 // Order for the Schema is as follows. Change as you see fit:
@@ -276,6 +277,24 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true, 
     canRead: ['guests'],
+  },
+  postingDisabled: {
+    type: Boolean,
+    optional: true,
+    group: formGroups.banUser,
+    label: "Disable posting",
+    canCreate: ['sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    ...schemaDefaultValue(false)
+  },
+  commentingDisabled: {
+    type: Boolean,
+    optional: true,
+    group: formGroups.banUser,
+    label: "Disable commenting",
+    canCreate: ['sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    ...schemaDefaultValue(false)
   }
 };
 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -611,6 +611,8 @@ interface DbUser extends DbObject {
   slug: string
   groups: Array<string>
   lwWikiImport: boolean
+  postingDisabled: boolean
+  commentingDisabled: boolean
   whenConfirmationEmailSent: Date
   legacy: boolean
   commentSorting: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1425,6 +1425,8 @@ interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBo
   readonly petrovPressedButtonDate: Date,
   readonly sortDrafts: string,
   readonly reenableDraftJs: boolean,
+  readonly postingDisabled: boolean,
+  readonly commentingDisabled: boolean,
 }
 
 interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on Users

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1396,6 +1396,8 @@ interface UsersMinimumInfo { // fragment on Users
   readonly afCommentCount: number,
   readonly spamRiskScore: number,
   readonly tagRevisionCount: number,
+  readonly postingDisabled: boolean,
+  readonly commentingDisabled: boolean,
 }
 
 interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBooleans { // fragment on Users
@@ -1425,8 +1427,6 @@ interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBo
   readonly petrovPressedButtonDate: Date,
   readonly sortDrafts: string,
   readonly reenableDraftJs: boolean,
-  readonly postingDisabled: boolean,
-  readonly commentingDisabled: boolean,
 }
 
 interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on Users

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -54,8 +54,9 @@ voteCallbacks.castVoteAsync.add(async function handleDisableCommenting (document
   const power = await Users.findOne(document.vote.power)
   console.log("author karma: ", author?.karma, " author commenting disabled: ", author?.commentingDisabled)
 
+  // TODO: make it robust to unfortunate first comment
   // Prevent users from commenting once their karma goes below a threshold
-  const threshold = -1
+  const threshold = -10
   if (author) {
     // BUG: this can fail for async reasons, in the case where the karma is updated before the author object is queried, and hence power has already been included
     if (author?.karma <= threshold ) {


### PR DESCRIPTION
Co-authored-by: Raemon <Raemon@users.noreply.github.com>

TODO:
[ ] Find all the places where users can leave comments and posts, and update the UI to conditionally show this based on userCanDo
[ ] The way we've implemented this so far doesn't seem to route through userCanDo, and I think that's bad (it's the function we'd otherwise be relying on to holistically check if a user can do a thing). Update the permission setup somehow so it's more directly integrated
[ ] Update the messaging to be a bit friendlier and clearer about what the user should do

Later on, we'll also want to integrate this into the sunshine sidebar for easier use, and/or make this get triggered automatically via karma levels.