### PR TITLE
[EA Forum only] Use html bio for community members tab

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -198,7 +198,7 @@ const CommunityMembers = ({userLocation, distanceUnit='km', locationFilterNode, 
           </div>
         </div>
         <div className={classes.location}>{hit.mapLocationAddress}</div>
-        {hit.bio && <div className={classes.description}>{hit.bio}</div>}
+        {hit.htmlBio && <div className={classes.description} dangerouslySetInnerHTML={{__html: hit.htmlBio}} />}
       </div>
     </div>
   }

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -111,7 +111,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[800],
     fontSize: 14,
     lineHeight: '1.8em',
-    whiteSpace: 'pre-wrap',
     display: '-webkit-box',
     "-webkit-line-clamp": 3,
     "-webkit-box-orient": 'vertical',

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -104,7 +104,7 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, classes}: {
             hideBottomLinks
           >
             <div className={classes.popupAddress}>{hit.mapLocationAddress}</div>
-            <div className={classes.popupBio}>{hit.bio}</div>
+            {hit.htmlBio && <div className={classes.popupBio} dangerouslySetInnerHTML={{__html: hit.htmlBio}} />}
           </StyledMapPopup>}
         </React.Fragment>
       })}

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -33,7 +33,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[800],
     fontSize: 14,
     lineHeight: '1.8em',
-    whiteSpace: 'pre-wrap',
     display: '-webkit-box',
     "-webkit-line-clamp": 3,
     "-webkit-box-orient": 'vertical',

--- a/packages/lesswrong/server/search/algoliaDocuments.d.ts
+++ b/packages/lesswrong/server/search/algoliaDocuments.d.ts
@@ -43,6 +43,7 @@ interface AlgoliaUser {
   createdAt: Date,
   isAdmin: boolean,
   bio: string,
+  htmlBio: string,
   karma: number,
   slug: string,
   website: string,

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -109,6 +109,7 @@ Users.toAlgolia = async (user: DbUser): Promise<Array<AlgoliaUser>|null> => {
     createdAt: user.createdAt,
     isAdmin: user.isAdmin,
     bio: user.bio?.slice(0, USER_BIO_MAX_SEARCH_CHARACTERS),
+    htmlBio: user.htmlBio?.slice(0, USER_BIO_MAX_SEARCH_CHARACTERS),
     karma: user.karma,
     slug: user.slug,
     website: user.website,


### PR DESCRIPTION
I thought it would be fine to use the `bio` field, but on prod it was a bit confusing when the `bio` and `htmlBio` (used on the actual profile page) were formatted differently, ex. links turn into long URL strings.