### PR TITLE
properly center shortform comment count icon

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemComments.tsx
+++ b/packages/lesswrong/components/posts/PostsItemComments.tsx
@@ -11,7 +11,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 4,
     height: 24,
     position: "relative",
-    
+    display: "flex",
+    "justify-content": "center",
+    "align-items": "center",
     "& .MuiSvgIcon-root": {
       height: "100%",
     },
@@ -24,7 +26,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 24,
     cursor: "pointer",
     position: "relative",
-    flexShrink: 0,
+    display: "flex",
+    "justify-content": "center",
+    "align-items": "center",
     top: 2,
     '& div': {
       marginTop: -3,
@@ -49,10 +53,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.icon.commentsBubble.newPromoted,
   },
   commentCountIcon: {
-    position:"absolute",
-    right:"50%",
-    top:"50%",
-    transform:"translate(50%, -50%)",
     width:30,
     height:30,
   },


### PR DESCRIPTION
Previously, the comment count icon in shortform posts was often off-center.  It should now be centered regardless of how wide the truncated text in the parent becomes.

After/before:
<img width="1600" alt="image" src="https://user-images.githubusercontent.com/9090789/168453708-a24fd69a-055b-44ea-a390-b7f67773fc34.png">
