### PR TITLE
Cast number to boolean when conditioning on it in react

### DIFF
--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -99,7 +99,7 @@ const TagPageButtonRow = ({tag, editing, setEditing, className, classes}: {
   }
   
   const editTooltip = <>
-    {numFlags && <>
+    {!!numFlags && <>
       <div>
         This article has the following flag{tag.tagFlagsIds?.length > 1 ? "s" : ""}:{' '}
         {tag.tagFlags.map((flag, i) => <span key={flag._id}>{flag.name}{(i+1) < tag.tagFlags?.length && ", "}</span>)}
@@ -145,7 +145,7 @@ const TagPageButtonRow = ({tag, editing, setEditing, className, classes}: {
       className={classes.helpImprove}
       title={editTooltip}
     >
-      Help improve this page {numFlags && <>({numFlags} flag{numFlags > 1 ? "s" : ""})</>}
+      Help improve this page {!!numFlags && <>({numFlags} flag{numFlags > 1 ? "s" : ""})</>}
     </LWTooltip>}
   </div>
 }


### PR DESCRIPTION
React has a gotcha when using && syntax.

- `{false && <Foo/>}` returns false, which doesn't get rendered
- `{null && <Foo/>}` returns null, which doesn't get rendered
- `{undefined && <Foo/>}` returns undefined, which doesn't get rendered
- `{'' && <Foo/>}` returns '', which doesn't get rendered

But!

- `{0 && <Foo/>}` returns 0, which **does** get rendered

RIP

JP making final changes to a PR and not testing carefully enough.