### PR TITLE
Tweak indexes to address mongodb performance issues

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -389,12 +389,6 @@ ensureIndex(Posts,
   }
 );
 ensureIndex(Posts,
-  augmentForDefaultView({"tagRelevance.tNsqhzTibgGJKPEWB": 1, question: 1}),
-  {
-    name: "posts.coronavirus_questions"
-  }
-);
-ensureIndex(Posts,
   augmentForDefaultView({ afSticky:-1, score:-1 }),
   {
     name: "posts.afSticky_score",
@@ -721,6 +715,28 @@ Posts.addView("legacyIdPost", (terms: PostsViewTerms) => {
   }
 });
 ensureIndex(Posts, {legacyId: "hashed"});
+
+
+// Corresponds to the postCommented subquery in recentDiscussionFeed.ts
+ensureIndex(Posts,
+  {
+    status: 1,
+    isFuture: 1,
+    draft: 1,
+    unlisted: 1,
+    authorIsUnreviewed: 1,
+    hideFrontpageComments: 1,
+    
+    lastCommentedAt: -1,
+    _id: 1,
+    
+    baseScore: 1,
+    af: 1,
+    isEvent: 1,
+    onlineEvent: 1,
+    commentCount: 1,
+  },
+);
 
 const recentDiscussionFilter = {
   baseScore: {$gt:0},

--- a/packages/lesswrong/lib/collections/revisions/views.ts
+++ b/packages/lesswrong/lib/collections/revisions/views.ts
@@ -21,7 +21,7 @@ Revisions.addView('revisionsByUser', (terms: RevisionsViewTerms) => {
     options: {sort: {editedAt: -1}},
   }
 });
-ensureIndex(Revisions, {userId: 1, editedAt: 1});
+ensureIndex(Revisions, {userId: 1, collectionName: 1, editedAt: 1});
 
 Revisions.addView('revisionsOnDocument', (terms: RevisionsViewTerms) => {
   const result = {
@@ -44,4 +44,4 @@ Revisions.addView('revisionsOnDocument', (terms: RevisionsViewTerms) => {
   return result;
 });
 
-ensureIndex(Revisions, {collectionName:1, fieldName:1, editedAt:1, changeMetrics:1});
+ensureIndex(Revisions, {collectionName:1, fieldName:1, editedAt:1, _id: 1, changeMetrics:1});

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -44,6 +44,8 @@ ensureIndex(Users, {createdAt:-1,_id:-1});
 // Case-insensitive email index
 ensureIndex(Users, {'emails.address': 1}, {sparse: 1, unique: true, collation: { locale: 'en', strength: 2 }})
 
+ensureIndex(Users, {email: 1})
+
 const termsToMongoSort = (terms: UsersViewTerms) => {
   if (!terms.sort)
     return undefined;


### PR DESCRIPTION
Tweak some mongodb indexes to address performance issues, which I believe were causing 502s.

These have already been applied to the production DB. Note that we had issues with being over the maximum number of indexes on the posts collection; EA forum will likely run into the same issue. To fix this, you'll want to drop some indexes that are in the intersection of <1 usage/min reported in Atlas (in mongodb cloud, Browse Collections>posts>Indexes), and appearing as an "extra index" (ie exists in DB but not in code) on `servername.com/admin`.