### PR TITLE
Copy fix: Specify category in empty notifications message.

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -68,7 +68,13 @@ const NotificationsList = ({ terms, currentUser, classes }: {
   } else if (loading) {
     return <Components.Loading/>
   } else {
-    return <div className={classes.empty}> You don't have any notifications yet!</div>
+    const modifier =
+        (terms.type === undefined) ? (<></>)
+      : (terms.type === 'newPost') ? (<b>new post</b>)
+      : (terms.type === 'newComment') ? (<b>new comment</b>)
+      : (terms.type === 'newMessage') ? (<b>new message</b>)
+      : "of these";
+    return <div className={classes.empty}> You don't have any {modifier} notifications yet!</div>
   }
 }
 


### PR DESCRIPTION
The notifications tabbed list currently gives the same "you don't have any notifications yet" message for every tab, which can be confusing -- at least, it confused me. Here's what it looks like after this PR:

![Selection_001](https://user-images.githubusercontent.com/5351154/162985787-967f487b-e231-4aaf-966e-021d40c37847.png)
![Selection_002](https://user-images.githubusercontent.com/5351154/162985800-d0f60bfa-5d3b-4d63-98c8-743504432f40.png)
![Selection_003](https://user-images.githubusercontent.com/5351154/162985810-33296150-687c-41b7-bb6e-68f96509c4ee.png)
![Selection_004](https://user-images.githubusercontent.com/5351154/162985821-a7d0b521-f675-4da2-8bc0-851505c7772f.png)


