### PR TITLE
PostsPage title link

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -51,8 +51,8 @@ const PostsPageTitle = ({classes, post}: {
         </Link>
       </Typography>}
       <Typography variant="display3" className={classes.root}>
-        {post.draft && <span className={classes.draft}>[Draft] </span>}
-        {post.title}
+        <Link to={postGetPageUrl(post)}>{post.draft && <span className={classes.draft}>[Draft] </span>}
+        {post.title}</Link>
       </Typography>
     </div>
   )

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -28,6 +28,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   question: {
     color: theme.palette.grey[600],
     display: "block",
+  },
+  link: {
+    '&:hover': {
+      opacity: "unset"
+    }
   }
 })
 
@@ -51,7 +56,7 @@ const PostsPageTitle = ({classes, post}: {
         </Link>
       </Typography>}
       <Typography variant="display3" className={classes.root}>
-        <Link to={postGetPageUrl(post)}>{post.draft && <span className={classes.draft}>[Draft] </span>}
+        <Link to={postGetPageUrl(post)} className={classes.link}>{post.draft && <span className={classes.draft}>[Draft] </span>}
         {post.title}</Link>
       </Typography>
     </div>


### PR DESCRIPTION
This simply makes it so that a post-page title is a link to the canonical post page. This may seem a bit silly, but I've wanted it for two reasons:

1) I'm often on a weird version of a post (such as a link to a specific comment on the post, or a sequence version of a post, etc). And I want to quickly get to the simple, original version of the post to grab the url and link to it (or something like that). And it's oddly annoying.

2) I wanted to re-use the PostsPagePostHeader on the reviewVoting page (in ReviewVotingExpandedPost), so I could get all the convenient metadata and have a convenient link to the post as well. This isn't the first time I wanted to use it in a different context.

I think #1 is worthwhile even if we didn't care about #2.