### PR TITLE
Payment Admin Page + TemplateComponent

### DIFF
--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -10,6 +10,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 export const TemplateComponent = ({classes}: {
   classes: ClassesType,
 }) => {
+  // eslint-disable-next-line no-empty-pattern
   const { } = Components
   return <div className={classes.root}>
 

--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -10,8 +10,6 @@ const styles = (theme: ThemeType): JssStyles => ({
 export const TemplateComponent = ({classes}: {
   classes: ClassesType,
 }) => {
-  // eslint-disable-next-line no-empty-pattern
-  const { } = Components
   return <div className={classes.root}>
 
   </div>;

--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+
+  }
+});
+
+export const TemplateComponent = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const { } = Components
+  return <div className={classes.root}>
+
+  </div>;
+}
+
+const TemplateComponentComponent = registerComponent('TemplateComponent', TemplateComponent, {styles});
+
+declare global {
+  interface ComponentTypes {
+    TemplateComponent: typeof TemplateComponentComponent
+  }
+}
+

--- a/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
+++ b/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import Table from '@material-ui/core/Table';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import { useCurrentUser } from '../common/withUser';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  row: {
+    display: "flex"
+  }
+});
+
+export const AdminPaymentsPage = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const { SingleColumnSection, SectionTitle, Loading, UsersNameDisplay } = Components
+
+  const currentUser = useCurrentUser()
+
+  if (!currentUser?.isAdmin) return null
+
+  const { results, loading } = useMulti({
+    terms: {view: "usersWithPaymentInfo"},
+    collectionName: "Users",
+    fragmentName: 'UsersProfile',
+    fetchPolicy: 'cache-and-network',
+  });
+    
+  return <div className={classes.root}>
+    <SingleColumnSection>
+      <SectionTitle title="Payment Admin"/>
+      {loading && <Loading/>}
+      <Table>
+        {results?.map(user => <TableRow key={user._id}>
+            <TableCell><UsersNameDisplay user={user}/></TableCell>
+            <TableCell>{user.paymentEmail}</TableCell>
+            <TableCell>{user.paymentInfo}</TableCell>
+          </TableRow>
+        )}
+      </Table>
+    </SingleColumnSection>
+  </div>;
+}
+
+const AdminPaymentsPageComponent = registerComponent('AdminPaymentsPage', AdminPaymentsPage, {styles});
+
+declare global {
+  interface ComponentTypes {
+    AdminPaymentsPage: typeof AdminPaymentsPageComponent
+  }
+}
+

