### PR TITLE
Two-line version of events sidebar and restyle LW sidebar

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -23,10 +23,17 @@ const styles = (theme: ThemeType): JssStyles => ({
       opacity:.6,
       backgroundColor: 'transparent' // Prevent MUI default behavior of rendering solid background on hover
     },
-    paddingTop: theme.spacing.unit*2,
-    paddingBottom: theme.spacing.unit*2,
-    paddingLeft: theme.spacing.unit*2,
-    paddingRight: theme.spacing.unit*2,
+    
+    ...(theme.forumType === "LessWrong"
+      ? {
+        paddingTop: 7,
+        paddingBottom: 8,
+        paddingLeft: 16,
+        paddingRight: 16,
+      } : {
+        padding: 16,
+      }
+    ),
     display: "flex",
     alignItems: "center",
     justifyContent: "flex-start",
@@ -45,12 +52,16 @@ const styles = (theme: ThemeType): JssStyles => ({
     opacity: .3,
     width: iconWidth,
     height: 28,
-    marginRight: theme.spacing.unit*2,
+    marginRight: 16,
     display: "inline",
     
     "& svg": {
       fill: "currentColor",
       color: theme.palette.icon.navigationSidebarIcon,
+      ...(theme.forumType === "LessWrong"
+        ? { transform: "scale(0.8)" }
+        : {}
+      ),
     },
   },
   navText: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -86,6 +86,14 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnMobileStandalone: true,
       showOnCompressed: true,
     }, {
+      id: 'allPosts',
+      title: 'All Posts',
+      link: '/allPosts',
+      icon: allPostsIcon,
+      tooltip: 'See all posts, filtered and sorted however you like.',
+      showOnMobileStandalone: true,
+      showOnCompressed: true,
+    }, {
       id: 'concepts',
       title: 'Concepts',
       mobileTitle: 'Concepts',
@@ -155,36 +163,12 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'eventsList',
       customComponentName: "EventsList",
     }, {
-      id: 'allPosts',
-      title: 'All Posts',
-      link: '/allPosts',
-      icon: allPostsIcon,
-      tooltip: 'See all posts, filtered and sorted however you like.',
-      showOnMobileStandalone: true,
-      showOnCompressed: true,
-    }, {
       id: 'divider',
       divider: true,
       showOnCompressed: true,
     }, {
       id: 'subscribeWidget',
       customComponentName: "SubscribeWidget",
-    }, {
-      id: 'questions',
-      title: 'Open Questions',
-      mobileTitle: 'Questions',
-      link: '/questions',
-      tooltip: <div>
-        <div>• Ask simple newbie questions.</div>
-        <div>• Collaborate on open research questions.</div>
-        <div>• Pose and resolve confusions.</div>
-      </div>,
-      subItem: true
-    }, {
-      id: 'contact',
-      title: 'Contact Us',
-      link: '/contact',
-      subItem: true,
     }, {
       id: 'about',
       title: 'About',
@@ -197,11 +181,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       title: 'FAQ',
       link: '/faq',
       subItem: true,
-    }, {
-      id: 'donate',
-      title: "Donate",
-      link: '/donate',
-      subItem: true
     }
   ],
   AlignmentForum: [

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -31,10 +31,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     height: "auto",
   },
   city: {
-    marginRight: 8,
+    marginLeft: 6,
   },
   date: {
-    marginLeft: 8,
+    marginRight: 6,
   },
   displayTime: {
     fontSize: ".85rem",
@@ -195,11 +195,11 @@ const TabNavigationEventTwoLines = ({event, onClick, classes}: {
       <span className={classes.title}>{event.title}</span>
       <div/>
       <span className={classes.secondLine}>
-        {cityName && <>
-          <span className={classes.city}>{cityName}</span>
-          {"•"}
-        </>}
         <span className={classes.date}>{shortDate}</span>
+        {cityName && <>
+          {"•"}
+          <span className={classes.city}>{cityName}</span>
+        </>}
       </span>
     </TabNavigationSubItem>
   </MenuItemUntyped>

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -90,8 +90,11 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis",
   },
   twoLineEvent: {
-    lineHeight: "1.2rem !important",
+    lineHeight: "1.3rem !important",
   },
+  dot: {
+    color: theme.palette.grey[500]
+  }
 }))
 
 
