### PR TITLE
add nofollow to links by users with less than 10 karma

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { commentExcerptFromHTML } from '../../../lib/editor/ellipsize'
 import { useCurrentUser } from '../../common/withUser'
+import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   commentStyling: {
@@ -60,6 +61,7 @@ const CommentBody = ({ comment, classes, collapsed, truncated, postPage }: {
         className={bodyClasses}
         dangerouslySetInnerHTML={{__html: innerHtml }}
         description={`comment ${comment._id}`}
+        nofollow={(comment.user?.karma || 0) < nofollowKarmaThreshold.get()}
       />
     </ContentStyles>
   )

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -77,6 +77,7 @@ interface ContentItemBodyProps extends WithStylesProps {
   description?: string,
   // Only Implemented for Tag Hover Previews
   noHoverPreviewPrefetch?: boolean,
+  nofollow?: boolean,
 }
 interface ContentItemBodyState {
   updatedElements: boolean,
@@ -135,11 +136,13 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
   }
   
   render() {
+    const html = this.props.nofollow ? addNofollowToHTML(this.props.dangerouslySetInnerHTML.__html) : this.props.dangerouslySetInnerHTML.__html
+    
     return (<React.Fragment>
       <div
         className={this.props.className}
         ref={this.bodyRef}
-        dangerouslySetInnerHTML={this.props.dangerouslySetInnerHTML}
+        dangerouslySetInnerHTML={{__html: html}}
       />
       {
         this.replacedElements.map(replaced => {
@@ -262,7 +265,14 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
           continue;
         const id = linkTag.getAttribute("id");
         const rel = linkTag.getAttribute("rel")
-        const replacementElement = <Components.HoverPreviewLink href={href} innerHTML={tagContentsHTML} contentSourceDescription={this.props.description} id={id} rel={rel} noPrefetch={this.props.noHoverPreviewPrefetch}/>
+        const replacementElement = <Components.HoverPreviewLink
+          href={href}
+          innerHTML={tagContentsHTML}
+          contentSourceDescription={this.props.description}
+          id={id}
+          rel={rel}
+          noPrefetch={this.props.noHoverPreviewPrefetch}
+        />
         this.replaceElement(linkTag, replacementElement);
       }
     }
@@ -289,6 +299,10 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
     });
     replacedElement.parentElement.replaceChild(replacementContainer, replacedElement);
   }
+}
+
+const addNofollowToHTML = (html: string): string => {
+  return html.replace('<a ', '<a rel="nofollow" ')
 }
 
 const ContentItemBodyComponent = registerComponent('ContentItemBody', ContentItemBody, {

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -302,7 +302,7 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
 }
 
 const addNofollowToHTML = (html: string): string => {
-  return html.replace('<a ', '<a rel="nofollow" ')
+  return html.replace(/<a /g, '<a rel="nofollow" ')
 }
 
 const ContentItemBodyComponent = registerComponent('ContentItemBody', ContentItemBody, {

--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -12,7 +12,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 // ContentItemTruncated: Wrapper around ContentItemBody with options for
 // limiting length and height in various ways.
-const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description}: {
+const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description, nofollow}: {
   classes: ClassesType,
   maxLengthWords: number,
   graceWords?: number,
@@ -27,6 +27,7 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
   dangerouslySetInnerHTML: { __html: string },
   className?: string,
   description?: string,
+  nofollow?: boolean
 }) => {
   const {ContentItemBody} = Components;
   
@@ -43,6 +44,7 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
       dangerouslySetInnerHTML={{__html: truncatedHtml}}
       className={classNames(className, {[classes.maxHeight]:!expanded})}
       description={description}
+      nofollow={nofollow}
     />
     {wasTruncated && getTruncatedSuffix && getTruncatedSuffix({wordsLeft})}
     {!wasTruncated && nonTruncatedSuffix}

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -28,6 +28,7 @@ import DescriptionIcon from '@material-ui/icons/Description'
 import LibraryAddIcon from '@material-ui/icons/LibraryAdd'
 import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
+import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -398,6 +399,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
           <ContentItemBody
             dangerouslySetInnerHTML={{__html: user.htmlBio }}
             description={`user ${user._id} bio`}
+            nofollow={userKarma < nofollowKarmaThreshold.get()}
           />
         </ContentStyles>}
         {user.howOthersCanHelpMe && <>
@@ -405,7 +407,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
             <Typography variant="headline" className={classes.sectionSubHeading}>How others can help me</Typography>
           </div>
           <ContentStyles contentType="post">
-            <ContentItemBody dangerouslySetInnerHTML={{__html: user.howOthersCanHelpMe.html }} />
+            <ContentItemBody dangerouslySetInnerHTML={{__html: user.howOthersCanHelpMe.html }} nofollow={userKarma < nofollowKarmaThreshold.get()}/>
           </ContentStyles>
         </>}
         {user.howICanHelpOthers && <>
@@ -413,7 +415,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
             <Typography variant="headline" className={classes.sectionSubHeading}>How I can help others</Typography>
           </div>
           <ContentStyles contentType="post">
-            <ContentItemBody dangerouslySetInnerHTML={{__html: user.howICanHelpOthers.html }} />
+            <ContentItemBody dangerouslySetInnerHTML={{__html: user.howICanHelpOthers.html }} nofollow={userKarma < nofollowKarmaThreshold.get()}/>
           </ContentStyles>
         </>}
       </>,

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -3,6 +3,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import React, {useState, useCallback} from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useSingle } from '../../lib/crud/withSingle';
+import { nofollowKarmaThreshold } from '../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   highlightContinue: {
@@ -50,6 +51,7 @@ const PostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
       </div>}
       dangerouslySetInnerHTML={{__html: expandedDocument?.contents?.html || htmlHighlight}}
       description={`post ${post._id}`}
