### PR TITLE
sunshine hoverovers allow overflow

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
@@ -24,7 +24,7 @@ const SidebarHoverOver = ({children, classes, hover, anchorEl, width=500}: {
   width?: number,
 }) => {
   const { LWPopper } = Components;
-  return <LWPopper className={classes.root} open={hover} anchorEl={anchorEl} placement="left-start">
+  return <LWPopper className={classes.root} open={hover} anchorEl={anchorEl} placement="left-start" allowOverflow>
     <div className={classes.hoverInfo} style={{width:width}}>
       { children }
     </div>


### PR DESCRIPTION
The new LWPopper resulted in sunshine sidebar hoverovers positioning themselves unpredictably, and sometimes trying overlapping with the site header. This restores their functionality to the previous version, where they are always aligned with the top of the parent sunshine item.