### PR TITLE
Fix user search 'top' property on xs screens

### DIFF
--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -20,7 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       width: "100%"
     },
     [theme.breakpoints.down('xs')]: {
-      top: 48,
+      top: forumTypeSetting.get() === 'EAForum' ? 78 : 48,
     },
     "& .ais-CurrentRefinements": {
       display: 'inline-block',


### PR DESCRIPTION
Reported by Lizka on #forum-smalls

Before and after:
![image](https://user-images.githubusercontent.com/5075628/179493204-9147ac30-139a-400b-90e5-f5ccd5edf1e0.png)
<img width="570" alt="Screenshot 2022-07-18 at 11 28 26" src="https://user-images.githubusercontent.com/5075628/179493302-51b02e19-9eef-43fe-a6ce-da5650c8da8d.png">