### PR TITLE
Allow running the site on a different port in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ typings
 
 *.secret
 
-build
+build*
 yarn-error.log
 
 # Created by @shelf/jest-mongodb

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -65,6 +65,7 @@ export default {
     bundleIsTest: true,
     bundleIsProduction: false,
     defaultSiteAbsoluteUrl: "",
+    serverPort: 3000,
   },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.

--- a/packages/lesswrong/client/autoRefresh.ts
+++ b/packages/lesswrong/client/autoRefresh.ts
@@ -1,10 +1,10 @@
-import { onStartup } from '../lib/executionEnvironment';
+import { onStartup, getWebsocketPort } from '../lib/executionEnvironment';
 import type { MessageEvent, OpenEvent, CloseEvent } from 'ws';
 
 // In development, make a websocket connection (on a different port) to get
 // notified when the server has restarted with a new version.
 
-const websocketPort = 3001;
+const websocketPort = getWebsocketPort();
 let connectedWebsocket: any = null;
 let buildTimestamp: string|null = null;
 

--- a/packages/lesswrong/lib/executionEnvironment.ts
+++ b/packages/lesswrong/lib/executionEnvironment.ts
@@ -1,10 +1,11 @@
 import * as _ from 'underscore';
 
 declare global {
-  var bundleIsServer: boolean
-  var bundleIsTest: boolean
-  var bundleIsProduction: boolean
-  var defaultSiteAbsoluteUrl: string
+  let bundleIsServer: boolean;
+  let bundleIsTest: boolean;
+  let bundleIsProduction: boolean;
+  let defaultSiteAbsoluteUrl: string;
+  let serverPort: number;
 }
 
 export const isClient = !bundleIsServer
@@ -61,7 +62,7 @@ export const getAbsoluteUrl = (maybeRelativeUrl?: string): string => {
   if (defaultSiteAbsoluteUrl?.length>0) {
     return defaultSiteAbsoluteUrl;
   } else {
-    return "http://localhost:3000/"
+    return `http://localhost:${getServerPort()}/`
   }
 }
 
@@ -69,6 +70,8 @@ export const addGlobalForShell = (name: string, value: any) => {
   // TODO
 }
 
+export const getServerPort = () => serverPort;
+export const getWebsocketPort = () => serverPort + 1;
 
 // Polyfill
 import 'setimmediate';

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -1,4 +1,4 @@
-import { isServer } from './executionEnvironment';
+import { isServer, getServerPort } from './executionEnvironment';
 import qs from 'qs';
 import React, { useContext } from 'react';
 import { LocationContext, NavigationContext, ServerRequestStatusContext, SubscribeLocationContext, ServerRequestStatusContextType } from './vulcan-core/appContext';
@@ -135,8 +135,7 @@ const LwAfDomainWhitelist: Array<string> = [
   "alignmentforum.org",
   "alignment-forum.com",
   "greaterwrong.com",
-  "localhost:3000",
-  "localhost:8300"
+  `localhost:${getServerPort()}`,
 ]
 
 const forumDomainWhitelist: ForumOptions<Array<string>> = {
@@ -146,12 +145,10 @@ const forumDomainWhitelist: ForumOptions<Array<string>> = {
     'forum.effectivealtruism.org',
     'forum-staging.effectivealtruism.org',
     'ea.greaterwrong.com',
-    'localhost:3000',
-    'localhost:8300'
+    `localhost:${getServerPort()}`,
   ],
   default: [
-    'localhost:3000',
-    'localhost:8300',
+    `localhost:${getServerPort()}`,
   ],
 }
 

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -1,7 +1,7 @@
 import { ApolloServer } from 'apollo-server-express';
 import { GraphQLError, GraphQLFormattedError } from 'graphql';
 
-import { isDevelopment, getInstanceSettings } from '../lib/executionEnvironment';
+import { isDevelopment, getInstanceSettings, getServerPort } from '../lib/executionEnvironment';
 import { renderWithCache, getThemeOptions } from './vulcan-lib/apollo-ssr/renderPage';
 
 import bodyParser from 'body-parser';
@@ -283,7 +283,7 @@ export function startWebserver() {
   })
 
   // Start Server
-  const port = process.env.PORT || 3000
+  const port = getServerPort();
   const env = process.env.NODE_ENV || 'production'
   const server = app.listen({ port }, () => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
This allows multiple instances of the site to be run locally on different ports (needed whilst developing LessWrong/EAForum crossposting).

For instance, you can run a second instance on port 4000 with a local database with: `SERVER_PORT=4000 MONGO_URL="mongodb://localhost:27017/eaforum" ./build.js -run -watch --settings ../ForumCredentials/lw-settings-dev.json`



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202791329591921) by [Unito](https://www.unito.io)
