### PR TITLE
Save as Draft button adapts to collab/non-collab

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -44,7 +44,7 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
     return <div className={classes.formSubmit}>
       {!eventForm && <SubmitToFrontpageCheckbox {...props} />}
       <PostSubmit
-        saveDraftLabel={saveDraftLabel} //{isDraft ? "Preview" : "Move to Drafts"}
+        saveDraftLabel={saveDraftLabel} 
         feedbackLabel={"Get Feedback"}
         {...props}
       />

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -11,7 +11,6 @@ import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
-import {forumTypeSetting, testServerSetting} from "../../lib/instanceSettings";
 import { isCollaborative } from '../editor/EditorFormComponent';
 import { userIsAdmin } from '../../lib/vulcan-users/permissions';
 
@@ -33,11 +32,19 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
   const { params } = location; // From withLocation
   const isDraft = document && document.draft;
   const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags } = Components
+  
+  const saveDraftLabel: string = ((post) => {
+    if (!post) return "Save Draft"
+    if (!post.draft) return "Move to Drafts"
+    if (isCollaborative(post, "contents")) return "Preview"
+    return "Save Draft"
+  })(document)
+  
   const EditPostsSubmit = (props) => {
     return <div className={classes.formSubmit}>
       {!eventForm && <SubmitToFrontpageCheckbox {...props} />}
       <PostSubmit
-        saveDraftLabel={isDraft ? "Preview" : "Move to Drafts"}
+        saveDraftLabel={saveDraftLabel} //{isDraft ? "Preview" : "Move to Drafts"}
         feedbackLabel={"Get Feedback"}
         {...props}
       />

--- a/packages/lesswrong/components/spuriousChange.ts
+++ b/packages/lesswrong/components/spuriousChange.ts
@@ -2,5 +2,5 @@
 // This file gets rewritten by scripts/benchmarkIncrementalStart.sh as a way
 // of realistically triggering a server restart, as though a source file had
 // been edited.
-const someVar = 0
+const someVar = 26241
 


### PR DESCRIPTION
Makes it so the save as draft button still says save as draft for non-collab documents