### PR TITLE
sticky leftColumn on ReviewVotingPage

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
@@ -7,6 +7,10 @@ import { REVIEW_COMMENTS_VIEW } from './ReviewVotingPage';
 import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = theme => ({
+  root: {
+    height: "90vh",
+    overflow: "scroll"
+  },
   postTitle: {
     ...postPageTitleStyles(theme),
     display: "block",

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -366,7 +366,7 @@ const ReviewVotingPage = ({classes}: {
             </h1>
             {instructions}
           </div>}
-          <ReviewVotingExpandedPost post={expandedPost}/>
+          <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost}/>
         </div>
         <div className={classes.rightColumn}>
           <div className={classes.menu}>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -36,7 +36,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     gridTemplateAreas: `
     "... leftColumn ... rightColumn ..."
     `,
-    paddingBottom: 175
+    paddingBottom: 175,
+    alignItems: "start"
   },
   instructions: {
     ...theme.typography.body2,
@@ -45,6 +46,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   leftColumn: {
     gridArea: "leftColumn",
+    position: "sticky",
+    top: 72,
     [theme.breakpoints.down('sm')]: {
       display: "none"
     }


### PR DESCRIPTION
Makes it so the left column on the ReviewVotingPage is static, so if you've scrolled down a bunch on the giant post-list you can still see the post data