### PR TITLE
fix display of welcome box on posts without a ToC

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -116,7 +116,7 @@ export const ToCColumn = ({tableOfContents, header, welcomeBox, children, classe
   welcomeBox: React.ReactNode|null
 }) => {
   return (
-    <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents})}>
+    <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents || !!welcomeBox})}>
       <div className={classes.header}>
         {header}
       </div>


### PR DESCRIPTION
The Welcome Box currently doesn't show on posts that don't have a table of contents.

![](https://user-images.githubusercontent.com/2136984/179155790-7c37c195-932a-47fe-802f-62bf5b63a555.png)

With the fix, it does.

![](https://user-images.githubusercontent.com/2136984/179155837-614d0807-f40e-4531-901b-bb82b5b15718.png)


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202611495419029) by [Unito](https://www.unito.io)
