### PR TITLE
Fix spurious event-location-changed notification happening with every RSVP

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -671,7 +671,7 @@ getCollectionHooks("Posts").updateAsync.add(async function PostsEditMeetupNotifi
   if (
     (
       (!newPost.draft && oldPost.draft) || 
-      (newPost.mongoLocation !== oldPost.mongoLocation) ||
+      !_.isEqual(newPost.mongoLocation, oldPost.mongoLocation) ||
       (newPost.startTime !== oldPost.startTime) || 
       (newPost.endTime !== oldPost.endTime) || 
       (newPost.contents?.html !== oldPost.contents?.html) ||


### PR DESCRIPTION
Caused by doing a shallow comparison on `mongoLocation` which needs to be a deep comparison. Introduced in: 0458d3930eee3f141d9c02402b3fc40040fd61ba (which fixed one problem in a line which had two problems in it).