### PR TITLE
Show 'Default' label on tag filters that are set to 0

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -60,7 +60,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     justifyContent: "flex-end",
     flexGrow: 1,
     "& *": {
-      marginLeft: 4,
+      marginLeft: 5,
     },
   },
   defaultLabel: {

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -12,6 +12,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { userHasNewTagSubscriptions } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
 import { forumTypeSetting, taggingNameIsSet, taggingNamePluralSetting, taggingNameSetting } from '../../lib/instanceSettings';
+import { usePersonalBlogpostInfo } from './usePersonalBlogpostInfo';
 import { defaultVisibilityTags } from '../../lib/publicSettings';
 
 const LATEST_POSTS_NAME = forumTypeSetting.get() === 'EAForum' ? 'Frontpage Posts' : 'Latest Posts';
@@ -170,7 +171,8 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
       ? mode
       : "";
 
-  const defaultLabel = label === "Personal" ? "personal blogposts" : `the ${label} ${taggingNameSetting.get()}`;
+  const { name: personalBlogpostName } = usePersonalBlogpostInfo();
+  const defaultLabel = label === personalBlogpostName ? "personal blogposts" : `the ${label} ${taggingNameSetting.get()}`;
 
   return <span {...eventHandlers} className={classNames(classes.tag, {[classes.noTag]: !tagId})}>
     <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag?._id} tagName={tag?.name}>

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -4,9 +4,9 @@ import { FilterSettings, FilterMode, isCustomFilterMode } from '../../lib/filter
 import { useCurrentUser } from '../common/withUser';
 import { tagStyle } from './FooterTag';
 import { filteringStyles } from './FilterMode';
+import { usePersonalBlogpostInfo } from './usePersonalBlogpostInfo';
 import Card from '@material-ui/core/Card';
 import { userHasNewTagSubscriptions } from '../../lib/betas';
-import { ForumOptions, forumSelect } from '../../lib/forumTypeUtils';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -42,42 +42,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const lwafPersonalBlogpostInfo = {
-  name: "Personal Blog",
-  tooltip: <div>
-    <p><b>Personal Blogposts</b> are posts that don't fit LessWrong's Frontpage Guidelines. They get less visibility by default. The frontpage guidelines are:</p>
-    <ul>
-      <li><em>Timelessness</em>. Will people still care about this in 5 years?</li>
-      <li><em>Avoid political topics</em>. They're important to discuss sometimes, but we try to avoid it on LessWrong.</li>
-      <li><em>General Appeal</em>. Is this a niche post that only a small fraction of users will care about?</li>
-    </ul>
-  </div>
-}
-
-const personalBlogpostInfo: ForumOptions<{name: string, tooltip: JSX.Element}> = {
-  LessWrong: lwafPersonalBlogpostInfo,
-  AlignmentForum: lwafPersonalBlogpostInfo,
-  EAForum: {
-    name: 'Personal',
-    tooltip: <div>
-      <div>
-        By default, the home page only displays Frontpage Posts, which are selected by moderators as especially interesting or useful to people with interest in doing good effectively. Personal posts get to have looser standards of relevance, and may include topics that could lead to more emotive or heated discussion (e.g. politics), which are generally excluded from Frontpage.
-      </div>
-    </div>
-  },
-  default: {
-    name: 'Personal',
-    tooltip: <div>
-      <div>
-        By default, the home page only displays Frontpage Posts, which are selected by moderators as especially interesting or useful to people with interest in doing good effectively. Personal posts get to have looser standards of relevance, and may include topics that could lead to more emotive or heated discussion (e.g. politics), which are generally excluded from Frontpage.
-      </div>
-    </div>
-  },
-}
-
-const personalBlogpostName = forumSelect(personalBlogpostInfo).name
-const personalBlogpostTooltip = forumSelect(personalBlogpostInfo).tooltip
-
 /**
  * Adjust the weighting the frontpage gives to posts with the given tags
  *
@@ -99,6 +63,11 @@ const TagFilterSettings = ({
 }) => {
   const { AddTagButton, FilterMode, Loading, LWTooltip, ContentStyles } = Components
   const currentUser = useCurrentUser()
+
+  const {
+    name: personalBlogpostName,
+    tooltip: personalBlogpostTooltip,
+  } = usePersonalBlogpostInfo();
 
   const personalBlogpostCard = <Card>
     <ContentStyles contentType="comment" className={classes.personalTooltip}>

--- a/packages/lesswrong/components/tagging/usePersonalBlogpostInfo.tsx
+++ b/packages/lesswrong/components/tagging/usePersonalBlogpostInfo.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ForumOptions, forumSelect } from "../../lib/forumTypeUtils";
+
+const lwafPersonalBlogpostInfo = {
+  name: "Personal Blog",
+  tooltip: <div>
+    <p><b>Personal Blogposts</b> are posts that don"t fit LessWrong"s Frontpage Guidelines. They get less visibility by default. The frontpage guidelines are:</p>
+    <ul>
+      <li><em>Timelessness</em>. Will people still care about this in 5 years?</li>
+      <li><em>Avoid political topics</em>. They"re important to discuss sometimes, but we try to avoid it on LessWrong.</li>
+      <li><em>General Appeal</em>. Is this a niche post that only a small fraction of users will care about?</li>
+    </ul>
+  </div>
+}
+
+const personalBlogpostInfo: ForumOptions<{name: string, tooltip: JSX.Element}> = {
+  LessWrong: lwafPersonalBlogpostInfo,
+  AlignmentForum: lwafPersonalBlogpostInfo,
+  EAForum: {
+    name: "Personal",
+    tooltip: <div>
+      <div>
+        By default, the home page only displays Frontpage Posts, which are selected by moderators as especially interesting or useful to people with interest in doing good effectively. Personal posts get to have looser standards of relevance, and may include topics that could lead to more emotive or heated discussion (e.g. politics), which are generally excluded from Frontpage.
+      </div>
+    </div>
+  },
+  default: {
+    name: "Personal",
+    tooltip: <div>
+      <div>
+        By default, the home page only displays Frontpage Posts, which are selected by moderators as especially interesting or useful to people with interest in doing good effectively. Personal posts get to have looser standards of relevance, and may include topics that could lead to more emotive or heated discussion (e.g. politics), which are generally excluded from Frontpage.
+      </div>
+    </div>
+  },
+}
+
+export const usePersonalBlogpostInfo = () => forumSelect(personalBlogpostInfo);


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202422289278835/f)

This PR adds a "Default" label to the FilterMode when the filter is set to 0. For now, I've only added this to the EAForum - it seems a little unneccesary on LW since there's already a "+0" button that can be clicked. Enabling it for LW would be very simple though; we'd just need to remove `userHasNewTagSubscriptions(currentUser) &&` at line 240.

![](https://user-images.githubusercontent.com/5075628/178961691-7d2ded12-0ba9-41b8-be22-e9482f266429.png)

![](https://user-images.githubusercontent.com/5075628/178961952-de407f6d-8a67-4ac6-88a1-05bb59cbcd03.png)

I also included 2 more small changes here:


* A fix for a minor bug where buttons sometimes have to be clicked twice to reset the filter to default due to `inputTime` not being reset.
* A change to the tooltip text on the EAForum from "Latest Posts" to "Frontpage Posts". "Latest Posts" makes sense on LW because the section is titled "Latest", but it doesn't make sense on the EAForum where the section is titled "Frontpage Posts".



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202605656452517) by [Unito](https://www.unito.io)
