### PR TITLE
fix navigation between posts in a non-canonical collection-sequence, and between those sequences

### DIFF
--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -380,7 +380,7 @@ registerFragment(`
       slug
       commentCount
       baseScore
-      sequence(sequenceId: $sequenceId) {
+      sequence(sequenceId: $sequenceId, prevOrNext: "prev") {
         _id
       }
     }
@@ -390,7 +390,7 @@ registerFragment(`
       slug
       commentCount
       baseScore
-      sequence(sequenceId: $sequenceId) {
+      sequence(sequenceId: $sequenceId, prevOrNext: "next") {
         _id
       }
     }

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -98,11 +98,11 @@ const getSurroundingSequencePostIdTuples = async function (sequenceId: string, c
  * Gets the next post ID from the collection the post belongs to, which is determined by the sequenceId
  */
  export const getNextPostIdFromNextSequence = async function (sequenceId: string, postId: string, context: ResolverContext): Promise<SequencePostId | undefined> {
-  const sequencePostIds = await getSurroundingSequencePostIdTuples(sequenceId, context);
-  if (!sequencePostIds) return;
+  const sequencePostIdTuples = await getSurroundingSequencePostIdTuples(sequenceId, context);
+  if (!sequencePostIdTuples) return;
 
-  const index = sequencePostIds.findIndex((idTuple) => idTuple.postId === postId);
-  return sequencePostIds[index + 1];
+  const index = sequencePostIdTuples.findIndex((idTuple) => idTuple.postId === postId);
+  return sequencePostIdTuples[index + 1];
 }
 
 // Given a post ID and the ID of a sequence which contains that post, return the
@@ -129,11 +129,11 @@ export const sequenceGetNextPostID = async function(sequenceId: string, postId: 
  * Gets the previous post ID from the collection the post belongs to, which is determined by the sequenceId
  */
 export const getPrevPostIdFromPrevSequence = async function (sequenceId: string, postId: string, context: ResolverContext): Promise<SequencePostId | undefined> {
-  const sequencePostIds = await getSurroundingSequencePostIdTuples(sequenceId, context);
-  if (!sequencePostIds) return;
+  const sequencePostIdTuples = await getSurroundingSequencePostIdTuples(sequenceId, context);
+  if (!sequencePostIdTuples) return;
 
-  const index = sequencePostIds.findIndex((idTuple) => idTuple.postId === postId);
-  return sequencePostIds[index - 1];
+  const index = sequencePostIdTuples.findIndex((idTuple) => idTuple.postId === postId);
+  return sequencePostIdTuples[index - 1];
 }
 
 // Given a post ID and the ID of a sequence which contains that post, return the

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -1,9 +1,17 @@
 import { mongoFind } from '../../mongoQueries';
 import { getSiteUrl } from '../../vulcan-lib/utils';
+import { Books } from '../books/collection';
+import { Collections } from '../collections/collection';
 import { Posts } from '../posts/collection';
+import { Sequences } from './collection';
 import { accessFilterMultiple } from '../../utils/schemaUtils';
 import keyBy from 'lodash/keyBy';
 import * as _ from 'underscore';
+
+interface SequencePostId {
+  sequenceId: string,
+  postId: string
+}
 
 // TODO: Make these functions able to use loaders for caching.
 
@@ -46,6 +54,57 @@ export const sequenceGetAllPosts = async (sequenceId: string, context: ResolverC
   return _.map(allPostIds, id=>postsById[id]).filter(post => !!post);
 }
 
+const getSequenceCollectionBooks = async function(sequenceId: string) {
+  const sequence = await Sequences.findOne({ _id: sequenceId });
+  if (!sequence) return;
+
+  const { canonicalCollectionSlug } = sequence;
+
+  const collection = await Collections.findOne({ slug: canonicalCollectionSlug });
+  if (!collection) return;
+
+  const { _id: collectionId } = collection;
+
+  return Books.find({ collectionId }).fetch();
+}
+
+const getSurroundingSequencePostIdTuples = async function (sequenceId: string, context: ResolverContext) {
+  const books = await getSequenceCollectionBooks(sequenceId);
+  if (!books) return;
+
+  const allSequenceIds = books.flatMap(book => book.sequenceIds);
+
+  const currentSequenceIndex = allSequenceIds.indexOf(sequenceId);
+
+  // We don't need to get all the sequences in the collection, that'd be expensive
+  // Just get the one before the current one (if it's not the first) and the one after the current one (if it's not the last)
+  const surroundingSequenceIds = [
+    allSequenceIds[currentSequenceIndex - 1],
+    allSequenceIds[currentSequenceIndex],
+    allSequenceIds[currentSequenceIndex + 1]
+  ].filter(id => !!id);
+
+  const postIdsBySequence = await Promise.all(
+    surroundingSequenceIds.map(seqId =>
+      sequenceGetAllPostIDs(seqId, context)
+        .then((postIds) => postIds.map(postId => ({ sequenceId: seqId, postId })))
+    )
+  );
+
+  return postIdsBySequence.flat();
+}
+
+/**
+ * Gets the next post ID from the collection the post belongs to, which is determined by the sequenceId
+ */
+ export const getNextPostIdFromNextSequence = async function (sequenceId: string, postId: string, context: ResolverContext): Promise<SequencePostId | undefined> {
+  const sequencePostIds = await getSurroundingSequencePostIdTuples(sequenceId, context);
+  if (!sequencePostIds) return;
+
+  const index = sequencePostIds.findIndex((idTuple) => idTuple.postId === postId);
+  return sequencePostIds[index + 1];
+}
+
 // Given a post ID and the ID of a sequence which contains that post, return the
 // next post in the sequence, or null if it was the last post. Does not handle
 // cross-sequence boundaries. If the given post ID is not in the sequence,
@@ -64,6 +123,17 @@ export const sequenceGetNextPostID = async function(sequenceId: string, postId: 
     // Post is in this sequence, not last. Return the next post ID.
     return postIDs[postIndex+1];
   }
+}
+
+/**
+ * Gets the previous post ID from the collection the post belongs to, which is determined by the sequenceId
+ */
+export const getPrevPostIdFromPrevSequence = async function (sequenceId: string, postId: string, context: ResolverContext): Promise<SequencePostId | undefined> {
+  const sequencePostIds = await getSurroundingSequencePostIdTuples(sequenceId, context);
+  if (!sequencePostIds) return;
+
+  const index = sequencePostIds.findIndex((idTuple) => idTuple.postId === postId);
+  return sequencePostIds[index - 1];
 }
 
 // Given a post ID and the ID of a sequence which contains that post, return the

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -171,6 +171,41 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly votingSystem: string,
 }
 
+interface BooksDefaultFragment { // fragment on Books
+  readonly createdAt: Date,
+  readonly postedAt: Date,
+  readonly title: string,
+  readonly subtitle: string,
+  readonly collectionId: string,
+  readonly number: number,
+  readonly postIds: Array<string>,
+  readonly sequenceIds: Array<string>,
+}
+
+interface CollectionsDefaultFragment { // fragment on Collections
+  readonly createdAt: Date,
+  readonly userId: string,
+  readonly title: string,
+  readonly slug: string,
+  readonly gridImageId: string,
+  readonly firstPageLink: string,
+}
+
+interface SequencesDefaultFragment { // fragment on Sequences
+  readonly createdAt: Date,
+  readonly userId: string,
+  readonly title: string,
+  readonly gridImageId: string,
+  readonly bannerImageId: string,
+  readonly curatedOrder: number,
+  readonly userProfileOrder: number,
+  readonly draft: boolean,
+  readonly isDeleted: boolean,
+  readonly canonicalCollectionSlug: string,
+  readonly hidden: boolean,
+  readonly hideFromAuthorPage: boolean,
+}
+
 interface VotesDefaultFragment { // fragment on Votes
   readonly documentId: string,
   readonly collectionName: string,
@@ -224,21 +259,6 @@ interface RSSFeedsDefaultFragment { // fragment on RSSFeeds
   readonly status: string,
   readonly rawFeed: any /*{"definitions":[{}]}*/,
   readonly setCanonicalUrl: boolean,
-}
-
-interface SequencesDefaultFragment { // fragment on Sequences
-  readonly createdAt: Date,
-  readonly userId: string,
-  readonly title: string,
-  readonly gridImageId: string,
-  readonly bannerImageId: string,
-  readonly curatedOrder: number,
-  readonly userProfileOrder: number,
-  readonly draft: boolean,
-  readonly isDeleted: boolean,
-  readonly canonicalCollectionSlug: string,
-  readonly hidden: boolean,
-  readonly hideFromAuthorPage: boolean,
 }
 
 interface TagsDefaultFragment { // fragment on Tags
@@ -1148,26 +1168,6 @@ interface ChaptersDefaultFragment { // fragment on Chapters
   readonly postIds: Array<string>,
 }
 
-interface BooksDefaultFragment { // fragment on Books
-  readonly createdAt: Date,
-  readonly postedAt: Date,
-  readonly title: string,
-  readonly subtitle: string,
-  readonly collectionId: string,
-  readonly number: number,
-  readonly postIds: Array<string>,
-  readonly sequenceIds: Array<string>,
-}
-
-interface CollectionsDefaultFragment { // fragment on Collections
-  readonly createdAt: Date,
-  readonly userId: string,
-  readonly title: string,
-  readonly slug: string,
-  readonly gridImageId: string,
-  readonly firstPageLink: string,
-}
-
 interface ReviewVotesDefaultFragment { // fragment on ReviewVotes
   readonly createdAt: Date,
   readonly userId: string,
@@ -1937,10 +1937,12 @@ interface FragmentTypes {
   LocalgroupsDefaultFragment: LocalgroupsDefaultFragment
   TagRelsDefaultFragment: TagRelsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
+  BooksDefaultFragment: BooksDefaultFragment
+  CollectionsDefaultFragment: CollectionsDefaultFragment
+  SequencesDefaultFragment: SequencesDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
   CommentsDefaultFragment: CommentsDefaultFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
-  SequencesDefaultFragment: SequencesDefaultFragment
   TagsDefaultFragment: TagsDefaultFragment
   RevisionsDefaultFragment: RevisionsDefaultFragment
   PostsMinimumInfo: PostsMinimumInfo
@@ -2005,8 +2007,6 @@ interface FragmentTypes {
   BansDefaultFragment: BansDefaultFragment
   BansAdminPageFragment: BansAdminPageFragment
   ChaptersDefaultFragment: ChaptersDefaultFragment
-  BooksDefaultFragment: BooksDefaultFragment
-  CollectionsDefaultFragment: CollectionsDefaultFragment
   ReviewVotesDefaultFragment: ReviewVotesDefaultFragment
   reviewVoteFragment: reviewVoteFragment
   reviewVoteWithUserAndPost: reviewVoteWithUserAndPost
@@ -2084,10 +2084,12 @@ interface CollectionNamesByFragmentName {
   LocalgroupsDefaultFragment: "Localgroups"
   TagRelsDefaultFragment: "TagRels"
   PostsDefaultFragment: "Posts"
+  BooksDefaultFragment: "Books"
+  CollectionsDefaultFragment: "Collections"
+  SequencesDefaultFragment: "Sequences"
   VotesDefaultFragment: "Votes"
   CommentsDefaultFragment: "Comments"
   RSSFeedsDefaultFragment: "RSSFeeds"
-  SequencesDefaultFragment: "Sequences"
   TagsDefaultFragment: "Tags"
   RevisionsDefaultFragment: "Revisions"
   PostsMinimumInfo: "Posts"
@@ -2152,8 +2154,6 @@ interface CollectionNamesByFragmentName {
   BansDefaultFragment: "Bans"
   BansAdminPageFragment: "Bans"
   ChaptersDefaultFragment: "Chapters"
-  BooksDefaultFragment: "Books"
-  CollectionsDefaultFragment: "Collections"
   ReviewVotesDefaultFragment: "ReviewVotes"
   reviewVoteFragment: "ReviewVotes"
   reviewVoteWithUserAndPost: "ReviewVotes"


### PR DESCRIPTION
Previously, if you were viewing a post in the context of a non-canonical sequence, and it was either the first or last post, trying to navigate to the previous/next post (i.e. crossing the boundary to another sequence in the collection) would take you to the post before it in its canonical sequence, rather than to the last/first post of the previous/next sequence in the contextual collection.  i.e. going "back" from `The Bottom Line`, in the Sequences Highlights (sequence: `Pitfalls of Human Cognition`) would take you to `One Argument Against An Army`, rather than `Twelve Virtues of Rationality` (as the last post of the `Thinking Better on Purpose` sequence).

This fixes that behavior.

Tested the matrix:
(first | middle | last sequence) x (first | middle | last post) x ("previous" | "next" navigation)

Confirmed that within- and cross-sequence navigation works for all sequence/post/direction combinations, and that the first & last posts in a collection (where they canonically belong to another sequence) do not have a "previous" & "next" post, respectively.

TODO: test the matrix against other cases, i.e. posts in the context of their canonical sequence, or absent a sequence context at all, to check for regressions.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202642035257399) by [Unito](https://www.unito.io)
