### PR TITLE
Restore curated hidden functionality

### DIFF
--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -35,9 +35,8 @@ const styles = (theme: ThemeType): JssStyles => ({
 //    more posts (default true)
 //  * showNoResults: Show a placeholder if there are no results (otherwise
 //    render only whiteness) (default true)
-//  * hideLastUnread: If the initial set of posts ends with N consecutive
-//    already-read posts, hide the last N-1 of them. Used for abbreviating
-//    read posts from the Recently Curated section on the front page.
+//  * hideLastUnread: If the list ends with N sequential read posts, 
+//    hide them, except for the first post in the list
 const PostsList2 = ({
   children, terms,
   dimWhenLoading = false,

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -108,44 +108,19 @@ const PostsList2 = ({
     ...tagVariables
   });
 
-
-  let hidePosts: Array<boolean>|null = null;
-
   // Map from post._id to whether to hide it. Used for client side post filtering like e.g. hiding read posts
   const hiddenPosts: {[key: string]: boolean} = {}
 
-  if (hideLastUnread && results?.length && !haveLoadedMore) {
-    // If the list ends with N sequential read posts, hide N-1 of them.
-    let numUnreadAtEnd = 0;
-    for (let i=results.length-1; i>=0; i--) {
-      // FIXME: This uses the initial-load version of the read-status, and won't
-      // update based on the client-side read status cache.
-      if (results[i].isRead) numUnreadAtEnd++;
-      else break;
-    }
-    if (numUnreadAtEnd > 1) {
-      const numHiddenAtEnd = numUnreadAtEnd - 1;
-
-      results.forEach((post,i) => {
-        if (i >= results.length-numHiddenAtEnd) {
-          hiddenPosts[post._id] = true;
-        }
-      })
-    }
-  }
-
   const currentUser = useCurrentUser();
   if (results?.length) {
-    // if (hideLastUnread && !haveLoadedMore) {
-    //   // If the list ends with N sequential read posts, hide N-1 of them.
-    //   for (let i=results.length-1; i>=0; i--) {
-    //     // FIXME: This uses the initial-load version of the read-status, and won't
-    //     // update based on the client-side read status cache.
-    //     const post = results[i]
-    //     if (post.isRead) hiddenPosts[post._id] = true; 
-    //     else break;
-    //   }
-    // }
+    if (hideLastUnread && !haveLoadedMore) {
+      // hide unread posts, except for the first one
+      results.forEach((post, i) => {
+        // FIXME: This uses the initial-load version of the read-status, and won't
+        // update based on the client-side read status cache.
+        if (post.isRead && i > 0) hiddenPosts[post._id] = true; 
+      })
+    }
 
     if (currentUser && hideHiddenFrontPagePosts) {
       // Hide any posts that a user has explicitly hidden

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -108,21 +108,44 @@ const PostsList2 = ({
     ...tagVariables
   });
 
+
+  let hidePosts: Array<boolean>|null = null;
+
   // Map from post._id to whether to hide it. Used for client side post filtering like e.g. hiding read posts
   const hiddenPosts: {[key: string]: boolean} = {}
 
+  if (hideLastUnread && results?.length && !haveLoadedMore) {
+    // If the list ends with N sequential read posts, hide N-1 of them.
+    let numUnreadAtEnd = 0;
+    for (let i=results.length-1; i>=0; i--) {
+      // FIXME: This uses the initial-load version of the read-status, and won't
+      // update based on the client-side read status cache.
+      if (results[i].isRead) numUnreadAtEnd++;
+      else break;
+    }
+    if (numUnreadAtEnd > 1) {
+      const numHiddenAtEnd = numUnreadAtEnd - 1;
+
+      results.forEach((post,i) => {
+        if (i >= results.length-numHiddenAtEnd) {
+          hiddenPosts[post._id] = true;
+        }
+      })
+    }
+  }
+
   const currentUser = useCurrentUser();
   if (results?.length) {
-    if (hideLastUnread && !haveLoadedMore) {
-      // If the list ends with N sequential read posts, hide N-1 of them.
-      for (let i=results.length-1; i>=0; i--) {
-        // FIXME: This uses the initial-load version of the read-status, and won't
-        // update based on the client-side read status cache.
-        const post = results[i]
-        if (post.isRead) hiddenPosts[post._id] = true; 
-        else break;
-      }
-    }
+    // if (hideLastUnread && !haveLoadedMore) {
+    //   // If the list ends with N sequential read posts, hide N-1 of them.
+    //   for (let i=results.length-1; i>=0; i--) {
+    //     // FIXME: This uses the initial-load version of the read-status, and won't
+    //     // update based on the client-side read status cache.
+    //     const post = results[i]
+    //     if (post.isRead) hiddenPosts[post._id] = true; 
+    //     else break;
+    //   }
+    // }
 
     if (currentUser && hideHiddenFrontPagePosts) {
       // Hide any posts that a user has explicitly hidden

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -114,12 +114,15 @@ const PostsList2 = ({
   const currentUser = useCurrentUser();
   if (results?.length) {
     if (hideLastUnread && !haveLoadedMore) {
-      // hide unread posts, except for the first one
-      results.forEach((post, i) => {
+      // If the list ends with N sequential read posts, hide them, except for the first post in the list
+      for (let i=results.length-1; i>=0; i--) {
         // FIXME: This uses the initial-load version of the read-status, and won't
         // update based on the client-side read status cache.
-        if (post.isRead && i > 0) hiddenPosts[post._id] = true; 
-      })
+        if (results[i].isRead && i > 0) {
+          hiddenPosts[results[i]._id] = true;
+        }
+        else break;
+      }
     }
 
     if (currentUser && hideHiddenFrontPagePosts) {

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -157,7 +157,6 @@ const RecommendationsAndCurated = ({
         </div>
       </div>}
 
-      {/* Disabled during 2018 Review [and coronavirus season] */}
       <div className={classes.subsection}>
         <div className={classes.posts}>
           {!settings.hideFrontpage &&
@@ -170,7 +169,7 @@ const RecommendationsAndCurated = ({
               terms={{view:"curated", limit: currentUser ? 3 : 2}}
               showNoResults={false}
               showLoadMore={false}
-              hideLastUnread={true}
+              // hideLastUnread={true}
               boxShadow={false}
               curatedIconLeft={true}
             />

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -169,7 +169,7 @@ const RecommendationsAndCurated = ({
               terms={{view:"curated", limit: currentUser ? 3 : 2}}
               showNoResults={false}
               showLoadMore={false}
-              // hideLastUnread={true}
+              hideLastUnread={true}
               boxShadow={false}
               curatedIconLeft={true}
             />


### PR DESCRIPTION
The recent "hide posts from frontpage" PR broke the intended curated functionality. This restores and slightly refactors it