### PR TITLE
Fix broken Arbital links in hover-preview when using [-id] markdown link format

### DIFF
--- a/packages/lesswrong/server/resolvers/arbitalPageData.ts
+++ b/packages/lesswrong/server/resolvers/arbitalPageData.ts
@@ -25,6 +25,13 @@ async function getArbitalPageData(pageAlias = "hyperexistential_separation") {
   return await response.text()
 }
 
+// Make a string safe for use in the text part of a link, by backslash-escaping brackets.
+// (This is not particularly well tested. However, it's a text transform over markdown not
+// over HTML, so even if it's totally wrong it can only break links, not cause XSS.)
+function markdownEscapeLinkText(text: string) {
+  return text.replace(/[[\]]/g, match=>'\\'+match);
+}
+
 const arbitalPageResolvers = {
   Query: {
     async ArbitalPageData(root: void, { pageAlias }: { pageAlias:string }, context: ResolverContext) {
@@ -40,13 +47,36 @@ const arbitalPageResolvers = {
       const page:any = Object.values(processedData.pages).find((page:any) => page?.alias === pageAlias)
       if (!page) return null
       const textField = page.summaries?.Summary || page.clickbait
-      const fixedMarkdown = textField.replace(/\[([a-zA-Z0-9]+)?\s*([^\]]*)\]/g, (fullMatch: string, cg1: string, cg2: string, cg3: string) => {
-        const linkedPageAlias = processedData.pages[cg1]?.alias
-        if (!cg1 || !linkedPageAlias) {
-          return `[${cg2}](https://arbital.com/edit/)`
+      const fixedMarkdown = textField.replace(
+        /\[([^\]]+)\]/g,
+        (fullMatch: string, insideBrackets: string) => {
+          if (insideBrackets.startsWith("-")) {
+            // Formatted like [-id]
+            const linkedPageId = insideBrackets.substr(1);
+            const linkedPageAlias = processedData.pages[linkedPageId]?.alias;
+            if (linkedPageAlias) {
+              const linkedPageTitle = processedData.pages[linkedPageId]?.title;
+              const destinationLink = `http://arbital.com/p/${encodeURIComponent(linkedPageAlias)}`;
+              return `[${markdownEscapeLinkText(linkedPageTitle)}](${destinationLink})`;
+            } else {
+              return `[New Page](https://arbital.com/edit/)`
+            }
+          } else {
+            // Formatted like [id title]
+            // Split on the first space
+            const spaceIndex = insideBrackets.indexOf(' ');
+            const linkedPageId = insideBrackets.substr(0, spaceIndex);
+            const linkedText = insideBrackets.substr(spaceIndex+1);
+            const linkedPageAlias = processedData.pages[linkedPageId]?.alias;
+            if (linkedPageAlias) {
+              const destinationLink = `http://arbital.com/p/${encodeURIComponent(linkedPageAlias)}`;
+              return `[${markdownEscapeLinkText(linkedText)}](destinationLink)`;
+            } else {
+              return `[${markdownEscapeLinkText(linkedText)}](https://arbital.com/edit/)`;
+            }
+          }
         }
-        return `[${cg2}](https://arbital.com/p/${linkedPageAlias})`
-      })
+      )
       let htmlWithLaTeX: string;
       try {
         const htmlNoLaTeX = mdi.render(fixedMarkdown)


### PR DESCRIPTION
Fix broken Arbital links in hover-preview when using [-id] markdown link format. An affected example was the link to "moral uncertainty" in the hover-over of the link to "problem of fully updated (non-)deference" on https://www.lesswrong.com/posts/7im8at9PmhbT4JHsW/ngo-and-yudkowsky-on-alignment-difficulty which would render as a non-link text of the destination page ID.