### PR TITLE
Fix PostsResults loading bug on /reviewVoting page

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -329,6 +329,8 @@ const ReviewVotingPage = ({classes}: {
 
   const { LWTooltip, Loading, ReviewVotingExpandedPost, ReviewVoteTableRow, SectionTitle, RecentComments, FrontpageReviewWidget } = Components
 
+  const canInitialResort = !!postsResults
+
   const reSortPosts = useCallback((sortPosts, sortReversed) => {
     if (!postsResults) return
 
@@ -401,10 +403,8 @@ const ReviewVotingPage = ({classes}: {
     setPostsHaveBeenSorted(true)
     captureEvent(undefined, {eventSubType: "postsResorted"})
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser, captureEvent])
+  }, [currentUser, captureEvent, canInitialResort])
   
-  const canInitialResort = !!postsResults
-
   useEffect(() => {
     setCostTotal(getCostTotal(postsResults))
   }, [canInitialResort, postsResults])


### PR DESCRIPTION
While fix a bunch of other bugs and weird UI experiences, Oli and I introduced this bug where the posts on /reviewVoting don't load if you navigate there from the frontpage. 

We had removed the postsResults argument from the useEffect hook that sorts the page, to avoid resorting every time we changed a vote. We were testing on a normal page load, where postsResults is available the first time the resort function is called. 

To get the best of both worlds I moved the "canInitialResort" variable further up the file so it can be used to detect when postsResults has first loaded.