### PR TITLE
needsFinalVote sort option

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -300,7 +300,16 @@ const ReviewVotingPage = ({classes}: {
   const [expandedPost, setExpandedPost] = useState<PostsListWithVotes|null>(null)
   const [showKarmaVotes] = useState<any>(true)
   const [postsHaveBeenSorted, setPostsHaveBeenSorted] = useState(false)
-  const [sortPosts, setSortPosts] = useState("needsReview")
+
+  let defaultSort = ""
+  console.log(getReviewPhase())
+  if (getReviewPhase() === "REVIEWS") { 
+    defaultSort = "needsReview"
+  }
+  if (getReviewPhase() === "VOTING") { defaultSort = "needsFinalVote"}
+  console.log(defaultSort)
+
+  const [sortPosts, setSortPosts] = useState(defaultSort)
   const [sortReversed, setSortReversed] = useState(false)
 
   const handleSetUseQuadratic = (newUseQuadratic: boolean) => {
@@ -351,6 +360,14 @@ const ReviewVotingPage = ({classes}: {
           if (post2NeedsReview && !post1NeedsReview) return 1
           if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
           if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
+        }
+
+        if (sortPosts === "needsFinalVote") {
+          console.log(post1)
+          const post1NotVoted = post1.currentUserReviewVote === null && post1.userId !== currentUser?._id
+          const post2NotVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
+          if (post1NotVoted && !post2NotVoted) return -1
+          if (post2NotVoted && !post1NotVoted) return 1
         }
 
         if (post1[sortPosts] > post2[sortPosts]) return -1
@@ -586,9 +603,14 @@ const ReviewVotingPage = ({classes}: {
                 <MenuItem value={'reviewCount'}>
                   <span className={classes.sortBy}>Sort by</span> Review Count
                 </MenuItem>
-                <MenuItem value={'needsReview'}>
-                  <span className={classes.sortBy}>Sort by</span> Needs Review
-                </MenuItem>
+                {getReviewPhase() === "REVIEWS" && 
+                  <MenuItem value={'needsReview'}>
+                    <span className={classes.sortBy}>Sort by</span> Needs Review
+                  </MenuItem>}
+                {getReviewPhase() === "VOTING" && 
+                  <MenuItem value={'needsFinalVote'}>
+                    <span className={classes.sortBy}>Sort by</span> Needs Vote
+                  </MenuItem>}
               </Select>
             </div>
           </div>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -1,16 +1,13 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import Button from '@material-ui/core/Button';
 import sumBy from 'lodash/sumBy'
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { updateEachQueryResultOfType, handleUpdateMutation } from '../../lib/crud/cacheUpdates';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useMutation, gql } from '@apollo/client';
-import Paper from '@material-ui/core/Paper';
 import { useCurrentUser } from '../common/withUser';
 import classNames from 'classnames';
 import * as _ from "underscore"
-import KeyboardTabIcon from '@material-ui/icons/KeyboardTab';
 import { commentBodyStyles } from '../../themes/stylePiping';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward'
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward'
@@ -24,7 +21,6 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import Card from '@material-ui/core/Card';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
-import { object } from 'underscore';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -365,6 +365,8 @@ const ReviewVotingPage = ({classes}: {
           const post2NotVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
           if (post1NotVoted && !post2NotVoted) return -1
           if (post2NotVoted && !post1NotVoted) return 1
+          if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
+          if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
         }
 
         if (post1[sortPosts] > post2[sortPosts]) return -1

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -358,10 +358,14 @@ const ReviewVotingPage = ({classes}: {
         }
 
         if (sortPosts === "needsFinalVote") {
-          const post1NotVoted = post1.currentUserReviewVote === null && post1.userId !== currentUser?._id
-          const post2NotVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
-          if (post1NotVoted && !post2NotVoted) return -1
-          if (post2NotVoted && !post1NotVoted) return 1
+          const post1NotReviewVoted = post1.currentUserReviewVote === null && post1.userId !== currentUser?._id
+          const post2NotReviewVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
+          const post1NotKarmaVoted = post1.currentUserVote === null 
+          const post2NotKarmaVoted = post2.currentUserVote === null
+          if (post1NotReviewVoted && !post2NotReviewVoted) return -1
+          if (post2NotReviewVoted && !post1NotReviewVoted) return 1
+          if (post1NotKarmaVoted && !post2NotKarmaVoted) return 1
+          if (post2NotKarmaVoted && !post1NotKarmaVoted) return -1
           if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
           if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
           if (permuted1 < permuted2) return -1;

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -302,12 +302,10 @@ const ReviewVotingPage = ({classes}: {
   const [postsHaveBeenSorted, setPostsHaveBeenSorted] = useState(false)
 
   let defaultSort = ""
-  console.log(getReviewPhase())
   if (getReviewPhase() === "REVIEWS") { 
     defaultSort = "needsReview"
   }
   if (getReviewPhase() === "VOTING") { defaultSort = "needsFinalVote"}
-  console.log(defaultSort)
 
   const [sortPosts, setSortPosts] = useState(defaultSort)
   const [sortReversed, setSortReversed] = useState(false)
@@ -363,7 +361,6 @@ const ReviewVotingPage = ({classes}: {
         }
 
         if (sortPosts === "needsFinalVote") {
-          console.log(post1)
           const post1NotVoted = post1.currentUserReviewVote === null && post1.userId !== currentUser?._id
           const post2NotVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
           if (post1NotVoted && !post2NotVoted) return -1

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -24,6 +24,7 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import Card from '@material-ui/core/Card';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
+import { object } from 'underscore';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -367,6 +368,8 @@ const ReviewVotingPage = ({classes}: {
           if (post2NotVoted && !post1NotVoted) return 1
           if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
           if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
+          if (permuted1 < permuted2) return -1;
+          if (permuted1 > permuted2) return 1;
         }
 
         if (post1[sortPosts] > post2[sortPosts]) return -1

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1344,7 +1344,7 @@ Posts.addView("reviewFinalVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
       reviewCount: { $gte: 1 },
-      reviewVoteScoreHighKarma2: { $gte: 4 },
+      positiveReviewVoteCount: { $gte: 1 }, // TODO: Ray thinks next year this should change to "has at least 4 points"
     },
     options: {
       // This sorts the posts deterministically, which is important for the

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1343,8 +1343,8 @@ ensureIndex(Posts,
 Posts.addView("reviewFinalVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
-      reviewCount: { $gte: 1},
-      positiveReviewVoteCount: { $gte: 1 },
+      reviewCount: { $gte: 1 },
+      reviewVoteScoreHighKarma2: { $gte: 4 },
     },
     options: {
       // This sorts the posts deterministically, which is important for the


### PR DESCRIPTION
Previously we had needsReview as the main sorting option for the review phase. This creates the default sorting option for the voting phase, which is "posts I haven't voted on, followed by posts I have voted on sorted by vote-weight".