### PR TITLE
Add ability to lock post comments to new accounts

### DIFF
--- a/packages/lesswrong/components/comments/CantCommentExplanation.tsx
+++ b/packages/lesswrong/components/comments/CantCommentExplanation.tsx
@@ -28,6 +28,7 @@ const CantCommentExplanation = ({post, classes}: {
     <div className={classNames("i18n-message", "author_has_banned_you", classes.root)}>
       { userBlockedCommentingReason(currentUser, post, author)}{" "}
       { forumTypeSetting.get() !== 'AlignmentForum' && <span>
+        {/* TODO add EA mod email here */}
         (Questions? Send an email to <a className={classes.emailLink} href="mailto:moderation@lesserwrong.com">moderation@lesserwrong.com</a>)
       </span> }
     </div>

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -682,6 +682,15 @@ addFieldsDict(Posts, {
     optional: true,
     control: "checkbox",
   },
+  commentsLockedToAccountsCreatedAfter: {
+    type: Date,
+    control: 'datetime',
+    viewableBy: ['guests'],
+    group: formGroups.moderationGroup,
+    insertableBy: (currentUser: DbUser|null) => userCanCommentLock(currentUser, null),
+    editableBy: (currentUser: DbUser|null, document: DbPost) => userCanCommentLock(currentUser, document),
+    optional: true,
+  },
 
   // Event specific fields:
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -52,6 +52,7 @@ registerFragment(`
     canonicalCollectionSlug
     curatedDate
     commentsLocked
+    commentsLockedToAccountsCreatedAfter
 
     # questions
     question

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -186,7 +186,6 @@ export const userIsAllowedToComment = (user: UsersCurrent|DbUser|null, post: Pos
   return true
 }
 
-// TODO change to JSX element
 export const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post: PostsDetails|DbPost, postAuthor: PostsAuthors_user|null): JSX.Element => {
   if (!user) {
     return <>Can't recognize user</>

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -5,9 +5,8 @@ import { forumTypeSetting } from "../../instanceSettings";
 import { getSiteUrl } from '../../vulcan-lib/utils';
 import { mongoFind, mongoAggregate } from '../../mongoQueries';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { getBrowserLocalStorage } from '../../../components/async/localStorageHandlers';
-import React from 'react';
 import { Components } from '../../vulcan-lib';
 
 // Get a user's display name (not unique, can take special characters and spaces)

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -7,6 +7,8 @@ import { mongoFind, mongoAggregate } from '../../mongoQueries';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
 import { useEffect, useState } from 'react';
 import { getBrowserLocalStorage } from '../../../components/async/localStorageHandlers';
+import React from 'react';
+import { Components } from '../../vulcan-lib';
 
 // Get a user's display name (not unique, can take special characters and spaces)
 export const userGetDisplayName = (user: UsersMinimumInfo|DbUser|null): string => {
@@ -168,6 +170,7 @@ export const userIsAllowedToComment = (user: UsersCurrent|DbUser|null, post: Pos
 
   if (!post) return true
   if (post.commentsLocked) return false
+  if (post?.commentsLockedToAccountsCreatedAfter < user.createdAt) return false
 
   if (userIsBannedFromPost(user, post, postAuthor)) {
     return false
@@ -184,27 +187,33 @@ export const userIsAllowedToComment = (user: UsersCurrent|DbUser|null, post: Pos
   return true
 }
 
-export const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post: PostsDetails|DbPost, postAuthor: PostsAuthors_user|null): string => {
+// TODO change to JSX element
+export const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post: PostsDetails|DbPost, postAuthor: PostsAuthors_user|null): JSX.Element => {
   if (!user) {
-    return "Can't recognize user"
+    return <>Can't recognize user</>
   }
 
   if (userIsBannedFromPost(user, post, postAuthor)) {
-    return "This post's author has blocked you from commenting."
+    return <>This post's author has blocked you from commenting.</>
   }
 
   if (userIsBannedFromAllPosts(user, post, postAuthor)) {
-    return "This post's author has blocked you from commenting."
+    return <>This post's author has blocked you from commenting.</>
   }
 
   if (userIsBannedFromAllPersonalPosts(user, post, postAuthor)) {
-    return "This post's author has blocked you from commenting on any of their personal blog posts."
+    return <>This post's author has blocked you from commenting on any of their personal blog posts.</>
   }
 
-  if (post.commentsLocked) {
-    return "Comments on this post are disabled."
+  if (post?.commentsLocked) {
+    return <>Comments on this post are disabled.</>
   }
-  return "You cannot comment at this time"
+
+  if (post?.commentsLockedToAccountsCreatedAfter) {
+    return <>Comments on this post are disabled to accounts created after <Components.CalendarDate date={post.commentsLockedToAccountsCreatedAfter}/></>
+  }
+
+  return <>You cannot comment at this time</>
 }
 
 // Return true if the user's account has at least one verified email address.

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -425,6 +425,7 @@ interface DbPost extends DbObject {
   scoreExceeded200Date: Date
   bannedUserIds: Array<string>
   commentsLocked: boolean
+  commentsLockedToAccountsCreatedAfter: Date
   organizerIds: Array<string>
   groupId: string
   eventType: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -364,6 +364,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly canonicalCollectionSlug: string,
   readonly curatedDate: Date,
   readonly commentsLocked: boolean,
+  readonly commentsLockedToAccountsCreatedAfter: Date,
   readonly question: boolean,
   readonly hiddenRelatedQuestion: boolean,
   readonly originalPostRelationSourceId: string,


### PR DESCRIPTION
for this issue: https://github.com/ForumMagnum/ForumMagnum/issues/5344

The following features already existed:


* the ability to lock comments on a post completely
* the ability to lock replies to a comment completely until a certain date

so I have just added the ability to block replies on a post to accounts created after a certain date (any date, not necessarily the createdAt date of the post). I could also add the same thing to individual comments fairly easily if anyone thinks that would be useful



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202725388297843) by [Unito](https://www.unito.io)
