### PR TITLE
Fix EA Forum Drawer Nav on iOS

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -97,7 +97,7 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
   return <LWTooltip placement='right-start' title={tab.tooltip || ''}>
     <MenuItemUntyped
       onClick={handleClick}
-      // We tried making this an function that return an a tag once. It made the
+      // We tried making this a function that return an a tag once. It made the
       // entire sidebar fail on iOS. True story.
       component={Link}
       to={tab.link}

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -85,14 +85,23 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
   // React router links don't handle external URLs, so use a
   // normal HTML a tag if the URL is external
   const externalLink = /https?:\/\//.test(tab.link);
-  const Element = externalLink ?
-    ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
-    : Link;
+  // const Element = externalLink ?
+  //   ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
+  //   : Link;
+
+  let handleClick = onClick
+  if (externalLink) {
+    handleClick = (e) => {
+      e.preventDefault()
+      window.open(tab.link, '_blank')?.focus()
+      onClick && onClick(e)
+    }
+  }
 
   return <LWTooltip placement='right-start' title={tab.tooltip || ''}>
     <MenuItemUntyped
-      onClick={onClick}
-      component={Element} to={tab.link}
+      onClick={handleClick}
+      component={Link} to={tab.link}
       disableGutters
       classes={{root: classNames({
         [classes.navButton]: !tab.subItem,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -82,13 +82,9 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
   // Cast to any to work around it, to be able to pass a "to" parameter.
   const MenuItemUntyped = MenuItem as any;
   
-  // React router links don't handle external URLs, so use a
-  // normal HTML a tag if the URL is external
+  // Due to an issue with using anchor tags, we use react-router links, even for
+  // external links, we just use window.open to actuate the link.
   const externalLink = /https?:\/\//.test(tab.link);
-  // const Element = externalLink ?
-  //   ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
-  //   : Link;
-
   let handleClick = onClick
   if (externalLink) {
     handleClick = (e) => {
@@ -101,7 +97,10 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
   return <LWTooltip placement='right-start' title={tab.tooltip || ''}>
     <MenuItemUntyped
       onClick={handleClick}
-      component={Link} to={tab.link}
+      // We tried making this an function that return an a tag once. It made the
+      // entire sidebar fail on iOS. True story.
+      component={Link}
+      to={tab.link}
       disableGutters
       classes={{root: classNames({
         [classes.navButton]: !tab.subItem,


### PR DESCRIPTION
You're not going to believe me, but the presence of a single `a` tag in sidebar links caused the whole sidebar to fail to register taps. Only on iOS. This is why the issue only affects the EA Forum. We have an external link (which causes the a tag) in our sidebar. LW does not. Comment out the external link and the sidebar works.

This is a rather hacky solution to that. I swear to god it fixes the bug.

I believe this to be the actual cause of a mis-diagnosed: https://github.com/ForumMagnum/ForumMagnum/issues/4950. I need to test that in a few more places before I'm sure. But first I need to run for tonight.