### PR TITLE
Hide voting for non-eligible people more reliably

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -12,7 +12,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../commentTree';
 import { commentGetPageUrlFromIds } from '../../../lib/collections/comments/helpers';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
-import { REVIEW_NAME_IN_SITU, REVIEW_YEAR, reviewIsActive } from '../../../lib/reviewUtils';
+import { REVIEW_NAME_IN_SITU, REVIEW_YEAR, reviewIsActive, eligibleToNominate } from '../../../lib/reviewUtils';
 
 const isEAForum= forumTypeSetting.get() === "EAForum"
 
@@ -269,7 +269,8 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     reviewIsActive() &&
     comment.reviewingForReview === REVIEW_YEAR+"" &&
     post &&
-    currentUser?._id !== post.userId
+    currentUser?._id !== post.userId &&
+    eligibleToNominate(currentUser)
   
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -6,6 +6,7 @@ import forumThemeExport from '../../themes/forumTheme';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
+import { eligibleToNominate } from '../../lib/reviewUtils';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -79,6 +80,8 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {c
   }
 
   if (currentUser?._id === post.userId) return <div className={classes.root}>You can't vote on your own posts</div>
+
+  if (!eligibleToNominate(currentUser)) return <div className={classes.root}>You aren't eligible to vote</div>
 
   return <AnalyticsContext pageElementContext="reviewVotingButtons">
     <div className={classes.root}>

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -2,11 +2,12 @@ import { useMutation } from '@apollo/client';
 import gql from 'graphql-tag';
 import React, { useCallback } from 'react';
 import { updateEachQueryResultOfType, handleUpdateMutation } from '../../lib/crud/cacheUpdates';
-import { REVIEW_NAME_IN_SITU } from '../../lib/reviewUtils';
+import { eligibleToNominate, REVIEW_NAME_IN_SITU } from '../../lib/reviewUtils';
 import { Components, getFragment, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { annualReviewAnnouncementPostPathSetting } from '../../lib/publicSettings';
 import { overviewTooltip } from './FrontpageReviewWidget';
+import { useCurrentUser } from '../common/withUser';
 
 const styles = (theme) => ({
   root: {
@@ -24,6 +25,8 @@ const styles = (theme) => ({
 const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classes:ClassesType, post: PostsMinimumInfo, showTitle?: boolean, setNewVote?: (newVote:number)=>void}) => {
 
   const { ReviewVotingButtons, ErrorBoundary, LWTooltip } = Components
+  
+  const currentUser = useCurrentUser()
 
   // TODO: Refactor these + the ReviewVotingPage dispatch
   const [submitVote] = useMutation(gql`
@@ -51,6 +54,8 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
     if (setNewVote) setNewVote(score)
     return await submitVote({variables: {postId, qualitativeScore: score, year: 2020+"", dummy: false}})
   }, [submitVote, setNewVote]);
+
+  if (!eligibleToNominate(currentUser)) return null
 
   return <ErrorBoundary>
       <div className={classes.root}>


### PR DESCRIPTION
I hadn't properly hidden the votes of non-eligible users on CommentItems. This PR fixes those permissions in multiple places (because I expect to use different components in different combinations and it seemed better to err on the side of thoroughness)