### PR TITLE
Collapse topic descriptions at 'Further reading' / 'Bibliography'

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -15,7 +15,6 @@ import { MAX_COLUMN_WIDTH } from '../posts/PostsPage/PostsPage';
 import { EditTagForm } from './EditTagPage';
 import { useTagBySlug } from './useTag';
 import { forumTypeSetting, taggingNameCapitalSetting } from '../../lib/instanceSettings';
-import { html } from "cheerio";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -6,7 +6,7 @@ import { userHasNewTagSubscriptions } from "../../lib/betas";
 import { subscriptionTypes } from '../../lib/collections/subscriptions/schema';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { useMulti } from '../../lib/crud/withMulti';
-import { getTruncationCharCount, truncate } from '../../lib/editor/ellipsize';
+import { truncate } from '../../lib/editor/ellipsize';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { Components, registerComponent } from '../../lib/vulcan-lib';

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -259,7 +259,7 @@ const TagPage = ({classes}: {
       new DOMParser().parseFromString(htmlWithAnchors.slice(0, truncationLength), 'text/html').body.innerHTML +  "<span>...<p><a>(Read More)</a></p></span>" :
       htmlWithAnchors;
   } else {
-    description = (truncated && !tag.wikiOnly && !isEAForum)
+    description = (truncated && !tag.wikiOnly)
     ? truncate(htmlWithAnchors, tag.descriptionTruncationCount || 4, "paragraphs", "<span>...<p><a>(Read More)</a></p></span>")
     : htmlWithAnchors
   }

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -243,21 +243,33 @@ const TagPage = ({classes}: {
   }
 
   const htmlWithAnchors = tag.tableOfContents?.html || tag.description?.html;
-  let description;
+  let description = htmlWithAnchors;
   if(isEAForum) {
-    /**
-     * The `truncate` method used below uses a complicated criterion for what
-     * counts as a character. Here, we want to truncate at a known index in
-     * the string. So rather than using `truncate`, we can slice the string
-     * at the desired index, use `parseFromString` to clean up the HTML,
-     * and then append our footer 'read more' element.
-     */
-    const truncationLength = htmlWithAnchors.includes('id="Further_reading"') ? 
-      htmlWithAnchors.indexOf('id="Further_reading"') :
-      htmlWithAnchors.indexOf('id="Bibliography"');
-    description = truncated && truncationLength !== -1 ?
-      new DOMParser().parseFromString(htmlWithAnchors.slice(0, truncationLength), 'text/html').body.innerHTML +  "<span>...<p><a>(Read More)</a></p></span>" :
-      htmlWithAnchors;
+    description = htmlWithAnchors;
+    for (let matchString of [
+        'id="Further_reading"',
+        'id="Bibliography"',
+        'id="Related_entries"',
+        'class="footnotes"',
+      ]) {
+      if(htmlWithAnchors.includes(matchString)) {
+        const truncationLength = htmlWithAnchors.indexOf(matchString);
+        /**
+         * The `truncate` method used below uses a complicated criterion for what
+         * counts as a character. Here, we want to truncate at a known index in
+         * the string. So rather than using `truncate`, we can slice the string
+         * at the desired index, use `parseFromString` to clean up the HTML,
+         * and then append our footer 'read more' element.
+         */
+        description = truncated ?
+          new DOMParser().parseFromString(
+            htmlWithAnchors.slice(0, truncationLength), 
+            'text/html'
+          ).body.innerHTML + "<span>...<p><a>(Read More)</a></p></span>" :
+          htmlWithAnchors;
+        break;
+      }
+    }
   } else {
     description = (truncated && !tag.wikiOnly)
     ? truncate(htmlWithAnchors, tag.descriptionTruncationCount || 4, "paragraphs", "<span>...<p><a>(Read More)</a></p></span>")


### PR DESCRIPTION
This PR collapses topic descriptions on the EA Forum at the 'Further Reading' heading if it exists, or the 'Bibliography' heading otherwise.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202578080349578) by [Unito](https://www.unito.io)
