### PR TITLE
Sequence hover over

### DIFF
--- a/packages/lesswrong/components/common/LinkCard.tsx
+++ b/packages/lesswrong/components/common/LinkCard.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
-import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -47,6 +46,7 @@ const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
   classes: ClassesType,
   onClick?: any
 }) => {
+  const { LWTooltip } = Components
   const card = (
     <div className={classNames(className, classes.root)}>
       <div className={classes.background}>
@@ -57,11 +57,13 @@ const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
   );
   
   if (tooltip) {
-    return <Tooltip title={tooltip} placement="bottom-start">
+    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false}>
       {card}
-    </Tooltip>;
+    </LWTooltip>;
   } else {
-    return card;
+    return <div className={classNames(className, classes.root)}>
+      {card}
+      </div>
   }
 }
 

--- a/packages/lesswrong/components/common/LinkCard.tsx
+++ b/packages/lesswrong/components/common/LinkCard.tsx
@@ -57,7 +57,7 @@ const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
   );
   
   if (tooltip) {
-    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false}>
+    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false} clickable>
       {card}
     </LWTooltip>;
   } else {

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -262,6 +262,13 @@ const SequencePreview = ({classes, targetLocation, href, innerHTML}: {
   const sequenceId = targetLocation.params._id;
   const { eventHandlers, anchorEl, hover } = useHover();
 
+  const { document: sequence } = useSingle({
+    documentId: sequenceId,
+    collectionName: "Sequences",
+    fragmentName: 'SequencesPageFragment',
+    fetchPolicy: 'cache-then-network' as any,
+  });
+
   return (
     <span {...eventHandlers}>
       <LWPopper
@@ -270,7 +277,7 @@ const SequencePreview = ({classes, targetLocation, href, innerHTML}: {
         placement="bottom-start"
         allowOverflow
       >
-        <SequencesHoverOver sequenceId={sequenceId} />
+        <SequencesHoverOver sequence={sequence || null} />
       </LWPopper>
       <Link className={classes.link} to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={sequenceId}/>
     </span>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -252,6 +252,36 @@ const CommentLinkPreviewWithCommentComponent = registerComponent('CommentLinkPre
   styles,
 });
 
+const SequencePreview = ({classes, targetLocation, href, innerHTML}: {
+  classes: ClassesType,
+  targetLocation: any,
+  href: string,
+  innerHTML: string
+}) => {
+  const { LWPopper, SequencesHoverOver } = Components
+  const sequenceId = targetLocation.params._id;
+  const { eventHandlers, anchorEl, hover } = useHover();
+
+  return (
+    <span {...eventHandlers}>
+      <LWPopper
+        open={hover}
+        anchorEl={anchorEl}
+        placement="bottom-start"
+        allowOverflow
+      >
+        <SequencesHoverOver sequenceId={sequenceId} />
+      </LWPopper>
+      <Link className={classes.link} to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={sequenceId}/>
+    </span>
+  )
+}
+
+const SequencePreviewComponent = registerComponent('SequencePreview', SequencePreview, {
+  styles,
+});
+
+
 const footnotePreviewStyles = (theme: ThemeType): JssStyles => ({
   hovercard: {
     padding: `${theme.spacing.unit*3}px ${theme.spacing.unit*2}px ${theme.spacing.unit*2}px`,
@@ -751,5 +781,6 @@ declare global {
     ArbitalPreview: typeof ArbitalPreviewComponent,
     FootnotePreview: typeof FootnotePreviewComponent,
     DefaultPreview: typeof DefaultPreviewComponent,
+    SequencePreview: typeof SequencePreviewComponent
   }
 }

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -7,6 +7,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import { sequenceGetPageUrl } from '../../../lib/collections/sequences/helpers';
 import { postGetPageUrl } from '../../../lib/collections/posts/helpers';
 import { useCurrentUser } from '../../common/withUser';
+import { useHover } from '../../common/withHover';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -29,6 +30,7 @@ const PostsTopSequencesNav = ({post, classes}: {
   post: PostSequenceNavigation,
   classes: ClassesType,
 }) => {
+  const { LWTooltip, SequencesHoverOver } = Components 
   const { history } = useNavigation();
   const currentUser = useCurrentUser();
 
@@ -66,10 +68,12 @@ const PostsTopSequencesNav = ({post, classes}: {
         post={post.prevPost}
         direction="left" />
 
-      <div className={classes.title}>
-        {post.sequence.draft && "[Draft] "}
-        <Link to={sequenceGetPageUrl(post.sequence)}>{ post.sequence.title }</Link>
-      </div>
+      <LWTooltip tooltip={false} title={<SequencesHoverOver sequenceId={post.sequence._id} />} clickable={true}>
+        <div className={classes.title}>
+          {post.sequence.draft && "[Draft] "}
+          <Link to={sequenceGetPageUrl(post.sequence)}>{ post.sequence.title }</Link>
+        </div>
+      </LWTooltip>
 
       <Components.SequencesNavigationLink
         post={post.nextPost}

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -68,7 +68,7 @@ const PostsTopSequencesNav = ({post, classes}: {
         post={post.prevPost}
         direction="left" />
 
-      <LWTooltip tooltip={false} title={<SequencesHoverOver sequenceId={post.sequence._id} />} clickable={true}>
+      <LWTooltip tooltip={false} title={<SequencesHoverOver sequence={post.sequence} />} clickable={true}>
         <div className={classes.title}>
           {post.sequence.draft && "[Draft] "}
           <Link to={sequenceGetPageUrl(post.sequence)}>{ post.sequence.title }</Link>

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -109,10 +109,10 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   const getSequenceUrl = () => {
     return '/s/' + sequence._id
   }
-  const { LinkCard } = Components;
+  const { LinkCard, SequencesHoverOver } = Components;
   const url = getSequenceUrl()
 
-  return <LinkCard className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})} to={url} tooltip={sequence?.contents?.plaintextDescription?.slice(0, 750)}>
+  return <LinkCard className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})} to={url} tooltip={<SequencesHoverOver sequenceId={sequence._id}/>}>
     <div className={classes.image}>
       <NoSSR>
         <Components.CloudinaryImage

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -3,6 +3,7 @@ import NoSSR from 'react-no-ssr';
 import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
+import { title } from 'process';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -112,11 +113,13 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   const { LinkCard, SequencesHoverOver } = Components;
   const url = getSequenceUrl()
 
-
-  const positionAdjustment = showAuthor ? - 55 : -35
+  // The hoverover is adjusted so that it's title lines up with where the SequencesGridItem title would have been, to avoid seeing the title twice
+  let positionAdjustment = -35
+  if (showAuthor) positionAdjustment -= 20
+  if (sequence.title.length > 25) positionAdjustment -= 17
 
   return <div className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})}>
-    <LinkCard to={url} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequenceId={sequence._id}/></div>}>
+    <LinkCard to={url} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequence={sequence} showAuthor={showAuthor}/></div>}>
       <div className={classes.image}>
         <NoSSR>
           <Components.CloudinaryImage

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -112,27 +112,32 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   const { LinkCard, SequencesHoverOver } = Components;
   const url = getSequenceUrl()
 
-  return <LinkCard className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})} to={url} tooltip={<SequencesHoverOver sequenceId={sequence._id}/>}>
-    <div className={classes.image}>
-      <NoSSR>
-        <Components.CloudinaryImage
-          publicId={sequence.gridImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"}
-          height={124}
-          width={315}
-        />
-      </NoSSR>
-    </div>
-    <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor, [classes.bookItemContentStyle]: bookItemStyle})}>
-      <div className={classes.title}>
-        {sequence.draft && <span className={classes.draft}>[Draft] </span>}
-        {sequence.title}
+
+  const positionAdjustment = showAuthor ? - 55 : -35
+
+  return <div className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})}>
+    <LinkCard to={url} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequenceId={sequence._id}/></div>}>
+      <div className={classes.image}>
+        <NoSSR>
+          <Components.CloudinaryImage
+            publicId={sequence.gridImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"}
+            height={124}
+            width={315}
+          />
+        </NoSSR>
       </div>
-      { showAuthor && sequence.user &&
-        <div className={classes.author}>
-          by <Components.UsersName user={sequence.user} />
-        </div>}
-    </div>
-  </LinkCard>
+      <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor, [classes.bookItemContentStyle]: bookItemStyle})}>
+        <div className={classes.title}>
+          {sequence.draft && <span className={classes.draft}>[Draft] </span>}
+          {sequence.title}
+        </div>
+        { showAuthor && sequence.user &&
+          <div className={classes.author}>
+            by <Components.UsersName user={sequence.user} />
+          </div>}
+      </div>
+    </LinkCard>
+  </div>
 }
 
 const SequencesGridItemComponent = registerComponent('SequencesGridItem', SequencesGridItem, {styles});

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -19,25 +19,36 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.postStyle,
     paddingTop: 8,
     paddingBottom: 8,
