### PR TITLE
Messages icon refreshes on navigate and focus

### DIFF
--- a/packages/lesswrong/components/common/NavigationEventSender.tsx
+++ b/packages/lesswrong/components/common/NavigationEventSender.tsx
@@ -33,9 +33,11 @@ const NavigationEventSender = () => {
   return null;
 }
 
-/// Register a callback to be run when the user navigates the tab. This happens
-/// at the *start* of the navigation, ie, when the link is first clicked (but
-/// before most of the stuff at the destination has loaded).
+/**
+ * Register a callback to be run when the user navigates the tab. This happens
+ * at the *start* of the navigation, ie, when the link is first clicked (but
+ * before most of the stuff at the destination has loaded).
+ */
 export function useOnNavigate(fn: ({oldLocation,newLocation}: {oldLocation: RouterLocation|null, newLocation: RouterLocation})=>void) {
   useEffect(() => {
     routerOnUpdate.add(fn);

--- a/packages/lesswrong/components/common/NavigationEventSender.tsx
+++ b/packages/lesswrong/components/common/NavigationEventSender.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { CallbackChainHook  } from '../../lib/vulcan-lib/callbacks';
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
@@ -13,7 +13,7 @@ export const routerOnUpdate = new CallbackChainHook<{oldLocation:RouterLocation|
 const NavigationEventSender = () => {
   const location = useSubscribedLocation();
   
-  React.useEffect(() => {
+  useEffect(() => {
     // Only handle navigation events on the client (they don't apply to SSR)
     if (isClient) {
       // Check if the path has actually changed
@@ -31,6 +31,18 @@ const NavigationEventSender = () => {
   }, [location]);
   
   return null;
+}
+
+/// Register a callback to be run when the user navigates the tab. This happens
+/// at the *start* of the navigation, ie, when the link is first clicked (but
+/// before most of the stuff at the destination has loaded).
+export function useOnNavigate(fn: ({oldLocation,newLocation}: {oldLocation: RouterLocation|null, newLocation: RouterLocation})=>void) {
+  useEffect(() => {
+    routerOnUpdate.add(fn);
+    return () => {
+      routerOnUpdate.remove(fn);
+    };
+  }, [fn]);
 }
 
 const NavigationEventSenderComponent = registerComponent("NavigationEventSender", NavigationEventSender);

--- a/packages/lesswrong/components/common/withGlobalKeydown.tsx
+++ b/packages/lesswrong/components/common/withGlobalKeydown.tsx
@@ -10,5 +10,5 @@ export const useGlobalKeydown = (keyboardHandlerFn: (this: Document, ev: Keyboar
         document.removeEventListener('keydown', keyboardHandlerFn);
       };
     }
-  });
+  }, [keyboardHandlerFn]);
 }

--- a/packages/lesswrong/components/hooks/useOnFocusTab.ts
+++ b/packages/lesswrong/components/hooks/useOnFocusTab.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+export function useOnFocusTab(fn: (ev: FocusEvent)=>void) {
+  useEffect(() => {
+    window.addEventListener('focus', fn);
+    return () => {
+      window.removeEventListener('focus', fn);
+    };
+  }, [fn]);
+}

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -81,7 +81,6 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
     },
     collectionName: "Notifications",
     fragmentName: 'NotificationsList',
-    pollInterval: 0,
     limit: 20,
     enableTotal: false,
   });

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Badge from '@material-ui/core/Badge';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
+import { useOnNavigate } from '../common/NavigationEventSender';
+import { useOnFocusTab } from '../hooks/useOnFocusTab';
 import IconButton from '@material-ui/core/IconButton';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
@@ -40,18 +42,24 @@ const NotificationsMenuButton = ({ open, toggle, currentUser, classes }: {
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
-  const { results } = useMulti({
+  const { results, refetch } = useMulti({
     terms: {
       view: 'userNotifications',
       userId: currentUser._id
     },
     collectionName: "Notifications",
     fragmentName: 'NotificationsList',
-    pollInterval: 0,
     limit: 20,
     enableTotal: false,
     fetchPolicy: 'cache-and-network',
   });
+  
+  useOnNavigate(useCallback(() => {
+    refetch();
+  }, [refetch]));
+  useOnFocusTab(useCallback(() => {
+    refetch();
+  }, [refetch]));
   
   let filteredResults: Array<NotificationsList> | undefined = results && _.filter(results,
     (x) => !currentUser.lastNotificationsCheck || x.createdAt > currentUser.lastNotificationsCheck
@@ -74,7 +82,10 @@ const NotificationsMenuButton = ({ open, toggle, currentUser, classes }: {
   )
 }
 
-const NotificationsMenuButtonComponent = registerComponent('NotificationsMenuButton', NotificationsMenuButton, {styles});
+const NotificationsMenuButtonComponent = registerComponent('NotificationsMenuButton', NotificationsMenuButton, {
+  styles,
+  areEqual: "auto",
+});
 
 declare global {
   interface ComponentTypes {


### PR DESCRIPTION
Co-Authored-By: jpaddison3 <jp@centreforeffectivealtruism.com>

Makes it so that when you navigate or focus on a tab, it rechecks for notifications. This prevents spurious notifications if you open background tabs while you have an unread message and read the notification before visiting those tabs.

(Also fix in a missing dependency list on `useGlobalKeydown` because we initially had a bug caused by a missing dependency list and looked for instances of the same thing. In this case it doesn't matter much, just a few spurious event-handler attachments.)