### PR TITLE
Fix 'undefined' error when tag page has no content

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -245,7 +245,7 @@ const TagPage = ({classes}: {
     captureEvent("readMoreClicked", {tagId: tag._id, tagName: tag.name, pageSectionContext: "wikiSection"})
   }
 
-  const htmlWithAnchors = tag.tableOfContents?.html || tag.description?.html;
+  const htmlWithAnchors = tag.tableOfContents?.html ?? tag.description?.html ?? "";
   let description = htmlWithAnchors;
   // EA Forum wants to truncate much less than LW
   if(isEAForum) {


### PR DESCRIPTION
The error occurs when the tag has no content.

Reported on slask by Lizka and Pablo: created a new entry for [Conjecture](https://forum.effectivealtruism.org/topics/conjecture) (the AI safety org) but when I click on it I get the following error:
`Error: TypeError: Cannot read properties of undefined (reading 'includes')`