### PR TITLE
Disable prefetch of tag hover preview on all tags page

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -77,6 +77,8 @@ interface ContentItemBodyProps extends WithStylesProps {
   dangerouslySetInnerHTML: { __html: string },
   className?: string,
   description?: string,
+  // Only Implemented for Tag Hover Previews
+  noHoverPreviewPrefetch?: boolean,
 }
 interface ContentItemBodyState {
   updatedElements: boolean,
@@ -262,7 +264,7 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
           continue;
         const id = linkTag.getAttribute("id");
         const rel = linkTag.getAttribute("rel")
-        const replacementElement = <Components.HoverPreviewLink href={href} innerHTML={tagContentsHTML} contentSourceDescription={this.props.description} id={id} rel={rel}/>
+        const replacementElement = <Components.HoverPreviewLink href={href} innerHTML={tagContentsHTML} contentSourceDescription={this.props.description} id={id} rel={rel} noPrefetch={this.props.noHoverPreviewPrefetch}/>
         this.replaceElement(linkTag, replacementElement);
       }
     }

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -45,12 +45,14 @@ export const linkIsExcludedFromPreview = (url: string): boolean => {
 //   contentSourceDescription: (Optional) A human-readabe string describing
 //     where this content came from. Used in error logging only, not displayed
 //     to users.
-const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }: {
+const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel, noPrefetch }: {
   innerHTML: string,
   href: string,
   contentSourceDescription?: string,
   id?: string,
-  rel?: string
+  rel?: string,
+  // Only Implemented for Tag Hover Previews
+  noPrefetch?: boolean,
 }) => {
   const URLClass = getUrlClass()
   const location = useLocation();
@@ -82,7 +84,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }
 
         if (PreviewComponent) {
           return <AnalyticsContext pageElementContext="linkPreview" href={destinationUrl} hoverPreviewType={parsedUrl.currentRoute.previewComponentName} onsite>
-            <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id}/>
+            <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id} noPrefetch={noPrefetch}/>
           </AnalyticsContext>
         } else {
           return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} rel={rel} />
@@ -116,4 +118,3 @@ declare global {
     HoverPreviewLink: typeof HoverPreviewLinkComponent
   }
 }
-

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -98,7 +98,7 @@ const AllTagsPage = ({classes}: {
                 :
                 <ContentItemBody
                   dangerouslySetInnerHTML={{__html: tag?.description?.html || ""}}
-                  description={`tag ${tag?.name}`}
+                  description={`tag ${tag?.name}`} noHoverPreviewPrefetch
                 />
               }
             </div>

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -27,17 +27,18 @@ function normalizeTagLink(link: string) {
   return removeUrlParameters(link, ["showPostCount", "useTagName"]);
 }
 
-const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}: {
+const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6, noPrefetch}: {
   href: string,
   targetLocation: any,
   innerHTML: string,
   classes: ClassesType,
-  postCount?: number
+  postCount?: number,
+  noPrefetch?: boolean,
 }) => {
   const { params: {slug} } = targetLocation;
-  const { tag } = useTagBySlug(slug, "TagPreviewFragment");
-  const { PopperCard, TagPreview, Loading } = Components;
-  const { hover, anchorEl, eventHandlers } = useHover();
+  const { hover, anchorEl, eventHandlers, everHovered } = useHover();
+  const { tag, loading } = useTagBySlug(slug, "TagPreviewFragment", {skip: noPrefetch && !everHovered});
+  const { PopperCard, TagPreview } = Components;
   const { showPostCount: showPostCountQuery, useTagName: useTagNameQuery } = targetLocation.query
   const showPostCount = showPostCountQuery === "true" // query parameters are strings
   const useTagName = tag && tag.name && useTagNameQuery === "true" // query parameters are strings
@@ -47,9 +48,7 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}
 
   return <span {...eventHandlers}>
     <PopperCard open={hover} anchorEl={anchorEl}>
-      {tag
-        ? <TagPreview tag={tag} postCount={postCount}/>
-        : <Loading/>}
+      <TagPreview tag={tag} postCount={postCount} loading={loading} />
     </PopperCard>
     <Link
       className={showPostCount ? classes.linkWithoutDegreeSymbol : classes.link}

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -51,11 +51,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
-  tag: TagPreviewFragment,
+const TagPreview = ({tag, loading, classes, showCount=true, postCount=6}: {
+  tag: TagPreviewFragment | null,
+  loading?: boolean,
   classes: ClassesType,
   showCount?: boolean,
-  postCount?: number
+  postCount?: number,
 }) => {
   const { TagPreviewDescription, TagSmallPostLink, Loading } = Components;
   const { results } = useMulti({
@@ -66,17 +67,18 @@ const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
     limit: postCount,
   });
 
-  if (!tag) return null
-
   return (<div className={classes.card}>
-    <TagPreviewDescription tag={tag}/>
-    {!tag.wikiOnly && <>
-      {results ? <div className={classes.posts}>
-        {results.map((post,i) => post && <TagSmallPostLink key={post._id} post={post} widerSpacing={postCount > 3} />)}
-      </div> : <Loading /> }
-      {showCount && <div className={classes.footerCount}>
-        <Link to={tagGetUrl(tag)}>View all {tag.postCount} posts</Link>
-      </div>}
+    {loading && <Loading />}
+    {tag && <>
+      <TagPreviewDescription tag={tag}/>
+      {!tag.wikiOnly && <>
+        {results ? <div className={classes.posts}>
+          {results.map((post,i) => post && <TagSmallPostLink key={post._id} post={post} widerSpacing={postCount > 3} />)}
+        </div> : <Loading /> }
+        {showCount && <div className={classes.footerCount}>
+          <Link to={tagGetUrl(tag)}>View all {tag.postCount} posts</Link>
+        </div>}
+      </>}
     </>}
   </div>)
 }

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -66,7 +66,13 @@ const TagPreview = ({tag, loading, classes, showCount=true, postCount=6}: {
     fragmentName: "PostsList",
     limit: postCount,
   });
-
+  
+  // I kinda want the type system to forbid this, but the obvious union approach
+  // didn't work
+  if (!loading && !tag) {
+    return null
+  }
+  
   return (<div className={classes.card}>
     {loading && <Loading />}
     {tag && <>


### PR DESCRIPTION
The All Tags page on LessWrong and the EA Forum is a slow experience. On a fast macbook LessWrong's is an acceptable page, but on an older computer or a phone, it's pretty bad (>10 seconds till interactive), and the EA Forum's ranges from "noticeably slow" to "unusable garbage".

When you hover your mouse over a tag, you get a preview of that tag. I suspected that the slowness of the allTags page was due to the prefetching, which Jim & I confirmed. The problem lies entirely in the previews fetched by the Wiki Portal *description*, not the all tags list. The description is sent inside ContentItemBody, which only fetches its previews on the client, and does so in 500 individual apollo queries. We could not find out why 500 queries is enough to kill peg the CPU for 7 seconds, but it is. It is unfortunate to disable prefetched previews, as it does degrade the user experience. However a single query for a small document is a pretty fast wait, and better options were not forthcoming.