### PR TITLE
Make the restore-saved-content notice more prominent

### DIFF
--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -8,6 +8,16 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.commentStyle,
     color: theme.palette.text.normal,
     paddingBottom: 12,
+    
+    border: theme.palette.border.normal,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: theme.palette.panelBackground.restoreSavedContentNotice,
+    margin: 10,
+    
+    "& a": {
+      textDecoration: "underline",
+    }
   },
   restoreLink: {
     color: theme.palette.lwTertiary.main,

--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -7,13 +7,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.commentStyle,
     color: theme.palette.text.normal,
-    paddingBottom: 12,
     
     border: theme.palette.border.normal,
     padding: 8,
-    borderRadius: 8,
+    borderRadius: 4,
     backgroundColor: theme.palette.panelBackground.restoreSavedContentNotice,
-    margin: 10,
+    marginTop: 10,
+    marginBottom: 10,
     
     "& a": {
       textDecoration: "underline",

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -335,6 +335,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     singleLineCommentOddHovered: shades.grey[110],
     sequenceImageGradient: 'linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 42%, rgba(255, 255, 255, 0) 100%)',
     sequencesBanner: shades.greyAlpha(.5),
+    restoreSavedContentNotice: "rgba(255,0,0,.1)",
   },
   boxShadow: {
     default: `0 1px 5px ${shades.boxShadowColor(.025)}`,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -236,6 +236,7 @@ declare global {
       singleLineCommentOddHovered: ColorString,
       sequenceImageGradient: string,
       sequencesBanner: ColorString,
+      restoreSavedContentNotice: ColorString,
     },
     boxShadow: {
       default: string,


### PR DESCRIPTION
In response to a user having overlooked the restore-saved-content button (which is pretty subtle), make it more prominent. Screenshot:

![Screen Shot 2022-07-26 at 16 36 42](https://user-images.githubusercontent.com/101191/181130094-22939761-65a4-4e5f-93e1-2820f3f8b153.png)

This is against `lw-deploy` because in `master` the localStorage works differently (an on-page-load modal popup which is a little broken).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202673132004235) by [Unito](https://www.unito.io)
