### PR TITLE
Preload stylesheet and bundle during SSR

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -578,6 +578,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name: 'home',
       path: '/',
       componentName: 'EAHome',
+      enableResourcePrefetch: true,
       sunshineSidebar: true
     },
     {
@@ -691,6 +692,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name: 'home',
       path: '/',
       componentName: 'Home2',
+      enableResourcePrefetch: true,
       sunshineSidebar: true
     },
     {
@@ -909,6 +911,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name:'alignment.home',
       path:'/',
       componentName: 'AlignmentForumHome',
+      enableResourcePrefetch: true,
       sunshineSidebar: true //TODO: remove this in production?
     },
     {
@@ -990,11 +993,13 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name: 'sequencesHome',
       path: '/library',
       componentName: 'LibraryPage',
+      enableResourcePrefetch: true,
       title: "The Library"
     },
     {
       name: 'Sequences',
       path: '/sequences',
+      enableResourcePrefetch: true,
       componentName: 'CoreSequences',
       title: "Rationality: A-Z"
     },
@@ -1020,6 +1025,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name:'home',
       path:'/',
       componentName: 'Home2',
+      enableResourcePrefetch: true,
       sunshineSidebar: true //TODO: remove this in production?
     },
     {
@@ -1054,6 +1060,7 @@ addRoute(
     name: 'AllComments',
     path: '/allComments',
     componentName: 'AllComments',
+    enableResourcePrefetch: true,
     title: "All Comments"
   },
   {
@@ -1254,12 +1261,14 @@ addRoute(
     name: 'home2',
     path: '/home2',
     componentName: 'Home2',
+    enableResourcePrefetch: true,
     title: "Home2 Beta",
   },
   {
     name: 'allPosts',
     path: '/allPosts',
     componentName: 'AllPostsPage',
+    enableResourcePrefetch: true,
     title: "All Posts",
   },
   {

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -12,6 +12,12 @@ export interface ServerRequestStatusContextType {
   redirectUrl?: string
 };
 
+interface SegmentedUrl {
+  pathname: string
+  search: string
+  hash: string
+}
+
 export const LocationContext = React.createContext<RouterLocation|null>(null);
 export const SubscribeLocationContext = React.createContext<RouterLocation|null>(null);
 export const NavigationContext = React.createContext<any>(null);
@@ -19,7 +25,7 @@ export const ServerRequestStatusContext = React.createContext<ServerRequestStatu
 
 // From react-router-v4
 // https://github.com/ReactTraining/history/blob/master/modules/PathUtils.js
-export const parsePath = function parsePath(path: string) {
+export const parsePath = function parsePath(path: string): SegmentedUrl {
   var pathname = path || '/';
   var search = '';
   var hash = '';
@@ -60,7 +66,7 @@ export function parseQuery(location) {
 // If there is no match, returns a special 404 route, and calls onError if
 // provided.
 export function parseRoute({location, followRedirects=true, onError=null}: {
-  location: any,
+  location: SegmentedUrl,
   followRedirects?: boolean,
   onError?: null|((err: string)=>void),
 }): RouterLocation {

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -42,6 +42,20 @@ export type Route = {
   disableAutoRefresh?: boolean,
   initialScroll?: "top"|"bottom",
   standalone?: boolean // if true, this page has no header / intercom
+  
+  // enablePrefetch: Start loading stylesheet and JS bundle before the page is
+  // rendered. This requires sending headers before rendering, which means
+  // that the page can't return an HTTP error status or an HTTP redirect. In
+  // exchange, loading time is significantly improved for users who don't have
+  // the stylesheet and JS bundle already in their cache.
+  //
+  // This should only be set for routes which are guaranteed to be valid, ie,
+  // they don't have a post-ID or anything variable in them.
+  //
+  // Currently used for / and for /allPosts which is where this matters most.
+  // Not used for post-pages because we don't know whether a post page is going
+  // to be a 404 until we render it.
+  enableResourcePrefetch?: boolean
 };
 
 /** Populated by calls to addRoute */

--- a/packages/lesswrong/testing/routes.tests.ts
+++ b/packages/lesswrong/testing/routes.tests.ts
@@ -1,0 +1,21 @@
+import { testStartup } from './testMain';
+import chai from 'chai';
+import { Routes } from '../lib/vulcan-lib/routes';
+
+testStartup();
+
+describe("routes table", () => {
+  it("doesn't have enableResourcePrefetch on routes with URL parameters or redirect", () => {
+    for (const routeName of Object.keys(Routes)) {
+      const route = Routes[routeName];
+      if (route.enableResourcePrefetch) {
+        if (route.redirect) {
+          throw new Error(`Route ${route.name} has enableResourcePrefetch set but is a server-side redirect`);
+        }
+        if (route.path.indexOf(':')>=0) {
+          throw new Error(`Route ${route.name} has enableResourcePrefetch set but has a URL parameter.`); 
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Makes it so that the server answers certain pageloads with a streaming response, sending part of the `<head>` block prior to doing server-side rendering. This allows the client to start downloading the main stylesheet and the Javascript bundle immediately, before SSR has started. If the client already has these cached this won't do anything, but if they don't (because this is their first visit since the last server version change), this will significantly speed up their pageload.

This is restricted to a handful of whitelisted pages (including the front page and `/allPosts`, but not including post pages) because this sort of streaming response has a nasty caveat: once you've started sending a response, you can't change your mind about the response's status code or http headers. So if a route is potentially a redirect or a 404, we would have to either split the part that figures out whether it's one of these things from the rest of the rendering process (which is a pain), or wait until rendering is finished before sending anything.

I also tried making `nginx` push preloads with http/2, using a config similar to the one described in [this post](https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/), but this strategy did not work out. I was able to get a locally running nginx server that would server-push the bundle, and verified that server-push was working, but for some reason it waited until the proxied server sent a request status before doing the push, which defeats the entire purpose. It also looked like bringing this to production would require some pretty hairy changes in order to make the backend servers do SSL termination instead of the Amazon load balancer.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202627325509191) by [Unito](https://www.unito.io)
