### PR TITLE
posts.slug.single route

### DIFF
--- a/packages/lesswrong/components/posts/PostsSingleSlugRedirect.tsx
+++ b/packages/lesswrong/components/posts/PostsSingleSlugRedirect.tsx
@@ -1,0 +1,26 @@
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import React from 'react';
+import { useLocation } from '../../lib/routeUtil';
+import { usePostBySlug } from './usePost';
+import { postGetPageUrl } from '../../lib/collections/posts/helpers';
+
+const PostsSingleSlugRedirect = () => {
+  const { params } = useLocation();
+  const slug = params.slug;
+  const { post, loading } = usePostBySlug({ slug });
+
+  if (post) {
+    const canonicalUrl = postGetPageUrl(post);
+    return <Components.PermanentRedirect url={canonicalUrl}/>
+  } else {
+    return loading ? <Components.Loading/> : <Components.Error404 />
+  }
+};
+
+const PostsSingleSlugRedirectComponent = registerComponent('PostsSingleSlugRedirect', PostsSingleSlugRedirect);
+
+declare global {
+  interface ComponentTypes {
+    PostsSingleSlugRedirect: typeof PostsSingleSlugRedirectComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -204,6 +204,7 @@ importComponent("PostsCompareRevisions", () => require('../components/posts/Post
 importComponent("AddToCalendarIcon", () => require('../components/posts/AddToCalendar/AddToCalendarIcon'));
 
 importComponent("PostsSingleSlug", () => require('../components/posts/PostsSingleSlug'));
+importComponent("PostsSingleSlugRedirect", () => require('../components/posts/PostsSingleSlugRedirect'));
 importComponent("PostsSingleRoute", () => require('../components/posts/PostsSingleRoute'));
 importComponent("PostsList2", () => require('../components/posts/PostsList2'));
 importComponent("PostsByVote", () => require('../components/posts/PostsByVote'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -954,7 +954,7 @@ addRoute(
   {
     name:'posts.slug.single',
     path:'/posts/slug/:slug?',
-    componentName: 'PostsSingleSlug',
+    componentName: 'PostsSingleSlugRedirect',
     titleComponentName: 'PostsPageHeaderTitle',
     subtitleComponentName: 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreviewSlug',

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -957,8 +957,9 @@ addRoute(
     componentName: 'PostsSingleSlug',
     titleComponentName: 'PostsPageHeaderTitle',
     subtitleComponentName: 'PostsPageHeaderTitle',
-    previewComponentName: 'PostLinkPreview',
+    previewComponentName: 'PostLinkPreviewSlug',
     getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    background: postBackground
   },
   {
     name: 'posts.revisioncompare',

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -952,6 +952,15 @@ addRoute(
     background: postBackground
   },
   {
+    name:'posts.slug.single',
+    path:'/posts/slug/:slug?',
+    componentName: 'PostsSingleSlug',
+    titleComponentName: 'PostsPageHeaderTitle',
+    subtitleComponentName: 'PostsPageHeaderTitle',
+    previewComponentName: 'PostLinkPreview',
+    getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+  },
+  {
     name: 'posts.revisioncompare',
     path: '/compare/post/:_id/:slug',
     componentName: 'PostsCompareRevisions',


### PR DESCRIPTION
This makes a generic /posts/slug/:slug route, so that occasionally when we need to link to a post by slug there's a cleaner way to do it. (Previously this only worked for /hpmor/:slug, /codex/:slug and /rationality/:slug, which were all oddly specific sequences)

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/3246710/152469026-9e62b183-8f56-4671-ba0f-0133b0802412.png">
