### PR TITLE
Remove good heart UI from user profile (lw-deploy) 

### DIFF
--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -11,7 +11,6 @@ import StarIcon from '@material-ui/icons/Star'
 import DescriptionIcon from '@material-ui/icons/Description'
 import MessageIcon from '@material-ui/icons/Message'
 import PencilIcon from '@material-ui/icons/Create'
-import FavoriteIcon from '@material-ui/icons/Favorite'
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -125,7 +124,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const renderMeta = () => {
     const document = getUserFromResults(results)
     if (!document) return null
-    const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma, tagRevisionCount, goodHeartTokens } = document;
+    const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma, tagRevisionCount } = document;
 
     const userKarma = karma || 0
     const userAfKarma = afKarma || 0
@@ -133,14 +132,6 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const userCommentCount = forumTypeSetting.get() !== 'AlignmentForum' ? commentCount || 0 : afCommentCount || 0
 
       return <div className={classes.meta}>
-        { forumTypeSetting.get() !== 'AlignmentForum' && <Tooltip title={`${goodHeartTokens} Good Heart Tokens`}>
-          <span className={classes.userMetaInfo}>
-            <FavoriteIcon className={classNames(classes.icon, classes.specificalz)}/>
-            <Components.MetaInfo title="GoodHeartTokens">
-              {goodHeartTokens || 0}
-            </Components.MetaInfo>
-          </span>
-        </Tooltip>}
 
         { forumTypeSetting.get() !== 'AlignmentForum' && <Tooltip title={`${userKarma} karma`}>
           <span className={classes.userMetaInfo}>


### PR DESCRIPTION
Oli made changes to the UsersProfile component for April Fools 2022,. The change was only made off the lw-deploy, not master. This should be merged before https://github.com/ForumMagnum/ForumMagnum/pull/4756 is merged into lw-deploy, so that we don't end up with user profile pages with missing UI elements.