### PR TITLE
mark users who add themselves to the map as "needs review" if they haven't been reviewed

### DIFF
--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -82,6 +82,13 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
   }
 });
 
+getCollectionHooks("Users").editSync.add(function mapLocationMayTriggerReview(modifier, user: DbUser) {
+  // if mapLocation is being modified and the user is not reviewed, mark them for review
+  if (modifier.$set && modifier.$set.mapLocation && !user.reviewedByUserId) {
+    modifier.$set.needsReview = true
+  }
+})
+
 // When the very first user account is being created, add them to Sunshine
 // Regiment. Patterned after a similar callback in
 // vulcan-users/lib/server/callbacks.js which makes the first user an admin.

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -82,10 +82,10 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
   }
 });
 
-getCollectionHooks("Users").editSync.add(function mapLocationMayTriggerReview(modifier, user: DbUser) {
-  // if mapLocation is being modified and the user is not reviewed, mark them for review
-  if (modifier.$set && modifier.$set.mapLocation && !user.reviewedByUserId) {
-    modifier.$set.needsReview = true
+getCollectionHooks("Users").editAsync.add(function mapLocationMayTriggerReview(newUser: DbUser, oldUser: DbUser) {
+  // if the user has a mapLocation and they have not been reviewed, mark them for review
+  if (newUser.mapLocation && !newUser.reviewedByUserId && !newUser.needsReview) {
+    void Users.rawUpdateOne({_id: newUser._id}, {$set: {needsReview: true}})
   }
 })
 


### PR DESCRIPTION
In an effort to reduce the number of spam accounts that appear on our [map of users](https://forum.effectivealtruism.org/community#individuals), I'm flagging users who add themselves to the map as `needsReview` if they haven't already been reviewed. For now I'm not hiding them from the list/map while they are in this state, since I'm assuming users marked as `needsReview` tend to get reviewed within a few days, and most accounts who go through this process are not spam.

Currently, our database has around 10K users who have been reviewed and 7.5K who have not, so I would prefer not to filter out all users who have not been reviewed.

