### PR TITLE
Send a welcome PM and email 1 hour after a new account is created

### DIFF
--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -39,7 +39,7 @@ const schema: SchemaType<DbMessage> = {
     viewableBy: ['admins'],
     insertableBy: ['admins'],
     ...schemaDefaultValue(false)
-  }
+  },
 };
 
 export default schema;

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -19,7 +19,7 @@ import { ensureIndex } from '../../lib/collectionUtils';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
-let adminTeamUserData = forumTypeSetting.get() === 'EAForum' ?
+const adminTeamUserData = forumTypeSetting.get() === 'EAForum' ?
   {
     username: "AdminTeam",
     email: "forum@effectivealtruism.org"
@@ -29,7 +29,7 @@ let adminTeamUserData = forumTypeSetting.get() === 'EAForum' ?
     email: "lesswrong@lesswrong.com"
   }
 
-const getLessWrongAccount = async () => {
+export const getAdminTeamAccount = async () => {
   let account = await Users.findOne({username: adminTeamUserData.username});
   if (!account) {
     const newAccount = await createMutator({
@@ -252,7 +252,7 @@ export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser
         : null
       );
     const moderatingUser = comment.deletedByUserId ? await Users.findOne(comment.deletedByUserId) : null;
-    const lwAccount = await getLessWrongAccount();
+    const lwAccount = await getAdminTeamAccount();
 
     const conversationData = {
       participantIds: [comment.userId, lwAccount._id],

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -324,7 +324,7 @@ const welcomeMessageDelayer = new EventDebouncer<string,{}>({
   defaultTiming: {type: "delayed", delayMinutes: 60 },
   
   callback: (userId: string) => {
-    sendWelcomeMessageTo(userId);
+    void sendWelcomeMessageTo(userId);
   },
 });
 
@@ -340,11 +340,13 @@ const welcomeEmailPostId = new DatabaseServerSetting<string|null>("welcomeEmailP
 async function sendWelcomeMessageTo(userId: string) {
   const postId = welcomeEmailPostId.get();
   if (!postId || !postId.length) {
+    // eslint-disable-next-line no-console
     console.log("Not sending welcome email, welcomeEmailPostId setting is not configured");
     return;
   }
   const welcomePost = await Posts.findOne({_id: postId});
   if (!welcomePost) {
+    // eslint-disable-next-line no-console
     console.error(`Not sending welcome email, welcomeEmailPostId of ${postId} does not match any post`);
     return;
   }


### PR DESCRIPTION
Co-Authored-By: Sarah Cheng <sarah.cheng@centreforeffectivealtruism.org>

When users create a new account, send a welcome email, as both a PM conversation with the admin account, and as an email. This uses the database server setting `welcomeEmailPostId` to find the message to send (if not configured, nothing is sent).

* TODO for EA forum: Write a welcome post, mark it unlisted, and put its ID into the database setting.
* TODO for LW: Check over the pinnned "welcome to Less Wrong" post and make sure nothing about it is weird and bad if it's converted to an email instead of a post. Then put its ID into the database setting.
* TODO for AIAF: I think AF accounts always start as LW accounts that get promoted, but if that's wrong we need two different welcome posts.

(No emails get sent until the `welcomeEmailPostId` setting is configured, so this PR can merge without waiting for other forums to figure out their content.)