### PR TITLE
hide the event image field on the new post form

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -867,7 +867,7 @@ addFieldsDict(Posts, {
   eventImageId: {
     type: String,
     optional: true,
-    hidden: !isEAForum,
+    hidden: (props) => !props.eventForm || !isEAForum,
     label: "Event Image",
     viewableBy: ['guests'],
     insertableBy: ['members'],


### PR DESCRIPTION
Just noticed that the event image upload appears on the new post form on production - this is to hide it.