### PR TITLE
Nested ordered list styling

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -263,7 +263,13 @@ const baseBodyStyles = (theme: ThemeType): JssStyles => ({
   '& figcaption': {
     ...theme.typography.caption,
     ...theme.typography.postStyle
-  }
+  },
+  '& ol > li > ol': {
+    listStyle: 'lower-alpha',
+  },
+  '& ol > li > ol > li > ol': {
+    listStyle: 'lower-roman',
+  },
 })
 
 export const postBodyStyles = (theme: ThemeType): JssStyles => {


### PR DESCRIPTION
This PR adds the typical numbering convention for nested ordered lists used by Google Docs, Slack, and most of other places.
### Before / After 
<img width=49% src=https://user-images.githubusercontent.com/25752873/175505762-b6a98a2b-970a-4dc3-9889-5e22b0dfae3a.png /> <img width=49% src=https://user-images.githubusercontent.com/25752873/175505783-401cf623-f2b9-4fe7-ae34-8c233daeae20.png />