### PR TITLE
Disable co-author notification due to bugs

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -462,9 +462,10 @@ getCollectionHooks("Posts").newAsync.add(async function CoauthorRequestNotificat
   await checkCoauthorRequestNotifications(post);
 });
 
-getCollectionHooks("Posts").updateAfter.add(async function CoauthorRequestNotifications(post: DbPost) {
-  return await checkCoauthorRequestNotifications(post);
-});
+//TODO: Currently broken, disable so we don't get bad emails
+// getCollectionHooks("Posts").updateAfter.add(async function CoauthorRequestNotifications(post: DbPost) {
+//   return await checkCoauthorRequestNotifications(post);
+// });
 
 async function checkCoauthorRequestNotifications(post: DbPost) {
   const { _id, coauthorStatuses = [], hasCoauthorPermission } = post;


### PR DESCRIPTION
Currently there's a bug with our fix of coauthor notifications, don't want any spurious notifications, so disabling