### PR TITLE
Fix flexbox wrapping in Answer header

### DIFF
--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -29,7 +29,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   answerHeader: {
     display: "flex",
     alignItems: "center",
-    marginBottom: theme.spacing.unit*2
+    marginBottom: theme.spacing.unit*2,
+    flexWrap: "wrap",
   },
   author: {
     display: 'inline-block',
@@ -39,12 +40,15 @@ const styles = (theme: ThemeType): JssStyles => ({
   date: {
     display: 'inline-block',
     marginLeft: 10,
+    flexGrow: 0,
+    flexShrink: 0,
   },
   vote: {
     display: 'inline-block',
     marginLeft: 10,
     fontFamily: theme.typography.commentStyle.fontFamily,
     color: theme.palette.grey[500],
+    flexShrink: 0,
     flexGrow: 1,
     position: "relative",
     top: -4


### PR DESCRIPTION
Fixes some broken wrapping in the headers of Answers, at narrow page widths (or with very long author names).

![Image from iOS](https://user-images.githubusercontent.com/101191/162818803-6a9dec72-5ffd-4520-bb47-3c744c826a78.jpg)
.