### PR TITLE
Fix image width on tag banner image

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -25,13 +25,16 @@ export const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   imageContainer: {
+    width: '100%',
     '& > img': {
       height: 300,
       objectFit: 'cover',
+      width: '100%',
     },
     position: 'absolute',
     top: 90,
     [theme.breakpoints.down('sm')]: {
+      width: 'unset',
       '& > img': {
         height: 200,
         width: '100%',


### PR DESCRIPTION
Was previously, for at least Lizka, sometimes not showing up as 100% width. I believe Cloudinary should have been taking care of that, but we can ensure it happens via CSS.

Thinking about it, I realize I don't actually know how Cloudinary figures out your screen size to size your images correctly. Since we are relying on them being at least as wide as your screen*, if they serve us a smaller image, we were previously screwed. Seems not that surprising they would sometimes serve us smaller images than necessary?

* Otherwise the div is not as wide as your screen.

Actually, maybe as I'm editing this description with more context, I'm convincing myself to add `width: 100%` to the LocalGroups page from which I copied? @s-cheng any reason not to?