### PR TITLE
Change sequencesGridDisplay to displaySequencesAsGrid

### DIFF
--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -76,8 +76,8 @@ const BooksItem = ({ book, canEdit, classes }: {
           <SequencesPostsList posts={book.posts} />
         </div>}
 
-        {book.sequencesGridDisplay && <SequencesGrid sequences={book.sequences}/>}
-        {!book.sequencesGridDisplay && book.sequences.map(sequence =>
+        {book.displaySequencesAsGrid && <SequencesGrid sequences={book.sequences}/>}
+        {!book.displaySequencesAsGrid && book.sequences.map(sequence =>
           <LargeSequencesItem key={sequence._id} sequence={sequence} showChapters={book.showChapters} />
         )}
       </SingleColumnSection>

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -19,7 +19,7 @@ registerFragment(`
       ...PostsList
     }
     collectionId
-    sequencesGridDisplay
+    displaySequencesAsGrid
     hideProgressBar
     showChapters
   }

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -90,7 +90,7 @@ const schema: SchemaType<DbBook> = {
     foreignKey: "Sequences",
     optional: true,
   },
-  sequencesGridDisplay: {
+  displaySequencesAsGrid: {
     type: Boolean,
     optional: true,
     viewableBy: ['guests'],

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -34,7 +34,7 @@ interface DbBook extends DbObject {
   number: number
   postIds: Array<string>
   sequenceIds: Array<string>
-  sequencesGridDisplay: boolean
+  displaySequencesAsGrid: boolean
   hideProgressBar: boolean
   showChapters: boolean
   contents: EditableFieldContents

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -222,7 +222,7 @@ interface BooksDefaultFragment { // fragment on Books
   readonly number: number,
   readonly postIds: Array<string>,
   readonly sequenceIds: Array<string>,
-  readonly sequencesGridDisplay: boolean,
+  readonly displaySequencesAsGrid: boolean,
   readonly hideProgressBar: boolean,
   readonly showChapters: boolean,
 }
@@ -1343,7 +1343,7 @@ interface BookPageFragment { // fragment on Books
   readonly postIds: Array<string>,
   readonly posts: Array<PostsList>,
   readonly collectionId: string,
-  readonly sequencesGridDisplay: boolean,
+  readonly displaySequencesAsGrid: boolean,
   readonly hideProgressBar: boolean,
   readonly showChapters: boolean,
 }


### PR DESCRIPTION
Jim had left a comment about this which I meant to address but forgot in this PR: https://github.com/ForumMagnum/ForumMagnum/pull/5391

> Nitpick: This field name is a noun phrase, but it should be a verb phrase because it's a flag. A correct name would be something like showAsGrid or displaySequencesAsGrid.

> (This is one of the unwritten conventions that fails to show up in style guides because it's hard to articulate, but which most programmers pick up linguistically.)