### PR TITLE
New feature tooltip 2

### DIFF
--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { useHover } from './withHover';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import classNames from 'classnames';
+
+const HANDLE_SIZE = 9; // Should be an odd number
+const ARROW_SIZE = 8;
+
+const styles = (theme: ThemeType): JssStyles => ({
+  container: {
+    display: 'inline-block',
+    position: 'relative',
+  },
+  tooltip: {
+    background: theme.palette.lwTertiary.main,
+  },
+  'tooltip-left': {
+    marginRight: ARROW_SIZE,
+  },
+  'tooltip-right': {
+    marginLeft: ARROW_SIZE,
+  },
+  'tooltip-top': {
+    marginBottom: ARROW_SIZE,
+  },
+  'tooltip-bottom': {
+    marginTop: ARROW_SIZE,
+  },
+  content: {
+    maxWidth: 250,
+  },
+  handle: {
+    cursor: 'pointer',
+    position: 'absolute',
+    width: HANDLE_SIZE,
+    height: HANDLE_SIZE,
+    borderRadius: '50%',
+    margin: `${-Math.floor(HANDLE_SIZE / 2)}px 0 0 ${-Math.floor(HANDLE_SIZE / 2)}px`,
+    background: theme.palette.lwTertiary.main,
+  },
+  'handle-left': {
+    left: 0,
+    top: '50%',
+  },
+  'handle-right': {
+    right: -Math.floor(HANDLE_SIZE / 2),
+    top: '50%',
+  },
+  'handle-top': {
+    left: '50%',
+    top: 0,
+  },
+  'handle-bottom': {
+    left: '50%',
+    bottom: -Math.floor(HANDLE_SIZE / 2),
+  },
+  arrow: {
+    background: theme.palette.lwTertiary.main,
+    position: 'absolute',
+    '&:after': {
+      content: '""',
+      position: 'absolute',
+      border: `${ARROW_SIZE}px solid transparent`,
+    },
+  },
+  'arrow-left': {
+    right: 0,
+    top: '50%',
+    '&:after': {
+      marginTop: -ARROW_SIZE,
+      borderLeftColor: theme.palette.lwTertiary.main,
+    },
+  },
+  'arrow-right': {
+    left: -2 * ARROW_SIZE,
+    top: '50%',
+    '&:after': {
+      marginTop: -ARROW_SIZE,
+      borderRightColor: theme.palette.lwTertiary.main,
+    },
+  },
+  'arrow-top': {
+    bottom: 0,
+    left: '50%',
+    '&:after': {
+      marginLeft: -ARROW_SIZE,
+      borderTopColor: theme.palette.lwTertiary.main,
+    },
+  },
+  'arrow-bottom': {
+    top: -2 * ARROW_SIZE,
+    left: '50%',
+    '&:after': {
+      marginLeft: -ARROW_SIZE,
+      borderBottomColor: theme.palette.lwTertiary.main,
+    },
+  },
+});
+
+const NewFeatureTooltip = ({classes, children, title = 'New feature!', placement = 'left'}: {
+  children?: any,
+  title?: string,
+  placement?: 'top'|'right'|'left'|'bottom',
+  classes: ClassesType,
+}) => {
+  const { hover, everHovered, anchorEl, eventHandlers } = useHover({
+    pageElementContext: 'newFeatureHovered',
+    title,
+  });
+
+  const { LWPopper } = Components;
+
+  return (
+    <span className={classes.container}>
+      {everHovered &&
+        <LWPopper
+          placement={placement}
+          open={hover}
+          anchorEl={anchorEl}
+          tooltip
+          allowOverflow={false}
+          clickable={false}
+          className={classNames(classes.tooltip, classes[`tooltip-${placement}`])}
+        >
+          <div className={classes.content}>{title}</div>
+          <div className={classNames(classes.arrow, classes[`arrow-${placement}`])} />
+        </LWPopper>
+      }
+      {children}
+      <div
+        className={classNames(classes.handle, classes[`handle-${placement}`])}
+        {...eventHandlers}
+      />
+    </span>
+  );
+}
+
+const NewFeatureTooltipComponent = registerComponent('NewFeatureTooltip', NewFeatureTooltip, { styles });
+
+declare global {
+  interface ComponentTypes {
+    NewFeatureTooltip: typeof NewFeatureTooltipComponent
+  }
+}

