### PR TITLE
Add enableGoodHeartProject setting

### DIFF
--- a/packages/lesswrong/components/seasonal/AprilFools2022.tsx
+++ b/packages/lesswrong/components/seasonal/AprilFools2022.tsx
@@ -5,8 +5,9 @@ import FavoriteIcon from '@material-ui/icons/Favorite';
 import deepOrange from '@material-ui/core/colors/deepOrange';
 import yellow from '@material-ui/core/colors/yellow';
 import green from '@material-ui/core/colors/green';
+import { DatabasePublicSetting } from '../../lib/publicSettings';
 
-
+export const enableGoodHeartProject = new DatabasePublicSetting<boolean>('enableGoodHeartProject', false) // enables all UI for 2022 LW April Fools
 export const goodHeartStartDate = new Date("01/01/2022")
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -78,6 +79,9 @@ export const AprilFools2022 = ({classes}: {
       enableTotal: false,
       limit: 15,
     });
+
+  if (!enableGoodHeartProject.get()) return null
+
   return <SingleColumnSection>
     <SectionTitle title="The Good Heart Project"/>
     <div className={classes.row}>

--- a/packages/lesswrong/components/seasonal/AprilFools2022.tsx
+++ b/packages/lesswrong/components/seasonal/AprilFools2022.tsx
@@ -7,7 +7,7 @@ import yellow from '@material-ui/core/colors/yellow';
 import green from '@material-ui/core/colors/green';
 import { DatabasePublicSetting } from '../../lib/publicSettings';
 
-export const enableGoodHeartProject = new DatabasePublicSetting<boolean>('enableGoodHeartProject', false) // enables all UI for 2022 LW April Fools
+export const enableGoodHeartProject = new DatabasePublicSetting<boolean>('enableGoodHeartProject', false) // enables UI for 2022 LW April Fools
 export const goodHeartStartDate = new Date("01/01/2022")
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -14,6 +14,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import deepOrange from '@material-ui/core/colors/deepOrange';
 import yellow from '@material-ui/core/colors/yellow';
 import green from '@material-ui/core/colors/green';
+import { enableGoodHeartProject } from '../seasonal/AprilFools2022';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -45,6 +46,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const getRankColorAndDescription = (goodHeartRank) => {
+  if (!enableGoodHeartProject.get()) { return {}}
   if (goodHeartRank === -1) { return {}}
   if (goodHeartRank >= 0 && goodHeartRank < 5) { return {rankColor : deepOrange[700], rankDescription :<p>This user has the goodest of hearts</p>}}
   if (goodHeartRank >= 5 && goodHeartRank < 10) { return {rankColor : yellow[900], rankDescription : <p>This user has a good heart</p>}}

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -11,7 +11,7 @@ import { Revisions } from '../../lib/collections/revisions/collection';
 import classNames from 'classnames';
 import type { VotingProps } from './withVote';
 import FavoriteIcon from '@material-ui/icons/Favorite'
-import { goodHeartStartDate } from '../seasonal/AprilFools2022';
+import { enableGoodHeartProject, goodHeartStartDate } from '../seasonal/AprilFools2022';
 
 const styles = (theme: ThemeType): JssStyles => ({
   overallSection: {
@@ -114,7 +114,8 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
     </div>
   )
 
-  const goodHeart = isPostOrComment(document) && new Date(document.postedAt) > goodHeartStartDate
+  const goodHeartEnabled = enableGoodHeartProject.get()
+  const goodHeart = goodHeartEnabled && isPostOrComment(document) && new Date(document.postedAt) > goodHeartStartDate
 
   return (
     <span className={classes.vote} {...eventHandlers}>

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { useVote } from './withVote';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import FavoriteIcon from '@material-ui/icons/Favorite'
-import { goodHeartStartDate } from '../seasonal/AprilFools2022';
+import { enableGoodHeartProject, goodHeartStartDate } from '../seasonal/AprilFools2022';
 
 const styles = (theme: ThemeType): JssStyles => ({
   upvote: {
@@ -87,7 +87,8 @@ const PostsVote = ({ post, classes }: {
     }
   </div>
 
-  const goodHeart = new Date(post.postedAt) > goodHeartStartDate
+  const goodHeartEnabled = enableGoodHeartProject.get()
+  const goodHeart = goodHeartEnabled && new Date(post.postedAt) > goodHeartStartDate
 
   const voteStyling = goodHeart ? <div className={classes.goodHeartWrapper}> 
     <Typography variant="headline" className={classes.voteScore}>${voteProps.baseScore}</Typography>


### PR DESCRIPTION
This turns off UI for the Good Heart Project (aka LW April Fools 2022) by default unless the databasemetadata field "enableGoodHeartProject" is true.

This *doesn't* currently turn off the UserProfile heart, because that was only merged into lw-deploy, not master, and I didn't deal with it yet.