### PR TITLE
Rename callback-less collection operations to avoid footguns

### DIFF
--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -155,16 +155,16 @@ export class MongoCollection<T extends DbObject> {
       return insertResult.insertedId;
     });
   }
-  update = async (selector, update, options) => {
+  rawUpdate = async (selector, update, options) => {
     if (disableAllWrites) return;
     try {
       const table = this.getTable();
       return await wrapQuery(`${this.tableName}.update`, async () => {
         if (typeof selector === 'string') {
-          const updateResult = await table.update({_id: selector}, update, options);
+          const updateResult = await table.rawUpdate({_id: selector}, update, options);
           return updateResult.matchedCount;
         } else {
-          const updateResult = await table.update(removeUndefinedFields(selector), update, options);
+          const updateResult = await table.rawUpdate(removeUndefinedFields(selector), update, options);
           return updateResult.matchedCount;
         }
       });
@@ -228,7 +228,7 @@ export class MongoCollection<T extends DbObject> {
     update: async (selector, update, options) => {
       if (disableAllWrites) return;
       const table = this.getTable();
-      return await table.update(selector, update, options);
+      return await table.rawUpdate(selector, update, options);
     },
   })
 }

--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -144,7 +144,7 @@ export class MongoCollection<T extends DbObject> {
       return await table.findOne({});
     });
   }
