### PR TITLE
Docs with Collaborative Editing enabled are only editable on test server (LessestWrong)

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -50,7 +50,6 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
   function isCollaborative(post): boolean {
     if (!post) return false;
     if (!post._id) return false;
-    // if (fieldName !== "contents") return false;
     if (post?.shareWithUsers) return true;
     if (post?.sharingSettings?.anyoneWithLinkCan && post.sharingSettings.anyoneWithLinkCan !== "none")
       return true;

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -11,7 +11,6 @@ import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
-import {userHasCkCollaboration} from "../../lib/betas";
 import {testServerSetting} from "../../lib/instanceSettings";
 
 const PostsEditForm = ({ documentId, eventForm, classes }: {
@@ -48,15 +47,27 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
     fragmentName: 'SuggestAlignmentPost',
   })
   
-  console.log({testServer: testServerSetting.get()})
-  
-  // if (!testServerSetting.get() && userHasCkCollaboration(currentUser) && document?._id && document?.shareWithUsers) {
-    if (userHasCkCollaboration(currentUser) && document?._id && document?.shareWithUsers) {
-    return <div>
-      This post has experimental collaborative editing enabled. It can only be edited on the development server.
-      {`https://www.lessestwrong.com/posts/${document._id}`}
-    </div>
+  function isCollaborative(post): boolean {
+    if (!post) return false;
+    if (!post._id) return false;
+    // if (fieldName !== "contents") return false;
+    if (post?.shareWithUsers) return true;
+    if (post?.sharingSettings?.anyoneWithLinkCan && post.sharingSettings.anyoneWithLinkCan !== "none")
+      return true;
+    return false;
   }
+  
+  
+  if (!testServerSetting.get() && isCollaborative(document)) {
+    return <Components.SingleColumnSection>
+      <p>This post has experimental collaborative editing enabled.</p>
+      <p>It can only be edited on the development server.</p>
+      <a className={classes.collaborativeRedirectLink} href={`https://www.lessestwrong.com/editPost?postId=${document?._id}`}>
+        <h1>EDIT THE POST HERE</h1>
+      </a>     
+    </Components.SingleColumnSection>
+  }
+      
   
   return (
     <div className={classes.postForm}>

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -11,6 +11,8 @@ import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
+import {userHasCkCollaboration} from "../../lib/betas";
+import {testServerSetting} from "../../lib/instanceSettings";
 
 const PostsEditForm = ({ documentId, eventForm, classes }: {
   documentId: string,
@@ -45,7 +47,16 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
     collectionName: "Posts",
     fragmentName: 'SuggestAlignmentPost',
   })
-
+  
+  console.log({testServer: testServerSetting.get()})
+  
+  // if (!testServerSetting.get() && userHasCkCollaboration(currentUser) && document?._id && document?.shareWithUsers) {
+    if (userHasCkCollaboration(currentUser) && document?._id && document?.shareWithUsers) {
+    return <div>
+      This post has experimental collaborative editing enabled. It can only be edited on the development server.
+      {`https://www.lessestwrong.com/posts/${document._id}`}
+    </div>
+  }
   
   return (
     <div className={classes.postForm}>

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -85,6 +85,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     flexWrap: "wrap",
+  },
+  collaborativeRedirectLink: {
+    color:  theme.palette.secondary.main
   }
 })
 

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -931,6 +931,7 @@ addFieldsDict(Posts, {
     label: "Sharing Settings",
     group: formGroups.title,
     blackbox: true,
+    hidden: true,
   },
   
   shareWithUsers: {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -9,7 +9,8 @@ import { getWithLoader } from '../../loaders';
 import { accessFilterMultiple, accessFilterSingle, addFieldsDict, arrayOfForeignKeysField, denormalizedCountOfReferences, denormalizedField, foreignKeyField, googleLocationToMongoLocation, resolverOnlyField } from '../../utils/schemaUtils';
 import { Utils } from '../../vulcan-lib';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
-import { userCanCommentLock, userCanModeratePost } from '../users/helpers';
+import { userOwns } from '../../vulcan-users/permissions';
+import { userCanCommentLock, userCanModeratePost, userIsSharedOn } from '../users/helpers';
 import { Posts } from './collection';
 import { sequenceGetNextPostID, sequenceGetPrevPostID, sequenceContainsPost } from '../sequences/helpers';
 import { postCanEditHideCommentKarma } from './helpers';
@@ -920,6 +921,18 @@ addFieldsDict(Posts, {
     }
   },
 
+  sharingSettings: {
+    type: Object,
+    order: 16,
+    viewableBy: [userOwns, userIsSharedOn, 'admins'],
+    editableBy: [userOwns, 'admins'],
+    insertableBy: ['members'],
+    optional: true,
+    label: "Sharing Settings",
+    group: formGroups.title,
+    blackbox: true,
+  },
+  
   shareWithUsers: {
     type: Array,
     order: 15,

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -34,6 +34,7 @@ registerFragment(`
     meta
 
     shareWithUsers
+    sharingSettings
     
     commentCount
     voteCount

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -434,6 +434,7 @@ interface DbPost extends DbObject {
   eventImageId: string
   types: Array<string>
   metaSticky: boolean
+  sharingSettings: any /*{"definitions":[{"blackbox":true}]}*/
   shareWithUsers: Array<string>
   commentSortOrder: string
   hideAuthor: boolean

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -310,6 +310,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly frontpageDate: Date,
   readonly meta: boolean,
   readonly shareWithUsers: Array<string>,
+  readonly sharingSettings: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly commentCount: number,
   readonly voteCount: number,
   readonly baseScore: number,

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -127,3 +127,6 @@ export const sentryReleaseSetting = new PublicInstanceSetting<string|null>('sent
 export const siteUrlSetting = new PublicInstanceSetting<string>('siteUrl', getAbsoluteUrl(), "optional")
 
 // Stripe setting
+
+//Test vs Production Setting
+export const testServerSetting = new PublicInstanceSetting<boolean>("testServer", false, "warning")

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -282,6 +282,7 @@ export const forcePendingEvents = async (upToDate=null) => {
     // Keep checking for more events to handle so long as one was handled.
   } while (eventToHandle);
 }
+
 Vulcan.forcePendingEvents = forcePendingEvents;
 
 if (!testServerSetting.get()) {
@@ -294,3 +295,4 @@ if (!testServerSetting.get()) {
     }
   });
 }
+

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -1,6 +1,6 @@
 import { captureException } from '@sentry/core';
 import { DebouncerEvents } from '../lib/collections/debouncerEvents/collection';
-import { forumTypeSetting, PublicInstanceSetting } from '../lib/instanceSettings';
+import { forumTypeSetting, testServerSetting } from '../lib/instanceSettings';
 import moment from '../lib/moment-timezone';
 import { addCronJob } from './cronUtil';
 import { Vulcan } from '../lib/vulcan-lib/config';
@@ -284,7 +284,6 @@ export const forcePendingEvents = async (upToDate=null) => {
 }
 Vulcan.forcePendingEvents = forcePendingEvents;
 
-export const testServerSetting = new PublicInstanceSetting<boolean>("testServer", false, "warning")
 if (!testServerSetting.get()) {
   addCronJob({
     name: "Debounced event handler",

--- a/packages/lesswrong/server/eventReminders.tsx
+++ b/packages/lesswrong/server/eventReminders.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Components } from '../lib/vulcan-lib/components';
-import { testServerSetting } from './debouncer';
+import { testServerSetting } from '../lib/instanceSettings';
 import { Posts } from '../lib/collections/posts/collection';
 import { postStatuses } from '../lib/collections/posts/constants';
 import { Users } from '../lib/collections/users/collection';


### PR DESCRIPTION
This PR makes it so that if a document has been edited in collaborative mode, it can only be edited on LessestWrong/test server. This lets us start testing with some users and have them use LessestWrong without the issues if they tried to also edit on LessWrong.

![LessWrong 2022-01-27 16-15-33](https://user-images.githubusercontent.com/7250541/151464716-836c9915-4994-4bf9-a97e-651804ac63f2.png)
