### PR TITLE
Add link coloring and website link to sunshine new user hoverover

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -125,7 +125,20 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   sortSelected: {
     color: theme.palette.grey[900]
-  }
+  },
+  bio: {
+    '& a': {
+      color: theme.palette.primary.main,
+    },
+  },
+  website: {
+    color: theme.palette.primary.main,
+  },
+  info: {
+    '& > * + *': {
+      marginTop: 8,
+    },
+  },
 })
 const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
   user: SunshineUsersList,
@@ -295,20 +308,23 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
       <div className={classes.root}>
         <Typography variant="body2">
           <MetaInfo>
-            {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/></em></p> : null }
-            {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
-            <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
-            <div dangerouslySetInnerHTML={{__html: user.htmlBio}}/>
-            <div className={classes.notes}>
-              <Input 
-                value={notes} 
-                fullWidth
-                onChange={e => setNotes(e.target.value)}
-                onClick={e => handleClick()}
-                disableUnderline 
-                placeholder="Notes for other moderators"
-                multiline
-              />
+            <div className={classes.info}>
+              {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/></em></p> : null }
+              {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
+              <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
+              <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
+              {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
+              <div className={classes.notes}>
+                <Input 
+                  value={notes} 
+                  fullWidth
+                  onChange={e => setNotes(e.target.value)}
+                  onClick={e => handleClick()}
+                  disableUnderline 
+                  placeholder="Notes for other moderators"
+                  multiline
+                />
+              </div>
             </div>
             <div className={classes.row}>
               <div className={classes.row}>

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -227,6 +227,7 @@ registerFragment(`
     ...UsersMinimumInfo
     karma
     htmlBio
+    website
     createdAt
     email
     commentCount

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1714,6 +1714,7 @@ interface UsersBannedFromUsersModerationLog { // fragment on Users
 interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
   readonly karma: number,
   readonly htmlBio: string,
+  readonly website: string,
   readonly createdAt: Date,
   readonly email: string,
   readonly commentCount: number,


### PR DESCRIPTION
This is per request from Lizka: "Could mods/admins see links people add to their profiles when we hover over new users in the sidebar?"

Jonathan and I figured this would cover it, by coloring the links that appear in the bio, and also listing any `website` link if the user has that filled in.

![](https://user-images.githubusercontent.com/9057804/179874233-d7c464d1-ebf3-4da3-885f-32ad5082fc46.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202634934338948) by [Unito](https://www.unito.io)
