### PR TITLE
enable filtering out events from "All Posts" page

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -67,14 +67,15 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
     })
   }
 
-  renderPostsList = ({currentTimeframe, currentFilter, currentSorting, currentShowLowKarma}) => {
+  renderPostsList = ({currentTimeframe, currentFilter, currentSorting, currentShowLowKarma, currentIncludeEvents}) => {
     const { timezone, location } = this.props
     const { query } = location
     const { showSettings } = this.state
     const {PostsTimeframeList, PostsList2} = Components
 
-    const baseTerms = {
+    const baseTerms: PostsViewTerms = {
       karmaThreshold: query.karmaThreshold || (currentShowLowKarma ? MAX_LOW_KARMA_THRESHOLD : DEFAULT_LOW_KARMA_THRESHOLD),
+      includeEvents: currentIncludeEvents || currentFilter === 'events',
       filter: currentFilter,
       sortedBy: currentSorting,
       after: query.after,
@@ -96,7 +97,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
     const numTimeBlocks = timeframeToNumTimeBlocks[currentTimeframe]
     const timeBlock = timeframeToTimeBlock[currentTimeframe]
     
-    let postListParameters: any = {
+    let postListParameters: PostsViewTerms = {
       view: 'timeframe',
       ...baseTerms
     }
@@ -136,6 +137,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
     const currentFilter = query.filter       || currentUser?.allPostsFilter    || 'all'
     const currentShowLowKarma = (parseInt(query.karmaThreshold) === MAX_LOW_KARMA_THRESHOLD) ||
       currentUser?.allPostsShowLowKarma || false
+    const currentIncludeEvents = (query.includeEvents === 'true') || currentUser?.allPostsIncludeEvents || false
 
     return (
       <React.Fragment>
@@ -155,10 +157,11 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
               currentSorting={currentSorting}
               currentFilter={currentFilter}
               currentShowLowKarma={currentShowLowKarma}
+              currentIncludeEvents={currentIncludeEvents}
               persistentSettings
               showTimeframe
             />
-            {this.renderPostsList({currentTimeframe, currentSorting, currentFilter, currentShowLowKarma})}
+            {this.renderPostsList({currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, currentIncludeEvents})}
           </SingleColumnSection>
         </AnalyticsContext>
       </React.Fragment>

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -66,6 +66,10 @@ const FILTERS_ALL = {
       label: "Questions",
       tooltip: "Open questions and answers, ranging from newcomer questions to important unsolved scientific problems."
     },
+    events: {
+      label: "Events",
+      tooltip: "Events from around the world."
+    },
   }
 }
 const FILTERS = FILTERS_ALL[forumTypeSetting.get()]

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -173,15 +173,17 @@ const USER_SETTING_NAMES = {
   sortedBy: 'allPostsSorting',
   filter: 'allPostsFilter',
   showLowKarma: 'allPostsShowLowKarma',
+  showEvents: 'allPostsIncludeEvents'
 }
 
-const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, timeframes=defaultTimeframes, sortings=defaultSortings, showTimeframe, classes}: {
+const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, currentIncludeEvents, timeframes=defaultTimeframes, sortings=defaultSortings, showTimeframe, classes}: {
   persistentSettings?: any,
   hidden: boolean,
   currentTimeframe?: any,
   currentSorting: any,
   currentFilter: any,
   currentShowLowKarma: boolean,
+  currentIncludeEvents: boolean,
   timeframes?: any,
   sortings?: any,
   showTimeframe?: boolean,
@@ -228,21 +230,39 @@ const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, curren
           classes={classes}
         />
 
-        <Tooltip title={<div><div>By default, posts below -10 karma are hidden.</div><div>Toggle to show them.</div></div>}>
-          <QueryLink
-            className={classes.checkboxGroup}
-            onClick={() => setSetting('showLowKarma', !currentShowLowKarma)}
-            query={{karmaThreshold: (currentShowLowKarma ? DEFAULT_LOW_KARMA_THRESHOLD : MAX_LOW_KARMA_THRESHOLD)}}
-            merge
-            rel="nofollow"
-          >
-            <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentShowLowKarma} />
+        <div>
+          <Tooltip title={<div><div>By default, posts below -10 karma are hidden.</div><div>Toggle to show them.</div></div>} placement="left-start">
+            <QueryLink
+              className={classes.checkboxGroup}
+              onClick={() => setSetting('showLowKarma', !currentShowLowKarma)}
+              query={{karmaThreshold: (currentShowLowKarma ? DEFAULT_LOW_KARMA_THRESHOLD : MAX_LOW_KARMA_THRESHOLD)}}
+              merge
+              rel="nofollow"
+            >
+              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentShowLowKarma} />
 
-            <MetaInfo className={classes.checkboxLabel}>
-              Show Low Karma
-            </MetaInfo>
-          </QueryLink>
-        </Tooltip>
+              <MetaInfo className={classes.checkboxLabel}>
+                Show Low Karma
+              </MetaInfo>
+            </QueryLink>
+          </Tooltip>
+          
+          <Tooltip title={<div><div>By default, events are hidden.</div><div>Toggle to show them.</div></div>} placement="left-start">
+            <QueryLink
+              className={classes.checkboxGroup}
+              onClick={() => setSetting('showEvents', !currentIncludeEvents)}
+              query={{includeEvents: !currentIncludeEvents}}
+              merge
+              rel="nofollow"
+            >
+              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentIncludeEvents}/>
+
+              <MetaInfo className={classes.checkboxLabel}>
+                Show Events
+              </MetaInfo>
+            </QueryLink>
+          </Tooltip>
+        </div>
       </div>
   );
 };

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -228,6 +228,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const currentFilter = query.filter ||  "all"
     const ownPage = currentUser?._id === user._id
     const currentShowLowKarma = (parseInt(query.karmaThreshold) !== DEFAULT_LOW_KARMA_THRESHOLD)
