### PR TITLE
Adjust Vote Weight for reviewers who overspent [wip]

### DIFF
--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import Card from '@material-ui/core/Card';
 import { useCurrentUser } from '../common/withUser';
-import { indexToTermsLookup } from './ReviewVotingButtons';
+import { getReviewVoteCostData } from './ReviewVotingButtons';
 import { forumTitleSetting, forumTypeSetting } from '../../lib/instanceSettings';
 import { canNominate, getReviewPhase, REVIEW_YEAR } from '../../lib/reviewUtils';
 import classNames from 'classnames';
@@ -79,7 +79,7 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
   if (!canNominate(currentUser, post)) return null
 
   const voteIndex = newVote || post.currentUserReviewVote
-  const displayVote = indexToTermsLookup[voteIndex]?.label
+  const displayVote = getReviewVoteCostData({})[voteIndex]?.label
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 
   return <div onMouseLeave={() => setAnchorEl(null)}>

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -264,10 +264,9 @@ const ReviewVoteTableRow = (
           </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classNames(classes.votes, {[classes.votesVotingPhase]: getReviewPhase() === "VOTING"})}>
-          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} costTotal={costTotal} currentUserVote={currentVote} />}
+          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} costTotal={costTotal} currentUserVoteScore={currentVote?.score || null} />}
           {currentUserIsAuthor && <MetaInfo>You can't vote on your own posts</MetaInfo>}
         </div>}
-
       </div>
     </div>
   </AnalyticsContext>

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -170,18 +170,17 @@ const arrayDiff = (arr1:Array<any>, arr2:Array<any>) => {
 }
 
 const ReviewVoteTableRow = (
-  { post, dispatch, dispatchQuadraticVote, useQuadratic, classes, expandedPostId, currentVote, showKarmaVotes }: {
+  { post, dispatch, costTotal, classes, expandedPostId, currentVote, showKarmaVotes }: {
     post: PostsListWithVotes,
+    costTotal?: number,
     dispatch: React.Dispatch<SyntheticReviewVote>,
-    dispatchQuadraticVote: any,
     showKarmaVotes: boolean,
-    useQuadratic: boolean,
     classes:ClassesType,
     expandedPostId?: string|null,
     currentVote: SyntheticReviewVote|null,
   }
 ) => {
-  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, QuadraticVotingButtons, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote, ReviewPostComments } = Components
+  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote, ReviewPostComments } = Components
 
   const currentUser = useCurrentUser()
 
