### PR TITLE
SequencesGridItem links to collection page

### DIFF
--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -146,7 +146,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
 
   const highlight = sequence.contents?.htmlHighlight || ""
 
-  return <div className={classes.root} >
+  return <div className={classes.root} id={sequence._id}>
 
     <div className={classes.columns}>
       <div className={classes.left}>

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -3,8 +3,7 @@ import NoSSR from 'react-no-ssr';
 import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
-import { title } from 'process';
-import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
+import { sequenceGetCollectionPageUrl } from '../../lib/collections/sequences/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -120,7 +119,7 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   if (sequence.title.length > 26) positionAdjustment -= 17
 
   return <div className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})}>
-    <LinkCard to={sequenceGetPageUrl(sequence)} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequence={sequence} showAuthor={showAuthor}/></div>}>
+    <LinkCard to={sequenceGetCollectionPageUrl(sequence)} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequence={sequence} showAuthor={showAuthor}/></div>}>
       <div className={classes.image}>
         <NoSSR>
           <Components.CloudinaryImage

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -3,7 +3,7 @@ import NoSSR from 'react-no-ssr';
 import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
-import { sequenceGetCollectionPageUrl } from '../../lib/collections/sequences/helpers';
+import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -119,7 +119,7 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   if (sequence.title.length > 26) positionAdjustment -= 17
 
   return <div className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})}>
-    <LinkCard to={sequenceGetCollectionPageUrl(sequence)} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequence={sequence} showAuthor={showAuthor}/></div>}>
+    <LinkCard to={getCollectionOrSequenceUrl(sequence)} tooltip={<div style={{marginTop:positionAdjustment}}><SequencesHoverOver sequence={sequence} showAuthor={showAuthor}/></div>}>
       <div className={classes.image}>
         <NoSSR>
           <Components.CloudinaryImage

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -3,6 +3,8 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card';
 import { useSingle } from '../../lib/crud/withSingle';
+import { Link } from '../../lib/reactRouterWrapper';
+import { sequenceGetCollectionPageUrl } from '../../lib/collections/sequences/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -54,7 +56,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   
   return <Card className={classes.root}>
     {!sequence && <Loading/>}
