### PR TITLE
Small maintenance to SmartForm component

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentDate.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDate.tsx
@@ -4,7 +4,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 class FormComponentDate extends Component {
   render() {
     return <Components.MuiTextField
-      {...this.props}
+      {...this.props as any}
       InputLabelProps={{
         shrink: true,
       }}
@@ -20,4 +20,3 @@ declare global {
     FormComponentDate: typeof FormComponentDateComponent
   }
 }
-

--- a/packages/lesswrong/components/form-components/FormComponentDefault.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDefault.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 
 class FormComponentDefault extends Component {
   render() {
-    return <Components.MuiTextField {...this.props} />
+    return <Components.MuiTextField {...this.props as any} />
   }
 }
 
@@ -14,4 +14,3 @@ declare global {
     FormComponentDefault: typeof FormComponentDefaultComponent
   }
 }
-

--- a/packages/lesswrong/components/form-components/FormComponentNumber.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentNumber.tsx
@@ -22,7 +22,7 @@ class FormComponentNumber extends PureComponent<any> {
   render() {
     return <Components.MuiTextField
       type="number"
-      {...this.props}
+      {...this.props as any}
     />
   }
 }
@@ -42,5 +42,3 @@ declare global {
     FormComponentNumber: typeof FormComponentNumberComponent
   }
 }
-
-

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -1,5 +1,4 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
+import React, { ChangeEventHandler } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import TextField from '@material-ui/core/TextField';
 import classnames from 'classnames';
