### PR TITLE
collapse Edit Account form groups by default

### DIFF
--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -149,7 +149,7 @@ const UsersMenu = ({color="rgba(0, 0, 0, 0.6)", classes}: {
                 <ListItemIcon>
                   <SettingsButton className={classes.icon}/>
                 </ListItemIcon>
-                Edit Settings
+                Edit Account
               </MenuItem>
             </Link>
             <Link to={`/inbox`}>

--- a/packages/lesswrong/lib/collections/conversations/schema.ts
+++ b/packages/lesswrong/lib/collections/conversations/schema.ts
@@ -1,5 +1,6 @@
 import { arrayOfForeignKeysField, denormalizedCountOfReferences } from '../../utils/schemaUtils'
 import * as _ from 'underscore';
+import { forumTypeSetting } from '../../instanceSettings';
 
 const schema: SchemaType<DbConversation> = {
   createdAt: {
@@ -50,6 +51,7 @@ const schema: SchemaType<DbConversation> = {
     insertableBy: ['members'],
     editableBy: ['admins'],
     optional: true,
+    hidden: !['LessWrong', 'AlignmentForum'].includes(forumTypeSetting.get())
   },
   messageCount: {
     ...denormalizedCountOfReferences({

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -203,6 +203,19 @@ addFieldsDict(Users, {
       }
     },
   },
+  
+  showHideKarmaOption: {
+    type: Boolean,
+    optional: true,
+    label: "Enable option on posts to hide karma visibility",
+    canRead: [userOwns, 'admins'],
+    canUpdate: [userOwnsAndInGroup('trustLevel1'), 'sunshineRegiment', 'admins'],
+    canCreate: ['members', 'sunshineRegiment', 'admins'],
+    hidden: forumTypeSetting.get() !== 'EAForum',
+    control: 'checkbox',
+    group: formGroups.siteCustomizations,
+    order: 69,
+  },
 
   // Intercom: Will the user display the intercom while logged in?
   hideIntercom: {
@@ -255,6 +268,45 @@ addFieldsDict(Users, {
     group: formGroups.siteCustomizations,
     hidden: forumTypeSetting.get() !== 'AlignmentForum',
     label: "Hide explanations of how AIAF submissions work for non-members", //TODO: just hide this in prod
+  },
+  
+  noSingleLineComments: {
+    order: 91,
+    type: Boolean,
+    optional: true,
+    group: formGroups.siteCustomizations,
+    defaultValue: false,
+    canRead: ['guests'],
+    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    canCreate: ['members'],
+    control: 'checkbox',
+    label: "Do not collapse comments to Single Line"
+  },
+
+  noCollapseCommentsPosts: {
+    order: 92,
+    type: Boolean,
+    optional: true,
+    group: formGroups.siteCustomizations,
+    defaultValue: false,
+    canRead: ['guests'],
+    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    canCreate: ['members'],
+    control: 'checkbox',
+    label: "Do not truncate comments (in large threads on Post Pages)"
+  },
+
+  noCollapseCommentsFrontpage: {
+    order: 93,
+    type: Boolean,
+    optional: true,
+    group: formGroups.siteCustomizations,
+    defaultValue: false,
+    canRead: ['guests'],
+    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    canCreate: ['members'],
+    control: 'checkbox',
+    label: "Do not truncate comments (on home page)"
   },
 
   hideNavigationSidebar: {
@@ -437,19 +489,6 @@ addFieldsDict(Users, {
     canCreate: ['members', 'sunshineRegiment', 'admins'],
     control: 'checkbox',
     order: 56,
-  },
-
-  showHideKarmaOption: {
-    type: Boolean,
-    optional: true,
-    label: "Enable option on posts to hide karma visibility",
-    canRead: [userOwns, 'admins'],
-    canUpdate: [userOwnsAndInGroup('trustLevel1'), 'sunshineRegiment', 'admins'],
-    canCreate: ['members', 'sunshineRegiment', 'admins'],
-    hidden: forumTypeSetting.get() !== 'EAForum',
-    control: 'checkbox',
-    group: formGroups.default,
-    order: 72,
   },
 
   // bannedUserIds: users who are not allowed to comment on this user's posts
@@ -1203,45 +1242,6 @@ addFieldsDict(Users, {
     canUpdate: [userOwns, 'sunshineRegiment'],
     hidden: !['LessWrong', 'AlignmentForum'].includes(forumTypeSetting.get()),
     order: 39,
-  },
-
-  noSingleLineComments: {
-    order: 70,
-    type: Boolean,
-    optional: true,
-    group: formGroups.truncationOptions,
-    defaultValue: false,
-    canRead: ['guests'],
-    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-    canCreate: ['members'],
-    control: 'checkbox',
-    label: "Do not collapse comments to Single Line"
-  },
-
-  noCollapseCommentsPosts: {
-    order: 70,
-    type: Boolean,
-    optional: true,
-    group: formGroups.truncationOptions,
-    defaultValue: false,
-    canRead: ['guests'],
-    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-    canCreate: ['members'],
-    control: 'checkbox',
-    label: "Do not truncate comments (in large threads on Post Pages)"
-  },
-
-  noCollapseCommentsFrontpage: {
-    order: 70,
-    type: Boolean,
-    optional: true,
-    group: formGroups.truncationOptions,
-    defaultValue: false,
-    canRead: ['guests'],
-    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-    canCreate: ['members'],
-    control: 'checkbox',
-    label: "Do not truncate comments (on home page)"
   },
 
   shortformFeedId: {

--- a/packages/lesswrong/lib/collections/users/formGroups.ts
+++ b/packages/lesswrong/lib/collections/users/formGroups.ts
@@ -9,11 +9,13 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     order:60,
     name: "moderation",
     label: "Moderation & Moderation Guidelines",
+    startCollapsed: true,
   },
   siteCustomizations: {
     order: 1,
     label: "Site Customizations",
-    name: "siteCustomizations"
+    name: "siteCustomizations",
+    startCollapsed: true,
   },
   banUser: {
     order:50,
@@ -24,12 +26,14 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
   notifications: {
     order: 10,
     name: "notifications",
-    label: "Notifications"
+    label: "Notifications",
+    startCollapsed: true,
   },
   emails: {
     order: 15,
     name: "emails",
-    label: "Emails"
+    label: "Emails",
+    startCollapsed: true,
   },
   paymentInfo: {
     name: "paymentInfo",
@@ -42,11 +46,5 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     order: 25,
     label: "Admin Options",
     startCollapsed: true,
-  },
-  truncationOptions: {
-    name: "truncationOptions",
-    order: 9,
-    label: "Comment Truncation Options",
-    startCollapsed: false,
   },
 }

--- a/packages/lesswrong/lib/vulcan-i18n-en-us.ts
+++ b/packages/lesswrong/lib/vulcan-i18n-en-us.ts
@@ -49,7 +49,7 @@ addStrings('en', {
 
   'settings': 'Settings',
   'settings.json_message': 'Note: settings already provided in your <code>settings.json</code> file will be disabled.',
-  'settings.edit': 'Edit Settings',
+  'settings.edit': 'Edit Account',
   'settings.edited': 'Settings edited (please reload).',
   'settings.title': 'Title',
   'settings.siteUrl': 'Site URL',


### PR DESCRIPTION
As I will be adding more fields to the Edit Account form, I wanted to clean it up a bit first. Worked with @jpaddison3 on this so he already pre-approved it. :)

Basically we moved some things into "Site Customization" and now all the sections are collapsed by default, so you might actually be able to see the "Submit" button when the page loads (prevents people from losing their changes by assuming this auto-saves).

<img width="580" alt="Screen Shot 2022-04-20 at 9 51 29 PM" src="https://user-images.githubusercontent.com/9057804/164505824-24415134-903f-408f-892a-a6497a2b8aed.png">
