### PR TITLE
change sort on review admin page

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -259,7 +259,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     )
   }
   
-  const { ShowParentComment, CommentsItemDate, CommentUserName, CommentShortformIcon, SmallSideVote, LWTooltip, PostsPreviewTooltipSingle, ReviewVotingWidget } = Components
+  const { ShowParentComment, CommentsItemDate, CommentUserName, CommentShortformIcon, SmallSideVote, LWTooltip, PostsPreviewTooltipSingle, ReviewVotingWidget, LWHelpIcon } = Components
 
   if (!comment) {
     return null;
@@ -357,7 +357,12 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {!comment.deleted && !collapsed && renderCommentBottom()}
         </div>
         {displayReviewVoting && !collapsed && <div className={classes.reviewVotingButtons}>
-          <div className={classes.updateVoteMessage}>Update your {REVIEW_NAME_IN_SITU} vote:</div>
+          <div className={classes.updateVoteMessage}>
+            Update {REVIEW_NAME_IN_SITU} vote for this post. 
+            <LWTooltip title={`If this review changed your mind, update your ${REVIEW_NAME_IN_SITU} vote for the original post `}>
+              <LWHelpIcon/>
+            </LWTooltip>
+          </div>
           {post && <ReviewVotingWidget post={post} showTitle={false}/>}
         </div>}
         { showReplyState && !collapsed && renderReply() }

--- a/packages/lesswrong/components/common/LWHelpIcon.tsx
+++ b/packages/lesswrong/components/common/LWHelpIcon.tsx
@@ -4,9 +4,10 @@ import { registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme) => ({
   icon: {
-    height: 18,
+    fontSize: "1.2em",
+    width: "1.5em",
     position: "relative",
-    top: 2, // seems to be necessary so that it lines up nicely with text, might revisit this if it looks weird next to other text sizes
+    top: ".1em", // seems to be necessary so that it lines up nicely with text, might revisit this if it looks weird next to other text sizes
     color: theme.palette.grey[500]
   }
 })

--- a/packages/lesswrong/components/common/LWHelpIcon.tsx
+++ b/packages/lesswrong/components/common/LWHelpIcon.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import HelpIcon from '@material-ui/icons/Help';
+import { registerComponent } from '../../lib/vulcan-lib';
+
+const styles = (theme) => ({
+  icon: {
+    height: 18,
+    position: "relative",
+    top: 2, // seems to be necessary so that it lines up nicely with text, might revisit this if it looks weird next to other text sizes
+    color: theme.palette.grey[500]
+  }
+})
+
+const LWHelpIcon = ({classes}:{classes:ClassesType}) => {
+  return <span><HelpIcon className={classes.icon}/></span>
+}
+
+const LWHelpIconComponent = registerComponent("LWHelpIcon", LWHelpIcon, {styles});
+
+declare global {
+  interface ComponentTypes {
+    LWHelpIcon: typeof LWHelpIconComponent
+  }
+}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -183,7 +183,7 @@ export const overviewTooltip = isEAForum ?
   </div>
 
 const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: ClassesType, showFrontpageItems?: boolean}) => {
-  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, LatestReview, PostsList2, LWHelpIcon } = Components
+  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, LatestReview, PostsList2 } = Components
   const currentUser = useCurrentUser();
 
   // These should be calculated at render
@@ -280,7 +280,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         >
           <LWTooltip title={overviewTooltip} className={classes.hideOnMobile}>
             <Link to={reviewPostPath || ""}>
-              <SettingsButton showIcon={false} label={<div>How does the {REVIEW_NAME_IN_SITU} work? <LWHelpIcon/></div>}/>
+              <SettingsButton showIcon={false} label={`How does the ${REVIEW_NAME_IN_SITU} work?`}/>
             </Link>
           </LWTooltip>
         </SectionTitle>

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -183,7 +183,7 @@ export const overviewTooltip = isEAForum ?
   </div>
 
 const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: ClassesType, showFrontpageItems?: boolean}) => {
-  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, LatestReview, PostsList2 } = Components
+  const { SectionTitle, SettingsButton, RecommendationsList, LWTooltip, LatestReview, PostsList2, LWHelpIcon } = Components
   const currentUser = useCurrentUser();
 
   // These should be calculated at render
@@ -280,7 +280,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         >
           <LWTooltip title={overviewTooltip} className={classes.hideOnMobile}>
             <Link to={reviewPostPath || ""}>
