### PR TITLE
Reverse curated and recommendations on page

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -20,7 +20,6 @@ const RecommendationsPage = ({classes}: {
         <AnalyticsContext listContext={"curatedPosts"}>
           <PostsList2
             terms={{view:"curated", limit: 12}}
-            itemsPerPage={50}
             showNoResults={false}
             boxShadow={false}
             curatedIconLeft={true}

--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -19,7 +19,8 @@ const RecommendationsPage = ({classes}: {
         <SectionTitle title="Curated Posts"/>
         <AnalyticsContext listContext={"curatedPosts"}>
           <PostsList2
-            terms={{view:"curated", limit: 20}}
+            terms={{view:"curated", limit: 12}}
+            itemsPerPage={50}
             showNoResults={false}
             boxShadow={false}
             curatedIconLeft={true}

--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -15,9 +15,6 @@ const RecommendationsPage = ({classes}: {
 
   return (
     <div>
-      <AnalyticsContext listContext={"recommendationsPage"} capturePostItemOnMount>
-        <ConfigurableRecommendationsList configName="recommendationspage" />
-      </AnalyticsContext>
       {showCurated && <SingleColumnSection>
         <SectionTitle title="Curated Posts"/>
         <AnalyticsContext listContext={"curatedPosts"}>
@@ -29,6 +26,9 @@ const RecommendationsPage = ({classes}: {
           />
         </AnalyticsContext>
       </SingleColumnSection>}
+      <AnalyticsContext listContext={"recommendationsPage"} capturePostItemOnMount>
+        <ConfigurableRecommendationsList configName="recommendationspage" />
+      </AnalyticsContext>
     </div>
   )
 };


### PR DESCRIPTION
More people came to the curated-and-recommendations-page looking for curated than for recommendations, so reversing their order.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202581203791990) by [Unito](https://www.unito.io)
