### PR TITLE
Remove extra headroom from EA homepage

### DIFF
--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -7,6 +7,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...sectionTitleStyle(theme),
     display: "inline",
     marginRight: "auto",
+    [theme.breakpoints.down("sm")]: {
+      marginTop: theme.spacing.unit*3,
+    },
   },
 });
 
@@ -17,8 +20,8 @@ const StickiedPosts = ({
 }) => {
   const { SingleColumnSection, PostsList2, SectionTitle } = Components;
 
-  return <SingleColumnSection className={classes.section}>
-    <SectionTitle title="Pinned Posts" className={classes.title} />
+  return <SingleColumnSection>
+    <SectionTitle title="Pinned Posts" noTopMargin className={classes.title} />
     <PostsList2
       terms={{view:"stickied", limit:100}}
       showNoResults={false}


### PR DESCRIPTION
This PR removes extra padding from the desktop view of the EA homepage caused by the heading at the top. The result is the same top padding that exists on other pages.

## Before
<img width="1716" alt="image" src="https://user-images.githubusercontent.com/25752873/159994502-7e3e9c55-8e76-4995-afd8-261251fd07b1.png">

## After
<img width="1716" alt="image" src="https://user-images.githubusercontent.com/25752873/159994579-21ad14aa-2d3c-47e5-b99c-a06a354e486f.png">

## Mobile (unchanged)
<div>
<img width="392" alt="image" src="https://user-images.githubusercontent.com/25752873/159995897-f17c0c55-ce20-4b22-8230-0b2292ae9ea3.png">
<img width="392" alt="image" src="https://user-images.githubusercontent.com/25752873/159995042-4c9674c2-dc58-4d81-b723-2bb33e46977f.png">
</div>