### PR TITLE
Fix new-private-messages-count badge from disappearing after the notification drawer is opened

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -85,7 +85,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
     enableTotal: false,
   });
 
-  const lastNotificationsCheck = currentUser?.lastNotificationsCheck ?? "";
+  const [lastNotificationsCheck] = useState(currentUser?.lastNotificationsCheck ?? "");
   const newMessages = results && _.filter(results, (x) => x.createdAt > lastNotificationsCheck);
   if (!currentUser) {
     return null;


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/ForumMagnum/ForumMagnum/pull/4769 which caused the private-messages-count badge in the notifications drawer to disappear a ~second after the drawer is opened.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202804002860037) by [Unito](https://www.unito.io)
