### PR TITLE
Add tooltip to canonicalCollectionSlug on sequences

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -133,6 +133,7 @@ const schema: SchemaType<DbSequence> = {
     control: "text",
     order: 30,
     label: "Collection Slug",
+    tooltip: "The machine-readable slug for the collection this sequence belongs to. Will affect links, so don't set it unless you have the slug exactly right.",
     resolveAs: {
       fieldName: 'canonicalCollection',
       addOriginalField: true,


### PR DESCRIPTION
We had someone set it for a number of sequences. Some admin was apparently guessing and just filling it in according to their guess. Best to add a tooltip.