### PR TITLE
[EA Forum only] use event cards on the group details page

### DIFF
--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -40,7 +40,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Load More button. The simplest way to use this is to take `loadMoreProps`
 // from the return value of `useMulti` and spread it into this component's
 // props.
-const LoadMore = ({ loadMore, count, totalCount, className=null, disabled=false, networkStatus, loading=false, hideLoading=false, hidden=false, classes, sectionFooterStyles }: {
+const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassName, disabled=false, networkStatus, loading=false, hideLoading=false, hidden=false, classes, sectionFooterStyles }: {
   // loadMore: Callback when clicked.
   loadMore: LoadMoreCallback,
   // count/totalCount: If provided, looks like "Load More (10/25)"
@@ -48,6 +48,7 @@ const LoadMore = ({ loadMore, count, totalCount, className=null, disabled=false,
   totalCount?: number,
   // className: If provided, replaces the root style (default typography).
   className?: string|null|undefined,
+  loadingClassName?: string,
   // disabled: If true, this is grayed out (eg because everything's already loaded).
   disabled?: boolean,
   networkStatus?: any,
@@ -68,7 +69,7 @@ const LoadMore = ({ loadMore, count, totalCount, className=null, disabled=false,
   }
 
   if (!hideLoading && (loading || (networkStatus && queryIsUpdating(networkStatus)))) {
-    return <Loading className={classNames(classes.loading, {[classes.sectionFooterStyles]: sectionFooterStyles})} />
+    return <Loading className={classNames(classes.loading, loadingClassName, {[classes.sectionFooterStyles]: sectionFooterStyles})} />
   }
 
   if (hidden) return null;

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -28,18 +28,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   communityLink: {
     color: theme.palette.primary.main,
   },
-  eventCards: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, 373px)',
-    gridGap: '20px',
-    justifyContent: 'center',
-    [theme.breakpoints.down('md')]: {
-      gridTemplateColumns: 'repeat(2, 373px)',
-    },
-    '@media (max-width: 812px)': {
-      gridTemplateColumns: 'auto',
-    }
-  },
   eventCard: {
     position: 'relative',
     width: 373,
@@ -170,6 +158,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
           </div>
         </PostsItemTooltipWrapper>
         <div className={classes.eventCardLocation}>{getEventLocation(event)}</div>
+        {/* TODO; hide group name in group event list */}
         {event.group && <div className={classes.eventCardGroup} title={event.group.name}>
           <Link to={`/groups/${event.group._id}`}>{event.group.name}</Link>
         </div>}

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -10,6 +10,7 @@ import { useTimezone } from '../../common/withTimezone';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 import { getDefaultEventImg } from './HighlightedEventCard';
 import { useCurrentUser } from '../../common/withUser';
+import classNames from 'classnames';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -96,11 +97,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }))
 
 
-const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes}: {
+const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, hideGroupNames, cardClassName, classes}: {
   events?: PostsList[],
   loading?: boolean,
   numDefaultCards?: number,
   hideSpecialCards?: boolean,
+  hideGroupNames?: boolean,
+  cardClassName?: string,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser()
@@ -117,7 +120,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
   if (loading && !events?.length) {
     return numDefaultCards ? <>
       {_.range(numDefaultCards).map((i) => {
-        return <Card key={i} className={classes.eventCard}></Card>
+        return <Card key={i} className={classNames(classes.eventCard, cardClassName)}></Card>
       })}
     </> : null
   }
@@ -141,7 +144,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
   }
   
   const eventCards = events.map(event => {
-    return <Card key={event._id} className={classes.eventCard}>
+    return <Card key={event._id} className={classNames(classes.eventCard, cardClassName)}>
       <Link to={`/events/${event._id}/${event.slug}`}>
         {event.eventImageId ?
           <CloudinaryImage2 height={200} width={373} publicId={event.eventImageId} /> :
@@ -158,8 +161,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, classes
           </div>
         </PostsItemTooltipWrapper>
         <div className={classes.eventCardLocation}>{getEventLocation(event)}</div>
-        {/* TODO; hide group name in group event list */}
-        {event.group && <div className={classes.eventCardGroup} title={event.group.name}>
+        {!hideGroupNames && event.group && <div className={classes.eventCardGroup} title={event.group.name}>
           <Link to={`/groups/${event.group._id}`}>{event.group.name}</Link>
         </div>}
         <div className={classes.addToCal}>

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -50,7 +50,7 @@ const cloudinaryArgsByImageType = {
     uploadPreset: cloudinaryUploadPresetGridImageSetting.get(),
   },
   bannerImageId: {
-    minImageHeight: 400,
+    minImageHeight: 350,
     minImageWidth: 700,
     croppingAspectRatio: 1.91,
     croppingDefaultSelectionRatio: 1,

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -50,7 +50,7 @@ const cloudinaryArgsByImageType = {
     uploadPreset: cloudinaryUploadPresetGridImageSetting.get(),
   },
   bannerImageId: {
-    minImageHeight: 350,
+    minImageHeight: 300,
     minImageWidth: 700,
     croppingAspectRatio: 1.91,
     croppingDefaultSelectionRatio: 1,

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -78,6 +78,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
       gridTemplateColumns: 'auto',
     }
   },
+  loading: {
+    marginLeft: 0
+  },
   noUpcomingEvents: {
     color: theme.palette.grey[500],
   },
@@ -97,7 +100,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginTop: 50,
     marginLeft: 'auto',
     marginRight: 'auto'
-  },
+  }
 }));
 
 const LocalGroupPage = ({ classes, documentId: groupId }: {
@@ -196,6 +199,73 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
       mapOptions={{zoom:11, center: group.googleLocation.geometry.location, initialOpenWindows:[groupId]}}
     />
   }
+  
+  // the EA Forum shows the group's events as event cards instead of post list items
+  let upcomingEventsList = <PostsList2 terms={{view: 'upcomingEvents', groupId: groupId}} />
+  if (isEAForum) {
+    upcomingEventsList = !!upcomingEvents?.length ? (
+      <div className={classes.eventCards}>
+        <EventCards
+          events={upcomingEvents}
+          loading={upcomingEventsLoading}
+          numDefaultCards={2}
+          hideSpecialCards
+          hideGroupNames
+        />
+        <LoadMore {...upcomingEventsLoadMoreProps} loadingClassName={classes.loading} />
+      </div>
+    ) : <Components.Typography variant="body2" className={classes.noUpcomingEvents}>No upcoming events.{' '}
+        <NotifyMeButton
+          showIcon={false}
+          document={group}
+          subscribeMessage="Subscribe to be notified when an event is added."
+          componentIfSubscribed={<span>We'll notify you when an event is added.</span>}
+          className={classes.notifyMeButton}
+        />
+      </Components.Typography>
+  }
+  
+  let tbdEventsList: JSX.Element|null = <PostsList2 terms={{view: 'tbdEvents', groupId: groupId}} showNoResults={false} />
+  if (isEAForum) {
+    tbdEventsList = tbdEvents?.length ? <>
+      <Components.Typography variant="headline" className={classes.eventsHeadline}>
+        Events Yet To Be Scheduled
+      </Components.Typography>
+      <div className={classes.eventCards}>
+        <EventCards
+          events={tbdEvents}
+          loading={tbdEventsLoading}
+          hideSpecialCards
+          hideGroupNames
+        />
+        <LoadMore {...tbdEventsLoadMoreProps}  />
+      </div>
+    </> : null
+  }
+  
+  let pastEventsList: JSX.Element|null = <>
+    <Components.Typography variant="headline" className={classes.eventsHeadline}>
+      Past Events
+    </Components.Typography>
+    <PostsList2 terms={{view: 'pastEvents', groupId: groupId}} />
+  </>
+  if (isEAForum) {
+    pastEventsList = pastEvents?.length ? <>
+      <Components.Typography variant="headline" className={classes.eventsHeadline}>
+        Past Events
+      </Components.Typography>
+      <div className={classes.eventCards}>
+        <EventCards
+          events={pastEvents}
+          loading={pastEventsLoading}
+          hideSpecialCards
+          hideGroupNames
+          cardClassName={classes.pastEventCard}
+        />
+        <LoadMore {...pastEventsLoadMoreProps}  />
+      </div>
+    </> : null
+  }
 
   return (
     <div className={classes.root}>
@@ -247,57 +317,11 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
         <Components.Typography variant="headline" className={classes.eventsHeadline}>
           Upcoming Events
         </Components.Typography>
-        {!!upcomingEvents?.length ? (
-          <div className={classes.eventCards}>
-            <EventCards
-              events={upcomingEvents}
-              loading={upcomingEventsLoading}
-              numDefaultCards={2}
-              hideSpecialCards
-              hideGroupNames
-            />
-            <LoadMore {...upcomingEventsLoadMoreProps}  />
-          </div>
-        ) : <Components.Typography variant="body2" className={classes.noUpcomingEvents}>No upcoming events.{' '}
-            <NotifyMeButton
-              showIcon={false}
-              document={group}
-              subscribeMessage="Subscribe to be notified when an event is added."
-              componentIfSubscribed={<span>We'll notify you when an event is added.</span>}
-              className={classes.notifyMeButton}
-            />
-          </Components.Typography>}
+        {upcomingEventsList}
 
-        {!!tbdEvents?.length && <>
-          <Components.Typography variant="headline" className={classes.eventsHeadline}>
-            Events Yet To Be Scheduled
-          </Components.Typography>
-          <div className={classes.eventCards}>
-            <EventCards
-              events={tbdEvents}
-              loading={tbdEventsLoading}
-              hideSpecialCards
-              hideGroupNames
-            />
-            <LoadMore {...tbdEventsLoadMoreProps}  />
-          </div>
-        </>}
+        {tbdEventsList}
 
-        {!!pastEvents?.length && <>
-          <Components.Typography variant="headline" className={classes.eventsHeadline}>
-            Past Events
-          </Components.Typography>
-          <div className={classes.eventCards}>
-            <EventCards
-              events={pastEvents}
-              loading={pastEventsLoading}
-              hideSpecialCards
-              hideGroupNames
-              cardClassName={classes.pastEventCard}
-            />
-            <LoadMore {...pastEventsLoadMoreProps}  />
-          </div>
-        </>}
+        {pastEventsList}
 
         {bottomSection}
       </SingleColumnSection>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -12,6 +12,7 @@ import qs from 'qs'
 import { userIsAdmin } from '../../lib/vulcan-users';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useMulti } from '../../lib/crud/withMulti';
+import classNames from 'classnames';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},
@@ -83,6 +84,16 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginTop: 50,
     marginLeft: 'auto',
     marginRight: 'auto'
+  },
+  notifyMeButton: {
+    display: 'inline !important',
+    color: theme.palette.primary.main,
+  },
+  noUpcomingEvents: {
+    color: theme.palette.grey[600],
+  },
+  pastEvents: {
+    filter: 'saturate(0.5) opacity(0.8)',
   }
 }));
 