-  insert = async (doc, options) => {
+  rawInsert = async (doc, options) => {
     if (disableAllWrites) return;
     if (!doc._id) {
       doc._id = randomId();
@@ -176,7 +176,7 @@ export class MongoCollection<T extends DbObject> {
       throw e;
     }
   }
-  remove = async (selector, options) => {
+  rawRemove = async (selector, options) => {
     if (disableAllWrites) return;
     const table = this.getTable();
     return await wrapQuery(`${this.tableName}.remove`, async () => {

--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -161,10 +161,10 @@ export class MongoCollection<T extends DbObject> {
       const table = this.getTable();
       return await wrapQuery(`${this.tableName}.update`, async () => {
         if (typeof selector === 'string') {
-          const updateResult = await table.rawUpdate({_id: selector}, update, options);
+          const updateResult = await table.update({_id: selector}, update, options);
           return updateResult.matchedCount;
         } else {
-          const updateResult = await table.rawUpdate(removeUndefinedFields(selector), update, options);
+          const updateResult = await table.update(removeUndefinedFields(selector), update, options);
           return updateResult.matchedCount;
         }
       });
@@ -228,7 +228,7 @@ export class MongoCollection<T extends DbObject> {
     update: async (selector, update, options) => {
       if (disableAllWrites) return;
       const table = this.getTable();
-      return await table.rawUpdate(selector, update, options);
+      return await table.update(selector, update, options);
     },
   })
 }

--- a/packages/lesswrong/lib/mongoQueries.ts
+++ b/packages/lesswrong/lib/mongoQueries.ts
@@ -32,11 +32,11 @@ export async function mongoUpdate<N extends CollectionNameString>(collectionName
 export async function mongoRemove<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, options?: MongoRemoveOptions<ObjectsByCollectionName[N]>)
 {
   const collection = getCollection(collectionName);
-  return await collection.remove(selector, options);
+  return await collection.rawRemove(selector, options);
 }
 
 export async function mongoInsert<N extends CollectionNameString>(collectionName: N, insertedObject: ObjectsByCollectionName[N], options: MongoInsertOptions<ObjectsByCollectionName[N]>)
 {
   const collection = getCollection(collectionName);
-  return await collection.insert(insertedObject, options);
+  return await collection.rawInsert(insertedObject, options);
 }

--- a/packages/lesswrong/lib/mongoQueries.ts
+++ b/packages/lesswrong/lib/mongoQueries.ts
@@ -27,7 +27,7 @@ export async function mongoAggregate<N extends CollectionNameString>(collectionN
 export async function mongoUpdate<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, modifier?: MongoModifier<ObjectsByCollectionName[N]>, options?: MongoUpdateOptions<ObjectsByCollectionName[N]>): Promise<number>
 {
   const collection = getCollection(collectionName);
-  return await collection.update(selector, modifier, options);
+  return await collection.rawUpdate(selector, modifier, options);
 }
 export async function mongoRemove<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, options?: MongoRemoveOptions<ObjectsByCollectionName[N]>)
 {

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -35,11 +35,8 @@ interface CollectionBase<
   findOne: (selector?: string|MongoSelector<T>, options?: MongoFindOneOptions<T>, projection?: MongoProjection<T>) => Promise<T|null>
   findOneArbitrary: () => Promise<T|null>
   /**
-   * rawUpdate runs relatively directly on the database, bypassing the callbacks
-   * we have registered
-   *
-   * You should start by considering whether you should instead be using
-   * updateMutator, which will run those callbacks.
+   * Update without running callbacks. Consider using updateMutator, which wraps
+   * this.
    *
    * Return result is number of documents **matched** not affected
    *
@@ -52,7 +49,11 @@ interface CollectionBase<
    * away.
    */
   rawUpdate: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
+  /** Remove without running callbacks. Consider using deleteMutator, which
+   * wraps this. */
   rawRemove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>
+  /** Inserts without running callbacks. Consider using createMutator, which
+   * wraps this. */
   rawInsert: (data: any, options?: any) => string
   aggregate: (aggregationPipeline: MongoAggregationPipeline<T>, options?: any) => any
   _ensureIndex: any

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -12,6 +12,7 @@ import type { Request, Response } from 'express';
 /// file (meaning types in this file can be used without being imported).
 declare global {
 
+// See mongoCollection.ts for implementation
 interface CollectionBase<
   T extends DbObject,
   N extends CollectionNameString = CollectionNameString
@@ -33,12 +34,24 @@ interface CollectionBase<
   find: (selector?: MongoSelector<T>, options?: MongoFindOptions<T>, projection?: MongoProjection<T>) => FindResult<T>
   findOne: (selector?: string|MongoSelector<T>, options?: MongoFindOneOptions<T>, projection?: MongoProjection<T>) => Promise<T|null>
   findOneArbitrary: () => Promise<T|null>
-  // Return result is number of documents **matched** not affected
-  //
-  // You might have expected that the return type would be MongoDB's WriteResult. Unfortunately, no.
-  // Meteor is maintaining backwards compatibility with an old version that returned nMatched. See:
-  // https://github.com/meteor/meteor/issues/4436#issuecomment-283974686
-  update: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
+  /**
+   * rawUpdate runs relatively directly on the database, bypassing the callbacks
+   * we have registered
+   *
+   * You should start by considering whether you should instead be using
+   * updateMutator, which will run those callbacks.
+   *
+   * Return result is number of documents **matched** not affected
+   *
+   * You might have expected that the return type would be MongoDB's
+   * WriteResult. Unfortunately, no. Meteor was maintaining backwards
+   * compatibility with an old version that returned nMatched. See:
+   * https://github.com/meteor/meteor/issues/4436#issuecomment-283974686
+   *
+   * We then decided to maintain compatibility with meteor when we switched
+   * away.
+   */
+  rawUpdate: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
   remove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>
   insert: (data: any, options?: any) => string
   aggregate: (aggregationPipeline: MongoAggregationPipeline<T>, options?: any) => any

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -52,8 +52,8 @@ interface CollectionBase<
    * away.
    */
   rawUpdate: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
-  remove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>
-  insert: (data: any, options?: any) => string
+  rawRemove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>
+  rawInsert: (data: any, options?: any) => string
   aggregate: (aggregationPipeline: MongoAggregationPipeline<T>, options?: any) => any
   _ensureIndex: any
 }

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -288,7 +288,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     const createCallback = async (newDoc, {currentUser, collection, context}) => {
       if (newDoc[foreignFieldName] && filter(newDoc)) {
         const collection = getCollection(collectionName);
-        await collection.update(newDoc[foreignFieldName], {
+        await collection.rawUpdate(newDoc[foreignFieldName], {
           $inc: { [fieldName]: 1 }
         });
       }
@@ -302,18 +302,18 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     // out, or we may need to both but on different documents.
     addCallback(`${foreignCollectionCallbackPrefix}.update.after`,
       async (newDoc, {oldDocument, currentUser, collection}) => {
-        const countingCollection: any = getCollection(collectionName);
+        const countingCollection = getCollection(collectionName);
         if (filter(newDoc) && !filter(oldDocument)) {
           // The old doc didn't count, but the new doc does. Increment on the new doc.
           if (newDoc[foreignFieldName]) {
-            await countingCollection.update(newDoc[foreignFieldName], {
+            await countingCollection.rawUpdate(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
           }
         } else if (!filter(newDoc) && filter(oldDocument)) {
           // The old doc counted, but the new doc doesn't. Decrement on the old doc.
           if (oldDocument[foreignFieldName]) {
-            await countingCollection.update(oldDocument[foreignFieldName], {
+            await countingCollection.rawUpdate(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
@@ -321,12 +321,12 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
           // The old and new doc both count, but the reference target has changed.
           // Decrement on one doc and increment on the other.
           if (oldDocument[foreignFieldName]) {
-            await countingCollection.update(oldDocument[foreignFieldName], {
+            await countingCollection.rawUpdate(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
           if (newDoc[foreignFieldName]) {
-            await countingCollection.update(newDoc[foreignFieldName], {
+            await countingCollection.rawUpdate(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
           }
@@ -338,7 +338,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
       async ({document, currentUser, collection}) => {
         if (document[foreignFieldName] && filter(document)) {
           const countingCollection = getCollection(collectionName);
-          await countingCollection.update(document[foreignFieldName], {
+          await countingCollection.rawUpdate(document[foreignFieldName], {
             $inc: { [fieldName]: -1 }
           });
         }

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -110,7 +110,7 @@ export function startWebserver() {
   addClientIdMiddleware(addMiddleware);
   
   //eslint-disable-next-line no-console
-  console.log("Starting LessWrong server. Versions: "+JSON.stringify(process.versions));
+  console.log("Starting ForumMagnum server. Versions: "+JSON.stringify(process.versions));
   
   // create server
   // given options contains the schema

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -284,7 +284,7 @@ export async function userIPBanAndResetLoginTokens(user: DbUser) {
   }
 
   // Remove login tokens
-  await Users.update({_id: user._id}, {$set: {"services.resume.loginTokens": []}});
+  await Users.rawUpdate({_id: user._id}, {$set: {"services.resume.loginTokens": []}});
 }
 
 
@@ -297,7 +297,7 @@ getCollectionHooks("LWEvents").newSync.add(async function updateReadStatus(event
     //   https://docs.mongodb.com/manual/core/retryable-writes/#retryable-update-upsert
     // In particular, this means the selector has to exactly match the unique
     // index's keys.
-    await ReadStatuses.update({
+    await ReadStatuses.rawUpdate({
       postId: event.documentId,
       userId: event.userId,
       tagId: null,

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -230,7 +230,7 @@ async function deleteUserTagsAndRevisions(user: DbUser, deletingUser: DbUser) {
   const tagRevisions = await Revisions.find({userId: user._id, collectionName: 'Tags'}).fetch()
   // eslint-disable-next-line no-console
   console.info("Deleting tag revisions: ", tagRevisions)
-  await Revisions.remove({userId: user._id})
+  await Revisions.rawRemove({userId: user._id})
   // Revert revision documents
   for (let revision of tagRevisions) {
     const collection = getCollectionsByName()[revision.collectionName] as CollectionBase<DbObject, any>

--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
@@ -44,7 +44,7 @@ getCollectionHooks("Comments").newAsync.add(async function AlignmentCommentsNewO
 
 //TODO: Probably change these to take a boolean argument?
 const updateParentsSetAFtrue = async (comment: DbComment) => {
-  await Comments.update({_id:comment.parentCommentId}, {$set: {af: true}});
+  await Comments.rawUpdate({_id:comment.parentCommentId}, {$set: {af: true}});
   const parent = await Comments.findOne({_id: comment.parentCommentId});
   if (parent) {
     await updateParentsSetAFtrue(parent)
@@ -54,7 +54,7 @@ const updateParentsSetAFtrue = async (comment: DbComment) => {
 const updateChildrenSetAFfalse = async (comment: DbComment) => {
   const children = await Comments.find({parentCommentId: comment._id}).fetch();
   await asyncForeachSequential(children, async (child) => {
-    await Comments.update({_id:child._id}, {$set: {af: false}});
+    await Comments.rawUpdate({_id:child._id}, {$set: {af: false}});
     await updateChildrenSetAFfalse(child)
   })
 }

--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentPostCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentPostCallbacks.ts
@@ -3,7 +3,7 @@ import { postsAlignmentAsync } from '../../resolvers/alignmentForumMutations';
 
 async function PostsMoveToAFAddsAlignmentVoting (post: DbPost, oldPost: DbPost) {
   if (post.af && !oldPost.af) {
-    await Users.update({_id:post.userId}, {$addToSet: {groups: 'alignmentVoters'}})
+    await Users.rawUpdate({_id:post.userId}, {$addToSet: {groups: 'alignmentVoters'}})
   }
 }
 

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -24,12 +24,12 @@ async function updateAlignmentKarmaServer (newDocument: DbVoteableType, vote: Db
   if (userCanDo(voter, "votes.alignment")) {
     const votePower = calculateVotePower(voter.afKarma, vote.voteType)
 
-    await Votes.update({_id:vote._id, documentId: newDocument._id}, {$set:{afPower: votePower}})
+    await Votes.rawUpdate({_id:vote._id, documentId: newDocument._id}, {$set:{afPower: votePower}})
     const newAFBaseScore = await recalculateAFBaseScore(newDocument)
 
     const collection = getCollection(vote.collectionName as VoteableCollectionName)
 
-    await collection.update({_id: newDocument._id}, {$set: {afBaseScore: newAFBaseScore}});
+    await collection.rawUpdate({_id: newDocument._id}, {$set: {afBaseScore: newAFBaseScore}});
 
     return {
       newDocument:{
@@ -61,12 +61,12 @@ async function updateAlignmentUserServer (newDocument: VoteableType, vote: DbVot
     if (!documentUser) throw Error("Can't find user to update Alignment Karma")
     const newAfKarma = (documentUser.afKarma || 0) + ((vote.afPower || 0) * multiplier)
     if (newAfKarma > 0) {
-      await Users.update({_id:newDocument.userId}, {
+      await Users.rawUpdate({_id:newDocument.userId}, {
         $set: {afKarma: newAfKarma },
         $addToSet: {groups: 'alignmentVoters'}
       })
     } else {
-      await Users.update({_id:newDocument.userId}, {
+      await Users.rawUpdate({_id:newDocument.userId}, {
         $set: {afKarma: newAfKarma },
         $pull: {groups: 'alignmentVoters'}
       })
@@ -94,11 +94,11 @@ voteCallbacks.cancelSync.add(function cancelAlignmentKarmaServerCallback({newDoc
 
 async function MoveToAFUpdatesUserAFKarma (document: DbPost|DbComment, oldDocument: DbPost|DbComment) {
   if (document.af && !oldDocument.af) {
-    await Users.update({_id:document.userId}, {
+    await Users.rawUpdate({_id:document.userId}, {
       $inc: {afKarma: document.afBaseScore || 0},
       $addToSet: {groups: 'alignmentVoters'}
     })
-    await Votes.update({documentId: document._id}, {
+    await Votes.rawUpdate({documentId: document._id}, {
       $set: {documentIsAf: true}
     }, {multi: true})
   } else if (!document.af && oldDocument.af) {
@@ -106,14 +106,14 @@ async function MoveToAFUpdatesUserAFKarma (document: DbPost|DbComment, oldDocume
     if (!documentUser) throw Error("Can't find user for updating karma after moving document to AIAF")
     const newAfKarma = (documentUser.afKarma || 0) - (document.afBaseScore || 0)
     if (newAfKarma > 0) {
-      await Users.update({_id:document.userId}, {$inc: {afKarma: -document.afBaseScore || 0}})
+      await Users.rawUpdate({_id:document.userId}, {$inc: {afKarma: -document.afBaseScore || 0}})
     } else {
-      await Users.update({_id:document.userId}, {
+      await Users.rawUpdate({_id:document.userId}, {
         $inc: {afKarma: -document.afBaseScore || 0},
         $pull: {groups: 'alignmentVoters'}
       })
     }
-    await Votes.update({documentId: document._id}, {
+    await Votes.rawUpdate({documentId: document._id}, {
       $set: {documentIsAf: false}
     }, {multi: true})
   }

--- a/packages/lesswrong/server/callbacks/bookCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/bookCallbacks.ts
@@ -76,7 +76,7 @@ async function getAllCollectionPosts(id: string) {
 
 async function updateCollectionSequences(sequences: Array<DbSequence>, collectionSlug: string) {
   await asyncForeachSequential(_.range(sequences.length), async (i) => {
-    await Sequences.update(sequences[i]._id, {$set: {
+    await Sequences.rawUpdate(sequences[i]._id, {$set: {
       canonicalCollectionSlug: collectionSlug,
     }});
   })
@@ -94,7 +94,7 @@ async function updateCollectionPosts(posts: Array<DbPost>, collectionSlug: strin
     if (i+1<posts.length) {
       nextPost = posts[i+1]
     }
-    await Posts.update({slug: currentPost.slug}, {$set: {
+    await Posts.rawUpdate({slug: currentPost.slug}, {$set: {
       canonicalPrevPostSlug: prevPost.slug,
       canonicalNextPostSlug: nextPost.slug,
       canonicalBookId: currentPost.canonicalBookId,
@@ -111,7 +111,7 @@ getCollectionHooks("Books").editAsync.add(async function UpdateCollectionLinks (
   //eslint-disable-next-line no-console
   console.log(`Updating Collection Links for ${collectionId}...`)
 
-  await Collections.update(collectionId, { $set: {
+  await Collections.rawUpdate(collectionId, { $set: {
     firstPageLink: "/" + results.collectionSlug + "/" + results.posts[0].slug
   }})
 

--- a/packages/lesswrong/server/callbacks/chapterCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/chapterCallbacks.ts
@@ -15,7 +15,7 @@ async function ChaptersEditCanonizeCallback (chapter: DbChapter) {
   const removedPosts = _.difference(_.pluck(postsWithCanonicalSequenceId, '_id'), _.pluck(posts, '_id'))
 
   await asyncForeachSequential(removedPosts, async (postId) => {
-    await Posts.update({_id: postId}, {$unset: {
+    await Posts.rawUpdate({_id: postId}, {$unset: {
       canonicalPrevPostSlug: true,
       canonicalNextPostSlug: true,
       canonicalSequenceId: true,
@@ -38,7 +38,7 @@ async function ChaptersEditCanonizeCallback (chapter: DbChapter) {
       if (i+1<posts.length) {
         nextPost = posts[i+1]
       }
-      await Posts.update({slug: currentPost.slug}, {$set: {
+      await Posts.rawUpdate({slug: currentPost.slug}, {$set: {
         canonicalPrevPostSlug: prevPost.slug,
         canonicalNextPostSlug: nextPost.slug,
         canonicalSequenceId: chapter.sequenceId,

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -122,11 +122,11 @@ getCollectionHooks("Comments").newValidate.add(async function createShortformPos
 getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations (comment: DbComment) {
   // update lastCommentedAt field on post or tag
   if (comment.postId) {
-    await Posts.update(comment.postId, {
+    await Posts.rawUpdate(comment.postId, {
       $set: {lastCommentedAt: new Date()},
     });
   } else if (comment.tagId) {
-    await Tags.update(comment.tagId, {
+    await Tags.rawUpdate(comment.tagId, {
       $set: {lastCommentedAt: new Date()},
     });
   }
@@ -146,7 +146,7 @@ getCollectionHooks("Comments").removeAsync.add(async function CommentsRemovePost
     const lastCommentedAt = postComments[0] && postComments[0].postedAt;
   
     // update post with a decremented comment count, and corresponding last commented at date
-    await Posts.update(postId, {
+    await Posts.rawUpdate(postId, {
       $set: {lastCommentedAt},
     });
   }
@@ -325,7 +325,7 @@ getCollectionHooks("Comments").newAsync.add(async function NewCommentNeedsReview
   const user = await Users.findOne({_id:comment.userId})
   const karma = user?.karma || 0
   if (karma < 100) {
-    await Comments.update({_id:comment._id}, {$set: {needsReview: true}});
+    await Comments.rawUpdate({_id:comment._id}, {$set: {needsReview: true}});
   }
 });
 
@@ -371,9 +371,9 @@ getCollectionHooks("Comments").editSync.add(async function validateDeleteOperati
 getCollectionHooks("Comments").editSync.add(async function moveToAnswers (modifier, comment: DbComment) {
   if (modifier.$set) {
     if (modifier.$set.answer === true) {
-      await Comments.update({topLevelCommentId: comment._id}, {$set:{parentAnswerId:comment._id}}, { multi: true })
+      await Comments.rawUpdate({topLevelCommentId: comment._id}, {$set:{parentAnswerId:comment._id}}, { multi: true })
     } else if (modifier.$set.answer === false) {
-      await Comments.update({topLevelCommentId: comment._id}, {$unset:{parentAnswerId:true}}, { multi: true })
+      await Comments.rawUpdate({topLevelCommentId: comment._id}, {$unset:{parentAnswerId:true}}, { multi: true })
     }
   }
   return modifier
@@ -431,7 +431,7 @@ getCollectionHooks("Comments").createBefore.add(async function SetTopLevelCommen
 getCollectionHooks("Comments").createAfter.add(async function UpdateDescendentCommentCounts (comment: DbComment) {
   const ancestorIds: string[] = await getCommentAncestorIds(comment);
   
-  await Comments.update({ _id: {$in: ancestorIds} }, {
+  await Comments.rawUpdate({ _id: {$in: ancestorIds} }, {
     $set: {lastSubthreadActivity: new Date()},
     $inc: {descendentCount:1},
   });
@@ -443,7 +443,7 @@ getCollectionHooks("Comments").updateAfter.add(async function UpdateDescendentCo
   if (context.oldDocument.deleted !== context.newDocument.deleted) {
     const ancestorIds: string[] = await getCommentAncestorIds(comment);
     const increment = context.oldDocument.deleted ? 1 : -1;
-    await Comments.update({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
+    await Comments.rawUpdate({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
   }
   return comment;
 });

--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -2,5 +2,5 @@ import Conversations from '../../lib/collections/conversations/collection'
 import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("Messages").createAsync.add(function unArchiveConversations({document}) {
-  void Conversations.update({_id:document.conversationId}, {$set: {archivedByIds: []}});
+  void Conversations.rawUpdate({_id:document.conversationId}, {$set: {archivedByIds: []}});
 });

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -44,7 +44,7 @@ voteCallbacks.castVoteAsync.add(async function increaseMaxBaseScore ({newDocumen
       if (!post.scoreExceeded75Date && post.baseScore >= 75) {
         thresholdTimestamp.scoreExceeded75Date = new Date();
       }
-      await Posts.update({_id: post._id}, {$set: {maxBaseScore: post.baseScore, ...thresholdTimestamp}})
+      await Posts.rawUpdate({_id: post._id}, {$set: {maxBaseScore: post.baseScore, ...thresholdTimestamp}})
     }
   }
 });
@@ -116,7 +116,7 @@ getCollectionHooks("Posts").newAfter.add(function PostsNewPostRelation (post) {
 getCollectionHooks("Posts").editAsync.add(async function UpdatePostShortform (newPost, oldPost) {
   if (!!newPost.shortform !== !!oldPost.shortform) {
     const shortform = !!newPost.shortform;
-    await Comments.update(
+    await Comments.rawUpdate(
       { postId: newPost._id },
       { $set: {
         shortform: shortform
@@ -149,7 +149,7 @@ getCollectionHooks("Posts").editAsync.add(async function UpdateCommentHideKarma 
 export async function newDocumentMaybeTriggerReview (document: DbPost|DbComment) {
   const author = await Users.findOne(document.userId);
   if (author && (!author.reviewedByUserId || author.sunshineSnoozed)) {
-    await Users.update({_id:author._id}, {$set:{needsReview: true}})
+    await Users.rawUpdate({_id:author._id}, {$set:{needsReview: true}})
   }
   return document
 }
@@ -196,7 +196,7 @@ async function extractSocialPreviewImage (post: DbPost) {
   // returned value
   // It's important to run this regardless of whether or not we found an image,
   // as removing an image should remove the social preview for that image
-  await Posts.update({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
+  await Posts.rawUpdate({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
   
   return {...post, socialPreviewImageAutoUrl}
   
@@ -213,7 +213,7 @@ getCollectionHooks("Posts").newAfter.add(extractSocialPreviewImage)
 async function oldPostsLastCommentedAt (post: DbPost) {
   if (post.commentCount) return
 
-  await Posts.update({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
+  await Posts.rawUpdate({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
 }
 
 getCollectionHooks("Posts").editAsync.add(oldPostsLastCommentedAt)

--- a/packages/lesswrong/server/callbacks/sequenceCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/sequenceCallbacks.ts
@@ -3,6 +3,6 @@ import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("Sequences").newAsync.add(function SequenceNewCreateChapter(sequence) {
   if (sequence._id) {
-    Chapters.insert({sequenceId:sequence._id})
+    Chapters.rawInsert({sequenceId:sequence._id})
   }
 });

--- a/packages/lesswrong/server/callbacks/subscriptionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/subscriptionCallbacks.ts
@@ -3,6 +3,6 @@ import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("Subscriptions").createBefore.add(async function deleteOldSubscriptions(subscription) {
   const { userId, documentId, collectionName, type } = subscription
-  await Subscriptions.update({userId, documentId, collectionName, type}, {$set: {deleted: true}}, {multi: true})
+  await Subscriptions.rawUpdate({userId, documentId, collectionName, type}, {$set: {deleted: true}}, {multi: true})
   return subscription;
 });

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -25,7 +25,7 @@ const TRUSTLEVEL1_THRESHOLD = 2000
 voteCallbacks.castVoteAsync.add(async function updateTrustedStatus ({newDocument, vote}: VoteDocTuple) {
   const user = await Users.findOne(newDocument.userId)
   if (user && user.karma >= TRUSTLEVEL1_THRESHOLD && (!userGetGroups(user).includes('trustLevel1'))) {
-    await Users.update(user._id, {$push: {groups: 'trustLevel1'}});
+    await Users.rawUpdate(user._id, {$push: {groups: 'trustLevel1'}});
     const updatedUser = await Users.findOne(newDocument.userId)
     //eslint-disable-next-line no-console
     console.info("User gained trusted status", updatedUser?.username, updatedUser?._id, updatedUser?.karma, updatedUser?.groups)
@@ -36,7 +36,7 @@ voteCallbacks.castVoteAsync.add(async function updateModerateOwnPersonal({newDoc
   const user = await Users.findOne(newDocument.userId)
   if (!user) throw Error("Couldn't find user")
   if (user.karma >= MODERATE_OWN_PERSONAL_THRESHOLD && (!userGetGroups(user).includes('canModeratePersonal'))) {
-    await Users.update(user._id, {$push: {groups: 'canModeratePersonal'}});
+    await Users.rawUpdate(user._id, {$push: {groups: 'canModeratePersonal'}});
     const updatedUser = await Users.findOne(newDocument.userId)
     if (!updatedUser) throw Error("Couldn't find user to update")
     //eslint-disable-next-line no-console
@@ -78,7 +78,7 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
     // reset the postedAt for comments, since those are by default visible
     // almost everywhere. This can bypass the mutation system fine, because the
     // flag doesn't control whether they're indexed in Algolia.
-    await Comments.update({userId:newUser._id, authorIsUnreviewed:true}, {$set:{authorIsUnreviewed:false}}, {multi: true})
+    await Comments.rawUpdate({userId:newUser._id, authorIsUnreviewed:true}, {$set:{authorIsUnreviewed:false}}, {multi: true})
   }
 });
 
@@ -128,7 +128,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeOnSignup (user:
 getCollectionHooks("Users").newAsync.add(async function setABTestKeyOnSignup (user: DbInsertion<DbUser>) {
   if (!user.abTestKey) {
     const abTestKey = user.profile?.clientId || randomId();
-    await Users.update(user._id, {$set: {abTestKey: abTestKey}});
+    await Users.rawUpdate(user._id, {$set: {abTestKey: abTestKey}});
   }
 });
 

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -15,14 +15,14 @@ const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
 voteCallbacks.castVoteAsync.add(function updateKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
   // only update karma is the operation isn't done by the item's author
   if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
-    void Users.update({_id: newDocument.userId}, {$inc: {"karma": vote.power}});
+    void Users.rawUpdate({_id: newDocument.userId}, {$inc: {"karma": vote.power}});
   }
 });
 
 voteCallbacks.cancelAsync.add(function cancelVoteKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
   // only update karma is the operation isn't done by the item's author
   if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
-    void Users.update({_id: newDocument.userId}, {$inc: {"karma": -vote.power}});
+    void Users.rawUpdate({_id: newDocument.userId}, {$inc: {"karma": -vote.power}});
   }
 });
 
@@ -31,7 +31,7 @@ voteCallbacks.castVoteAsync.add(async function incVoteCount ({newDocument, vote}
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {
-    void Users.update({_id: vote.userId}, {$inc: {[field]: 1, voteCount: 1}});
+    void Users.rawUpdate({_id: vote.userId}, {$inc: {[field]: 1, voteCount: 1}});
   }
 });
 
@@ -39,7 +39,7 @@ voteCallbacks.cancelAsync.add(async function cancelVoteCount ({newDocument, vote
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {
-    void Users.update({_id: vote.userId}, {$inc: {[field]: -1, voteCount: -1}});
+    void Users.rawUpdate({_id: vote.userId}, {$inc: {[field]: -1, voteCount: -1}});
   }
 });
 
@@ -47,7 +47,7 @@ voteCallbacks.castVoteAsync.add(async function updateNeedsReview (document: Vote
   const voter = await Users.findOne(document.vote.userId);
   // voting should only be triggered once (after getting snoozed, they will not re-trigger for sunshine review)
   if (voter && voter.voteCount >= 20 && !voter.reviewedByUserId) {
-    void Users.update({_id:voter._id}, {$set:{needsReview: true}})
+    void Users.rawUpdate({_id:voter._id}, {$set:{needsReview: true}})
   }
 });
 
@@ -61,7 +61,7 @@ postPublishedCallback.add(async (publishedPost: DbPost) => {
   // whole collection. (This is already something being done frequently by a
   // cronjob.)
   if (publishedPost.inactive) {
-    await Posts.update({_id: publishedPost._id}, {$set: {inactive: false}});
+    await Posts.rawUpdate({_id: publishedPost._id}, {$set: {inactive: false}});
   }
   
   await batchUpdateScore({collection: Posts});

--- a/packages/lesswrong/server/cronUtil.ts
+++ b/packages/lesswrong/server/cronUtil.ts
@@ -40,7 +40,7 @@ export function addCronJob(options: {
 }
 
 export function removeCronJob(name: string) {
-  SyncedCron.remove(name);
+  SyncedCron.rawRemove(name);
 }
 
 export function startSyncedCron() {

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -243,7 +243,7 @@ export const dispatchPendingEvents = async () => {
       try {
         await dispatchEvent(eventToHandle);
       } catch (e) {
-        await DebouncerEvents.update({
+        await DebouncerEvents.rawUpdate({
           _id: eventToHandle._id
         }, {
           $set: { failed: true }
@@ -295,4 +295,3 @@ if (!testServerSetting.get()) {
     }
   });
 }
-

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -500,7 +500,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
   {
     // Update revision to point to the document that owns it.
     const revisionID = newDoc[`${fieldName}_latest`];
-    await Revisions.update(
+    await Revisions.rawUpdate(
       { _id: revisionID },
       { $set: { documentId: newDoc._id } }
     );

--- a/packages/lesswrong/server/editor/utils.tests.ts
+++ b/packages/lesswrong/server/editor/utils.tests.ts
@@ -41,7 +41,7 @@ describe("syncDocumentWithLatestRevision", () => {
     const revisions = await Revisions.find({documentId: post._id}, {sort: {createdAt: 1}}).fetch()
     const lastRevision = revisions[revisions.length-1]
     expect(lastRevision?.originalContents.data).toMatch(/version 3/)
-    await Revisions.remove({_id: lastRevision._id})
+    await Revisions.rawRemove({_id: lastRevision._id})
     
     // Function we're actually testing
     await syncDocumentWithLatestRevision(Posts, post, 'contents')

--- a/packages/lesswrong/server/editor/utils.ts
+++ b/packages/lesswrong/server/editor/utils.ts
@@ -133,7 +133,7 @@ export async function syncDocumentWithLatestRevision<T extends DbObject>(
       )
     }
   }
-  await collection.update(document._id, {
+  await collection.rawUpdate(document._id, {
     $set: {
       [fieldName]: pick(latestRevision, revisionFieldsToCopy),
       [`${fieldName}_latest`]: latestRevision._id

--- a/packages/lesswrong/server/emails/emailTokens.ts
+++ b/packages/lesswrong/server/emails/emailTokens.ts
@@ -39,7 +39,7 @@ export class EmailTokenType
     if (!userId) throw new Error("Missing required argument: userId");
     
     const token = randomSecret();
-    await EmailTokens.insert({
+    await EmailTokens.rawInsert({
       token: token,
       tokenType: this.name,
       userId: userId,

--- a/packages/lesswrong/server/markAsUnread.ts
+++ b/packages/lesswrong/server/markAsUnread.ts
@@ -11,7 +11,7 @@ addGraphQLResolvers({
       
       // TODO: Create an entry in LWEvents
       
-      await ReadStatuses.update({
+      await ReadStatuses.rawUpdate({
         postId: postId,
         userId: currentUser._id,
         tagId: null,

--- a/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
+++ b/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
@@ -49,7 +49,7 @@ registerMigration({
         },
         migrate: async (documents: Array<any>) => {
           for (let doc of documents) {
-            await collection.update(
+            await collection.rawUpdate(
               {_id: doc._id},
               {
                 $set: {

--- a/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
+++ b/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
@@ -37,7 +37,7 @@ registerMigration({
             { ordered: false }
           )
           const _ids = _.pluck(documents, '_id')
-          await collection.remove({_id: {$in: _ids}})
+          await collection.rawRemove({_id: {$in: _ids}})
         }
       })
       await migrateDocuments({

--- a/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.ts
+++ b/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.ts
@@ -105,7 +105,7 @@ registerMigration({
           
           // Remove subscribedItems from the user
           if (oldSubscriptions) {
-            await Users.update(
+            await Users.rawUpdate(
               { _id: user._id },
               { $unset: {
                 subscribedItems: 1

--- a/packages/lesswrong/server/migrations/2020-01-02-fillMissingRevisionFieldNames.ts
+++ b/packages/lesswrong/server/migrations/2020-01-02-fillMissingRevisionFieldNames.ts
@@ -15,7 +15,7 @@ registerMigration({
       await forEachDocumentBatchInCollection({
         collection, batchSize: 1000,
         callback: async (documents: any[]) => {
-          await Revisions.update(
+          await Revisions.rawUpdate(
             { documentId: { $in: documents.map(doc => doc._id) } },
             { $set: {fieldName} },
             { multiple: true }

--- a/packages/lesswrong/server/migrations/2020-03-30-fixLostUnapprovedComments.ts
+++ b/packages/lesswrong/server/migrations/2020-03-30-fixLostUnapprovedComments.ts
@@ -29,6 +29,6 @@ registerMigration({
     
     // eslint-disable-next-line no-console
     console.log(commentsToMarkReviewed.length+" comments to mark as reviewed");
-    await Comments.update({_id: {$in: commentsToMarkReviewed}}, {$set: {authorIsUnreviewed: false}}, {multi: true});
+    await Comments.rawUpdate({_id: {$in: commentsToMarkReviewed}}, {$set: {authorIsUnreviewed: false}}, {multi: true});
   }
 });

--- a/packages/lesswrong/server/migrations/2020-05-05-addRevisionCollectionName.ts
+++ b/packages/lesswrong/server/migrations/2020-05-05-addRevisionCollectionName.ts
@@ -17,7 +17,7 @@ registerMigration({
         callback: async (documents: DbObject[]) => {
           // eslint-disable-next-line no-console
           console.log(`Migrating a batch of ${documents.length} documents`);
-          await Revisions.update(
+          await Revisions.rawUpdate(
             { documentId: { $in: documents.map(doc => doc._id) } },
             { $set: {collectionName} },
             { multi: true }

--- a/packages/lesswrong/server/migrations/2020-09-15-tagLastCommentedAt.ts
+++ b/packages/lesswrong/server/migrations/2020-09-15-tagLastCommentedAt.ts
@@ -20,7 +20,7 @@ registerMigration({
           }).fetch();
           if (newestComment.length>0) {
             const lastCommentedAt = newestComment[0].postedAt;
-            await Tags.update({_id: tag._id}, {$set: {lastCommentedAt: lastCommentedAt}});
+            await Tags.rawUpdate({_id: tag._id}, {$set: {lastCommentedAt: lastCommentedAt}});
           }
         }));
       }

--- a/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
+++ b/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
@@ -22,7 +22,7 @@ registerMigration({
   idempotent: true,
   action: async () => {
     // Ensure that the tagId field is not missing (ie replace missing with null)
-    await ReadStatuses.update({tagId: {$exists: false}}, {$set: {tagId: null}}, {multi: true})
+    await ReadStatuses.rawUpdate({tagId: {$exists: false}}, {$set: {tagId: null}}, {multi: true})
     
     // Download all ReadStatuses, and identify the duplicates
     const allReadStatuses = await ReadStatuses.find().fetch();

--- a/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
+++ b/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
@@ -45,7 +45,7 @@ registerMigration({
     console.log(`${idsToRemove.length} duplicate read status entries found`);
     
     // Remove duplicate read statuses, then add index to prevent them in the future
-    await ReadStatuses.remove({_id: {$in: idsToRemove}});
+    await ReadStatuses.rawRemove({_id: {$in: idsToRemove}});
     await ensureIndexAsync(ReadStatuses, {userId:1, postId:1, tagId:1}, {unique: true})
   }
 })

--- a/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
+++ b/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
@@ -25,7 +25,7 @@ registerMigration({
           const descendentCount = subtreeFiltered.length-1;
           if (descendentCount !== comment.descendentCount || !comment.lastSubthreadActivity) {
             updates.updated++;
-            await Comments.update(
+            await Comments.rawUpdate(
               {_id: comment._id},
               {$set: {
                 descendentCount,

--- a/packages/lesswrong/server/migrations/2021-08-23-fillEmailsFieldForOrganizers.ts
+++ b/packages/lesswrong/server/migrations/2021-08-23-fillEmailsFieldForOrganizers.ts
@@ -10,7 +10,7 @@ registerMigration({
     const organizers = await Users.find({createdAt: {$gt: new Date("2021-08-22T05:48:35.336Z")}, emails: null}).fetch()
     for (const organizer of organizers) {
       if (organizer.email) {
-        await Users.update({_id: organizer._id}, {$set: {emails: [{address: organizer.email, verified: true}]}})
+        await Users.rawUpdate({_id: organizer._id}, {$set: {emails: [{address: organizer.email, verified: true}]}})
       }
     }
   },

--- a/packages/lesswrong/server/migrations/2021-10-05-fillRevisionDraftsField.ts
+++ b/packages/lesswrong/server/migrations/2021-10-05-fillRevisionDraftsField.ts
@@ -14,23 +14,22 @@ registerMigration({
         collectionName: {$ne: "Tags"},
       },
       fn: async (bucketSelector) => {
-        await Revisions.update(bucketSelector, {$set: {draft: true}}, {multi:true})
+        await Revisions.rawUpdate(bucketSelector, {$set: {draft: true}}, {multi:true})
       }
     })
     await forEachBucketRangeInCollection({
       collection: Revisions,
       filter: { collectionName: "Tags", },
       fn: async (bucketSelector) => {
-        await Revisions.update(bucketSelector, {$set: {draft: false}}, {multi:true})
+        await Revisions.rawUpdate(bucketSelector, {$set: {draft: false}}, {multi:true})
       }
     })
     await forEachBucketRangeInCollection({
       collection: Revisions,
       filter: { version: {$gte: "1"} },
       fn: async (bucketSelector) => {
-        await Revisions.update(bucketSelector, {$set: {draft: false}}, {multi:true})
+        await Revisions.rawUpdate(bucketSelector, {$set: {draft: false}}, {multi:true})
       }
     })
   },
 });
-

--- a/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
+++ b/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
@@ -72,7 +72,7 @@ registerMigration({
         if (!vote.qualitativeScore) continue
         
         totalUserPoints += getCost(vote)
-        await ReviewVotes.update({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})
+        await ReviewVotes.rawUpdate({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})
         
         updatePost(postsAllUsers, vote)
         if (user.karma >= 1000) {
@@ -87,19 +87,19 @@ registerMigration({
     }
 
     for (let postId in postsAllUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesAllKarma: postsAllUsers[postId].sort((a,b) => b - a), 
         reviewVoteScoreAllKarma: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
     }
     for (let postId in postsHighKarmaUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesHighKarma: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreHighKarma: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
     }
     for (let postId in postsAFUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-01-12-updateQuadraticVotes-2.ts
+++ b/packages/lesswrong/server/migrations/2022-01-12-updateQuadraticVotes-2.ts
@@ -71,7 +71,7 @@ registerMigration({
         if (!vote.qualitativeScore) continue
         
         totalUserPoints += getCost(vote)
-        await ReviewVotes.update({_id:vote._id}, {$set: {quadraticScore: getValue(vote)}})
+        await ReviewVotes.rawUpdate({_id:vote._id}, {$set: {quadraticScore: getValue(vote)}})
         
         updatePost(postsAllUsers, vote)
 
@@ -88,19 +88,19 @@ registerMigration({
     }
 
     for (let postId in postsAllUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesAllKarma2: postsAllUsers[postId].sort((a,b) => b - a), 
         reviewVoteScoreAllKarma2: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
     }
     for (let postId in postsHighKarmaUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesHighKarma2: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreHighKarma2: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
     }
     for (let postId in postsAFUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         reviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-01-30-updateFinal2020ReviewVotes.ts
+++ b/packages/lesswrong/server/migrations/2022-01-30-updateFinal2020ReviewVotes.ts
@@ -63,7 +63,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating all karma...")
     for (let postId in postsAllUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         finalReviewVotesAllKarma: postsAllUsers[postId].sort((a,b) => b - a), 
         finalReviewVoteScoreAllKarma: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
@@ -72,7 +72,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating high karma...")
     for (let postId in postsHighKarmaUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         finalReviewVotesHighKarma: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         finalReviewVoteScoreHighKarma: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
@@ -80,7 +80,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating AF...")
     for (let postId in postsAFUsers) {
-      await Posts.update({_id:postId}, {$set: { 
+      await Posts.rawUpdate({_id:postId}, {$set: { 
         finalReviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         finalReviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
+++ b/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
@@ -25,7 +25,7 @@ async function maybeFixAccount(user: DbUser): Promise<void> {
   if (isSensibleEmail(user.email) && JSON.stringify(user.emails)==='{"0":{"verified":true}}') {
     // eslint-disable-next-line no-console
     console.log(`Fixing emails for ${user.slug}`);
-    await Users.update(
+    await Users.rawUpdate(
       {_id: user._id},
       {$set: {
         emails: [{address: user.email, verified: true}]
@@ -56,7 +56,7 @@ async function maybeFixAccount(user: DbUser): Promise<void> {
         return;
       }
       
-      await Users.update(
+      await Users.rawUpdate(
         {_id: user._id},
         {$set: {
           [`services.${oauthProvider}`]: user.services[oauthProvider].id,

--- a/packages/lesswrong/server/migrations/migrationUtils.ts
+++ b/packages/lesswrong/server/migrations/migrationUtils.ts
@@ -52,7 +52,7 @@ export async function runMigration(name: string)
   // eslint-disable-next-line no-console
   console.log(`Beginning migration: ${name}`);
 
-  const migrationLogId = await Migrations.insert({
+  const migrationLogId = await Migrations.rawInsert({
     name: name,
     started: new Date(),
   });

--- a/packages/lesswrong/server/migrations/migrationUtils.ts
+++ b/packages/lesswrong/server/migrations/migrationUtils.ts
@@ -60,7 +60,7 @@ export async function runMigration(name: string)
   try {
     await action();
     
-    await Migrations.update({_id: migrationLogId}, {$set: {
+    await Migrations.rawUpdate({_id: migrationLogId}, {$set: {
       finished: true, succeeded: true,
     }});
 
@@ -72,7 +72,7 @@ export async function runMigration(name: string)
     // eslint-disable-next-line no-console
     console.error(e);
     
-    await Migrations.update({_id: migrationLogId}, {$set: {
+    await Migrations.rawUpdate({_id: migrationLogId}, {$set: {
       finished: true, succeeded: false,
     }});
   }
@@ -141,7 +141,7 @@ export async function fillDefaultValues<T extends DbObject>({ collection, fieldN
         const mutation = { $set: {
           [fieldName]: defaultValue
         } };
-        const writeResult = await collection.update(bucketSelector, mutation, {multi: true});
+        const writeResult = await collection.rawUpdate(bucketSelector, mutation, {multi: true});
         
         nMatched += writeResult || 0;
         // eslint-disable-next-line no-console
@@ -264,7 +264,7 @@ export async function dropUnusedField(collection, fieldName) {
         const mutation = { $unset: {
           [fieldName]: 1
         } };
-        const writeResult = await collection.update(
+        const writeResult = await collection.rawUpdate(
           bucketSelector,
           mutation,
           {multi: true}

--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -36,7 +36,7 @@ const sendNotificationBatch = async ({userId, notificationIds}: {userId: string,
   
   const user = await getUser(userId);
   if (!user) throw new Error(`Missing user: ID ${userId}`);
-  await Notifications.update(
+  await Notifications.rawUpdate(
     { _id: {$in: notificationIds} },
     { $set: { waitingForBatch: false } },
     { multi: true }

--- a/packages/lesswrong/server/posts/cron.ts
+++ b/packages/lesswrong/server/posts/cron.ts
@@ -16,7 +16,7 @@ addCronJob({
     // update posts found
     if (!_.isEmpty(postsToUpdate)) {
       const postsIds = _.pluck(postsToUpdate, '_id');
-      await Posts.update({_id: {$in: postsIds}}, {$set: {isFuture: false}}, {multi: true});
+      await Posts.rawUpdate({_id: {$in: postsIds}}, {$set: {isFuture: false}}, {multi: true});
 
       // log the action
       console.log('// Scheduled posts approved:', postsIds); // eslint-disable-line

--- a/packages/lesswrong/server/posts/graphql.ts
+++ b/packages/lesswrong/server/posts/graphql.ts
@@ -9,13 +9,10 @@ import { addGraphQLMutation, addGraphQLResolvers } from '../vulcan-lib';
 const specificResolvers = {
   Mutation: {
     increasePostViewCount(root: void, {postId}: {postId: string}, context: ResolverContext) {
-      return context.Posts.update({_id: postId}, { $inc: { viewCount: 1 }});
+      return context.Posts.rawUpdate({_id: postId}, { $inc: { viewCount: 1 }});
     }
   }
 };
 
 addGraphQLResolvers(specificResolvers);
 addGraphQLMutation('increasePostViewCount(postId: String): Float');
-
-
-

--- a/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
+++ b/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
@@ -15,7 +15,7 @@ const alignmentCommentResolvers = {
 
       if (userCanDo(context.currentUser, "comments.alignment.move.all")) {
         let modifier = { $set: {af: af} };
-        await context.Comments.update({_id: commentId}, modifier);
+        await context.Comments.rawUpdate({_id: commentId}, modifier);
         const updatedComment = (await context.Comments.findOne(commentId))!
         await commentsAlignmentAsync.runCallbacksAsync(
           [updatedComment, comment, context]
@@ -40,7 +40,7 @@ const alignmentPostResolvers = {
 
       if (userCanMakeAlignmentPost(context.currentUser, post)) {
         let modifier = { $set: {af: af} };
-        await context.Posts.update({_id: postId}, modifier);
+        await context.Posts.rawUpdate({_id: postId}, modifier);
         const updatedPost = (await context.Posts.findOne(postId))!
         await postsAlignmentAsync.runCallbacksAsync(
           [updatedPost, post, context]

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -30,7 +30,7 @@ const specificResolvers = {
           set.deletedByUserId = null;
         }
         let modifier = { $set: set };
-        await context.Comments.update({_id: commentId}, modifier);
+        await context.Comments.rawUpdate({_id: commentId}, modifier);
         const updatedComment = await context.Comments.findOne(commentId)
         await moderateCommentsPostUpdate(updatedComment!, currentUser);
         return await accessFilterSingle(context.currentUser, context.Comments, updatedComment, context);

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -271,7 +271,7 @@ export async function updateDenormalizedContributorsList(tag: DbTag): Promise<Co
   const contributionStats = await buildContributorsList(tag, null);
   
   if (JSON.stringify(tag.contributionStats) !== JSON.stringify(contributionStats)) {
-    await Tags.update({_id: tag._id}, {$set: {
+    await Tags.rawUpdate({_id: tag._id}, {$set: {
       contributionStats: contributionStats,
     }});
   }
@@ -281,7 +281,7 @@ export async function updateDenormalizedContributorsList(tag: DbTag): Promise<Co
 
 export async function updateDenormalizedHtmlAttributions(tag: DbTag) {
   const html = await annotateAuthors(tag._id, "Tags", "description");
-  await Tags.update({_id: tag._id}, {$set: {
+  await Tags.rawUpdate({_id: tag._id}, {$set: {
     htmlWithContributorAnnotations: html,
   }});
   return html;

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -110,7 +110,7 @@ async function convertImagesInPost(postId: string) {
     changeMetrics: htmlToChangeMetrics(oldHtml, newHtml),
   };
   const insertedRevisionId: string = await Revisions.insert(newRevision);
-  await Posts.update({_id: postId}, {
+  await Posts.rawUpdate({_id: postId}, {
     $set: {
       contents_latest: insertedRevisionId,
       contents: {

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -109,7 +109,7 @@ async function convertImagesInPost(postId: string) {
     commitMessage: "Move images to CDN",
     changeMetrics: htmlToChangeMetrics(oldHtml, newHtml),
   };
-  const insertedRevisionId: string = await Revisions.insert(newRevision);
+  const insertedRevisionId: string = await Revisions.rawInsert(newRevision);
   await Posts.rawUpdate({_id: postId}, {
     $set: {
       contents_latest: insertedRevisionId,

--- a/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
+++ b/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
@@ -43,7 +43,7 @@ Vulcan.ensureEmailInEmails = wrapVulcanAsyncScript(
         // add email to emails
         const newEmail = {address: user.email, verified: true};
         const newEmails = user.emails ? [...user.emails, newEmail] : [newEmail]
-        void Users.update(user._id, {$set: {'emails': newEmails}});
+        void Users.rawUpdate(user._id, {$set: {'emails': newEmails}});
         // eslint-disable-next-line no-console
         console.log('updating user account:', user.email, user.emails, newEmails);
       }

--- a/packages/lesswrong/server/scripts/fillUserEmail.ts
+++ b/packages/lesswrong/server/scripts/fillUserEmail.ts
@@ -14,6 +14,6 @@ Vulcan.fillUserEmail = wrapVulcanAsyncScript('fillUserEmail', async () => {
   // eslint-disable-next-line no-console
   console.log('userSlugs', userSlugs)
   for (const user of users) {
-    await Users.update({_id: user._id}, {$set: {email: user.emails[0].address}})
+    await Users.rawUpdate({_id: user._id}, {$set: {email: user.emails[0].address}})
   }
 })

--- a/packages/lesswrong/server/scripts/fixBodyField.ts
+++ b/packages/lesswrong/server/scripts/fixBodyField.ts
@@ -14,7 +14,7 @@ if (runFix) { void (async ()=>{
     if (html) {
       const plaintextBody = htmlToText.fromString(html);
       const excerpt =  plaintextBody.slice(0,140);
-      await Posts.update(post._id, {$set: {body: plaintextBody, excerpt: excerpt}});
+      await Posts.rawUpdate(post._id, {$set: {body: plaintextBody, excerpt: excerpt}});
       postCount++;
       if (postCount % 100 == 0) {
         //eslint-disable-next-line no-console

--- a/packages/lesswrong/server/scripts/fixEmailField.ts
+++ b/packages/lesswrong/server/scripts/fixEmailField.ts
@@ -12,7 +12,7 @@ if (fixEmail) { void (async ()=>{
   await asyncForeachSequential(allUsers, async (user) => {
     if (user.legacy && user.email) {
       try {
-      await Users.update({_id: user._id}, {$set: {'emails': [{address: user.email, verified: true}]}});
+      await Users.rawUpdate({_id: user._id}, {$set: {'emails': [{address: user.email, verified: true}]}});
       usersCount++;
       if (usersCount % 1000 == 0 ){
         //eslint-disable-next-line no-console

--- a/packages/lesswrong/server/scripts/fixKarmaField.ts
+++ b/packages/lesswrong/server/scripts/fixKarmaField.ts
@@ -41,7 +41,7 @@ if (fixKarma) { void (async ()=>{
         + (discussionPostKarmaWeight*discussionPostKarma)
         + (discussionCommentKarmaWeight*discussionCommentKarma)
 
-      await Users.update({_id: user._id}, {$set :{karma: karma}});
+      await Users.rawUpdate({_id: user._id}, {$set :{karma: karma}});
       usersCount++;
 
       if (usersCount % 1000 == 0 ){

--- a/packages/lesswrong/server/scripts/fixSSCDrafts.ts
+++ b/packages/lesswrong/server/scripts/fixSSCDrafts.ts
@@ -68,7 +68,7 @@ if (runSSCFix) {
       allCodexPostIds = allCodexPostIds.map((post) => post._id);
       //eslint-disable-next-line no-console
       console.log(allCodexPostIds)
-      await Posts.update({_id: {$in: allCodexPostIds}}, {$set: {draft: false}}, {multi: true})
+      await Posts.rawUpdate({_id: {$in: allCodexPostIds}}, {$set: {draft: false}}, {multi: true})
       //eslint-disable-next-line no-console
       console.log("Updated codex draft status");
     }

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -55,7 +55,7 @@ const transferEditableField = async ({documentId, targetUserId, collection, fiel
     validate: false
   })
   // Update the revisions themselves
-  await Revisions.update({ documentId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
+  await Revisions.rawUpdate({ documentId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
 }
 
 const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sourceUserId: string, targetUserId: string, postId: string}) => {
@@ -65,7 +65,7 @@ const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sou
   const readStatus = sourceMostRecentlyUpdated ? sourceUserStatus?.isRead : targetUserStatus?.isRead
   const lastUpdated = sourceMostRecentlyUpdated ? sourceUserStatus?.lastUpdated : targetUserStatus?.lastUpdated
   if (targetUserStatus) {
-    await ReadStatuses.update({_id: targetUserStatus._id}, {$set: {isRead: readStatus, lastUpdated}})
+    await ReadStatuses.rawUpdate({_id: targetUserStatus._id}, {$set: {isRead: readStatus, lastUpdated}})
   } else if (sourceUserStatus) {
     // eslint-disable-next-line no-unused-vars
     const {_id, ...sourceUserStatusWithoutId} = sourceUserStatus
@@ -86,7 +86,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   await transferCollection({sourceUserId, targetUserId, collectionName: "Comments"})
 
   // Transfer conversations
-  await Conversations.update({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
+  await Conversations.rawUpdate({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
 
   // Transfer private messages
   await transferCollection({sourceUserId, targetUserId, collectionName: "Messages"})
@@ -111,12 +111,12 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Transfer votes that target content from source user (authorId)
   // eslint-disable-next-line no-console
   console.log("Transferring votes that target source user")
-  await Votes.update({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
+  await Votes.rawUpdate({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
 
   // Transfer votes cast by source user
   // eslint-disable-next-line no-console
   console.log("Transferring votes cast by source user")
-  await Votes.update({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
+  await Votes.rawUpdate({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
 
   // Transfer karma
   // eslint-disable-next-line no-console
@@ -137,7 +137,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Change slug of source account by appending "old" and reset oldSlugs array
   // eslint-disable-next-line no-console
   console.log("Change slugs of source account")
-  await Users.update(
+  await Users.rawUpdate(
     {_id: sourceUserId},
     {$set: {
       slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -69,7 +69,7 @@ const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sou
   } else if (sourceUserStatus) {
     // eslint-disable-next-line no-unused-vars
     const {_id, ...sourceUserStatusWithoutId} = sourceUserStatus
-    ReadStatuses.insert({...sourceUserStatusWithoutId, userId: targetUserId})
+    ReadStatuses.rawInsert({...sourceUserStatusWithoutId, userId: targetUserId})
   }
 }
 

--- a/packages/lesswrong/server/scripts/rerunAFvotes.ts
+++ b/packages/lesswrong/server/scripts/rerunAFvotes.ts
@@ -4,7 +4,7 @@ import { Vulcan, getCollection } from '../vulcan-lib';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
 Vulcan.rerunAFVotes = async () => {
-  await Users.update({}, {$set:{afKarma:0}}, {multi:true})
+  await Users.rawUpdate({}, {$set:{afKarma:0}}, {multi:true})
   const afVotes = await Votes.find({
     afPower:{$exists:true},
     cancelled:false,
@@ -19,7 +19,7 @@ Vulcan.rerunAFVotes = async () => {
     const collection = getCollection(vote.collectionName as VoteableCollectionName);
     const document = await collection.findOne({_id: vote.documentId}) as VoteableType;
     if (document.af) {
-      await Users.update({_id:document.userId}, {$inc: {afKarma: vote.afPower}})
+      await Users.rawUpdate({_id:document.userId}, {$inc: {afKarma: vote.afPower}})
     }
   })
 }

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -28,7 +28,7 @@ export async function updatePostDenormalizedTags(postId: string) {
       tagRelDict[tagRel.tagId] = tagRel.baseScore;
   }
   
-  await Posts.update({_id:postId}, {$set: {tagRelevance: tagRelDict}});
+  await Posts.rawUpdate({_id:postId}, {$set: {tagRelevance: tagRelDict}});
 }
 
 getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any>, {document: tag}: {document: DbTag}) => {
@@ -78,7 +78,7 @@ getCollectionHooks("Tags").updateAfter.add(async (newDoc: DbTag, {oldDocument}: 
   // If this is soft deleting a tag, then cascade to also soft delete any
   // tagRels that go with it.
   if (newDoc.deleted && !oldDocument.deleted) {
-    await TagRels.update({ tagId: newDoc._id }, { $set: { deleted: true } }, { multi: true });
+    await TagRels.rawUpdate({ tagId: newDoc._id }, { $set: { deleted: true } }, { multi: true });
   }
   return newDoc;
 });

--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
@@ -233,7 +233,7 @@ SyncedCron._entryWrapper = function(entry: any) {
 
       log.info('Finished "' + entry.name + '".');
       if(entry.persist) {
-        await self._collection.update({_id: jobHistory._id}, {
+        await self._collection.rawUpdate({_id: jobHistory._id}, {
           $set: {
             finishedAt: new Date(),
             result: output
@@ -243,7 +243,7 @@ SyncedCron._entryWrapper = function(entry: any) {
     } catch(e) {
       log.info('Exception "' + entry.name +'" ' + ((e && e.stack) ? e.stack : e));
       if(entry.persist) {
-        await self._collection.update({_id: jobHistory._id}, {
+        await self._collection.rawUpdate({_id: jobHistory._id}, {
           $set: {
             finishedAt: new Date(),
             error: (e && e.stack) ? e.stack : e

--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
@@ -213,7 +213,7 @@ SyncedCron._entryWrapper = function(entry: any) {
       // If we have a dup key error, another instance has already tried to run
       // this job.
       try {
-        jobHistory._id = await self._collection.insert(jobHistory);
+        jobHistory._id = await self._collection.rawInsert(jobHistory);
       } catch(e) {
         // http://www.mongodb.org/about/contributors/error-codes/
         // 11000 == duplicate key error
@@ -257,7 +257,7 @@ SyncedCron._entryWrapper = function(entry: any) {
 // for tests
 SyncedCron._reset = async function() {
   this._entries = {};
-  await this._collection.remove({});
+  await this._collection.rawRemove({});
   this.running = false;
 }
 

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -304,7 +304,7 @@ async function insertHashedLoginToken(userId: string, hashedToken: string) {
     hashedToken
   }
 
-  await Users.update({_id: userId}, {
+  await Users.rawUpdate({_id: userId}, {
     $addToSet: {
       "services.resume.loginTokens": tokenWithMetadata
     }

--- a/packages/lesswrong/server/vulcan-lib/connectors.ts
+++ b/packages/lesswrong/server/vulcan-lib/connectors.ts
@@ -79,7 +79,7 @@ export const Connectors = {
     logger('---------->')
     logger('document', document)
     logger('options', options)
-    const result = await collection.insert(document);
+    const result = await collection.rawInsert(document);
     logger('result', result)
     logger('---<')
     return result
@@ -115,7 +115,7 @@ export const Connectors = {
     logger('selector', selector)
     logger('options', options)
     const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
-    const result = await collection.remove(convertedSelector);
+    const result = await collection.rawRemove(convertedSelector);
     logger('result', result)
     logger('---<')
     return result

--- a/packages/lesswrong/server/vulcan-lib/connectors.ts
+++ b/packages/lesswrong/server/vulcan-lib/connectors.ts
@@ -98,7 +98,7 @@ export const Connectors = {
     logger('modifier', modifier)
     logger('options', options)
     const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
-    const result = await collection.update(convertedSelector, modifier, options);
+    const result = await collection.rawUpdate(convertedSelector, modifier, options);
     logger('result', result)
     logger('---<')
     return result

--- a/packages/lesswrong/testing/debouncer.tests.ts
+++ b/packages/lesswrong/testing/debouncer.tests.ts
@@ -14,7 +14,7 @@ describe('EventDebouncer', () => {
     
     try {
       // Clear the DebouncerEvents table
-      await DebouncerEvents.remove({});
+      await DebouncerEvents.rawRemove({});
       
       let numEventsHandled = 0;
       let numEventBatchesHandled = 0;
@@ -98,4 +98,3 @@ describe('EventDebouncer', () => {
     getWeeklyBatchTimeAfter(new Date("1980-01-01 03:20:00Z"), 3, "Tuesday").toString().should.equal(new Date("1980-01-08 03:00:00Z").toString());
   });
 });
-

--- a/packages/lesswrong/testing/utils.ts
+++ b/packages/lesswrong/testing/utils.ts
@@ -267,13 +267,13 @@ export const createDummyLocalgroup = async (data?: any) => {
 
 export const clearDatabase = async () => {
   await asyncForeachSequential(await Users.find().fetch(), async (i) => {
-    await Users.remove(i._id)
+    await Users.rawRemove(i._id)
   });
   await asyncForeachSequential(await Posts.find().fetch(), async (i) => {
-    await Posts.remove(i._id)
+    await Posts.rawRemove(i._id)
   });
   await asyncForeachSequential(await Comments.find().fetch(), async (i) => {
-    await Comments.remove(i._id)
+    await Comments.rawRemove(i._id)
   });
 }
 

--- a/packages/lesswrong/testing/voting.tests.ts
+++ b/packages/lesswrong/testing/voting.tests.ts
@@ -18,7 +18,7 @@ describe('Voting', function() {
       const user = await createDummyUser();
       const yesterday = new Date().getTime()-(1*24*60*60*1000)
       const post = await createDummyPost(user, {postedAt: yesterday})
-      await Posts.update(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
+      await Posts.rawUpdate(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
       const preUpdatePost = await Posts.find({_id: post._id}).fetch();
       await batchUpdateScore({collection: Posts});
       const updatedPost = await Posts.find({_id: post._id}).fetch();
@@ -69,7 +69,7 @@ describe('Voting', function() {
       const user = await createDummyUser();
       const yesterday = new Date().getTime()-(1*24*60*60*1000)
       const post = await createDummyPost(user, {postedAt: yesterday})
-      await Posts.update(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
+      await Posts.rawUpdate(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
       await performVoteServer({ documentId: post._id, voteType: 'smallUpvote', collection: Posts, user })
       const updatedPost = await Posts.find({_id: post._id}).fetch();
 


### PR DESCRIPTION
Discussed in #ea_forum_joint on [2021-12-01](https://cea-core.slack.com/archives/CJZ7QMY5V/p1638383605139500)[^1], there have been multiple bugs due to callbacks failing to run because developers don't realize they should be using [update]Mutator functions. To help developers realize this difference, this PR renames the callback-less functions to have 'raw' in their name, and gives them docstrings which explain the situation.

[^1]: Let me know if you can/can't click on that link, LW-ers.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/628521446211730/1201988183452234) by [Unito](https://www.unito.io)
