### PR TITLE
Allow running of forcePendingEvents without passing in any optional args

### DIFF
--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -264,12 +264,12 @@ export const dispatchPendingEvents = async () => {
  * want to wait.
  */
 export const forcePendingEvents = async (
-  {upToDate=null, delay}:
+  {upToDate, delay}:
   {
-    upToDate: string|null,
+    upToDate?: string,
     /** Delay between pending events in ms */
-    delay: number
-  }
+    delay?: number
+  } = {}
 ) => {
   let eventToHandle = null;
   const af = forumTypeSetting.get() === 'AlignmentForum'


### PR DESCRIPTION
Without setting the arg to a default, you'd have to call it like

```
❯ ./scripts/serverShellCommand.sh 'Globals.forcePendingEvents({})'
```

Now you can call it like

```
❯ ./scripts/serverShellCommand.sh 'Globals.forcePendingEvents()'
```

Clearly a big improvement.

(But seriously, it would be annoying for people to run it the way they were used to and then get an error and have to figure out why. Also it is just kinda lame.)