### PR TITLE
Fixes for Review Phase of the 2020/Decade Review

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -337,7 +337,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         </LWTooltip>}
       </div>}
       
-      {activeRange === 'REVIEWS' && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
+      {activeRange === 'REVIEWS' && showFrontpageItems && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
         <Link to={"/reviews"} className={classes.actionButtonCTA}>
           Review {REVIEW_YEAR} Posts
         </Link>

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -343,7 +343,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         </Link>
       </div>}
 
-      {activeRange === 'VOTING' && currentUserCanVote(currentUser) && <div className={classes.actionButtonRow}>
+      {activeRange === 'VOTING' && showFrontpageItems && currentUserCanVote(currentUser) && <div className={classes.actionButtonRow}>
         <Link to={"/reviewVoting"} className={classes.actionButtonCTA}>
           Vote on {REVIEW_YEAR} Posts
         </Link>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -347,11 +347,9 @@ const ReviewVotingPage = ({classes}: {
     <div className={classes.instructions}>
       <p><b>Welcome to the {REVIEW_NAME_IN_SITU} dashboard.</b></p>
 
-      <p>We begin with Preliminary Voting. Posts with at least one positive vote will appear in the public list to the right. You are encouraged to vote on as many posts as you have an opinion on.</p>
-      
-      <p>At the end of the Preliminary Voting phase, the EA Forum team will publish a ranked list of the results. This will help you decide how to spend attention during the Review phase. You may want to focus on high-ranking posts, or those which seem undervalued or controversial.</p>
+      <p>This is the Review Phase. Posts with two nomations will appear in the public list to the right. Please write reviews of whatever posts you have opinions about.</p>
 
-      <p>During Preliminary Voting, you can sort posts into seven categories (roughly "super strong downvote" to "super strong upvote"). During the Final Voting phase, you'll have the opportunity to fine-tune those votes using our quadratic voting system; see <a href="https://lesswrong.com/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this LessWrong post</a> for details.</p>
+      <p>If you wish to adjust your votes, you can sort posts into seven categories (roughly "super strong downvote" to "super strong upvote"). During the Final Voting phase, you'll have the opportunity to fine-tune those votes using our quadratic voting system; see <a href="https://lesswrong.com/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this LessWrong post</a> for details.</p>
       
       <p><b>FAQ</b></p>
       

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -445,7 +445,7 @@ const ReviewVotingPage = ({classes}: {
             {(postsLoading || loading) && <Loading/>}
             
             {/* Turned off for the Preliminary Voting phase */}
-            {getReviewPhase() !== "NOMINATIONS" && <>
+            {getReviewPhase() === "VOTING" && <>
               {!useQuadratic && <LWTooltip title="WARNING: Once you switch to quadratic voting, you cannot go back to default voting without losing your quadratic data.">
                 <Button className={classes.convert} onClick={async () => {
                   setLoading(true)

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -335,7 +335,7 @@ const ReviewVotingPage = ({classes}: {
   }
 
   const voteTotal = (useQuadratic && quadraticVotes) ? computeTotalCost(quadraticVotes) : 0
-  const voteAverage = (sortedPosts && sortedPosts?.length > 0) ? voteTotal/sortedPosts?.length : 0
+  const voteAverage = (sortedPosts && sortedPosts.length > 0) ? voteTotal/sortedPosts.length : 0
 
   const renormalizeVotes = (quadraticVotes: SyntheticQuadraticVote[] | undefined, voteAverage: number) => {
     if (!quadraticVotes) return
@@ -374,7 +374,7 @@ const ReviewVotingPage = ({classes}: {
       <p>If you have any trouble, please <Link to="/contact">contact the Forum team</Link>, or leave a comment on <Link to={annualReviewAnnouncementPostPathSetting.get()}>this post</Link>.</p>
     </div> :
     <div className={classes.instructions}>
-      <p>During the <em>Preliminary Voting Phase</em>, eligible users are encouraged to:</p>
+      {getReviewPhase() === "NOMINATIONS" && <><p>During the <em>Preliminary Voting Phase</em>, eligible users are encouraged to:</p>
       <ul>
         <li>
           Vote on posts that represent important intellectual progress.
@@ -383,7 +383,13 @@ const ReviewVotingPage = ({classes}: {
       </ul> 
       <p>Posts with at least one positive vote will appear on this page, to the right. Posts with at least one review are sorted to the top, to make them easier to vote on.</p>
 
-      <p>At the end of the Preliminary Voting phase, the LessWrong team will publish a ranked list of the results. This will help inform how to spend attention during <em>the Review Phase</em>. High-ranking, undervalued or controversial posts can get additional focus.</p>
+      <p>At the end of the Preliminary Voting phase, the LessWrong team will publish a ranked list of the results. This will help inform how to spend attention during <em>the Review Phase</em>. High-ranking, undervalued or controversial posts can get additional focus.</p></>}
+
+      {getReviewPhase() === "REVIEWS"  && <><p><b>Welcome to the {REVIEW_NAME_IN_SITU} dashboard.</b></p>
+
+      <p>This is the Review Phase. Posts with two nomations will appear in the public list to the right. Please write reviews of whatever posts you have opinions about.</p>
+
+      <p>If you wish to adjust your votes, you can sort posts into seven categories (roughly "super strong downvote" to "super strong upvote"). During the Final Voting phase, you'll have the opportunity to fine-tune those votes using our quadratic voting system; see <a href="https://lesswrong.com/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this LessWrong post</a> for details.</p></>}
 
       <p><b>FAQ</b></p>
 

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -3,6 +3,7 @@ import * as _ from 'underscore';
 import { combineIndexWithDefaultViewIndex, ensureIndex } from '../../collectionUtils';
 import type { FilterMode, FilterSettings } from '../../filterSettings';
 import { forumTypeSetting } from '../../instanceSettings';
+import { getReviewPhase } from '../../reviewUtils';
 import { defaultScoreModifiers, timeDecayExpr } from '../../scoring';
 import { viewFieldAllowAny, viewFieldNullOrMissing } from '../../vulcan-lib';
 import { Posts } from './collection';
@@ -1300,9 +1301,10 @@ ensureIndex(Posts,
 
 // Nominations for the (≤)2020 review are determined by the number of votes
 Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
+  const nominationThreshold = getReviewPhase() === "NOMINATIONS" ? 1 : 2
   return {
     selector: {
-      positiveReviewVoteCount: { $gt: 0 },
+      positiveReviewVoteCount: { $gte: nominationThreshold },
     },
     options: {
       // This sorts the posts deterministically, which is important for the

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -74,8 +74,18 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
     }
   }
   if (algorithm.reviewReviews) {
+    if (isEAForum) {
+      return {
+        postedAt: {$lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)},
+        positiveReviewVoteCount: {$gte: 2},
+      }
+    }
     return {
-      [algorithm.reviewReviews === 2018 ? "nominationCount2018" : "nominationCount2019"]: {$gte: 2}
+      postedAt: {
+        $gt: new Date(`${algorithm.reviewReviews}-01-01`),
+        $lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)
+      },
+      positiveReviewVoteCount: {$gte: 2},
     }
   }
   if (algorithm.reviewNominations) {


### PR DESCRIPTION
* Hide review CTA button on non-frontpage uses of the FrontpageReviewWidget 
* Update EA Forum text for this phase
* Hide quadratic voting for yet another phase
* Increase threshold for appearing on ReviewVotingPage to 2 positive votes
* Make frontpage recommendation section work for review phase
