### PR TITLE
Add types to the Menu Tabs array

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import MenuItem from '@material-ui/core/MenuItem';
 import { Link } from '../../../lib/reactRouterWrapper';
 import classNames from 'classnames';
+import { MenuTabRegular } from './menuTabs';
 
 const compressedIconSize = 23
 
@@ -30,7 +31,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const TabNavigationCompressedItem = ({tab, onClick, classes}) => {
+type TabNavigationCompressedItemProps = {
+  tab: MenuTabRegular,
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void,
+  classes: ClassesType,
+}
+
+const TabNavigationCompressedItem = ({tab, onClick, classes}: TabNavigationCompressedItemProps) => {
   // MenuItem takes a component and passes unrecognized props to that component,
   // but its material-ui-provided type signature does not include this feature.
   // Case to any to work around it, to be able to pass a "to" parameter.

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { useLocation } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import Tooltip from '@material-ui/core/Tooltip';
+import { MenuTabRegular } from './menuTabs';
 
 const smallIconSize = 23
 
@@ -52,13 +53,18 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const TabNavigationFooterItem = ({tab, classes}) => {
+type TabNavigationFooterItemProps = {
+  tab: MenuTabRegular,
+  classes: ClassesType,
+}
+
+const TabNavigationFooterItem = ({tab, classes}: TabNavigationFooterItemProps) => {
   const { TabNavigationSubItem } = Components
   const { pathname } = useLocation()
   // React router links don't handle external URLs, so use a
   // normal HTML a tag if the URL is external
   const externalLink = /https?:\/\//.test(tab.link);
-  const Element = externalLink ? 
+  const Element = externalLink ?
     ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
     : Link;
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -4,6 +4,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { Link } from '../../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { useLocation } from '../../../lib/routeUtil';
+import { MenuTabRegular } from './menuTabs';
 
 export const iconWidth = 30
 
@@ -61,19 +62,25 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const TabNavigationItem = ({tab, onClick, classes}) => {
+type TabNavigationItemProps = {
+  tab: MenuTabRegular,
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void,
+  classes: ClassesType,
+}
+
+const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
   const { TabNavigationSubItem, LWTooltip } = Components
   const { pathname } = useLocation()
   
   // MenuItem takes a component and passes unrecognized props to that component,
   // but its material-ui-provided type signature does not include this feature.
-  // Case to any to work around it, to be able to pass a "to" parameter.
+  // Cast to any to work around it, to be able to pass a "to" parameter.
   const MenuItemUntyped = MenuItem as any;
   
   // React router links don't handle external URLs, so use a
   // normal HTML a tag if the URL is external
   const externalLink = /https?:\/\//.test(tab.link);
-  const Element = externalLink ? 
+  const Element = externalLink ?
     ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
     : Link;
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -40,10 +40,10 @@ const TabNavigationMenu = ({onClickSection, classes}: {
       <AnalyticsContext pageSectionContext="navigationMenu">
         <div className={classes.root}>
           {menuTabs[forumTypeSetting.get()].map(tab => {
-            if (tab.divider) {
+            if ('divider' in tab) {
               return <div key={tab.id} className={classes.divider} />
             }
-            if (tab.customComponentName) {
+            if ('customComponentName' in tab) {
               const CustomComponent = Components[tab.customComponentName];
               return <CustomComponent
                 key={tab.id}

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuCompressed.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuCompressed.tsx
@@ -28,10 +28,10 @@ const TabNavigationMenuCompressed = ({onClickSection, classes}) => {
   return (
     <div className={classes.root}>
       {menuTabs[forumTypeSetting.get()].map(tab => {
-        if (!tab.showOnCompressed) {
+        if (!('showOnCompressed' in tab) || !tab.showOnCompressed) {
           return
         }
-        if (tab.divider) {
+        if ('divider' in tab) {
           return <Divider key={tab.id} className={classes.divider} />
         }
         return <TabNavigationCompressedItem key={tab.id} tab={tab} onClick={onClickSection} />

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
@@ -22,7 +22,7 @@ const TabNavigationMenuFooter = ({classes}) => {
       <AnalyticsContext pageSectionContext="tabNavigationFooter">
         <div className={classes.root}>
           {menuTabs[forumTypeSetting.get()].map(tab => {
-            if (!tab.showOnMobileStandalone) {
+            if (!('showOnMobileStandalone' in tab) || !tab.showOnMobileStandalone) {
               return
             }
             // NB: No support for custom components or dividers on footer

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -41,7 +41,34 @@ import { communityPath } from '../../../lib/routes';
 //   customComponentName: string; instead of a TabNavigationItem, display this component
 //
 // See TabNavigation[Footer|Compressed]?Item.jsx for how these are used by the code
-type MenuTab = any;
+
+type MenuTabDivider = {
+  id: string
+  divider: true
+  showOnCompressed?: boolean
+}
+
+type MenuTabCustomComponent = {
+  id: string
+  customComponentName: string
+}
+
+export type MenuTabRegular = {
+  id: string
+  title: string
+  mobileTitle?: string
+  link: string
+  icon?: React.ReactNode
+  iconComponent?: any // I tried
+  compressedIconComponent?: any
+  tooltip?: React.ReactNode
+  showOnMobileStandalone?: boolean
+  showOnCompressed?: boolean
+  subItem?: boolean
+}
+
+type MenuTab = MenuTabDivider | MenuTabCustomComponent | MenuTabRegular
+
 export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
   LessWrong: [
     {


### PR DESCRIPTION
Already reviewed in: https://github.com/centre-for-effective-altruism/EAForum/pull/230

---

Today in "marginally productive escapades", I on a whim added types to menuTabs. There should be no functional change to the behavior, which I tested in the 4 scenarios.