@@ -197,7 +200,7 @@ const TabNavigationEventTwoLines = ({event, onClick, classes}: {
       <span className={classes.secondLine}>
         <span className={classes.date}>{shortDate}</span>
         {cityName && <>
-          {"•"}
+          <span className={classes.dot}>{"•"}</span>
           <span className={classes.city}>{cityName}</span>
         </>}
       </span>

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -90,7 +90,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis",
   },
   twoLineEvent: {
-    lineHeight: "1.2rem",
+    lineHeight: "1.2rem !important",
   },
 }))
 

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -8,6 +8,8 @@ import { createStyles } from '@material-ui/core/styles'
 import moment from '../../lib/moment-timezone';
 import { useTimezone } from '../common/withTimezone';
 import { truncate } from '../../lib/editor/ellipsize';
+import { twoLineEventsSidebarABTest } from '../../lib/abTests';
+import { useABTest } from '../../lib/abTestImpl';
 import classNames from 'classnames';
 
 const YESTERDAY_STRING = "[Yesterday]"
@@ -16,7 +18,7 @@ const TOMORROW_STRING = "[Tomorrow]"
 const HIGHLIGHT_LENGTH = 600
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
-  subItemOverride: {
+  eventWrapper: {
     paddingTop: 0,
     paddingBottom: 0,
     paddingLeft: 0,
@@ -24,6 +26,15 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     '&:hover': {
       backgroundColor: 'transparent' // Prevent MUI default behavior of rendering solid background on hover
     }
+  },
+  twoLine: {
+    height: "auto",
+  },
+  city: {
+    marginRight: 8,
+  },
+  date: {
+    marginLeft: 8,
   },
   displayTime: {
     fontSize: ".85rem",
@@ -77,7 +88,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   event: {
     textOverflow: "ellipsis",
-  }
+  },
+  twoLineEvent: {
+    lineHeight: "1.2rem",
+  },
 }))
 
 
