### PR TITLE
ReviewVoteTableRow singleLineComment UI improvements

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -142,7 +142,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   
   const currentUser = useCurrentUser();
 
-  const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineCollapse } = treeOptions;
+  const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineCollapse, hideReviewVoteButtons } = treeOptions;
 
   const showReply = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -266,6 +266,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   }
 
   const displayReviewVoting = 
+    !hideReviewVoteButtons &&
     reviewIsActive() &&
     comment.reviewingForReview === REVIEW_YEAR+"" &&
     post &&

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -15,4 +15,5 @@ export interface CommentTreeOptions {
   singleLinePostTitle?: boolean,
   post?: PostsMinimumInfo,
   tag?: TagBasicInfo,
+  hideReviewVoteButtons?: boolean
 }

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -26,13 +26,15 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const ReviewPostComments = ({ terms, classes, title, post, singleLine, placeholderCount }: {
+const ReviewPostComments = ({ terms, classes, title, post, singleLine, placeholderCount, hideReviewVoteButtons, singleLineCollapse }: {
   terms: CommentsViewTerms,
   classes: ClassesType,
   title?: string,
   post: PostsList,
   singleLine?: boolean,
-  placeholderCount?: number
+  placeholderCount?: number,
+  hideReviewVoteButtons?: boolean
+  singleLineCollapse?: boolean
 }) => {
   const [markedVisitedAt, setMarkedVisitedAt] = React.useState<Date|null>(null);
   const { recordPostView } = useRecordPostView(post)
@@ -78,6 +80,8 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
             lastCommentId: lastCommentId,
             highlightDate: markedVisitedAt || post.lastVisitedAt,
             hideSingleLineMeta: true,
+            hideReviewVoteButtons: hideReviewVoteButtons,
+            singleLineCollapse: singleLineCollapse,
             enableHoverPreview: false,
             markAsRead: markAsRead,
             post: post,

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -221,6 +221,8 @@ const ReviewVoteTableRow = (
         {getReviewPhase() === "VOTING" && <div className={classes.reviews}>
           <ReviewPostComments
             singleLine
+            hideReviewVoteButtons
+            singleLineCollapse
             placeholderCount={post.reviewCount}
             terms={{
               view: "reviews",


### PR DESCRIPTION
Two quick UI nice-to-haves:
– the single line comments are now collapsible after expanding them (useful for giant ones you might not have realized were so giant)
– removed the voting UI because it was redundant/confusing in this context.

![image](https://user-images.githubusercontent.com/3246710/150056508-65e3e0b4-f1b9-4432-a3a3-82346d1189f0.png)
