### PR TITLE
Create section title anchors

### DIFF
--- a/packages/lesswrong/components/common/SectionTitle.tsx
+++ b/packages/lesswrong/components/common/SectionTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { registerComponent, Components, slugify } from '../../lib/vulcan-lib';
 import classNames from 'classnames'
 
 export const sectionTitleStyle = (theme: ThemeType): JssStyles => ({
@@ -31,18 +31,30 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const SectionTitle = ({children, classes, className, title, noTopMargin }: {
+const getAnchorId = (anchor: string|undefined, title: React.ReactNode) => {
+  if (anchor) {
+    return anchor;
+  }
+  if (typeof title === 'string') {
+    return slugify(title);
+  }
+}
+
+const SectionTitle = ({children, classes, className, title, noTopMargin, anchor}: {
   children?: React.ReactNode,
   classes: ClassesType,
   className?: string,
   title: React.ReactNode,
-  noTopMargin?: Boolean
+  noTopMargin?: Boolean,
+  anchor?: string,
 }) => {
-
-  
   return (
     <div className={noTopMargin ? classNames(classes.root, classes.noTopMargin) : classes.root}>
-      <Components.Typography variant='display1' className={classNames(classes.title, className)}>
+      <Components.Typography
+        id={getAnchorId(anchor, title)}
+        variant='display1'
+        className={classNames(classes.title, className)}
+      >
         {title}
       </Components.Typography>
       <div className={classes.children}>{ children }</div>

--- a/packages/lesswrong/components/common/Typography.tsx
+++ b/packages/lesswrong/components/common/Typography.tsx
@@ -37,7 +37,7 @@ const variantToDefaultComponent: Record<VariantString, string> = {
   body1: 'p',
 };
 
-const Typography = ({children, variant, component, className, onClick, gutterBottom=false, classes}: {
+const Typography = ({children, variant, component, className, onClick, gutterBottom=false, classes, id}: {
   children: React.ReactNode,
   variant: VariantString,
   component?: "div"|"span"|"label"|"aside",
@@ -45,12 +45,19 @@ const Typography = ({children, variant, component, className, onClick, gutterBot
   onClick?: any,
   gutterBottom?: boolean,
   classes: ClassesType,
+  id?: string,
 }) => {
   const Component: any = component || variantToDefaultComponent[variant] || "span";
-  
-  return <Component className={classNames(classes.root, classes[variant], className, {[classes.gutterBottom]: gutterBottom})} onClick={onClick}>
-    {children}
-  </Component>
+
+  return (
+    <Component
+      id={id}
+      className={classNames(classes.root, classes[variant], className, {[classes.gutterBottom]: gutterBottom})}
+      onClick={onClick}
+    >
+      {children}
+    </Component>
+  );
 }
 
 const TypographyComponent = registerComponent("Typography", Typography, {

--- a/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
@@ -41,7 +41,10 @@ const AllTagsAlphabetical = ({classes}: {
 
   return (
     <div className={classes.root}>
-      <SectionTitle title={`All ${taggingNamePluralCapitalSetting.get()} (${loading ? "loading" : results?.length})`}>
+      <SectionTitle
+        title={`All ${taggingNamePluralCapitalSetting.get()} (${loading ? "loading" : results?.length})`}
+        anchor={`all-${taggingNamePluralSetting.get()}`}
+      >
         {userCanCreateTags(currentUser) && <SectionButton>
           <AddBoxIcon/>
           <Link to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}>


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202465710122588/f)

This approach automatically creates an anchor for any section title where this is trivial, ie; when the title is a string. The existing code allows the title to be an arbitrary React element and, whilst is would be possible to extract some text from this, it could be expensive so we probably don't want to automatically do this for every current and future title on the site.

I also added the ability to specify a custom anchor - this is actually needed for "All Topics", otherwise it would include the total number of topics (like `#all-topics-597`) which obviously isn't stable. The link for the all topics section will now be `/topics/all#all-topics`.

In the end, I decided against turning the titles into clickable links (at least, for now). The main reason for this is that is causes some issues with titles that are already wrapped in an `a` tag. Perhaps this could be an opt-in feature in the future.

There's a lot of places around the site where this isn't actually very useful; pages with a single `SectionTitle` right at the top of the page. On other place (apart from "All Topics") where it works quite nicely though is the `/library` page where we get `#core-reading` and `#sequences`.