### PR TITLE
Better chapter titles

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -415,10 +415,10 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
     }
     return {
       ...submission,
-      [fieldName]: data ? {
+      [fieldName]: {
         originalContents: {type, data},
         commitMessage, updateType,
-      } : null
+      }
     }
   }
 

--- a/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
+++ b/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
@@ -30,7 +30,7 @@ function WrappedSmartForm(props) {
             fieldName, // _.object takes array of tuples, with first value being fieldName and second being value
             (originalContents?.data) ? // Ensure that we have data
               { originalContents, updateType, commitMessage } : // If so, constrain it to correct shape
-              undefined // If not, set field to undefined
+              {} // If not, set field to an empty object
           ]
         }))
         return {...data, ...editableFields}

--- a/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
+++ b/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
@@ -28,9 +28,9 @@ function WrappedSmartForm(props) {
           const { originalContents, updateType, commitMessage } = (data && data[fieldName]) || {}
           return [
             fieldName, // _.object takes array of tuples, with first value being fieldName and second being value
-            (originalContents?.data) ? // Ensure that we have data
+            (originalContents?.data !== undefined && originalContents?.data !== null) ? // Ensure that we have data
               { originalContents, updateType, commitMessage } : // If so, constrain it to correct shape
-              {} // If not, set field to an empty object
+              undefined // If not, set field to undefined
           ]
         }))
         return {...data, ...editableFields}

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -87,6 +87,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 125,
     objectFit: "cover"
   },
+  chapterTitle: {
+    fontSize: "20px !important",
+  },
   postIcon: {
     height: 12,
     width: 12,
@@ -143,7 +146,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
   showChapters?: boolean,
   classes: ClassesType,
 }) => {
-  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, ContentItemBody, LWTooltip } = Components
+  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, SectionTitle, LWTooltip } = Components
 
   const [expanded, setExpanded] = useState<boolean>(false)
 
@@ -201,13 +204,9 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
         </div>
       </div>
       <div className={classes.right}>
-        {sequence.chapters?.flatMap(({posts, title, contents}) =>
-          <>
-            {showChapters && contents?.htmlHighlight && (
-              <ContentStyles contentType="postHighlight">
-                <ContentItemBody dangerouslySetInnerHTML={{__html: title ?? contents.htmlHighlight}} />
-              </ContentStyles>
-            )}
+        {sequence.chapters?.flatMap(({posts, title}, index) =>
+          <React.Fragment key={index}>
+            {showChapters && title && <SectionTitle title={title} className={classes.chapterTitle} />}
             {posts.map((post) => (
               <SequencesSmallPostLink
                 key={sequence._id + post._id}
@@ -215,7 +214,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
                 sequenceId={sequence._id}
               />
             ))}
-          </>
+          </React.Fragment>
         )}
       </div>
     </div>

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -88,7 +88,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     objectFit: "cover"
   },
   chapterTitle: {
-    fontSize: "20px !important",
+    fontSize: "1.25rem !important",
   },
   postIcon: {
     height: 12,


### PR DESCRIPTION
A couple of weeks ago we added the ability to show chapter titles on the collections page for the new EA intro curriculum. After some discussion on Slack, Max and Jesse decided they wanted to change the way this works a little to make the titles use styling like the sequences page, instead of using the chapter description to get bold/italic text. This is implemented in this PR.

Whilst testing this, I also realised that it's not currently possible to set the body of an editable field (posts/chapter descriptions/etc.) to an empty string, so that's also implemented in this PR - let me know if there's any reason that this is a bad idea.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202802357058115) by [Unito](https://www.unito.io)
