### PR TITLE
Return curated to recommendations-section, add to rec page

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -95,17 +95,6 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
           </AnalyticsContext>
         </div>
         <AnalyticsContext listContext={"latestPosts"}>
-          <AnalyticsContext listContext={"curatedPosts"}>
-            <PostsList2
-              terms={{view:"curated", limit: currentUser ? 3 : 2}}
-              showNoResults={false}
-              showLoadMore={false}
-              hideLastUnread={true}
-              boxShadow={false}
-              curatedIconLeft={true}
-              showFinalBottomBorder={true}
-            />
-          </AnalyticsContext>
           <PostsList2 terms={recentPostsTerms} alwaysShowLoadMore={true}>
             <Link to={"/allPosts"}>Advanced Sorting/Filtering</Link>
           </PostsList2>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -9,7 +9,7 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
 
-export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
+export const curatedUrl = "/recommendations"
 
 const styles = (theme: ThemeType): JssStyles => ({
   section: {
@@ -92,7 +92,7 @@ const RecommendationsAndCurated = ({
   }, [showSettings, setShowSettings]);
 
   const render = () => {
-    const { SequencesGridWrapper, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList, RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip } = Components;
+    const { SequencesGridWrapper, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList, RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip, PostsList2 } = Components;
 
     const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
     const frontpageRecommendationSettings: RecommendationsAlgorithm = {
@@ -165,7 +165,7 @@ const RecommendationsAndCurated = ({
               <RecommendationsList algorithm={frontpageRecommendationSettings} />
             </AnalyticsContext>
           }
-          {/* <AnalyticsContext listContext={"curatedPosts"}>
+          <AnalyticsContext listContext={"curatedPosts"}>
             <PostsList2
               terms={{view:"curated", limit: currentUser ? 3 : 2}}
               showNoResults={false}
@@ -174,7 +174,7 @@ const RecommendationsAndCurated = ({
               boxShadow={false}
               curatedIconLeft={true}
             />
-          </AnalyticsContext> */}
+          </AnalyticsContext>
         </div>
       </div>
 

--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
 });
@@ -8,12 +9,27 @@ const styles = (theme: ThemeType): JssStyles => ({
 const RecommendationsPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { ConfigurableRecommendationsList } = Components;
-  
+  const { ConfigurableRecommendationsList, PostsList2, SingleColumnSection, SectionTitle } = Components;
+
+  const showCurated = forumTypeSetting.get() === 'LessWrong'
+
   return (
-  <AnalyticsContext listContext={"recommendationsPage"} capturePostItemOnMount>
-    <ConfigurableRecommendationsList configName="recommendationspage" />
-  </AnalyticsContext>
+    <div>
+      <AnalyticsContext listContext={"recommendationsPage"} capturePostItemOnMount>
+        <ConfigurableRecommendationsList configName="recommendationspage" />
+      </AnalyticsContext>
+      {showCurated && <SingleColumnSection>
+        <SectionTitle title="Curated Posts"/>
+        <AnalyticsContext listContext={"curatedPosts"}>
+          <PostsList2
+            terms={{view:"curated", limit: 20}}
+            showNoResults={false}
+            boxShadow={false}
+            curatedIconLeft={true}
+          />
+        </AnalyticsContext>
+      </SingleColumnSection>}
+    </div>
   )
 };
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -705,6 +705,11 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       ...hpmorSubtitle,
     },
     {
+      name: 'Curated',
+      path: '/curated',
+      redirect: () => `/recommendations`,
+    },
+    {
       name: 'Walled Garden',
       path: '/walledGarden',
       componentName: 'WalledGardenHome',


### PR DESCRIPTION
Over a year ago we moved the curated section to the Latest Posts section temporarily (I think during Review Season when the Recommendations section was removed or moved lower on the page). This PR finally moves it back. It also adds a longer Curated to the Recommendations page, so that when you click on the "Recommendations" link it takes you to a page that roughly matches the formatting of the frontpage RecommendationsAndCurated section.

The curated section sorts by curation date instead of postedAt, which is an improvement over the previous All Posts solution for the curated posts list.

(The curated section on the /recommendations page only appears on LessWrong, so EA forum and AF don't have a weird empty section)

Also adds a "/curated" link that redirects to "/recommendations" on LessWrong so people making reasonable guesses about how to find things can find the curated posts.

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/3246710/171311104-7121b7ea-3498-4a85-a104-9fa507996b59.png">

<img width="1462" alt="image" src="https://user-images.githubusercontent.com/3246710/171311144-819232e6-3bc1-474c-b0d7-de421b4679bd.png">


