### PR TITLE
Fix a bug in development autorefresh that could cause a refresh loop

### DIFF
--- a/build.js
+++ b/build.js
@@ -149,6 +149,11 @@ async function asyncSleep(durationMs) {
   });
 }
 
+function getClientBundleTimestamp() {
+  const stats = fs.statSync('./build/client/js/bundle.js');
+  return stats.mtime.toISOString();
+}
+
 function generateBuildId() {
   return crypto.randomBytes(12).toString('base64');
 }
@@ -168,7 +173,7 @@ async function initiateRefresh() {
     await waitForServerReady();
     console.log("Notifying connected browser windows to refresh");
     for (let connection of openWebsocketConnections) {
-      connection.send(`{"latestBuildId": "${latestCompletedBuildId}"}`);
+      connection.send(`{"latestBuildTimestamp": "${getClientBundleTimestamp()}"}`);
     }
     refreshIsPending = false;
   }
@@ -189,7 +194,7 @@ function startWebsocketServer() {
         openWebsocketConnections.splice(connectionIndex, 1);
       }
     });
-    ws.send(`{"latestBuildId": "${latestCompletedBuildId}"}`);
+    ws.send(`{"latestBuildTimestamp": "${getClientBundleTimestamp()}"}`);
   });
 }
 

--- a/packages/lesswrong/client/autoRefresh.ts
+++ b/packages/lesswrong/client/autoRefresh.ts
@@ -1,15 +1,12 @@
 import { onStartup } from '../lib/executionEnvironment';
 import type { MessageEvent, OpenEvent, CloseEvent } from 'ws';
 
-declare global {
-  var buildId: string; //Preprocessor-replaced with an ID in the bundle
-}
-
 // In development, make a websocket connection (on a different port) to get
 // notified when the server has restarted with a new version.
 
 const websocketPort = 3001;
 let connectedWebsocket: any = null;
+let buildTimestamp: string|null = null;
 
 function connectWebsocket() {
   if (connectedWebsocket) return;
@@ -18,10 +15,12 @@ function connectWebsocket() {
   connectedWebsocket.addEventListener("message", (event: MessageEvent) => {
     try {
       const data = JSON.parse(event.data+"");
-      if (data.latestBuildId) {
-        if (data.latestBuildId !== buildId) {
+      if (data.latestBuildTimestamp) {
+        if (!buildTimestamp) {
+          buildTimestamp = data.latestBuildTimestamp;
+        } else if (data.latestBuildTimestamp !== buildTimestamp) {
           // eslint-disable-next-line no-console
-          console.log(`There is a newer build (my build: ${buildId}; new build: ${data.latestBuildId}. Refreshing.`);
+          console.log(`There is a newer build (my build: ${buildTimestamp}; new build: ${data.latestBuildTimestamp}. Refreshing.`);
           window.location.reload();
         }
       } else {


### PR DESCRIPTION
If you triggered two rebuilds concurrently, the first of which succeeds and the second of which fails, this could lead to a case where connected browser tabs enter a refresh loop. Only affects development.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202610274687750) by [Unito](https://www.unito.io)
