### PR TITLE
Voting Weight

### DIFF
--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -78,7 +78,7 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
 
   if (!canNominate(currentUser, post)) return null
 
-  const voteIndex = newVote || post.currentUserReviewVote
+  const voteIndex = newVote || post.currentUserReviewVote?.qualitativeScore || 0
   const displayVote = indexToTermsLookup[voteIndex]?.label
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import Card from '@material-ui/core/Card';
 import { useCurrentUser } from '../common/withUser';
-import { indexToTermsLookup } from './ReviewVotingButtons';
+import { getCostData } from './ReviewVotingButtons';
 import { forumTitleSetting, forumTypeSetting } from '../../lib/instanceSettings';
 import { canNominate, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
 import classNames from 'classnames';
@@ -79,7 +79,7 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
   if (!canNominate(currentUser, post)) return null
 
   const voteIndex = newVote || post.currentUserReviewVote?.qualitativeScore || 0
-  const displayVote = indexToTermsLookup[voteIndex]?.label
+  const displayVote = getCostData({})[voteIndex]?.label
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 
   return <div onMouseLeave={() => setAnchorEl(null)}>

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -2,9 +2,8 @@ import React, { useState } from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import Card from '@material-ui/core/Card';
 import { useCurrentUser } from '../common/withUser';
-import { getCostData } from './ReviewVotingButtons';
 import { forumTitleSetting, forumTypeSetting } from '../../lib/instanceSettings';
-import { canNominate, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
+import { canNominate, getCostData, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
 import classNames from 'classnames';
 
 const isEAForum = forumTypeSetting.get() === "EAForum"

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -170,12 +170,11 @@ const arrayDiff = (arr1:Array<any>, arr2:Array<any>) => {
 }
 
 const ReviewVoteTableRow = (
-  { post, dispatch, dispatchQuadraticVote, useQuadratic, classes, expandedPostId, currentVote, showKarmaVotes }: {
+  { post, dispatch, costTotal, classes, expandedPostId, currentVote, showKarmaVotes }: {
     post: PostsListWithVotes,
+    costTotal?: number,
     dispatch: React.Dispatch<SyntheticQualitativeVote>,
-    dispatchQuadraticVote: any,
     showKarmaVotes: boolean,
-    useQuadratic: boolean,
     classes:ClassesType,
     expandedPostId?: string|null,
     currentVote: SyntheticQualitativeVote|null,
@@ -265,7 +264,7 @@ const ReviewVoteTableRow = (
           </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classNames(classes.votes, {[classes.votesVotingPhase]: getReviewPhase() === "VOTING"})}>
-          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} currentUserVote={currentVote} />}
+          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} costTotal={costTotal} currentUserVote={currentVote} />}
           {currentUserIsAuthor && <MetaInfo>You can't vote on your own posts</MetaInfo>}
         </div>}
 

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
-import type { SyntheticQuadraticVote, SyntheticReviewVote } from './ReviewVotingPage';
+import type { SyntheticQuadraticVote, SyntheticQualitativeVote, SyntheticReviewVote } from './ReviewVotingPage';
 import { postGetCommentCount } from "../../lib/collections/posts/helpers";
 import { eligibleToNominate, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
 import indexOf from 'lodash/indexOf'
@@ -172,13 +172,13 @@ const arrayDiff = (arr1:Array<any>, arr2:Array<any>) => {
 const ReviewVoteTableRow = (
   { post, dispatch, dispatchQuadraticVote, useQuadratic, classes, expandedPostId, currentVote, showKarmaVotes }: {
     post: PostsListWithVotes,
-    dispatch: React.Dispatch<SyntheticReviewVote>,
+    dispatch: React.Dispatch<SyntheticQualitativeVote>,
     dispatchQuadraticVote: any,
     showKarmaVotes: boolean,
     useQuadratic: boolean,
     classes:ClassesType,
     expandedPostId?: string|null,
-    currentVote: SyntheticReviewVote|null,
+    currentVote: SyntheticQualitativeVote|null,
   }
 ) => {
   const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, QuadraticVotingButtons, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote, ReviewPostComments } = Components
@@ -265,10 +265,7 @@ const ReviewVoteTableRow = (
           </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classNames(classes.votes, {[classes.votesVotingPhase]: getReviewPhase() === "VOTING"})}>
-          {!currentUserIsAuthor && <div>{useQuadratic ?
-            <QuadraticVotingButtons postId={post._id} voteForCurrentPost={currentVote as SyntheticQuadraticVote} vote={dispatchQuadraticVote} /> :
-            <ReviewVotingButtons post={post} dispatch={dispatch} currentUserVoteScore={currentVote?.score || null} />}
-          </div>}
+          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} currentUserVote={currentVote} />}
           {currentUserIsAuthor && <MetaInfo>You can't vote on your own posts</MetaInfo>}
         </div>}
 

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/sche
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { eligibleToNominate } from '../../lib/reviewUtils';
+import { SyntheticQualitativeVote } from './ReviewVotingPage';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -91,19 +92,19 @@ export const indexToTermsLookup = {
 }
 
 
-const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVoteScore: number|null}) => {
+const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVote: SyntheticQualitativeVote|null}) => {
   const { LWTooltip } = Components
 
   const currentUser = useCurrentUser()
 
-  const [selection, setSelection] = useState(currentUserVoteScore || DEFAULT_QUALITATIVE_VOTE)
-  const [isDefaultVote, setIsDefaultVote] = useState(!currentUserVoteScore)
+  const [selection, setSelection] = useState(currentUserVote?.score || DEFAULT_QUALITATIVE_VOTE)
+  const [isDefaultVote, setIsDefaultVote] = useState(!currentUserVote?.score)
 
   const createClickHandler = (index:number) => {
     return () => {
       setSelection(index)
       setIsDefaultVote(false)
-      dispatch({postId: post._id, score: index})
+      dispatch({_id: currentUserVote?._id, postId: post._id, score: index})
     }
   }
 

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -117,7 +117,11 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTota
   const [isDefaultVote, setIsDefaultVote] = useState(!currentUserVote?.score)
 
   const createClickHandler = (index:number) => {
-    return () => {
+    return (e:React.MouseEvent) => {
+      // We don't want to change the currently focused post when clicking
+      // on the vote buttons, so we stop the event here
+      e.preventDefault()
+      e.stopPropagation()
       setSelection(index)
       setIsDefaultVote(false)
       dispatch({_id: currentUserVote?._id, postId: post._id, score: index})

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -6,9 +6,8 @@ import forumThemeExport from '../../themes/forumTheme';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
-import { eligibleToNominate } from '../../lib/reviewUtils';
+import { eligibleToNominate, getCostData } from '../../lib/reviewUtils';
 import { SyntheticQualitativeVote } from './ReviewVotingPage';
-import round from 'lodash/round';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -53,61 +52,6 @@ const styles = (theme: ThemeType) => ({
   7: { color: upvoteColor},
 })
 
-const getPointsFromCost = (cost) => {
-  // the formula to quadratic cost from a number of points is (n^2 + n)/2
-  // this uses the inverse of that formula to take in a cost and output a number of points
-  return (-1 + Math.sqrt((8 * cost)+1)) / 2
-}
-
-const getLabelFromCost = (cost) => {
-  // rounds the points to 1 decimal for easier reading
-  return round(getPointsFromCost(cost), 1)
-}
-
-export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
-  // This 
-  const divider = costTotal > 500 ? costTotal/500 : 1
-  return ({
-    0: {label: null, cost: 0, tooltip: null},
-    1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
-      <div>
-        <p>Highly misleading, harmful, or unimportant.</p>
-        <p><em>Costs 45 points</em></p>
-      </div>},
-    2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
-    <div>
-      <p>Very misleading, harmful, or unimportant.</p>
-      <p><em>Costs 10 points</em></p>
-    </div>},
-    3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
-    <div>
-      <p>Misleading, harmful or unimportant.</p>
-      <p><em>Costs 1 point</em></p>
-    </div>},
-    4: { label: `0`, cost: 0, tooltip: 
-    <div>
-      <p>No strong opinion on this post,</p>
-      <p><em>Costs 0 points</em></p>
-    </div>},
-    5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
-    <div>
-      <p>Good</p>
-      <p><em>Costs 1 point</em></p>
-    </div>},
-    6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
-    <div>
-      <p>Quite important</p>
-      <p><em>Costs 10 points</em></p>
-    </div>},
-    7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
-    <div>
-      <p>Extremely important</p>
-      <p><em>Costs 45 points</em></p>
-    </div>},
-  })
-}
-
-
 const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTotal}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVote: SyntheticQualitativeVote|null, costTotal?: number}) => {
   const { LWTooltip } = Components
 
@@ -135,8 +79,8 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTota
   return <AnalyticsContext pageElementContext="reviewVotingButtons">
     <div className={classes.root}>
         {[1,2,3,4,5,6,7].map((i) => {
-          return <LWTooltip title={getCostData({})[i].tooltip} 
-          key={`${getCostData({})[i]}-${i}`}>
+          return <LWTooltip title={getCostData({costTotal})[i].tooltip} 
+          key={`${getCostData({costTotal})[i]}-${i}`}>
             <span
                 className={classNames(classes.button, classes[i], {
                   [classes.selectionHighlight]:selection === i && !isDefaultVote,
@@ -144,7 +88,7 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTota
                 })}
                 onClick={createClickHandler(i)}
               >
-              {getCostData({costTotal:costTotal})[i].label}
+              {getCostData({costTotal})[i].label}
             </span>
           </LWTooltip>
         })}

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -8,6 +8,7 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { eligibleToNominate } from '../../lib/reviewUtils';
 import { SyntheticQualitativeVote } from './ReviewVotingPage';
+import { round } from 'lodash';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -17,13 +18,13 @@ const styles = (theme: ThemeType) => ({
     whiteSpace: "pre"
   },
   button: {
-    paddingTop: 2,
-    paddingBottom: 2,
+    paddingTop: 3,
+    paddingBottom: 3,
     marginRight: 2,
     display: "inline-block",
     border: "solid 1px rgba(0,0,0,.1)",
     borderRadius: 3,
-    width: 24,
+    width: 26,
     textAlign: "center",
     ...theme.typography.smallText,
     ...theme.typography.commentStyle,
@@ -52,47 +53,62 @@ const styles = (theme: ThemeType) => ({
   7: { color: upvoteColor},
 })
 
-export const indexToTermsLookup = {
-  0: {label: null, cost: 0, tooltip: null},
-  1: { label: "-9", cost: 45, tooltip: 
+const getPointsFromCost = (cost) => {
+  // the formula to quadratic cost from a number of points is (n^2 + n)/2
+  // this uses the inverse of that formula to take in a cost and output a number of points
+  return (-1 + Math.sqrt((8 * cost)+1)) / 2
+}
+
+const getLabelFromCost = (cost) => {
+  // rounds the points to 1 decimal for easier reading
+  return round(getPointsFromCost(cost), 1)
+}
+
+export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
+  // This 
+  const divider = costTotal > 500 ? costTotal/500 : 1
+  return ({
+    0: {label: null, cost: 0, tooltip: null},
+    1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+      <div>
+        <p>Highly misleading, harmful, or unimportant.</p>
+        <p><em>Costs 45 points</em></p>
+      </div>},
+    2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
-      <p>Highly misleading, harmful, or unimportant.</p>
+      <p>Very misleading, harmful, or unimportant.</p>
+      <p><em>Costs 10 points</em></p>
+    </div>},
+    3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Misleading, harmful or unimportant.</p>
+      <p><em>Costs 1 point</em></p>
+    </div>},
+    4: { label: `0`, cost: 0, tooltip: 
+    <div>
+      <p>No strong opinion on this post,</p>
+      <p><em>Costs 0 points</em></p>
+    </div>},
+    5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Good</p>
+      <p><em>Costs 1 point</em></p>
+    </div>},
+    6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
+    <div>
+      <p>Quite important</p>
+      <p><em>Costs 10 points</em></p>
+    </div>},
+    7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+    <div>
+      <p>Extremely important</p>
       <p><em>Costs 45 points</em></p>
     </div>},
-  2: { label: "-4", cost: 10, tooltip: 
-  <div>
-    <p>Very misleading, harmful, or unimportant.</p>
-    <p><em>Costs 10 points</em></p>
-  </div>},
-  3: { label: "-1", cost: 1, tooltip: 
-  <div>
-    <p>Misleading, harmful or unimportant.</p>
-    <p><em>Costs 1 point</em></p>
-  </div>},
-  4: { label: "0", cost: 0, tooltip: 
-  <div>
-    <p>No strong opinion on this post,</p>
-    <p><em>Costs 0 points</em></p>
-  </div>},
-  5: { label: "1", cost: 1, tooltip: 
-  <div>
-    <p>Good</p>
-    <p><em>Costs 1 point</em></p>
-  </div>},
-  6: { label: "4", cost: 10, tooltip: 
-  <div>
-    <p>Quite important</p>
-    <p><em>Costs 10 points</em></p>
-  </div>},
-  7: { label: "9", cost: 45, tooltip: 
-  <div>
-    <p>Extremely important</p>
-    <p><em>Costs 45 points</em></p>
-  </div>},
+  })
 }
 
 
