### PR TITLE
Fix login form word wrapping

### DIFF
--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -12,6 +12,7 @@ import { useLocation } from '../../lib/routeUtil';
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...commentBodyStyles(theme, true),
+    wordBreak: "normal",
     padding: 16,
     marginTop: 0,
     marginBottom: 0,


### PR DESCRIPTION
Fix the word wrapping issue shown in this screenshot. This is specific to something about the afffected users's system fonts/dpi settings/something, and I can't reproduce it directly, but tested the fix by tweaking the font size.

![BrokenLoginForm](https://user-images.githubusercontent.com/101191/148844837-cdab633e-e724-401b-9056-833dcde8b179.png)
