### PR TITLE
Links to most important century now go to new sequence page

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -284,7 +284,7 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
     }, {
       id: 'most-important-century',
       title: 'Most Important Century',
-      link: '/posts/TwQzyP3QgttmuTHym/all-possible-views-about-humanity-s-future-are-wild',
+      link: '/s/isENJuPdB3fhjWYHd',
       tooltip: `Holden Karnofsky argues that there's a good chance of a productivity explosion by 2100, which could quickly lead to a "technologically mature" civilization.`,
       subItem: true,
     }, {

--- a/packages/lesswrong/components/sequences/CoreReading.tsx
+++ b/packages/lesswrong/components/sequences/CoreReading.tsx
@@ -58,7 +58,7 @@ const coreReadingCollections: Array<CoreReadingCollection> = isEAForum ?
       imageId: "jacob-mejicanos-P6s8EbcSgmA-unsplash.jpg",
       color: "#d96704",
       big: false,
-      url: '/posts/TwQzyP3QgttmuTHym/all-possible-views-about-humanity-s-future-are-wild',
+      url: '/s/isENJuPdB3fhjWYHd',
     }
   ] :
   [
@@ -105,7 +105,7 @@ const CoreReading = ({minimal=false, classes}: {
     <div className={classes.razSmallVersion}>
       <Components.CollectionsCard collection={coreReadingCollections[0]} url={coreReadingCollections[0].url}/>
     </div>
-    
+
     {!minimal && <Components.CollectionsCard collection={coreReadingCollections[1]} url={coreReadingCollections[1].url}/>}
     {!minimal && <Components.CollectionsCard collection={coreReadingCollections[2]} url={coreReadingCollections[2].url} mergeTitle={!isEAForum} />}
   </Components.CollectionsCardContainer>


### PR DESCRIPTION
This sequence now exists: https://forum.effectivealtruism.org/s/isENJuPdB3fhjWYHd , so we should link to it.

Note that this won't work on dev and staging. I think we should just re-clone dev and staging soon, which would make this work.