### PR TITLE
Intro curriculum improvements

### DIFF
--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -74,7 +74,9 @@ const BooksItem = ({ book, canEdit, classes }: {
           <SequencesPostsList posts={book.posts} />
         </div>}
 
-        {book.sequences.map(sequence => <LargeSequencesItem key={sequence._id} sequence={sequence} />)}
+        {book.sequences.map(sequence =>
+          <LargeSequencesItem key={sequence._id} sequence={sequence} showChapters={book.showChapters} />
+        )}
       </SingleColumnSection>
       <Divider />
     </div>

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -98,12 +98,14 @@ const CollectionsPage = ({ documentId, classes }: {
             {html && <ContentItemBody dangerouslySetInnerHTML={{__html: html}} description={`collection ${document._id}`}/>}
           </ContentStyles>
 
-          <ButtonUntyped
-            className={classes.startReadingButton}
-            component={Link} to={document.firstPageLink}
-          >
-            {startedReading ? "Continue Reading" : "Start Reading"}
-          </ButtonUntyped>
+          {!collection.hideStartReadingButton &&
+            <ButtonUntyped
+              className={classes.startReadingButton}
+              component={Link} to={document.firstPageLink}
+            >
+              {startedReading ? "Continue Reading" : "Start Reading"}
+            </ButtonUntyped>
+          }
         </div>
       </SingleColumnSection>
       <div>

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -195,11 +195,11 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
         </div>
       </div>
       <div className={classes.right}>
-        {sequence.chapters?.flatMap(({posts, contents}) =>
+        {sequence.chapters?.flatMap(({posts, title, contents}) =>
           <>
             {showChapters && contents?.htmlHighlight && (
               <ContentStyles contentType="postHighlight">
-                <ContentItemBody dangerouslySetInnerHTML={{__html: contents.htmlHighlight}} />
+                <ContentItemBody dangerouslySetInnerHTML={{__html: title ?? contents.htmlHighlight}} />
               </ContentStyles>
             )}
             {posts.map((post) => (

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -134,12 +134,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
+export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=false, classes}: {
   sequence: SequencesPageWithChaptersFragment,
   showAuthor?: boolean,
+  showChapters?: boolean,
   classes: ClassesType,
 }) => {
-  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, LWTooltip } = Components
+  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, ContentItemBody, LWTooltip } = Components
   
   const [expanded, setExpanded] = useState<boolean>(false)
 
@@ -194,11 +195,21 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, classes}: {
         </div>
       </div>
       <div className={classes.right}>
-        {posts.map(post => <SequencesSmallPostLink 
-            key={sequence._id + post._id} 
-            post={post}
-            sequenceId={sequence._id}
-          />
+        {sequence.chapters?.flatMap(({posts, contents}) =>
+          <>
+            {showChapters && contents?.htmlHighlight && (
+              <ContentStyles contentType="postHighlight">
+                <ContentItemBody dangerouslySetInnerHTML={{__html: contents.htmlHighlight}} />
+              </ContentStyles>
+            )}
+            {posts.map((post) => (
+              <SequencesSmallPostLink
+                key={sequence._id + post._id}
+                post={post}
+                sequenceId={sequence._id}
+              />
+            ))}
+          </>
         )}
       </div>
     </div>

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -19,6 +19,7 @@ registerFragment(`
       ...PostsList
     }
     collectionId
+    showChapters
   }
 `);
 

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -89,7 +89,15 @@ const schema: SchemaType<DbBook> = {
     type: String,
     foreignKey: "Sequences",
     optional: true,
-  }
+  },
+
+  showChapters: {
+    type: Boolean,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['admins'],
+    insertableBy: ['admins'],
+  },
 
 }
 

--- a/packages/lesswrong/lib/collections/collections/fragments.ts
+++ b/packages/lesswrong/lib/collections/collections/fragments.ts
@@ -18,6 +18,7 @@ registerFragment(`
     books {
       ...BookPageFragment
     }
+    hideStartReadingButton
   }
 `);
 

--- a/packages/lesswrong/lib/collections/collections/schema.ts
+++ b/packages/lesswrong/lib/collections/collections/schema.ts
@@ -79,7 +79,15 @@ const schema: SchemaType<DbCollection> = {
     viewableBy: ["guests"],
     editableBy: ["admins"],
     insertableBy: ["admins"],
-  }
+  },
+
+  hideStartReadingButton: {
+    type: Boolean,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['admins'],
+    insertableBy: ['admins'],
+  },
 }
 
 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -63,6 +63,7 @@ interface DbCollection extends DbObject {
   slug: string
   gridImageId: string
   firstPageLink: string
+  hideStartReadingButton: boolean
   contents: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -34,6 +34,7 @@ interface DbBook extends DbObject {
   number: number
   postIds: Array<string>
   sequenceIds: Array<string>
+  showChapters: boolean
   contents: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -180,6 +180,7 @@ interface BooksDefaultFragment { // fragment on Books
   readonly number: number,
   readonly postIds: Array<string>,
   readonly sequenceIds: Array<string>,
+  readonly showChapters: boolean,
 }
 
 interface CollectionsDefaultFragment { // fragment on Collections
@@ -1304,6 +1305,7 @@ interface BookPageFragment { // fragment on Books
   readonly postIds: Array<string>,
   readonly posts: Array<PostsList>,
   readonly collectionId: string,
+  readonly showChapters: boolean,
 }
 
 interface BookEdit extends BookPageFragment { // fragment on Books

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -190,6 +190,7 @@ interface CollectionsDefaultFragment { // fragment on Collections
   readonly slug: string,
   readonly gridImageId: string,
   readonly firstPageLink: string,
+  readonly hideStartReadingButton: boolean,
 }
 
 interface SequencesDefaultFragment { // fragment on Sequences
@@ -1323,6 +1324,7 @@ interface CollectionsPageFragment { // fragment on Collections
   readonly firstPageLink: string,
   readonly gridImageId: string,
   readonly books: Array<BookPageFragment>,
+  readonly hideStartReadingButton: boolean,
 }
 
 interface CollectionsEditFragment extends CollectionsPageFragment { // fragment on Collections


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202662252311003/f)

This PR implements 2 features for the intro curriculum collection page requested by Jesse:


* Showing chapter names
* Hiding the 'Start Reading' button

It's slightly inconsistent that one setting is 'show' whilst the other is 'hide'. In an ideal world they'd both match, but I choose to do it like this for the sake of backwards compatability with LW and so that we don't need to run a migration.

Showing chapter names:
![](https://user-images.githubusercontent.com/5075628/181063145-52211a2c-e8fd-42f7-afc2-dc37345d7b43.png)

Hiding the 'Start Reading' button:
![](https://user-images.githubusercontent.com/5075628/181063214-211e0295-406c-4ea0-8144-98e90c40ba1c.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202671022343464) by [Unito](https://www.unito.io)
