### PR TITLE
[EA Forum only] update Community page search

### DIFF
--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -23,6 +23,7 @@ import EmailIcon from '@material-ui/icons/MailOutline';
 import Search from '@material-ui/icons/Search';
 import classNames from 'classnames';
 import { userIsAdmin } from '../../lib/vulcan-users';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   section: {
@@ -154,8 +155,34 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginLeft: 10,
     marginRight: 5
   },
+  eventsPageLinkRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    ...theme.typography.commentStyle,
+    marginTop: 40,
+    '@media (max-width: 1200px)': {
+      padding: '0 20px',
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'none'
+    }
+  },
+  eventsPagePrompt: {
+    color: theme.palette.grey[600],
+    fontSize: 14,
+    marginRight: 16
+  },
+  eventsPageLink: {
+    backgroundColor: theme.palette.primary.main,
+    color: 'white',
+    fontSize: 13,
+    padding: '8px 16px',
+    borderRadius: 4,
+    marginTop: 10
+  },
   addGroup: {
-    marginTop: 20
+    marginTop: 40
   }
 }))
 
@@ -399,6 +426,11 @@ const Community = ({classes}: {
           </div>
           <OnlineGroups keywordSearch={keywordSearch} />
         </div>}
+        
+        <div className={classes.eventsPageLinkRow}>
+          <div className={classes.eventsPagePrompt}>Want to see what's happening now?</div>
+          <Link to="/events" className={classes.eventsPageLink}>Explore all upcoming events</Link>
+        </div>
         
         {canCreateGroups && <div className={classes.addGroup} title="Currently only visible to admins">
           <GroupFormLink isOnline={tab === 'online'} />

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -172,7 +172,9 @@ const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', classes}: 
   // filter the list of groups if the user has typed in a keyword
   let localGroups = results
   if (results && keywordSearch) {
-    localGroups = results.filter(group => group.name.toLowerCase().includes(keywordSearch.toLowerCase()))
+    localGroups = results.filter(group => (
+      `${group.name.toLowerCase()} ${group.location.toLowerCase()}`.includes(keywordSearch.toLowerCase())
+    ))
   }
 
   return (


### PR DESCRIPTION
In this PR, I updated the local groups keyword search on the Community page to also match on locations, and started tracking some data on what people search for.

EDIT: I also added a link to the Events page at the bottom of the Community page:

<img width="738" alt="Screen Shot 2022-03-09 at 11 24 17 AM" src="https://user-images.githubusercontent.com/9057804/157485957-7eb3917b-5ac1-4192-8221-b01a742ca5fd.png">
