### PR TITLE
BooksItem subtitle is above progress

### DIFF
--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -59,10 +59,12 @@ const BooksItem = ({ book, canEdit, classes }: {
         <SectionTitle title={book.title}>
           {canEdit && <SectionButton><a onClick={showEdit}>Edit</a></SectionButton>}
         </SectionTitle>
+        {book.subtitle && <div className={classes.subtitle}>{book.subtitle}</div>}
+
         <AnalyticsContext pageElementContext="booksProgressBar">
           <BooksProgressBar book={book} />
         </AnalyticsContext>
-        <div className={classes.subtitle}>{book.subtitle}</div>
+
         {html  && <ContentStyles contentType="post" className={classes.description}>
           <ContentItemBody
             dangerouslySetInnerHTML={{__html: html}}

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -7,7 +7,7 @@ import { useItemsRead } from '../common/withRecordPostView';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    display: "inline"
+    marginBottom: 16
   },
   postProgressBox: {
     border: theme.palette.border.normal,


### PR DESCRIPTION
Previously the BooksProgressBar was accidentally positioned above the subtitle, so it looked like this:

![](https://user-images.githubusercontent.com/3246710/182261988-f5d9f9d9-594d-4fbf-9b0e-d255a8ef97f1.png)

Now it looks like this instead:

![](https://user-images.githubusercontent.com/3246710/182261923-ae5958ba-a8ce-4183-8a24-9e70c7080120.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202704024066734) by [Unito](https://www.unito.io)
