### PR TITLE
Add ability to have a mirror postgres DB

### DIFF
--- a/packages/lesswrong/server/analytics/postgresConnection.ts
+++ b/packages/lesswrong/server/analytics/postgresConnection.ts
@@ -7,18 +7,14 @@ import { forumTypeSetting } from "../../lib/instanceSettings";
 export const pgPromiseLib = pgp({});
 
 export const connectionStringSetting = new DatabaseServerSetting<string | null>("analytics.connectionString", null);
+export const mirrorConnectionSettingString = new DatabaseServerSetting<string | null>("analytics.mirrorConnectionString", null); //for streaming to two DB at once
 
 export type AnalyticsConnectionPool = IDatabase<{}, IClient>;
-let analyticsConnectionPool: AnalyticsConnectionPool | null = null;
+let analyticsConnectionPools: Map<string, AnalyticsConnectionPool> = new Map();
 let missingConnectionStringWarned = false;
 
-// Return the Analytics database connection pool, if configured. If no
-// analytics DB is specified in the server config, returns null instead. The
-// first time this is called, it will block briefly.
-export const getAnalyticsConnection = (): AnalyticsConnectionPool | null => {
-  // We make sure that the settingsCache is initialized before we access the connection strings
-  const connectionString = connectionStringSetting.get();
 
+function getAnalyticsConnectionFromString(connectionString: string | null): AnalyticsConnectionPool | null{
   if (isAnyTest && forumTypeSetting.get() !== 'EAForum') {
     return null;
   }
@@ -26,10 +22,25 @@ export const getAnalyticsConnection = (): AnalyticsConnectionPool | null => {
     if (!missingConnectionStringWarned) {
       missingConnectionStringWarned = true;
       //eslint-disable-next-line no-console
-      console.log("Analytics logging disabled: analytics.connectionString is not configured");
+      console.log("Analytics logging disabled: no analytics connectionString passed in");
     }
     return null;
   }
-  if (!analyticsConnectionPool) analyticsConnectionPool = pgPromiseLib(connectionString);
-  return analyticsConnectionPool;
+  if (!analyticsConnectionPools.get(connectionString)) analyticsConnectionPools.set(connectionString, pgPromiseLib(connectionString))
+  return analyticsConnectionPools.get(connectionString)!
+}
+
+// Return the Analytics database connection pool, if configured. If no
+// analytics DB is specified in the server config, returns null instead. The
+// first time this is called, it will block briefly.
+export const getAnalyticsConnection = (): AnalyticsConnectionPool | null => {
+  // We make sure that the settingsCache is initialized before we access the connection strings
+  const connectionString = connectionStringSetting.get();
+  return getAnalyticsConnectionFromString(connectionString);
+};
+
+export const getMirrorAnalyticsConnection = (): AnalyticsConnectionPool | null => {
+  // We make sure that the settingsCache is initialized before we access the connection strings
+  const connectionString = mirrorConnectionSettingString.get();
+  return getAnalyticsConnectionFromString(connectionString);
 };

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -100,7 +100,7 @@ async function writeEventsToAnalyticsDB(events: {type, timestamp, props}[]) {
       inFlightRequestCounter.inFlightRequests++;
       try {
         await Promise.all([
-          connection.none(query),
+          connection?.none(query),
           mirrorConnection?.none(query)
         ])
       } finally {

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -4,7 +4,7 @@ import { AnalyticsUtil } from '../lib/analyticsEvents';
 import { PublicInstanceSetting } from '../lib/instanceSettings';
 import { addStaticRoute } from './vulcan-lib/staticRoutes';
 import { addGraphQLMutation, addGraphQLResolvers } from './vulcan-lib';
-import { pgPromiseLib, getAnalyticsConnection } from './analytics/postgresConnection'
+import {pgPromiseLib, getAnalyticsConnection, getMirrorAnalyticsConnection} from './analytics/postgresConnection'
 
 // Since different environments are connected to the same DB, this setting cannot be moved to the database
 const environmentDescriptionSetting = new PublicInstanceSetting<string>("analytics.environment", "misconfigured", "warning")
@@ -76,7 +76,8 @@ const analyticsColumnSet = new pgPromiseLib.helpers.ColumnSet(['environment', 'e
 // use captureEvent.
 // Writes an event to the analytics database.
 async function writeEventsToAnalyticsDB(events: {type, timestamp, props}[]) {
-  const connection = getAnalyticsConnection();
+  const connection = getAnalyticsConnection()
+  const mirrorConnection = getMirrorAnalyticsConnection()
   
   if (connection) {
     try {
@@ -98,7 +99,10 @@ async function writeEventsToAnalyticsDB(events: {type, timestamp, props}[]) {
       
       inFlightRequestCounter.inFlightRequests++;
       try {
-        await connection.none(query);
+        await Promise.all([
+          connection.none(query),
+          mirrorConnection?.none(query)
+        ])
       } finally {
         inFlightRequestCounter.inFlightRequests--;
       }


### PR DESCRIPTION
To make migrations easier and safer, this PR adds the ability to configure a "mirror" database (really a second destination) so the analytics will stream to two places.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202571304226634) by [Unito](https://www.unito.io)