+  },
+  author: {
+    color: theme.palette.text.dim
   }
 });
 
-export const SequencesHoverOver = ({classes, sequenceId}: {
+export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   classes: ClassesType,
-  sequenceId: string,
+  sequence: SequencesPageFragment,
+  showAuthor?: boolean
 }) => {
-  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated } = Components
+  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName } = Components
 
-  const { document: sequence, loading } = useSingle({
-    documentId: sequenceId,
-    collectionName: "Sequences",
-    fragmentName: 'SequenceHoverOver',
-  })
+  const { results: chapters, loading } = useMulti({
+    terms: {
+      view: "SequenceChapters",
+      sequenceId: sequence?._id,
+      limit: 100
+    },
+    collectionName: "Chapters",
+    fragmentName: 'ChaptersFragment',
+    enableTotal: false,
+  });
   
   return <Card className={classes.root}>
-    {!sequence && loading && <Loading />}
-
     <div className={classes.title}>{sequence?.title}</div>
+    { showAuthor && sequence.user &&
+      <div className={classes.author}>
+        by <UsersName user={sequence.user} />
+      </div>}
     <ContentStyles contentType="postHighlight" className={classes.description}>
       <ContentItemTruncated
         maxLengthWords={100}
@@ -49,7 +60,8 @@ export const SequencesHoverOver = ({classes, sequenceId}: {
         description={`sequence ${sequence?._id}`}
       />
     </ContentStyles>
-    {sequence?.chapters?.map((chapter) => <span key={chapter._id}>
+    {!chapters && loading && <Loading />}
+    {chapters?.map((chapter) => <span key={chapter._id}>
         {chapter.posts?.map(post => <SequencesSmallPostLink 
                                       key={chapter._id + post._id} 
                                       post={post}

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import Card from '@material-ui/core/Card';
+import { useSingle } from '../../lib/crud/withSingle';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    padding: 16,
+    width: 450
+  },
+  title: {
+    ...theme.typography.body1,
+    ...theme.typography.postStyle,
+    fontVariant: "small-caps",
+  },
+  description: {
+    ...theme.typography.body2,
+    ...theme.typography.postStyle,
+    paddingTop: 8,
+    paddingBottom: 8,
+  }
+});
+
+export const SequencesHoverOver = ({classes, sequenceId}: {
+  classes: ClassesType,
+  sequenceId: string,
+}) => {
+  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated } = Components
+
+  const { document: sequence, loading } = useSingle({
+    documentId: sequenceId,
+    collectionName: "Sequences",
+    fragmentName: 'SequenceHoverOver',
+  })
+  
+  return <Card className={classes.root}>
+    {!sequence && loading && <Loading />}
+
+    <div className={classes.title}>{sequence?.title}</div>
+    <ContentStyles contentType="postHighlight" className={classes.description}>
+      <ContentItemTruncated
+        maxLengthWords={100}
+        graceWords={20}
+        rawWordCount={sequence?.contents?.wordCount || 0}
+        expanded={false}
+        getTruncatedSuffix={() => null}
+        dangerouslySetInnerHTML={{__html: sequence?.contents?.htmlHighlight || ""}}
+        description={`sequence ${sequence?._id}`}
+      />
+    </ContentStyles>
+    {sequence?.chapters?.map((chapter) => <span key={chapter._id}>
+        {chapter.posts?.map(post => <SequencesSmallPostLink 
+                                      key={chapter._id + post._id} 
+                                      post={post}
+                                    />
+        )}
+      </span>
+    )}
+  </Card>;
+}
+
+const SequencesHoverOverComponent = registerComponent('SequencesHoverOver', SequencesHoverOver, {styles});
+
+declare global {
+  interface ComponentTypes {
+    SequencesHoverOver: typeof SequencesHoverOverComponent
+  }
+}
+

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -27,7 +27,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   classes: ClassesType,
-  sequence: SequencesPageFragment,
+  sequence: SequencesPageFragment|null,
   showAuthor?: boolean
 }) => {
   const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName } = Components
@@ -44,10 +44,11 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   });
   
   return <Card className={classes.root}>
