### PR TITLE
Hide deleted tag revisions from user profile

### DIFF
--- a/packages/lesswrong/components/tagging/TagEditsByUser.tsx
+++ b/packages/lesswrong/components/tagging/TagEditsByUser.tsx
@@ -37,14 +37,18 @@ const TagEditsByUser = ({userId, limit, classes}: {
     return <Components.Loading />
   }
 
-  if (results.length === 0) {
+  const resultsWithLiveTags = results
+    .filter(tagUpdates => tagUpdates.tag && !tagUpdates.tag.deleted)
+
+  if (resultsWithLiveTags.length === 0) {
     return <Components.Typography variant="body2" className={classes.wikiEmpty}>
       No {taggingNameIsSet.get() ? taggingNameSetting.get() : 'wiki'} contributions to display.
     </Components.Typography>
   }
 
   return <div className={classes.root}>
-    {results.filter(elm => !!elm.tag).map(tagUpdates => <Components.SingleLineTagUpdates
+    {resultsWithLiveTags.map(tagUpdates =>
+      <Components.SingleLineTagUpdates
       key={tagUpdates.documentId + " " + tagUpdates.editedAt}
       tag={tagUpdates.tag!}
       revisionIds={[tagUpdates._id]}

--- a/packages/lesswrong/lib/collections/revisions/views.ts
+++ b/packages/lesswrong/lib/collections/revisions/views.ts
@@ -12,6 +12,7 @@ declare global {
   }
 }
 
+// NB: Includes revisions on deleted tags
 Revisions.addView('revisionsByUser', (terms: RevisionsViewTerms) => {
   return {
     selector: {

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -13,13 +13,13 @@ registerFragment(`
     descriptionTruncationCount
     createdAt
     wikiOnly
+    deleted
   }
 `);
 
 registerFragment(`
   fragment TagDetailsFragment on Tag {
     ...TagBasicInfo
-    deleted
     oldSlugs
     isRead
     defaultOrder

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1404,10 +1404,10 @@ interface TagBasicInfo { // fragment on Tags
   readonly descriptionTruncationCount: number,
   readonly createdAt: Date,
   readonly wikiOnly: boolean,
+  readonly deleted: boolean,
 }
 
 interface TagDetailsFragment extends TagBasicInfo { // fragment on Tags
-  readonly deleted: boolean,
   readonly oldSlugs: Array<string>,
   readonly isRead: boolean,
   readonly defaultOrder: number,
@@ -1504,6 +1504,7 @@ interface TagFullContributorsList { // fragment on Tags
 
 interface TagEditFragment extends TagBasicInfo { // fragment on Tags
   readonly tagFlagsIds: Array<string>,
+  readonly postsDefaultSortOrder: string,
   readonly description: RevisionEdit|null,
 }
 


### PR DESCRIPTION
Deals with the situation where a user has edited a spam tag

Fixes: https://github.com/ForumMagnum/ForumMagnum/issues/4947
