### PR TITLE
[EA Forum only] allow admins to edit other users profiles

### DIFF
--- a/cypress/integration/messages/create_message.spec.js
+++ b/cypress/integration/messages/create_message.spec.js
@@ -12,7 +12,7 @@ describe('Messages', function() {
   it('can receive and send messages', function() {
     const testReply = 'Test reply';
     cy.visit(`/users/${this.testOtherUser.slug}`);
-    cy.get('a').contains('Message').click();
+    cy.get('[data-cy=message]').click();
     cy.contains('Test seeded message').should('exist');
     cy.get('.ck-editor__editable').type(testReply);
     cy.contains("Submit").click();

--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -34,9 +34,12 @@ const EditProfileForm = ({classes}: {
   
   const { Typography, WrappedSmartForm } = Components
   
-  const terms: {slug?: string, documentId?: string} = params.slug ?
-    { slug: params.slug } :
-    currentUser ? { documentId: currentUser._id } : {}
+  let terms: {slug?: string, documentId?: string} = {}
+  if (params.slug) {
+    terms.slug = params.slug
+  } else if (currentUser) {
+    terms.documentId = currentUser._id
+  }
 
   // no matching user
   if ((!terms.slug && !terms.documentId) || !currentUser) {

--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -77,7 +77,7 @@ const UsersEditForm = ({terms, classes}: {
 
   return (
     <div className={classes.root}>
-      <Typography variant="display2" className={classes.header}>Edit Account</Typography>
+      <Typography variant="display2" className={classes.header}>Account Settings</Typography>
       {/* TODO(EA): Need to add a management API call to get the reset password
           link, but for now users can reset their password from the login
           screen */}

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -159,7 +159,7 @@ const UsersMenu = ({classes}: {
                 <ListItemIcon>
                   <SettingsButton className={classes.icon}/>
                 </ListItemIcon>
-                Edit Account
+                Account Settings
               </MenuItem>
             </Link>
             <Link to={`/inbox`}>

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -337,7 +337,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     
     const socialMediaIcon = (field) => {
       if (!user[field]) return null
-      return <a href={`https://${combineUrls(SOCIAL_MEDIA_PROFILE_FIELDS[field],user[field])}`} target="_blank" rel="noopener noreferrer">
+      return <a key={field} href={`https://${combineUrls(SOCIAL_MEDIA_PROFILE_FIELDS[field],user[field])}`} target="_blank" rel="noopener noreferrer">
         <svg viewBox="0 0 24 24" className={classes.socialMediaIcon}>{socialMediaIconPaths[field]}</svg>
       </a>
     }

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -72,13 +72,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     boxShadow: 'none'
   },
   mapLocation: {
-    display: 'flex',
+    display: 'inline-flex',
     alignItems: 'center',
     columnGap: 4,
     ...theme.typography.commentStyle,
     fontSize: 13,
     color: theme.palette.grey[800],
-    marginBottom: 20
+    marginBottom: 12
   },
   locationIcon: {
     fontSize: 14,
@@ -298,7 +298,20 @@ const UsersProfileFn = ({terms, slug, classes}: {
         return <Components.Error404/>
       }
     }
-
+    
+    // on the EA Forum, the user's location links to the Community map
+    let mapLocationNode
+    if (user.mapLocation) {
+      mapLocationNode = forumTypeSetting.get() === 'EAForum' ? <div>
+        <Link to="/community#individuals" className={classes.mapLocation}>
+          <LocationIcon className={classes.locationIcon} />
+          {user.mapLocation.formatted_address}
+        </Link>
+      </div> : <div className={classes.mapLocation}>
+        <LocationIcon className={classes.locationIcon} />
+        {user.mapLocation.formatted_address}
+      </div>
+    }
 
     const draftTerms: PostsViewTerms = {view: "drafts", userId: user._id, limit: 4, sortDrafts: currentUser?.sortDrafts || "modifiedAt" }
     const unlistedTerms: PostsViewTerms = {view: "unlisted", userId: user._id, limit: 20}
@@ -362,10 +375,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                 </NewConversationButton>
               )}
             </div>
-            {user.mapLocation && <div className={classes.mapLocation}>
-              <LocationIcon className={classes.locationIcon} />
-              {user.mapLocation.formatted_address}
-            </div>}
+            {mapLocationNode}
             <Typography variant="body2" className={classes.userInfo}>
               { renderMeta() }
               { currentUser?.isAdmin &&

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -22,6 +22,7 @@ import { taglineSetting } from '../common/HeadTags';
 import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { socialMediaIconPaths } from '../form-components/PrefixedInput';
 import { SOCIAL_MEDIA_PROFILE_FIELDS } from '../../lib/collections/users/custom_fields';
+import Button from '@material-ui/core/Button';
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -44,16 +45,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingRight: 10,
     marginLeft: "auto",
     [theme.breakpoints.down('md')]: {
-      ...(forumTypeSetting.get() === "EAForum" ? {
-        gridTemplateColumns: `${SECTION_WIDTH}px 1fr`,
-        gridTemplateAreas: `
-          'center right'
-        `,
-      } : {}),
+      display: 'block',
       marginTop: -20
     },
     [theme.breakpoints.down('sm')]: {
-      display: 'block',
       paddingLeft: 5,
       paddingRight: 5,
       margin: 0,
@@ -63,6 +58,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     gridArea: 'center'
   },
   usernameTitle: {
+    display: 'flex',
+    justifyContent: 'space-between',
     fontSize: "3rem",
     ...theme.typography.display3,
     ...theme.typography.postStyle,
@@ -70,6 +67,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('sm')]: {
       marginTop: 15
     }
+  },
+  messageBtn: {
+    boxShadow: 'none'
   },
   mapLocation: {
     display: 'flex',
@@ -131,7 +131,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     color: theme.palette.grey[700],
     paddingTop: theme.spacing.unit * 3,
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       display: 'none',
     }
   },
@@ -141,7 +141,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     color: theme.palette.grey[700],
     marginTop: 30,
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       display: 'block',
     }
   },
@@ -352,7 +352,16 @@ const UsersProfileFn = ({terms, slug, classes}: {
           <div className={classes.centerColumnWrapper}>
           {/* Bio Section */}
           <SingleColumnSection>
-            <div className={classes.usernameTitle}>{username}</div>
+            <div className={classes.usernameTitle}>
+              <div>{username}</div>
+              {forumTypeSetting.get() === "EAForum" && currentUser?._id != user._id && (
+                <NewConversationButton user={user} currentUser={currentUser}>
+                  <Button color="primary" variant="contained" className={classes.messageBtn}>
+                    Message
+                  </Button>
+                </NewConversationButton>
+              )}
+            </div>
             {user.mapLocation && <div className={classes.mapLocation}>
               <LocationIcon className={classes.locationIcon} />
               {user.mapLocation.formatted_address}
@@ -376,7 +385,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
               { currentUser && currentUser._id === user._id && <Link to="/manageSubscriptions">
                 Manage Subscriptions
               </Link>}
-              { currentUser?._id != user._id && <NewConversationButton user={user} currentUser={currentUser}>
+              { forumTypeSetting.get() !== "EAForum" && currentUser?._id != user._id && <NewConversationButton user={user} currentUser={currentUser}>
                 <a>Message</a>
               </NewConversationButton>}
               { <NotifyMeButton

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -356,7 +356,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
               <div>{username}</div>
               {forumTypeSetting.get() === "EAForum" && currentUser?._id != user._id && (
                 <NewConversationButton user={user} currentUser={currentUser}>
-                  <Button color="primary" variant="contained" className={classes.messageBtn}>
+                  <Button color="primary" variant="contained" className={classes.messageBtn} data-cy="message">
                     Message
                   </Button>
                 </NewConversationButton>
@@ -386,7 +386,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                 Manage Subscriptions
               </Link>}
               { forumTypeSetting.get() !== "EAForum" && currentUser?._id != user._id && <NewConversationButton user={user} currentUser={currentUser}>
-                <a>Message</a>
+                <a data-cy="message">Message</a>
               </NewConversationButton>}
               { <NotifyMeButton
                 document={user}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -404,7 +404,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                 unsubscribeMessage="Unsubscribe from posts"
               /> }
               {userCanEdit(currentUser, user) && <Link to={userGetEditUrl(user)}>
-                Edit Account
+                Account Settings
               </Link>}
             </Typography>
 

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -370,7 +370,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                   </DialogGroup>
                 </div>
               }
-              { forumTypeSetting.get() === "EAForum" && currentUser && currentUser._id === user._id && <Link to="/profile/edit">
+              { forumTypeSetting.get() === "EAForum" && userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
                 Edit Profile
               </Link>}
               { currentUser && currentUser._id === user._id && <Link to="/manageSubscriptions">

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -626,8 +626,15 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       ...communitySubtitle
     },
     {
-      name: 'EditProfile',
+      name: 'EditMyProfile',
       path: '/profile/edit',
+      componentName: 'EditProfileForm',
+      title: 'Edit Profile',
+      background: 'white',
+    },
+    {
+      name: 'EditProfile',
+      path: '/profile/:slug/edit',
       componentName: 'EditProfileForm',
       title: 'Edit Profile',
       background: 'white',

--- a/packages/lesswrong/lib/vulcan-i18n-en-us.ts
+++ b/packages/lesswrong/lib/vulcan-i18n-en-us.ts
@@ -12,7 +12,7 @@ addStrings('en', {
   'users.profile': 'Profile',
   'users.complete_profile': 'Complete your Profile',
   'users.profile_completed': 'Profile completed.',
-  'users.edit_account': 'Edit Account',
+  'users.edit_account': 'Account Settings',
   'users.edit_success': 'User “{name}” edited',
   'users.log_in': 'Log In',
   'users.sign_up': 'Sign Up',
@@ -49,7 +49,7 @@ addStrings('en', {
 
   'settings': 'Settings',
   'settings.json_message': 'Note: settings already provided in your <code>settings.json</code> file will be disabled.',
-  'settings.edit': 'Edit Account',
+  'settings.edit': 'Account Settings',
   'settings.edited': 'Settings edited (please reload).',
   'settings.title': 'Title',
   'settings.siteUrl': 'Site URL',


### PR DESCRIPTION
This PR provides a way for admins to edit other users' profiles.

EDIT: Ok, decided to go ahead and move the "Message" button up. All this is still EA Forum only.

<img width="791" alt="Screen Shot 2022-05-10 at 6 38 25 PM" src="https://user-images.githubusercontent.com/9057804/167733623-7d8e843d-656d-4493-b9b2-5b238361ebed.png">

-----
~~Unfortunately now there are too many links here, which causes one to wrap. I was hoping this would be quick, but I think I'll have to figure out how to update this part of the page to fix it. Maybe I will just go ahead and move the "Message" button above the rest.~~

<img width="791" alt="Screen Shot 2022-05-10 at 5 37 10 PM" src="https://user-images.githubusercontent.com/9057804/167726167-53cebf47-0b49-4faf-9194-3a9a58b01267.png">
