### PR TITLE
display default innerHTML for link previews

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -27,7 +27,7 @@ const PostLinkPreview = ({href, targetLocation, innerHTML, id}: {
     documentId: postID,
   });
 
-  if (!post) return null;
+  if (!post) return <span dangerouslySetInnerHTML={{__html: innerHTML}}/>;
 
   return <Components.PostLinkPreviewVariantCheck post={post} targetLocation={targetLocation} error={error} href={href} innerHTML={innerHTML} id={id} />
 }
@@ -47,7 +47,7 @@ const PostLinkPreviewSequencePost = ({href, targetLocation, innerHTML, id}: {
     fetchPolicy: 'cache-then-network' as any, //TODO
     documentId: postID,
   });
-  if (!post) {return null;}
+  if (!post) {return <span dangerouslySetInnerHTML={{__html: innerHTML}}/>;}
 
   return <Components.PostLinkPreviewVariantCheck post={post} targetLocation={targetLocation} error={error} href={href} innerHTML={innerHTML} id={id} />
 }
@@ -116,7 +116,7 @@ const PostCommentLinkPreviewGreaterWrong = ({href, targetLocation, innerHTML, id
     documentId: postId,
   });
 
-  if (!post) {return null;}
+  if (!post) {return <span dangerouslySetInnerHTML={{__html: innerHTML}}/>;}
 
   return <Components.PostLinkCommentPreview href={href} innerHTML={innerHTML} commentId={commentId} post={post} id={id}/>
 }


### PR DESCRIPTION
Sometimes, a link-preview takes awhile to load, and then it doesn't initially display anything. This looks confusing. This PR makes it so it always displays the innerHTML even if the fancy hovers haven't loaded yet.