### PR TITLE
Fix unit test memory leak

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [14.x]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/packages/lesswrong/testing/testMain.ts
+++ b/packages/lesswrong/testing/testMain.ts
@@ -7,7 +7,6 @@ import { MongoClient } from 'mongodb';
 import { setDatabaseConnection, closeDatabaseConnection } from '../lib/mongoCollection';
 import { waitUntilCallbacksFinished } from '../lib/vulcan-lib/callbacks';
 import process from 'process';
-import jestMongoSetup from '@shelf/jest-mongodb/setup';
 import { initGraphQL } from '../server/vulcan-lib/apollo-server/initGraphQL';
 import { createVoteableUnionType } from '../server/votingGraphQL';
 
@@ -25,7 +24,6 @@ async function ensureDbConnection() {
     return;
   
   try {
-    await jestMongoSetup();
     const connectionString = process.env.MONGO_URL as string; //Provided by @shelf/jest-mongodb
     const client = new MongoClient(connectionString, {
       // See https://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html


### PR DESCRIPTION
The out-of-memory errors in unit tests were caused by two separate issues each of which leaked lots of memory, adding up to just barely reach the threshold of where things would fail (by increasing slightly every time we added more tests, until it started breaking so we noticed it). The first is https://github.com/facebook/jest/issues/10550, which leaks about 50MB per test file (about 1GB total). The second was a double-initialization of `jest-mongodb` which leaks a subprocess and some metadata with each test file (about 200MB total).

There is no proper fix for the Jest module caching leak, but downgrading from nodejs 15+ to nodejs 14 is an effective mitigation which reduces the size of the leak by an order of magnitude. So I've changed the nodejs version in `.github/workflows/unitTests.yaml`. Peak memory usage is still O(n) in codebase size and in number of test files, which will eventually become a problem, but hopefully by then it will have been fixed upstream.