### PR TITLE
Improve Quicksearch UI

### DIFF
--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -11,13 +11,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingLeft: 10,
     paddingRight: 10,
     display: 'flex',
+    alignItems: 'center',
   },
   icon: {
     width: 20,
     color: theme.palette.grey[600],
     marginRight: 12,
-    marginLeft: 4,
-    marginTop: 5
+    marginLeft: 4
   },
   snippet: {
     overflowWrap: "break-word",

--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -7,21 +7,23 @@ import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    padding: 10,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 10,
     display: 'flex',
-    alignItems: 'center',
-    borderBottom: theme.palette.border.faint
   },
   icon: {
     width: 20,
     color: theme.palette.grey[600],
     marginRight: 12,
-    marginLeft: 4
+    marginLeft: 4,
+    marginTop: 5
   },
   snippet: {
     overflowWrap: "break-word",
     ...theme.typography.body2,
-    wordBreak: "break-word"
+    wordBreak: "break-word",
+    color: theme.palette.grey[600],
   }
 })
 

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -8,22 +8,22 @@ import DescriptionIcon from '@material-ui/icons/Description';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    padding: 10,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 10,
     display: 'flex',
-    alignItems: 'center',
-    borderBottom: theme.palette.border.faint,
     overflowWrap: "break-word"
   },
   icon: {
     width: 20,
     color: theme.palette.grey[500],
     marginRight: 12,
-    marginLeft: 4
+    marginLeft: 4,
+    marginTop: 5
   },
   snippet: {
     ...theme.typography.postStyle,
     lineHeight: "1.3rem",
-    marginTop: 4,
     wordBreak: "break-word"
   },
   title: {
@@ -68,7 +68,11 @@ const PostsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
             <Components.FormatDate date={post.postedAt}/>
           </Components.MetaInfo>}
         </div>
-        {showSnippet && <div className={classes.snippet}><Snippet attribute="body" hit={post} tagName="mark" /></div>}
+        {showSnippet && <div className={classes.snippet}>
+          <Components.MetaInfo>
+            <Snippet attribute="body" hit={post} tagName="mark" />
+          </Components.MetaInfo>
+        </div>}
     </Link>
   </div>
 }

--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -49,10 +49,15 @@ const styles = (theme: ThemeType): JssStyles => ({
       height: "calc(100vh - 64px)",
     },
   },
-  usersList: {
-    paddingTop: 6,
-    paddingBottom: 4,
-    borderBottom: theme.palette.border.faint
+  list: {
+    '& .ais-Hits-list':{
+      paddingTop: 6,
+      paddingBottom: 4,
+      borderBottom: theme.palette.border.grey300,
+    },
+    '& .ais-Hits-list:empty':{
+      display:"none"
+    },
   },
   seeAll: {
     ...theme.typography.body2,
@@ -86,7 +91,7 @@ const SearchBarResults = ({closeSearch, currentQuery, classes}: {
     <div className={classes.searchResults}>
         <CurrentRefinements />
         <Components.ErrorBoundary>
-          <div className={classes.usersList}>
+          <div className={classes.list}>
             <Index indexName={getAlgoliaIndexName("Users")}>
               <Configure hitsPerPage={3} />
               <Hits hitComponent={(props) => <UsersSearchHit clickAction={closeSearch} {...props} showIcon/>} />
@@ -94,28 +99,36 @@ const SearchBarResults = ({closeSearch, currentQuery, classes}: {
           </div>
         </Components.ErrorBoundary>
         <Components.ErrorBoundary>
-          <Index indexName={getAlgoliaIndexName("Tags")}>
-            <Configure hitsPerPage={3} />
-            <Hits hitComponent={(props) => <TagsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-          </Index>
+          <div className={classes.list}>
+            <Index indexName={getAlgoliaIndexName("Tags")}>
+              <Configure hitsPerPage={3} />
+              <Hits hitComponent={(props) => <TagsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
+            </Index>
+          </div>
         </Components.ErrorBoundary>
         <Components.ErrorBoundary>
-          <Index indexName={getAlgoliaIndexName("Posts")}>
-            <Configure hitsPerPage={3} />
-            <Hits hitComponent={(props) => <PostsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-          </Index>
+          <div className={classes.list}>
+            <Index indexName={getAlgoliaIndexName("Posts")}>
+              <Configure hitsPerPage={3} />
+              <Hits hitComponent={(props) => <PostsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
+            </Index>
+          </div>
         </Components.ErrorBoundary>
         <Components.ErrorBoundary>
-          <Index indexName={getAlgoliaIndexName("Comments")}>
-            <Configure hitsPerPage={3} />
-            <Hits hitComponent={(props) => <CommentsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-          </Index>
+          <div className={classes.list}>
+            <Index indexName={getAlgoliaIndexName("Comments")}>
+              <Configure hitsPerPage={3} />
+              <Hits hitComponent={(props) => <CommentsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
+            </Index>
+          </div>
         </Components.ErrorBoundary>
         <Components.ErrorBoundary>
-          <Index indexName={getAlgoliaIndexName("Sequences")}>
-            <Configure hitsPerPage={3} />
-            <Hits hitComponent={(props) => <SequencesSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-          </Index>
+          <div className={classes.list}>
+            <Index indexName={getAlgoliaIndexName("Sequences")}>
+              <Configure hitsPerPage={3} />
+              <Hits hitComponent={(props) => <SequencesSearchHit clickAction={closeSearch} {...props} showIcon/>} />
+            </Index>
+          </div>
         </Components.ErrorBoundary>
         <Link to={`/search?terms=${currentQuery}`} className={classes.seeAll}>
           See all results

--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -7,10 +7,11 @@ import { Snippet } from 'react-instantsearch-dom';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    padding: 10,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 10,
     display: 'flex',
-    alignItems: 'center',
-    borderBottom: theme.palette.border.faint
+    alignItems: 'center'
   },
   title: {
     display: "inline",

--- a/packages/lesswrong/components/search/TagsSearchHit.tsx
+++ b/packages/lesswrong/components/search/TagsSearchHit.tsx
@@ -9,10 +9,11 @@ import { taggingNameCapitalSetting, taggingNameIsSet } from '../../lib/instanceS
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    padding: 10,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 10,
     display: 'flex',
     alignItems: 'center',
-    borderBottom: theme.palette.border.faint
   },
   name: {
     ...theme.typography.body2,


### PR DESCRIPTION
Tweaks the UI for quick search. Some principles:
– removed the lines in between each item, instead having lines between in section so that it's easier to skim for which section you're looking for
– hides empty sections (instead of seeing a janky border-bottom with a bit of padding)
– shifts the positioning of the icon for posts higher, so that it's easier to use it as the anchor-point of where to start reading the PostsSearchItem

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/3246710/171746998-0da077f6-2a6a-4967-bb8b-6d929569ba70.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/3246710/171747229-5e5707ea-dd3f-49d0-b3f4-fb8b61b8d076.png">

(previous version:)

<img width="1723" alt="image" src="https://user-images.githubusercontent.com/3246710/171751411-9daadc2f-4ede-43f7-96a4-2b459d5dfe22.png">
