### PR TITLE
Fix editing bio on LessWrong

### DIFF
--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -275,6 +275,9 @@ registerFragment(`
 registerFragment(`
   fragment UsersEdit on User {
     ...UsersProfile
+    biography {
+      ...RevisionEdit
+    }
     # Moderation Guidelines editor information
     moderationGuidelines {
       ...RevisionEdit


### PR DESCRIPTION
Pairing with Jim. Problem was the fragment was missing the information necessary to populate ckeditor.