### PR TITLE
Fix keyboard-shortcut handling of the notifications menu drawer close button

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -141,7 +141,11 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
               value={tab}
               className={classes.tabBar}
               onChange={(event, tabIndex) => {
-                setTab(tabIndex);
+                if (tabIndex >= notificationCategoryTabs.length) {
+                  setIsOpen(false);
+                } else {
+                  setTab(tabIndex);
+                }
               }}
             >
               {notificationCategoryTabs.map(notificationCategory =>
@@ -156,8 +160,11 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
                 />
               )}
               
-              {/* Include an extra, hidden tab to reserve space for the
-                  close/X button (which hovers over the tabs). */}
+              {/* Include an extra, hidden tab to reserve space for the close/X
+                * button (which hovers over the tabs). Selecting this "tab"
+                * (with a keyboard shortcut) closes the drawer (with a special
+                * case in onChange).
+                */}
               <Tab className={classes.hiddenTab} />
             </Tabs>
             <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />


### PR DESCRIPTION
Corresponds to this Sentry error: https://sentry.io/organizations/lesswrong/issues/3479588959/?project=1301611&query=is%3Aunresolved&statsPeriod=14d



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202803941048646) by [Unito](https://www.unito.io)
