### PR TITLE
Login prompt when subscribing

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AFNonMemberInitialPopup.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFNonMemberInitialPopup.tsx
@@ -28,7 +28,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Makes its child a link (wrapping it in an <a> tag) which opens a login
 // dialog.
 const AFNonMemberInitialPopup = ({onClose, classes}: {
-  onClose: ()=>void,
+  onClose?: ()=>void,
   classes: ClassesType,
 }) => {
   const updateCurrentUser = useUpdateCurrentUser();
@@ -39,7 +39,8 @@ const AFNonMemberInitialPopup = ({onClose, classes}: {
   
   const handleClose = () => {
     setOpen(false)
-    onClose()
+    if (onClose)
+      onClose();
   };
 
   return (

--- a/packages/lesswrong/components/alignment-forum/AFNonMemberSuccessPopup.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFNonMemberSuccessPopup.tsx
@@ -30,8 +30,8 @@ const styles = (theme: ThemeType): JssStyles => ({
 // dialog.
 const AFNonMemberSuccessPopup = ({_id, postId, onClose, classes}: {
   _id: string,
-  postId: string | null,
-  onClose: ()=>void,
+  postId?: string,
+  onClose?: ()=>void,
   classes: ClassesType,
 }) => {
   const [open, setOpen] = useState(true)
@@ -40,7 +40,8 @@ const AFNonMemberSuccessPopup = ({_id, postId, onClose, classes}: {
   
   const handleClose = () => {
     setOpen(false)
-    onClose()
+    if (onClose)
+      onClose();
   };
   
   

--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -19,7 +19,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const DeleteCommentDialog = ({comment, onClose, classes}: {
   comment: CommentsList,
-  onClose: ()=>void,
+  onClose?: ()=>void,
   classes: ClassesType,
 }) => {
   const [deletedReason, setDeletedReason] = useState("");
@@ -35,7 +35,8 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
       deletedReason: deletedReason,
     }).then(()=>{
       flash({messageString: "Successfully deleted comment", type: "success"})
-      onClose()
+      if (onClose)
+        onClose();
     }).catch(/* error */);
   }
 
@@ -49,7 +50,8 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
       deletedReason: deletedReason,
     }).then(()=>{
       flash({messageString: "Successfully deleted comment", type: "success"})
-      onClose()
+      if (onClose)
+        onClose();
     }).catch(/* error */);
   }
 

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const ModerationGuidelinesEditForm = ({ postId, onClose, classes }: {
   postId: string,
-  onClose: ()=>void,
+  onClose?: ()=>void,
   classes: ClassesType,
 }) => {
   const SubmitComponent = ({submitLabel = "Submit"}) => {

--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -5,7 +5,11 @@ import { hookToHoc } from '../../lib/hocUtils';
 import { useTracking } from '../../lib/analyticsEvents';
 
 export interface OpenDialogContextType {
-  openDialog: ({componentName, componentProps, noClickawayCancel}: {componentName: string, componentProps?: Record<string,any>, noClickawayCancel?: boolean}) => void,
+  openDialog: <T extends keyof ComponentTypes>({componentName, componentProps, noClickawayCancel}: {
+    componentName: T,
+    componentProps?: React.ComponentProps<typeof Components[T]>,
+    noClickawayCancel?: boolean,
+  }) => void,
   closeDialog: ()=>void,
 }
 export const OpenDialogContext = React.createContext<OpenDialogContextType|null>(null);
@@ -14,7 +18,7 @@ export const OpenDialogContext = React.createContext<OpenDialogContextType|null>
 export const DialogManager = ({children}: {
   children: React.ReactNode,
 }) => {
-  const [componentName,setComponentName] = useState<string|null>(null);
+  const [componentName,setComponentName] = useState<keyof ComponentTypes|null>(null);
   const [componentProps,setComponentProps] = useState<any>(null);
   const [noClickawayCancel,setNoClickawayCancel] = useState<any>(false);
   const {captureEvent} = useTracking();

--- a/packages/lesswrong/components/form-components/ImageUploadDefaultsDialog.tsx
+++ b/packages/lesswrong/components/form-components/ImageUploadDefaultsDialog.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const ImageUploadDefaultsDialog = ({ onSelect, onClose, classes, type }: {
   onSelect: Function,
-  onClose: ()=>void,
+  onClose?: ()=>void,
   classes: ClassesType,
   type?: string
 }) => {
@@ -32,7 +32,8 @@ const ImageUploadDefaultsDialog = ({ onSelect, onClose, classes, type }: {
   
   const selectImg = (img) => {
     onSelect(img)
-    onClose()
+    if (onClose)
+      onClose();
   }
   
   // these are EA Forum-specific

--- a/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
+++ b/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
@@ -11,7 +11,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
 const ConversationTitleEditForm = ({onClose, documentId}: {
-  onClose: ()=>void,
+  onClose?: ()=>void,
   documentId: string,
 }) =>{
   return <Components.LWDialog open onClose={onClose}>
@@ -24,7 +24,8 @@ const ConversationTitleEditForm = ({onClose, documentId}: {
           queryFragment={getFragment('conversationsListFragment')}
           mutationFragment={getFragment('conversationsListFragment')}
           successCallback={document => {
-            onClose();
+            if (onClose)
+              onClose();
           }}
         />
       </DialogContent>

--- a/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
@@ -18,10 +18,9 @@ export const responseToText = {
 }
 
 const RSVPForm = ({ post, onClose, initialResponse = "yes" }: {
-  userId: string,
   post: PostsWithNavigation | PostsWithNavigationAndRevision,
   initialResponse: string,
-  onClose: ()=>void,
+  onClose?: ()=>void,
 }) => {
   const [registerRSVP] = useMutation(gql`
     mutation RegisterRSVP($postId: String, $name: String, $email: String, $private: Boolean, $response: String) {
@@ -44,7 +43,8 @@ const RSVPForm = ({ post, onClose, initialResponse = "yes" }: {
       open={true}
       onClose={() => {
         history.push({...location, search: ``})
-        onClose()
+        if (onClose)
+          onClose()
       }}
     >
       <DialogTitle>
@@ -85,7 +85,7 @@ const RSVPForm = ({ post, onClose, initialResponse = "yes" }: {
               const { errors } = await registerRSVP({variables: {postId: post._id, name, email, response}})
               if (errors) {
                 setError(`Oops, something went wrong: ${errors[0].message}`)
-              } else {
+              } else if (onClose) {
                 onClose()
               }
             } else {

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -39,7 +39,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     lineHeight: 1.3,
   },
   loginForm: {
-    margin: "0 auto",
+    margin: "0 auto -4px",
     maxWidth: 252,
   },
   message: {

--- a/packages/lesswrong/components/review/NominatePostDialog.tsx
+++ b/packages/lesswrong/components/review/NominatePostDialog.tsx
@@ -36,7 +36,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const NominatePostDialog = ({classes, post, onClose}: {
   classes: ClassesType,
   post: PostsBase,
-  onClose: ()=>void,
+  onClose?: ()=>void,
 }) => {
   const { CommentsNewForm, Typography, LWDialog } = Components;
 

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
@@ -7,7 +7,7 @@ const ReportForm = ({ userId, postId, commentId, onClose, title, link }: {
   userId: string,
   postId: string,
   commentId?: string,
-  onClose: ()=>void,
+  onClose?: ()=>void,
   title?: string,
   link: string,
 }) => {

--- a/packages/lesswrong/components/tagging/EditTagsDialog.tsx
+++ b/packages/lesswrong/components/tagging/EditTagsDialog.tsx
@@ -6,7 +6,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const EditTagsDialog = ({post, onClose }: {
   post: PostsList,
-  onClose: ()=>void
+  onClose?: ()=>void
 }) => {
   const { FooterTagList, LWDialog } = Components
   return <LWDialog open={true} onClose={onClose} fullWidth maxWidth="sm">

--- a/packages/lesswrong/components/tagging/SubscribeButton.tsx
+++ b/packages/lesswrong/components/tagging/SubscribeButton.tsx
@@ -48,11 +48,11 @@ const SubscribeButton = ({
     try {
       e.preventDefault();
 
-      if (currentUser) {
-        const newMode = isSubscribed ? "Default" : "Subscribed";
-        captureEvent('newSubscribeClicked', {tagId: tag._id, newMode});
-        subscribeUserToTag(tag, newMode);
+      const newMode = isSubscribed ? "Default" : "Subscribed";
+      captureEvent('newSubscribeClicked', {tagId: tag._id, newMode});
 
+      if (currentUser) {
+        subscribeUserToTag(tag, newMode);
         flash({messageString: isSubscribed ? "Unsubscribed" : "Subscribed"});
       } else {
         openDialog({

--- a/packages/lesswrong/components/tagging/SubscribeButton.tsx
+++ b/packages/lesswrong/components/tagging/SubscribeButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Components, registerComponent, getCollectionName } from '../../lib/vulcan-lib';
 import { useMessages } from '../common/withMessages';
+import { useCurrentUser } from '../common/withUser';
+import { useDialog } from '../common/withDialog';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { useTracking } from "../../lib/analyticsEvents";
@@ -35,26 +37,36 @@ const SubscribeButton = ({
   className?: string,
   classes: ClassesType,
 }) => {
+  const currentUser = useCurrentUser();
+  const { openDialog } = useDialog();
   const { isSubscribed, subscribeUserToTag } = useSubscribeUserToTag(tag)
   const { flash } = useMessages();
   const { captureEvent } = useTracking()
   const { LWTooltip, NotifyMeButton } = Components
-  
+
   const onSubscribe = async (e: React.MouseEvent<HTMLButtonElement>) => {
     try {
       e.preventDefault();
-      const newMode = isSubscribed ? "Default" : "Subscribed"
-      captureEvent('newSubscribeClicked', {tagId: tag._id, newMode})
-      subscribeUserToTag(tag, newMode)
-      
-      flash({messageString: isSubscribed ? "Unsubscribed" : "Subscribed"});
+
+      if (currentUser) {
+        const newMode = isSubscribed ? "Default" : "Subscribed";
+        captureEvent('newSubscribeClicked', {tagId: tag._id, newMode});
+        subscribeUserToTag(tag, newMode);
+
+        flash({messageString: isSubscribed ? "Unsubscribed" : "Subscribed"});
+      } else {
+        openDialog({
+          componentName: "LoginPopup",
+          componentProps: {}
+        });
+      }
     } catch(error) {
       flash({messageString: error.message});
     }
   }
-  
+
   const postsWording = taggingNameIsSet.get() ? `posts tagged with this ${taggingNameSetting.get()}` : "posts with this tag"
-  
+
   return <div className={classNames(className, classes.root)}>
     <LWTooltip title={isSubscribed ?
       `Remove homepage boost for ${postsWording}` :

--- a/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
@@ -6,8 +6,8 @@ import { TagFlags } from '../../lib/collections/tagFlags/collection';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
 
 const TagFlagEditAndNewForm = ({ tagFlagId, onClose, classes }: {
-  tagFlagId: string,
-  onClose: () => void,
+  tagFlagId?: string,
+  onClose?: () => void,
   classes: ClassesType,
 }) => {
   const { LWDialog } = Components;

--- a/packages/lesswrong/components/users/LoginPopup.tsx
+++ b/packages/lesswrong/components/users/LoginPopup.tsx
@@ -17,7 +17,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Makes its child a link (wrapping it in an <a> tag) which opens a login
 // dialog.
 const LoginPopup = ({onClose, classes}: {
-  onClose: ()=>void,
+  onClose?: ()=>void,
   classes: ClassesType,
 }) => {
   const { LWDialog } = Components;

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -53,7 +53,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     justifyContent: 'space-between',
     '&.ea-forum': {
-      justifyContent: 'space-around'
+      justifyContent: 'space-around',
+      padding: '8px 20px',
     }
   },
   oAuthComment: {


### PR DESCRIPTION
Fixes #5023 

This adds a login/sign up prompt when clicking "Subscribe" on a topic whilst logged out.

I also added a small amount of padding for the dialog as mentioned in the issue:
<img width="419" alt="Screenshot 2022-06-30 at 12 37 48" src="https://user-images.githubusercontent.com/5075628/176669056-138e79c9-cd86-4e71-a2d9-2823533c9dfd.png">
<img width="368" alt="Screenshot 2022-06-30 at 12 38 01" src="https://user-images.githubusercontent.com/5075628/176669076-370efb59-61ed-4917-aab6-dd0ccc0de606.png">

This same component is also used on the post analytics page:
<img width="749" alt="Screenshot 2022-06-30 at 12 37 15" src="https://user-images.githubusercontent.com/5075628/176669116-68155d92-2418-4141-b66e-41a1e5d38d99.png">
and on the email subscription form, where I added a little negative margin to even things up:
<img width="604" alt="Screenshot 2022-06-30 at 12 37 10" src="https://user-images.githubusercontent.com/5075628/176669205-fe83b55d-6018-4166-9f96-a06f59765aa4.png">

These changes also shouldn't cause any issues for LessWrong:
<img width="384" alt="Screenshot 2022-06-30 at 12 39 03" src="https://user-images.githubusercontent.com/5075628/176669276-4976332e-0073-4e17-a0d3-68c26a229406.png">
<img width="605" alt="Screenshot 2022-06-30 at 12 39 19" src="https://user-images.githubusercontent.com/5075628/176669286-b40d82c7-2a3e-4f36-962f-cd30a1073232.png">
