### PR TITLE
update migration script

### DIFF
--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -80,7 +80,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   if (!targetUser) throw Error(`Can't find targetUser with Id: ${targetUserId}`)
 
   // DO NOT transfer LWEvents, there are way too many and they're probably not important after the fact
-  // await transferCollection({sourceUserId, targetUserId, collectionName: "Notifications"})
+  // await transferCollection({sourceUserId, targetUserId, collectionName: "LWEvents"})
 
   // Do not transfer gardencodes, they aren't in use
   // await transferCollection({sourceUserId, targetUserId, collectionName: "GardenCodes"})

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -52,7 +52,7 @@ const transferCollection = async ({sourceUserId, targetUserId, collectionName, f
           }
         } catch (err) {
           console.log("")
-          console.log("Error Transferring Document", doc._id, collectionName)
+          console.log("%c Error Transferring Document", doc._id, collectionName, 'color: red')
           console.log(err)
         }
       }
@@ -62,7 +62,7 @@ const transferCollection = async ({sourceUserId, targetUserId, collectionName, f
 
   } catch (err) {
     console.log()
-    console.log(`Error while transferring collection ${collectionName}`)
+    console.log(`%c Error while transferring collection ${collectionName}`, "color: red")
     console.log(err)
   }
 }
@@ -162,7 +162,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
     }
   } catch (err) {
     console.log()
-    console.log("Error merging conversations")
+    console.log("%c Error merging conversations", "color:red")
     console.log(err)
   }
 
@@ -189,7 +189,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
     }
   } catch (err) {
     console.log()
-    console.log("Error merging readStatuses")
+    console.log("%c Error merging readStatuses", "color: red")
     console.log(err)
   }
 
@@ -240,7 +240,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
     }    
   } catch (err) {
     console.log()
-    console.log("Error merging votes")
+    console.log("%c Error merging votes", "color: red")
     console.log(err)
   }
 
@@ -276,7 +276,7 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
     }
   } catch (err) {
     console.log()
-    console.log("Error changing slugs")
+    console.log("%c Error changing slugs", "color: red")
     console.log(err)
   }
 

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -79,11 +79,35 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   if (!sourceUser) throw Error(`Can't find sourceUser with Id: ${sourceUserId}`)
   if (!targetUser) throw Error(`Can't find targetUser with Id: ${targetUserId}`)
 
+  // Transfer bans
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Bans"})
+
+  // Transfer subscriptions (i.e. email subscriptions)
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Subscriptions"})
+
   // Transfer posts
   await transferCollection({sourceUserId, targetUserId, collectionName: "Posts"})
 
+  // Transfer revisions
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Revisions"})
+
   // Transfer comments
   await transferCollection({sourceUserId, targetUserId, collectionName: "Comments"})
+
+  // Transfer user-created tags
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Tags"})
+
+  // Transfer tag-post relationships (first user who voted on that tag for that post)
+  await transferCollection({sourceUserId, targetUserId, collectionName: "TagRels"})
+
+  // Transfer rss feeds (for crossposting)
+  await transferCollection({sourceUserId, targetUserId, collectionName: "RSSFeeds"})
+
+  // Transfer petrov day launches
+  await transferCollection({sourceUserId, targetUserId, collectionName: "PetrovDayLaunchs"})
+
+  // Transfer reports (i.e. user reporting a comment/tag/etc)
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Reports"})
 
   // Transfer conversations
   await Conversations.rawUpdateMany({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
@@ -107,6 +131,9 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
 
   // Transfer localgroups
   await transferCollection({sourceUserId, targetUserId, collectionName: "Localgroups"})
+
+  // Transfer review votes
+  await transferCollection({sourceUserId, targetUserId, collectionName: "ReviewVotes"})
   
   // Transfer votes that target content from source user (authorId)
   // eslint-disable-next-line no-console
@@ -160,6 +187,9 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
     set: {oldSlugs: newOldSlugs}, 
     validate: false
   })
