### PR TITLE
Collapsible Frontpage SingleLineComments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -142,7 +142,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   
   const currentUser = useCurrentUser();
 
-  const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineLargePreview } = treeOptions;
+  const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineCollapse } = treeOptions;
 
   const showReply = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -317,7 +317,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               [<span>{collapsed ? "+" : "-"}</span>]
             </a>
             }
-            {singleLineLargePreview && <a className={classes.collapse} onClick={() => 
+            {singleLineCollapse && <a className={classes.collapse} onClick={() => 
               setSingleLine && setSingleLine(true)}>
               [<span>{collapsed ? "+" : "-"}</span>]
             </a>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -121,7 +121,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, truncated, parentAnswerId, classes }: {
+export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, setSingleLine, truncated, parentAnswerId, classes }: {
   treeOptions: CommentTreeOptions,
   comment: CommentsList|CommentsListWithParentMetadata,
   nestingLevel: number,
@@ -131,6 +131,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   parentCommentId?: string,
   scrollIntoView?: ()=>void,
   toggleCollapse?: ()=>void,
+  setSingleLine?: (boolean)=>void,
   truncated: boolean,
   parentAnswerId?: string|undefined,
   classes: ClassesType,
@@ -141,7 +142,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   
   const currentUser = useCurrentUser();
 
-  const { postPage, tag, post, refetch, hideReply, showPostTitle } = treeOptions;
+  const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineLargePreview } = treeOptions;
 
   const showReply = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -316,6 +317,11 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               [<span>{collapsed ? "+" : "-"}</span>]
             </a>
             }
+            {singleLineLargePreview && <a className={classes.collapse} onClick={() => 
+              setSingleLine && setSingleLine(true)}>
+              [<span>{collapsed ? "+" : "-"}</span>]
+            </a>
+            }
             <CommentUserName comment={comment} className={classes.username}/>
             <CommentsItemDate
               comment={comment} post={post} tag={tag}
@@ -349,7 +355,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
-        {displayReviewVoting && <div className={classes.reviewVotingButtons}>
+        {displayReviewVoting && !collapsed && <div className={classes.reviewVotingButtons}>
           <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
           {post && <ReviewVotingWidget post={post} showTitle={false}/>}
         </div>}

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -59,7 +59,7 @@ const CommentsNode = ({ treeOptions, comment, startThreadTruncated, truncated, s
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
   const [collapsed, setCollapsed] = useState(comment.deleted || comment.baseScore < KARMA_COLLAPSE_THRESHOLD);
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
-  const { lastCommentId, condensed, postPage, post, highlightDate, markAsRead, scrollOnExpand, singleLineLargePreview } = treeOptions;
+  const { lastCommentId, condensed, postPage, post, highlightDate, markAsRead, scrollOnExpand } = treeOptions;
 
   const beginSingleLine = (): boolean => {
     // TODO: Before hookification, this got nestingLevel without the default value applied, which may have changed its behavior?

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -138,7 +138,7 @@ const CommentsNode = ({ treeOptions, comment, startThreadTruncated, truncated, s
 
   const handleExpand = async (event: React.MouseEvent) => {
     event.stopPropagation()
-    if (isTruncated || (isSingleLine && !singleLineLargePreview)) {
+    if (isTruncated || isSingleLine) {
       markAsRead && await markAsRead()
       setTruncated(false);
       setSingleLine(false);
@@ -194,6 +194,7 @@ const CommentsNode = ({ treeOptions, comment, startThreadTruncated, truncated, s
               toggleCollapse={toggleCollapse}
               key={comment._id}
               scrollIntoView={scrollIntoView}
+              setSingleLine={setSingleLine}
               { ...passedThroughItemProps}
             />
         }

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -141,14 +141,14 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   showDescendentCount?: boolean,
   classes: ClassesType,
 }) => {
-  const {hover, anchorEl, eventHandlers} = useHover();
+  const {hover, eventHandlers} = useHover();
   
   if (!comment) return null
   
-  const { enableHoverPreview=true, hideSingleLineMeta, post, singleLineLargePreview, singleLinePostTitle } = treeOptions;
+  const { enableHoverPreview=true, hideSingleLineMeta, post, singleLinePostTitle } = treeOptions;
 
   const plaintextMainText = comment.contents?.plaintextMainText;
-  const { CommentsNode, CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments, LWPopper } = Components
+  const { CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments } = Components
 
   const displayHoverOver = hover && (comment.baseScore > -5) && !isMobile() && enableHoverPreview
 
@@ -186,22 +186,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           newPromotedComments={false}
         />}
       </div>
-      <LWPopper
-        open={displayHoverOver && !!singleLineLargePreview}
-        anchorEl={anchorEl}
-        placement="bottom-end"
-        modifiers={{
-          flip: {
-            behavior: ["bottom-end"],
-            boundariesElement: 'viewport'
-          }
-        }}
-      >
-          <div className={classes.preview}>
-            <CommentsNode truncated comment={comment} treeOptions={treeOptions} forceNotSingleLine hoverPreview/>
-          </div>
-      </LWPopper>
-      {displayHoverOver && !singleLineLargePreview && <span className={classNames(classes.highlight)}>
+      {displayHoverOver && <span className={classNames(classes.highlight)}>
          <div className={classes.highlightPadding}><CommentBody truncated comment={comment}/></div>
       </span>}
     </div>

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -9,7 +9,7 @@ export interface CommentTreeOptions {
   scrollOnExpand?: boolean,
   hideSingleLineMeta?: boolean,
   enableHoverPreview?: boolean,
-  singleLineLargePreview?: boolean,
+  singleLineCollapse?: boolean,
   hideReply?: boolean,
   showPostTitle?: boolean,
   singleLinePostTitle?: boolean,

--- a/packages/lesswrong/components/review/SingleLineReviewsList.tsx
+++ b/packages/lesswrong/components/review/SingleLineReviewsList.tsx
@@ -17,9 +17,10 @@ const SingleLineReviewsList = () => {
           <Components.CommentsNode
             treeOptions={{
               condensed: true,
-              singleLineLargePreview: true,
+              singleLineCollapse: true,
               hideSingleLineMeta: true,
               singleLinePostTitle: true,
+              showPostTitle: true,
               post: comment.post || undefined
             }}
             comment={comment}


### PR DESCRIPTION
I'm not thrilled with my current implementation of this, but, this makes it so that you can click to expand the single-line-comments on the frontpage. 

Previously I had delibarely not enabled this because it resulted in a large, permanently expanded single-line-comment at the top of the home page, which seemed undesireable. But a) I found it annoying that I couldn't expand the singleLineComments the way I was used to, and, b) on mobile the hoverover option didn't even work so the component was basically broken.

This makes it so you can expand then, and then also collapse them. My shoulder Oli is warning me about spaghetti code of special-cases for comments though, and thinks maybe we want to reflect on that.

![image](https://user-images.githubusercontent.com/3246710/147374653-ebac3480-8d9f-4d76-aff6-c607b7ddaf4c.png)
