### PR TITLE
Fix bug that allowed broken collaborative editor to be shown

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -29,7 +29,6 @@ export const userCanCreateCommitMessages = moderatorOnly;
 export const userHasNewTagSubscriptions =  isEAForum ? optInOnly : disabled
 
 // Shipped Features
-export const userHasCkEditor = shippedFeature;
 export const userCanManageTags = shippedFeature;
 export const userCanCreateTags = shippedFeature;
 export const userCanUseTags = shippedFeature;

--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -1,6 +1,6 @@
 import bowser from 'bowser';
 import { isClient, isServer } from '../../executionEnvironment';
-import { userHasCkEditor } from "../../betas";
+import { userHasCkCollaboration } from "../../betas";
 import { forumTypeSetting } from "../../instanceSettings";
 import { getSiteUrl } from '../../vulcan-lib/utils';
 import { mongoFind, mongoAggregate } from '../../mongoQueries';
@@ -39,7 +39,7 @@ export const userIsSharedOn = (currentUser: DbUser|UsersMinimumInfo|null, docume
 }
 
 export const userCanCollaborate = (currentUser: UsersCurrent|null, document: PostsList): boolean => {
-  return userHasCkEditor(currentUser) && userIsSharedOn(currentUser, document)
+  return userHasCkCollaboration(currentUser) && userIsSharedOn(currentUser, document)
 }
 
 export const userCanEditUsersBannedUserIds = (currentUser: DbUser|null, targetUser: DbUser): boolean => {


### PR DESCRIPTION
Currently users who are shared on drafts can get into a broken collaborative ckeditor state.

Quoting myself from slack:

> One might expect that userHasCkeditor is used for enabling the editor itself, while userHasCkCollaboration  (currently set to disabled) is used to enable collaboration. Upon checking, it looks like one would be wrong.

This fixes that.