### PR TITLE
hide past events and only show nearby in-person events on the main Community page

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -71,10 +71,15 @@ const CommunityHome = ({classes}: {
     const filters = query?.filters || [];
     const { SingleColumnSection, SectionTitle, PostsList2, GroupFormLink, SectionFooter, Typography, SectionButton } = Components
 
-    const eventsListTerms = {
+    const eventsListTerms = currentUserLocation.known ? {
       view: 'nearbyEvents',
       lat: currentUserLocation.lat,
       lng: currentUserLocation.lng,
+      limit: 5,
+      filters: filters,
+      onlineEvent: false
+    } : {
+      view: 'events',
       limit: 5,
       filters: filters,
       onlineEvent: false

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -137,7 +137,7 @@ const CommunityHome = ({classes}: {
               </AnalyticsContext>
             </SingleColumnSection>
             <SingleColumnSection>
-              <SectionTitle title="In-Person Events">
+              <SectionTitle title="Nearby In-Person Events">
                 {canCreateEvents && <Link to="/newPost?eventForm=true"><SectionButton>
                   <LibraryAddIcon /> Create New Event
                 </SectionButton></Link>}
@@ -145,7 +145,7 @@ const CommunityHome = ({classes}: {
               <AnalyticsContext listContext={"communityEvents"}>
                 {!currentUserLocation.known && !currentUserLocation.loading && 
                   <Typography variant="body2" className={classes.enableLocationPermissions}>
-                    Enable location permissions to sort this list by distance to you.
+                    Enable location permissions to see events near you.
                   </Typography>
                 }
                 {!currentUserLocation.loading && <PostsList2 terms={eventsListTerms}>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -821,7 +821,7 @@ Posts.addView("onlineEvents", (terms: PostsViewTerms) => {
       onlineEvent: true,
       isEvent: true,
       groupId: null,
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
     },
     options: {
       sort: {
@@ -846,7 +846,7 @@ Posts.addView("nearbyEvents", (terms: PostsViewTerms) => {
       groupId: null,
       isEvent: true,
       onlineEvent: onlineEvent,
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
       mongoLocation: {
         $near: {
           $geometry: {
@@ -887,12 +887,11 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       createdAt: {$gte: twoMonthsAgo},
       groupId: terms.groupId ? terms.groupId : null,
       baseScore: {$gte: 1},
-      $or: [{startTime: {$exists: false}}, {startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
+      $or: [{startTime: {$gt: new Date()}}, {endTime: {$gt: new Date()}}],
     },
     options: {
       sort: {
-        baseScore: -1,
-        startTime: -1,
+        startTime: 1
       }
     }
   }


### PR DESCRIPTION
This PR makes a few improvements to the In-Person Events list:
1. We no longer show events that have already ended
2. We limit the list to events within ~50 miles of the user, and order the events chronologically (previously we ordered by proximity to the user)
3. If the user doesn't provide a location, we list all upcoming events chronologically (excluding those without a start time)

<img width="500" alt="Screen Shot 2021-10-14 at 3 36 05 PM" src="https://user-images.githubusercontent.com/9057804/137383992-2e12c359-51b4-4aec-920f-d7b124d9e292.png">

I recommend you merge in https://github.com/LessWrong2/Lesswrong2/pull/4230 right after this PR, since this one updates the `nearbyEvents` and `events` views and will probably cause the Community map to show only nearby events without the next PR.

Original PR: https://github.com/centre-for-effective-altruism/EAForum/pull/219
