### PR TITLE
Fix footnotes being added to the table of contents

### DIFF
--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -215,7 +215,7 @@ const tagIsWholeParagraph = (tag?: cheerio.TagElement): boolean => {
   // Ensure that the tag is inside a 'p' element and that all the text in that 'p' is in tags of
   // the same type as our base tag
   const para = cheerio(tag).closest('p');
-  if (!para || para.text().trim() !== para.find(tag.name).text().trim()) {
+  if (para.length < 1 || para.text().trim() !== para.find(tag.name).text().trim()) {
     return false;
   }
 


### PR DESCRIPTION
This is thankfully an easy fix. Cheerio objects are a kind of pseudo-array, so when there's no results for `cheerio(tag).closest('p')`, we don't get `null` or `undefined`, we actually get an object with a `length` property equal to 0.