### PR TITLE
add "Register" button for events with external registration

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -99,7 +99,7 @@ const PostsPageEventData = ({classes, post}: {
         { locationNode }
         { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
       </div>
-      {joinEventLink && post.startTime && <div className={classes.eventCTA}>
+      {eventCTA && post.startTime && <div className={classes.eventCTA}>
         {eventCTA}
       </div>}
   </Components.Typography>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -1,4 +1,5 @@
 import Button from '@material-ui/core/Button';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 import moment from '../../../lib/moment-timezone';
 import React from 'react'
 import { useTracking } from '../../../lib/analyticsEvents';
@@ -23,12 +24,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     overflow: 'hidden',
     whiteSpace: 'nowrap'
   },
-  joinEventLink: {
+  eventCTA: {
     flex: 'none',
     margin: '0 24px',
     [theme.breakpoints.down('xs')]: {
       margin: '20px 0 0 12px',
     },
+  },
+  registerBtnIcon: {
+    fontSize: 15,
+    marginTop: -4,
+    marginLeft: 6
   }
 })
 
@@ -38,11 +44,7 @@ const PostsPageEventData = ({classes, post}: {
 }) => {
   const {captureEvent} = useTracking()
   
-  const handleClick = () => {
-    captureEvent("joinEventLinkClick")
-  }
-  
-  const { location, contactInfo, onlineEvent, joinEventLink } = post
+  const { location, contactInfo, onlineEvent, eventRegistrationLink, joinEventLink } = post
   
   // event location - for online events, attempt to show the meeting link
   let locationNode = location && <div>{location}</div>
@@ -56,18 +58,40 @@ const PostsPageEventData = ({classes, post}: {
     </a> : <div>Online Event</div>
   }
   
-  // before the event starts, the "Join Event" button is disabled
+  // determine if it's currently before, during, or after the event
   const inTenMinutes = moment().add(10, 'minutes')
   const beforeEvent = post.startTime && moment(post.startTime).isAfter(inTenMinutes)
   
-  // if the event is over, disable the "Join Event" button and show "Event Ended"
   const now = moment()
   const twoHoursAgo = moment().subtract(2, 'hours')
   const afterEvent = (post.endTime && moment(post.endTime).isBefore(now)) ||
     (!post.endTime && post.startTime && moment(post.startTime).isBefore(twoHoursAgo))
-    
-  // if the event is soon/now, enable the "Join Event" button
+
   const duringEvent = post.startTime && !beforeEvent && !afterEvent
+
+  // before the event starts, the "Join Event" button is disabled
+  let eventCTA = joinEventLink && <Button variant="contained" color="primary" href={joinEventLink} disabled>
+    Join Event
+  </Button>
+  
+  // if the event has a registration link, display that instead
+  if (beforeEvent && eventRegistrationLink) {
+    eventCTA = <Button variant="contained" color="primary" href={eventRegistrationLink} onClick={() => captureEvent("eventRegistrationLinkClick")} target="_blank" rel="noopener noreferrer">
+      Register <OpenInNew className={classes.registerBtnIcon} />
+    </Button>
+  }
+  // if the event is soon/now, enable the "Join Event" button
+  else if (duringEvent) {
+    eventCTA = joinEventLink && <Button variant="contained" color="primary" href={joinEventLink} onClick={() => captureEvent("joinEventLinkClick")} target="_blank" rel="noopener noreferrer">
+      Join Event
+    </Button>
+  }
+  // if the event is over, disable the "Join Event" button and show "Event Ended"
+  else if (afterEvent) {
+    eventCTA = joinEventLink && <Button variant="contained" color="primary" href={joinEventLink} disabled>
+      Event Ended
+    </Button>
+  }
   
   return <Components.Typography variant="body2" className={classes.metadata}>
       <div>
@@ -75,10 +99,8 @@ const PostsPageEventData = ({classes, post}: {
         { locationNode }
         { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
       </div>
-      {post.joinEventLink && post.startTime && <div className={classes.joinEventLink}>
-        <Button variant="contained" color="primary" href={post.joinEventLink} disabled={!duringEvent} onClick={handleClick} target="_blank" rel="noopener noreferrer">
-          {afterEvent ? 'Event Ended' : 'Join Event'}
-        </Button>
+      {joinEventLink && post.startTime && <div className={classes.eventCTA}>
+        {eventCTA}
       </div>}
   </Components.Typography>
 }

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -721,6 +721,20 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
   },
   
+  eventRegistrationLink: {
+    type: String,
+    hidden: (props) => !props.eventForm,
+    viewableBy: ['guests'],
+    insertableBy: ['members'],
+    editableBy: ['members'],
+    label: "Event Registration Link",
+    control: "MuiTextField",
+    optional: true,
+    group: formGroups.event,
+    regEx: SimpleSchema.RegEx.Url,
+    tooltip: 'https://...'
+  },
+  
   joinEventLink: {
     type: String,
     hidden: (props) => !props.eventForm,

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -63,6 +63,7 @@ registerFragment(`
     endTime
     localStartTime
     localEndTime
+    eventRegistrationLink
     joinEventLink
     facebookLink
     meetupLink

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -420,6 +420,7 @@ interface DbPost extends DbObject {
   localStartTime: Date
   endTime: Date | null
   localEndTime: Date
+  eventRegistrationLink: string
   joinEventLink: string
   onlineEvent: boolean
   globalEvent: boolean

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -331,6 +331,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly endTime: Date | null,
   readonly localStartTime: Date,
   readonly localEndTime: Date,
+  readonly eventRegistrationLink: string,
   readonly joinEventLink: string,
   readonly facebookLink: string,
   readonly meetupLink: string,


### PR DESCRIPTION
After adding the "Join Event" button to the event page in https://github.com/ForumMagnum/ForumMagnum/pull/4470, I figured we could use that same CTA to prompt users to register for the event before the start time. Many (most?) events posted on the forum have a separate, external registration (ex. zoom, eventbrite, google forms, airtable), so it seems useful to call that out.

<img width="714" alt="Screen Shot 2022-01-14 at 8 20 26 PM" src="https://user-images.githubusercontent.com/9057804/149837316-3679f247-710c-408b-9a53-c9dbdc8df021.png">

<img width="374" alt="Screen Shot 2022-01-14 at 8 22 38 PM" src="https://user-images.githubusercontent.com/9057804/149837369-47a2775a-8515-4aa3-86d0-72843290c710.png">
