### PR TITLE
Make type of useMulti result include possibility of undefined 

### DIFF
--- a/packages/lesswrong/components/comments/UserCommentsReplies.tsx
+++ b/packages/lesswrong/components/comments/UserCommentsReplies.tsx
@@ -24,7 +24,7 @@ const UserCommentsReplies = ({ classes }) => {
     fragmentName: 'UsersProfile',
     enableTotal: false,
   });
-  const user = getUserFromResults(userResults)
+  const user = getUserFromResults(userResults ?? null)
   const { loadingInitial, loadMoreProps, results } = useMulti({
     terms: {view: 'allRecentComments', authorIsUnreviewed: null, limit: 50, userId: user?._id},
     collectionName: "Comments",

--- a/packages/lesswrong/components/common/TabNavigationMenu/FeaturedResourceBanner.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/FeaturedResourceBanner.tsx
@@ -93,7 +93,7 @@ const FeaturedResourceBanner = ({terms, classes} : {
   const { Typography } = Components
 
   useEffect(() => {
-    if (loading || !results.length) {
+    if (loading || !results?.length) {
       return;
     }
 

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -52,7 +52,7 @@ const NotificationsMenuButton = ({ open, color, toggle, currentUser, classes }: 
     fetchPolicy: 'cache-and-network',
   });
   
-  let filteredResults: Array<NotificationsList> = results && _.filter(results,
+  let filteredResults: Array<NotificationsList> | undefined = results && _.filter(results,
     (x) => !currentUser.lastNotificationsCheck || x.createdAt > currentUser.lastNotificationsCheck
   );
 
@@ -84,4 +84,3 @@ declare global {
     NotificationsMenuButton: typeof NotificationsMenuButtonComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsByVoteWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsByVoteWrapper.tsx
@@ -23,7 +23,7 @@ const PostsByVoteWrapper = ({voteType, year}: {voteType: string, year: number | 
 
   if (loading) return <div><Loading/><Typography variant="body2">Loading Votes</Typography></div>
     
-  const postIds = votes.map(vote=>vote.documentId)
+  const postIds = (votes ?? []).map(vote=>vote.documentId)
 
   return <ErrorBoundary>
     <PostsByVote postIds={postIds} year={year}/>

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -18,6 +18,8 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
   
   if (loading && !results) {
     return <Components.Loading/>
+  } else if (!results) {
+    return null
   } else {
     const nestedComments = unflattenComments(results);
     return (
@@ -45,4 +47,3 @@ declare global {
     PostsCommentsThread: typeof PostsCommentsThreadComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
@@ -36,11 +36,11 @@ const PostsItemNewCommentsWrapper = ({ terms, classes, title, post, treeOptions,
   
   else {
     const lastCommentId = results && results[0]?._id
-    const nestedComments = unflattenComments(results);
+    const nestedComments = results && unflattenComments(results);
     return (
       <div>
         {title && <div className={classes.title}>{title}</div>}
-        <CommentsList
+        {nestedComments && <CommentsList
           treeOptions={{
             ...treeOptions,
             lastCommentId: lastCommentId,
@@ -49,7 +49,7 @@ const PostsItemNewCommentsWrapper = ({ terms, classes, title, post, treeOptions,
           comments={nestedComments}
           startThreadTruncated={true}
           forceSingleLine={forceSingleLine}
-        />
+        />}
         {loading && <Loading/>}
       </div>
     );
@@ -67,4 +67,3 @@ declare global {
     PostsItemNewCommentsWrapper: typeof PostsItemNewCommentsWrapperComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -143,7 +143,7 @@ const PostsList2 = ({
   const maybeMorePosts = !!(results?.length && (results.length >= limit)) || alwaysShowLoadMore;
 
   let orderedResults = results
-  if (defaultToShowUnreadComments) {
+  if (defaultToShowUnreadComments && results) {
     orderedResults = _.sortBy(results, (post) => {
       return !post.lastVisitedAt || (post.lastVisitedAt >=  postGetLastCommentedAt(post));
     })
@@ -172,7 +172,9 @@ const PostsList2 = ({
             tagRel: tagId ? (post as PostsListTag).tagRel : undefined,
             defaultToShowUnreadComments, showPostedAt,
             showQuestionTag: terms.filter!=="questions",
-            showBottomBorder: showFinalBottomBorder || ((orderedResults.length > 1) && i < (orderedResults.length - 1))
+            // I don't know why TS is not narrowing orderedResults away from
+            // undefined given the truthy check above
+            showBottomBorder: showFinalBottomBorder || ((orderedResults!.length > 1) && i < (orderedResults!.length - 1))
           };
 
           if (!(hidePosts && hidePosts[i])) {
@@ -210,4 +212,3 @@ declare global {
     PostsList2: typeof PostsList2Component
   }
 }
-

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -55,7 +55,7 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
   }
   
   const lastCommentId = results && results[0]?._id
-  const nestedComments = unflattenComments(results);
+  const nestedComments = results ? unflattenComments(results) : [];
   const placeholderArray = new Array(placeholderCount).fill(1)
 
   return (

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -26,7 +26,7 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
     collectionName: "Posts",
     fragmentName: 'PostsList',
   });
-  const curatedDate = new Date(curatedResults && curatedResults[0]?.curatedDate)
+  const curatedDate = curatedResults ? new Date(curatedResults[0]?.curatedDate) : new Date();
   const twoAndAHalfDaysAgo = new Date(new Date().getTime()-(2.5*24*60*60*1000));
 
   if (!belowFold && (curatedDate > twoAndAHalfDaysAgo)) return null
@@ -64,4 +64,3 @@ declare global {
     SunshineCuratedSuggestionsList: typeof SunshineCuratedSuggestionsListComponent
   }
 }
-

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -27,7 +27,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const SunshineNewUserCommentsList = ({comments, user, classes}: {
-  comments: Array<CommentsListWithParentMetadata>,
+  comments?: Array<CommentsListWithParentMetadata>,
   classes: ClassesType,
   user: SunshineUsersList
 }) => {
@@ -59,4 +59,3 @@ declare global {
     SunshineNewUserCommentsList: typeof SunshineNewUserCommentsListComponent
   }
 }
-

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -30,7 +30,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const SunshineNewUserPostsList = ({posts, user, classes}: {
-  posts: SunshinePostsList[],
+  posts?: SunshinePostsList[],
   classes: ClassesType,
   user: SunshineUsersList
 }) => {
@@ -69,4 +69,3 @@ declare global {
     SunshineNewUserPostsList: typeof SunshineNewUserPostsListComponent
   }
 }
-

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -46,7 +46,7 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
     return <Loading/>
   
   return <div className={classes.root}>
-    {results.map(tag => <span key={tag._id} className={classes.tag}>
+    {results?.map(tag => <span key={tag._id} className={classes.tag}>
       <Checkbox
         className={classes.checkbox}
         checked={selections[tag._id]}
@@ -69,4 +69,3 @@ declare global {
     CoreTagsChecklist: typeof CoreTagsChecklistComponent
   }
 }
-

--- a/packages/lesswrong/components/tagging/PostsPageTopTag.tsx
+++ b/packages/lesswrong/components/tagging/PostsPageTopTag.tsx
@@ -19,7 +19,7 @@ const TopTagInner = ({ post, tag }: {post: PostsDetails, tag: TagPreviewFragment
   });
 
   let tagRel: TagRelMinimumFragment | null = null
-  if(!loading && results.filter(tagRelResult => tagRelResult.tagId === tag._id).length > 0) {
+  if(!loading && results && results.filter(tagRelResult => tagRelResult.tagId === tag._id).length > 0) {
     tagRel = results.filter(tagRelResult => tagRelResult.tagId === tag._id)[0]
   }
   return <FooterTag tag={tag} tagRel={tagRel || undefined} hideScore isTopTag />

--- a/packages/lesswrong/components/tagging/TagDiscussion.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussion.tsx
@@ -56,7 +56,8 @@ const TagDiscussion = ({classes, tag}: {
         postPage: true,
       }}
       totalComments={totalCount}
-      comments={nestedComments}
+      // Will be defined if results is defined, and we know results is truthy
+      comments={nestedComments!}
     />}
     <Link to={`/tag/${tag.slug}/discussion`} className={classes.seeAll}>
       See all

--- a/packages/lesswrong/components/tagging/TagDiscussionSection.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionSection.tsx
@@ -40,7 +40,9 @@ const TagDiscussionSection = ({classes, tag}: {
   
   const nestedComments = !!results && unflattenComments(results);
   
-  return (  
+  if (!nestedComments) return null
+  
+  return (
     <CommentsListSection
       comments={nestedComments} tag={tag ? tag : undefined}
       loadMoreComments={loadMore}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -205,10 +205,10 @@ const TagPage = ({classes}: {
   const [nextTagPosition, setNextTagPosition] = useState<number | null>(null);
   useEffect(() => {
     // Initial list position setting
-    if (tagPositionInList >= 0) {
+    if (tagPositionInList && tagPositionInList >= 0) {
       setNextTagPosition(tagPositionInList + 1)
     }
-    if (nextTagPosition !== null && tagPositionInList < 0) {
+    if (nextTagPosition !== null && tagPositionInList && tagPositionInList < 0) {
       // Here we want to decrement the list positions by one, because we removed the original tag and so
       // all the indices are moved to the next
       setNextTagPosition(nextTagPosition => (nextTagPosition || 1) - 1)

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -93,7 +93,7 @@ const sortings: Partial<Record<string,string>> = {
   top: "Top"
 }
 
-export const getUserFromResults = <T extends UsersMinimumInfo>(results: Array<T>|null): T|null => {
+export const getUserFromResults = <T extends UsersMinimumInfo>(results: Array<T>|null|undefined): T|null => {
   // HOTFIX: Filtering out invalid users
   return results?.find(user => !!user.displayName) || results?.[0] || null
 }

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -287,8 +287,7 @@ export function useMulti<
   loading: boolean,
   loadingInitial: boolean,
   loadingMore: boolean,
-  // TODO: Should be nullable
-  results: Array<FragmentTypes[FragmentTypeName]>,
+  results?: Array<FragmentTypes[FragmentTypeName]>,
   totalCount?: number,
   refetch: any,
   error: ApolloError|undefined,

--- a/packages/lesswrong/lib/filterSettings.ts
+++ b/packages/lesswrong/lib/filterSettings.ts
@@ -128,7 +128,7 @@ export const useFilterSettings = () => {
   }, [setFilterSettings, filterSettings, captureEvent])
   
   const removeTagFilter = useCallback((tagId: string) => {
-    if (suggestedTags.find(tag => tag._id === tagId)) {
+    if (suggestedTags && suggestedTags.find(tag => tag._id === tagId)) {
       throw new Error("Can't remove suggested tag")
     }
     captureEvent("tagRemovedFromFilters", {tagId});


### PR DESCRIPTION
After twice implementing a new component and running into a bug that was due to the incorrect typing of useMulti, I have finally fixed it. useMulti can absolutely return undefined results (ie: when loading, or when there's an error).

This is a risky PR. The previous [similar PR](https://github.com/ForumMagnum/ForumMagnum/pull/4213), applying this treatment to the useSingle hook, has been the cause of a few bugs. I was the author of that PR, while pairing with the (in an unrelated status update, now departed from GWWC) Jasper. That one we were pretty aggressive about returning null at the first sign of trouble. In this PR I've spent significantly more time on it, and tried to match existing behavior, or, where I thought the existing behavior was to throw an error, to read code pretty carefully and do something sensible. However, I have not tested every component I've touched.