### PR TITLE
Fixed link in sequence search hit

### DIFF
--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -61,7 +61,7 @@ const SequencesSearchHit = ({hit, clickAction, classes, showIcon=false}: {
       {showIcon && <LWTooltip title="Sequence">
         <LocalLibraryIcon className={classes.icon}/>
       </LWTooltip>}
-      <Link to={"sequences/" + sequence._id} onClick={() => clickAction(sequence._id)}>
+      <Link to={"/sequences/" + sequence._id} onClick={() => clickAction(sequence._id)}>
         <div className="sequences-item-body ">
           <div className={classes.title}>
             {sequence.title}


### PR DESCRIPTION
When I first made the sequence search PR I only tested it from the home page. Without adding a "/" at the beginning of the url, the url is appended to the current url, which most of the time was wrong.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202652463871414) by [Unito](https://www.unito.io)
