### PR TITLE
Tag rampage sanity

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -37,7 +37,7 @@ const RecentDiscussionFeed = ({
     [setShowShortformFeed, showShortformFeed]
   );
   
-  const { SingleColumnSection, SectionTitle, SectionButton, ShortformSubmitForm, MixedTypeFeed, RecentDiscussionThread, TagRevisionItem, RecentDiscussionTag, RecentDiscussionSubscribeReminder, RecentDiscussionMeetupsPoke } = Components
+  const { SingleColumnSection, SectionTitle, SectionButton, ShortformSubmitForm, MixedTypeFeed, RecentDiscussionThread, RecentDiscussionTagRevisionItem, RecentDiscussionTag, RecentDiscussionSubscribeReminder, RecentDiscussionMeetupsPoke } = Components
   
   const refetch = useCallback(() => {
     if (refetchRef.current)
@@ -97,7 +97,7 @@ const RecentDiscussionFeed = ({
           tagRevised: {
             fragmentName: "RevisionTagFragment",
             render: (revision: RevisionTagFragment) => <div>
-              {revision.tag && <TagRevisionItem
+              {revision.tag && <RecentDiscussionTagRevisionItem
                 tag={revision.tag}
                 revision={revision}
                 headingStyle="full"

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { forumTypeSetting } from "../../lib/instanceSettings"
+import { Components, registerComponent } from "../../lib/vulcan-lib"
+
+const isEAForum = forumTypeSetting.get() === 'EAForum'
+// Pablo, Leo
+const megaTagUsers = ['BkbwT5TzSj4aRxJMN', 'pkJTc4xXhsCbNqkZM']
+const onlyStyleEditors = ['pkJTc4xXhsCbNqkZM']
+
+/**
+ * This component's only job is to reduce the amount of room the EA frontpage
+ * gives to the most particularly active tag users doing routine cleanup
+ *
+ * Otherwise it's just a wrapper around TagRevisionItem
+ */
+function RecentDiscussionTagRevisionItem({
+  tag,
+  collapsed=false,
+  headingStyle,
+  revision,
+  documentId,
+}: {
+  tag: TagBasicInfo,
+  collapsed?: boolean,
+  headingStyle: "full"|"abridged",
+  revision: RevisionMetadataWithChangeMetrics,
+  documentId: string,
+}) {
+  const { TagRevisionItem } = Components
+  
+  if (
+    // Only a problem for the forum
+    isEAForum &&
+    // Only restrict the most active tag users
+    megaTagUsers.includes(revision.userId) &&
+    // Restrict all from cleanup-only users, restrict small edits from other mega users
+    (onlyStyleEditors.includes(revision.userId) || revision.changeMetrics.added < 600)
+  ) {
+    return null
+  }
+  return <TagRevisionItem
+    tag={tag}
+    collapsed={collapsed}
+    headingStyle={headingStyle}
+    revision={revision}
+    documentId={documentId}
+  />
+}
+
+const RecentDiscussionTagRevisionItemComponent = registerComponent(
+  'RecentDiscussionTagRevisionItem', RecentDiscussionTagRevisionItem
+)
+
+declare global {
+  interface ComponentTypes {
+    RecentDiscussionTagRevisionItem: typeof RecentDiscussionTagRevisionItemComponent,
+  }
+}

--- a/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
+++ b/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useQuery, gql } from '@apollo/client';
 import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
 import withErrorBoundary from '../common/withErrorBoundary'
+
+const INITIAL_LIMIT = 5
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -19,7 +21,7 @@ const TagEditsTimeBlock = ({before, after, reportEmpty, classes}: {
   reportEmpty: ()=>void,
   classes: ClassesType
 }) => {
-  const { ContentType, SingleLineTagUpdates } = Components;
+  const { ContentType, SingleLineTagUpdates, LoadMore } = Components;
   const { data, loading } = useQuery(gql`
     query getTagUpdates($before: Date!, $after: Date!) {
       TagUpdatesInTimeBlock(before: $before, after: $after) {
@@ -48,6 +50,17 @@ const TagEditsTimeBlock = ({before, after, reportEmpty, classes}: {
       reportEmpty();
     }
   }, [loading, data, reportEmpty]);
+  const [expanded, setExpanded] = useState(false)
+  
+  let tagUpdatesInTimeBlock = [...(data?.TagUpdatesInTimeBlock || [])]
+    .sort((update1, update2) => {
+      if (update1.added > update2.added) return -1
+      if (update2.added > update1.added) return 1
+      return 0
+    })
+  if (!expanded) {
+    tagUpdatesInTimeBlock = tagUpdatesInTimeBlock.slice(0, INITIAL_LIMIT)
+  }
   
   if (!data?.TagUpdatesInTimeBlock?.length)
     return null;
@@ -55,7 +68,7 @@ const TagEditsTimeBlock = ({before, after, reportEmpty, classes}: {
     <div className={classes.subtitle}>
       <ContentType type="tags" label="Wiki/Tag Page Edits and Discussion"/>
     </div>
-    {data.TagUpdatesInTimeBlock.map(tagUpdates => <SingleLineTagUpdates
+    {tagUpdatesInTimeBlock.map(tagUpdates => <SingleLineTagUpdates
       key={tagUpdates.tag._id}
       tag={tagUpdates.tag}
       revisionIds={tagUpdates.revisionIds}
@@ -63,6 +76,11 @@ const TagEditsTimeBlock = ({before, after, reportEmpty, classes}: {
       commentCount={tagUpdates.commentCount}
       changeMetrics={{added: tagUpdates.added, removed: tagUpdates.removed}}
     />)}
+    {!expanded && tagUpdatesInTimeBlock.length >= INITIAL_LIMIT && <LoadMore
+      loadMore={() => setExpanded(true)}
+      count={tagUpdatesInTimeBlock.length}
+      totalCount={data.TagUpdatesInTimeBlock.length}
+    />}
   </div>
 }
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -335,6 +335,7 @@ importComponent("CommentPermalink", () => require('../components/comments/Commen
 importComponent("RecentDiscussionThread", () => require('../components/recentDiscussion/RecentDiscussionThread'));
 importComponent("RecentDiscussionThreadsList", () => require('../components/recentDiscussion/RecentDiscussionThreadsList'));
 importComponent("RecentDiscussionFeed", () => require('../components/recentDiscussion/RecentDiscussionFeed'));
+importComponent("RecentDiscussionTagRevisionItem", () => require('../components/recentDiscussion/RecentDiscussionTagRevisionItem'))
 importComponent("RecentDiscussionSubscribeReminder", () => require('../components/recentDiscussion/RecentDiscussionSubscribeReminder'));
 importComponent("RecentDiscussionMeetupsPoke", () => require('../components/recentDiscussion/RecentDiscussionMeetupsPoke'));
 importComponent("CantCommentExplanation", () => require('../components/comments/CantCommentExplanation'));
@@ -622,4 +623,3 @@ importComponent("BookAnimation", () => require('../components/books/BookAnimatio
 importComponent("Book2019Animation", () => require('../components/books/Book2019Animation'));
 importComponent("BookFrontpageWidget", () => require('../components/books/BookFrontpageWidget'));
 importComponent("Book2019FrontpageWidget", () => require('../components/books/Book2019FrontpageWidget'));
-


### PR DESCRIPTION
Pablo and his assistant Leo have been on a tear of wiki edits recently. It's overwhelming the frontpage with housekeeping tag updates, which aren't helpful for ~anyone to read. I decided I wanted to cut them two off specifically, letting Pablo's edits through if they're more than 600 characters.

I happened to get complaints about it today in a user interview, so that'll be nice.

I also clean up the allPosts page. It currently doesn't limit the number of wiki edits that show up, and if there are 20 in a day it's a bad experience.