### PR TITLE
fix cookie handling

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/WelcomeBox.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/WelcomeBox.tsx
@@ -66,7 +66,9 @@ const WelcomeBox = ({ title, contents, classes }: {
     return null;
   }
 
-  const hideBox = () => setCookie(HIDE_WELCOME_BOX_COOKIE, "true");
+  const hideBox = () => setCookie(HIDE_WELCOME_BOX_COOKIE, "true", {
+    path: "/"
+  });
 
   const { Typography } = Components;
   return (

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -116,7 +116,7 @@ export const ToCColumn = ({tableOfContents, header, welcomeBox, children, classe
   welcomeBox: React.ReactNode|null
 }) => {
   return (
-    <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents})}>
+    <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents || !!welcomeBox})}>
       <div className={classes.header}>
         {header}
       </div>

--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -58,7 +58,7 @@ export function setCookieOnResponse({req, res, cookieName, cookieValue, maxAge}:
     // The server-side code depends on the cookie existing on the very first request, before the client can send back the cookie we set via header
     untypedReq.cookies = { [cookieName]: cookieValue };
   }
-  
+
   (res as any).setHeader("Set-Cookie", `${cookieName}=${cookieValue}; Max-Age=${maxAge}; Path=/`);
 }
 
@@ -71,9 +71,9 @@ export function getAllCookiesFromReq(req: Request) {
       Object.assign(returnCookies, untypedReq.universalCookies.getAll());
       return new Cookies(returnCookies);
     }
-    return untypedReq.universalCookies
+    return untypedReq.universalCookies;
   }
-  else
+  else {
     return new Cookies(untypedReq.cookies); // req.universalCookies;
-  
+  }
 }

--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -66,6 +66,13 @@ export function getAllCookiesFromReq(req: Request) {
   const untypedReq: any = req;
 
   if (untypedReq.universalCookies) {
+    /**
+     * Because of the current logic in setCookieOnResponse (for the clientIdMiddleware),
+     * we will have a clientId in cookies but not in universalCookies.
+     * In that case we want to prioritize cookies which exist in universalCookies,
+     * but default to whatever cookies exist in cookies for those that don't exist in universalCookies.
+     * We should be able to delete this after verifying that universalCookies is always present on inbound requests.
+     */
     if (untypedReq.cookies) {
       const returnCookies = new Cookies(untypedReq.cookies).getAll();
       Object.assign(returnCookies, untypedReq.universalCookies.getAll());

--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -59,13 +59,20 @@ export function setCookieOnResponse({req, res, cookieName, cookieValue, maxAge}:
     untypedReq.cookies = { [cookieName]: cookieValue };
   }
   
-  (res as any).setHeader("Set-Cookie", `${cookieName}=${cookieValue}; Max-Age=${maxAge}`);
+  (res as any).setHeader("Set-Cookie", `${cookieName}=${cookieValue}; Max-Age=${maxAge}; Path=/`);
 }
 
 export function getAllCookiesFromReq(req: Request) {
   const untypedReq: any = req;
-  if (untypedReq.universalCookies)
+
+  if (untypedReq.universalCookies) {
+    if (untypedReq.cookies) {
+      const returnCookies = new Cookies(untypedReq.cookies).getAll();
+      Object.assign(returnCookies, untypedReq.universalCookies.getAll());
+      return new Cookies(returnCookies);
+    }
     return untypedReq.universalCookies
+  }
   else
     return new Cookies(untypedReq.cookies); // req.universalCookies;
   


### PR DESCRIPTION
The Welcome Box was behaving erratically.  The div the WelcomeBox was nested in would sometimes appear inside of `gap3`, so I though it was a [client-server rendering mismatch issue](https://github.com/vercel/next.js/issues/7417).  However, there was another issue where the welcome box would show up at the very bottom of the page (beneath all the comments), because the `tocActivated` class was not being applied.  Digging in, this was because:

1. the abTestGroup was not being correctly assigned, because
1. the clientId was not getting picked up by the abTestGroup assignment logic, because
1. it was using the `useCookies` hook, which missed the cookie, because
1. that hook relies on the cookies passed in to `CookiesProvider`, which in turn relies on `getAllCookiesFromReq`, and that was missing the `clientId` cookie, because
1. it was getting all its cookies from `req.universalCookies`, which was missing the `clientId` cookie, because
1. the `clientId` cookie was only being hydrated on incoming requests without one using `setCookieOnResponse`, which only sets it on `cookies`, not `universalCookies`:

```
  // universalCookies should be defined here, but it isn't
  // @see https://github.com/meteor/meteor-feature-requests/issues/174#issuecomment-441047495
  const untypedReq: any = req;
  if (untypedReq.cookies) {
    untypedReq.cookies[cookieName] = cookieValue;
  } else {
    // We need this in the case of e.g. clientId
    // The server-side code depends on the cookie existing on the very first request, before the client can send back the cookie we set via header
    untypedReq.cookies = { [cookieName]: cookieValue };
  }
```

There were also multiple `clientId` being set on a bunch of different paths because there was no `Path=/` specified in `setHeader("Set-Cookie", ...)` in `setCookieOnResponse`.  I have no idea what effect that would have been having, but I don't expect it was the desired behavior.

I further suspect that in many places where we're using `setCookie` and failing to set `path: '/'`, it should in fact be set.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202627357873932) by [Unito](https://www.unito.io)
