### PR TITLE
Add Multiplicative Topic Weights, Topic Default Filters, and Fix a Bug

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -102,6 +102,11 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
     skip: !tagId
   })
 
+  if (mode === "TagDefault" && tag?.defaultFilterMode !== null && tag?.defaultFilterMode !== undefined) {
+    // Casting because the generated type does not realize the schema constrains
+    // it to be one of the FilterMode values
+    mode = tag.defaultFilterMode as FilterMode
+  }
 
   const tagLabel = <span>
     {label}
@@ -125,6 +130,11 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
             <LWTooltip title={filterModeToTooltip("Hidden")}>
               <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Hidden"})} onClick={ev => onChangeMode("Hidden")}>
                 Hidden
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip("Halved")}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: [0.5, "Halved"].includes(mode)})} onClick={ev => onChangeMode("Halved")}>
+                Halved
               </span>
             </LWTooltip>
             <LWTooltip title={filterModeToTooltip(-25)}>
@@ -189,6 +199,8 @@ function filterModeToTooltip(mode: FilterMode): React.ReactNode {
       return <div><em>Required.</em> ONLY posts with this {taggingNameSetting.get()} will appear in Latest Posts.</div>
     case "Hidden":
       return <div><em>Hidden.</em> Posts with this {taggingNameSetting.get()} will be not appear in Latest Posts.</div>
+    case "Halved":
+      return <div><em>Halved.</em> Posts with this {taggingNameSetting.get()} with be shown as if they had half as much karma.</div>
     case 0:
     case "Default":
       return <div><em>+0.</em> This {taggingNameSetting.get()} will be ignored for filtering and sorting.</div>
@@ -214,6 +226,7 @@ function filterModeToStr(mode: FilterMode, currentUser: UsersCurrent | null): st
     case "Required": return "Required";
     case "Subscribed": return "Subscribed";
     case "Reduced": return "Reduced";
+    case "Halved": return "Halved";
   }
 }
 

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -14,6 +14,7 @@ registerFragment(`
     createdAt
     wikiOnly
     deleted
+    defaultFilterMode
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -10,6 +10,7 @@ import { captureException } from '@sentry/core';
 import { forumTypeSetting, taggingNamePluralSetting, taggingNameSetting } from '../../instanceSettings';
 import { SORT_ORDER_OPTIONS, SettingsOption } from '../posts/schema';
 import omit from 'lodash/omit';
+import { FILTER_MODE_CHOICES } from '../../filterSettings';
 
 const formGroups: Partial<Record<string,FormGroup>> = {
   advancedOptions: {
@@ -422,7 +423,21 @@ export const schema: SchemaType<DbTag> = {
       value: key,
       label: val.label
     })),
-  }
+  },
+  
+  defaultFilterMode: {
+    type: SimpleSchema.oneOf(String, Number),
+    optional: true,
+    group: formGroups.advancedOptions,
+    viewableBy: ['guests'],
+    editableBy: ['admins'],
+    insertableBy: ['admins'],
+    control: 'select',
+    options: () => FILTER_MODE_CHOICES.map(mode => ({
+      value: mode,
+      label: mode
+    })),
+  },
 }
 
 export const wikiGradeDefinitions: Partial<Record<number,string>> = {

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -437,7 +437,7 @@ export const schema: SchemaType<DbTag> = {
       value: mode,
       label: mode
     })),
-    tooltip: `Default ${taggingNameSetting.get()} filter for new and logged out users. If setting this on a tag for the first time, ask a dev to add a defaultVisibilityTags to the DB.`
+    tooltip: `Default ${taggingNameSetting.get()} filter for new and logged out users. If setting this on a ${taggingNameSetting.get()} for the first time, ask a dev to add a defaultVisibilityTags to the DB.`
   },
 }
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -437,6 +437,7 @@ export const schema: SchemaType<DbTag> = {
       value: mode,
       label: mode
     })),
+    tooltip: `Default ${taggingNameSetting.get()} filter for new and logged out users. If setting this on a tag for the first time, ask a dev to add a defaultVisibilityTags to the DB.`
   },
 }
 

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -182,3 +182,4 @@ Tags.addView('allPublicTags', (terms: TagsViewTerms) => {
 });
 
 ensureIndex(Tags, {name: 1});
+// ensureIndex(Tags, {defaultFilterMode: 1});

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -182,4 +182,6 @@ Tags.addView('allPublicTags', (terms: TagsViewTerms) => {
 });
 
 ensureIndex(Tags, {name: 1});
-// ensureIndex(Tags, {defaultFilterMode: 1});
+
+// Used in packages/lesswrong/server/defaultTagWeights/cache.ts
+ensureIndex(Tags, {defaultFilterMode: 1});

--- a/packages/lesswrong/lib/filterSettings.ts
+++ b/packages/lesswrong/lib/filterSettings.ts
@@ -16,7 +16,11 @@ export interface FilterTag {
   tagName: string,
   filterMode: FilterMode,
 }
-export type FilterMode = "Hidden"|"Default"|"Required"|"Subscribed"|"Reduced"|number
+/** TagDefault relies on there being a FilterMode on the tag */
+export const FILTER_MODE_CHOICES = [
+  'Hidden', 'Default', 'Required', 'Subscribed', 'Reduced', 'Halved', 0.75, 0.25,
+] as const;
+export type FilterMode = typeof FILTER_MODE_CHOICES[number]|"TagDefault"|number
 
 export const getDefaultFilterSettings = (): FilterSettings => ({
   personalBlog: "Hidden",

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -654,6 +654,7 @@ interface DbTag extends DbObject {
   contributionStats: any /*{"definitions":[{"blackbox":true}]}*/
   introSequenceId: string
   postsDefaultSortOrder: string
+  defaultFilterMode: string
   description: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -171,6 +171,39 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly votingSystem: string,
 }
 
+interface TagsDefaultFragment { // fragment on Tags
+  readonly createdAt: Date,
+  readonly name: string,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
+  readonly core: boolean,
+  readonly suggestedAsFilter: boolean,
+  readonly defaultOrder: number,
+  readonly descriptionTruncationCount: number,
+  readonly postCount: number,
+  readonly userId: string,
+  readonly adminOnly: boolean,
+  readonly charsAdded: number,
+  readonly charsRemoved: number,
+  readonly deleted: boolean,
+  readonly lastCommentedAt: Date,
+  readonly needsReview: boolean,
+  readonly reviewedByUserId: string,
+  readonly wikiGrade: number,
+  readonly wikiOnly: boolean,
+  readonly bannerImageId: string,
+  readonly tagFlagsIds: Array<string>,
+  readonly lesswrongWikiImportRevision: string,
+  readonly lesswrongWikiImportSlug: string,
+  readonly lesswrongWikiImportCompleted: boolean,
+  readonly htmlWithContributorAnnotations: string,
+  readonly contributors: any /*TagContributorsList*/,
+  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly introSequenceId: string,
+  readonly postsDefaultSortOrder: string,
+  readonly defaultFilterMode: string,
+}
+
 interface VotesDefaultFragment { // fragment on Votes
   readonly documentId: string,
   readonly collectionName: string,
@@ -239,38 +272,6 @@ interface SequencesDefaultFragment { // fragment on Sequences
   readonly canonicalCollectionSlug: string,
   readonly hidden: boolean,
   readonly hideFromAuthorPage: boolean,
-}
-
-interface TagsDefaultFragment { // fragment on Tags
-  readonly createdAt: Date,
-  readonly name: string,
-  readonly slug: string,
-  readonly oldSlugs: Array<string>,
-  readonly core: boolean,
-  readonly suggestedAsFilter: boolean,
-  readonly defaultOrder: number,
-  readonly descriptionTruncationCount: number,
-  readonly postCount: number,
-  readonly userId: string,
-  readonly adminOnly: boolean,
-  readonly charsAdded: number,
-  readonly charsRemoved: number,
-  readonly deleted: boolean,
-  readonly lastCommentedAt: Date,
-  readonly needsReview: boolean,
-  readonly reviewedByUserId: string,
-  readonly wikiGrade: number,
-  readonly wikiOnly: boolean,
-  readonly bannerImageId: string,
-  readonly tagFlagsIds: Array<string>,
-  readonly lesswrongWikiImportRevision: string,
-  readonly lesswrongWikiImportSlug: string,
-  readonly lesswrongWikiImportCompleted: boolean,
-  readonly htmlWithContributorAnnotations: string,
-  readonly contributors: any /*TagContributorsList*/,
-  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly introSequenceId: string,
-  readonly postsDefaultSortOrder: string,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions
@@ -1405,6 +1406,7 @@ interface TagBasicInfo { // fragment on Tags
   readonly createdAt: Date,
   readonly wikiOnly: boolean,
   readonly deleted: boolean,
+  readonly defaultFilterMode: string,
 }
 
 interface TagDetailsFragment extends TagBasicInfo { // fragment on Tags
@@ -1921,11 +1923,11 @@ interface FragmentTypes {
   LocalgroupsDefaultFragment: LocalgroupsDefaultFragment
   TagRelsDefaultFragment: TagRelsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
+  TagsDefaultFragment: TagsDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
   CommentsDefaultFragment: CommentsDefaultFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
   SequencesDefaultFragment: SequencesDefaultFragment
-  TagsDefaultFragment: TagsDefaultFragment
   RevisionsDefaultFragment: RevisionsDefaultFragment
   PostsMinimumInfo: PostsMinimumInfo
   PostsBase: PostsBase
@@ -2066,11 +2068,11 @@ interface CollectionNamesByFragmentName {
   LocalgroupsDefaultFragment: "Localgroups"
   TagRelsDefaultFragment: "TagRels"
   PostsDefaultFragment: "Posts"
+  TagsDefaultFragment: "Tags"
   VotesDefaultFragment: "Votes"
   CommentsDefaultFragment: "Comments"
   RSSFeedsDefaultFragment: "RSSFeeds"
   SequencesDefaultFragment: "Sequences"
-  TagsDefaultFragment: "Tags"
   RevisionsDefaultFragment: "Revisions"
   PostsMinimumInfo: "Posts"
   PostsBase: "Posts"

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -11,6 +11,7 @@ import './server/database-import/database_import_new';
 import './server/rss-integration/cron';
 import './server/rss-integration/callbacks';
 import './server/karmaInflation/cron';
+import './server/defaultTagWeights/cron';
 import './server/database-import/force_batch_update_scores';
 import './server/database-import/cleanup_scripts';
 import './server/robots';

--- a/packages/lesswrong/server/defaultTagWeights/cache.ts
+++ b/packages/lesswrong/server/defaultTagWeights/cache.ts
@@ -1,0 +1,13 @@
+import Tags from "../../lib/collections/tags/collection";
+import type { FilterMode } from "../../lib/filterSettings";
+
+export let tagDefaultWeights: { [_id: string]: FilterMode } = {};
+
+export async function refreshTagDefaultWeights() {
+  tagDefaultWeights = Object.fromEntries(
+    (await Tags.find({defaultFilterMode: {$exists: true}}).fetch())
+      // Casting because the generated type does not realize the schema
+      // constrains it to be one of the FilterMode values
+      .map(tag => [tag._id, tag.defaultFilterMode as FilterMode])
+  )
+}

--- a/packages/lesswrong/server/defaultTagWeights/cron.ts
+++ b/packages/lesswrong/server/defaultTagWeights/cron.ts
@@ -1,0 +1,15 @@
+import { onStartup } from "../../lib/executionEnvironment";
+import { addCronJob } from "../cronUtil";
+import { refreshTagDefaultWeights } from "./cache";
+
+onStartup(async () => {
+  await refreshTagDefaultWeights();
+});
+
+addCronJob({
+  name: 'refreshTagDefaultWeightsCron',
+  interval: 'every 5 minutes',
+  job() {
+    void refreshTagDefaultWeights();
+  }
+});

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -82,7 +82,6 @@ const inProgressRenders: Record<string,Array<InProgressRender>> = {};
 // may not be relevant to the request).
 export const cachedPageRender = async (req: Request, abTestGroups, renderFn: (req:Request)=>Promise<RenderResult>) => {
   const path = getPathFromReq(req);
-  //eslint-disable-next-line no-console
   const cacheKey = cacheKeyFromReq(req);
   const cached = cacheLookup(cacheKey, abTestGroups);
   


### PR DESCRIPTION
When setting a negative tag weighting, I claim you actually want to apply a multiplying factor less than 1, rather than something like -25. That way new posts still can get a little bit of your attention, and big popular posts are not ~unaffected.*

We'd also like to take our default visibility tags, and have them be adjustable without migrating all the user objects. So we instead store the default tag weighting on the tag object. If a user does not touch the setting, their setting will still be changeable with the default tag weighting. However, once they touch it, it will no longer be affected.

Tag default visibility could be done by a database join. However I was hitting really frustrating mongodb issues, and I decided I would rather simplify things at the cost of a bit of inelegance, and store the default tag visibility in global state that updates every 5 minutes.

Finally, bugfix: Previously the behavior of:
```ts
$multiply: [
  filterModeToKarmaModifier(t.filterMode),
  {$ifNull: [
    "$tagRelevance."+t.tagId,
    0
  ]}
]
```
Was to multiply the tag relevance by the filterMode. So if you meant to be applying +25, but the tag relevance was 2, you were actually applying +50.

Thanks to @soof-golan and @hibukki (https://github.com/ForumMagnum/ForumMagnum/pull/4973) for heavy inspiration for this PR. I decided it was important to use our Forum's native tag filtering system and let it be user-modifiable, and decided to write my vision into code. For expediency if nothing else — @Xodarap convinced me this was an urgent issue.

*However, I'm happy to make this EA Forum only if desired.