### PR TITLE
Change text to "can't vote"

### DIFF
--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -259,7 +259,7 @@ const ReviewVoteTableRow = (
             <PostsItemReviewVote post={post} marginRight={false}/>
           </div>}
           {currentUserIsAuthor && <LWTooltip title="You can't vote on your own posts">
-            <div className={classes.disabledVote}>Vote</div>
+            <div className={classes.disabledVote}>Can't Vote</div>
           </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classNames(classes.votes, {[classes.votesVotingPhase]: getReviewPhase() === "VOTING"})}>


### PR DESCRIPTION
In the Review Phase, the "you can't vote on your own posts" text had changed to a greyed out "Vote" button, which you couldn't search for with Cmd-F. This makes it more searchable, so you can find your own posts.