--- a/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
+++ b/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
@@ -35,15 +35,18 @@ export const AdminPaymentsPage = ({classes}: {
       <Table>
         <TableRow>
           <TableCell><b>Username</b></TableCell>
+          <TableCell><b>Contact Email</b></TableCell>
           <TableCell><b>Payment Email</b></TableCell>
           <TableCell><b>Payment Info</b></TableCell>
         </TableRow>
-        {results?.map(user => <TableRow key={user._id}>
-            <TableCell><UsersNameDisplay user={user}/></TableCell>
-            <TableCell>{user.paymentEmail}</TableCell>
-            <TableCell>{user.paymentInfo}</TableCell>
+        {results?.map(user => {
+          return <TableRow key={user._id}>
+              <TableCell><UsersNameDisplay user={user}/></TableCell>
+              <TableCell>{user.email}</TableCell>
+              <TableCell>{user.paymentEmail}</TableCell>
+              <TableCell>{user.paymentInfo}</TableCell>
           </TableRow>
-        )}
+        })}
       </Table>
       <LoadMore {...loadMoreProps}/>
     </SingleColumnSection>

--- a/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
+++ b/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
@@ -17,17 +17,16 @@ export const AdminPaymentsPage = ({classes}: {
 }) => {
   const { SingleColumnSection, SectionTitle, Loading, UsersNameDisplay } = Components
 
-  const currentUser = useCurrentUser()
-
-  if (!currentUser?.isAdmin) return null
-
   const { results, loading } = useMulti({
     terms: {view: "usersWithPaymentInfo"},
     collectionName: "Users",
     fragmentName: 'UsersProfile',
     fetchPolicy: 'cache-and-network',
   });
-    
+
+  const currentUser = useCurrentUser()
+  if (!currentUser?.isAdmin) return null
+
   return <div className={classes.root}>
     <SingleColumnSection>
       <SectionTitle title="Payment Admin"/>

--- a/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
+++ b/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
@@ -33,6 +33,11 @@ export const AdminPaymentsPage = ({classes}: {
       <SectionTitle title="Payment Admin"/>
       {loading && <Loading/>}
       <Table>
+        <TableRow>
+          <TableCell><b>Username</b></TableCell>
+          <TableCell><b>Payment Email</b></TableCell>
+          <TableCell><b>Payment Info</b></TableCell>
+        </TableRow>
         {results?.map(user => <TableRow key={user._id}>
             <TableCell><UsersNameDisplay user={user}/></TableCell>
             <TableCell>{user.paymentEmail}</TableCell>

--- a/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
+++ b/packages/lesswrong/components/payments/AdminPaymentsPage.tsx
@@ -15,13 +15,14 @@ const styles = (theme: ThemeType): JssStyles => ({
 export const AdminPaymentsPage = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, SectionTitle, Loading, UsersNameDisplay } = Components
+  const { SingleColumnSection, SectionTitle, Loading, UsersNameDisplay, LoadMore } = Components
 
-  const { results, loading } = useMulti({
-    terms: {view: "usersWithPaymentInfo"},
+  const { results, loading, loadMoreProps } = useMulti({
+    terms: {view: "usersWithPaymentInfo", limit: 100},
     collectionName: "Users",
     fragmentName: 'UsersProfile',
     fetchPolicy: 'cache-and-network',
+    enableTotal: true
   });
 
   const currentUser = useCurrentUser()
@@ -44,6 +45,7 @@ export const AdminPaymentsPage = ({classes}: {
           </TableRow>
         )}
       </Table>
+      <LoadMore {...loadMoreProps}/>
     </SingleColumnSection>
   </div>;
 }

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -167,7 +167,7 @@ Users.addView("usersWithPaymentInfo", function (terms: UsersViewTerms) {
     },
     options: {
       sort: {
-        karma: -1
+        displayName: 1
       }
     }
   }

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -160,6 +160,19 @@ Users.addView("reviewAdminUsers", function (terms: UsersViewTerms) {
   }
 })
 
+Users.addView("usersWithPaymentInfo", function (terms: UsersViewTerms) {
+  return {
+    selector: {
+      $or: [{ paymentEmail: {$exists: true}}, {paymentInfo: {$exists: true}}],
+    },
+    options: {
+      sort: {
+        karma: -1
+      }
+    }
+  }
+})
+
 
 export const hashedPetrovLaunchCodes = [
   "KEDzA2lmOdFDFweWi6jWe9kerEYXGn4qvXjrI41S4bc=",

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -624,3 +624,6 @@ importComponent("BookAnimation", () => require('../components/books/BookAnimatio
 importComponent("Book2019Animation", () => require('../components/books/Book2019Animation'));
 importComponent("BookFrontpageWidget", () => require('../components/books/BookFrontpageWidget'));
 importComponent("Book2019FrontpageWidget", () => require('../components/books/Book2019FrontpageWidget'));
+
+importComponent("AdminPaymentsPage", () => require('../components/payments/AdminPaymentsPage'));
+

--- a/packages/lesswrong/lib/generated/viewTypes.ts
+++ b/packages/lesswrong/lib/generated/viewTypes.ts
@@ -28,7 +28,7 @@ type SubscriptionsViewName = "subscriptionState"|"subscriptionsOfType";
 type TagFlagsViewName = "allTagFlags";
 type TagRelsViewName = "postsWithTag"|"tagsOnPost";
 type TagsViewName = "allTagsAlphabetical"|"userTags"|"allPagesByNewest"|"allTagsHierarchical"|"tagBySlug"|"coreTags"|"newTags"|"unreviewedTags"|"suggestedFilterTags"|"allLWWikiTags"|"unprocessedLWWikiTags"|"tagsByTagFlag"|"allPublicTags";
-type UsersViewName = "usersProfile"|"LWSunshinesList"|"LWTrustLevel1List"|"LWUsersAdmin"|"usersWithBannedUsers"|"sunshineNewUsers"|"allUsers"|"usersMapLocations"|"reviewAdminUsers"|"walledGardenInvitees"|"alignmentSuggestedUsers";
+type UsersViewName = "usersProfile"|"LWSunshinesList"|"LWTrustLevel1List"|"LWUsersAdmin"|"usersWithBannedUsers"|"sunshineNewUsers"|"allUsers"|"usersMapLocations"|"reviewAdminUsers"|"usersWithPaymentInfo"|"walledGardenInvitees"|"alignmentSuggestedUsers";
 type VotesViewName = "tagVotes"|"userPostVotes";
 
 interface ViewTermsByCollectionName {

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -711,6 +711,16 @@ addRoute(
     title: "Tagging Dashboard",
     ...taggingDashboardSubtitle
   },
+  {
+    name: 'paymentsAdmin',
+    path: '/payments/admin',
+    componentName: 'AdminPaymentsPage'
+  },
+  {
+    name: 'payments',
+    path: '/payments',
+    redirect: () => `/payments/admin`, // eventually, payments might be a userfacing feature, and we might do something else with this url
+  },
 );
 
 addRoute(
@@ -927,7 +937,7 @@ if (['AlignmentForum', 'LessWrong'].includes(forumTypeSetting.get())) {
       path: '/reviews/2019',
       componentName: 'Reviews2019',
       title: "2019 Reviews",
-    }
+    },
   )
 }
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -524,6 +524,16 @@ if (forumTypeSetting.get() === 'LessWrong') {
       title: "Books: Engines of Cognition",
       background: "white"
     },
+    {
+      name: 'paymentsAdmin',
+      path: '/payments/admin',
+      componentName: 'AdminPaymentsPage'
+    },
+    {
+      name: 'payments',
+      path: '/payments',
+      redirect: () => `/payments/admin`, // eventually, payments might be a userfacing feature, and we might do something else with this url
+    },
   );
 }
 
@@ -710,17 +720,7 @@ addRoute(
     componentName: "TaggingDashboard",
     title: "Tagging Dashboard",
     ...taggingDashboardSubtitle
-  },
-  {
-    name: 'paymentsAdmin',
-    path: '/payments/admin',
-    componentName: 'AdminPaymentsPage'
-  },
-  {
-    name: 'payments',
-    path: '/payments',
-    redirect: () => `/payments/admin`, // eventually, payments might be a userfacing feature, and we might do something else with this url
-  },
+  }
 );
 
 addRoute(


### PR DESCRIPTION
This creates a simple page for admins to view users who have a paymentEmail or paymentInfo, to make that easier to track.

It also adds a TemplateComponent which can be copied to get a minimal bare-bones component setup.