### PR TITLE
Book item sequence grid

### DIFF
--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -75,7 +75,7 @@ const BooksItem = ({ book, canEdit, classes }: {
         </div>}
 
         {book.sequencesGridDisplay && <SequencesGrid sequences={book.sequences}/>}
-        {!!book.sequencesGridDisplay && book.sequences.map(sequence =>
+        {!book.sequencesGridDisplay && book.sequences.map(sequence =>
           <LargeSequencesItem key={sequence._id} sequence={sequence} showChapters={book.showChapters} />
         )}
       </SingleColumnSection>

--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -38,7 +38,7 @@ const BooksItem = ({ book, canEdit, classes }: {
 
   const { html = "" } = book.contents || {}
   const { BooksProgressBar, SingleColumnSection, SectionTitle, SectionButton, LargeSequencesItem,
-    SequencesPostsList, Divider, ContentItemBody, ContentStyles } = Components
+    SequencesPostsList, Divider, ContentItemBody, ContentStyles, SequencesGrid } = Components
   
   const showEdit = useCallback(() => {
     setEdit(true);
@@ -74,7 +74,8 @@ const BooksItem = ({ book, canEdit, classes }: {
           <SequencesPostsList posts={book.posts} />
         </div>}
 
-        {book.sequences.map(sequence =>
+        {book.sequencesGridDisplay && <SequencesGrid sequences={book.sequences}/>}
+        {!!book.sequencesGridDisplay && book.sequences.map(sequence =>
           <LargeSequencesItem key={sequence._id} sequence={sequence} showChapters={book.showChapters} />
         )}
       </SingleColumnSection>

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -54,6 +54,8 @@ const BooksProgressBar = ({ book, classes }: {
 
   const postsReadText = `${readPosts} / ${totalPosts} posts read`;
 
+  if (book.hideProgressBar) return null
+
   return <div key={book._id} className={classes.root}>
     <div className={classes.bookProgress}>
       {

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -20,6 +20,7 @@ registerFragment(`
     }
     collectionId
     sequencesGridDisplay
+    hideProgressBar
     showChapters
   }
 `);

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -19,6 +19,7 @@ registerFragment(`
       ...PostsList
     }
     collectionId
+    sequencesGridDisplay
     showChapters
   }
 `);

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -90,6 +90,13 @@ const schema: SchemaType<DbBook> = {
     foreignKey: "Sequences",
     optional: true,
   },
+  sequencesGridDisplay: {
+    type: Boolean,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['admins'],
+    insertableBy: ['admins'],
+  },
 
   showChapters: {
     type: Boolean,

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -97,7 +97,13 @@ const schema: SchemaType<DbBook> = {
     editableBy: ['admins'],
     insertableBy: ['admins'],
   },
-
+  hideProgressBar: {
+    type: Boolean,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['admins'],
+    insertableBy: ['admins'],
+  },
   showChapters: {
     type: Boolean,
     optional: true,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -35,6 +35,7 @@ interface DbBook extends DbObject {
   postIds: Array<string>
   sequenceIds: Array<string>
   sequencesGridDisplay: boolean
+  hideProgressBar: boolean
   showChapters: boolean
   contents: EditableFieldContents
 }

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -34,6 +34,7 @@ interface DbBook extends DbObject {
   number: number
   postIds: Array<string>
   sequenceIds: Array<string>
+  sequencesGridDisplay: boolean
   showChapters: boolean
   contents: EditableFieldContents
 }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -215,6 +215,7 @@ interface BooksDefaultFragment { // fragment on Books
   readonly postIds: Array<string>,
   readonly sequenceIds: Array<string>,
   readonly sequencesGridDisplay: boolean,
+  readonly hideProgressBar: boolean,
   readonly showChapters: boolean,
 }
 
@@ -1309,6 +1310,7 @@ interface BookPageFragment { // fragment on Books
   readonly posts: Array<PostsList>,
   readonly collectionId: string,
   readonly sequencesGridDisplay: boolean,
+  readonly hideProgressBar: boolean,
   readonly showChapters: boolean,
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -214,6 +214,7 @@ interface BooksDefaultFragment { // fragment on Books
   readonly number: number,
   readonly postIds: Array<string>,
   readonly sequenceIds: Array<string>,
+  readonly sequencesGridDisplay: boolean,
   readonly showChapters: boolean,
 }
 
@@ -1307,6 +1308,7 @@ interface BookPageFragment { // fragment on Books
   readonly postIds: Array<string>,
   readonly posts: Array<PostsList>,
   readonly collectionId: string,
+  readonly sequencesGridDisplay: boolean,
   readonly showChapters: boolean,
 }
 


### PR DESCRIPTION
This allows you to create books that use the old SequencesGrid layout, and toggle off the progress bar. This is primarily to enable a "further reading" section that feels distinct from most of the collection, but it seemed good to design it in such a way it could be applied to other problems we might run into.

Here's an example of what the UI could look like:

![](https://user-images.githubusercontent.com/3246710/182739332-03894f99-9346-49e4-9263-511e466700dd.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202720213880637) by [Unito](https://www.unito.io)
