### PR TITLE
Fix link clicking on link post hint text

### DIFF
--- a/packages/lesswrong/components/editor/EditUrl.tsx
+++ b/packages/lesswrong/components/editor/EditUrl.tsx
@@ -85,9 +85,9 @@ const EditUrl = ({ value, path, classes, document, defaultValue, label, hintText
   }
 
   const waitAndWipeFooterContent = async () => {
-    // Yield context to let the other click events fire first, so that link
-    // clicks can happen before we remove the link
-    await sleep(0);
+    // Delay to let the other click events fire first, so that link clicks can
+    // happen before we remove the link
+    await sleep(300);
     setFooterContent(null);
   }
 


### PR DESCRIPTION
Reports exist that chrome on windows falls afoul of the link disappearing before the click goes through. I could not get the repro there. But I could on Firefox. So apparently my beautiful theory of how the system dynamics work has been destroyed by ugly data.

As a hack for now, add a 300 millisecond delay before clearing the link. That's about the upper limit of what feels natural.