### PR TITLE
add an option to set the default sort order of a tag page's posts list

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -10,6 +10,7 @@ import withTimezone from '../common/withTimezone';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { forumAllPostsNumDaysSetting, DatabasePublicSetting } from '../../lib/publicSettings';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/schema';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -34,14 +35,6 @@ const timeframeToNumTimeBlocks = {
   weekly: forumAllPostsNumWeeksSetting.get(),
   monthly: forumAllPostsNumMonthsSetting.get(),
   yearly: forumAllPostsNumYearsSetting.get(),
-}
-
-export const sortings = {
-  magic: 'Magic (New & Upvoted)',
-  recentComments: 'Recent Comments',
-  new: 'New',
-  old: 'Old',
-  top: 'Top',
 }
 
 interface AllPostsPageProps extends WithUserProps, WithStylesProps, WithTimezoneProps, WithLocationProps, WithUpdateCurrentUserProps {
@@ -147,7 +140,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
             <Tooltip title={`${showSettings ? "Hide": "Show"} options for sorting and filtering`} placement="top-end">
               <div className={classes.title} onClick={this.toggleSettings}>
                 <SectionTitle title="All Posts">
-                  <SettingsButton label={`Sorted by ${ sortings[currentSorting] }`}/>
+                  <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting] }`}/>
                 </SectionTitle>
               </div>
             </Tooltip>

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -9,8 +9,9 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { useCurrentUser } from '../common/withUser';
 import { DEFAULT_LOW_KARMA_THRESHOLD, MAX_LOW_KARMA_THRESHOLD } from '../../lib/collections/posts/views'
 
-import { sortings as defaultSortings, timeframes as defaultTimeframes } from './AllPostsPage'
+import { timeframes as defaultTimeframes } from './AllPostsPage'
 import { ForumOptions, forumSelect } from '../../lib/forumTypeUtils';
+import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/schema';
 
 type Filters = 'all'|'questions'|'meta'|'frontpage'|'curated'|'events';
 
@@ -201,7 +202,7 @@ const USER_SETTING_NAMES = {
   showEvents: 'allPostsIncludeEvents'
 }
 
-const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, currentIncludeEvents, timeframes=defaultTimeframes, sortings=defaultSortings, showTimeframe, classes}: {
+const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, currentIncludeEvents, timeframes=defaultTimeframes, sortings=SORT_ORDER_OPTIONS, showTimeframe, classes}: {
   persistentSettings?: any,
   hidden: boolean,
   currentTimeframe?: any,

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { sortings } from './AllPostsPage';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/schema';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -39,7 +39,7 @@ const PostsListSortDropdown = ({classes, value}:{
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   
   const newSortings = {
-    ...sortings,
+    ...SORT_ORDER_OPTIONS,
     relevance: "Most Relevant"
   }
 
@@ -57,7 +57,7 @@ const PostsListSortDropdown = ({classes, value}:{
             {newSortings["relevance"]}
           </MenuItem>
         </QueryLink>
-        {Object.keys(sortings).map(sorting => (
+        {Object.keys(SORT_ORDER_OPTIONS).map(sorting => (
           <QueryLink key={sorting} query={{sortedBy:sorting}} merge>
             <MenuItem value={sorting} onClick={()=>setAnchorEl(null)}>
               {newSortings[sorting]}

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -5,6 +5,7 @@ import Menu from '@material-ui/core/Menu';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/schema';
+import { TAG_POSTS_SORT_ORDER_OPTIONS } from '../../lib/collections/tags/schema';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -37,15 +38,10 @@ const PostsListSortDropdown = ({classes, value}:{
   value: string
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  
-  const newSortings = {
-    ...SORT_ORDER_OPTIONS,
-    relevance: "Most Relevant"
-  }
 
   return <div className={classes.root}>
     <span className={classes.selectMenu} onClick={e=>setAnchorEl(e.currentTarget)}>
-      {newSortings[value]} <ArrowDropDownIcon className={classes.icon}/>
+      {TAG_POSTS_SORT_ORDER_OPTIONS[value]} <ArrowDropDownIcon className={classes.icon}/>
     </span>
     <Menu
       open={Boolean(anchorEl)}
@@ -54,13 +50,13 @@ const PostsListSortDropdown = ({classes, value}:{
     >
         <QueryLink query={{sortedBy: undefined}} merge className={classes.menuItem}>
           <MenuItem value={"relevance"} onClick={()=>setAnchorEl(null)}>
-            {newSortings["relevance"]}
+            {TAG_POSTS_SORT_ORDER_OPTIONS["relevance"]}
           </MenuItem>
         </QueryLink>
         {Object.keys(SORT_ORDER_OPTIONS).map(sorting => (
           <QueryLink key={sorting} query={{sortedBy:sorting}} merge>
             <MenuItem value={sorting} onClick={()=>setAnchorEl(null)}>
-              {newSortings[sorting]}
+              {SORT_ORDER_OPTIONS[sorting]}
             </MenuItem>
           </QueryLink>
         ))}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -352,11 +352,11 @@ const TagPage = ({classes}: {
           {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
             {tag.sequence ?
               <SectionTitle title={`Posts tagged ${tag.name}`}>
-                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+                <PostsListSortDropdown value={query.sortedBy || tag.postsDefaultSortOrder || "relevance"}/>
               </SectionTitle> :
               <div className={classes.tagHeader}>
                 <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
-                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+                <PostsListSortDropdown value={query.sortedBy || tag.postsDefaultSortOrder || "relevance"}/>
               </div>
             }
             <PostsList2

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -21,6 +21,14 @@ const STICKY_PRIORITIES = {
   4: "Max",
 }
 
+export const SORT_ORDER_OPTIONS = {
+  magic: 'Magic (New & Upvoted)',
+  recentComments: 'Recent Comments',
+  new: 'New',
+  old: 'Old',
+  top: 'Top',
+}
+
 export interface RSVPType {
   name: string
   email: string

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -131,6 +131,7 @@ registerFragment(`
   fragment TagPageFragment on Tag {
     ...TagWithFlagsFragment
     tableOfContents
+    postsDefaultSortOrder
     contributors(limit: $contributorsLimit) {
       totalCount
       contributors {
@@ -149,6 +150,7 @@ registerFragment(`
   fragment TagPageWithRevisionFragment on Tag {
     ...TagWithFlagsAndRevisionFragment
     tableOfContents(version: $version)
+    postsDefaultSortOrder
     contributors(limit: $contributorsLimit, version: $version) {
       totalCount
       contributors {
@@ -183,6 +185,7 @@ registerFragment(`
   fragment TagEditFragment on Tag {
     ...TagBasicInfo
     tagFlagsIds
+    postsDefaultSortOrder
     description {
       ...RevisionEdit
     }

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -8,6 +8,7 @@ import GraphQLJSON from 'graphql-type-json';
 import moment from 'moment';
 import { captureException } from '@sentry/core';
 import { forumTypeSetting } from '../../instanceSettings';
+import { SORT_ORDER_OPTIONS } from '../posts/schema';
 
 const formGroups: Partial<Record<string,FormGroup>> = {
   advancedOptions: {
@@ -401,6 +402,20 @@ export const schema: SchemaType<DbTag> = {
     editableBy: ['sunshineRegiment', 'admins'],
     insertableBy: ['sunshineRegiment', 'admins'],
   },
+  
+  postsDefaultSortOrder: {
+    type: String,
+    optional: true,
+    group: formGroups.advancedOptions,
+    viewableBy: ['guests'],
+    editableBy: ['sunshineRegiment', 'admins'],
+    insertableBy: ['sunshineRegiment', 'admins'],
+    control: 'select',
+    options: () => Object.entries(SORT_ORDER_OPTIONS).map(([key, val]) => ({
+      value: key,
+      label: val
+    })),
+  }
 }
 
 export const wikiGradeDefinitions: Partial<Record<number,string>> = {

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -32,6 +32,11 @@ addGraphQLSchema(`
   }
 `);
 
+export const TAG_POSTS_SORT_ORDER_OPTIONS = {
+  relevance: 'Most Relevant',
+  ...SORT_ORDER_OPTIONS
+}
+
 export const schema: SchemaType<DbTag> = {
   createdAt: {
     optional: true,
@@ -411,7 +416,7 @@ export const schema: SchemaType<DbTag> = {
     editableBy: ['sunshineRegiment', 'admins'],
     insertableBy: ['sunshineRegiment', 'admins'],
     control: 'select',
-    options: () => Object.entries(SORT_ORDER_OPTIONS).map(([key, val]) => ({
+    options: () => Object.entries(TAG_POSTS_SORT_ORDER_OPTIONS).map(([key, val]) => ({
       value: key,
       label: val
     })),

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -653,6 +653,7 @@ interface DbTag extends DbObject {
   htmlWithContributorAnnotations: string
   contributionStats: any /*{"definitions":[{"blackbox":true}]}*/
   introSequenceId: string
+  postsDefaultSortOrder: string
   description: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -270,6 +270,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly contributors: any /*TagContributorsList*/,
   readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly introSequenceId: string,
+  readonly postsDefaultSortOrder: string,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions
@@ -1487,11 +1488,13 @@ interface TagWithFlagsAndRevisionFragment extends TagRevisionFragment { // fragm
 
 interface TagPageFragment extends TagWithFlagsFragment { // fragment on Tags
   readonly tableOfContents: any,
+  readonly postsDefaultSortOrder: string,
   readonly contributors: any,
 }
 
 interface TagPageWithRevisionFragment extends TagWithFlagsAndRevisionFragment { // fragment on Tags
   readonly tableOfContents: any,
+  readonly postsDefaultSortOrder: string,
   readonly contributors: any,
 }
 


### PR DESCRIPTION
This PR lets you set the default sort order of a tag/topic page's posts list.

Based on a request from Lizka: https://cea-core.slack.com/archives/C038J512SD8/p1652364522576919