@@ -86,7 +100,6 @@ const TabNavigationEventsList = ({ terms, onClick, classes }: {
   onClick: ()=>void,
   classes: ClassesType,
 }) => {
-  const { timezone } = useTimezone();
   const { results } = useMulti({
     terms,
     collectionName: "Posts",
@@ -94,79 +107,149 @@ const TabNavigationEventsList = ({ terms, onClick, classes }: {
     enableTotal: false,
     fetchPolicy: 'cache-and-network',
   });
-  const { TabNavigationSubItem, EventTime, LWTooltip } = Components
+
+  const abTestGroup = useABTest(twoLineEventsSidebarABTest);
+  const EventComponent = (abTestGroup === "expanded") ? TabNavigationEventTwoLines : TabNavigationEventSingleLine;
+  const {LWTooltip} = Components;
 
   if (!results) return null
-
-  // MenuItem takes a component and passes unrecognized props to that component,
-  // but its material-ui-provided type signature does not include this feature.
-  // Case to any to work around it, to be able to pass a "to" parameter.
-  const MenuItemUntyped = MenuItem as any;
   
-  return (
-    <div>
-      {results.map((event) => {
-
-        const startTime = event.startTime && moment(event.startTime).tz(timezone)
-
-        const displayTime = startTime ? startTime.calendar(undefined, {
-          sameDay: `[${TODAY_STRING}]`,
-          nextDay: `[${TOMORROW_STRING}]`,
-          nextWeek: ' ',
-          lastDay: `[${YESTERDAY_STRING}]`,
-          lastWeek: ' ',
-          sameElse: ' ',
-        }) : ' '
-
-        const { htmlHighlight = "" } = event.contents || {}
-
-        const highlight = truncate(htmlHighlight, HIGHLIGHT_LENGTH)
-
-        const tooltip = <div>
-            {event.group && <div className={classes.tooltipGroup}>{event.group.name}</div>}
-            <div className={classes.tooltipTitle}>{event.title}</div>
-            <div className={classes.tooltipLogisticsTitle}>
-              {event.onlineEvent ? "Online Event" : "Location"}
-            </div>
-            {!event.onlineEvent && <div>{event.location}</div>}
-            <div className={classes.tooltipLogisticsTitle}>Time</div>
-            <div>
-              {event.startTime
-                ? <EventTime post={event} />
-                : <span>Start time TBD</span>}
-            </div>
-            {highlight && <React.Fragment>
-                <div className={classes.tooltipDivider} />
-                <div className={classes.tooltipLogisticsTitle}>Description</div>
-                <div dangerouslySetInnerHTML={{__html: highlight}} className={classes.highlight} />
-              </React.Fragment>}
-          </div>
-        return (
-          <LWTooltip key={event._id} placement="right-start" title={tooltip}>
-            <MenuItemUntyped
-              onClick={onClick}
-              component={Link} to={postGetPageUrl(event)}
-              classes={{root: classes.subItemOverride}}
-            >
-              <TabNavigationSubItem className={classes.event}>
-                {(displayTime && displayTime !== " ") && <span className={classNames(
-                    classes.displayTime, {[classes.yesterday]: displayTime === YESTERDAY_STRING})
-                  }>
-                    {displayTime}
-                </span>} 
-                <span className={classes.title}>{event.title}</span>
-              </TabNavigationSubItem>
-            </MenuItemUntyped>
-          </LWTooltip>
-        )
-      })}
-    </div>
-  )
+  return <div>
+    {results.map((event) =>
+      <LWTooltip
+        key={event._id}
+        placement="right-start"
+        title={<EventSidebarTooltip event={event} classes={classes}/>}
+      >
+        <EventComponent
+          event={event}
+          onClick={onClick}
+          classes={classes}
+        />
+      </LWTooltip>)}
+  </div>
 }
 
-const TabNavigationEventsListComponent = registerComponent('TabNavigationEventsList', TabNavigationEventsList, {
-  styles,
-});
+const TabNavigationEventSingleLine = ({event, onClick, classes}: {
+  event: PostsList,
+  onClick: ()=>void,
+  classes: ClassesType,
+}) => {
+  const { timezone } = useTimezone();
+  const { TabNavigationSubItem } = Components
+  
+  // MenuItem takes a component and passes unrecognized props to that component,
+  // but its material-ui-provided type signature does not include this feature.
+  // Cast to any to work around it, to be able to pass a "to" parameter.
+  const MenuItemUntyped = MenuItem as any;
+  
+  const startTime = event.startTime && moment(event.startTime).tz(timezone)
+
+  const displayTime = startTime ? startTime.calendar(undefined, {
+    sameDay: `[${TODAY_STRING}]`,
+    nextDay: `[${TOMORROW_STRING}]`,
+    nextWeek: ' ',
+    lastDay: `[${YESTERDAY_STRING}]`,
+    lastWeek: ' ',
+    sameElse: ' ',
+  }) : ' '
+
+  return <MenuItemUntyped
+    onClick={onClick}
+    component={Link} to={postGetPageUrl(event)}
+    classes={{root: classes.eventWrapper}}
+  >
+    <TabNavigationSubItem className={classes.event}>
+      {(displayTime && displayTime !== " ") && <span className={classNames(
+        classes.displayTime, {[classes.yesterday]: displayTime === YESTERDAY_STRING})
+      }>
+        {displayTime}
+      </span>}
+      <span className={classes.title}>{event.title}</span>
+    </TabNavigationSubItem>
+  </MenuItemUntyped>
+}
+
+const TabNavigationEventTwoLines = ({event, onClick, classes}: {
+  event: PostsList,
+  onClick: ()=>void,
+  classes: ClassesType,
+}) => {
+  const { timezone } = useTimezone();
+  const MenuItemUntyped = MenuItem as any; //See comment in TabNavigationEventSingleLine 
+  const { TabNavigationSubItem } = Components
+  
+  const cityName = event.onlineEvent ? "Online" : getCityName(event)
+  const shortDate = event.startTime && moment(event.startTime)
+    .tz(timezone)
+    .format("ddd MMM D");
+  
+  return <MenuItemUntyped
+    onClick={onClick}
+    component={Link} to={postGetPageUrl(event)}
+    classes={{
+      root: classNames(classes.eventWrapper, classes.twoLine)
+    }}
+  >
+    <TabNavigationSubItem className={classNames(classes.event, classes.twoLineEvent)}>
+      <span className={classes.title}>{event.title}</span>
+      <div/>
+      <span className={classes.secondLine}>
+        {cityName && <>
+          <span className={classes.city}>{cityName}</span>
+          {"•"}
+        </>}
+        <span className={classes.date}>{shortDate}</span>
+      </span>
+    </TabNavigationSubItem>
+  </MenuItemUntyped>
+}
+
+function getCityName(event: PostsList): string|null {
+  if (event.googleLocation) {
+    const locationTypePreferenceOrdering = ["locality", "political", "country"];
+    for (let locationType of locationTypePreferenceOrdering) {
+      for (let addressComponent of event.googleLocation.address_components) {
+        if (addressComponent.types.indexOf(locationType) >= 0)
+          return addressComponent.long_name;
+      }
+    }
+    return null;
+  } else {
+    return "Online";
+  }
+}
+
+const EventSidebarTooltip = ({event, classes}: {
+  event: PostsList,
+  classes: ClassesType,
+}) => {
+  const { htmlHighlight = "" } = event.contents || {}
+  const highlight = truncate(htmlHighlight, HIGHLIGHT_LENGTH)
+  const { EventTime } = Components;
+
+  return <div>
+    {event.group && <div className={classes.tooltipGroup}>{event.group.name}</div>}
+    <div className={classes.tooltipTitle}>{event.title}</div>
+    <div className={classes.tooltipLogisticsTitle}>
+      {event.onlineEvent ? "Online Event" : "Location"}
+    </div>
+    {!event.onlineEvent && <div>{event.location}</div>}
+    <div className={classes.tooltipLogisticsTitle}>Time</div>
+    <div>
+      {event.startTime
+        ? <EventTime post={event} />
+        : <span>Start time TBD</span>}
+    </div>
+    {highlight && <React.Fragment>
+        <div className={classes.tooltipDivider} />
+        <div className={classes.tooltipLogisticsTitle}>Description</div>
+        <div dangerouslySetInnerHTML={{__html: highlight}} className={classes.highlight} />
+      </React.Fragment>}
+  </div>
+}
+
+const TabNavigationEventsListComponent = registerComponent('TabNavigationEventsList', TabNavigationEventsList, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -64,3 +64,18 @@ export const welcomeBoxABTest = new ABTest({
     }
   }
 });
+
+export const twoLineEventsSidebarABTest = new ABTest({
+  name: "twoLineEventsSidebar",
+  description: "Events sidebar shows more information",
+  groups: {
+    control: {
+      description: "One line per event",
+      weight: 1,
+    },
+    expanded: {
+      description: "Two lines per event",
+      weight: 1,
+    },
+  },
+});

--- a/packages/lesswrong/themes/forumTheme.ts
+++ b/packages/lesswrong/themes/forumTheme.ts
@@ -3,6 +3,7 @@ import { baseTheme } from './createThemeDefaults';
 import { createMuiTheme, Theme as MuiThemeType } from '@material-ui/core/styles';
 import { getUserTheme } from './userThemes/index';
 import { getSiteTheme } from './siteThemes/index';
+import type { ForumTypeString } from '../lib/instanceSettings';
 import deepmerge from 'deepmerge';
 
 const themeCache = new Map<string,ThemeType>();
@@ -19,14 +20,14 @@ export const getForumTheme = (themeOptions: ThemeOptions): MuiThemeType&ThemeTyp
   if (!themeCache.has(themeCacheKey)) {
     const siteTheme = getSiteTheme(forumType);
     const userTheme = getUserTheme(themeOptions.name);
-    const theme = buildTheme(userTheme, siteTheme);
+    const theme = buildTheme(userTheme, siteTheme, forumType);
     themeCache.set(themeCacheKey, theme);
   }
   
   return themeCache.get(themeCacheKey)! as any;
 }
 
