### PR TITLE
two small event-related fixes

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -11,6 +11,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import {forumTitleSetting, forumTypeSetting} from '../../../lib/instanceSettings';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import { viewNames } from '../../comments/CommentsViews';
+import classNames from 'classnames';
 
 export const MAX_COLUMN_WIDTH = 720
 
@@ -51,6 +52,17 @@ export const styles = (theme: ThemeType): JssStyles => ({
     },
     [theme.breakpoints.down('xs')]: {
       marginTop: -10,
+    }
+  },
+  headerImageContainerWithComment: {
+    [theme.breakpoints.up('md')]: {
+      marginTop: 10,
+    },
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 10,
+    },
+    [theme.breakpoints.down('xs')]: {
+      marginTop: 10,
     }
   },
   headerImage: {
@@ -144,7 +156,7 @@ const PostsPage = ({post, refetch, classes}: {
         <AnalyticsContext pageSectionContext="postHeader"><div className={classes.title}>
           <div className={classes.centralColumn}>
             {commentId && <CommentPermalink documentId={commentId} post={post} />}
-            {post.eventImageId && <div className={classes.headerImageContainer}>
+            {post.eventImageId && <div className={classNames(classes.headerImageContainer, commentId ? classes.headerImageContainerWithComment : '')}>
               <CloudinaryImage2
                 publicId={post.eventImageId}
                 imgProps={{ar: '16:9', w: '682', q: 'auto:best'}}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -73,6 +73,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
     background: "white",
     position: "relative"
   },
+  // these marginTops are necessary to make sure the image is flush with the header,
+  // since the page layout has different paddingTop values for different widths
   headerImageContainer: {
     paddingBottom: 15,
     [theme.breakpoints.up('md')]: {
@@ -87,6 +89,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
       marginTop: -10,
     }
   },
+  // if there is a comment above the image,
+  // then we DON'T want to account for those paddingTop values
   headerImageContainerWithComment: {
     [theme.breakpoints.up('md')]: {
       marginTop: 10,
@@ -183,7 +187,7 @@ const PostsPage = ({post, refetch, classes}: {
         <AnalyticsContext pageSectionContext="postHeader"><div className={classes.title}>
           <div className={classes.centralColumn}>
             {commentId && <CommentPermalink documentId={commentId} post={post} />}
-            {post.eventImageId && <div className={classNames(classes.headerImageContainer, commentId ? classes.headerImageContainerWithComment : '')}>
+            {post.eventImageId && <div className={classNames(classes.headerImageContainer, {[classes.headerImageContainerWithComment]: commentId})}>
               <CloudinaryImage2
                 publicId={post.eventImageId}
                 imgProps={{ar: '16:9', w: '682', q: 'auto:best'}}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -121,7 +121,8 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
   const shared = post.draft && (post.userId !== currentUser?._id) && post.shareWithUsers
 
   // const shouldRenderQuestionTag = (pathname !== "/questions") && showQuestionTag
-  const shouldRenderEventsTag = pathname !== communityPath;
+  const shouldRenderEventsTag = (pathname !== communityPath) && (pathname !== '/pastEvents') && (pathname !== '/upcomingEvents') &&
+    !pathname.includes('/events') && !pathname.includes('/groups');
 
   const url = postLink || postGetPageUrl(post)
   

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -136,8 +136,8 @@ getCollectionHooks("Posts").updateAsync.add(async function eventUpdatedNotificat
     (
       !_.isEqual(newPost.mongoLocation, oldPost.mongoLocation) ||
       (newPost.joinEventLink !== oldPost.joinEventLink) ||
-      (newPost.startTime !== oldPost.startTime) || 
-      (newPost.endTime !== oldPost.endTime)
+      !moment(newPost.startTime).isSame(moment(oldPost.startTime)) ||
+      !moment(newPost.endTime).isSame(moment(oldPost.endTime))
     )
     && newPost.isEvent && isUpcomingEvent && alreadyPublished)
   {


### PR DESCRIPTION
This PR fixes a couple small issues:
1. Spacing between comment and event image for event comment permalink
2. Sending too many "event updated" emails

I saw this on production today:
<img width="706" alt="Screen Shot 2022-01-20 at 1 57 27 PM" src="https://user-images.githubusercontent.com/9057804/150404273-3a4d3404-b9d0-4233-b836-9057e87a91f6.png">

Here is the updated spacing:
<img width="706" alt="Screen Shot 2022-01-20 at 1 13 01 PM" src="https://user-images.githubusercontent.com/9057804/150404293-1cd0358d-4dbb-41f8-8908-4dbed0eca497.png">
