### PR TITLE
Add Meetup.com and Facebook Page links to groups and events

### DIFF
--- a/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
+++ b/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
@@ -9,7 +9,7 @@ import { editableCollections, editableCollectionsFields } from '../../lib/editor
 import * as _ from 'underscore';
 
 /**
- * This is a wrapper around SmartForm which adds a submit callback that filters
+ * This is a wrapper around FormWrapper which adds a submit callback that filters
  * out any data that would cause problems with editable fields. This is
  * necessary because editable fields have a different input type than they have
  * query type, and so we have to make sure to not resubmit any data that we
@@ -19,7 +19,7 @@ function WrappedSmartForm(props) {
   const { collection } = props
   const collectionName = collection && collection.options && collection.options.collectionName
   if (editableCollections.has(collectionName)) {
-    return <Components.SmartForm
+    return <Components.FormWrapper
       {...props}
       submitCallback={(data) => {
         if (props.submitCallback) {data = props.submitCallback(data)}
@@ -38,7 +38,7 @@ function WrappedSmartForm(props) {
       }}
     />  
   } else {
-    return <Components.SmartForm {...props}/>
+    return <Components.FormWrapper {...props}/>
   }
 }
 

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import LinkIcon from '@material-ui/icons/Link';
 import SvgIcon from '@material-ui/core/SvgIcon';
-import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import { createStyles } from '@material-ui/core/styles';
 import { forumTypeSetting } from '../../lib/instanceSettings';

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -8,14 +8,34 @@ import { createStyles } from '@material-ui/core/styles';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 
+// just the "f", used for the FB Group link
 export const FacebookIcon = (props: any) => <SvgIcon viewBox="0 0 155.139 155.139" {...props}>
   <path id="f_1_" d="M89.584,155.139V84.378h23.742l3.562-27.585H89.584V39.184
   c0-7.984,2.208-13.425,13.67-13.425l14.595-0.006V1.08C115.325,0.752,106.661,0,96.577,0C75.52,0,61.104,12.853,61.104,36.452 v20.341H37.29v27.585h23.814v70.761H89.584z"/>
 </SvgIcon>
 
+// circle with the "f" cut out, used for the FB Page link
+export const RoundFacebookIcon = (props: any) => <SvgIcon viewBox="0 0 24 24" {...props}>
+  <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm3 8h-1.35c-.538 0-.65.221-.65.778v1.222h2l-.209 2h-1.791v7h-3v-7h-2v-2h2v-2.308c0-1.769.931-2.692 3.029-2.692h1.971v3z"/>
+</SvgIcon>
+
+export const MeetupIcon = (props: any) => <SvgIcon viewBox="15 15 70 70" {...props}>
+  <path d="M80.952,74.251c-0.74,0.802-1.917,1.41-3.104,1.721c-3.226,0.844-7.038-0.031-10.038-1.351
+  c-9.568-4.21-7.455-14.872-3.259-22.225c1.26-2.208,2.503-4.431,3.754-6.666c0.984-1.76,3.114-4.724,2.28-6.875
+  c-0.875-2.256-3.216-2.27-4.753-0.369c-1.479,1.829-2.726,4.454-3.746,6.584c-1.111,2.319-6.656,14.507-6.656,14.507
+  c-1.024,1.985-2.751,4.839-4.624,6.416c-1.397,1.177-3.95,1.522-5.629,0.303c-1.275-0.927-1.527-2.159-1.277-3.594
+  c1.156-6.625,11.204-22.04,4.274-23.125c-2.656-0.416-3.377,2.539-4.196,4.426c-1.354,3.116-2.386,6.361-3.834,9.441
+  c-1.664,3.536-2.939,7.219-3.813,11.02c-0.698,3.037-1.602,6.907-5.06,7.832c-9.465,2.531-12.341-3.718-12.341-3.719
+  c-1.545-4.916-0.08-9.338,1.408-14.066c1.15-3.652,1.837-7.419,3.293-10.973c2.598-6.336,5.187-19.556,14.549-18.711
+  c2.39,0.216,5.063,1.424,7.128,2.628c1.877,1.095,3.305,1.679,5.49,0.499c2.126-1.146,3.099-3.277,5.632-4.008
+  c2.715-0.783,4.5,0.376,6.53,2.009c2.846,2.288,3.156,1.254,5.504,0.653c1.947-0.499,4.208-0.73,6.342-0.365
+  c10.982,1.882,3.988,15.901,1.368,21.535c-1.705,3.665-9.844,18.404-2.633,20.385c2.175,0.597,4.979,0.325,6.79,1.885
+  C82.172,71.633,81.989,73.13,80.952,74.251z" />
+</SvgIcon>
+
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   groupTypes: {
-    marginLeft: 20,
+    marginLeft: 12,
     display: 'inline-block',
   },
 
@@ -25,17 +45,34 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     width: 'initial',
     height: '20px',
     fontSize: '14px',
-    marginRight: 5
+    marginLeft: theme.spacing.unit
   },
 
   groupLinks: {
-    display: 'inline-block',
+    display: 'inline-flex',
+    alignItems: 'baseline',
     marginLeft: '6px'
   },
+  
+  groupLink: {
+    marginLeft: theme.spacing.unit
+  },
+  
+  websiteLink: {
+    marginLeft: theme.spacing.unit - 3
+  },
+  
+  facebookGroupIcon: {
+    width: "13px",
+    height: "13px",
+    display: "inline-block",
+    color: "rgba(0, 0, 0, 0.7)",
+    paddingTop: "0px",
+  },
 
-  facebookIcon: {
-    width: "12px",
-    height: "12px",
+  socialIcon: {
+    width: "15px",
+    height: "15px",
     display: "inline-block",
     color: "rgba(0, 0, 0, 0.7)",
     paddingTop: "0px",
@@ -45,7 +82,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   linkIcon: {
     height: "17px",
     width: "17px",
-    paddingTop: "2px",
+    paddingTop: "0px",
     transform: "translateY(3px) rotate(-45deg)",
   },
 
@@ -69,8 +106,11 @@ const GroupLinks = ({ document, classes }: {
   classes: ClassesType,
 }) => {
   const isEAForum = forumTypeSetting.get() === 'EAForum';
+  // tooltip text differs between group and event
+  const isEvent = 'isEvent' in document;
+  
   return(
-    <span className="group-links">
+    <div className={classes.root}>
       {!isEAForum && <div className={classes.groupTypes}>
         {document.types && document.types.map(type => {
           return (
@@ -89,21 +129,36 @@ const GroupLinks = ({ document, classes }: {
       <div className={classes.groupLinks}>
         {document.facebookLink
           && <Tooltip
-            title="Link to Facebook Group"
+            title={`Link to Facebook ${isEvent ? 'Event' : 'Group'}`}
             placement="top-end"
           >
-            <a href={document.facebookLink}><IconButton className={classes.iconButton} color="inherit">
-              <FacebookIcon className={classes.facebookIcon}/>
-            </IconButton></a>
+            <a href={document.facebookLink} className={classes.groupLink}>
+              <FacebookIcon className={classes.facebookGroupIcon}/>
+            </a>
+          </Tooltip>}
+        {document.facebookPageLink
+        && <Tooltip
+          title={`Link to Facebook ${isEvent ? 'Event' : 'Page'}`}
+          placement="top-end"
+        >
+          <a href={document.facebookPageLink} className={classes.groupLink}>
+            <RoundFacebookIcon className={classes.socialIcon}/>
+          </a>
+        </Tooltip>}
+        {document.meetupLink
+          && <Tooltip title={`Link to Meetup.com ${isEvent ? 'Event' : 'Group'}`} placement="top-end">
+            <a href={document.meetupLink} className={classes.groupLink}>
+              <MeetupIcon className={classes.socialIcon}/>
+            </a>
           </Tooltip>}
         {document.website
           && <Tooltip title={<span>Link to Group Website ({document.website})</span>} placement="top-end">
-            <a href={document.website}><IconButton className={classes.iconButton} color="inherit">
+            <a href={document.website} className={classes.websiteLink}>
               <LinkIcon className={classes.linkIcon}/>
-            </IconButton></a>
+            </a>
           </Tooltip>}
       </div>
-    </span>
+    </div>
   )
 }
 

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -15,7 +15,8 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},
   groupInfo: {
-    ...sectionFooterLeftStyles
+    ...sectionFooterLeftStyles,
+    alignItems: 'baseline'
   },
   groupName: {
     ...theme.typography.headerStyle,

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -33,6 +33,7 @@ export const styles = createStyles((theme: ThemeType): JssStyles => ({
   markerPageLink: {
     fontWeight: 400,
     color: "rgba(0,0,0,0.4)",
+    flex: 'none'
   },
   linksWrapper: {
     display: 'flex',

--- a/packages/lesswrong/components/questions/NewAnswerForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerForm.tsx
@@ -67,7 +67,7 @@ const NewAnswerForm = ({post, classes}: {
     answer: true,
     af: commentDefaultToAlignment(currentUser, post),
   }
-  const { SmartForm } = Components
+  const { FormWrapper } = Components
   
   if (currentUser && !Comments.options.mutations.new.check(currentUser, prefilledProps)) {
     return <span>Sorry, you do not have permission to comment at this time.</span>
@@ -75,7 +75,7 @@ const NewAnswerForm = ({post, classes}: {
   
   return (
     <div className={classes.answersForm}>
-      <SmartForm
+      <FormWrapper
         collection={Comments}
         formComponents={{
           FormSubmit: SubmitComponent,

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -137,7 +137,7 @@ const getInitialStateFromProps = nextProps => {
 /**
  * Note: Only use this through WrappedSmartForm
  */
