### PR TITLE
Cleanup: Remove extraneous state from NotificationsMenu

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -74,10 +74,6 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
 }) => {
   const currentUser = useCurrentUser();
   const [tab,setTab] = useState(0);
-  const [notificationTerms,setNotificationTerms] = useState<NotificationsViewTerms>({view: 'userNotifications'});
-  const [lastNotificationsCheck,setLastNotificationsCheck] = useState(
-    (currentUser?.lastNotificationsCheck) || ""
-  );
   const { results } = useMulti({
     terms: {
       view: 'userNotifications',
@@ -91,88 +87,88 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
     enableTotal: false,
   });
 
+  const lastNotificationsCheck = currentUser?.lastNotificationsCheck ?? "";
   const newMessages = results && _.filter(results, (x) => x.createdAt > lastNotificationsCheck);
   if (!currentUser) {
     return null;
-  } else {
-  
-    const notificationCategoryTabs: Array<{ name: string, icon: ()=>React.ReactNode, terms: NotificationsViewTerms }> = [
-      {
-        name: "All Notifications",
-        icon: () => (<AllIcon classes={{root: classes.icon}}/>),
-        terms: {view: "userNotifications"},
-      },
-      {
-        name: "New Posts",
-        icon: () => (<PostsIcon classes={{root: classes.icon}}/>),
-        terms: {view: 'userNotifications', type: "newPost"},
-      },
-      {
-        name: "New Comments",
-        icon: () => (<CommentsIcon classes={{root: classes.icon}}/>),
-        terms: {view: 'userNotifications', type: "newComment"},
-      },
-      {
-        name: "New Messages",
-        icon: () => (
-          <Badge
-            classes={{ root: classes.badgeContainer, badge: classes.badge }}
-            badgeContent={(newMessages && newMessages.length) || ""}
-          >
-            <MailIcon classes={{root: classes.icon}} />
-          </Badge>
-        ),
-        terms: {view: 'userNotifications', type: "newMessage"},
-      }
-    ];
-  
-    return (
-      <div className={classes.root}>
-        <Components.ErrorBoundary>
-          {open && <SwipeableDrawer
-            open={open}
-            anchor="right"
-            onClose={() => setIsOpen(false)}
-            onOpen={() => setIsOpen(true)}
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            variant="persistent"
-          >
-            { hasOpened && <div className="notifications-menu-content">
-              <Tabs
-                fullWidth={true}
-                value={tab}
-                className={classes.tabBar}
-                onChange={(event, tabIndex) => {
-                  setTab(tabIndex);
-                  setNotificationTerms(notificationCategoryTabs[tabIndex].terms);
-                }}
-              >
-                {notificationCategoryTabs.map(notificationCategory =>
-                  <Tab
-                    icon={
-                      <span title={notificationCategory.name}>
-                        {notificationCategory.icon()}
-                      </span>
-                    }
-                    key={notificationCategory.name}
-                    className={classes.tabLabel}
-                  />
-                )}
-                
-                {/* Include an extra, hidden tab to reserve space for the
-                    close/X button (which hovers over the tabs). */}
-                <Tab className={classes.hiddenTab} />
-              </Tabs>
-              <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />
-              <Components.NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser} />
-            </div>}
-          </SwipeableDrawer>}
-        </Components.ErrorBoundary>
-      </div>
-    )
   }
+  const notificationCategoryTabs: Array<{ name: string, icon: ()=>React.ReactNode, terms: NotificationsViewTerms }> = [
+    {
+      name: "All Notifications",
+      icon: () => (<AllIcon classes={{root: classes.icon}}/>),
+      terms: {view: "userNotifications"},
+    },
+    {
+      name: "New Posts",
+      icon: () => (<PostsIcon classes={{root: classes.icon}}/>),
+      terms: {view: 'userNotifications', type: "newPost"},
+    },
+    {
+      name: "New Comments",
+      icon: () => (<CommentsIcon classes={{root: classes.icon}}/>),
+      terms: {view: 'userNotifications', type: "newComment"},
+    },
+    {
+      name: "New Messages",
+      icon: () => (
+        <Badge
+          classes={{ root: classes.badgeContainer, badge: classes.badge }}
+          badgeContent={(newMessages && newMessages.length) || ""}
+        >
+          <MailIcon classes={{root: classes.icon}} />
+        </Badge>
+      ),
+      terms: {view: 'userNotifications', type: "newMessage"},
+    }
+  ];
+  const category = notificationCategoryTabs[tab];
+  const notificationTerms = category.terms;
+
+  return (
+    <div className={classes.root}>
+      <Components.ErrorBoundary>
+        {open && <SwipeableDrawer
+          open={open}
+          anchor="right"
+          onClose={() => setIsOpen(false)}
+          onOpen={() => setIsOpen(true)}
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          variant="persistent"
+        >
+          { hasOpened && <div className="notifications-menu-content">
+            <Tabs
+              fullWidth={true}
+              value={tab}
+              className={classes.tabBar}
+              onChange={(event, tabIndex) => {
+                setTab(tabIndex);
+              }}
+            >
+              {notificationCategoryTabs.map(notificationCategory =>
+                <Tab
+                  icon={
+                    <span title={notificationCategory.name}>
+                      {notificationCategory.icon()}
+                    </span>
+                  }
+                  key={notificationCategory.name}
+                  className={classes.tabLabel}
+                />
+              )}
+              
+              {/* Include an extra, hidden tab to reserve space for the
+                  close/X button (which hovers over the tabs). */}
+              <Tab className={classes.hiddenTab} />
+            </Tabs>
+            <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />
+            <Components.NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser}/>
+          </div>}
+        </SwipeableDrawer>}
+      </Components.ErrorBoundary>
+    </div>
+  )
 };
 
 const NotificationsMenuComponent = registerComponent('NotificationsMenu', NotificationsMenu, {


### PR DESCRIPTION
This is just a small refactoring/cleanup change. Explanations are inline. Please view the diff with "hide whitespace".