### PR TITLE
Suppress spurious field-change logging for things that haven't actually changed

### DIFF
--- a/packages/lesswrong/server/fieldChanges.ts
+++ b/packages/lesswrong/server/fieldChanges.ts
@@ -19,7 +19,7 @@ export const logFieldChanges = async <T extends DbObject>({currentUser, collecti
     //  * It's a denormalized field
     //  * The logChanges option is present on the field, and false
     //  * The logChanges option is undefined on the field, and is false on the collection
-    if (before===after) continue;
+    if (before===after || JSON.stringify(before)===JSON.stringify(after)) continue;
     if (schema[key]?.denormalized) continue;
     if (schema[key]?.logChanges != undefined && !schema[key]?.logChanges)
       continue;


### PR DESCRIPTION
`logFieldChanges` records to the `LWEvents` collection when some fields of some other collections change, which isn't used in the UI anywhere but can be useful for reconstructing past events, eg I recently used it to find out the history of an author changing a post's title after it was frontpaged.

Make it deep-compare the old and new values, rather than shallow-compare, so that it doesn't produce spurious log entries for array- and object-typed fields that haven't actually changed.