### PR TITLE
Updates to ReviewAdminDashboard

### DIFF
--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -41,17 +41,17 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
   const { params: {year} } = useLocation()
 
   const { results: votes, loading: votesLoading } = useMulti({
-    terms: {view: "reviewVotesAdminDashboard", limit: 2000, year: year},
+    terms: {view: "reviewVotesAdminDashboard", limit: 10000, year: year},
     collectionName: "ReviewVotes",
     fragmentName: "reviewVoteWithUserAndPost",
     fetchPolicy: 'network-only',
   })
 
   const { results: users, loading: usersLoading } = useMulti({
-    terms: {view: "reviewAdminUsers", limit: 2000},
+    terms: {view: "reviewAdminUsers", limit: 500},
     collectionName: "Users",
     fragmentName: "UsersWithReviewInfo",
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'network-only'
   })
 
   if (!userIsAdmin(currentUser)) {
@@ -86,7 +86,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
       </div>
       <p><i>Users with at least 1 vote</i></p>
       {votes && userRows.map((userRow, i) => {
-        return <div key={userRow[0]} className={classes.voteItem}>
+        return <div key={userRow[0]} className={classes.voteItem} onClick={()=> console.log(userRow)}>
           <PostsItemMetaInfo className={classes.count}>
             {i+1}
           </PostsItemMetaInfo>
@@ -142,7 +142,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
           <b>Username</b>
         </PostsItemMetaInfo>
       </div>
-      {votes && votes.map(vote=><div className={classes.voteItem} key={vote._id}>
+      {votes && votes.map(vote=><div className={classes.voteItem} key={vote._id} onClick={() => console.log(vote)}>
         <PostsItemMetaInfo className={classes.date}>
           <FormatDate date={vote.createdAt}/>
         </PostsItemMetaInfo>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -6,6 +6,7 @@ import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
 import { useCurrentUser } from '../common/withUser';
 import { userIsAdmin } from '../../lib/vulcan-users/permissions';
+import { useLocation } from '../../lib/routeUtil';
 
 
 const styles = theme => ({
@@ -37,9 +38,10 @@ const styles = theme => ({
 const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
   const { FormatDate, PostsItemMetaInfo, Loading, Error404, Typography, UsersNameDisplay } = Components
   const currentUser = useCurrentUser()
+  const { params: {year} } = useLocation()
 
   const { results: votes, loading: votesLoading } = useMulti({
-    terms: {view: "reviewVotesAdminDashboard", limit: 2000, year: REVIEW_YEAR+""},
+    terms: {view: "reviewVotesAdminDashboard", limit: 2000, year: year},
     collectionName: "ReviewVotes",
     fragmentName: "reviewVoteWithUserAndPost",
     fetchPolicy: 'network-only',
@@ -58,11 +60,10 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
 
   const userRows = sortBy(
     Object.entries(groupBy(votes, (vote) => vote.userId)),
-    obj => -(obj[1].length || 0)
+    obj => -obj[1].length
   ) 
 
   return <div className={classes.root}>
-    {votesLoading && <Loading/>}
     <div>
       <Typography variant="display1">Users ({userRows.length})</Typography>
       <br/>
@@ -129,6 +130,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
     <div>
       <Typography variant="display1">All Votes ({votes?.length})</Typography>
       <br/>
+      {votesLoading && <Loading/>}
       <div className={classes.voteItem} >
         <PostsItemMetaInfo className={classes.date}>
           <b>Date</b>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -85,6 +85,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
       </div>
       <p><i>Users with at least 1 vote</i></p>
       {votes && userRows.map((userRow, i) => {
+        // eslint-disable-next-line no-console
         return <div key={userRow[0]} className={classes.voteItem} onClick={()=> console.log(userRow)}>
           <PostsItemMetaInfo className={classes.count}>
             {i+1}
@@ -141,6 +142,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
           <b>Username</b>
         </PostsItemMetaInfo>
       </div>
+      {/* eslint-disable-next-line no-console */}
       {votes && votes.map(vote=><div className={classes.voteItem} key={vote._id} onClick={() => console.log(vote)}>
         <PostsItemMetaInfo className={classes.date}>
           <FormatDate date={vote.createdAt}/>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -63,7 +63,10 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
     <div>
       <Typography variant="display1">Users ({userRows.length})</Typography>
       <div className={classes.voteItem} >
-      <PostsItemMetaInfo className={classes.karma}>
+        <PostsItemMetaInfo className={classes.count}>
+          <b>Count</b>
+        </PostsItemMetaInfo>
+        <PostsItemMetaInfo className={classes.karma}>
           <b>Votes</b>
         </PostsItemMetaInfo>
         <PostsItemMetaInfo className={classes.karma}>
@@ -98,8 +101,11 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
       })}
       <p><i>1000+ karma users</i></p>
       {usersLoading && <Loading/>}
-      {users && users.map(user => {
+      {users && users.map((user, i) => {
         return <div key={user._id} className={classes.voteItem}>
+          <PostsItemMetaInfo className={classes.count}>
+            {i+1}
+          </PostsItemMetaInfo>
           <PostsItemMetaInfo className={classes.karma}>
             {user.reviewVoteCount}
           </PostsItemMetaInfo>

--- a/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
+++ b/packages/lesswrong/components/review/ReviewAdminDashboard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
-import { REVIEW_YEAR } from '../../lib/reviewUtils';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
@@ -19,6 +18,10 @@ const styles = theme => ({
   },
   author: {
     width: 200
+  },
+  count: {
+    width: 50,
+    color: theme.palette.grey[400]
   },
   karma: {
     width: 100
@@ -62,6 +65,7 @@ const ReviewAdminDashboard = ({classes}:{classes:ClassesType}) => {
   return <div className={classes.root}>
     <div>
       <Typography variant="display1">Users ({userRows.length})</Typography>
+      <br/>
       <div className={classes.voteItem} >
         <PostsItemMetaInfo className={classes.count}>
           <b>Count</b>

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -996,6 +996,11 @@ addRoute(
   {
     name: 'reviewAdmin',
     path: '/reviewAdmin',
+    redirect: () => `/reviewAdmin/2020`,
+  },
+  {
+    name: 'reviewAdmin-year',
+    path: '/reviewAdmin/:year',
     componentName: 'ReviewAdminDashboard',
     title: "Review Admin Dashboard",
   }


### PR DESCRIPTION
This makes three changes
– The first list of users is sorted by "number of votes" instead of karma, so that we can more quickly scan for "how many users are actually voting a lot?"
– There's a "count" for the users, also to make it easy to count how many users cast 1 vote, 2 votes, 10 votes, etc,
– Instead of relying on REVIEW_YEAR for grabbing the votes, it takes in a url parameter so that we can compare vote metrics from multiple years.
– increase limit on votes to 10000 so that we don't miss any. I just realized I'd been looking at artificially low voting metrics because we were only looking at the most recent 2000 votes. 

(I'm not including a screenshot since the data is private)