### PR TITLE
[EA Forum only] add tooltip text on the Pinned Posts heading

### DIFF
--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -18,10 +18,12 @@ const StickiedPosts = ({
 }: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, PostsList2, SectionTitle } = Components;
+  const { SingleColumnSection, PostsList2, SectionTitle, LWTooltip } = Components;
 
   return <SingleColumnSection>
-    <SectionTitle title="Pinned Posts" noTopMargin className={classes.title} />
+    <LWTooltip title="The Forum Team thinks these posts and threads should stay at the top of the Frontpage for a while" placement="left">
+      <SectionTitle title="Pinned Posts" noTopMargin className={classes.title} />
+    </LWTooltip>
     <PostsList2
       terms={{view:"stickied", limit:100}}
       showNoResults={false}


### PR DESCRIPTION
Based on a request from Lizka:

> Could we add a hover-over for "Pinned Posts" ?
It could read: "The Forum Team thinks these posts and threads should stay at the top of the Frontpage for a while"

https://cea-core.slack.com/archives/C038J512SD8/p1657114395636789