### PR TITLE
add event type filter to Events page

### DIFF
--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -18,6 +18,9 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { getBrowserLocalStorage } from '../async/localStorageHandlers';
 import Geosuggest from 'react-geosuggest';
 import Button from '@material-ui/core/Button';
+import { EVENT_TYPES } from '../../lib/collections/posts/custom_fields';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import classNames from 'classnames';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   section: {
@@ -77,6 +80,17 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     fontSize: 20
   },
   filter: {
+    '& .MuiOutlinedInput-input': {
+      paddingRight: 30
+    },
+  },
+  formatFilter: {
+    '@media (max-width: 812px)': {
+      display: 'none'
+    }
+  },
+  placeholder: {
+    color: "rgba(0,0,0,0.4)",
   },
   notifications: {
     flex: '1 0 0',
@@ -155,6 +169,8 @@ const EventsHome = ({classes}: {
   
   // in-person, online, or all
   const [modeFilter, setModeFilter] = useState('all')
+  // ex. presentation, discussion, course, etc. (see EVENT_TYPES for full list)
+  const [formatFilter, setFormatFilter] = useState<Array<string>>([])
 
   // used to set the user's location if they did not already have one
   const { mutate: updateUser } = useUpdate({
@@ -245,13 +261,16 @@ const EventsHome = ({classes}: {
   const { HighlightedEventCard, EventCards, Loading } = Components
   
   // if certain filters are active, we hide the special event cards (ex. Intro VP card)
-  const hideSpecialCards = modeFilter === 'in-person'
+  const hideSpecialCards = modeFilter === 'in-person' || (formatFilter.length > 0 && !formatFilter.includes('course'))
 
   const filters: PostsViewTerms = {}
   if (modeFilter === 'in-person') {
     filters.onlineEvent = false
   } else if (modeFilter === 'online') {
     filters.onlineEvent = true
+  }
+  if (formatFilter.length) {
+    filters.eventType = formatFilter
   }
   
   const eventsListTerms: PostsViewTerms = queryLocation ? {
@@ -345,11 +364,35 @@ const EventsHome = ({classes}: {
             <Select
               className={classes.filter}
               value={modeFilter}
+              input={<OutlinedInput labelWidth={0} />}
               onChange={(e) => setModeFilter(e.target.value)}>
                 <MenuItem key="all" value="all">In-person and online</MenuItem>
                 <MenuItem key="in-person" value="in-person">In-person only</MenuItem>
                 <MenuItem key="online" value="online">Online only</MenuItem>
             </Select>
+            <Select
+              className={classNames(classes.filter, classes.formatFilter)}
+              value={formatFilter}
+              input={<OutlinedInput labelWidth={0} />}
+              onChange={e => {
+                // MUI documentation says e.target.value is always an array: https://mui.com/components/selects/#multiple-select
+                // @ts-ignore
+                setFormatFilter(e.target.value)
+              }}
+              multiple
+              displayEmpty
+              renderValue={(selected: Array<string>) => {
+                if (selected.length === 0) {
+                  return <em className={classes.placeholder}>Filter by format</em>
+                }
+                // if any options are selected, display them separated by commas
+                return selected.map(type => EVENT_TYPES.find(t => t.value === type)?.label).join(', ')
+              }}>
+                {EVENT_TYPES.map(type => {
+                  return <MenuItem key={type.value} value={type.value}>{type.label}</MenuItem>
+                })}
+            </Select>
+            
             <div className={classes.notifications}>
               <Button variant="text" color="primary" onClick={openEventNotificationsForm} className={classes.notificationsBtn}>
                 {currentUser?.nearbyEventsNotifications ? <NotificationsIcon className={classes.notificationsIcon} /> : <NotificationsNoneIcon className={classes.notificationsIcon} />} Notify me

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -669,6 +669,7 @@ addFieldsDict(Posts, {
     group: formGroups.event,
     optional: true,
     order: 2,
+    label: 'Event Format',
     form: {
       options: EVENT_TYPES
     },

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -34,6 +34,7 @@ declare global {
     excludeEvents?: boolean,
     onlineEvent?: boolean,
     globalEvent?: boolean,
+    eventType?: Array<string>,
     groupId?: string,
     lat?: number,
     lng?: number,
@@ -866,6 +867,7 @@ Posts.addView("globalEvents", (terms: PostsViewTerms) => {
       globalEvent: true,
       isEvent: true,
       groupId: null,
+      eventType: terms.eventType ? {$in: terms.eventType} : null,
       $and: [
         timeSelector, onlineEventSelector
       ],
@@ -880,7 +882,7 @@ Posts.addView("globalEvents", (terms: PostsViewTerms) => {
   return query
 })
 ensureIndex(Posts,
-  augmentForDefaultView({ globalEvent:1, startTime:1 }),
+  augmentForDefaultView({ globalEvent:1, eventType:1, startTime:1 }),
   { name: "posts.globalEvents" }
 );
 
@@ -896,11 +898,12 @@ Posts.addView("nearbyEvents", (terms: PostsViewTerms) => {
       {onlineEvent: false}, {onlineEvent: {$exists: false}}
     ]}
   }
-
+  
   let query: any = {
     selector: {
       groupId: null,
       isEvent: true,
+      eventType: terms.eventType ? {$in: terms.eventType} : null,
       $and: [
         timeSelector, onlineEventSelector
       ],
@@ -930,7 +933,7 @@ Posts.addView("nearbyEvents", (terms: PostsViewTerms) => {
   return query;
 });
 ensureIndex(Posts,
-  augmentForDefaultView({ mongoLocation:"2dsphere", location:1, startTime:1 }),
+  augmentForDefaultView({ mongoLocation:"2dsphere", eventType:1, startTime:1 }),
   { name: "posts.2dsphere" }
 );
 

--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -158,6 +158,17 @@ const theme = createLWTheme({
         padding: ".7rem",
       }
     },
+    MuiMenuItem: {
+      root: {
+        '&.MuiMenuItem-selected': {
+          backgroundColor: "#c69c6a",
+          color: 'white',
+          '&:hover': {
+            backgroundColor: "#b6ab9f"
+          }
+        }
+      }
+    },
     Header: {
       root: {
         height: 90,

--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -161,10 +161,10 @@ const theme = createLWTheme({
     MuiMenuItem: {
       root: {
         '&.MuiMenuItem-selected': {
-          backgroundColor: "#c69c6a",
+          backgroundColor: palette.primary.main,
           color: 'white',
           '&:hover': {
-            backgroundColor: "#b6ab9f"
+            backgroundColor: "#679299"
           }
         }
       }


### PR DESCRIPTION
In this PR, I'm adding a filter on the Events page for the `eventType` field. I refer to it as "event format" because I think "event type" is too vague, but I'm not totally sold on "event format" being the right term for this either. [Eventbrite](https://www.eventbrite.com/d/ma--boston/all-events/) uses the term "format" for a similar filter.

<img width="1204" alt="Screen Shot 2022-02-16 at 6 16 18 PM" src="https://user-images.githubusercontent.com/9057804/154379194-363be204-1c22-437d-832a-a98fc26cba82.png">

The "format" filter allows you to select multiple values. I also took this opportunity to use this orange again, to represent the selected values (the grayer orange is the hover state).

<img width="1173" alt="Screen Shot 2022-02-16 at 6 39 05 PM" src="https://user-images.githubusercontent.com/9057804/154379351-11b2fcff-5729-420b-b2d9-6e8291a73eb3.png">

On mobile, I decided to just hide the "format" filter.

<img width="411" alt="Screen Shot 2022-02-16 at 6 18 39 PM" src="https://user-images.githubusercontent.com/9057804/154379558-97ac317f-45c8-431e-8a15-5a14079da5bf.png">
