### PR TITLE
Queue jobs that should not be run concurrently

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,5 +1,6 @@
 name: Run Cypress Tests
 on: [push]
+concurrency: cypress
 jobs:
   buildAndRunCypressTests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployBaserates.yaml
+++ b/.github/workflows/deployBaserates.yaml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Deploy Baserates
+concurrency: deploy-baserates
 on:
   push:
     branches: [ baserates, devel ]
@@ -24,4 +25,3 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: "us-east-1"
-

--- a/.github/workflows/deployEADev.yaml
+++ b/.github/workflows/deployEADev.yaml
@@ -1,4 +1,5 @@
 name: Deploy EA Staging
+concurrency: deploy-ea-dev
 on:
   push:
     branches: [ ea-deploy, master, review-2020 ]

--- a/.github/workflows/deployEAProd.yaml
+++ b/.github/workflows/deployEAProd.yaml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Deploy EA Prod
+concurrency: deploy-ea-prod
 on:
   push:
     branches: [ ea-deploy ]

--- a/.github/workflows/deployLWAFProd.yaml
+++ b/.github/workflows/deployLWAFProd.yaml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Deploy LW / AF Prod
+concurrency: deploy-lw-prod
 on:
   push:
     branches: [ lw-deploy ]

--- a/.github/workflows/deployLWDevel.yaml
+++ b/.github/workflows/deployLWDevel.yaml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Deploy LW-Devel
+concurrency: deploy-lw-devel
 on:
   push:
     branches: [ deployLessestWrong ]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yarn [start|ea-start]
 
 You should now have a local version running at [http://localhost:3000](http://localhost:3000/).
 
-It will start out with an empty database. (This means that some of the hardcoded links on the frontpage will not work). You can create users via the normal sign up process (entering a fake email is fine). The first user you’ll create will be an admin, so you’ll probably want to create at least two users to check how the site looks for non-admins. [Note for CEA, this doesn't apply to you, your database is shared with other developers.]
+It will start out with an empty database. (This means that some of the hardcoded links on the frontpage will not work). You can create users via the normal sign up process (entering a fake email is fine). The first user you’ll create will be an admin, so you’ll probably want to create at least two users to check how the site looks for non-admins. [Note for CEA: this doesn't apply to you, your database is shared with other developers.]
 
 ## Documentation
 


### PR DESCRIPTION
One hypothesis for what is going wrong with cypress tests is that they are running at the same time and doing conflicting operations in the database. We can force the workflows to run one after another to prevent this.

![image](https://user-images.githubusercontent.com/10352319/148267854-cf44b726-0da1-4099-a668-db8ad804081c.png)

When making that change we can realize that we should obviously do the same thing with deploys which currently just fail if they run concurrently. Which leads to inconsistencies between the code on master and what's running on staging, for example.