### PR TITLE
Extract presentational components from DistanceUnitToggle

### DIFF
--- a/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
+++ b/packages/lesswrong/components/community/modules/DistanceUnitToggle.tsx
@@ -1,39 +1,12 @@
 import { registerComponent, } from '../../../lib/vulcan-lib';
 import React, { useEffect } from 'react';
 import { createStyles } from '@material-ui/core/styles';
-import classNames from 'classnames';
+import ToggleButtonGroup from './ToggleButtonGroup';
+import ToggleButton from './ToggleButton';
 
-const styles = createStyles((theme: ThemeType): JssStyles => ({
+const styles = createStyles((): JssStyles => ({
   root: {
-    display: 'inline-block',
-    ...theme.typography.commentStyle,
     marginLeft: 5
-  },
-  radio: {
-    display: 'none'
-  },
-  label: {
-    padding: '5px 10px',
-    cursor: 'pointer',
-    border: `1px solid ${theme.palette.grey[315]}`,
-    '&.left': {
-      borderRightColor: theme.palette.primary.dark,
-      borderRadius: '4px 0 0 4px',
-    },
-    '&.right': {
-      borderLeftWidth: 0,
-      borderRadius: '0 4px 4px 0'
-    },
-    '&.selected': {
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.text.invertedBackgroundText,
-      borderColor: theme.palette.primary.dark,
-    },
-    '&:hover': {
-      backgroundColor: theme.palette.primary.dark,
-      color: theme.palette.text.invertedBackgroundText,
-      borderColor: theme.palette.primary.dark,
-    }
   },
 }))
 
@@ -55,20 +28,16 @@ const DistanceUnitToggle = ({distanceUnit='km', onChange, skipDefaultEffect, cla
     //No exhaustive deps because this is supposed to run only on mount
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  
-  return <div className={classes.root}>
-    <input type="radio" id="km" name="distanceUnit" value="km" className={classes.radio}
-      checked={distanceUnit === 'km'} onChange={() => onChange('km')} />
-    <label htmlFor="km" className={classNames(classes.label, 'left', {'selected': distanceUnit === 'km'})}>
-      km
-    </label>
 
-    <input type="radio" id="mi" name="distanceUnit" value="mi" className={classes.radio}
-      checked={distanceUnit === 'mi'} onChange={() => onChange('mi')} />
-    <label htmlFor="mi" className={classNames(classes.label, 'right', {'selected': distanceUnit === 'mi'})}>
-      mi
-    </label>
-  </div>
+  return <ToggleButtonGroup
+    value={distanceUnit}
+    onChange={( _e, newUnit) => onChange(newUnit)}
+    name="distanceUnit"
+    className={classes.root}
+  >
+    <ToggleButton value="km">km</ToggleButton>
+    <ToggleButton value="mi">mi</ToggleButton>
+  </ToggleButtonGroup>
 }
 
 const DistanceUnitToggleComponent = registerComponent('DistanceUnitToggle', DistanceUnitToggle, {styles});

--- a/packages/lesswrong/components/community/modules/ToggleButton.tsx
+++ b/packages/lesswrong/components/community/modules/ToggleButton.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { createStyles, withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+
+/**
+ * To be used together with ToggleButtonGroup.
+ *
+ * Should be replace with the official material-ui component
+ * after update to material-ui v5.
+ */
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {},
+  radio: {
+    display: 'none'
+  },
+  label: {
+    padding: '5px 10px',
+    cursor: 'pointer',
+    border: `1px solid ${theme.palette.grey[315]}`,
+    'white-space': 'nowrap',
+    '&:first-of-type': {
+      borderRadius: '4px 0 0 4px',
+    },
+    '&:last-of-type': {
+      borderRadius: '0 4px 4px 0'
+    },
+    '&.selected': {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.text.invertedBackgroundText,
+      borderColor: theme.palette.primary.dark,
+    },
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+      color: theme.palette.text.invertedBackgroundText,
+      borderColor: theme.palette.primary.dark,
+    }
+  },
+}))
+
+const ToggleButton = (
+  { classes, children, value, onChange = () => {}, selectedValue, name }: {
+    classes: ClassesType, children: any, value: string, onChange?: Function, selectedValue?: string, name?: string
+  }
+) => {
+
+  // What is the established pattern for generating IDs in this repo?
+  const uniqueId = `toggle-button-${Math.random()}`;
+
+  return <React.Fragment>
+    <input
+      type="radio"
+      className={classes.radio}
+      id={uniqueId}
+      value={value}
+      checked={value === selectedValue}
+      onChange={(e) => onChange(e, value)}
+      name={name}
+    />
+    <label
+      htmlFor={uniqueId}
+      className={classNames(classes.label, {'selected': value === selectedValue})}
+    >{children}</label>
+  </React.Fragment>
+}
+
+export default withStyles(styles)(ToggleButton);

--- a/packages/lesswrong/components/community/modules/ToggleButtonGroup.tsx
+++ b/packages/lesswrong/components/community/modules/ToggleButtonGroup.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { createStyles, withStyles } from '@material-ui/core/styles';
+
+/**
+ * reimplementation of the ToggleButtonGroup from material-ui
+ * with the styles of the DistanceUnitToggle.
+ *
+ * should be replaced with the official material-ui component
+ * after update to material-ui v5.
+ *
+ *
+ */
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {
+    display: 'inline-block',
+    ...theme.typography.commentStyle,
+  },
+}))
+
+const ToggleButtonGroup = (
+  {classes, className = '', children, value, onChange, name}:{classes: ClassesType, className?: string, children: any, value: string, onChange: Function, name?: string}
+) => {
+
+  if (!name) {
+    name = `toggle-button-group-name-${Math.random()}`
+  }
+  const childrenWithProps = children.map((child: any, index: number) => {
+    return React.cloneElement(child, {
+      selectedValue: value,
+      onChange: (e: any, value: string) => onChange(e, value),
+      name,
+      key: index
+    })
+  });
+
+  return <div className={classes.root + ' ' + className}>{childrenWithProps}</div>
+};
+
+export default withStyles(styles)(ToggleButtonGroup);

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -12,6 +12,8 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { pickBestReverseGeocodingResult } from '../../server/mapsUtils';
 import { useGoogleMaps, geoSuggestStyles } from '../form-components/LocationFormComponent';
