### PR TITLE
Load chapters with collection page

### DIFF
--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -110,9 +110,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: "55%",
     padding: 20,
     paddingLeft: 40,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
     [theme.breakpoints.down('xs')]: {
       width: "100%",
       paddingLeft: 16,
@@ -122,30 +119,16 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
-  sequence: SequencesPageFragment,
+  sequence: SequencesPageWithChaptersFragment,
   showAuthor?: boolean,
   classes: ClassesType,
 }) => {
   const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated } = Components
   
-  const getSequenceUrl = () => {
-    return '/s/' + sequence._id
-  }
-  
   const [expanded, setExpanded] = useState<boolean>(false)
 
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
 
-  const { results: chapters } = useMulti({
-    terms: {
-      view: "SequenceChapters",
-      sequenceId: sequence._id,
-      limit: 100
-    },
-    collectionName: "Chapters",
-    fragmentName: 'ChaptersFragment',
-    enableTotal: false
-  });
 
   return <div className={classes.root} >
 
@@ -180,7 +163,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
         </div>
       </div>
       <div className={classes.right}>
-        {chapters?.map((chapter) => <span key={chapter._id}>
+        {sequence.chapters?.map((chapter) => <span key={chapter._id}>
             {chapter.posts?.map(post => <SequencesSmallPostLink 
                                           key={chapter._id + post._id} 
                                           post={post}

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -12,7 +12,7 @@ registerFragment(`
     }
     sequenceIds
     sequences {
-      ...SequencesPageFragment
+      ...SequencesPageWithChaptersFragment
     }
     postIds
     posts {

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -32,6 +32,15 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment SequencesPageWithChaptersFragment on Sequence {
+    ...SequencesPageFragment
+    chapters {
+      ...ChaptersFragment
+    }
+  }
+`)
+
+registerFragment(`
   fragment SequencesEdit on Sequence {
     ...SequencesPageFragment
     contents { 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1279,6 +1279,10 @@ interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment
   readonly af: boolean,
 }
 
+interface SequencesPageWithChaptersFragment extends SequencesPageFragment { // fragment on Sequences
+  readonly chapters: Array<ChaptersFragment>,
+}
+
 interface SequencesEdit extends SequencesPageFragment { // fragment on Sequences
   readonly contents: RevisionEdit|null,
 }
@@ -1291,7 +1295,7 @@ interface BookPageFragment { // fragment on Books
   readonly subtitle: string,
   readonly contents: RevisionDisplay|null,
   readonly sequenceIds: Array<string>,
-  readonly sequences: Array<SequencesPageFragment>,
+  readonly sequences: Array<SequencesPageWithChaptersFragment>,
   readonly postIds: Array<string>,
   readonly posts: Array<PostsList>,
   readonly collectionId: string,
@@ -2012,6 +2016,7 @@ interface FragmentTypes {
   ChaptersEdit: ChaptersEdit
   SequencesPageTitleFragment: SequencesPageTitleFragment
   SequencesPageFragment: SequencesPageFragment
+  SequencesPageWithChaptersFragment: SequencesPageWithChaptersFragment
   SequencesEdit: SequencesEdit
   BookPageFragment: BookPageFragment
   BookEdit: BookEdit
@@ -2157,6 +2162,7 @@ interface CollectionNamesByFragmentName {
   ChaptersEdit: "Chapters"
   SequencesPageTitleFragment: "Sequences"
   SequencesPageFragment: "Sequences"
+  SequencesPageWithChaptersFragment: "Sequences"
   SequencesEdit: "Sequences"
   BookPageFragment: "Books"
   BookEdit: "Books"


### PR DESCRIPTION
This PR makes the new collections page load all posts at once, so that you don't have to wait for them to appear.