### PR TITLE
Add Content-Type header to main page loads to allow gzip compression

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -211,6 +211,8 @@ export function startWebserver() {
   })
 
   app.get('*', async (request, response) => {
+    response.setHeader("Content-Type", "text/html; charset=utf-8"); // allows compression
+
     const {bundleHash} = getClientBundle();
     const clientScript = `<script defer src="/js/bundle.js?hash=${bundleHash}"></script>`
     const instanceSettingsHeader = embedAsGlobalVar("publicInstanceSettings", getInstanceSettings().public);


### PR DESCRIPTION
The main page load wasn't being compressed (with gzip even) because the Content-Type wasn't set, this fixes that. This gives a 70-80% reduction in download size on pages I have tested (and so pretty much removes any need to consider truncating the length of the response)

NOTE: We currently rely on sending the start of the file containing `<script defer src="/js/bundle.js?hash=${bundleHash}"></script>` as soon as possible (before SSR) so that bundle.js starts downloading immediately. You may worry that compressing the response would cause this not to be parsed until the whole response is downloaded and thus make things slower. I tested this in a separate Elastic Beanstalk configuration and the result is: it's fine, it still downloads bundle.js straight away