### PR TITLE
Add voting countdown

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -363,7 +363,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
            }}
           >       
             <div>
-              {/* If there's less than a day remaining, show the remaining time */}
+              {/* If there's less than 24 hours remaining, show the remaining time */}
               {voteEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
                 {voteEndDate.fromNow()} remaining
               </span>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -14,8 +14,6 @@ import { userIsAdmin } from '../../lib/vulcan-users';
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
-  timeRemaining: {
-  },
   learnMore: {
     color: theme.palette.lwTertiary.main
   },
@@ -111,6 +109,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.up('md')]: {
       display: 'none'
     }
+  },
+  timeRemaining: {
+    ...theme.typography.commentStyle,
+    fontSize: 14,
+    color: theme.palette.grey[500]
   }
 })
 
@@ -359,12 +362,15 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
             itemsPerPage: 10
            }}
           >       
-            {eligibleToNominate(currentUser) &&
+            <div>
+              <span className={classes.timeRemaining}>{voteEndDate.fromNow()} remaining</span>
+              {eligibleToNominate(currentUser) &&
               <Link to={"/reviews"} className={classes.actionButtonCTA}>
                 {activeRange === "REVIEWS" && <span>Review {REVIEW_YEAR} Posts</span>}
                 {activeRange === "VOTING" && <span>Cast Final Votes</span>}
               </Link>
-            }
+              }
+            </div>
           </PostsList2>
         </AnalyticsContext>}
 

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -363,7 +363,10 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
            }}
           >       
             <div>
-              <span className={classes.timeRemaining}>{voteEndDate.fromNow()} remaining</span>
+              {/* If there's less than a day remaining, show the remaining time */}
+              {voteEndDate.diff(new Date()) < (24 * 3600 * 1000) && <span className={classes.timeRemaining}>
+                {voteEndDate.fromNow()} remaining
+              </span>}
               {eligibleToNominate(currentUser) &&
               <Link to={"/reviews"} className={classes.actionButtonCTA}>
                 {activeRange === "REVIEWS" && <span>Review {REVIEW_YEAR} Posts</span>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -364,7 +364,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
           >       
             <div>
               {/* If there's less than a day remaining, show the remaining time */}
-              {voteEndDate.diff(new Date()) < (24 * 3600 * 1000) && <span className={classes.timeRemaining}>
+              {voteEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
                 {voteEndDate.fromNow()} remaining
               </span>}
               {eligibleToNominate(currentUser) &&


### PR DESCRIPTION
I've personally felt annoyed *as the person nominally in charge of everything* that it was very hard to tell exactly how much time was remaining. This adds an element that lets you know when there's less than 24 hours left, exactly how much time is remaining.

I'm not 100% sure on styling, the current option is here:

![image](https://user-images.githubusercontent.com/3246710/151865728-f729263a-3dd8-4304-a843-c14721a6b64a.png)

And I could imagining something like this being good instead:

![image](https://user-images.githubusercontent.com/3246710/151864577-7da099b5-a293-49e8-a1a5-05374f1b9bd8.png)
