### PR TITLE
Fix the width of private messages previews

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationPreview.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPreview.tsx
@@ -3,12 +3,11 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useMulti } from '../../lib/crud/withMulti';
 import { conversationGetTitle } from '../../lib/collections/conversations/helpers';
-import Card from '@material-ui/core/Card';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: theme.spacing.unit,
-    // width: 500,
+    maxWidth: 700,
     [theme.breakpoints.down('xs')]: {
       display: "none"
     },
@@ -66,4 +65,3 @@ declare global {
     ConversationPreview: typeof ConversationPreviewComponent
   }
 }
-


### PR DESCRIPTION
#4475 introduced a bug where PM previews could take up the full width of the page. This css works in both the notification sidebar, and the inbox page.