### PR TITLE
Preserve query string when clicking on Table of Contents

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import qs from 'qs'
+import * as _ from 'underscore';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { isServer } from '../../../lib/executionEnvironment';
@@ -57,7 +59,10 @@ const TableOfContentsList = ({sectionData, title, onClickSection, drawerStyle}: 
 
     const anchorY = getAnchorY(anchor);
     if (anchorY !== null) {
-      history.push(`#${anchor}`)
+      history.push({
+        search: _.isEmpty(query) ? '' : `?${qs.stringify(query)}`,
+        hash: `#${anchor}`,
+      });
       let sectionYdocumentSpace = anchorY + window.scrollY;
       jumpToY(sectionYdocumentSpace);
     }


### PR DESCRIPTION
Ooopsie.

Sorting answers by newest and clicking on an answer in the ToC now changes the sorting after scrolling to the answer location, in practice scrolling you to an unrelated answer.

This fixes that.

Btw, I was amazed to see the sorting change already in production on the EA forum, thanks! Continuous deployment to the extreme!