### PR TITLE
Fix coauthors erroneously showing as pending

### DIFF
--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -268,6 +268,9 @@ export const prettyEventDateTimes = (post: PostsBase|DbPost, timezone?: string, 
 }
 
 export const postCoauthorIsPending = (post: DbPost|PostsList|PostsDetails, coauthorUserId: string) => {
+  if (post.hasCoauthorPermission) {
+    return false;
+  }
   const status = post.coauthorStatuses.find(({ userId }) => coauthorUserId === userId);
   return status && !status.confirmed;
 }


### PR DESCRIPTION
Closes #5437 

I _think_ this should fix the issue, but I'd really appreciate if somebody (darkruby501 perhaps?) could test this out against the LW database at some point as the only way I was able to reproduce the bug was by manually breaking a post directly in the database. It is possible that the cause could actually be something else.

Interestingly, it already works correctly [on GreaterWrong](https://www.greaterwrong.com/posts/bJ2haLkcGeLtTWaD5/welcome-to-lesswrong).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202802328286855) by [Unito](https://www.unito.io)
