### PR TITLE
Fix crash in sequences editor

### DIFF
--- a/packages/lesswrong/components/form-components/PostsListEditor.tsx
+++ b/packages/lesswrong/components/form-components/PostsListEditor.tsx
@@ -39,6 +39,7 @@ const PostsListEditor = ({value, path, label, classes}: {
       setValue={(newValue: string[]) => {
         updateCurrentValues({[path]: newValue});
       }}
+      classes={classes}
     />
     <Components.PostsSearchAutoComplete
       clickAction={(postId: string) => {

--- a/packages/lesswrong/components/form-components/SequencesListEditor.tsx
+++ b/packages/lesswrong/components/form-components/SequencesListEditor.tsx
@@ -35,6 +35,7 @@ const SequencesListEditor = ({value, path, label, classes}: {
       setValue={(newValue: string[]) => {
         updateCurrentValues({[path]: newValue});
       }}
+      classes={classes}
     />
     <Components.SequencesSearchAutoComplete
       clickAction={(sequenceId: string) => {


### PR DESCRIPTION
Introduced in the `collabEditing` branch and fixed here, so merging into `lw-deploy` rather than `master`. Refactoring some hacky list-editor components so that they could be used in both the old and new forms system, accidentally broke the sequences post-list editor by mishandling a HoC prop.