### PR TITLE
Type-annotate our extensions to the Window object

### DIFF
--- a/packages/lesswrong/client/apolloClient.ts
+++ b/packages/lesswrong/client/apolloClient.ts
@@ -25,7 +25,7 @@ export const createApolloClient = () => {
       ...apolloCacheVoteablePossibleTypes()
     }
   })
-    .restore((window as any).__APOLLO_STATE__); //ssr
+    .restore(window.__APOLLO_STATE__); //ssr
   
   const httpLink = new BatchHttpLink({
     uri: '/graphql',

--- a/packages/lesswrong/client/publicSettings.ts
+++ b/packages/lesswrong/client/publicSettings.ts
@@ -1,4 +1,4 @@
 import { setPublicSettings } from '../lib/settingsCache'
 
 // Here we load publicSettings from the data we injected in a header in `renderPage.ts` 
-setPublicSettings((window as any).publicSettings);
+setPublicSettings(window.publicSettings);

--- a/packages/lesswrong/client/start.tsx
+++ b/packages/lesswrong/client/start.tsx
@@ -12,7 +12,7 @@ onStartup(() => {
   const apolloClient = createApolloClient();
   apolloClient.disableNetworkFetches = true;
   
-  const ssrRenderedAt: Date = (window as any).ssrRenderedAt;
+  const ssrRenderedAt: Date = window.ssrRenderedAt;
   const timeOverride: TimeOverride = {currentTime: ssrRenderedAt};
 
   // Create the root element, if it doesn't already exist.
@@ -23,7 +23,7 @@ onStartup(() => {
   }
 
   const Main = () => (
-    <AppGenerator apolloClient={apolloClient} abTestGroupsUsed={{}} themeOptions={(window as any).themeOptions} timeOverride={timeOverride} />
+    <AppGenerator apolloClient={apolloClient} abTestGroupsUsed={{}} themeOptions={window.themeOptions} timeOverride={timeOverride} />
   );
 
   const container = document.getElementById('react-app');

--- a/packages/lesswrong/components/common/ReCaptcha.tsx
+++ b/packages/lesswrong/components/common/ReCaptcha.tsx
@@ -23,8 +23,8 @@ const defaultProps = {
 
 const isReady = () =>
   typeof window !== 'undefined' &&
-  typeof (window as any).grecaptcha !== 'undefined' &&
-  typeof (window as any).grecaptcha.execute !== 'undefined'
+  typeof window.grecaptcha !== 'undefined' &&
+  typeof window.grecaptcha.execute !== 'undefined'
 
 let readyCheck
 
@@ -77,7 +77,7 @@ class ReCaptcha extends Component<ReCaptchaProps,ReCaptchaState> {
     } = this.props
 
     if (this.state.ready) {
-      (window as any).grecaptcha.execute(sitekey, { action })
+      window.grecaptcha.execute(sitekey, { action })
         .then(token => {
 
           if (typeof verifyCallback !== 'undefined') {

--- a/packages/lesswrong/components/form-components/LocationFormComponent.tsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.tsx
@@ -110,7 +110,7 @@ export const useGoogleMaps = (): [boolean, any] => {
         var tag = document.createElement('script');
         tag.async = false;
         tag.src = `https://maps.googleapis.com/maps/api/js?key=${mapsAPIKeySetting.get()}&libraries=places&callback=googleMapsFinishedLoading`;
-        (window as any).googleMapsFinishedLoading = () => {
+        window.googleMapsFinishedLoading = () => {
           mapsLoadingState = "loaded";
           let callbacks = onMapsLoaded;
           onMapsLoaded = [];
@@ -124,7 +124,7 @@ export const useGoogleMaps = (): [boolean, any] => {
   }, []);
   
   if (!isMapsLoaded) return [false, null];
-  return [true, (window as any)?.google?.maps];
+  return [true, window?.google?.maps];
 }
 
 

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -93,7 +93,7 @@ const PostSubmit = ({
             if (!!document.title) {
               updateCurrentValues({draft: true});
               // eslint-disable-next-line
-              (window as any).Intercom(
+              window.Intercom(
                 'trackEvent',
                 'requested-feedback',
                 {title: document.title, _id: document._id, url: getSiteUrl() + "posts/" + document._id}

--- a/packages/lesswrong/components/themes/ThemePickerMenu.tsx
+++ b/packages/lesswrong/components/themes/ThemePickerMenu.tsx
@@ -61,16 +61,16 @@ const ThemePickerMenu = ({children, classes}: {
 }) => {
   const [cookies, setCookie] = useCookies([THEME_COOKIE_NAME]);
   const { LWTooltip, Typography } = Components;
-  const [currentThemeOptions, setCurrentThemeOptions] = useState((window as any)?.themeOptions as ThemeOptions);
+  const [currentThemeOptions, setCurrentThemeOptions] = useState(window?.themeOptions);
   const setPageTheme = useSetTheme();
   const currentUser = useCurrentUser();
   
   const setTheme = async (themeOptions: ThemeOptions) => {
     setCurrentThemeOptions(themeOptions);
-    if (JSON.stringify((window as any).themeOptions) !== JSON.stringify(themeOptions)) {
-      const oldThemeOptions = (window as any).themeOptions;
+    if (JSON.stringify(window.themeOptions) !== JSON.stringify(themeOptions)) {
+      const oldThemeOptions = window.themeOptions;
       const serializedThemeOptions = JSON.stringify(themeOptions);
-      (window as any).themeOptions = themeOptions;
+      window.themeOptions = themeOptions;
       setPageTheme(themeOptions);
       setCookie(THEME_COOKIE_NAME, JSON.stringify(themeOptions));
       addStylesheet(`/allStyles?theme=${encodeURIComponent(serializedThemeOptions)}`, (success: boolean) => {

--- a/packages/lesswrong/lib/executionEnvironment.ts
+++ b/packages/lesswrong/lib/executionEnvironment.ts
@@ -26,7 +26,7 @@ export const getInstanceSettings = (): any => {
       instanceSettings = loadInstanceSettings();
     } else {
       instanceSettings = {
-        public: (window as any).publicInstanceSettings,
+        public: window.publicInstanceSettings,
       };
     }
   }

--- a/packages/lesswrong/lib/types/windowObjectExtensions.ts
+++ b/packages/lesswrong/lib/types/windowObjectExtensions.ts
@@ -1,0 +1,22 @@
+import type { ThemeOptions } from '../../themes/themeNames';
+
+declare global {
+  // Typechecking for things we add to the window object on the client.
+  // These are generally inserted into the SSR'ed document using the
+  // embedAsGlobalVar function (in renderUtil), then read by the client in
+  // various places. These should NOT be being read anywhere by the server,
+  // or in shared code.
+  interface Window {
+    themeOptions: ThemeOptions,
+    ssrRenderedAt: Date,
+    publicSettings: any,
+    publicInstanceSettings: any,
+    __APOLLO_STATE__: any,
+    missingMainStylesheet?: boolean,
+    
+    googleMapsFinishedLoading?: ()=>void,
+    Intercom: any,
+    grecaptcha?: any,
+    google?: any,
+  }
+}

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -123,7 +123,7 @@ export function registerComponent<PropType>(name: string, rawComponent: React.Co
 {
   const { styles=null, hocs=[] } = options || {};
   if (styles) {
-    if (isClient && (window as any).missingMainStylesheet) {
+    if (isClient && window?.missingMainStylesheet) {
       hocs.push(withStyles(styles, {name: name}));
     } else {
       hocs.push(addClassnames(name, styles));

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderUtil.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderUtil.ts
@@ -1,3 +1,5 @@
+import type { ThemeOptions } from '../../../themes/themeNames';
+
 // Given something serializable (can be JSON.stringify'ed), serialize it into
 // a form that can be embedded into an HTML document. Escapes </script> tags
 // but does *not* wrap it in quotes or escape quotes.
@@ -6,6 +8,6 @@ const toEmbeddableJson = (serializable: any): string => {
     .replace(/<\//g, "<\\/")
 }
 
-export const embedAsGlobalVar = (name: string, value: any): string => {
+export const embedAsGlobalVar = (name: keyof Window, value: any): string => {
   return `<script>window.${name} = ${toEmbeddableJson(value)}</script>`;
 };


### PR DESCRIPTION
Type-check when we add things to the client's `window` object, so that we aren't casting it to `any` everywhere. (This came up in a pairing session with @jpaddison3 and was living in my git stash.)