### PR TITLE
remove redundant edit post link

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -209,7 +209,6 @@ const PostActions = ({post, closeMenu, classes}: {
   
   return (
       <div className={classes.actions}>
-        {editLink}
         { postCanEdit(currentUser,post) && post.isEvent && <Link to={{pathname:'/newPost', search:`?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`}}>
           <MenuItem>
             <ListItemIcon>
@@ -218,14 +217,7 @@ const PostActions = ({post, closeMenu, classes}: {
             Duplicate Event
           </MenuItem>
         </Link>}
-        { postCanEdit(currentUser,post) && <Link to={{pathname:'/editPost', search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`}}>
-          <MenuItem>
-            <ListItemIcon>
-              <EditIcon />
-            </ListItemIcon>
-            Edit
-          </MenuItem>
-        </Link>}
+        {editLink}
         { forumTypeSetting.get() === 'EAForum' && postCanEdit(currentUser, post) && <Link
           to={{pathname: '/postAnalytics', search: `?${qs.stringify({postId: post._id})}`}}
         >


### PR DESCRIPTION
Removing an old version of the edit post link (without the collaborative editing logic) that was added back to `PostActions` by accident in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/5263).

Broken:
![](https://user-images.githubusercontent.com/2136984/179630882-dc0196a3-366b-4f41-beb5-d9abd71d4317.png)

Fixed:
![](https://user-images.githubusercontent.com/2136984/179630750-fffec834-795e-4a5d-a409-fdc01693ae0a.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202627380433526) by [Unito](https://www.unito.io)
