### PR TITLE
implement live-updating post read progress using client-side state

### DIFF
--- a/packages/lesswrong/components/common/withRecordPostView.tsx
+++ b/packages/lesswrong/components/common/withRecordPostView.tsx
@@ -39,6 +39,9 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
       // a post id has been found & it's has not been seen yet on this client session
       if (!postsRead[post._id]) {
 
+        // Update the client-side read status cache
+        setPostRead(post._id, true);
+
         // Trigger the asynchronous mutation with postId as an argument
         // Deliberately not awaiting, because this should be fire-and-forget
         await increasePostViewCount({
@@ -47,8 +50,6 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
           }
         });
 
-        // Update the client-side read status cache
-        setPostRead(post._id, true);
       }
 
       // Register page-visit event

--- a/packages/lesswrong/components/common/withRecordPostView.tsx
+++ b/packages/lesswrong/components/common/withRecordPostView.tsx
@@ -39,9 +39,6 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
       // a post id has been found & it's has not been seen yet on this client session
       if (!postsRead[post._id]) {
 
-        // Update the client-side read status cache
-        setPostRead(post._id, true);
-
         // Trigger the asynchronous mutation with postId as an argument
         // Deliberately not awaiting, because this should be fire-and-forget
         await increasePostViewCount({
@@ -50,6 +47,8 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
           }
         });
 
+        // Update the client-side read status cache
+        setPostRead(post._id, true);
       }
 
       // Register page-visit event

--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -29,11 +29,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const BooksItem = ({ book, canEdit, classes, refetch }: {
+const BooksItem = ({ book, canEdit, classes }: {
   book: BookPageFragment,
   canEdit: boolean,
   classes: ClassesType,
-  refetch?: () => void
 }) => {
   const [edit,setEdit] = useState(false);
 
@@ -47,10 +46,6 @@ const BooksItem = ({ book, canEdit, classes, refetch }: {
   const showBook = useCallback(() => {
     setEdit(false);
   }, []);
-
-  useEffect(() => {
-    refetch?.();
-  });
 
   if (edit) {
     return <Components.BooksEditForm

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -46,7 +46,6 @@ const BooksProgressBar = ({ book, classes }: {
   const { LWTooltip, PostsPreviewTooltip, LoginPopupButton } = Components;
 
   const { postsRead: clientPostsRead } = useItemsRead();
-  console.log({ clientPostsRead });
 
   const bookPosts = book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts));
   // Check whether the post is marked as read either on the server or in the client-side context

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import classNames from 'classnames';
+import { useItemsRead } from '../common/withRecordPostView';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -44,8 +45,12 @@ const BooksProgressBar = ({ book, classes }: {
 }) => {
   const { LWTooltip, PostsPreviewTooltip, LoginPopupButton } = Components;
 
+  const { postsRead: clientPostsRead } = useItemsRead();
+  console.log({ clientPostsRead });
+
   const bookPosts = book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts));
-  const readPosts = bookPosts.filter(post => post.isRead).length;
+  // Check whether the post is marked as read either on the server or in the client-side context
+  const readPosts = bookPosts.filter(post => post.isRead || clientPostsRead[post._id]).length;
   const totalPosts = bookPosts.length;
 
   const postsReadText = `${readPosts} / ${totalPosts} posts read`;
@@ -56,7 +61,7 @@ const BooksProgressBar = ({ book, classes }: {
         bookPosts.map(post => (
           <LWTooltip key={post._id} title={<PostsPreviewTooltip post={post}/>} tooltip={false} flip={false}>
             <Link to={postGetPageUrl(post)}>
-              <div className={classNames(classes.postProgressBox, {[classes.read]: post.isRead})} />
+              <div className={classNames(classes.postProgressBox, {[classes.read]: post.isRead || clientPostsRead[post._id]})} />
             </Link>
           </LWTooltip>
           ))

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -54,7 +54,7 @@ const CollectionsPage = ({ documentId, classes }: {
   const currentUser = useCurrentUser();
   const [edit, setEdit] = useState(false);
   const [addingBook, setAddingBook] = useState(false);
-  const { document, loading, refetch } = useSingle({
+  const { document, loading } = useSingle({
     documentId,
     collectionName: "Collections",
     fragmentName: 'CollectionsPageFragment',
@@ -108,7 +108,7 @@ const CollectionsPage = ({ documentId, classes }: {
       </SingleColumnSection>
       <div>
         {/* For each book, print a section with a grid of sequences */}
-        {collection.books.map(book => <BooksItem key={book._id} book={book} canEdit={canEdit} refetch={refetch}/>)}
+        {collection.books.map(book => <BooksItem key={book._id} book={book} canEdit={canEdit} />)}
       </div>
       
       {canEdit && <SectionFooter>

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -107,7 +107,6 @@ const CollectionsPage = ({ documentId, classes }: {
         </div>
       </SingleColumnSection>
       <div>
-        {/* For each book, print a section with a grid of sequences */}
         {collection.books.map(book => <BooksItem key={book._id} book={book} canEdit={canEdit} />)}
       </div>
       

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import CheckBoxTwoToneIcon from '@material-ui/icons/CheckBoxTwoTone';
+import { useItemsRead } from '../common/withRecordPostView';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -39,7 +40,11 @@ const SequencesSmallPostLink = ({classes, post, sequenceId}: {
 }) => {
   const { LWTooltip, PostsPreviewTooltip } = Components
 
-  const icon = !!post.lastVisitedAt ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
+  const { postsRead: clientPostsRead } = useItemsRead();
+
+  const isPostRead = !!post.lastVisitedAt || clientPostsRead[post._id];
+
+  const icon = isPostRead ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
 
   return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement="left-start" inlineBlock={false}>
         <Link to={postGetPageUrl(post, false, sequenceId)} className={classes.title}>

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -42,7 +42,7 @@ const SequencesSmallPostLink = ({classes, post, sequenceId}: {
 
   const { postsRead: clientPostsRead } = useItemsRead();
 
-  const isPostRead = !!post.lastVisitedAt || clientPostsRead[post._id];
+  const isPostRead = post.isRead || clientPostsRead[post._id];
 
   const icon = isPostRead ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
 


### PR DESCRIPTION
Previous attempt introduced infinite(?) refetch loop, breaking R:A-Z (and possibly other collections) due to the rerenders.  Using only client-side state to eliminate the need for a network request (which causes the rerenders).

Tested locally in branches off both `master` and `lw-deploy`.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202579087041445) by [Unito](https://www.unito.io)