-              <SettingsButton showIcon={false} label={`How does the ${REVIEW_NAME_IN_SITU} work?`}/>
+              <SettingsButton showIcon={false} label={<div>How does the {REVIEW_NAME_IN_SITU} work? <LWHelpIcon/></div>}/>
             </Link>
           </LWTooltip>
         </SectionTitle>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -20,7 +20,7 @@ const styles = theme => ({
     width: 200
   },
   count: {
-    width: 40,
+    width: 50,
     color: theme.palette.grey[400]
   },
   karma: {
@@ -67,7 +67,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
       <Typography variant="display1">Users ({userRows.length})</Typography>
       <div className={classes.voteItem} >
         <PostsItemMetaInfo className={classes.count}>
-          
+          <b>Count</b>
         </PostsItemMetaInfo>
         <PostsItemMetaInfo className={classes.karma}>
           <b>Votes</b>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -65,6 +65,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
     {votesLoading && <Loading/>}
     <div>
       <Typography variant="display1">Users ({userRows.length})</Typography>
+      <br/>
       <div className={classes.voteItem} >
         <PostsItemMetaInfo className={classes.count}>
           <b>Count</b>
@@ -127,6 +128,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
 
     <div>
       <Typography variant="display1">All Votes ({votes?.length})</Typography>
+      <br/>
       <div className={classes.voteItem} >
         <PostsItemMetaInfo className={classes.date}>
           <b>Date</b>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -19,6 +19,10 @@ const styles = theme => ({
   author: {
     width: 200
   },
+  count: {
+    width: 40,
+    color: theme.palette.grey[400]
+  },
   karma: {
     width: 100
   },
@@ -54,7 +58,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
 
   const userRows = sortBy(
     Object.entries(groupBy(votes, (vote) => vote.userId)),
-    obj => -(obj[1][0].user?.karma || 0)
+    obj => -(obj[1].length || 0)
   ) 
 
   return <div className={classes.root}>
@@ -62,7 +66,10 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
     <div>
       <Typography variant="display1">Users ({userRows.length})</Typography>
       <div className={classes.voteItem} >
-      <PostsItemMetaInfo className={classes.karma}>
+        <PostsItemMetaInfo className={classes.count}>
+          
+        </PostsItemMetaInfo>
+        <PostsItemMetaInfo className={classes.karma}>
           <b>Votes</b>
         </PostsItemMetaInfo>
         <PostsItemMetaInfo className={classes.karma}>
@@ -76,8 +83,11 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
         </PostsItemMetaInfo>
       </div>
       <p><i>Users with at least 1 vote</i></p>
-      {votes && userRows.map(userRow => {
+      {votes && userRows.map((userRow, i) => {
         return <div key={userRow[0]} className={classes.voteItem}>
+          <PostsItemMetaInfo className={classes.count}>
+            {i+1}
+          </PostsItemMetaInfo>
           <PostsItemMetaInfo className={classes.karma}>
             {userRow[1].length}
           </PostsItemMetaInfo>
@@ -94,8 +104,11 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
       })}
       <p><i>1000+ karma users</i></p>
       {usersLoading && <Loading/>}
-      {users && users.map(user => {
+      {users && users.map((user, i) => {
         return <div key={user._id} className={classes.voteItem}>
+          <PostsItemMetaInfo className={classes.count}>
+            {i+1}
+          </PostsItemMetaInfo>
           <PostsItemMetaInfo className={classes.karma}>
             {user.reviewVoteCount}
           </PostsItemMetaInfo>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -601,6 +601,8 @@ importComponent("AnalyticsTracker", () => require('../components/common/Analytic
 importComponent("AnalyticsInViewTracker", () => require('../components/common/AnalyticsInViewTracker'));
 importComponent("AnalyticsPageInitializer", () => require('../components/common/AnalyticsPageInitializer'));
 
+importComponent("LWHelpIcon", () => require('../components/common/LWHelpIcon'));
+
 // vulcan:ui-bootstrap
 importComponent("FormComponentCheckboxGroup", () => require('../components/vulcan-ui-bootstrap/forms/Checkboxgroup'));
 importComponent("FormComponentEmail", () => require('../components/vulcan-ui-bootstrap/forms/Email'));


### PR DESCRIPTION
I found myself wanting to know which people were voting the most and what the distribution was like, more than I wanted to know what the top-karma users were doing. Also, you could already get the top-karma users from the second half of the users-votes-list (which includes all users with 1000+ karma, sorted by karma)

So, this PR changes the initial sorting of the users-section to be based on vote-count, rather than karma. Does some minor styling changes. (I think it looks kinda ugly but this page isn't very important so not prioritizing it)

![image](https://user-images.githubusercontent.com/3246710/149685803-e12ef33c-bf45-4a0e-814a-8dac6c9a978a.png)
