### PR TITLE
Switch preview back to save

### DIFF
--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -53,6 +53,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   collabModeSelect: {
   },
   saveStatus: {
+    '&:hover': {
+      background: "unset"
+    }
   },
 });
 
@@ -65,8 +68,8 @@ const EditorTopBar = ({presenceListRef, accessLevel, collaborationMode, setColla
   setCollaborationMode: (mode: CollaborationMode)=>void,
   classes: ClassesType
 }) => {
-  const availableModes = ["Viewing","Commenting","Editing"]; //TODO: Filter by permissions
-  
+  const { LWTooltip } = Components
+
   return <div className={classes.editorTopBar}>
     <div className={classes.presenceList} ref={presenceListRef}/>
     
@@ -93,10 +96,12 @@ const EditorTopBar = ({presenceListRef, accessLevel, collaborationMode, setColla
       </MenuItem>
     </Select>
     
-    <Button className={classes.saveStatus}>
-      Saved
-      {/*TODO: Make this track offline status etc*/}
-    </Button>
+    <LWTooltip title="Collaborative docs automatically save all changes">
+      <Button className={classes.saveStatus}>
+        Auto-Saved
+        {/*TODO: Make this track offline status etc*/}
+      </Button>
+    </LWTooltip>
   </div>
 }
 

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -37,7 +37,6 @@ const PostsEditForm = ({ documentId, classes }: {
   const saveDraftLabel: string = ((post) => {
     if (!post) return "Save Draft"
     if (!post.draft) return "Move to Drafts"
-    if (isCollaborative(post, "contents")) return "Preview"
     return "Save Draft"
   })(document)
   


### PR DESCRIPTION
Part of the Collaborative editor feature was to change the phrase "Save Draft" to "Preview", which was meant to help convey that collaborative docs autosave. I personally find this confusing, because it is still totally a thing that I sometimes want to save drafts (which get logged as minor updates rather than patches, and which update the actual post document, which doesn't necessarily happen when autosaving in collaborative mode)

This PR reverts that, but also updates the "saved" text at the top of the page to say "Auto Saved", and with a hoverover saying a bit more about how collaborative editor autosaves. Also fixes unnecessary hover-highlight for the "saved" "button" which isn't really clickable.

![](https://user-images.githubusercontent.com/3246710/181656196-a68aaeb1-af24-413e-b575-317d19239d68.png)

![](https://user-images.githubusercontent.com/3246710/181656205-66423d75-8036-4114-9180-daaae9833067.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202687007383798) by [Unito](https://www.unito.io)
