### PR TITLE
[EA Forum only] Add profile images to private messages

### DIFF
--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -9,8 +9,23 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { useCurrentUser } from '../common/withUser';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    marginBottom:theme.spacing.unit*1.5,
+  },
+  rootWithImages: {
+    display: 'grid',
+    columnGap: 10,
+    maxWidth: '95%',
+    gridTemplateColumns: '36px 1fr',
+    gridTemplateAreas: '"image message"',
+  },
+  rootCurrentUserWithImages: {
+    marginLeft: 'auto',
+  },
   message: {
     backgroundColor: theme.palette.grey[200],
     paddingTop: theme.spacing.unit,
@@ -18,8 +33,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingLeft: theme.spacing.unit*1.5,
     paddingRight: theme.spacing.unit*1.5,
     borderRadius:5,
-    marginBottom:theme.spacing.unit*1.5,
-    wordWrap: "break-word"
+    wordWrap: "break-word",
+    flexGrow: 1,
+    gridArea: 'message',
   },
   backgroundIsCurrent: {
     backgroundColor: theme.palette.grey[700],
@@ -39,7 +55,22 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& img': {
       maxWidth: '100%',
     },
-  }
+  },
+  profileImage: {
+    'box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
+    '-webkit-box-shadow': `0px 0px 2px 0px ${theme.palette.boxShadowColor(.25)}`,
+    '-moz-box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
+    borderRadius: '50%',
+    gridArea: 'image',
+    alignSelf: 'flex-end',
+  },
+  defaultProfileImage: {
+    gridArea: 'image',
+    alignSelf: 'flex-end',
+    fontSize: 36,
+    color: theme.palette.grey[500],
+    borderRadius: '50%',
+  },
 })
 
 const MessageItem = ({message, classes}: {
@@ -54,23 +85,39 @@ const MessageItem = ({message, classes}: {
   const isCurrentUser = (currentUser && message.user) && currentUser._id === message.user._id
   const htmlBody = {__html: html};
   const colorClassName = classNames({[classes.whiteMeta]: isCurrentUser})
+  const isEAForum = forumTypeSetting.get() === 'EAForum'
+
+  let profilePhoto
+  
+  if(!isCurrentUser && isEAForum) {
+    profilePhoto = message.user?.profileImageId ? <Components.CloudinaryImage2
+      height={36}
+      width={36}
+      imgProps={{q: '100'}}
+      publicId={message.user.profileImageId}
+      className={classes.profileImage}
+    /> : <AccountCircleIcon width={36} height={36} viewBox="3 3 18 18" className={classes.defaultProfileImage}/>
+  }
   
   return (
-    <Components.Typography variant="body2" className={classNames(classes.message, {[classes.backgroundIsCurrent]: isCurrentUser})}>
-      <div className={classes.meta}>
-        {message.user && <Components.MetaInfo>
-          <span className={colorClassName}><Components.UsersName user={message.user}/></span>
-        </Components.MetaInfo>}
-        {message.createdAt && <Components.MetaInfo>
-          <span className={colorClassName}><Components.FormatDate date={message.createdAt}/></span>
-        </Components.MetaInfo>}
-      </div>
-      <Components.ContentItemBody
-        dangerouslySetInnerHTML={htmlBody}
-        className={classes.messageBody}
-        description={`message ${message._id}`}
-      />
-    </Components.Typography>
+    <div className={classNames(classes.root, {[classes.rootWithImages]: isEAForum, [classes.rootCurrentUserWithImages]: isEAForum && isCurrentUser})}>
+      {profilePhoto}
+      <Components.Typography variant="body2" className={classNames(classes.message, {[classes.backgroundIsCurrent]: isCurrentUser})}>
+        <div className={classes.meta}>
+          {message.user && <Components.MetaInfo>
+            <span className={colorClassName}><Components.UsersName user={message.user}/></span>
+          </Components.MetaInfo>}
+          {message.createdAt && <Components.MetaInfo>
+            <span className={colorClassName}><Components.FormatDate date={message.createdAt}/></span>
+          </Components.MetaInfo>}
+        </div>
+        <Components.ContentItemBody
+          dangerouslySetInnerHTML={htmlBody}
+          className={classes.messageBody}
+          description={`message ${message._id}`}
+        />
+      </Components.Typography>
+    </div>
   )
 }
 

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -9,11 +9,9 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { useCurrentUser } from '../common/withUser';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { PROFILE_IMG_DIAMETER, PROFILE_IMG_DIAMETER_MOBILE } from './ProfilePhoto';
 
-const PROFILE_IMG_WIDTH = 36
-const PROFILE_IMG_WIDTH_MOBILE = 26
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -23,10 +21,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'grid',
     columnGap: 10,
     maxWidth: '95%',
-    gridTemplateColumns: `${PROFILE_IMG_WIDTH}px 1fr`,
+    gridTemplateColumns: `${PROFILE_IMG_DIAMETER}px 1fr`,
     gridTemplateAreas: '"image message"',
     [theme.breakpoints.down('xs')]: {
-      gridTemplateColumns: `${PROFILE_IMG_WIDTH_MOBILE}px 1fr`,
+      gridTemplateColumns: `${PROFILE_IMG_DIAMETER_MOBILE}px 1fr`,
     }
   },
   rootCurrentUserWithImages: {
@@ -63,27 +61,9 @@ const styles = (theme: ThemeType): JssStyles => ({
       maxWidth: '100%',
     },
   },
-  profileImage: {
-    'box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
-    '-webkit-box-shadow': `0px 0px 2px 0px ${theme.palette.boxShadowColor(.25)}`,
-    '-moz-box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
-    borderRadius: '50%',
+  profileImg: {
     gridArea: 'image',
-    alignSelf: 'flex-end',
-    [theme.breakpoints.down('xs')]: {
-      height: PROFILE_IMG_WIDTH_MOBILE,
-      width: PROFILE_IMG_WIDTH_MOBILE
-    }
-  },
-  defaultProfileImage: {
-    gridArea: 'image',
-    alignSelf: 'flex-end',
-    fontSize: PROFILE_IMG_WIDTH,
-    color: theme.palette.grey[400],
-    borderRadius: '50%',
-    [theme.breakpoints.down('xs')]: {
-      fontSize: PROFILE_IMG_WIDTH_MOBILE
-    }
+    alignSelf: 'flex-end'
   },
 })
 
@@ -103,11 +83,7 @@ const MessageItem = ({message, classes}: {
 
   let profilePhoto
   if (!isCurrentUser && isEAForum) {
-    profilePhoto = message.user?.profileImageId ? <Components.CloudinaryImage2
-      imgProps={{q: '100', h: `${PROFILE_IMG_WIDTH}`, w: `${PROFILE_IMG_WIDTH}`}}
-      publicId={message.user.profileImageId}
-      className={classes.profileImage}
-    /> : <AccountCircleIcon viewBox="3 3 18 18" className={classes.defaultProfileImage}/>
+    profilePhoto = <Components.ProfilePhoto user={message.user} className={classes.profileImg} />
   }
   
   return (

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -12,6 +12,9 @@ import { useCurrentUser } from '../common/withUser';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
+const PROFILE_IMG_WIDTH = 36
+const PROFILE_IMG_WIDTH_MOBILE = 26
+
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom:theme.spacing.unit*1.5,
@@ -20,10 +23,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'grid',
     columnGap: 10,
     maxWidth: '95%',
-    gridTemplateColumns: '36px 1fr',
+    gridTemplateColumns: `${PROFILE_IMG_WIDTH}px 1fr`,
     gridTemplateAreas: '"image message"',
+    [theme.breakpoints.down('xs')]: {
+      gridTemplateColumns: `${PROFILE_IMG_WIDTH_MOBILE}px 1fr`,
+    }
   },
   rootCurrentUserWithImages: {
+    columnGap: 0,
     marginLeft: 'auto',
   },
   message: {
@@ -63,13 +70,20 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderRadius: '50%',
     gridArea: 'image',
     alignSelf: 'flex-end',
+    [theme.breakpoints.down('xs')]: {
+      height: PROFILE_IMG_WIDTH_MOBILE,
+      width: PROFILE_IMG_WIDTH_MOBILE
+    }
   },
   defaultProfileImage: {
     gridArea: 'image',
     alignSelf: 'flex-end',
-    fontSize: 36,
-    color: theme.palette.grey[500],
+    fontSize: PROFILE_IMG_WIDTH,
+    color: theme.palette.grey[400],
     borderRadius: '50%',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: PROFILE_IMG_WIDTH_MOBILE
+    }
   },
 })
 
@@ -88,15 +102,12 @@ const MessageItem = ({message, classes}: {
   const isEAForum = forumTypeSetting.get() === 'EAForum'
 
   let profilePhoto
-  
-  if(!isCurrentUser && isEAForum) {
+  if (!isCurrentUser && isEAForum) {
     profilePhoto = message.user?.profileImageId ? <Components.CloudinaryImage2
-      height={36}
-      width={36}
-      imgProps={{q: '100'}}
+      imgProps={{q: '100', h: `${PROFILE_IMG_WIDTH}`, w: `${PROFILE_IMG_WIDTH}`}}
       publicId={message.user.profileImageId}
       className={classes.profileImage}
-    /> : <AccountCircleIcon width={36} height={36} viewBox="3 3 18 18" className={classes.defaultProfileImage}/>
+    /> : <AccountCircleIcon viewBox="3 3 18 18" className={classes.defaultProfileImage}/>
   }
   
   return (

--- a/packages/lesswrong/components/messaging/ProfilePhoto.tsx
+++ b/packages/lesswrong/components/messaging/ProfilePhoto.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import classNames from 'classnames';
+import { Link } from '../../lib/reactRouterWrapper';
+
+export const PROFILE_IMG_DIAMETER = 36
+export const PROFILE_IMG_DIAMETER_MOBILE = 26
+
+const styles = (theme: ThemeType): JssStyles => ({
+  img: {
+    height: PROFILE_IMG_DIAMETER,
+    width: PROFILE_IMG_DIAMETER,
+    borderRadius: '50%',
+    [theme.breakpoints.down('xs')]: {
+      height: PROFILE_IMG_DIAMETER_MOBILE,
+      width: PROFILE_IMG_DIAMETER_MOBILE
+    }
+  },
+  emptyProfileImg: {
+    color: theme.palette.grey[400],
+    fontSize: PROFILE_IMG_DIAMETER,
+    [theme.breakpoints.down('xs')]: {
+      fontSize: PROFILE_IMG_DIAMETER_MOBILE,
+    }
+  },
+  defaultProfileImg: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: theme.palette.grey[400],
+    color: theme.palette.grey[0],
+    fontFamily: theme.typography.fontFamily,
+    fontSize: PROFILE_IMG_DIAMETER/2,
+    textTransform: 'uppercase',
+    overflow: 'hidden',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: PROFILE_IMG_DIAMETER_MOBILE/2,
+    }
+  },
+  profileImg: {
+    'box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
+    '-webkit-box-shadow': `0px 0px 2px 0px ${theme.palette.boxShadowColor(.25)}`,
+    '-moz-box-shadow': `3px 3px 1px ${theme.palette.boxShadowColor(.25)}`,
+  },
+})
+
+const getUserInitials = (displayName: string) => {
+  // TODO: include uppercase char that comes after lowercase char
+  return displayName.split(/[\s_\-.]/).reduce((prev, next) => {
+    if (!next.length || prev.length > 1) {
+      return prev
+    }
+    return `${prev}${next[0]}`
+  }, '')
+}
+
+/**
+ * In almost all places where we use profile photos, if we don't have one to show,
+ * we can just show nothing. So far the only exception is in private messaging,
+ * where we didn't like how the layout looked with that empty space.
+ * So this component includes a couple fallbacks in case the user has no photo.
+ */
+const ProfilePhoto = ({user, className, classes}: {
+  user: {
+    slug: string,
+    profileImageId: string,
+    displayName?: string
+  }|null,
+  className?: string,
+  classes: ClassesType,
+}) => {
+  // placeholder icon, in case nothing else is available
+  let imgNode = <AccountCircleIcon
+    viewBox="3 3 18 18"
+    className={classNames(classes.img, classes.emptyProfileImg)}
+  />
+  
+  // if for some reason we have no user, just show the placeholder icon
+  if (!user) {
+    return <div className={className}>
+      {imgNode}
+    </div>
+  }
+  
+  if (user.profileImageId) {
+    // use the profile photo if possible
+    imgNode = <Components.CloudinaryImage2
+      imgProps={{q: '100', h: `${PROFILE_IMG_DIAMETER}`, w: `${PROFILE_IMG_DIAMETER}`}}
+      publicId={user.profileImageId}
+      className={classNames(classes.img, classes.profileImg)}
+    />
+  } else if (user.displayName) {
+    // if the user has no profile photo, default to using their initials
+    // TODO: instead of a single grey background, randomly assign a color
+    imgNode = <div className={classNames(classes.img, classes.defaultProfileImg)}>
+      {getUserInitials(user.displayName)}
+    </div>
+  }
+  
+  return <Link to={`/users/${user.slug}`} className={className}>
+    {imgNode}
+  </Link>
+}
+
+
+const ProfilePhotoComponent = registerComponent('ProfilePhoto', ProfilePhoto, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ProfilePhoto: typeof ProfilePhotoComponent
+  }
+}
+

--- a/packages/lesswrong/lib/collections/messages/fragments.ts
+++ b/packages/lesswrong/lib/collections/messages/fragments.ts
@@ -5,6 +5,7 @@ registerFragment(`
     _id
     user {
       ...UsersMinimumInfo
+      profileImageId
     }
     contents {
       html

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -36,6 +36,7 @@ importComponent("ConversationWrapper", () => require('../components/messaging/Co
 importComponent("ConversationPage", () => require('../components/messaging/ConversationPage'));
 importComponent("ConversationPreview", () => require('../components/messaging/ConversationPreview'));
 importComponent("MessageItem", () => require('../components/messaging/MessageItem'));
+importComponent("ProfilePhoto", () => require('../components/messaging/ProfilePhoto'));
 importComponent("InboxWrapper", () => require('../components/messaging/InboxWrapper'));
 importComponent("InboxNavigation", () => require('../components/messaging/InboxNavigation'));
 importComponent("NewConversationButton", () => require('../components/messaging/NewConversationButton'));

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -933,10 +933,14 @@ interface MessagesDefaultFragment { // fragment on Messages
 
 interface messageListFragment { // fragment on Messages
   readonly _id: string,
-  readonly user: UsersMinimumInfo|null,
+  readonly user: messageListFragment_user|null,
   readonly contents: messageListFragment_contents|null,
   readonly createdAt: Date,
   readonly conversationId: string,
+}
+
+interface messageListFragment_user extends UsersMinimumInfo { // fragment on Users
+  readonly profileImageId: string,
 }
 
 interface messageListFragment_contents { // fragment on Revisions


### PR DESCRIPTION
This PR adds profile photos to private message threads, on the EA Forum only. Perhaps most controversially, it adds a placeholder icon for users without a photo, since the alternatives felt either clunky UI-wise or too involved to be worth the effort.

## EA Forum
![](https://user-images.githubusercontent.com/25752873/183153477-1b7966f6-f58a-4bd3-bca1-f6eec35d4d0b.png)

## Lesswrong
![](https://user-images.githubusercontent.com/25752873/183153577-a9ed83c0-61ea-4134-95cd-6cfd040abdad.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202730790513560) by [Unito](https://www.unito.io)
