### PR TITLE
Remove categories from LessWrong localgroups

### DIFF
--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -5,6 +5,7 @@ import { schemaDefaultValue } from '../../collectionUtils';
 import { forumTypeSetting } from '../../instanceSettings';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum';
+const isLW = forumTypeSetting.get() === 'LessWrong';
 
 export const GROUP_CATEGORIES = [
   {value: 'national', label: 'National'},
@@ -108,6 +109,7 @@ const schema: SchemaType<DbLocalgroup> = {
     form: {
       options: GROUP_CATEGORIES
     },
+    hidden: isLW,
   },
   
   'categories.$': {


### PR DESCRIPTION
EA Forum added a 'categories' field to localgroups which feels a bit redundant on LessWrong (it's similar to our "types" field, which is hidden on EA forum). This PR just hides it on LW.