### PR TITLE
Only admins can vote on community

### DIFF
--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -55,6 +55,7 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           orientation="left"
           color="error"
           upOrDown="Downvote"
+          enabled={tagRel.currentUserCanVote}
           {...voteProps}
         />
       </div>
@@ -66,6 +67,7 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           orientation="right"
           color="secondary"
           upOrDown="Upvote"
+          enabled={tagRel.currentUserCanVote}
           {...voteProps}
         />
       </div>

--- a/packages/lesswrong/components/votes/OverallVoteButton.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteButton.tsx
@@ -8,6 +8,7 @@ const OverallVoteButton = <T extends VoteableTypeClient>({
   vote, collectionName, document, upOrDown,
   color = "secondary",
   orientation = "up",
+  enabled = true,
   solidArrow,
   classes,
 }: {
@@ -18,6 +19,7 @@ const OverallVoteButton = <T extends VoteableTypeClient>({
   upOrDown: "Upvote"|"Downvote",
   color: "error"|"primary"|"secondary",
   orientation: "up"|"down"|"left"|"right",
+  enabled?: boolean,
   solidArrow?: boolean
   classes: ClassesType
 }) => {
@@ -58,6 +60,7 @@ const OverallVoteButton = <T extends VoteableTypeClient>({
     color={color}
     orientation={orientation}
     solidArrow={solidArrow}
+    enabled={enabled}
   />
 }
 

--- a/packages/lesswrong/components/votes/VoteArrowIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIcon.tsx
@@ -1,4 +1,4 @@
-import { registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 import React, { useState } from 'react';
 import classNames from 'classnames';
 import UpArrowIcon from '@material-ui/icons/KeyboardArrowUp';
@@ -17,6 +17,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     '&:hover': {
       backgroundColor: 'transparent',
     }
+  },
+  disabled: {
+    cursor: 'not-allowed',
   },
   smallArrow: {
     fontSize: '50%',
@@ -63,6 +66,7 @@ export interface VoteArrowIconProps {
   solidArrow?: boolean,
   strongVoteDelay: number,
   orientation: "up"|"down"|"left"|"right",
+  enabled?: boolean,
   color: "error"|"primary"|"secondary",
   voted: boolean,
   eventHandlers: {
@@ -77,36 +81,51 @@ export interface VoteArrowIconProps {
   alwaysColored: boolean,
 }
 
-const VoteArrowIcon = ({ solidArrow, strongVoteDelay, orientation, color, voted, eventHandlers, bigVotingTransition, bigVoted, bigVoteCompleted, alwaysColored, classes }: VoteArrowIconProps & {
+const VoteArrowIcon = ({ solidArrow, strongVoteDelay, orientation, enabled = true, color, voted, eventHandlers, bigVotingTransition, bigVoted, bigVoteCompleted, alwaysColored, classes }: VoteArrowIconProps & {
   classes: ClassesType
 }) => {
   const theme = useTheme();
   const Icon = solidArrow ? ArrowDropUpIcon : UpArrowIcon
-  
+  const { LWTooltip } = Components;
+
+  const Tooltip = enabled
+    ? ({ children }) => children
+    : ({ children }) => (
+      <LWTooltip title={"You do not have permission to vote on this"}>
+        {children}
+      </LWTooltip>
+    );
+
+  if (!enabled) {
+    eventHandlers = {};
+  }
+
   return (
-    <IconButton
-      className={classNames(classes.root, classes[orientation])}
-      onMouseDown={eventHandlers.handleMouseDown}
-      onMouseUp={eventHandlers.handleMouseUp}
-      onMouseOut={eventHandlers.clearState}
-      onClick={eventHandlers.handleClick}
-      disableRipple
-    >
-      <Icon
-        className={classes.smallArrow}
-        color={(voted || alwaysColored) ? color : 'inherit'}
-        viewBox='6 6 12 12'
-      />
-      <Transition in={!!(bigVotingTransition || bigVoted)} timeout={strongVoteDelay}>
-        {(state) => (
-          <UpArrowIcon
-            style={bigVoteCompleted ? {color: theme.palette[color].light} : undefined}
-            className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
-            color={(bigVoted || bigVoteCompleted) ? color : 'inherit'}
-            viewBox='6 6 12 12'
-          />)}
-      </Transition>
-    </IconButton>
+    <Tooltip>
+      <IconButton
+        className={classNames(classes.root, classes[orientation], {[classes.disabled]: !enabled})}
+        onMouseDown={eventHandlers.handleMouseDown}
+        onMouseUp={eventHandlers.handleMouseUp}
+        onMouseOut={eventHandlers.clearState}
+        onClick={eventHandlers.handleClick}
+        disableRipple
+      >
+        <Icon
+          className={classes.smallArrow}
+          color={(voted || alwaysColored) ? color : 'inherit'}
+          viewBox='6 6 12 12'
+        />
+        <Transition in={!!(bigVotingTransition || bigVoted)} timeout={strongVoteDelay}>
+          {(state) => (
+            <UpArrowIcon
+              style={bigVoteCompleted ? {color: theme.palette[color].light} : undefined}
+              className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
+              color={(bigVoted || bigVoteCompleted) ? color : 'inherit'}
+              viewBox='6 6 12 12'
+            />)}
+        </Transition>
+      </IconButton>
+    </Tooltip>
   )
 }
 

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -11,6 +11,7 @@ const VoteButton = ({
   vote, currentStrength, upOrDown,
   color = "secondary",
   orientation = "up",
+  enabled = true,
   solidArrow,
   VoteIconComponent,
 }: {
@@ -20,6 +21,7 @@ const VoteButton = ({
   upOrDown: "Upvote"|"Downvote",
   color: "error"|"primary"|"secondary",
   orientation: "up"|"down"|"left"|"right",
+  enabled?: boolean,
   solidArrow?: boolean
   VoteIconComponent: React.ComponentType<VoteArrowIconProps>,
 }) => {
@@ -79,7 +81,7 @@ const VoteButton = ({
   }
 
   const voteArrowProps = {
-    solidArrow, strongVoteDelay, orientation, color, voted,
+    solidArrow, strongVoteDelay, orientation, enabled, color, voted,
     bigVotingTransition, bigVoted,
     bigVoteCompleted, theme,
     eventHandlers: {handleMouseDown, handleMouseUp, handleClick, clearState},

--- a/packages/lesswrong/lib/collections/tagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/tagRels/collection.ts
@@ -3,8 +3,6 @@ import { addUniversalFields, getDefaultResolvers, getDefaultMutations, schemaDef
 import { foreignKeyField } from '../../utils/schemaUtils'
 import { makeVoteable } from '../../make_voteable';
 import { userCanUseTags } from '../../betas';
-import { userGetGroups } from '../../vulcan-users/permissions';
-import { Tags } from '../tags/collection';
 import GraphQLJSON from 'graphql-type-json';
 
 const schema: SchemaType<DbTagRel> = {
@@ -100,24 +98,6 @@ TagRels.checkAccess = async (currentUser: DbUser|null, tagRel: DbTagRel, context
 addUniversalFields({collection: TagRels})
 makeVoteable(TagRels, {
   timeDecayScoresCronjob: true,
-  userCanVoteOn: async (user: DbUser, document: DbTagRel) => {
-    const tag = await Tags.findOne({_id: document.tagId}, {slug: 1});
-    if (!tag) {
-      return false;
-    }
-    if (!tag.canVoteOnRels) {
-      return true;
-    }
-
-    const userGroups = userGetGroups(user);
-    for (const group of tag.canVoteOnRels) {
-      if (userGroups.includes(group)) {
-        return true;
-      }
-    }
-
-    return false;
-  },
 });
 
 export default TagRels;

--- a/packages/lesswrong/lib/collections/tagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/tagRels/collection.ts
@@ -3,6 +3,8 @@ import { addUniversalFields, getDefaultResolvers, getDefaultMutations, schemaDef
 import { foreignKeyField } from '../../utils/schemaUtils'
 import { makeVoteable } from '../../make_voteable';
 import { userCanUseTags } from '../../betas';
+import { userGetGroups } from '../../vulcan-users/permissions';
+import { Tags } from '../tags/collection';
 import GraphQLJSON from 'graphql-type-json';
 
 const schema: SchemaType<DbTagRel> = {
@@ -98,6 +100,24 @@ TagRels.checkAccess = async (currentUser: DbUser|null, tagRel: DbTagRel, context
 addUniversalFields({collection: TagRels})
 makeVoteable(TagRels, {
   timeDecayScoresCronjob: true,
+  userCanVoteOn: async (user: DbUser, document: DbTagRel) => {
+    const tag = await Tags.findOne({_id: document.tagId}, {slug: 1});
+    if (!tag) {
+      return false;
+    }
+    if (!tag.canVoteOnRels) {
+      return true;
+    }
+
+    const userGroups = userGetGroups(user);
+    for (const group of tag.canVoteOnRels) {
+      if (userGroups.includes(group)) {
+        return true;
+      }
+    }
+
+    return false;
+  },
 });
 
 export default TagRels;

--- a/packages/lesswrong/lib/collections/tagRels/fragments.ts
+++ b/packages/lesswrong/lib/collections/tagRels/fragments.ts
@@ -26,6 +26,7 @@ registerFragment(`
     }
     currentUserVote
     currentUserExtendedVote
+    currentUserCanVote
   }
 `);
 
@@ -68,6 +69,7 @@ registerFragment(`
     }
     currentUserVote
     currentUserExtendedVote
+    currentUserCanVote
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -383,7 +383,7 @@ export const schema: SchemaType<DbTag> = {
   // this tag to a particular post
   canVoteOnRels: {
     type: Array,
-    canRead: ['admins', 'sunshineRegiment'],
+    canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
     optional: true,

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -378,7 +378,19 @@ export const schema: SchemaType<DbTag> = {
     hidden: true,
     denormalized: true,
   },
-  
+
+  canVoteOnRels: {
+    type: Array,
+    canRead: ['admins', 'sunshineRegiment'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    optional: true,
+    hidden: true,
+  },
+  'canVoteOnRels.$': {
+    type: String,
+  },
+
   // See resolver in tagResolvers.ts. Takes optional limit and version arguments.
   // Returns a list of contributors and the total karma of their contributions
   // (counting only up to the specified revision, if a revision is specified).

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -379,6 +379,8 @@ export const schema: SchemaType<DbTag> = {
     denormalized: true,
   },
 
+  // Optional array of groups who have permission to vote on the relevancy of
+  // this tag to a particular post
   canVoteOnRels: {
     type: Array,
     canRead: ['admins', 'sunshineRegiment'],

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -117,6 +117,7 @@ interface DbComment extends DbObject {
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
   score: number
   inactive: boolean
+  canVote: Array<string>
   af: boolean
   afBaseScore: number
   afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
@@ -389,6 +390,7 @@ interface DbPost extends DbObject {
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
   score: number
   inactive: boolean
+  canVote: Array<string>
   legacy: boolean
   legacyId: string
   legacySpam: boolean
@@ -553,6 +555,7 @@ interface DbRevision extends DbObject {
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
   score: number
   inactive: boolean
+  canVote: Array<string>
 }
 
 interface SequencesCollection extends CollectionBase<DbSequence, "Sequences"> {
@@ -620,6 +623,7 @@ interface DbTagRel extends DbObject {
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
   score: number
   inactive: boolean
+  canVote: Array<string>
 }
 
 interface TagsCollection extends CollectionBase<DbTag, "Tags"> {

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -652,6 +652,7 @@ interface DbTag extends DbObject {
   lesswrongWikiImportSlug: string
   lesswrongWikiImportCompleted: boolean
   htmlWithContributorAnnotations: string
+  canVoteOnRels: Array<string>
   contributionStats: any /*{"definitions":[{"blackbox":true}]}*/
   introSequenceId: string
   postsDefaultSortOrder: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1364,6 +1364,7 @@ interface TagRelFragment extends TagRelBasicInfo { // fragment on TagRels
   readonly post: PostsList|null,
   readonly currentUserVote: string,
   readonly currentUserExtendedVote: any,
+  readonly currentUserCanVote: boolean,
 }
 
 interface TagRelHistoryFragment extends TagRelBasicInfo { // fragment on TagRels
@@ -1388,6 +1389,7 @@ interface TagRelMinimumFragment extends TagRelBasicInfo { // fragment on TagRels
   readonly tag: TagPreviewFragment|null,
   readonly currentUserVote: string,
   readonly currentUserExtendedVote: any,
+  readonly currentUserCanVote: boolean,
 }
 
 interface WithVoteTagRel { // fragment on TagRels

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -104,40 +104,6 @@ interface LocalgroupsDefaultFragment { // fragment on Localgroups
   readonly deleted: boolean,
 }
 
-interface TagsDefaultFragment { // fragment on Tags
-  readonly createdAt: Date,
-  readonly name: string,
-  readonly slug: string,
-  readonly oldSlugs: Array<string>,
-  readonly core: boolean,
-  readonly suggestedAsFilter: boolean,
-  readonly defaultOrder: number,
-  readonly descriptionTruncationCount: number,
-  readonly descriptionHtmlWithToc: string,
-  readonly postCount: number,
-  readonly userId: string,
-  readonly adminOnly: boolean,
-  readonly charsAdded: number,
-  readonly charsRemoved: number,
-  readonly deleted: boolean,
-  readonly lastCommentedAt: Date,
-  readonly needsReview: boolean,
-  readonly reviewedByUserId: string,
-  readonly wikiGrade: number,
-  readonly wikiOnly: boolean,
-  readonly bannerImageId: string,
-  readonly tagFlagsIds: Array<string>,
-  readonly lesswrongWikiImportRevision: string,
-  readonly lesswrongWikiImportSlug: string,
-  readonly lesswrongWikiImportCompleted: boolean,
-  readonly htmlWithContributorAnnotations: string,
-  readonly canVoteOnRels: Array<string>,
-  readonly contributors: any /*TagContributorsList*/,
-  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly introSequenceId: string,
-  readonly postsDefaultSortOrder: string,
-}
-
 interface TagRelsDefaultFragment { // fragment on TagRels
   readonly createdAt: Date,
   readonly tagId: string,
@@ -273,6 +239,40 @@ interface SequencesDefaultFragment { // fragment on Sequences
   readonly canonicalCollectionSlug: string,
   readonly hidden: boolean,
   readonly hideFromAuthorPage: boolean,
+}
+
+interface TagsDefaultFragment { // fragment on Tags
+  readonly createdAt: Date,
+  readonly name: string,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
+  readonly core: boolean,
+  readonly suggestedAsFilter: boolean,
+  readonly defaultOrder: number,
+  readonly descriptionTruncationCount: number,
+  readonly descriptionHtmlWithToc: string,
+  readonly postCount: number,
+  readonly userId: string,
+  readonly adminOnly: boolean,
+  readonly charsAdded: number,
+  readonly charsRemoved: number,
+  readonly deleted: boolean,
+  readonly lastCommentedAt: Date,
+  readonly needsReview: boolean,
+  readonly reviewedByUserId: string,
+  readonly wikiGrade: number,
+  readonly wikiOnly: boolean,
+  readonly bannerImageId: string,
+  readonly tagFlagsIds: Array<string>,
+  readonly lesswrongWikiImportRevision: string,
+  readonly lesswrongWikiImportSlug: string,
+  readonly lesswrongWikiImportCompleted: boolean,
+  readonly htmlWithContributorAnnotations: string,
+  readonly canVoteOnRels: Array<string>,
+  readonly contributors: any /*TagContributorsList*/,
+  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly introSequenceId: string,
+  readonly postsDefaultSortOrder: string,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions
@@ -1936,13 +1936,13 @@ interface FragmentTypes {
   emailHistoryFragment: emailHistoryFragment
   PostRelationsDefaultFragment: PostRelationsDefaultFragment
   LocalgroupsDefaultFragment: LocalgroupsDefaultFragment
-  TagsDefaultFragment: TagsDefaultFragment
   TagRelsDefaultFragment: TagRelsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
   CommentsDefaultFragment: CommentsDefaultFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
   SequencesDefaultFragment: SequencesDefaultFragment
+  TagsDefaultFragment: TagsDefaultFragment
   RevisionsDefaultFragment: RevisionsDefaultFragment
   PostsMinimumInfo: PostsMinimumInfo
   PostsBase: PostsBase
@@ -2083,13 +2083,13 @@ interface CollectionNamesByFragmentName {
   emailHistoryFragment: "LWEvents"
   PostRelationsDefaultFragment: "PostRelations"
   LocalgroupsDefaultFragment: "Localgroups"
-  TagsDefaultFragment: "Tags"
   TagRelsDefaultFragment: "TagRels"
   PostsDefaultFragment: "Posts"
   VotesDefaultFragment: "Votes"
   CommentsDefaultFragment: "Comments"
   RSSFeedsDefaultFragment: "RSSFeeds"
   SequencesDefaultFragment: "Sequences"
+  TagsDefaultFragment: "Tags"
   RevisionsDefaultFragment: "Revisions"
   PostsMinimumInfo: "Posts"
   PostsBase: "Posts"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -104,6 +104,40 @@ interface LocalgroupsDefaultFragment { // fragment on Localgroups
   readonly deleted: boolean,
 }
 
+interface TagsDefaultFragment { // fragment on Tags
+  readonly createdAt: Date,
+  readonly name: string,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
+  readonly core: boolean,
+  readonly suggestedAsFilter: boolean,
+  readonly defaultOrder: number,
+  readonly descriptionTruncationCount: number,
+  readonly descriptionHtmlWithToc: string,
+  readonly postCount: number,
+  readonly userId: string,
+  readonly adminOnly: boolean,
+  readonly charsAdded: number,
+  readonly charsRemoved: number,
+  readonly deleted: boolean,
+  readonly lastCommentedAt: Date,
+  readonly needsReview: boolean,
+  readonly reviewedByUserId: string,
+  readonly wikiGrade: number,
+  readonly wikiOnly: boolean,
+  readonly bannerImageId: string,
+  readonly tagFlagsIds: Array<string>,
+  readonly lesswrongWikiImportRevision: string,
+  readonly lesswrongWikiImportSlug: string,
+  readonly lesswrongWikiImportCompleted: boolean,
+  readonly htmlWithContributorAnnotations: string,
+  readonly canVoteOnRels: Array<string>,
+  readonly contributors: any /*TagContributorsList*/,
+  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly introSequenceId: string,
+  readonly postsDefaultSortOrder: string,
+}
+
 interface TagRelsDefaultFragment { // fragment on TagRels
   readonly createdAt: Date,
   readonly tagId: string,
@@ -239,39 +273,6 @@ interface SequencesDefaultFragment { // fragment on Sequences
   readonly canonicalCollectionSlug: string,
   readonly hidden: boolean,
   readonly hideFromAuthorPage: boolean,
-}
-
-interface TagsDefaultFragment { // fragment on Tags
-  readonly createdAt: Date,
-  readonly name: string,
-  readonly slug: string,
-  readonly oldSlugs: Array<string>,
-  readonly core: boolean,
-  readonly suggestedAsFilter: boolean,
-  readonly defaultOrder: number,
-  readonly descriptionTruncationCount: number,
-  readonly descriptionHtmlWithToc: string,
-  readonly postCount: number,
-  readonly userId: string,
-  readonly adminOnly: boolean,
-  readonly charsAdded: number,
-  readonly charsRemoved: number,
-  readonly deleted: boolean,
-  readonly lastCommentedAt: Date,
-  readonly needsReview: boolean,
-  readonly reviewedByUserId: string,
-  readonly wikiGrade: number,
-  readonly wikiOnly: boolean,
-  readonly bannerImageId: string,
-  readonly tagFlagsIds: Array<string>,
-  readonly lesswrongWikiImportRevision: string,
-  readonly lesswrongWikiImportSlug: string,
-  readonly lesswrongWikiImportCompleted: boolean,
-  readonly htmlWithContributorAnnotations: string,
-  readonly contributors: any /*TagContributorsList*/,
-  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly introSequenceId: string,
-  readonly postsDefaultSortOrder: string,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions
@@ -1935,13 +1936,13 @@ interface FragmentTypes {
   emailHistoryFragment: emailHistoryFragment
   PostRelationsDefaultFragment: PostRelationsDefaultFragment
   LocalgroupsDefaultFragment: LocalgroupsDefaultFragment
+  TagsDefaultFragment: TagsDefaultFragment
   TagRelsDefaultFragment: TagRelsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
   CommentsDefaultFragment: CommentsDefaultFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
   SequencesDefaultFragment: SequencesDefaultFragment
-  TagsDefaultFragment: TagsDefaultFragment
   RevisionsDefaultFragment: RevisionsDefaultFragment
   PostsMinimumInfo: PostsMinimumInfo
   PostsBase: PostsBase
@@ -2082,13 +2083,13 @@ interface CollectionNamesByFragmentName {
   emailHistoryFragment: "LWEvents"
   PostRelationsDefaultFragment: "PostRelations"
   LocalgroupsDefaultFragment: "Localgroups"
+  TagsDefaultFragment: "Tags"
   TagRelsDefaultFragment: "TagRels"
   PostsDefaultFragment: "Posts"
   VotesDefaultFragment: "Votes"
   CommentsDefaultFragment: "Comments"
   RSSFeedsDefaultFragment: "RSSFeeds"
   SequencesDefaultFragment: "Sequences"
-  TagsDefaultFragment: "Tags"
   RevisionsDefaultFragment: "Revisions"
   PostsMinimumInfo: "Posts"
   PostsBase: "Posts"

--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -4,7 +4,8 @@ import GraphQLJSON from 'graphql-type-json';
 
 interface CollectionVoteOptions {
   timeDecayScoresCronjob: boolean,
-  customBaseScoreReadAccess?: (user: DbUser|null, object: any) => boolean
+  customBaseScoreReadAccess?: (user: DbUser|null, object: any) => boolean,
+  userCanVoteOn?: (user: DbUser, document: DbVoteableType) => boolean|Promise<boolean>,
 }
 
 export const VoteableCollections: Array<CollectionBase<DbVoteableType>> = [];

--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -4,8 +4,7 @@ import GraphQLJSON from 'graphql-type-json';
 
 interface CollectionVoteOptions {
   timeDecayScoresCronjob: boolean,
-  customBaseScoreReadAccess?: (user: DbUser|null, object: any) => boolean,
-  userCanVoteOn?: (user: DbUser, document: DbVoteableType) => boolean|Promise<boolean>,
+  customBaseScoreReadAccess?: (user: DbUser|null, object: any) => boolean
 }
 
 export const VoteableCollections: Array<CollectionBase<DbVoteableType>> = [];
@@ -184,6 +183,18 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
       type: Boolean,
       optional: true,
       onInsert: () => false
+    },
+    // Optional array of groups who have permission to vote on this document
+    canVote: {
+      type: Array,
+      canRead: ['admins', 'sunshineRegiment'],
+      canUpdate: ['admins', 'sunshineRegiment'],
+      canCreate: ['admins', 'sunshineRegiment'],
+      optional: true,
+      hidden: true,
+    },
+    'canVote.$': {
+      type: String,
     },
   });
 }

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -147,7 +147,8 @@ interface VoteableType extends HasIdType, HasUserIdType {
   af?: boolean
   afBaseScore?: number
   afExtendedScore?: any,
-  afVoteCount?: number
+  afVoteCount?: number,
+  canVote?: string[],
 }
 
 interface VoteableTypeClient extends VoteableType {

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -103,6 +103,7 @@ import './server/callbacks/subscriptionCallbacks';
 import './server/callbacks/rateLimits';
 import './server/callbacks/reviewVoteCallbacks';
 import './server/callbacks/tagFlagCallbacks';
+import './server/callbacks/tagRelsCallbacks';
 
 import './server/resolvers/alignmentForumMutations';
 import './server/callbacks/alignment-forum/callbacks';

--- a/packages/lesswrong/server/callbacks/tagRelsCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/tagRelsCallbacks.ts
@@ -1,0 +1,13 @@
+import { getCollectionHooks } from '../mutationCallbacks';
+import { Tags } from '../../lib/collections/tags/collection';
+
+getCollectionHooks("TagRels").createBefore.add(async (tagrel: DbTagRel) => {
+  const tag = await Tags.findOne({_id: tagrel.tagId});
+  if (!tag) {
+    throw new Error("Tag not found");
+  }
+  if (tag.canVoteOnRels) {
+    tagrel.canVote = tag.canVoteOnRels;
+  }
+  return tagrel;
+});

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -391,7 +391,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
       const userId = currentUser._id
       const editedAt = new Date()
       const changeMetrics = htmlToChangeMetrics("", html);
-      const newRevision: Omit<DbRevision, "documentId" | "schemaVersion" | "_id" | "voteCount" | "baseScore" | "extendedScore" | "score" | "inactive" > = {
+      const newRevision: Omit<DbRevision, "documentId" | "schemaVersion" | "_id" | "voteCount" | "baseScore" | "extendedScore" | "score" | "inactive" | "canVote"> = {
         ...(await buildRevision({
           originalContents: doc[fieldName].originalContents,
           currentUser,
@@ -450,7 +450,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
         const previousRev = await getLatestRev(newDocument._id, fieldName);
         const changeMetrics = htmlToChangeMetrics(previousRev?.html || "", html);
 
-        const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "extendedScore"| "score" | "inactive" > = {
+        const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "extendedScore"| "score" | "inactive" | "canVote"> = {
           documentId: document._id,
           ...await buildRevision({
             originalContents: newDocument[fieldName].originalContents,

--- a/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
+++ b/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
@@ -1,6 +1,6 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
 import { Tags } from '../../lib/collections/tags/collection';
-import { TagRels } from '../../lib/collections/tagrels/collection';
+import { TagRels } from '../../lib/collections/tagRels/collection';
 
 registerMigration({
   name: "onlyAdminsCanVoteOnCommunityTopic",

--- a/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
+++ b/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
@@ -1,11 +1,40 @@
-import { registerMigration } from './migrationUtils';
+import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
 import { Tags } from '../../lib/collections/tags/collection';
+import { TagRels } from '../../lib/collections/tagrels/collection';
 
 registerMigration({
   name: "onlyAdminsCanVoteOnCommunityTopic",
   dateWritten: "2022-07-15",
   idempotent: true,
   action: async () => {
-    await Tags.rawUpdateOne({ slug: "community" }, { $set: { canVoteOnRels: ["admins"] } });
+    const canVote = ["admins"];
+
+    const communityTag = await Tags.findOne({ slug: "community" });
+    if (!communityTag) {
+      throw new Error("Cannot find community tag");
+    }
+
+    await Tags.rawUpdateOne({ _id: communityTag._id }, { $set: { canVoteOnRels: canVote } });
+
+    await forEachDocumentBatchInCollection({
+      collection: TagRels,
+      batchSize: 1000,
+      filter: {
+        tagId: communityTag._id
+      },
+      callback: async (tagrels: Array<DbTagRel>) => {
+        // eslint-disable-next-line no-console
+        console.log("Migrating TagRel batch");
+        const changes = tagrels.map(({ _id }) => {
+          return {
+            updateOne: {
+              filter: { _id },
+              update: {$set: {canVote}},
+            }
+          };
+        });
+        await TagRels.rawCollection().bulkWrite(changes, { ordered: false });
+      },
+    });
   },
 });

--- a/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
+++ b/packages/lesswrong/server/migrations/2022-07-15-onlyAdminsCanVoteOnCommunityTopic.ts
@@ -1,0 +1,11 @@
+import { registerMigration } from './migrationUtils';
+import { Tags } from '../../lib/collections/tags/collection';
+
+registerMigration({
+  name: "onlyAdminsCanVoteOnCommunityTopic",
+  dateWritten: "2022-07-15",
+  idempotent: true,
+  action: async () => {
+    await Tags.rawUpdateOne({ slug: "community" }, { $set: { canVoteOnRels: ["admins"] } });
+  },
+});

--- a/packages/lesswrong/server/migrations/index.ts
+++ b/packages/lesswrong/server/migrations/index.ts
@@ -95,3 +95,4 @@ import './2022-06-02-updateCoauthorsSchema'
 import './2022-06-30-migrateCommunityFilterSettings'
 import './2022-07-07-allowMultipleVoteAuthors'
 import './2022-07-07-removeVoteAuthorId'
+import './2022-07-15-onlyAdminsCanVoteOnCommunityTopic';

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -1,6 +1,6 @@
 import { addGraphQLSchema, addGraphQLResolvers, addGraphQLMutation } from '../lib/vulcan-lib/graphql';
 import { performVoteServer, clearVotesServer } from './voteServer';
-import { VoteableCollections, collectionIsVoteable } from '../lib/make_voteable';
+import { VoteableCollections, VoteableCollectionOptions, collectionIsVoteable } from '../lib/make_voteable';
 
 export function createVoteableUnionType() {
   const voteableSchema = VoteableCollections.length ? `union Voteable = ${VoteableCollections.map(collection => collection.typeName).join(' | ')}` : '';
@@ -73,7 +73,12 @@ function addVoteMutations(collection: CollectionBase<DbVoteableType>) {
         
         if (!currentUser) throw new Error("Error casting vote: Not logged in.");
         if (!document) throw new Error("No such document ID");
-  
+
+        const { userCanVoteOn } = VoteableCollectionOptions[collection.collectionName] ?? {};
+        if (userCanVoteOn && !(await userCanVoteOn(currentUser, document))) {
+          throw new Error("You do not have permission to vote on this document");
+        }
+
         if (!voteType && !extendedVote) {
           return await clearVotesServer({document, user: currentUser, collection, context});
         } else {

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -1,6 +1,6 @@
 import { addGraphQLSchema, addGraphQLResolvers, addGraphQLMutation } from '../lib/vulcan-lib/graphql';
 import { performVoteServer, clearVotesServer } from './voteServer';
-import { VoteableCollections, VoteableCollectionOptions, collectionIsVoteable } from '../lib/make_voteable';
+import { VoteableCollections, collectionIsVoteable } from '../lib/make_voteable';
 import { userGetGroups } from '../lib/vulcan-users/permissions';
 
 export function createVoteableUnionType() {


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202391551231993/f)

Arguably, this task could have been completed in one line of code by just hard-coding the document ID, but I thought it would be much better to have a generic way of configuring in the database who can vote on any particular document.

Any voteable type can now have an optional `canVote` field which is an array of user groups with permission to vote (that works in the same way as `canRead`, `canUpdate` or `canCreate` in the schemas, except this is per document rather than per collection). The status of this is returned by graphql in the resolver-only field `currentUserCanVote`.

In this case, we want to configure this on the `Tag`, but the voteable document is the `TagRel`, so I also added a `canVoteOnRels` field to `Tags` which is denormalized onto the `TagRels` when they are created.

When the user does not have permission the buttons will be disabled and they will see this UI:
![Screenshot 2022-07-18 at 10 58 35 (2)](https://user-images.githubusercontent.com/5075628/179489819-e651eb84-c3aa-44ce-9ad9-f5c866f12a83.png)

For LessWrong, these code changes should make no difference as they are only used once the migration is run to setup the `canVote` field.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202622689374342) by [Unito](https://www.unito.io)
