### PR TITLE
Reviews on frontpage

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -59,7 +59,7 @@ const CommentsNode = ({ treeOptions, comment, startThreadTruncated, truncated, s
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
   const [collapsed, setCollapsed] = useState(comment.deleted || comment.baseScore < KARMA_COLLAPSE_THRESHOLD);
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
-  const { lastCommentId, condensed, postPage, post, highlightDate, markAsRead, scrollOnExpand } = treeOptions;
+  const { lastCommentId, condensed, postPage, post, highlightDate, markAsRead, scrollOnExpand, singleLineLargePreview } = treeOptions;
 
   const beginSingleLine = (): boolean => {
     // TODO: Before hookification, this got nestingLevel without the default value applied, which may have changed its behavior?
@@ -138,7 +138,7 @@ const CommentsNode = ({ treeOptions, comment, startThreadTruncated, truncated, s
 
   const handleExpand = async (event: React.MouseEvent) => {
     event.stopPropagation()
-    if (isTruncated || isSingleLine) {
+    if (isTruncated || (isSingleLine && !singleLineLargePreview)) {
       markAsRead && await markAsRead()
       setTruncated(false);
       setSingleLine(false);

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -128,7 +128,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     backgroundColor: "white",
     border: "solid 1px rgba(0,0,0,.1)",
     boxShadow: "0 0 10px rgba(0,0,0,.2)",
-    width: POST_PREVIEW_WIDTH
+    width: 500
   }
 })
 
@@ -198,7 +198,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
         }}
       >
           <div className={classes.preview}>
-            <CommentsNode truncated nestingLevel={1} comment={comment} treeOptions={treeOptions} forceNotSingleLine/>
+            <CommentsNode truncated comment={comment} treeOptions={treeOptions} forceNotSingleLine hoverPreview/>
           </div>
       </LWPopper>
       {displayHoverOver && !singleLineLargePreview && <span className={classNames(classes.highlight)}>

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -8,6 +8,7 @@ import { commentGetKarma } from '../../lib/collections/comments/helpers'
 import { isMobile } from '../../lib/utils/isMobile'
 import { styles as commentsItemStyles } from './CommentsItem/CommentsItem';
 import { CommentTreeOptions } from './commentTree';
+import { POST_PREVIEW_WIDTH } from '../posts/PostsPreviewTooltip';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -122,6 +123,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   postTitle: {
     ...commentsItemStyles(theme).metaNotice,
     marginRight: 20
+  },
+  preview: {
+    backgroundColor: "white",
+    border: "solid 1px rgba(0,0,0,.1)",
+    boxShadow: "0 0 10px rgba(0,0,0,.2)",
+    width: POST_PREVIEW_WIDTH
   }
 })
 
@@ -134,14 +141,14 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   showDescendentCount?: boolean,
   classes: ClassesType,
 }) => {
-  const {hover, eventHandlers} = useHover();
+  const {hover, anchorEl, eventHandlers} = useHover();
   
   if (!comment) return null
   
-  const { enableHoverPreview=true, hideSingleLineMeta, post } = treeOptions;
+  const { enableHoverPreview=true, hideSingleLineMeta, post, singleLineLargePreview, singleLinePostTitle } = treeOptions;
 
   const plaintextMainText = comment.contents?.plaintextMainText;
-  const { CommentsItem, CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments } = Components
+  const { CommentsNode, CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments, LWPopper } = Components
 
   const displayHoverOver = hover && (comment.baseScore > -5) && !isMobile() && enableHoverPreview
 
@@ -166,7 +173,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           <Components.FormatDate date={comment.postedAt} tooltip={false}/>
         </span>}
         {renderHighlight && <span className={classes.truncatedHighlight}> 
-          {treeOptions.singleLinePostTitle && <span className={classes.postTitle}>{treeOptions.post?.title}</span>}
+          {singleLinePostTitle && <span className={classes.postTitle}>{post?.title}</span>}
           { comment.nominatedForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Nomination</span>}
           { comment.reviewingForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Review</span>}
           { comment.promoted && !hideSingleLineMeta && <span className={classes.metaNotice}>Promoted</span>}
@@ -179,8 +186,23 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           newPromotedComments={false}
         />}
       </div>
