### PR TITLE
Adjust Twitter title meta tags

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -58,7 +58,7 @@ const HeadTags = ({ogUrl: ogUrlProp, canonicalUrl: canonicalUrlProp, description
           {/* twitter */}
           <meta name='twitter:card' content='summary_large_image'/>
           {image && <meta name='twitter:image:src' content={image}/>}
-          { /* <meta name='twitter:title' content={title}/> */ }
+          {<meta name='twitter:title' content={title}/>}
           <meta name='twitter:description' content={description}/>
 
           {(noIndex || currentRoute?.noIndex) && <meta name='robots' content='noindex' />}


### PR DESCRIPTION
I see that the EA site has been updated with the adjusted image meta tags, but the large Twitter cards are still not working. I tested on my private Twitter account.

After reviewing the [Twitter Cards documentation](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image), it seems I missed the 'title' tags. The tags were in the code— just commented out. Sorry! Silly of me to miss that.

<img width="400" alt="twitter-cards-reference" src="https://user-images.githubusercontent.com/55752861/175379279-0316c391-88e7-4320-a256-a78eb800ff7b.png">