### PR TITLE
stop sending blank emails for new events

### DIFF
--- a/packages/lesswrong/lib/collections/revisions/collection.ts
+++ b/packages/lesswrong/lib/collections/revisions/collection.ts
@@ -25,7 +25,9 @@ Revisions.checkAccess = async (user: DbUser|null, revision: DbRevision, context:
   if (!revision) return false
   if ((user && user._id) === revision.userId) return true
   if (userCanDo(user, 'posts.view.all')) return true
-  
+  // not sure why some revisions have no collectionName,
+  // but this will cause an error below so just exclude them
+  if (!revision.collectionName) return false
   
   // Get the document that this revision is a field of, and check for access to
   // it. This is necessary for correctly handling things like posts' draft
@@ -37,7 +39,7 @@ Revisions.checkAccess = async (user: DbUser|null, revision: DbRevision, context:
   // ResolverContext, use a findOne query; this is slow, but doesn't come up
   // in any contexts where speed matters.
   const { major: majorVersion } = extractVersionsFromSemver(revision.version)
-  const collectionName= revision.collectionName as CollectionNameString;
+  const collectionName= revision.collectionName;
   const documentId = revision.documentId;
   const collection = getCollection(collectionName);
   const document = context

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -324,7 +324,7 @@ export const EditedEventInNotificationRadiusNotification = registerNotificationT
   userSettingField: "notificationEventInRadius",
   async getMessage({documentType, documentId}: {documentType: string|null, documentId: string|null}) {
     let document = await getDocument(documentType, documentId) as DbPost
-    return `The event ${document.title} changed locations`
+    return `The event ${document.title} has been updated`
   },
   getIcon() {
     return <EventIcon style={iconStyles} />


### PR DESCRIPTION
I've gotten reports from multiple users who have received a blank email regarding a new event posted on the forum (and I've received those emails too).
<img width="861" alt="Screen Shot 2021-12-22 at 4 12 54 PM" src="https://user-images.githubusercontent.com/9057804/147155883-6c35fa66-0cd3-4337-92b2-f8fafde6728b.png">
JP and I discovered that this happens when we are trying to render the email. When we query for the event/post data, if `Revisions.checkAccess()` is called on a revision with the event/post's `documentId` but the revision has no `collectionName`, that causes an error that prevents the email body from rendering properly.

In our production database, we have 161,750 revisions and 84,318 of them have no `collectionName`. Not sure why there are revisions with no `collectionName`?