### PR TITLE
Return 404 on disallowed draft access

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useSingle } from '../../../lib/crud/withSingle';
-import { isMissingDocumentError } from '../../../lib/utils/errorUtil';
+import { isMissingDocumentError, isOperationNotAllowedError } from '../../../lib/utils/errorUtil';
 
 const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   sequenceId: string|null,
@@ -30,7 +30,7 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   })
 
   const { Error404, Loading, PostsPage } = Components;
-  if (error && !isMissingDocumentError(error)) {
+  if (error && !isMissingDocumentError(error) && !isOperationNotAllowedError(error)) {
     throw new Error(error.message);
   } else if (loading) {
     return <div><Loading/></div>

--- a/packages/lesswrong/lib/utils/errorUtil.ts
+++ b/packages/lesswrong/lib/utils/errorUtil.ts
@@ -23,3 +23,7 @@ export function getGraphQLErrorMessage(error: any): string {
 export function isMissingDocumentError(error: any): boolean {
   return (error && error.message==='app.missing_document');
 }
+
+export function isOperationNotAllowedError(error: any): boolean {
+  return (error && error.message==='app.operation_not_allowed');
+}


### PR DESCRIPTION
Previously you got an app.operation_not_allowed error. Normal site behavior is to return 404 in these cases, usually to avoid leaking the information about whether a page by that name even exists. In our case, I think it's just a better user experience, though I could be convinced we should return a custom page. The current experience where you get an angry red error message in machine readable language I definitely don't like.