### PR TITLE
When other sections are closed, bookmarks limit increases to 6 from 3

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -123,6 +123,8 @@ const RecommendationsAndCurated = ({
 
     const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
     const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
+    
+    const bookmarksLimit = (settings.hideFrontpage && settings.hideContinueReading) ? 6 : 3 
 
     return <SingleColumnSection className={classes.section}>
       <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
@@ -196,7 +198,7 @@ const RecommendationsAndCurated = ({
           </Link>
         </LWTooltip>
         <AnalyticsContext listContext={"frontpageBookmarksList"} capturePostItemOnMount>
-          <BookmarksList limit={3} />
+          <BookmarksList limit={bookmarksLimit} />
         </AnalyticsContext>
       </div>}
 


### PR DESCRIPTION
This PR makes so that the bookmarks section in the Recommendations section on the frontpage increases from 3 slots to 6 when Continue Reading and From the Archives are closed.