### PR TITLE
Updated the client bundle copyright info.

### DIFF
--- a/build.js
+++ b/build.js
@@ -46,11 +46,11 @@ if (opts.mongoUrl) {
 
 const clientBundleBanner = `/*
  * LessWrong 2.0 (client JS bundle)
- * Copyright (c) 2020 the LessWrong development team. See http://github.com/LessWrong2/Lesswrong2
+ * Copyright (c) 2022 the LessWrong development team. See https://github.com/ForumMagnum/ForumMagnum
  * for source and license details.
  *
  * Includes CkEditor.
- * Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * Copyright (c) 2003-2022, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see https://github.com/ckeditor/ckeditor5/blob/master/LICENSE.md
  */`
 


### PR DESCRIPTION
This updates the LessWrong copyright year from 2020 to 2022 and its link to point at the correct repository. It also updates the CKEditor copyright info to match the currently used vendored version.