+import ToggleButton from '../community/modules/ToggleButton';
+import ToggleButtonGroup from '../community/modules/ToggleButtonGroup';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { useMulti } from '../../lib/crud/withMulti';
@@ -429,16 +431,17 @@ const EventsHome = ({classes}: {
               />
               <DistanceUnitToggle distanceUnit={distanceUnit} onChange={handleChangeDistanceUnit} skipDefaultEffect />
             </div>
-            
-            <Select
-              className={classes.filter}
+
+            <ToggleButtonGroup
               value={modeFilter}
-              input={<OutlinedInput labelWidth={0} />}
-              onChange={(e) => setModeFilter(e.target.value)}>
-                <MenuItem key="all" value="all">In-person and online</MenuItem>
-                <MenuItem key="in-person" value="in-person">In-person only</MenuItem>
-                <MenuItem key="online" value="online">Online only</MenuItem>
-            </Select>
+              onChange={(_e, newMode) => {
+                setModeFilter(newMode)}
+              }
+            >
+              <ToggleButton value="in-person">In-person</ToggleButton>
+              <ToggleButton value="online">Online</ToggleButton>
+              <ToggleButton value="all">All</ToggleButton>
+            </ToggleButtonGroup>
 
             <Select
               className={classNames(classes.filter, classes.formatFilter)}


### PR DESCRIPTION
TODO:
- [ ] Review and (if you think it is a good idea) merge #5018 first!
- [ ] ensure responsiveness on small screens (maybe this has to be an extra PR with css grid, not sure yet)
- [ ] move ToggleButton(Group) and DistanceUnitToggle to a better location?

This fixes #4965. It is intended to be merged after #5018, but GitHub does not allow to target a branch on my fork and still create a PR on this main repo. The relevant changes for this PR are in `EventsHome.tsx`, everything else is identical to #4965.

This commit replaces the Select for in-person / online / all events with a
ToggleButtonGroup in the same style of the distance unit selector as a
select is usually not ideal for just three options. It hides the
available alternatives and requires the user to click in order to see
them.

Also, this no longer applies the class that hides the element on small
screens, as especially on mobile the user is more likely to be only
interested in in-person events, and always showing all events can add a
lot of noise to their experience.