### PR TITLE
Fix missing access-filtering in some resolvers

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -297,7 +297,8 @@ addFieldsDict(Posts, {
       // work out of the box with the id-resolver generators
       resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<DbCollection|null> => {
         if (!post.canonicalCollectionSlug) return null;
-        return await context.Collections.findOne({slug: post.canonicalCollectionSlug})
+        const collection = await context.Collections.findOne({slug: post.canonicalCollectionSlug})
+        return await accessFilterSingle(context.currentUser, context.Collections, collection, context);
       }
     },
   },

--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -1,4 +1,4 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, accessFilterSingle, accessFilterMultiple } from '../../utils/schemaUtils';
 import { schemaDefaultValue } from '../../collectionUtils';
 
 const schema: SchemaType<DbSequence> = {
@@ -45,10 +45,10 @@ const schema: SchemaType<DbSequence> = {
       fieldName: 'chapters',
       type: '[Chapter]',
       resolver: async (sequence: DbSequence, args: void, context: ResolverContext): Promise<Array<DbChapter>> => {
-        const books = await context.Chapters.find(
+        const chapters = await context.Chapters.find(
           {sequenceId: sequence._id},
         ).fetch();
-        return books;
+        return await accessFilterMultiple(context.currentUser, context.Chapters, chapters, context);
       }
     }
   },
@@ -141,7 +141,8 @@ const schema: SchemaType<DbSequence> = {
       // work out of the box with the id-resolver generators
       resolver: async (sequence: DbSequence, args: void, context: ResolverContext): Promise<DbCollection|null> => {
         if (!sequence.canonicalCollectionSlug) return null;
-        return await context.Collections.findOne({slug: sequence.canonicalCollectionSlug})
+        const collection = await context.Collections.findOne({slug: sequence.canonicalCollectionSlug})
+        return await accessFilterSingle(context.currentUser, context.Collections, collection, context);
       }
     }
   },

--- a/packages/lesswrong/server/bookmarkMutation.ts
+++ b/packages/lesswrong/server/bookmarkMutation.ts
@@ -1,5 +1,6 @@
 import { addGraphQLMutation, addGraphQLResolvers } from './vulcan-lib';
 import Users from '../lib/collections/users/collection';
+import { accessFilterSingle } from '../lib/utils/schemaUtils';
 import { updateMutator } from './vulcan-lib/mutators';
 import * as _ from 'underscore';
 
@@ -26,7 +27,8 @@ addGraphQLResolvers({
         validate: false,
       });
       
-      return (await Users.findOne(currentUser._id))!;
+      const updatedUser = await Users.findOne(currentUser._id)!;
+      return (await accessFilterSingle(currentUser, Users, updatedUser, context))!;
     }
   }
 });

--- a/packages/lesswrong/server/rsvpToEvent.ts
+++ b/packages/lesswrong/server/rsvpToEvent.ts
@@ -1,7 +1,8 @@
 import { Posts } from '../lib/collections/posts';
 import { addGraphQLMutation, addGraphQLResolvers, updateMutator } from './vulcan-lib';
-import sortBy from 'lodash/sortBy';
 import { createNotification } from './notificationCallbacks';
+import { accessFilterSingle } from '../lib/utils/schemaUtils';
+import sortBy from 'lodash/sortBy';
 
 const responseSortOrder = {
   yes: 1,
@@ -42,7 +43,7 @@ addGraphQLResolvers({
       })).data
 
       await createNotification({userId: post.userId, notificationType: "newRSVP", documentType: "post", documentId: post._id})
-      return updatedPost
+      return await accessFilterSingle(currentUser, Posts, updatedPost, context);
     }
   }
 });


### PR DESCRIPTION
I went through all our resolvers looking for missing `accessFilterSingle`/`accessFilterMutiple` usage, since omitting that would mean field-level access permissions aren't enforced. Most of these are minor (collections that don't actually have much in the way of field-level permissions *to* enforce), but one is more significant (could leak a user's email address).