### PR TITLE
Mobile review buttons

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -332,10 +332,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
           </ul>
           </div>}>
           <Link to={"/reviewVoting/2020"} className={classes.actionButtonCTA}>
-            <span>
-              <span className={classes.hideOnMobile}>Vote on nominated posts</span>
-              <span className={classes.showOnMobile}>Review Dashboard</span>
-            </span>
+            Vote on <span className={classes.hideOnMobile}>nominated</span> posts
           </Link>
         </LWTooltip>}
       </div>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -78,7 +78,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderRadius: 3,
     color: "white",
     ...theme.typography.commentStyle,
-    display: "inline-block"
+    display: "inline-block",
+    marginLeft: 12
   },
   actionButton: {
     border: `solid 1px ${theme.palette.grey[400]}`,
@@ -90,7 +91,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[600],
     ...theme.typography.commentStyle,
     display: "inline-block",
-    marginRight: 12
+    marginLeft: 12
   },
   buttonWrapper: {
     flexGrow: 0,
@@ -101,13 +102,8 @@ const styles = (theme: ThemeType): JssStyles => ({
       display: 'none'
     }
   },
-  hideOnXs: {
-    [theme.breakpoints.down('xs')]: {
-      display: 'none'
-    }
-  },
-  showOnXs: {
-    [theme.breakpoints.up('sm')]: {
+  showOnMobile: {
+    [theme.breakpoints.up('md')]: {
       display: 'none'
     }
   }
@@ -316,17 +312,14 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <LWTooltip className={classes.buttonWrapper} title={`Nominate posts you previously upvoted.`}>
           <Link to={`/votesByYear/${isEAForum ? '%e2%89%a42020' : REVIEW_YEAR}`} className={classes.actionButton}>
             <span>
-              <span className={classes.hideOnXs}>
-                Your Upvotes from {isEAForum && '≤'}{REVIEW_YEAR}
-              </span>
-              <span className={classes.showOnXs}>{REVIEW_YEAR} Upvotes</span>
+              <span className={classes.hideOnMobile}>Your</span> {isEAForum && '≤'}{REVIEW_YEAR} Upvotes
             </span>
           </Link>
         </LWTooltip>
         
         <LWTooltip className={classes.buttonWrapper} title={`Nominate posts ${isEAForum ? 'in or before' : 'from'} ${REVIEW_YEAR}`}>
           <Link to={allEligiblePostsUrl} className={classes.actionButton}>
-            All <span className={classes.hideOnXs}>{isEAForum ? 'Eligible' : REVIEW_YEAR}</span> Posts
+            All <span className={classes.hideOnMobile}>{isEAForum ? 'Eligible' : REVIEW_YEAR}</span> Posts
           </Link>
         </LWTooltip>
         
@@ -339,7 +332,10 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
           </ul>
           </div>}>
           <Link to={"/reviewVoting/2020"} className={classes.actionButtonCTA}>
-            Vote on nominated posts
+            <span>
+              <span className={classes.hideOnMobile}>Vote on nominated posts</span>
+              <span className={classes.showOnMobile}>Review Dashboard</span>
+            </span>
           </Link>
         </LWTooltip>}
       </div>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -101,6 +101,16 @@ const styles = (theme: ThemeType): JssStyles => ({
       display: 'none'
     }
   },
+  hideOnXs: {
+    [theme.breakpoints.down('xs')]: {
+      display: 'none'
+    }
+  },
+  showOnXs: {
+    [theme.breakpoints.up('sm')]: {
+      display: 'none'
+    }
+  }
 })
 
 /**
@@ -253,7 +263,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
     <div>
       <SectionTitle 
         title={<LWTooltip title={overviewTooltip} placement="bottom-start">
-          <Link to={reviewPostPath || ""}>
+          <Link to={"/reviewVoting"}>
             {REVIEW_NAME_TITLE}
           </Link>
         </LWTooltip>}
@@ -300,17 +310,26 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
       {/* TODO: Improve logged out user experience */}
       
       {activeRange === "NOMINATIONS" && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
+        
         {showFrontpageItems && <LatestReview/>}
+
         <LWTooltip className={classes.buttonWrapper} title={`Nominate posts you previously upvoted.`}>
           <Link to={`/votesByYear/${isEAForum ? '%e2%89%a42020' : REVIEW_YEAR}`} className={classes.actionButton}>
-            Your Upvotes from {isEAForum && '≤'}{REVIEW_YEAR}
+            <span>
+              <span className={classes.hideOnXs}>
+                Your Upvotes from {isEAForum && '≤'}{REVIEW_YEAR}
+              </span>
+              <span className={classes.showOnXs}>{REVIEW_YEAR} Upvotes</span>
+            </span>
           </Link>
         </LWTooltip>
+        
         <LWTooltip className={classes.buttonWrapper} title={`Nominate posts ${isEAForum ? 'in or before' : 'from'} ${REVIEW_YEAR}`}>
           <Link to={allEligiblePostsUrl} className={classes.actionButton}>
-            All {isEAForum ? 'Eligible' : REVIEW_YEAR} Posts
+            All <span className={classes.hideOnXs}>{isEAForum ? 'Eligible' : REVIEW_YEAR}</span> Posts
           </Link>
         </LWTooltip>
+        
         {showFrontpageItems && <LWTooltip className={classes.buttonWrapper} title={<div>
           <p>Reviews Dashboard</p>
           <ul>
@@ -319,7 +338,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
             <li>Start writing reviews.</li>
           </ul>
           </div>}>
-          <Link to={"/reviewVoting/2020"} className={classNames(classes.actionButtonCTA, classes.hideOnMobile)}>
+          <Link to={"/reviewVoting/2020"} className={classes.actionButtonCTA}>
             Vote on nominated posts
           </Link>
         </LWTooltip>}

--- a/packages/lesswrong/components/review/LatestReview.tsx
+++ b/packages/lesswrong/components/review/LatestReview.tsx
@@ -13,7 +13,10 @@ const styles = theme => ({
     overflow: "hidden",
     padding: 6,
     whiteSpace: "nowrap",
-    marginRight: 15
+    marginRight: 15,
+    [theme.breakpoints.down('xs')]: {
+      display: "none"
+    }
   },
   lastReview: {
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -92,10 +92,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 175,
   },
   widget: {
-    marginBottom: 32,
-    [theme.breakpoints.down('sm')]: {
-      display: "none"
-    }
+    marginBottom: 32
   },
   menu: {
     position: "sticky",


### PR DESCRIPTION
This makes the Voting on Nominations button available on mobile, and streamlines various bits of text on mobile to make it fit better.

Makes the Big Review Header link to the /reviewVoting page instead of the post, because that's what I kept intuitively expecting and wanting.

Adds the FrontpageReviewWidget back to the mobile view, since it felt a bit weird without it. I may experiment further with the optimal header.

![image](https://user-images.githubusercontent.com/3246710/145333127-590f62d6-df39-455f-bcf6-b6aec5a68605.png)
