### PR TITLE
Properly Show/Hide Review Voting Buttons

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import Info from '@material-ui/icons/Info';
 import { forumTitleSetting, siteNameWithArticleSetting } from '../../../lib/instanceSettings';
 import { useCurrentUser } from '../../common/withUser';
-import { canNominate, postEligibleForReview, reviewIsActive, REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../../lib/reviewUtils';
+import { canNominate, postEligibleForReview, postIsVoteable, reviewIsActive, REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../../lib/reviewUtils';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -55,9 +55,9 @@ const PostBodyPrefix = ({post, query, classes}: {
   return <>
     {reviewIsActive() && postEligibleForReview(post) && <div className={classes.reviewVoting}>
       {canNominate(currentUser, post) && <ReviewVotingWidget post={post}/>}
-      <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
+      {postIsVoteable(post) && <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
         <div className={classes.reviewButton}>Write a Review</div>
-      </LWTooltip>}/>
+      </LWTooltip>}/>}
     </div>}
 
     <AlignmentCrosspostMessage post={post} />

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -53,11 +53,11 @@ const PostBodyPrefix = ({post, query, classes}: {
   const currentUser = useCurrentUser();
 
   return <>
-    {reviewIsActive() && postEligibleForReview(post) && <div className={classes.reviewVoting}>
+    {reviewIsActive() && postEligibleForReview(post) && postIsVoteable(post) && <div className={classes.reviewVoting}>
       {canNominate(currentUser, post) && <ReviewVotingWidget post={post}/>}
-      {postIsVoteable(post) && <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
+      <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
         <div className={classes.reviewButton}>Write a Review</div>
-      </LWTooltip>}/>}
+      </LWTooltip>}/>
     </div>}
 
     <AlignmentCrosspostMessage post={post} />

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -4,18 +4,26 @@ import Card from '@material-ui/core/Card';
 import { useCurrentUser } from '../common/withUser';
 import { indexToTermsLookup } from './ReviewVotingButtons';
 import { forumTitleSetting, forumTypeSetting } from '../../lib/instanceSettings';
-import { canNominate, REVIEW_YEAR } from '../../lib/reviewUtils';
+import { canNominate, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
+import classNames from 'classnames';
 
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
-  button: {
+  buttonWrapper: {
     ...theme.typography.smallText,
     ...theme.typography.commentStyle,
     cursor: "pointer",
     width: 28,
-    marginRight: 10,
-    textAlign: "center"
+    textAlign: "center",
+  },
+  button: {
+    border: "solid 1px rgba(0,0,0,.2)",
+    borderRadius: 3,
+    paddingTop: 2,
+    paddingBottom: 2,
+    paddingLeft: 6,
+    paddingRight: 6
   },
   card: {
     padding: isEAForum ? "8px 24px" : 8,
@@ -26,10 +34,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 4,
     ...theme.typography.body2,
     color: theme.palette.primary.main
+  },
+  marginRight: {
+    marginRight: 10
   }
 })
 
-const PostsItemReviewVote = ({classes, post}: {classes:ClassesType, post:PostsListBase}) => {
+const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:ClassesType, post:PostsListBase, marginRight?: boolean}) => {
   const { ReviewVotingWidget, LWPopper, LWTooltip, ReviewPostButton } = Components
   const [anchorEl, setAnchorEl] = useState<any>(null)
   const [newVote, setNewVote] = useState<number|null>(null)
@@ -39,12 +50,13 @@ const PostsItemReviewVote = ({classes, post}: {classes:ClassesType, post:PostsLi
   if (!canNominate(currentUser, post)) return null
 
   const displayVote = indexToTermsLookup[newVote || post.currentUserReviewVote]?.label
+  const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 
   return <div onMouseLeave={() => setAnchorEl(null)}>
 
-    <LWTooltip title={<div>Nominate this post by casting a preliminary vote.</div>} placement="right">
-      <div className={classes.button} onClick={(e) => setAnchorEl(e.target)}>
-        {displayVote || "Vote"}
+    <LWTooltip title={`${nominationsPhase ? "Nominate this post by casting a preliminary vote" : "Update your vote"}`} placement="right">
+      <div className={classNames(classes.buttonWrapper, {[classes.marginRight]:marginRight})} onClick={(e) => setAnchorEl(e.target)}>
+        {displayVote ? <span className={classes.button}>{displayVote}</span> : "Vote"}
       </div>
     </LWTooltip>
 

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -9,13 +9,17 @@ import classNames from 'classnames';
 
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
+export const voteTextStyling = theme => ({
+  ...theme.typography.smallText,
+  ...theme.typography.commentStyle,
+  textAlign: "center",
+  width: 28,
+})
+
 const styles = (theme: ThemeType): JssStyles => ({
   buttonWrapper: {
-    ...theme.typography.smallText,
-    ...theme.typography.commentStyle,
     cursor: "pointer",
-    width: 28,
-    textAlign: "center",
+    ...voteTextStyling(theme)
   },
   button: {
     border: "solid 1px rgba(0,0,0,.2)",

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../common/withUser';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import type { SyntheticQuadraticVote, SyntheticQualitativeVote, SyntheticReviewVote } from './ReviewVotingPage';
 import { postGetCommentCount } from "../../lib/collections/posts/helpers";
-import { getReviewPhase } from '../../lib/reviewUtils';
+import { eligibleToNominate, getReviewPhase } from '../../lib/reviewUtils';
 import indexOf from 'lodash/indexOf'
 import pullAt from 'lodash/pullAt'
 
@@ -97,14 +97,11 @@ const styles = (theme: ThemeType) => ({
     display: "flex",
     alignItems: "center",
   },
+  yourVote: {
+    marginLeft: 6
+  },
   voteResults: {
-    backgroundColor: "rgba(0,0,0,.04)",
-    padding: 10,
     width: 140,
-    display: "flex",
-    alignItems: "center",
-    alignSelf: "stretch",
-    flexWrap: "wrap",
     ...theme.typography.commentStyle,
     fontSize: 12,
   },
@@ -182,7 +179,8 @@ const ReviewVoteTableRow = (
             { post.reviewCount }
           </LWTooltip>
         </PostsItem2MetaInfo>
-        {getReviewPhase() === "REVIEWS" && <div className={classes.voteResults}>
+        {getReviewPhase() === "REVIEWS" && <div className={classes.votes}>
+          <div className={classes.voteResults}>
             { highVotes.map((v, i)=>
               <LWTooltip className={classes.highVote} title="Voters with 1000+ karma" key={`${post._id}${i}H`}>
                   {v}
@@ -193,9 +191,12 @@ const ReviewVoteTableRow = (
                   {v}
               </LWTooltip>
             )}
-            <PostsItemReviewVote post={post}/>
+          </div>
+          {eligibleToNominate(currentUser) && <div className={classes.yourVote}>
+            <PostsItemReviewVote post={post} marginRight={false}/>
+          </div>}
         </div>}
-        {getReviewPhase() !== "REVIEWS" && <div className={classes.votes}>
+        {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classes.votes}>
           {!currentUserIsAuthor && <div>{useQuadratic ?
             <QuadraticVotingButtons postId={post._id} voteForCurrentPost={currentVote as SyntheticQuadraticVote} vote={dispatchQuadraticVote} /> :
             <ReviewVotingButtons postId={post._id} dispatch={dispatch} currentUserVoteScore={currentVote?.score || null} />}

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -8,6 +8,7 @@ import { postGetCommentCount } from "../../lib/collections/posts/helpers";
 import { eligibleToNominate, getReviewPhase } from '../../lib/reviewUtils';
 import indexOf from 'lodash/indexOf'
 import pullAt from 'lodash/pullAt'
+import { voteTextStyling } from './PostsItemReviewVote';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -115,6 +116,11 @@ const styles = (theme: ThemeType) => ({
     color: "rgba(0,0,0,.45)",
     padding: 2,
     cursor: "pointer"
+  },
+  disabledVote: {
+    ...voteTextStyling(theme),
+    color: theme.palette.grey[500],
+    cursor: "default"
   }
 });
 
@@ -191,10 +197,14 @@ const ReviewVoteTableRow = (
                   {v}
               </LWTooltip>
             )}
+            
           </div>
           {eligibleToNominate(currentUser) && <div className={classes.yourVote}>
             <PostsItemReviewVote post={post} marginRight={false}/>
           </div>}
+          {currentUserIsAuthor && <LWTooltip title="You can't vote on your own posts">
+            <div className={classes.disabledVote}>Vote</div>
+          </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classes.votes}>
           {!currentUserIsAuthor && <div>{useQuadratic ?

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -142,7 +142,7 @@ const ReviewVoteTableRow = (
     currentVote: SyntheticReviewVote|null,
   }
 ) => {
-  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, QuadraticVotingButtons, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo } = Components
+  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, QuadraticVotingButtons, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote } = Components
 
   const currentUser = useCurrentUser()
   if (!currentUser) return null;
@@ -193,6 +193,7 @@ const ReviewVoteTableRow = (
                   {v}
               </LWTooltip>
             )}
+            <PostsItemReviewVote post={post}/>
         </div>}
         {getReviewPhase() !== "REVIEWS" && <div className={classes.votes}>
           {!currentUserIsAuthor && <div>{useQuadratic ?

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -328,17 +328,6 @@ const ReviewVotingPage = ({classes}: {
     [sortedPosts]
   )
 
-  // if (!currentUserCanVote(currentUser)) {
-  //   return (
-  //     <div className={classes.message}>
-  //       {isEAForum ?
-  //         `Only users regerested before ${moment.utc(annualReviewStart.get()).format('MMM Do')} can vote in the ${REVIEW_NAME_IN_SITU}` :
-  //         `Only users registered before ${REVIEW_YEAR} can vote in the ${REVIEW_NAME_IN_SITU}`
-  //       }
-  //     </div>
-  //   )
-  // }
-
   const voteTotal = (useQuadratic && quadraticVotes) ? computeTotalCost(quadraticVotes) : 0
   const voteAverage = (sortedPosts && sortedPosts.length > 0) ? voteTotal/sortedPosts.length : 0
 

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -328,16 +328,16 @@ const ReviewVotingPage = ({classes}: {
     [sortedPosts]
   )
 
-  if (!currentUserCanVote(currentUser)) {
-    return (
-      <div className={classes.message}>
-        {isEAForum ?
-          `Only users regerested before ${moment.utc(annualReviewStart.get()).format('MMM Do')} can vote in the ${REVIEW_NAME_IN_SITU}` :
-          `Only users registered before ${REVIEW_YEAR} can vote in the ${REVIEW_NAME_IN_SITU}`
-        }
-      </div>
-    )
-  }
+  // if (!currentUserCanVote(currentUser)) {
+  //   return (
+  //     <div className={classes.message}>
+  //       {isEAForum ?
+  //         `Only users regerested before ${moment.utc(annualReviewStart.get()).format('MMM Do')} can vote in the ${REVIEW_NAME_IN_SITU}` :
+  //         `Only users registered before ${REVIEW_YEAR} can vote in the ${REVIEW_NAME_IN_SITU}`
+  //       }
+  //     </div>
+  //   )
+  // }
 
   const voteTotal = (useQuadratic && quadraticVotes) ? computeTotalCost(quadraticVotes) : 0
   const voteAverage = (sortedPosts && sortedPosts.length > 0) ? voteTotal/sortedPosts.length : 0

--- a/packages/lesswrong/lib/reviewUtils.ts
+++ b/packages/lesswrong/lib/reviewUtils.ts
@@ -48,9 +48,15 @@ export function postEligibleForReview (post: PostsBase) {
   return true
 }
 
+export function postIsVoteable (post: PostsBase) {
+  return getReviewPhase() === "NOMINATIONS" || post.positiveReviewVoteCount > 0
+}
+
+
 export function canNominate (currentUser: UsersCurrent|null, post: PostsBase) {
   if (!eligibleToNominate(currentUser)) return false
   if (post.userId === currentUser!._id) return false
+  if (!postIsVoteable(post)) return false
   return (postEligibleForReview(post))
 }
 


### PR DESCRIPTION
Covers a bunch of cases when Review and Voting buttons should be shown/hid. Also tweaks the UI styling of the PostsItemReviewVoting component.

New styling:
![image](https://user-images.githubusercontent.com/3246710/146268709-1a0de182-b880-4fa9-be0b-ce381839ecf6.png)

3 cases where users are eligible to vote (where they have voted, not voted, and can't vote on a post)
![image](https://user-images.githubusercontent.com/3246710/146269641-39d58251-5a93-4578-a5a5-9dcc2f394c00.png)

Makes it so all users can now look at the /reviewVoting page (because it's how you track reviews), and instead non-vote-eligible-users just don't have the voting UI:

![image](https://user-images.githubusercontent.com/3246710/146270789-0eedfea5-92dc-47c4-8e2e-67bf9b6e5133.png)

![image](https://user-images.githubusercontent.com/3246710/146270544-122a5b2f-1328-4c8b-af50-57f64b670dc6.png)

During the Review Phase, voting buttons only appear on post-items for posts that got at least one positive vote.

![image](https://user-images.githubusercontent.com/3246710/146271004-3b37738f-84f8-421e-b77b-cf61950c43a2.png)

compared to during Nominations phase, where all Paul's 2020 posts are voteable:

![image](https://user-images.githubusercontent.com/3246710/146271221-51af2266-6cb8-4d44-96e0-01597171232a.png)

During Nominations phase, PostsPages show voting buttons and review buttons for all 2020 posts:

![image](https://user-images.githubusercontent.com/3246710/146271289-7f33dc11-fa86-4c0f-8694-4e77dcd22f66.png)

During Review phase, they only show those buttons if the post has at least one upvote:

![image](https://user-images.githubusercontent.com/3246710/146271500-5b96e604-d4b4-494d-b6b5-0c6455b02778.png)

(contrasted with a post that does have an upvote)

![image](https://user-images.githubusercontent.com/3246710/146271792-eb249e37-7cc5-4cf9-aa5d-100cc6bd1786.png)

Non-voting users get to see the Review Button but not voting buttons:

![image](https://user-images.githubusercontent.com/3246710/146271881-f4a72818-90af-4bd3-b702-4f14ef5159e5.png)
