### PR TITLE
Fix coauthor notifications

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -458,14 +458,6 @@ getCollectionHooks("Posts").newAsync.add(async function PostsNewNotifyUsersShare
   await createNotifications({userIds, notificationType: "postSharedWithUser", documentType: "post", documentId: _id})
 });
 
-getCollectionHooks("Posts").newAsync.add(async function CreateCoauthorRequestNotifications(post: DbPost) {
-  await sendCoauthorRequestNotifications(post);
-});
-
-getCollectionHooks("Posts").updateAfter.add(function UpdateCoauthorRequestNotifications(post: DbPost) {
-  return sendCoauthorRequestNotifications(post);
-});
-
 const sendCoauthorRequestNotifications = async (post: DbPost) => {
   const { _id, coauthorStatuses, hasCoauthorPermission } = post;
 
@@ -483,6 +475,9 @@ const sendCoauthorRequestNotifications = async (post: DbPost) => {
 
   return post;
 }
+
+getCollectionHooks("Posts").newAfter.add(sendCoauthorRequestNotifications);
+getCollectionHooks("Posts").updateAfter.add(sendCoauthorRequestNotifications);
 
 const AlignmentSubmissionApprovalNotifyUser = async (newDocument: DbPost|DbComment, oldDocument: DbPost|DbComment) => {
   const newlyAF = newDocument.af && !oldDocument.af

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -471,7 +471,7 @@ const sendCoauthorRequestNotifications = async (post: DbPost) => {
 
   if (hasCoauthorPermission === false && coauthorStatuses?.length) {
     await createNotifications({
-      userIds: coauthorStatuses.filter(({ requested }) => !requested).map(({ userId }) => userId),
+      userIds: coauthorStatuses.filter(({requested, confirmed}) => !requested && !confirmed).map(({userId}) => userId),
       notificationType: "coauthorRequestNotification",
       documentType: "post",
       documentId: _id,


### PR DESCRIPTION
Fixes [this Asana issue](https://app.asana.com/0/inbox/1202509647380319).

Here we fix the bug by adding a separate hook for `updateAfter`.

We check `hasCoauthorPermission === false` instead of `!hasCoauthorPermission` as it's possible for `hasCoauthorPermission` to be `undefined` in some cases where the post is only partially updated. Ideally, it would probably be best to retype these update hooks throughout the whole codebase with a parameter of type `Partial<DbPost>` instead of `DbPost`, but this is quite a big job worthy of it's own ticket.

We've also switched from `updateMutator` to `Posts.rawUpdateOne`; we don't want to retrigger the hooks here and this seems better semantically as well. The bug on lw-deploy also seemed to be caused by `updateMutator` not actually updating the record in some cases.