-class SmartForm extends Component<any,any> {
+class Form extends Component<any,any> {
   constructor(props) {
     super(props);
 
@@ -1064,7 +1064,7 @@ class SmartForm extends Component<any,any> {
   }
 }
 
-(SmartForm as any).propTypes = {
+(Form as any).propTypes = {
   // main options
   collection: PropTypes.object.isRequired,
   collectionName: PropTypes.string.isRequired,
@@ -1097,18 +1097,18 @@ class SmartForm extends Component<any,any> {
   currentUser: PropTypes.object,
 };
 
-(SmartForm as any).defaultProps = {
+(Form as any).defaultProps = {
   layout: 'horizontal',
   prefilledProps: {},
   repeatErrors: false,
   showRemove: true
 };
 
-(SmartForm as any).contextTypes = {
+(Form as any).contextTypes = {
   intl: intlShape
 };
 
-(SmartForm as any).childContextTypes = {
+(Form as any).childContextTypes = {
   addToDeletedValues: PropTypes.func,
   deletedValues: PropTypes.array,
   addToSubmitForm: PropTypes.func,
@@ -1128,7 +1128,7 @@ class SmartForm extends Component<any,any> {
   currentValues: PropTypes.object
 };
 
-const FormComponent = registerComponent("Form", SmartForm, {
+const FormComponent = registerComponent("Form", Form, {
   hocs: [withCollectionProps]
 });
 

--- a/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
@@ -341,12 +341,12 @@ class FormWrapper extends PureComponent<any> {
   intl: intlShape
 };
 
-const SmartFormComponent = registerComponent('SmartForm', FormWrapper, {
+const FormWrapperComponent = registerComponent('FormWrapper', FormWrapper, {
   hocs: [withUser, withApollo, withRouter, withCollectionProps]
 });
 
 declare global {
   interface ComponentTypes {
-    SmartForm: typeof SmartFormComponent
+    FormWrapper: typeof FormWrapperComponent
   }
 }

--- a/packages/lesswrong/lib/collections/localgroups/fragments.ts
+++ b/packages/lesswrong/lib/collections/localgroups/fragments.ts
@@ -16,6 +16,8 @@ registerFragment(`
     types
     contactInfo
     facebookLink
+    facebookPageLink
+    meetupLink
     website
     inactive
   }

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -1,3 +1,4 @@
+import SimpleSchema from 'simpl-schema';
 import { arrayOfForeignKeysField, denormalizedField, googleLocationToMongoLocation } from '../../utils/schemaUtils'
 import { localGroupTypeFormOptions } from './groupTypes';
 import { schemaDefaultValue } from '../../collectionUtils';
@@ -19,7 +20,7 @@ const schema: SchemaType<DbLocalgroup> = {
     editableBy: ['members'],
     order:10,
     insertableBy: ['members'],
-    control: "MuiInput",
+    control: "MuiTextField",
     label: "Local Group Name"
   },
 
@@ -112,18 +113,41 @@ const schema: SchemaType<DbLocalgroup> = {
     insertableBy: ['members'],
     editableBy: ['members'],
     label: "Contact Info",
-    control: "MuiInput",
+    control: "MuiTextField",
     optional: true,
   },
 
-  facebookLink: {
+  facebookLink: { // FB Group link
     type: String,
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: ['members'],
-    label: "Facebook group",
-    control: "MuiInput",
+    label: "Facebook Group",
+    control: "MuiTextField",
     optional: true,
+    regEx: SimpleSchema.RegEx.Url
+  },
+  
+  facebookPageLink: {
+    type: String,
+    viewableBy: ['guests'],
+    insertableBy: ['members'],
+    editableBy: ['members'],
+    label: "Facebook Page",
+    control: "MuiTextField",
+    optional: true,
+    regEx: SimpleSchema.RegEx.Url
+  },
+  
+  meetupLink: {
+    type: String,
+    viewableBy: ['guests'],
+    insertableBy: ['members'],
+    editableBy: ['members'],
+    label: "Meetup.com Group",
+    control: "MuiTextField",
+    optional: true,
+    regEx: SimpleSchema.RegEx.Url
   },
 
   website: {
@@ -131,8 +155,9 @@ const schema: SchemaType<DbLocalgroup> = {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: ['members'],
-    control: "MuiInput",
+    control: "MuiTextField",
     optional: true,
+    regEx: SimpleSchema.RegEx.Url
   },
 
   inactive: {

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -125,7 +125,8 @@ const schema: SchemaType<DbLocalgroup> = {
     label: "Facebook Group",
     control: "MuiTextField",
     optional: true,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.facebook.com/groups/...'
   },
   
   facebookPageLink: {
@@ -136,7 +137,8 @@ const schema: SchemaType<DbLocalgroup> = {
     label: "Facebook Page",
     control: "MuiTextField",
     optional: true,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.facebook.com/...'
   },
   
   meetupLink: {
@@ -147,7 +149,8 @@ const schema: SchemaType<DbLocalgroup> = {
     label: "Meetup.com Group",
     control: "MuiTextField",
     optional: true,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.meetup.com/...'
   },
 
   website: {
@@ -157,7 +160,8 @@ const schema: SchemaType<DbLocalgroup> = {
     editableBy: ['members'],
     control: "MuiTextField",
     optional: true,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://...'
   },
 
   inactive: {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -785,7 +785,8 @@ addFieldsDict(Posts, {
     control: "MuiTextField",
     optional: true,
     group: formGroups.event,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.facebook.com/groups/...'
   },
   
   facebookPageLink: {
@@ -798,7 +799,8 @@ addFieldsDict(Posts, {
     control: "MuiTextField",
     optional: true,
     group: formGroups.event,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.facebook.com/...'
   },
   
   meetupLink: {
@@ -811,7 +813,8 @@ addFieldsDict(Posts, {
     control: "MuiTextField",
     optional: true,
     group: formGroups.event,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://www.meetup.com/...'
   },
 
   website: {
@@ -823,7 +826,8 @@ addFieldsDict(Posts, {
     control: "MuiTextField",
     optional: true,
     group: formGroups.event,
-    regEx: SimpleSchema.RegEx.Url
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://...'
   },
 
   types: {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -1,6 +1,7 @@
 import GraphQLJSON from 'graphql-type-json';
 import moment from 'moment';
 import * as _ from 'underscore';
+import SimpleSchema from 'simpl-schema';
 import { schemaDefaultValue } from '../../collectionUtils';
 import { makeEditable } from '../../editor/make_editable';
 import { forumTypeSetting } from '../../instanceSettings';
@@ -769,7 +770,7 @@ addFieldsDict(Posts, {
     insertableBy: ['members'],
     editableBy: ['members'],
     label: "Contact Info",
-    control: "MuiInput",
+    control: "MuiTextField",
     optional: true,
     group: formGroups.event,
   },
@@ -780,10 +781,37 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: [userOwns, 'sunshineRegiment', 'admins'],
-    label: "Facebook Event",
-    control: "MuiInput",
+    label: "Facebook Group Event",
+    control: "MuiTextField",
     optional: true,
     group: formGroups.event,
+    regEx: SimpleSchema.RegEx.Url
+  },
+  
+  facebookPageLink: {
+    type: String,
+    hidden: (props) => !props.eventForm,
+    viewableBy: ['guests'],
+    insertableBy: ['members'],
+    editableBy: [userOwns, 'sunshineRegiment', 'admins'],
+    label: "Facebook Page Event",
+    control: "MuiTextField",
+    optional: true,
+    group: formGroups.event,
+    regEx: SimpleSchema.RegEx.Url
+  },
+  
+  meetupLink: {
+    type: String,
+    hidden: (props) => !props.eventForm,
+    viewableBy: ['guests'],
+    insertableBy: ['members'],
+    editableBy: [userOwns, 'sunshineRegiment', 'admins'],
+    label: "Meetup.com Event",
+    control: "MuiTextField",
+    optional: true,
+    group: formGroups.event,
+    regEx: SimpleSchema.RegEx.Url
   },
 
   website: {
@@ -792,9 +820,10 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: [userOwns, 'sunshineRegiment', 'admins'],
-    control: "MuiInput",
+    control: "MuiTextField",
     optional: true,
     group: formGroups.event,
+    regEx: SimpleSchema.RegEx.Url
   },
 
   types: {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -60,6 +60,8 @@ registerFragment(`
     localStartTime
     localEndTime
     facebookLink
+    facebookPageLink
+    meetupLink
     website
     contactInfo
     isEvent

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -234,6 +234,8 @@ interface DbLocalgroup extends DbObject {
   location: string
   contactInfo: string
   facebookLink: string
+  facebookPageLink: string
+  meetupLink: string
   website: string
   inactive: boolean
   contents: EditableFieldContents
@@ -395,6 +397,8 @@ interface DbPost extends DbObject {
   location: string
   contactInfo: string
   facebookLink: string
+  facebookPageLink: string
+  meetupLink: string
   website: string
   types: Array<string>
   metaSticky: boolean

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -290,6 +290,8 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly localStartTime: Date,
   readonly localEndTime: Date,
   readonly facebookLink: string,
+  readonly facebookPageLink: string,
+  readonly meetupLink: string,
   readonly website: string,
   readonly contactInfo: string,
   readonly isEvent: boolean,
@@ -1081,6 +1083,8 @@ interface LocalgroupsDefaultFragment { // fragment on Localgroups
   readonly location: string,
   readonly contactInfo: string,
   readonly facebookLink: string,
+  readonly facebookPageLink: string,
+  readonly meetupLink: string,
   readonly website: string,
   readonly inactive: boolean,
 }
@@ -1098,6 +1102,8 @@ interface localGroupsBase { // fragment on Localgroups
   readonly types: Array<string>,
   readonly contactInfo: string,
   readonly facebookLink: string,
+  readonly facebookPageLink: string,
+  readonly meetupLink: string,
   readonly website: string,
   readonly inactive: boolean,
 }

--- a/packages/lesswrong/lib/vulcan-forms/components.ts
+++ b/packages/lesswrong/lib/vulcan-forms/components.ts
@@ -11,5 +11,5 @@ importComponent("FormNestedHead", () => require('../../components/vulcan-forms/F
 importComponent(["FormNestedObjectLayout", "FormNestedObject"], () => require('../../components/vulcan-forms/FormNestedObject'));
 importComponent(["FormNestedItemLayout", "FormNestedItem"], () => require('../../components/vulcan-forms/FormNestedItem'));
 importComponent(["FormGroupHeader", "FormGroupLayout", "FormGroup", "IconRight", "IconDown"], () => require('../../components/vulcan-forms/FormGroup'));
-importComponent("SmartForm", () => require('../../components/vulcan-forms/FormWrapper'));
+importComponent("FormWrapper", () => require('../../components/vulcan-forms/FormWrapper'));
 importComponent("Form", () => require('../../components/vulcan-forms/Form'));

--- a/packages/lesswrong/lib/vulcan-i18n-en-us.ts
+++ b/packages/lesswrong/lib/vulcan-i18n-en-us.ts
@@ -87,4 +87,5 @@ addStrings('en', {
   'errors.expectedType': 'Expected a field “{label}” of type {dataType}, got “{value}” instead.',
   'errors.required': 'Field “{label}” is required.',
   'errors.maxString': 'Field “{label}” is limited to {max} characters.',
+  'errors.regEx': 'Field "{label}" is invalid.',
 });


### PR DESCRIPTION
<img width="500" alt="Screen Shot 2021-10-12 at 4 31 06 PM" src="https://user-images.githubusercontent.com/9057804/137024888-78e664c7-1b96-4523-858b-4cb60a4e6312.png">

Here we are adding fields for groups and events to have a Meetup.com link and a Facebook Page link (in addition to the existing Facebook Group link and website link).

<img width="400" alt="Screen Shot 2021-10-12 at 3 18 15 PM" src="https://user-images.githubusercontent.com/9057804/137025110-ee6c72db-466f-4ca0-bcc0-2bca87c7e60b.png">

<img width="500" alt="Screen Shot 2021-10-12 at 3 17 57 PM" src="https://user-images.githubusercontent.com/9057804/137023382-efda929d-7352-41e9-bafa-43cb24a74610.png">

Also turned some of the inputs into text fields, so they look nicer:

<img width="300" alt="Screen Shot 2021-10-12 at 3 29 49 PM" src="https://user-images.githubusercontent.com/9057804/137023396-2acc9695-4a76-4c51-a905-9691faa34e32.png">



Original PR: https://github.com/centre-for-effective-altruism/EAForum/pull/217