### PR TITLE
TagPage now uses CloudinaryImage2 to prevent loading bug

### DIFF
--- a/packages/lesswrong/components/common/CloudinaryImage2.tsx
+++ b/packages/lesswrong/components/common/CloudinaryImage2.tsx
@@ -52,14 +52,15 @@ const CloudinaryImage2 = ({width, height, objectFit, publicId, imgProps, header,
     cloudinaryProps.w = width.toString()
     imageStyle.width = width
   }
-  // ignore input width if we're told we have a header
-  if (header) {
-    cloudinaryProps.w = 'iw'
-    imageStyle.width="100%"
-  }
   if (height) {
     cloudinaryProps.h = height.toString()
     imageStyle.height = height+"px";
+  }
+  // ignore input width if we're told we have a header
+  if (header) {
+    cloudinaryProps.h = ((height || DEFAULT_HEADER_HEIGHT)*2).toString()
+    cloudinaryProps.w = 'iw'
+    imageStyle.width="100%"
   }
   if (objectFit) {
     imageStyle.objectFit = objectFit

--- a/packages/lesswrong/components/common/CloudinaryImage2.tsx
+++ b/packages/lesswrong/components/common/CloudinaryImage2.tsx
@@ -1,6 +1,8 @@
 import { registerComponent } from '../../lib/vulcan-lib';
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
+
+const DEFAULT_HEADER_HEIGHT = 300;
 
 // see their documentation: https://cloudinary.com/documentation/transformation_reference
 export type CloudinaryPropsType = {
@@ -11,6 +13,7 @@ export type CloudinaryPropsType = {
   c?: string,   // crop
   g?: string,   // gravity
   q?: string    // quality
+  f?: string    // format
 }
 
 function cloudinaryPropsToStr(props) {
@@ -20,34 +23,42 @@ function cloudinaryPropsToStr(props) {
   return sb.join(",");
 }
 
+function makeCloudinaryImageUrl (publicId: string, cloudinaryProps: CloudinaryPropsType) {
+  return `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/${cloudinaryPropsToStr(cloudinaryProps)}/${publicId}`
+}
+
 // Cloudinary image without using cloudinary-react. Allows SSR. See:
 // https://github.com/LessWrong2/Lesswrong2/pull/937 "Drop cloudinary react"
 // https://github.com/LessWrong2/Lesswrong2/pull/964 "Temporarily revert removal of cloudinary-react"
-const CloudinaryImage2 = ({width, height, objectFit, publicId, imgProps, className}: {
+const CloudinaryImage2 = ({width, height, objectFit, publicId, imgProps, header, className}: {
   width?: number|string,
   height?: number,
-  objectFit?: string,
+  objectFit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down',
   publicId: string,
   imgProps?: CloudinaryPropsType,
+  header?: boolean,
   className?: string,
 }) => {
-  const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
-
-  let cloudinaryProps: any = {
+  let cloudinaryProps: CloudinaryPropsType = {
     c: "fill",
     dpr: "auto",
     g: "custom",
     q: "auto",
     f: "auto"
   };
-  let imageStyle: any = {};
+  let imageStyle: CSSProperties = {};
 
   if (width) {
-    cloudinaryProps.w = width
+    cloudinaryProps.w = width.toString()
     imageStyle.width = width
   }
+  // ignore input width if we're told we have a header
+  if (header) {
+    cloudinaryProps.w = 'iw'
+    imageStyle.width="100%"
+  }
   if (height) {
-    cloudinaryProps.h = height;
+    cloudinaryProps.h = height.toString()
     imageStyle.height = height+"px";
   }
   if (objectFit) {
@@ -56,10 +67,26 @@ const CloudinaryImage2 = ({width, height, objectFit, publicId, imgProps, classNa
   
   cloudinaryProps = {...cloudinaryProps, ...imgProps}
 
-  const imageUrl = `https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/${cloudinaryPropsToStr(cloudinaryProps)}/${publicId}`;
+  const imageUrl = makeCloudinaryImageUrl(publicId, cloudinaryProps)
+
+  // header images are big and so need srcsets
+  let srcSet = {}
+  if (header) {
+    const srcSetHeight = ((height || DEFAULT_HEADER_HEIGHT)*2).toString()
+    srcSet = {
+      // we generally double the size because lots of screens these days are
+      // retina or similar
+      srcSet: `
+        ${makeCloudinaryImageUrl(publicId, {...cloudinaryProps, ...{w: '900', h: srcSetHeight}})} 450w,
+        ${makeCloudinaryImageUrl(publicId, {...cloudinaryProps, ...{w: '1800', h: srcSetHeight}})} 900w,
+        ${makeCloudinaryImageUrl(publicId, {...cloudinaryProps, ...{w: '3000', h: srcSetHeight}})} 1500w,
+      `
+    }
+  }
 
   return <img
     src={imageUrl}
+    {...srcSet}
     style={imageStyle}
     className={className}
   />

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -268,9 +268,8 @@ const TagPage = ({classes}: {
     {tag.bannerImageId && <div className={classes.imageContainer}>
       <CloudinaryImage2
         publicId={tag.bannerImageId}
-        width="100%"
         height={300}
-        imgProps={{w: 'iw', h: 'ih'}}
+        header
       />
     </div>}
     <div className={tag.bannerImageId ? classes.rootGivenImage : ''}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -148,10 +148,11 @@ export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect,
-    HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn,
-    TableOfContents, TableOfContentsRow, TagContributorsList, SubscribeButton, CloudinaryImage,
-    TagIntroSequence, SectionTitle
+  const {
+    PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404,
+    PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography,
+    TagPageButtonRow, ToCColumn, TableOfContents, TableOfContentsRow, TagContributorsList,
+    SubscribeButton, CloudinaryImage2, TagIntroSequence, SectionTitle
    } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -265,10 +266,11 @@ const TagPage = ({classes}: {
       {`.by_${hoveredContributorId} {background: rgba(95, 155, 101, 0.35);}`}
     </style>}
     {tag.bannerImageId && <div className={classes.imageContainer}>
-      <CloudinaryImage
+      <CloudinaryImage2
         publicId={tag.bannerImageId}
-        width="auto"
+        width="100%"
         height={300}
+        imgProps={{w: 'iw', h: 'ih'}}
       />
     </div>}
     <div className={tag.bannerImageId ? classes.rootGivenImage : ''}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -269,7 +269,7 @@ const TagPage = ({classes}: {
       <CloudinaryImage2
         publicId={tag.bannerImageId}
         height={300}
-        header
+        fullWidthHeader
       />
     </div>}
     <div className={tag.bannerImageId ? classes.rootGivenImage : ''}>


### PR DESCRIPTION
The bug briefly showed a broken image icon while loading the image. Instead of figuring that one out, I went ahead and switched to the better component, which we want to do anyway.

I'd be interested in feedback on my introduction of a `header` flag to CloudinaryImage2. Header banners are common, and I was thinking they'd need custom srcsets and it seemed worth making a special case, but I could be talked out of it.
