### PR TITLE
Makes a link to the Best of LessWrong collection

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -125,6 +125,12 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
       tooltip: 'What if Harry Potter was a scientist? What would you do if the universe had magic in it? A story that illustrates many rationality concepts.',
       subItem: true,
     }, {
+      id: 'bestoflesswrong',
+      title: 'Best of LessWrong',
+      link: '/bestoflesswrong',
+      tooltip: 'Top-voted posts from the 2018 and 2019 Review',
+      subItem: true,
+    }, {
       id: 'events',
       title: 'Community Events', // Events hide on mobile
       mobileTitle: 'Community',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -129,7 +129,7 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
       id: 'bestoflesswrong',
       title: 'Best of LessWrong',
       link: '/bestoflesswrong',
-      tooltip: `Top-voted posts from the Annual Review (2018 – ${REVIEW_YEAR - 1})`,
+      tooltip: `Top-voted posts from the Annual Review (2018 - ${REVIEW_YEAR - 1})`,
       subItem: true,
     }, {
       id: 'events',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -129,7 +129,7 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
       id: 'bestoflesswrong',
       title: 'Best of LessWrong',
       link: '/bestoflesswrong',
-      tooltip: `Top-voted posts from the Annual Review (2018 - ${REVIEW_YEAR - 1})`,
+      tooltip: "Top posts from the Annual Review (2018 through " + REVIEW_YEAR + ")",
       subItem: true,
     }, {
       id: 'events',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -16,6 +16,7 @@ import LocalLibrary from '@material-ui/icons/LocalLibrary';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
 import type { ForumTypeString } from '../../../lib/instanceSettings';
 import { communityPath } from '../../../lib/routes';
+import { REVIEW_YEAR } from '../../../lib/reviewUtils';
 
 // The sidebar / bottom bar of the Forum contain 10 or so similar tabs, unique to each Forum. The
 // tabs can appear in
@@ -128,7 +129,7 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
       id: 'bestoflesswrong',
       title: 'Best of LessWrong',
       link: '/bestoflesswrong',
-      tooltip: 'Top-voted posts from the 2018 and 2019 Review',
+      tooltip: `Top-voted posts from the Annual Review (2018 – ${REVIEW_YEAR - 1})`,
       subItem: true,
     }, {
       id: 'events',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3246710/147719444-b3dc2203-4afe-48ee-9b7d-a54ad92d4052.png)

It's a little bad that the title in the sidebar is so long, sticking slightly awkwardly out underneath HPMOR. If anyone has suggestions for a shorter name, lemme know.

I think it might be reasonable to cut out the "Open Questions" menu item to preserve complexity, although it does still get ~600 (900?) clicks a month)