+
+  // Transfer email tokens
+  await transferCollection({sourceUserId, targetUserId, collectionName: "EmailTokens"})
   
   // Mark old acccount as deleted
   // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -79,6 +79,12 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   if (!sourceUser) throw Error(`Can't find sourceUser with Id: ${sourceUserId}`)
   if (!targetUser) throw Error(`Can't find targetUser with Id: ${targetUserId}`)
 
+  // DO NOT transfer LWEvents, there are way too many and they're probably not important after the fact
+  // await transferCollection({sourceUserId, targetUserId, collectionName: "Notifications"})
+
+  // Do not transfer gardencodes, they aren't in use
+  // await transferCollection({sourceUserId, targetUserId, collectionName: "GardenCodes"})
+
   // Transfer bans
   await transferCollection({sourceUserId, targetUserId, collectionName: "Bans"})
 

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -32,8 +32,11 @@ const transferCollection = async ({sourceUserId, targetUserId, collectionName, f
       collection.find({[fieldName]: sourceUserId}).count(),
       collection.find({[fieldName]: targetUserId}).count(),
     ])
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log(`Source user ${sourceUserId} ${collectionName} count: ${sourceUserCount}`)
+    // eslint-disable-next-line no-console
     console.log(`Target user ${targetUserId} ${collectionName} count: ${targetUserCount}`)
 
     if (!dryRun) {
@@ -51,18 +54,25 @@ const transferCollection = async ({sourceUserId, targetUserId, collectionName, f
             })
           }
         } catch (err) {
+          // eslint-disable-next-line no-console
           console.log("")
+          // eslint-disable-next-line no-console
           console.log("%c Error Transferring Document", doc._id, collectionName, 'color: red')
+          // eslint-disable-next-line no-console
           console.log(err)
         }
       }
       const finalTargetUserCount = await collection.find({[fieldName]: targetUserId}).count()
+      // eslint-disable-next-line no-console
       console.log(`Final target user ${targetUserId} ${collectionName} count: ${finalTargetUserCount} (compare ${sourceUserCount + targetUserCount})`)
     }
 
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log(`%c Error while transferring collection ${collectionName}`, "color: red")
+    // eslint-disable-next-line no-console
     console.log(err)
   }
 }
@@ -153,7 +163,9 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       Conversations.find({participantIds: sourceUserId}).count(),
       Conversations.find({participantIds: sourceUserId}).count()
     ])
+    // eslint-disable-next-line no-console
     console.log(`conversations from source user: ${sourceConversationsCount}`)
+    // eslint-disable-next-line no-console
     console.log(`conversations from target user: ${targetConversationsCount}`)
 
     if (!dryRun) {
@@ -161,8 +173,11 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       await Conversations.rawUpdateMany({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log("%c Error merging conversations", "color:red")
+    // eslint-disable-next-line no-console
     console.log(err)
   }
 
@@ -176,7 +191,9 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
     const readStatuses = await ReadStatuses.find({userId: sourceUserId}).fetch()
     const readPostIds = readStatuses.map((status) => status.postId).filter(postId => !!postId)
     const readTagIds = readStatuses.map((status) => status.tagId).filter(tagId => !!tagId)
+    // eslint-disable-next-line no-console
     console.log(`source readPostIds count: ${readPostIds.length}`)
+    // eslint-disable-next-line no-console
     console.log(`source readTagIds count: ${readTagIds.length}`)
     if (!dryRun) {
       // Transfer readStatuses
@@ -188,8 +205,11 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       })
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log("%c Error merging readStatuses", "color: red")
+    // eslint-disable-next-line no-console
     console.log(err)
   }
 
@@ -208,7 +228,9 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       Votes.find({authorIds: sourceUserId}).count(),
       Votes.find({userId: sourceUserId}).count()
     ]) 
+    // eslint-disable-next-line no-console
     console.log(`authorVotesCount: ${authorVotesCount}`)
+    // eslint-disable-next-line no-console
     console.log(`userVoteCounts: ${userVoteCounts}`)
     if (!dryRun) {
       // Transfer votes that target content from source user (authorId)
@@ -239,8 +261,11 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       })
     }    
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log("%c Error merging votes", "color: red")
+    // eslint-disable-next-line no-console
     console.log(err)
   }
 
