### PR TITLE
Add `$comment` to queries using views

### DIFF
--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -1,0 +1,15 @@
+
+// Given a view (which gets translated into a mongo query), provide a string
+// which describes what's being queried (ie the view name, and a list of
+// parameters that were attached, but not the values of those parameters). This
+// is attached to the mongodb query by putting a $comment in the selector, so
+// that when we see slow queries in the profiler, we can easily identify the
+// source.
+export function describeTerms(terms: ViewTermsBase) {
+  const viewName = terms.view || "defaultView";
+  const otherTerms = Object.keys(terms).filter(key => key!=='view').join(',');
+  if (otherTerms.length>0)
+    return `${viewName}(${otherTerms})`;
+  else
+    return viewName;
+}

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -2,6 +2,7 @@ import { Utils, getTypeName, getCollection } from '../vulcan-lib';
 import { restrictViewableFields } from '../vulcan-users/permissions';
 import { asyncFilter } from '../utils/asyncUtils';
 import { loggerConstructor, logGroupConstructor } from '../utils/logging';
+import { describeTerms } from '../utils/viewUtils';
 
 interface DefaultResolverOptions {
   cacheMaxAge: number
@@ -164,7 +165,10 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
   if (parameters.syntheticFields && Object.keys(parameters.syntheticFields).length>0) {
     const pipeline = [
       // First stage: Filter by selector
-      { $match: selector },
+      { $match: {
+        ...selector,
+        $comment: describeTerms(terms),
+      }},
       // Second stage: Add computed fields
       { $addFields: parameters.syntheticFields },
       

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -189,6 +189,11 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
     logger('aggregation pipeline', pipeline);
     return await collection.aggregate(pipeline).toArray();
   } else {
-    return await Utils.Connectors.find(collection, selector, options);
+    return await Utils.Connectors.find(collection,
+      {
+        ...selector,
+        $comment: describeTerms(terms),
+      },
+      options);
   }
 }

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -9,6 +9,7 @@ import { camelCaseify } from './utils';
 import { pluralize } from './pluralize';
 export * from './getCollection';
 import { loggerConstructor } from '../utils/logging'
+import { describeTerms } from '../utils/viewUtils';
 
 // 'Maximum documents per request'
 const maxDocumentsPerRequestSetting = new DatabasePublicSetting<number>('maxDocumentsPerRequest', 5000)
@@ -114,7 +115,9 @@ export const createCollection = <
     logger('getParameters(), terms:', terms);
 
     let parameters: any = {
-      selector: {},
+      selector: {
+        $comment: describeTerms(terms),
+      },
       options: {},
     };
 

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -9,7 +9,6 @@ import { camelCaseify } from './utils';
 import { pluralize } from './pluralize';
 export * from './getCollection';
 import { loggerConstructor } from '../utils/logging'
-import { describeTerms } from '../utils/viewUtils';
 
 // 'Maximum documents per request'
 const maxDocumentsPerRequestSetting = new DatabasePublicSetting<number>('maxDocumentsPerRequest', 5000)
@@ -115,9 +114,7 @@ export const createCollection = <
     logger('getParameters(), terms:', terms);
 
     let parameters: any = {
-      selector: {
-        $comment: describeTerms(terms),
-      },
+      selector: {},
       options: {},
     };
 


### PR DESCRIPTION
Add `$comment` to the selector of all queries going through the view system, containing the name of the view and a list of terms that were attached.

This doesn't directly fix any performance problems, but should make interpreting the mongodb cloud profiler much easier.