### PR TITLE
Remove LargeSequencesItem AB test 

### DIFF
--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useABTest } from '../../lib/abTestImpl';
-import { collectionsPageABTest } from '../../lib/abTests';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { LargeSequencesItem } from './LargeSequencesItem';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -40,7 +37,7 @@ const BooksItem = ({ book, canEdit, classes }: {
 
   const { html = "" } = book.contents || {}
   const { SingleColumnSection, SectionTitle, SectionButton, LargeSequencesItem,
-    SequencesPostsList, Divider, ContentItemBody, ContentStyles, SequencesGrid } = Components
+    SequencesPostsList, Divider, ContentItemBody, ContentStyles } = Components
   
   const showEdit = useCallback(() => {
     setEdit(true);
@@ -48,8 +45,6 @@ const BooksItem = ({ book, canEdit, classes }: {
   const showBook = useCallback(() => {
     setEdit(false);
   }, []);
-
-  const useLargeSequencesItem = useABTest(collectionsPageABTest) === "largeSequenceItemGroup";
 
   if (edit) {
     return <Components.BooksEditForm
@@ -75,8 +70,7 @@ const BooksItem = ({ book, canEdit, classes }: {
           <SequencesPostsList posts={book.posts} />
         </div>}
 
-        {useLargeSequencesItem && book.sequences.map(sequence => <LargeSequencesItem key={sequence._id} sequence={sequence} />)}
-        {!useLargeSequencesItem && <SequencesGrid sequences={book.sequences} bookItemStyle/>}
+        {book.sequences.map(sequence => <LargeSequencesItem key={sequence._id} sequence={sequence} />)}
       </SingleColumnSection>
       <Divider />
     </div>


### PR DESCRIPTION
Removing the AB test for LargeSequencesItem, since a) it seemed basically like an obvious improvement, b) there were some bugs of how different components interacted with different versions of the A/B test, and either I had to started applying the AB-test all over the place, or just remove it. Seemed better to do the latter.