### PR TITLE
Fix postsResults dropping bug on ReviewVotingPage

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
@@ -39,7 +39,6 @@ const ReviewVotingExpandedPost = ({classes, post}:{classes: ClassesType, post?: 
   const { ReviewPostButton, ReviewPostComments, PostsHighlight, PingbacksList, Loading} = Components
 
   const {document: postWithContents, loading} = useSingle({
-    skip: !!post?.contents,
     documentId: post?._id,
     collectionName: "Posts",
     fetchPolicy: "cache-first",

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -263,7 +263,6 @@ const ReviewVotingPage = ({classes}: {
       before: `${REVIEW_YEAR+1}-01-01`,
       ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
       limit: 600,
-      excludeContents: true,
     },
     collectionName: "Posts",
     fragmentName: 'PostsListWithVotes',

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -265,7 +265,7 @@ const ReviewVotingPage = ({classes}: {
       limit: 600,
     },
     collectionName: "Posts",
-    fragmentName: 'PostsListWithVotes',
+    fragmentName: 'PostsReviewVotingList',
     fetchPolicy: 'cache-and-network',
   });
   // useMulti is incorrectly typed

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -548,7 +548,8 @@ const ReviewVotingPage = ({classes}: {
           <div className={classes.votingTitle}>Voting</div>
           <div className={classes.menu}>
 
-            {!postsResults && !postsLoading && <div className={classes.postCount}>ERROR: Please Refresh</div>}
+            {/* TODO: Remove this if we haven't seen the error in awhile. I think I've fixed it but... model uncertainty */}
+            {!postsResults && !postsLoading && <div className={classes.postCount}>ERROR: Please Refresh</div>} 
 
             {sortedPosts && 
               <div className={classes.postCount}>

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -473,10 +473,7 @@ registerFragment(`
   fragment HighlightWithHash on Post {
     _id
     contents {
-      _id
       htmlHighlightStartingAtHash(hash: $hash)
-      wordCount
-      version
     }
   }
 `);

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -133,6 +133,14 @@ registerFragment(`
   }
 `)
 
+registerFragment(`
+  fragment PostsReviewVotingList on Post {
+    ...PostsListBase
+    currentUserVote
+    currentUserExtendedVote
+  }
+`)
+
 
 registerFragment(`
   fragment PostsAuthors on Post {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -473,7 +473,10 @@ registerFragment(`
   fragment HighlightWithHash on Post {
     _id
     contents {
+      _id
       htmlHighlightStartingAtHash(hash: $hash)
+      wordCount
+      version
     }
   }
 `);

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -650,10 +650,7 @@ interface HighlightWithHash { // fragment on Posts
 }
 
 interface HighlightWithHash_contents { // fragment on Revisions
-  readonly _id: string,
   readonly htmlHighlightStartingAtHash: string,
-  readonly wordCount: number,
-  readonly version: string,
 }
 
 interface CommentsList { // fragment on Comments

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -650,7 +650,10 @@ interface HighlightWithHash { // fragment on Posts
 }
 
 interface HighlightWithHash_contents { // fragment on Revisions
+  readonly _id: string,
   readonly htmlHighlightStartingAtHash: string,
+  readonly wordCount: number,
+  readonly version: string,
 }
 
 interface CommentsList { // fragment on Comments

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -389,6 +389,11 @@ interface PostsListWithVotes extends PostsList { // fragment on Posts
   readonly currentUserExtendedVote: any,
 }
 
+interface PostsReviewVotingList extends PostsListBase { // fragment on Posts
+  readonly currentUserVote: string,
+  readonly currentUserExtendedVote: any,
+}
+
 interface PostsAuthors { // fragment on Posts
   readonly user: PostsAuthors_user|null,
   readonly coauthors: Array<UsersMinimumInfo>,
@@ -1849,6 +1854,7 @@ interface FragmentTypes {
   PostsBase: PostsBase
   PostsWithVotes: PostsWithVotes
   PostsListWithVotes: PostsListWithVotes
+  PostsReviewVotingList: PostsReviewVotingList
   PostsAuthors: PostsAuthors
   PostsListBase: PostsListBase
   PostsList: PostsList
@@ -1991,6 +1997,7 @@ interface CollectionNamesByFragmentName {
   PostsBase: "Posts"
   PostsWithVotes: "Posts"
   PostsListWithVotes: "Posts"
+  PostsReviewVotingList: "Posts"
   PostsAuthors: "Posts"
   PostsListBase: "Posts"
   PostsList: "Posts"


### PR DESCRIPTION
The "sorting failure" bug and the "post contents stop appearing in the 'expanded post view' bug both seem to be due to some fragment mismatches, where loading a single post (via the PostsTitle hoverover) with the HighlightWithHash classes with the existing PostsListWithVotes fragment.

This PR makes some changes that fixes the bugs.

See this slack convo:
https://lworg.slack.com/archives/C01GXLMPU2C/p1642389171115800