+    const currentIncludeEvents = (query.includeEvents === 'true')
 
     const username = userGetDisplayName(user)
     const metaDescription = `${username}'s profile on ${siteNameWithArticleSetting.get()} — ${taglineSetting.get()}`
@@ -329,6 +330,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
               currentSorting={currentSorting}
               currentFilter={currentFilter}
               currentShowLowKarma={currentShowLowKarma}
+              currentIncludeEvents={currentIncludeEvents}
               sortings={sortings}
             />}
             <AnalyticsContext listContext={"userPagePosts"}>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -30,6 +30,7 @@ declare global {
     sortByMost?: boolean,
     sortedBy?: string,
     af?: boolean,
+    includeEvents?: boolean,
     onlineEvent?: boolean,
     groupId?: string,
     lat?: number,
@@ -141,7 +142,7 @@ export const sortings = {
  */
 Posts.addDefaultView((terms: PostsViewTerms) => {
   const validFields: any = _.pick(terms, 'userId', 'meta', 'groupId', 'af','question', 'authorIsUnreviewed');
-  // Also valid fields: before, after, timeField (select on postedAt), and
+  // Also valid fields: before, after, timeField (select on postedAt), includeEvents, and
   // karmaThreshold (selects on baseScore).
 
   const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
@@ -166,6 +167,9 @@ Posts.addDefaultView((terms: PostsViewTerms) => {
   if (terms.karmaThreshold && terms.karmaThreshold !== "0") {
     params.selector.baseScore = {$gte: parseInt(terms.karmaThreshold+"", 10)}
     params.selector.maxBaseScore = {$gte: parseInt(terms.karmaThreshold+"", 10)}
+  }
+  if (!terms.includeEvents) {
+    params.selector.isEvent = false
   }
   if (terms.userId) {
     params.selector.hideAuthor = false

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -83,7 +83,8 @@ export const filters: Record<string,any> = {
     hiddenRelatedQuestion: viewFieldAllowAny
   },
   "events": {
-    isEvent: true
+    isEvent: true,
+    groupId: null
   },
   "meta": {
     meta: true

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -314,6 +314,14 @@ addFieldsDict(Users, {
     canCreate: 'guests',
     hidden: true,
   },
+  allPostsIncludeEvents: {
+    type: Boolean,
+    optional: true,
+    canRead: userOwns,
+    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    canCreate: 'guests',
+    hidden: true,
+  },
   allPostsOpenSettings: {
     type: Boolean,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -80,6 +80,7 @@ registerFragment(`
     allPostsSorting
     allPostsFilter
     allPostsShowLowKarma
+    allPostsIncludeEvents
     allPostsOpenSettings
     lastNotificationsCheck
     bannedUserIds

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -654,6 +654,7 @@ interface DbUser extends DbObject {
   allPostsFilter: string
   allPostsSorting: string
   allPostsShowLowKarma: boolean
+  allPostsIncludeEvents: boolean
   allPostsOpenSettings: boolean
   lastNotificationsCheck: Date
   bio: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1499,6 +1499,7 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly allPostsSorting: string,
   readonly allPostsFilter: string,
   readonly allPostsShowLowKarma: boolean,
+  readonly allPostsIncludeEvents: boolean,
   readonly allPostsOpenSettings: boolean,
   readonly lastNotificationsCheck: Date,
   readonly bannedUserIds: Array<string>,


### PR DESCRIPTION
In this PR, I'm excluding events from the list on the "All Posts" page by default, and adding a checkbox in case people want to include them.

I also added the "Events" filter to the EA Forum (which already existed on LW) and fixed a bug with that filter.

<img width="815" alt="Screen Shot 2021-12-02 at 1 08 56 PM" src="https://user-images.githubusercontent.com/9057804/144478924-1bec549a-d02b-4512-b4a2-5ffd0edfb41c.png">