### PR TITLE
Limit algolia text size

### DIFF
--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -171,7 +171,11 @@ Posts.toAlgolia = async (post: DbPost): Promise<Array<AlgoliaPost>|null> => {
       postBatch.push(_.clone({
         ...algoliaMetaInfo,
         objectID: post._id + "_" + paragraphCounter,
-        body: paragraph,
+        
+        // Algolia limits text to 20 KB. They don't say what encoding they use though. 
+        // Some random tests seem to imply that they use UTF-8, which means between 1 and 4 bytes per character.
+        // So limit to 18,000 characters under the assumption that we have ~1.1 bytes/character.
+        body: paragraph.slice(0, 18000),
       }));
     })
   } else {


### PR DESCRIPTION
We currently split each post into paragraphs and index each paragraph separately, to avoid algolia's maximum text size limit. We recently encountered a post with a paragraph with more than 20 kB of data though, this handles that case by just truncating the paragraph.

[This branch](https://github.com/ForumMagnum/ForumMagnum/tree/split-algolia) has a better fix for this (indexes each chunk of 20 KB separately) but Oli [convinced me](https://cea-core.slack.com/archives/CJZ7QMY5V/p1637270655100400) it's not worth us accidentally breaking some algolia feature.