### PR TITLE
Filter out admin-only Topic updates from recent discussion

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
@@ -8,10 +8,8 @@ const megaTagUsers = ['BkbwT5TzSj4aRxJMN', 'pkJTc4xXhsCbNqkZM']
 const onlyStyleEditors = ['pkJTc4xXhsCbNqkZM']
 
 /**
- * This component's only job is to reduce the amount of room the EA frontpage
- * gives to the most particularly active tag users doing routine cleanup
- *
- * Otherwise it's just a wrapper around TagRevisionItem
+ * This component's only job is to filter out tag edits that shouldn't be shown.
+ * Otherwise it's just a wrapper around TagRevisionItem.
  */
 function RecentDiscussionTagRevisionItem({
   tag,
@@ -28,6 +26,12 @@ function RecentDiscussionTagRevisionItem({
 }) {
   const { TagRevisionItem } = Components
   
+  if (tag.adminOnly) {
+    return null
+  }
+  
+  // reduce the amount of room the EA frontpage gives to the most particularly
+  // active tag users doing routine cleanup
   if (
     // Only a problem for the forum
     isEAForum &&


### PR DESCRIPTION
Lizka is about to drop a huge update on the wiki main page. I want it not to blow up recent discussion, which it totally would. I think this is a change that should happen anyway.

@darkruby501 please let me know monday if you don't want this on LW.