### PR TITLE
Fix EditSequenceTitle bug 

### DIFF
--- a/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
+++ b/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
@@ -17,7 +17,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "absolute",
     bottom: 10,
     left: "50%",
-    zIndex: 1,
     width: 0,
     
     [theme.breakpoints.down('sm')]: {
@@ -36,7 +35,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: '36px',
     color: 'white',
     fontVariant: 'small-caps',
-    zIndex: 2,
+    zIndex: theme.zIndexes.editSequenceTitleInput,
     height: '1em',
     resize: 'none',
     backgroundColor: 'transparent',

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -25,6 +25,7 @@ export const zIndexes = {
   commentsMenu: 2,
   sequencesPageContent: 2,
   sequencesImageScrim: 2,
+  editSequenceTitleInput: 3,
   postsVote: 2,
   postItemAuthor: 2,
   singleLineCommentMeta: 3,


### PR DESCRIPTION
This was another casualty of the recent zIndexes changes (you couldn't click into the editSequenceTitle input). Streamlining some more zIndexes fixes the issue.