### PR TITLE
Show pending coauthors

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -18,13 +18,13 @@ const PostsAuthors = ({classes, post}: {
   classes: ClassesType,
   post: PostsDetails,
 }) => {
-  const { UsersName, Typography } = Components
+  const { UsersName, PostsCoauthor, Typography } = Components
   return <Typography variant="body1" component="span" className={classes.root}>
     by <span className={classes.authorName}>
       {!post.user || post.hideAuthor ? <Components.UserNameDeleted/> : <UsersName user={post.user} />}
-      { post.coauthors?.map(coauthor=><span key={coauthor._id} >
-        , <UsersName user={coauthor} />
-      </span>)}
+      {post.coauthors?.map(coauthor =>
+        <PostsCoauthor key={coauthor._id} post={post} coauthor={coauthor} />
+      )}
     </span>
   </Typography>
 }

--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -7,19 +7,22 @@ const PostsCoauthor = ({ post, coauthor }: {
   post: PostsDetails,
   coauthor: UsersMinimumInfo,
 }) => {
-  const isPending = postCoauthorIsPending(post, coauthor._id);
-
   const currentUser = useCurrentUser();
-  if (isPending && currentUser?._id !== post.userId) {
+  if (
+    currentUser?._id !== post.userId &&
+    !post.coauthorStatuses.find(({ userId }) => currentUser?._id === userId)
+  ) {
     return null;
   }
 
   const { UsersNamePending, UsersName } = Components;
-  const Component = isPending ? UsersNamePending : UsersName;
+  const Component = postCoauthorIsPending(post, coauthor._id)
+    ? UsersNamePending
+    : UsersName;
   return (
-    <span>
+    <>
       , <Component user={coauthor} />
-    </span>
+    </>
   );
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useCurrentUser } from '../../common/withUser';
+import { registerComponent, Components } from '../../../lib/vulcan-lib';
+import { postCoauthorIsPending } from '../../../lib/collections/posts/helpers';
+
+const PostsCoauthor = ({ post, coauthor }: {
+  post: PostsDetails,
+  coauthor: UsersMinimumInfo,
+}) => {
+  const isPending = postCoauthorIsPending(post, coauthor._id);
+
+  const currentUser = useCurrentUser();
+  if (isPending && currentUser?._id !== post.userId) {
+    return null;
+  }
+
+  const { UsersNamePending, UsersName } = Components;
+  const Component = isPending ? UsersNamePending : UsersName;
+  return (
+    <span>
+      , <Component user={coauthor} />
+    </span>
+  );
+}
+
+const PostsCoauthorComponent = registerComponent(
+  'PostsCoauthor', PostsCoauthor
+);
+
+declare global {
+  interface ComponentTypes {
+    PostsCoauthor: typeof PostsCoauthorComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
@@ -52,13 +52,10 @@ const PostsUserAndCoauthors = ({post, abbreviateIfLong=false, classes, simple=fa
   
   return <div className={abbreviateIfLong ? classes.lengthLimited : classes.lengthUnlimited}>
     {<UsersName user={post.user} simple={simple} />}
-    {post.coauthors.map(coauthor => postCoauthorIsPending(post, coauthor._id)
-      ? null
-      : (
-        <span key={coauthor._id}>
-          , <UsersName user={coauthor} simple={simple} />
-        </span>
-      )
+    {post.coauthors.filter(({ _id }) => !postCoauthorIsPending(post, _id)).map((coauthor) =>
+      <React.Fragment key={coauthor._id}>
+        , <UsersName user={coauthor} simple={simple} />
+      </React.Fragment>
     )}
     {renderTopCommentAuthor && <span className={classNames(classes.topCommentAuthor, {[classes.new]: newPromotedComments})}>
       , <ModeCommentIcon className={classNames(classes.topAuthorIcon, {[classes.new]: newPromotedComments})}/>

--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import classNames from 'classnames';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { postCoauthorIsPending } from '../../lib/collections/posts/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   lengthLimited: {
@@ -51,8 +52,14 @@ const PostsUserAndCoauthors = ({post, abbreviateIfLong=false, classes, simple=fa
   
   return <div className={abbreviateIfLong ? classes.lengthLimited : classes.lengthUnlimited}>
     {<UsersName user={post.user} simple={simple} />}
-    {post.coauthors.map(coauthor =>
-      <span key={coauthor._id}>, <UsersName user={coauthor} simple={simple}  /></span>)}
+    {post.coauthors.map(coauthor => postCoauthorIsPending(post, coauthor._id)
+      ? null
+      : (
+        <span key={coauthor._id}>
+          , <UsersName user={coauthor} simple={simple} />
+        </span>
+      )
+    )}
     {renderTopCommentAuthor && <span className={classNames(classes.topCommentAuthor, {[classes.new]: newPromotedComments})}>
       , <ModeCommentIcon className={classNames(classes.topAuthorIcon, {[classes.new]: newPromotedComments})}/>
       <UsersName user={topCommentAuthor || undefined} simple={simple} />

--- a/packages/lesswrong/components/users/UsersNamePending.tsx
+++ b/packages/lesswrong/components/users/UsersNamePending.tsx
@@ -27,18 +27,16 @@ const UsersNamePending = ({ user, classes }: {
   const { LWTooltip } = Components;
   const name = userGetDisplayName(user)
   const tooltip = <p>
-    You have requested <span className={classes.tooltipUserName}>{name}</span> to
-    co-author this post. They can accept or decline this request.
+    <span className={classes.tooltipUserName}>{name}</span> has been requested
+    as a co-author of this post. They can accept or decline this request.
   </p>;
 
   return (
-    <span>
-      <LWTooltip title={tooltip} placement="right" inlineBlock={false}>
-        <Link to={userGetProfileUrl(user)} className={classes.userName}>
-          {name} <ErrorIcon fontSize="small" className={classes.icon} />
-        </Link>
-      </LWTooltip>
-    </span>
+    <LWTooltip title={tooltip} placement="right">
+      <Link to={userGetProfileUrl(user)} className={classes.userName}>
+        {name} <ErrorIcon fontSize="small" className={classes.icon} />
+      </Link>
+    </LWTooltip>
   );
 }
 

--- a/packages/lesswrong/components/users/UsersNamePending.tsx
+++ b/packages/lesswrong/components/users/UsersNamePending.tsx
@@ -1,0 +1,53 @@
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import React from 'react';
+import { Link } from '../../lib/reactRouterWrapper';
+import ErrorIcon from '@material-ui/icons/ErrorOutline';
+import {
+  userGetDisplayName,
+  userGetProfileUrl,
+} from '../../lib/collections/users/helpers';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  userName: {
+    whiteSpace: "nowrap",
+    color: theme.palette.text.secondary,
+  },
+  tooltipUserName: {
+    fontWeight: "bold",
+  },
+  icon: {
+    transform: "translateY(4px)",
+  },
+});
+
+const UsersNamePending = ({ user, classes }: {
+  user: UsersMinimumInfo,
+  classes: ClassesType,
+}) => {
+  const { LWTooltip } = Components;
+  const name = userGetDisplayName(user)
+  const tooltip = <p>
+    You have requested <span className={classes.tooltipUserName}>{name}</span> to
+    co-author this post. They can accept or decline this request.
+  </p>;
+
+  return (
+    <span>
+      <LWTooltip title={tooltip} placement="right" inlineBlock={false}>
+        <Link to={userGetProfileUrl(user)} className={classes.userName}>
+          {name} <ErrorIcon fontSize="small" className={classes.icon} />
+        </Link>
+      </LWTooltip>
+    </span>
+  );
+}
+
+const UsersNamePendingComponent = registerComponent(
+  'UsersNamePending', UsersNamePending, {styles}
+);
+
+declare global {
+  interface ComponentTypes {
+    UsersNamePending: typeof UsersNamePendingComponent
+  }
+}

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -237,7 +237,7 @@ addFieldsDict(Posts, {
       resolver: async (post: DbPost, args: void, context: ResolverContext) =>  {
         const loader = context.loaders['Users'];
         const resolvedDocs = await loader.loadMany(
-          post.coauthorStatuses?.filter(({ confirmed }) => confirmed).map(({ userId }) => userId) || []
+          post.coauthorStatuses?.map(({ userId }) => userId) || []
         );
         return await accessFilterMultiple(context.currentUser, context['Users'], resolvedDocs, context);
       },

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -267,7 +267,7 @@ addFieldsDict(Posts, {
     insertableBy: ['members'],
     optional: true,
     hidden: true,
-    ...schemaDefaultValue(false),
+    ...schemaDefaultValue(true),
   },
 
   // Cloudinary image id for an image that will be used as the OpenGraph image

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -266,3 +266,8 @@ export const prettyEventDateTimes = (post: PostsBase|DbPost, timezone?: string, 
   const endYear = (now.isSame(end, 'year') || end.isBefore(sixMonthsFromNow)) ? '' : `, ${end.format('YYYY')}`
   return `${startDate}${startYear} at ${startTime}${startAmPm} - ${endDate}${endYear} at ${endTime}${tz}`
 }
+
+export const postCoauthorIsPending = (post: PostsList|PostsDetails, coauthorUserId: string) => {
+  const status = post.coauthorStatuses.find(({ userId }) => coauthorUserId === userId);
+  return status && !status.confirmed;
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -145,6 +145,7 @@ importComponent("BookmarksList", () => require('../components/posts/BookmarksLis
 importComponent("UsersName", () => require('../components/users/UsersName'));
 importComponent("UsersNameWrapper", () => require('../components/users/UsersNameWrapper'));
 importComponent("UsersNameDisplay", () => require('../components/users/UsersNameDisplay'));
+importComponent("UsersNamePending", () => require('../components/users/UsersNamePending'));
 importComponent("UsersSingle", () => require('../components/users/UsersSingle'));
 importComponent("UsersEmailVerification", () => require('../components/users/UsersEmailVerification'));
 importComponent("UsersViewABTests", () => require('../components/users/UsersViewABTests'));
@@ -225,7 +226,6 @@ importComponent("PostsEditPage", () => require('../components/posts/PostsEditPag
 importComponent("PostsAnalyticsPage", () => require('../components/posts/PostsAnalyticsPage'));
 importComponent("PostCollaborationEditor", () => require('../components/posts/PostCollaborationEditor'));
 
-
 importComponent("PostsGroupDetails", () => require('../components/posts/PostsGroupDetails'));
 importComponent("PostsStats", () => require('../components/posts/PostsStats'));
 importComponent("PostsUserAndCoauthors", () => require('../components/posts/PostsUserAndCoauthors'));
@@ -238,6 +238,7 @@ importComponent("ElicitBlock", () => require('../components/posts/ElicitBlock'))
 importComponent("UserPageTitle", () => require('../components/titles/UserPageTitle'));
 importComponent("SequencesPageTitle", () => require('../components/titles/SequencesPageTitle'));
 importComponent("PostsPageHeaderTitle", () => require('../components/titles/PostsPageTitle'));
+importComponent("PostsCoauthor", () => require('../components/posts/PostsPage/PostsCoauthor'));
 importComponent("LocalgroupPageTitle", () => require('../components/titles/LocalgroupPageTitle'));
 
 importComponent("ShortformPage", () => require('../components/shortform/ShortformPage'));

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -285,7 +285,7 @@ getCollectionHooks("Posts").newSync.add((post: DbPost): DbPost => {
 });
 
 getCollectionHooks("Posts").updateBefore.add((post: DbPost, {oldDocument: oldPost}: UpdateCallbackProperties<DbPost>) => {
-  if (postHasUnconfirmedCoauthors(post) && !post.draft && oldPost.draft) {
+  if (postHasUnconfirmedCoauthors(post) && post.draft === false && oldPost.draft) {
     post = scheduleCoauthoredPost(post);
   }
   return post;

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -285,6 +285,8 @@ getCollectionHooks("Posts").newSync.add((post: DbPost): DbPost => {
 });
 
 getCollectionHooks("Posts").updateBefore.add((post: DbPost, {oldDocument: oldPost}: UpdateCallbackProperties<DbPost>) => {
+  // Here we schedule the post for 1-day in the future when publishing an existing draft with unconfirmed coauthors
+  // We must check post.draft === false instead of !post.draft as post.draft may be undefined in some cases
   if (postHasUnconfirmedCoauthors(post) && post.draft === false && oldPost.draft) {
     post = scheduleCoauthoredPost(post);
   }

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -425,7 +425,8 @@ export const PostCoauthorRequestNotification = serverRegisterNotificationType({
     if (!post) {
       throw Error(`Can't find post for notification: ${notifications[0]}`);
     }
-    return  `${user.displayName} requested that you co-author their post: ${post.title}`;
+    const name = await postGetAuthorName(post);
+    return `${name} requested that you co-author their post: ${post.title}`;
   },
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const post = await Posts.findOne(notifications[0].documentId);


### PR DESCRIPTION
There's several very closely related fixes/changes in this PR:
- "This person has agreed to coauthor this post" is now the default when creating a post (there's an Asana ticket for this, but there doesn't seem to be a Github issue).
- Fixes #5111 the email subject now shows the name of the post author.
- Fixes another bug I found where draft posts which requested a coauthor would sometimes be inadvertently published when they were updated due to checking `!post.draft` instead of `post.draft === false`, where `post.draft` could be `undefined`.
- Fixes #5071 which is the majority of this PR and includes some UI changes which are described below.

We now display unconfirmed coauthors when viewing a draft post (UI suggestions are welcome!):
![Screenshot_2022-06-28_14-56-56](https://user-images.githubusercontent.com/5075628/176197218-0ec5d946-1a57-4ec5-bbde-d245dce8bc35.png)
![Screenshot_2022-06-28_15-14-42](https://user-images.githubusercontent.com/5075628/176214624-69062441-a240-428e-8518-e4084731240b.png)
This is only viewable by the post author - coauthors will not see it:
![Screenshot_2022-06-28_11-35-33](https://user-images.githubusercontent.com/5075628/176192125-656bbe8a-9035-42ee-9986-9432fba35bfe.png)
If the post is published before the co-author accepts then it will still be shown to other users without the co-author until they accept:
![Screenshot_2022-06-28_11-25-34](https://user-images.githubusercontent.com/5075628/176195547-0bf76675-be65-4275-8748-8b2c9f474fb4.png)
![Screenshot_2022-06-28_11-34-53](https://user-images.githubusercontent.com/5075628/176196138-87b83de1-27c4-4678-9f24-7e592e7db529.png)
