### PR TITLE
fix a bug around "new comment" notifications for group organizers

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -256,7 +256,7 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
         <SearchResultsMap {...mapOptions} />
       </div>
     </div>
-    <Configure hitsPerPage={200} {...searchOptions} />
+    <Configure hitsPerPage={200} aroundRadius="all" {...searchOptions} />
   </InstantSearch>
 }
 

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -659,7 +659,7 @@ addFieldsDict(Users, {
     ...schemaDefaultValue(true),
   },
   autoSubscribeAsOrganizer: {
-    label: "Auto-subscribe to posts and meetups in groups I organize",
+    label: `Auto-subscribe to posts/events in groups I organize`,
     group: formGroups.notifications,
     type: Boolean,
     optional: true,
@@ -672,7 +672,7 @@ addFieldsDict(Users, {
   },
 
   notificationCommentsOnSubscribedPost: {
-    label: "Comments on posts I'm subscribed to",
+    label: `Comments on posts/events I'm subscribed to`,
     ...notificationTypeSettingsField(),
   },
   notificationShortformContent: {
@@ -714,7 +714,7 @@ addFieldsDict(Users, {
     ...notificationTypeSettingsField({ channel: "both"})
   },
   notificationEventInRadius: {
-    label: "New Events in my notification radius",
+    label: "New events in my notification radius",
     hidden: !hasEventsSetting.get(),
     ...notificationTypeSettingsField({ channel: "both" }),
   },

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -378,23 +378,29 @@ getCollectionHooks("Comments").newAsync.add(async function CommentsNewNotificati
   
   // 2. Notify users who are subscribed to the post (which may or may not include the post's author)
   let userIdsSubscribedToPost: Array<string> = [];
-  let defaultSubscribedUserIds: Array<string> = post ? [post.userId] : []
-  // if the post is associated with a group, also notify the group organizers
-  if (post && post.groupId) {
-    const group = await Localgroups.findOne(post.groupId)
-    if (group?.organizerIds) {
-      defaultSubscribedUserIds = _.union(defaultSubscribedUserIds, group.organizerIds)
-    }
-  }
-  
   const usersSubscribedToPost = await getSubscribedUsers({
     documentId: comment.postId,
     collectionName: "Posts",
     type: subscriptionTypes.newComments,
-    potentiallyDefaultSubscribedUserIds: defaultSubscribedUserIds,
+    potentiallyDefaultSubscribedUserIds: post ? [post.userId] : [],
     userIsDefaultSubscribed: u => u.auto_subscribe_to_my_posts
   })
   userIdsSubscribedToPost = _.map(usersSubscribedToPost, u=>u._id);
+  
+  // if the post is associated with a group, also (potentially) notify the group organizers
+  if (post && post.groupId) {
+    const group = await Localgroups.findOne(post.groupId)
+    if (group?.organizerIds && group.organizerIds.length) {
+      const subsWithOrganizers = await getSubscribedUsers({
+        documentId: comment.postId,
+        collectionName: "Posts",
+        type: subscriptionTypes.newComments,
+        potentiallyDefaultSubscribedUserIds: group.organizerIds,
+        userIsDefaultSubscribed: u => u.autoSubscribeAsOrganizer
+      })
+      userIdsSubscribedToPost = _.union(userIdsSubscribedToPost, _.map(subsWithOrganizers, u=>u._id))
+    }
+  }
 
   // Notify users who are subscribed to shortform posts
   if (!comment.topLevelCommentId && comment.shortform) {


### PR DESCRIPTION
I initially misunderstood how "default subscribed" to notifications worked - hopefully the logic is correct now.

I also fixed a small bug with the EA Forum's community map.