### PR TITLE
a bit of cleanup around online groups

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -90,7 +90,7 @@ const CommunityHome = ({classes}: {
     }
     const onlineGroupsListTerms: LocalgroupsViewTerms = {
       view: 'online',
-      limit: 10,
+      limit: 5,
       filters: filters
     }
     const groupsListTerms: LocalgroupsViewTerms = {

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -13,7 +13,11 @@ import { userIsAdmin } from '../../lib/vulcan-users';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
-  root: {},
+  root: {
+    [theme.breakpoints.down('md')]: {
+      marginTop: 20
+    }
+  },
   groupInfo: {
     ...sectionFooterLeftStyles,
     alignItems: 'baseline'

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -13,9 +13,10 @@ import { userIsAdmin } from '../../lib/vulcan-users';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
-  root: {
-    [theme.breakpoints.down('md')]: {
-      marginTop: 20
+  root: {},
+  bannerImage: {
+    [theme.breakpoints.up('md')]: {
+      marginTop: -50
     }
   },
   groupInfo: {
@@ -83,13 +84,13 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
 
   return (
     <div className={classes.root}>
-      {group.googleLocation && <CommunityMapWrapper
+      {group.googleLocation ? <CommunityMapWrapper
         terms={{view: "events", groupId: groupId}}
         groupQueryTerms={{view: "single", groupId: groupId}}
         mapOptions={{zoom:11, center: group.googleLocation.geometry.location, initialOpenWindows:[groupId]}}
-      />}
+      /> : <div className={classes.bannerImage}></div>}
       <SingleColumnSection>
-        <SectionTitle title={`${group.inactive ? "[Inactive] " : " "}${group.name}`} noTopMargin={group.isOnline}>
+        <SectionTitle title={`${group.inactive ? "[Inactive] " : " "}${group.name}`}>
           {currentUser && <SectionButton>
             <SubscribeTo
               showIcon

--- a/packages/lesswrong/lib/collections/localgroups/views.ts
+++ b/packages/lesswrong/lib/collections/localgroups/views.ts
@@ -73,10 +73,10 @@ Localgroups.addView("single", function (terms: LocalgroupsViewTerms) {
   };
 });
 
-Localgroups.addView("online", function (terms: LocalgroupsViewTerms) {
+Localgroups.addView("online", function () {
   return {
     selector: {isOnline: true},
-    options: {sort: {createdAt: -1}}
+    options: {sort: {name: 1}}
   };
 });
-ensureIndex(Localgroups, { isOnline: 1 });
+ensureIndex(Localgroups, { isOnline: 1, name: 1 });

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2007,3 +2007,4 @@ interface CollectionNamesByFragmentName {
 }
 
 type CollectionNameString = "Bans"|"Books"|"Chapters"|"Collections"|"Comments"|"Conversations"|"DatabaseMetadata"|"DebouncerEvents"|"EmailTokens"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"LegacyData"|"Localgroups"|"Messages"|"Migrations"|"Notifications"|"PetrovDayLaunchs"|"PostRelations"|"Posts"|"RSSFeeds"|"ReadStatuses"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"Users"|"Votes"
+


### PR DESCRIPTION
A few small updates around online groups:

1. Only show up to 5 on the main Community page
2. Order them alphabetically instead of by date created
2. Fix the top margin on the Group Page on mobile