### PR TITLE
Speed up docker to fix build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ COPY package.json package.json
 COPY yarn.lock yarn.lock
 COPY public/lesswrong-editor public/lesswrong-editor
 COPY scripts/postinstall.sh scripts/postinstall.sh
-RUN yarn
+# clear the cache -- it's not useful and it adds to the time docker takes to
+# save the layer diff
+RUN yarn install && yarn cache clean
 COPY . .
 EXPOSE 8080
 CMD [ "yarn", "run", "production" ]


### PR DESCRIPTION
EA Forum production deploys intermittently time out during the docker build step. Speed up docker to address the issue.

The timeout of the build as a whole can be adjusted with a configuration variable, however the timeout of the docker build step seems to be pinned at 5 minutes. Our builds seem to take around 5:20. I have a support ticket open with AWS about this.

Most of the time is spent right after the yarn install step. It's after the yarn command returns and before the next command starts. All evidence points to the slow piece being saving the layer diff. When we use the fancy new [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/), docker build saves layer diffs at the end, and sure enough we observe the extra time moving to the end.

With the guess that docker was struggling with the number of files generated by yarn, @colophonemes and I decided to clear the yarn cache after the yarn install. Doing so cut the time required to save the layer in ~half. Our builds now take ~4 minutes, which isn't a great buffer, but will do to get deploys working again.

If AWS doesn't get back to us with a way to increase that timeout, we may want to consider building our docker images in a Github action, or, I claim, moving away from beanstalk. I claim that we should give Heroku a try. Beanstalk has not treated us well, and we could potentially save ourselves lots of devops time.