### PR TITLE
zoom community map into current user's location

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -91,15 +91,13 @@ const CommunityHome = ({classes}: {
       filters: filters,
     }
     const mapEventTerms: PostsViewTerms = {
-      view: 'nearbyEvents',
-      lat: currentUserLocation.lat,
-      lng: currentUserLocation.lng,
+      view: 'events',
       filters: filters,
     }
     const title = forumTypeSetting.get() === 'EAForum' ? 'Groups and Events' : 'Welcome to the Community Section';
     const WelcomeText = () => (isEAForum ?
     <Typography variant="body2" className={classes.welcomeText}>
-      <p>On the map above you can find nearby events (blue pin icons) and local groups (green house icons).</p>
+      <p>On the map above you can find nearby events (blue pin icons) and local groups (green people icons).</p>
       <p>This page is being trialed with a handful of EA groups, so the map isn't yet fully populated.
       For more, visit the <a className={classes.link} href="https://eahub.org/groups?utm_source=forum.effectivealtruism.org&utm_medium=Organic&utm_campaign=Forum_Homepage">EA Hub Groups Directory</a>.</p>
     </Typography> : 
@@ -112,6 +110,7 @@ const CommunityHome = ({classes}: {
         <AnalyticsContext pageContext="communityHome">
           <Components.CommunityMapWrapper
             terms={mapEventTerms}
+            mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
           />
             <SingleColumnSection>
               <SectionTitle title={title}/>

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -105,7 +105,7 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
       longitude: center.lng,
       zoom: zoom
     })
-  }, [center])
+  }, [center, zoom])
 
   const { results: events = [] } = useMulti({
     terms: eventTerms,

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { createStyles } from '@material-ui/core/styles';
@@ -63,7 +63,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 
 // Make these variables have file-scope references to avoid rerending the scripts or map
 const defaultCenter = {lat: 39.5, lng: -43.636047}
-const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center = defaultCenter, zoom = 3, classes, showUsers, showHideMap = false, petrovButton }: {
+const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, showUsers, showHideMap = false, petrovButton }: {
   groupTerms: LocalgroupsViewTerms,
   eventTerms: PostsViewTerms,
   initialOpenWindows: Array<any>,
@@ -95,9 +95,17 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
   const [ viewport, setViewport ] = useState({
     latitude: center.lat,
     longitude: center.lng,
-    zoom: 2
+    zoom: zoom
   })
   
+  // when getting the location from the browser, we want to re-center the map
+  useEffect(() => {
+    setViewport({
+      latitude: center.lat,
+      longitude: center.lng,
+      zoom: zoom
+    })
+  }, [center])
 
   const { results: events = [] } = useMulti({
     terms: eventTerms,

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -11,7 +11,7 @@ import VisibilityIcon from '@material-ui/icons/VisibilityOff';
 import EmailIcon from '@material-ui/icons/Email';
 import AddIcon from '@material-ui/icons/Add';
 import RoomIcon from '@material-ui/icons/Room';
-import HomeIcon from '@material-ui/icons/Home';
+import MUIGroup from '@material-ui/icons/Group';
 import Tooltip from '@material-ui/core/Tooltip';
 import withDialog from '../common/withDialog'
 import withUser from '../common/withUser';
@@ -248,7 +248,7 @@ class CommunityMapFilter extends Component<CommunityMapFilterProps,CommunityMapF
     const { classes, openDialog, currentUser, showHideMap, toggleGroups, showGroups, toggleEvents, showEvents, toggleIndividuals, showIndividuals, history } = this.props;
   
     const isEAForum = forumTypeSetting.get() === 'EAForum';
-    const GroupIcon = () => isEAForum ? <HomeIcon className={classes.eaButtonIcon}/> : <GroupIconSVG className={classes.buttonIcon}/>;
+    const GroupIcon = () => isEAForum ? <MUIGroup className={classes.eaButtonIcon}/> : <GroupIconSVG className={classes.buttonIcon}/>;
     const EventIcon = () => isEAForum ? <RoomIcon  className={classes.eaButtonIcon}/> : <ArrowSVG className={classes.buttonIcon}/>;
 
     const isAdmin = userIsAdmin(currentUser);

--- a/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
@@ -17,7 +17,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eaIcon: {
     width: 20,
     height: 20,
-    fill: theme.palette.primary.main,
+    fill: theme.palette.event,
     opacity: 0.8,
   },
 }))

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -16,7 +16,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eaIcon: {
     width: 20,
     height: 20,
-    fill: '#4b8e10',
+    fill: theme.palette.group,
     opacity: 0.8,
   },
 }))

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { GroupIconSVG } from './Icons'
 import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
-import HomeIcon from '@material-ui/icons/Home';
+import MUIGroup from '@material-ui/icons/Group';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -16,7 +16,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eaIcon: {
     width: 20,
     height: 20,
-    fill: '#90b733',
+    fill: '#4b8e10',
     opacity: 0.8,
   },
 }))
@@ -37,7 +37,7 @@ const LocalGroupMarker = ({ group, handleMarkerClick, handleInfoWindowClose, inf
   const htmlBody = {__html: html};
 
   const GroupIcon = () =>  forumTypeSetting.get() === 'EAForum' ? 
-    <HomeIcon className={classes.eaIcon}/> : <GroupIconSVG className={classes.icon}/>;
+    <MUIGroup className={classes.eaIcon}/> : <GroupIconSVG className={classes.icon}/>;
 
   return <React.Fragment>
     <Marker

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -122,7 +122,7 @@ const TabNavigationEventsList = ({ terms, onClick, classes }: {
         const tooltip = <div>
             <div className={classes.tooltipTitle}>{event.title}</div>
             <div className={classes.tooltipLogisticsTitle}>
-             {event.onlineEvent ? "Onlne Event" : "Location"}
+             {event.onlineEvent ? "Online Event" : "Location"}
             </div>
             <div>{event.location}</div>
             <div className={classes.tooltipLogisticsTitle}>Time</div>

--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -49,6 +49,9 @@ const palette = {
   background: {
     default: '#f6f8f9'
   },
+  event: '#0C869B',
+  group: '#538747',
+  individual: '#BF577D',
 }
 
 const basicText = {

--- a/packages/lesswrong/themes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/lesswrongTheme.ts
@@ -45,7 +45,10 @@ const palette = {
   },
   background: {
     default: '#f8f8f8'
-  }
+  },
+  event: '#2b6a99',
+  group: '#588f27',
+  individual: '#3f51b5',
 }
 
 const theme = createLWTheme({


### PR DESCRIPTION
Most of this is just EA Forum changes, but I also updated the main Community map to zoom in to the current user's location.

I recommend you merge this in after https://github.com/LessWrong2/Lesswrong2/pull/4224 since that PR updates the `events` view and this PR uses it for populating the map markers.

Original PR: https://github.com/centre-for-effective-altruism/EAForum/pull/224