### PR TITLE
The Hackiest Fix for the Sorting Bug [gives a warning label when postsResults fails to load]

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -538,6 +538,7 @@ const ReviewVotingPage = ({classes}: {
         <div className={classes.rightColumn}>
           <div className={classes.votingTitle}>Voting</div>
           <div className={classes.menu}>
+            {!postsResults && <div className={classes.postCount}>ERROR: Please Refresh</div>}
             {sortedPosts && 
               <div className={classes.postCount}>
                 <LWTooltip title="Posts need at least 1 review to enter the Final Voting Phase">

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -257,7 +257,7 @@ const ReviewVotingPage = ({classes}: {
   const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
   
 
-  const { results, loading: postsLoading } = useMulti({
+  const { results, loading: postsLoading, error: postsError } = useMulti({
     terms: {
       view: getReviewPhase() === "VOTING" ? "reviewFinalVoting" : "reviewVoting",
       before: `${REVIEW_YEAR+1}-01-01`,
@@ -301,6 +301,10 @@ const ReviewVotingPage = ({classes}: {
   const [expandedPost, setExpandedPost] = useState<PostsListWithVotes|null>(null)
   const [showKarmaVotes] = useState<any>(true)
   const [postsHaveBeenSorted, setPostsHaveBeenSorted] = useState(false)
+
+  if (postsError) {
+    console.error('Error loading posts', postsError);
+  }
 
   function getVoteTotal (posts) {
     return posts?.map(post=>indexToTermsLookup[post.currentUserReviewVote || 0].cost).reduce((a,b)=>a+b, 0)

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -303,6 +303,7 @@ const ReviewVotingPage = ({classes}: {
   const [postsHaveBeenSorted, setPostsHaveBeenSorted] = useState(false)
 
   if (postsError) {
+    // eslint-disable-next-line no-console
     console.error('Error loading posts', postsError);
   }
 

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -538,7 +538,7 @@ const ReviewVotingPage = ({classes}: {
         <div className={classes.rightColumn}>
           <div className={classes.votingTitle}>Voting</div>
           <div className={classes.menu}>
-            {!postsResults && <div className={classes.postCount}>ERROR: Please Refresh</div>}
+            {!postsResults && !postsLoading && <div className={classes.postCount}>ERROR: Please Refresh</div>}
             {sortedPosts && 
               <div className={classes.postCount}>
                 <LWTooltip title="Posts need at least 1 review to enter the Final Voting Phase">


### PR DESCRIPTION
We know what causes the Review Sorting Bug – somehow postsResults doesn't load, or gets lost. Why? Who knows. But meanwhile we can let people know to refresh.

(This bug also now causes the vote total to fail to display, since it has no posts to build itself out of)