### PR TITLE
Fix margin for 'Show Personal Blogposts' settings

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -19,7 +19,7 @@ export const filteringStyles = (theme: ThemeType) => ({
   paddingTop: 12,
   paddingRight: 16,
   width: 500,
-  marginBottom: -4,
+  marginBottom: 20,
   ...theme.typography.commentStyle,
   [theme.breakpoints.down('xs')]: {
     width: "calc(100% - 32px)",
@@ -76,7 +76,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   input: {
     padding: 0,
     paddingBottom: 2,
-    width: 50,
+    width: 60,
     "-webkit-appearance": "none",
     "-moz-appearance": "textfield"
   }


### PR DESCRIPTION
Fixes #5016 

This is a quick fix. I also fixed the width of the input which was cutting off the "r" in "Other".

Before:
![Screenshot 2022-06-29 at 10 20 36](https://user-images.githubusercontent.com/5075628/176401817-780af7e6-acbc-4d16-8475-54782e3b4b3f.png)
![Screenshot 2022-06-29 at 10 20 42](https://user-images.githubusercontent.com/5075628/176401838-caddaea3-b6a1-4618-837f-9ea05c1d3301.png)

After:
![Screenshot 2022-06-29 at 10 05 48](https://user-images.githubusercontent.com/5075628/176401868-6801477c-a4f2-41d6-a11b-aececf39534d.png)
![Screenshot 2022-06-29 at 10 05 58](https://user-images.githubusercontent.com/5075628/176401896-c1e33a78-b059-4598-b9bd-0b8950abe38a.png)
