### PR TITLE
Improve logged out review experience

### DIFF
--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -157,6 +157,9 @@ const styles = (theme: ThemeType) => ({
     ...voteTextStyling(theme),
     color: theme.palette.grey[500],
     cursor: "default"
+  },
+  commentsCount: {
+    paddingBottom: 8
   }
 });
 
@@ -191,10 +194,9 @@ const ReviewVoteTableRow = (
     setMarkedVisitedAt(new Date()) 
   }
 
-  if (!currentUser) return null;
   const expanded = expandedPostId === post._id
 
-  const currentUserIsAuthor = post.userId === currentUser._id || post.coauthors?.map(author => author?._id).includes(currentUser._id)
+  const currentUserIsAuthor = currentUser && (post.userId === currentUser._id || post.coauthors?.map(author => author?._id).includes(currentUser._id))
 
   const voteMap = {
     'bigDownvote': 'a strong downvote',
@@ -231,12 +233,14 @@ const ReviewVoteTableRow = (
             post={post}
           />
         </div>}
-        <PostsItemComments
-          small={false}
-          commentCount={postGetCommentCount(post)}
-          unreadComments={(markedVisitedAt || post.lastVisitedAt) < post.lastCommentedAt}
-          newPromotedComments={false}
-        />
+        <div className={classes.commentsCount}>
+          <PostsItemComments
+            small={false}
+            commentCount={postGetCommentCount(post)}
+            unreadComments={(markedVisitedAt || post.lastVisitedAt) < post.lastCommentedAt}
+            newPromotedComments={false}
+          />
+        </div>
         {getReviewPhase() !== "VOTING" && <PostsItem2MetaInfo className={classes.count}>
           <LWTooltip title={`This post has ${post.reviewCount} review${post.reviewCount > 1 ? "s" : ""}`}>
             { post.reviewCount }

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -532,7 +532,7 @@ const ReviewVotingPage = ({classes}: {
             }
             {(postsLoading || loading) && <Loading/>}
 
-            {!isEAForum && costTotal && <div className={classNames(classes.costTotal, {[classes.excessVotes]: costTotal > 500})}>
+            {!isEAForum && (costTotal !== null) && <div className={classNames(classes.costTotal, {[classes.excessVotes]: costTotal > 500})}>
               <LWTooltip title={costTotalTooltip}>
                 {costTotal}/500
               </LWTooltip>


### PR DESCRIPTION
Previously, logged out users simply hadn't seen any posts on the /reviewVoting page. This was originally to prevent them from voting (and we showed them a giant "you can't use this page" warning). But, we've since been optimizing it more so other people can follow along, and this makes a couple stylistic tweaks to improve that experience. Now they see this, instead of a blank posts-list:

![image](https://user-images.githubusercontent.com/3246710/151483180-74fecd3f-afc8-4854-852e-86788f00faa5.png)
