### PR TITLE
[EA Forum only] enable searching each groups list on the new Community page

### DIFF
--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -13,12 +13,14 @@ import { getBrowserLocalStorage } from '../async/localStorageHandlers';
 import Geosuggest from 'react-geosuggest';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import Button from '@material-ui/core/Button';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import EmailIcon from '@material-ui/icons/MailOutline';
+import Search from '@material-ui/icons/Search';
 import classNames from 'classnames';
 import { userIsAdmin } from '../../lib/vulcan-users';
 
@@ -56,12 +58,36 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   filters: {
     display: 'flex',
-    justifyContent: 'space-between',
+    flexWrap: 'wrap',
     alignItems: 'baseline',
     columnGap: 10,
+    rowGap: '20px',
     marginTop: 10,
+    '@media (max-width: 1200px)': {
+      padding: '0 20px',
+    },
+    [theme.breakpoints.down('sm')]: {
+      padding: 0
+    },
+  },
+  keywordSearch: {
+    maxWidth: '100%',
+  },
+  keywordSearchInput: {
+    width: 350,
+    maxWidth: '100%',
+    verticalAlign: 'sub',
+    paddingLeft: 10,
+    '& input': {
+      padding: '15px 14px 15px 0'
+    }
+  },
+  searchIcon: {
+    color: theme.palette.primary.main,
+    marginRight: 6
   },
   where: {
+    display: 'inline-block',
     ...theme.typography.commentStyle,
     fontSize: 13,
     color: "rgba(0,0,0,0.6)",
@@ -83,10 +109,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     display: 'inline-block',
     marginLeft: 6
   },
-  filter: {
-  },
   distanceUnit: {
+    display: 'inline-block',
     ...theme.typography.commentStyle,
+    marginLeft: 8
   },
   distanceUnitRadio: {
     display: 'none'
@@ -117,7 +143,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   notifications: {
     flex: '1 0 0',
     textAlign: 'right',
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('md')]: {
       display: 'none'
     }
   },
