### PR TITLE
hide map for online groups

### DIFF
--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -279,7 +279,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
   const isEAForum = forumTypeSetting.get() === 'EAForum';
   
   // by default, we try to show the map at the top if the group has a location
-  let topSection = group.googleLocation ? <CommunityMapWrapper
+  let topSection = (group.googleLocation && !group.isOnline) ? <CommunityMapWrapper
     className={classes.topSectionMap}
     terms={{view: "events", groupId: groupId}}
     groupQueryTerms={{view: "single", groupId: groupId}}
@@ -292,7 +292,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
     topSection = <div className={classes.imageContainer}>
       <CloudinaryImage2 imgProps={{ar: '191:100', w: '765'}} publicId={group.bannerImageId} className={classes.bannerImg} />
     </div>
-    smallMap = group.googleLocation && <CommunityMapWrapper
+    smallMap = (group.googleLocation && !group.isOnline) && <CommunityMapWrapper
       className={classes.mapContainer}
       terms={{view: "events", groupId: groupId}}
       groupQueryTerms={{view: "single", groupId: groupId}}


### PR DESCRIPTION
I noticed that a group that got converted from in-person to online (so still had a location) had a map on their page:

<img width="1107" alt="Screen Shot 2022-04-14 at 11 01 49 AM" src="https://user-images.githubusercontent.com/9057804/163418814-c8c2cd97-9985-4859-b8dc-2e9c35733903.png">
