### PR TITLE
Intro Sequences for Tags

### DIFF
--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -13,6 +13,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "inline-block",
     minHeight: 20,
   },
+  afterPostsListMarginTop: {
+    marginTop: 6,
+  },
   loading: {
     minHeight: 20,
   },
@@ -40,7 +43,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Load More button. The simplest way to use this is to take `loadMoreProps`
 // from the return value of `useMulti` and spread it into this component's
 // props.
-const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassName, disabled=false, networkStatus, loading=false, hideLoading=false, hidden=false, classes, sectionFooterStyles }: {
+const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassName, disabled=false, networkStatus, loading=false, hideLoading=false, hidden=false, classes, sectionFooterStyles, afterPostsListMarginTop }: {
   // loadMore: Callback when clicked.
   loadMore: LoadMoreCallback,
   // count/totalCount: If provided, looks like "Load More (10/25)"
@@ -57,7 +60,8 @@ const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassNam
   hideLoading?: boolean,
   hidden?: boolean,
   classes: ClassesType,
-  sectionFooterStyles?: boolean
+  sectionFooterStyles?: boolean,
+  afterPostsListMarginTop?: boolean,
 }) => {
   const { captureEvent } = useTracking()
 
@@ -76,7 +80,7 @@ const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassNam
 
   return (
     <a
-      className={classNames(className ? className : classes.root, {[classes.disabled]: disabled, [classes.sectionFooterStyles]: sectionFooterStyles})}
+      className={classNames(className ? className : classes.root, {[classes.disabled]: disabled, [classes.sectionFooterStyles]: sectionFooterStyles, [classes.afterPostsListMarginTop]: afterPostsListMarginTop})}
       href="#"
       onClick={handleClickLoadMore}
     >

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -54,8 +54,6 @@ const ChaptersItem = ({ chapter, canEdit, limit, classes }: {
   </SectionButton>
 
   const posts = limit ? chapter.posts.slice(0, limit) : chapter.posts
-  console.log('🚀 ~ file: ChaptersItem.tsx ~ line 57 ~ limit', limit)
-  console.log('🚀 ~ file: ChaptersItem.tsx ~ line 57 ~ posts', posts.length)
 
   return (
     <div>

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -24,10 +24,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const ChaptersItem = ({ chapter, canEdit, limit, classes }: {
+const ChaptersItem = ({ chapter, canEdit, classes }: {
   chapter: ChaptersFragment,
   canEdit: boolean,
-  limit?: number,
   classes: ClassesType,
 }) => {
   const [edit,setEdit] = useState(false);
@@ -53,8 +52,6 @@ const ChaptersItem = ({ chapter, canEdit, limit, classes }: {
     <a onClick={showEdit}>Add/Remove Posts</a>
   </SectionButton>
 
-  const posts = limit ? chapter.posts.slice(0, limit) : chapter.posts
-
   return (
     <div>
       {chapter.title && <SectionTitle title={chapter.title}>
@@ -68,7 +65,7 @@ const ChaptersItem = ({ chapter, canEdit, limit, classes }: {
       </div>}
       <div className={classes.posts}>
         <AnalyticsContext chapter={chapter._id} capturePostItemOnMount>
-          <SequencesPostsList posts={posts} chapter={chapter} />
+          <SequencesPostsList posts={chapter.posts} chapter={chapter} />
         </AnalyticsContext>
       </div>
       {!chapter.title && canEdit && <SectionFooter>{editButton}</SectionFooter>}

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -24,9 +24,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const ChaptersItem = ({ chapter, canEdit, classes }: {
+const ChaptersItem = ({ chapter, canEdit, limit, classes }: {
   chapter: ChaptersFragment,
   canEdit: boolean,
+  limit?: number,
   classes: ClassesType,
 }) => {
   const [edit,setEdit] = useState(false);
@@ -52,6 +53,10 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
     <a onClick={showEdit}>Add/Remove Posts</a>
   </SectionButton>
 
+  const posts = limit ? chapter.posts.slice(0, limit) : chapter.posts
+  console.log('🚀 ~ file: ChaptersItem.tsx ~ line 57 ~ limit', limit)
+  console.log('🚀 ~ file: ChaptersItem.tsx ~ line 57 ~ posts', posts.length)
+
   return (
     <div>
       {chapter.title && <SectionTitle title={chapter.title}>
@@ -65,7 +70,7 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
       </div>}
       <div className={classes.posts}>
         <AnalyticsContext chapter={chapter._id} capturePostItemOnMount>
-          <SequencesPostsList posts={chapter.posts} chapter={chapter} />
+          <SequencesPostsList posts={posts} chapter={chapter} />
         </AnalyticsContext>
       </div>
       {!chapter.title && canEdit && <SectionFooter>{editButton}</SectionFooter>}
@@ -80,4 +85,3 @@ declare global {
     ChaptersItem: typeof ChaptersItemComponent
   }
 }
-

--- a/packages/lesswrong/components/sequences/ChaptersList.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersList.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 
-const ChaptersList = ({sequenceId, canEdit, preview}: {
+const ChaptersList = ({sequenceId, canEdit}: {
   sequenceId: string,
   canEdit: boolean,
-  preview?: boolean,
 }) => {
   const { results, loading } = useMulti({
     terms: {
       view: "SequenceChapters",
       sequenceId,
-      limit: preview ? 1 : 100
+      limit: 100
     },
     collectionName: "Chapters",
     fragmentName: 'ChaptersFragment',
@@ -19,7 +18,11 @@ const ChaptersList = ({sequenceId, canEdit, preview}: {
   });
   if (results && !loading) {
     return <div className="chapters-list">
-      {results.map((chapter) => <Components.ChaptersItem key={chapter._id} chapter={chapter} canEdit={canEdit} limit={preview ? 3 : undefined} />)}
+      {results.map((chapter) => <Components.ChaptersItem
+        key={chapter._id}
+        chapter={chapter}
+        canEdit={canEdit}
+      />)}
     </div>
   } else {
     return <Components.Loading />

--- a/packages/lesswrong/components/sequences/ChaptersList.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersList.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 
-const ChaptersList = ({sequenceId, canEdit}: {
+const ChaptersList = ({sequenceId, canEdit, preview}: {
   sequenceId: string,
   canEdit: boolean,
+  preview?: boolean,
 }) => {
   const { results, loading } = useMulti({
     terms: {
       view: "SequenceChapters",
       sequenceId,
-      limit: 100
+      limit: preview ? 1 : 100
     },
     collectionName: "Chapters",
     fragmentName: 'ChaptersFragment',
@@ -18,7 +19,7 @@ const ChaptersList = ({sequenceId, canEdit}: {
   });
   if (results && !loading) {
     return <div className="chapters-list">
-      {results.map((chapter) => <Components.ChaptersItem key={chapter._id} chapter={chapter} canEdit={canEdit} />)}
+      {results.map((chapter) => <Components.ChaptersItem key={chapter._id} chapter={chapter} canEdit={canEdit} limit={preview ? 3 : undefined} />)}
     </div>
   } else {
     return <Components.Loading />
@@ -32,4 +33,3 @@ declare global {
     ChaptersList: typeof ChaptersListComponent
   }
 }
-

--- a/packages/lesswrong/components/sequences/SequencesPostsList.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPostsList.tsx
@@ -17,4 +17,3 @@ declare global {
     SequencesPostsList: typeof SequencesPostsListComponent
   }
 }
-

--- a/packages/lesswrong/components/tagging/TagIntroSequence.tsx
+++ b/packages/lesswrong/components/tagging/TagIntroSequence.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { AnalyticsContext } from '../../lib/analyticsEvents'
-import { useSingle } from '../../lib/crud/withSingle'
+import { useMulti } from '../../lib/crud/withMulti'
 import { Components, registerComponent } from '../../lib/vulcan-lib'
+
+const PREVIEW_N = 3
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -13,14 +15,44 @@ const TagIntroSequence = ({tag, classes}: {
   tag: TagPageFragment,
   classes: ClassesType
 }) => {
-  const { SectionTitle, ChaptersList } = Components
+  const { SectionTitle, Loading, PostsItem2, LoadMore } = Components
+  const { results: seqChapters, loading } = useMulti({
+    terms: {
+      view: "SequenceChapters",
+      sequenceId: tag.sequence?._id,
+      limit: 100,
+    },
+    collectionName: "Chapters",
+    fragmentName: 'ChaptersFragment',
+    enableTotal: false,
+    skip: !tag.sequence,
+  });
+  const [loadedMore, setLoadedMore] = useState(false)
 
   if (!tag.sequence) return null
-  
+
+  // Get all the posts together, we're ignoring chapters here
+  let posts = seqChapters?.flatMap(chapter => chapter.posts) || []
+  const totalCount = posts.length
+  if (!loadedMore) {
+    posts = posts.slice(0, PREVIEW_N)
+  }
+
   return <div className={classes.root}>
     <SectionTitle title={`Introduction to ${tag.name}`} />
     <AnalyticsContext listContext={'tagIntroSequnce'}>
-      <ChaptersList sequenceId={tag.sequence._id} canEdit={false} preview />
+      {loading && <Loading />}
+      {posts.map((post) => <PostsItem2
+        key={post._id}
+        post={post}
+        sequenceId={tag.sequence?._id}
+      />)}
+      {totalCount > PREVIEW_N && !loadedMore && <LoadMore
+        loadMore={() => setLoadedMore(true)}
+        count={PREVIEW_N}
+        totalCount={totalCount}
+        afterPostsListMarginTop
+      />}
     </AnalyticsContext>
   </div>
 }

--- a/packages/lesswrong/components/tagging/TagIntroSequence.tsx
+++ b/packages/lesswrong/components/tagging/TagIntroSequence.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { AnalyticsContext } from '../../lib/analyticsEvents'
+import { useSingle } from '../../lib/crud/withSingle'
+import { Components, registerComponent } from '../../lib/vulcan-lib'
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    marginBottom: 16,
+  },
+})
+
+const TagIntroSequence = ({tag, classes}: {
+  tag: TagPageFragment,
+  classes: ClassesType
+}) => {
+  const { SectionTitle, ChaptersList } = Components
+
+  if (!tag.sequence) return null
+  
+  return <div className={classes.root}>
+    <SectionTitle title={`Introduction to ${tag.name}`} />
+    <AnalyticsContext listContext={'tagIntroSequnce'}>
+      <ChaptersList sequenceId={tag.sequence._id} canEdit={false} preview />
+    </AnalyticsContext>
+  </div>
+}
+
+const TagIntroSequenceComponent = registerComponent("TagIntroSequence", TagIntroSequence, {styles})
+
+declare global {
+  interface ComponentTypes {
+    TagIntroSequence: typeof TagIntroSequenceComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -150,7 +150,9 @@ const TagPage = ({classes}: {
 }) => {
   const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect,
     HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn,
-    TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton, CloudinaryImage } = Components;
+    TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton, CloudinaryImage,
+    TagIntroSequence
+   } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;
@@ -344,6 +346,7 @@ const TagPage = ({classes}: {
             key={tag._id}
             tag={tag}
           />}
+          {tag.sequence && <TagIntroSequence tag={tag} />}
           {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
             <div className={classes.tagHeader}>
               <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -151,7 +151,7 @@ const TagPage = ({classes}: {
   const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect,
     HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn,
     TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton, CloudinaryImage,
-    TagIntroSequence
+    TagIntroSequence, SectionTitle
    } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -348,10 +348,15 @@ const TagPage = ({classes}: {
           />}
           {tag.sequence && <TagIntroSequence tag={tag} />}
           {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
-            <div className={classes.tagHeader}>
-              <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
-              <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
-            </div>
+            {tag.sequence ?
+              <SectionTitle title={`Posts tagged ${tag.name}`}>
+                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+              </SectionTitle> :
+              <div className={classes.tagHeader}>
+                <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
+                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+              </div>
+            }
             <PostsList2
               terms={terms}
               enableTotal

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -28,6 +28,9 @@ registerFragment(`
     bannerImageId
     lesswrongWikiImportSlug
     lesswrongWikiImportRevision
+    sequence {
+      ...SequencesPageFragment
+    }
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -386,6 +386,21 @@ export const schema: SchemaType<DbTag> = {
     viewableBy: ['guests'],
     denormalized: true,
   },
+  
+  introSequenceId: {
+    ...foreignKeyField({
+      idFieldName: "introSequenceId",
+      resolverName: "sequence",
+      collectionName: "Sequences",
+      type: "Sequence",
+      nullable: true,
+    }),
+    optional: true,
+    group: formGroups.advancedOptions,
+    viewableBy: ['guests'],
+    editableBy: ['sunshineRegiment', 'admins'],
+    insertableBy: ['sunshineRegiment', 'admins'],
+  },
 }
 
 export const wikiGradeDefinitions: Partial<Record<number,string>> = {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -438,6 +438,7 @@ importComponent("CoreTagsChecklist", () => require('../components/tagging/CoreTa
 importComponent("TagPage", () => require('../components/tagging/TagPage'));
 importComponent("TagPageButtonRow", () => require('../components/tagging/TagPageButtonRow'));
 importComponent("TagPageTitle", () => require('../components/tagging/TagPageTitle'));
+importComponent("TagIntroSequence", () => require('../components/tagging/TagIntroSequence'));
 importComponent("TagHistoryPageTitle", () => require('../components/tagging/TagHistoryPageTitle'));
 importComponent("AddPostsToTag", () => require('../components/tagging/AddPostsToTag'));
 importComponent("FooterTagList", () => require('../components/tagging/FooterTagList'));

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -649,6 +649,7 @@ interface DbTag extends DbObject {
   lesswrongWikiImportCompleted: boolean
   htmlWithContributorAnnotations: string
   contributionStats: any /*{"definitions":[{"blackbox":true}]}*/
+  introSequenceId: string
   description: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -267,6 +267,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly htmlWithContributorAnnotations: string,
   readonly contributors: any /*TagContributorsList*/,
   readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly introSequenceId: string,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions
@@ -1407,6 +1408,7 @@ interface TagDetailsFragment extends TagBasicInfo { // fragment on Tags
   readonly bannerImageId: string,
   readonly lesswrongWikiImportSlug: string,
   readonly lesswrongWikiImportRevision: string,
+  readonly sequence: SequencesPageFragment|null,
 }
 
 interface TagFragment extends TagDetailsFragment { // fragment on Tags


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/10352319/158703324-dae3ff38-b839-4488-b174-94726722c26d.png)

The goal of this is to give newbies a curated "here's where to start". It probably still needs a load more, and I want to think about if I want to bother deploying this without any intro sequence selected, but the code is basically there.

- [x] Load more gets you all the posts in the intro sequence
- [x] We need a SectionTitle for the Posts Tagged ${Tag} now

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/628521446211730/1201981539334652) by [Unito](https://www.unito.io)
