### PR TITLE
Fix #4695 (Possible null result)

### DIFF
--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -287,7 +287,6 @@ export function useMulti<
   loading: boolean,
   loadingInitial: boolean,
   loadingMore: boolean,
-  // TODO: Should be nullable
   results: Array<FragmentTypes[FragmentTypeName]>,
   totalCount?: number,
   refetch: any,
@@ -390,8 +389,8 @@ export function useMulti<
     hidden: !showLoadMore,
   };
   
-  let results = data?.[resolverName]?.results;
-  if (results && results.length > limit) {
+  let results = data?.[resolverName]?.results ?? [];
+  if (results.length > limit) {
     results = _.take(results, limit);
   }
   


### PR DESCRIPTION
Tiny fix for https://github.com/ForumMagnum/ForumMagnum/issues/4695 -- possibility of null that that isn't allowed by the type --  the lazy way by just returning an empty array instead of null. This way no need to update callers (and easier for future callers too, I think).