### PR TITLE
Don't have console errors on front page if DB config settings for review aren't set

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -249,13 +249,13 @@ const FrontpageReviewWidget = ({classes}: {classes: ClassesType}) => {
     <SingleColumnSection>
       <SectionTitle 
         title={<LWTooltip title={overviewTooltip} placement="bottom-start">
-          <Link to={reviewPostPath}>
+          <Link to={reviewPostPath || ""}>
             {REVIEW_NAME_TITLE}
           </Link>
         </LWTooltip>}
       >
         <LWTooltip title={overviewTooltip}>
-          <Link to={reviewPostPath}>
+          <Link to={reviewPostPath || ""}>
             <SettingsButton showIcon={false} label={`How does the ${REVIEW_NAME_IN_SITU} work?`}/>
           </Link>
         </LWTooltip>


### PR DESCRIPTION
Fix some errors in the browser console on the front page, if DB settings for the review aren't set (eg on the development database).

