### PR TITLE
fix bug that prevents self-vote when duplicating an event

### DIFF
--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -274,6 +274,8 @@ export const postCoauthorIsPending = (post: DbPost|PostsList|PostsDetails, coaut
 
 export const getConfirmedCoauthorIds = (post: DbPost|PostsList|PostsDetails): string[] => {
   let { coauthorStatuses = [], hasCoauthorPermission = true } = post;
+  if (!coauthorStatuses) return []
+
   if (!hasCoauthorPermission) {
     coauthorStatuses = coauthorStatuses.filter(({ confirmed }) => confirmed);
   }

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -453,7 +453,7 @@ getCollectionHooks("Posts").editAsync.add(async function PostsEditNotifyUsersSha
 
 getCollectionHooks("Posts").newAsync.add(async function PostsNewNotifyUsersSharedOnPost (post: DbPost) {
   const { _id, shareWithUsers = [], coauthorStatuses = [] } = post;
-  const coauthors = coauthorStatuses.filter(({ confirmed }) => confirmed).map(({ userId }) => userId);
+  const coauthors = coauthorStatuses ? coauthorStatuses.filter(({ confirmed }) => confirmed).map(({ userId }) => userId) : []
   const userIds = shareWithUsers.filter((user) => !coauthors.includes(user));
   await createNotifications({userIds, notificationType: "postSharedWithUser", documentType: "post", documentId: _id})
 });

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -14,7 +14,7 @@ import * as _ from 'underscore';
 import sumBy from 'lodash/sumBy'
 import uniq from 'lodash/uniq';
 import keyBy from 'lodash/keyBy';
-import { postCoauthorIsPending, getConfirmedCoauthorIds } from '../lib/collections/posts/helpers';
+import { getConfirmedCoauthorIds } from '../lib/collections/posts/helpers';
 
 // Test if a user has voted on the server
 const getExistingVote = async ({ document, user }: {
@@ -317,7 +317,7 @@ export const recalculateDocumentScores = async (document: VoteableType, context:
   
   const userIdsThatVoted = uniq(votes.map(v=>v.userId));
   // make sure that votes associated with users that no longer exist get ignored for the AF score
-  const usersThatVoted = (await context.loaders.Users.loadMany(userIdsThatVoted)).filter(u=>!!u);
+  const usersThatVoted = (await context.loaders.Users.loadMany(userIdsThatVoted))?.filter(u=>!!u);
   const usersThatVotedById = keyBy(usersThatVoted, u=>u._id);
   
   const afVotes = _.filter(votes, v=>userCanDo(usersThatVotedById[v.userId], "votes.alignment"));


### PR DESCRIPTION
I was creating a new event on prod by duplicating an existing one, and I ran into an error like this. It didn't prevent the event from being created, but the event had no votes on it.

![](https://user-images.githubusercontent.com/9057804/179342043-68b241d4-624d-4e82-87f4-e46f32851f5f.png)

```
["TypeError: Cannot read property 'map' of null","    at getConfirmedCoauthorIds (/Users/sarah/EAForum/packages/lesswrong/lib/collections/posts/helpers.ts:280:27)","    at createVote (/Users/sarah/EAForum/packages/lesswrong/server/voteServer.ts:85:7)","    at addVoteServer (/Users/sarah/EAForum/packages/lesswrong/server/voteServer.ts:43:23)","    at performVoteServer (/Users/sarah/EAForum/packages/lesswrong/server/voteServer.ts:218:44)","    at processTicksAndRejections (node:internal/process/task_queues:96:5)","    at LWPostsNewUpvoteOwnPost (/Users/sarah/EAForum/packages/lesswrong/server/callbacks/postCallbacks.ts:75:34)"]}}}]
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202616232298493) by [Unito](https://www.unito.io)
