### PR TITLE
fix a small bug preventing voting on a few posts

### DIFF
--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -312,7 +312,8 @@ export const recalculateDocumentScores = async (document: VoteableType, context:
   ).fetch() || [];
   
   const userIdsThatVoted = uniq(votes.map(v=>v.userId));
-  const usersThatVoted = await context.loaders.Users.loadMany(userIdsThatVoted);
+  // make sure that votes associated with users that no longer exist get ignored for the AF score
+  const usersThatVoted = (await context.loaders.Users.loadMany(userIdsThatVoted)).filter(u=>!!u);
   const usersThatVotedById = keyBy(usersThatVoted, u=>u._id);
   
   const afVotes = _.filter(votes, v=>userCanDo(usersThatVotedById[v.userId], "votes.alignment"));


### PR DESCRIPTION
Got a report of a mysterious bug that only seemed to prevent voting on [this post](https://forum.effectivealtruism.org/posts/SbwWBhi6T6qZwxu2X/the-righteous-mind-book-review). Turns out this was caused by one of the votes being associated with a `userId` that doesn't have a matching user. Not sure how that happened, but this should fix the immediate issue.