### PR TITLE
fix clientId cookie assignment for first logged out per-device requests

### DIFF
--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -20,14 +20,7 @@ export function getCookieFromReq(req: Request, cookieName: string) {
   if (!untypedReq.universalCookies && !untypedReq.cookies)
     throw new Error("Tried to get a cookie but middleware not correctly configured");
 
-  let cookieValue;
-  if (untypedReq.universalCookies)
-    cookieValue = untypedReq.universalCookies.get(cookieName);
-
-  if (untypedReq.cookies)
-    cookieValue = cookieValue ?? untypedReq.cookies[cookieName];
-
-  return cookieValue;
+  return untypedReq.universalCookies?.get(cookieName) ?? untypedReq.cookies?.[cookieName];
 }
 
 // Given an HTTP request, clear a named cookie. Handles the difference between

--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -7,16 +7,27 @@ import Cookies from 'universal-cookie';
 // Express; after we've gotten rid of Meteor, these functions will be trivial
 // and unnecessary wrappers.
 
-// Given an HTTP request, get a cookie. Exists mainly to cover up a difference
-// between the Meteor and Express server middleware setups.
+/** 
+ * Given an HTTP request, get a cookie. Exists mainly to cover up a difference
+ * between the Meteor and Express server middleware setups.
+ * 
+ * Default to the value pulled from `universalCookies` if there is one, but if not try `cookies` as well
+ *  
+ * We need to do this because {@link setCookieOnResponse} can only assign to `cookies`, not `universalCookies`, so sometimes `universalCookies` will exist but won't have the (newly assigned) cookie value.
+ */
 export function getCookieFromReq(req: Request, cookieName: string) {
   const untypedReq: any = req;
-  if (untypedReq.universalCookies)
-    return untypedReq.universalCookies.get(cookieName);
-  else if (untypedReq.cookies)
-    return untypedReq.cookies[cookieName];
-  else
+  if (!untypedReq.universalCookies && !untypedReq.cookies)
     throw new Error("Tried to get a cookie but middleware not correctly configured");
+
+  let cookieValue;
+  if (untypedReq.universalCookies)
+    cookieValue = untypedReq.universalCookies.get(cookieName);
+
+  if (untypedReq.cookies)
+    cookieValue = cookieValue ?? untypedReq.cookies[cookieName];
+
+  return cookieValue;
 }
 
 // Given an HTTP request, clear a named cookie. Handles the difference between
@@ -49,7 +60,12 @@ export function setCookieOnResponse({req, res, cookieName, cookieValue, maxAge}:
   const untypedReq: any = req;
   if (untypedReq.cookies) {
     untypedReq.cookies[cookieName] = cookieValue;
+  } else {
+    // We need this in the case of e.g. clientId
+    // The server-side code depends on the cookie existing on the very first request, before the client can send back the cookie we set via header
+    untypedReq.cookies = { [cookieName]: cookieValue };
   }
+  
   (res as any).setHeader("Set-Cookie", `${cookieName}=${cookieValue}; Max-Age=${maxAge}`);
 }
 


### PR DESCRIPTION
This should fix the issue where AB test assignments were lopsided, due to the `clientId` being cast to `"undefined"` on a device's first request (before the cookie had a chance to be set in the browser for future requests).

I'm not sure this is the best way to do it, but it was the minimally-invasive solution.

Biggest uncertainty: `getCookieFromReq` is used in a bunch of places.  In theory, the change I made would only ever affect other cookies if they were for some reason being set in `req.cookies` rather than `req.universalCookies` while the latter existed, and as far as I can tell the clientIdMiddleware is the only thing that does that.  I'm not familiar with the historical context around meteor/etc; if there's a better way to handle this let me know.