### PR TITLE
[EA Forum only] review profile photos, use profile photo as social preview img, display profile photos on Community map

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -88,6 +88,20 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
       paddingBottom: 30
     },
   },
+  photoRow: {
+    display: 'flex',
+    columnGap: 10,
+    alignItems: 'center',
+  },
+  profileImage: {
+    'box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),
+    '-webkit-box-shadow': '0px 0px 2px 0px ' + theme.palette.boxShadowColor(.25),
+    '-moz-box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),
+    borderRadius: '50%',
+  },
+  photoRowText: {
+    flex: '1 1 0'
+  },
   nameRow: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -225,15 +239,26 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
     
     return <div className={classes.person}>
       <div className={classes.content}>
-        <div className={classes.nameRow}>
-          <Link to={`/users/${hit.slug}?from=community_members_tab`} className={classes.displayName}>
-            {hit.displayName}
-          </Link>
-          <div className={classes.distance}>
-            {distanceToPerson}
+        <div className={classes.photoRow}>
+          {hit.profileImageId && <Components.CloudinaryImage2
+            height={50}
+            width={50}
+            imgProps={{q: '100'}}
+            publicId={hit.profileImageId}
+            className={classes.profileImage}
+          />}
+          <div className={classes.photoRowText}>
+            <div className={classes.nameRow}>
+              <Link to={`/users/${hit.slug}?from=community_members_tab`} className={classes.displayName}>
+                {hit.displayName}
+              </Link>
+              <div className={classes.distance}>
+                {distanceToPerson}
+              </div>
+            </div>
+            <div className={classes.location}>{hit.mapLocationAddress}</div>
           </div>
         </div>
-        <div className={classes.location}>{hit.mapLocationAddress}</div>
         {hit.htmlBio && <div className={classes.description}><div dangerouslySetInnerHTML={{__html: hit.htmlBio}} /></div>}
         {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
           <NewConversationButton user={hit} currentUser={currentUser} from="community_members_tab">

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -21,11 +21,24 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     opacity: 0.8,
     cursor: 'pointer'
   },
+  popupTitle: {
+    display: 'flex',
+    columnGap: 10,
+    alignItems: 'center'
+  },
+  profileImage: {
+    'box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),
+    '-webkit-box-shadow': '0px 0px 2px 0px ' + theme.palette.boxShadowColor(.25),
+    '-moz-box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),
+    borderRadius: '50%',
+  },
   popupAddress: {
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
     fontSize: 12,
     fontStyle: 'italic',
+    fontWeight: 'normal',
+    marginTop: 2
   },
   popupBio: {
     ...theme.typography.commentStyle,
@@ -36,7 +49,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     "-webkit-line-clamp": 3,
     "-webkit-box-orient": 'vertical',
     overflow: 'hidden',
-    marginTop: 12,
   }
 }))
 
@@ -117,11 +129,22 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, className, cl
             lat={markerLocations[hit._id].lat}
             lng={markerLocations[hit._id].lng}
             link={`/users/${hit.slug}?from=community_members_tab`}
-            title={hit.displayName}
+            title={<div className={classes.popupTitle}>
+              {hit.profileImageId && <Components.CloudinaryImage2
+                height={50}
+                width={50}
+                imgProps={{q: '100'}}
+                publicId={hit.profileImageId}
+                className={classes.profileImage}
+              />}
+              <div>
+                <div>{hit.displayName}</div>
+                <div className={classes.popupAddress}>{hit.mapLocationAddress}</div>
+              </div>
+            </div>}
             onClose={() => setActiveResultId('')}
             hideBottomLinks
           >
-            <div className={classes.popupAddress}>{hit.mapLocationAddress}</div>
             {hit.htmlBio && <div className={classes.popupBio} dangerouslySetInnerHTML={{__html: hit.htmlBio}} />}
           </StyledMapPopup>}
         </React.Fragment>

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { createStyles } from '@material-ui/core/styles';
 import { Link } from '../../lib/reactRouterWrapper';
 import { registerComponent } from '../../lib/vulcan-lib';