+      nofollow={(post.user?.karma || 0) < nofollowKarmaThreshold.get()}
     />
     {loading && expanded && <Components.Loading/>}
   </Components.ContentStyles>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -8,7 +8,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import { useRecordPostView } from '../../common/withRecordPostView';
 import { AnalyticsContext, captureEvent } from "../../../lib/analyticsEvents";
 import {forumTitleSetting, forumTypeSetting} from '../../../lib/instanceSettings';
-import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
+import { cloudinaryCloudNameSetting, nofollowKarmaThreshold } from '../../../lib/publicSettings';
 import { viewNames } from '../../comments/CommentsViews';
 import classNames from 'classnames';
 import { forumSelect } from '../../../lib/forumTypeUtils';
@@ -238,7 +238,7 @@ const PostsPage = ({post, refetch, classes}: {
         <ContentStyles contentType="post" className={classes.postContent}>
           <PostBodyPrefix post={post} query={query}/>
           <AnalyticsContext pageSectionContext="postBody">
-            { htmlWithAnchors && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`}/> }
+            { htmlWithAnchors && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`} nofollow={(post.user?.karma || 0) < nofollowKarmaThreshold.get()}/> }
           </AnalyticsContext>
         </ContentStyles>
 

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -6,6 +6,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import classNames from 'classnames';
 import { Comments } from "../../lib/collections/comments";
 import { styles as commentsItemStyles } from "../comments/CommentsItem/CommentsItem";
+import { nofollowKarmaThreshold } from '../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -178,6 +179,7 @@ const Answer = ({ comment, post, classes }: {
                       className={classNames({[classes.retracted]: comment.retracted})}
                       dangerouslySetInnerHTML={{__html:html}}
                       description={`comment ${comment._id} on post ${post._id}`}
+                      nofollow={(comment.user?.karma || 0) < nofollowKarmaThreshold.get()}
                     />
                   </ContentStyles>
                   <CommentBottomCaveats comment={comment}/>

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -8,6 +8,7 @@ import { useCurrentUser } from '../common/withUser';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import { sectionFooterLeftStyles } from '../users/UsersProfile'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
+import { nofollowKarmaThreshold } from '../../lib/publicSettings';
 
 export const sequencesImageScrim = (theme: ThemeType) => ({
   position: 'absolute',
@@ -167,7 +168,7 @@ const SequencesPage = ({ documentId, classes }: {
         </SectionFooter>
         
         <ContentStyles contentType="post" className={classes.description}>
-          {html && <ContentItemBody dangerouslySetInnerHTML={{__html: html}} description={`sequence ${document._id}`}/>}
+          {html && <ContentItemBody dangerouslySetInnerHTML={{__html: html}} description={`sequence ${document._id}`} nofollow={(document.user?.karma || 0) < nofollowKarmaThreshold.get()}/>}
         </ContentStyles>
         <div>
           <AnalyticsContext listContext={"sequencePage"} sequenceId={document._id} capturePostItemOnMount>

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -21,6 +21,7 @@ import { taglineSetting } from '../common/HeadTags';
 import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/schema';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { useMessages } from '../common/withMessages';
+import { nofollowKarmaThreshold } from '../../lib/publicSettings';
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -299,7 +300,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
             </Typography>
 
             {user.htmlBio && <ContentStyles contentType="post">
-              <ContentItemBody className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} description={`user ${user._id} bio`} />
+              <ContentItemBody className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} description={`user ${user._id} bio`} nofollow={(user.karma || 0) < nofollowKarmaThreshold.get()}/>
             </ContentStyles>}
           </SingleColumnSection>
 

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -63,6 +63,8 @@ export const cloudinaryCloudNameSetting = new DatabasePublicSetting<string>('clo
 
 export const forumAllPostsNumDaysSetting = new DatabasePublicSetting<number>('forum.numberOfDays', 10) // Number of days to display in the timeframe view
 
+export const nofollowKarmaThreshold = new DatabasePublicSetting<number>('nofollowKarmaThreshold', 10) // Users with less than this much karma have their links marked as nofollow
+
 export const localeSetting = new DatabasePublicSetting<string>('locale', 'en-US')
 export const legacyRouteAcronymSetting = new DatabasePublicSetting<string>('legacyRouteAcronym', 'lw') // Because the EA Forum was identical except for the change from /lw/ to /ea/
 


### PR DESCRIPTION
for https://github.com/ForumMagnum/ForumMagnum/issues/5075

Add `nofollow` to all links in content created by users with less than 10 karma. The threshold is configurable. Applied at render time so when they gain karma their links change retroactively.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202615985522670) by [Unito](https://www.unito.io)
