### PR TITLE
Fix mobile frontpage sequences

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -146,7 +146,7 @@ const RecommendationsAndCurated = ({
           onChange={(newSettings) => setSettings(newSettings)}
         /> }
 
-      {!currentUser && forumTypeSetting.get() !== 'EAForum' && <div>
+      {forumTypeSetting.get() !== 'EAForum' && <div>
         <div className={classes.largeScreenLoggedOutSequences}>
           <AnalyticsContext pageSectionContext="frontpageCuratedSequences">
             <CuratedSequences />
@@ -164,9 +164,6 @@ const RecommendationsAndCurated = ({
               <RecommendationsList algorithm={frontpageRecommendationSettings} />
             </AnalyticsContext>
           }
-          {isLW && <AnalyticsContext pageSectionContext="frontpageCuratedSequences">
-            <CuratedSequences />
-          </AnalyticsContext>}
           <AnalyticsContext listContext={"curatedPosts"}>
             <PostsList2
               terms={{view:"curated", limit: currentUser ? 3 : 2}}


### PR DESCRIPTION
In a previous PR I accidentally created multiple sequence-recommendations on mobile for logged out users and non-ideal-looking sequence recommendations for logged in ones. This fixes that.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202565676154469) by [Unito](https://www.unito.io)