@@ -275,8 +300,11 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun
       })
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log()
+    // eslint-disable-next-line no-console
     console.log("%c Error changing slugs", "color: red")
+    // eslint-disable-next-line no-console
     console.log(err)
   }
 

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -8,8 +8,6 @@ import { Conversations } from '../../lib/collections/conversations/collection'
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 import sumBy from 'lodash/sumBy';
 
-
-
 const transferOwnership = async ({documentId, targetUserId, collection, fieldName = "userId"}) => {
   await updateMutator({
     collection,
@@ -20,32 +18,62 @@ const transferOwnership = async ({documentId, targetUserId, collection, fieldNam
   })
 }
 
-const transferCollection = async ({sourceUserId, targetUserId, collectionName, fieldName = "userId"}: {
+const transferCollection = async ({sourceUserId, targetUserId, collectionName, fieldName = "userId", dryRun}: {
   sourceUserId: string,
   targetUserId: string,
   collectionName: CollectionNameString,
-  fieldName?: string
+  fieldName?: string,
+  dryRun: boolean
 }) => {
   const collection = getCollection(collectionName)
-  const documents = await collection.find({[fieldName]: sourceUserId}).fetch()
-  // eslint-disable-next-line no-console
-  console.log(`Transferring ${documents.length} documents in collection ${collectionName}`)
-  for (const doc of documents) {
-    await transferOwnership({documentId: doc._id, targetUserId, collection, fieldName})
-    // Transfer ownership of all revisions and denormalized references for editable fields
-    const editableFieldNames = editableCollectionsFields[collectionName]
-    if (editableFieldNames?.length) {
-      await asyncForeachSequential(editableFieldNames, async (editableFieldName) => {
-        await transferEditableField({documentId: doc._id, targetUserId, collection, fieldName: editableFieldName})
-      })
+
+  try {
+    const [sourceUserCount, targetUserCount] = await Promise.all([
+      collection.find({[fieldName]: sourceUserId}).count(),
+      collection.find({[fieldName]: targetUserId}).count(),
+    ])
+    console.log()
+    console.log(`Source user ${sourceUserId} ${collectionName} count: ${sourceUserCount}`)
+    console.log(`Target user ${targetUserId} ${collectionName} count: ${targetUserCount}`)
+
+    if (!dryRun) {
+      const documents = await collection.find({[fieldName]: sourceUserId}).fetch()
+      // eslint-disable-next-line no-console
+      console.log(`Transferring ${documents.length} documents in collection ${collectionName}`)
+      for (const doc of documents) {
+        try {
+          await transferOwnership({documentId: doc._id, targetUserId, collection, fieldName})
+          // Transfer ownership of all revisions and denormalized references for editable fields
+          const editableFieldNames = editableCollectionsFields[collectionName]
+          if (editableFieldNames?.length) {
+            await asyncForeachSequential(editableFieldNames, async (editableFieldName) => {
+              await transferEditableField({documentId: doc._id, sourceUserId, targetUserId, collection, fieldName: editableFieldName})
+            })
+          }
+        } catch (err) {
+          console.log("")
+          console.log("Error Transferring Document", doc._id, collectionName)
+          console.log(err)
+        }
+      }
+      const finalTargetUserCount = await collection.find({[fieldName]: targetUserId}).count()
+      console.log(`Final target user ${targetUserId} ${collectionName} count: ${finalTargetUserCount} (compare ${sourceUserCount + targetUserCount})`)
     }
+
+  } catch (err) {
+    console.log()
+    console.log(`Error while transferring collection ${collectionName}`)
+    console.log(err)
   }
-  documents.forEach((doc) => {
-    
-  })
 }
 
-const transferEditableField = async ({documentId, targetUserId, collection, fieldName = "contents"}) => {
+const transferEditableField = async ({documentId, sourceUserId, targetUserId, collection, fieldName = "contents"}: {
+  documentId: string,
+  sourceUserId: string,
+  targetUserId: string,
+  collection: CollectionBase<DbObject>,
+  fieldName: string
+}) => {
   // Update the denormalized revision on the document
   await updateMutator({
     collection,
@@ -55,12 +83,18 @@ const transferEditableField = async ({documentId, targetUserId, collection, fiel
     validate: false
   })
   // Update the revisions themselves
-  await Revisions.rawUpdateMany({ documentId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
+  await Revisions.rawUpdateMany({ documentId, userId: sourceUserId, fieldName }, {$set: {userId: targetUserId}}, { multi: true })
 }
 
-const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sourceUserId: string, targetUserId: string, postId: string}) => {
-  const sourceUserStatus = await ReadStatuses.findOne({userId: sourceUserId, postId})
-  const targetUserStatus = await ReadStatuses.findOne({userId: targetUserId, postId})
+type PostOrTagSelector = {postId: string} | {tagId: string}
+
+const mergeReadStatus = async ({sourceUserId, targetUserId, postOrTagSelector}: {
+  sourceUserId: string, 
+  targetUserId: string, 
+  postOrTagSelector: PostOrTagSelector
+}) => {
+  const sourceUserStatus = await ReadStatuses.findOne({userId: sourceUserId, ...postOrTagSelector})
+  const targetUserStatus = await ReadStatuses.findOne({userId: targetUserId, ...postOrTagSelector})
   const sourceMostRecentlyUpdated = (sourceUserStatus && targetUserStatus) ? (new Date(sourceUserStatus.lastUpdated) > new Date(targetUserStatus.lastUpdated)) : !!sourceUserStatus
   const readStatus = sourceMostRecentlyUpdated ? sourceUserStatus?.isRead : targetUserStatus?.isRead
   const lastUpdated = sourceMostRecentlyUpdated ? sourceUserStatus?.lastUpdated : targetUserStatus?.lastUpdated
@@ -73,7 +107,9 @@ const mergeReadStatusForPost = async ({sourceUserId, targetUserId, postId}: {sou
   }
 }
 
-Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
+Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string, dryRun: boolean) => {
+  if (typeof dryRun !== "boolean") throw Error("dryRun value missing")
+
   const sourceUser = await Users.findOne({_id: sourceUserId})
   const targetUser = await Users.findOne({_id: targetUserId})
   if (!sourceUser) throw Error(`Can't find sourceUser with Id: ${sourceUserId}`)
@@ -83,129 +119,181 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // await transferCollection({sourceUserId, targetUserId, collectionName: "LWEvents"})
 
   // Do not transfer gardencodes, they aren't in use
-  // await transferCollection({sourceUserId, targetUserId, collectionName: "GardenCodes"})
+  // We don't transfer revisions because that's handled by transferEditableField
 
   // Transfer bans
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Bans"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Bans", dryRun})
 
   // Transfer subscriptions (i.e. email subscriptions)
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Subscriptions"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Subscriptions", dryRun})
 
   // Transfer posts
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Posts"})
-
-  // Transfer revisions
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Revisions"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Posts", dryRun})
 
   // Transfer comments
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Comments"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Comments", dryRun})
 
   // Transfer user-created tags
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Tags"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Tags", dryRun})
 
   // Transfer tag-post relationships (first user who voted on that tag for that post)
-  await transferCollection({sourceUserId, targetUserId, collectionName: "TagRels"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "TagRels", dryRun})
 
   // Transfer rss feeds (for crossposting)
-  await transferCollection({sourceUserId, targetUserId, collectionName: "RSSFeeds"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "RSSFeeds", dryRun})
 
   // Transfer petrov day launches
-  await transferCollection({sourceUserId, targetUserId, collectionName: "PetrovDayLaunchs"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "PetrovDayLaunchs", dryRun})
 
   // Transfer reports (i.e. user reporting a comment/tag/etc)
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Reports"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Reports", dryRun})
 
