### PR TITLE
[EA Forum only?] fix bug that prevented new users from changing their usernames

### DIFF
--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -44,7 +44,9 @@ getCollectionHooks("Users").editAsync.add(async function userEditNullifyVotesCal
 });
 
 getCollectionHooks("Users").editAsync.add(async function userEditChangeDisplayNameCallbacksAsync(user: DbUser, oldUser: DbUser) {
-  if (user.displayName !== oldUser.displayName) {
+  // on the EA Forum, we assign new users a randomized "new_user_#" which we prompt them to change right away,
+  // and we don't want this action to count toward their one username change
+  if (user.displayName !== oldUser.displayName && !oldUser.displayName.startsWith('new_user_')) {
     await updateMutator({
       collection: Users,
       documentId: user._id,

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -44,9 +44,10 @@ getCollectionHooks("Users").editAsync.add(async function userEditNullifyVotesCal
 });
 
 getCollectionHooks("Users").editAsync.add(async function userEditChangeDisplayNameCallbacksAsync(user: DbUser, oldUser: DbUser) {
-  // on the EA Forum, we assign new users a randomized "new_user_#" which we prompt them to change right away,
-  // and we don't want this action to count toward their one username change
-  if (user.displayName !== oldUser.displayName && !oldUser.displayName.startsWith('new_user_')) {
+  // if the user is setting up their profile and their username changes from that form,
+  // we don't want this action to count toward their one username change
+  const isSettingUsername = oldUser.usernameUnset && !user.usernameUnset
+  if (user.displayName !== oldUser.displayName && !isSettingUsername) {
     await updateMutator({
       collection: Users,
       documentId: user._id,


### PR DESCRIPTION
We want to give all users one chance to change their usernames themselves (although this is not explained anywhere). After that they would need to contact us to make further changes.

On the EA Forum, we randomly assign new users a username like `new_user_#` and immediately prompt them to change it, which means they use up that one chance right away. (See below for an admin view of a new user's account.) This PR is for us to ignore this initial step of setting up the username.

<img width="378" alt="Screen Shot 2022-04-27 at 1 03 53 PM" src="https://user-images.githubusercontent.com/9057804/165596881-0d611108-9d48-4e26-9ba6-442924e1e70a.png">