@@ -46,10 +46,10 @@ const StyledMapPopup = ({
   metaInfo, cornerLinks, lat, lng,
   onClose, offsetTop=-20, hideBottomLinks
 }: {
-  children?: React.ReactNode,
+  children?: ReactNode,
   classes: ClassesType,
   link: string,
-  title: string,
+  title: string|ReactNode,
   metaInfo?: any,
   cornerLinks?: any,
   lat: number,

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -504,6 +504,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
         <HeadTags
           description={metaDescription}
           noIndex={(!user.postCount && !user.commentCount) || user.karma <= 0 || user.noindex}
+          image={user.profileImageId && `https://res.cloudinary.com/cea/image/upload/q_auto,f_auto/${user.profileImageId}.jpg`}
         />
         <AnalyticsContext pageContext={"userPage"}>
           <div className={classes.centerColumnWrapper}>
@@ -708,7 +709,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
             </SingleColumnSection>
           </AnalyticsContext>
 
-          {currentUser && !user.reviewedByUserId && !user.needsReview && (currentUser._id !== user._id) &&
+          {currentUser && user.karma < 50 && !user.needsReview && (currentUser._id !== user._id) &&
             <SingleColumnSection className={classes.reportUserSection}>
               <button className={classes.reportUserBtn} onClick={reportUser}>Report user</button>
             </SingleColumnSection>

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -85,9 +85,12 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
 getCollectionHooks("Users").editAsync.add(function mapLocationMayTriggerReview(newUser: DbUser, oldUser: DbUser) {
   // on the EA Forum, we are testing out reviewing all unreviewed users who add a bio
   const addedBio = !oldUser.biography?.html && newUser.biography?.html && forumTypeSetting.get() === 'EAForum'
+  
+  // on the EA Forum, we are reviewing all unreviewed users who add a profile photo
+  const addedProfilePhoto = !oldUser.profileImageId && newUser.profileImageId && forumTypeSetting.get() === 'EAForum'
 
   // if the user has a mapLocation and they have not been reviewed, mark them for review
-  if ((addedBio || newUser.mapLocation) && !newUser.reviewedByUserId && !newUser.needsReview) {
+  if ((addedBio || addedProfilePhoto || newUser.mapLocation) && !newUser.reviewedByUserId && !newUser.needsReview) {
     void Users.rawUpdateOne({_id: newUser._id}, {$set: {needsReview: true}})
   }
 })

--- a/packages/lesswrong/server/search/algoliaDocuments.d.ts
+++ b/packages/lesswrong/server/search/algoliaDocuments.d.ts
@@ -42,6 +42,7 @@ interface AlgoliaUser {
   displayName: string,
   createdAt: Date,
   isAdmin: boolean,
+  profileImageId?: string,
   bio: string,
   htmlBio: string,
   karma: number,

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -124,6 +124,7 @@ Users.toAlgolia = async (user: DbUser): Promise<Array<AlgoliaUser>|null> => {
     displayName: user.displayName,
     createdAt: user.createdAt,
     isAdmin: user.isAdmin,
+    profileImageId: user.profileImageId,
     bio: bio.slice(0, USER_BIO_MAX_SEARCH_CHARACTERS),
     htmlBio: truncatise(htmlBio, {
       TruncateBy: 'characters',


### PR DESCRIPTION
Some followup work after deploying profile photos:

1. Unreviewed users who add a profile photo get added to the "New User" sunshine queue
2. Users can now report other users (with <50 karma) who have already been reviewed, including those who have been snoozed
3. We use the profile photo as the social preview img for the profile page if available
4. We show profile photos on the Community map

![Screen Shot 2022-06-23 at 3 59 14 PM](https://user-images.githubusercontent.com/9057804/175388492-538913e8-6b7e-4bc8-917d-121b9fc3ba10.png)
