### PR TITLE
Include phase ending dates in review phase

### DIFF
--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -91,6 +91,7 @@ export const isProductionDBSetting = new DatabasePublicSetting<boolean>('isProdu
 // You will need to restart your server after changing these at present;
 // FrontpageReviewWidget reads them at startup.
 export const annualReviewStart = new DatabasePublicSetting('annualReview.start', "2021-11-30")
+// The following dates cut off their phase at the end of the day
 export const annualReviewNominationPhaseEnd = new DatabasePublicSetting('annualReview.nominationPhaseEnd', "2021-12-14")
 export const annualReviewReviewPhaseEnd = new DatabasePublicSetting('annualReview.reviewPhaseEnd', "2022-01-15")
 export const annualReviewEnd = new DatabasePublicSetting('annualReview.end', "2022-02-01")

--- a/packages/lesswrong/lib/reviewUtils.ts
+++ b/packages/lesswrong/lib/reviewUtils.ts
@@ -19,9 +19,10 @@ export type ReviewPhase = "NOMINATIONS" | "REVIEWS" | "VOTING"
 export function getReviewPhase(): ReviewPhase | void {
   const currentDate = moment.utc()
   const reviewStart = moment.utc(annualReviewStart.get())
-  const nominationsPhaseEnd = moment.utc(annualReviewNominationPhaseEnd.get())
-  const reviewPhaseEnd = moment.utc(annualReviewReviewPhaseEnd.get())
-  const reviewEnd = moment.utc(annualReviewEnd.get())
+  // Add 1 day because the end dates are inclusive
+  const nominationsPhaseEnd = moment.utc(annualReviewNominationPhaseEnd.get()).add(1, "day")
+  const reviewPhaseEnd = moment.utc(annualReviewReviewPhaseEnd.get()).add(1, "day")
+  const reviewEnd = moment.utc(annualReviewEnd.get()).add(1, "day")
   
   if (currentDate < reviewStart) return
   if (currentDate < nominationsPhaseEnd) return "NOMINATIONS"


### PR DESCRIPTION
Aligns us with the UI and things I've written.

I've tested this locally. We only use the getReviewPhase function when choosing behavior, which is fortunate. The other uses of these dates are for display, and reflect the intended behavior.