### PR TITLE
End the review for LessWrong

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -154,8 +154,8 @@ const voteEndDate = moment.utc(annualReviewEnd.get())
 const forumTitle = forumTitleSetting.get()
 
 const nominationPhaseDateRange = <span>{nominationStartDate.format('MMM Do')} – {nominationEndDate.format('MMM Do')}</span>
-const reviewPhaseDateRange = <span>{nominationEndDate.clone().add(1, 'day').format('MMM Do')} – {reviewEndDate.format('MMM Do')}</span>
-const votingPhaseDateRange = <span>{reviewEndDate.clone().add(1, 'day').format('MMM Do')} – {voteEndDate.format('MMM Do')}</span>
+const reviewPhaseDateRange = <span>{nominationEndDate.clone().format('MMM Do')} – {reviewEndDate.format('MMM Do')}</span>
+const votingPhaseDateRange = <span>{reviewEndDate.clone().format('MMM Do')} – {voteEndDate.format('MMM Do')}</span>
 
 // EA will use LW text next year, so I've kept the forumType genericization
 export const overviewTooltip = isEAForum ?
@@ -212,14 +212,14 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
 
   const reviewTooltip = isEAForum ?
     <>
-      <div>Review posts for the {REVIEW_NAME_IN_SITU} (Opens {nominationEndDate.clone().add(1, 'day').format('MMM Do')})</div>
+      <div>Review posts for the {REVIEW_NAME_IN_SITU} (Opens {nominationEndDate.clone().format('MMM Do')})</div>
       <ul>
         <li>Write reviews of posts nominated for the {REVIEW_NAME_IN_SITU}</li>
         <li>Only posts with at least one review are eligible for the final vote</li>
       </ul>
     </> :
     <>
-      <div>Review posts for the {REVIEW_YEAR} Review (Opens {nominationEndDate.clone().add(1, 'day').format('MMM Do')})</div>
+      <div>Review posts for the {REVIEW_YEAR} Review (Opens {nominationEndDate.clone().format('MMM Do')})</div>
       <ul>
         <li>Write reviews of posts nominated for the {REVIEW_YEAR} Review</li>
         <li>Only posts with at least one review are eligible for the final vote</li>
@@ -228,14 +228,14 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
 
   const voteTooltip = isEAForum ?
     <>
-      <div>Cast your final votes for the {REVIEW_NAME_IN_SITU}. (Opens {reviewEndDate.clone().add(1, 'day').format('MMM Do')})</div>
+      <div>Cast your final votes for the {REVIEW_NAME_IN_SITU}. (Opens {reviewEndDate.clone().format('MMM Do')})</div>
       <ul>
         <li>Look over nominated posts and vote on them</li>
         <li>Any user registered before {nominationStartDate.format('MMM Do')} can vote in the review</li>
       </ul>
     </> :
     <>
-      <div>Cast your final votes for the {REVIEW_YEAR} Review. (Opens {reviewEndDate.clone().add(1, 'day').format('MMM Do')})</div>
+      <div>Cast your final votes for the {REVIEW_YEAR} Review. (Opens {reviewEndDate.clone().format('MMM Do')})</div>
       <ul>
         <li>Look over {/* TODO: Raymond Arnold look here, sentence fragment */} </li>
         <li>Any user registered before {REVIEW_YEAR} can vote in the review</li>

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -6,7 +6,7 @@ import forumThemeExport from '../../themes/forumTheme';
 import { DEFAULT_QUALITATIVE_VOTE } from '../../lib/collections/reviewVotes/schema';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
-import { eligibleToNominate, getCostData } from '../../lib/reviewUtils';
+import { eligibleToNominate, getCostData, reviewIsActive } from '../../lib/reviewUtils';
 import { SyntheticQualitativeVote } from './ReviewVotingPage';
 
 const downvoteColor = "rgba(125,70,70, .87)"
@@ -14,7 +14,8 @@ const upvoteColor = forumTypeSetting.get() === "EAForum" ? forumThemeExport.pale
 
 const styles = (theme: ThemeType) => ({
   root: { 
-    whiteSpace: "pre"
+    whiteSpace: "pre",
+    ...theme.typography.commentStyle,
   },
   button: {
     paddingTop: 3,
@@ -71,6 +72,8 @@ const ReviewVotingButtons = ({classes, post, dispatch, currentUserVote, costTota
       dispatch({_id: currentUserVote?._id, postId: post._id, score: index})
     }
   }
+
+  if (!reviewIsActive()) return <div className={classes.root}>Voting period is over.</div>
 
   if (currentUser?._id === post.userId) return <div className={classes.root}>You can't vote on your own posts</div>
 

--- a/packages/lesswrong/lib/reviewUtils.ts
+++ b/packages/lesswrong/lib/reviewUtils.ts
@@ -20,9 +20,9 @@ export function getReviewPhase(): ReviewPhase | void {
   const currentDate = moment.utc()
   const reviewStart = moment.utc(annualReviewStart.get())
   // Add 1 day because the end dates are inclusive
-  const nominationsPhaseEnd = moment.utc(annualReviewNominationPhaseEnd.get()).add(1, "day")
-  const reviewPhaseEnd = moment.utc(annualReviewReviewPhaseEnd.get()).add(1, "day")
-  const reviewEnd = moment.utc(annualReviewEnd.get()).add(1, "day")
+  const nominationsPhaseEnd = moment.utc(annualReviewNominationPhaseEnd.get())
+  const reviewPhaseEnd = moment.utc(annualReviewReviewPhaseEnd.get())
+  const reviewEnd = moment.utc(annualReviewEnd.get())
   
   if (currentDate < reviewStart) return
   if (currentDate < nominationsPhaseEnd) return "NOMINATIONS"

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -21,7 +21,7 @@ export type ReviewPhase = "NOMINATIONS" | "REVIEWS" | "VOTING"
 export function getReviewPhase(): ReviewPhase | void {
   const currentDate = moment.utc()
   const reviewStart = moment.utc(annualReviewStart.get())
-  // Add 1 day because the end dates are inclusive
+
   const nominationsPhaseEnd = moment.utc(annualReviewNominationPhaseEnd.get())
   const reviewPhaseEnd = moment.utc(annualReviewReviewPhaseEnd.get())
   const reviewEnd = moment.utc(annualReviewEnd.get())


### PR DESCRIPTION
This replaces https://github.com/ForumMagnum/ForumMagnum/pull/4510.

This PR makes it so voting buttons stop working after the Review ends, and makes it so the review ends (more intuitively, for me), at exact time of the voteEndDate, rather than a day later.