### PR TITLE
maybe fix sorting review bug [update: current implementation doesn't work]

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -332,11 +332,12 @@ const ReviewVotingPage = ({classes}: {
 
   const { LWTooltip, Loading, ReviewVotingExpandedPost, ReviewVoteTableRow, SectionTitle, RecentComments, FrontpageReviewWidget } = Components
 
-  const reSortPosts = useCallback((sortPosts, sortReversed) => {
-    if (!postsResults) return
+  const reSortPosts = useCallback((sortPosts, sortReversed, posts) => {
+    const oldPosts = postsResults || posts
+    if (!oldPosts) return
 
-    const randomPermutation = generatePermutation(postsResults.length, currentUser)
-    const newlySortedPosts = postsResults
+    const randomPermutation = generatePermutation(oldPosts.length, currentUser)
+    const newlySortedPosts = posts
       .map((post, i) => ([post, randomPermutation[i]] as const))
       .sort(([inputPost1, permuted1], [inputPost2, permuted2]) => {
         const post1 = sortReversed ? inputPost2 : inputPost1
@@ -380,7 +381,7 @@ const ReviewVotingPage = ({classes}: {
   
   const canInitialResort = !!postsResults
   useEffect(() => {
-    reSortPosts(sortPosts, sortReversed)
+    reSortPosts(sortPosts, sortReversed, sortedPosts)
   }, [canInitialResort, reSortPosts, sortPosts, sortReversed])
   
   const quadraticVotes = useMemo(

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -337,7 +337,7 @@ const ReviewVotingPage = ({classes}: {
     if (!oldPosts) return
 
     const randomPermutation = generatePermutation(oldPosts.length, currentUser)
-    const newlySortedPosts = posts
+    const newlySortedPosts = oldPosts
       .map((post, i) => ([post, randomPermutation[i]] as const))
       .sort(([inputPost1, permuted1], [inputPost2, permuted2]) => {
         const post1 = sortReversed ? inputPost2 : inputPost1

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -293,6 +293,7 @@ const ReviewVotingPage = ({classes}: {
     }
   });
 
+  const [originalSortedPosts, setOriginalSortedPosts] = useState(postsResults)
   const [sortedPosts, setSortedPosts] = useState(postsResults)
   const [useQuadratic, setUseQuadratic] = useState(currentUser ? currentUser[userVotesAreQuadraticField] : false)
   const [loading, setLoading] = useState(false)
@@ -381,8 +382,8 @@ const ReviewVotingPage = ({classes}: {
   
   const canInitialResort = !!postsResults
   useEffect(() => {
-    reSortPosts(sortPosts, sortReversed, sortedPosts)
-  }, [canInitialResort, reSortPosts, sortPosts, sortReversed])
+    reSortPosts(sortPosts, sortReversed, originalSortedPosts)
+  }, [canInitialResort, reSortPosts, sortPosts, sortReversed, originalSortedPosts])
   
   const quadraticVotes = useMemo(
     () => sortedPosts?.map(post => (post.currentUserReviewVote !== null ? {


### PR DESCRIPTION
The sorting bug is due to... _sometimes_, the postsResults just disappears (i.e. somehow the useMulti is retriggered, and for some reason it sometimes returned null)

Oli and I couldn't figure out why that happened, only that it did. So this PR is a bit of a hack – it provides the sortedPosts state variable to reSortPosts function, so that if postsResults doesn't exist, it can instead use sortedPosts as the source of its post.