### PR TITLE
fix event join link wrapping, add link in event email

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -21,6 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.primary.main,
     textOverflow: 'ellipsis',
     overflow: 'hidden',
+    whiteSpace: 'nowrap'
   },
   joinEventLink: {
     flex: 'none',

--- a/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
@@ -51,6 +51,17 @@ const EventUpdatedEmail = ({postId, classes}: {
   if (loading || !post) return null;
   
   const link = postGetPageUrl(post, true);
+  
+  // event location - for online events, attempt to show the meeting link
+  let eventLocation: any = post.location
+  if (post.onlineEvent) {
+    eventLocation = post.joinEventLink ? <a
+      className={classes.onlineEventLocation}
+      href={post.joinEventLink}
+      target="_blank" rel="noopener noreferrer">
+        {post.joinEventLink}
+    </a> : "Online event"
+  }
     
   return <div className={classes.root}>
     <div className={classes.headingSection}>
@@ -67,7 +78,7 @@ const EventUpdatedEmail = ({postId, classes}: {
     </p>
     <p>
       <div className={classes.label}>Location</div>
-      <div className={classes.data}>{post.onlineEvent ? 'Online event' : post.location}</div>
+      <div className={classes.data}>{eventLocation}</div>
     </p>
   </div>
 }

--- a/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
@@ -53,7 +53,7 @@ const EventUpdatedEmail = ({postId, classes}: {
   const link = postGetPageUrl(post, true);
   
   // event location - for online events, attempt to show the meeting link
-  let eventLocation: any = post.location
+  let eventLocation: string|JSX.Element = post.location
   if (post.onlineEvent) {
     eventLocation = post.joinEventLink ? <a
       className={classes.onlineEventLocation}

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -58,7 +58,7 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
   if (!document) return null;
   
   // event location - for online events, attempt to show the meeting link
-  let eventLocation: any = document.location
+  let eventLocation: string|JSX.Element = document.location
   if (document.onlineEvent) {
     eventLocation = document.joinEventLink ? <a
       className={classes.onlineEventLocation}

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -57,9 +57,15 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
   const { EmailPostAuthors, EmailContentItemBody, EmailPostDate, EmailFooterRecommendations } = Components;
   if (!document) return null;
   
-  let eventLocation = document.joinEventLink || 'Online event'
-  if (document.isEvent && !document.onlineEvent) {
-    eventLocation = document.location
+  // event location - for online events, attempt to show the meeting link
+  let eventLocation: any = document.location
+  if (document.onlineEvent) {
+    eventLocation = document.joinEventLink ? <a
+      className={classes.onlineEventLocation}
+      href={document.joinEventLink}
+      target="_blank" rel="noopener noreferrer">
+        {document.joinEventLink}
+    </a> : "Online Event"
   }
 
   return (<React.Fragment>

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -135,7 +135,7 @@ getCollectionHooks("Posts").updateAsync.add(async function eventUpdatedNotificat
   if (
     (
       !_.isEqual(newPost.mongoLocation, oldPost.mongoLocation) ||
-      (newPost.onlineEvent !== oldPost.onlineEvent) ||
+      (newPost.joinEventLink !== oldPost.joinEventLink) ||
       (newPost.startTime !== oldPost.startTime) || 
       (newPost.endTime !== oldPost.endTime)
     )


### PR DESCRIPTION
I realized I forgot one of the CSS props for displaying the join event link in a single line with ellipsis. Also updated the join event link in emails to be an actual link.

<img width="737" alt="Screen Shot 2022-01-13 at 12 14 05 PM" src="https://user-images.githubusercontent.com/9057804/149377246-8dffeab1-471d-4176-8987-4a9d2e37c652.png">