### PR TITLE
Change order of twitter card header

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -48,18 +48,18 @@ const HeadTags = ({ogUrl: ogUrlProp, canonicalUrl: canonicalUrlProp, description
           <meta name='description' content={description}/>
           <meta name='viewport' content='width=device-width, initial-scale=1'/>
 
+          {/* twitter */}
+          <meta name='twitter:card' content='summary_large_image'/>
+          {image && <meta name='twitter:image:src' content={image}/>}
+          { /* <meta name='twitter:title' content={title}/> */ }
+          <meta name='twitter:description' content={description}/>
+
           {/* facebook */}
           <meta property='og:type' content='article'/>
           <meta property='og:url' content={ogUrl}/>
           {image && <meta property='og:image' content={image}/>}
           { /* <meta property='og:title' content={title}/> */ }
           <meta property='og:description' content={description}/>
-
-          {/* twitter */}
-          <meta name='twitter:card' content='summary_large_image'/>
-          {image && <meta name='twitter:image:src' content={image}/>}
-          { /* <meta name='twitter:title' content={title}/> */ }
-          <meta name='twitter:description' content={description}/>
 
           {(noIndex || currentRoute?.noIndex) && <meta name='robots' content='noindex' />}
           <link rel='canonical' href={canonicalUrl}/>


### PR DESCRIPTION
Twitter cards have been broken since [this deployment](https://github.com/ForumMagnum/ForumMagnum/pull/5358), our (me and jimrandomh ) best guess was that our `meta` tags are actually correct but something about the ordering or page load time is confusing the twitter web crawler.

While I had an Elastic Beanstalk environment set up to test other stuff I thought I may as well try and fix it, and it seems like reordering the tags has done so 🤷‍♂️. I'm not that confident in this because the twitter card validator was also getting confused by the SSL certificate of my test env so I couldn't get reliable results, but here is one example of it working with this change

From test environment (card appears, even though it's a new post):
![](https://user-images.githubusercontent.com/77623106/184718689-7f039dce-44b1-4cc4-be62-49dcbf7b9515.png)

From production (cards don't appear for posts newer than a few weeks ago):
![](https://user-images.githubusercontent.com/77623106/184719404-381a34c0-6d4d-45ad-a36c-a305980fd6e5.png)

It's also possible that [this change](https://github.com/ForumMagnum/ForumMagnum/pull/5447) fixed it for a different reason as that was also in the test env at the time



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202803128077635) by [Unito](https://www.unito.io)
