### PR TITLE
Don't use akismet to review posts for spam

### DIFF
--- a/packages/lesswrong/server/akismet.ts
+++ b/packages/lesswrong/server/akismet.ts
@@ -63,7 +63,7 @@ async function constructAkismetReport({document, type = "post"}) {
     }
 }
 
-async function checkForAkismetSpam({document, type = "post"}) {
+async function checkForAkismetSpam({document, type}) {
   try {
     if (document?.contents?.html?.indexOf("spam-test-string-123") >= 0) {
       // eslint-disable-next-line no-console
@@ -81,30 +81,6 @@ async function checkForAkismetSpam({document, type = "post"}) {
     return false
   }
 }
-
-getCollectionHooks("Posts").newAfter.add(async function checkPostForSpamWithAkismet(post: DbPost, currentUser: DbUser|null) {
-  if (!currentUser) throw new Error("Submitted post has no associated user");
-  
-  if (akismetKeySetting.get()) {
-    const spam = await checkForAkismetSpam({document: post,type: "post"})
-    if (spam) {
-      if (((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD) && !currentUser.reviewedByUserId) {
-        // eslint-disable-next-line no-console
-        console.log("Deleting post from user below spam threshold", post)
-        await updateMutator({
-          collection: Posts,
-          documentId: post._id,
-          set: {status: postStatuses.STATUS_SPAM},
-          validate: false,
-        });
-      }
-    } else {
-      //eslint-disable-next-line no-console
-      console.log('Post marked as not spam', post._id);
-    }
-  }
-  return post
-});
 
 getCollectionHooks("Comments").newAfter.add(async function checkCommentForSpamWithAkismet(comment: DbComment, currentUser: DbUser|null) {
     if (!currentUser) throw new Error("Submitted comment has no associated user");


### PR DESCRIPTION
Quoting myself on slack:

> Does anyone know what purpose is served by akismet reviewing posts for spam? We still review posts that are marked as spam, so it doesn't save labor. And we don't show posts to users until after review, so it doesn't save time of spam on the frontpage. All that it seems to do is introduce an annoying problem where we have to manually fix posts that have been marked as spam. We could fix it so that if users are approved their posts are retroactively marked as not-spam, but instead it seems easier to just remove the entire check, as it is entirely without utility. Unless I'm missing something.

https://cea-core.slack.com/archives/C75BWSNBH/p1649971224115419

Gonna hold off on merging to give a chance for people to tell me I'm missing something.