@@ -176,6 +202,7 @@ const Community = ({classes}: {
   // local or online
   const [tab, setTab] = useState('local')
   const [distanceUnit, setDistanceUnit] = useState<"km"|"mi">('km')
+  const [keywordSearch, setKeywordSearch] = useState('')
   
   useEffect(() => {
     // unfortunately the hash is unavailable on the server, so we check it here instead
@@ -292,6 +319,7 @@ const Community = ({classes}: {
   
   const handleChangeTab = (e, value) => {
     setTab(value)
+    setKeywordSearch('')
     history.replace({...location, hash: `#${value}`})
   }
   
@@ -321,49 +349,63 @@ const Community = ({classes}: {
         
         {tab === 'local' && <div key="local">
           <div className={classes.filters}>
-            <div className={classes.where}>
-              <span className={classes.whereTextDesktop}>Showing groups near</span>
-              <span className={classes.whereTextMobile}>Location</span>
-              {mapsLoaded
-                && <div className={classes.geoSuggest}>
-                    <Geosuggest
-                      placeholder="search for a location"
-                      onSuggestSelect={(suggestion) => {
-                        if (suggestion?.location) {
-                          saveUserLocation({
-                            ...suggestion.location,
-                            gmaps: suggestion.gmaps
-                          })
-                        }
-                      }}
-                      initialValue={userLocation?.label}
-                    />
-                  </div>
-              }
+            <div className={classes.keywordSearch}>
+              <OutlinedInput
+                labelWidth={0}
+                startAdornment={<Search className={classes.searchIcon}/>}
+                placeholder="Search groups"
+                onChange={(e) => setKeywordSearch(e.target.value)}
+                className={classes.keywordSearchInput}
+              />
             </div>
-            
-            {userLocation.known && <div className={classes.distanceUnit}>
-              <input type="radio" id="km" name="distanceUnit" value="km" className={classes.distanceUnitRadio}
-                checked={distanceUnit === 'km'} onClick={() => setDistanceUnit('km')} />
-              <label htmlFor="km" className={classNames(classes.distanceUnitLabel, 'left', {'selected': distanceUnit === 'km'})}>
-                km
-              </label>
+            <div>
+              <div className={classes.where}>
+                <span className={classes.whereTextDesktop}>Groups near</span>
+                <span className={classes.whereTextMobile}>Near</span>
+                {mapsLoaded
+                  && <div className={classes.geoSuggest}>
+                      <Geosuggest
+                        placeholder="search for a location"
+                        onSuggestSelect={(suggestion) => {
+                          if (suggestion?.location) {
+                            saveUserLocation({
+                              ...suggestion.location,
+                              gmaps: suggestion.gmaps
+                            })
+                          }
+                        }}
+                        initialValue={userLocation?.label}
+                      />
+                    </div>
+                }
+              </div>
+              
+              {userLocation.known && <div className={classes.distanceUnit}>
+                <input type="radio" id="km" name="distanceUnit" value="km" className={classes.distanceUnitRadio}
+                  checked={distanceUnit === 'km'} onClick={() => setDistanceUnit('km')} />
+                <label htmlFor="km" className={classNames(classes.distanceUnitLabel, 'left', {'selected': distanceUnit === 'km'})}>
+                  km
+                </label>
 
-              <input type="radio" id="mi" name="distanceUnit" value="mi" className={classes.distanceUnitRadio}
-                checked={distanceUnit === 'mi'} onClick={() => setDistanceUnit('mi')} />
-              <label htmlFor="mi" className={classNames(classes.distanceUnitLabel, 'right', {'selected': distanceUnit === 'mi'})}>
-                mi
-              </label>
-            </div>}
-            
+                <input type="radio" id="mi" name="distanceUnit" value="mi" className={classes.distanceUnitRadio}
+                  checked={distanceUnit === 'mi'} onClick={() => setDistanceUnit('mi')} />
+                <label htmlFor="mi" className={classNames(classes.distanceUnitLabel, 'right', {'selected': distanceUnit === 'mi'})}>
+                  mi
+                </label>
+              </div>}
+            </div>
+              
             <div className={classes.notifications}>
               <Button variant="text" color="primary" onClick={openEventNotificationsForm} className={classes.notificationsBtn}>
-                {currentUser?.nearbyEventsNotifications ? <NotificationsIcon className={classes.notificationsIcon} /> : <NotificationsNoneIcon className={classes.notificationsIcon} />} Notify me
+                {currentUser?.nearbyEventsNotifications ?
+                  <NotificationsIcon className={classes.notificationsIcon} /> :
+                  <NotificationsNoneIcon className={classes.notificationsIcon} />
+                } Notify me
               </Button>
             </div>
           </div>
           
-          <LocalGroups userLocation={userLocation} distanceUnit={distanceUnit} />
+          <LocalGroups keywordSearch={keywordSearch} userLocation={userLocation} distanceUnit={distanceUnit} />
           
           <div className={classes.localGroupsBtns}>
             <Button href="https://resources.eagroups.org/" variant="outlined" color="primary" target="_blank" rel="noopener noreferrer" className={classes.localGroupsBtn}>
@@ -377,7 +419,20 @@ const Community = ({classes}: {
           
         </div>}
         
-        {tab === 'online' && <OnlineGroups />}
+        {tab === 'online' && <div key="online">
+          <div className={classes.filters}>
+            <div className={classes.keywordSearch}>
+              <OutlinedInput
+                labelWidth={0}
+                startAdornment={<Search className={classes.searchIcon}/>}
+                placeholder="Search groups"
+                onChange={(e) => setKeywordSearch(e.target.value)}
+                className={classes.keywordSearchInput}
+              />
+            </div>
+          </div>
+          <OnlineGroups keywordSearch={keywordSearch} />
+        </div>}
         
         {canCreateGroups && <div className={classes.addGroup} title="Currently only visible to admins">
           <GroupFormLink isOnline={tab === 'online'} />

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -218,6 +218,7 @@ const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', classes}: 
       <div className={classes.localGroupsMap}>
         <CommunityMapWrapper
           mapOptions={userLocation.known ? {center: userLocation, zoom: 5} : {zoom: 1}}
+          keywordSearch={keywordSearch}
           hideLegend
           showUsers={false}
         />

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -7,6 +7,21 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
+  noResults: {
+    ...theme.typography.commentStyle,
+    textAlign: 'center',
+    fontSize: 18,
+  },
+  noResultsText: {
+    marginTop: 30
+  },
+  noResultsCTA: {
+    fontSize: 14,
+    marginTop: 20
+  },
+  eventsLink: {
+    color: theme.palette.primary.main,
+  },
   localGroups: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
@@ -100,7 +115,8 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }))
 
 
-const LocalGroups = ({userLocation, distanceUnit='km', classes}: {
+const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', classes}: {
+  keywordSearch: string,
   userLocation: {
     lat: number,
     lng: number,
@@ -141,7 +157,7 @@ const LocalGroups = ({userLocation, distanceUnit='km', classes}: {
     view: 'local',
   }
   
-  const { results } = useMulti({
+  const { results, loading } = useMulti({
     terms: groupsListTerms,
     collectionName: "Localgroups",
     fragmentName: 'localGroupsHomeFragment',
@@ -152,11 +168,24 @@ const LocalGroups = ({userLocation, distanceUnit='km', classes}: {
   });
   
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
+  
+  // filter the list of groups if the user has typed in a keyword
+  let localGroups = results
+  if (results && keywordSearch) {
+    localGroups = results.filter(group => group.name.toLowerCase().includes(keywordSearch.toLowerCase()))
+  }
 
   return (
     <div className={classes.localGroups}>
-      <div className={classes.localGroupsList}>
-        {results?.map(group => {
+      {(!loading && !localGroups?.length) ? <div className={classes.noResults}>
+        <div className={classes.noResultsText}>No local groups matching your search</div>
+        <div className={classes.noResultsCTA}>
+          <Link to={'/events'} className={classes.eventsLink}>
+            Find an upcoming event near you
+          </Link>
+        </div>
+      </div> : <div className={classes.localGroupsList}>
+        {localGroups?.map(group => {
           const rowStyle = group.bannerImageId ? {
             backgroundImage: `linear-gradient(to right, transparent, white 140px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,g_custom,h_115,w_140,q_auto,f_auto/${group.bannerImageId})`
           } : {
@@ -185,7 +214,7 @@ const LocalGroups = ({userLocation, distanceUnit='km', classes}: {
             </div>
           </div>
         })}
-      </div>
+      </div>}
       <div className={classes.localGroupsMap}>
         <CommunityMapWrapper
           mapOptions={userLocation.known ? {center: userLocation, zoom: 5} : {zoom: 1}}

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -9,7 +9,23 @@ import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import { FacebookIcon, SlackIcon } from '../../localGroups/GroupLinks';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
+  noResults: {
+    ...theme.typography.commentStyle,
+    textAlign: 'center',
+    fontSize: 18,
+  },
+  noResultsText: {
+    marginTop: 30
+  },
+  noResultsCTA: {
+    fontSize: 14,
+    marginTop: 20
+  },
+  eventsLink: {
+    color: theme.palette.primary.main,
+  },
   onlineGroups: {
+    marginTop: 20,
     [theme.breakpoints.down('sm')]: {
       marginLeft: -4,
       marginRight: -4,
@@ -121,12 +137,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }))
 
 
-const OnlineGroups = ({classes}: {
+const OnlineGroups = ({keywordSearch, classes}: {
+  keywordSearch: string,
   classes: ClassesType,
 }) => {
   const { CloudinaryImage2 } = Components
   
-  const { results } = useMulti({
+  const { results, loading } = useMulti({
     terms: {view: 'online'},
     collectionName: "Localgroups",
     fragmentName: 'localGroupsHomeFragment',
@@ -136,11 +153,29 @@ const OnlineGroups = ({classes}: {
   });
   
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
+  
+  // filter the list of groups if the user has typed in a keyword
+  let onlineGroups = results
+  if (results && keywordSearch) {
+    onlineGroups = results.filter(group => group.name.toLowerCase().includes(keywordSearch.toLowerCase()))
+  }
+  
+  if (!loading && !onlineGroups?.length) {
+    // link to the Events page when there are no groups to show
+    return <div className={classes.noResults}>
+      <div className={classes.noResultsText}>No online groups matching your search</div>
+      <div className={classes.noResultsCTA}>
+        <Link to={'/events'} className={classes.eventsLink}>
+          Find an online event
+        </Link>
+      </div>
+    </div>
+  }
 
   return (
     <div className={classes.onlineGroups}>
       <div className={classes.onlineGroupsList}>
-        {results?.map(group => {
+        {onlineGroups?.map(group => {
           const rowStyle = group.bannerImageId ? {
             backgroundImage: `linear-gradient(to right, transparent, white 200px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,g_custom,h_115,w_200,q_auto,f_auto/${group.bannerImageId})`
           } : {

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -64,9 +64,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 
 // Make these variables have file-scope references to avoid rerending the scripts or map
 const defaultCenter = {lat: 39.5, lng: -43.636047}
-const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', showUsers, showHideMap = false, hideLegend, petrovButton }: {
+const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', showUsers, showHideMap = false, hideLegend, petrovButton }: {
   groupTerms: LocalgroupsViewTerms,
   eventTerms?: PostsViewTerms,
+  keywordSearch?: string,
   initialOpenWindows: Array<any>,
   center?: {lat: number, lng: number},
   zoom: number,
@@ -108,7 +109,7 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
       longitude: center.lng,
       zoom: zoom
     })
-  }, [center, zoom])
+  }, [center.lat, center.lng, zoom])
 
   const { results: events = [] } = useMulti({
     terms: eventTerms || {view: 'events'},
@@ -124,6 +125,11 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
     fragmentName: "localGroupsHomeFragment",
     limit: 500,
   })
+  // filter the list of groups if the user has typed in a keyword
+  let visibleGroups = groups
+  if (keywordSearch) {
+    visibleGroups = groups.filter(group => group.name.toLowerCase().includes(keywordSearch.toLowerCase()))
+  }
 
   const { results: users = [] } = useMulti({
     terms: {view: "usersMapLocations"},
@@ -138,7 +144,7 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
   const renderedMarkers = useMemo(() => {
     return <React.Fragment>
       {showEvents && <LocalEventsMapMarkers events={events} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
-      {showGroups && <LocalGroupsMapMarkers groups={groups} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
+      {showGroups && <LocalGroupsMapMarkers groups={visibleGroups} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
       {showIndividuals && <Components.PersonalMapLocationMarkers users={users} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
       {!hideLegend && <div className={classes.mapButtons}>
         <Components.CommunityMapFilter 
@@ -151,7 +157,7 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
         />
       </div>}
     </React.Fragment>
-  }, [showEvents, events, handleClick, handleClose, openWindows, showGroups, groups, showIndividuals, users, classes.mapButtons, showHideMap, hideLegend])
+  }, [showEvents, events, handleClick, handleClose, openWindows, showGroups, visibleGroups, showIndividuals, users, classes.mapButtons, showHideMap, hideLegend])
 
   if (!showMap) return null
 

--- a/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, showHideMap, hideLegend, showUsers, petrovButton}: {
+const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, keywordSearch, showHideMap, hideLegend, showUsers, petrovButton}: {
   className?: string,
   groupQueryTerms?: LocalgroupsViewTerms,
   currentUserLocation?: any,
   hideLegend?: boolean,
   mapOptions?: any,
   terms?: PostsViewTerms,
+  keywordSearch?: string,
   showHideMap?: boolean,
   showUsers?: boolean,
   petrovButton?: any,
@@ -19,6 +20,7 @@ const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, m
       className={className}
       groupTerms={groupQueryTerms}
       eventTerms={terms}
+      keywordSearch={keywordSearch}
       center={currentUserLocation}
       showHideMap={showHideMap}
       petrovButton={petrovButton}


### PR DESCRIPTION
I added simple keyword search functionality to each of the groups lists on the new Community page. It filters both the lists and the icons on the map.

<img width="1105" alt="Screen Shot 2022-03-07 at 3 12 02 PM" src="https://user-images.githubusercontent.com/9057804/157110668-75255030-442c-4372-9bea-224f27d7a620.png">

If there are no results, we also link the user to the Events page:

<img width="1105" alt="Screen Shot 2022-03-07 at 3 12 27 PM" src="https://user-images.githubusercontent.com/9057804/157110855-5bdbfa01-eb7c-4298-8c07-0a54c6707ae9.png">