+    {!sequence && <Loading/>}
     <div className={classes.title}>{sequence?.title}</div>
-    { showAuthor && sequence.user &&
+    { showAuthor && sequence?.user &&
       <div className={classes.author}>
-        by <UsersName user={sequence.user} />
+        by <UsersName user={sequence?.user} />
       </div>}
     <ContentStyles contentType="postHighlight" className={classes.description}>
       <ContentItemTruncated

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -63,13 +63,13 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     </ContentStyles>
     {!chapters && loading && <Loading />}
     {chapters?.map((chapter) => <span key={chapter._id}>
-        {chapter.posts?.map(post => <SequencesSmallPostLink 
-                                      key={chapter._id + post._id} 
-                                      post={post}
-                                    />
-        )}
-      </span>
-    )}
+      {chapter.posts?.map(post => 
+        <SequencesSmallPostLink 
+          key={chapter._id + post._id} 
+          post={post}
+        />
+      )}
+     </span>)}
   </Card>;
 }
 

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -373,10 +373,7 @@ registerFragment(`
   fragment PostSequenceNavigation on Post {
     # Prev/next sequence navigation
     sequence(sequenceId: $sequenceId) {
-      _id
-      title
-      draft
-      userId
+      ...SequencesPageFragment
     }
     prevPost(sequenceId: $sequenceId) {
       _id

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -8,19 +8,6 @@ registerFragment(`
 `);
 
 registerFragment(`
-  fragment SequenceHoverOver on Sequence {
-    _id
-    title
-    contents {
-      ...RevisionDisplay
-    }
-    chapters {
-      ...ChaptersFragment
-    }
-  }
-`);
-
-registerFragment(`
   fragment SequencesPageFragment on Sequence {
     ...SequencesPageTitleFragment
     createdAt

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -8,6 +8,19 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment SequenceHoverOver on Sequence {
+    _id
+    title
+    contents {
+      ...RevisionDisplay
+    }
+    chapters {
+      ...ChaptersFragment
+    }
+  }
+`);
+
+registerFragment(`
   fragment SequencesPageFragment on Sequence {
     ...SequencesPageTitleFragment
     createdAt

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -521,6 +521,7 @@ importComponent("BottomNavigationItem", () => require('../components/sequences/B
 importComponent("SequencesPost", () => require('../components/sequences/SequencesPost'));
 importComponent("SequencesGridItem", () => require('../components/sequences/SequencesGridItem'));
 importComponent("LargeSequencesItem", () => require('../components/sequences/LargeSequencesItem'));
+importComponent("SequencesHoverOver", () => require('../components/sequences/SequencesHoverOver'));
 importComponent("SequencesSmallPostLink", () => require('../components/sequences/SequencesSmallPostLink'));
 importComponent("ChaptersItem", () => require('../components/sequences/ChaptersItem'));
 importComponent("ChaptersList", () => require('../components/sequences/ChaptersList'));

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -575,16 +575,9 @@ interface PostsWithNavigation extends PostsPage, PostSequenceNavigation { // fra
 }
 
 interface PostSequenceNavigation { // fragment on Posts
-  readonly sequence: PostSequenceNavigation_sequence|null,
+  readonly sequence: SequencesPageFragment|null,
   readonly prevPost: PostSequenceNavigation_prevPost|null,
   readonly nextPost: PostSequenceNavigation_nextPost|null,
-}
-
-interface PostSequenceNavigation_sequence { // fragment on Sequences
-  readonly _id: string,
-  readonly title: string,
-  readonly draft: boolean,
-  readonly userId: string,
 }
 
 interface PostSequenceNavigation_prevPost { // fragment on Posts
@@ -1267,13 +1260,6 @@ interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
 interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
-}
-
-interface SequenceHoverOver { // fragment on Sequences
-  readonly _id: string,
-  readonly title: string,
-  readonly contents: RevisionDisplay|null,
-  readonly chapters: Array<ChaptersFragment>,
 }
 
 interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment on Sequences
@@ -2025,7 +2011,6 @@ interface FragmentTypes {
   ChaptersFragment: ChaptersFragment
   ChaptersEdit: ChaptersEdit
   SequencesPageTitleFragment: SequencesPageTitleFragment
-  SequenceHoverOver: SequenceHoverOver
   SequencesPageFragment: SequencesPageFragment
   SequencesEdit: SequencesEdit
   BookPageFragment: BookPageFragment
@@ -2171,7 +2156,6 @@ interface CollectionNamesByFragmentName {
   ChaptersFragment: "Chapters"
   ChaptersEdit: "Chapters"
   SequencesPageTitleFragment: "Sequences"
-  SequenceHoverOver: "Sequences"
   SequencesPageFragment: "Sequences"
   SequencesEdit: "Sequences"
   BookPageFragment: "Books"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1269,6 +1269,13 @@ interface SequencesPageTitleFragment { // fragment on Sequences
   readonly title: string,
 }
 
+interface SequenceHoverOver { // fragment on Sequences
+  readonly _id: string,
+  readonly title: string,
+  readonly contents: RevisionDisplay|null,
+  readonly chapters: Array<ChaptersFragment>,
+}
+
 interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment on Sequences
   readonly createdAt: Date,
   readonly userId: string,
@@ -2018,6 +2025,7 @@ interface FragmentTypes {
   ChaptersFragment: ChaptersFragment
   ChaptersEdit: ChaptersEdit
   SequencesPageTitleFragment: SequencesPageTitleFragment
+  SequenceHoverOver: SequenceHoverOver
   SequencesPageFragment: SequencesPageFragment
   SequencesEdit: SequencesEdit
   BookPageFragment: BookPageFragment
@@ -2163,6 +2171,7 @@ interface CollectionNamesByFragmentName {
   ChaptersFragment: "Chapters"
   ChaptersEdit: "Chapters"
   SequencesPageTitleFragment: "Sequences"
+  SequenceHoverOver: "Sequences"
   SequencesPageFragment: "Sequences"
   SequencesEdit: "Sequences"
   BookPageFragment: "Books"

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -245,6 +245,7 @@ addRoute(
     name: 'sequences.single.old',
     path: '/sequences/:_id',
     componentName: 'SequencesSingle',
+    previewComponentName: 'SequencePreview'
   },
   {
     name: 'sequences.single',
@@ -252,6 +253,7 @@ addRoute(
     componentName: 'SequencesSingle',
     titleComponentName: 'SequencesPageTitle',
     subtitleComponentName: 'SequencesPageTitle',
+    previewComponentName: 'SequencePreview'
   },
   {
     name: 'sequencesEdit',


### PR DESCRIPTION
This adds Sequence hoverovers both for SequencesGridItem and for links (i.e. in the body of posts).

<img width="593" alt="image" src="https://user-images.githubusercontent.com/3246710/175436606-183b8346-5394-46e0-8ab4-e2f6ccfeac36.png">
 
<img width="710" alt="image" src="https://user-images.githubusercontent.com/3246710/175437658-cede3127-1750-44fe-88a6-5343da000400.png">

It uses the SequencesPageFragment for the post hoverpreviews, which I'm pretty sure is a fine amount of data to be querying but worth doublechecking.

Currently, the link-preview for SequencesGridItem has "clickable" activated so you can mouse over it. This is useful to clicking on the posts, but might be kinda annoying since it means mousing over a SequencesGridItem list is overwhelming with hard-to-get-rid-of-previews