### PR TITLE
add multiline argument to text input to make wrapping happen

### DIFF
--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -11,6 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.display3,
     ...theme.typography.headerStyle,
     width: "100%",
+    color: 'red',
     resize: "none",
     textAlign: "left",
     marginTop: 0,
@@ -67,6 +68,7 @@ const EditTitle = ({document, value, path, placeholder, updateCurrentValues, cla
     }}
     onBlur={(event) =>  handleChangeTitle(event)}
     disableUnderline={true}
+    multiline
   />
 };
 


### PR DESCRIPTION
Currently the title doesn't wrap when editing. Somehow the `multiline` keyword to <input> got lost. This puts it back.