### PR TITLE
Tweaks sequence styles

### DIFF
--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -18,7 +18,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     maxWidth: 600,
     marginTop: 90,
-    marginBottom: 90,
+    marginBottom: 30,
     [theme.breakpoints.down('xs')]: {
       marginTop: 60,
       marginBottom: 0

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -18,14 +18,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 6
   },
   read: {
-    width: 10,
+    width: 12,
     color: theme.palette.primary.light,
     marginRight: 10,
     position: "relative",
     top: -1
   },
   unread: {
-    width: 10,
+    width: 12,
     color: theme.palette.grey[400],
     marginRight: 10,
     top: -1


### PR DESCRIPTION
Slightly increase checkbox size, decrease padding beneath each large sequence item.

New:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/3246710/178065777-66af514d-617e-443e-84a1-edaa046e2194.png">

Old:
<img width="909" alt="image" src="https://user-images.githubusercontent.com/3246710/178065829-d09b492c-299a-4b92-99b8-a6b7ee14c375.png">