-const buildTheme = (userTheme: UserThemeSpecification, siteTheme: SiteThemeSpecification): ThemeType => {
+const buildTheme = (userTheme: UserThemeSpecification, siteTheme: SiteThemeSpecification, forumType: ForumTypeString): ThemeType => {
   let shadePalette: ThemeShadePalette = baseTheme.shadePalette;
   if (siteTheme.shadePalette) shadePalette = deepmerge(shadePalette, siteTheme.shadePalette);
   if (userTheme.shadePalette) shadePalette = deepmerge(shadePalette, userTheme.shadePalette);
@@ -41,6 +42,10 @@ const buildTheme = (userTheme: UserThemeSpecification, siteTheme: SiteThemeSpeci
   if (siteTheme.make) combinedTheme = deepmerge(combinedTheme, siteTheme.make(palette));
   if (userTheme.make) combinedTheme = deepmerge(combinedTheme, userTheme.make(palette));
   
-  let themeWithPalette = {...combinedTheme, palette};
+  let themeWithPalette = {
+    forumType,
+    ...combinedTheme,
+    palette
+  };
   return createMuiTheme(themeWithPalette as any) as any;
 }

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line no-restricted-imports
 import type { Color as MuiColorShades } from '@material-ui/core';
 import type { PartialDeep, Merge } from 'type-fest'
+import type { ThemeOptions } from './themeNames';
+import type { ForumTypeString } from '../lib/instanceSettings';
 
 declare global {
   type BreakpointName = "xs"|"sm"|"md"|"lg"|"xl"|"tiny"
@@ -337,6 +339,8 @@ declare global {
   type ThemePalette = Merge<ThemeShadePalette,ThemeComponentPalette>
   
   type ThemeType = {
+    forumType: ForumTypeString,
+    
     breakpoints: {
       down:  (breakpoint: BreakpointName|number)=>string,
       up: (breakpoint: BreakpointName|number)=>string,


### PR DESCRIPTION
The left sidebar of the front page shows nearby events, but it's not very useful because you can't look at it and tell whether the events are near you and on a day when you'll be free. This PR redesigns the sidebar so that there are now two lines per event rather than one, with the second line showing the city name and the date.

This is set up as an A/B test; half of users will see no change, half of users will see the modified version. I'll consider it successful if people in the modified-sidebar group click through and RSVP to events at a noticeably higher rate. (Reminder, you can see and override your A/B test groups by going to `/abTestGroups`)

In addition, for LW only (other forums not affected), this changes the order of some sidebar items, tweaks padding and icon sizes, and removes some less-used links from the bottom in order to make the sidebar less overwhelming.

There's also a change to theme-wiring to allow conditioning on site name within a styles block, without having to fully extract things into the site theme. (Open to architecture discussion, it's plausible that we shouldn't branch like this and should just always put stuff in the site theme.)

Screenshot:

![Screen Shot 2022-08-03 at 11 29 11](https://user-images.githubusercontent.com/101191/182682531-8909154e-e393-4517-8fca-fa8d84aa6ca9.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202705293286118) by [Unito](https://www.unito.io)
