### PR TITLE
Fix bug in post description, add more ellipsis

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -33,13 +33,16 @@ export const getPostDescription = (post: PostsWithNavigation | PostsWithNavigati
       .reduce((acc, curr, i) => {
         const concat = `${acc}${i > 0 ? ` • ` : ""}${curr}`;
         if (acc.length < 40) return concat;
-        if (concat.length < 150) return concat;
+        // If we have room, concatenate the next paragraph. The statelessness of
+        // this reducer makes it hard to tell if this is the next paragraph, so
+        // we cut it off at the second paragraph.
+        if (concat.length < 150 && i <= 1) return concat;
         return acc;
       }, "");
-    if (firstFewPars.length > 200) {
+    if (firstFewPars.length > 198) {
       return firstFewPars.slice(0, 199).trim() + "…";
     }
-    return firstFewPars;
+    return firstFewPars + " …";
   }
   if (post.shortform)
     return `A collection of shorter posts ${


### PR DESCRIPTION
We try to prevent very short descriptions by concatenating multiple paragraphs. But we don't want to make a really long description either, so we only want to concatenate if the resulting concatenation is <150 characters.

The bug: Previously if the first paragraph was <40 characters, and the next paragraph was > 110 characters, we would search through all the paragraphs in the plaintextDescription for another paragraph that was <110 characters, and then concatenate it with the first.