### PR TITLE
User profile page shows both location fields

### DIFF
--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -269,7 +269,7 @@ const Community = ({classes}: {
   
   // if the current user provides their browser location and we don't have a location saved for them,
   // save it accordingly
-  const [mapsLoaded, googleMaps] = useGoogleMaps("CommunityHome")
+  const [mapsLoaded, googleMaps] = useGoogleMaps()
   const [geocodeError, setGeocodeError] = useState(false)
   const saveReverseGeocodedLocation = async ({lat, lng, known}) => {
     if (

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -239,7 +239,7 @@ const EventsHome = ({classes}: {
   
   // if the current user provides their browser location and we don't have a location saved for them,
   // save it accordingly
-  const [mapsLoaded, googleMaps] = useGoogleMaps("CommunityHome")
+  const [mapsLoaded, googleMaps] = useGoogleMaps()
   const [geocodeError, setGeocodeError] = useState(false)
   const saveReverseGeocodedLocation = async ({lat, lng, known}) => {
     if (

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -57,7 +57,7 @@ const CommunityHome = ({classes}: {
   
   // if the current user provides their browser location and they do not yet have a location in their user settings,
   // assign their browser location to their user settings location
-  const [mapsLoaded, googleMaps] = useGoogleMaps("CommunityHome")
+  const [mapsLoaded, googleMaps] = useGoogleMaps()
   const [geocodeError, setGeocodeError] = useState(false)
   const updateUserLocation = useCallback(async ({lat, lng, known}) => {
     if (isEAForum && mapsLoaded && !geocodeError && currentUser && !currentUser.location && known) {

--- a/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
+++ b/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
@@ -114,7 +114,7 @@ const EventNotificationsDialog = ({ onClose, classes }: {
   const { Loading, Typography, LWDialog } = Components
   const { nearbyEventsNotificationsLocation, mapLocation, googleLocation, nearbyEventsNotificationsRadius, nearbyPeopleNotificationThreshold } = currentUser || {}
 
-  const [ mapsLoaded ] = useGoogleMaps("CommunityHome")
+  const [ mapsLoaded ] = useGoogleMaps()
   const [ location, setLocation ] = useState(nearbyEventsNotificationsLocation || mapLocation || googleLocation)
   const [ label, setLabel ] = useState(nearbyEventsNotificationsLocation?.formatted_address || mapLocation?.formatted_address || googleLocation?.formatted_address)
   const [ distance, setDistance ] = useState(nearbyEventsNotificationsRadius || 50)

--- a/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
+++ b/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
@@ -28,7 +28,7 @@ const SetPersonalMapLocationDialog = ({ onClose, classes }: {
   const { mapLocation, googleLocation, mapMarkerText, bio } = currentUser || {}
   const { Loading, Typography, LWDialog } = Components
   
-  const [ mapsLoaded ] = useGoogleMaps("CommunityHome")
+  const [ mapsLoaded ] = useGoogleMaps()
   const [ location, setLocation ] = useState(mapLocation || googleLocation)
   const [ label, setLabel ] = useState(mapLocation?.formatted_address || googleLocation?.formatted_address)
   const [ mapText, setMapText ] = useState(mapMarkerText || bio)

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionMeetupsPoke.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionMeetupsPoke.tsx
@@ -60,7 +60,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const RecentDiscussionMeetupsPoke = ({classes}: {
   classes: ClassesType,
 }) => {
-  const [mapsLoaded, googleMaps] = useGoogleMaps("CommunityHome")
+  const [mapsLoaded, googleMaps] = useGoogleMaps()
   const [geolocationLoading, setGeolocationLoading] = useState(false);
   const [label, setLabel] = useState<any>(null)
   const [location, setLocation] = useState<any>(null);

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -837,7 +837,7 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: ['members', 'sunshineRegiment', 'admins'],
-    label: "Group Location",
+    label: "Event Location",
     control: 'LocationFormComponent',
     blackbox: true,
     group: formGroups.event,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -889,10 +889,10 @@ addFieldsDict(Users, {
   // Should match googleLocation/location
   // Determines which events are considered nearby for default sorting on the community page
   // Determines where the community map is centered/zoomed in on by default
-  // Publicly readable but not shown to other users
+  // Not shown to other users
   mongoLocation: {
     type: Object,
-    canRead: ['guests'],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     blackbox: true,
     optional: true,
     ...denormalizedField({
@@ -911,12 +911,12 @@ addFieldsDict(Users, {
     form: {
       stringVersionFieldName: "location",
     },
-    canRead: ['guests'],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     group: formGroups.default,
-    hidden: false,
-    label: "Location",
+    hidden: !hasEventsSetting.get(),
+    label: "Account location (used for location-based recommendations)",
     control: 'LocationFormComponent',
     blackbox: true,
     optional: true,
@@ -925,7 +925,7 @@ addFieldsDict(Users, {
 
   location: {
     type: String,
-    canRead: ['guests'],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
     hidden: true,
@@ -940,8 +940,7 @@ addFieldsDict(Users, {
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     group: formGroups.default,
-    hidden: false,
-    label: "Your location on the community map",
+    label: "Public location (used for your public profile)",
     control: 'LocationFormComponent',
     blackbox: true,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -902,12 +902,15 @@ addFieldsDict(Users, {
 
   googleLocation: {
     type: Object,
+    form: {
+      stringVersionFieldName: "location",
+    },
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     group: formGroups.default,
-    hidden: !hasEventsSetting.get(),
-    label: "Group Location",
+    hidden: false,
+    label: "Location",
     control: 'LocationFormComponent',
     blackbox: true,
     optional: true,
@@ -928,7 +931,8 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-    hidden: true,
+    group: formGroups.default,
+    hidden: false,
     label: "Your location on the community map",
     control: 'LocationFormComponent',
     blackbox: true,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -886,6 +886,10 @@ addFieldsDict(Users, {
     canRead: ['guests'],
   },
 
+  // Should match googleLocation/location
+  // Determines which events are considered nearby for default sorting on the community page
+  // Determines where the community map is centered/zoomed in on by default
+  // Publicly readable but not shown to other users
   mongoLocation: {
     type: Object,
     canRead: ['guests'],
@@ -900,6 +904,8 @@ addFieldsDict(Users, {
     }),
   },
 
+  // Is the canonical value for denormalized mongoLocation and location
+  // Edited from the /events page to choose where to show events near
   googleLocation: {
     type: Object,
     form: {
@@ -926,6 +932,8 @@ addFieldsDict(Users, {
     optional: true
   },
 
+  // Used to place a map marker pin on the where-are-other-users map.
+  // Public.
   mapLocation: {
     type: Object,
     canRead: ['guests'],
@@ -980,6 +988,7 @@ addFieldsDict(Users, {
     ...schemaDefaultValue(false),
   },
 
+  // Should probably be merged with the other location field.
   nearbyEventsNotificationsLocation: {
     type: Object,
     canRead: [userOwns, 'sunshineRegiment', 'admins'],


### PR DESCRIPTION
Changes Google Maps loading and field-name handling in LocationFormComponent
so that having multiple location fields on the page at once works properly.
Slightly changes the location-input styling (there is now a label,
separate from the placeholder, so you can tell the two fields apart).

Co-Authored-By: Sarah Cheng <sarah.cheng@centreforeffectivealtruism.org>