### PR TITLE
Prevent React SSR mismatches from timestamps

### DIFF
--- a/packages/lesswrong/client/AppGenerator.tsx
+++ b/packages/lesswrong/client/AppGenerator.tsx
@@ -7,17 +7,22 @@ import { CookiesProvider } from 'react-cookie';
 // eslint-disable-next-line no-restricted-imports
 import { BrowserRouter } from 'react-router-dom';
 import { ABTestGroupsUsedContext, RelevantTestGroupAllocation } from '../lib/abTestImpl';
+import type { TimeOverride } from '../lib/utils/timeUtil';
 
-const AppGenerator = ({ apolloClient, abTestGroupsUsed }: {
+// Client-side wrapper around the app. There's another AppGenerator which is
+// the server-side version, which differs in how it sets up the wrappers for
+// routing and cookies and such.
+const AppGenerator = ({ apolloClient, abTestGroupsUsed, timeOverride }: {
   apolloClient: any,
   abTestGroupsUsed: RelevantTestGroupAllocation,
+  timeOverride: TimeOverride,
 }) => {
   const App = (
     <ApolloProvider client={apolloClient}>
       <CookiesProvider>
         <BrowserRouter>
           <ABTestGroupsUsedContext.Provider value={abTestGroupsUsed}>
-            <Components.App apolloClient={apolloClient} />
+            <Components.App apolloClient={apolloClient} timeOverride={timeOverride}/>
           </ABTestGroupsUsedContext.Provider>
         </BrowserRouter>
       </CookiesProvider>

--- a/packages/lesswrong/client/start.tsx
+++ b/packages/lesswrong/client/start.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import AppGenerator from './AppGenerator';
 import { onStartup } from '../lib/executionEnvironment';
+import type { TimeOverride } from '../lib/utils/timeUtil';
 
 import { createApolloClient } from './apolloClient';
 import { populateComponentsAppDebug } from '../lib/vulcan-lib';
@@ -10,6 +11,9 @@ onStartup(() => {
   populateComponentsAppDebug();
   const apolloClient = createApolloClient();
   apolloClient.disableNetworkFetches = true;
+  
+  const ssrRenderedAt: Date = (window as any).ssrRenderedAt;
+  const timeOverride: TimeOverride = {currentTime: ssrRenderedAt};
 
   // Create the root element, if it doesn't already exist.
   if (!document.getElementById('react-app')) {
@@ -19,12 +23,13 @@ onStartup(() => {
   }
 
   const Main = () => (
-    <AppGenerator apolloClient={apolloClient} abTestGroupsUsed={{}} />
+    <AppGenerator apolloClient={apolloClient} abTestGroupsUsed={{}} timeOverride={timeOverride}/>
   );
   
   const container = document.getElementById('react-app');
   const root = hydrateRoot(container!, <Main/>);
   setTimeout(() => {
     apolloClient.disableNetworkFetches = false;
+    timeOverride.currentTime = null;
   }, 0);
 });

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
+import { useCurrentTime } from '../../../lib/utils/timeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   blockedReplies: {
@@ -11,7 +12,8 @@ const CommentBottomCaveats = ({comment, classes}: {
   comment: CommentsList,
   classes: ClassesType,
 }) => {
-  const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > new Date();
+  const now = useCurrentTime();
+  const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > now;
   
   return <>
     { blockedReplies &&

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -13,6 +13,7 @@ import type { CommentTreeOptions } from '../commentTree';
 import { commentGetPageUrlFromIds } from '../../../lib/collections/comments/helpers';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 import { REVIEW_NAME_IN_SITU, REVIEW_YEAR, reviewIsActive, eligibleToNominate } from '../../../lib/reviewUtils';
+import { useCurrentTime } from '../../../lib/utils/timeUtil';
 
 const isEAForum= forumTypeSetting.get() === "EAForum"
 
@@ -139,6 +140,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   const [showReplyState, setShowReplyState] = useState(false);
   const [showEditState, setShowEditState] = useState(false);
   const [showParentState, setShowParentState] = useState(false);
+  const now = useCurrentTime();
   
   const currentUser = useCurrentUser();
 
@@ -214,7 +216,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   const renderCommentBottom = () => {
     const { CommentBottomCaveats } = Components
 
-    const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > new Date();
+    const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > now;
 
     const showReplyButton = (
       !hideReply &&

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
-import {
-  Components,
-  registerComponent
-} from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { useCurrentTime } from '../../lib/utils/timeUtil';
 import moment from 'moment';
 import { userIsAllowedToComment } from '../../lib/collections/users/helpers';
 import Menu from '@material-ui/core/Menu';
@@ -80,6 +78,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
   const [highlightDate,setHighlightDate] = useState<Date|undefined>(post?.lastVisitedAt && new Date(post.lastVisitedAt));
   const [anchorEl,setAnchorEl] = useState<HTMLElement|null>(null);
   const newCommentsSinceDate = highlightDate ? _.filter(comments, comment => new Date(comment.item.postedAt).getTime() > new Date(highlightDate).getTime()).length : 0;
+  const now = useCurrentTime();
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     setAnchorEl(event.currentTarget);
@@ -96,7 +95,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
 
   const renderTitleComponent = () => {
     const { CommentsListMeta, Typography } = Components
-    const suggestedHighlightDates = [moment().subtract(1, 'day'), moment().subtract(1, 'week'), moment().subtract(1, 'month'), moment().subtract(1, 'year')]
+    const suggestedHighlightDates = [moment(now).subtract(1, 'day'), moment(now).subtract(1, 'week'), moment(now).subtract(1, 'month'), moment(now).subtract(1, 'year')]
     const newLimit = commentCount + (loadMoreCount || commentCount)
     return <CommentsListMeta>
       <Typography
@@ -123,7 +122,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         {highlightDate && !newCommentsSinceDate && "No new comments since "}
         {!highlightDate && "Click to highlight new comments since: "}
         <a className={classes.button} onClick={handleClick}>
-          <Components.CalendarDate date={highlightDate || new Date()}/>
+          <Components.CalendarDate date={highlightDate || now}/>
         </a>
         <Menu
           anchorEl={anchorEl}

--- a/packages/lesswrong/components/common/FormatDate.tsx
+++ b/packages/lesswrong/components/common/FormatDate.tsx
@@ -2,6 +2,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import React from 'react';
 import moment from '../../lib/moment-timezone';
 import { useTimezone } from '../common/withTimezone';
+import { useCurrentTime } from '../../lib/utils/timeUtil';
 
 export const ExpandedDate = ({date}: {date: Date}) => {
   const { timezone } = useTimezone();
@@ -15,12 +16,13 @@ const FormatDate = ({date, format, tooltip=true}: {
   format?: string,
   tooltip?: boolean,
 }) => {
-
+  const now = useCurrentTime();
+  const dateToRender = date||now;
   const { LWTooltip } = Components
 
   const formatted: string = (format
-    ? moment(new Date(date)).format(format)
-    : moment(new Date(date)).fromNow()
+    ? moment(dateToRender).format(format)
+    : moment(dateToRender).from(now)
   );
   
   if (tooltip) {

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -11,12 +11,14 @@ import { Components, registerComponent, Strings } from '../../lib/vulcan-lib';
 import { userIdentifiedCallback } from '../../lib/analyticsEvents';
 import { MessageContext } from '../common/withMessages';
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
+import { TimeOverride, TimeContext } from '../../lib/utils/timeUtil';
 
 const siteImageSetting = new DatabasePublicSetting<string | null>('siteImage', 'https://res.cloudinary.com/lesswrong-2-0/image/upload/v1503704344/sequencesgrid/h6vrwdypijqgsop7xwa0.jpg') // An image used to represent the site on social media
 
 interface ExternalProps {
   apolloClient: any
   serverRequestStatus?: ServerRequestStatusContextType
+  timeOverride: TimeOverride
 }
 interface AppProps extends ExternalProps {
   // From withRouter
@@ -97,7 +99,7 @@ class App extends PureComponent<AppProps,any> {
   render() {
     const { flash } = this;
     const { messages } = this.state;
-    const { currentUser, serverRequestStatus } = this.props;
+    const { currentUser, serverRequestStatus, timeOverride } = this.props;
 
     // Parse the location into a route/params/query/etc.
     const location = parseRoute({location: this.props.location});
@@ -136,6 +138,7 @@ class App extends PureComponent<AppProps,any> {
       <SubscribeLocationContext.Provider value={this.subscribeLocationContext}>
       <NavigationContext.Provider value={this.navigationContext}>
       <ServerRequestStatusContext.Provider value={serverRequestStatus||null}>
+      <TimeContext.Provider value={timeOverride}>
       <IntlProvider locale={this.getLocale()} key={this.getLocale()} messages={Strings[this.getLocale()]}>
         <MessageContext.Provider value={{ messages, flash, clear: this.clear }}>
           <Components.HeadTags image={siteImageSetting.get()} />
@@ -145,6 +148,7 @@ class App extends PureComponent<AppProps,any> {
           </Components.Layout>
         </MessageContext.Provider>
       </IntlProvider>
+      </TimeContext.Provider>
       </ServerRequestStatusContext.Provider>
       </NavigationContext.Provider>
       </SubscribeLocationContext.Provider>

--- a/packages/lesswrong/lib/utils/timeUtil.ts
+++ b/packages/lesswrong/lib/utils/timeUtil.ts
@@ -1,4 +1,32 @@
+import React, { useContext } from 'react';
 import moment from '../moment-timezone';
+import { isClient } from '../executionEnvironment';
+
+export interface TimeOverride {
+  currentTime: Date|null;
+}
+export const TimeContext = React.createContext<TimeOverride>({currentTime: null});
+
+// useCurrentTime: If we're rehydrating a server-side render, returns the
+// time the SSR was prepared. If we're preparing an SSR, returns the time the
+// SSR was started. Otherwise return the current wall-clock time.
+// (This switch will not cause components to rerender during pageload.)
+//
+// The motivation for this is to prevent SSR mismatches caused by the time
+// that passes in between when the server renders a page, and when the client
+// hydrates the page into React. Components that display dates can use this as
+// a drop-in replacement for `new Date()` or `moment()` and should do so any
+// time they use the current time in a way that affects the HTML they return.
+// (This isn't necessary inside of event handlers or in any context that
+// isn't a component or used by components.)
+export function useCurrentTime(): Date {
+  const time = useContext(TimeContext);
+  if (time?.currentTime) {
+    return time.currentTime;
+  } else {
+    return new Date();
+  }
+}
 
 // Given a time of day (number of hours, 0-24), a day of the week (string or
 // number 0-6), and a pair of timezones, convert the time/day to the new time

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -191,7 +191,7 @@ export function startWebserver() {
   app.get('*', async (request, response) => {
     const renderResult = await renderWithCache(request, response);
     
-    const {ssrBody, headers, serializedApolloState, jssSheets, status, redirectUrl, allAbTestGroups} = renderResult;
+    const {ssrBody, headers, serializedApolloState, jssSheets, status, redirectUrl, renderedAt, allAbTestGroups} = renderResult;
     const {bundleHash} = getClientBundle();
 
     const clientScript = `<script defer src="/js/bundle.js?hash=${bundleHash}"></script>`
@@ -217,6 +217,7 @@ export function startWebserver() {
         + '<body class="'+classesForAbTestGroups(allAbTestGroups)+'">\n'
           + ssrBody
         +'</body>\n'
+        + embedAsGlobalVar("ssrRenderedAt", renderedAt)
         + serializedApolloState)
     }
   })

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
@@ -1,6 +1,3 @@
-/**
- * The App + relevant wrappers
- */
 import React from 'react';
 import { ApolloProvider } from '@apollo/client';
 // eslint-disable-next-line no-restricted-imports
@@ -11,16 +8,17 @@ import { ABTestGroupsUsedContext, RelevantTestGroupAllocation } from '../../../.
 import { ServerRequestStatusContextType } from '../../../../lib/vulcan-core/appContext';
 import type { CompleteTestGroupAllocation } from '../../../../lib/abTestImpl';
 import { getAllCookiesFromReq } from '../../../utils/httpUtil';
+import type { TimeOverride } from '../../../../lib/utils/timeUtil';
 
-// The client-side App will instead use <BrowserRouter>
-// see client-side vulcan:core/lib/client/start.jsx implementation
-// we do the same server side
-
-const AppGenerator = ({ req, apolloClient, serverRequestStatus, abTestGroupsUsed }: {
+// Server-side wrapper around the app. There's another AppGenerator which is
+// the client-side version, which differs in how it sets up the wrappers for
+// routing and cookies and such. See client/start.tsx.
+const AppGenerator = ({ req, apolloClient, serverRequestStatus, abTestGroupsUsed, timeOverride }: {
   req: any
   apolloClient: any
   serverRequestStatus: ServerRequestStatusContextType,
   abTestGroupsUsed: RelevantTestGroupAllocation,
+  timeOverride: TimeOverride,
 }) => {
   const App = (
     <ApolloProvider client={apolloClient}>
@@ -28,7 +26,7 @@ const AppGenerator = ({ req, apolloClient, serverRequestStatus, abTestGroupsUsed
       <StaticRouter location={req.url} context={{}}>
         <CookiesProvider cookies={getAllCookiesFromReq(req)}>
           <ABTestGroupsUsedContext.Provider value={abTestGroupsUsed}>
-            <Components.App apolloClient={apolloClient} serverRequestStatus={serverRequestStatus}/>
+            <Components.App apolloClient={apolloClient} serverRequestStatus={serverRequestStatus} timeOverride={timeOverride}/>
           </ABTestGroupsUsedContext.Provider>
         </CookiesProvider>
       </StaticRouter>


### PR DESCRIPTION
We display a lot of timestamps relative the current time; eg a comment's age may be displayed as `4m` for 4 minutes ago. However, using the system clock (with `new Date()` or `moment()`) breaks the rule that React components must always return the same thing when you rerun them; if the time that passes in between calls happens to cross from 3:59 to 4:00, the result will be different. This creates React SSR mismatches. It's particularly likely to happen when serving logged-out users from the page cache, which may be up to 90 seconds old. The symptoms of this aren't especially severe, but it creates a lot of console-log and Sentry spam, since it affects the logged-out front page.

To fix this, we attach a timestamp to renders, embed that in the page, and put that timestamp in a context-provider. Then after the first render is finished, we remove the time from the context provider (in a referentially stable way), so that any rerenders that happen after rehydration go back to using the system clock.

I wasn't thorough in hunting down all usages of the system clock in components, but I got the one which produces all the log spam, which is `FormatDate`. I tested that there are no longer React console errors after applying this change, that the timestamps on comments/etc revert to using the system clock when I poke at them, and that the relative timestamps in the initial render aren't off by more than the page-cache expiration.