### PR TITLE
Edit nginx.conf to allow proxies to use gzip

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -32,6 +32,14 @@ http {
         gzip on;
         gzip_comp_level 4;
         gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+        # Compress data even for clients that are connecting to us via proxies,
+        # identified by the "Via" header (required for CloudFront).
+        gzip_proxied any;
+        # Tell proxies to cache both the gzipped and regular version of a resource
+        # whenever the client's Accept-Encoding capabilities header varies;
+        # Avoids the issue where a non-gzip capable client (which is extremely rare
+        # today) would display gibberish if their proxy gave them the gzipped version.
+        gzip_vary on;
 
         access_log    /var/log/nginx/access.log main;
 


### PR DESCRIPTION
The CDN I am testing (Cloudfront) requires the `gzip_proxied: any` directive to serve compressed files (see [here](https://iwader.co.uk/post/enabling-gzip-compression-on-nginx), it's actually the inclusion of the "via" header which causes nginx to drop compression, this may apply to other CDNs too)

NOTE: I have not tested this, and I am aware that it's slightly dodgy to deploy an nginx config change without testing it first, but I think this one is simple enough that it's unlikely to cause any problems. I am going to set up a non-master test environment to test brotli compression and some other things anyway, so if you're not happy with deploying this then I can wait and test it there first. It's just that that will take a while to set up and I wanted to get the basic setup working right away



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202795866048576) by [Unito](https://www.unito.io)
