### PR TITLE
fix bug that stopped populating location fields

### DIFF
--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -144,6 +144,9 @@ const schema: SchemaType<DbLocalgroup> = {
 
   googleLocation: {
     type: Object,
+    form: {
+      stringVersionFieldName: "location",
+    },
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: ['members'],

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -833,6 +833,9 @@ addFieldsDict(Posts, {
 
   googleLocation: {
     type: Object,
+    form: {
+      stringVersionFieldName: "location",
+    },
     hidden: (props) => !props.eventForm,
     viewableBy: ['guests'],
     insertableBy: ['members'],


### PR DESCRIPTION
When we updated the `LocationFormComponent`, we forgot to update all the necessary fields to match.