### PR TITLE
[LW-only] Make the Tag Edit CTA text a clickable button

### DIFF
--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -145,7 +145,9 @@ const TagPageButtonRow = ({tag, editing, setEditing, className, classes}: {
       className={classes.helpImprove}
       title={editTooltip}
     >
-      Help improve this page {!!numFlags && <>({numFlags} flag{numFlags > 1 ? "s" : ""})</>}
+      <a onClick={handleEditClick}>
+        Help improve this page {!!numFlags && <>({numFlags} flag{numFlags > 1 ? "s" : ""})</>}
+      </a>
     </LWTooltip>}
   </div>
 }


### PR DESCRIPTION
Mirrors the behavior of the edit button. As discussed with @darkruby501, we're fixing this obvious bug, but not returning to the previous behavior of a modal as well.