### PR TITLE
Image Preview Links

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -27,12 +27,7 @@ export const linkIsExcludedFromPreview = (url: string): boolean => {
   // Don't try to preview special JS links
   if (!url || url==="#" || url==="")
     return true;
-  
-  // Don't try to preview links that go directly to images. The usual use case
-  // for such links is an image where you click for a larger version.
-  return !!(url.endsWith('.png') || url.endsWith('.jpg') || url.endsWith('.jpeg') || url.endsWith('.gif'));
-
-
+  return false
 }
 
 // A link, which will have a hover preview auto-selected and attached. Used from
@@ -69,6 +64,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }
     const linkTargetAbsolute = new URLClass(href, currentURL);
 
     const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
+
     if (!linkIsExcludedFromPreview(onsiteUrl) && (hostIsOnsite(linkTargetAbsolute.host) || isServer)) {
       const parsedUrl = parseRouteWithErrors(onsiteUrl, contentSourceDescription)
       const destinationUrl = parsedUrl.url;
@@ -93,6 +89,9 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }
       }
       if (linkTargetAbsolute.host === "arbital.com" || linkTargetAbsolute.host === "www.arbital.com") {
         return <Components.ArbitalPreview href={href} innerHTML={innerHTML} id={id} />
+      }
+      if (onsiteUrl.endsWith('.png') || onsiteUrl.endsWith('.jpg') || onsiteUrl.endsWith('.jpeg') || onsiteUrl.endsWith('.gif')) {
+        return <Components.ImagePreview href={href} innerHTML={innerHTML} id={id} />
       }
       return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} rel={rel} />
     }

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -90,7 +90,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }
       if (linkTargetAbsolute.host === "arbital.com" || linkTargetAbsolute.host === "www.arbital.com") {
         return <Components.ArbitalPreview href={href} innerHTML={innerHTML} id={id} />
       }
-      if (onsiteUrl.endsWith('.png') || onsiteUrl.endsWith('.jpg') || onsiteUrl.endsWith('.jpeg') || onsiteUrl.endsWith('.gif')) {
+      if (onsiteUrl.endsWith('.png') || onsiteUrl.endsWith('.jpg') || onsiteUrl.endsWith('.jpeg') || onsiteUrl.endsWith('.gif')) { // TODO: make it so that images that don't end precisely in ".jpg-etc" work. i.e. some end like ".png&r=g" or something.
         return <Components.ImagePreview href={href} innerHTML={innerHTML} id={id} />
       }
       return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} rel={rel} />

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -584,6 +584,10 @@ const imageLinkStyles = (theme: ThemeType): JssStyles => ({
   },
   image: {
     maxWidth: 400
+  },
+  hoverCard: {
+    padding: 6,
+    paddingBottom: 3, // hack that's fixing an issue where by default the image has a few extra pixels at the bottom for some reason.
   }
 })
 
@@ -601,7 +605,7 @@ const ImagePreview = ({classes, href, innerHTML, id}: {
       <a className={classes.link} href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-        <Card>
+        <Card className={classes.hoverCard}>
           <img src={href} className={classes.image} />
         </Card>
       </LWPopper>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -529,9 +529,6 @@ const arbitalStyles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-
-
-
 const ArbitalPreview = ({classes, href, innerHTML, id}: {
   classes: ClassesType,
   href: string,
@@ -581,6 +578,39 @@ const ArbitalPreviewComponent = registerComponent('ArbitalPreview', ArbitalPrevi
   styles: arbitalStyles
 })
 
+const imageLinkStyles = (theme: ThemeType): JssStyles => ({
+  link: {
+    ...linkStyle(theme)
+  },
+  image: {
+    maxWidth: 400
+  }
+})
+
+const ImagePreview = ({classes, href, innerHTML, id}: {
+  classes: ClassesType,
+  href: string,
+  innerHTML: string,
+  id?: string
+}) => {
+  const { AnalyticsTracker, LWPopper } = Components
+  const { anchorEl, hover, eventHandlers } = useHover();
+
+  return <AnalyticsTracker eventType="link" eventProps={{to: href}}>
+    <span {...eventHandlers}>
+      <a className={classes.link} href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />
+      
+      <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
+        <Card>
+          <img src={href} className={classes.image} />
+        </Card>
+      </LWPopper>
+    </span>
+  </AnalyticsTracker>
+}
+
+const ImagePreviewComponent = registerComponent('ImagePreview', ImagePreview, {styles: imageLinkStyles})
+
 declare global {
   interface ComponentTypes {
     PostLinkPreview: typeof PostLinkPreviewComponent,
@@ -596,6 +626,7 @@ declare global {
     MozillaHubPreview: typeof MozillaHubPreviewComponent,
     MetaculusPreview: typeof MetaculusPreviewComponent,
     ArbitalPreview: typeof ArbitalPreviewComponent,
+    ImagePreview: typeof ImagePreviewComponent
     DefaultPreview: typeof DefaultPreviewComponent,
   }
 }

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -126,7 +126,7 @@ importComponent("SubscribeWidget", () => require('../components/common/Subscribe
 importComponent("SubscribeDialog", () => require('../components/common/SubscribeDialog'));
 
 importComponent("HoverPreviewLink", () => require('../components/linkPreview/HoverPreviewLink'));
-importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview", "MetaculusPreview", "ArbitalPreview"], () => require('../components/linkPreview/PostLinkPreview'));
+importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "ImagePreview", "DefaultPreview", "MozillaHubPreview", "MetaculusPreview", "ArbitalPreview"], () => require('../components/linkPreview/PostLinkPreview'));
 importComponent("LinkToPost", () => require('../components/linkPreview/LinkToPost'));
 
 importComponent("BannedNotice", () => require('../components/users/BannedNotice'));


### PR DESCRIPTION
Makes it so image-links preview on hoveover.

There was a weird thing where by default the image had a couple extra pixels of whitespace underneath it. Probably there is a reason for this that is fixable but spending more time on it didn't seem worth it given that this was a random-lark-of-a-PR anyway. (I hacked around by adding padding that balanced it out)

![image](https://user-images.githubusercontent.com/3246710/143655781-5fa79c1d-561f-4b45-acd5-eabe39d65bb1.png)
