### PR TITLE
Replace foreach with for loops to fix async issue

### DIFF
--- a/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
+++ b/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
@@ -64,11 +64,13 @@ registerMigration({
       }
     }
 
-    Object.keys(votesByUserId).forEach(async (userId) => {
+    for (let userId in votesByUserId) {
       let totalUserPoints = 0 
       const user = usersByUserId[userId][0]
 
-      votesByUserId[userId].forEach(async vote => {
+      for (let vote of votesByUserId[userId]) {
+        if (!vote.qualitativeScore) return
+        
         totalUserPoints += getCost(vote)
         await ReviewVotes.update({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})
         
@@ -79,29 +81,28 @@ registerMigration({
         if (user.groups?.includes('alignmentForum')) {
           updatePost(postsAFUsers, vote)
         }
-      })
+      }
       // eslint-disable-next-line no-console
       console.log(userId, totalUserPoints, totalUserPoints > 500 ? "Over 500" : "")
-    })
+    }
 
-    Object.keys(postsAllUsers).forEach(async postId => {
+    for (let postId in postsAllUsers) {
       await Posts.update({_id:postId}, {$set: { 
         reviewVotesAllKarma: postsAllUsers[postId].sort((a,b) => b - a), 
         reviewVoteScoreAllKarma: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
-    })
-    Object.keys(postsHighKarmaUsers).forEach(async postId => {
+    }
+    for (let postId in postsHighKarmaUsers) {
       await Posts.update({_id:postId}, {$set: { 
         reviewVotesHighKarma: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreHighKarma: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
-    })
-    Object.keys(postsAFUsers).forEach(async postId => {
+    }
+    for (let postId in postsAFUsers) {
       await Posts.update({_id:postId}, {$set: { 
         reviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})
-    })
+    }
   },
 });
-

--- a/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
+++ b/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
@@ -69,7 +69,7 @@ registerMigration({
       const user = usersByUserId[userId][0]
 
       for (let vote of votesByUserId[userId]) {
-        if (!vote.qualitativeScore) return
+        if (!vote.qualitativeScore) continue
         
         totalUserPoints += getCost(vote)
         await ReviewVotes.update({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})


### PR DESCRIPTION
Fixes breaking bug with `updateQuadraticVotes` migration.

---

## Explanation

Let's talk about how forEach works. It has a bunch of values in an array. You pass it a callback. It takes the first element of the array and passes it to your callback. Then it moves on to the next one, and so on, until it has finished calling your functions with each of its elements.

Now, let's think carefully about what happens when your function is async. When async functions are called, they return a promise at the first await. So the question becomes, will forEach function await the promise? At this point we can google it, however I leave it as an exercise to the reader to see how the code could not have worked as written.

The answer is: no forEach does not await the promise. So all of the functions will be called immediately, one after another, without a chance for any network requests to happen.

"Ok fine," I hear you say, "but I don't care about those network requests. They can be done asynchronously." And if your name is Ray, you might further say, "Any anyway it was working for me, so what gives?"

Before you were discarding the result of your network requests. The forEach ran each of your functions one after another, and the `update` functions return values were discarded. But after the innocuous "add awaits" commit, you're returning a promise and *waiting for the result of the network call* before adding to the update objects. So now when you perform the important final update, the objects are empty.