### PR TITLE
Fix highlights bugs

### DIFF
--- a/packages/lesswrong/components/common/LinkCard.tsx
+++ b/packages/lesswrong/components/common/LinkCard.tsx
@@ -38,13 +38,14 @@ const styles = (theme: ThemeType): JssStyles => ({
 // described in https://www.sarasoueidan.com/blog/nested-links/, we make the
 // card background and card contents siblings rather than nested, then use
 // z-index to control which is clickable.
-const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
+const LinkCard = ({children, to, tooltip, className, classes, onClick, clickable}: {
   children?: React.ReactNode,
   to: string,
   tooltip?: any,
   className?: string,
   classes: ClassesType,
-  onClick?: any
+  onClick?: any,
+  clickable?: boolean
 }) => {
   const { LWTooltip } = Components
   const card = (
@@ -57,7 +58,7 @@ const LinkCard = ({children, to, tooltip, className, classes, onClick}: {
   );
   
   if (tooltip) {
-    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false} clickable flip={false}>
+    return <LWTooltip className={classNames(className, classes.root)} title={tooltip} placement="bottom-start" tooltip={false} inlineBlock={false} clickable={clickable} flip={false}>
       {card}
     </LWTooltip>;
   } else {

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -109,7 +109,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'highlights',
       title: 'Sequence Highlights',
       link: '/highlights',
-      tooltip: "A curated selection of Eliezer's sequences, covering important background material for participating in the LessWrong Community (50 posts, approx. 7 hour read)",
+      tooltip: "A curated selection of Eliezer's sequences, covering important background material for participating in the LessWrong community (50 posts, approx. 7 hour read)",
       subItem: true,
     }, {
       id: 'r-az',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -119,6 +119,12 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       </div>,
       subItem: true,
     }, {
+      id: 'highlights',
+      title: 'Sequence Highlights',
+      link: '/highlights',
+      tooltip: "An abridged overview of Eliezer's sequences, covering important background material for participating in the LessWrong Community (40 posts, approx. 7 hour read)",
+      subItem: true,
+    }, {
       id: 'codex',
       title: 'The Codex',
       link: '/codex',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -106,6 +106,12 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnCompressed: true,
     // next 3 are subItems
     }, {
+      id: 'highlights',
+      title: 'Sequence Highlights',
+      link: '/highlights',
+      tooltip: "A curated selection of Eliezer's sequences, covering important background material for participating in the LessWrong Community (50 posts, approx. 7 hour read)",
+      subItem: true,
+    }, {
       id: 'r-az',
       title: 'Rationality: A-Z',
       link: '/rationality',
@@ -117,12 +123,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
           Those posts have been edited down into this introductory collection, recommended for new users.
         </p>
       </div>,
-      subItem: true,
-    }, {
-      id: 'highlights',
-      title: 'Sequence Highlights',
-      link: '/highlights',
-      tooltip: "An abridged overview of Eliezer's sequences, covering important background material for participating in the LessWrong Community (40 posts, approx. 7 hour read)",
       subItem: true,
     }, {
       id: 'codex',

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -30,7 +30,7 @@ const PostsTopSequencesNav = ({post, classes}: {
   post: PostSequenceNavigation,
   classes: ClassesType,
 }) => {
-  const { LWTooltip, SequencesHoverOver } = Components 
+  const { LWTooltip, SequencesHoverOver, SequencesNavigationLink } = Components 
   const { history } = useNavigation();
   const currentUser = useCurrentUser();
 
@@ -64,7 +64,7 @@ const PostsTopSequencesNav = ({post, classes}: {
   
   return (
     <div className={classes.root}>
-      <Components.SequencesNavigationLink
+      <SequencesNavigationLink
         post={post.prevPost}
         direction="left" />
 
@@ -75,7 +75,7 @@ const PostsTopSequencesNav = ({post, classes}: {
         </div>
       </LWTooltip>
 
-      <Components.SequencesNavigationLink
+      <SequencesNavigationLink
         post={post.nextPost}
         direction="right" />
     </div>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -146,7 +146,7 @@ const RecommendationsAndCurated = ({
           onChange={(newSettings) => setSettings(newSettings)}
         /> }
 
-      {forumTypeSetting.get() !== 'EAForum' && <div>
+      {!currentUser && forumTypeSetting.get() !== 'EAForum' && <div>
         <div className={classes.largeScreenLoggedOutSequences}>
           <AnalyticsContext pageSectionContext="frontpageCuratedSequences">
             <CuratedSequences />
@@ -159,7 +159,7 @@ const RecommendationsAndCurated = ({
 
       <div className={classes.subsection}>
         <div className={classes.posts}>
-          {!settings.hideFrontpage && !isLW && 
+          {!settings.hideFrontpage && 
             <AnalyticsContext listContext={"frontpageFromTheArchives"} capturePostItemOnMount>
               <RecommendationsList algorithm={frontpageRecommendationSettings} />
             </AnalyticsContext>

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -187,6 +187,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
         {posts.map(post => <SequencesSmallPostLink 
             key={sequence._id + post._id} 
             post={post}
+            sequenceId={sequence._id}
           />
         )}
       </div>

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -38,7 +38,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
 }) => {
   const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip } = Components
 
-  const { results: chapters, loading } = useMulti({
+  const { results: chapters, loading: chaptersLoading } = useMulti({
     terms: {
       view: "SequenceChapters",
       sequenceId: sequence?._id,
@@ -69,7 +69,8 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
         description={`sequence ${sequence?._id}`}
       />
     </ContentStyles>
-    {(!sequence || (!chapters && loading)) && <Loading/>}
+    {/* show a loading spinner if either sequences hasn't loaded or chapters haven't loaded */}
+    {(!sequence || (!chapters && chaptersLoading)) && <Loading/>}
     {sequence && posts.map(post => 
       <SequencesSmallPostLink 
         key={sequence._id + post._id} 

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -33,7 +33,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   classes: ClassesType,
-  sequence: SequencesPageFragment|null,
+  sequence: SequencesPageFragment,
   showAuthor?: boolean
 }) => {
   const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip } = Components
@@ -73,8 +73,9 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     {!chapters && loading && <Loading />}
     {posts.map(post => 
       <SequencesSmallPostLink 
-        key={sequence?._id + post._id} 
+        key={sequence._id + post._id} 
         post={post}
+        sequenceId={sequence._id}
       />
     )}
     <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -69,7 +69,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
         description={`sequence ${sequence?._id}`}
       />
     </ContentStyles>
-    {!sequence || (!chapters && loading) && <Loading/>}
+    {(!sequence || (!chapters && loading)) && <Loading/>}
     {sequence && posts.map(post => 
       <SequencesSmallPostLink 
         key={sequence._id + post._id} 

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -33,7 +33,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   classes: ClassesType,
-  sequence: SequencesPageFragment,
+  sequence: SequencesPageFragment|null,
   showAuthor?: boolean
 }) => {
   const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip } = Components
@@ -53,7 +53,6 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
   
   return <Card className={classes.root}>
-    {!sequence && <Loading/>}
     <div className={classes.title}>{sequence?.title}</div>
     { showAuthor && sequence?.user &&
       <div className={classes.author}>
@@ -70,8 +69,8 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
         description={`sequence ${sequence?._id}`}
       />
     </ContentStyles>
-    {!chapters && loading && <Loading />}
-    {posts.map(post => 
+    {!sequence || (!chapters && loading) && <Loading/>}
+    {sequence && posts.map(post => 
       <SequencesSmallPostLink 
         key={sequence._id + post._id} 
         post={post}

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -32,16 +32,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const SequencesSmallPostLink = ({classes, post}: {
+const SequencesSmallPostLink = ({classes, post, sequenceId}: {
   classes: ClassesType,
   post: PostsList,
+  sequenceId: string
 }) => {
   const { LWTooltip, PostsPreviewTooltip } = Components
 
   const icon = !!post.lastVisitedAt ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
 
   return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement="left-start" inlineBlock={false}>
-        <Link to={postGetPageUrl(post)} className={classes.title}>
+        <Link to={postGetPageUrl(post, false, sequenceId)} className={classes.title}>
           {icon} {post.title}
         </Link>
       </LWTooltip>

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -11,6 +11,7 @@ export const communityPath = '/community';
 
 const communitySubtitle = { subtitleLink: communityPath, subtitle: 'Community' };
 const rationalitySubtitle = { subtitleLink: "/rationality", subtitle: "Rationality: A-Z" };
+const highlightsSubtitle = { subtitleLink: "/highlights", subtitle: "Sequence Highlights" };
 
 const hpmorSubtitle = { subtitleLink: "/hpmor", subtitle: "HPMoR" };
 const codexSubtitle = { subtitleLink: "/codex", subtitle: "SlateStarCodex" };
@@ -298,6 +299,15 @@ addRoute(
     path: '/highlights',
     title: "Sequences Highlights",
     componentName: 'SequencesHighlightsCollection'
+  },
+  {
+    name: 'highlights.posts.single',
+    path: '/highlights/:slug',
+    componentName: 'PostsSingleSlug',
+    previewComponentName: 'PostLinkPreviewSlug',
+    ...highlightsSubtitle,
+    getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    background: postBackground
   },
   {
     name: 'bookmarks',


### PR DESCRIPTION
– SequencesSmallPostLink now links you to the proper sequence url for a post

– SequenceGridItems now don't have clickable hoverovers

– Reverted the logged-in user frontpage experience (so that they don't accidentally tune out the curated sequences before we have a chance to make them better. This also fixes a bug where people where logged in users were seeing the Recommended Reading on mobile, despite having tried to filter it out)

– Adds /highlights to the sidebar