### PR TITLE
disable the localgroup select when there are no options

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentMultiSelect.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentMultiSelect.tsx
@@ -38,7 +38,8 @@ const FormComponentMultiSelect = ({ value, classes, placeholder, separator, opti
       }
       // if any options are selected, display them separated by commas
       return selected.map(s => options.find(option => option.value === s)?.label).join(separator || ', ')
-    }}>
+    }}
+    {...!options.length ? {disabled: true} : {}}>
       {options.map(option => {
         return <MenuItem key={option.value} value={option.value}>
           <Checkbox checked={value.some(v => v === option.value)} />

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -33,6 +33,7 @@ const MuiTextField = ({
   rows,
   variant,
   type,
+  disabled=false,
   InputLabelProps
 }) => {
   const onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> = (event) => {
@@ -60,6 +61,7 @@ const MuiTextField = ({
       classes.textField,
       {[classes.fullWidth] :fullWidth}
     )}
+    disabled={disabled}
   >
     {children}
   </TextField>

--- a/packages/lesswrong/components/form-components/SelectLocalgroup.tsx
+++ b/packages/lesswrong/components/form-components/SelectLocalgroup.tsx
@@ -37,7 +37,7 @@ const SelectLocalgroup = (props: any) => {
       {group.name}
     </MenuItem>
   })
-  return <Components.MuiTextField select {...props}>
+  return <Components.MuiTextField select {...props} {...!selectOptions?.length ? {disabled: true} : {}}>
     {selectOptions || []}
   </Components.MuiTextField>
 }


### PR DESCRIPTION
This PR is to improve the UI of localgroup selects, so that it doesn't show you an empty list of options when you have none to choose from.

Single select:
<img width="733" alt="Screen Shot 2022-06-27 at 11 52 48 AM" src="https://user-images.githubusercontent.com/9057804/175982008-0a730829-4ed3-4c0c-b249-c30d298adff9.png">

Multi select:
<img width="468" alt="Screen Shot 2022-06-27 at 11 53 15 AM" src="https://user-images.githubusercontent.com/9057804/175982033-29ed56a1-bb3c-4838-9bf8-f8a24b34d225.png">
