### PR TITLE
Fix titles being squeezed with many coauthors

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -81,8 +81,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     minHeight: 26,
-    flexGrow: 1,
-    flexShrink: 1,
+    flex: 1500,
+    maxWidth: "fit-content",
     overflow: "hidden",
     textOverflow: "ellipsis",
     marginRight: 12,
@@ -101,6 +101,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
       opacity: 1,
     }
   },
+  spacer: {
+    flex: 1,
+  },
   author: {
     justifyContent: "flex",
     overflow: "hidden",
@@ -108,6 +111,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis", // I'm not sure this line worked properly?
     marginRight: theme.spacing.unit*1.5,
     zIndex: theme.zIndexes.postItemAuthor,
+    flex: 1000,
+    maxWidth: "fit-content",
     [theme.breakpoints.down('xs')]: {
       justifyContent: "flex-end",
       width: "unset",
@@ -487,6 +492,9 @@ const PostsItem2 = ({
                   <Components.EventVicinity post={post} />
                 </PostsItem2MetaInfo>}
 
+                {/* space in-between title and author if there is width remaining */}
+                <span className={classes.spacer} />
+
                 { !post.isEvent && !hideAuthor && <PostsItem2MetaInfo className={classes.author}>
                   <PostsUserAndCoauthors post={post} abbreviateIfLong={true} newPromotedComments={hasNewPromotedComments()}/>
                 </PostsItem2MetaInfo>}
@@ -568,6 +576,7 @@ const PostsItem2 = ({
 
 const PostsItem2Component = registerComponent('PostsItem2', PostsItem2, {
   styles,
+  stylePriority: 1,
   hocs: [withErrorBoundary],
   areEqual: {
     terms: "deep",

--- a/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
@@ -33,4 +33,3 @@ declare global {
     PostsItem2MetaInfo: typeof PostsItem2MetaInfoComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -15,6 +15,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
     lineHeight: "1.0rem",
+    '&:empty': {
+      display: 'none',
+    },
   },
   postIcon: {
     marginRight: 4,


### PR DESCRIPTION
Made by JP & Jim pairing

Changes the width-allocation between post title and coauthors when one or both is long and has ellipses, fixing a case where there was a range of screen widths in which most of the width went to coauthors and very little title was shown. Also makes it so that the post icons don't reserve extra space for their margins if there are no post icons.

Previously:
![image (15)](https://user-images.githubusercontent.com/10352319/179072121-63b56c30-a7e9-482f-bca0-4e782cc6433f.png)

Now:
![](https://user-images.githubusercontent.com/10352319/179072323-145fd509-e9a5-445e-9fa3-18c377c50a24.png)

Normal:
![](https://user-images.githubusercontent.com/10352319/179072209-0bd3cdf9-0d62-40a9-9b0f-3e0a95f7929e.png)

LessWrong:
![](https://user-images.githubusercontent.com/10352319/179072231-a74460f2-eee0-4f4c-80e9-44963fb0b360.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202610376404388) by [Unito](https://www.unito.io)
