### PR TITLE
Extract presentational components from DistanceUnitToggle

### DIFF
--- a/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
+++ b/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
@@ -1,39 +1,12 @@
 import { registerComponent, } from '../../../lib/vulcan-lib';
 import React, { useEffect } from 'react';
 import { createStyles } from '@material-ui/core/styles';
-import classNames from 'classnames';
+import ToggleButtonGroup from './ToggleButtonGroup';
+import ToggleButton from './ToggleButton';
 
-const styles = createStyles((theme: ThemeType): JssStyles => ({
+const styles = createStyles((): JssStyles => ({
   root: {
-    display: 'inline-block',
-    ...theme.typography.commentStyle,
     marginLeft: 5
-  },
-  radio: {
-    display: 'none'
-  },
-  label: {
-    padding: '5px 10px',
-    cursor: 'pointer',
-    border: `1px solid ${theme.palette.grey[315]}`,
-    '&.left': {
-      borderRightColor: theme.palette.primary.dark,
-      borderRadius: '4px 0 0 4px',
-    },
-    '&.right': {
-      borderLeftWidth: 0,
-      borderRadius: '0 4px 4px 0'
-    },
-    '&.selected': {
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.text.invertedBackgroundText,
-      borderColor: theme.palette.primary.dark,
-    },
-    '&:hover': {
-      backgroundColor: theme.palette.primary.dark,
-      color: theme.palette.text.invertedBackgroundText,
-      borderColor: theme.palette.primary.dark,
-    }
   },
 }))
 
@@ -55,20 +28,16 @@ const DistanceUnitToggle = ({distanceUnit='km', onChange, skipDefaultEffect, cla
     //No exhaustive deps because this is supposed to run only on mount
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  
-  return <div className={classes.root}>
-    <input type="radio" id="km" name="distanceUnit" value="km" className={classes.radio}
-      checked={distanceUnit === 'km'} onChange={() => onChange('km')} />
-    <label htmlFor="km" className={classNames(classes.label, 'left', {'selected': distanceUnit === 'km'})}>
-      km
-    </label>
 
-    <input type="radio" id="mi" name="distanceUnit" value="mi" className={classes.radio}
-      checked={distanceUnit === 'mi'} onChange={() => onChange('mi')} />
-    <label htmlFor="mi" className={classNames(classes.label, 'right', {'selected': distanceUnit === 'mi'})}>
-      mi
-    </label>
-  </div>
+  return <ToggleButtonGroup
+    value={distanceUnit}
+    onChange={( _e, newUnit) => onChange(newUnit)}
+    name="distanceUnit"
+    className={classes.root}
+  >
+    <ToggleButton value="km">km</ToggleButton>
+    <ToggleButton value="mi">mi</ToggleButton>
+  </ToggleButtonGroup>
 }
 
 const DistanceUnitToggleComponent = registerComponent('DistanceUnitToggle', DistanceUnitToggle, {styles});

--- a/packages/lesswrong/components/community/modules/ToggleButton.tsx
+++ b/packages/lesswrong/components/community/modules/ToggleButton.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { createStyles, withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+
+/**
+ * To be used together with ToggleButtonGroup.
+ *
+ * Should be replace with the official material-ui component
+ * after update to material-ui v5.
+ */
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {},
+  radio: {
+    display: 'none'
+  },
+  label: {
+    padding: '5px 10px',
+    cursor: 'pointer',
+    border: `1px solid ${theme.palette.grey[315]}`,
+    'white-space': 'nowrap',
+    '&:first-of-type': {
+      borderRadius: '4px 0 0 4px',
+    },
+    '&:last-of-type': {
+      borderRadius: '0 4px 4px 0'
+    },
+    '&.selected': {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.text.invertedBackgroundText,
+      borderColor: theme.palette.primary.dark,
+    },
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+      color: theme.palette.text.invertedBackgroundText,
+      borderColor: theme.palette.primary.dark,
+    }
+  },
+}))
+
+const ToggleButton = (
+  { classes, children, value, onChange = () => {}, selectedValue, name }: {
+    classes: ClassesType, children: any, value: string, onChange?: Function, selectedValue?: string, name?: string
+  }
+) => {
+
+  // What is the established pattern for generating IDs in this repo?
+  const uniqueId = `toggle-button-${Math.random()}`;
+
+  return <React.Fragment>
+    <input
+      type="radio"
+      className={classes.radio}
+      id={uniqueId}
+      value={value}
+      checked={value === selectedValue}
+      onChange={(e) => onChange(e, value)}
+      name={name}
+    />
+    <label
+      htmlFor={uniqueId}
+      className={classNames(classes.label, {'selected': value === selectedValue})}
+    >{children}</label>
+  </React.Fragment>
+}
+
+export default withStyles(styles)(ToggleButton);

--- a/packages/lesswrong/components/community/modules/ToggleButtonGroup.tsx
+++ b/packages/lesswrong/components/community/modules/ToggleButtonGroup.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { createStyles, withStyles } from '@material-ui/core/styles';
+
+/**
+ * reimplementation of the ToggleButtonGroup from material-ui
+ * with the styles of the DistanceUnitToggle.
+ *
+ * should be replaced with the official material-ui component
+ * after update to material-ui v5.
+ *
+ *
+ */
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {
+    display: 'inline-block',
+    ...theme.typography.commentStyle,
+  },
+}))
+
+const ToggleButtonGroup = (
+  {classes, className = '', children, value, onChange, name}:{classes: ClassesType, className?: string, children: any, value: string, onChange: Function, name?: string}
+) => {
+
+  if (!name) {
+    name = `toggle-button-group-name-${Math.random()}`
+  }
+  const childrenWithProps = children.map((child: any, index: number) => {
+    return React.cloneElement(child, {
+      selectedValue: value,
+      onChange: (e: any, value: string) => onChange(e, value),
+      name,
+      key: index
+    })
+  });
+
+  return <div className={classes.root + ' ' + className}>{childrenWithProps}</div>
+};
+
+export default withStyles(styles)(ToggleButtonGroup);


### PR DESCRIPTION
This PR is part of the work to fix the issue identified in #4965.

We want to reuse toggle buttons in the same style of the DistanceUnitToggle. Therefore this commit extracts two components and gives them an interface similar to the respective component in material-ui.

The [ToggleButton(Group) in material ui v3](https://v3.mui.com/lab/toggle-button/) is not yet viable, but when this repository has been migrated to mui v5, then using the stock [v5 ToggleButton(Group)](https://mui.com/material-ui/react-toggle-button/) should be strongly considered.

Also, the DistanceUnitToggle is not only used in the community page but also on the events page and maybe even in more places. It should probably move to a more shared location, but that can happen in a new commit.

Furthermore, that component is still fully inaccessible to screen readers / keyboard navigation. Fixing that would probably also be another PR.

Finally, I'm not yet sure what pattern this repository uses to generate unique Ids. Is there a preferred library method for this?


