### PR TITLE
Only LW and EAforum have review

### DIFF
--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -35,6 +35,7 @@ export function getReviewPhase(): ReviewPhase | void {
 
 /** Is there an active review taking place? */
 export function reviewIsActive(): boolean {
+  if (!(isLWForum || isEAForum)) return false
   return !!getReviewPhase()
 }
 


### PR DESCRIPTION
This makes it so review-UI doesn't appear on the Alignment Forum. (Someday we might want to integrate the review into AF, but we haven't put any optimization into it and I think it's more confusing than helpful)