### PR TITLE
Fix Bug in Sharing New Posts due to notificationCallbacks changes

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -453,8 +453,8 @@ getCollectionHooks("Posts").editAsync.add(async function PostsEditNotifyUsersSha
 
 getCollectionHooks("Posts").newAsync.add(async function PostsNewNotifyUsersSharedOnPost (post: DbPost) {
   const { _id, shareWithUsers = [], coauthorStatuses = [] } = post;
-  const coauthors = coauthorStatuses.filter(({ confirmed }) => confirmed).map(({ userId }) => userId);
-  const userIds = shareWithUsers.filter((user) => !coauthors.includes(user));
+  const coauthors: Array<string> = coauthorStatuses.filter(({ confirmed }) => confirmed).map(({ userId }) => userId);
+  const userIds: Array<string> = shareWithUsers?.filter((user) => !coauthors.includes(user)) || [];
   await createNotifications({userIds, notificationType: "postSharedWithUser", documentType: "post", documentId: _id})
 });
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -453,7 +453,7 @@ getCollectionHooks("Posts").editAsync.add(async function PostsEditNotifyUsersSha
 
 getCollectionHooks("Posts").newAsync.add(async function PostsNewNotifyUsersSharedOnPost (post: DbPost) {
   const { _id, shareWithUsers = [], coauthorStatuses = [] } = post;
-  const coauthors: Array<string> = coauthorStatuses.filter(({ confirmed }) => confirmed).map(({ userId }) => userId);
+  const coauthors: Array<string> = coauthorStatuses?.filter(({ confirmed }) => confirmed).map(({ userId }) => userId) || [];
   const userIds: Array<string> = shareWithUsers?.filter((user) => !coauthors.includes(user)) || [];
   await createNotifications({userIds, notificationType: "postSharedWithUser", documentType: "post", documentId: _id})
 });


### PR DESCRIPTION
Fix bug in `PostsNewNotifyUsersSharedOnPost` caused by null `shareWithUsers` being returned from post object.

Seems like the ideal fix in preventing this kind of thing is deeper typing solution.


