### PR TITLE
Prizes review update

### DIFF
--- a/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
@@ -70,24 +70,31 @@ export const FrontpageBestOfLWWidget = ({classes}: {
 }) => {
   const { SectionTitle, RecommendationsList, SingleColumnSection, PostsItem2 } = Components
 
-  const { document: post } = useSingle({
+  const { document: postVoting } = useSingle({
     documentId: "TSaJ9Zcvc3KWh3bjX",
+    collectionName: "Posts",
+    fragmentName: "PostsList"
+  });
+
+  const { document: postPrizes } = useSingle({
+    documentId: "y2qydZosrttzgm65H",
     collectionName: "Posts",
     fragmentName: "PostsList"
   });
   
   return <div className={classes.root}>
-    <Link className={classes.imageWrapper} to="/posts/TSaJ9Zcvc3KWh3bjX/voting-results-for-the-2020-review"><img className={classes.image} src={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1644368355/enlarge_books-8_bk0yj6_eoige0_gpqvvr.webp"}/></Link>
+    <Link className={classes.imageWrapper} to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results"><img className={classes.image} src={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1644368355/enlarge_books-8_bk0yj6_eoige0_gpqvvr.webp"}/></Link>
     <SingleColumnSection>
-      <div className={classes.title}><SectionTitle title="Best of LessWrong 2020">
-        <Link to="/posts/TSaJ9Zcvc3KWh3bjX/voting-results-for-the-2020-review#Results">
+      {/* <div className={classes.title}><SectionTitle title="Best of LessWrong 2020">
+        <Link to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results">
           <div className={classes.viewResultsCTA}>
             Donate to Thank Authors
           </div>
         </Link>
-      </SectionTitle></div>
-      {post && <PostsItem2 post={post} translucentBackground forceSticky />}
-      <RecommendationsList algorithm={recommendationsAlgorithm} translucentBackground/>
+      </SectionTitle></div> */}
+      {postVoting && <PostsItem2 post={postVoting} translucentBackground forceSticky />}
+      {postPrizes && <PostsItem2 post={postPrizes} translucentBackground forceSticky />}
+      {/* <RecommendationsList algorithm={recommendationsAlgorithm} translucentBackground/> */}
     </SingleColumnSection>
   </div>;
 }

--- a/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
@@ -52,7 +52,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 export const recommendationsAlgorithm: RecommendationsAlgorithm = {
   method: 'sample',
-  count: 2,
+  count: 1,
   scoreOffset: 0,
   scoreExponent: 0,
   personalBlogpostModifier: 0,
@@ -85,16 +85,16 @@ export const FrontpageBestOfLWWidget = ({classes}: {
   return <div className={classes.root}>
     <Link className={classes.imageWrapper} to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results"><img className={classes.image} src={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1644368355/enlarge_books-8_bk0yj6_eoige0_gpqvvr.webp"}/></Link>
     <SingleColumnSection>
-      {/* <div className={classes.title}><SectionTitle title="Best of LessWrong 2020">
-        <Link to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results">
+      <div className={classes.title}><SectionTitle title="Best of LessWrong 2020">
+        {/* <Link to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results">
           <div className={classes.viewResultsCTA}>
             Donate to Thank Authors
           </div>
-        </Link>
-      </SectionTitle></div> */}
-      {postVoting && <PostsItem2 post={postVoting} translucentBackground forceSticky />}
+        </Link> */}
+      </SectionTitle></div>
       {postPrizes && <PostsItem2 post={postPrizes} translucentBackground forceSticky />}
-      {/* <RecommendationsList algorithm={recommendationsAlgorithm} translucentBackground/> */}
+      {postVoting && <PostsItem2 post={postVoting} translucentBackground forceSticky />}
+      <RecommendationsList algorithm={recommendationsAlgorithm} translucentBackground/>
     </SingleColumnSection>
   </div>;
 }

--- a/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageBestOfLWWidget.tsx
@@ -83,7 +83,7 @@ export const FrontpageBestOfLWWidget = ({classes}: {
   });
   
   return <div className={classes.root}>
-    <Link className={classes.imageWrapper} to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results"><img className={classes.image} src={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1644368355/enlarge_books-8_bk0yj6_eoige0_gpqvvr.webp"}/></Link>
+    <Link className={classes.imageWrapper} to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review"><img className={classes.image} src={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1644368355/enlarge_books-8_bk0yj6_eoige0_gpqvvr.webp"}/></Link>
     <SingleColumnSection>
       <div className={classes.title}><SectionTitle title="Best of LessWrong 2020">
         {/* <Link to="/posts/y2qydZosrttzgm65H/prizes-for-the-2020-review#Results">


### PR DESCRIPTION
This puts the "prizes for 2020 Review" as a sticky in the FrontpageBestOfLWWidget. I chose to leave the "Voting results" post as well because I figured people's eyes would just glaze over the prizes post if it were in the exact same place, without any other changes in the widget. (i.e. hoping that showing both of them together makes it more clear there is a new post)

<img width="1503" alt="image" src="https://user-images.githubusercontent.com/3246710/154865004-1074599e-2869-41f8-9b1c-bb2a87d649ad.png">
