### PR TITLE
Banned users no longer appear in sunshine sidebar

### DIFF
--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -4,6 +4,7 @@ import { spamRiskScoreThreshold } from "../../../components/common/RecaptchaWarn
 import pick from 'lodash/pick';
 import isNumber from 'lodash/isNumber';
 import mapValues from 'lodash/mapValues';
+import { viewFieldNullOrMissing } from "../../vulcan-lib";
 
 declare global {
   interface UsersViewTerms extends ViewTermsBase {
@@ -111,6 +112,7 @@ Users.addView("sunshineNewUsers", function (terms: UsersViewTerms) {
   return {
     selector: {
       needsReview: true,
+      banned: viewFieldNullOrMissing,
       reviewedByUserId: null,
       $or: [{signUpReCaptchaRating: {$gt: spamRiskScoreThreshold*1.25}}, {signUpReCaptchaRating: {$exists: false}}, {signUpReCaptchaRating:null}]
     },


### PR DESCRIPTION
Sometimes users get banned in ways other than clicking the sunshine-ban-button, and it's annoying that they still show up in the sidebar. This fixes that.