### PR TITLE
[EA Forum only] fix bug on Events page that caused an extra event card to appear

### DIFF
--- a/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
+++ b/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
@@ -37,13 +37,16 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
 }))
 
-const DistanceUnitToggle = ({distanceUnit='km', onChange, classes}: {
+const DistanceUnitToggle = ({distanceUnit='km', onChange, skipEffect, classes}: {
   distanceUnit: "km"|"mi",
   onChange: Function,
+  skipEffect?: boolean,
   classes: ClassesType,
 }) => {
   
   useEffect(() => {
+    if (skipEffect) return
+    
     // only US and UK default to miles - everyone else defaults to km
     // (this is checked here to allow SSR to work properly)
     if (['en-US', 'en-GB'].some(lang => lang === window?.navigator?.language)) {

--- a/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
+++ b/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
@@ -37,15 +37,15 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
 }))
 
-const DistanceUnitToggle = ({distanceUnit='km', onChange, skipEffect, classes}: {
+const DistanceUnitToggle = ({distanceUnit='km', onChange, skipDefaultEffect, classes}: {
   distanceUnit: "km"|"mi",
   onChange: Function,
-  skipEffect?: boolean,
+  skipDefaultEffect?: boolean,
   classes: ClassesType,
 }) => {
   
   useEffect(() => {
-    if (skipEffect) return
+    if (skipDefaultEffect) return
     
     // only US and UK default to miles - everyone else defaults to km
     // (this is checked here to allow SSR to work properly)

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -427,7 +427,7 @@ const EventsHome = ({classes}: {
                 onChange={handleChangeDistance}
                 className={classes.distanceInput}
               />
-              <DistanceUnitToggle distanceUnit={distanceUnit} onChange={handleChangeDistanceUnit} skipEffect />
+              <DistanceUnitToggle distanceUnit={distanceUnit} onChange={handleChangeDistanceUnit} skipDefaultEffect />
             </div>
             
             <Select


### PR DESCRIPTION
I noticed a weird bug on the prod Events page. Moving the default distance filter logic to `useEffect` seems to have fixed it (I think it was an SSR issue).

<img width="913" alt="Screen Shot 2022-03-14 at 2 52 34 PM" src="https://user-images.githubusercontent.com/9057804/158247196-dde0d513-12d4-4a8b-92b3-34913072cdae.png">
