### PR TITLE
Revert "Share karma among co-authors"

### DIFF
--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -148,7 +148,6 @@ interface VoteableType extends HasIdType, HasUserIdType {
   afBaseScore?: number
   afExtendedScore?: any,
   afVoteCount?: number
-  coauthorUserIds?: string[]
 }
 
 interface VoteableTypeClient extends VoteableType {


### PR DESCRIPTION
Oli noted that this PR didn't have the right behavior:

> Alas, we'll likely have to revert this PR. It is quite important that the vote totals are directly derivable from nothing but the vote table, so that we can rerun vote totals from time to time, so any change to how karma gets allocated also needs to change the code for rerunning vote totals.

Reverts ForumMagnum/ForumMagnum#4976