### PR TITLE
Fix cron jobs

### DIFF
--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
@@ -143,13 +143,11 @@ SyncedCron.add = async function(entry: {
 SyncedCron.start = function() {
   var self = this;
 
-  onStartup(async function() {
-    // Schedule each job with later.js
-    _.each(self._entries, function(entry) {
-      scheduleEntry(entry);
-    });
-    self.running = true;
+  // Schedule each job with later.js
+  _.each(self._entries, function(entry) {
+    scheduleEntry(entry);
   });
+  self.running = true;
 }
 
 // Return the next scheduled date of the first matching entry or undefined


### PR DESCRIPTION
Cron jobs were not running due to a bug where after #4966, nested onStartup calls now fail. Removed the onStartup call from `SyncedCron.start`, which is already called inside an onStartup.