### PR TITLE
Review button on PostsItem

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -12,6 +12,8 @@ import { useRecordPostView } from '../common/withRecordPostView';
 import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
+import { forumTitleSetting } from '../../lib/instanceSettings';
+import { getReviewPhase, postEligibleForReview, postIsVoteable, REVIEW_YEAR } from '../../lib/reviewUtils';
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
 
@@ -392,7 +394,7 @@ const PostsItem2 = ({
   const { PostsItemComments, PostsItemKarma, PostsTitle, PostsUserAndCoauthors, LWTooltip, 
     PostsPageActions, PostsItemIcons, PostsItem2MetaInfo, PostsItemTooltipWrapper,
     BookmarkButton, PostsItemDate, PostsItemNewCommentsWrapper, AnalyticsTracker,
-    AddToCalendarIcon, PostsItemReviewVote } = (Components as ComponentTypes)
+    AddToCalendarIcon, PostsItemReviewVote, ReviewPostButton } = (Components as ComponentTypes)
 
   const postLink = postGetPageUrl(post, false, sequenceId || chapter?.sequenceId);
 
@@ -501,7 +503,13 @@ const PostsItem2 = ({
                   unreadComments={hasUnreadComments()}
                   newPromotedComments={hasNewPromotedComments()}
                 />}
-                <PostsItemReviewVote post={post}/>
+
+                {getReviewPhase() === "NOMINATIONS" && <PostsItemReviewVote post={post}/>}
+                
+                {postEligibleForReview(post) && postIsVoteable(post)  && getReviewPhase() === "REVIEWS" && <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={<div><div>What was good about this post? How it could be improved? Does it stand the test of time?</div><p><em>This post has {post.reviewCount || "no"} Review{post.reviewCount !== 1 && "s"}</em></p></div>} placement="bottom">
+                  Review
+                </LWTooltip>}/>}
+
                 {(showNominationCount || showReviewCount) && <LWTooltip title={reviewCountsTooltip} placement="top">
                   
                   <PostsItem2MetaInfo className={classes.reviewCounts}>

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -506,7 +506,7 @@ const PostsItem2 = ({
 
                 {getReviewPhase() === "NOMINATIONS" && <PostsItemReviewVote post={post}/>}
                 
-                {postEligibleForReview(post) && postIsVoteable(post)  && getReviewPhase() === "REVIEWS" && <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={<div><div>What was good about this post? How it could be improved? Does it stand the test of time?</div><p><em>This post has {post.reviewCount || "no"} Review{post.reviewCount !== 1 && "s"}</em></p></div>} placement="bottom">
+                {postEligibleForReview(post) && postIsVoteable(post)  && getReviewPhase() === "REVIEWS" && <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={<div><div>What was good about this post? How it could be improved? Does it stand the test of time?</div><p><em>{post.reviewCount || "No"} review{post.reviewCount !== 1 && "s"}</em></p></div>} placement="bottom">
                   Review
                 </LWTooltip>}/>}
 

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -56,7 +56,7 @@ const PostBodyPrefix = ({post, query, classes}: {
     {reviewIsActive() && postEligibleForReview(post) && postIsVoteable(post) && <div className={classes.reviewVoting}>
       {canNominate(currentUser, post) && <ReviewVotingWidget post={post}/>}
       <ReviewPostButton post={post} year={REVIEW_YEAR+""} reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
-        <div className={classes.reviewButton}>Write a Review</div>
+        <div className={classes.reviewButton}>Review</div>
       </LWTooltip>}/>
     </div>}
 

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -77,7 +77,7 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
     if (isEAForum) {
       return {
         postedAt: {$lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)},
-        positiveReviewVoteCount: {$gte: 2},
+        positiveReviewVoteCount: {$gte: 1}, // EA-forum look here
       }
     }
     return {
@@ -85,7 +85,7 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
         $gt: new Date(`${algorithm.reviewReviews}-01-01`),
         $lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)
       },
-      positiveReviewVoteCount: {$gte: 2},
+      positiveReviewVoteCount: {$gte: 1},
     }
   }
   if (algorithm.reviewNominations) {


### PR DESCRIPTION
This PR makes PostItems have a Review button instead of a Vote button during the Review Phase

![image](https://user-images.githubusercontent.com/3246710/146320049-c9204325-63ef-43a0-abfa-acc383882fe6.png)

I've tested that 
– the Review button works
– if you switch to the NOMINATIONS phase the vote button returns.
– on the UsersProfile page, if I scroll down till I see the 2020 posts, posts that have a nomination show the Review button, and posts without a nomination do not.