### PR TITLE
[LW only] Restore share drafts button

### DIFF
--- a/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
@@ -68,7 +68,7 @@ const groupLayoutStyles = (theme: ThemeType): JssStyles => ({
   },
   flex: {
     display: "flex",
-    alignItems: "flex-start",
+    alignItems: "center",
     flexWrap: "wrap"
   }
 });

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -968,7 +968,7 @@ addFieldsDict(Posts, {
     insertableBy: ['members'],
     editableBy: ['members', 'sunshineRegiment', 'admins'],
     optional: true,
-    hidden: true,
+    hidden: false, //Temporary while testing new collab editing
     control: "UsersListEditor",
     label: "Share draft with users",
     group: formGroups.options


### PR DESCRIPTION
The Collab Editing PR removed the existing "Share with Users" button leaving users with no way to share drafts. I've put that button back. If users use it now, it will make their post collaborative (meaning they become testers of the new collab editor
.