### PR TITLE
Hide budget from top bar on the EA Forum

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -550,11 +550,11 @@ const ReviewVotingPage = ({classes}: {
               </div>
             }
 
-            <div className={classNames(classes.voteTotal, {[classes.excessVotes]: voteTotal > 500})}>
+            {!isEAForum && <div className={classNames(classes.voteTotal, {[classes.excessVotes]: voteTotal > 500})}>
               <LWTooltip title={<div><p>You have {500 - voteTotal} points remaining</p><p><em>The vote budget feature is only partially complete. Requires page refresh and doesn't yet do any rebalancing if you overspend.</em></p></div>}>
                 {voteTotal}/500
               </LWTooltip>
-            </div>
+            </div>}
             
             {/* Turned off for the Preliminary Voting phase */}
             {/* {getReviewPhase() === "VOTING" && <>


### PR DESCRIPTION
Previously: https://github.com/ForumMagnum/ForumMagnum/pull/4498

After discussion with @Raemon, I'm somewhat convinced that we should include it, but I think we'd need to figure out how many users have gone over-budget, and make it somewhat less broken. For now, our Forums can diverge in this one UI element.