### PR TITLE
[EA Forum only] updates to the EA Forum Digest reminder in recent discussion feed

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -53,6 +53,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 8
   },
   mailIcon: {
+    color: theme.palette.primary.main,
     marginTop: 4,
     marginRight: 12
   },
@@ -196,10 +197,10 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
         Sign up for the Forum's email digest
       </div>
       <div className={classes.messageDescription}>
-        Want a weekly email containing the best posts from the past week?
-        Our moderator Aaron sends out a weekly digest of recent posts that
-        have a lot of karma/discussion or seemed really good to him, as well
-        as question posts that could use more answers.
+        You'll get a weekly email with the best posts from the past week.
+        The Forum team selects the posts to feature based on personal preference
+        and Forum popularity, and also adds some question posts that could use
+        more answers.
       </div>
     </>
   );

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -68,6 +68,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: 6,
     textTransform: 'uppercase'
   },
+  primaryBtn: {
+    background: theme.palette.primary.main,
+    color: 'white !important',
+    fontSize: '0.9em',
+    padding: '6px 12px',
+    textTransform: 'uppercase',
+    borderRadius: 4
+  },
   toggle: {
     cursor: 'pointer',
     '&:hover': {
@@ -189,13 +197,15 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
   </React.Fragment>;
 }
 
-const WrappedLoginFormEA = ({classes}: WrappedLoginFormProps) => {
+const WrappedLoginFormEA = ({startingState, classes}: WrappedLoginFormProps) => {
   const { pathname } = useLocation()
   
   return <div className={classes.root}>
     <div className={classnames(classes.oAuthBlock, 'ea-forum')}>
-      <a className={classes.oAuthLink} href={`/auth/auth0?returnTo=${pathname}`}>Login</a>
-      <a className={classes.oAuthLink} href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`}>Sign Up</a>
+      <a className={startingState === 'login' ? classes.primaryBtn : classes.oAuthLink}
+        href={`/auth/auth0?returnTo=${pathname}`}>Login</a>
+      <a className={startingState === 'signup' ? classes.primaryBtn : classes.oAuthLink}
+        href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`}>Sign Up</a>
     </div>
   </div>
 }

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -2,6 +2,7 @@ import { mergeFeedQueries, defineFeedResolver, viewBasedSubquery, fixedIndexSubq
 import { Posts } from '../../lib/collections/posts/collection';
 import { Tags } from '../../lib/collections/tags/collection';
 import { Revisions } from '../../lib/collections/revisions/collection';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 defineFeedResolver<Date>({
   name: "RecentDiscussionFeed",
@@ -68,7 +69,7 @@ defineFeedResolver<Date>({
         // Suggestion to subscribe to curated
         fixedIndexSubquery({
           type: "subscribeReminder",
-          index: 6,
+          index: forumTypeSetting.get() === 'EAForum' ? 3 : 6,
           result: {},
         }),
         


### PR DESCRIPTION
Based on Lizka's suggestions:

1. Updated the text, to stop referring to Aaron
2. Moved it up in Recent Discussion, to appear after 3 items rather than after 6 items
3. Made the "Sign Up" button primary
4. Made the envelope icon teal instead of black

<img width="784" alt="Screen Shot 2022-03-08 at 11 16 53 AM" src="https://user-images.githubusercontent.com/9057804/157279582-20fdb7ef-6f8a-4b43-a91d-9f5ded7fb3e6.png">
