### PR TITLE
Enforce display name uniqueness when updating

### DIFF
--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -405,3 +405,15 @@ async function sendWelcomeMessageTo(userId: string) {
     })
   }
 }
+
+getCollectionHooks("Users").updateBefore.add(async function UpdateDisplayName(data: DbUser, {oldDocument}) {
+  if (data.displayName !== undefined && data.displayName !== oldDocument.displayName) {
+    if (!data.displayName) {
+      throw new Error("You must enter a display name");
+    }
+    if (await Users.findOne({displayName: data.displayName})) {
+      throw new Error("This display name is already taken");
+    }
+  }
+  return data;
+});


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202473655524358/f)

We don't need a create hook here because the user is initially created without a display name, and then a display name is automatically set from the username chosen after being redirected back to the forum from auth0 (this will trigger the same update hook to make sure both the username and the display name are unique).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202671002894426) by [Unito](https://www.unito.io)
