### PR TITLE
Reset autosave after publication

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -425,6 +425,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
   resetEditor = () => {
     const { name, document } = this.props;
     // On Form submit, create a new empty editable
+    this.setEditorValue("");
     this.getStorageHandlers().reset({doc: document, name, prefix:this.getLSKeyPrefix()})
     this.setState({
       draftJSValue: EditorState.createEmpty(),

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -241,13 +241,13 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
     const Editor = EditorModule.default
     this.ckEditor = Editor
     this.setState({ckEditorLoaded: true})
-    
+
     if (isClient) {
       this.restoreFromLocalStorage();
       this.setState({loading: false})
     }
   }
-  
+
   setEditorValue(newValue: string) {
     const html = markdownToHtmlSimple(newValue)
     this.setState({
@@ -327,7 +327,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
       this.setState(savedState);
     }
   }
-  
+
   isEmpty = (): boolean => {
     switch(this.getCurrentEditorType()) {
       case "draftJS": {
@@ -360,7 +360,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
   getStorageHandlers = () => {
     const { fieldName, form } = this.props
     const collectionName = form.collectionName;
-    
+
     const getLocalStorageId = editableCollectionsFieldOptions[collectionName][fieldName].getLocalStorageId;
     return getLSHandlers(getLocalStorageId)
   }
@@ -425,7 +425,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
   resetEditor = () => {
     const { name, document } = this.props;
     // On Form submit, create a new empty editable
-    this.setEditorValue("");
+    this.state.ckEditorReference?.setData("");
     this.getStorageHandlers().reset({doc: document, name, prefix:this.getLSKeyPrefix()})
     this.setState({
       draftJSValue: EditorState.createEmpty(),
@@ -506,14 +506,14 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
       this.hasUnsavedData = false;
     } else {
       const serialized = this.editorContentsToJson();
-  
+
       const success = this.getStorageHandlers().set({
         state: serialized,
         doc: document,
         name,
         prefix: this.getLSKeyPrefix()
       });
-  
+
       if (success) {
         this.hasUnsavedData = false;
       }
@@ -574,7 +574,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
   getCurrentEditorType = () => {
     // Tags can only be edited via CKEditor
     if (this.props.collectionName === 'Tags') return "ckEditorMarkup"
-    
+
     const { editorOverride } = this.state || {} // Provide default since we can call this function before we initialize state
 
     // If there is an override, return that
@@ -625,18 +625,18 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
       <MenuItem value={'patch'}>Patch</MenuItem>
     </Select>
   }
-  
+
   renderCommitMessageInput = () => {
     const { currentUser, formType, fieldName, form, classes } = this.props
-    
+
     const collectionName = form.collectionName;
     if (!currentUser || (!userCanCreateCommitMessages(currentUser) && collectionName !== "Tags") || formType !== "edit") { return null }
-    
-    
+
+
     const fieldHasCommitMessages = editableCollectionsFieldOptions[collectionName][fieldName].revisionsHaveCommitMessages;
     if (!fieldHasCommitMessages) return null;
     if (form.hideControls) return null
-    
+
     return <div className={classes.changeDescriptionRow}>
       <span className={classes.changeDescriptionLabel}>Edit summary (Briefly describe your changes):{" "}</span>
       <Input
@@ -656,9 +656,9 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
     if (form.hideControls) return null
     if (!currentUser?.reenableDraftJs && !currentUser?.isAdmin) return null
     const editors = currentUser?.isAdmin ? adminEditors : nonAdminEditors
-    
+
     const tooltip = collectionName === 'Tags' ? `Tags can only be edited in the ${ckEditorName} editor` : "Warning! Changing format will erase your content"
-    
+
     return (
       <LWTooltip title={tooltip} placement="left">
         <Select
@@ -778,7 +778,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
     const { classes, document, form: { commentStyles } } = this.props
     const value = (editorType === "html" ? htmlValue : markdownValue) || ""
     const {className, contentType} = this.getBodyStyles();
-    
+
     return <div>
       { this.renderPlaceholder(!value, false) }
       <Components.ContentStyles contentType={contentType}>


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202410434172092/f)

Originally I thought this was a feature request, but it turned out to just be a bugfix.
`this.getStorageHandlers().reset` already clears the session storage, but we then call `this.setState` which triggers a callback chain and resets the value in session storage using the value cached by the editor. We can prevent this from happening by simply clearing the cached value to an empty string first.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202676768502606) by [Unito](https://www.unito.io)
