### PR TITLE
Update slug on displayName update

### DIFF
--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -101,8 +101,11 @@ const UsersEditForm = ({terms, classes}: {
         hideFields={["paymentEmail", "paymentInfo"]}
         successCallback={async (user) => {
           flash(`User "${userGetDisplayName(user)}" edited`);
-          await client.clearStore()
-          history.push(userGetProfileUrl(user));
+          try {
+            await client.resetStore()
+          } finally {
+            history.push(userGetProfileUrl(user))
+          }
         }}
         queryFragment={getFragment('UsersEdit')}
         mutationFragment={getFragment('UsersEdit')}

--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -101,7 +101,7 @@ const UsersEditForm = ({terms, classes}: {
         hideFields={["paymentEmail", "paymentInfo"]}
         successCallback={async (user) => {
           flash(`User "${userGetDisplayName(user)}" edited`);
-          await client.resetStore()
+          await client.clearStore()
           history.push(userGetProfileUrl(user));
         }}
         queryFragment={getFragment('UsersEdit')}

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -14,6 +14,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { formGroups } from './formGroups';
 import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../reviewUtils';
 import uniqBy from 'lodash/uniqBy'
+import { slugify, Utils } from '../../vulcan-lib';
 
 export const MAX_NOTIFICATION_RADIUS = 300
 export const karmaChangeNotifierDefaultSettings = {
@@ -1426,9 +1427,16 @@ addFieldsDict(Users, {
     type: Array,
     optional: true,
     canRead: ['guests'],
-    onUpdate: ({data, oldDocument}) => {
+    onUpdate: async ({data, oldDocument}) => {
       if (data.slug && data.slug !== oldDocument.slug)  {
         return [...(oldDocument.oldSlugs || []), oldDocument.slug]
+      }
+      // The next three lines are copy-pasted from slug.onUpdate
+      if (data.displayName && data.displayName !== oldDocument.displayName) {
+        const slugForNewName = slugify(data.displayName);
+        if (!await Utils.slugIsUsed("Users", slugForNewName)) {
+          return [...(oldDocument.oldSlugs || []), oldDocument.slug]
+        }
       }
     }
   },

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -222,6 +222,12 @@ const schema: SchemaType<DbUser> = {
         }
         return slugLower;
       }
+      if (data.displayName && data.displayName !== oldDocument.displayName) {
+        const slugForNewName = slugify(data.displayName);
+        if (!await Utils.slugIsUsed("Users", slugForNewName)) {
+          return slugForNewName;
+        }
+      }
     }
   },
   

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -215,10 +215,12 @@ const schema: SchemaType<DbUser> = {
     },
     onUpdate: async ({data, oldDocument}) => {
       if (data.slug && data.slug !== oldDocument.slug) {
-        const slugIsUsed = await Utils.slugIsUsed("Users", data.slug)
+        const slugLower = data.slug.toLowerCase();
+        const slugIsUsed = await Utils.slugIsUsed("Users", slugLower)
         if (slugIsUsed) {
-          throw Error(`Specified slug is already used: ${data.slug}`)
+          throw Error(`Specified slug is already used: ${slugLower}`)
         }
+        return slugLower;
       }
     }
   },

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -41,6 +41,7 @@ import clone from 'lodash/clone';
 import isEmpty from 'lodash/isEmpty';
 import { createError } from 'apollo-errors';
 import pickBy from 'lodash/pickBy';
+import { loggerConstructor } from '../../lib/utils/logging';
 
 /**
  * Create mutation
@@ -271,6 +272,8 @@ export const updateMutator = async <T extends DbObject>({
 }> => {
   const { collectionName } = collection;
   const schema = getSchema(collection);
+  const logger = loggerConstructor(`mutators-${collectionName.toLowerCase()}-update`);
+  logger('updateMutator() begin')
 
   // If no context is provided, create a new one (so that callbacks will have
   // access to loaders)
@@ -326,6 +329,7 @@ export const updateMutator = async <T extends DbObject>({
 
   */
   if (validate) {
+    logger('vadidating')
     let validationErrors: any = [];
 
     validationErrors = validationErrors.concat(validateData(data, document, collection, context));
@@ -362,11 +366,9 @@ export const updateMutator = async <T extends DbObject>({
     let autoValue;
     const schemaField = schema[fieldName];
     if (schemaField.onUpdate) {
-      // eslint-disable-next-line no-await-in-loop
       autoValue = await schemaField.onUpdate({...properties, fieldName});
     } else if (schemaField.onEdit) {
       // OpenCRUD backwards compatibility
-      // eslint-disable-next-line no-await-in-loop
       autoValue = await schemaField.onEdit(
         dataToModifier(clone(data)),
         oldDocument,
@@ -375,6 +377,7 @@ export const updateMutator = async <T extends DbObject>({
       );
     }
     if (typeof autoValue !== 'undefined') {
+      logger(`onUpdate returned a value to update for ${fieldName}: ${autoValue}`)
       data![fieldName] = autoValue;
     }
   }

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -329,7 +329,7 @@ export const updateMutator = async <T extends DbObject>({
 
   */
   if (validate) {
-    logger('vadidating')
+    logger('validating')
     let validationErrors: any = [];
 
     validationErrors = validationErrors.concat(validateData(data, document, collection, context));


### PR DESCRIPTION
lesswrongteam let me know if you don't want this and I'll forum gate it. My argument in favor: most users who want to change their displayName also want to change their slug, many of them pretty strongly. Although I think it's reasonably to have a "formerly known as" field or something, I don't think using the slug is the right way to do it, and it should probably not be mandatory.

This PR also prevents admins from accidentally adding upper case letters to slugs, which is how I got started on this rabbit hole.

This leads to an error on the resetStore call, as apollo's attempt to rerun the `{slug: 'outdatedSlug'}` query will now fail. I decided I didn't mind the rare console error here, but I could be persuaded to find a more elegant solution. (I can't find anything in the apollo docs about removing a _query_ from the store. I could try to modify that query on the mutation result, but my attempts to do similar things in the past have been a pain, and the upside here is low.)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202654344329585) by [Unito](https://www.unito.io)
