### PR TITLE
[EA Forum only] remove post author card

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -42,7 +42,7 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const { PostsVote, BottomNavigation, PingbacksList, FooterTagList, PostAuthorCard } = Components;
+  const { PostsVote, BottomNavigation, PingbacksList, FooterTagList } = Components;
   const wordCount = post.contents?.wordCount || 0
   
   return <>
@@ -68,8 +68,6 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
     {userHasPingbacks(currentUser) && <AnalyticsContext pageSectionContext="pingbacks">
       <PingbacksList postId={post._id}/>
     </AnalyticsContext>}
-    
-    {!sequenceId && !post.isEvent && post.user?.showPostAuthorCard && <PostAuthorCard author={post.user} currentUser={currentUser} />}
   </>
 }
 

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -166,7 +166,6 @@ registerFragment(`
   fragment PostsAuthors on Post {
     user {
       ...UsersMinimumInfo
-      showPostAuthorCard
       biography {
         ...RevisionDisplay
       }
@@ -493,7 +492,6 @@ registerFragment(`
     
     user {
       ...UsersMinimumInfo
-      showPostAuthorCard
       biography {
         ...RevisionDisplay
       }

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -261,6 +261,8 @@ addFieldsDict(Users, {
     order: 69,
   },
   
+  // We tested this on the EA Forum and it didn't encourage more PMs, but it led to some profile views.
+  // Hiding for now, will probably delete or test another version in the future.
   showPostAuthorCard: {
     type: Boolean,
     optional: true,
@@ -268,7 +270,7 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
-    hidden: forumTypeSetting.get() !== 'EAForum',
+    hidden: true,
     control: 'checkbox',
     group: formGroups.siteCustomizations,
     order: 70,

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -120,7 +120,6 @@ registerFragment(`
       ...RevisionEdit
     }
     showHideKarmaOption
-    showPostAuthorCard
     markDownPostEditor
     hideElicitPredictions
     hideAFNonMemberInitialWarning
@@ -300,7 +299,6 @@ registerFragment(`
     noCollapseCommentsFrontpage
     noSingleLineComments
     beta
-    showPostAuthorCard
 
     # Emails
     email

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -432,7 +432,6 @@ interface PostsAuthors { // fragment on Posts
 }
 
 interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
-  readonly showPostAuthorCard: boolean,
   readonly biography: RevisionDisplay|null,
   readonly profileImageId: string,
   readonly moderationStyle: string,
@@ -667,7 +666,6 @@ interface SunshinePostsList_contents { // fragment on Revisions
 }
 
 interface SunshinePostsList_user extends UsersMinimumInfo { // fragment on Users
-  readonly showPostAuthorCard: boolean,
   readonly biography: RevisionDisplay|null,
   readonly profileImageId: string,
   readonly moderationStyle: string,
@@ -1660,7 +1658,6 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly moderationStyle: string,
   readonly moderationGuidelines: RevisionEdit|null,
   readonly showHideKarmaOption: boolean,
-  readonly showPostAuthorCard: boolean,
   readonly markDownPostEditor: boolean,
   readonly hideElicitPredictions: boolean,
   readonly hideAFNonMemberInitialWarning: boolean,
@@ -1783,7 +1780,6 @@ interface UsersEdit extends UsersProfile { // fragment on Users
   readonly noCollapseCommentsFrontpage: boolean,
   readonly noSingleLineComments: boolean,
   readonly beta: boolean,
-  readonly showPostAuthorCard: boolean,
   readonly email: string,
   readonly whenConfirmationEmailSent: Date,
   readonly emailSubscribedToCurated: boolean,


### PR DESCRIPTION
We tested this out on the EA Forum for ~10 days to see if it would encourage more PMs. Only 2 PMs were attributed to it, and ~100 users used it to view the author's profile. Since it didn't move the needle we're just going to remove it for now.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202564745379694) by [Unito](https://www.unito.io)
