### PR TITLE
Fix sizing of images in private messages

### DIFF
--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -35,7 +35,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   messageBody: {
     '& a': {
       color: theme.palette.primary.light
-    }
+    },
+    '& img': {
+      maxWidth: '100%',
+    },
   }
 })
 


### PR DESCRIPTION
Reported by Lizka. Before and after:

<img width="896" alt="Screenshot 2022-07-20 at 10 37 41" src="https://user-images.githubusercontent.com/5075628/179950681-db448381-2b9f-49e3-8dfc-f857ea4a12bf.png">

<img width="896" alt="Screenshot 2022-07-20 at 10 37 17" src="https://user-images.githubusercontent.com/5075628/179950697-f083076f-d5ff-4adc-8fb5-203195704106.png">