-    <div className={classes.title}>{sequence?.title}</div>
+    <Link to={sequenceGetCollectionPageUrl(sequence)}><div className={classes.title}>{sequence?.title}</div></Link>
     { showAuthor && sequence?.user &&
       <div className={classes.author}>
         by <UsersName user={sequence?.user} />

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -56,7 +56,9 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   
   return <Card className={classes.root}>
     {!sequence && <Loading/>}
-    <Link to={getCollectionOrSequenceUrl(sequence)}><div className={classes.title}>{sequence?.title}</div></Link>
+    {sequence && <Link to={getCollectionOrSequenceUrl(sequence)}>
+      <div className={classes.title}>{sequence.title}</div>
+    </Link>}
     { showAuthor && sequence?.user &&
       <div className={classes.author}>
         by <UsersName user={sequence?.user} />

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -4,7 +4,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Link } from '../../lib/reactRouterWrapper';
-import { sequenceGetCollectionPageUrl } from '../../lib/collections/sequences/helpers';
+import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -56,7 +56,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   
   return <Card className={classes.root}>
     {!sequence && <Loading/>}
-    <Link to={sequenceGetCollectionPageUrl(sequence)}><div className={classes.title}>{sequence?.title}</div></Link>
+    <Link to={getCollectionOrSequenceUrl(sequence)}><div className={classes.title}>{sequence?.title}</div></Link>
     { showAuthor && sequence?.user &&
       <div className={classes.author}>
         by <UsersName user={sequence?.user} />

--- a/packages/lesswrong/components/titles/SequencesPageTitle.tsx
+++ b/packages/lesswrong/components/titles/SequencesPageTitle.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
-import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
+import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
 import { Helmet } from 'react-helmet';
 import { styles } from '../common/HeaderSubtitle';
 
@@ -25,8 +25,8 @@ const SequencesPageTitle = ({isSubtitle, siteName, classes}: {
   const titleString = `${sequence.title} - ${siteName}`
   if (isSubtitle) {
     return (<span className={classes.subtitle}>
-      <Link to={sequenceGetPageUrl(sequence, false)}>
-        {sequence.title}
+      <Link to={getCollectionOrSequenceUrl(sequence)}>
+        {sequence.canonicalCollectionSlug || sequence.title}
       </Link>
     </span>);
   } else {

--- a/packages/lesswrong/components/titles/SequencesPageTitle.tsx
+++ b/packages/lesswrong/components/titles/SequencesPageTitle.tsx
@@ -26,7 +26,7 @@ const SequencesPageTitle = ({isSubtitle, siteName, classes}: {
   if (isSubtitle) {
     return (<span className={classes.subtitle}>
       <Link to={getCollectionOrSequenceUrl(sequence)}>
-        {sequence.canonicalCollectionSlug || sequence.title}
+        {sequence.canonicalCollection?.title ?? sequence.title}
       </Link>
     </span>);
   } else {
@@ -47,5 +47,9 @@ declare global {
   interface ComponentTypes {
     SequencesPageTitle: typeof SequencesPageTitleComponent
   }
+}
+
+function useMulti(arg0: { documentId: string; collectionName: string; fragmentName: string; fetchPolicy: string; }): { document: any; loading: any; } {
+  throw new Error('Function not implemented.');
 }
 

--- a/packages/lesswrong/components/titles/SequencesPageTitle.tsx
+++ b/packages/lesswrong/components/titles/SequencesPageTitle.tsx
@@ -49,7 +49,4 @@ declare global {
   }
 }
 
-function useMulti(arg0: { documentId: string; collectionName: string; fragmentName: string; fetchPolicy: string; }): { document: any; loading: any; } {
-  throw new Error('Function not implemented.');
-}
 

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -5,6 +5,9 @@ registerFragment(`
     _id
     title
     canonicalCollectionSlug
+    canonicalCollection {
+      title
+    }
   }
 `);
 

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -4,6 +4,7 @@ registerFragment(`
   fragment SequencesPageTitleFragment on Sequence {
     _id
     title
+    canonicalCollectionSlug
     canonicalCollection {
       title
     }

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -4,7 +4,6 @@ registerFragment(`
   fragment SequencesPageTitleFragment on Sequence {
     _id
     title
-    canonicalCollectionSlug
     canonicalCollection {
       title
     }

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -4,6 +4,7 @@ registerFragment(`
   fragment SequencesPageTitleFragment on Sequence {
     _id
     title
+    canonicalCollectionSlug
   }
 `);
 

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -7,13 +7,13 @@ import * as _ from 'underscore';
 
 // TODO: Make these functions able to use loaders for caching.
 
-export const sequenceGetPageUrl = function(sequence, isAbsolute = false){
+export const sequenceGetPageUrl = function(sequence: SequencesPageTitleFragment, isAbsolute: boolean = false){
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
 
   return `${prefix}/s/${sequence._id}`;
 };
 
-export const getCollectionOrSequenceUrl = function (sequence, isAbsolute = false) {
+export const getCollectionOrSequenceUrl = function (sequence: SequencesPageTitleFragment, isAbsolute: boolean = false) {
   if (!sequence.canonicalCollectionSlug) return sequenceGetPageUrl(sequence, isAbsolute)
   
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -13,9 +13,11 @@ export const sequenceGetPageUrl = function(sequence, isAbsolute = false){
   return `${prefix}/s/${sequence._id}`;
 };
 
-export const sequenceGetCollectionPageUrl = function (sequence) {
-  if (!sequence.canonicalCollectionSlug) return sequenceGetPageUrl(sequence)
-  return `${sequence.canonicalCollectionSlug}#${sequence._id}`
+export const getCollectionOrSequenceUrl = function (sequence, isAbsolute = false) {
+  if (!sequence.canonicalCollectionSlug) return sequenceGetPageUrl(sequence, isAbsolute)
+  
+  const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
+  return `${prefix}/${sequence.canonicalCollectionSlug}#${sequence._id}`
 }
 
 export const sequenceGetAllPostIDs = async (sequenceId: string, context: ResolverContext): Promise<Array<string>> => {

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -13,6 +13,11 @@ export const sequenceGetPageUrl = function(sequence, isAbsolute = false){
   return `${prefix}/s/${sequence._id}`;
 };
 
+export const sequenceGetCollectionPageUrl = function (sequence) {
+  if (!sequence.canonicalCollectionSlug) return sequenceGetPageUrl(sequence)
+  return `${sequence.canonicalCollectionSlug}#${sequence._id}`
+}
+
 export const sequenceGetAllPostIDs = async (sequenceId: string, context: ResolverContext): Promise<Array<string>> => {
   const chapters = await mongoFind("Chapters", {sequenceId: sequenceId}, {sort: {number: 1}});
   let allPostIds = _.flatten(_.pluck(chapters, 'postIds'))

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -7,13 +7,13 @@ import * as _ from 'underscore';
 
 // TODO: Make these functions able to use loaders for caching.
 
-export const sequenceGetPageUrl = function(sequence: SequencesPageTitleFragment, isAbsolute: boolean = false){
+export const sequenceGetPageUrl = function(sequence: SequencesPageTitleFragment, isAbsolute = false){
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
 
   return `${prefix}/s/${sequence._id}`;
 };
 
-export const getCollectionOrSequenceUrl = function (sequence: SequencesPageTitleFragment, isAbsolute: boolean = false) {
+export const getCollectionOrSequenceUrl = function (sequence: SequencesPageTitleFragment, isAbsolute = false) {
   if (!sequence.canonicalCollectionSlug) return sequenceGetPageUrl(sequence, isAbsolute)
   
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1260,6 +1260,11 @@ interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
   readonly canonicalCollectionSlug: string,
+  readonly canonicalCollection: SequencesPageTitleFragment_canonicalCollection|null,
+}
+
+interface SequencesPageTitleFragment_canonicalCollection { // fragment on Collections
+  readonly title: string,
 }
 
 interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment on Sequences

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1259,7 +1259,6 @@ interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
 interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
-  readonly canonicalCollectionSlug: string,
   readonly canonicalCollection: SequencesPageTitleFragment_canonicalCollection|null,
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1259,6 +1259,7 @@ interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
 interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
+  readonly canonicalCollectionSlug: string,
 }
 
 interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment on Sequences

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1259,6 +1259,7 @@ interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
 interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
+  readonly canonicalCollectionSlug: string,
   readonly canonicalCollection: SequencesPageTitleFragment_canonicalCollection|null,
 }
 


### PR DESCRIPTION
It was a bit sad that the sequence items on the frontpage don't link to the full collection page for their respective collections. After thinking about whether/how to change that, or maybe creating a new Collection item, I thought it'd actually work best if I gave each sequence an anchor-tag that could be directly linked to.

SequencesGridItem now checks if the sequence has a canonicalCollectionSlug, and if so links to the _id of the sequence on that collection page.

...

Additionally, this PR makes it so on a sequence page, if the sequence has a canonicalCollectionSlug, the page's subtitle links to the collection instead of the sequence itself (which was sort of useless anyway).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202571406254813) by [Unito](https://www.unito.io)
