### PR TITLE
fix Community page map keyword filtering

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -128,7 +128,9 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   // filter the list of groups if the user has typed in a keyword
   let visibleGroups = groups
   if (keywordSearch) {
-    visibleGroups = groups.filter(group => group.name.toLowerCase().includes(keywordSearch.toLowerCase()))
+    visibleGroups = groups.filter(group => (
+      `${group.name.toLowerCase()} ${group.location?.toLowerCase()}`.includes(keywordSearch.toLowerCase())
+    ))
   }
 
   const { results: users = [] } = useMulti({


### PR DESCRIPTION
I forgot to update the filtering on the map to match the local groups list, so I'm updating it here.