### PR TITLE
Fix zIndex for Sequence Pages

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -43,6 +43,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 60,
     width: "100vw",
     height: 380,
+    zIndex: theme.zIndexes.sequenceBanner,
     [legacyBreakpoints.maxTiny]: {
       top: 40,
     },

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -20,6 +20,7 @@ const titleDividerSpacing = 20
 export const zIndexes = {
   frontpageBooks: 0,
   frontpageSplashImage: 0,
+  sequenceBanner: 0,
   singleColumnSection: 1,
   commentsMenu: 2,
   sequencesPageContent: 2,


### PR DESCRIPTION
The previous PR introduced at least one zIndex bug (by setting a number of zIndexes explicitly, where the ordering had previously done implicitly)