### PR TITLE
tag page posts default sort order should actually sort the posts

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -228,6 +228,9 @@ const TagPage = ({classes}: {
     return <PermanentRedirect url={tagGetUrl(tag)} />
   }
 
+  // if no sort order was selected, try to use the tag page's default sort order for posts
+  query.sortedBy = query.sortedBy || tag.postsDefaultSortOrder
+
   const terms = {
     ...tagPostTerms(tag, query),
     limit: 15
@@ -352,11 +355,11 @@ const TagPage = ({classes}: {
           {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
             {tag.sequence ?
               <SectionTitle title={`Posts tagged ${tag.name}`}>
-                <PostsListSortDropdown value={query.sortedBy || tag.postsDefaultSortOrder || "relevance"}/>
+                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
               </SectionTitle> :
               <div className={classes.tagHeader}>
                 <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
-                <PostsListSortDropdown value={query.sortedBy || tag.postsDefaultSortOrder || "relevance"}/>
+                <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
               </div>
             }
             <PostsList2

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -386,10 +386,10 @@ const UsersProfileFn = ({terms, slug, classes}: {
               {forumTypeSetting.get() === "EAForum" && currentUser?._id != user._id && (
                 <div className={classes.messageBtnDesktop}>
                   <NewConversationButton user={user} currentUser={currentUser}>
-                  <Button color="primary" variant="contained" className={classes.messageBtn} data-cy="message">
-                    Message
-                  </Button>
-                </NewConversationButton>
+                    <Button color="primary" variant="contained" className={classes.messageBtn} data-cy="message">
+                      Message
+                    </Button>
+                  </NewConversationButton>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Follow up to https://github.com/ForumMagnum/ForumMagnum/pull/4914

Now the posts actually get sorted.