### PR TITLE
Tag Page Banner Images

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -30,10 +30,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   header: {
     paddingTop: 19,
-    paddingBottom: 5,
+    paddingBottom: 10,
     paddingLeft: 42,
     paddingRight: 42,
-    background: "white",
+    [theme.breakpoints.down('xs')]: {
+      backgroundColor: 'white'
+    }
   },
   tableOfContentsWrapper: {
     position: "relative",
@@ -75,7 +77,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   wikiSection: {
-    paddingTop: 5,
+    paddingTop: 24,
     paddingLeft: 42,
     paddingRight: 42,
     paddingBottom: 12,

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -18,13 +18,28 @@ import { useTagBySlug } from './useTag';
 
 // Also used in TagCompareRevisions, TagDiscussionPage
 export const styles = (theme: ThemeType): JssStyles => ({
-  root: {
+  rootGivenImage: {
     marginTop: 185,
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 130,
+    },
   },
   imageContainer: {
-    height: 300,
+    '& > img': {
+      height: 300,
+      objectFit: 'cover',
+    },
     position: 'absolute',
     top: 90,
+    [theme.breakpoints.down('sm')]: {
+      '& > img': {
+        height: 200,
+        width: '100%',
+      },
+      top: 77,
+      left: -4,
+      right: -4,
+    },
   },
   description: {
     marginTop: 18,
@@ -251,7 +266,7 @@ const TagPage = ({classes}: {
         height={300}
       />
     </div>}
-    <div className={classes.root}>
+    <div className={tag.bannerImageId ? classes.rootGivenImage : ''}>
       <ToCColumn
         tableOfContents={
           tag.tableOfContents

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -56,7 +56,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 5,
     paddingLeft: 42,
     paddingRight: 42,
-    background: 'white'
+    background: "white",
   },
   tableOfContentsWrapper: {
     position: "relative",

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -18,6 +18,14 @@ import { useTagBySlug } from './useTag';
 
 // Also used in TagCompareRevisions, TagDiscussionPage
 export const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    marginTop: 185,
+  },
+  imageContainer: {
+    height: 300,
+    position: 'absolute',
+    top: 90,
+  },
   description: {
     marginTop: 18,
     ...tagBodyStyles(theme),
@@ -30,12 +38,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   header: {
     paddingTop: 19,
-    paddingBottom: 10,
+    paddingBottom: 5,
     paddingLeft: 42,
     paddingRight: 42,
-    [theme.breakpoints.down('xs')]: {
-      backgroundColor: 'white'
-    }
+    background: 'white'
   },
   tableOfContentsWrapper: {
     position: "relative",
@@ -77,7 +83,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   wikiSection: {
-    paddingTop: 24,
+    paddingTop: 5,
     paddingLeft: 42,
     paddingRight: 42,
     paddingBottom: 12,
@@ -126,7 +132,7 @@ const TagPage = ({classes}: {
 }) => {
   const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect,
     HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn,
-    TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton } = Components;
+    TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton, CloudinaryImage } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;
@@ -238,96 +244,105 @@ const TagPage = ({classes}: {
     {hoveredContributorId && <style>
       {`.by_${hoveredContributorId} {background: rgba(95, 155, 101, 0.35);}`}
     </style>}
-    <ToCColumn
-      tableOfContents={
-        tag.tableOfContents
-          ? <span className={classes.tableOfContentsWrapper}>
-              <TableOfContents
-                sectionData={tag.tableOfContents}
-                title={tag.name}
-                onClickSection={expandAll}
+    {tag.bannerImageId && <div className={classes.imageContainer}>
+      <CloudinaryImage
+        publicId={tag.bannerImageId}
+        width="auto"
+        height={300}
+      />
+    </div>}
+    <div className={classes.root}>
+      <ToCColumn
+        tableOfContents={
+          tag.tableOfContents
+            ? <span className={classes.tableOfContentsWrapper}>
+                <TableOfContents
+                  sectionData={tag.tableOfContents}
+                  title={tag.name}
+                  onClickSection={expandAll}
+                />
+                <Link to="/tags/random" className={classes.randomTagLink}>Random Tag</Link>
+                <TableOfContentsRow href="#" divider={true}/>
+                <TagContributorsList onHoverUser={onHoverContributor} tag={tag}/>
+              </span>
+            : null
+        }
+        header={<div className={classNames(classes.header,classes.centralColumn)}>
+          {query.flagId && <span>
+            <Link to={`/tags/dashboard?focus=${query.flagId}`}>
+              <TagFlagItem 
+                itemType={["allPages", "myPages"].includes(query.flagId) ? tagFlagItemType[query.flagId] : "tagFlagId"}
+                documentId={query.flagId}
               />
-              <Link to="/tags/random" className={classes.randomTagLink}>Random Tag</Link>
-              <TableOfContentsRow href="#" divider={true}/>
-              <TagContributorsList onHoverUser={onHoverContributor} tag={tag}/>
-            </span>
-          : null
-      }
-      header={<div className={classNames(classes.header,classes.centralColumn)}>
-        {query.flagId && <span>
-          <Link to={`/tags/dashboard?focus=${query.flagId}`}>
-            <TagFlagItem 
-              itemType={["allPages", "myPages"].includes(query.flagId) ? tagFlagItemType[query.flagId] : "tagFlagId"}
-              documentId={query.flagId}
-            />
-          </Link>
-          {nextTag && <span onClick={() => setEditing(true)}><Link
-            className={classes.nextLink}
-            to={tagGetUrl(nextTag, {flagId: query.flagId, edit: true})}>
-              Next Tag ({nextTag.name})
-          </Link></span>}
-        </span>}
-        <div className={classes.titleRow}>
-          <Typography variant="display3" className={classes.title}>
-            {tag.name}
-          </Typography>
-          <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.mobileButtonRow)} />
-          {!tag.wikiOnly && !editing && userHasNewTagSubscriptions(currentUser) &&
-            <SubscribeButton
-              tag={tag}
-              className={classes.notifyMeButton}
-              subscribeMessage="Subscribe"
-              unsubscribeMessage="Unsubscribe"
-              subscriptionType={subscriptionTypes.newTagPosts}
-            />
-          }
-        </div>
-        <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.nonMobileButtonRow)} />
-      </div>}
-    >
-      <div className={classNames(classes.wikiSection,classes.centralColumn)}>
-        <AnalyticsContext pageSectionContext="wikiSection">
-          { revision && tag.description && (tag.description as TagRevisionFragment_description).user && <div className={classes.pastRevisionNotice}>
-            You are viewing revision {tag.description.version}, last edited by <UsersNameDisplay user={(tag.description as TagRevisionFragment_description).user}/>
-          </div>}
-          {editing ? <EditTagForm
-            tag={tag}
-            successCallback={ async () => {
-              setEditing(false)
-              await client.resetStore()
-            }}
-            cancelCallback={() => setEditing(false)}
-          /> :
-          <div onClick={clickReadMore}>
-            <ContentItemBody
-              dangerouslySetInnerHTML={{__html: description||""}}
-              description={`tag ${tag.name}`}
-              className={classes.description}
-            />
-          </div>}
-        </AnalyticsContext>
-      </div>
-      <div className={classes.centralColumn}>
-        {editing && <TagDiscussionSection
-          key={tag._id}
-          tag={tag}
-        />}
-        {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
-          <div className={classes.tagHeader}>
-            <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
-            <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+            </Link>
+            {nextTag && <span onClick={() => setEditing(true)}><Link
+              className={classes.nextLink}
+              to={tagGetUrl(nextTag, {flagId: query.flagId, edit: true})}>
+                Next Tag ({nextTag.name})
+            </Link></span>}
+          </span>}
+          <div className={classes.titleRow}>
+            <Typography variant="display3" className={classes.title}>
+              {tag.name}
+            </Typography>
+            <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.mobileButtonRow)} />
+            {!tag.wikiOnly && !editing && userHasNewTagSubscriptions(currentUser) &&
+              <SubscribeButton
+                tag={tag}
+                className={classes.notifyMeButton}
+                subscribeMessage="Subscribe"
+                unsubscribeMessage="Unsubscribe"
+                subscriptionType={subscriptionTypes.newTagPosts}
+              />
+            }
           </div>
-          <PostsList2
-            terms={terms}
-            enableTotal
-            tagId={tag._id}
-            itemsPerPage={200}
-          >
-            <AddPostsToTag tag={tag} />
-          </PostsList2>
-        </AnalyticsContext>}
-      </div>
-    </ToCColumn>
+          <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.nonMobileButtonRow)} />
+        </div>}
+      >
+        <div className={classNames(classes.wikiSection,classes.centralColumn)}>
+          <AnalyticsContext pageSectionContext="wikiSection">
+            { revision && tag.description && (tag.description as TagRevisionFragment_description).user && <div className={classes.pastRevisionNotice}>
+              You are viewing revision {tag.description.version}, last edited by <UsersNameDisplay user={(tag.description as TagRevisionFragment_description).user}/>
+            </div>}
+            {editing ? <EditTagForm
+              tag={tag}
+              successCallback={ async () => {
+                setEditing(false)
+                await client.resetStore()
+              }}
+              cancelCallback={() => setEditing(false)}
+            /> :
+            <div onClick={clickReadMore}>
+              <ContentItemBody
+                dangerouslySetInnerHTML={{__html: description||""}}
+                description={`tag ${tag.name}`}
+                className={classes.description}
+              />
+            </div>}
+          </AnalyticsContext>
+        </div>
+        <div className={classes.centralColumn}>
+          {editing && <TagDiscussionSection
+            key={tag._id}
+            tag={tag}
+          />}
+          {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
+            <div className={classes.tagHeader}>
+              <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
+              <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+            </div>
+            <PostsList2
+              terms={terms}
+              enableTotal
+              tagId={tag._id}
+              itemsPerPage={200}
+            >
+              <AddPostsToTag tag={tag} />
+            </PostsList2>
+          </AnalyticsContext>}
+        </div>
+      </ToCColumn>
+    </div>
   </AnalyticsContext>
 }
 

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -25,6 +25,7 @@ registerFragment(`
     defaultOrder
     reviewedByUserId
     wikiGrade
+    bannerImageId
     lesswrongWikiImportSlug
     lesswrongWikiImportRevision
   }

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -7,6 +7,7 @@ import { getWithLoader } from '../../loaders';
 import GraphQLJSON from 'graphql-type-json';
 import moment from 'moment';
 import { captureException } from '@sentry/core';
+import { forumTypeSetting } from '../../instanceSettings';
 
 const formGroups: Partial<Record<string,FormGroup>> = {
   advancedOptions: {
@@ -262,6 +263,7 @@ export const schema: SchemaType<DbTag> = {
     control: "ImageUpload",
     tooltip: "Minimum 200x600 px",
     group: formGroups.advancedOptions,
+    hidden: forumTypeSetting.get() !== 'EAForum',
   },
 
   tagFlagsIds: {

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -250,6 +250,19 @@ export const schema: SchemaType<DbTag> = {
     optional: true,
     ...schemaDefaultValue(false),
   },
+  
+  // Cloudinary image id for the banner image (high resolution)
+  bannerImageId: {
+    type: String,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['admins', 'sunshineRegiment'],
+    insertableBy: ['admins', 'sunshineRegiment'],
+    label: "Banner Image",
+    control: "ImageUpload",
+    tooltip: "Minimum 200x600 px",
+    group: formGroups.advancedOptions,
+  },
 
   tagFlagsIds: {
     ...arrayOfForeignKeysField({

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -640,6 +640,7 @@ interface DbTag extends DbObject {
   reviewedByUserId: string
   wikiGrade: number
   wikiOnly: boolean
+  bannerImageId: string
   tagFlagsIds: Array<string>
   lesswrongWikiImportRevision: string
   lesswrongWikiImportSlug: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -257,6 +257,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly reviewedByUserId: string,
   readonly wikiGrade: number,
   readonly wikiOnly: boolean,
+  readonly bannerImageId: string,
   readonly tagFlagsIds: Array<string>,
   readonly lesswrongWikiImportRevision: string,
   readonly lesswrongWikiImportSlug: string,
@@ -1398,6 +1399,7 @@ interface TagDetailsFragment extends TagBasicInfo { // fragment on Tags
   readonly defaultOrder: number,
   readonly reviewedByUserId: string,
   readonly wikiGrade: number,
+  readonly bannerImageId: string,
   readonly lesswrongWikiImportSlug: string,
   readonly lesswrongWikiImportRevision: string,
 }


### PR DESCRIPTION
Tag pages take their first step towards the [sprint prototype](https://www.figma.com/file/lYIUu1lWDFpjJKp4nLqny7/Forum-topics-Design-Sprint-Prototype?node-id=267%3A425) by getting a banner image. (LessWrong should read [this document](https://docs.google.com/document/d/1WbrFoDPoAba8J-jegGc2WMmHFIc7VP3Nl0WS6pjVF-E/edit) if you haven't yet.) Images were one of the most positive pieces of  feedback we got from the prototype interviews.

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/10352319/155598334-291628fd-a576-4b97-9d61-2aecc5be2218.png">

<img width="414" alt="image" src="https://user-images.githubusercontent.com/10352319/155599006-b62d4580-c224-4ea2-8c39-ebfeb2df1b06.png">

The main reason to have the white background encompass the title (deviating from the design) comes down to:
 1. It's easier to deal with the TOC. (Otherwise we'd have to substantially refactor the component to allow the grid layout to lower it.)
 2. It's easier to deal with the menu items, which require some conceptual thinking to get right.

I recommend viewing this PR after asking github to stop showing you whitespace differences. In order to add a root div, I had to indent most of the component.

@darkruby501 I have *not* enabled this on LW, or made it work with y'all's header sizes. If you would like me to, please let me know and I can.