### PR TITLE
Have different link-post hint text for different forums

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -16,6 +16,11 @@ import { getVotingSystems } from '../../voting/votingSystems';
 import { forumTypeSetting } from '../../instanceSettings';
 
 const isLWorAF = (forumTypeSetting.get() === 'LessWrong') || (forumTypeSetting.get() === 'AlignmentForum')
+const isEAForum = (forumTypeSetting.get() === 'EAForum')
+
+const urlHintText = isEAForum 
+    ? 'Please write what you liked about the post, and sample liberally. Or, if the author allows it, copy in the entire post text. If you know the author\'s username you can add them as a co-author of this post in the "Options" menu below.'
+    : 'Please write what you liked about the post and sample liberally! If the author allows it, copy in the entire post text. (Link-posts without text get far fewer views and most people don\'t click offsite links.)' 
 
 const STICKY_PRIORITIES = {
   1: "Low",
@@ -135,7 +140,7 @@ const schema: SchemaType<DbPost> = {
         inactive: 'Link-post?',
         active: 'Add a linkpost URL',
       },
-      hintText: 'Please write what you liked about the post, and sample liberally. Or, if the author allows it, copy in the entire post text. If you know the author\'s username you can add them as a co-author of this post in the "Options" menu below.',
+      hintText: urlHintText
     },
     group: formGroups.options,
   },


### PR DESCRIPTION
The use-case of mixed link-poster and actual-author usernames as co-authors seems incredibly confusing to me. Link-poster status and actual author status are very different things, but listing them both as authors makes it seem like they wrote it together – and worse, the link-poster will be the first author!

Made a PR to remove the encouragement of that use-case by default, but left the existing text for EA Forum.

I do like having a popup that gives instructions about link posts though! People not inserting any text, just the link, has been a failure mode that's come up enough times.