### PR TITLE
[EA Forum only] drafts should be expanded by default when viewing your own profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -258,7 +258,13 @@ const EAUsersProfile = ({terms, slug, classes}: {
   
   // although both the owner and admins can see the drafts section,
   // admins need to click a button to view it (so it's not distracting)
-  const [draftsSectionExpanded, setDraftsSectionExpanded] = useState(currentUser && user?._id === currentUser._id)
+  const [draftsSectionExpanded, setDraftsSectionExpanded] = useState(!user || (currentUser && user._id === currentUser._id))
+  useEffect(() => {
+    if (user) {
+      setDraftsSectionExpanded(currentUser && user._id === currentUser._id)
+    }
+  }, [user])
+  
   // show/hide the "Posts" section sort/filter settings
   const [showPostSettings, setShowPostSetttings] = useState(false)
   
@@ -267,6 +273,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
     collectionName: "Localgroups",
     fragmentName: 'localGroupsHomeFragment',
     enableTotal: false,
+    skip: !user
   })
 
   const { flash } = useMessages()

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -263,7 +263,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
     if (user) {
       setDraftsSectionExpanded(currentUser && user._id === currentUser._id)
     }
-  }, [user])
+  }, [currentUser, user])
   
   // show/hide the "Posts" section sort/filter settings
   const [showPostSettings, setShowPostSetttings] = useState(false)

--- a/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
+++ b/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
@@ -69,7 +69,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: 'relative'
   },
   collapsedTabBody: {
-    maxHeight: COLLAPSED_SECTION_HEIGHT,
+    height: COLLAPSED_SECTION_HEIGHT,
     overflow: 'hidden',
     '&::after': {
       position: 'absolute',
@@ -112,7 +112,7 @@ const EAUsersProfileTabbedSection = ({tabs, classes}: {
     if (bodyRef.current) {
       // show/hide the collapse-related buttons depending on whether or not the content all fits
       resizeObserver.current = new ResizeObserver(elements => {
-        setMeritsCollapse(elements[0].contentRect.height >= COLLAPSED_SECTION_HEIGHT)
+        setMeritsCollapse(Math.round(elements[0].contentRect.height) >= COLLAPSED_SECTION_HEIGHT)
       })
       resizeObserver.current.observe(bodyRef.current)
     }


### PR DESCRIPTION
This fixes a bug where sometimes your drafts would be collapsed by default when viewing your own profile. Also fixes a bug I encountered around the collapsable tab body while changing my page zoom.