### PR TITLE
Fix titles being squeezed with many coauthors, redux

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -95,7 +95,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
       height: "unset",
       maxWidth: "unset",
       width: "100%",
-      paddingRight: theme.spacing.unit
+      paddingRight: theme.spacing.unit,
+      flex: "unset",
     },
     '&:hover': {
       opacity: 1,
@@ -103,6 +104,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   spacer: {
     flex: 1,
+    [theme.breakpoints.down('xs')]: {
+      display: "none"
+    },
   },
   author: {
     justifyContent: "flex",

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -81,8 +81,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     minHeight: 26,
-    flexGrow: 1,
-    flexShrink: 1,
+    flex: 1500,
+    maxWidth: "fit-content",
     overflow: "hidden",
     textOverflow: "ellipsis",
     marginRight: 12,
@@ -101,6 +101,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
       opacity: 1,
     }
   },
+  spacer: {
+    flex: 1,
+  },
   author: {
     justifyContent: "flex",
     overflow: "hidden",
@@ -108,6 +111,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis", // I'm not sure this line worked properly?
     marginRight: theme.spacing.unit*1.5,
     zIndex: theme.zIndexes.postItemAuthor,
+    flex: 1000,
+    maxWidth: "fit-content",
     [theme.breakpoints.down('xs')]: {
       justifyContent: "flex-end",
       width: "unset",
@@ -487,6 +492,9 @@ const PostsItem2 = ({
                   <Components.EventVicinity post={post} />
                 </PostsItem2MetaInfo>}
 
+                {/* space in-between title and author if there is width remaining */}
+                <span className={classes.spacer} />
+
                 { !post.isEvent && !hideAuthor && <PostsItem2MetaInfo className={classes.author}>
                   <PostsUserAndCoauthors post={post} abbreviateIfLong={true} newPromotedComments={hasNewPromotedComments()}/>
                 </PostsItem2MetaInfo>}
@@ -568,6 +576,7 @@ const PostsItem2 = ({
 
 const PostsItem2Component = registerComponent('PostsItem2', PostsItem2, {
   styles,
+  stylePriority: 1,
   hocs: [withErrorBoundary],
   areEqual: {
     terms: "deep",

--- a/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
@@ -33,4 +33,3 @@ declare global {
     PostsItem2MetaInfo: typeof PostsItem2MetaInfoComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -15,6 +15,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
     lineHeight: "1.0rem",
+    '&:empty': {
+      display: 'none',
+    },
   },
   postIcon: {
     marginRight: 4,


### PR DESCRIPTION
Previously: https://github.com/ForumMagnum/ForumMagnum/pull/5259

Unfortunately, that broke mobile views. Disaster. Gotta revert that.

This PR reintroduces the change, with some simple media queries keeping mobile the same as it was pre-change. See the second commit in this PR for the commit that is unique to this PR.