-  // Transfer conversations
-  await Conversations.rawUpdateMany({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
+  try {
+    const [sourceConversationsCount, targetConversationsCount] = await Promise.all([
+      Conversations.find({participantIds: sourceUserId}).count(),
+      Conversations.find({participantIds: sourceUserId}).count()
+    ])
+    console.log(`conversations from source user: ${sourceConversationsCount}`)
+    console.log(`conversations from target user: ${targetConversationsCount}`)
+
+    if (!dryRun) {
+      // Transfer conversations
+      await Conversations.rawUpdateMany({participantIds: sourceUserId}, {$set: {"participantIds.$": targetUserId}}, { multi: true })
+    }
+  } catch (err) {
+    console.log()
+    console.log("Error merging conversations")
+    console.log(err)
+  }
 
   // Transfer private messages
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Messages"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Messages", dryRun})
 
   // Transfer notifications
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Notifications"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Notifications", dryRun})
 
-  // Transfer readStatuses
-  const readStatuses = await ReadStatuses.find({userId: sourceUserId}).fetch()
-  const readPostIds = readStatuses.map((status) => status.postId)
-  await asyncForeachSequential(readPostIds, async (postId) => {
-    await mergeReadStatusForPost({sourceUserId, targetUserId, postId})
-  })
+  try {
+    const readStatuses = await ReadStatuses.find({userId: sourceUserId}).fetch()
+    const readPostIds = readStatuses.map((status) => status.postId).filter(postId => !!postId)
+    const readTagIds = readStatuses.map((status) => status.tagId).filter(tagId => !!tagId)
+    console.log(`source readPostIds count: ${readPostIds.length}`)
+    console.log(`source readTagIds count: ${readTagIds.length}`)
+    if (!dryRun) {
+      // Transfer readStatuses
+      await asyncForeachSequential(readPostIds, async (postId) => {
+        await mergeReadStatus({sourceUserId, targetUserId, postOrTagSelector:{postId}})
+      })
+      await asyncForeachSequential(readTagIds, async (tagId) => {
+        await mergeReadStatus({sourceUserId, targetUserId, postOrTagSelector:{tagId}})
+      })
+    }
+  } catch (err) {
+    console.log()
+    console.log("Error merging readStatuses")
+    console.log(err)
+  }
 
   // Transfer sequences
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Sequences"})
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Collections"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Sequences", dryRun})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Collections", dryRun})
 
   // Transfer localgroups
