### PR TITLE
fix post nomination notification bug

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -507,7 +507,7 @@ async function notifyRsvps(comment: DbComment, post: DbPost) {
 getCollectionHooks("ReviewVotes").newAsync.add(async function PositiveReviewVoteNotifications(reviewVote: DbReviewVote) {
   const post = reviewVote.postId ? await Posts.findOne(reviewVote.postId) : null;
   if (post && post.positiveReviewVoteCount > 1) {
-    const notifications = await Notifications.find({documentId:post._id, notificationType: "postNominated" }).fetch()
+    const notifications = await Notifications.find({documentId:post._id, type: "postNominated" }).fetch()
     if (!notifications.length) {
       await createNotifications({userIds: [post.userId], notificationType: "postNominated", documentType: "post", documentId: post._id})
     }


### PR DESCRIPTION
I had previously tried to prevent users from getting nominated multiple times about the same nomination, but I accidentally was filtering on "nominationType" instead of "type" (which is the actual correct field)

This is fixing a live bug that's pretty bad and so will be merging now and getting a review after-the-fact