### PR TITLE
Fix sunshine layout

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -22,6 +22,7 @@ import { forumTypeSetting } from '../lib/instanceSettings';
 import { globalStyles } from '../themes/globalStyles/globalStyles';
 import type { ToCData, ToCSection } from '../server/tableOfContents';
 import { ForumOptions, forumSelect } from '../lib/forumTypeUtils';
+import { userCanDo } from '../lib/vulcan-users/permissions';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 1631226712000)
@@ -239,6 +240,8 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
     const standaloneNavigation = !currentRoute ||
       forumSelect(standaloneNavMenuRouteNames)
         .includes(currentRoute?.name)
+    
+    const showSunshineSidebar = currentRoute?.sunshineSidebar && userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins')
         
     const shouldUseGridLayout = standaloneNavigation
 
@@ -321,7 +324,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                   </ErrorBoundary>
                   <Footer />
                 </div>
-                {currentRoute?.sunshineSidebar && <div className={classes.sunshine}>
+                {showSunshineSidebar && <div className={classes.sunshine}>
                   <Components.SunshineSidebar/>
                 </div>}
               </div>

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -241,7 +241,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
       forumSelect(standaloneNavMenuRouteNames)
         .includes(currentRoute?.name)
     
-    const showSunshineSidebar = currentRoute?.sunshineSidebar && userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins')
+    const showSunshineSidebar = (currentRoute?.sunshineSidebar && userCanDo(currentUser, 'posts.moderate.all')) || currentUser?.groups?.includes('alignmentForumAdmins')
         
     const shouldUseGridLayout = standaloneNavigation
 


### PR DESCRIPTION
Logged in non-admin users currently still hold space for where the sunshine sidebar is supposed to be, which isn't the intended behavior (though looks like it's been this way for 2 years). This fixes it.

Correct layout when logged out: 
![image](https://user-images.githubusercontent.com/9090789/182775205-c17eda71-6619-4e97-8b83-5226b75d5f92.png)

Wrong layout when logged in: 
![image](https://user-images.githubusercontent.com/9090789/182775267-ae486ada-f4a6-411e-9def-9b5921e18537.png)

After this PR: 
![](https://user-images.githubusercontent.com/9090789/182775291-96d5059e-b10b-422e-a7e8-fcde3e042837.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202718910210019) by [Unito](https://www.unito.io)
