### PR TITLE
Fix sorting by tag relevance on topic page

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -513,11 +513,13 @@ ensureIndex(Posts,
   }
 );
 
-Posts.addView("tagRelevance", (terms: PostsViewTerms) => ({
+Posts.addView("tagRelevance", ({ sortedBy, tagId }: PostsViewTerms) => ({
   // note: this relies on the selector filtering done in the default view
   // sorts by the "sortedBy" parameter if it's been passed in, or otherwise sorts by tag relevance
   options: {
-    sort: terms.sortedBy ? sortings[terms.sortedBy] : { [`tagRelevance.${terms.tagId}`]: -1, baseScore: -1}
+    sort: sortedBy && sortedBy !== "relevance"
+      ? sortings[sortedBy]
+      : { [`tagRelevance.${tagId}`]: -1, baseScore: -1 },
   }
 }));
 


### PR DESCRIPTION
Fixes #5017

The issue here is that we pass in `"relevance"` as the type of sort from the frontend, but `sortings["relevance"]` is undefined as it's a special case.

An alternative solution would be to change the frontend code to pass in `undefined` or `null` as the type of sort, but I think that's a bit more fragile and makes less sense semantically.