### PR TITLE
add global event field for posts

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -51,6 +51,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingLeft: theme.spacing.unit*1.5,
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
+    fontStyle: 'italic',
     marginTop: 4,
   }
 })
@@ -159,7 +160,7 @@ const CommentsListSection = ({lastEvent, post, tag, commentCount, loadMoreCount,
           <div className={classes.newCommentLabel}>New Comment</div>
           {post?.isEvent && post?.rsvps?.length && (
             <div className={classes.newCommentSublabel}>
-              Your comment will be emailed to everyone who RSVP'd for this event.
+              Everyone who RSVP'd to this event will be notified.
             </div>
           )}
           <Components.CommentsNewForm

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -46,6 +46,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.body2,
     fontWeight: 600,
     marginTop: 12
+  },
+  newCommentSublabel: {
+    paddingLeft: theme.spacing.unit*1.5,
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[600],
+    marginTop: 4,
   }
 })
 
@@ -151,6 +157,11 @@ const CommentsListSection = ({lastEvent, post, tag, commentCount, loadMoreCount,
       {newForm && (!currentUser || !post || userIsAllowedToComment(currentUser, post, postAuthor)) && !post?.draft &&
         <div id="posts-thread-new-comment" className={classes.newComment}>
           <div className={classes.newCommentLabel}>New Comment</div>
+          {post?.isEvent && post?.rsvps?.length && (
+            <div className={classes.newCommentSublabel}>
+              Your comment will be emailed to everyone who RSVP'd for this event.
+            </div>
+          )}
           <Components.CommentsNewForm
             post={post} tag={tag}
             prefilledProps={{

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -115,7 +115,9 @@ const PostsNewForm = ({classes}: {
   const af = forumTypeSetting.get() === 'AlignmentForum'
   const prefilledProps = {
     isEvent: query && !!query.eventForm,
+    activateRSVPs: true,
     onlineEvent: groupData?.isOnline,
+    globalEvent: groupData?.isOnline,
     types: query && query.ssc ? ['SSC'] : [],
     meta: query && !!query.meta,
     af: af || (query && !!query.af),

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -726,6 +726,19 @@ addFieldsDict(Posts, {
     order: 0,
     ...schemaDefaultValue(false),
   },
+  
+  globalEvent: {
+    type: Boolean,
+    hidden: (props) => !props.eventForm,
+    viewableBy: ['guests'],
+    editableBy: [userOwns, 'sunshineRegiment', 'admins'],
+    insertableBy: ['members'],
+    optional: true,
+    group: formGroups.event,
+    label: "This event is intended for a global audience",
+    tooltip: 'By default, events are only advertised to people who are located nearby (for both in-person and online events). Check this to advertise it people located anywhere.',
+    ...schemaDefaultValue(false),
+  },
 
   mongoLocation: {
     type: Object,

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -55,6 +55,7 @@ registerFragment(`
     location
     googleLocation
     onlineEvent
+    globalEvent
     startTime
     endTime
     localStartTime

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -698,6 +698,7 @@ const schema: SchemaType<DbPost> = {
     group: formGroups.event,
     control: 'checkbox',
     label: "Enable RSVPs for this event",
+    tooltip: "RSVPs are public, but the associated email addresses are only visible to organizers.",
     optional: true
   },
   

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -407,6 +407,7 @@ interface DbPost extends DbObject {
   endTime: Date
   localEndTime: Date
   onlineEvent: boolean
+  globalEvent: boolean
   mongoLocation: any /*{"definitions":[{"blackbox":true}]}*/
   googleLocation: any /*{"definitions":[{"blackbox":true}]}*/
   location: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -290,6 +290,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly location: string,
   readonly googleLocation: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly onlineEvent: boolean,
+  readonly globalEvent: boolean,
   readonly startTime: Date,
   readonly endTime: Date,
   readonly localStartTime: Date,


### PR DESCRIPTION
This PR adds the `globalEvent` flag to the posts collection. This is based on feedback that it's confusing to see online events hosted by local groups advertised to everyone on the forum, when many of them likely don't intend for people outside of their local area to attend.

I added the `globalEvent` field, which defaults to checked when creating a new event within an online group, but otherwise defaults to unchecked.
<img width="729" alt="Screen Shot 2021-11-30 at 5 41 02 PM" src="https://user-images.githubusercontent.com/9057804/144140407-19be2643-2df2-48b5-90fe-242ec125bc72.png">

Although the tooltip says we only advertise online events locally, that's not yet the case - I plan to make that change in an upcoming PR.

I also made a couple other related improvements, including defaulting the "Enable RSVPs for this event" checkbox to `true`, adding a tooltip for it, and displaying this note when a user adds a comment to an event with RSVPs:

<img width="767" alt="Screen Shot 2021-11-30 at 5 30 17 PM" src="https://user-images.githubusercontent.com/9057804/144140910-213f2469-bf3d-4885-a0ee-251fa7764e17.png">
