### PR TITLE
make font size of text in list items in tooltip previews the same as other text in the tooltips

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -35,6 +35,9 @@ const highlightStyles = (theme: ThemeType) => ({
   '& h3': {
     fontSize: "1.1rem"
   },
+  '& li': {
+    fontSize: "1.1rem"
+  },
   ...highlightSimplifiedStyles
 })
 


### PR DESCRIPTION
This fixes a minor styling bug where list item text in tooltip previews was larger than the other text in those tooltip previews.  Modified the styling in `PostsPreviewTooltip` to avoid impacting Question answer styling.

Before
<img width="554" alt="Screen Shot 2022-05-15 at 5 41 42 PM" src="https://user-images.githubusercontent.com/9090789/168502051-7a252938-5a62-4c46-90f4-54d31a62a0b1.png">

After
<img width="507" alt="Screen Shot 2022-05-15 at 5 41 15 PM" src="https://user-images.githubusercontent.com/9090789/168502048-db91f3aa-dc9a-4b75-874a-f52304cd6fe3.png">
