### PR TITLE
Some small event-related improvements

### DIFF
--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -140,7 +140,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, hideGro
     return <Card key={event._id} className={classNames(classes.eventCard, cardClassName)}>
       <Link to={`/events/${event._id}/${event.slug}`}>
         {event.eventImageId ?
-          <CloudinaryImage2 height={200} width={373} publicId={event.eventImageId} /> :
+          <CloudinaryImage2 height={200} width={373} publicId={event.eventImageId} imgProps={{q: '100'}} /> :
           <img src={getDefaultEventImg(373)} style={{height: 200, width: 373}} />}
       </Link>
       {event.eventType === 'conference' && <div className={classes.eventCardTag}>Conference</div>}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -207,7 +207,7 @@ const PostsPage = ({post, refetch, classes}: {
             {post.eventImageId && <div className={classNames(classes.headerImageContainer, {[classes.headerImageContainerWithComment]: commentId})}>
               <CloudinaryImage2
                 publicId={post.eventImageId}
-                imgProps={{ar: '16:9', w: '682'}}
+                imgProps={{ar: '16:9', w: '682', q: '100'}}
                 className={classes.headerImage}
               />
             </div>}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -14,6 +14,7 @@ import moment from '../../../lib/moment-timezone';
 import React from 'react'
 import { useTracking } from '../../../lib/analyticsEvents';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
+import { forumTypeSetting } from '../../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   metadata: {
@@ -31,7 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     columnGap: 8,
   },
   iconWrapper: {
-    paddingTop: 3
+    paddingTop: forumTypeSetting.get() === 'EAForum' ? 3 : 2
   },
   icon: {
     fontSize: 16,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -6,6 +6,9 @@ import CreateIcon from '@material-ui/icons/Create';
 import PeopleIcon from '@material-ui/icons/People';
 import LaptopIcon from '@material-ui/icons/LaptopMac';
 import ViewListIcon from '@material-ui/icons/ViewList';
+import ClockIcon from '@material-ui/icons/AccessTime';
+import LocationIcon from '@material-ui/icons/LocationOn'
+import MailIcon from '@material-ui/icons/MailOutline'
 import LocalActivityIcon from '@material-ui/icons/LocalActivity';
 import moment from '../../../lib/moment-timezone';
 import React from 'react'
@@ -22,6 +25,19 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('xs')]: {
       display: 'block',
     },
+  },
+  iconRow: {
+    display: 'flex',
+    columnGap: 8,
+  },
+  iconWrapper: {
+    paddingTop: 3
+  },
+  icon: {
+    fontSize: 16,
+  },
+  location: {
+    color: theme.palette.primary.main
   },
   onlineEventLocation: {
     display: 'block',
@@ -88,7 +104,7 @@ const PostsPageEventData = ({classes, post}: {
   
   // event location - for online events, attempt to show the meeting link
   let locationNode = location && <div>
-    <a href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`}>
+    <a className={classes.location} href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`}>
       {location}
     </a>
   </div>
@@ -187,9 +203,19 @@ const PostsPageEventData = ({classes, post}: {
   
   return <Components.Typography variant="body2" className={classes.metadata}>
       <div>
-        <Components.EventTime post={post} dense={false} />
-        { locationNode }
-        { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
+        <div className={classes.iconRow}>
+          <div className={classes.iconWrapper}><ClockIcon className={classes.icon} /></div>
+          <Components.EventTime post={post} dense={false} />
+        </div>
+        <div className={classes.iconRow}>
+          <div className={classes.iconWrapper}><LocationIcon className={classes.icon} /></div>
+          {locationNode}
+        </div>
+        {contactInfo && <div className={classes.iconRow}>
+          <div className={classes.iconWrapper}><MailIcon className={classes.icon} /></div>
+          <div className={classes.eventContact}>{contactInfo}</div>
+        </div>}
+        
         { eventType && (eventType in eventTypeIcons) && eventTypeNode(eventTypeIcons[eventType], eventType) }
         {eventCTA && post.startTime && !post.onlineEvent && <div className={classes.inPersonEventCTA}>
           {eventCTA}

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -378,11 +378,20 @@ getCollectionHooks("Comments").newAsync.add(async function CommentsNewNotificati
   
   // 2. Notify users who are subscribed to the post (which may or may not include the post's author)
   let userIdsSubscribedToPost: Array<string> = [];
+  let defaultSubscribedUserIds: Array<string> = post ? [post.userId] : []
+  // if the post is associated with a group, also notify the group organizers
+  if (post && post.groupId) {
+    const group = await Localgroups.findOne(post.groupId)
+    if (group?.organizerIds) {
+      defaultSubscribedUserIds = _.union(defaultSubscribedUserIds, group.organizerIds)
+    }
+  }
+  
   const usersSubscribedToPost = await getSubscribedUsers({
     documentId: comment.postId,
     collectionName: "Posts",
     type: subscriptionTypes.newComments,
-    potentiallyDefaultSubscribedUserIds: post ? [post.userId] : [],
+    potentiallyDefaultSubscribedUserIds: defaultSubscribedUserIds,
     userIsDefaultSubscribed: u => u.auto_subscribe_to_my_posts
   })
   userIdsSubscribedToPost = _.map(usersSubscribedToPost, u=>u._id);


### PR DESCRIPTION
1. Higher quality event images
2. Icons next to event metadata
3. Event location link is link-colored now
4. When someone adds a comment to an event that is associated with a group, the group's organizers also get notified (this is especially useful for the EA Forum, where we have a contractor posting many events for groups)

<img width="706" alt="Screen Shot 2022-05-17 at 3 59 45 PM" src="https://user-images.githubusercontent.com/9057804/168909971-719f58a4-9bc1-4fac-bb66-d440e838919c.png">
