### PR TITLE
remove broken flip behavior in pingback tooltip

### DIFF
--- a/packages/lesswrong/components/posts/Pingback.tsx
+++ b/packages/lesswrong/components/posts/Pingback.tsx
@@ -26,12 +26,6 @@ const Pingback = ({classes, post}: {
         open={hover} 
         anchorEl={anchorEl} 
         placement="bottom-end"
-        modifiers={{
-          flip: {
-            behavior: ["bottom-end", "top", "bottom-end"],
-            boundariesElement: 'viewport'
-          } 
-        }}
       >
         <PostsPreviewTooltip post={post}/>
       </LWPopper>


### PR DESCRIPTION
Previously, tooltips would overflow the bottom of the screen in all cases.  Undesirable behavior!  Now they match the post preview tooltip behavior.

Before:
![image](https://user-images.githubusercontent.com/2136984/168445331-d126bd8a-1b97-49be-a71e-a3eda0c8d2fa.png)

After:
![image](https://user-images.githubusercontent.com/2136984/168445343-f9e933b7-2504-4c63-8535-43cacaf1fe3a.png)
