### PR TITLE
hide the linkpost option for events

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostAuthorCard.tsx
@@ -114,7 +114,7 @@ const PostAuthorCard = ({author, currentUser, classes}: {
         </div>
       </div>
       {author.biography?.html && <ContentStyles contentType="comment" className={classes.bio}>
-        <div dangerouslySetInnerHTML={{__html: truncate(author.biography.html, 340)}} />
+        <div dangerouslySetInnerHTML={{__html: truncate(author.biography.html, 100, 'words')}} />
       </ContentStyles>}
     </div>
   </AnalyticsContext>

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -155,6 +155,7 @@ const schema: SchemaType<DbPost> = {
       hintText: urlHintText
     },
     group: formGroups.options,
+    hidden: (props) => props.eventForm,
   },
   // Title
   title: {


### PR DESCRIPTION
I don't think it makes sense for events to be a linkpost, since there are multiple other event-specific fields to add external links. So I'm hiding that option for events.

Also made a small EA Forum only update, to truncate the post author card bio by word instead of character.