### PR TITLE
Review voting no longer displays on old review CommentItems

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -12,8 +12,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../commentTree';
 import { commentGetPageUrlFromIds } from '../../../lib/collections/comments/helpers';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
-import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../../lib/reviewUtils';
-import { reviewIsActive } from '../../../lib/reviewUtils';
+import { REVIEW_NAME_IN_SITU, REVIEW_YEAR, reviewIsActive } from '../../../lib/reviewUtils';
 
 const isEAForum= forumTypeSetting.get() === "EAForum"
 
@@ -264,12 +263,6 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   if (!comment) {
     return null;
   }
-
-  const displayReviewVoting = 
-    reviewIsActive() &&
-    comment.reviewingForReview === REVIEW_YEAR+"" &&
-    post &&
-    currentUser?._id !== post.userId
   
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>
@@ -350,10 +343,12 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        { displayReviewVoting && <div className={classes.reviewVotingButtons}>
-          <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
-          <ReviewVotingWidget post={post} showTitle={false}/>
-        </div>}
+        { reviewIsActive() && comment.reviewingForReview === REVIEW_YEAR+"" && post && currentUser?._id !== post.userId && 
+          <div className={classes.reviewVotingButtons}>
+            <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
+            <ReviewVotingWidget post={post} showTitle={false}/>
+          </div>
+        }
         { showReplyState && !collapsed && renderReply() }
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -13,6 +13,7 @@ import type { CommentTreeOptions } from '../commentTree';
 import { commentGetPageUrlFromIds } from '../../../lib/collections/comments/helpers';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../../lib/reviewUtils';
+import { reviewIsActive } from '../../../lib/reviewUtils';
 
 const isEAForum= forumTypeSetting.get() === "EAForum"
 
