### PR TITLE
Use onMouseDown to properly solve clicking on dismounting component

### DIFF
--- a/packages/lesswrong/components/editor/EditUrl.tsx
+++ b/packages/lesswrong/components/editor/EditUrl.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { Components, ComponentsTable, DeferredComponentsTable, registerComponent } from '../../lib/vulcan-lib';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import classNames from 'classnames'
 import Input from '@material-ui/core/Input';
@@ -77,18 +77,15 @@ const EditUrl = ({ value, path, classes, document, defaultValue, label, hintText
 }) => {
   const [active, setActive] = useState(!!value);
   const inputRef = useRef<HTMLInputElement>();
+  let HintTextComponent: () => JSX.Element;
+  if (hintText && (hintText in ComponentsTable || hintText in DeferredComponentsTable)) {
+    HintTextComponent = Components[hintText]
+  }
 
   const updateValue = (value: string | null) => {
     updateCurrentValues({
       [path]: value,
     });
-  }
-
-  const waitAndWipeFooterContent = async () => {
-    // Delay to let the other click events fire first, so that link clicks can
-    // happen before we remove the link
-    await sleep(300);
-    setFooterContent(null);
   }
 
   const setEditorActive = (value: boolean) => {
@@ -99,13 +96,13 @@ const EditUrl = ({ value, path, classes, document, defaultValue, label, hintText
       setFooterContent(
         <div className={classes.footer}>
           <Components.Typography variant='body2' className={classes.hintText}>
-            {hintText}
+            {HintTextComponent ? <HintTextComponent /> : hintText}
           </Components.Typography>
         </div>
       );
     } else {
       updateValue(null);
-      void waitAndWipeFooterContent();
+      setFooterContent(null);
     }
     setActive(value);
   }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -21,17 +21,7 @@ const isLWorAF = (forumTypeSetting.get() === 'LessWrong') || (forumTypeSetting.g
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
 
 const urlHintText = isEAForum
-    ? <>Please write what you liked about the post, and consider sharing some relevant excerpts. If you have permission from the author, you can also copy in the entire post text. If you know the author's username you can add them as a co-author of this post in the "Options" menu below. You can find more guidelines{' '}
-    <Link
-      to='/posts/8yDsenRQhNF4HEDwu/link-posting-is-an-act-of-community-service'
-      // This link gets removed as soon as focus shifts from the input,
-      // mousedown would shift focus from the input, and prevent the link from
-      // being clicked.
-      onMouseDown={e => e.preventDefault()}
-    >
-      here
-    </Link>.
-    </>
+    ? 'UrlHintText'
     : 'Please write what you liked about the post and sample liberally! If the author allows it, copy in the entire post text. (Link-posts without text get far fewer views and most people don\'t click offsite links.)'
 
 const STICKY_PRIORITIES = {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -23,6 +23,7 @@ if (forumTypeSetting.get() === 'EAForum') {
   importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
   importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
   importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
+  importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))
   importComponent("EAGApplicationImportForm", () => require('../components/ea-forum/users/EAGApplicationImportForm'))
   importComponent("EAUsersProfile", () => require('../components/ea-forum/users/EAUsersProfile'))
   importComponent("EAUsersProfileTabbedSection", () => require('../components/ea-forum/users/modules/EAUsersProfileTabbedSection'))

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -39,6 +39,7 @@ export const Link = (props: LinkProps) => {
   const { captureEvent } = useTracking({eventType: "linkClicked", eventProps: {to: props.to}})
   const handleClick = (e) => {
     captureEvent(undefined, {buttonPressed: e.button})
+    props.onMouseDown && props.onMouseDown(e)
   }
 
   if (!isLinkValid(props)) {

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -78,7 +78,7 @@ const PreparedComponents: Record<string,any> = {};
 // storage for infos about components
 export const ComponentsTable: Record<string, ComponentsTableEntry> = {};
 
-const DeferredComponentsTable: Record<string,()=>void> = {};
+export const DeferredComponentsTable: Record<string,()=>void> = {};
 
 type EmailRenderContextType = {
   isEmailRender: boolean


### PR DESCRIPTION
Previously I was unaware that reactRouterWrapper was discarding my onMouseDown callback, which is why my onMouseDown callback was so ineffectual. This is the right was to solve the issue, and prevent a race between the click and the component dismount.