### PR TITLE
Fix decrementing of commentCount on comment deletion

### DIFF
--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -69,7 +69,7 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
           <br/>
           <TextField
             id="comment-menu-item-delete-reason"
-            label="Reason for deleting"
+            label="Reason for deleting (optional)"
             className={classes.modalTextField}
             value={deletedReason}
             onChange={(event) => setDeletedReason(event.target.value)}

--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -61,11 +61,15 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
           What is your reason for deleting this comment?
         </DialogTitle>
         <DialogContent>
-          <p><em>(If you delete without a trace, the reason will be sent to the author of the comment privately. Otherwise it will be publicly displayed below the comment.)</em></p>
+          <p><em>
+            (If you delete without a trace, the reason will be sent to the
+            author of the comment privately. Otherwise it will be publicly
+            displayed below the comment.)
+          </em></p>
           <br/>
           <TextField
             id="comment-menu-item-delete-reason"
-            label="Reason for deleting (optional)"
+            label="Reason for deleting"
             className={classes.modalTextField}
             value={deletedReason}
             onChange={(event) => setDeletedReason(event.target.value)}

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -278,7 +278,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
   foreignFieldName: string,
   filterFn?: (doc: ObjectsByCollectionName[TargetCollectionName])=>boolean,
 }): CollectionFieldSpecification<SourceType> {
-  const denormalizedLogger = loggerConstructor(`${collectionName.toLowerCase()}-callbacks-denormalized-${fieldName}`)
+  const denormalizedLogger = loggerConstructor(`callbacks-${collectionName.toLowerCase()}-denormalized-${fieldName}`)
   
   type TargetType = ObjectsByCollectionName[TargetCollectionName];
   const foreignCollectionCallbackPrefix = foreignTypeName.toLowerCase();

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -7,6 +7,7 @@ import { asyncFilter } from './asyncUtils';
 import type { GraphQLScalarType } from 'graphql';
 import DataLoader from 'dataloader';
 import * as _ from 'underscore';
+import { loggerConstructor } from './logging';
 
 export const generateIdResolverSingle = <CollectionName extends CollectionNameString>({
   collectionName, fieldName, nullable
@@ -277,6 +278,8 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
   foreignFieldName: string,
   filterFn?: (doc: ObjectsByCollectionName[TargetCollectionName])=>boolean,
 }): CollectionFieldSpecification<SourceType> {
+  const denormalizedLogger = loggerConstructor(`${collectionName.toLowerCase()}-callbacks-denormalized-${fieldName}`)
+  
   type TargetType = ObjectsByCollectionName[TargetCollectionName];
   const foreignCollectionCallbackPrefix = foreignTypeName.toLowerCase();
   const filter = filterFn || ((doc: ObjectsByCollectionName[TargetCollectionName]) => true);
@@ -286,7 +289,9 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     // When inserting a new document which potentially needs to be counted, follow
     // its reference and update with $inc.
     const createCallback = async (newDoc, {currentUser, collection, context}) => {
+      denormalizedLogger(`about to test new ${foreignTypeName}`, newDoc)
       if (newDoc[foreignFieldName] && filter(newDoc)) {
+        denormalizedLogger(`new ${foreignTypeName} should increment ${newDoc[foreignFieldName]}`)
         const collection = getCollection(collectionName);
         await collection.rawUpdateOne(newDoc[foreignFieldName], {
           $inc: { [fieldName]: 1 }
@@ -302,10 +307,12 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     // out, or we may need to both but on different documents.
     addCallback(`${foreignCollectionCallbackPrefix}.update.after`,
       async (newDoc, {oldDocument, currentUser, collection}) => {
+        denormalizedLogger(`about to test updating ${foreignTypeName}`, newDoc, oldDocument)
         const countingCollection = getCollection(collectionName);
         if (filter(newDoc) && !filter(oldDocument)) {
           // The old doc didn't count, but the new doc does. Increment on the new doc.
           if (newDoc[foreignFieldName]) {
+            denormalizedLogger(`updated ${foreignTypeName} should increment ${newDoc[foreignFieldName]}`)
             await countingCollection.rawUpdateOne(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
@@ -313,19 +320,23 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
         } else if (!filter(newDoc) && filter(oldDocument)) {
           // The old doc counted, but the new doc doesn't. Decrement on the old doc.
           if (oldDocument[foreignFieldName]) {
+            denormalizedLogger(`updated ${foreignTypeName} should decrement ${newDoc[foreignFieldName]}`)
             await countingCollection.rawUpdateOne(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
-        } else if(filter(newDoc) && oldDocument[foreignFieldName] !== newDoc[foreignFieldName]) {
+        } else if (filter(newDoc) && oldDocument[foreignFieldName] !== newDoc[foreignFieldName]) {
+          denormalizedLogger(`${foreignFieldName} of ${foreignTypeName} has changed from ${oldDocument[foreignFieldName]} to ${newDoc[foreignFieldName]}`)
           // The old and new doc both count, but the reference target has changed.
           // Decrement on one doc and increment on the other.
           if (oldDocument[foreignFieldName]) {
+            denormalizedLogger(`changing ${foreignFieldName} leads to decrement of ${oldDocument[foreignFieldName]}`)
             await countingCollection.rawUpdateOne(oldDocument[foreignFieldName], {
               $inc: { [fieldName]: -1 }
             });
           }
           if (newDoc[foreignFieldName]) {
+            denormalizedLogger(`changing ${foreignFieldName} leads to increment of ${newDoc[foreignFieldName]}`)
             await countingCollection.rawUpdateOne(newDoc[foreignFieldName], {
               $inc: { [fieldName]: 1 }
             });
@@ -336,7 +347,9 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
     );
     addCallback(`${foreignCollectionCallbackPrefix}.delete.async`,
       async ({document, currentUser, collection}) => {
+        denormalizedLogger(`about to test deleting ${foreignTypeName}`, document)
         if (document[foreignFieldName] && filter(document)) {
+          denormalizedLogger(`deleting ${foreignTypeName} should decrement ${document[foreignFieldName]}`)
           const countingCollection = getCollection(collectionName);
           await countingCollection.rawUpdateOne(document[foreignFieldName], {
             $inc: { [fieldName]: -1 }

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -242,6 +242,7 @@ getCollectionHooks("Comments").newValidate.add(function NewCommentsEmptyCheck (c
 });
 
 export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser: DbUser | undefined) {
+  console.log('made it here cdspma 1')
   if ((!comment.deletedByUserId || comment.deletedByUserId !== comment.userId) && comment.deleted && comment.contents?.html) {
     const onWhat = comment.tagId
       ? (await Tags.findOne(comment.tagId))?.name
@@ -268,6 +269,7 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
     if (comment.deletedReason && moderatingUser) {
       firstMessageContents += ` They gave the following reason: "${comment.deletedReason}".`;
     }
+    console.log('made it here cdspma 2')
 
     const firstMessageData = {
       userId: lwAccount._id,
@@ -292,6 +294,7 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
       currentUser: lwAccount,
       validate: false
     })
+    console.log('made it here cdspma 3')
 
     await createMutator({
       collection: Messages,
@@ -299,6 +302,7 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
       currentUser: lwAccount,
       validate: false
     })
+    console.log('made it here cdspma 4')
 
     // eslint-disable-next-line no-console
     console.log("Sent moderation messages for comment", comment)

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -242,7 +242,6 @@ getCollectionHooks("Comments").newValidate.add(function NewCommentsEmptyCheck (c
 });
 
 export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser: DbUser | undefined) {
-  console.log('made it here cdspma 1')
   if ((!comment.deletedByUserId || comment.deletedByUserId !== comment.userId) && comment.deleted && comment.contents?.html) {
     const onWhat = comment.tagId
       ? (await Tags.findOne(comment.tagId))?.name
@@ -269,7 +268,6 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
     if (comment.deletedReason && moderatingUser) {
       firstMessageContents += ` They gave the following reason: "${comment.deletedReason}".`;
     }
-    console.log('made it here cdspma 2')
 
     const firstMessageData = {
       userId: lwAccount._id,
@@ -294,7 +292,6 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
       currentUser: lwAccount,
       validate: false
     })
-    console.log('made it here cdspma 3')
 
     await createMutator({
       collection: Messages,
@@ -302,7 +299,6 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
       currentUser: lwAccount,
       validate: false
     })
-    console.log('made it here cdspma 4')
 
     // eslint-disable-next-line no-console
     console.log("Sent moderation messages for comment", comment)

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -337,10 +337,6 @@ getCollectionHooks("Comments").editSync.add(async function validateDeleteOperati
         throw new Error("You cannot publicly delete a comment without also deleting it")
       }
 
-      if (deletedPublic && !deletedReason) {
-        throw new Error("Publicly deleted comments need to have a deletion reason");
-      }
-
       if (
         (comment.deleted || comment.deletedPublic) &&
         (deletedPublic || deletedReason) &&

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -31,7 +31,6 @@ const specificResolvers = {
           set.deletedByUserId = null;
         }
         
-        console.log('got here 1', set)
         const {data: updatedComment} = await updateMutator({
           collection: Comments,
           documentId: commentId,

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -20,9 +20,13 @@ const specificResolvers = {
       {
         let set: Record<string,any> = {deleted: deleted}
         if (deleted) {
-          set.deletedPublic = deletedPublic;
+          if(deletedPublic !== undefined) {
+            set.deletedPublic = deletedPublic;
+          }
           set.deletedDate = comment.deletedDate || new Date();
-          set.deletedReason = deletedReason;
+          if(deletedReason !== undefined) {
+            set.deletedReason = deletedReason;
+          }
           set.deletedByUserId = currentUser._id;
         } else { //When you undo delete, reset all delete-related fields
           set.deletedPublic = false;

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -31,6 +31,7 @@ const specificResolvers = {
           set.deletedByUserId = null;
         }
         
+        console.log('got here 1', set)
         const {data: updatedComment} = await updateMutator({
           collection: Comments,
           documentId: commentId,

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -42,13 +42,13 @@ import isEmpty from 'lodash/isEmpty';
 import { createError } from 'apollo-errors';
 import pickBy from 'lodash/pickBy';
 
-//
-// Create mutation
-// Inserts an entry in a collection, and runs a bunch of callback functions to
-// fill in its denormalized fields etc. Input is a Partial<T>, because some
-// fields will be filled in by those callbacks; result is a T, but nothing
-// in the type system ensures that everything actually gets filled in.
-//
+/**
+ * Create mutation
+ * Inserts an entry in a collection, and runs a bunch of callback functions to
+ * fill in its denormalized fields etc. Input is a Partial<T>, because some
+ * fields will be filled in by those callbacks; result is a T, but nothing
+ * in the type system ensures that everything actually gets filled in. 
+ */
 export const createMutator = async <T extends DbObject>({
   collection,
   document,
@@ -237,13 +237,13 @@ export const createMutator = async <T extends DbObject>({
   return { data: completedDocument };
 };
 
-//
-// Update mutation
-// Updates a single database entry, and runs callbacks/etc to update its
-// denormalized fields. The preferred way to do this is with a documentId;
-// in theory you can use a selector, but you should only do this if you're sure
-// there's only one matching document (eg, slug). Returns the modified document.
-//
+/**
+ * Update mutation
+ * Updates a single database entry, and runs callbacks/etc to update its
+ * denormalized fields. The preferred way to do this is with a documentId;
+ * in theory you can use a selector, but you should only do this if you're sure
+ * there's only one matching document (eg, slug). Returns the modified document.
+ */
 export const updateMutator = async <T extends DbObject>({
   collection,
   documentId,

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -96,17 +96,6 @@ export const createMutator = async <T extends DbObject>({
     newDocument: document as unknown as T, // Pretend this isn't Partial<T>
     schema
   };
-  
-  /*
-
-  Remove undefines from insertion document
-
-  */
-
-  // cast is necessary b/c Ojbect.entries returns [string, any]
-  document = Object.fromEntries(
-    Object.entries(document).filter((_key, value) => value !== undefined)
-  ) as Partial<DbInsertion<T>>
 
   /*
 
@@ -114,7 +103,6 @@ export const createMutator = async <T extends DbObject>({
 
   */
   if (validate) {
-    console.log('create validation??')
     let validationErrors: Array<any> = [];
     validationErrors = validationErrors.concat(validateDocument(document, collection, context));
     // run validation callbacks
@@ -317,8 +305,7 @@ export const updateMutator = async <T extends DbObject>({
   // FIXME: Filtering out null-valued fields here is a very sketchy, probably
   // wrong thing to do. This originates from Vulcan, and it's not clear why it's
   // doing it. Explicit cast to make it type-check anyways.
-  document = pickBy(document, f => f !== null && f !== undefined) as any;
-  console.log('🚀 ~ file: mutators.ts ~ line 321 ~ document', document)
+  document = pickBy(document, f => f !== null) as any;
 
   /*
 
@@ -333,15 +320,12 @@ export const updateMutator = async <T extends DbObject>({
     currentUser, collection, context, schema
   };
 
-  console.log('got here 1.5')
-
   /*
 
   Validation
 
   */
   if (validate) {
-    console.log('validating??')
     let validationErrors: any = [];
 
     validationErrors = validationErrors.concat(validateData(data, document, collection, context));
@@ -378,25 +362,22 @@ export const updateMutator = async <T extends DbObject>({
     let autoValue;
     const schemaField = schema[fieldName];
     if (schemaField.onUpdate) {
-      console.log('got an onUpdate')
+      // eslint-disable-next-line no-await-in-loop
       autoValue = await schemaField.onUpdate({...properties, fieldName});
-      console.log('that completed')
     } else if (schemaField.onEdit) {
-      console.log('got an onedit')
       // OpenCRUD backwards compatibility
+      // eslint-disable-next-line no-await-in-loop
       autoValue = await schemaField.onEdit(
         dataToModifier(clone(data)),
         oldDocument,
         currentUser,
         document
       );
-      console.log('that completed')
     }
     if (typeof autoValue !== 'undefined') {
       data![fieldName] = autoValue;
     }
   }
-  console.log('got here 1.6')
 
   /*
 
@@ -428,13 +409,10 @@ export const updateMutator = async <T extends DbObject>({
       ]
     })
   );
-  
-  console.log('got here 1.7')
 
   // update connector requires a modifier, so get it from data
   const modifier = dataToModifier(data);
 
-  console.log('got here 1.8')
   // remove empty modifiers
   if (isEmpty(modifier.$set)) {
     delete modifier.$set;
@@ -442,16 +420,12 @@ export const updateMutator = async <T extends DbObject>({
   if (isEmpty(modifier.$unset)) {
     delete modifier.$unset;
   }
-  
 
   /*
 
   DB Operation
 
   */
- 
-  
-  console.log('got here 2')
   if (!isEmpty(modifier)) {
     // update document
     await Connectors.updateOne(collection, selector, modifier, { removeEmptyStrings: false });
@@ -487,8 +461,6 @@ export const updateMutator = async <T extends DbObject>({
       currentUser
     ]
   });
-  
-  console.log('got here 3')
 
   /*
 


### PR DESCRIPTION
And add a logger for denormalized updater callbacks.

Comment deletion goes through a custom resolver. The resolver was previously calling `Comments.rawUpdateOne`, this PR converts it to use updateMutator, which ensures it calls all the callbacks registered on the Comments collection.

This caused `deletedReason` to no longer be optional. From my experience, it's valuable to have people write the reason why they're deleting their own comments, so I decided to leave it required, as a callback intended, and not as the frontend claimed. 