### PR TITLE
display post reading time on desktop

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -44,14 +44,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: theme.typography.body2.fontSize,
   },
   wordCount: {
-    display: 'none',
+    display: 'inline-block',
     marginRight: SECONDARY_SPACING,
     color: theme.palette.grey[600],
     whiteSpace: "no-wrap",
     fontSize: theme.typography.body2.fontSize,
-    [theme.breakpoints.down('sm')]: {
-      display: 'inline-block'
-    }
   },
   actions: {
     display: 'inline-block',


### PR DESCRIPTION
We already displayed post reading time, but only on mobile. Aaron asked me to display it on desktop as well.

<img width="714" alt="Screen Shot 2021-11-23 at 9 59 51 AM" src="https://user-images.githubusercontent.com/9057804/143049168-4ab33996-f37b-4280-b7ed-899d2e5d3459.png">

