### PR TITLE
Replace 'be.visible' with 'exists'

### DIFF
--- a/cypress/integration/comments/create_comment.spec.js
+++ b/cypress/integration/comments/create_comment.spec.js
@@ -12,6 +12,6 @@ describe('Comments', function() {
     cy.visit('/posts/test-seeded-post/test-seeded-post');
     cy.get('#new-comment-form').type('Test comment');
     cy.get('#new-comment-submit').click();
-    cy.contains('.CommentBody-root', 'Test comment').should('be.visible');
+    cy.contains('.CommentBody-root', 'Test comment').should('exist');
   });
 });

--- a/cypress/integration/comments/edit_comment.spec.js
+++ b/cypress/integration/comments/edit_comment.spec.js
@@ -18,6 +18,6 @@ describe('Comments', function() {
     const newCommentText = 'Edited comment';
     cy.get('.comments-edit-form .ck-editor__editable').click().clear().type(newCommentText);
     cy.contains('button', 'Save').click();
-    cy.contains('.CommentBody-root', newCommentText).should('be.visible');
+    cy.contains('.CommentBody-root', newCommentText).should('exist');
   });
 });

--- a/cypress/integration/messages/create_message.spec.js
+++ b/cypress/integration/messages/create_message.spec.js
@@ -13,9 +13,9 @@ describe('Messages', function() {
     const testReply = 'Test reply';
     cy.visit(`/users/${this.testOtherUser.slug}`);
     cy.get('a').contains('Message').click();
-    cy.contains('Test seeded message').should('be.visible');
+    cy.contains('Test seeded message').should('exist');
     cy.get('.ck-editor__editable').type(testReply);
     cy.contains("Submit").click();
-    cy.contains('.MessageItem-messageBody', testReply).should('be.visible');
+    cy.contains('.MessageItem-messageBody', testReply).should('exist');
   });
 });

--- a/cypress/integration/moderation/ban_user.spec.js
+++ b/cypress/integration/moderation/ban_user.spec.js
@@ -12,11 +12,11 @@ describe('Moderators', function() {
     // the not-yet-banned user should see a logged in view of the forum
     cy.loginAs(this.testUser);
     cy.visit('/');
-    cy.contains(this.testUser.displayName).should('be.visible');
+    cy.contains(this.testUser.displayName).should('exist');
 
     cy.loginAs(this.testAdmin);
     cy.visit('/');
-    cy.contains(this.bannedUserPost.title).should('be.visible');
+    cy.contains(this.bannedUserPost.title).should('exist');
     cy.visit(`/users/${this.testUser.slug}/edit`);
     cy.get('.form-section-ban-and-purge-user .form-section-heading-toggle').click();
     cy.get('.input-deleteContent .MuiCheckbox-root').click()
@@ -33,6 +33,6 @@ describe('Moderators', function() {
     
     // the banned user should see a logged out version of the forum
     cy.contains(this.testUser.displayName).should('not.exist');
-    cy.contains('.UsersAccountMenu-userButton', 'Login').should('be.visible');
+    cy.contains('.UsersAccountMenu-userButton', 'Login').should('exist');
   });
 })

--- a/cypress/integration/moderation/move_post_to_draft.spec.js
+++ b/cypress/integration/moderation/move_post_to_draft.spec.js
@@ -12,7 +12,7 @@ describe('Moderators', function() {
     cy.loginAs(this.testAdmin);
     cy.visit('/posts/test-seeded-post');
     cy.get('.PostsPageActions-root').click();
-    cy.contains(this.testPost.title).should('be.visible');
+    cy.contains(this.testPost.title).should('exist');
     cy.contains('li', 'Move to Draft').click();
 
     /** this stops the test from auto-failing when the operation_not_allowed 

--- a/cypress/integration/posts/edit_post.spec.js
+++ b/cypress/integration/posts/edit_post.spec.js
@@ -18,7 +18,7 @@ describe('Posts', function() {
     cy.get('.form-component-EditTitle').click().clear().type(newPostTitle);
     cy.get('.input-contents .ck-editor__editable').click().clear().type(newPostBody);
     cy.contains('Publish Changes').click();
-    cy.contains('.PostsPageTitle-root', newPostTitle).should('be.visible');
-    cy.contains('.PostsPage-postContent', newPostBody).should('be.visible');
+    cy.contains('.PostsPageTitle-root', newPostTitle).should('exist');
+    cy.contains('.PostsPage-postContent', newPostBody).should('exist');
   });
 });

--- a/cypress/integration/set_username.spec.js
+++ b/cypress/integration/set_username.spec.js
@@ -11,9 +11,9 @@ describe('Basic Login and Signup', function() {
     const newUsername = 'new-user-123123';
     cy.loginAs(this.testUserUnsetUsername);
     cy.visit('/');
-    cy.contains('Please choose a username').should('be.visible');
+    cy.contains('Please choose a username').should('exist');
     cy.get('input[type="text"]').type(newDisplayname);
     cy.get('.NewUserCompleteProfile-submitButtonSection > button').click();
-    cy.contains(`a[href="/users/${newUsername}"]`, newDisplayname).should('be.visible');
+    cy.contains(`a[href="/users/${newUsername}"]`, newDisplayname).should('exist');
   });
 })


### PR DESCRIPTION
The Cypress `should('be.visible')` assertion checks whether an element is visible on the page, not just whether it exists in the DOM. `set_username.spec.js` was failing from a change that affected page scroll behavior, which I suspect isn't something we want to flag as a test failure. This PR fixes the issue by swapping out all `be.visible` assertions for `exists` assertions.