### PR TITLE
Fix bugs in clearCourseEndTime and mergeAccounts

### DIFF
--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -92,7 +92,7 @@ interface MergedViewQueryAndOptions<
 
 type MongoSelector<T extends DbObject> = any; //TODO
 type MongoProjection<T extends DbObject> = Partial<Record<keyof T, 0|1>>;
-type MongoModifier<T extends DbObject> = any; //TODO
+type MongoModifier<T extends DbObject> = {$inc?: any, $min?: any, $max?: any, $mul?: any, $rename?: any, $set?: any, $setOnInsert?: any, $unset?: any, $addToSet?: any, $pop?: any, $pull?: any, $push?: any, $pullAll?: any, $bit?: any}; //TODO
 
 type MongoFindOptions<T extends DbObject> = any; //TODO
 type MongoFindOneOptions<T extends DbObject> = any; //TODO

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -251,15 +251,12 @@ getCollectionHooks("Posts").newSync.add(async function FixEventStartAndEndTimes(
   return post;
 });
 
-getCollectionHooks("Posts").editSync.add(async function clearCourseEndTime(post: DbPost): Promise<DbPost> {
+getCollectionHooks("Posts").editSync.add(async function clearCourseEndTime(modifier: MongoModifier<DbPost>, post: DbPost): Promise<MongoModifier<DbPost>> {
   // make sure courses/programs have no end time
   // (we don't want them listed for the length of the course, just until the application deadline / start time)
   if (post.eventType === 'course') {
-    return {
-      ...post,
-      endTime: null
-    }
+    modifier.$set.endTime = null;
   }
   
-  return post
+  return modifier
 })

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -137,7 +137,12 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Change slug of source account by appending "old" and reset oldSlugs array
   // eslint-disable-next-line no-console
   console.log("Change slugs of source account")
-  await Users.update({_id: sourceUserId}, {slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)})
+  await Users.update(
+    {_id: sourceUserId},
+    {$set: {
+      slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)
+    }}
+  );
 
   // Add slug to oldSlugs array of target account
   const newOldSlugs = [

--- a/packages/lesswrong/server/vulcan-lib/validation.ts
+++ b/packages/lesswrong/server/vulcan-lib/validation.ts
@@ -4,7 +4,7 @@ import { userCanCreateField, userCanUpdateField } from '../../lib/vulcan-users/p
 import { getSchema, getSimpleSchema } from '../../lib/utils/getSchema';
 import * as _ from 'underscore';
 
-export const dataToModifier = <T extends DbObject>(data: Partial<T>): MongoModifier<T> => ({ 
+export const dataToModifier = <T extends DbObject>(data: Partial<DbInsertion<T>>): MongoModifier<DbInsertion<T>> => ({ 
   $set: pickBy(data, f => f !== null), 
   $unset: mapValues(pickBy(data, f => f === null), () => true),
 });
@@ -78,7 +78,7 @@ export const validateDocument = (document, collection, context: ResolverContext)
   2. Run SimpleSchema validation step
   
 */
-export const validateModifier = <T extends DbObject>(modifier: MongoModifier<T>, document: T, collection: CollectionBase<T>, context: ResolverContext) => {
+export const validateModifier = <T extends DbObject>(modifier: MongoModifier<DbInsertion<T>>, document: any, collection: CollectionBase<T>, context: ResolverContext) => {
   
   const { currentUser } = context;
   const schema = getSchema(collection);


### PR DESCRIPTION
I tightened the typechecking around MongoModifier, and this turned up two bugs: One in the `clearCourseEndTime` callback, the other in the `mergeAccounts` script.

(In the `clearCourseEndTime` case, the result was that the callback did nothing. For the `mergeAccounts` script, which is only used when run manually by an admin, the effect of the bug was to clobber the old account rather than put it into the intended deleted state.)