@@ -343,7 +344,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        { comment.reviewingForReview === REVIEW_YEAR+"" && post && <div className={classes.reviewVotingButtons}>
+        { reviewIsActive() && comment.reviewingForReview === REVIEW_YEAR+"" && post && <div className={classes.reviewVotingButtons}>
           <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
           <ReviewVotingWidget post={post} showTitle={false}/>
         </div>}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -264,6 +264,12 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   if (!comment) {
     return null;
   }
+
+  const displayReviewVoting = 
+    reviewIsActive() &&
+    comment.reviewingForReview === REVIEW_YEAR+"" &&
+    post &&
+    currentUser?._id !== post.userId
   
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>
@@ -344,7 +350,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        { reviewIsActive() && comment.reviewingForReview === REVIEW_YEAR+"" && post && <div className={classes.reviewVotingButtons}>
+        { displayReviewVoting && <div className={classes.reviewVotingButtons}>
           <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
           <ReviewVotingWidget post={post} showTitle={false}/>
         </div>}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -263,6 +263,12 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   if (!comment) {
     return null;
   }
+
+  const displayReviewVoting = 
+    reviewIsActive() &&
+    comment.reviewingForReview === REVIEW_YEAR+"" &&
+    post &&
+    currentUser?._id !== post.userId
   
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>
@@ -343,12 +349,10 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        { reviewIsActive() && comment.reviewingForReview === REVIEW_YEAR+"" && post && currentUser?._id !== post.userId && 
-          <div className={classes.reviewVotingButtons}>
-            <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
-            <ReviewVotingWidget post={post} showTitle={false}/>
-          </div>
-        }
+        {displayReviewVoting && <div className={classes.reviewVotingButtons}>
+          <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
+          {post && <ReviewVotingWidget post={post} showTitle={false}/>}
+        </div>}
         { showReplyState && !collapsed && renderReply() }
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -12,7 +12,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../commentTree';
 import { commentGetPageUrlFromIds } from '../../../lib/collections/comments/helpers';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
-import { REVIEW_NAME_IN_SITU } from '../../../lib/reviewUtils';
+import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../../lib/reviewUtils';
 
 const isEAForum= forumTypeSetting.get() === "EAForum"
 
@@ -343,7 +343,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        { comment.reviewingForReview && post && <div className={classes.reviewVotingButtons}>
+        { comment.reviewingForReview === REVIEW_YEAR+"" && post && <div className={classes.reviewVotingButtons}>
           <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
           <ReviewVotingWidget post={post} showTitle={false}/>
         </div>}

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -209,7 +209,7 @@ const ReviewVoteTableRow = (
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classes.votes}>
           {!currentUserIsAuthor && <div>{useQuadratic ?
             <QuadraticVotingButtons postId={post._id} voteForCurrentPost={currentVote as SyntheticQuadraticVote} vote={dispatchQuadraticVote} /> :
-            <ReviewVotingButtons postId={post._id} dispatch={dispatch} currentUserVoteScore={currentVote?.score || null} />}
+            <ReviewVotingButtons post={post} dispatch={dispatch} currentUserVoteScore={currentVote?.score || null} />}
           </div>}
           {currentUserIsAuthor && <MetaInfo>You can't vote on your own posts</MetaInfo>}
         </div>}

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -5,6 +5,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import forumThemeExport from '../../themes/forumTheme';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
+import { useCurrentUser } from '../common/withUser';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -61,9 +62,10 @@ export const indexToTermsLookup = {
 }
 
 
-const ReviewVotingButtons = ({classes, postId, dispatch, currentUserVoteScore}: {classes: ClassesType, postId: string, dispatch: any, currentUserVoteScore: number|null}) => {
+const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVoteScore: number|null}) => {
   const { LWTooltip } = Components
 
+  const currentUser = useCurrentUser()
 
   const [selection, setSelection] = useState(currentUserVoteScore || DEFAULT_QUALITATIVE_VOTE)
   const [isDefaultVote, setIsDefaultVote] = useState(!currentUserVoteScore)
@@ -72,9 +74,11 @@ const ReviewVotingButtons = ({classes, postId, dispatch, currentUserVoteScore}: 
     return () => {
       setSelection(index)
       setIsDefaultVote(false)
-      dispatch({postId, score: index})
+      dispatch({postId: post._id, score: index})
     }
   }
+
+  if (currentUser?._id === post.userId) return <div className={classes.root}>You can't vote on your own posts</div>
 
   return <AnalyticsContext pageElementContext="reviewVotingButtons">
     <div className={classes.root}>

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -57,7 +57,7 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
         {showTitle && <p>
           Vote on this post for the <LWTooltip title={overviewTooltip}><Link to={annualReviewAnnouncementPostPathSetting.get()}>{REVIEW_NAME_IN_SITU}</Link></LWTooltip>
         </p>}
-        <ReviewVotingButtons postId={post._id} dispatch={dispatchQualitativeVote} currentUserVoteScore={post.currentUserReviewVote}/>
+        <ReviewVotingButtons post={post} dispatch={dispatchQualitativeVote} currentUserVoteScore={post.currentUserReviewVote}/>
       </div>
     </ErrorBoundary>
 }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -11,6 +11,7 @@ registerFragment(`
     hideCommentKarma
     af
     currentUserReviewVote
+    userId
   }
 `);
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -286,6 +286,7 @@ interface PostsMinimumInfo { // fragment on Posts
   readonly hideCommentKarma: boolean,
   readonly af: boolean,
   readonly currentUserReviewVote: number,
+  readonly userId: string,
 }
 
 interface PostsBase extends PostsMinimumInfo { // fragment on Posts


### PR DESCRIPTION
When I recently added the ReviewVotingButtons to the bottom of CommentsItem, I forgot to exclude it from old review comments on previous years.

This PR makes it so that it only appears on comments reviewing the current REVIEW_YEAR, and only while the review is active.

I have tested
– That an old post's reviews does NOT show voting-buttons (while getReviewPhase returns a string)
– That a current-review-year comments DOES show voting-buttons (while getReviewPhase returns a string)
– That a current-review-year-comment does NOT show voting buttons (While getReviewPhase returns undefined)