### PR TITLE
Auth0 also gets OAuth data fix

### DIFF
--- a/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
+++ b/packages/lesswrong/server/migrations/2022-03-10-oauthCleanup.ts
@@ -41,7 +41,7 @@ async function maybeFixAccount(user: DbUser): Promise<void> {
   // Move services.<oauthprovider>.id to services.<oauthprovider>
   // This would have been created by an OAuth bug where OAuth profiles merge
   // into the wrong field.
-  for (let oauthProvider of ['google', 'facebook', 'github']) {
+  for (let oauthProvider of ['google', 'facebook', 'github', 'auth0']) {
     if (user.services?.[oauthProvider]?.id?.id) {
       const realId = user.services[oauthProvider].id.id;
       if (typeof realId !== 'number' && typeof realId !== 'string') {


### PR DESCRIPTION
Previously: https://github.com/ForumMagnum/ForumMagnum/pull/4673

(The tl;dr of which is that some data in the database was in the wrong shape due to a bug. The PR fixes it with a migration.)

When reviewing that PR, I thought it didn't affect Auth0. I saw an account today that had the bug. So apparently it did. Add Auth0 to the list of services that we run the fix-it migration against.