### PR TITLE
remove old "hide book" from UsersEdit

### DIFF
--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -993,6 +993,7 @@ addFieldsDict(Users, {
   },
 
   hideFrontpageBookAd: {
+    // this was for the 2018 book, no longer relevant
     type: Boolean,
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -996,7 +996,7 @@ addFieldsDict(Users, {
     type: Boolean,
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
-    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    // canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     order: 46,
     hidden: forumTypeSetting.get() === "EAForum",


### PR DESCRIPTION
We'll never need the 2018 hide book option again, so removing it from the UserEdit form