### PR TITLE
Fix text spacing on EA handbook page

### DIFF
--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -51,6 +51,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.postStyle,
     marginBottom: 12
   },
+  eaDescription: {
+    fontSize: "1rem",
+  },
   author: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
@@ -105,7 +108,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: "45%",
     display: "flex",
     flexDirection: "column",
-    justifyContent: "center",
+    justifyContent: forumTypeSetting.get() === "EAForum" ? "flex-start" : "center",
     maxHeight: 600,
     [theme.breakpoints.down('xs')]: {
       width: "100%",
@@ -141,7 +144,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
   classes: ClassesType,
 }) => {
   const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, ContentItemBody, LWTooltip } = Components
-  
+
   const [expanded, setExpanded] = useState<boolean>(false)
 
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
@@ -178,7 +181,10 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
               by <UsersName user={sequence.user} />
             </div>}
           </div>
-          {(highlight.length > 0) && <ContentStyles contentType="postHighlight" className={classes.description}>
+          {(highlight.length > 0) && <ContentStyles
+            contentType="postHighlight"
+            className={classNames(classes.description, {[classes.eaDescription]: forumTypeSetting.get() === "EAForum"})}
+          >
             <ContentItemTruncated
               maxLengthWords={100}
               graceWords={20}


### PR DESCRIPTION
This PR fixes some small spacing issues on the handbook page reported by Max on Slack. The changes are localised to the EA forum.