### PR TITLE
add button on event details page to see the event on Facebook (or Meetup)

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -58,6 +58,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     textTransform: 'none',
     fontSize: 12
   },
+  externalEventPageBtnIcon: {
+    fontSize: 15,
+    marginLeft: 6
+  },
   registerBtnIcon: {
     fontSize: 15,
     marginTop: -4,
@@ -167,7 +171,7 @@ const PostsPageEventData = ({classes, post}: {
       target="_blank" rel="noopener noreferrer"
       className={classes.externalEventPageBtn}
     >
-      See event on Facebook <OpenInNewIcon className={classes.registerBtnIcon} />
+      See event on Facebook <OpenInNewIcon className={classes.externalEventPageBtnIcon} />
     </Button>
   } else if (!eventCTA && post.meetupLink) {
     eventCTA = <Button
@@ -177,7 +181,7 @@ const PostsPageEventData = ({classes, post}: {
       target="_blank" rel="noopener noreferrer"
       className={classes.externalEventPageBtn}
     >
-      See event on Meetup <OpenInNewIcon className={classes.registerBtnIcon} />
+      See event on Meetup <OpenInNewIcon className={classes.externalEventPageBtnIcon} />
     </Button>
   }
   

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -54,6 +54,10 @@ const styles = (theme: ThemeType): JssStyles => ({
       margin: '20px 0 0 12px',
     },
   },
+  externalEventPageBtn: {
+    textTransform: 'none',
+    fontSize: 12
+  },
   registerBtnIcon: {
     fontSize: 15,
     marginTop: -4,
@@ -127,13 +131,23 @@ const PostsPageEventData = ({classes, post}: {
   
   // if the event has a registration link, display that instead
   if (beforeEvent && eventRegistrationLink) {
-    eventCTA = <Button variant="contained" color="primary" href={eventRegistrationLink} onClick={() => captureEvent("eventRegistrationLinkClick")} target="_blank" rel="noopener noreferrer">
+    eventCTA = <Button
+      variant="contained" color="primary"
+      href={eventRegistrationLink}
+      onClick={() => captureEvent("eventRegistrationLinkClick")}
+      target="_blank" rel="noopener noreferrer"
+    >
       Register <OpenInNewIcon className={classes.registerBtnIcon} />
     </Button>
   }
   // if the event is soon/now, enable the "Join Event" button
   else if (duringEvent) {
-    eventCTA = joinEventLink && <Button variant="contained" color="primary" href={joinEventLink} onClick={() => captureEvent("joinEventLinkClick")} target="_blank" rel="noopener noreferrer">
+    eventCTA = joinEventLink && <Button
+      variant="contained" color="primary"
+      href={joinEventLink}
+      onClick={() => captureEvent("joinEventLinkClick")}
+      target="_blank" rel="noopener noreferrer"
+    >
       Join Event
     </Button>
   }
@@ -141,6 +155,29 @@ const PostsPageEventData = ({classes, post}: {
   else if (afterEvent) {
     eventCTA = joinEventLink && <Button variant="contained" color="primary" href={joinEventLink} disabled>
       Event Ended
+    </Button>
+  }
+  
+  // if we have no other CTA, then link to the FB or Meetup event page
+  if (!eventCTA && post.facebookLink) {
+    eventCTA = <Button
+      variant={afterEvent ? "outlined" : "contained"} color="primary"
+      href={post.facebookLink}
+      onClick={() => captureEvent("facebookEventBtnClick")}
+      target="_blank" rel="noopener noreferrer"
+      className={classes.externalEventPageBtn}
+    >
+      See event on Facebook <OpenInNewIcon className={classes.registerBtnIcon} />
+    </Button>
+  } else if (!eventCTA && post.meetupLink) {
+    eventCTA = <Button
+      variant={afterEvent ? "outlined" : "contained"} color="primary"
+      href={post.meetupLink}
+      onClick={() => captureEvent("meetupEventBtnClick")}
+      target="_blank" rel="noopener noreferrer"
+      className={classes.externalEventPageBtn}
+    >
+      See event on Meetup <OpenInNewIcon className={classes.registerBtnIcon} />
     </Button>
   }
   

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -64,7 +64,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   registerBtnIcon: {
     fontSize: 15,
-    marginTop: -4,
+    marginTop: -2,
     marginLeft: 6
   },
   mapbox: {


### PR DESCRIPTION
In this PR, I'm adding a version of the existing CTA button on the event details page that links to the event on Facebook or Meetup. The existing links next to the post author will remain, since we still want them to be accessible even if another CTA takes precedence.

I decided to make it a version of the existing CTA (rather than a separate button) so that there wouldn't be multiple competing actions for the user, but maybe I should consider making it a separate button that is less prominent than the "Register" button. I'm not sure which is best here - open to suggestions.

<img width="696" alt="Screen Shot 2022-03-09 at 3 31 12 PM" src="https://user-images.githubusercontent.com/9057804/157531712-62e55c87-1c0b-4e58-801f-1485fc6c2698.png">
