### PR TITLE
post editor sets post title in browser

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -29,7 +29,7 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
   const currentUser = useCurrentUser();
   const { params } = location; // From withLocation
   const isDraft = document && document.draft;
-  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox } = Components
+  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags } = Components
   const EditPostsSubmit = (props) => {
     return <div className={classes.formSubmit}>
       {!eventForm && <SubmitToFrontpageCheckbox {...props} />}
@@ -49,6 +49,7 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
   
   return (
     <div className={classes.postForm}>
+      <HeadTags title={document?.title} />
       <NoSsr>
         <WrappedSmartForm
           collection={Posts}


### PR DESCRIPTION
Sets the title of your browser window to be the post-title, while editing a post.

(I'm not 100% sure how HeaderTags works under the hood but seemed to be the right component to do the job)