### PR TITLE
Redirect /walledGardenPortal

### DIFF
--- a/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
@@ -21,7 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   button: {
     background: theme.palette.primary.main,
     borderRadius: 3,
-    color: "white",
+    color: theme.palette.text.invertedBackgroundText,
     display: "block",
     width: 300,
     padding: 16,

--- a/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
@@ -18,6 +18,19 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.body2,
     ...theme.typography.commentStyle
   },
+  button: {
+    background: theme.palette.primary.main,
+    borderRadius: 3,
+    color: "white",
+    display: "block",
+    width: 300,
+    padding: 16,
+    marginTop: 36,
+    textAlign: "center",
+    fontWeight: 600,
+    marginLeft: "auto",
+    marginRight: "auto"
+  }
 })
 
 const WalledGardenHome = ({classes}:{classes:ClassesType}) => {
@@ -41,26 +54,12 @@ const WalledGardenHome = ({classes}:{classes:ClassesType}) => {
         Walled Garden
       </Typography>
       <p>
-        <a href="https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus"><strong>Link to the Garden</strong></a><br/>
-      </p>
-      <p>
-        There are many kinds of important social interactions; and not all of those can be achieved on a scheduled Zoom call or from behind a keyboard. Even before the pandemic, it was challenging to make all the worthwhile conversations happen.
-      </p>
-      <p>
-        To address this, The LessWrong team is experimenting with a permanent, virtual world for rationalists. The vision to provide an always-available, 24/7 communal hub where you can socialize, cowork, play games, and attend events.
-      </p>
-      <p>
-        We’re calling it <strong>The Walled Garden</strong>. The plan is to only invite folks if we trust them to embody the virtues, norms, and culture of the LessWrong/Rationality community at its best. &nbsp;If you're seeing this, we invited you with that in mind. <i>Please don't share the password.</i>
+        Walled Garden is a virtual world hosted on <a href="https://gather.town/">gather.town</a>. You control an avatar who can walk around, videochatting with other nearby avatars. It was created to enable social interaction during the 2020 pandemic, and continues getting some use as a place people host online meetups.
       </p>
       <p>
         Come visit! Reconnect with old friends, make new ones. And if you're keen to stretch your legs, take a virtual walk together through the waterfalls or explore the abandoned (for now) university campus.
       </p>
-      <p>
-        <strong>The Garden is open 24/7</strong></p>
-      <ul>
-        <li>Schelling socializing hours at 1pm and 7pm PT</li>
-        <li>Schelling co-working hours between 2pm-7pm PT</li>
-      </ul>
+      <a href="https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus"><div className={classes.button}>Click to enter the Garden</div></a><br/>
       <h2>A Culture of Truth-Seeking</h2><p>As a home for Rationalists, the Garden will have a culture of truth-seeking. Inhabitants should reflect on their thought-processes, embody these <a href="https://lesswrong.com/posts/7ZqGiPHTpiDMwqMN2/twelve-virtues-of-rationality">12 virtues of Rationality</a> (and others), and generally try to be right rather than Right.
       </p>
       <h2>Garden Etiquette</h2>

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -716,10 +716,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
     {
       name: 'Walled Garden Portal',
       path: '/walledGardenPortal',
-      componentName: 'WalledGardenPortal',
-      title: "Walled Garden Portal",
-      ...walledGardenPortalSubtitle,
-      disableAutoRefresh: true,
+      redirect: () => `/walledGarden`,
     },
     {
       name: 'HPMOR.posts.single',


### PR DESCRIPTION
The route garden.lesswrong.com previously directed to lesswrong.com/walledGardenPortal, which is an iframe housing our gather.town instance. Gather.town no longer lets us do an iframe, and we're not really supporting Walled Garden anyway. But it's occasionally used (John Wentworth is using it soon for SERI MATS), so it seemed worth briefly cleaning it up.

This PR redirects it to lesswrong.com/walledGarden, a page that just provides a text overview of what the garden is about, and a link that goes to https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus

The PR also updates the text a bit to be more up-to-date

<img width="2077" alt="image" src="https://user-images.githubusercontent.com/3246710/171963559-256b2161-6bf9-460b-a255-10ea88030bc5.png">
