### PR TITLE
New feature tooltip

### DIFF
--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -14,29 +14,28 @@ const styles = (theme: ThemeType): JssStyles => ({
       height: 10,
       borderRadius: '50%',
       alignSelf: 'center',
-      position: 'absolute',
-      right: 5
+      position: 'absolute'
+    },
+    NewFeatureTooltipArrow: {
+      pointerEvents: "none",
+      content:'""',
+      position: "absolute",
+      left: -10,
+      top: -5,
+      width: 0,
+      height: 0,
+      border: "10px solid transparent",
+      borderRightColor: theme.palette.lwTertiary.main
     },
     NewFeatureTooltip: {
       background: theme.palette.lwTertiary.main,
       color: theme.palette.primary.contrastText,
       padding: 3,
       borderRadius: 2,
-      display:'flex',
       width: 100,
-      marginLeft: 15,
-        '&:before': {
-          pointerEvents: "none",
-          content:'""',
-          position: "absolute",
-          left: -5,
-          width: 0,
-          height: 0,
-          zIndex: -1,
-          border: "10px solid transparent",
-          borderRightColor: theme.palette.lwTertiary.main,
-          alignSelf: 'center'
-      }
+      marginLeft: 10,
+      marginTop: -10,
+      minHeight: 40
     },
     wrapper: {
       display: 'flex',
@@ -66,9 +65,10 @@ const NewFeatureTooltip = ({classes, children, className, text} :
     
     open={hover}
     anchorEl={anchorEl}
-    placement="right"
+    placement="right-start"
     allowOverflow>
       <div>
+        <div className={classes.NewFeatureTooltipArrow}></div>
         <div className={classes.NewFeatureTooltip}>{text}</div>
       </div>
     </LWPopper>

--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -1,20 +1,42 @@
 import classNames from 'classnames';
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { useHover } from './withHover';
 
 const styles = (theme: ThemeType): JssStyles => ({
     root: {
       // inline-block makes sure that the popper placement works properly (without flickering). "block" would also work, but there may be situations where we want to wrap an object in a tooltip that shouldn't be a block element.
       display: "inline-block",
     },
-    tooltip: {
-      background: 'blue',
-      width: 5,
-      height: 5,
+    newFeatureHandle: {
+      background: theme.palette.lwTertiary.main,
+      width: 10,
+      height: 10,
       borderRadius: '50%',
       alignSelf: 'center',
       position: 'absolute',
       right: 5
+    },
+    NewFeatureTooltip: {
+      background: theme.palette.lwTertiary.main,
+      color: theme.palette.primary.contrastText,
+      padding: 3,
+      borderRadius: 2,
+      display:'flex',
+      width: 100,
+      marginLeft: 15,
+        '&:before': {
+          pointerEvents: "none",
+          content:'""',
+          position: "absolute",
+          left: -5,
+          width: 0,
+          height: 0,
+          zIndex: -1,
+          border: "10px solid transparent",
+          borderRightColor: theme.palette.lwTertiary.main,
+          alignSelf: 'center'
+      }
     },
     wrapper: {
       display: 'flex',
@@ -36,9 +58,22 @@ const NewFeatureTooltip = ({classes, children, className, text} :
     text: string
   }) => {
 
+  const {LWPopper} = Components
+  const { anchorEl, hover, eventHandlers } = useHover();
+
   return <div className={classes.wrapper}>
-    {children}
-    <span className={classNames(classes.tooltip, className)}/>
+    <LWPopper
+    
+    open={hover}
+    anchorEl={anchorEl}
+    placement="right"
+    allowOverflow>
+      <div>
+        <div className={classes.NewFeatureTooltip}>{text}</div>
+      </div>
+    </LWPopper>
+      {children}
+    <span className={classNames(classes.newFeatureHandle, className)} {...eventHandlers}/>
   </div>
 }
 

--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -1,0 +1,55 @@
+import classNames from 'classnames';
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+    root: {
+      // inline-block makes sure that the popper placement works properly (without flickering). "block" would also work, but there may be situations where we want to wrap an object in a tooltip that shouldn't be a block element.
+      display: "inline-block",
+    },
+    tooltip: {
+      background: 'blue',
+      width: 5,
+      height: 5,
+      borderRadius: '50%',
+      alignSelf: 'center',
+      position: 'absolute',
+      right: 5
+    },
+    wrapper: {
+      display: 'flex',
+      position: 'relative'
+    }
+  })
+/**
+ * 
+ * @param props 
+ * @returns 
+ */
+const NewFeatureTooltip = ({classes, children, className, text} :
+  { classes : ClassesType, 
+    children: any, 
+    /**
+     * Test
+     */
+    className?: string,
+    text: string
+  }) => {
+
+  return <div className={classes.wrapper}>
+    {children}
+    <span className={classNames(classes.tooltip, className)}/>
+  </div>
+}
+
+
+const LWTooltipComponent = registerComponent("NewFeatureTooltip", NewFeatureTooltip, {
+  styles,
+  stylePriority: -1
+});
+
+declare global {
+  interface ComponentTypes {
+    NewFeatureTooltip: typeof LWTooltipComponent
+  }
+}

--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useHover } from './withHover';
 
@@ -14,7 +14,8 @@ const styles = (theme: ThemeType): JssStyles => ({
       height: 10,
       borderRadius: '50%',
       alignSelf: 'center',
-      position: 'absolute'
+      position: 'absolute',
+      cursor: 'pointer'
     },
     NewFeatureTooltipArrow: {
       pointerEvents: "none",
@@ -30,18 +31,64 @@ const styles = (theme: ThemeType): JssStyles => ({
     NewFeatureTooltip: {
       background: theme.palette.lwTertiary.main,
       color: theme.palette.primary.contrastText,
-      padding: 3,
+      padding: 5,
+      paddingRight: 12,
       borderRadius: 2,
       width: 100,
       marginLeft: 10,
       marginTop: -10,
       minHeight: 40
     },
+    closeButton: {cursor: 'pointer', position:'absolute', top:-10, right:1},
     wrapper: {
       display: 'flex',
       position: 'relative'
     }
   })
+
+
+
+const useTooltipToggle = () => {
+  const tooltipRef = useRef(null)
+  const [open, setOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState();
+  /**
+   * Hook that alerts clicks outside of the passed ref
+   */
+  function useOutsideAlerter(ref, anchorEl) {
+    useEffect(() => {
+      /**
+       * Alert if clicked on outside of element
+       */
+      function handleClickOutside(event) {
+        if (ref.current && !ref.current.contains(event.target) && anchorEl && !anchorEl.contains(event.target)) {
+          setOpen(false)
+        }
+      }
+      // Bind the event listener
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        // Unbind the event listener on clean up
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, [ref, anchorEl]);
+  }
+
+  useOutsideAlerter(tooltipRef, anchorEl)
+
+  const closeEvents = {onClick : () => {
+    setOpen(false)
+  }}
+
+  const handleEvents = {onClick: (e) => {
+    setOpen(open => !open)
+    setAnchorEl(e.target);
+  }}
+
+  return {tooltipRef, anchorEl, open, closeEvents, handleEvents}
+
+}
+
 /**
  * 
  * @param props 
@@ -58,22 +105,24 @@ const NewFeatureTooltip = ({classes, children, className, text} :
   }) => {
 
   const {LWPopper} = Components
-  const { anchorEl, hover, eventHandlers } = useHover();
+  //const { anchorEl, hover, eventHandlers } = useHover();
+  const {tooltipRef, anchorEl, open, closeEvents, handleEvents} = useTooltipToggle()
 
   return <div className={classes.wrapper}>
     <LWPopper
-    
-    open={hover}
+    open={open}
     anchorEl={anchorEl}
     placement="right-start"
     allowOverflow>
-      <div>
+      <div ref={tooltipRef}>
         <div className={classes.NewFeatureTooltipArrow}></div>
-        <div className={classes.NewFeatureTooltip}>{text}</div>
+        <div className={classes.NewFeatureTooltip}>{text}
+        <div {...closeEvents} className={classes.closeButton}>&#x2715;</div> 
+        </div>
       </div>
     </LWPopper>
       {children}
-    <span className={classNames(classes.newFeatureHandle, className)} {...eventHandlers}/>
+    <span className={classNames(classes.newFeatureHandle, className)} {...handleEvents}/>
   </div>
 }
 

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -80,6 +80,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
       marginTop: 6,
     },
   },
+  newFeatureSubscribe: {
+    top: 22,
+    right: -5
+  },
   nonMobileButtonRow: {
     [theme.breakpoints.down('xs')]: {
       // Ensure this takes priority over the properties in TagPageButtonRow
@@ -149,7 +153,7 @@ const TagPage = ({classes}: {
     PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404,
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography,
     TagPageButtonRow, ToCColumn, TableOfContents, TableOfContentsRow, TagContributorsList,
-    SubscribeButton, CloudinaryImage2, TagIntroSequence, SectionTitle, ContentStyles
+    SubscribeButton, CloudinaryImage2, TagIntroSequence, SectionTitle, ContentStyles, NewFeatureTooltip
    } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -310,13 +314,15 @@ const TagPage = ({classes}: {
             </Typography>
             <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.mobileButtonRow)} />
             {!tag.wikiOnly && !editing && userHasNewTagSubscriptions(currentUser) &&
+              <NewFeatureTooltip className={classes.newFeatureSubscribe} text="New! Subscribe to this Topic to see more posts that you're interested in!">
               <SubscribeButton
                 tag={tag}
                 className={classes.notifyMeButton}
                 subscribeMessage="Subscribe"
                 unsubscribeMessage="Unsubscribe"
                 subscriptionType={subscriptionTypes.newTagPosts}
-              />
+                />
+              </NewFeatureTooltip>
             }
           </div>
           <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.nonMobileButtonRow)} />

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -80,10 +80,6 @@ export const styles = (theme: ThemeType): JssStyles => ({
       marginTop: 6,
     },
   },
-  newFeatureSubscribe: {
-    top: 22,
-    right: -5
-  },
   nonMobileButtonRow: {
     [theme.breakpoints.down('xs')]: {
       // Ensure this takes priority over the properties in TagPageButtonRow
@@ -153,7 +149,7 @@ const TagPage = ({classes}: {
     PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404,
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography,
     TagPageButtonRow, ToCColumn, TableOfContents, TableOfContentsRow, TagContributorsList,
-    SubscribeButton, CloudinaryImage2, TagIntroSequence, SectionTitle, ContentStyles, NewFeatureTooltip
+    SubscribeButton, CloudinaryImage2, TagIntroSequence, SectionTitle, ContentStyles
    } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -314,7 +310,6 @@ const TagPage = ({classes}: {
             </Typography>
             <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.mobileButtonRow)} />
             {!tag.wikiOnly && !editing && userHasNewTagSubscriptions(currentUser) &&
-              <NewFeatureTooltip className={classes.newFeatureSubscribe} text="New! Subscribe to this Topic to see more posts that you're interested in!">
               <SubscribeButton
                 tag={tag}
                 className={classes.notifyMeButton}
@@ -322,7 +317,6 @@ const TagPage = ({classes}: {
                 unsubscribeMessage="Unsubscribe"
                 subscriptionType={subscriptionTypes.newTagPosts}
                 />
-              </NewFeatureTooltip>
             }
           </div>
           <TagPageButtonRow tag={tag} editing={editing} setEditing={setEditing} className={classNames(classes.editMenu, classes.nonMobileButtonRow)} />

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -114,10 +114,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 8,
     ...separatorBulletStyles(theme)
   },
-  editUserNewFeature: {
-    right: 25,
-    top: 5
-  },
   meta: {
     ...sectionFooterLeftStyles,
     [theme.breakpoints.down('sm')]: {
@@ -528,11 +524,9 @@ const UsersProfileFn = ({terms, slug, classes}: {
                   </DialogGroup>
                 </div>
               }
-              <Components.NewFeatureTooltip text="New! You can edit your profile here to add a bio and profile image!" className={classes.editUserNewFeature}>
               { isEAForum && userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
                 Edit Profile
               </Link>}
-              </Components.NewFeatureTooltip>
               { currentUser && currentUser._id === user._id && <Link to="/manageSubscriptions">
                 Manage Subscriptions
               </Link>}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -114,6 +114,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 8,
     ...separatorBulletStyles(theme)
   },
+  editUserNewFeature: {
+    right: 25,
+    top: 5
+  },
   meta: {
     ...sectionFooterLeftStyles,
     [theme.breakpoints.down('sm')]: {
@@ -524,7 +528,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                   </DialogGroup>
                 </div>
               }
-              <Components.NewFeatureTooltip text="New! You can edit your profile here to add a bio and profile image!">
+              <Components.NewFeatureTooltip text="New! You can edit your profile here to add a bio and profile image!" className={classes.editUserNewFeature}>
               { isEAForum && userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
                 Edit Profile
               </Link>}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -524,7 +524,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                   </DialogGroup>
                 </div>
               }
-              <Components.NewFeatureTooltip text="Test">
+              <Components.NewFeatureTooltip text="New! You can edit your profile here to add a bio and profile image!">
               { isEAForum && userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
                 Edit Profile
               </Link>}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -524,9 +524,11 @@ const UsersProfileFn = ({terms, slug, classes}: {
                   </DialogGroup>
                 </div>
               }
+              <Components.NewFeatureTooltip text="Test">
               { isEAForum && userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
                 Edit Profile
               </Link>}
+              </Components.NewFeatureTooltip>
               { currentUser && currentUser._id === user._id && <Link to="/manageSubscriptions">
                 Manage Subscriptions
               </Link>}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -107,6 +107,7 @@ importComponent("LinkCard", () => require('../components/common/LinkCard'));
 importComponent("LWDialog", () => require('../components/common/LWDialog'));
 importComponent("Error404", () => require('../components/common/Error404'));
 importComponent("PermanentRedirect", () => require('../components/common/PermanentRedirect'));
+importComponent("NewFeatureTooltip", () => require('../components/common/NewFeatureTooltip'));
 importComponent("SeparatorBullet", () => require('../components/common/SeparatorBullet'));
 
 importComponent("TabNavigationMenu", () => require('../components/common/TabNavigationMenu/TabNavigationMenu'));


### PR DESCRIPTION
Added a new feature tooltip component

![image](https://user-images.githubusercontent.com/1339094/174115704-a1792513-5eb8-4e5f-bee8-259518928f1a.png)
![image](https://user-images.githubusercontent.com/1339094/174115693-61f34e40-c6cf-481c-9e46-5e3a2a4fa10e.png)

Currently you can open the tooltip by clicking on the blue bubble and close it by clicking anywhere else or on the X. FWIW I prefer the hover functionality I started with which is a couple commits back (although does have examples). I'm submitting the PR as is so JP can see what I finished at the end of day 2.