### PR TITLE
special card for advanced VPs on the Events page

### DIFF
--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -18,6 +18,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { getBrowserLocalStorage } from '../async/localStorageHandlers';
 import Geosuggest from 'react-geosuggest';
 import Button from '@material-ui/core/Button';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   section: {
@@ -244,8 +245,12 @@ const EventsHome = ({classes}: {
   
   const { HighlightedEventCard, EventCards, Loading } = Components
   
-  // if certain filters are active, we hide the special event cards (ex. Intro VP card)
-  const hideSpecialCards = modeFilter === 'in-person'
+  // on the EA Forum, we insert some special event cards (ex. Intro VP card)
+  let numSpecialCards = currentUser ? 1 : 2
+  // hide them on other forums, and when certain filters are set
+  if (forumTypeSetting.get() !== 'EAForum' || modeFilter === 'in-person') {
+    numSpecialCards = 0
+  }
 
   const filters: PostsViewTerms = {}
   if (modeFilter === 'in-person') {
@@ -270,7 +275,7 @@ const EventsHome = ({classes}: {
     fragmentName: 'PostsList',
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: "cache-first",
-    limit: hideSpecialCards ? 12 : 11,
+    limit: 12 - numSpecialCards,
     itemsPerPage: 12,
     skip: !queryLocation && currentUserLocation.loading
   });
@@ -357,7 +362,7 @@ const EventsHome = ({classes}: {
             </div>
           </div>
 
-          <EventCards events={results} loading={loading} numDefaultCards={6} hideSpecialCards={hideSpecialCards} />
+          <EventCards events={results} loading={loading} numDefaultCards={6} hideSpecialCards={!numSpecialCards} />
           
           <div className={classes.loadMoreRow}>
             {loadMoreButton}

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -181,15 +181,15 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
   })
   
   // on the EA Forum, insert card(s) advertising Virtual Programs
-  if (forumTypeSetting.get() === 'EAForum' && !hideSpecialCards && events.length >= 2) {
+  if (forumTypeSetting.get() === 'EAForum' && !hideSpecialCards) {
+    // NOTE: splice() will just insert the card at the end of the list if the first param > length
     if (currentUser) {
       // for logged in users, just display the In-Depth / Precipice VP card
       eventCards.splice(2, 0, <VirtualProgramCard program="advanced" />)
     } else {
       // for logged logged out users, display both VP cards
       eventCards.splice(2, 0, <VirtualProgramCard program="intro" />)
-      // we try to space out the two cards, but if there are less than 5 other items
-      // then luckily splice() will just insert this card at the end of the list
+      // we try to space out the two cards
       eventCards.splice(5, 0, <VirtualProgramCard program="advanced" />)
     }
   }

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -9,9 +9,7 @@ import { prettyEventDateTimes } from '../../../lib/collections/posts/helpers';
 import { useTimezone } from '../../common/withTimezone';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 import { getDefaultEventImg } from './HighlightedEventCard';
-import classNames from 'classnames';
-import moment from 'moment';
-import { useTracking } from '../../../lib/analyticsEvents';
+import { useCurrentUser } from '../../common/withUser';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -53,27 +51,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
       maxWidth: '100vw'
     }
   },
-  specialEventCardLink: {
-    '&:hover': {
-      opacity: '0.9'
-    }
-  },
-  specialEventCard: {
-    background: "linear-gradient(rgba(0, 87, 102, 0.7), rgba(0, 87, 102, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_373,c_fill,q_auto,f_auto/Event/pz3xmsm63xl8thlyt2up.jpg')",
-    padding: '50px 24px',
-    '& div': {
-      color: 'white'
-    },
-    '& .EventCards-eventCardTitle': {
-      fontSize: 24
-    },
-    '& .EventCards-eventCardLocation': {
-      opacity: '0.7'
-    },
-    '&:hover .EventCards-eventCardDeadline': {
-      borderBottom: '2px solid white'
-    }
-  },
   eventCardContent: {
     position: 'relative',
     height: 170,
@@ -107,13 +84,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     overflow: 'hidden',
     marginTop: 8,
   },
-  eventCardDescription: {
-    ...theme.typography.commentStyle,
-    color: "rgba(0, 0, 0, 0.7)",
-    fontSize: 14,
-    lineHeight: '1.8em',
-    marginTop: 30,
-  },
   eventCardGroup: {
     ...theme.typography.commentStyle,
     maxWidth: 290,
@@ -124,15 +94,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     marginTop: 10,
-  },
-  eventCardDeadline: {
-    ...theme.typography.commentStyle,
-    display: 'inline-block',
-    fontWeight: 'bold',
-    color: "rgba(0, 0, 0, 0.5)",
-    fontSize: 16,
-    paddingBottom: 5,
-    marginTop: 20,
   },
   addToCal: {
     ...theme.typography.commentStyle,
@@ -154,15 +115,15 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
   hideSpecialCards?: boolean,
   classes: ClassesType,
 }) => {
+  const currentUser = useCurrentUser()
   const { timezone } = useTimezone()
-  const { captureEvent } = useTracking()
   
   const getEventLocation = (event: PostsList): string => {
     if (event.onlineEvent) return 'Online'
     return event.location ? event.location.slice(0, event.location.lastIndexOf(',')) : ''
   }
   
-  const { AddToCalendarIcon, PostsItemTooltipWrapper, CloudinaryImage2 } = Components
+  const { AddToCalendarIcon, PostsItemTooltipWrapper, CloudinaryImage2, VirtualProgramCard } = Components
   
   // while the data is loading, show some placeholder empty cards
   if (loading && !events?.length) {
@@ -219,49 +180,16 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
     </Card>
   })
   
-  // on the EA Forum, insert a card advertising the Intro VP
+  // on the EA Forum, insert card(s) advertising Virtual Programs
   if (forumTypeSetting.get() === 'EAForum' && !hideSpecialCards && events.length >= 2) {
-    // find the next deadline for applying to the Intro VP, which is the last Sunday of every month
-    let sunday = moment().day(0)
-    _.range(5).forEach(() => {
-      const nextSunday = moment(sunday).add(1, 'week')
-      // needs to be in the future
-      if (sunday.isBefore(moment(), 'day')) {
-        sunday = nextSunday
-      }
-      // needs to be the last Sunday of the month
-      if (nextSunday.month() === sunday.month()) {
-        sunday = nextSunday
-      }
-    })
-    
-    // VP starts 8 days after the deadline, on a Monday
-    const startOfVp = moment(sunday).add(8, 'days')
-    // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
-    const endOfVp = moment(startOfVp).add(8, 'weeks').subtract(1, 'day')
-    
-    eventCards.splice(2, 0, (
-      <a key="intro-vp"
-        href="https://www.effectivealtruism.org/virtual-programs/introductory-program?from=forum_events_page"
-        className={classes.specialEventCardLink}
-        onClick={() => captureEvent('introVPClicked')}
-      >
-        <Card className={classNames(classes.eventCard, classes.specialEventCard)}>
-          <div className={classes.eventCardTime}>
-            {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
-          </div>
-          <div className={classes.eventCardTitle}>
-            Introductory EA Program
-          </div>
-          <div className={classes.eventCardLocation}>Online</div>
-          <div className={classes.eventCardDescription}>
-            This program is ideal for those new to effective altruism, or for those who have some familiarity,
-            but want to explore the core ideas in a structured way.
-          </div>
-          <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
-        </Card>
-      </a>
-    ))
+    if (currentUser) {
+      // for logged in users, just display the In-Depth / Precipice VP card
+      eventCards.splice(2, 0, <VirtualProgramCard program="advanced" />)
+    } else {
+      // for logged logged out users, display both VP cards
+      eventCards.splice(2, 0, <VirtualProgramCard program="intro" />)
+      eventCards.splice(5, 0, <VirtualProgramCard program="advanced" />)
+    }
   }
 
   return <>

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -138,8 +138,7 @@ const VirtualProgramCard = ({program, classes}: {
         </div>
         <div className={classes.eventCardLocation}>Online</div>
         <div className={classes.eventCardDescription}>
-          For those new to effective altruism, or those who have some familiarity,
-          but want to explore the core ideas in a structured way
+          Explore key ideas in effective altruism through short readings and weekly discussions
         </div>
         <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
       </Card>
@@ -179,7 +178,7 @@ const VirtualProgramCard = ({program, classes}: {
               <em>The Precipice</em> Reading Group
             </div>
             <div className={classes.eventCardDescription}>
-              Read and discuss this book about existential risks and safeguarding the future of humanity
+              Learn more about existential risks and safeguarding the future of humanity
             </div>
             <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
           </div>

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -106,7 +106,8 @@ const VirtualProgramCard = ({program, classes}: {
   
   // find the next deadline for applying to the Intro VP, which is the last Sunday of every month
   let result = moment()
-  _.range(5).forEach(() => {
+    // Iterate through 5 sundays to find the one we want
+  for (const sunday of _.range(5).map(x => moment().day(0).add(x, 'week'))) {
     const nextSunday = moment(sunday).add(1, 'week')
     // needs to be in the future, and needs to be the last Sunday of the month
     if (sunday.isAfter(moment(), 'day') && nextSunday.month() !== sunday.month()) {

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, } from '../../../lib/vulcan-lib';
+import { registerComponent, } from '../../../lib/vulcan-lib';
 import React from 'react';
 import { createStyles } from '@material-ui/core/styles';
 import * as _ from 'underscore';
@@ -24,6 +24,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     padding: '50px 24px',
     '& .VirtualProgramCard-eventCardDescription': {
       opacity: 1,
+      lineHeight: '1.8em',
       marginTop: 30
     },
     '& .VirtualProgramCard-eventCardDeadline': {
@@ -47,15 +48,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   inDepthSection: {
     background: "linear-gradient(rgba(0, 87, 102, 0.7), rgba(0, 87, 102, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
-    // background: "linear-gradient(rgb(95, 73, 47, 0.7), rgb(95, 73, 47, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
-    // background: "linear-gradient(rgb(198, 156, 106, 0.7), rgb(198, 156, 106, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
     clipPath: 'polygon(0 0, 100% 0, 100% 54%, 0 100%)'
   },
   precipiceSection: {
-    // background: "linear-gradient(rgb(153, 106, 0, 0.6), rgb(153, 106, 0, 0.6)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
-    // background: "linear-gradient(rgb(95, 73, 47, 0.7), rgb(95, 73, 47, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
     background: "linear-gradient(rgb(168, 114, 51, 0.5), rgb(168, 114, 51, 0.5)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
-    // background: "linear-gradient(rgb(198, 156, 106, 0.4), rgb(198, 156, 106, 0.4)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
     clipPath: 'polygon(0 46%, 100% 0, 100% 100%, 0 100%)',
     position: 'absolute',
     bottom: 0,
@@ -71,10 +67,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     ...theme.typography.headline,
     color: 'white',
     fontSize: 22,
-    display: '-webkit-box',
-    "-webkit-line-clamp": 2,
-    "-webkit-box-orient": 'vertical',
-    overflow: 'hidden',
     marginTop: 8,
     marginBottom: 0
   },
@@ -133,7 +125,7 @@ const VirtualProgramCard = ({program, classes}: {
 
   if (program === 'intro') {
     return <a
-      href="https://www.effectivealtruism.org/virtual-programs/introductory-program?from=forum_events_page"
+      href="https://www.effectivealtruism.org/virtual-programs/introductory-program?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
       className={classes.cardLink}
       onClick={() => captureEvent('introVPClicked')}
     >
@@ -157,7 +149,7 @@ const VirtualProgramCard = ({program, classes}: {
   if (program === 'advanced') {
     return <Card className={classes.eventCard}>
         <a
-          href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?from=forum_events_page"
+          href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
           className={classNames(classes.cardLink, classes.cardSection, classes.inDepthSection)}
           onClick={() => captureEvent('inDepthVPClicked')}
         >
@@ -175,7 +167,7 @@ const VirtualProgramCard = ({program, classes}: {
           </div>
         </a>
         <a
-          href="https://www.effectivealtruism.org/virtual-programs/the-precipice-reading-group?from=forum_events_page"
+          href="https://www.effectivealtruism.org/virtual-programs/the-precipice-reading-group?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
           className={classNames(classes.cardLink, classes.cardSection, classes.precipiceSection)}
           onClick={() => captureEvent('precipiceVPClicked')}
         >

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -105,19 +105,19 @@ const VirtualProgramCard = ({program, classes}: {
   const { captureEvent } = useTracking()
   
   // find the next deadline for applying to the Intro VP, which is the last Sunday of every month
-  let result = moment()
-    // Iterate through 5 sundays to find the one we want
+  let deadline = moment()
+  // Iterate through 5 Sundays to find the one we want
   for (const sunday of _.range(5).map(x => moment().day(0).add(x, 'week'))) {
     const nextSunday = moment(sunday).add(1, 'week')
     // needs to be in the future, and needs to be the last Sunday of the month
-    if (sunday.isAfter(moment(), 'day') && nextSunday.month() !== sunday.month()) {
-      result = sunday
+    if (sunday.isSameOrAfter(moment(), 'day') && nextSunday.month() !== sunday.month()) {
+      deadline = sunday
       break
     }
-  })
+  }
   
   // VP starts 8 days after the deadline, on a Monday
-  const startOfVp = moment(sunday).add(8, 'days')
+  const startOfVp = moment(deadline).add(8, 'days')
   // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
   const endOfVp = moment(startOfVp).add(8, 'weeks').subtract(1, 'day')
 
@@ -138,50 +138,50 @@ const VirtualProgramCard = ({program, classes}: {
         <div className={classes.eventCardDescription}>
           Explore key ideas in effective altruism through short readings and weekly discussions
         </div>
-        <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+        <div className={classes.eventCardDeadline}>Apply by Sunday, {deadline.format('MMMM D')}</div>
       </Card>
     </a>
   }
   
   if (program === 'advanced') {
     return <Card className={classes.eventCard}>
-        <a
-          href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
-          className={classNames(classes.cardLink, classes.cardSection, classes.inDepthSection)}
-          onClick={() => captureEvent('inDepthVPClicked')}
-        >
-          <div>
-            <div className={classes.eventCardTime}>
-              {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
-            </div>
-            <div className={classes.eventCardTitle}>
-              In-Depth EA Program
-            </div>
-            <div className={classes.eventCardDescription}>
-              Dive deeper into more complex EA ideas and examine your key uncertainties
-            </div>
-            <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+      <a
+        href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
+        className={classNames(classes.cardLink, classes.cardSection, classes.inDepthSection)}
+        onClick={() => captureEvent('inDepthVPClicked')}
+      >
+        <div>
+          <div className={classes.eventCardTime}>
+            {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
           </div>
-        </a>
-        <a
-          href="https://www.effectivealtruism.org/virtual-programs/the-precipice-reading-group?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
-          className={classNames(classes.cardLink, classes.cardSection, classes.precipiceSection)}
-          onClick={() => captureEvent('precipiceVPClicked')}
-        >
-          <div>
-            <div className={classes.eventCardTime}>
-              {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
-            </div>
-            <div className={classes.eventCardTitle}>
-              <em>The Precipice</em> Reading Group
-            </div>
-            <div className={classes.eventCardDescription}>
-              Learn more about existential risks and safeguarding the future of humanity
-            </div>
-            <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+          <div className={classes.eventCardTitle}>
+            In-Depth EA Program
           </div>
-        </a>
-      </Card>
+          <div className={classes.eventCardDescription}>
+            Dive deeper into more complex EA ideas and examine your key uncertainties
+          </div>
+          <div className={classes.eventCardDeadline}>Apply by Sunday, {deadline.format('MMMM D')}</div>
+        </div>
+      </a>
+      <a
+        href="https://www.effectivealtruism.org/virtual-programs/the-precipice-reading-group?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
+        className={classNames(classes.cardLink, classes.cardSection, classes.precipiceSection)}
+        onClick={() => captureEvent('precipiceVPClicked')}
+      >
+        <div>
+          <div className={classes.eventCardTime}>
+            {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
+          </div>
+          <div className={classes.eventCardTitle}>
+            <em>The Precipice</em> Reading Group
+          </div>
+          <div className={classes.eventCardDescription}>
+            Join weekly discussions about existential risks and safeguarding the future of humanity
+          </div>
+          <div className={classes.eventCardDeadline}>Apply by Sunday, {deadline.format('MMMM D')}</div>
+        </div>
+      </a>
+    </Card>
   }
   
   return null

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -1,0 +1,207 @@
+import { Components, registerComponent, } from '../../../lib/vulcan-lib';
+import React from 'react';
+import { createStyles } from '@material-ui/core/styles';
+import * as _ from 'underscore';
+import Card from '@material-ui/core/Card';
+import classNames from 'classnames';
+import moment from 'moment';
+import { useTracking } from '../../../lib/analyticsEvents';
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  eventCard: {
+    position: 'relative',
+    width: 373,
+    height: 374,
+    borderRadius: 0,
+    overflow: 'visible',
+    boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
+    [theme.breakpoints.down('xs')]: {
+      maxWidth: '100vw'
+    }
+  },
+  introVPCard: {
+    background: "linear-gradient(rgba(0, 87, 102, 0.7), rgba(0, 87, 102, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_373,c_fill,q_auto,f_auto/Event/pz3xmsm63xl8thlyt2up.jpg')",
+    padding: '50px 24px',
+    '& .VirtualProgramCard-eventCardDescription': {
+      opacity: 1,
+      marginTop: 30
+    },
+    '& .VirtualProgramCard-eventCardDeadline': {
+      marginTop: 30
+    }
+  },
+  cardLink: {
+    '&:hover': {
+      opacity: '0.9'
+    },
+    '&:hover .VirtualProgramCard-eventCardDeadline': {
+      borderBottom: '2px solid white'
+    }
+  },
+  cardSection: {
+    display: 'flex',
+    width: 373,
+    height: 243,
+    padding: 20,
+    overflow: 'hidden'
+  },
+  inDepthSection: {
+    background: "linear-gradient(rgba(0, 87, 102, 0.7), rgba(0, 87, 102, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
+    // background: "linear-gradient(rgb(95, 73, 47, 0.7), rgb(95, 73, 47, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
+    // background: "linear-gradient(rgb(198, 156, 106, 0.7), rgb(198, 156, 106, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/f2cbeqvjyhyl6rhhzdsu.jpg')",
+    clipPath: 'polygon(0 0, 100% 0, 100% 54%, 0 100%)'
+  },
+  precipiceSection: {
+    // background: "linear-gradient(rgb(153, 106, 0, 0.6), rgb(153, 106, 0, 0.6)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
+    // background: "linear-gradient(rgb(95, 73, 47, 0.7), rgb(95, 73, 47, 0.7)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
+    background: "linear-gradient(rgb(168, 114, 51, 0.5), rgb(168, 114, 51, 0.5)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
+    // background: "linear-gradient(rgb(198, 156, 106, 0.4), rgb(198, 156, 106, 0.4)), url('https://res.cloudinary.com/cea/image/upload/w_374,h_243,c_fill,q_auto,f_auto/Event/xfhrtorwdxxmplaofqa8.jpg')",
+    clipPath: 'polygon(0 46%, 100% 0, 100% 100%, 0 100%)',
+    position: 'absolute',
+    bottom: 0,
+    alignItems: 'flex-end',
+    textAlign: 'right'
+  },
+  eventCardTime: {
+    ...theme.typography.commentStyle,
+    fontSize: 14,
+    color: 'white'
+  },
+  eventCardTitle: {
+    ...theme.typography.headline,
+    color: 'white',
+    fontSize: 22,
+    display: '-webkit-box',
+    "-webkit-line-clamp": 2,
+    "-webkit-box-orient": 'vertical',
+    overflow: 'hidden',
+    marginTop: 8,
+    marginBottom: 0
+  },
+  eventCardLocation: {
+    ...theme.typography.commentStyle,
+    opacity: '0.7',
+    color: 'white',
+    fontSize: 14,
+    marginTop: 8,
+  },
+  eventCardDescription: {
+    ...theme.typography.commentStyle,
+    opacity: '0.7',
+    color: 'white',
+    fontSize: 14,
+    lineHeight: '1.5em',
+    marginTop: 10,
+  },
+  eventCardDeadline: {
+    ...theme.typography.commentStyle,
+    display: 'inline-block',
+    fontWeight: 'bold',
+    color: 'white',
+    fontSize: 16,
+    paddingBottom: 5,
+    marginTop: 10,
+    borderBottom: '2px solid transparent'
+  },
+}))
+
+
+const VirtualProgramCard = ({program, classes}: {
+  program: string,
+  classes: ClassesType,
+}) => {
+  const { captureEvent } = useTracking()
+  
+  // find the next deadline for applying to the Intro VP, which is the last Sunday of every month
+  let sunday = moment().day(0)
+  _.range(5).forEach(() => {
+    const nextSunday = moment(sunday).add(1, 'week')
+    // needs to be in the future
+    if (sunday.isBefore(moment(), 'day')) {
+      sunday = nextSunday
+    }
+    // needs to be the last Sunday of the month
+    if (nextSunday.month() === sunday.month()) {
+      sunday = nextSunday
+    }
+  })
+  
+  // VP starts 8 days after the deadline, on a Monday
+  const startOfVp = moment(sunday).add(8, 'days')
+  // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
+  const endOfVp = moment(startOfVp).add(8, 'weeks').subtract(1, 'day')
+
+  if (program === 'intro') {
+    return <a
+      href="https://www.effectivealtruism.org/virtual-programs/introductory-program?from=forum_events_page"
+      className={classes.cardLink}
+      onClick={() => captureEvent('introVPClicked')}
+    >
+      <Card className={classNames(classes.eventCard, classes.introVPCard)}>
+        <div className={classes.eventCardTime}>
+          {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
+        </div>
+        <div className={classes.eventCardTitle}>
+          Introductory EA Program
+        </div>
+        <div className={classes.eventCardLocation}>Online</div>
+        <div className={classes.eventCardDescription}>
+          For those new to effective altruism, or those who have some familiarity,
+          but want to explore the core ideas in a structured way
+        </div>
+        <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+      </Card>
+    </a>
+  }
+  
+  if (program === 'advanced') {
+    return <Card className={classes.eventCard}>
+        <a
+          href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?from=forum_events_page"
+          className={classNames(classes.cardLink, classes.cardSection, classes.inDepthSection)}
+          onClick={() => captureEvent('inDepthVPClicked')}
+        >
+          <div>
+            <div className={classes.eventCardTime}>
+              {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
+            </div>
+            <div className={classes.eventCardTitle}>
+              In-Depth EA Program
+            </div>
+            <div className={classes.eventCardDescription}>
+              Dive deeper into more complex EA ideas and examine your key uncertainties
+            </div>
+            <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+          </div>
+        </a>
+        <a
+          href="https://www.effectivealtruism.org/virtual-programs/the-precipice-reading-group?from=forum_events_page"
+          className={classNames(classes.cardLink, classes.cardSection, classes.precipiceSection)}
+          onClick={() => captureEvent('precipiceVPClicked')}
+        >
+          <div>
+            <div className={classes.eventCardTime}>
+              {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
+            </div>
+            <div className={classes.eventCardTitle}>
+              <em>The Precipice</em> Reading Group
+            </div>
+            <div className={classes.eventCardDescription}>
+              Read and discuss this book about existential risks and safeguarding the future of humanity
+            </div>
+            <div className={classes.eventCardDeadline}>Apply by Sunday, {sunday.format('MMMM D')}</div>
+          </div>
+        </a>
+      </Card>
+  }
+  
+  return null
+}
+
+const VirtualProgramCardComponent = registerComponent('VirtualProgramCard', VirtualProgramCard, {styles});
+
+declare global {
+  interface ComponentTypes {
+    VirtualProgramCard: typeof VirtualProgramCardComponent
+  }
+}

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -105,7 +105,7 @@ const VirtualProgramCard = ({program, classes}: {
   const { captureEvent } = useTracking()
   
   // find the next deadline for applying to the Intro VP, which is the last Sunday of every month
-  let sunday = moment().day(0)
+  let result = moment()
   _.range(5).forEach(() => {
     const nextSunday = moment(sunday).add(1, 'week')
     // needs to be in the future

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -108,13 +108,10 @@ const VirtualProgramCard = ({program, classes}: {
   let result = moment()
   _.range(5).forEach(() => {
     const nextSunday = moment(sunday).add(1, 'week')
-    // needs to be in the future
-    if (sunday.isBefore(moment(), 'day')) {
-      sunday = nextSunday
-    }
-    // needs to be the last Sunday of the month
-    if (nextSunday.month() === sunday.month()) {
-      sunday = nextSunday
+    // needs to be in the future, and needs to be the last Sunday of the month
+    if (sunday.isAfter(moment(), 'day') && nextSunday.month() !== sunday.month()) {
+      result = sunday
+      break
     }
   })
   

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -269,6 +269,7 @@ importComponent("EventsUpcoming", () => require('../components/posts/EventsUpcom
 importComponent("EventsHome", () => require('../components/events/EventsHome'));
 importComponent("HighlightedEventCard", () => require('../components/events/modules/HighlightedEventCard'));
 importComponent("EventCards", () => require('../components/events/modules/EventCards'));
+importComponent("VirtualProgramCard", () => require('../components/events/modules/VirtualProgramCard'));
 importComponent("CommunityHome", () => require('../components/localGroups/CommunityHome'));
 importComponent(["CommunityMap", "PersonalMapLocationMarkers"], () => require('../components/localGroups/CommunityMap'));
 importComponent("CommunityMapFilter", () => require('../components/localGroups/CommunityMapFilter'));


### PR DESCRIPTION
In a previous PR I created a special card for the Intro VP. Here I'm adding another one for the two more advanced VPs. Each half of the card is separately clickable. I'm not totally sold on the coloring, especially the orangey color - please let me know if you have suggestions.

<img width="1061" alt="Screen Shot 2022-02-17 at 11 22 26 PM" src="https://user-images.githubusercontent.com/9057804/154748351-a72733e4-8e05-47af-97a5-7d987e13ed6a.png">

Also for logged in forum users, they now only see the advanced VPs card:

<img width="1061" alt="Screen Shot 2022-02-17 at 11 23 32 PM" src="https://user-images.githubusercontent.com/9057804/154748699-59a347fd-5afc-41e8-97cd-bdada67f35a1.png">
