### PR TITLE
Remove events from review recommendations

### DIFF
--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -83,6 +83,7 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
       return {postedAt: {$lt: new Date(`${(algorithm.reviewNominations as number) + 1}-01-01`)}}
     }
     return {
+      isEvent: false,
       postedAt: {$gt: new Date(`${algorithm.reviewNominations}-01-01`), $lt: new Date(`${(algorithm.reviewNominations as number) + 1}-01-01`)},
       meta: false
     }


### PR DESCRIPTION
I think this might have gotten obviated by a recent CEA PR (which filtered out events at a higher level), but I'm not sure. I recently have seen events show up in the Review Recommendations and wanted that to not happen anymore.