### PR TITLE
Fix coauthors not being shown to non-author users

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -8,15 +8,17 @@ const PostsCoauthor = ({ post, coauthor }: {
   coauthor: UsersMinimumInfo,
 }) => {
   const currentUser = useCurrentUser();
+  const isPending = postCoauthorIsPending(post, coauthor._id);
   if (
     currentUser?._id !== post.userId &&
-    !post.coauthorStatuses.find(({ userId }) => currentUser?._id === userId)
+    !post.coauthorStatuses.find(({ userId }) => currentUser?._id === userId) &&
+    isPending
   ) {
     return null;
   }
 
   const { UsersNamePending, UsersName } = Components;
-  const Component = postCoauthorIsPending(post, coauthor._id)
+  const Component = isPending
     ? UsersNamePending
     : UsersName;
   return (


### PR DESCRIPTION
Currently co-authors are always shown on the homepage, but on the post page they are only shown to the author and other co-authors.

The logic should now be:
 * If the user is the author or a co-author (either confirmed or pending) then all co-authors will be shown
 * otherwise only confirmed co-authors will be shown.