### PR TITLE
FrontpageReviewWidget shows posts, sorted by lastCommentedAt

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -310,26 +310,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
             </LWTooltip>
           </div>
         </div>
-        
-        {/* Post list */}
-        {showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
-          {/* TODO:(Review) I think we can improve this */}
-          {/* <SingleLineReviewsList /> */}
-          <PostsList2 terms={{
-            view:"reviewVoting",
-            before: `${REVIEW_YEAR+1}-01-01`,
-            ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
-            limit: 3
-           }}
-          >       
-            {activeRange === 'REVIEWS' && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
-              {allPhaseButtons}
-              <Link to={"/reviews"} className={classes.actionButtonCTA}>
-                Review {REVIEW_YEAR} Posts
-              </Link>
-            </div>}
-          </PostsList2>
-        </AnalyticsContext>}
 
         {/* TODO: Improve logged out user experience */}
         
@@ -366,6 +346,32 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
             </Link>
           </LWTooltip>}
         </div>}
+
+        {/* Post list */}
+        {showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
+          {/* TODO:(Review) I think we can improve this */}
+          {/* <SingleLineReviewsList /> */}
+          <PostsList2 terms={{
+            view:"reviewVoting",
+            before: `${REVIEW_YEAR+1}-01-01`,
+            ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
+            limit: 3,
+            itemsPerPage: 10
+           }}
+          >       
+            {activeRange === 'REVIEWS' && eligibleToNominate(currentUser) &&
+              <Link to={"/reviews"} className={classes.actionButtonCTA}>
+                Review {REVIEW_YEAR} Posts
+              </Link>
+            }
+          </PostsList2>
+        </AnalyticsContext>}
+
+        {!showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
+          {eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
+            {allPhaseButtons}
+          </div>}
+        </AnalyticsContext>}
 
         {activeRange === 'VOTING' && currentUserCanVote(currentUser) && <div className={classes.actionButtonRow}>
           {allPhaseButtons}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -183,7 +183,7 @@ export const overviewTooltip = isEAForum ?
   </div>
 
 const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: ClassesType, showFrontpageItems?: boolean}) => {
-  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, SingleLineReviewsList, LatestReview } = Components
+  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, SingleLineReviewsList, LatestReview, PostsList2 } = Components
   const currentUser = useCurrentUser();
 
   // These should be calculated at render
@@ -312,14 +312,23 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         </div>
         
         {/* Post list */}
-        {showFrontpageItems && (activeRange === "NOMINATIONS" || !eligibleToNominate(currentUser) ) && <AnalyticsContext listContext={`frontpageReviewRecommendations`} reviewYear={`${REVIEW_YEAR}`} capturePostItemOnMount>
+        {showFrontpageItems && activeRange !== "NOMINATIONS" && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
           {/* TODO:(Review) I think we can improve this */}
-          <RecommendationsList algorithm={getReviewAlgorithm()} />
-        </AnalyticsContext>}
-
-        {showFrontpageItems && (activeRange !== "NOMINATIONS" && eligibleToNominate(currentUser) ) && <AnalyticsContext listContext={`frontpageReviewReviews`} reviewYear={`${REVIEW_YEAR}`}>
-          {/* TODO:(Review) I think we can improve this */}
-          <SingleLineReviewsList />
+          {/* <SingleLineReviewsList /> */}
+          <PostsList2 terms={{
+            view:"reviewVoting",
+            before: `${REVIEW_YEAR+1}-01-01`,
+            ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
+            limit: 3
+           }}
+          >       
+            {activeRange === 'REVIEWS' && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
+              {allPhaseButtons}
+              <Link to={"/reviews"} className={classes.actionButtonCTA}>
+                Review {REVIEW_YEAR} Posts
+              </Link>
+            </div>}
+          </PostsList2>
         </AnalyticsContext>}
 
         {/* TODO: Improve logged out user experience */}
@@ -356,13 +365,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
               Vote on <span className={classes.hideOnMobile}>nominated</span> posts
             </Link>
           </LWTooltip>}
-        </div>}
-        
-        {activeRange === 'REVIEWS' && eligibleToNominate(currentUser) && <div className={classes.actionButtonRow}>
-          {allPhaseButtons}
-          {showFrontpageItems && <Link to={"/reviews"} className={classes.actionButtonCTA}>
-            Review {REVIEW_YEAR} Posts
-          </Link>}
         </div>}
 
         {activeRange === 'VOTING' && currentUserCanVote(currentUser) && <div className={classes.actionButtonRow}>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1326,7 +1326,7 @@ Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
       // This sorts the posts deterministically, which is important for the
       // relative stability of the seeded frontend sort
       sort: {
-        createdAt: -1
+        lastCommentedAt: -1
       },
       ...(terms.excludeContents ?
         {projection: {contents: 0}} :


### PR DESCRIPTION
In retrospect, this is probably better than showing reviews themselves – show nominated posts sorted by "lastCommentedAt", which a) lets you see when a new review is posted, b) lets you catch up on other discussion. I was surprised I had missed some previous discussion because I'd just been looking at reviews. 

Somewhat controversially also adds a loadMore. To make it work I had to resort to a less elegant CTA Button.

![image](https://user-images.githubusercontent.com/3246710/147906359-017a0aa8-cada-4960-b43c-2d695a07312d.png)

It's possible I should make the latest review use the "top comment" UI, a la:

![image](https://user-images.githubusercontent.com/3246710/147906385-504184e0-2f89-4f3f-bf69-dcb73d113fa3.png)

(but I have not currently done so)

Curious if JP thinks any of this is actually an improvement