### PR TITLE
improve co-author feature tooltip, [EA Forum only] list future posts in user profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -319,6 +319,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
   }
   
   const draftTerms: PostsViewTerms = {view: "drafts", userId: user._id, limit: 4, sortDrafts: currentUser?.sortDrafts || "modifiedAt" }
+  const scheduledPostsTerms: PostsViewTerms = {view: "scheduled", userId: user._id, limit: 20}
   const unlistedTerms: PostsViewTerms = {view: "unlisted", userId: user._id, limit: 20}
   const postTerms: PostsViewTerms = {view: "userPosts", ...query, userId: user._id, authorIsUnreviewed: null}
 
@@ -359,6 +360,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
       </div>
       <AnalyticsContext listContext="userPageDrafts">
         <PostsList2 hideAuthor showDraftTag={false} terms={draftTerms} boxShadow={false} />
+        <PostsList2 hideAuthor showDraftTag={false} terms={scheduledPostsTerms} showNoResults={false} showLoading={false} showLoadMore={false} boxShadow={false} />
         <PostsList2 hideAuthor showDraftTag={false} terms={unlistedTerms} showNoResults={false} showLoading={false} showLoadMore={false} boxShadow={false} />
       </AnalyticsContext>
       <div className={classes.sectionSubHeadingRow}>

--- a/packages/lesswrong/components/form-components/CoauthorsListEditor.tsx
+++ b/packages/lesswrong/components/form-components/CoauthorsListEditor.tsx
@@ -70,7 +70,7 @@ const CoauthorsListEditor = ({ value, path, document, classes, label, currentUse
       </div>
       <div className={classes.checkboxContainer}>
         <Components.LWTooltip
-          title='If this box is left unchecked then these users will be asked if they want to be co-authors when the post is published'
+          title='If this box is left unchecked then these users will be asked if they want to be co-authors. If you click Publish with pending co-authors, publishing will be delayed for up to 24 hours to allow for co-authors to give permission.'
           placement='left'
         >
           <Checkbox className={classes.checkbox} checked={hasPermission} onChange={toggleHasPermission} />

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -51,8 +51,6 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
-const coauthorTooltip = 'Your post will be scheduled so your co-authors can give their permission. If they do not respond, your post will be automatically published in 24 hours.';
-
 interface PostSubmitProps {
   submitLabel?: string,
   cancelLabel?: string,
@@ -77,17 +75,7 @@ const PostSubmit = ({
   const { captureEvent } = useTracking();
   if (!currentUser) throw Error("must be logged in to post")
 
-  const waitForCoauthors = !document.hasCoauthorPermission &&
-    document.coauthorStatuses?.findIndex?.(({ confirmed }) => !confirmed) >= 0;
-
   const { LWTooltip } = Components;
-  const SubmitTooltip = waitForCoauthors
-    ? ({ children }) => (
-      <LWTooltip title={coauthorTooltip} placement="top">
-        {children}
-      </LWTooltip>
-    )
-    : ({ children }) => children;
 
   return (
     <React.Fragment>
@@ -139,9 +127,7 @@ const PostSubmit = ({
           className={classNames("primary-form-submit-button", classes.formButton, classes.submitButton)}
           variant={collectionName=="users" ? "outlined" : undefined}
         >
-          <SubmitTooltip>
-            {submitLabel}
-          </SubmitTooltip>
+          {submitLabel}
         </Button>
       </div>
     </React.Fragment>

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -124,6 +124,7 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}
 
     {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}
+    {post.isFuture && <span className={classes.tag}>[Pending]</span>}
     {post.unlisted && <span className={classes.tag}>[Unlisted]</span>}
     {shared && <span className={classes.tag}>[Shared]</span>}
     {post.isEvent && shouldRenderEventsTag && <span className={classes.tag}>[Event]</span>}


### PR DESCRIPTION
The existing tooltips on the edit post form around adding co-authors was outdated and confusing, so we made a small improvement. I think this is still kind of confusing so we should revisit how to explain this complicated feature here in the future.

Also on the EA Forum user profile, we now show the user's scheduled posts under their drafts.

![](https://user-images.githubusercontent.com/9057804/182727375-5d005d35-cd44-4076-9365-910e5aa33812.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202720109303159) by [Unito](https://www.unito.io)
