### PR TITLE
Add count to "Highlighting [n] new comments since [date]" on post page

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -11,6 +11,7 @@ import Divider from '@material-ui/core/Divider';
 import { useCurrentUser } from '../common/withUser';
 import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import classNames from 'classnames';
+import * as _ from 'underscore';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 
@@ -61,8 +62,7 @@ interface CommentsListSectionState {
   anchorEl: any,
 }
 
-const CommentsListSection = ({lastEvent, post, tag, commentCount, loadMoreCount, totalComments, loadMoreComments, loadingMoreComments, comments, parentAnswerId, startThreadTruncated, newForm=true, classes}: {
-  lastEvent?: any,
+const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComments, loadMoreComments, loadingMoreComments, comments, parentAnswerId, startThreadTruncated, newForm=true, classes}: {
   post?: PostsDetails,
   tag?: TagBasicInfo,
   commentCount: number,
@@ -77,14 +77,9 @@ const CommentsListSection = ({lastEvent, post, tag, commentCount, loadMoreCount,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const [highlightDate,setHighlightDate] = useState(
-    (lastEvent?.properties?.createdAt
-      && new Date(lastEvent.properties.createdAt))
-    || (post?.lastVisitedAt &&
-      new Date(post.lastVisitedAt))
-    || new Date()
-  );
+  const [highlightDate,setHighlightDate] = useState<Date|undefined>(post?.lastVisitedAt && new Date(post.lastVisitedAt));
   const [anchorEl,setAnchorEl] = useState<HTMLElement|null>(null);
+  const newCommentsSinceDate = highlightDate ? _.filter(comments, comment => new Date(comment.item.postedAt).getTime() > new Date(highlightDate).getTime()).length : 0;
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     setAnchorEl(event.currentTarget);
@@ -124,8 +119,11 @@ const CommentsListSection = ({lastEvent, post, tag, commentCount, loadMoreCount,
         component='span'
         className={classes.inline}
       >
-        Highlighting new comments since <a className={classes.button} onClick={handleClick}>
-          <Components.CalendarDate date={highlightDate}/>
+        {highlightDate && newCommentsSinceDate>0 && `Highlighting ${newCommentsSinceDate} new comments since `}
+        {highlightDate && !newCommentsSinceDate && "No new comments since "}
+        {!highlightDate && "Click to highlight new comments since: "}
+        <a className={classes.button} onClick={handleClick}>
+          <Components.CalendarDate date={highlightDate || new Date()}/>
         </a>
         <Menu
           anchorEl={anchorEl}

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -23,7 +23,6 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
     return (
       <Components.CommentsListSection
         comments={nestedComments}
-        lastEvent={post.lastVisitedAt}
         loadMoreComments={loadMore}
         totalComments={totalCount as number}
         commentCount={(results && results.length) || 0}

--- a/packages/lesswrong/components/questions/AnswerCommentsList.tsx
+++ b/packages/lesswrong/components/questions/AnswerCommentsList.tsx
@@ -43,8 +43,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 export const ABRIDGE_COMMENT_COUNT = 500;
 
-const AnswerCommentsList = ({lastEvent, classes, post, parentAnswer}: {
-  lastEvent?: any,
+const AnswerCommentsList = ({classes, post, parentAnswer}: {
   classes: ClassesType,
   post: PostsList,
   parentAnswer: CommentsList,
@@ -65,9 +64,7 @@ const AnswerCommentsList = ({lastEvent, classes, post, parentAnswer}: {
   });
   
   const highlightDate =
-    (lastEvent?.properties?.createdAt
-      && new Date(lastEvent.properties.createdAt))
-    || (post?.lastVisitedAt
+    (post?.lastVisitedAt
       && new Date(post.lastVisitedAt))
     || new Date();
 


### PR DESCRIPTION
Remove the lastEvent prop on CommentsListSection, which was untyped (type any) and was never doing anything because a Date was being passed but the function was trying to use it as an LWEvent. Then split the "Highlighting new comments since [date]" message/widget into three branches: Either
 * Highlighting [n] new comments since [date]
 * New new comments since [date]

or

 * Click to highlight new comments since: [now]


