### PR TITLE
remove duplicate bio in sunshine user info component

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -340,7 +340,6 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
               <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
               <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
-              <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
               {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
               <div className={classes.notes}>
                 <Input 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -860,6 +860,7 @@ interface DbUser extends DbObject {
   sunshineNotes: string
   sunshineFlagged: boolean
   needsReview: boolean
+  sunshineSnoozed: boolean
   snoozedUntilContentCount: number
   reviewedByUserId: string
   reviewedAt: Date

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -440,13 +440,13 @@ getCollectionHooks("Comments").updateAfter.add(async function UpdateDescendentCo
 });
 
 // This function and the latter function seem redundant. TODO decide whether/where the karma < 100 clause should live
-getCollectionHooks("Comments").createAsync.add(async function NewCommentNeedsReview ({document}: CreateCallbackProperties<DbComment>) {
-  const user = await Users.findOne({_id:document.userId})
-  const karma = user?.karma || 0
-  if (karma < 100) {
-    await triggerReviewIfNeeded(document.userId);
-  }
-});
+// getCollectionHooks("Comments").createAsync.add(async function NewCommentNeedsReview ({document}: CreateCallbackProperties<DbComment>) {
+//   const user = await Users.findOne({_id:document.userId})
+//   const karma = user?.karma || 0
+//   if (karma < 100) {
+//     await triggerReviewIfNeeded(document.userId);
+//   }
+// });
 
 getCollectionHooks("Comments").createAsync.add(async ({document}: CreateCallbackProperties<DbComment>) => {
   await triggerReviewIfNeeded(document.userId);

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -160,10 +160,9 @@ getCollectionHooks("Posts").createAsync.add(async ({document}: CreateCallbackPro
 });
 
 getCollectionHooks("Posts").updateAsync.add(async function updatedPostMaybeTriggerReview ({document, oldDocument}: UpdateCallbackProperties<DbPost>) {
+  if (document.draft) return
 
   await triggerReviewIfNeeded(oldDocument.userId)
-  
-  if (document.draft) return 
   
   // if the post author is already approved and the post is getting undrafted,
   // or the post author is getting approved,

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -91,7 +91,7 @@ getCollectionHooks("Users").editAsync.add(async function approveUnreviewedSubmis
   }
 });
 
-getCollectionHooks("Users").updateAsync.add(function mapLocationMayTriggerReview({document}: UpdateCallbackProperties<DbUser>) {
+getCollectionHooks("Users").updateAsync.add(function updateUserMayTriggerReview({document}: UpdateCallbackProperties<DbUser>) {
   void triggerReviewIfNeeded(document._id)
 })
 


### PR DESCRIPTION
I wanted to remove the duplicate bio before deploying, but also did a light code review and cleaned up some other things.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202803251988291) by [Unito](https://www.unito.io)