-      {displayHoverOver && <span className={classNames(classes.highlight)}>
-        {treeOptions.singleLineLargePreview ?  <CommentsItem truncated nestingLevel={0} comment={comment} treeOptions={treeOptions}/> : <div className={classes.highlightPadding}><CommentBody truncated comment={comment}/></div>}
+      <LWPopper
+        open={displayHoverOver && !!singleLineLargePreview}
+        anchorEl={anchorEl}
+        placement="bottom-end"
+        modifiers={{
+          flip: {
+            behavior: ["bottom-end"],
+            boundariesElement: 'viewport'
+          }
+        }}
+      >
+          <div className={classes.preview}>
+            <CommentsNode truncated nestingLevel={1} comment={comment} treeOptions={treeOptions} forceNotSingleLine/>
+          </div>
+      </LWPopper>
+      {displayHoverOver && !singleLineLargePreview && <span className={classNames(classes.highlight)}>
+         <div className={classes.highlightPadding}><CommentBody truncated comment={comment}/></div>
       </span>}
     </div>
   )

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -81,9 +81,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   highlight: {
-    ...commentBodyStyles(theme),
     backgroundColor: "white",
-    padding: theme.spacing.unit*1.5,
     width: "inherit",
     maxWidth: 625,
     position: "absolute",
@@ -97,6 +95,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& img': {
       maxHeight: "200px"
     }
+  },
+  highlightPadding: {
+    padding: theme.spacing.unit*1.5
   },
   isAnswer: {
     ...postBodyStyles(theme),
@@ -117,6 +118,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   metaNotice: {
     ...commentsItemStyles(theme).metaNotice,
     marginRight: theme.spacing.unit
+  },
+  postTitle: {
+    ...commentsItemStyles(theme).metaNotice,
+    marginRight: 20
   }
 })
 
@@ -136,7 +141,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   const { enableHoverPreview=true, hideSingleLineMeta, post } = treeOptions;
 
   const plaintextMainText = comment.contents?.plaintextMainText;
-  const { CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments } = Components
+  const { CommentsItem, CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments } = Components
 
   const displayHoverOver = hover && (comment.baseScore > -5) && !isMobile() && enableHoverPreview
 
@@ -161,6 +166,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           <Components.FormatDate date={comment.postedAt} tooltip={false}/>
         </span>}
         {renderHighlight && <span className={classes.truncatedHighlight}> 
+          {treeOptions.singleLinePostTitle && <span className={classes.postTitle}>{treeOptions.post?.title}</span>}
           { comment.nominatedForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Nomination</span>}
           { comment.reviewingForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Review</span>}
           { comment.promoted && !hideSingleLineMeta && <span className={classes.metaNotice}>Promoted</span>}
@@ -174,7 +180,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
         />}
       </div>
       {displayHoverOver && <span className={classNames(classes.highlight)}>
-        <CommentBody truncated comment={comment}/>
+        {treeOptions.singleLineLargePreview ?  <CommentsItem truncated nestingLevel={0} comment={comment} treeOptions={treeOptions}/> : <div className={classes.highlightPadding}><CommentBody truncated comment={comment}/></div>}
       </span>}
     </div>
   )

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -9,8 +9,10 @@ export interface CommentTreeOptions {
   scrollOnExpand?: boolean,
   hideSingleLineMeta?: boolean,
   enableHoverPreview?: boolean,
+  singleLineLargePreview?: boolean,
   hideReply?: boolean,
   showPostTitle?: boolean,
+  singleLinePostTitle?: boolean,
   post?: PostsMinimumInfo,
   tag?: TagBasicInfo,
 }

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -313,12 +313,12 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         
         {/* Post list */}
         {/* ea-forum-look-here */}
-        {showFrontpageItems && activeRange === "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewRecommendations`} reviewYear={`${REVIEW_YEAR}`} capturePostItemOnMount>
+        {showFrontpageItems && (activeRange === "NOMINATIONS" || !eligibleToNominate(currentUser) ) && <AnalyticsContext listContext={`frontpageReviewRecommendations`} reviewYear={`${REVIEW_YEAR}`} capturePostItemOnMount>
           {/* TODO:(Review) I think we can improve this */}
           <RecommendationsList algorithm={getReviewAlgorithm()} />
         </AnalyticsContext>}
 
-        {showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
+        {showFrontpageItems && (activeRange !== "NOMINATIONS" && eligibleToNominate(currentUser) ) && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
           {/* TODO:(Review) I think we can improve this */}
           <SingleLineReviewsList />
         </AnalyticsContext>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -318,7 +318,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
           <RecommendationsList algorithm={getReviewAlgorithm()} />
         </AnalyticsContext>}
 
-        {showFrontpageItems && activeRange === "REVIEWS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
+        {showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
           {/* TODO:(Review) I think we can improve this */}
           <SingleLineReviewsList />
         </AnalyticsContext>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -183,7 +183,7 @@ export const overviewTooltip = isEAForum ?
   </div>
 
 const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: ClassesType, showFrontpageItems?: boolean}) => {
-  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, LatestReview } = Components
+  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, SingleLineReviewsList, LatestReview } = Components
   const currentUser = useCurrentUser();
 
   // These should be calculated at render
@@ -261,7 +261,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
   }
 
   const allPhaseButtons = <>        