--- a/packages/lesswrong/components/common/NewFeatureTooltip.tsx
+++ b/packages/lesswrong/components/common/NewFeatureTooltip.tsx
@@ -28,6 +28,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   content: {
     maxWidth: 250,
+    '@media (max-width: 800px)': {
+      maxWidth: 180,
+    },
   },
   handle: {
     cursor: 'pointer',
@@ -37,6 +40,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderRadius: '50%',
     margin: `${-Math.floor(HANDLE_SIZE / 2)}px 0 0 ${-Math.floor(HANDLE_SIZE / 2)}px`,
     background: theme.palette.lwTertiary.main,
+    '@media (max-width: 450px), (hover: none)': {
+      display: 'none',
+    },
   },
   'handle-left': {
     left: 0,

--- a/packages/lesswrong/components/tagging/SubscribeButton.tsx
+++ b/packages/lesswrong/components/tagging/SubscribeButton.tsx
@@ -42,7 +42,7 @@ const SubscribeButton = ({
   const { isSubscribed, subscribeUserToTag } = useSubscribeUserToTag(tag)
   const { flash } = useMessages();
   const { captureEvent } = useTracking()
-  const { LWTooltip, NotifyMeButton, NewFeatureTooltip } = Components
+  const { LWTooltip, NotifyMeButton } = Components
 
   const onSubscribe = async (e: React.MouseEvent<HTMLButtonElement>) => {
     try {
@@ -68,16 +68,14 @@ const SubscribeButton = ({
   const postsWording = taggingNameIsSet.get() ? `posts tagged with this ${taggingNameSetting.get()}` : "posts with this tag"
 
   return <div className={classNames(className, classes.root)}>
-    <NewFeatureTooltip title="New! Subscribe to this topic to see more posts you're interested in">
-      <LWTooltip title={isSubscribed ?
-        `Remove homepage boost for ${postsWording}` :
-        `See more ${postsWording} on the homepage`
-      }>
-        <Button variant="outlined" onClick={onSubscribe}>
-          <span className={classes.subscribeText}>{ isSubscribed ? unsubscribeMessage : subscribeMessage}</span>
-        </Button>
-      </LWTooltip>
-    </NewFeatureTooltip>
+    <LWTooltip title={isSubscribed ?
+      `Remove homepage boost for ${postsWording}` :
+      `See more ${postsWording} on the homepage`
+    }>
+      <Button variant="outlined" onClick={onSubscribe}>
+        <span className={classes.subscribeText}>{ isSubscribed ? unsubscribeMessage : subscribeMessage}</span>
+      </Button>
+    </LWTooltip>
     <NotifyMeButton
       document={tag}
       tooltip={`Click to toggle notifications for ${postsWording}`}

--- a/packages/lesswrong/components/tagging/SubscribeButton.tsx
+++ b/packages/lesswrong/components/tagging/SubscribeButton.tsx
@@ -42,7 +42,7 @@ const SubscribeButton = ({
   const { isSubscribed, subscribeUserToTag } = useSubscribeUserToTag(tag)
   const { flash } = useMessages();
   const { captureEvent } = useTracking()
-  const { LWTooltip, NotifyMeButton } = Components
+  const { LWTooltip, NotifyMeButton, NewFeatureTooltip } = Components
 
   const onSubscribe = async (e: React.MouseEvent<HTMLButtonElement>) => {
     try {
@@ -68,14 +68,16 @@ const SubscribeButton = ({
   const postsWording = taggingNameIsSet.get() ? `posts tagged with this ${taggingNameSetting.get()}` : "posts with this tag"
 
   return <div className={classNames(className, classes.root)}>
-    <LWTooltip title={isSubscribed ?
-      `Remove homepage boost for ${postsWording}` :
-      `See more ${postsWording} on the homepage`
-    }>
-      <Button variant="outlined" onClick={onSubscribe}>
-        <span className={classes.subscribeText}>{ isSubscribed ? unsubscribeMessage : subscribeMessage}</span>
-      </Button>
-    </LWTooltip>
+    <NewFeatureTooltip title="New! Subscribe to this topic to see more posts you're interested in">
+      <LWTooltip title={isSubscribed ?
+        `Remove homepage boost for ${postsWording}` :
+        `See more ${postsWording} on the homepage`
+      }>
+        <Button variant="outlined" onClick={onSubscribe}>
+          <span className={classes.subscribeText}>{ isSubscribed ? unsubscribeMessage : subscribeMessage}</span>
+        </Button>
+      </LWTooltip>
+    </NewFeatureTooltip>
     <NotifyMeButton
       document={tag}
       tooltip={`Click to toggle notifications for ${postsWording}`}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -101,6 +101,7 @@ importComponent("RevisionComparisonNotice", () => require('../components/revisio
 importComponent("TagPageRevisionSelect", () => require('../components/revisions/TagPageRevisionSelect'));
 importComponent("LWPopper", () => require('../components/common/LWPopper'));
 importComponent("LWTooltip", () => require('../components/common/LWTooltip'));
+importComponent("NewFeatureTooltip", () => require('../components/common/NewFeatureTooltip'));
 importComponent("Typography", () => require('../components/common/Typography'));
 importComponent("PopperCard", () => require('../components/common/PopperCard'));
 importComponent("Footer", () => require('../components/common/Footer'));


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/628521446211730/1202391450244268/f)

This PR implements a "new feature" tooltip, which can be placed above, below, left or right of any particular component.

![](https://user-images.githubusercontent.com/5075628/182477609-3d43bd50-3b0e-4b7e-8b0a-229acf98b06d.png)
![](https://user-images.githubusercontent.com/5075628/182477614-e2a27d17-6d41-4291-9291-2f55e376a6ed.png)
![](https://user-images.githubusercontent.com/5075628/182477616-2aa07e04-8feb-446d-af36-15d7bced4548.png)
![](https://user-images.githubusercontent.com/5075628/182477619-66e2e2c5-7030-4e27-ab1a-5fe69986aa17.png)

The usage on the `SubscribeButton` component is only an example for testing - I'll remove this before deploying.

I also tried an approach where we generate each of the `-left`, `-right`, `-top` and `-bottom` classes programatically, but this made the code a lot more complicated and a lot less readable. I think it's a lot easy to reason about if we just do it manually like this, even if it does mean updating a couple of different places when making changes.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202720109557676) by [Unito](https://www.unito.io)