@@ -20,47 +19,50 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-class MuiTextField extends PureComponent<any> {
-  constructor(props, context) {
-    super(props,context);
-  }
-
-  onChange = (event) => {
-    this.context.updateCurrentValues({
-      [this.props.path]: event.target.value
+const MuiTextField = ({
+  classes,
+  value,
+  updateCurrentValues,
+  path,
+  children,
+  select,
+  defaultValue,
+  label,
+  fullWidth,
+  multiLine,
+  rows,
+  variant,
+  type,
+  InputLabelProps
+}) => {
+  const onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> = (event) => {
+    updateCurrentValues({
+      [path]: event.target.value
     })
   }
 
-  render() {
-    const { classes, value, select, children, label, multiLine, variant, rows, fullWidth, type, defaultValue, InputLabelProps } = this.props
-
-    return <TextField
-        variant={variant || 'standard'}
-        select={select}
-        value={value||""}
-        defaultValue={defaultValue}
-        label={label}
-        onChange={this.onChange}
-        multiline={multiLine}
-        rows={rows}
-        type={type}
-        fullWidth={fullWidth}
-        InputLabelProps={{
-          className: classes.cssLabel,
-          ...InputLabelProps
-        }}
-        className={classnames(
-          classes.textField,
-          {[classes.fullWidth]: fullWidth}
-        )}
-      >
-        {children}
-      </TextField>
-  }
-};
-
-(MuiTextField as any).contextTypes = {
-  updateCurrentValues: PropTypes.func,
+  return <TextField
+    variant={variant || 'standard'}
+    select={select}
+    value={value||""}
+    defaultValue={defaultValue}
+    label={label}
+    onChange={onChange}
+    multiline={multiLine}
+    rows={rows}
+    type={type}
+    fullWidth={fullWidth}
+    InputLabelProps={{
+      className: classes.cssLabel,
+      ...InputLabelProps
+    }}
+    className={classnames(
+      classes.textField,
+      {[classes.fullWidth] :fullWidth}
+    )}
+  >
+    {children}
+  </TextField>
 };
 
 const MuiTextFieldComponent = registerComponent("MuiTextField", MuiTextField, {styles});

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -52,6 +52,13 @@ import { callbackProps } from './propTypes';
 import withCollectionProps from './withCollectionProps';
 
 type FieldTodo<T extends DbObject> = CollectionFieldSpecification<T> & {
+  document: any,
+  name: string,
+  datatype: any,
+  layout: string,
+  input: CollectionFieldSpecification<T>["input"] | CollectionFieldSpecification<T>["control"] 
+  label: string,
+  help: string
   //
 }
 type FieldTodoUnfinished<T extends DbObject> = Partial<FieldTodo<T>>
@@ -489,7 +496,7 @@ class Form<T extends DbObject> extends Component<any,any> {
    Get a field's label
 
    */
-  getLabel = (fieldName, fieldLocale?: any) => {
+  getLabel = (fieldName: string, fieldLocale?: any): string => {
     const collectionName = this.props.collectionName.toLowerCase();
     const label = this.context.intl.formatLabel({
       fieldName: fieldName,

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -51,17 +51,22 @@ import { removeProperty } from '../../lib/vulcan-lib/utils';
 import { callbackProps } from './propTypes';
 import withCollectionProps from './withCollectionProps';
 
-type FieldTodo<T extends DbObject> = CollectionFieldSpecification<T> & {
-  document: any,
-  name: string,
-  datatype: any,
-  layout: string,
-  input: CollectionFieldSpecification<T>["input"] | CollectionFieldSpecification<T>["control"] 
-  label: string,
+
+// TODO: document these types
+type FormField<T extends DbObject> = Pick<CollectionFieldSpecification<T>, typeof formProperties[number]> & {
+  document: any
+  name: string
+  datatype: any
+  layout: string
+  input: CollectionFieldSpecification<T>["input"] | CollectionFieldSpecification<T>["control"]
+  label: string
   help: string
+  path: string
+  parentFieldName?: string
+  disabled?: boolean
   //
 }
-type FieldTodoUnfinished<T extends DbObject> = Partial<FieldTodo<T>>
+type FormFieldUnfinished<T extends DbObject> = Partial<FormField<T>>
 
 // props that should trigger a form reset
 const RESET_PROPS = [
@@ -89,6 +94,7 @@ const getDefaultValues = convertedSchema => {
 
 const getInitialStateFromProps = nextProps => {
   const collection = nextProps.collection;
+  // TODO; maybe type this
   const schema = nextProps.schema
     ? new SimpleSchema(nextProps.schema)
     : getSimpleSchema(collection);
@@ -376,7 +382,7 @@ class Form<T extends DbObject> extends Component<any,any> {
 
   initField = (fieldName: string, fieldSchema: CollectionFieldSpecification<T>) => {
     // intialize properties
-    let field: FieldTodoUnfinished<T> = {
+    let field: FormFieldUnfinished<T> = {
       ...pick(fieldSchema, formProperties),
       document: this.state.initialDocument,
       name: fieldName,
@@ -409,7 +415,7 @@ class Form<T extends DbObject> extends Component<any,any> {
     }
     return field;
   };
-  handleFieldPath = (field, fieldName, parentPath?: any) => {
+  handleFieldPath = (field: FormFieldUnfinished<T>, fieldName: string, parentPath?: string): FormFieldUnfinished<T> => {
     const fieldPath = parentPath ? `${parentPath}.${fieldName}` : fieldName;
     field.path = fieldPath;
     if (field.defaultValue) {
@@ -417,7 +423,7 @@ class Form<T extends DbObject> extends Component<any,any> {
     }
     return field;
   };
-  handleFieldParent = (field, parentFieldName) => {
+  handleFieldParent = (field: FormFieldUnfinished<T>, parentFieldName?: string) => {
     // if field has a parent field, pass it on
     if (parentFieldName) {
       field.parentFieldName = parentFieldName;
@@ -425,14 +431,15 @@ class Form<T extends DbObject> extends Component<any,any> {
 
     return field;
   };
-  handlePermissions = (field, fieldName, schema) => {
+  handlePermissions = (field: FormFieldUnfinished<T>, fieldName: string, schema: SchemaType<T>) => {
     // if field is not creatable/updatable, disable it
     if (!this.getMutableFields(schema).includes(fieldName)) {
       field.disabled = true;
     }
     return field;
   };
-  handleFieldChildren = (field, fieldName, fieldSchema, schema) => {
+  // TODO; fieldSchema is typed wrong
+  handleFieldChildren = (field: FormFieldUnfinished<T>, fieldName: string, fieldSchema: CollectionFieldSpecification<T>, schema: SchemaType<T>) => {
     // array field
     if (fieldSchema.field) {
       field.arrayFieldSchema = fieldSchema.field;
@@ -470,9 +477,10 @@ class Form<T extends DbObject> extends Component<any,any> {
    * Given a field's name, the containing schema, and parent, create the
    * complete field object to be passed to the component
    */
-  createField = (fieldName: string, schema: SchemaType<T>, parentFieldName?: any, parentPath?: any) => {
+  // TODO; check on type of schema
+  createField = (fieldName: string, schema: SchemaType<T>, parentFieldName?: string, parentPath?: string) => {
     const fieldSchema = schema[fieldName];
-    let field: FieldTodoUnfinished<T> = this.initField(fieldName, fieldSchema);
+    let field: FormFieldUnfinished<T> = this.initField(fieldName, fieldSchema);
     field = this.handleFieldPath(field, fieldName, parentPath);
     field = this.handleFieldParent(field, parentFieldName);
     field = this.handlePermissions(field, fieldName, schema);

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -50,8 +50,8 @@ import { getErrors, mergeWithComponents, registerComponent, runCallbacksList } f
 import { removeProperty } from '../../lib/vulcan-lib/utils';
 import { callbackProps } from './propTypes';
 import withCollectionProps from './withCollectionProps';
-import { inspect }  from "util";
 
+type FieldTodoUnfinished<T extends DbObject> = Partial<CollectionFieldSpecification<T>>
 
 // props that should trigger a form reset
 const RESET_PROPS = [
@@ -137,7 +137,7 @@ const getInitialStateFromProps = nextProps => {
 /**
  * Note: Only use this through WrappedSmartForm
  */
-class Form extends Component<any,any> {
+class Form<T extends DbObject> extends Component<any,any> {
   constructor(props) {
     super(props);
 
@@ -364,10 +364,11 @@ class Form extends Component<any,any> {
     return relevantFields;
   };
 
-  initField = (fieldName, fieldSchema) => {
+  initField = (fieldName: string, fieldSchema: ) => {
+    let field0: FieldTodoUnfinished = _.pick(fieldSchema, formProperties)
     // intialize properties
-    let field: any = {
-      ..._.pick(fieldSchema, formProperties),
+    let field: FieldTodoUnfinished = {
+      // ..._.pick(fieldSchema, formProperties as Mutable<typeof formProperties>),
       document: this.state.initialDocument,
       name: fieldName,
       datatype: fieldSchema.type,
@@ -375,15 +376,6 @@ class Form extends Component<any,any> {
       input: fieldSchema.input || fieldSchema.control
     };
     field.label = this.getLabel(fieldName);
-    // // replace value by prefilled value if value is empty
-    // const prefill = fieldSchema.prefill || (fieldSchema.form && fieldSchema.form.prefill);
-    // if (prefill) {
-    //   const prefilledValue = typeof prefill === 'function' ? prefill.call(fieldSchema) : prefill;
-    //   if (!!prefilledValue && !field.value) {
-    //     field.prefilledValue = prefilledValue;
-    //     field.value = prefilledValue;
-    //   }
-    // }
 
     // if options are a function, call it
     if (typeof field.options === 'function') {
@@ -465,14 +457,13 @@ class Form extends Component<any,any> {
     return field;
   };
 
-  /*
-  Given a field's name, the containing schema, and parent, create the
-  complete field object to be passed to the component
-
-  */
-  createField = (fieldName, schema, parentFieldName?: any, parentPath?: any) => {
+  /**
+   * Given a field's name, the containing schema, and parent, create the
+   * complete field object to be passed to the component
+   */
+  createField = (fieldName: string, schema: SchemaType<T>, parentFieldName?: any, parentPath?: any) => {
     const fieldSchema = schema[fieldName];
-    let field = this.initField(fieldName, fieldSchema);
+    let field: FieldTodoUnfinished = this.initField(fieldName, fieldSchema);
     field = this.handleFieldPath(field, fieldName, parentPath);
     field = this.handleFieldParent(field, parentFieldName);
     field = this.handlePermissions(field, fieldName, schema);

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -52,8 +52,11 @@ import { callbackProps } from './propTypes';
 import withCollectionProps from './withCollectionProps';
 
 
-// TODO: document these types
-type FormField<T extends DbObject> = Pick<CollectionFieldSpecification<T>, typeof formProperties[number]> & {
+/** Field specification for a Form field, created from the collection schema */
+type FormField<T extends DbObject> = Pick<
+  CollectionFieldSpecification<T>,
+  typeof formProperties[number]
+> & {
   document: any
   name: string
   datatype: any
@@ -64,8 +67,14 @@ type FormField<T extends DbObject> = Pick<CollectionFieldSpecification<T>, typeo
   path: string
   parentFieldName?: string
   disabled?: boolean
-  //
+  arrayField: any
+  arrayFieldSchema: any
+  nestedInput: any
+  nestedSchema: any
+  nestedFields: any
 }
+
+/** FormField in the process of being created */
 type FormFieldUnfinished<T extends DbObject> = Partial<FormField<T>>
 
 // props that should trigger a form reset
@@ -73,7 +82,7 @@ const RESET_PROPS = [
   'collection', 'collectionName', 'typeName', 'document', 'schema', 'currentUser',
   'fields', 'removeFields',
   'prefilledProps' // TODO: prefilledProps should be merged instead?
-];
+] as const;
 
 const compactParent = (object, path) => {
   const parentPath = getParentPath(path);
@@ -94,7 +103,6 @@ const getDefaultValues = convertedSchema => {
 
 const getInitialStateFromProps = nextProps => {
   const collection = nextProps.collection;
-  // TODO; maybe type this
   const schema = nextProps.schema
     ? new SimpleSchema(nextProps.schema)
     : getSimpleSchema(collection);
@@ -129,6 +137,7 @@ const getInitialStateFromProps = nextProps => {
     deletedValues: [],
     currentValues: {},
     // convert SimpleSchema schema into JSON object
+    // TODO: type convertedSchema
     schema: convertedSchema,
     // Also store all field schemas (including nested schemas) in a flat structure
     flatSchema: convertSchema(schema as any, true),
@@ -380,6 +389,9 @@ class Form<T extends DbObject> extends Component<any,any> {
     return relevantFields;
   };
 
+  // TODO: fieldSchema is actually a slightly added-to version of
+  // CollectionFieldSpecification, see convertSchema in schema_utils, but in
+  // this function, it acts like CollectionFieldSpecification
   initField = (fieldName: string, fieldSchema: CollectionFieldSpecification<T>) => {
     // intialize properties
     let field: FormFieldUnfinished<T> = {
@@ -438,8 +450,7 @@ class Form<T extends DbObject> extends Component<any,any> {
     }
     return field;
   };
-  // TODO; fieldSchema is typed wrong
-  handleFieldChildren = (field: FormFieldUnfinished<T>, fieldName: string, fieldSchema: CollectionFieldSpecification<T>, schema: SchemaType<T>) => {
+  handleFieldChildren = (field: FormFieldUnfinished<T>, fieldName: string, fieldSchema: any, schema: any) => {
     // array field
     if (fieldSchema.field) {
       field.arrayFieldSchema = fieldSchema.field;
@@ -475,10 +486,9 @@ class Form<T extends DbObject> extends Component<any,any> {
 
   /**
    * Given a field's name, the containing schema, and parent, create the
-   * complete field object to be passed to the component
+   * complete form-field object to be passed to the component
    */
-  // TODO; check on type of schema
-  createField = (fieldName: string, schema: SchemaType<T>, parentFieldName?: string, parentPath?: string) => {
+  createField = (fieldName: string, schema: any, parentFieldName?: string, parentPath?: string) => {
     const fieldSchema = schema[fieldName];
     let field: FormFieldUnfinished<T> = this.initField(fieldName, fieldSchema);
     field = this.handleFieldPath(field, fieldName, parentPath);

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -495,7 +495,8 @@ class Form<T extends DbObject> extends Component<any,any> {
     field = this.handleFieldParent(field, parentFieldName);
     field = this.handlePermissions(field, fieldName, schema);
     field = this.handleFieldChildren(field, fieldName, fieldSchema, schema);
-    return field;
+    // Now that it's done being constructed, all the required fields will be set
+    return field as FormField<T>;
   };
   createArraySubField = (fieldName, subFieldSchema, schema) => {
     const subFieldName = `${fieldName}.$`;

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -51,7 +51,10 @@ import { removeProperty } from '../../lib/vulcan-lib/utils';
 import { callbackProps } from './propTypes';
 import withCollectionProps from './withCollectionProps';
 
-type FieldTodoUnfinished<T extends DbObject> = Partial<CollectionFieldSpecification<T>>
+type FieldTodo<T extends DbObject> = CollectionFieldSpecification<T> & {
+  //
+}
+type FieldTodoUnfinished<T extends DbObject> = Partial<FieldTodo<T>>
 
 // props that should trigger a form reset
 const RESET_PROPS = [
@@ -364,11 +367,10 @@ class Form<T extends DbObject> extends Component<any,any> {
     return relevantFields;
   };
 
-  initField = (fieldName: string, fieldSchema: ) => {
-    let field0: FieldTodoUnfinished = _.pick(fieldSchema, formProperties)
+  initField = (fieldName: string, fieldSchema: CollectionFieldSpecification<T>) => {
     // intialize properties
-    let field: FieldTodoUnfinished = {
-      // ..._.pick(fieldSchema, formProperties as Mutable<typeof formProperties>),
+    let field: FieldTodoUnfinished<T> = {
+      ...pick(fieldSchema, formProperties),
       document: this.state.initialDocument,
       name: fieldName,
       datatype: fieldSchema.type,
@@ -463,7 +465,7 @@ class Form<T extends DbObject> extends Component<any,any> {
    */
   createField = (fieldName: string, schema: SchemaType<T>, parentFieldName?: any, parentPath?: any) => {
     const fieldSchema = schema[fieldName];
-    let field: FieldTodoUnfinished = this.initField(fieldName, fieldSchema);
+    let field: FieldTodoUnfinished<T> = this.initField(fieldName, fieldSchema);
     field = this.handleFieldPath(field, fieldName, parentPath);
     field = this.handleFieldParent(field, parentFieldName);
     field = this.handlePermissions(field, fieldName, schema);

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1549,7 +1549,7 @@ addFieldsDict(Users, {
   
   website: {
     type: String,
-    // hidden: true,
+    hidden: true,
     optional: true,
     control: 'PrefixedInput',
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1549,7 +1549,7 @@ addFieldsDict(Users, {
   
   website: {
     type: String,
-    hidden: true,
+    // hidden: true,
     optional: true,
     control: 'PrefixedInput',
     canCreate: ['members'],

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -49,14 +49,39 @@ interface CollectionFieldSpecification<T extends DbObject> {
   max?: number,
   regEx?: any,
   minCount?: number,
+  /** NOTE: not in use or tested as of 2022-05 */
+  maxCount?: number,
   options?: any,
   allowedValues?: any,
   query?: any,
   
   form?: any,
   input?: any,
-  inputProperties?: any, //TODO;
+  /**
+   * Custom props that will be passed to the input component. Can pass in
+   * values or functions. All functions will be called before being passed into
+   * the input component. Example:
+   *
+   * {
+   *   emphasis: 'bold',
+   *   defaultValue: () => new Date(),
+   * }
+   *
+   * Note that if you want to put a component as one of the input values (you're
+   * doing something crazy aren't you), components are functions and so would be
+   * called. To get your intended behavior, wrap it in a callback:
+   *
+   * {
+   *   decorativeComponent: () => MyDecorativeComponent
+   * }
+   *
+   * NOTE: this is unused and untested as of 2022-05
+   */
+  inputProperties?: any,
+  
   beforeComponent?: keyof ComponentTypes,
+  /** NOTE: not in use or tested as of 2022-05 */
+  afterComponent?: keyof ComponentTypes,
   order?: number,
   label?: string,
   tooltip?: string,

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -55,6 +55,7 @@ interface CollectionFieldSpecification<T extends DbObject> {
   
   form?: any,
   input?: any,
+  inputProperties?: any, //TODO;
   beforeComponent?: keyof ComponentTypes,
   order?: number,
   label?: string,

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -204,22 +204,23 @@ export const schemaProperties = [
   'tooltip'
 ];
 
+// TODO;
 export const formProperties = [
   'optional',
-  'required',
+  // 'required',
   'min',
   'max',
-  'exclusiveMin',
-  'exclusiveMax',
+  // 'exclusiveMin',
+  // 'exclusiveMax',
   'minCount',
-  'maxCount',
+  // 'maxCount',
   'allowedValues',
   'regEx',
   'blackbox',
-  'trim',
-  'custom',
+  // 'trim',
+  // 'custom',
   'defaultValue',
-  'autoValue',
+  // 'autoValue',
   'form', // form placeholder
   'inputProperties', // form placeholder
   'control', // SmartForm control (String or React component)
@@ -228,10 +229,10 @@ export const formProperties = [
   'group', // form fieldset group
   'description',
   'beforeComponent',
-  'afterComponent',
+  // 'afterComponent',
   'placeholder',
   'options',
   'query',
-  'fieldProperties',
+  // 'fieldProperties',
   'tooltip'
 ] as const;

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -195,7 +195,6 @@ export const schemaProperties = [
   'tooltip'
 ] as const;
 
-// TODO;
 export const formProperties = [
   'optional',
   'min',

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -55,12 +55,10 @@ export const getEditableFields = function<T extends DbObject>(schema: SchemaType
   return fields;
 };
 
-/*
-
-Convert a nested SimpleSchema schema into a JSON object
-If flatten = true, will create a flat object instead of nested tree
-
-*/
+/**
+ * Convert a nested SimpleSchema schema into a JSON object
+ * If flatten = true, will create a flat object instead of nested tree
+ */
 export const convertSchema = <T extends DbObject>(schema: SimpleSchemaType<T>, flatten = false) => {
   if (schema._schema) {
     let jsonSchema = {};
@@ -160,20 +158,14 @@ export const schemaProperties = [
   'type',
   'label',
   'optional',
-  'required',
   'min',
   'max',
-  'exclusiveMin',
-  'exclusiveMax',
   'minCount',
   'maxCount',
   'allowedValues',
   'regEx',
   'blackbox',
-  'trim',
-  'custom',
   'defaultValue',
-  'autoValue',
   'hidden', // hidden: true means the field is never shown in a form no matter what
   'form', // form placeholder
   'inputProperties', // form placeholder
@@ -200,27 +192,20 @@ export const schemaProperties = [
   'placeholder',
   'options',
   'query',
-  'fieldProperties',
   'tooltip'
-];
+] as const;
 
 // TODO;
 export const formProperties = [
   'optional',
-  // 'required',
   'min',
   'max',
-  // 'exclusiveMin',
-  // 'exclusiveMax',
   'minCount',
-  // 'maxCount',
+  'maxCount',
   'allowedValues',
   'regEx',
   'blackbox',
-  // 'trim',
-  // 'custom',
   'defaultValue',
-  // 'autoValue',
   'form', // form placeholder
   'inputProperties', // form placeholder
   'control', // SmartForm control (String or React component)
@@ -229,10 +214,9 @@ export const formProperties = [
   'group', // form fieldset group
   'description',
   'beforeComponent',
-  // 'afterComponent',
+  'afterComponent',
   'placeholder',
   'options',
   'query',
-  // 'fieldProperties',
   'tooltip'
 ] as const;

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -234,4 +234,4 @@ export const formProperties = [
   'query',
   'fieldProperties',
   'tooltip'
-];
+] as const;


### PR DESCRIPTION
Mostly I was focused on understanding how the component worked, and added some types as I read, specifically reading through the construction of the `field` object.

I also changed MUITextField to be a functional component. My eventual goal is to make it so the custom `control` components have their props typed, among other things.

The most interesting part of this PR was me (and Sarah) looking at `schema_utils.ts`, and noticing how many of the keys it expected to be there were declared in `CollectionFieldSpecification`. I decided to remove many of them as they were otherwise completely unmentioned in the codebase. However other keys looked like they were still supported by the form system, and we were merely not utilizing them. So I added them to `CollectionFieldSpecification`. 