-    {showFrontpageItems && <LatestReview/>}
     {!showFrontpageItems && userIsAdmin(currentUser) && <LWTooltip className={classes.buttonWrapper} title={`Look at metrics related to the Review`}>
       <Link to={'/reviewAdmin'} className={classNames(classes.actionButton, classes.adminButton)}>
         Review Admin
@@ -314,15 +313,22 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         
         {/* Post list */}
         {/* ea-forum-look-here */}
-        {showFrontpageItems && <AnalyticsContext listContext={`frontpageReviewRecommendations`} reviewYear={`${REVIEW_YEAR}`} capturePostItemOnMount>
+        {showFrontpageItems && activeRange === "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewRecommendations`} reviewYear={`${REVIEW_YEAR}`} capturePostItemOnMount>
           {/* TODO:(Review) I think we can improve this */}
           <RecommendationsList algorithm={getReviewAlgorithm()} />
+        </AnalyticsContext>}
+
+        {showFrontpageItems && activeRange === "REVIEWS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
+          {/* TODO:(Review) I think we can improve this */}
+          <SingleLineReviewsList />
         </AnalyticsContext>}
 
         {/* TODO: Improve logged out user experience */}
         
         {activeRange === "NOMINATIONS" && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
           
+          {showFrontpageItems && <LatestReview/>}
+
           {allPhaseButtons}
 
           <LWTooltip className={classes.buttonWrapper} title={`Nominate posts you previously upvoted.`}>

--- a/packages/lesswrong/components/review/SingleLineReviewsList.tsx
+++ b/packages/lesswrong/components/review/SingleLineReviewsList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { REVIEW_YEAR } from '../../lib/reviewUtils';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+
+const SingleLineReviewsList = () => {
+  const { results } = useMulti({
+    terms: { view: "reviews", reviewYear: REVIEW_YEAR, sortBy: "new"},
+    collectionName: "Comments",
+    fragmentName: 'CommentsListWithParentMetadata',
+    enableTotal: false,
+    limit: 3
+  });
+  return <div>
+    {results?.map(comment =>
+        <div key={comment._id}>
+          <Components.CommentsNode
+            treeOptions={{
+              condensed: true,
+              singleLineLargePreview: true,
+              hideSingleLineMeta: true,
+              singleLinePostTitle: true,
+              post: comment.post || undefined
+            }}
+            comment={comment}
+            forceSingleLine
+          />
+        </div>
+      )}
+  </div>
+}
+
+const SingleLineReviewsListComponent = registerComponent('SingleLineReviewsList', SingleLineReviewsList);
+
+declare global {
+  interface ComponentTypes {
+    SingleLineReviewsList: typeof SingleLineReviewsListComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -590,6 +590,7 @@ importComponent("ReviewVotingWidget", () => require('../components/review/Review
 importComponent("LatestReview", () => require('../components/review/LatestReview'));
 importComponent("ReviewAdminDashboard", () => require('../components/review/ReviewAdminDashboard'));
 importComponent("PostNominatedNotification", () => require('../components/review/PostNominatedNotification'));
+importComponent("SingleLineReviewsList", () => require('../components/review/SingleLineReviewsList'));
 
 importComponent("QuadraticVotingButtons", () => require('../components/review/QuadraticVotingButtons'))
 importComponent("ReviewVoteTableRow", () => require('../components/review/ReviewVoteTableRow'))


### PR DESCRIPTION
This replaces the FrontpageReviewWidget's post-list with a reviews list after the nominations phase has ended, to help encourage engagement with reviews.

Things I tested:
– if I set reviewPhase to "NOMINATIONS", I still get the nominations-phase post list
– if I set reviewPhase to "REVIEWS" I get the list of singleline comments
– for the single-line-comments in the FrontpageReviewWidget, where singleLineLargePreview is true, you can click on the hoverpreview to expand the preview (without expanding the original single line comment)
– for other single-line-comments in the RecentDiscussionSection, clicking them expands the original single-line-comment

(I changed how clicking works because it seemed like I wanted different behavior on the FrontpageReviewWidget – in that case a core feature is being able to change my vote, so I want clicking that to be easy. I also found it pretty overwhelming when it expanded the entire comment, which doesn't currently have a way to collapse)

![image](https://user-images.githubusercontent.com/3246710/147175811-8fb72a32-bd61-4ce6-8b59-8fcb1b69d9d8.png)
