### PR TITLE
[EA Forum only] replace line-clamp with truncatise for CKEditor fields

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -9,6 +9,7 @@ import Search from '@material-ui/icons/Search';
 import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';
 import { useTracking } from '../../../lib/analyticsEvents';
+import { truncatise } from '../../../lib/truncatise';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   filters: {
@@ -132,14 +133,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginTop: 4,
   },
   description: {
-    ...theme.typography.commentStyle,
     color: theme.palette.grey[800],
-    fontSize: 14,
-    lineHeight: '1.8em',
-    display: '-webkit-box',
-    "-webkit-line-clamp": 3,
-    "-webkit-box-orient": 'vertical',
-    overflow: 'hidden',
     marginTop: 12,
   },
   buttonRow: {
@@ -196,7 +190,7 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
   const { captureEvent } = useTracking()
   const keywordSearchTimer = useRef<any>(null)
 
-  const { NewConversationButton, SearchResultsMap } = Components
+  const { NewConversationButton, SearchResultsMap, ContentStyles } = Components
   
   const SearchBox = ({currentRefinement, refine}) => {
     return <div className={classes.keywordSearch}>
@@ -259,7 +253,9 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
             <div className={classes.location}>{hit.mapLocationAddress}</div>
           </div>
         </div>
-        {hit.htmlBio && <div className={classes.description}><div dangerouslySetInnerHTML={{__html: hit.htmlBio}} /></div>}
+        {hit.htmlBio && <ContentStyles contentType="comment" className={classes.description}>
+          <div dangerouslySetInnerHTML={{__html: truncatise(hit.htmlBio, {TruncateBy: 'characters', TruncateLength: 160})}} />
+        </ContentStyles>}
         {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
           <NewConversationButton user={hit} currentUser={currentUser} from="community_members_tab">
             <Button variant="contained" color="primary" className={classes.messageBtn}>Message</Button>

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -9,7 +9,7 @@ import Search from '@material-ui/icons/Search';
 import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';
 import { useTracking } from '../../../lib/analyticsEvents';
-import { truncatise } from '../../../lib/truncatise';
+import { truncate } from '../../../lib/editor/ellipsize';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   filters: {
@@ -254,7 +254,7 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
           </div>
         </div>
         {hit.htmlBio && <ContentStyles contentType="comment" className={classes.description}>
-          <div dangerouslySetInnerHTML={{__html: truncatise(hit.htmlBio, {TruncateBy: 'characters', TruncateLength: 160})}} />
+          <div dangerouslySetInnerHTML={{__html: truncate(hit.htmlBio, 220)}} />
         </ContentStyles>}
         {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
           <NewConversationButton user={hit} currentUser={currentUser} from="community_members_tab">

--- a/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { Link } from '../../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
+import { truncatise } from '../../../lib/truncatise';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -61,11 +62,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: '8px 16px',
   },
   bio: {
-    fontSize: 14,
-    display: '-webkit-box',
-    "-webkit-line-clamp": 3,
-    "-webkit-box-orient": 'vertical',
-    overflow: 'hidden',
     marginTop: 20,
   },
 });
@@ -117,8 +113,8 @@ const PostAuthorCard = ({author, currentUser, classes}: {
           />}
         </div>
       </div>
-      {author.biography?.html && <ContentStyles contentType="comment">
-        <div dangerouslySetInnerHTML={{__html: author.biography?.html}} className={classes.bio} />
+      {author.biography?.html && <ContentStyles contentType="comment" className={classes.bio}>
+        <div dangerouslySetInnerHTML={{__html: truncatise(author.biography.html, {TruncateBy: 'characters', TruncateLength: 250})}} />
       </ContentStyles>}
     </div>
   </AnalyticsContext>

--- a/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { Link } from '../../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
-import { truncatise } from '../../../lib/truncatise';
+import { truncate } from '../../../lib/editor/ellipsize';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -114,7 +114,7 @@ const PostAuthorCard = ({author, currentUser, classes}: {
         </div>
       </div>
       {author.biography?.html && <ContentStyles contentType="comment" className={classes.bio}>
-        <div dangerouslySetInnerHTML={{__html: truncatise(author.biography.html, {TruncateBy: 'characters', TruncateLength: 250})}} />
+        <div dangerouslySetInnerHTML={{__html: truncate(author.biography.html, 340)}} />
       </ContentStyles>}
     </div>
   </AnalyticsContext>


### PR DESCRIPTION
Again [Safari is messing up my line-clamps](https://stackoverflow.com/questions/70679732/css-line-clamp-does-not-work-in-safari-on-inner-block-level-elements). :(

I think just cutting off the text using `truncatise()` is the solution that works best overall.