### PR TITLE
User profile shortform

### DIFF
--- a/packages/lesswrong/components/shortform/ProfileShortform.tsx
+++ b/packages/lesswrong/components/shortform/ProfileShortform.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useSingle } from '../../lib/crud/withSingle';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+
+  }
+});
+
+export const ProfileShortform = ({classes, user}: {
+  classes: ClassesType,
+  user: UsersProfile
+}) => {
+
+  const { PostsItem2 } = Components
+
+  const { document } = useSingle({
+    documentId: user.shortformFeedId,
+    collectionName: "Posts",
+    fragmentName: "PostsList"
+  });
+
+  return <div className={classes.root}>
+      {document && <PostsItem2 post={document} hideAuthor forceSticky />}
+  </div>;
+}
+
+const ProfileShortformComponent = registerComponent('ProfileShortform', ProfileShortform, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ProfileShortform: typeof ProfileShortformComponent
+  }
+}
+

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -639,13 +639,14 @@ const UsersProfileFn = ({terms, slug, classes}: {
               currentIncludeEvents={currentIncludeEvents}
             />}
             <AnalyticsContext listContext={"userPagePosts"}>
+              {user.shortformFeedId && <Components.ProfileShortform user={user}/>}
               <PostsList2 terms={terms} hideAuthor />
             </AnalyticsContext>
           </SingleColumnSection>
           {/* Groups Section */
             (ownPage || currentUser?.isAdmin) && <LocalGroupsList terms={{
                 view: 'userActiveGroups',
-                userId: user?._id,
+                userId: user._id,
                 limit: 300
               }} heading="Organizer of" showNoResults={false} />
           }

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -245,6 +245,7 @@ importComponent("RepliesToCommentList", () => require('../components/shortform/R
 importComponent("NewShortformDialog", () => require('../components/shortform/NewShortformDialog'));
 importComponent("ShortformSubmitForm", () => require('../components/shortform/ShortformSubmitForm'));
 importComponent("ShortformTimeBlock", () => require('../components/shortform/ShortformTimeBlock'));
+importComponent("ProfileShortform", () => require('../components/shortform/ProfileShortform'));
 
 importComponent("VoteArrowIcon", () => require('../components/votes/VoteArrowIcon'));
 importComponent("VoteAgreementIcon", () => require('../components/votes/VoteAgreementIcon'));


### PR DESCRIPTION
Not sure this is the best possible implementation of shortform-on-user-profiles, but it's what I could implement quickly, and I think is better than not-existing.

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/3246710/172024950-45e68d01-37ea-4593-9ea8-43a49604dcb2.png">
