### PR TITLE
move /events page to EA Forum only route

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -471,6 +471,14 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       componentName: 'EASequencesHome'
     },
     {
+      name: 'EventsHome',
+      path: '/events',
+      componentName: 'EventsHome',
+      title: 'Events',
+      subtitle: 'Events',
+      subtitleLink: '/events'
+    },
+    {
       name: "communityRedirect",
       path:'/groupsAndEvents',
       redirect: () => '/community'
@@ -869,15 +877,6 @@ if (hasEventsSetting.get()) {
       componentName: 'EventsUpcoming',
       title: "Upcoming Events by Day"
     },
-    {
-      name: 'EventsHome',
-      path: '/events',
-      componentName: 'EventsHome',
-      title: 'Events',
-      subtitle: 'Events',
-      subtitleLink: '/events'
-    }, 
-
     {
       name: 'CommunityHome',
       path: communityPath,


### PR DESCRIPTION
The new /events page is designed with a bunch of EA Forum aesthetic choices that don't feel right to me on LessWrong – we haven't had time to reflect on it, for now seemed better to turn it off.

Currently live on production, the page looks like this:

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/3246710/154867625-0ed1b259-ecef-49a2-a772-bd640118367c.png">
