### PR TITLE
rename "pingbacks" to "mentioned in" on post page

### DIFF
--- a/packages/lesswrong/components/posts/PingbacksList.tsx
+++ b/packages/lesswrong/components/posts/PingbacksList.tsx
@@ -51,7 +51,7 @@ const PingbacksList = ({classes, postId}: {
       return <div className={classes.root}>
         <div className={classes.title}>
           <LWTooltip title="Posts that linked to this post" placement="right">
-            <span>Pingbacks</span>
+            <span>Mentioned in</span>
           </LWTooltip>
         </div>
         <div className={classes.list}>


### PR DESCRIPTION
During our recent user interviews, people were very confused by the term "pingbacks", so we're changing it to say "mentioned in". (I also didn't know what they were for a long time.) Feel free to suggest alternatives.