### PR TITLE
[EA] Hide user moderation actions from non moderators

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -449,3 +449,7 @@ export const userGetCommentCount = (user: UsersMinimumInfo|DbUser): number => {
     return user.commentCount;
   }
 }
+
+export const isMod = (user: UsersProfile|DbUser): boolean => {
+  return user.isAdmin || user.groups?.includes('sunshineRegiment')
+}


### PR DESCRIPTION
Most users are unaware that their moderation actions are public. Indeed, `/moderation` isn't linked to anywhere in the site UI. It seems bad that that page lists moderation actions like "Bob banned Sue from their posts", when Bob wasn't expecting that to be public. So this PR hides it.

I speculate that LW will not want this change, so I've made it EA-only. It can easily applied to LW of course.

This PR does NOT hide that info from a properly constructed GraphQL query, because end-user moderation has only been used 4 times ever, so if you really want to see that information, fine. I don't think it's worth the dev time to fix, and I'm slightly nervous about making it viewable by mods-only and breaking something.

Submitted against `fix-moderation-log` for the avoidance of merge-conflicts.