### PR TITLE
add link from alignmentForum post comments to LW post comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -52,6 +52,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[600],
     fontStyle: 'italic',
     marginTop: 4,
+  },
+  afLwCommentCount: {
+    marginLeft: 3,
+    color: theme.palette.primary.main,
+    opacity: .8
   }
 })
 
@@ -60,7 +65,7 @@ interface CommentsListSectionState {
   anchorEl: any,
 }
 
-const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComments, loadMoreComments, loadingMoreComments, comments, parentAnswerId, startThreadTruncated, newForm=true, classes}: {
+const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComments, lwPostTotalComments, loadMoreComments, loadingMoreComments, comments, parentAnswerId, startThreadTruncated, newForm=true, classes}: {
   post?: PostsDetails,
   tag?: TagBasicInfo,
   commentCount: number,
@@ -73,6 +78,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
   startThreadTruncated?: boolean,
   newForm: boolean,
   classes: ClassesType,
+  lwPostTotalComments?: number;
 }) => {
   const currentUser = useCurrentUser();
   const [highlightDate,setHighlightDate] = useState<Date|undefined>(post?.lastVisitedAt && new Date(post.lastVisitedAt));
@@ -97,6 +103,8 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
     const { CommentsListMeta, Typography } = Components
     const suggestedHighlightDates = [moment(now).subtract(1, 'day'), moment(now).subtract(1, 'week'), moment(now).subtract(1, 'month'), moment(now).subtract(1, 'year')]
     const newLimit = commentCount + (loadMoreCount || commentCount)
+    const lwPostLink = post && `https://lesswrong.com/posts/${post._id}/${post.slug}#comments`
+
     return <CommentsListMeta>
       <Typography
         variant="body2"
@@ -110,6 +118,10 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
             </span> :
             <span>
               { totalComments } comments, sorted by <Components.CommentsViews post={post} />
+              { typeof lwPostTotalComments === 'number' &&
+                <span className={classes.afLwCommentCount}>
+                  (<a href={lwPostLink}>{lwPostTotalComments} comments on LessWrong</a>)
+                </span> }
             </span>
         }
       </Typography>

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { unflattenComments } from "../../lib/utils/unflatten";
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const PostsCommentsThread = ({ post, terms, newForm=true }: {
   post: PostsDetails,
@@ -15,6 +16,16 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
     fetchPolicy: 'cache-and-network',
     enableTotal: true,
   });
+
+  const lwPostCountTerms: CommentsViewTerms = { ...terms, view: 'postLWComments' };
+  const { totalCount: lwPostTotalCount } = useMulti({
+    terms: lwPostCountTerms,
+    collectionName: "Comments",
+    fragmentName: 'CommentsList',
+    fetchPolicy: 'cache-and-network',
+    enableTotal: true,
+    skip: forumTypeSetting.get() !== 'AlignmentForum'
+  });
   
   if (loading && !results) {
     return <Components.Loading/>
@@ -27,6 +38,7 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
         comments={nestedComments}
         loadMoreComments={loadMore}
         totalComments={totalCount as number}
+        lwPostTotalComments={lwPostTotalCount}
         commentCount={(results && results.length) || 0}
         loadingMoreComments={loadingMore}
         post={post}


### PR DESCRIPTION
Add a link from the Alignment Forum post comments count to the LW post comments, while displaying the LW comments count.

<img width="585" alt="image" src="https://user-images.githubusercontent.com/9090789/168512418-d0ca2a2c-a15b-45fe-bfe1-7a1145f64894.png">