@@ -265,10 +264,7 @@ const ReviewVoteTableRow = (
           </LWTooltip>}
         </div>}
         {getReviewPhase() !== "REVIEWS" && eligibleToNominate(currentUser) && <div className={classNames(classes.votes, {[classes.votesVotingPhase]: getReviewPhase() === "VOTING"})}>
-          {!currentUserIsAuthor && <div>{useQuadratic ?
-            <QuadraticVotingButtons postId={post._id} voteForCurrentPost={currentVote as SyntheticQuadraticVote} vote={dispatchQuadraticVote} /> :
-            <ReviewVotingButtons post={post} dispatch={dispatch} currentUserVoteScore={currentVote?.score || null} />}
-          </div>}
+          {!currentUserIsAuthor && <ReviewVotingButtons post={post} dispatch={dispatch} costTotal={costTotal} currentUserVote={currentVote} />}
           {currentUserIsAuthor && <MetaInfo>You can't vote on your own posts</MetaInfo>}
         </div>}
 

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/sche
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { eligibleToNominate } from '../../lib/reviewUtils';
+import round from 'lodash/round';
 
 const downvoteColor = "rgba(125,70,70, .87)"
 const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.palette.primary.main : "rgba(70,125,70, .87)"
@@ -51,47 +52,62 @@ const styles = (theme: ThemeType) => ({
   7: { color: upvoteColor},
 })
 
-export const indexToTermsLookup = {
-  0: {label: null, cost: 0, tooltip: null},
-  1: { label: "-9", cost: 45, tooltip: 
+const getPointsFromCost = (cost) => {
+  // the formula to quadratic cost from a number of points is (n^2 + n)/2
+  // this uses the inverse of that formula to take in a cost and output a number of points
+  return (-1 + Math.sqrt((8 * cost)+1)) / 2
+}
+
+const getLabelFromCost = (cost) => {
+  // rounds the points to 1 decimal for easier reading
+  return round(getPointsFromCost(cost), 1)
+}
+
+export const getReviewVoteCostData = ({costTotal=0}:{costTotal?:number}) => {
+  // This 
+  const divider = costTotal > 500 ? costTotal/500 : 1
+  return ({
+    0: {label: null, cost: 0, tooltip: null},
+    1: { label: `-${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+      <div>
+        <p>Highly misleading, harmful, or unimportant.</p>
+        <p><em>Costs 45 points</em></p>
+      </div>},
+    2: { label: `-${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
     <div>
-      <p>Highly misleading, harmful, or unimportant.</p>
+      <p>Very misleading, harmful, or unimportant.</p>
+      <p><em>Costs 10 points</em></p>
+    </div>},
+    3: { label: `-${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Misleading, harmful or unimportant.</p>
+      <p><em>Costs 1 point</em></p>
+    </div>},
+    4: { label: `0`, cost: 0, tooltip: 
+    <div>
+      <p>No strong opinion on this post,</p>
+      <p><em>Costs 0 points</em></p>
+    </div>},
+    5: { label: `${getLabelFromCost(1/divider)}`, cost: 1, tooltip: 
+    <div>
+      <p>Good</p>
+      <p><em>Costs 1 point</em></p>
+    </div>},
+    6: { label: `${getLabelFromCost(10/divider)}`, cost: 10, tooltip: 
+    <div>
+      <p>Quite important</p>
+      <p><em>Costs 10 points</em></p>
+    </div>},
+    7: { label: `${getLabelFromCost(45/divider)}`, cost: 45, tooltip: 
+    <div>
+      <p>Extremely important</p>
       <p><em>Costs 45 points</em></p>
     </div>},
-  2: { label: "-4", cost: 10, tooltip: 
-  <div>
-    <p>Very misleading, harmful, or unimportant.</p>
-    <p><em>Costs 10 points</em></p>
-  </div>},
-  3: { label: "-1", cost: 1, tooltip: 
-  <div>
-    <p>Misleading, harmful or unimportant.</p>
-    <p><em>Costs 1 point</em></p>
-  </div>},
-  4: { label: "0", cost: 0, tooltip: 
-  <div>
-    <p>No strong opinion on this post,</p>
-    <p><em>Costs 0 points</em></p>
-  </div>},
-  5: { label: "1", cost: 1, tooltip: 
-  <div>
-    <p>Good</p>
-    <p><em>Costs 1 point</em></p>
-  </div>},
-  6: { label: "4", cost: 10, tooltip: 
-  <div>
-    <p>Quite important</p>
-    <p><em>Costs 10 points</em></p>
-  </div>},
-  7: { label: "9", cost: 45, tooltip: 
-  <div>
-    <p>Extremely important</p>
-    <p><em>Costs 45 points</em></p>
-  </div>},
+  })
 }
 
 
-const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVoteScore: number|null}) => {
+const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore, costTotal }: {classes: ClassesType, post: PostsMinimumInfo, dispatch: any, currentUserVoteScore: number|null, costTotal?: number}) => {
   const { LWTooltip } = Components
 
   const currentUser = useCurrentUser()
@@ -114,8 +130,8 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {c
   return <AnalyticsContext pageElementContext="reviewVotingButtons">
     <div className={classes.root}>
         {[1,2,3,4,5,6,7].map((i) => {
-          return <LWTooltip title={indexToTermsLookup[i].tooltip} 
-          key={`${indexToTermsLookup[i]}-${i}`}>
+          return <LWTooltip title={getReviewVoteCostData({costTotal})[i].tooltip} 
+          key={`${getReviewVoteCostData({costTotal})[i]}-${i}`}>
             <span
                 className={classNames(classes.button, classes[i], {
                   [classes.selectionHighlight]:selection === i && !isDefaultVote,
@@ -123,7 +139,7 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVoteScore}: {c
                 })}
                 onClick={createClickHandler(i)}
               >
-              {indexToTermsLookup[i].label}
+              {getReviewVoteCostData({costTotal})[i].label}
             </span>
           </LWTooltip>
         })}

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType) => ({
     display: "inline-block",
     border: "solid 1px rgba(0,0,0,.1)",
     borderRadius: 3,
-    width: 24,
+    width: 26,
     textAlign: "center",
     ...theme.typography.smallText,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/review/ReviewVotingPage2019.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage2019.tsx
@@ -1,618 +1,618 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import Button from '@material-ui/core/Button';
-import sumBy from 'lodash/sumBy'
-import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
-import { useUpdate } from '../../lib/crud/withUpdate';
-import { updateEachQueryResultOfType, handleUpdateMutation } from '../../lib/crud/cacheUpdates';
-import { useMulti } from '../../lib/crud/withMulti';
-import { useMutation, gql } from '@apollo/client';
-import Paper from '@material-ui/core/Paper';
-import { useCurrentUser } from '../common/withUser';
-import classNames from 'classnames';
-import * as _ from "underscore"
-import { commentBodyStyles } from '../../themes/stylePiping';
-import CachedIcon from '@material-ui/icons/Cached';
-import KeyboardTabIcon from '@material-ui/icons/KeyboardTab';
-import { Link } from '../../lib/reactRouterWrapper';
-import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
-import seedrandom from '../../lib/seedrandom';
+// import React, { useState, useEffect, useCallback } from 'react';
+// import Button from '@material-ui/core/Button';
+// import sumBy from 'lodash/sumBy'
+// import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
+// import { useUpdate } from '../../lib/crud/withUpdate';
+// import { updateEachQueryResultOfType, handleUpdateMutation } from '../../lib/crud/cacheUpdates';
+// import { useMulti } from '../../lib/crud/withMulti';
+// import { useMutation, gql } from '@apollo/client';
+// import Paper from '@material-ui/core/Paper';
+// import { useCurrentUser } from '../common/withUser';
+// import classNames from 'classnames';
+// import * as _ from "underscore"
+// import { commentBodyStyles } from '../../themes/stylePiping';
+// import CachedIcon from '@material-ui/icons/Cached';
+// import KeyboardTabIcon from '@material-ui/icons/KeyboardTab';
+// import { Link } from '../../lib/reactRouterWrapper';
+// import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
+// import seedrandom from '../../lib/seedrandom';
 
-const YEAR = 2019
-const NOMINATIONS_VIEW = "nominations2019"
-const VOTING_VIEW = "voting2019" // unfortunately this can't just inhereit from YEAR. It needs to exactly match a view-type so that the type-check of the view can pass.
-const REVIEW_COMMENTS_VIEW = "reviews2019"
-const userVotesAreQuadraticField: keyof DbUser = "reviewVotesQuadratic2019";
+// const YEAR = 2019
+// const NOMINATIONS_VIEW = "nominations2019"
+// const VOTING_VIEW = "voting2019" // unfortunately this can't just inhereit from YEAR. It needs to exactly match a view-type so that the type-check of the view can pass.
+// const REVIEW_COMMENTS_VIEW = "reviews2019"
+// const userVotesAreQuadraticField: keyof DbUser = "reviewVotesQuadratic2019";
 
-export const currentUserCanVote = (currentUser: UsersCurrent|null) =>
-  currentUser && new Date(currentUser.createdAt) < new Date(`${YEAR}-01-01`)
+// export const currentUserCanVote = (currentUser: UsersCurrent|null) =>
+//   currentUser && new Date(currentUser.createdAt) < new Date(`${YEAR}-01-01`)
 
-//const YEAR = 2018
-//const NOMINATIONS_VIEW = "nominations2018"
-//const REVIEWS_VIEW = "reviews2018"
+// //const YEAR = 2018
+// //const NOMINATIONS_VIEW = "nominations2018"
+// //const REVIEWS_VIEW = "reviews2018"
 
-const defaultReactions = [
-  "I personally benefited from this post",
-  "Deserves followup work",
-  "Should be edited/improved",
-  "Important but shouldn't be in book",
-  "I spent 30+ minutes reviewing this in-depth"
-]
+// const defaultReactions = [
+//   "I personally benefited from this post",
+//   "Deserves followup work",
+//   "Should be edited/improved",
+//   "Important but shouldn't be in book",
+//   "I spent 30+ minutes reviewing this in-depth"
+// ]
 
-const styles = (theme: ThemeType): JssStyles => ({
-  grid: {
-    display: 'grid',
-    gridTemplateColumns: `
-      minmax(10px, 0.5fr) minmax(300px, 740px) minmax(30px, 0.5fr) minmax(100px, 600px) minmax(30px, 0.5fr)
-    `,
-    gridTemplateAreas: `
-    "... leftColumn ... rightColumn ..."
-    `,
-    paddingBottom: 175
-  },
-  instructions: {
-    ...theme.typography.body2,
-    ...commentBodyStyles(theme),
-    maxWidth: 545,
-    paddingBottom: 35
-  },
-  leftColumn: {
-    gridArea: "leftColumn",
-    [theme.breakpoints.down('sm')]: {
-      display: "none"
-    }
-  },
-  rightColumn: {
-    gridArea: "rightColumn",
-    [theme.breakpoints.down('sm')]: {
-      display: "none"
-    },
-  },
-  result: {
-    ...theme.typography.smallText,
-    ...theme.typography.commentStyle,
-    lineHeight: "1.3rem",
-    marginBottom: 10,
-    position: "relative"
-  },
-  votingBox: {
-    maxWidth: 700
-  },
-  expandedInfo: {
-    maxWidth: 600,
-    marginBottom: 175,
-  },
-  menu: {
-    position: "sticky",
-    top:0,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    backgroundColor: "white",
-    zIndex: theme.zIndexes.reviewVotingMenu,
-    padding: theme.spacing.unit,
-    background: "#ddd",
-    borderBottom: "solid 1px rgba(0,0,0,.15)"
-  },
-  menuIcon: {
-    marginLeft: theme.spacing.unit
-  },
-  returnToBasicIcon: {
-    transform: "rotate(180deg)",
-    marginRight: theme.spacing.unit
-  },
-  expandedInfoWrapper: {
-    position: "fixed",
-    top: 100,
-    overflowY: "auto",
-    height: "100vh",
-    paddingRight: 8
-  },
-  header: {
-    ...theme.typography.display3,
-    ...theme.typography.commentStyle,
-    marginTop: 6,
-  },
-  postHeader: {
-    ...theme.typography.display1,
-    ...theme.typography.postStyle,
-    marginTop: 0,
-  },
-  comments: {
-  },
-  voteTotal: {
-    ...theme.typography.body2,
-    ...theme.typography.commentStyle,
-  },
-  excessVotes: {
-    color: theme.palette.error.main,
-    border: `solid 1px ${theme.palette.error.light}`,
-    paddingLeft: 12,
-    paddingRight: 12,
-    paddingTop: 6,
-    paddingBottom: 6,
-    borderRadius: 3,
-    '&:hover': {
-      opacity: .5
-    }
-  },
-  message: {
-    width: "100%",
-    textAlign: "center",
-    paddingTop: 50,
-    ...theme.typography.body2,
-    ...theme.typography.commentStyle,
-  },
-  hideOnMobile: {
-    [theme.breakpoints.up('md')]: {
-      display: "none"
-    }
-  },
-  writeAReview: {
-    paddingTop: 12,
-    paddingLeft: 12,
-    paddingRight: 12,
-    paddingBottom: 8,
-    border: "solid 1px rgba(0,0,0,.3)",
-    marginBottom: 8,
-  },
-  reviewPrompt: {
-    fontWeight: 600,
-    fontSize: "1.2rem",
-    color: "rgba(0,0,0,.87)",
-    width: "100%",
-    display: "block"
-  },
-  fakeTextfield: {
-    marginTop: 5,
-    width: "100%",
-    borderBottom: "dashed 1px rgba(0,0,0,.25)",
-    color: theme.palette.grey[400]
-  },
-  warning: {
-    color: theme.palette.error.main
-  },
+// const styles = (theme: ThemeType): JssStyles => ({
+//   grid: {
+//     display: 'grid',
+//     gridTemplateColumns: `
+//       minmax(10px, 0.5fr) minmax(300px, 740px) minmax(30px, 0.5fr) minmax(100px, 600px) minmax(30px, 0.5fr)
+//     `,
+//     gridTemplateAreas: `
+//     "... leftColumn ... rightColumn ..."
+//     `,
+//     paddingBottom: 175
+//   },
+//   instructions: {
+//     ...theme.typography.body2,
+//     ...commentBodyStyles(theme),
+//     maxWidth: 545,
+//     paddingBottom: 35
+//   },
+//   leftColumn: {
+//     gridArea: "leftColumn",
+//     [theme.breakpoints.down('sm')]: {
+//       display: "none"
+//     }
+//   },
+//   rightColumn: {
+//     gridArea: "rightColumn",
+//     [theme.breakpoints.down('sm')]: {
+//       display: "none"
+//     },
+//   },
+//   result: {
+//     ...theme.typography.smallText,
+//     ...theme.typography.commentStyle,
+//     lineHeight: "1.3rem",
+//     marginBottom: 10,
+//     position: "relative"
+//   },
+//   votingBox: {
+//     maxWidth: 700
+//   },
+//   expandedInfo: {
+//     maxWidth: 600,
+//     marginBottom: 175,
+//   },
+//   menu: {
+//     position: "sticky",
+//     top:0,
+//     display: "flex",
+//     alignItems: "center",
+//     justifyContent: "space-between",
+//     backgroundColor: "white",
+//     zIndex: theme.zIndexes.reviewVotingMenu,
+//     padding: theme.spacing.unit,
+//     background: "#ddd",
+//     borderBottom: "solid 1px rgba(0,0,0,.15)"
+//   },
+//   menuIcon: {
+//     marginLeft: theme.spacing.unit
+//   },
+//   returnToBasicIcon: {
+//     transform: "rotate(180deg)",
+//     marginRight: theme.spacing.unit
+//   },
+//   expandedInfoWrapper: {
+//     position: "fixed",
+//     top: 100,
+//     overflowY: "auto",
+//     height: "100vh",
+//     paddingRight: 8
+//   },
+//   header: {
+//     ...theme.typography.display3,
+//     ...theme.typography.commentStyle,
+//     marginTop: 6,
+//   },
+//   postHeader: {
+//     ...theme.typography.display1,
+//     ...theme.typography.postStyle,
+//     marginTop: 0,
+//   },
+//   comments: {
+//   },
+//   voteTotal: {
+//     ...theme.typography.body2,
+//     ...theme.typography.commentStyle,
+//   },
+//   excessVotes: {
+//     color: theme.palette.error.main,
+//     border: `solid 1px ${theme.palette.error.light}`,
+//     paddingLeft: 12,
+//     paddingRight: 12,
+//     paddingTop: 6,
+//     paddingBottom: 6,
+//     borderRadius: 3,
+//     '&:hover': {
+//       opacity: .5
+//     }
+//   },
+//   message: {
+//     width: "100%",
+//     textAlign: "center",
+//     paddingTop: 50,
+//     ...theme.typography.body2,
+//     ...theme.typography.commentStyle,
+//   },
+//   hideOnMobile: {
+//     [theme.breakpoints.up('md')]: {
+//       display: "none"
+//     }
+//   },
+//   writeAReview: {
+//     paddingTop: 12,
+//     paddingLeft: 12,
+//     paddingRight: 12,
+//     paddingBottom: 8,
+//     border: "solid 1px rgba(0,0,0,.3)",
+//     marginBottom: 8,
+//   },
+//   reviewPrompt: {
+//     fontWeight: 600,
+//     fontSize: "1.2rem",
+//     color: "rgba(0,0,0,.87)",
+//     width: "100%",
+//     display: "block"
+//   },
+//   fakeTextfield: {
+//     marginTop: 5,
+//     width: "100%",
+//     borderBottom: "dashed 1px rgba(0,0,0,.25)",
+//     color: theme.palette.grey[400]
+//   },
+//   warning: {
+//     color: theme.palette.error.main
+//   },
   
-  // averageVoteInstructions: {
-  //   padding: 12,
-  //   ...theme.typography.body2,
-  //   ...commentBodyStyles(theme),
-  // },
-  // averageVoteRow: {
-  //   padding: 12,
-  //   display: "flex",
-  // },
-  // averageVoteLabel: {
-  //   marginTop: 8,
-  //   flexGrow: 1,
+//   // averageVoteInstructions: {
+//   //   padding: 12,
+//   //   ...theme.typography.body2,
+//   //   ...commentBodyStyles(theme),
+//   // },
+//   // averageVoteRow: {
+//   //   padding: 12,
+//   //   display: "flex",
+//   // },
+//   // averageVoteLabel: {
+//   //   marginTop: 8,
+//   //   flexGrow: 1,
     
-  //   fontSize: "1.3rem",
-  //   fontFamily: theme.typography.postStyle.fontFamily,
-  // },
-  // averageVote: {
-  //   ...theme.typography.body1,
-  //   ...theme.typography.commentStyle
-  // },
-  // averageVoteButton: {
-  //   ...theme.typography.body2,
-  //   ...theme.typography.commentStyle,
-  //   fontWeight: 600,
-  //   paddingLeft: 10,
-  //   paddingRight: 10,
-  //   cursor: "pointer"
-  // },
+//   //   fontSize: "1.3rem",
+//   //   fontFamily: theme.typography.postStyle.fontFamily,
+//   // },
+//   // averageVote: {
+//   //   ...theme.typography.body1,
+//   //   ...theme.typography.commentStyle
+//   // },
+//   // averageVoteButton: {
+//   //   ...theme.typography.body2,
+//   //   ...theme.typography.commentStyle,
+//   //   fontWeight: 600,
+//   //   paddingLeft: 10,
+//   //   paddingRight: 10,
+//   //   cursor: "pointer"
+//   // },
   
-  voteAverage: {
-    cursor: 'pointer',
-  },
-  leaveReactions: {
-    marginTop: 16,
-  }
-});
+//   voteAverage: {
+//     cursor: 'pointer',
+//   },
+//   leaveReactions: {
+//     marginTop: 16,
+//   }
+// });
 
-export type ReviewVote = {_id: string, postId: string, score: number, type?: string, reactions: string[]}
-export type quadraticVote = ReviewVote & {type: "quadratic"}
-export type qualitativeVote = ReviewVote & {type: "qualitative", score: 0|1|2|3|4}
+// export type ReviewVote = {_id: string, postId: string, score: number, type?: string, reactions: string[]}
+// export type quadraticVote = ReviewVote & {type: "quadratic"}
+// export type qualitativeVote = ReviewVote & {type: "qualitative", score: 0|1|2|3|4}
 
 
-const generatePermutation = (count: number, user: UsersCurrent|null): Array<number> => {
-  const seed = user?._id || "";
-  const rng = seedrandom(seed);
+// const generatePermutation = (count: number, user: UsersCurrent|null): Array<number> => {
+//   const seed = user?._id || "";
+//   const rng = seedrandom(seed);
   
-  let remaining = _.range(count);
-  let result: Array<number> = [];
-  while(remaining.length > 0) {
-    let idx = Math.floor(rng() * remaining.length);
-    result.push(remaining[idx]);
-    remaining.splice(idx, 1);
-  }
-  return result;
-}
+//   let remaining = _.range(count);
+//   let result: Array<number> = [];
+//   while(remaining.length > 0) {
+//     let idx = Math.floor(rng() * remaining.length);
+//     result.push(remaining[idx]);
+//     remaining.splice(idx, 1);
+//   }
+//   return result;
+// }
 
-const ReviewVotingPage2019 = ({classes}: {
-  classes: ClassesType,
-}) => {
-  // return <div>This page no longer exists, sorry. :(</div>
+// const ReviewVotingPage2019 = ({classes}: {
+//   classes: ClassesType,
+// }) => {
+//   // return <div>This page no longer exists, sorry. :(</div>
 
-  const currentUser = useCurrentUser()
-  const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
+//   const currentUser = useCurrentUser()
+//   const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
   
 
-  const { results: posts, loading: postsLoading } = useMulti({
-    terms: {view: VOTING_VIEW, limit: 300},
-    collectionName: "Posts",
-    fragmentName: 'PostsListWithVotes',
-    fetchPolicy: 'cache-and-network',
-  });
+//   const { results: posts, loading: postsLoading } = useMulti({
+//     terms: {view: VOTING_VIEW, limit: 300},
+//     collectionName: "Posts",
+//     fragmentName: 'PostsListWithVotes',
+//     fetchPolicy: 'cache-and-network',
+//   });
   
-  const { results: dbVotes, loading: dbVotesLoading } = useMulti({
-    terms: {view: "reviewVotesFromUser", limit: 300, userId: currentUser?._id, year: YEAR+""},
-    collectionName: "ReviewVotes",
-    fragmentName: "reviewVoteFragment",
-    fetchPolicy: 'cache-and-network',
-  })
+//   const { results: dbVotes, loading: dbVotesLoading } = useMulti({
+//     terms: {view: "reviewVotesFromUser", limit: 300, userId: currentUser?._id, year: YEAR+""},
+//     collectionName: "ReviewVotes",
+//     fragmentName: "reviewVoteFragment",
+//     fetchPolicy: 'cache-and-network',
+//   })
 
-  const {mutate: updateUser} = useUpdate({
-    collectionName: "Users",
-    fragmentName: 'UsersCurrent',
-  });
+//   const {mutate: updateUser} = useUpdate({
+//     collectionName: "Users",
+//     fragmentName: 'UsersCurrent',
+//   });
 
-  const [submitVote] = useMutation(gql`
-    mutation submitReviewVote($postId: String, $qualitativeScore: Int, $quadraticChange: Int, $newQuadraticScore: Int, $comment: String, $year: String, $dummy: Boolean, $reactions: [String]) {
-      submitReviewVote(postId: $postId, qualitativeScore: $qualitativeScore, quadraticChange: $quadraticChange, comment: $comment, newQuadraticScore: $newQuadraticScore, year: $year, dummy: $dummy, reactions: $reactions) {
-        ...reviewVoteFragment
-      }
-    }
-    ${getFragment("reviewVoteFragment")}
-  `, {
-    update: (store, mutationResult) => {
-      updateEachQueryResultOfType({
-        func: handleUpdateMutation,
-        document: mutationResult.data.submitReviewVote,
-        store, typeName: "ReviewVote",
-      });
-    }
-  });
+//   const [submitVote] = useMutation(gql`
+//     mutation submitReviewVote($postId: String, $qualitativeScore: Int, $quadraticChange: Int, $newQuadraticScore: Int, $comment: String, $year: String, $dummy: Boolean, $reactions: [String]) {
+//       submitReviewVote(postId: $postId, qualitativeScore: $qualitativeScore, quadraticChange: $quadraticChange, comment: $comment, newQuadraticScore: $newQuadraticScore, year: $year, dummy: $dummy, reactions: $reactions) {
+//         ...reviewVoteFragment
+//       }
+//     }
+//     ${getFragment("reviewVoteFragment")}
+//   `, {
+//     update: (store, mutationResult) => {
+//       updateEachQueryResultOfType({
+//         func: handleUpdateMutation,
+//         document: mutationResult.data.submitReviewVote,
+//         store, typeName: "ReviewVote",
+//       });
+//     }
+//   });
 
-  const [useQuadratic, setUseQuadratic] = useState(currentUser ? currentUser[userVotesAreQuadraticField] : false)
-  const [loading, setLoading] = useState(false)
-  const [expandedPost, setExpandedPost] = useState<any>(null)
-  const [showKarmaVotes, setShowKarmaVotes] = useState<any>(null)
+//   const [useQuadratic, setUseQuadratic] = useState(currentUser ? currentUser[userVotesAreQuadraticField] : false)
+//   const [loading, setLoading] = useState(false)
+//   const [expandedPost, setExpandedPost] = useState<any>(null)
+//   const [showKarmaVotes, setShowKarmaVotes] = useState<any>(null)
 
-  const votes = dbVotes?.map(({_id, qualitativeScore, postId, reactions}) => ({_id, postId, score: qualitativeScore, type: "qualitative", reactions})) as qualitativeVote[]
+//   const votes = dbVotes?.map(({_id, qualitativeScore, postId, reactions}) => ({_id, postId, score: qualitativeScore, type: "qualitative", reactions})) as qualitativeVote[]
   
-  const handleSetUseQuadratic = (newUseQuadratic: boolean) => {
-    if (!newUseQuadratic) {
-      if (!confirm("WARNING: This will discard your quadratic vote data. Are you sure you want to return to basic voting?")) {
-        return
-      }
-    }
+//   const handleSetUseQuadratic = (newUseQuadratic: boolean) => {
+//     if (!newUseQuadratic) {
+//       if (!confirm("WARNING: This will discard your quadratic vote data. Are you sure you want to return to basic voting?")) {
+//         return
+//       }
+//     }
 
-    setUseQuadratic(newUseQuadratic)
-    void updateUser({
-      selector: {_id: currentUser?._id},
-      data: {
-        [userVotesAreQuadraticField]: newUseQuadratic,
-      }
-    });
-  }
+//     setUseQuadratic(newUseQuadratic)
+//     void updateUser({
+//       selector: {_id: currentUser?._id},
+//       data: {
+//         [userVotesAreQuadraticField]: newUseQuadratic,
+//       }
+//     });
+//   }
 
-  const dispatchQualitativeVote = useCallback(async ({_id, postId, score, reactions}: {
-    _id: string|null,
-    postId: string,
-    score: number,
-    reactions?: string[],
-  }) => {
-    const existingVote = _id ? dbVotes.find(vote => vote._id === _id) : null;
-    const newReactions = reactions || existingVote?.reactions || []
-    return await submitVote({variables: {postId, qualitativeScore: score, year: YEAR+"", dummy: false, reactions: newReactions}})
-  }, [submitVote, dbVotes]);
+//   const dispatchQualitativeVote = useCallback(async ({_id, postId, score, reactions}: {
+//     _id: string|null,
+//     postId: string,
+//     score: number,
+//     reactions?: string[],
+//   }) => {
+//     const existingVote = _id ? dbVotes.find(vote => vote._id === _id) : null;
+//     const newReactions = reactions || existingVote?.reactions || []
+//     return await submitVote({variables: {postId, qualitativeScore: score, year: YEAR+"", dummy: false, reactions: newReactions}})
+//   }, [submitVote, dbVotes]);
 
-  const quadraticVotes = dbVotes?.map(({_id, quadraticScore, postId}) => ({_id, postId, score: quadraticScore, type: "quadratic"})) as quadraticVote[]
-  const dispatchQuadraticVote = async ({_id, postId, change, set, reactions}: {
-    _id?: string|null,
-    postId: string,
-    change?: number,
-    set?: number,
-    reactions?: string[],
-  }) => {
-    const existingVote = _id ? dbVotes.find(vote => vote._id === _id) : null;
-    const newReactions = reactions || existingVote?.reactions || []
-    await submitVote({
-      variables: {postId, quadraticChange: change, newQuadraticScore: set, year: YEAR+"", reactions: newReactions, dummy: false},
-      optimisticResponse: _id && {
-        __typename: "Mutation",
-        submitReviewVote: {
-          __typename: "ReviewVote",
-          ...existingVote,
-          quadraticScore: (typeof set !== 'undefined') ? set : ((existingVote?.quadraticScore || 0) + (change || 0)),
-          reactions: newReactions
-        }
-      }
-    })
-  }
+//   const quadraticVotes = dbVotes?.map(({_id, quadraticScore, postId}) => ({_id, postId, score: quadraticScore, type: "quadratic"})) as quadraticVote[]
+//   const dispatchQuadraticVote = async ({_id, postId, change, set, reactions}: {
+//     _id?: string|null,
+//     postId: string,
+//     change?: number,
+//     set?: number,
+//     reactions?: string[],
+//   }) => {
+//     const existingVote = _id ? dbVotes.find(vote => vote._id === _id) : null;
+//     const newReactions = reactions || existingVote?.reactions || []
+//     await submitVote({
+//       variables: {postId, quadraticChange: change, newQuadraticScore: set, year: YEAR+"", reactions: newReactions, dummy: false},
+//       optimisticResponse: _id && {
+//         __typename: "Mutation",
+//         submitReviewVote: {
+//           __typename: "ReviewVote",
+//           ...existingVote,
+//           quadraticScore: (typeof set !== 'undefined') ? set : ((existingVote?.quadraticScore || 0) + (change || 0)),
+//           reactions: newReactions
+//         }
+//       }
+//     })
+//   }
 
-  const { ReviewPostComments, LWTooltip, Loading, ReviewPostButton, ReviewVoteTableRow, ReactionsButton } = Components
+//   const { ReviewPostComments, LWTooltip, Loading, ReviewPostButton, ReviewVoteTableRow, ReactionsButton } = Components
 
-  const [postOrder, setPostOrder] = useState<Map<number, number> | undefined>(undefined)
-  const reSortPosts = () => {
-    setPostOrder(new Map(getPostOrder(posts, useQuadratic ? quadraticVotes : votes, currentUser)))
-    captureEvent(undefined, {eventSubType: "postsResorted"})
-  }
+//   const [postOrder, setPostOrder] = useState<Map<number, number> | undefined>(undefined)
+//   const reSortPosts = () => {
+//     setPostOrder(new Map(getPostOrder(posts, useQuadratic ? quadraticVotes : votes, currentUser)))
+//     captureEvent(undefined, {eventSubType: "postsResorted"})
+//   }
 
-  // Re-sort in response to changes. (But we don't need to re-sort in response
-  // to everything exhaustively)
-  useEffect(() => {
-    if (!!posts && useQuadratic ? !!quadraticVotes : !!votes) setPostOrder(new Map(getPostOrder(posts, useQuadratic ? quadraticVotes : votes, currentUser)))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!!posts, useQuadratic, !!quadraticVotes, !!votes])
+//   // Re-sort in response to changes. (But we don't need to re-sort in response
+//   // to everything exhaustively)
+//   useEffect(() => {
+//     if (!!posts && useQuadratic ? !!quadraticVotes : !!votes) setPostOrder(new Map(getPostOrder(posts, useQuadratic ? quadraticVotes : votes, currentUser)))
+//     // eslint-disable-next-line react-hooks/exhaustive-deps
+//   }, [!!posts, useQuadratic, !!quadraticVotes, !!votes])
 
-  if (!currentUserCanVote(currentUser)) {
-    return (
-      <div className={classes.message}>
-        Only users registered before {YEAR} can vote in the {YEAR} LessWrong Review
-      </div>
-    )
-  }
+//   if (!currentUserCanVote(currentUser)) {
+//     return (
+//       <div className={classes.message}>
+//         Only users registered before {YEAR} can vote in the {YEAR} LessWrong Review
+//       </div>
+//     )
+//   }
 
-  const voteTotal = useQuadratic ? computeTotalCost(quadraticVotes) : 0
-  // const averageQuadraticVote = posts?.length>0 ? sumBy(quadraticVotes, v=>v.score)/posts.length : 0;
-  // const averageQuadraticVoteStr = averageQuadraticVote.toFixed(2);
+//   const voteTotal = useQuadratic ? computeTotalCost(quadraticVotes) : 0
+//   // const averageQuadraticVote = posts?.length>0 ? sumBy(quadraticVotes, v=>v.score)/posts.length : 0;
+//   // const averageQuadraticVoteStr = averageQuadraticVote.toFixed(2);
   
-  // const adjustAllQuadratic = (delta: number) => {
-  //   for (let post of posts) {
-  //     const existingVote = votes.find(vote => vote.postId === post._id);
-  //     void dispatchQuadraticVote({
-  //       _id: existingVote?._id || null,
-  //       postId: post._id,
-  //       change: delta,
-  //     });
-  //   }
-  // }
+//   // const adjustAllQuadratic = (delta: number) => {
+//   //   for (let post of posts) {
+//   //     const existingVote = votes.find(vote => vote.postId === post._id);
+//   //     void dispatchQuadraticVote({
+//   //       _id: existingVote?._id || null,
+//   //       postId: post._id,
+//   //       change: delta,
+//   //     });
+//   //   }
+//   // }
 
-  const currentReactions = expandedPost ? [...(votes.find(vote => vote.postId === expandedPost._id)?.reactions || [])] : []
+//   const currentReactions = expandedPost ? [...(votes.find(vote => vote.postId === expandedPost._id)?.reactions || [])] : []
   
-  // TODO: Redundancy here due to merge
-  const voteSum = useQuadratic ? computeTotalVote(quadraticVotes) : 0
-  const voteAverage = posts?.length > 0 ? voteSum/posts?.length : 0
+//   // TODO: Redundancy here due to merge
+//   const voteSum = useQuadratic ? computeTotalVote(quadraticVotes) : 0
+//   const voteAverage = posts?.length > 0 ? voteSum/posts?.length : 0
 
-  const renormalizeVotes = (quadraticVotes:quadraticVote[], voteAverage: number) => {
-    const voteAdjustment = -Math.trunc(voteAverage)
-    quadraticVotes.forEach(vote => dispatchQuadraticVote({...vote, change: voteAdjustment, set: undefined }))
-  }
+//   const renormalizeVotes = (quadraticVotes:quadraticVote[], voteAverage: number) => {
+//     const voteAdjustment = -Math.trunc(voteAverage)
+//     quadraticVotes.forEach(vote => dispatchQuadraticVote({...vote, change: voteAdjustment, set: undefined }))
+//   }
 
-  return (
-    <AnalyticsContext pageContext="ReviewVotingPage">
-    <div>
-      <div className={classNames(classes.hideOnMobile, classes.message)}>
-        Voting is not available on small screens
-      </div>
-      <div className={classes.grid}>
-        <div className={classes.leftColumn}>
-          <div className={classes.menu}>
-            <LWTooltip title="Sorts the list of post by vote-strength">
-              <Button onClick={reSortPosts}>
-                Re-Sort <CachedIcon className={classes.menuIcon} />
-              </Button>
-            </LWTooltip>
-            <LWTooltip title="Show which posts you have upvoted or downvoted">
-              <Button onClick={() => setShowKarmaVotes(!showKarmaVotes)}>
-                {showKarmaVotes ? "Hide Karma Votes" : "Show Karma Votes"} 
-              </Button>
-            </LWTooltip>
-            {(postsLoading || dbVotesLoading || loading) && <Loading/>}
-            {!useQuadratic && <LWTooltip title="WARNING: Once you switch to quadratic-voting, you cannot go back to default-voting without losing your quadratic data.">
-              <Button className={classes.convert} onClick={async () => {
-                  setLoading(true)
-                  await Promise.all(votesToQuadraticVotes(votes, posts).map(dispatchQuadraticVote))
-                  handleSetUseQuadratic(true)
-                  captureEvent(undefined, {eventSubType: "quadraticVotingSet", quadraticVoting:true})
-                  setLoading(false)
-              }}>
-                Convert to Quadratic <KeyboardTabIcon className={classes.menuIcon} />
-              </Button>
-            </LWTooltip>}
-            {useQuadratic && <LWTooltip title="Discard your quadratic data and return to default voting.">
-              <Button className={classes.convert} onClick={async () => {
-                  handleSetUseQuadratic(false)
-                  captureEvent(undefined, {eventSubType: "quadraticVotingSet", quadraticVoting:false})
-              }}>
-                <KeyboardTabIcon className={classes.returnToBasicIcon} />  Return to Basic Voting
-              </Button>
-            </LWTooltip>}
-            {useQuadratic && <LWTooltip title={`You have ${500 - voteTotal} points remaining`}>
-                <div className={classNames(classes.voteTotal, {[classes.excessVotes]: voteTotal > 500})}>
-                  {voteTotal}/500
-                </div>
-            </LWTooltip>}
-            {useQuadratic && Math.abs(voteAverage) > 1 && <LWTooltip title={<div>
-                <p><em>Click to renormalize your votes, closer to an optimal allocation</em></p>
-                <p>If the average of your votes is above 1 or below -1 you are always better off by shifting all of your votes by 1 to move closer to an average of 0. See voting instructions for details.</p></div>}>
-                <div className={classNames(classes.voteTotal, classes.excessVotes, classes.voteAverage)} onClick={() => renormalizeVotes(quadraticVotes, voteAverage)}>
-                  Avg: {(voteSum / posts.length).toFixed(2)}
-                </div>
-            </LWTooltip>}
-            <Button disabled={!expandedPost} onClick={()=>{
-              setExpandedPost(null)
-              captureEvent(undefined, {eventSubType: "showInstructionsClicked"})
-            }}>Show Instructions</Button>
-          </div>
-          <Paper>
-            {!!posts && !!postOrder && applyOrdering(posts, postOrder).map((post) => {
-                const currentQualitativeVote = votes.find(vote => vote.postId === post._id)
-                const currentQuadraticVote = quadraticVotes.find(vote => vote.postId === post._id)
+//   return (
+//     <AnalyticsContext pageContext="ReviewVotingPage">
+//     <div>
+//       <div className={classNames(classes.hideOnMobile, classes.message)}>
+//         Voting is not available on small screens
+//       </div>
+//       <div className={classes.grid}>
+//         <div className={classes.leftColumn}>
+//           <div className={classes.menu}>
+//             <LWTooltip title="Sorts the list of post by vote-strength">
+//               <Button onClick={reSortPosts}>
+//                 Re-Sort <CachedIcon className={classes.menuIcon} />
+//               </Button>
+//             </LWTooltip>
+//             <LWTooltip title="Show which posts you have upvoted or downvoted">
+//               <Button onClick={() => setShowKarmaVotes(!showKarmaVotes)}>
+//                 {showKarmaVotes ? "Hide Karma Votes" : "Show Karma Votes"} 
+//               </Button>
+//             </LWTooltip>
+//             {(postsLoading || dbVotesLoading || loading) && <Loading/>}
+//             {!useQuadratic && <LWTooltip title="WARNING: Once you switch to quadratic-voting, you cannot go back to default-voting without losing your quadratic data.">
+//               <Button className={classes.convert} onClick={async () => {
+//                   setLoading(true)
+//                   await Promise.all(votesToQuadraticVotes(votes, posts).map(dispatchQuadraticVote))
+//                   handleSetUseQuadratic(true)
+//                   captureEvent(undefined, {eventSubType: "quadraticVotingSet", quadraticVoting:true})
+//                   setLoading(false)
+//               }}>
+//                 Convert to Quadratic <KeyboardTabIcon className={classes.menuIcon} />
+//               </Button>
+//             </LWTooltip>}
+//             {useQuadratic && <LWTooltip title="Discard your quadratic data and return to default voting.">
+//               <Button className={classes.convert} onClick={async () => {
+//                   handleSetUseQuadratic(false)
+//                   captureEvent(undefined, {eventSubType: "quadraticVotingSet", quadraticVoting:false})
+//               }}>
+//                 <KeyboardTabIcon className={classes.returnToBasicIcon} />  Return to Basic Voting
+//               </Button>
+//             </LWTooltip>}
+//             {useQuadratic && <LWTooltip title={`You have ${500 - voteTotal} points remaining`}>
+//                 <div className={classNames(classes.voteTotal, {[classes.excessVotes]: voteTotal > 500})}>
+//                   {voteTotal}/500
+//                 </div>
+//             </LWTooltip>}
+//             {useQuadratic && Math.abs(voteAverage) > 1 && <LWTooltip title={<div>
+//                 <p><em>Click to renormalize your votes, closer to an optimal allocation</em></p>
+//                 <p>If the average of your votes is above 1 or below -1 you are always better off by shifting all of your votes by 1 to move closer to an average of 0. See voting instructions for details.</p></div>}>
+//                 <div className={classNames(classes.voteTotal, classes.excessVotes, classes.voteAverage)} onClick={() => renormalizeVotes(quadraticVotes, voteAverage)}>
+//                   Avg: {(voteSum / posts.length).toFixed(2)}
+//                 </div>
+//             </LWTooltip>}
+//             <Button disabled={!expandedPost} onClick={()=>{
+//               setExpandedPost(null)
+//               captureEvent(undefined, {eventSubType: "showInstructionsClicked"})
+//             }}>Show Instructions</Button>
+//           </div>
+//           <Paper>
+//             {!!posts && !!postOrder && applyOrdering(posts, postOrder).map((post) => {
+//                 const currentQualitativeVote = votes.find(vote => vote.postId === post._id)
+//                 const currentQuadraticVote = quadraticVotes.find(vote => vote.postId === post._id)
   
-                return <div key={post._id} onClick={()=>{
-                  setExpandedPost(post)
-                  captureEvent(undefined, {eventSubType: "voteTableRowClicked", postId: post._id})}}
-                >
-                  <ReviewVoteTableRow
-                    post={post}
-                    showKarmaVotes={showKarmaVotes}
-                    dispatch={dispatchQualitativeVote as any}
-                    currentVote={(useQuadratic ? currentQuadraticVote : currentQualitativeVote) as any}
-                    dispatchQuadraticVote={dispatchQuadraticVote}
-                    useQuadratic={useQuadratic}
-                    expandedPostId={expandedPost?._id}
-                  />
-                </div>
-              })}
-          </Paper>
-        </div>
-        <div className={classes.rightColumn}>
-          {!expandedPost && <div className={classes.expandedInfoWrapper}>
-            <div className={classes.expandedInfo}>
-              <h1 className={classes.header}>Vote on nominated and reviewed posts from {YEAR}</h1>
-              <div className={classes.instructions}>
-                {/* <p className={classes.warning}>For now this is just a dummy page that you can use to understand how the vote works. All submissions will be discarded, and the list of posts replaced by posts in the {YEAR} Review on January 12th.</p> */}
-                <p> Your vote should reflect a post’s overall level of importance (with whatever weightings seem right to you for “usefulness”, “accuracy”, “following good norms”, and other virtues).</p>
-                <p>Voting is done in two passes. First, roughly sort each post into one of the following buckets:</p>
-                <ul>
-                  <li><b>No</b> – Misleading, harmful or low quality.</li>
-                  <li><b>Neutral</b> – You wouldn't personally recommend it, but seems fine if others do. <em>(If you don’t have strong opinions about a post, leaving it ‘neutral’ is fine)</em></li>
-                  <li><b>Good</b> – Useful ideas that I still think about sometimes.</li>
-                  <li><b>Important</b> – A key insight or excellent distillation.</li>
-                  <li><b>Crucial</b> – One of the most significant posts of {YEAR}, for LessWrong to discuss and build upon over the coming years.</li>
-                </ul>
-                <p>After that, click “Convert to Quadratic”, and you will then have the option to use the quadratic voting system to fine-tune your votes. (Quadratic voting gives you a limited number of “points” to spend on votes, allowing you to vote multiple times, with each additional vote on an item costing more. See <Link to="/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this post</Link> for details. Also note that your vote allocation is not optimal if the average of your votes is above 1 or below -1, see <Link to="/posts/3yqf6zJSwBF34Zbys/2018-review-voting-results?commentId=HL9cPrFqMexGn4jmZ">this comment</Link> for details..)</p>
-                <p>If you’re having difficulties, please message the LessWrong Team using Intercom, the circle at the bottom right corner of the screen, or leave a comment on <Link to="/posts/QFBEjjAvT6KbaA3dY/the-lesswrong-2019-review">this post</Link>.</p>
-                <p>The vote closes on Jan 26th. If you leave this page and come back, your votes will be saved.</p>
-              </div>
-            </div>
-          </div>}
-          {expandedPost && <div className={classes.expandedInfoWrapper}>
-            <div className={classes.expandedInfo}>
-              <div className={classes.leaveReactions}>
-                {[...new Set([...defaultReactions, ...currentReactions])].map(reaction =>  <ReactionsButton 
-                  postId={expandedPost._id} 
-                  key={reaction}
-                  vote={useQuadratic ? dispatchQuadraticVote : dispatchQualitativeVote} 
-                  votes={votes as any}
-                  reaction={reaction} 
-                  freeEntry={false}
-                />)}
-                <ReactionsButton 
-                  postId={expandedPost._id} 
-                  vote={useQuadratic ? dispatchQuadraticVote : dispatchQualitativeVote} 
-                  votes={votes as any}
-                  reaction={"Other..."} 
-                  freeEntry={true}
-                />
-              </div>
-              <ReviewPostButton post={expandedPost} year={YEAR+""} reviewMessage={<div>
-                <div className={classes.writeAReview}>
-                  <div className={classes.reviewPrompt}>Write a review for "{expandedPost.title}"</div>
-                  <div className={classes.fakeTextfield}>Any thoughts about this post you want to share with other voters?</div>
-                </div>
-              </div>}/>
+//                 return <div key={post._id} onClick={()=>{
+//                   setExpandedPost(post)
+//                   captureEvent(undefined, {eventSubType: "voteTableRowClicked", postId: post._id})}}
+//                 >
+//                   <ReviewVoteTableRow
+//                     post={post}
+//                     showKarmaVotes={showKarmaVotes}
+//                     dispatch={dispatchQualitativeVote as any}
+//                     currentVote={(useQuadratic ? currentQuadraticVote : currentQualitativeVote) as any}
+//                     dispatchQuadraticVote={dispatchQuadraticVote}
+//                     useQuadratic={useQuadratic}
+//                     expandedPostId={expandedPost?._id}
+//                   />
+//                 </div>
+//               })}
+//           </Paper>
+//         </div>
+//         <div className={classes.rightColumn}>
+//           {!expandedPost && <div className={classes.expandedInfoWrapper}>
+//             <div className={classes.expandedInfo}>
+//               <h1 className={classes.header}>Vote on nominated and reviewed posts from {YEAR}</h1>
+//               <div className={classes.instructions}>
+//                 {/* <p className={classes.warning}>For now this is just a dummy page that you can use to understand how the vote works. All submissions will be discarded, and the list of posts replaced by posts in the {YEAR} Review on January 12th.</p> */}
+//                 <p> Your vote should reflect a post’s overall level of importance (with whatever weightings seem right to you for “usefulness”, “accuracy”, “following good norms”, and other virtues).</p>
+//                 <p>Voting is done in two passes. First, roughly sort each post into one of the following buckets:</p>
+//                 <ul>
+//                   <li><b>No</b> – Misleading, harmful or low quality.</li>
+//                   <li><b>Neutral</b> – You wouldn't personally recommend it, but seems fine if others do. <em>(If you don’t have strong opinions about a post, leaving it ‘neutral’ is fine)</em></li>
+//                   <li><b>Good</b> – Useful ideas that I still think about sometimes.</li>
+//                   <li><b>Important</b> – A key insight or excellent distillation.</li>
+//                   <li><b>Crucial</b> – One of the most significant posts of {YEAR}, for LessWrong to discuss and build upon over the coming years.</li>
+//                 </ul>
+//                 <p>After that, click “Convert to Quadratic”, and you will then have the option to use the quadratic voting system to fine-tune your votes. (Quadratic voting gives you a limited number of “points” to spend on votes, allowing you to vote multiple times, with each additional vote on an item costing more. See <Link to="/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this post</Link> for details. Also note that your vote allocation is not optimal if the average of your votes is above 1 or below -1, see <Link to="/posts/3yqf6zJSwBF34Zbys/2018-review-voting-results?commentId=HL9cPrFqMexGn4jmZ">this comment</Link> for details..)</p>
+//                 <p>If you’re having difficulties, please message the LessWrong Team using Intercom, the circle at the bottom right corner of the screen, or leave a comment on <Link to="/posts/QFBEjjAvT6KbaA3dY/the-lesswrong-2019-review">this post</Link>.</p>
+//                 <p>The vote closes on Jan 26th. If you leave this page and come back, your votes will be saved.</p>
+//               </div>
+//             </div>
+//           </div>}
+//           {expandedPost && <div className={classes.expandedInfoWrapper}>
+//             <div className={classes.expandedInfo}>
+//               <div className={classes.leaveReactions}>
+//                 {[...new Set([...defaultReactions, ...currentReactions])].map(reaction =>  <ReactionsButton 
+//                   postId={expandedPost._id} 
+//                   key={reaction}
+//                   vote={useQuadratic ? dispatchQuadraticVote : dispatchQualitativeVote} 
+//                   votes={votes as any}
+//                   reaction={reaction} 
+//                   freeEntry={false}
+//                 />)}
+//                 <ReactionsButton 
+//                   postId={expandedPost._id} 
+//                   vote={useQuadratic ? dispatchQuadraticVote : dispatchQualitativeVote} 
+//                   votes={votes as any}
+//                   reaction={"Other..."} 
+//                   freeEntry={true}
+//                 />
+//               </div>
+//               <ReviewPostButton post={expandedPost} year={YEAR+""} reviewMessage={<div>
+//                 <div className={classes.writeAReview}>
+//                   <div className={classes.reviewPrompt}>Write a review for "{expandedPost.title}"</div>
+//                   <div className={classes.fakeTextfield}>Any thoughts about this post you want to share with other voters?</div>
+//                 </div>
+//               </div>}/>
 
-              <div className={classes.comments}>
-                <ReviewPostComments
-                  title="nomination"
-                  singleLine
-                  terms={{view: NOMINATIONS_VIEW, postId: expandedPost._id}}
-                  post={expandedPost}
-                />
-                <ReviewPostComments
-                  title="review"
-                  terms={{view: REVIEW_COMMENTS_VIEW, postId: expandedPost._id}}
-                  post={expandedPost}
-                />
-              </div>
-            </div>
-          </div>}
-        </div>
-      </div>
-    </div>
-    </AnalyticsContext>
-  );
-}
+//               <div className={classes.comments}>
+//                 <ReviewPostComments
+//                   title="nomination"
+//                   singleLine
+//                   terms={{view: NOMINATIONS_VIEW, postId: expandedPost._id}}
+//                   post={expandedPost}
+//                 />
+//                 <ReviewPostComments
+//                   title="review"
+//                   terms={{view: REVIEW_COMMENTS_VIEW, postId: expandedPost._id}}
+//                   post={expandedPost}
+//                 />
+//               </div>
+//             </div>
+//           </div>}
+//         </div>
+//       </div>
+//     </div>
+//     </AnalyticsContext>
+//   );
+// }
 
-function getPostOrder(posts: Array<PostsList>, votes: Array<qualitativeVote|quadraticVote>, currentUser: UsersCurrent|null): Array<[number,number]> {
-  const randomPermutation = generatePermutation(posts.length, currentUser);
-  const result = posts.map(
-    (post: PostsList, i: number): [PostsList, qualitativeVote | quadraticVote | undefined, number, number, number] => {
-      const voteForPost = votes.find(vote => vote.postId === post._id)
-      const  voteScore = voteForPost ? voteForPost.score : 1;
-      return [post, voteForPost, voteScore, i, randomPermutation[i]]
-    })
-    .sort(([post1, vote1, voteScore1, i1, permuted1], [post2, vote2, voteScore2, i2, permuted2]) => {
-      if (voteScore1 < voteScore2) return -1;
-      if (voteScore1 > voteScore2) return 1;
-      if (permuted1 < permuted2) return -1;
-      if (permuted1 > permuted2) return 1;
-      else return 0;
-    })
-    .reverse()
-    .map(([post,vote,voteScore,originalIndex,permuted], sortedIndex) => [sortedIndex, originalIndex])
-  return result as Array<[number,number]>;
-}
+// function getPostOrder(posts: Array<PostsList>, votes: Array<qualitativeVote|quadraticVote>, currentUser: UsersCurrent|null): Array<[number,number]> {
+//   const randomPermutation = generatePermutation(posts.length, currentUser);
+//   const result = posts.map(
+//     (post: PostsList, i: number): [PostsList, qualitativeVote | quadraticVote | undefined, number, number, number] => {
+//       const voteForPost = votes.find(vote => vote.postId === post._id)
+//       const  voteScore = voteForPost ? voteForPost.score : 1;
+//       return [post, voteForPost, voteScore, i, randomPermutation[i]]
+//     })
+//     .sort(([post1, vote1, voteScore1, i1, permuted1], [post2, vote2, voteScore2, i2, permuted2]) => {
+//       if (voteScore1 < voteScore2) return -1;
+//       if (voteScore1 > voteScore2) return 1;
+//       if (permuted1 < permuted2) return -1;
+//       if (permuted1 > permuted2) return 1;
+//       else return 0;
+//     })
+//     .reverse()
+//     .map(([post,vote,voteScore,originalIndex,permuted], sortedIndex) => [sortedIndex, originalIndex])
+//   return result as Array<[number,number]>;
+// }
 
-function applyOrdering<T extends any>(array:T[], order:Map<number, number>):T[] {
-  const newArray = array.map((value, i) => {
-    const newIndex = order.get(i)
-    if (typeof newIndex !== 'number') throw Error(`Can't find value for key: ${i}`)
-    return array[newIndex]
-  })
-  return newArray
-}
+// function applyOrdering<T extends any>(array:T[], order:Map<number, number>):T[] {
+//   const newArray = array.map((value, i) => {
+//     const newIndex = order.get(i)
+//     if (typeof newIndex !== 'number') throw Error(`Can't find value for key: ${i}`)
+//     return array[newIndex]
+//   })
+//   return newArray
+// }
 
-const qualitativeScoreScaling = {
-  0: -4,
-  1: 0,
-  2: 1,
-  3: 4,
-  4: 15
-}
+// const qualitativeScoreScaling = {
+//   0: -4,
+//   1: 0,
+//   2: 1,
+//   3: 4,
+//   4: 15
+// }
 
-const VOTE_BUDGET = 500
-const MAX_SCALING = 6
-const votesToQuadraticVotes = (votes:qualitativeVote[], posts: any[]):{postId: string, change?: number, set?: number, _id?: string, previousValue?: number}[] => {
-  const sumScaled = sumBy(votes, vote => Math.abs(qualitativeScoreScaling[vote ? vote.score : 1]) || 0)
-  return createPostVoteTuples(posts, votes).map(([post, vote]) => {
-    if (vote) {
-      const newScore = computeQuadraticVoteScore(vote.score, sumScaled)
-      return {postId: post._id, set: newScore}
-    } else {
-      return {postId: post._id, set: 0}
-    }
-  })
-}
+// const VOTE_BUDGET = 500
+// const MAX_SCALING = 6
+// const votesToQuadraticVotes = (votes:qualitativeVote[], posts: any[]):{postId: string, change?: number, set?: number, _id?: string, previousValue?: number}[] => {
+//   const sumScaled = sumBy(votes, vote => Math.abs(qualitativeScoreScaling[vote ? vote.score : 1]) || 0)
+//   return createPostVoteTuples(posts, votes).map(([post, vote]) => {
+//     if (vote) {
+//       const newScore = computeQuadraticVoteScore(vote.score, sumScaled)
+//       return {postId: post._id, set: newScore}
+//     } else {
+//       return {postId: post._id, set: 0}
+//     }
+//   })
+// }
 
-const computeQuadraticVoteScore = (qualitativeScore: 0|1|2|3|4, totalCost: number) => {
-  const scaledScore = qualitativeScoreScaling[qualitativeScore]
-  const scaledCost = scaledScore * Math.min(VOTE_BUDGET/totalCost, MAX_SCALING)
-  const newScore = Math.sign(scaledCost) * Math.floor(inverseSumOf1ToN(Math.abs(scaledCost)))
-  return newScore
-}
+// const computeQuadraticVoteScore = (qualitativeScore: 0|1|2|3|4, totalCost: number) => {
+//   const scaledScore = qualitativeScoreScaling[qualitativeScore]
+//   const scaledCost = scaledScore * Math.min(VOTE_BUDGET/totalCost, MAX_SCALING)
+//   const newScore = Math.sign(scaledCost) * Math.floor(inverseSumOf1ToN(Math.abs(scaledCost)))
+//   return newScore
+// }
 
-const inverseSumOf1ToN = (x:number) => {
-  return Math.sign(x)*(1/2 * (Math.sqrt((8 * Math.abs(x)) + 1) - 1))
-}
+// const inverseSumOf1ToN = (x:number) => {
+//   return Math.sign(x)*(1/2 * (Math.sqrt((8 * Math.abs(x)) + 1) - 1))
+// }
 
-const sumOf1ToN = (x:number) => {
-  const absX = Math.abs(x)
-  return absX*(absX+1)/2
-}
+// const sumOf1ToN = (x:number) => {
+//   const absX = Math.abs(x)
+//   return absX*(absX+1)/2
+// }
 
-const computeTotalCost = (votes: ReviewVote[]) => {
-  return sumBy(votes, ({score}) => sumOf1ToN(score))
-}
+// const computeTotalCost = (votes: ReviewVote[]) => {
+//   return sumBy(votes, ({score}) => sumOf1ToN(score))
+// }
 
-const computeTotalVote = (votes: ReviewVote[]) => {
-  return sumBy(votes, ({score}) => score)
-}
+// const computeTotalVote = (votes: ReviewVote[]) => {
+//   return sumBy(votes, ({score}) => score)
+// }
 
-function createPostVoteTuples<K extends HasIdType,T extends ReviewVote> (posts: K[], votes: T[]):[K, T | undefined][] {
-  return posts.map(post => {
-    const voteForPost = votes.find(vote => vote.postId === post._id)
-    return [post, voteForPost]
-  })
-}
+// function createPostVoteTuples<K extends HasIdType,T extends ReviewVote> (posts: K[], votes: T[]):[K, T | undefined][] {
+//   return posts.map(post => {
+//     const voteForPost = votes.find(vote => vote.postId === post._id)
+//     return [post, voteForPost]
+//   })
+// }
 
-const ReviewVotingPage2019Component = registerComponent('ReviewVotingPage2019', ReviewVotingPage2019, {styles});
+// const ReviewVotingPage2019Component = registerComponent('ReviewVotingPage2019', ReviewVotingPage2019, {styles});
 
-declare global {
-  interface ComponentTypes {
-    ReviewVotingPage2019: typeof ReviewVotingPage2019Component
-  }
-}
+// declare global {
+//   interface ComponentTypes {
+//     ReviewVotingPage2019: typeof ReviewVotingPage2019Component
+//   }
+// }


### PR DESCRIPTION
This PR accomplishes half the goals of this other PR: https://github.com/ForumMagnum/ForumMagnum/pull/4554

It makes it so that, on the /reviewVOting page, when your vote-cost-total is more than 500, the value of your votes is reduced. It doesn't show updates as you're doing your voting, just when you refresh the page. It works via passing down the vote-cost-total, and then using the inverse of the quadratic voting equation to downweight the votes.

The other PR had some finnicky issues trying to get the refresh/responsiveness to feel natural, instead of confusing or buggy. 

![image](https://user-images.githubusercontent.com/3246710/151238982-2d8321a6-fff8-42d3-8202-87b31fc8690c.png)
