### PR TITLE
improve sequence styling

### DIFF
--- a/packages/lesswrong/components/common/LinkCard.tsx
+++ b/packages/lesswrong/components/common/LinkCard.tsx
@@ -57,7 +57,7 @@ const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
   );
   
   if (tooltip) {
-    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false} clickable>
+    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false} clickable flip={false}>
       {card}
     </LWTooltip>;
   } else {

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -150,7 +150,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
 
     <div className={classes.columns}>
       <div className={classes.left}>
-        <Link className={classes.imageLink} to={'/s/' + sequence._id}>
+        <Link className={classes.imageLink} to={`/s/${sequence._id}`}>
           <div className={classes.sequenceImage}>
             <img className={classes.sequenceImageImg}
               src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
@@ -161,7 +161,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
         </Link>
         <div className={classes.text}>
           <div className={classes.titleAndAuthor}>
-            <Link  to={'/s/' + sequence._id} className={classes.title}>{sequence.title}</Link>
+            <Link to={`/s/${sequence._id}`} className={classes.title}>{sequence.title}</Link>
           { showAuthor && sequence.user &&
             <div className={classes.author}>
               by <UsersName user={sequence.user} />

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -185,10 +185,10 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
       </div>
       <div className={classes.right}>
         {posts.map(post => <SequencesSmallPostLink 
-                              key={sequence._id + post._id} 
-                              post={post}
-                            />
-            )}
+            key={sequence._id + post._id} 
+            post={post}
+          />
+        )}
       </div>
     </div>
   </div>
@@ -198,7 +198,7 @@ const LargeSequencesItemComponent = registerComponent('LargeSequencesItem', Larg
 
 declare global {
   interface ComponentTypes {
-    LargeSequencesItem: typeof LargeSequencesItemComponent
+    LargeSequencesItem: typeof LargeSequencesItemCompone{posts.map(post => nt
   }
 }
 

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -198,7 +198,7 @@ const LargeSequencesItemComponent = registerComponent('LargeSequencesItem', Larg
 
 declare global {
   interface ComponentTypes {
-    LargeSequencesItem: typeof LargeSequencesItemCompone{posts.map(post => nt
+    LargeSequencesItem: typeof LargeSequencesItemComponent
   }
 }
 

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -3,8 +3,9 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
+import Chapters from '../../lib/collections/chapters/collection';
+import { each, reduce } from 'lodash';
 
-const shadow = theme => `0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}`
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -37,19 +38,22 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontVariant: "small-caps",
     color: theme.palette.grey[900],
     display: "block",
-    textShadow: shadow(theme)
+    textShadow: `0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}, 0 0 25px ${theme.palette.panelBackground.default}`,
+    '&:hover': {
+      opacity: 1,
+      color: theme.palette.grey[600],
+    }
   },
   description: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
-    textShadow: shadow(theme)
+    marginBottom: 16
   },
   author: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
     color: theme.palette.text.dim,
-    fontStyle: "italic",
-    textShadow: shadow(theme)
+    fontStyle: "italic"
   },
   sequenceImage: {
     position: "absolute",
@@ -57,7 +61,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     left: 0,
     height: 125,
     width: "45%",
-    opacity: .6,
+    opacity: .85,
     [theme.breakpoints.down('xs')]: {
       width: "100%",
     },
@@ -115,6 +119,16 @@ const styles = (theme: ThemeType): JssStyles => ({
       paddingLeft: 16,
       paddingTop: 0
     }
+  },
+  wordcount: {
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[500],
+    fontSize: "1rem"
+  },
+  imageLink: {
+    '&:hover': {
+      opacity: 1
+    }
   }
 });
 
@@ -129,48 +143,53 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
 
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
 
+  let posts : PostsList[] = []
+  sequence.chapters?.forEach(chapter => chapter.posts?.forEach(post => posts.push(post)))
+  const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
+
+  const highlight = sequence.contents?.htmlHighlight || ""
 
   return <div className={classes.root} >
 
     <div className={classes.columns}>
       <div className={classes.left}>
-        <div className={classes.sequenceImage}>
-          <img className={classes.sequenceImageImg}
-            src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
-              sequence.gridImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"
-            }`}
-            />
-        </div>
+        <Link className={classes.imageLink} to={'/s/' + sequence._id}>
+          <div className={classes.sequenceImage}>
+            <img className={classes.sequenceImageImg}
+              src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
+                sequence.gridImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"
+              }`}
+              />
+          </div>
+        </Link>
         <div className={classes.text}>
           <div className={classes.titleAndAuthor}>
-            <Link to={'/s/' + sequence._id} className={classes.title}>{sequence.title}</Link>
+            <Link  to={'/s/' + sequence._id} className={classes.title}>{sequence.title}</Link>
           { showAuthor && sequence.user &&
             <div className={classes.author}>
               by <UsersName user={sequence.user} />
             </div>}
           </div>
-          <ContentStyles contentType="postHighlight" className={classes.description}>
+          {(highlight.length > 0) && <ContentStyles contentType="postHighlight" className={classes.description}>
             <ContentItemTruncated
               maxLengthWords={100}
               graceWords={20}
               rawWordCount={sequence.contents?.wordCount || 0}
               expanded={expanded}
               getTruncatedSuffix={() => null}
-              dangerouslySetInnerHTML={{__html: sequence.contents?.htmlHighlight || ""}}
+              dangerouslySetInnerHTML={{__html: highlight}}
               description={`sequence ${sequence._id}`}
             />
-          </ContentStyles>
+          </ContentStyles>}
+          <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read ({totalWordcount.toLocaleString("en-US")} words)</div>
         </div>
       </div>
       <div className={classes.right}>
