### PR TITLE
Change the default LW voting system to two-axis (for real this time)

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -933,7 +933,6 @@ const schema: SchemaType<DbPost> = {
     insertableBy: ['admins', 'sunshineRegiment'],
     editableBy: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
-    defaultValue: isLWorAF ? "twoAxis" : "default",
     control: "select",
     form: {
       options: () => {
@@ -941,6 +940,7 @@ const schema: SchemaType<DbPost> = {
           .map(votingSystem => ({label: votingSystem.description, value: votingSystem.name}));
       }
     },
+    ...schemaDefaultValue(isLWorAF ? "twoAxis" : "default"),
   },
 };
 


### PR DESCRIPTION
Change the default voting system on LW and AF to two-axis.

(https://github.com/ForumMagnum/ForumMagnum/pull/5090 tried to do this but it didn't work because it was only changing the default value of a form-field with moderator-only permissions).