### PR TITLE
Remove erroneous yarn lock record for ckeditor bundle

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,9 +2195,6 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lesswrong/lesswrong-editor@./public/lesswrong-editor":
-  version "0.1.1"
-
 "@mapbox/geojson-area@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz"


### PR DESCRIPTION
Co-authored-by: jimrandomh <jim@jimrandomh.org>

Probably someone accidentally committed this line from the master lockfile.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202793756313071) by [Unito](https://www.unito.io)
