### PR TITLE
Replace collection.update with updateOne/updateMany

### DIFF
--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -155,16 +155,37 @@ export class MongoCollection<T extends DbObject> {
       return insertResult.insertedId;
     });
   }
-  rawUpdate = async (selector, update, options) => {
+  rawUpdateOne = async (selector, update, options) => {
     if (disableAllWrites) return;
     try {
       const table = this.getTable();
-      return await wrapQuery(`${this.tableName}.update`, async () => {
+      return await wrapQuery(`${this.tableName}.updateOne`, async () => {
         if (typeof selector === 'string') {
-          const updateResult = await table.update({_id: selector}, update, options);
+          const updateResult = await table.updateOne({_id: selector}, update, options);
           return updateResult.matchedCount;
         } else {
-          const updateResult = await table.update(removeUndefinedFields(selector), update, options);
+          const updateResult = await table.updateOne(removeUndefinedFields(selector), update, options);
+          return updateResult.matchedCount;
+        }
+      });
+    } catch(e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+      // eslint-disable-next-line no-console
+      console.log(`Selector was: ${selector}`);
+      throw e;
+    }
+  }
+  rawUpdateMany = async (selector, update, options) => {
+    if (disableAllWrites) return;
+    try {
+      const table = this.getTable();
+      return await wrapQuery(`${this.tableName}.updateMany`, async () => {
+        if (typeof selector === 'string') {
+          const updateResult = await table.updateMany({_id: selector}, update, options);
+          return updateResult.matchedCount;
+        } else {
+          const updateResult = await table.updateMany(removeUndefinedFields(selector), update, options);
           return updateResult.matchedCount;
         }
       });
@@ -225,10 +246,15 @@ export class MongoCollection<T extends DbObject> {
       const table = this.getTable();
       return await table.indexes(options);
     },
-    update: async (selector, update, options) => {
+    updateOne: async (selector, update, options) => {
       if (disableAllWrites) return;
       const table = this.getTable();
-      return await table.update(selector, update, options);
+      return await table.updateOne(selector, update, options);
+    },
+    updateMany: async (selector, update, options) => {
+      if (disableAllWrites) return;
+      const table = this.getTable();
+      return await table.updateMany(selector, update, options);
     },
   })
 }

--- a/packages/lesswrong/lib/mongoQueries.ts
+++ b/packages/lesswrong/lib/mongoQueries.ts
@@ -1,5 +1,16 @@
 import { getCollection } from './vulcan-lib/collections';
 
+// Simple function wrappers around mongodb operations. These are slightly silly
+// and exist primarily for the purpose of breaking import cycles; because they
+// use collection *names* rather than collection *operators*, they can be used
+// without issue from inside collection schemas and the functions those schemas
+// import. If you don't need to break an import cycle, prefer using the methods
+// on the collections themselves.
+//
+// Only usable server side. These are in `lib` because some other server-side-
+// only code is in `lib` when technically it shouldn't be, mainly resolvers
+// that are embedded in schemas that are shared between client and server.
+
 export async function mongoFindOne<N extends CollectionNameString>(collectionName: N, selector: string|MongoSelector<ObjectsByCollectionName[N]>, options?: MongoFindOneOptions<ObjectsByCollectionName[N]>, projection?: MongoProjection<ObjectsByCollectionName[N]>): Promise<ObjectsByCollectionName[N]|null>
 {
   const collection = getCollection(collectionName);

--- a/packages/lesswrong/lib/mongoQueries.ts
+++ b/packages/lesswrong/lib/mongoQueries.ts
@@ -24,10 +24,15 @@ export async function mongoAggregate<N extends CollectionNameString>(collectionN
   return await collection.aggregate(pipeline).toArray();
 }
 
-export async function mongoUpdate<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, modifier?: MongoModifier<ObjectsByCollectionName[N]>, options?: MongoUpdateOptions<ObjectsByCollectionName[N]>): Promise<number>
+export async function mongoUpdateOne<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, modifier?: MongoModifier<ObjectsByCollectionName[N]>, options?: MongoUpdateOptions<ObjectsByCollectionName[N]>): Promise<number>
 {
   const collection = getCollection(collectionName);
-  return await collection.rawUpdate(selector, modifier, options);
+  return await collection.rawUpdateOne(selector, modifier, options);
+}
+export async function mongoUpdateMany<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, modifier?: MongoModifier<ObjectsByCollectionName[N]>, options?: MongoUpdateOptions<ObjectsByCollectionName[N]>): Promise<number>
+{
+  const collection = getCollection(collectionName);
+  return await collection.rawUpdateMany(selector, modifier, options);
 }
 export async function mongoRemove<N extends CollectionNameString>(collectionName: N, selector?: string|MongoSelector<ObjectsByCollectionName[N]>, options?: MongoRemoveOptions<ObjectsByCollectionName[N]>)
 {

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -29,11 +29,12 @@ interface CollectionBase<
   _schemaFields: SchemaType<T>
   _simpleSchema: any
   
-  rawCollection: ()=>{bulkWrite: any, findOneAndUpdate: any, dropIndex: any, indexes: any, update: any}
+  rawCollection: ()=>{bulkWrite: any, findOneAndUpdate: any, dropIndex: any, indexes: any, updateOne: any, updateMany: any}
   checkAccess: (user: DbUser|null, obj: T, context: ResolverContext|null, outReasonDenied?: {reason?: string}) => Promise<boolean>
   find: (selector?: MongoSelector<T>, options?: MongoFindOptions<T>, projection?: MongoProjection<T>) => FindResult<T>
   findOne: (selector?: string|MongoSelector<T>, options?: MongoFindOneOptions<T>, projection?: MongoProjection<T>) => Promise<T|null>
   findOneArbitrary: () => Promise<T|null>
+  
   /**
    * Update without running callbacks. Consider using updateMutator, which wraps
    * this.
@@ -48,7 +49,9 @@ interface CollectionBase<
    * We then decided to maintain compatibility with meteor when we switched
    * away.
    */
-  rawUpdate: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
+  rawUpdateOne: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
+  rawUpdateMany: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
+  
   /** Remove without running callbacks. Consider using deleteMutator, which
    * wraps this. */
   rawRemove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -288,7 +288,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     const createCallback = async (newDoc, {currentUser, collection, context}) => {
       if (newDoc[foreignFieldName] && filter(newDoc)) {
         const collection = getCollection(collectionName);
-        await collection.rawUpdate(newDoc[foreignFieldName], {
+        await collection.rawUpdateOne(newDoc[foreignFieldName], {
           $inc: { [fieldName]: 1 }
         });
       }
@@ -306,14 +306,14 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
         if (filter(newDoc) && !filter(oldDocument)) {
           // The old doc didn't count, but the new doc does. Increment on the new doc.
           if (newDoc[foreignFieldName]) {
-            await countingCollection.rawUpdate(newDoc[foreignFieldName], {
+            await countingCollection.rawUpdateOne(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
           }
         } else if (!filter(newDoc) && filter(oldDocument)) {
           // The old doc counted, but the new doc doesn't. Decrement on the old doc.
           if (oldDocument[foreignFieldName]) {
-            await countingCollection.rawUpdate(oldDocument[foreignFieldName], {
+            await countingCollection.rawUpdateOne(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
@@ -321,12 +321,12 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
           // The old and new doc both count, but the reference target has changed.
           // Decrement on one doc and increment on the other.
           if (oldDocument[foreignFieldName]) {
-            await countingCollection.rawUpdate(oldDocument[foreignFieldName], {
+            await countingCollection.rawUpdateOne(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
           if (newDoc[foreignFieldName]) {
-            await countingCollection.rawUpdate(newDoc[foreignFieldName], {
+            await countingCollection.rawUpdateOne(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
           }
@@ -338,7 +338,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
       async ({document, currentUser, collection}) => {
         if (document[foreignFieldName] && filter(document)) {
           const countingCollection = getCollection(collectionName);
-          await countingCollection.rawUpdate(document[foreignFieldName], {
+          await countingCollection.rawUpdateOne(document[foreignFieldName], {
             $inc: { [fieldName]: -1 }
           });
         }

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -284,7 +284,7 @@ export async function userIPBanAndResetLoginTokens(user: DbUser) {
   }
 
   // Remove login tokens
-  await Users.rawUpdate({_id: user._id}, {$set: {"services.resume.loginTokens": []}});
+  await Users.rawUpdateOne({_id: user._id}, {$set: {"services.resume.loginTokens": []}});
 }
 
 
@@ -297,7 +297,7 @@ getCollectionHooks("LWEvents").newSync.add(async function updateReadStatus(event
     //   https://docs.mongodb.com/manual/core/retryable-writes/#retryable-update-upsert
     // In particular, this means the selector has to exactly match the unique
     // index's keys.
-    await ReadStatuses.rawUpdate({
+    await ReadStatuses.rawUpdateOne({
       postId: event.documentId,
       userId: event.userId,
       tagId: null,

--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
@@ -44,7 +44,7 @@ getCollectionHooks("Comments").newAsync.add(async function AlignmentCommentsNewO
 
 //TODO: Probably change these to take a boolean argument?
 const updateParentsSetAFtrue = async (comment: DbComment) => {
-  await Comments.rawUpdate({_id:comment.parentCommentId}, {$set: {af: true}});
+  await Comments.rawUpdateOne({_id:comment.parentCommentId}, {$set: {af: true}});
   const parent = await Comments.findOne({_id: comment.parentCommentId});
   if (parent) {
     await updateParentsSetAFtrue(parent)
@@ -54,7 +54,7 @@ const updateParentsSetAFtrue = async (comment: DbComment) => {
 const updateChildrenSetAFfalse = async (comment: DbComment) => {
   const children = await Comments.find({parentCommentId: comment._id}).fetch();
   await asyncForeachSequential(children, async (child) => {
-    await Comments.rawUpdate({_id:child._id}, {$set: {af: false}});
+    await Comments.rawUpdateOne({_id:child._id}, {$set: {af: false}});
     await updateChildrenSetAFfalse(child)
   })
 }

--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentPostCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentPostCallbacks.ts
@@ -3,7 +3,7 @@ import { postsAlignmentAsync } from '../../resolvers/alignmentForumMutations';
 
 async function PostsMoveToAFAddsAlignmentVoting (post: DbPost, oldPost: DbPost) {
   if (post.af && !oldPost.af) {
-    await Users.rawUpdate({_id:post.userId}, {$addToSet: {groups: 'alignmentVoters'}})
+    await Users.rawUpdateOne({_id:post.userId}, {$addToSet: {groups: 'alignmentVoters'}})
   }
 }
 

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -24,12 +24,12 @@ async function updateAlignmentKarmaServer (newDocument: DbVoteableType, vote: Db
   if (userCanDo(voter, "votes.alignment")) {
     const votePower = calculateVotePower(voter.afKarma, vote.voteType)
 
-    await Votes.rawUpdate({_id:vote._id, documentId: newDocument._id}, {$set:{afPower: votePower}})
+    await Votes.rawUpdateOne({_id:vote._id, documentId: newDocument._id}, {$set:{afPower: votePower}})
     const newAFBaseScore = await recalculateAFBaseScore(newDocument)
 
     const collection = getCollection(vote.collectionName as VoteableCollectionName)
 
-    await collection.rawUpdate({_id: newDocument._id}, {$set: {afBaseScore: newAFBaseScore}});
+    await collection.rawUpdateOne({_id: newDocument._id}, {$set: {afBaseScore: newAFBaseScore}});
 
     return {
       newDocument:{
@@ -61,12 +61,12 @@ async function updateAlignmentUserServer (newDocument: VoteableType, vote: DbVot
     if (!documentUser) throw Error("Can't find user to update Alignment Karma")
     const newAfKarma = (documentUser.afKarma || 0) + ((vote.afPower || 0) * multiplier)
     if (newAfKarma > 0) {
-      await Users.rawUpdate({_id:newDocument.userId}, {
+      await Users.rawUpdateOne({_id:newDocument.userId}, {
         $set: {afKarma: newAfKarma },
         $addToSet: {groups: 'alignmentVoters'}
       })
     } else {
-      await Users.rawUpdate({_id:newDocument.userId}, {
+      await Users.rawUpdateOne({_id:newDocument.userId}, {
         $set: {afKarma: newAfKarma },
         $pull: {groups: 'alignmentVoters'}
       })
@@ -94,11 +94,11 @@ voteCallbacks.cancelSync.add(function cancelAlignmentKarmaServerCallback({newDoc
 
 async function MoveToAFUpdatesUserAFKarma (document: DbPost|DbComment, oldDocument: DbPost|DbComment) {
   if (document.af && !oldDocument.af) {
-    await Users.rawUpdate({_id:document.userId}, {
+    await Users.rawUpdateOne({_id:document.userId}, {
       $inc: {afKarma: document.afBaseScore || 0},
       $addToSet: {groups: 'alignmentVoters'}
     })
-    await Votes.rawUpdate({documentId: document._id}, {
+    await Votes.rawUpdateMany({documentId: document._id}, {
       $set: {documentIsAf: true}
     }, {multi: true})
   } else if (!document.af && oldDocument.af) {
@@ -106,14 +106,14 @@ async function MoveToAFUpdatesUserAFKarma (document: DbPost|DbComment, oldDocume
     if (!documentUser) throw Error("Can't find user for updating karma after moving document to AIAF")
     const newAfKarma = (documentUser.afKarma || 0) - (document.afBaseScore || 0)
     if (newAfKarma > 0) {
-      await Users.rawUpdate({_id:document.userId}, {$inc: {afKarma: -document.afBaseScore || 0}})
+      await Users.rawUpdateOne({_id:document.userId}, {$inc: {afKarma: -document.afBaseScore || 0}})
     } else {
-      await Users.rawUpdate({_id:document.userId}, {
+      await Users.rawUpdateOne({_id:document.userId}, {
         $inc: {afKarma: -document.afBaseScore || 0},
         $pull: {groups: 'alignmentVoters'}
       })
     }
-    await Votes.rawUpdate({documentId: document._id}, {
+    await Votes.rawUpdateMany({documentId: document._id}, {
       $set: {documentIsAf: false}
     }, {multi: true})
   }

--- a/packages/lesswrong/server/callbacks/bookCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/bookCallbacks.ts
@@ -76,7 +76,7 @@ async function getAllCollectionPosts(id: string) {
 
 async function updateCollectionSequences(sequences: Array<DbSequence>, collectionSlug: string) {
   await asyncForeachSequential(_.range(sequences.length), async (i) => {
-    await Sequences.rawUpdate(sequences[i]._id, {$set: {
+    await Sequences.rawUpdateOne(sequences[i]._id, {$set: {
       canonicalCollectionSlug: collectionSlug,
     }});
   })
@@ -94,7 +94,7 @@ async function updateCollectionPosts(posts: Array<DbPost>, collectionSlug: strin
     if (i+1<posts.length) {
       nextPost = posts[i+1]
     }
-    await Posts.rawUpdate({slug: currentPost.slug}, {$set: {
+    await Posts.rawUpdateOne({slug: currentPost.slug}, {$set: {
       canonicalPrevPostSlug: prevPost.slug,
       canonicalNextPostSlug: nextPost.slug,
       canonicalBookId: currentPost.canonicalBookId,
@@ -111,7 +111,7 @@ getCollectionHooks("Books").editAsync.add(async function UpdateCollectionLinks (
   //eslint-disable-next-line no-console
   console.log(`Updating Collection Links for ${collectionId}...`)
 
-  await Collections.rawUpdate(collectionId, { $set: {
+  await Collections.rawUpdateOne(collectionId, { $set: {
     firstPageLink: "/" + results.collectionSlug + "/" + results.posts[0].slug
   }})
 

--- a/packages/lesswrong/server/callbacks/chapterCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/chapterCallbacks.ts
@@ -15,7 +15,7 @@ async function ChaptersEditCanonizeCallback (chapter: DbChapter) {
   const removedPosts = _.difference(_.pluck(postsWithCanonicalSequenceId, '_id'), _.pluck(posts, '_id'))
 
   await asyncForeachSequential(removedPosts, async (postId) => {
-    await Posts.rawUpdate({_id: postId}, {$unset: {
+    await Posts.rawUpdateOne({_id: postId}, {$unset: {
       canonicalPrevPostSlug: true,
       canonicalNextPostSlug: true,
       canonicalSequenceId: true,
@@ -38,7 +38,7 @@ async function ChaptersEditCanonizeCallback (chapter: DbChapter) {
       if (i+1<posts.length) {
         nextPost = posts[i+1]
       }
-      await Posts.rawUpdate({slug: currentPost.slug}, {$set: {
+      await Posts.rawUpdateOne({slug: currentPost.slug}, {$set: {
         canonicalPrevPostSlug: prevPost.slug,
         canonicalNextPostSlug: nextPost.slug,
         canonicalSequenceId: chapter.sequenceId,

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -122,11 +122,11 @@ getCollectionHooks("Comments").newValidate.add(async function createShortformPos
 getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations (comment: DbComment) {
   // update lastCommentedAt field on post or tag
   if (comment.postId) {
-    await Posts.rawUpdate(comment.postId, {
+    await Posts.rawUpdateOne(comment.postId, {
       $set: {lastCommentedAt: new Date()},
     });
   } else if (comment.tagId) {
-    await Tags.rawUpdate(comment.tagId, {
+    await Tags.rawUpdateOne(comment.tagId, {
       $set: {lastCommentedAt: new Date()},
     });
   }
@@ -146,7 +146,7 @@ getCollectionHooks("Comments").removeAsync.add(async function CommentsRemovePost
     const lastCommentedAt = postComments[0] && postComments[0].postedAt;
   
     // update post with a decremented comment count, and corresponding last commented at date
-    await Posts.rawUpdate(postId, {
+    await Posts.rawUpdateOne(postId, {
       $set: {lastCommentedAt},
     });
   }
@@ -325,7 +325,7 @@ getCollectionHooks("Comments").newAsync.add(async function NewCommentNeedsReview
   const user = await Users.findOne({_id:comment.userId})
   const karma = user?.karma || 0
   if (karma < 100) {
-    await Comments.rawUpdate({_id:comment._id}, {$set: {needsReview: true}});
+    await Comments.rawUpdateOne({_id:comment._id}, {$set: {needsReview: true}});
   }
 });
 
@@ -371,9 +371,9 @@ getCollectionHooks("Comments").editSync.add(async function validateDeleteOperati
 getCollectionHooks("Comments").editSync.add(async function moveToAnswers (modifier, comment: DbComment) {
   if (modifier.$set) {
     if (modifier.$set.answer === true) {
-      await Comments.rawUpdate({topLevelCommentId: comment._id}, {$set:{parentAnswerId:comment._id}}, { multi: true })
+      await Comments.rawUpdateMany({topLevelCommentId: comment._id}, {$set:{parentAnswerId:comment._id}}, { multi: true })
     } else if (modifier.$set.answer === false) {
-      await Comments.rawUpdate({topLevelCommentId: comment._id}, {$unset:{parentAnswerId:true}}, { multi: true })
+      await Comments.rawUpdateMany({topLevelCommentId: comment._id}, {$unset:{parentAnswerId:true}}, { multi: true })
     }
   }
   return modifier
@@ -431,7 +431,7 @@ getCollectionHooks("Comments").createBefore.add(async function SetTopLevelCommen
 getCollectionHooks("Comments").createAfter.add(async function UpdateDescendentCommentCounts (comment: DbComment) {
   const ancestorIds: string[] = await getCommentAncestorIds(comment);
   
-  await Comments.rawUpdate({ _id: {$in: ancestorIds} }, {
+  await Comments.rawUpdateOne({ _id: {$in: ancestorIds} }, {
     $set: {lastSubthreadActivity: new Date()},
     $inc: {descendentCount:1},
   });
@@ -443,7 +443,7 @@ getCollectionHooks("Comments").updateAfter.add(async function UpdateDescendentCo
   if (context.oldDocument.deleted !== context.newDocument.deleted) {
     const ancestorIds: string[] = await getCommentAncestorIds(comment);
     const increment = context.oldDocument.deleted ? 1 : -1;
-    await Comments.rawUpdate({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
+    await Comments.rawUpdateOne({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
   }
   return comment;
 });

--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -2,5 +2,5 @@ import Conversations from '../../lib/collections/conversations/collection'
 import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("Messages").createAsync.add(function unArchiveConversations({document}) {
-  void Conversations.rawUpdate({_id:document.conversationId}, {$set: {archivedByIds: []}});
+  void Conversations.rawUpdateOne({_id:document.conversationId}, {$set: {archivedByIds: []}});
 });

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -44,7 +44,7 @@ voteCallbacks.castVoteAsync.add(async function increaseMaxBaseScore ({newDocumen
       if (!post.scoreExceeded75Date && post.baseScore >= 75) {
         thresholdTimestamp.scoreExceeded75Date = new Date();
       }
-      await Posts.rawUpdate({_id: post._id}, {$set: {maxBaseScore: post.baseScore, ...thresholdTimestamp}})
+      await Posts.rawUpdateOne({_id: post._id}, {$set: {maxBaseScore: post.baseScore, ...thresholdTimestamp}})
     }
   }
 });
@@ -116,7 +116,7 @@ getCollectionHooks("Posts").newAfter.add(function PostsNewPostRelation (post) {
 getCollectionHooks("Posts").editAsync.add(async function UpdatePostShortform (newPost, oldPost) {
   if (!!newPost.shortform !== !!oldPost.shortform) {
     const shortform = !!newPost.shortform;
-    await Comments.rawUpdate(
+    await Comments.rawUpdateMany(
       { postId: newPost._id },
       { $set: {
         shortform: shortform
@@ -149,7 +149,7 @@ getCollectionHooks("Posts").editAsync.add(async function UpdateCommentHideKarma 
 export async function newDocumentMaybeTriggerReview (document: DbPost|DbComment) {
   const author = await Users.findOne(document.userId);
   if (author && (!author.reviewedByUserId || author.sunshineSnoozed)) {
-    await Users.rawUpdate({_id:author._id}, {$set:{needsReview: true}})
+    await Users.rawUpdateOne({_id:author._id}, {$set:{needsReview: true}})
   }
   return document
 }
@@ -196,7 +196,7 @@ async function extractSocialPreviewImage (post: DbPost) {
   // returned value
   // It's important to run this regardless of whether or not we found an image,
   // as removing an image should remove the social preview for that image
-  await Posts.rawUpdate({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
+  await Posts.rawUpdateOne({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
   
   return {...post, socialPreviewImageAutoUrl}
   
@@ -213,7 +213,7 @@ getCollectionHooks("Posts").newAfter.add(extractSocialPreviewImage)
 async function oldPostsLastCommentedAt (post: DbPost) {
   if (post.commentCount) return
 
-  await Posts.rawUpdate({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
+  await Posts.rawUpdateOne({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
 }
 
 getCollectionHooks("Posts").editAsync.add(oldPostsLastCommentedAt)

--- a/packages/lesswrong/server/callbacks/subscriptionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/subscriptionCallbacks.ts
@@ -3,6 +3,6 @@ import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("Subscriptions").createBefore.add(async function deleteOldSubscriptions(subscription) {
   const { userId, documentId, collectionName, type } = subscription
-  await Subscriptions.rawUpdate({userId, documentId, collectionName, type}, {$set: {deleted: true}}, {multi: true})
+  await Subscriptions.rawUpdateMany({userId, documentId, collectionName, type}, {$set: {deleted: true}}, {multi: true})
   return subscription;
 });

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -25,7 +25,7 @@ const TRUSTLEVEL1_THRESHOLD = 2000
 voteCallbacks.castVoteAsync.add(async function updateTrustedStatus ({newDocument, vote}: VoteDocTuple) {
   const user = await Users.findOne(newDocument.userId)
   if (user && user.karma >= TRUSTLEVEL1_THRESHOLD && (!userGetGroups(user).includes('trustLevel1'))) {
-    await Users.rawUpdate(user._id, {$push: {groups: 'trustLevel1'}});
+    await Users.rawUpdateOne(user._id, {$push: {groups: 'trustLevel1'}});
     const updatedUser = await Users.findOne(newDocument.userId)
     //eslint-disable-next-line no-console
     console.info("User gained trusted status", updatedUser?.username, updatedUser?._id, updatedUser?.karma, updatedUser?.groups)
@@ -36,7 +36,7 @@ voteCallbacks.castVoteAsync.add(async function updateModerateOwnPersonal({newDoc
   const user = await Users.findOne(newDocument.userId)
   if (!user) throw Error("Couldn't find user")
   if (user.karma >= MODERATE_OWN_PERSONAL_THRESHOLD && (!userGetGroups(user).includes('canModeratePersonal'))) {
-    await Users.rawUpdate(user._id, {$push: {groups: 'canModeratePersonal'}});
+    await Users.rawUpdateOne(user._id, {$push: {groups: 'canModeratePersonal'}});
     const updatedUser = await Users.findOne(newDocument.userId)
     if (!updatedUser) throw Error("Couldn't find user to update")
     //eslint-disable-next-line no-console
@@ -78,7 +78,7 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
     // reset the postedAt for comments, since those are by default visible
     // almost everywhere. This can bypass the mutation system fine, because the
     // flag doesn't control whether they're indexed in Algolia.
-    await Comments.rawUpdate({userId:newUser._id, authorIsUnreviewed:true}, {$set:{authorIsUnreviewed:false}}, {multi: true})
+    await Comments.rawUpdateMany({userId:newUser._id, authorIsUnreviewed:true}, {$set:{authorIsUnreviewed:false}}, {multi: true})
   }
 });
 
@@ -128,7 +128,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeOnSignup (user:
 getCollectionHooks("Users").newAsync.add(async function setABTestKeyOnSignup (user: DbInsertion<DbUser>) {
   if (!user.abTestKey) {
     const abTestKey = user.profile?.clientId || randomId();
-    await Users.rawUpdate(user._id, {$set: {abTestKey: abTestKey}});
+    await Users.rawUpdateOne(user._id, {$set: {abTestKey: abTestKey}});
   }
 });
 

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -15,14 +15,14 @@ const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
 voteCallbacks.castVoteAsync.add(function updateKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
   // only update karma is the operation isn't done by the item's author
   if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
-    void Users.rawUpdate({_id: newDocument.userId}, {$inc: {"karma": vote.power}});
+    void Users.rawUpdateOne({_id: newDocument.userId}, {$inc: {"karma": vote.power}});
   }
 });
 
 voteCallbacks.cancelAsync.add(function cancelVoteKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
   // only update karma is the operation isn't done by the item's author
   if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
-    void Users.rawUpdate({_id: newDocument.userId}, {$inc: {"karma": -vote.power}});
+    void Users.rawUpdateOne({_id: newDocument.userId}, {$inc: {"karma": -vote.power}});
   }
 });
 
@@ -31,7 +31,7 @@ voteCallbacks.castVoteAsync.add(async function incVoteCount ({newDocument, vote}
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {
-    void Users.rawUpdate({_id: vote.userId}, {$inc: {[field]: 1, voteCount: 1}});
+    void Users.rawUpdateOne({_id: vote.userId}, {$inc: {[field]: 1, voteCount: 1}});
   }
 });
 
@@ -39,7 +39,7 @@ voteCallbacks.cancelAsync.add(async function cancelVoteCount ({newDocument, vote
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {
-    void Users.rawUpdate({_id: vote.userId}, {$inc: {[field]: -1, voteCount: -1}});
+    void Users.rawUpdateOne({_id: vote.userId}, {$inc: {[field]: -1, voteCount: -1}});
   }
 });
 
@@ -47,7 +47,7 @@ voteCallbacks.castVoteAsync.add(async function updateNeedsReview (document: Vote
   const voter = await Users.findOne(document.vote.userId);
   // voting should only be triggered once (after getting snoozed, they will not re-trigger for sunshine review)
   if (voter && voter.voteCount >= 20 && !voter.reviewedByUserId) {
-    void Users.rawUpdate({_id:voter._id}, {$set:{needsReview: true}})
+    void Users.rawUpdateOne({_id:voter._id}, {$set:{needsReview: true}})
   }
 });
 
@@ -61,7 +61,7 @@ postPublishedCallback.add(async (publishedPost: DbPost) => {
   // whole collection. (This is already something being done frequently by a
   // cronjob.)
   if (publishedPost.inactive) {
-    await Posts.rawUpdate({_id: publishedPost._id}, {$set: {inactive: false}});
+    await Posts.rawUpdateOne({_id: publishedPost._id}, {$set: {inactive: false}});
   }
   
   await batchUpdateScore({collection: Posts});

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -113,7 +113,7 @@ export class EventDebouncer<KeyType,ValueType>
     const { newDelayTime, newUpperBoundTime } = this.parseTiming(timingRule);
     
     // On rawCollection because minimongo doesn't support $max/$min on Dates
-    await DebouncerEvents.rawCollection().update({
+    await DebouncerEvents.rawCollection().updateOne({
       name: this.name,
       af: af,
       key: JSON.stringify(key),
@@ -243,7 +243,7 @@ export const dispatchPendingEvents = async () => {
       try {
         await dispatchEvent(eventToHandle);
       } catch (e) {
-        await DebouncerEvents.rawUpdate({
+        await DebouncerEvents.rawUpdateOne({
           _id: eventToHandle._id
         }, {
           $set: { failed: true }

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -500,7 +500,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
   {
     // Update revision to point to the document that owns it.
     const revisionID = newDoc[`${fieldName}_latest`];
-    await Revisions.rawUpdate(
+    await Revisions.rawUpdateOne(
       { _id: revisionID },
       { $set: { documentId: newDoc._id } }
     );

--- a/packages/lesswrong/server/editor/utils.ts
+++ b/packages/lesswrong/server/editor/utils.ts
@@ -133,7 +133,7 @@ export async function syncDocumentWithLatestRevision<T extends DbObject>(
       )
     }
   }
-  await collection.rawUpdate(document._id, {
+  await collection.rawUpdateOne(document._id, {
     $set: {
       [fieldName]: pick(latestRevision, revisionFieldsToCopy),
       [`${fieldName}_latest`]: latestRevision._id

--- a/packages/lesswrong/server/markAsUnread.ts
+++ b/packages/lesswrong/server/markAsUnread.ts
@@ -11,7 +11,7 @@ addGraphQLResolvers({
       
       // TODO: Create an entry in LWEvents
       
-      await ReadStatuses.rawUpdate({
+      await ReadStatuses.rawUpdateOne({
         postId: postId,
         userId: currentUser._id,
         tagId: null,

--- a/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
+++ b/packages/lesswrong/server/migrations/2019-02-04-replaceObjectIdsInEditableFields.ts
@@ -49,7 +49,7 @@ registerMigration({
         },
         migrate: async (documents: Array<any>) => {
           for (let doc of documents) {
-            await collection.rawUpdate(
+            await collection.rawUpdateOne(
               {_id: doc._id},
               {
                 $set: {

--- a/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.ts
+++ b/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.ts
@@ -105,7 +105,7 @@ registerMigration({
           
           // Remove subscribedItems from the user
           if (oldSubscriptions) {
-            await Users.rawUpdate(
+            await Users.rawUpdateOne(
               { _id: user._id },
               { $unset: {
                 subscribedItems: 1

--- a/packages/lesswrong/server/migrations/2020-01-02-fillMissingRevisionFieldNames.ts
+++ b/packages/lesswrong/server/migrations/2020-01-02-fillMissingRevisionFieldNames.ts
@@ -15,7 +15,7 @@ registerMigration({
       await forEachDocumentBatchInCollection({
         collection, batchSize: 1000,
         callback: async (documents: any[]) => {
-          await Revisions.rawUpdate(
+          await Revisions.rawUpdateMany(
             { documentId: { $in: documents.map(doc => doc._id) } },
             { $set: {fieldName} },
             { multiple: true }

--- a/packages/lesswrong/server/migrations/2020-03-30-fixLostUnapprovedComments.ts
+++ b/packages/lesswrong/server/migrations/2020-03-30-fixLostUnapprovedComments.ts
@@ -29,6 +29,6 @@ registerMigration({
     
     // eslint-disable-next-line no-console
     console.log(commentsToMarkReviewed.length+" comments to mark as reviewed");
-    await Comments.rawUpdate({_id: {$in: commentsToMarkReviewed}}, {$set: {authorIsUnreviewed: false}}, {multi: true});
+    await Comments.rawUpdateMany({_id: {$in: commentsToMarkReviewed}}, {$set: {authorIsUnreviewed: false}}, {multi: true});
   }
 });

--- a/packages/lesswrong/server/migrations/2020-05-05-addRevisionCollectionName.ts
+++ b/packages/lesswrong/server/migrations/2020-05-05-addRevisionCollectionName.ts
@@ -17,7 +17,7 @@ registerMigration({
         callback: async (documents: DbObject[]) => {
           // eslint-disable-next-line no-console
           console.log(`Migrating a batch of ${documents.length} documents`);
-          await Revisions.rawUpdate(
+          await Revisions.rawUpdateMany(
             { documentId: { $in: documents.map(doc => doc._id) } },
             { $set: {collectionName} },
             { multi: true }

--- a/packages/lesswrong/server/migrations/2020-09-15-tagLastCommentedAt.ts
+++ b/packages/lesswrong/server/migrations/2020-09-15-tagLastCommentedAt.ts
@@ -20,7 +20,7 @@ registerMigration({
           }).fetch();
           if (newestComment.length>0) {
             const lastCommentedAt = newestComment[0].postedAt;
-            await Tags.rawUpdate({_id: tag._id}, {$set: {lastCommentedAt: lastCommentedAt}});
+            await Tags.rawUpdateOne({_id: tag._id}, {$set: {lastCommentedAt: lastCommentedAt}});
           }
         }));
       }

--- a/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
+++ b/packages/lesswrong/server/migrations/2021-03-11-readStatusesIndex.ts
@@ -22,7 +22,7 @@ registerMigration({
   idempotent: true,
   action: async () => {
     // Ensure that the tagId field is not missing (ie replace missing with null)
-    await ReadStatuses.rawUpdate({tagId: {$exists: false}}, {$set: {tagId: null}}, {multi: true})
+    await ReadStatuses.rawUpdateMany({tagId: {$exists: false}}, {$set: {tagId: null}}, {multi: true})
     
     // Download all ReadStatuses, and identify the duplicates
     const allReadStatuses = await ReadStatuses.find().fetch();

--- a/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
+++ b/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
@@ -25,7 +25,7 @@ registerMigration({
           const descendentCount = subtreeFiltered.length-1;
           if (descendentCount !== comment.descendentCount || !comment.lastSubthreadActivity) {
             updates.updated++;
-            await Comments.rawUpdate(
+            await Comments.rawUpdateOne(
               {_id: comment._id},
               {$set: {
                 descendentCount,

--- a/packages/lesswrong/server/migrations/2021-08-23-fillEmailsFieldForOrganizers.ts
+++ b/packages/lesswrong/server/migrations/2021-08-23-fillEmailsFieldForOrganizers.ts
@@ -10,7 +10,7 @@ registerMigration({
     const organizers = await Users.find({createdAt: {$gt: new Date("2021-08-22T05:48:35.336Z")}, emails: null}).fetch()
     for (const organizer of organizers) {
       if (organizer.email) {
-        await Users.rawUpdate({_id: organizer._id}, {$set: {emails: [{address: organizer.email, verified: true}]}})
+        await Users.rawUpdateOne({_id: organizer._id}, {$set: {emails: [{address: organizer.email, verified: true}]}})
       }
     }
   },

--- a/packages/lesswrong/server/migrations/2021-10-05-fillRevisionDraftsField.ts
+++ b/packages/lesswrong/server/migrations/2021-10-05-fillRevisionDraftsField.ts
@@ -14,21 +14,21 @@ registerMigration({
         collectionName: {$ne: "Tags"},
       },
       fn: async (bucketSelector) => {
-        await Revisions.rawUpdate(bucketSelector, {$set: {draft: true}}, {multi:true})
+        await Revisions.rawUpdateMany(bucketSelector, {$set: {draft: true}}, {multi:true})
       }
     })
     await forEachBucketRangeInCollection({
       collection: Revisions,
       filter: { collectionName: "Tags", },
       fn: async (bucketSelector) => {
-        await Revisions.rawUpdate(bucketSelector, {$set: {draft: false}}, {multi:true})
+        await Revisions.rawUpdateMany(bucketSelector, {$set: {draft: false}}, {multi:true})
       }
     })
     await forEachBucketRangeInCollection({
       collection: Revisions,
       filter: { version: {$gte: "1"} },
       fn: async (bucketSelector) => {
-        await Revisions.rawUpdate(bucketSelector, {$set: {draft: false}}, {multi:true})
+        await Revisions.rawUpdateMany(bucketSelector, {$set: {draft: false}}, {multi:true})
       }
     })
   },

--- a/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
+++ b/packages/lesswrong/server/migrations/2021-12-13-updateQuadraticVotes.ts
@@ -72,7 +72,7 @@ registerMigration({
         if (!vote.qualitativeScore) continue
         
         totalUserPoints += getCost(vote)
-        await ReviewVotes.rawUpdate({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})
+        await ReviewVotes.rawUpdateOne({_id:vote._id}, {$set: {quadraticVote: getValue(vote)}})
         
         updatePost(postsAllUsers, vote)
         if (user.karma >= 1000) {
@@ -87,19 +87,19 @@ registerMigration({
     }
 
     for (let postId in postsAllUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesAllKarma: postsAllUsers[postId].sort((a,b) => b - a), 
         reviewVoteScoreAllKarma: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
     }
     for (let postId in postsHighKarmaUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesHighKarma: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreHighKarma: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
     }
     for (let postId in postsAFUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-01-12-updateQuadraticVotes-2.ts
+++ b/packages/lesswrong/server/migrations/2022-01-12-updateQuadraticVotes-2.ts
@@ -71,7 +71,7 @@ registerMigration({
         if (!vote.qualitativeScore) continue
         
         totalUserPoints += getCost(vote)
-        await ReviewVotes.rawUpdate({_id:vote._id}, {$set: {quadraticScore: getValue(vote)}})
+        await ReviewVotes.rawUpdateOne({_id:vote._id}, {$set: {quadraticScore: getValue(vote)}})
         
         updatePost(postsAllUsers, vote)
 
@@ -88,19 +88,19 @@ registerMigration({
     }
 
     for (let postId in postsAllUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesAllKarma2: postsAllUsers[postId].sort((a,b) => b - a), 
         reviewVoteScoreAllKarma2: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
     }
     for (let postId in postsHighKarmaUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesHighKarma2: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreHighKarma2: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
     }
     for (let postId in postsAFUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         reviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         reviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-01-30-updateFinal2020ReviewVotes.ts
+++ b/packages/lesswrong/server/migrations/2022-01-30-updateFinal2020ReviewVotes.ts
@@ -63,7 +63,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating all karma...")
     for (let postId in postsAllUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         finalReviewVotesAllKarma: postsAllUsers[postId].sort((a,b) => b - a), 
         finalReviewVoteScoreAllKarma: postsAllUsers[postId].reduce((x, y) => x + y, 0) 
       }})
@@ -72,7 +72,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating high karma...")
     for (let postId in postsHighKarmaUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         finalReviewVotesHighKarma: postsHighKarmaUsers[postId].sort((a,b) => b - a),
         finalReviewVoteScoreHighKarma: postsHighKarmaUsers[postId].reduce((x, y) => x + y, 0),
       }})
@@ -80,7 +80,7 @@ registerMigration({
     // eslint-disable-next-line no-console
     console.log("Updating AF...")
     for (let postId in postsAFUsers) {
-      await Posts.rawUpdate({_id:postId}, {$set: { 
+      await Posts.rawUpdateOne({_id:postId}, {$set: { 
         finalReviewVotesAF: postsAFUsers[postId].sort((a,b) => b - a),
         finalReviewVoteScoreAF: postsAFUsers[postId].reduce((x, y) => x + y, 0),
        }})

--- a/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
+++ b/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
@@ -25,7 +25,7 @@ async function maybeFixAccount(user: DbUser): Promise<void> {
   if (isSensibleEmail(user.email) && JSON.stringify(user.emails)==='{"0":{"verified":true}}') {
     // eslint-disable-next-line no-console
     console.log(`Fixing emails for ${user.slug}`);
-    await Users.rawUpdate(
+    await Users.rawUpdateOne(
       {_id: user._id},
       {$set: {
         emails: [{address: user.email, verified: true}]
@@ -56,7 +56,7 @@ async function maybeFixAccount(user: DbUser): Promise<void> {
         return;
       }
       
-      await Users.rawUpdate(
+      await Users.rawUpdateOne(
         {_id: user._id},
         {$set: {
           [`services.${oauthProvider}`]: user.services[oauthProvider].id,

--- a/packages/lesswrong/server/migrations/migrationUtils.ts
+++ b/packages/lesswrong/server/migrations/migrationUtils.ts
@@ -60,7 +60,7 @@ export async function runMigration(name: string)
   try {
     await action();
     
-    await Migrations.rawUpdate({_id: migrationLogId}, {$set: {
+    await Migrations.rawUpdateOne({_id: migrationLogId}, {$set: {
       finished: true, succeeded: true,
     }});
 
@@ -72,7 +72,7 @@ export async function runMigration(name: string)
     // eslint-disable-next-line no-console
     console.error(e);
     
-    await Migrations.rawUpdate({_id: migrationLogId}, {$set: {
+    await Migrations.rawUpdateOne({_id: migrationLogId}, {$set: {
       finished: true, succeeded: false,
     }});
   }
@@ -141,7 +141,7 @@ export async function fillDefaultValues<T extends DbObject>({ collection, fieldN
         const mutation = { $set: {
           [fieldName]: defaultValue
         } };
-        const writeResult = await collection.rawUpdate(bucketSelector, mutation, {multi: true});
+        const writeResult = await collection.rawUpdateMany(bucketSelector, mutation, {multi: true});
         
         nMatched += writeResult || 0;
         // eslint-disable-next-line no-console
@@ -264,7 +264,7 @@ export async function dropUnusedField(collection, fieldName) {
         const mutation = { $unset: {
           [fieldName]: 1
         } };
-        const writeResult = await collection.rawUpdate(
+        const writeResult = await collection.rawUpdateMany(
           bucketSelector,
           mutation,
           {multi: true}

--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -36,7 +36,7 @@ const sendNotificationBatch = async ({userId, notificationIds}: {userId: string,
   
   const user = await getUser(userId);
   if (!user) throw new Error(`Missing user: ID ${userId}`);
-  await Notifications.rawUpdate(
+  await Notifications.rawUpdateMany(
     { _id: {$in: notificationIds} },
     { $set: { waitingForBatch: false } },
     { multi: true }

--- a/packages/lesswrong/server/posts/cron.ts
+++ b/packages/lesswrong/server/posts/cron.ts
@@ -16,7 +16,7 @@ addCronJob({
     // update posts found
     if (!_.isEmpty(postsToUpdate)) {
       const postsIds = _.pluck(postsToUpdate, '_id');
-      await Posts.rawUpdate({_id: {$in: postsIds}}, {$set: {isFuture: false}}, {multi: true});
+      await Posts.rawUpdateMany({_id: {$in: postsIds}}, {$set: {isFuture: false}}, {multi: true});
 
       // log the action
       console.log('// Scheduled posts approved:', postsIds); // eslint-disable-line

--- a/packages/lesswrong/server/posts/graphql.ts
+++ b/packages/lesswrong/server/posts/graphql.ts
@@ -9,7 +9,7 @@ import { addGraphQLMutation, addGraphQLResolvers } from '../vulcan-lib';
 const specificResolvers = {
   Mutation: {
     increasePostViewCount(root: void, {postId}: {postId: string}, context: ResolverContext) {
-      return context.Posts.rawUpdate({_id: postId}, { $inc: { viewCount: 1 }});
+      return context.Posts.rawUpdateOne({_id: postId}, { $inc: { viewCount: 1 }});
     }
   }
 };

--- a/packages/lesswrong/server/posts/out.ts
+++ b/packages/lesswrong/server/posts/out.ts
@@ -1,4 +1,4 @@
-import { addStaticRoute, Connectors } from '../vulcan-lib';
+import { addStaticRoute } from '../vulcan-lib';
 import { Posts } from '../../lib/collections/posts';
 import { ensureIndex } from '../../lib/collectionUtils';
 
@@ -33,5 +33,5 @@ addStaticRoute('/out', async ({ query}, req, res, next) => {
 ensureIndex(Posts, {url:1, postedAt:-1});
 
 async function incrementPostClickCount(postId: string) {
-  await Connectors.update(Posts, {_id: postId}, { $inc: { clickCount: 1 } });
+  await Posts.rawUpdateOne({_id: postId}, { $inc: { clickCount: 1 } });
 }

--- a/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
+++ b/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
@@ -15,7 +15,7 @@ const alignmentCommentResolvers = {
 
       if (userCanDo(context.currentUser, "comments.alignment.move.all")) {
         let modifier = { $set: {af: af} };
-        await context.Comments.rawUpdate({_id: commentId}, modifier);
+        await context.Comments.rawUpdateOne({_id: commentId}, modifier);
         const updatedComment = (await context.Comments.findOne(commentId))!
         await commentsAlignmentAsync.runCallbacksAsync(
           [updatedComment, comment, context]
@@ -40,7 +40,7 @@ const alignmentPostResolvers = {
 
       if (userCanMakeAlignmentPost(context.currentUser, post)) {
         let modifier = { $set: {af: af} };
-        await context.Posts.rawUpdate({_id: postId}, modifier);
+        await context.Posts.rawUpdateOne({_id: postId}, modifier);
         const updatedPost = (await context.Posts.findOne(postId))!
         await postsAlignmentAsync.runCallbacksAsync(
           [updatedPost, post, context]

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -30,7 +30,7 @@ const specificResolvers = {
           set.deletedByUserId = null;
         }
         let modifier = { $set: set };
-        await context.Comments.rawUpdate({_id: commentId}, modifier);
+        await context.Comments.rawUpdateOne({_id: commentId}, modifier);
         const updatedComment = await context.Comments.findOne(commentId)
         await moderateCommentsPostUpdate(updatedComment!, currentUser);
         return await accessFilterSingle(context.currentUser, context.Comments, updatedComment, context);

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -271,7 +271,7 @@ export async function updateDenormalizedContributorsList(tag: DbTag): Promise<Co
   const contributionStats = await buildContributorsList(tag, null);
   
   if (JSON.stringify(tag.contributionStats) !== JSON.stringify(contributionStats)) {
-    await Tags.rawUpdate({_id: tag._id}, {$set: {
+    await Tags.rawUpdateOne({_id: tag._id}, {$set: {
       contributionStats: contributionStats,
     }});
   }
@@ -281,7 +281,7 @@ export async function updateDenormalizedContributorsList(tag: DbTag): Promise<Co
 
 export async function updateDenormalizedHtmlAttributions(tag: DbTag) {
   const html = await annotateAuthors(tag._id, "Tags", "description");
-  await Tags.rawUpdate({_id: tag._id}, {$set: {
+  await Tags.rawUpdateOne({_id: tag._id}, {$set: {
     htmlWithContributorAnnotations: html,
   }});
   return html;

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -110,7 +110,7 @@ async function convertImagesInPost(postId: string) {
     changeMetrics: htmlToChangeMetrics(oldHtml, newHtml),
   };
   const insertedRevisionId: string = await Revisions.rawInsert(newRevision);
-  await Posts.rawUpdate({_id: postId}, {
+  await Posts.rawUpdateOne({_id: postId}, {
     $set: {
       contents_latest: insertedRevisionId,
       contents: {

--- a/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
+++ b/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
@@ -43,7 +43,7 @@ Vulcan.ensureEmailInEmails = wrapVulcanAsyncScript(
         // add email to emails
         const newEmail = {address: user.email, verified: true};
         const newEmails = user.emails ? [...user.emails, newEmail] : [newEmail]
-        void Users.rawUpdate(user._id, {$set: {'emails': newEmails}});
+        void Users.rawUpdateOne(user._id, {$set: {'emails': newEmails}});
         // eslint-disable-next-line no-console
         console.log('updating user account:', user.email, user.emails, newEmails);
       }

--- a/packages/lesswrong/server/scripts/fillUserEmail.ts
+++ b/packages/lesswrong/server/scripts/fillUserEmail.ts
@@ -14,6 +14,6 @@ Vulcan.fillUserEmail = wrapVulcanAsyncScript('fillUserEmail', async () => {
   // eslint-disable-next-line no-console
   console.log('userSlugs', userSlugs)
   for (const user of users) {
-    await Users.rawUpdate({_id: user._id}, {$set: {email: user.emails[0].address}})
+    await Users.rawUpdateOne({_id: user._id}, {$set: {email: user.emails[0].address}})
   }
 })

--- a/packages/lesswrong/server/scripts/fixBodyField.ts
+++ b/packages/lesswrong/server/scripts/fixBodyField.ts
@@ -14,7 +14,7 @@ if (runFix) { void (async ()=>{
     if (html) {
       const plaintextBody = htmlToText.fromString(html);
       const excerpt =  plaintextBody.slice(0,140);
-      await Posts.rawUpdate(post._id, {$set: {body: plaintextBody, excerpt: excerpt}});
+      await Posts.rawUpdateOne(post._id, {$set: {body: plaintextBody, excerpt: excerpt}});
       postCount++;
       if (postCount % 100 == 0) {
         //eslint-disable-next-line no-console

--- a/packages/lesswrong/server/scripts/fixEmailField.ts
+++ b/packages/lesswrong/server/scripts/fixEmailField.ts
@@ -12,7 +12,7 @@ if (fixEmail) { void (async ()=>{
   await asyncForeachSequential(allUsers, async (user) => {
     if (user.legacy && user.email) {
       try {
-      await Users.rawUpdate({_id: user._id}, {$set: {'emails': [{address: user.email, verified: true}]}});
+      await Users.rawUpdateOne({_id: user._id}, {$set: {'emails': [{address: user.email, verified: true}]}});
       usersCount++;
       if (usersCount % 1000 == 0 ){
         //eslint-disable-next-line no-console

--- a/packages/lesswrong/server/scripts/fixKarmaField.ts
+++ b/packages/lesswrong/server/scripts/fixKarmaField.ts
@@ -41,7 +41,7 @@ if (fixKarma) { void (async ()=>{
         + (discussionPostKarmaWeight*discussionPostKarma)
         + (discussionCommentKarmaWeight*discussionCommentKarma)
 
-      await Users.rawUpdate({_id: user._id}, {$set :{karma: karma}});
+      await Users.rawUpdateOne({_id: user._id}, {$set :{karma: karma}});
       usersCount++;
 
       if (usersCount % 1000 == 0 ){

--- a/packages/lesswrong/server/scripts/fixSSCDrafts.ts
+++ b/packages/lesswrong/server/scripts/fixSSCDrafts.ts
@@ -68,7 +68,7 @@ if (runSSCFix) {
       allCodexPostIds = allCodexPostIds.map((post) => post._id);
       //eslint-disable-next-line no-console
       console.log(allCodexPostIds)
-      await Posts.rawUpdate({_id: {$in: allCodexPostIds}}, {$set: {draft: false}}, {multi: true})
+      await Posts.rawUpdateMany({_id: {$in: allCodexPostIds}}, {$set: {draft: false}}, {multi: true})
       //eslint-disable-next-line no-console
       console.log("Updated codex draft status");
     }

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -55,7 +55,7 @@ const transferEditableField = async ({documentId, targetUserId, collection, fiel
     validate: false
   })
   // Update the revisions themselves
-  await Revisions.rawUpdate({ documentId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
+  await Revisions.rawUpdateMany({ documentId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
 }
 
 const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sourceUserId: string, targetUserId: string, postId: string}) => {
@@ -65,7 +65,7 @@ const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sou
   const readStatus = sourceMostRecentlyUpdated ? sourceUserStatus?.isRead : targetUserStatus?.isRead
   const lastUpdated = sourceMostRecentlyUpdated ? sourceUserStatus?.lastUpdated : targetUserStatus?.lastUpdated
   if (targetUserStatus) {
-    await ReadStatuses.rawUpdate({_id: targetUserStatus._id}, {$set: {isRead: readStatus, lastUpdated}})
+    await ReadStatuses.rawUpdateOne({_id: targetUserStatus._id}, {$set: {isRead: readStatus, lastUpdated}})
   } else if (sourceUserStatus) {
     // eslint-disable-next-line no-unused-vars
     const {_id, ...sourceUserStatusWithoutId} = sourceUserStatus
@@ -86,7 +86,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   await transferCollection({sourceUserId, targetUserId, collectionName: "Comments"})
 
   // Transfer conversations
-  await Conversations.rawUpdate({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
+  await Conversations.rawUpdateMany({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
 
   // Transfer private messages
   await transferCollection({sourceUserId, targetUserId, collectionName: "Messages"})
@@ -111,12 +111,12 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Transfer votes that target content from source user (authorId)
   // eslint-disable-next-line no-console
   console.log("Transferring votes that target source user")
-  await Votes.rawUpdate({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
+  await Votes.rawUpdateMany({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
 
   // Transfer votes cast by source user
   // eslint-disable-next-line no-console
   console.log("Transferring votes cast by source user")
-  await Votes.rawUpdate({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
+  await Votes.rawUpdateMany({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
 
   // Transfer karma
   // eslint-disable-next-line no-console
@@ -137,7 +137,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Change slug of source account by appending "old" and reset oldSlugs array
   // eslint-disable-next-line no-console
   console.log("Change slugs of source account")
-  await Users.rawUpdate(
+  await Users.rawUpdateOne(
     {_id: sourceUserId},
     {$set: {
       slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)

--- a/packages/lesswrong/server/scripts/rerunAFvotes.ts
+++ b/packages/lesswrong/server/scripts/rerunAFvotes.ts
@@ -4,7 +4,7 @@ import { Vulcan, getCollection } from '../vulcan-lib';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
 Vulcan.rerunAFVotes = async () => {
-  await Users.rawUpdate({}, {$set:{afKarma:0}}, {multi:true})
+  await Users.rawUpdateMany({}, {$set:{afKarma:0}}, {multi:true})
   const afVotes = await Votes.find({
     afPower:{$exists:true},
     cancelled:false,
@@ -19,7 +19,7 @@ Vulcan.rerunAFVotes = async () => {
     const collection = getCollection(vote.collectionName as VoteableCollectionName);
     const document = await collection.findOne({_id: vote.documentId}) as VoteableType;
     if (document.af) {
-      await Users.rawUpdate({_id:document.userId}, {$inc: {afKarma: vote.afPower}})
+      await Users.rawUpdateOne({_id:document.userId}, {$inc: {afKarma: vote.afPower}})
     }
   })
 }

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -28,7 +28,7 @@ export async function updatePostDenormalizedTags(postId: string) {
       tagRelDict[tagRel.tagId] = tagRel.baseScore;
   }
   
-  await Posts.rawUpdate({_id:postId}, {$set: {tagRelevance: tagRelDict}});
+  await Posts.rawUpdateOne({_id:postId}, {$set: {tagRelevance: tagRelDict}});
 }
 
 getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any>, {document: tag}: {document: DbTag}) => {
@@ -78,7 +78,7 @@ getCollectionHooks("Tags").updateAfter.add(async (newDoc: DbTag, {oldDocument}: 
   // If this is soft deleting a tag, then cascade to also soft delete any
   // tagRels that go with it.
   if (newDoc.deleted && !oldDocument.deleted) {
-    await TagRels.rawUpdate({ tagId: newDoc._id }, { $set: { deleted: true } }, { multi: true });
+    await TagRels.rawUpdateMany({ tagId: newDoc._id }, { $set: { deleted: true } }, { multi: true });
   }
   return newDoc;
 });

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -1,4 +1,3 @@
-import { Connectors } from './vulcan-lib';
 import { recalculateScore, timeDecayExpr, defaultScoreModifiers, TIME_DECAY_FACTOR } from '../lib/scoring';
 import * as _ from 'underscore';
 
@@ -52,11 +51,11 @@ export const updateScore = async ({collection, item, forceUpdate}) => {
 
   // only update database if difference is larger than x to avoid unnecessary updates
   if (forceUpdate || scoreDiff > x) {
-    await Connectors.update(collection, item._id, {$set: {score: newScore, inactive: false}});
+    await collection.updateOne(item._id, {$set: {score: newScore, inactive: false}});
     return 1;
   } else if(ageInHours > n*24) {
     // only set a post as inactive if it's older than n days
-    await Connectors.update(collection, item._id, {$set: {inactive: true}});
+    await collection.updateOne(item._id, {$set: {inactive: true}});
   }
   return 0;
 };

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -53,7 +53,7 @@ const addVoteServer = async ({ document, collection, voteType, extendedVote, use
   }
   
   // update document score & set item as active
-  await Connectors.update(collection,
+  await collection.rawUpdateOne(
     {_id: document._id},
     {
       $set: {
@@ -63,7 +63,7 @@ const addVoteServer = async ({ document, collection, voteType, extendedVote, use
         extendedScore: newDocument.extendedScore,
       },
     },
-    {}, true
+    {}
   );
   void algoliaExportById(collection as any, newDocument._id);
   return {newDocument, vote};
@@ -155,12 +155,12 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
       );
     }
     const newScores = await recalculateDocumentScores(document, context);
-    await Connectors.update(collection,
+    await collection.rawUpdateOne(
       {_id: document._id},
       {
         $set: {...newScores },
       },
-      {}, true
+      {}
     );
     newDocument = {
       ...newDocument,

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -304,7 +304,7 @@ async function insertHashedLoginToken(userId: string, hashedToken: string) {
     hashedToken
   }
 
-  await Users.rawUpdate({_id: userId}, {
+  await Users.rawUpdateOne({_id: userId}, {
     $addToSet: {
       "services.resume.loginTokens": tokenWithMetadata
     }

--- a/packages/lesswrong/server/vulcan-lib/connectors.ts
+++ b/packages/lesswrong/server/vulcan-lib/connectors.ts
@@ -1,11 +1,18 @@
-/*
- * A light wrapper around the Meteor-provided CRUD functionality.
- *
- * NB: You can enable logging here, but be warned that we don't use these
- * functions everywhere, some paths access the DB without using this wapper
- */
 import { Utils } from '../../lib/vulcan-lib/utils';
 import { loggerConstructor } from '../../lib/utils/logging';
+
+//
+// Connectors: A set of wrappers around mongodb collection operators.
+// DEPRECATED. These originate in Vulcan, and they have a major pitfall.
+// At some point, Vulcan decided that `documentId` should be usable as a
+// synonym for `_id`, in utility functions and in the graphql API. But we were
+// already using `documentId` extensively as an actual field name (for foreign-
+// key fields), so this doesn't work at all, and it created a big mess.
+//
+// Usages of `Connectors` should be replaced with either `collection.someMongoFunction`
+// after verifying that they are not relying on the `documentId` translation
+// behavior.
+//
 
 // convert GraphQL selector into Mongo-compatible selector
 // TODO: add support for more than just documentId/_id and slug, potentially making conversion unnecessary

--- a/packages/lesswrong/server/vulcan-lib/connectors.ts
+++ b/packages/lesswrong/server/vulcan-lib/connectors.ts
@@ -85,7 +85,7 @@ export const Connectors = {
     return result
   },
   
-  update: async <T extends DbObject>(
+  updateOne: async <T extends DbObject>(
     collection: CollectionBase<T>,
     selector: MongoSelector<T>,
     modifier: MongoModifier<T>,
@@ -98,7 +98,7 @@ export const Connectors = {
     logger('modifier', modifier)
     logger('options', options)
     const convertedSelector = skipConversion ? selector : convertUniqueSelector(selector)
-    const result = await collection.rawUpdate(convertedSelector, modifier, options);
+    const result = await collection.rawUpdateOne(convertedSelector, modifier, options);
     logger('result', result)
     logger('---<')
     return result

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -428,7 +428,7 @@ export const updateMutator = async <T extends DbObject>({
   */
   if (!isEmpty(modifier)) {
     // update document
-    await Connectors.update(collection, selector, modifier, { removeEmptyStrings: false });
+    await Connectors.updateOne(collection, selector, modifier, { removeEmptyStrings: false });
 
     // get fresh copy of document from db
     const fetched = await Connectors.get(collection, selector);

--- a/packages/lesswrong/testing/voting.tests.ts
+++ b/packages/lesswrong/testing/voting.tests.ts
@@ -18,7 +18,7 @@ describe('Voting', function() {
       const user = await createDummyUser();
       const yesterday = new Date().getTime()-(1*24*60*60*1000)
       const post = await createDummyPost(user, {postedAt: yesterday})
-      await Posts.rawUpdate(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
+      await Posts.rawUpdateOne(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
       const preUpdatePost = await Posts.find({_id: post._id}).fetch();
       await batchUpdateScore({collection: Posts});
       const updatedPost = await Posts.find({_id: post._id}).fetch();
@@ -69,7 +69,7 @@ describe('Voting', function() {
       const user = await createDummyUser();
       const yesterday = new Date().getTime()-(1*24*60*60*1000)
       const post = await createDummyPost(user, {postedAt: yesterday})
-      await Posts.rawUpdate(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
+      await Posts.rawUpdateOne(post._id, {$set: {inactive: true}}); //Do after creation, since onInsert of inactive sets to false
       await performVoteServer({ documentId: post._id, voteType: 'smallUpvote', collection: Posts, user })
       const updatedPost = await Posts.find({_id: post._id}).fetch();
 


### PR DESCRIPTION
Mongodb's collection.update() function was a footgun, since it invites confusion about whether you're updating the first/unique match (the default), or updating all matches (requires passing {multi:true}). Mongodb deprecated it, replacing `update` with a pair of functions `updateOne` and `updateMany` which act more like you'd expect.

Follow mongodb's deprecation by using `updateOne`/`updateMany` instead of `update`, and push this change through to the various wrappers around `update` that we have.
