### PR TITLE
default non-EA voting is twoAxis

### DIFF
--- a/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
@@ -11,12 +11,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   agreementSection: {
     display: "inline-block",
     fontSize: 25,
-    marginLeft: 8,
+    marginLeft: 10,
     lineHeight: 0.6,
     height: 24,
-    minWidth: 70,
+    minWidth: 60,
     paddingTop: 2,
     outline: theme.palette.border.commentBorder,
+    borderRadius: 2,
     textAlign: 'center'
   },
   agreementScore: {
@@ -53,7 +54,7 @@ const AgreementVoteAxis = ({ document, hideKarma=false, voteProps, classes }: {
   return <>
     <span className={classes.agreementSection}>
       <LWTooltip
-        title={<div><b>Agreement: downvote</b><br />How much do you <b>agree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
+        title={<div><b>Agreement: Downvote</b><br />How much do you <b>agree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong upvote, click-and-hold.<br />(Click twice on mobile)</em></div>}
         placement="bottom"
       >
         <AxisVoteButton
@@ -73,7 +74,7 @@ const AgreementVoteAxis = ({ document, hideKarma=false, voteProps, classes }: {
       </span>
       
       <LWTooltip
-        title={<div><b>Agreement: upvote</b><br />How much do you <b>agree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
+        title={<div><b>Agreement: Upvote</b><br />How much do you <b>agree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
         placement="bottom"
       >
         <AxisVoteButton

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -18,9 +18,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 2
   },
   overallSectionBox: {
+    marginLeft: 8,
     outline: theme.palette.border.commentBorder,
+    borderRadius: 2,
     textAlign: 'center',
-    minWidth: 70
+    minWidth: 60
   },
   vote: {
     fontSize: 25,
@@ -115,7 +117,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
       {(forumTypeSetting.get() !== 'AlignmentForum' || !!af) &&
         <span className={classNames(classes.overallSection, {[classes.overallSectionBox]: showBox})}>
           <LWTooltip
-            title={<div><b>Overall Karma: downvote</b><br />How much do you like this overall?<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
+            title={<div><b>Overall Karma: Downvote</b><br />How much do you like this overall?<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
             <OverallVoteButton
@@ -136,7 +138,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
             </LWTooltip>
           }
           <LWTooltip
-            title={<div><b>Overall Karma: upvote</b><br />How much do you like this overall?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
+            title={<div><b>Overall Karma: Upvote</b><br />How much do you like this overall?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
             <OverallVoteButton

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -930,6 +930,7 @@ const schema: SchemaType<DbPost> = {
     insertableBy: ['admins', 'sunshineRegiment'],
     editableBy: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
+    defaultValue: forumTypeSetting.get() === "LessWrong" ? "twoAxis" : "default",
     control: "select",
     form: {
       options: () => {

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -13,6 +13,9 @@ import { formGroups } from './formGroups';
 import SimpleSchema from 'simpl-schema'
 import { DEFAULT_QUALITATIVE_VOTE } from '../reviewVotes/schema';
 import { getVotingSystems } from '../../voting/votingSystems';
+import { forumTypeSetting } from '../../instanceSettings';
+
+const isLWorAF = (forumTypeSetting.get() === 'LessWrong') || (forumTypeSetting.get() === 'AlignmentForum')
 
 const STICKY_PRIORITIES = {
   1: "Low",
@@ -930,7 +933,7 @@ const schema: SchemaType<DbPost> = {
     insertableBy: ['admins', 'sunshineRegiment'],
     editableBy: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
-    defaultValue: forumTypeSetting.get() === "LessWrong" ? "twoAxis" : "default",
+    defaultValue: isLWorAF ? "twoAxis" : "default",
     control: "select",
     form: {
       options: () => {


### PR DESCRIPTION
This sets the default voting system for LessWrong and AlignmentForum to two-axis. It sets it for LW and AF specifically so that things like Progress Forum aren't affected, and it sets it via the defaultValue instead of some of the other functions that handled default-voting-system-setting so that it only applies to future posts.

Also slightly updated the UI. I still really don't like the X and checkmark icons, but don't know what better thing to do.

<img width="768" alt="image" src="https://user-images.githubusercontent.com/3246710/175206553-7a8312d7-d4e9-4c16-883a-53f8eccc942a.png">
