### PR TITLE
fix karma threshold rounding cutoffs.

### DIFF
--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -29,12 +29,16 @@ export const getMeta = (url: string) => {
   };
 };
 
+type KarmaThreshold = 2 | 30 | 45 | 75 | 125 | 200;
+
 // LESSWRONG - this was added to handle karmaThresholds
-const roundKarmaThreshold = (threshold: number) =>
+const roundKarmaThreshold = (threshold: number): KarmaThreshold =>
     (threshold < 16 || !threshold) ? 2
   : (threshold < 37) ? 30
   : (threshold < 60) ? 45
-  : 75;
+  : (threshold < 100) ? 75
+  : (threshold < 162) ? 125
+  : 200;
 
 export const servePostRSS = async (terms: RSSTerms, url?: string) => {
   // LESSWRONG - this was added to handle karmaThresholds


### PR DESCRIPTION
Co-authored-by: Will Howard <w.howard256+github@gmail.com>

User reported that setting a karma threshold of 125 on an exported RSS feed resulted in posts with >75 karma being included in the feed.  Seems like the karma threshold cutoffs hadn't been updated to account for the higher levels of karma available as selections for RSS feeds.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202710592412451) by [Unito](https://www.unito.io)
