### PR TITLE
Fix bug that caused GreaterWrong posts to not appear in Latest Posts

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -684,6 +684,20 @@ addFieldsDict(Posts, {
     insertableBy: ['members'],
     optional: true,
     ...schemaDefaultValue(false),
+    
+    onCreate: ({newDocument}: {newDocument: DbInsertion<DbPost>}) => {
+      // HACK: This replaces the `onCreate` that normally comes with
+      // `schemaDefaultValue`. In addition to enforcing that the field must
+      // be present (not undefined), it also enforces that it cannot be null.
+      // There is a bug where GreaterWrong somehow submits posts with isEvent
+      // set to null (instead of false), which causes some post-views to filter
+      // it out (because they filter for non-events using isEvent:false which
+      // does not match null).
+      if (newDocument.isEvent===undefined || newDocument.isEvent===null)
+        return false;
+      else
+        return undefined;
+    }
   },
 
   reviewedByUserId: {


### PR DESCRIPTION
Posts submitted through GreaterWrong, for some reason, wind up with `isEvent` set to `null` rather than `false`. This causes them to be excluded from the Latest Posts list, and from the list of posts on user profile pages, because they filter out events with `isEvent:false` and the `null` doesn't match.

Fix by checking for isEvent being null and changing it to false. I'm not sure why GreaterWrong does this, probably there's more trouble to come here. Our API probably should be enforcing non-nullness for graphql fields of type Boolean *in general*, but it doesn't, and fixing that would be a larger change.


