### PR TITLE
standalone route that displays the groups map

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -286,16 +286,16 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
               <NavigationEventSender/>
 
               {/* Sign up user for Intercom, if they do not yet have an account */}
-              {showIntercom(currentUser)}
+              {!currentRoute?.standalone && showIntercom(currentUser)}
               <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
               {/* Google Tag Manager i-frame fallback */}
               <noscript><iframe src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerIdSetting.get()}`} height="0" width="0" style={{display:"none", visibility:"hidden"}}/></noscript>
-              <Header
+              {!currentRoute?.standalone && <Header
                 toc={this.state.toc}
                 searchResultsArea={this.searchResultsAreaRef}
                 standaloneNavigationPresent={standaloneNavigation}
                 toggleStandaloneNavigation={this.toggleStandaloneNavigation}
-              />
+              />}
               {renderPetrovDay && <PetrovDayWrapper/>}
               <div className={shouldUseGridLayout ? classes.gridActivated : null}>
                 {standaloneNavigation && <div className={classes.navSidebar}>

--- a/packages/lesswrong/components/localGroups/GroupsMap.tsx
+++ b/packages/lesswrong/components/localGroups/GroupsMap.tsx
@@ -1,0 +1,15 @@
+import { Components, registerComponent, } from '../../lib/vulcan-lib';
+import React from 'react';
+
+
+const GroupsMap = () => {
+  return <Components.CommunityMapWrapper mapOptions={{zoom: 1}} hideLegend />
+}
+
+const GroupsMapComponent = registerComponent('GroupsMap', GroupsMap);
+
+declare global {
+  interface ComponentTypes {
+    GroupsMap: typeof GroupsMapComponent
+  }
+}

--- a/packages/lesswrong/components/localGroups/GroupsMap.tsx
+++ b/packages/lesswrong/components/localGroups/GroupsMap.tsx
@@ -1,9 +1,26 @@
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import React from 'react';
+import { useLocation } from '../../lib/routeUtil';
 
-
+/**
+ * This component is for a standalone route that displays a map of all groups.
+ * Use the "zoom", "lat" and "lng" query params to set the initial map view.
+ */
 const GroupsMap = () => {
-  return <Components.CommunityMapWrapper mapOptions={{zoom: 1}} hideLegend />
+  const { query } = useLocation()
+  
+  let center = {}
+  if (query.lat && parseInt(query.lat) && query.lng && parseInt(query.lng)) {
+    center = {center: {lat: parseInt(query.lat), lng: parseInt(query.lng)}}
+  }
+  
+  return <Components.CommunityMap
+    groupTerms={{view: "all"}}
+    zoom={parseInt(query?.zoom) || 1}
+    initialOpenWindows={[]}
+    hideLegend
+    {...center}
+  />
 }
 
 const GroupsMapComponent = registerComponent('GroupsMap', GroupsMap);

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -298,6 +298,7 @@ importComponent("LocalGroupsItem", () => require('../components/localGroups/Loca
 importComponent("TabNavigationEventsList", () => require('../components/localGroups/TabNavigationEventsList'));
 importComponent("AllGroupsPage", () => require('../components/localGroups/AllGroupsPage'));
 importComponent("GroupFormDialog", () => require('../components/localGroups/GroupFormDialog'));
+importComponent("GroupsMap", () => require('../components/localGroups/GroupsMap'));
 
 importComponent("WalledGardenHome", () => require('../components/walledGarden/WalledGardenHome'));
 importComponent("WalledGardenPortal", () => require('../components/walledGarden/WalledGardenPortal'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -904,6 +904,14 @@ if (hasEventsSetting.get()) {
       componentName: 'AllGroupsPage',
       title: "All Local Groups"
     },
+    
+    {
+      name: 'GroupsMap',
+      path: '/groups-map',
+      componentName: 'GroupsMap',
+      title: "Groups Map",
+      standalone: true
+    },
 
     {
       name:'Localgroups.single',

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -41,6 +41,7 @@ export type Route = {
   sunshineSidebar?: boolean
   disableAutoRefresh?: boolean,
   initialScroll?: "top"|"bottom",
+  standalone?: boolean // if true, this page has no header / intercom
 };
 
 // populated by calls to addRoute


### PR DESCRIPTION
This is based on a request from the EA Germany team. They were interested in embedding our groups map on their website so that they could use our groups data and not have to maintain it on their own site. I've gotten a similar request in the past from EA New Zealand.

I tried to keep it simple, and created a new route which they can embed with an iframe.

<img width="1169" alt="Screen Shot 2022-03-30 at 5 16 34 PM" src="https://user-images.githubusercontent.com/9057804/160932540-7191d310-0f7c-4872-95d4-cf7593e26182.png">