-const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVote: SyntheticQualitativeVote|null}) => {
+const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTotal}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVote: SyntheticQualitativeVote|null, costTotal?: number}) => {
   const { LWTooltip } = Components
 
   const currentUser = useCurrentUser()
@@ -115,8 +131,8 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote}: {classe
   return <AnalyticsContext pageElementContext="reviewVotingButtons">
     <div className={classes.root}>
         {[1,2,3,4,5,6,7].map((i) => {
-          return <LWTooltip title={indexToTermsLookup[i].tooltip} 
-          key={`${indexToTermsLookup[i]}-${i}`}>
+          return <LWTooltip title={getCostData({})[i].tooltip} 
+          key={`${getCostData({})[i]}-${i}`}>
             <span
                 className={classNames(classes.button, classes[i], {
                   [classes.selectionHighlight]:selection === i && !isDefaultVote,
@@ -124,7 +140,7 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote}: {classe
                 })}
                 onClick={createClickHandler(i)}
               >
-              {indexToTermsLookup[i].label}
+              {getCostData({costTotal:costTotal})[i].label}
             </span>
           </LWTooltip>
         })}

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -8,7 +8,7 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { eligibleToNominate } from '../../lib/reviewUtils';
 import { SyntheticQualitativeVote } from './ReviewVotingPage';
-import { round } from 'lodash';
+import round from 'lodash/round';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -21,7 +21,7 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import Card from '@material-ui/core/Card';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
-import { indexToTermsLookup } from './ReviewVotingButtons';
+import { getCostData } from './ReviewVotingButtons';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -132,7 +132,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   comments: {
   },
-  voteTotal: {
+  costTotal: {
     ...theme.typography.commentStyle,
     marginLeft: 10,
     color: theme.palette.grey[600],
@@ -270,7 +270,6 @@ const ReviewVotingPage = ({classes}: {
   });
   // useMulti is incorrectly typed
   const postsResults = results as PostsListWithVotes[] | null;
-  postsResults?.forEach(post=>{if (post.title === "Most Prisoner's Dilemmas are Stag Hunts; Most Stag Hunts are Schelling Problems") { console.log(post.title, post.currentUserReviewVote?.qualitativeScore)}})
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",
@@ -307,10 +306,10 @@ const ReviewVotingPage = ({classes}: {
     console.error('Error loading posts', postsError);
   }
 
-  function getVoteTotal (posts) {
-    return posts?.map(post=>indexToTermsLookup[post.currentUserReviewVote?.qualitativeScore || 0].cost).reduce((a,b)=>a+b, 0)
+  function getCostTotal (posts) {
+    return posts?.map(post=>getCostData({})[post.currentUserReviewVote?.qualitativeScore || 0].cost).reduce((a,b)=>a+b, 0)
   }
-  const [voteTotal, setVoteTotal] = useState<number>(getVoteTotal(postsResults))
+  const [costTotal, setCostTotal] = useState<number>(getCostTotal(postsResults))
 
   let defaultSort = ""
   if (getReviewPhase() === "REVIEWS") { 
@@ -466,7 +465,7 @@ const ReviewVotingPage = ({classes}: {
   const canInitialResort = !!postsResults
 
   useEffect(() => {
-    setVoteTotal(getVoteTotal(postsResults))
+    setCostTotal(getCostTotal(postsResults))
   }, [canInitialResort, postsResults])
 
   useEffect(() => {
@@ -608,9 +607,9 @@ const ReviewVotingPage = ({classes}: {
             }
             {(postsLoading || loading) && <Loading/>}
 
-            {!isEAForum && voteTotal && <div className={classNames(classes.voteTotal, {[classes.excessVotes]: voteTotal > 500})}>
-              <LWTooltip title={<div><p>You have {500 - voteTotal} points remaining</p><p><em>The vote budget feature is only partially complete. Requires page refresh and doesn't yet do any rebalancing if you overspend.</em></p></div>}>
-                {voteTotal}/500
+            {!isEAForum && costTotal && <div className={classNames(classes.costTotal, {[classes.excessVotes]: costTotal > 500})}>
+              <LWTooltip title={<div><p>You have {500 - costTotal} points remaining</p><p><em>The vote budget feature is only partially complete. Requires page refresh and doesn't yet do any rebalancing if you overspend.</em></p></div>}>
+                {costTotal}/500
               </LWTooltip>
             </div>}
             
@@ -706,11 +705,10 @@ const ReviewVotingPage = ({classes}: {
               >
                 <ReviewVoteTableRow
                   post={post}
+                  costTotal={costTotal}
                   showKarmaVotes={showKarmaVotes}
                   dispatch={dispatchQualitativeVote}
                   currentVote={currentVote}
-                  dispatchQuadraticVote={dispatchQuadraticVote}
-                  useQuadratic={useQuadratic}
                   expandedPostId={expandedPost?._id}
                 />
               </div>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -342,7 +342,7 @@ const ReviewVotingPage = ({classes}: {
 
   const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: SyntheticQualitativeVote) => {
     
-    const post = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id) : null
+    const post = _id ? postsResults?.find(post => post?.currentUserReviewVote?._id === _id) : null
 
     return await submitVote({
       variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false},
@@ -592,7 +592,7 @@ const ReviewVotingPage = ({classes}: {
             </SectionTitle>
             <RecentComments terms={{ view: "reviews", reviewYear: REVIEW_YEAR, sortBy: sortReviews}} truncated/>
           </div>}
-          {/* <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost}/> */}
+          <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost}/>
         </div>
         <div className={classes.rightColumn}>
           <div className={classes.votingTitle}>Voting</div>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -343,7 +343,9 @@ const ReviewVotingPage = ({classes}: {
 
 
   const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: SyntheticQualitativeVote) => {
-    const existingVote = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id) : null
+    
+    const existingVote = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id)?.currentUserReviewVote : null
+
     return await submitVote({
       variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false},
       optimisticResponse: {

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -279,16 +279,16 @@ const ReviewVotingPage = ({classes}: {
   const [submitVote] = useMutation(gql`
     mutation submitReviewVote($postId: String, $qualitativeScore: Int, $quadraticChange: Int, $newQuadraticScore: Int, $comment: String, $year: String, $dummy: Boolean) {
       submitReviewVote(postId: $postId, qualitativeScore: $qualitativeScore, quadraticChange: $quadraticChange, comment: $comment, newQuadraticScore: $newQuadraticScore, year: $year, dummy: $dummy) {
-        ...reviewVoteFragment
+        ...PostsReviewVotingList
       }
     }
-    ${getFragment("reviewVoteFragment")}
+    ${getFragment("PostsReviewVotingList")} 
   `, {
     update: (store, mutationResult) => {  
       updateEachQueryResultOfType({
         func: handleUpdateMutation,
         document: mutationResult.data.submitReviewVote,
-        store, typeName: "ReviewVote",
+        store, typeName: "Post",
       });
     }
   });
@@ -351,6 +351,7 @@ const ReviewVotingPage = ({classes}: {
           __typename: "Post",
           ...post,
           currentUserReviewVote: {
+            __typename: "ReviewVote",
             _id: _id,
             qualitativeScore: score
           }

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -270,7 +270,7 @@ const ReviewVotingPage = ({classes}: {
   });
   // useMulti is incorrectly typed
   const postsResults = results as PostsListWithVotes[] | null;
-  postsResults?.forEach(post=>{if (post.title === "Nuclear war is unlikely to cause human extinction") { console.log(post.title, post.currentUserReviewVote?.qualitativeScore)}})
+  postsResults?.forEach(post=>{if (post.title === "Most Prisoner's Dilemmas are Stag Hunts; Most Stag Hunts are Schelling Problems") { console.log(post.title, post.currentUserReviewVote?.qualitativeScore)}})
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -354,7 +354,7 @@ const ReviewVotingPage = ({classes}: {
         }
       }
     })
-  }, [submitVote]);
+  }, [submitVote, postsResults]);
 
   // // 
   // const dispatchQuadraticVote = async ({_id, postId, change, set, reactions}: {
@@ -563,6 +563,8 @@ const ReviewVotingPage = ({classes}: {
 
   const reviewedPosts = sortedPosts?.filter(post=>post.reviewCount > 0)
 
+  const costTotalTooltip = costTotal > 500 ? <div>You have spent more than 500 points. Your vote strength will be reduced to account for this.</div> : <div>You have {500 - costTotal} points remaining before your vote-weight begins to reduce.</div>
+
   return (
     <AnalyticsContext pageContext="ReviewVotingPage">
     <div>
@@ -608,7 +610,7 @@ const ReviewVotingPage = ({classes}: {
             {(postsLoading || loading) && <Loading/>}
 
             {!isEAForum && costTotal && <div className={classNames(classes.costTotal, {[classes.excessVotes]: costTotal > 500})}>
-              <LWTooltip title={<div><p>You have {500 - costTotal} points remaining</p><p><em>The vote budget feature is only partially complete. Requires page refresh and doesn't yet do any rebalancing if you overspend.</em></p></div>}>
+              <LWTooltip title={costTotalTooltip}>
                 {costTotal}/500
               </LWTooltip>
             </div>}
@@ -697,7 +699,7 @@ const ReviewVotingPage = ({classes}: {
                 _id: post.currentUserReviewVote._id,
                 postId: post._id,
                 score: post.currentUserReviewVote.qualitativeScore,
-                type: "QUALITATIVE" as "QUALITATIVE" 
+                type: "QUALITATIVE" as const
               } : null
               return <div key={post._id} onClick={()=>{
                 setExpandedPost(post)

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -340,19 +340,20 @@ const ReviewVotingPage = ({classes}: {
   //   return await submitVote({variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false}})
   // }, [submitVote]);
 
-
-
   const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: SyntheticQualitativeVote) => {
     
-    const existingVote = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id)?.currentUserReviewVote : null
+    const post = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id) : null
 
     return await submitVote({
       variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false},
       optimisticResponse: {
         submitReviewVote: {
-          __typename: "ReviewVote",
-          ...existingVote,
-          qualitativeScore: score
+          __typename: "Post",
+          ...post,
+          currentUserReviewVote: {
+            _id: _id,
+            qualitativeScore: score
+          }
         }
       }
     })
@@ -590,7 +591,7 @@ const ReviewVotingPage = ({classes}: {
             </SectionTitle>
             <RecentComments terms={{ view: "reviews", reviewYear: REVIEW_YEAR, sortBy: sortReviews}} truncated/>
           </div>}
-          <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost}/>
+          {/* <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost}/> */}
         </div>
         <div className={classes.rightColumn}>
           <div className={classes.votingTitle}>Voting</div>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -232,7 +232,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 export type SyntheticReviewVote = {postId: string, score: number, type: 'QUALITATIVE' | 'QUADRATIC'}
-export type SyntheticQualitativeVote = {postId: string, score: number, type: 'QUALITATIVE'}
+export type SyntheticQualitativeVote = {_id: string, postId: string, score: number, type: 'QUALITATIVE'}
 export type SyntheticQuadraticVote = {postId: string, score: number, type: 'QUADRATIC'}
 
 const generatePermutation = (count: number, user: UsersCurrent|null): Array<number> => {
@@ -270,6 +270,7 @@ const ReviewVotingPage = ({classes}: {
   });
   // useMulti is incorrectly typed
   const postsResults = results as PostsListWithVotes[] | null;
+  postsResults?.forEach(post=>{if (post.title === "Nuclear war is unlikely to cause human extinction") { console.log(post.title, post.currentUserReviewVote?.qualitativeScore)}})
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",
@@ -307,7 +308,7 @@ const ReviewVotingPage = ({classes}: {
   }
 
   function getVoteTotal (posts) {
-    return posts?.map(post=>indexToTermsLookup[post.currentUserReviewVote || 0].cost).reduce((a,b)=>a+b, 0)
+    return posts?.map(post=>indexToTermsLookup[post.currentUserReviewVote?.qualitativeScore || 0].cost).reduce((a,b)=>a+b, 0)
   }
   const [voteTotal, setVoteTotal] = useState<number>(getVoteTotal(postsResults))
 
@@ -336,9 +337,49 @@ const ReviewVotingPage = ({classes}: {
     });
   }
 
-  const dispatchQualitativeVote = useCallback(async ({postId, score}: SyntheticQualitativeVote) => {
-    return await submitVote({variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false}})
+  // const dispatchQualitativeVote = useCallback(async ({postId, score}: SyntheticQualitativeVote) => {
+  //   return await submitVote({variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false}})
+  // }, [submitVote]);
+
+
+
+  const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: SyntheticQualitativeVote) => {
+    const existingVote = _id ? postsResults?.find(post => post.currentUserReviewVote?._id === _id) : null
+    return await submitVote({
+      variables: {postId, qualitativeScore: score, year: REVIEW_YEAR+"", dummy: false},
+      optimisticResponse: {
+        submitReviewVote: {
+          __typename: "ReviewVote",
+          ...existingVote,
+          qualitativeScore: score
+        }
+      }
+    })
   }, [submitVote]);
+
+  // // 
+  // const dispatchQuadraticVote = async ({_id, postId, change, set, reactions}: {
+  //   _id?: string|null,
+  //   postId: string,
+  //   change?: number,
+  //   set?: number,
+  //   reactions?: string[],
+  // }) => {
+  //   const existingVote = _id ? dbVotes.find(vote => vote._id === _id) : null;
+  //   const newReactions = reactions || existingVote?.reactions || []
+  //   await submitVote({
+  //     variables: {postId, quadraticChange: change, newQuadraticScore: set, year: YEAR+"", reactions: newReactions, dummy: false},
+  //     optimisticResponse: _id && {
+  //       __typename: "Mutation",
+  //       submitReviewVote: {
+  //         __typename: "ReviewVote",
+  //         ...existingVote,
+  //         quadraticScore: (typeof set !== 'undefined') ? set : ((existingVote?.quadraticScore || 0) + (change || 0)),
+  //         reactions: newReactions
+  //       }
+  //     }
+  //   })
+  // }
 
   // TODO: This is untested in 2021
   const dispatchQuadraticVote = async ({postId, change, set}: QuadraticVoteUpdate) => {
@@ -359,6 +400,9 @@ const ReviewVotingPage = ({classes}: {
         const post1 = sortReversed ? inputPost2 : inputPost1
         const post2 = sortReversed ? inputPost1 : inputPost2
 
+        const post1Score = post1.currentUserReviewVote?.qualitativeScore || 0
+        const post2Score = post2.currentUserReviewVote?.qualitativeScore || 0
+
         if (sortPosts === "needsReview") {
           // This prioritizes posts with no reviews, which you highly upvoted
           const post1NeedsReview = post1.reviewCount === 0 && post1.reviewVoteScoreHighKarma > 4
@@ -371,8 +415,8 @@ const ReviewVotingPage = ({classes}: {
           if (post2NeedsReview && !post1NeedsReview) return 1
           if (post1isCurrentUsers && !post2isCurrentUsers) return -1
           if (post2isCurrentUsers && !post1isCurrentUsers) return 1
-          if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
-          if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
+          if (post1Score > post2Score) return -1
+          if (post1Score < post2Score) return 1
         }
 
         if (sortPosts === "needsFinalVote") {
@@ -382,12 +426,17 @@ const ReviewVotingPage = ({classes}: {
           const post2NotKarmaVoted = post2.currentUserVote === null
           if (post1NotReviewVoted && !post2NotReviewVoted) return -1
           if (post2NotReviewVoted && !post1NotReviewVoted) return 1
-          if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
-          if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
+          if (post1Score < post2Score) return 1
+          if (post1Score > post2Score) return -1
           if (post1NotKarmaVoted && !post2NotKarmaVoted) return 1
           if (post2NotKarmaVoted && !post1NotKarmaVoted) return -1
           if (permuted1 < permuted2) return -1;
           if (permuted1 > permuted2) return 1;
+        }
+
+        if (sortPosts === "currentUserReviewVote") {
+          if (post1Score > post2Score) return -1
+          if (post2Score < post1Score) return 1
         }
 
         if (post1[sortPosts] > post2[sortPosts]) return -1
@@ -398,12 +447,12 @@ const ReviewVotingPage = ({classes}: {
 
         // TODO: figure out why commenting this out makes it sort correctly.
 
-        const reviewedNotVoted1 = post1.reviewCount > 0 && !post1.currentUserReviewVote
-        const reviewedNotVoted2 = post2.reviewCount > 0 && !post2.currentUserReviewVote
+        const reviewedNotVoted1 = post1.reviewCount > 0 && !post1Score
+        const reviewedNotVoted2 = post2.reviewCount > 0 && !post2Score
         if (reviewedNotVoted1 && !reviewedNotVoted2) return -1
         if (!reviewedNotVoted1 && reviewedNotVoted2) return 1
-        if (post1.currentUserReviewVote < post2.currentUserReviewVote) return 1
-        if (post1.currentUserReviewVote > post2.currentUserReviewVote) return -1
+        if (post1Score < post2Score) return 1
+        if (post1Score > post2Score) return -1
         if (permuted1 < permuted2) return -1;
         if (permuted1 > permuted2) return 1;
         return 0
@@ -646,9 +695,10 @@ const ReviewVotingPage = ({classes}: {
           <div className={classNames({[classes.postList]: getReviewPhase() !== "VOTING", [classes.postLoading]: postsLoading || loading})}>
             {postsHaveBeenSorted && sortedPosts?.map((post) => {
               const currentVote = post.currentUserReviewVote !== null ? {
+                _id: post.currentUserReviewVote._id,
                 postId: post._id,
-                score: post.currentUserReviewVote,
-                type: useQuadratic ? "QUADRATIC" : "QUALITATIVE" as "QUALITATIVE" | "QUADRATIC"
+                score: post.currentUserReviewVote.qualitativeScore,
+                type: "QUALITATIVE" as "QUALITATIVE" 
               } : null
               return <div key={post._id} onClick={()=>{
                 setExpandedPost(post)
@@ -697,13 +747,13 @@ const votesToQuadraticVotes = (posts: PostsListWithVotes[] | null): QuadraticVot
   if (!posts) {
     throw new Error("Cannot convert votes to quadratic votes without posts")
   }
-  const sumScaled = sumBy(posts, post => Math.abs(qualitativeScoreScaling[post.currentUserReviewVote || DEFAULT_QUALITATIVE_VOTE]) || 0)
+  const sumScaled = sumBy(posts, post => Math.abs(qualitativeScoreScaling[post.currentUserReviewVote?.qualitativeScore || DEFAULT_QUALITATIVE_VOTE]) || 0)
   return posts.map(post => {
-    if (post.currentUserReviewVote) {
+    if (post.currentUserReviewVote?.qualitativeScore) {
       const newScore = computeQuadraticVoteScore(
         // DB stores it as number, sadly
-        post.currentUserReviewVote as keyof typeof qualitativeScoreScaling,
-        sumScaled
+        post.currentUserReviewVote.qualitativeScore as keyof typeof qualitativeScoreScaling,
+        sumScaled 
       )
       return {postId: post._id, set: newScore}
     } else {

--- a/packages/lesswrong/components/review/ReviewVotingPage2019.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage2019.tsx
@@ -450,8 +450,8 @@ const ReviewVotingPage2019 = ({classes}: {
                     showKarmaVotes={showKarmaVotes}
                     dispatch={dispatchQualitativeVote as any}
                     currentVote={(useQuadratic ? currentQuadraticVote : currentQualitativeVote) as any}
-                    dispatchQuadraticVote={dispatchQuadraticVote}
-                    useQuadratic={useQuadratic}
+                    // dispatchQuadraticVote={dispatchQuadraticVote}
+                    // useQuadratic={useQuadratic}
                     expandedPostId={expandedPost?._id}
                   />
                 </div>

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -30,21 +30,13 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
 
   // TODO: Refactor these + the ReviewVotingPage dispatch
   const [submitVote] = useMutation(gql`
-    mutation submitReviewVote($postId: String, $qualitativeScore: Int, $quadraticChange: Int, $newQuadraticScore: Int, $comment: String, $year: String, $dummy: Boolean, $reactions: [String]) {
-      submitReviewVote(postId: $postId, qualitativeScore: $qualitativeScore, quadraticChange: $quadraticChange, comment: $comment, newQuadraticScore: $newQuadraticScore, year: $year, dummy: $dummy, reactions: $reactions) {
-        ...reviewVoteFragment
+    mutation submitReviewVote($postId: String, $qualitativeScore: Int, $quadraticChange: Int, $newQuadraticScore: Int, $comment: String, $year: String, $dummy: Boolean) {
+      submitReviewVote(postId: $postId, qualitativeScore: $qualitativeScore, quadraticChange: $quadraticChange, comment: $comment, newQuadraticScore: $newQuadraticScore, year: $year, dummy: $dummy) {
+        ...PostsReviewVotingList
       }
     }
-    ${getFragment("reviewVoteFragment")}
-  `, {
-    update: (store, mutationResult) => {
-      updateEachQueryResultOfType({
-        func: handleUpdateMutation,
-        document: mutationResult.data.submitReviewVote,
-        store, typeName: "ReviewVote",
-      });
-    }
-  });
+    ${getFragment("PostsReviewVotingList")} 
+  `);
 
   const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: {
     _id: string|null,

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -57,12 +57,19 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
 
   if (!eligibleToNominate(currentUser)) return null
 
+  const currentUserVote = post.currentUserReviewVote !== null ? {
+    _id: post.currentUserReviewVote._id,
+    postId: post._id,
+    score: post.currentUserReviewVote.qualitativeScore || 0,
+    type: "QUALITATIVE" as "QUALITATIVE"
+  } : null
+
   return <ErrorBoundary>
       <div className={classes.root}>
         {showTitle && <p>
           Vote on this post for the <LWTooltip title={overviewTooltip}><Link to={"/reviewVoting"}>{REVIEW_NAME_IN_SITU}</Link></LWTooltip>
         </p>}
-        <ReviewVotingButtons post={post} dispatch={dispatchQualitativeVote} currentUserVoteScore={post.currentUserReviewVote}/>
+        <ReviewVotingButtons post={post} dispatch={dispatchQualitativeVote} currentUserVote={currentUserVote}/>
       </div>
     </ErrorBoundary>
 }

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -61,7 +61,7 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
     _id: post.currentUserReviewVote._id,
     postId: post._id,
     score: post.currentUserReviewVote.qualitativeScore || 0,
-    type: "QUALITATIVE" as "QUALITATIVE"
+    type: "QUALITATIVE" as const
   } : null
 
   return <ErrorBoundary>

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -10,7 +10,10 @@ registerFragment(`
     draft
     hideCommentKarma
     af
-    currentUserReviewVote
+    currentUserReviewVote {
+      _id
+      qualitativeScore
+    }
     userId
   }
 `);

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -830,9 +830,10 @@ const schema: SchemaType<DbPost> = {
   },
 
   currentUserReviewVote: resolverOnlyField({
-    type: Number,
+    type: "ReviewVote",
+    graphQLtype: "ReviewVote",
     viewableBy: ['members'],
-    resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<number|null> => {
+    resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<DbReviewVote|null> => {
       const { ReviewVotes, currentUser } = context;
       if (!currentUser) return null;
       const votes = await getWithLoader(context, ReviewVotes,
@@ -843,7 +844,8 @@ const schema: SchemaType<DbPost> = {
         "postId", post._id
       );
       if (!votes.length) return null;
-      return votes[0].qualitativeScore;
+      const vote = await accessFilterSingle(currentUser, ReviewVotes, votes[0], context);
+      return vote;
     }
   }),
   

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -290,8 +290,13 @@ interface PostsMinimumInfo { // fragment on Posts
   readonly draft: boolean,
   readonly hideCommentKarma: boolean,
   readonly af: boolean,
-  readonly currentUserReviewVote: number,
+  readonly currentUserReviewVote: PostsMinimumInfo_currentUserReviewVote|null,
   readonly userId: string,
+}
+
+interface PostsMinimumInfo_currentUserReviewVote { // fragment on ReviewVotes
+  readonly _id: string,
+  readonly qualitativeScore: number,
 }
 
 interface PostsBase extends PostsMinimumInfo { // fragment on Posts

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import round from "lodash/round"
 import moment from "moment"
 import { forumTypeSetting } from "./instanceSettings"
 import { annualReviewEnd, annualReviewNominationPhaseEnd, annualReviewReviewPhaseEnd, annualReviewStart } from "./publicSettings"
@@ -66,4 +68,58 @@ export const currentUserCanVote = (currentUser: UsersCurrent|null) => {
   if (isLWForum && new Date(currentUser.createdAt) > new Date(`${REVIEW_YEAR+1}-01-01`)) return false
   if (isEAForum && new Date(currentUser.createdAt) > new Date(annualReviewStart.get())) return false
   return true
+}
+
+const getPointsFromCost = (cost) => {
+  // the formula to quadratic cost from a number of points is (n^2 + n)/2
+  // this uses the inverse of that formula to take in a cost and output a number of points
+  return (-1 + Math.sqrt((8 * cost)+1)) / 2
+}
+
+const getLabelFromCost = (cost) => {
+  // rounds the points to 1 decimal for easier reading
+  return round(getPointsFromCost(cost), 1)
+}
+
+export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
+  const divider = costTotal > 500 ? costTotal/500 : 1
+  const dividerWarning = divider && <div>Your vote is downweighted because you spent 500+ points</div>
+  return ({
+    0: {label: null, cost: 0, tooltip: null},
+    1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+      <div>
+        <p>Highly misleading, harmful, or unimportant.</p>
+        <p><em>Costs 45 points{dividerWarning}</em></p>
+      </div>},
+    2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
+    <div>
+      <p>Very misleading, harmful, or unimportant.</p>
+      <p><em>Costs 10 points{dividerWarning}</em></p>
+    </div>},
+    3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Misleading, harmful or unimportant.</p>
+      <p><em>Costs 1 point{dividerWarning}</em></p>
+    </div>},
+    4: { label: `0`, cost: 0, tooltip: 
+    <div>
+      <p>No strong opinion on this post,</p>
+      <p><em>Costs 0 points{dividerWarning}</em></p>
+    </div>},
+    5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Good</p>
+      <p><em>Costs 1 point{dividerWarning}</em></p>
+    </div>},
+    6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
+    <div>
+      <p>Quite important</p>
+      <p><em>Costs 10 points{dividerWarning}</em></p>
+    </div>},
+    7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+    <div>
+      <p>Extremely important</p>
+      <p><em>Costs 45 points{dividerWarning}</em></p>
+    </div>},
+  })
 }

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -89,43 +89,43 @@ export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
     1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
       <div>
         <p>Highly misleading, harmful, or unimportant.</p>
-        <p><em>Costs 45 points</em></p>
+        <div><em>Costs 45 points</em></div>
         {overSpentWarning}
       </div>},
     2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Very misleading, harmful, or unimportant.</p>
-      <p><em>Costs 10 points</em></p>
+      <div><em>Costs 10 points</em></div>
       {overSpentWarning}
     </div>},
     3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Misleading, harmful or unimportant.</p>
-      <p><em>Costs 1 point</em></p>
+      <div><em>Costs 1 point</em></div>
       {overSpentWarning}
     </div>},
     4: { label: `0`, cost: 0, tooltip: 
     <div>
       <p>No strong opinion on this post,</p>
-      <p><em>Costs 0 points</em></p>
+      <div><em>Costs 0 points</em></div>
       {overSpentWarning}
     </div>},
     5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Good</p>
-      <p><em>Costs 1 point</em></p>
+      <div><em>Costs 1 point</em></div>
       {overSpentWarning}
     </div>},
     6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Quite important</p>
-      <p><em>Costs 10 points</em></p>
+      <div><em>Costs 10 points</em></div>
       {overSpentWarning}
     </div>},
     7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
     <div>
       <p>Extremely important</p>
-      <p><em>Costs 45 points</em></p>
+      <div><em>Costs 45 points</em></div>
       {overSpentWarning}
     </div>},
   })

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -83,43 +83,50 @@ const getLabelFromCost = (cost) => {
 
 export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
   const divider = costTotal > 500 ? costTotal/500 : 1
-  const overSpentWarning = (divider !== 1) ? <div>Your vote is downweighted because you spent 500+ points</div> : null
+  const overSpentWarning = (divider !== 1) ? <div><em>Your vote is downweighted because you spent 500+ points</em></div> : null
   return ({
     0: {label: null, cost: 0, tooltip: null},
     1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
       <div>
         <p>Highly misleading, harmful, or unimportant.</p>
-        <p><em>Costs 45 points{overSpentWarning}</em></p>
+        <p><em>Costs 45 points</em></p>
+        {overSpentWarning}
       </div>},
     2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Very misleading, harmful, or unimportant.</p>
-      <p><em>Costs 10 points{overSpentWarning}</em></p>
+      <p><em>Costs 10 points</em></p>
+      {overSpentWarning}
     </div>},
     3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Misleading, harmful or unimportant.</p>
-      <p><em>Costs 1 point{overSpentWarning}</em></p>
+      <p><em>Costs 1 point</em></p>
+      {overSpentWarning}
     </div>},
     4: { label: `0`, cost: 0, tooltip: 
     <div>
       <p>No strong opinion on this post,</p>
-      <p><em>Costs 0 points{overSpentWarning}</em></p>
+      <p><em>Costs 0 points</em></p>
+      {overSpentWarning}
     </div>},
     5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Good</p>
-      <p><em>Costs 1 point{overSpentWarning}</em></p>
+      <p><em>Costs 1 point</em></p>
+      {overSpentWarning}
     </div>},
     6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Quite important</p>
-      <p><em>Costs 10 points{overSpentWarning}</em></p>
+      <p><em>Costs 10 points</em></p>
+      {overSpentWarning}
     </div>},
     7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
     <div>
       <p>Extremely important</p>
-      <p><em>Costs 45 points{overSpentWarning}</em></p>
+      <p><em>Costs 45 points</em></p>
+      {overSpentWarning}
     </div>},
   })
 }

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -83,43 +83,43 @@ const getLabelFromCost = (cost) => {
 
 export const getCostData = ({costTotal=500}:{costTotal?:number}) => {
   const divider = costTotal > 500 ? costTotal/500 : 1
-  const dividerWarning = divider && <div>Your vote is downweighted because you spent 500+ points</div>
+  const overSpentWarning = (divider !== 1) ? <div>Your vote is downweighted because you spent 500+ points</div> : null
   return ({
     0: {label: null, cost: 0, tooltip: null},
     1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
       <div>
         <p>Highly misleading, harmful, or unimportant.</p>
-        <p><em>Costs 45 points{dividerWarning}</em></p>
+        <p><em>Costs 45 points{overSpentWarning}</em></p>
       </div>},
     2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Very misleading, harmful, or unimportant.</p>
-      <p><em>Costs 10 points{dividerWarning}</em></p>
+      <p><em>Costs 10 points{overSpentWarning}</em></p>
     </div>},
     3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Misleading, harmful or unimportant.</p>
-      <p><em>Costs 1 point{dividerWarning}</em></p>
+      <p><em>Costs 1 point{overSpentWarning}</em></p>
     </div>},
     4: { label: `0`, cost: 0, tooltip: 
     <div>
       <p>No strong opinion on this post,</p>
-      <p><em>Costs 0 points{dividerWarning}</em></p>
+      <p><em>Costs 0 points{overSpentWarning}</em></p>
     </div>},
     5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
     <div>
       <p>Good</p>
-      <p><em>Costs 1 point{dividerWarning}</em></p>
+      <p><em>Costs 1 point{overSpentWarning}</em></p>
     </div>},
     6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
       <p>Quite important</p>
-      <p><em>Costs 10 points{dividerWarning}</em></p>
+      <p><em>Costs 10 points{overSpentWarning}</em></p>
     </div>},
     7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
     <div>
       <p>Extremely important</p>
-      <p><em>Costs 45 points{dividerWarning}</em></p>
+      <p><em>Costs 45 points{overSpentWarning}</em></p>
     </div>},
   })
 }

--- a/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
@@ -33,7 +33,7 @@ addGraphQLResolvers({
         // the user does two increments in a row and the second read happens
         // before the first write, leading to the discarding of the first
         // increment. We should consider adding an increment option to
-        // updateMutator
+        // updateMutator 
         const finalQuadraticScore = typeof newQuadraticScore !== 'undefined' ?
           newQuadraticScore :
           existingVote.quadraticScore + (quadraticChange || 0)
@@ -58,4 +58,4 @@ addGraphQLResolvers({
     }
   }
 });
-addGraphQLMutation('submitReviewVote(postId: String, qualitativeScore: Int, quadraticChange: Int, newQuadraticScore: Int, comment: String, year: String, dummy: Boolean, reactions: [String]): ReviewVote');
+addGraphQLMutation('submitReviewVote(postId: String, qualitativeScore: Int, quadraticChange: Int, newQuadraticScore: Int, comment: String, year: String, dummy: Boolean, reactions: [String]): Post');

--- a/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
@@ -52,8 +52,8 @@ addGraphQLResolvers({
           validate: false,
           currentUser,
         })
-        const newVote = await ReviewVotes.findOne({_id: existingVote._id})
-        return newVote;
+        const newPost = await Posts.findOne({_id:postId})
+        return newPost 
       }
     }
   }

--- a/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
@@ -6,7 +6,9 @@ import { ReviewVotes } from '../../lib/collections/reviewVotes/collection'
 
 addGraphQLResolvers({
   Mutation: {
-    // TODO:(Review) doc
+
+    // This mutation returns a post, with the reviewVote included as a field, so that we can get a fast-response-time on the list of ReviewVoteTableRows in ReviewVotingPage.
+    
     submitReviewVote: async (root: void, args: { postId: string, qualitativeScore: number, quadraticChange: number, newQuadraticScore: number, comment: string, year: string, dummy: boolean, reactions: string[] }, context: ResolverContext): Promise<DbPost> =>  {
       const { postId, qualitativeScore, quadraticChange, newQuadraticScore, comment, year, dummy, reactions } = args;
       const { currentUser } = context;

--- a/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewVoteResolvers.ts
@@ -7,7 +7,7 @@ import { ReviewVotes } from '../../lib/collections/reviewVotes/collection'
 addGraphQLResolvers({
   Mutation: {
     // TODO:(Review) doc
-    submitReviewVote: async (root: void, args: { postId: string, qualitativeScore: number, quadraticChange: number, newQuadraticScore: number, comment: string, year: string, dummy: boolean, reactions: string[] }, context: ResolverContext) => {
+    submitReviewVote: async (root: void, args: { postId: string, qualitativeScore: number, quadraticChange: number, newQuadraticScore: number, comment: string, year: string, dummy: boolean, reactions: string[] }, context: ResolverContext): Promise<DbPost> =>  {
       const { postId, qualitativeScore, quadraticChange, newQuadraticScore, comment, year, dummy, reactions } = args;
       const { currentUser } = context;
       if (!currentUser) throw new Error("You must be logged in to submit a review vote");
@@ -27,7 +27,9 @@ addGraphQLResolvers({
           validate: false,
           currentUser,
         });
-        return newVote.data;
+        const newPost = await Posts.findOne({_id:postId})
+        if (!newPost) throw Error("Can't find post corresponding to Review Vote")
+        return newPost
       } else {
         // TODO:(Review) this could potentially introduce a race condition where
         // the user does two increments in a row and the second read happens
@@ -53,6 +55,7 @@ addGraphQLResolvers({
           currentUser,
         })
         const newPost = await Posts.findOne({_id:postId})
+        if (!newPost) throw Error("Can't find post corresponding to Review Vote")
         return newPost 
       }
     }


### PR DESCRIPTION
This PR makes it so that
a) when you click on a vote button on the /reviewVoting page, it updates the vote-cost-total
b) when your vote-cost-total is over 500, your vote-weights are reduced.

It does not yet make it so that the vote-weights are visibly reduced in other parts of the site. 

It currently accomplishes A) via changing currentUserReviewVote into an object that includes the _id of the reviewVote, so that updating the reviewVote updates the the datastructure. But, it seems kinda sluggish and inconsistent and I'm not sure this is actually better than the previous solution of "you just have to refresh the page."

It accomplishes b) via passing down the costTotal of the votes and using that to do math to the point-values. 

**Some underlying philosophy:** Initially, I was going to solve the "what about people with more than 500-vote-cost?" by saying "you just can't spend more than 500 points. If you try, it warns you and disables buttons until you reduce your cost." But then, as a user, I found it fairly important to actually be able to differentiate my 9s from 4s where appropriate. The "500 max" rule made it so that I had to artificially lower my scores for a lot of posts that I thought were quite good.

I think it's important people can just vote on everything that feels qualitatively-very-important to them. 

![image](https://user-images.githubusercontent.com/3246710/150916382-b54845ac-d22f-46f6-ab06-aca2907cd7b7.png)
