### PR TITLE
Index long tags and comments

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -15,6 +15,9 @@ import { useCurrentUser } from '../common/withUser';
 import { MAX_COLUMN_WIDTH } from '../posts/PostsPage/PostsPage';
 import { EditTagForm } from './EditTagPage';
 import { useTagBySlug } from './useTag';
+import { forumTypeSetting } from '../../lib/instanceSettings';
+
+const isEAForum = forumTypeSetting.get() === 'EAForum'
 
 // Also used in TagCompareRevisions, TagDiscussionPage
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -242,7 +245,7 @@ const TagPage = ({classes}: {
   }
 
   const htmlWithAnchors = tag.tableOfContents?.html || tag.description?.html;
-  const description = (truncated && !tag.wikiOnly)
+  const description = (truncated && !tag.wikiOnly && !isEAForum)
     ? truncate(htmlWithAnchors, tag.descriptionTruncationCount || 4, "paragraphs", "<span>...<p><a>(Read More)</a></p></span>")
     : htmlWithAnchors
   const headTagDescription = tag.description?.plaintextDescription || `All posts related to ${tag.name}, sorted by relevance`

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -24,7 +24,7 @@ export interface AlgoliaIndexedCollection<T extends AlgoliaIndexedDbObject> exte
   toAlgolia: (document: T) => Promise<Array<AlgoliaDocument>|null>
 }
 
-const COMMENT_MAX_SEARCH_CHARACTERS = 2000
+const COMMENT_MAX_SEARCH_CHARACTERS = 18000
 const USER_BIO_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS
 const TAG_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS;
 


### PR DESCRIPTION
This PR increases our limits to index the first 18,000 characters of tags and comments, and also doesn't show "read more" on the EA Forum.

For testing: [this tag](http://localhost:3000/tag/anti-aging-research) has >18,000 characters on the EA dev DB.

