### PR TITLE
fix book ordering for post navigation within a collection

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -65,7 +65,7 @@ const getSequenceCollectionBooks = async function(sequenceId: string) {
 
   const { _id: collectionId } = collection;
 
-  return Books.find({ collectionId }).fetch();
+  return Books.find({ collectionId }, { sort: { number: 1 } }).fetch();
 }
 
 const getSurroundingSequencePostIdTuples = async function (sequenceId: string, context: ResolverContext) {


### PR DESCRIPTION
A user reported that post navigation was incorrect when going to the next post from "The Ritual": it was taking them to "Beginnings: An Introduction", which was the first post in the last book in R:A-Z, rather than "Minds: An Introduction", which was the first post in the correct "next" book.

Wrong behavior:
![](https://user-images.githubusercontent.com/2136984/182457782-565cc6f9-137d-4efe-872f-0ee88c3dbab3.png)

Correct behavior:
![](https://user-images.githubusercontent.com/2136984/182457809-729469a1-f250-4560-8f8f-90f881b658b0.png)

Also confirmed that none of the previous test cases from the first PR attempting to fix the navigation broke.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202710651780213) by [Unito](https://www.unito.io)