-  await transferCollection({sourceUserId, targetUserId, collectionName: "Localgroups"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "Localgroups", dryRun})
 
   // Transfer review votes
-  await transferCollection({sourceUserId, targetUserId, collectionName: "ReviewVotes"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "ReviewVotes", dryRun})
   
-  // Transfer votes that target content from source user (authorId)
-  // eslint-disable-next-line no-console
-  console.log("Transferring votes that target source user")
-  // https://www.mongodb.com/docs/manual/reference/operator/update/positional/
-  await Votes.rawUpdateMany({authorIds: sourceUserId}, {$set: {"authorIds.$": targetUserId}}, {multi: true})
+  try {
+    const [authorVotesCount, userVoteCounts] = await Promise.all([
+      Votes.find({authorIds: sourceUserId}).count(),
+      Votes.find({userId: sourceUserId}).count()
+    ]) 
+    console.log(`authorVotesCount: ${authorVotesCount}`)
+    console.log(`userVoteCounts: ${userVoteCounts}`)
+    if (!dryRun) {
+      // Transfer votes that target content from source user (authorId)
+      // eslint-disable-next-line no-console
+      console.log("Transferring votes that target source user")
+      // https://www.mongodb.com/docs/manual/reference/operator/update/positional/
+      await Votes.rawUpdateMany({authorIds: sourceUserId}, {$set: {"authorIds.$": targetUserId}}, {multi: true})
+  
+      // Transfer votes cast by source user
+      // eslint-disable-next-line no-console
+      console.log("Transferring votes cast by source user")
+      await Votes.rawUpdateMany({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
+  
+      // Transfer karma
+      // eslint-disable-next-line no-console
+      console.log("Transferring karma")
+      const newKarma = await recomputeKarma(targetUserId)
+      await updateMutator({
+        collection: Users,
+        documentId: targetUserId,
+        set: {
+          karma: newKarma, 
+          // We only recalculate the karma for non-af karma, because recalculating
+          // af karma is a lot more complicated
+          afKarma: sourceUser.afKarma + targetUser.afKarma 
+        },
+        validate: false
+      })
+    }    
+  } catch (err) {
+    console.log()
+    console.log("Error merging votes")
+    console.log(err)
+  }
 
-  // Transfer votes cast by source user
-  // eslint-disable-next-line no-console
-  console.log("Transferring votes cast by source user")
-  await Votes.rawUpdateMany({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
-
-  // Transfer karma
-  // eslint-disable-next-line no-console
-  console.log("Transferring karma")
-  const newKarma = await recomputeKarma(targetUserId)
-  await updateMutator({
-    collection: Users,
-    documentId: targetUserId,
-    set: {
-      karma: newKarma, 
-      // We only recalculate the karma for non-af karma, because recalculating
-      // af karma is a lot more complicated
-      afKarma: sourceUser.afKarma + targetUser.afKarma 
-    },
-    validate: false
-  })
   
   // Change slug of source account by appending "old" and reset oldSlugs array
   // eslint-disable-next-line no-console
   console.log("Change slugs of source account")
-  await Users.rawUpdateOne(
-    {_id: sourceUserId},
-    {$set: {
-      slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)
-    }}
-  );
+  try {
 
-  // Add slug to oldSlugs array of target account
-  const newOldSlugs = [
-    ...(targetUser.oldSlugs || []), 
-    ...(sourceUser.oldSlugs || []), 
-    sourceUser.slug
-  ]
-  // eslint-disable-next-line no-console
-  console.log("Changing slugs of target account", sourceUser.slug, newOldSlugs)
-  
-  await updateMutator({
-    collection: Users,
-    documentId: targetUserId,
-    set: {oldSlugs: newOldSlugs}, 
-    validate: false
-  })
+    if (!dryRun) {
+      await Users.rawUpdateOne(
+        {_id: sourceUserId},
+        {$set: {
+          slug: await Utils.getUnusedSlug(Users, `${sourceUser.slug}-old`, true)
+        }}
+      );
+    
+      // Add slug to oldSlugs array of target account
+      const newOldSlugs = [
+        ...(targetUser.oldSlugs || []), 
+        ...(sourceUser.oldSlugs || []), 
+        sourceUser.slug
+      ]
+      // eslint-disable-next-line no-console
+      console.log("Changing slugs of target account", sourceUser.slug, newOldSlugs)
+      
+      await updateMutator({
+        collection: Users,
+        documentId: targetUserId,
+        set: {oldSlugs: newOldSlugs}, 
+        validate: false
+      })
+    }
+  } catch (err) {
+    console.log()
+    console.log("Error changing slugs")
+    console.log(err)
+  }
 
   // Transfer email tokens
-  await transferCollection({sourceUserId, targetUserId, collectionName: "EmailTokens"})
+  await transferCollection({sourceUserId, targetUserId, collectionName: "EmailTokens", dryRun})
   
-  // Mark old acccount as deleted
-  // eslint-disable-next-line no-console
-  console.log("Marking old account as deleted")
-  await updateMutator({
-    collection: Users,
-    documentId: sourceUserId,
-    set: {deleted: true},
-    validate: false
-  })
+  if (!dryRun) {
+    // Mark old acccount as deleted
+    // eslint-disable-next-line no-console
+    console.log("Marking old account as deleted")
+    await updateMutator({
+      collection: Users,
+      documentId: sourceUserId,
+      set: {deleted: true},
+      validate: false
+    })
+  }
 }
 
 

--- a/scripts/mergeUsers.sh
+++ b/scripts/mergeUsers.sh
@@ -33,4 +33,4 @@ TARGET_ID=${@:$OPTIND+1:1}
 
 echo "Merging user $SOURCE_ID into $TARGET_ID"
 
-scripts/serverShellCommand.sh "Vulcan.mergeAccounts('$SOURCE_ID', '$TARGET_ID')"
+scripts/serverShellCommand.sh "Vulcan.mergeAccounts('$SOURCE_ID', '$TARGET_ID', false)"


### PR DESCRIPTION
We received a request from a user to merge some accounts.  On checking the migration script, discovered that quite a few collections were missing.  Before running it, would appreciate a sanity-check on the added collections (and on those we're specifically not merging, i.e. `LWEvents` and `GardenCodes`).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202774083246896) by [Unito](https://www.unito.io)