-        {sequence.chapters?.map((chapter) => <span key={chapter._id}>
-            {chapter.posts?.map(post => <SequencesSmallPostLink 
-                                          key={chapter._id + post._id} 
+        {posts.map(post => <SequencesSmallPostLink 
+                                          key={sequence._id + post._id} 
                                           post={post}
                                         />
             )}
-          </span>
-        )}
       </div>
     </div>
   </div>

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -140,8 +140,8 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
 
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
 
-  let posts : PostsList[] = []
-  sequence.chapters?.forEach(chapter => chapter.posts?.forEach(post => posts.push(post)))
+
+  const posts = sequence.chapters?.flatMap(chapter => chapter.posts ?? []) ?? []
   const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
 
   const highlight = sequence.contents?.htmlHighlight || ""

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
-import { useMulti } from '../../lib/crud/withMulti';
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
-import Chapters from '../../lib/collections/chapters/collection';
-import { each, reduce } from 'lodash';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -47,7 +44,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   description: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
-    marginBottom: 16
+    marginBottom: 12
   },
   author: {
     ...theme.typography.body2,
@@ -137,7 +134,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
   showAuthor?: boolean,
   classes: ClassesType,
 }) => {
-  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated } = Components
+  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, LWTooltip } = Components
   
   const [expanded, setExpanded] = useState<boolean>(false)
 
@@ -181,14 +178,16 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
               description={`sequence ${sequence._id}`}
             />
           </ContentStyles>}
-          <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read ({totalWordcount.toLocaleString("en-US")} words)</div>
+          <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>
+            <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read</div>
+          </LWTooltip>
         </div>
       </div>
       <div className={classes.right}>
         {posts.map(post => <SequencesSmallPostLink 
-                                          key={sequence._id + post._id} 
-                                          post={post}
-                                        />
+                              key={sequence._id + post._id} 
+                              post={post}
+                            />
             )}
       </div>
     </div>

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -73,11 +73,11 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     </ContentStyles>
     {!chapters && loading && <Loading />}
     {posts.map(post => 
-        <SequencesSmallPostLink 
-          key={sequence?._id + post._id} 
-          post={post}
-        />
-      )}
+      <SequencesSmallPostLink 
+        key={sequence?._id + post._id} 
+        post={post}
+      />
+    )}
     <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>
       <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read</div>
     </LWTooltip>

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -49,8 +49,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     enableTotal: false,
   });
 
-  let posts : PostsList[] = []
-  chapters?.forEach(chapter => chapter.posts?.forEach(post => posts.push(post)))
+  const posts = chapters?.flatMap(chapter => chapter.posts ?? []) ?? []
   const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
   
   return <Card className={classes.root}>

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -22,6 +22,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   author: {
     color: theme.palette.text.dim
+  },
+  wordcount: {
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[500],
+    marginTop: 16,
+    fontSize: "1rem"
   }
 });
 
@@ -42,6 +48,10 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     fragmentName: 'ChaptersFragment',
     enableTotal: false,
   });
+
+  let posts : PostsList[] = []
+  chapters?.forEach(chapter => chapter.posts?.forEach(post => posts.push(post)))
+  const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
   
   return <Card className={classes.root}>
     {!sequence && <Loading/>}
@@ -62,14 +72,13 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
       />
     </ContentStyles>
     {!chapters && loading && <Loading />}
-    {chapters?.map((chapter) => <span key={chapter._id}>
-      {chapter.posts?.map(post => 
+    {posts.map(post => 
         <SequencesSmallPostLink 
-          key={chapter._id + post._id} 
+          key={sequence?._id + post._id} 
           post={post}
         />
       )}
-     </span>)}
+    {chapters && <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read ({totalWordcount.toLocaleString("en-US")} words)</div>}
   </Card>;
 }
 

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -26,7 +26,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   wordcount: {
     ...theme.typography.commentStyle,
     color: theme.palette.grey[500],
-    marginTop: 16,
+    marginTop: 12,
     fontSize: "1rem"
   }
 });
@@ -36,7 +36,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   sequence: SequencesPageFragment|null,
   showAuthor?: boolean
 }) => {
-  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName } = Components
+  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip } = Components
 
   const { results: chapters, loading } = useMulti({
     terms: {
@@ -78,7 +78,9 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
           post={post}
         />
       )}
-    {chapters && <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read ({totalWordcount.toLocaleString("en-US")} words)</div>}
+    <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>
+      <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read</div>
+    </LWTooltip>
   </Card>;
 }
 

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -36,7 +36,7 @@ const SequencesSmallPostLink = ({classes, post}: {
   classes: ClassesType,
   post: PostsList,
 }) => {
-  const { LWTooltip, PostsPreviewTooltip, } = Components
+  const { LWTooltip, PostsPreviewTooltip } = Components
 
   const icon = !!post.lastVisitedAt ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
 


### PR DESCRIPTION
– Fixes an issue where the description of a sequence had a blurry gradient
– Adds total wordcount to the large sequence items as well as the sequence hoverovers.
– Makes the image in large sequence items into a link.
– increase opacity for large sequence item images.

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/3246710/177614851-fa438cb8-f60e-42c5-b4e5-dee478453de2.png">
