### PR TITLE
display browser timezone in datetime input label

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { registerComponent } from '../../lib/vulcan-lib';
 import DateTimePicker from 'react-datetime';
+import moment from '../../lib/moment-timezone';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 
@@ -19,6 +20,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& .rdtPicker': {
       bottom: 30,
     }
+  },
+  timezone: {
+    marginLeft: 4
   }
 })
 
@@ -31,7 +35,9 @@ const FormComponentDateTime = ({ path, value, name, label, classes, position }, 
   const date = value ? (typeof value === 'string' ? new Date(value) : value) : null;
 
   return <FormControl>
-    <InputLabel className={classes.label}>{ label }</InputLabel>
+    <InputLabel className={classes.label}>
+      { label } <span className={classes.timezone}>({moment().tz(moment.tz.guess()).zoneAbbr()})</span>
+    </InputLabel>
     <DateTimePicker
       className={classes.wrapper}
       value={date}

--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -33,10 +33,13 @@ const FormComponentDateTime = ({ path, value, name, label, classes, position }, 
   }
 
   const date = value ? (typeof value === 'string' ? new Date(value) : value) : null;
+  // since tz abbrev can depend on the date (i.e. EST vs EDT),
+  // we try to use the selected date to determine the tz (and default to now)
+  const tzDate = date ? moment(date) : moment();
 
   return <FormControl>
     <InputLabel className={classes.label}>
-      { label } <span className={classes.timezone}>({moment().tz(moment.tz.guess()).zoneAbbr()})</span>
+      { label } <span className={classes.timezone}>({tzDate.tz(moment.tz.guess()).zoneAbbr()})</span>
     </InputLabel>
     <DateTimePicker
       className={classes.wrapper}


### PR DESCRIPTION
This is to reduce the confusion around event timezones. Here I'm assuming that all datetimes submitted with this component use the browser's timezone and get converted to UTC before being saved to the db, since this happens for event start/end times.

<img width="264" alt="Screen Shot 2021-11-23 at 5 14 39 PM" src="https://user-images.githubusercontent.com/9057804/143137999-087f593f-eba2-4593-9c2c-374fec1a171c.png">
