### PR TITLE
fix a bug that hid events by default everywhere

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -75,7 +75,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
 
     const baseTerms: PostsViewTerms = {
       karmaThreshold: query.karmaThreshold || (currentShowLowKarma ? MAX_LOW_KARMA_THRESHOLD : DEFAULT_LOW_KARMA_THRESHOLD),
-      includeEvents: currentIncludeEvents || currentFilter === 'events',
+      excludeEvents: !currentIncludeEvents && currentFilter !== 'events',
       filter: currentFilter,
       sortedBy: currentSorting,
       after: query.after,

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -30,7 +30,7 @@ declare global {
     sortByMost?: boolean,
     sortedBy?: string,
     af?: boolean,
-    includeEvents?: boolean,
+    excludeEvents?: boolean,
     onlineEvent?: boolean,
     groupId?: string,
     lat?: number,
@@ -143,7 +143,7 @@ export const sortings = {
  */
 Posts.addDefaultView((terms: PostsViewTerms) => {
   const validFields: any = _.pick(terms, 'userId', 'meta', 'groupId', 'af','question', 'authorIsUnreviewed');
-  // Also valid fields: before, after, timeField (select on postedAt), includeEvents, and
+  // Also valid fields: before, after, timeField (select on postedAt), excludeEvents, and
   // karmaThreshold (selects on baseScore).
 
   const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
@@ -169,7 +169,7 @@ Posts.addDefaultView((terms: PostsViewTerms) => {
     params.selector.baseScore = {$gte: parseInt(terms.karmaThreshold+"", 10)}
     params.selector.maxBaseScore = {$gte: parseInt(terms.karmaThreshold+"", 10)}
   }
-  if (!terms.includeEvents) {
+  if (terms.excludeEvents) {
     params.selector.isEvent = false
   }
   if (terms.userId) {


### PR DESCRIPTION
I noticed that events had stopped appearing in the Recent Discussion feed, and realized that my recent PR https://github.com/ForumMagnum/ForumMagnum/pull/4323 updated the default posts view such that events were excluded by default. So I flipped the logic in the view.