### PR TITLE
Theming: Override post-provided colors

### DIFF
--- a/packages/lesswrong/components/common/ContentStyles.tsx
+++ b/packages/lesswrong/components/common/ContentStyles.tsx
@@ -79,7 +79,7 @@ const ContentStyles = ({contentType, className, children, classes}: {
   classes: ClassesType,
 }) => {
   return <div className={classNames(
-    className, classes.base, {
+    className, classes.base, "content", {
       [classes.postBody]: contentType==="post",
       [classes.postHighlight]: contentType==="postHighlight",
       [classes.commentBody]: contentType==="comment",

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -41,7 +41,8 @@ const generateMergedStylesheet = (themeOptions: ThemeOptions): string => {
   return [
     draftjsStyles(theme),
     miscStyles(theme),
-    jssStylesheet
+    jssStylesheet,
+    ...theme.rawCSS,
   ].join("\n");
 }
 

--- a/packages/lesswrong/themes/colorUtil.ts
+++ b/packages/lesswrong/themes/colorUtil.ts
@@ -1,45 +1,94 @@
 
-export function invertHexColor(color: string): string {
-  function fromHexDigit(s: string, offset: number): number {
-    let ch = s.charCodeAt(offset);
-    if (ch>=48 && ch<58) return ch-48; //'0'-'9'
-    else if (ch>=97 && ch<=102) return ch-97+10; //'a'-'f'
-    else if (ch>=65 && ch<=70) return ch-65+10; //'A'-'F'
-    else return 0;
+type ColorTuple=[number,number,number,number]; //RGBA, all channels floating point zero to one
+
+function fromHexDigit(s: string, offset: number): number {
+  let ch = s.charCodeAt(offset);
+  if (ch>=48 && ch<58) return ch-48; //'0'-'9'
+  else if (ch>=97 && ch<=102) return ch-97+10; //'a'-'f'
+  else if (ch>=65 && ch<=70) return ch-65+10; //'A'-'F'
+  else return 0;
+}
+function toHexDigit(n: number) {
+  if (n>=0 && n<10) return String.fromCharCode(48+n);
+  else if (n>=10 && n<=15) return String.fromCharCode(87+n);
+  else throw new Error(`Not a hex digit: ${n}`);
+}
+function toHex2(n: number): string {
+  if (n<0 || n>1.0) throw new Error("Color channel out of range");
+  let rescaled = n*255.0;
+  return toHexDigit(Math.floor(rescaled/16))+toHexDigit(Math.floor(rescaled%16));
+}
+
+export function parseColor(color: string): ColorTuple|null
+{
+  switch(color) {
+    case "white": return [1,1,1,1];
+    case "black": return [0,0,0,1];
+    case "transparent": return [0,0,0,0];
+    case "inherit": return null;
+    default: break;
   }
-  function parseHexColor(color: string): [number,number,number] {
-    const r = (fromHexDigit(color,1)*16) + fromHexDigit(color,2);
-    const g = (fromHexDigit(color,3)*16) + fromHexDigit(color,4);
-    const b = (fromHexDigit(color,5)*16) + fromHexDigit(color,6);
-    return [r,g,b];
+  if (color.startsWith("#")) {
+    // #rrggbb or #rgb format
+    if (/#[0-9a-fA-F]{6}/i.test(color)) {
+      const r = (fromHexDigit(color,1)*16) + fromHexDigit(color,2); //0-255
+      const g = (fromHexDigit(color,3)*16) + fromHexDigit(color,4); //0-255
+      const b = (fromHexDigit(color,5)*16) + fromHexDigit(color,6); //0-255
+      return [r/255.0, g/255.0, b/255.0, 1.0];
+    } else if (/#[0-9a-fA-F]{3}/i.test(color)) {
+      const r = fromHexDigit(color,1); //0-15
+      const g = fromHexDigit(color,2); //0-15
+      const b = fromHexDigit(color,3); //0-15
+      return [r/15.0, g/15.0, b/15.0, 1.0];
+    }
+  } else {
+    // TODO: Support more color formats
+    return null;
   }
-  function toHexDigit(n: number) {
-    if (n<10) return String.fromCharCode(48+n);
-    else return String.fromCharCode(87+n);
+  return null;
+}
+
+export function colorToString(color: ColorTuple): string
+{
+  function zeroTo255(n: number): string {
+    return ""+Math.floor(n*255);
   }
-  function toHex2(n: number) {
-    return toHexDigit(n/16)+toHexDigit(n%16);
-  }
-  function toHexColor(r: number, g: number, b: number) {
+  const [r,g,b,a] = color;
+  if (a>=1.0) {
     return `#${toHex2(r)}${toHex2(g)}${toHex2(b)}`;
+  } else {
+    return `rgba(${zeroTo255(r)},${zeroTo255(g)},${zeroTo255(b)},${a})`
   }
-  
-  // Parse and convert to RGB
-  const [r,g,b] = parseHexColor(color);
-  // Convert into linear color space
+}
+
+export function invertColor(color: ColorTuple): ColorTuple
+{
   // HACK: Gamma here is tuned empirically for a visual result, not based on
   // anything principled.
   const gamma=1.5;
-  const linR = Math.pow(r,gamma);
-  const linG = Math.pow(g,gamma);
-  const linB = Math.pow(b,gamma);
-  // Invert
-  const invLinR = Math.pow(255,gamma)-linR;
-  const invLinG = Math.pow(255,gamma)-linG;
-  const invLinB = Math.pow(255,gamma)-linB;
-  // Convert back into gamma color space
-  const invR = Math.round(Math.pow(invLinR, 1/gamma));
-  const invG = Math.round(Math.pow(invLinG, 1/gamma));
-  const invB = Math.round(Math.pow(invLinB, 1/gamma));
-  return toHexColor(invR,invG,invB);
+  
+  function invertChannel(channel: number) {
+    const linearized = Math.pow(channel, gamma);
+    const invertedLinearized = 1.0-linearized;
+    const inverted = Math.pow(invertedLinearized, 1.0/gamma);
+    return inverted;
+  }
+  const [r,g,b,a] = color;
+  return [invertChannel(r),invertChannel(g),invertChannel(b),1];
+}
+
+function validateColor(color: ColorTuple) {
+  const [r,g,b,a] = color;
+  if (r<0 || r>1) throw new Error("Invalid color");
+  if (g<0 || g>1) throw new Error("Invalid color");
+  if (b<0 || b>1) throw new Error("Invalid color");
+  if (a<0 || a>1) throw new Error("Invalid color");
+}
+
+export function invertHexColor(color: string): string {
+  const parsed = parseColor(color);
+  validateColor(parsed!);
+  const inverted = invertColor(parsed!);
+  validateColor(inverted);
+  return colorToString(inverted);
 }

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -288,7 +288,8 @@ export const baseTheme: BaseThemeSpecification = {
             wordBreak: "normal",
           }
         }
-      }
+      },
+      rawCSS: [],
     }
   }
 };

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -385,6 +385,8 @@ declare global {
     // `theme.palette.boxShadow` which defines shadows semantically rather than
     // with an arbitrary darkness number)
     shadows: string[],
+    
+    rawCSS: string[],
   };
   
   type BaseThemeSpecification = {

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -72,10 +72,19 @@ const greyAlpha = (alpha: number) => `rgba(255,255,255,${alpha})`;
 //   }
 // (Not real color values, but real syntax.)
 //
+const safeColorFallbacks = `
+.content td[style*="background-color:"], .content table[style*="background-color:"] {
+  background-color: black !important;
+  border-color: #333 !important;
+}
+`;
+
 const colorReplacements = {
   "hsl(0, 0%, 90%)":    "hsl(0, 0%, 10%)",
   "#F2F2F2":            invertHexColor("#f2f2f2"),
   "rgb(255, 247, 222)": "rgb(50,30,0)",
+  "rgb(255, 255, 255)": invertHexColor("#ffffff"),
+  "hsl(0,0%,100%)":     invertHexColor("#ffffff"),
   "#FFEEBB":            invertHexColor("#ffeebb"),
   "rgb(255, 238, 187)": invertColor([255/255.0,238/255.0,187/255.0,1]),
   "rgb(230, 230, 230)": invertColor([230/255.0,230/255.0,230/255.0,1]),
@@ -115,6 +124,9 @@ export const darkModeTheme: UserThemeSpecification = {
     },
   }),
   make: (palette: ThemePalette): PartialDeep<ThemeType> => ({
-    rawCSS: [generateColorOverrides()]
+    rawCSS: [
+      safeColorFallbacks,
+      generateColorOverrides()
+    ]
   }),
 };

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -1,4 +1,9 @@
-import { invertHexColor } from '../colorUtil';
+import type { PartialDeep } from 'type-fest'
+import deepmerge from 'deepmerge';
+// eslint-disable-next-line no-restricted-imports
+import type { Color as MuiColorShades } from '@material-ui/core';
+import { defaultComponentPalette } from '../defaultPalette';
+import { invertHexColor, parseColor, colorToString, invertColor } from '../colorUtil';
 
 export const invertedGreyscale = {
   // Present in @material-ui/core/colors/grey
@@ -44,6 +49,51 @@ export const invertedGreyscale = {
 
 const greyAlpha = (alpha: number) => `rgba(255,255,255,${alpha})`;
 
+// CkEditor allows users to provide colors for table cell backgrounds and
+// borders, which get embedded into the HTML looking like this:
+//   <td style="background-color: rgb(1,2,3)">
+// User-provided colors can be in any format that CSS accepts, and may set
+// the `background-color` and `border` properties on <table> and <td>
+// elements.
+//
+// We don't have any theme-specific HTML postprocessing, so this poses a bit of
+// a problem. Our solution is to override the `background-color` and `border`
+// properties on <td> and <table> to a safe default, to guarantee there won't
+// be any black-on-black or white-on-white text, and then then use CSS
+// attribute matching to replace specific colors that have been used in
+// posts we care about with proper aesthetic replacements. The CSS winds up
+// looking like this:
+//   .content td, .content table {
+//     background-color: black !important;
+//     border-color: #333 !important;
+//   }
+//   .content td[style*="background-color:rgb(230, 230, 230)"], .content table[style*="background-color:rgb(230, 230, 230)"] {
+//     background-color: #202020 !important;
+//   }
+// (Not real color values, but real syntax.)
+//
+const colorReplacements = {
+  "hsl(0, 0%, 90%)":    "hsl(0, 0%, 10%)",
+  "#F2F2F2":            invertHexColor("#f2f2f2"),
+  "rgb(255, 247, 222)": "rgb(50,30,0)",
+  "#FFEEBB":            invertHexColor("#ffeebb"),
+  "rgb(255, 238, 187)": invertColor([255/255.0,238/255.0,187/255.0,1]),
+  "rgb(230, 230, 230)": invertColor([230/255.0,230/255.0,230/255.0,1]),
+};
+function generateColorOverrides(): string {
+  return Object.keys(colorReplacements).map((colorString: string) => {
+    const replacement = colorReplacements[colorString];
+    return `
+      .content td[style*="background-color:${colorString}"], .content table[style*="background-color:${colorString}"] {
+        background-color: ${replacement} !important;
+      }
+      .content td[style*="border-color:${colorString}"], .content table[style*="border-color:${colorString}"] {
+        border-color: ${replacement} !important;
+      }
+    `;
+  }).join('\n');
+}
+
 export const darkModeTheme: UserThemeSpecification = {
   shadePalette: {
     grey: invertedGreyscale,
@@ -63,5 +113,8 @@ export const darkModeTheme: UserThemeSpecification = {
     border: {
       itemSeparatorBottom: shadePalette.greyBorder("1px", .2),
     },
+  }),
+  make: (palette: ThemePalette): PartialDeep<ThemeType> => ({
+    rawCSS: [generateColorOverrides()]
   }),
 };


### PR DESCRIPTION
I thought I had this in the `themePicker` branch (and mentioned it in the announcement post), but then I looked at my working directory and discovered pieces of it in a side branch and pieces of it in my git stash. Whoops. This is interesting enough that it's probably worth reviewing separately, though, so here it is.

(This is the same as the block comment in `darkMode.ts`):

CkEditor allows users to provide colors for table cell backgrounds and
borders, which get embedded into the HTML looking like this:

```
   <td style="background-color: rgb(1,2,3)">
```

User-provided colors can be in any format that CSS accepts, and may set
the `background-color` and `border` properties on `<table>` and `<td>`
elements.

We don't have any theme-specific HTML postprocessing, so this poses a bit of
a problem. Our solution is to override the `background-color` and `border`
properties on `<td>` and `<table>` to a safe default, to guarantee there won't
be any black-on-black or white-on-white text, and then then use CSS
attribute matching to replace specific colors that have been used in
posts we care about with proper aesthetic replacements. The CSS winds up
looking like this:

```
   .content td, .content table {
     background-color: black !important;
     border-color: #333 !important;
   }
   .content td[style*="background-color:rgb(230, 230, 230)"], .content table[style*="background-color:rgb(230, 230, 230)"] {
     background-color: #202020 !important;
   }
```

 (Not real color values, but real syntax.)