@@ -124,6 +135,20 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
     loadMoreProps: tbdEventsLoadMoreProps
   } = useMulti({
     terms: {view: 'tbdEvents', groupId: groupId},
+    collectionName: "Posts",
+    fragmentName: 'PostsList',
+    fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: "cache-first",
+    limit: 2,
+    itemsPerPage: 6,
+    enableTotal: true,
+  });
+  const {
+    results: pastEvents,
+    loading: pastEventsLoading,
+    loadMoreProps: pastEventsLoadMoreProps
+  } = useMulti({
+    terms: {view: 'pastEvents', groupId: groupId},
     collectionName: "Posts",
     fragmentName: 'PostsList',
     fetchPolicy: 'cache-and-network',
@@ -217,20 +242,29 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
         {/* TODO; refactor to return null if nothing found, if you're brave enough */}
         {/* Or pick margins that are good enough in either case */}
         <PostsList2 terms={{view: 'nonEventGroupPosts', groupId: groupId}} showNoResults={false} />
-        
         <Components.Typography variant="headline" className={classes.eventsHeadline}>
           Upcoming Events
         </Components.Typography>
-        <div className={classes.eventCards}>
-          <EventCards
-            events={upcomingEvents}
-            loading={upcomingEventsLoading}
-            numDefaultCards={2}
-            hideSpecialCards
-          />
-          <LoadMore {...upcomingEventsLoadMoreProps}  />
-        </div>
-        {!!tbdEvents.length && <>
+        {!!upcomingEvents?.length ? (<>
+          <div className={classes.eventCards}>
+            <EventCards
+              events={upcomingEvents}
+              loading={upcomingEventsLoading}
+              numDefaultCards={2}
+              hideSpecialCards
+            />
+            <LoadMore {...upcomingEventsLoadMoreProps}  />
+          </div>
+        </>) : <Components.Typography variant="body1" className={classes.noUpcomingEvents}>No upcoming events.{' '}
+            <NotifyMeButton
+              showIcon={false}
+              document={group}
+              subscribeMessage="Subscribe to be notified when an event is added."
+              componentIfSubscribed={<span>You are subscribed to be notified when an event is added.</span>}
+              className={classes.notifyMeButton}
+            />
+          </Components.Typography>}
+        {!!tbdEvents?.length && <>
           <Components.Typography variant="headline" className={classes.eventsHeadline}>
             To Be Scheduled Events
           </Components.Typography>
@@ -244,13 +278,20 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             <LoadMore {...tbdEventsLoadMoreProps}  />
           </div>
         </>}
-        {/* TODO; what do we do if there are no upcoming events */}
-        
-        <Components.Typography variant="headline" className={classes.eventsHeadline}>
-          Past Events
-        </Components.Typography>
-        <PostsList2 terms={{view: 'pastEvents', groupId: groupId}} />
-        
+        {!!pastEvents?.length && <>
+          <Components.Typography variant="headline" className={classes.eventsHeadline}>
+            Past Events
+          </Components.Typography>
+          <div className={classNames(classes.eventCards, classes.pastEvents)}>
+            <EventCards
+              events={pastEvents}
+              loading={pastEventsLoading}
+              numDefaultCards={2}
+              hideSpecialCards
+            />
+            <LoadMore {...pastEventsLoadMoreProps}  />
+          </div>
+        </>}
         {bottomSection}
       </SingleColumnSection>
     </div>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -74,9 +74,22 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(2, 373px)',
     gridGap: '20px',
-    justifyContent: 'center',
     '@media (max-width: 812px)': {
       gridTemplateColumns: 'auto',
+    }
+  },
+  noUpcomingEvents: {
+    color: theme.palette.grey[500],
+  },
+  notifyMeButton: {
+    display: 'inline !important',
+    color: theme.palette.primary.main,
+  },
+  pastEventCard: {
+    height: 350,
+    filter: 'saturate(0.3) opacity(0.8)',
+    '& .EventCards-addToCal': {
+      display: 'none'
     }
   },
   mapContainer: {
@@ -85,16 +98,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginLeft: 'auto',
     marginRight: 'auto'
   },
-  notifyMeButton: {
-    display: 'inline !important',
-    color: theme.palette.primary.main,
-  },
-  noUpcomingEvents: {
-    color: theme.palette.grey[600],
-  },
-  pastEventCard: {
-    filter: 'saturate(0.5) opacity(0.8)',
-  }
 }));
 
 const LocalGroupPage = ({ classes, documentId: groupId }: {
@@ -238,14 +241,13 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             description={`group ${groupId}`}
           />}
         </div>
-        
-        {/* TODO; refactor to return null if nothing found, if you're brave enough */}
-        {/* Or pick margins that are good enough in either case */}
+
         <PostsList2 terms={{view: 'nonEventGroupPosts', groupId: groupId}} showNoResults={false} />
+
         <Components.Typography variant="headline" className={classes.eventsHeadline}>
           Upcoming Events
         </Components.Typography>
-        {!!upcomingEvents?.length ? (<>
+        {!!upcomingEvents?.length ? (
           <div className={classes.eventCards}>
             <EventCards
               events={upcomingEvents}
@@ -256,18 +258,19 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             />
             <LoadMore {...upcomingEventsLoadMoreProps}  />
           </div>
-        </>) : <Components.Typography variant="body1" className={classes.noUpcomingEvents}>No upcoming events.{' '}
+        ) : <Components.Typography variant="body2" className={classes.noUpcomingEvents}>No upcoming events.{' '}
             <NotifyMeButton
               showIcon={false}
               document={group}
               subscribeMessage="Subscribe to be notified when an event is added."
-              componentIfSubscribed={<span>You are subscribed to be notified when an event is added.</span>}
+              componentIfSubscribed={<span>We'll notify you when an event is added.</span>}
               className={classes.notifyMeButton}
             />
           </Components.Typography>}
+
         {!!tbdEvents?.length && <>
           <Components.Typography variant="headline" className={classes.eventsHeadline}>
-            To Be Scheduled Events
+            Events Yet To Be Scheduled
           </Components.Typography>
           <div className={classes.eventCards}>
             <EventCards
@@ -279,6 +282,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             <LoadMore {...tbdEventsLoadMoreProps}  />
           </div>
         </>}
+
         {!!pastEvents?.length && <>
           <Components.Typography variant="headline" className={classes.eventsHeadline}>
             Past Events
@@ -294,6 +298,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             <LoadMore {...pastEventsLoadMoreProps}  />
           </div>
         </>}
+
         {bottomSection}
       </SingleColumnSection>
     </div>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -92,7 +92,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   noUpcomingEvents: {
     color: theme.palette.grey[600],
   },
-  pastEvents: {
+  pastEventCard: {
     filter: 'saturate(0.5) opacity(0.8)',
   }
 }));
@@ -252,6 +252,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
               loading={upcomingEventsLoading}
               numDefaultCards={2}
               hideSpecialCards
+              hideGroupNames
             />
             <LoadMore {...upcomingEventsLoadMoreProps}  />
           </div>
@@ -272,8 +273,8 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             <EventCards
               events={tbdEvents}
               loading={tbdEventsLoading}
-              numDefaultCards={2}
               hideSpecialCards
+              hideGroupNames
             />
             <LoadMore {...tbdEventsLoadMoreProps}  />
           </div>
@@ -282,12 +283,13 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
           <Components.Typography variant="headline" className={classes.eventsHeadline}>
             Past Events
           </Components.Typography>
-          <div className={classNames(classes.eventCards, classes.pastEvents)}>
+          <div className={classes.eventCards}>
             <EventCards
               events={pastEvents}
               loading={pastEventsLoading}
-              numDefaultCards={2}
               hideSpecialCards
+              hideGroupNames
+              cardClassName={classes.pastEventCard}
             />
             <LoadMore {...pastEventsLoadMoreProps}  />
           </div>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -12,7 +12,6 @@ import qs from 'qs'
 import { userIsAdmin } from '../../lib/vulcan-users';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useMulti } from '../../lib/crud/withMulti';
