### PR TITLE
[EA Forum only] fix Community Members tab in Safari

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -187,7 +187,7 @@ const CommunityMembers = ({userLocation, distanceUnit='km', locationFilterNode, 
     if (userLocation.known && hit._geoloc) {
       distanceToPerson = `${distance(userLocation, hit._geoloc, distanceUnit)} ${distanceUnit}`
     }
-    
+        
     return <div className={classes.person}>
       <div className={classes.content}>
         <div className={classes.nameRow}>
@@ -197,7 +197,7 @@ const CommunityMembers = ({userLocation, distanceUnit='km', locationFilterNode, 
           </div>
         </div>
         <div className={classes.location}>{hit.mapLocationAddress}</div>
-        {hit.htmlBio && <div className={classes.description} dangerouslySetInnerHTML={{__html: hit.htmlBio}} />}
+        {hit.htmlBio && <div className={classes.description} dangerouslySetInnerHTML={{__html: `${hit.htmlBio.split('</p>')[0]}</p>`}} />}
       </div>
     </div>
   }

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -197,7 +197,7 @@ const CommunityMembers = ({userLocation, distanceUnit='km', locationFilterNode, 
           </div>
         </div>
         <div className={classes.location}>{hit.mapLocationAddress}</div>
-        {hit.htmlBio && <div className={classes.description} dangerouslySetInnerHTML={{__html: `${hit.htmlBio.split('</p>')[0]}</p>`}} />}
+        {hit.htmlBio && <div className={classes.description}><div dangerouslySetInnerHTML={{__html: hit.htmlBio}} /></div>}
       </div>
     </div>
   }

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -187,7 +187,7 @@ const CommunityMembers = ({userLocation, distanceUnit='km', locationFilterNode, 
     if (userLocation.known && hit._geoloc) {
       distanceToPerson = `${distance(userLocation, hit._geoloc, distanceUnit)} ${distanceUnit}`
     }
-        
+    
     return <div className={classes.person}>
       <div className={classes.content}>
         <div className={classes.nameRow}>

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -677,10 +677,14 @@ interface DbUser extends DbObject {
   legacy: boolean
   commentSorting: string
   sortDrafts: string
+  showHideKarmaOption: boolean
   hideIntercom: boolean
   markDownPostEditor: boolean
   hideElicitPredictions: boolean
   hideAFNonMemberInitialWarning: boolean
+  noSingleLineComments: boolean
+  noCollapseCommentsPosts: boolean
+  noCollapseCommentsFrontpage: boolean
   hideNavigationSidebar: boolean
   currentFrontpageFilter: string
   frontpageFilterSettings: any /*{"definitions":[{"blackbox":true}]}*/
@@ -699,7 +703,6 @@ interface DbUser extends DbObject {
   moderationStyle: string
   moderatorAssistance: boolean
   collapseModerationGuidelines: boolean
-  showHideKarmaOption: boolean
   bannedUserIds: Array<string>
   bannedPersonalUserIds: Array<string>
   bookmarkedPostsMetadata: Array<any /*{"definitions":[{}]}*/>
@@ -766,9 +769,6 @@ interface DbUser extends DbObject {
   bigUpvoteCount: number
   bigDownvoteCount: number
   fullName: string
-  noSingleLineComments: boolean
-  noCollapseCommentsPosts: boolean
-  noCollapseCommentsFrontpage: boolean
   shortformFeedId: string
   viewUnreviewedComments: boolean
   partiallyReadSequences: Array<any /*{"definitions":[{"type":{"_constructorOptions":{"humanizeAutoLabels":true,"requiredByDefault":true},"_cleanOptions":{"autoConvert":true,"extendAutoValueContext":{},"filter":true,"getAutoValues":true,"removeEmptyStrings":true,"removeNullsFromArrays":false,"trimStrings":true},"_validators":[],"_docValidators":[],"_validationContexts":{},"_schema":{"sequenceId":{"foreignKey":"Sequences","optional":true,"type":{"definitions":[{}]},"label":"Sequence ID"},"collectionId":{"foreignKey":"Collections","optional":true,"type":{"definitions":[{}]},"label":"Collection ID"},"lastReadPostId":{"foreignKey":"Posts","type":{"definitions":[{}]},"optional":false,"label":"Last read post ID"},"nextPostId":{"foreignKey":"Posts","type":{"definitions":[{}]},"optional":false,"label":"Next post ID"},"numRead":{"type":{"definitions":[{"type":"SimpleSchema.Integer"}]},"optional":false,"label":"Num read"},"numTotal":{"type":{"definitions":[{"type":"SimpleSchema.Integer"}]},"optional":false,"label":"Num total"},"lastReadTime":{"optional":true,"type":{"definitions":[{}]},"label":"Last read time"}},"_depsLabels":{},"_schemaKeys":["sequenceId","collectionId","lastReadPostId","nextPostId","numRead","numTotal","lastReadTime"],"_autoValues":[],"_blackboxKeys":{},"_firstLevelSchemaKeys":["sequenceId","collectionId","lastReadPostId","nextPostId","numRead","numTotal","lastReadTime"],"_objectKeys":{},"messageBox":{"language":"en","messageList":{"en":{"required":"{{{label}}} is required","minString":"{{{label}}} must be at least {{min}} characters","maxString":"{{{label}}} cannot exceed {{max}} characters","minNumber":"{{{label}}} must be at least {{min}}","maxNumber":"{{{label}}} cannot exceed {{max}}","minNumberExclusive":"{{{label}}} must be greater than {{min}}","maxNumberExclusive":"{{{label}}} must be less than {{max}}","minDate":"{{{label}}} must be on or after {{min}}","maxDate":"{{{label}}} cannot be after {{max}}","badDate":"{{{label}}} is not a valid date","minCount":"You must specify at least {{minCount}} values","maxCount":"You cannot specify more than {{maxCount}} values","noDecimal":"{{{label}}} must be an integer","notAllowed":"{{{value}}} is not an allowed value","expectedType":"{{{label}}} must be of type {{dataType}}","keyNotInSchema":"{{name}} is not allowed by the schema"}},"interpolate":{},"escape":{}},"version":2}}]}*/>


### PR DESCRIPTION
Sadly for everyone, Safari doesn't handle [line clamping](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp) mixed with nested HTML very well. [Adding an extra `div`](https://stackoverflow.com/questions/57546280/clamping-lines-with-line-clamp-and-nested-p-tags) seems to make it look not broken on Safari, and still works fine for other browsers, so I went with that solution.

<img src="https://user-images.githubusercontent.com/9057804/164564444-d71d63c2-3e6f-47e2-b666-5ebaae328e4c.png" width="400">
