### PR TITLE
Colored vote buttons

### DIFF
--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -21,6 +21,28 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
     ...voteTextStyling(theme)
   },
+  style9: {
+    color: theme.palette.primary.dark,
+    border: `solid 2px ${theme.palette.primary.dark}`
+  },
+  style4: {
+
+  },
+  style1: {
+
+  },
+  style0: {
+
+  },
+  styleMinus1: {
+
+  },
+  styleMinus4: {
+
+  },
+  styleMinus9: {
+
+  },
   button: {
     border: "solid 1px rgba(0,0,0,.2)",
     borderRadius: 3,
@@ -60,7 +82,7 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
 
     <LWTooltip title={`${nominationsPhase ? "Nominate this post by casting a preliminary vote" : "Update your vote"}`} placement="right">
       <div className={classNames(classes.buttonWrapper, {[classes.marginRight]:marginRight})} onClick={(e) => setAnchorEl(e.target)}>
-        {displayVote ? <span className={classes.button}>{displayVote}</span> : "Vote"}
+        {displayVote ? <span className={classNames(classes.button)}>{displayVote}</span> : "Vote"}
       </div>
     </LWTooltip>
 

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -21,35 +21,38 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
     ...voteTextStyling(theme)
   },
-  style9: {
-    color: theme.palette.primary.dark,
-    border: `solid 2px ${theme.palette.primary.dark}`
+  7: {
+    color: "white",
+    background: theme.palette.primary.dark
   },
-  style4: {
-
+  6: {
+    color: "white",
+    background: theme.palette.primary.light
   },
-  style1: {
-
+  5: {
+    background: "rgba(0,0,0,.1)"
   },
-  style0: {
-
+  4: {
+    color: theme.palette.grey[600]
   },
-  styleMinus1: {
-
+  3: {
+    background: "rgba(0,0,0,.1)"
   },
-  styleMinus4: {
-
+  2: {
+    color: "white",
+    background: theme.palette.error.light
   },
-  styleMinus9: {
-
+  1: {
+    color: "white",
+    background: theme.palette.error.dark
   },
   button: {
     border: "solid 1px rgba(0,0,0,.2)",
     borderRadius: 3,
     paddingTop: 2,
     paddingBottom: 2,
-    paddingLeft: 6,
-    paddingRight: 6
+    width: 24,
+    display: "inline-block"
   },
   card: {
     padding: isEAForum ? "8px 24px" : 8,
@@ -75,14 +78,15 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
 
   if (!canNominate(currentUser, post)) return null
 
-  const displayVote = indexToTermsLookup[newVote || post.currentUserReviewVote]?.label
+  const voteIndex = newVote || post.currentUserReviewVote
+  const displayVote = indexToTermsLookup[voteIndex]?.label
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 
   return <div onMouseLeave={() => setAnchorEl(null)}>
 
     <LWTooltip title={`${nominationsPhase ? "Nominate this post by casting a preliminary vote" : "Update your vote"}`} placement="right">
       <div className={classNames(classes.buttonWrapper, {[classes.marginRight]:marginRight})} onClick={(e) => setAnchorEl(e.target)}>
-        {displayVote ? <span className={classNames(classes.button)}>{displayVote}</span> : "Vote"}
+        {displayVote ? <span className={classNames(classes.button, [classes[voteIndex]])}>{displayVote}</span> : "Vote"}
       </div>
     </LWTooltip>
 


### PR DESCRIPTION
I was finding it difficult to scan the /reviewVoting page for posts that were low-ranked, but which I had strong upvoted. This seemed like an important way to check for posts worth writing review for.

This PR adds colors to help your votes be more skimmable.

![image](https://user-images.githubusercontent.com/3246710/146484445-7e2e2234-e146-42b5-8ebe-878e71c2515e.png)