-import classNames from 'classnames';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},

--- a/packages/lesswrong/components/notifications/NotifyMeButton.tsx
+++ b/packages/lesswrong/components/notifications/NotifyMeButton.tsx
@@ -46,6 +46,7 @@ const NotifyMeButton = ({
   hideLabel = false,
   hideLabelOnMobile = false,
   hideIfNotificationsDisabled = false,
+  componentIfSubscribed,
 }: {
   document: any,
   subscriptionType?: string,
@@ -59,6 +60,7 @@ const NotifyMeButton = ({
   hideLabel?: boolean,
   hideLabelOnMobile?: boolean
   hideIfNotificationsDisabled?: boolean,
+  componentIfSubscribed?: JSX.Element,
 }) => {
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
@@ -160,7 +162,7 @@ const NotifyMeButton = ({
   
   const maybeMenuItemButton = asMenuItem ?
     <MenuItem onClick={onSubscribe}>
-      <a className={classNames(className, classes.root)}>
+      <a className={classNames(classes.root, className)}>
         {button}
       </a>
     </MenuItem> :
@@ -172,8 +174,8 @@ const NotifyMeButton = ({
       {maybeMenuItemButton}
     </Components.LWTooltip> :
     maybeMenuItemButton
-    
-  return maybeToolipButton
+  
+  return componentIfSubscribed && isSubscribed() ? componentIfSubscribed : maybeToolipButton
 }
 
 const SubscribeToComponent = registerComponent('NotifyMeButton', NotifyMeButton, {styles});

--- a/packages/lesswrong/components/notifications/NotifyMeButton.tsx
+++ b/packages/lesswrong/components/notifications/NotifyMeButton.tsx
@@ -60,6 +60,7 @@ const NotifyMeButton = ({
   hideLabel?: boolean,
   hideLabelOnMobile?: boolean
   hideIfNotificationsDisabled?: boolean,
+  // display this component if the user is already subscribed, instead of the unsubscribeMessage
   componentIfSubscribed?: JSX.Element,
 }) => {
   const currentUser = useCurrentUser();

--- a/packages/lesswrong/components/posts/PostsGroupDetails.tsx
+++ b/packages/lesswrong/components/posts/PostsGroupDetails.tsx
@@ -14,6 +14,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: 'rgba(0,0,0,0.5)',
     marginTop: -10,
   },
+  serif: {
+    fontFamily: theme.typography.body1.fontFamily,
+  },
   sansSerif: {
     fontSize: 16,
     fontFamily: theme.typography.fontFamily
@@ -35,15 +38,14 @@ const PostsGroupDetails = ({ documentId, post, inRecentDiscussion, classes }: {
     collectionName: "Localgroups",
     fragmentName: 'localGroupsHomeFragment',
   });
-  if (document) {
-    return <div className={inRecentDiscussion ? '' : classes.root}>
-      <div className={inRecentDiscussion ? classNames(classes.title, classes.sansSerif) : classes.title}>
-        {post?.group && <Link to={'/groups/' + post.group._id }>{ document.name }</Link>}
-      </div>
-    </div>
-  } else {
+  if (!document) {
     return null
   }
+  return <div className={inRecentDiscussion ? '' : classes.root}>
+    <div className={classNames(classes.title, {[classes.sansSerif]: inRecentDiscussion, [classes.serif]: !inRecentDiscussion})}>
+      {post?.group && <Link to={'/groups/' + post.group._id }>{ document.name }</Link>}
+    </div>
+  </div>
 }
 
 const PostsGroupDetailsComponent = registerComponent(
@@ -55,4 +57,3 @@ declare global {
     PostsGroupDetails: typeof PostsGroupDetailsComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -154,12 +154,13 @@ const PostsList2 = ({
   useOnMountTracking({eventType: "postList", eventProps: {postIds, hidePosts}, captureOnMount: eventProps => eventProps.postIds.length, skip: !postIds.length||loading})
 
   if (!orderedResults && loading) return <Loading />
+  if (results && !results.length && !showNoResults) return null
 
   return (
     <div className={classNames({[classes.itemIsLoading]: loading && dimWhenLoading})}>
       {error && <Error error={decodeIntlError(error)} />}
       {loading && showLoading && (topLoading || dimWhenLoading) && <Loading />}
-      {results && !results.length && showNoResults && <PostsNoResults />}
+      {results && !results.length && <PostsNoResults />}
 
       <div className={boxShadow ? classes.posts : null}>
         {orderedResults && orderedResults.map((post, i) => {


### PR DESCRIPTION
Since we created event cards for the Events page, we are now updating the group details page to list the group's events using those cards as well.

<img width="626" alt="Screen Shot 2022-03-02 at 7 22 06 PM" src="https://user-images.githubusercontent.com/9057804/156472432-d4980339-7a7d-406d-b15c-88fbe5163b8d.png">

Past events are desaturated, and events without a start date (very rare) get their own section, due to the fact that mongo won't let us order them at the end of the "Upcoming Events" list.

<img width="624" alt="Screen Shot 2022-03-02 at 7 23 17 PM" src="https://user-images.githubusercontent.com/9057804/156472523-64975d1d-0820-4552-a3fc-916e453cfce9.png">
