### PR TITLE
Update group banner img layout

### DIFF
--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -50,9 +50,9 @@ const cloudinaryArgsByImageType = {
     uploadPreset: cloudinaryUploadPresetGridImageSetting.get(),
   },
   bannerImageId: {
-    minImageHeight: 200,
-    minImageWidth: 600,
-    croppingAspectRatio: 2.5375,
+    minImageHeight: 400,
+    minImageWidth: 700,
+    croppingAspectRatio: 1.91,
     croppingDefaultSelectionRatio: 1,
     uploadPreset: cloudinaryUploadPresetBannerSetting.get(),
   },

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -20,14 +20,19 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     }
   },
   imageContainer: {
-    height: 200,
     [theme.breakpoints.up('md')]: {
       marginTop: -50,
     },
     [theme.breakpoints.down('sm')]: {
       marginLeft: -4,
       marginRight: -4,
-    }
+    },
+  },
+  bannerImg: {
+    display: 'block',
+    maxWidth: '100%',
+    objectFit: 'cover',
+    margin: '0 auto',
   },
   groupInfo: {
     ...sectionFooterLeftStyles,
@@ -84,7 +89,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
   const {
     HeadTags, CommunityMapWrapper, SingleColumnSection, SectionTitle, GroupLinks, PostsList2,
     Loading, SectionButton, NotifyMeButton, SectionFooter, GroupFormLink, ContentItemBody,
-    Error404, CloudinaryImage
+    Error404, CloudinaryImage2
   } = Components
 
   const { document: group, loading } = useSingle({
@@ -114,11 +119,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
   // if the group has a banner image, show that at the top instead, and move the map to the bottom
   if (group.bannerImageId) {
     topSection = <div className={classes.imageContainer}>
-      <CloudinaryImage
-        publicId={group.bannerImageId}
-        width="auto"
-        height={200}
-      />
+      <CloudinaryImage2 imgProps={{ar: '191:100', w: '765'}} publicId={group.bannerImageId} className={classes.bannerImg} />
     </div>
     bottomSection = group.googleLocation && <CommunityMapWrapper
       className={classes.mapContainer}

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -19,6 +19,16 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
       marginTop: -50,
     }
   },
+  topSectionMap: {
+    height: 250,
+    [theme.breakpoints.up('md')]: {
+      marginTop: -50,
+    },
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: -4,
+      marginRight: -4,
+    },
+  },
   imageContainer: {
     [theme.breakpoints.up('md')]: {
       marginTop: -50,
@@ -109,7 +119,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
   
   // by default, we try to show the map at the top if the group has a location
   let topSection = group.googleLocation ? <CommunityMapWrapper
-    className={classes.imageContainer}
+    className={classes.topSectionMap}
     terms={{view: "events", groupId: groupId}}
     groupQueryTerms={{view: "single", groupId: groupId}}
     hideLegend={true}

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -210,7 +210,7 @@ const schema: SchemaType<DbLocalgroup> = {
     insertableBy: ['members'],
     label: "Banner Image",
     control: "ImageUpload",
-    tooltip: "Minimum 200x600 px"
+    tooltip: "Recommend 1640x856 px, 1.91:1 aspect ratio (same as Facebook)"
   },
 };
 


### PR DESCRIPTION
The screen-wide banner image at the top of the group details page isn't the best, especially on wide screens where it becomes way shorter than it is long. I heard some concerns from group organizers as well, so I went ahead and copied [Facebook's](https://www.facebook.com/help/212144952271305) group cover image sizing - the image keeps the same aspect ratio for all screen sizes.

<img width="1140" alt="Screen Shot 2022-03-02 at 8 13 15 PM" src="https://user-images.githubusercontent.com/9057804/156478469-da6094e1-6e0d-4b00-9738-09716e647501.png">
