### PR TITLE
Add an admin-only static endpoint that echoes back your HTTP headers and IP

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -94,6 +94,7 @@ import './server/callbacks/collectionCallbacks';
 import './server/callbacks/messageCallbacks';
 import './server/callbacks/revisionCallbacks';
 import './server/callbacks/userCallbacks';
+import './server/staticRoutes/debugHeaders';
 import './server/tableOfContents';
 import './server/callbacks/subscriptionCallbacks';
 import './server/callbacks/rateLimits';

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -102,12 +102,12 @@ export function startWebserver() {
   }
   app.use(bodyParser.urlencoded({ extended: true })) // We send passwords + username via urlencoded form parameters
   app.use('/analyticsEvent', bodyParser.json({ limit: '50mb' }));
-  app.use(pickerMiddleware);
 
   addStripeMiddleware(addMiddleware);
   addAuthMiddlewares(addMiddleware);
   addSentryMiddlewares(addMiddleware);
   addClientIdMiddleware(addMiddleware);
+  app.use(pickerMiddleware);
   
   //eslint-disable-next-line no-console
   console.log("Starting ForumMagnum server. Versions: "+JSON.stringify(process.versions));

--- a/packages/lesswrong/server/staticRoutes/debugHeaders.ts
+++ b/packages/lesswrong/server/staticRoutes/debugHeaders.ts
@@ -1,0 +1,26 @@
+import { addStaticRoute } from '../vulcan-lib/staticRoutes';
+import { getUserFromReq, computeContextFromUser, configureSentryScope } from '../vulcan-lib/apollo-server/context';
+
+// Debug endpoint which, if you load it while logged in as an admin, echoes
+// back the HTTP headers you used to request it. Used for debugging header
+// changes while requests pass through load-balancers etc on prod, and in
+// particular for headers like X-Forwarded-For.
+addStaticRoute('/admin/debugHeaders', async (query,req,res,next) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    res.statusCode = 403;
+    res.end("Not logged in");
+    return;
+  }
+  if (!user.isAdmin) {
+    res.statusCode = 403;
+    res.end("Not an admin");
+    return;
+  }
+  
+  const headers = JSON.stringify(req.headers);
+  const otherIPsources =
+    `req.socket.remoteAddress: ${JSON.stringify(req?.socket?.remoteAddress)}\n`
+    +`req.connection.removeAddress: ${JSON.stringify(req?.connection?.remoteAddress)}\n`
+  res.end(`${JSON.stringify(req.headers)}\n${otherIPsources}`);
+});

--- a/packages/lesswrong/server/staticRoutes/debugHeaders.ts
+++ b/packages/lesswrong/server/staticRoutes/debugHeaders.ts
@@ -21,6 +21,6 @@ addStaticRoute('/admin/debugHeaders', async (query,req,res,next) => {
   const headers = JSON.stringify(req.headers);
   const otherIPsources =
     `req.socket.remoteAddress: ${JSON.stringify(req?.socket?.remoteAddress)}\n`
-    +`req.connection.removeAddress: ${JSON.stringify(req?.connection?.remoteAddress)}\n`
+    +`req.connection.remoteAddress: ${JSON.stringify(req?.connection?.remoteAddress)}\n`
   res.end(`${JSON.stringify(req.headers)}\n${otherIPsources}`);
 });

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
@@ -150,7 +150,7 @@ export const getCollectionsByName = (): CollectionsByName => {
   return result as CollectionsByName;
 }
 
-export const getUserFromReq = async (req) => {
+export const getUserFromReq = async (req): Promise<DbUser|null> => {
   return req.user
   // return getUser(getAuthToken(req));
 }

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -54,7 +54,11 @@ export const renderWithCache = async (req: Request, res: Response) => {
   const startTime = new Date();
   const user = await getUserFromReq(req);
   
-  const ip = req.headers["x-real-ip"] || req.headers['x-forwarded-for'];
+  let ipOrIpArray = req.headers['x-forwarded-for'] || req.headers["x-real-ip"] || req.connection.remoteAddress || "unknown";
+  let ip: string = ipOrIpArray.length ? (ipOrIpArray[0]) : (ipOrIpArray as string);
+  if (ip.indexOf(",")>=0)
+    ip = ip.split(",")[0];
+  
   const userAgent = req.headers["user-agent"];
   
   // Inject a tab ID into the page, by injecting a script fragment that puts

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -55,7 +55,7 @@ export const renderWithCache = async (req: Request, res: Response) => {
   const user = await getUserFromReq(req);
   
   let ipOrIpArray = req.headers['x-forwarded-for'] || req.headers["x-real-ip"] || req.connection.remoteAddress || "unknown";
-  let ip: string = ipOrIpArray.length ? (ipOrIpArray[0]) : (ipOrIpArray as string);
+  let ip: string = typeof ipOrIpArray==="object" ? (ipOrIpArray[0]) : (ipOrIpArray as string);
   if (ip.indexOf(",")>=0)
     ip = ip.split(",")[0];
   


### PR DESCRIPTION
Used for debugging why some logs have what look like what might be load-balancer IPs in them rather than end-user IPs. Changes some middleware ordering so that static routes can use `getUserFromReq` to enforce the admin-only bit.

Change which IP-address-forwarding header is used, so that we get the real external IP address instead of an internal load-balancer IP.