### PR TITLE
Add anchors to "All topics" subheadings

### DIFF
--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -57,7 +57,7 @@ const AllTagsPage = ({classes}: {
 }) => {
   const { openDialog } = useDialog()
   const currentUser = useCurrentUser()
-  const { tag } = useTagBySlug("portal", "TagFragment");
+  const { tag } = useTagBySlug("portal", "TagWithTocFragment");
   const [ editing, setEditing ] = useState(false)
 
   const { AllTagsAlphabetical, SectionButton, SectionTitle, ContentItemBody, ContentStyles } = Components;
@@ -106,7 +106,7 @@ const AllTagsPage = ({classes}: {
                 <EditTagForm tag={tag} successCallback={()=>setEditing(false)}/>
                 :
                 <ContentItemBody
-                  dangerouslySetInnerHTML={{__html: tag?.description?.html || ""}}
+                  dangerouslySetInnerHTML={{__html: tag?.descriptionHtmlWithToc || ""}}
                   description={`tag ${tag?.name}`} noHoverPreviewPrefetch
                 />
               }

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -49,6 +49,13 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment TagWithTocFragment on Tag {
+    ...TagFragment
+    descriptionHtmlWithToc
+  }
+`);
+
+registerFragment(`
   fragment TagHistoryFragment on Tag {
     ...TagBasicInfo
     user {

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -129,6 +129,11 @@ export const schema: SchemaType<DbTag> = {
     optional: true,
     ...schemaDefaultValue(0),
   },
+  descriptionHtmlWithToc: {
+    type: String,
+    viewableBy: ['guests'],
+    // See resolveAs in server/resolvers/tagResolvers.ts
+  },
   postCount: {
     ...denormalizedCountOfReferences({
       fieldName: "postCount",

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -250,6 +250,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly suggestedAsFilter: boolean,
   readonly defaultOrder: number,
   readonly descriptionTruncationCount: number,
+  readonly descriptionHtmlWithToc: string,
   readonly postCount: number,
   readonly userId: string,
   readonly adminOnly: boolean,
@@ -1436,6 +1437,10 @@ interface TagFragment_description { // fragment on Revisions
   readonly version: string,
 }
 
+interface TagWithTocFragment extends TagFragment { // fragment on Tags
+  readonly descriptionHtmlWithToc: string,
+}
+
 interface TagHistoryFragment extends TagBasicInfo { // fragment on Tags
   readonly user: UsersMinimumInfo|null,
 }
@@ -2026,6 +2031,7 @@ interface FragmentTypes {
   TagBasicInfo: TagBasicInfo
   TagDetailsFragment: TagDetailsFragment
   TagFragment: TagFragment
+  TagWithTocFragment: TagWithTocFragment
   TagHistoryFragment: TagHistoryFragment
   TagCreationHistoryFragment: TagCreationHistoryFragment
   TagRevisionFragment: TagRevisionFragment
@@ -2172,6 +2178,7 @@ interface CollectionNamesByFragmentName {
   TagBasicInfo: "Tags"
   TagDetailsFragment: "Tags"
   TagFragment: "Tags"
+  TagWithTocFragment: "Tags"
   TagHistoryFragment: "Tags"
   TagCreationHistoryFragment: "Tags"
   TagRevisionFragment: "Tags"

--- a/packages/lesswrong/server/callbacks/revisionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/revisionCallbacks.ts
@@ -3,7 +3,7 @@ import { Tags } from '../../lib/collections/tags/collection';
 import { Users } from '../../lib/collections/users/collection';
 import { afterCreateRevisionCallback } from '../editor/make_editable_callbacks';
 import { performVoteServer } from '../voteServer';
-import { updateDenormalizedHtmlAttributions } from '../resolvers/tagResolvers';
+import { updateDenormalizedHtmlAttributions } from '../tagging/updateDenormalizedHtmlAttributions';
 
 // TODO: Now that the make_editable callbacks use createMutator to create
 // revisions, we can now add these to the regular ${collection}.create.after

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -8,6 +8,7 @@ import { augmentFieldsDict, accessFilterMultiple } from '../../lib/utils/schemaU
 import { compareVersionNumbers } from '../../lib/editor/utils';
 import { annotateAuthors } from '../attributeEdits';
 import { toDictionary } from '../../lib/utils/toDictionary';
+import { extractTableOfContents } from "../tableOfContents";
 import moment from 'moment';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
@@ -188,6 +189,17 @@ augmentFieldsDict(Tags, {
         }
       }
     }
+  },
+  descriptionHtmlWithToc: {
+    resolveAs: {
+      type: "String",
+      resolver: async (tag: DbTag, args: {}, context: ResolverContext): Promise<string> => {
+        const description = tag?.description?.html;
+        return description
+          ? extractTableOfContents(description)?.html ?? description
+          : "";
+      },
+    },
   },
 });
 

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -6,7 +6,6 @@ import { Votes } from '../../lib/collections/votes/collection';
 import { Users } from '../../lib/collections/users/collection';
 import { augmentFieldsDict, accessFilterMultiple } from '../../lib/utils/schemaUtils';
 import { compareVersionNumbers } from '../../lib/editor/utils';
-import { annotateAuthors } from '../attributeEdits';
 import { toDictionary } from '../../lib/utils/toDictionary';
 import { extractTableOfContents } from "../tableOfContents";
 import moment from 'moment';
@@ -289,12 +288,4 @@ export async function updateDenormalizedContributorsList(tag: DbTag): Promise<Co
   }
   
   return contributionStats;
-}
-
-export async function updateDenormalizedHtmlAttributions(tag: DbTag) {
-  const html = await annotateAuthors(tag._id, "Tags", "description");
-  await Tags.rawUpdateOne({_id: tag._id}, {$set: {
-    htmlWithContributorAnnotations: html,
-  }});
-  return html;
 }

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -193,10 +193,7 @@ augmentFieldsDict(Tags, {
     resolveAs: {
       type: "String",
       resolver: async (tag: DbTag, args: {}, context: ResolverContext): Promise<string> => {
-        const description = tag?.description?.html;
-        return description
-          ? extractTableOfContents(description)?.html ?? description
-          : "";
+        return extractTableOfContents(tag?.description?.html)?.html ?? "";
       },
     },
   },

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -8,7 +8,7 @@ import { Revisions } from '../lib/collections/revisions/collection';
 import { answerTocExcerptFromHTML, truncate } from '../lib/editor/ellipsize';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { Utils } from '../lib/vulcan-lib';
-import { updateDenormalizedHtmlAttributions } from './resolvers/tagResolvers';
+import { updateDenormalizedHtmlAttributions } from './tagging/updateDenormalizedHtmlAttributions';
 import { annotateAuthors } from './attributeEdits';
 
 export interface ToCAnswer {

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -175,6 +175,7 @@ function titleToAnchor(title: string, usedAnchors: Record<string,boolean>): stri
 // `<b>` and `<strong>` tags are headings iff they are the only thing in their
 // paragraph. Return whether the given tag name is a tag with that property
 // (ie, is `<strong>` or `<b>`).
+// See tagIsWholeParagraph
 function tagIsHeadingIfWholeParagraph(tagName: string): boolean
 {
   return tagName.toLowerCase() in headingIfWholeParagraph;
@@ -191,6 +192,9 @@ const tagIsAlien = (baseTag: cheerio.TagElement, potentialAlienTag: cheerio.Elem
   }
 }
 
+// `<b>` and `<strong>` tags are headings iff they are the only thing in their
+// paragraph. Return whether or not the given cheerio tag satisfies these heuristics.
+// See tagIsHeadingIfWholeParagraph
 const tagIsWholeParagraph = (tag?: cheerio.TagElement): boolean => {
   if (!tag) {
     return false;

--- a/packages/lesswrong/server/tagging/updateDenormalizedHtmlAttributions.ts
+++ b/packages/lesswrong/server/tagging/updateDenormalizedHtmlAttributions.ts
@@ -1,0 +1,10 @@
+import { Tags } from '../../lib/collections/tags/collection';
+import { annotateAuthors } from '../attributeEdits';
+
+export async function updateDenormalizedHtmlAttributions(tag: DbTag) {
+  const html = await annotateAuthors(tag._id, "Tags", "description");
+  await Tags.rawUpdateOne({_id: tag._id}, {$set: {
+    htmlWithContributorAnnotations: html,
+  }});
+  return html;
+}


### PR DESCRIPTION
This solution is less hacky than the previous, but should still be superceded by a fix in the editor (I still kind of wanted to implement this, if only for the GraphQL practice).

If there's still any big issues/questions then maybe we can jump on a call as you suggested.

There's an argument to be made that this could be more strongly integrated with the existing tag description, but I think it's better to keep some level of separation since this is a temporary solution.