### PR TITLE
Add isMobile check to footnote hover preview

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -6,6 +6,7 @@ import { hostIsOnsite, useLocation, getUrlClass } from '../../lib/routeUtil';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { isServer } from '../../lib/executionEnvironment';
 import withErrorBoundary from '../common/withErrorBoundary';
+import { isMobile } from '../../lib/utils/isMobile'
 
 export const parseRouteWithErrors = (onsiteUrl: string, contentSourceDescription?: string) => {
   return parseRoute({
@@ -61,7 +62,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }
 
   // Within-page relative link?
   if (href.startsWith("#")) {
-    if(href.startsWith("#fn") && !href.startsWith("#fnref")){
+    if(href.startsWith("#fn") && !href.startsWith("#fnref") && !isMobile()){
       return <Components.FootnotePreview href={href} innerHTML={innerHTML} id={id} rel={rel}/>
     }
     return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel} />


### PR DESCRIPTION
Footnote hover previews on mobile run offscreen. Removing these for now.