### PR TITLE
Fix crash on event pages with no group-types field

### DIFF
--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -164,7 +164,7 @@ const GroupLinks = ({ document, noMargin, classes }: {
           )
         })}
       </div>}
-      <div className={(noMargin && (isEAForum || !document.types.length)) ? classNames(classes.groupLinks, classes.noMargin) : classes.groupLinks}>
+      <div className={(noMargin && (isEAForum || !document.types?.length)) ? classNames(classes.groupLinks, classes.noMargin) : classes.groupLinks}>
         {document.facebookLink
           && <Tooltip
             title={`Link to Facebook ${isEvent ? 'Event' : 'Group'}`}


### PR DESCRIPTION
Introduced in f1cd86f07f6a1575c08ddad79b4ef14e8a776c43. Probably only affects some events from far in the past when this field didn't exist, but showed up in Sentry nevertheless.


