### PR TITLE
Fix smallcaps styling for sequence titles on EA forum

### DIFF
--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -209,8 +209,8 @@ export const eaForumTheme: SiteThemeSpecification = {
             marginBottom: -8,
           },
           title: {
-            marginTop: -5,
-            textTransform: 'lowercase',
+            textTransform: 'uppercase',
+            fontSize: 18,
             color: 'rgba(0,0,0,.7)',
             fontWeight: 500,
           }


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1200830492067961/f)

Before and after:
<img width="385" alt="Screenshot 2022-07-12 at 15 23 24" src="https://user-images.githubusercontent.com/5075628/178515274-523508bc-181d-45b8-960e-3ce48d687565.png">
<img width="380" alt="Screenshot 2022-07-12 at 15 23 09" src="https://user-images.githubusercontent.com/5075628/178515291-dd9b4c59-de16-4bf3-b78c-7c986f14382b.png">

The suggested fix of using `font-variant: all-small-caps` doesn't seem to actually help. It looks like the problem actually exists somewhere in the font itself, because even trying to explicity enable old-style numerals with `font-feature-settings: "onum"` doesn't seem to make a difference.

The most direct solution is probably just to make the letters uppercase and to reduce the font size which should avoid any bugs in the font, and protect us from changes to the font in the future. We can do directly in the EAForum style config, since the bug isn't present in the font used by LW:
<img width="306" alt="Screenshot 2022-07-12 at 15 00 46" src="https://user-images.githubusercontent.com/5075628/178515225-44ff7943-3ddd-437b-b20e-4f3a93aa7555.png">

(A post in the dev database where this case be tested: [http://localhost:3000/s/bCEttNRSTJDZyGEeT/p/6MhznGtuiCivvPmf2](http://localhost:3000/s/bCEttNRSTJDZyGEeT/p/6MhznGtuiCivvPmf2))
