### PR TITLE
Minimal loading indication for review post comments

### DIFF
--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -68,10 +68,10 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
         {loading && <div>
             {placeholderArray.map((pl,i) => <div
               className={classes.singleLinePlaceholder}
-              key={`placeholder${post._id}${new Date()}${i}`}>
-                Loading...
-              </div>
-            )}
+              key={`placeholder${post._id}${new Date()}${i}`}
+            >
+              Loading...
+            </div>)}
           </div>}
         {singleLine ? <CommentsList
           treeOptions={{

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -20,7 +20,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...singleLineStyles(theme),
     backgroundColor: "white",
     border: `solid 1px ${theme.palette.commentBorderGrey}`,
-    marginBottom: CONDENSED_MARGIN_BOTTOM
+    marginBottom: CONDENSED_MARGIN_BOTTOM,
+    fontStyle: "italic",
+    paddingTop: 4,
   }
 })
 
@@ -64,7 +66,12 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
       </div>}
       <SubSection>
         {loading && <div>
-            {placeholderArray.map((pl,i) => <div className={classes.singleLinePlaceholder} key={`placeholder${post._id}${new Date()}${i}`}/>)}
+            {placeholderArray.map((pl,i) => <div
+              className={classes.singleLinePlaceholder}
+              key={`placeholder${post._id}${new Date()}${i}`}>
+                Loading...
+              </div>
+            )}
           </div>}
         {singleLine ? <CommentsList
           treeOptions={{


### PR DESCRIPTION
The comments on /reviewVoting take a while to load. We might like to show our standard `<Loading/>` component, but that would involve seeing 10 on your screen at once, which would be too much. So instead we were showing an empty box. According to me, that was insufficient evidence of loading. So I added a non-moving indication of loading:

![image](https://user-images.githubusercontent.com/10352319/149618707-ca509af0-02f1-4dfe-b46f-17548358dd0d.png)

Also looks fine on LW.