### PR TITLE
[EA] Prevent users who cannot edit or create Topics from seeing edit or new topic buttons

### DIFF
--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib
 import { InstantSearch, SearchBox, Hits, Configure } from 'react-instantsearch-dom';
 import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/algoliaUtil';
 import Divider from '@material-ui/core/Divider';
-import { Tags } from '../../lib/collections/tags/collection';
+import { tagMinimumKarmaPermissions, Tags } from '../../lib/collections/tags/collection';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 import { userCanCreateTags } from '../../lib/betas';
@@ -105,7 +105,7 @@ const AddTag = ({onTagSelected, classes}: {
     <Link target="_blank" to="/tags/all" className={classes.newTag}>
       All {taggingNamePluralCapitalSetting.get()}
     </Link>
-    {userCanCreateTags(currentUser) && <Link
+    {userCanCreateTags(currentUser) && ((currentUser?.karma ?? 0) >= tagMinimumKarmaPermissions.new) && <Link
       target="_blank"
       to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}
       className={classes.newTag}

--- a/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
@@ -7,6 +7,7 @@ import _sortBy from 'lodash/sortBy';
 import { userCanCreateTags } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
 import { taggingNameCapitalSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { tagMinimumKarmaPermissions } from '../../lib/collections/tags/collection';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -45,12 +46,15 @@ const AllTagsAlphabetical = ({classes}: {
         title={`All ${taggingNamePluralCapitalSetting.get()} (${loading ? "loading" : results?.length})`}
         anchor={`all-${taggingNamePluralSetting.get()}`}
       >
-        {userCanCreateTags(currentUser) && <SectionButton>
-          <AddBoxIcon/>
-          <Link to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}>
-            New {taggingNameCapitalSetting.get()}
-          </Link>
-        </SectionButton>}
+        {userCanCreateTags(currentUser) &&
+          (!currentUser || currentUser.karma > tagMinimumKarmaPermissions.new) &&
+          <SectionButton>
+            <AddBoxIcon/>
+            <Link to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}>
+              New {taggingNameCapitalSetting.get()}
+            </Link>
+          </SectionButton>
+        }
       </SectionTitle>
       {loading && <Loading/>}
       <div className={classes.alphabetical}>

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -10,6 +10,7 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import { useDialog } from '../common/withDialog';
 import { forumTypeSetting, taggingNameCapitalSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNamePluralSetting, taggingNameSetting } from '../../lib/instanceSettings';
 import { forumSelect } from '../../lib/forumTypeUtils';
+import { tagMinimumKarmaPermissions } from '../../lib/collections/tags/collection';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -80,22 +81,22 @@ const AllTagsPage = ({classes}: {
           <AnalyticsContext pageSectionContext="tagPortal">
             <SectionTitle title={sectionTitle}>
               <SectionButton>
-                {currentUser
-                  ? <Link to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}>
-                      <AddBoxIcon className={classes.addTagButton}/>
-                      New {taggingNameCapitalSetting.get()}
-                    </Link>
-                  : <a onClick={(ev) => {
-                      openDialog({
-                        componentName: "LoginPopup",
-                        componentProps: {}
-                      });
-                      ev.preventDefault();
-                    }}>
-                      <AddBoxIcon className={classes.addTagButton}/>
-                      New {taggingNameCapitalSetting.get()}
-                    </a>
-                }
+                {currentUser && currentUser.karma > tagMinimumKarmaPermissions.new && <Link
+                  to={`/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/create`}
+                >
+                  <AddBoxIcon className={classes.addTagButton}/>
+                  New {taggingNameCapitalSetting.get()}
+                </Link>}
+                {!currentUser && <a onClick={(ev) => {
+                  openDialog({
+                    componentName: "LoginPopup",
+                    componentProps: {}
+                  });
+                  ev.preventDefault();
+                }}>
+                  <AddBoxIcon className={classes.addTagButton}/>
+                  New {taggingNameCapitalSetting.get()}
+                </a>}
               </SectionButton>
             </SectionTitle>
             <ContentStyles contentType="comment" className={classes.portal}>

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import { useNavigation } from '../../lib/routeUtil'
 import { useCurrentUser } from '../common/withUser';
-import { Tags } from '../../lib/collections/tags/collection';
+import { tagMinimumKarmaPermissions, Tags } from '../../lib/collections/tags/collection';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 
@@ -17,6 +17,18 @@ const NewTagPage = () => {
         <SectionTitle title={`New ${taggingNameCapitalSetting.get()}`}/>
         <div>
           You must be logged in to define new {taggingNamePluralSetting.get()}.
+        </div>
+      </SingleColumnSection>
+    );
+  }
+  
+  if (currentUser.karma < tagMinimumKarmaPermissions.new) {
+    return (
+      <SingleColumnSection>
+        <SectionTitle title={`New ${taggingNameCapitalSetting.get()}`}/>
+        <div>
+          You do not have enough karma to define new {taggingNamePluralSetting.get()}. You must have
+          at least {tagMinimumKarmaPermissions.new} karma.
         </div>
       </SingleColumnSection>
     );

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -14,7 +14,8 @@ import { useCurrentUser } from '../common/withUser';
 import { MAX_COLUMN_WIDTH } from '../posts/PostsPage/PostsPage';
 import { EditTagForm } from './EditTagPage';
 import { useTagBySlug } from './useTag';
-import { forumTypeSetting, taggingNameCapitalSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { tagMinimumKarmaPermissions } from "../../lib/collections/tags/collection";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -226,6 +227,9 @@ const TagPage = ({classes}: {
   // If the slug in our URL is not the same as the slug on the tag, redirect to the canonical slug page
   if (tag.oldSlugs?.filter(slug => slug !== tag.slug)?.includes(slug)) {
     return <PermanentRedirect url={tagGetUrl(tag)} />
+  }
+  if (editing && currentUser && currentUser.karma < tagMinimumKarmaPermissions.edit) {
+    throw new Error(`Sorry, you cannot edit ${taggingNamePluralSetting.get()} without ${tagMinimumKarmaPermissions.edit} or more karma.`)
   }
 
   // if no sort order was selected, try to use the tag page's default sort order for posts

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -11,6 +11,7 @@ import { userHasNewTagSubscriptions } from '../../lib/betas';
 import classNames from 'classnames';
 import { useTagBySlug } from './useTag';
 import { forumTypeSetting, taggingNameIsSet, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import Tags, { tagMinimumKarmaPermissions } from '../../lib/collections/tags/collection';
 
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
@@ -113,7 +114,7 @@ const TagPageButtonRow = ({tag, editing, setEditing, className, classes}: {
   </>
   
   return <div className={classNames(classes.buttonsRow, className)}>
-    {!editing && <LWTooltip
+    {!editing && (!currentUser || currentUser.karma >= tagMinimumKarmaPermissions.edit) && <LWTooltip
       className={classes.buttonTooltip}
       title={editTooltip}
     >

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -6,7 +6,8 @@ import { userIsAdmin } from '../../vulcan-users/permissions';
 import { schema } from './schema';
 import { forumSelect } from '../../forumTypeUtils';
 
-const tagMinimumKarmaPermissions = forumSelect({
+export const tagMinimumKarmaPermissions = forumSelect({
+  // Topic spampocalypse defense
   EAForum: {
     new: 10,
     edit: 10,
@@ -34,13 +35,13 @@ export const Tags: ExtendedTagsCollection = createCollection({
   resolvers: getDefaultResolvers('Tags'),
   mutations: getDefaultMutations('Tags', {
     newCheck: (user: DbUser|null, tag: DbTag|null) => {
-      if ((user?.karma ?? 0) < tagMinimumKarmaPermissions['new']) {
+      if ((user?.karma ?? 0) < tagMinimumKarmaPermissions.new) {
         return false
       }
       return userCanCreateTags(user);
     },
     editCheck: (user: DbUser|null, tag: DbTag|null) => {
-      if ((user?.karma ?? 0) < tagMinimumKarmaPermissions['edit']) {
+      if ((user?.karma ?? 0) < tagMinimumKarmaPermissions.edit) {
         return false
       }
       return userCanCreateTags(user);


### PR DESCRIPTION
I've left it visible for logged out users. This may not be the optimal solution. Ideally I'd have some greyed out thing perhaps?