### PR TITLE
Filter recommendations to return only rationality content on LessWrong

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -89,6 +89,13 @@ const getFrontPageOverwrites = (haveCurrentUser: boolean): Partial<Recommendatio
       count: haveCurrentUser ? 3 : 5
     }
   }
+  if (forumTypeSetting.get() === "LessWrong") {
+    return {
+      lwRationalityOnly: true,
+      method: 'sample',
+      count: haveCurrentUser ? 3 : 2
+    }
+  }
   return {
     method: 'sample',
     count: haveCurrentUser ? 3 : 2
@@ -149,93 +156,97 @@ const RecommendationsAndCurated = ({
     const bookmarksLimit = (settings.hideFrontpage && settings.hideContinueReading) ? 6 : 3 
 
     return <SingleColumnSection className={classes.section}>
-      <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
-        <Link to={"/recommendations"}>Recommendations</Link>
-      </LWTooltip>}>
-        {currentUser &&
-          <LWTooltip title="Customize your recommendations">
-            <SettingsButton showIcon={false} onClick={toggleSettings} label="Customize"/>
-          </LWTooltip>
-        }
-      </SectionTitle>
-
-      {showSettings &&
-        <RecommendationsAlgorithmPicker
-          configName={configName}
-          settings={frontpageRecommendationSettings}
-          onChange={(newSettings) => setSettings(newSettings)}
-        /> }
-
-      {isLW && <AnalyticsContext pageSectionContext="frontpageCuratedCollections">
-        <CollectionsItem collection={sequenceHighlights} showCloseIcon/>
-      </AnalyticsContext>}
-
-      {!currentUser && forumTypeSetting.get() !== 'EAForum' && <div>
-        {/* <div className={classes.largeScreenLoggedOutSequences}>
-          <AnalyticsContext pageSectionContext="frontpageCuratedSequences">
-            <CuratedSequences />
-          </AnalyticsContext>
-        </div>
-        <div className={classes.smallScreenLoggedOutSequences}>
-          <ContinueReadingList continueReading={continueReading} />
-        </div> */}
-      </div>}
-
-      <div className={classes.subsection}>
-        <div className={classes.posts}>
-          {!settings.hideFrontpage && 
-            <AnalyticsContext listContext={"frontpageFromTheArchives"} capturePostItemOnMount>
-              <RecommendationsList algorithm={frontpageRecommendationSettings} />
-            </AnalyticsContext>
+      <AnalyticsContext pageSectionContext="recommendations">
+        <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
+          <Link to={"/recommendations"}>Recommendations</Link>
+        </LWTooltip>}>
+          {currentUser &&
+            <LWTooltip title="Customize your recommendations">
+              <SettingsButton showIcon={false} onClick={toggleSettings} label="Customize"/>
+            </LWTooltip>
           }
-          <AnalyticsContext listContext={"curatedPosts"}>
-            <PostsList2
-              terms={{view:"curated", limit: currentUser ? 3 : 2}}
-              showNoResults={false}
-              showLoadMore={false}
-              hideLastUnread={true}
-              boxShadow={false}
-              curatedIconLeft={true}
-            />
-          </AnalyticsContext>
-        </div>
-      </div>
+        </SectionTitle>
 
-      {renderContinueReading && <div className={currentUser ? classes.subsection : null}>
-          <LWTooltip placement="top-start" title={continueReadingTooltip}>
-            <Link to={"/library"}>
-              <SectionSubtitle className={classNames(classes.subtitle, classes.continueReading)}>
-                 Continue Reading
-              </SectionSubtitle>
-            </Link>
-          </LWTooltip>
-          <ContinueReadingList continueReading={continueReading} />
+        {showSettings &&
+          <RecommendationsAlgorithmPicker
+            configName={configName}
+            settings={frontpageRecommendationSettings}
+            onChange={(newSettings) => setSettings(newSettings)}
+          /> }
+
+        {isLW && <AnalyticsContext pageSubSectionContext="frontpageCuratedCollections">
+          <CollectionsItem collection={sequenceHighlights} showCloseIcon/>
+        </AnalyticsContext>}
+
+        {!currentUser && forumTypeSetting.get() === 'LessWrong' && <div>
+          {/* <div className={classes.largeScreenLoggedOutSequences}>
+            <AnalyticsContext pageSectionContext="frontpageCuratedSequences">
+              <CuratedSequences />
+            </AnalyticsContext>
+          </div>
+          <div className={classes.smallScreenLoggedOutSequences}>
+            <ContinueReadingList continueReading={continueReading} />
+          </div> */}
         </div>}
 
-      {renderBookmarks && <div className={classes.subsection}>
-        <LWTooltip placement="top-start" title={bookmarksTooltip}>
-          <Link to={"/bookmarks"}>
-            <SectionSubtitle>
-              Bookmarks
-            </SectionSubtitle>
-          </Link>
-        </LWTooltip>
-        <AnalyticsContext listContext={"frontpageBookmarksList"} capturePostItemOnMount>
-          <BookmarksList limit={bookmarksLimit} hideLoadMore={true}/>
-        </AnalyticsContext>
-      </div>}
-
-      {/* disabled except during review */}
-      {/* <AnalyticsContext pageSectionContext="LessWrong 2018 Review">
-        <FrontpageVotingPhase settings={frontpageRecommendationSettings} />
-      </AnalyticsContext> */}
-
-      {/* disabled except during coronavirus times */}
-      {/* <AnalyticsContext pageSectionContext="coronavirusWidget">
         <div className={classes.subsection}>
-          <CoronavirusFrontpageWidget settings={frontpageRecommendationSettings} />
+          <div className={classes.posts}>
+            {!settings.hideFrontpage && 
+              <AnalyticsContext listContext="frontpageFromTheArchives" pageSubSectionContext="frontpageFromTheArchives" capturePostItemOnMount>
+                <RecommendationsList algorithm={frontpageRecommendationSettings} />
+              </AnalyticsContext>
+            }
+            <AnalyticsContext listContext="curatedPosts" pageSubSectionContext="curatedPosts">
+              <PostsList2
+                terms={{view:"curated", limit: currentUser ? 3 : 2}}
+                showNoResults={false}
+                showLoadMore={false}
+                hideLastUnread={true}
+                boxShadow={false}
+                curatedIconLeft={true}
+              />
+            </AnalyticsContext>
+          </div>
         </div>
-      </AnalyticsContext> */}
+
+        {renderContinueReading && <div className={currentUser ? classes.subsection : null}>
+          <AnalyticsContext pageSubSectionContext="continueReading">
+            <LWTooltip placement="top-start" title={continueReadingTooltip}>
+              <Link to={"/library"}>
+                <SectionSubtitle className={classNames(classes.subtitle, classes.continueReading)}>
+                  Continue Reading
+                </SectionSubtitle>
+              </Link>
+            </LWTooltip>
+            <ContinueReadingList continueReading={continueReading} />
+          </AnalyticsContext>
+        </div>}
+
+        {renderBookmarks && <div className={classes.subsection}>
+          <AnalyticsContext pageSubSectionContext="frontpageBookmarksList" listContext={"frontpageBookmarksList"} capturePostItemOnMount>
+            <LWTooltip placement="top-start" title={bookmarksTooltip}>
+              <Link to={"/bookmarks"}>
+                <SectionSubtitle>
+                  Bookmarks
+                </SectionSubtitle>
+              </Link>
+            </LWTooltip>
+            <BookmarksList limit={bookmarksLimit} hideLoadMore={true}/>
+          </AnalyticsContext>
+        </div>}
+
+        {/* disabled except during review */}
+        {/* <AnalyticsContext pageSectionContext="LessWrong 2018 Review">
+          <FrontpageVotingPhase settings={frontpageRecommendationSettings} />
+        </AnalyticsContext> */}
+
+        {/* disabled except during coronavirus times */}
+        {/* <AnalyticsContext pageSectionContext="coronavirusWidget">
+          <div className={classes.subsection}>
+            <CoronavirusFrontpageWidget settings={frontpageRecommendationSettings} />
+          </div>
+        </AnalyticsContext> */}
+      </AnalyticsContext>
     </SingleColumnSection>
   }
 

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -127,10 +127,11 @@ USE THIS CONVENTION FOR TRACKING EVENT LOCATION
     - (only needs to defined once for each page)
 * pageSectionContext={sectionName}, e.g. recentDiscussion, gatherTownWidget, wikiSection, userDrafts
     - use for larger sections of a page
+* pageSubSectionContext is used when a section meaningfully has subsections (such as bookmarks list within the recommendations section on the frontpage)
 * pageElementContext={elementName}> e.g. hoverPreview, commentItem, answerItem
     -use when wanting to mark where within a section something occurs
 * listContext is historical. Now just use pageSection.
-* pageSubSectionContext has been used in a couple of places, but is largely superceded by elementContext
+
 
 Also, context labels and their values should be camelCase, e.g. `pageSectionContext="fromTheArchives"`, 
 and *not* `page_section_context="From the Archives" or the like.

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -18,7 +18,8 @@ export interface RecommendationsAlgorithm {
   minimumBaseScore?: number
   excludeDefaultRecommendations?: boolean
   onlyUnread?: boolean
-  
+  lwRationalityOnly?: boolean,
+
   curatedModifier?: number
   frontpageModifier?: number
   personalBlogpostModifier?: number

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -91,8 +91,8 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
   if (algorithm.lwRationalityOnly) {
     return {
       $or: [
-        {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}},
-        {canonicalCollectionSlug: "rationality"},
+        {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}}, // rationality tag
+        {canonicalCollectionSlug: "rationality"}, // posts from the rationality a-z collection (some of which are not tagged rationality)
       ]
     }
   }

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -90,9 +90,7 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
   }
   if (algorithm.lwRationalityOnly) {
     return {
-      $or: [
-        {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}}, // rationality tag
-      ]
+      "tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0} // rationality tag
     }
   }
   if (algorithm.reviewNominations) {

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -92,7 +92,6 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
     return {
       $or: [
         {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}}, // rationality tag
-        {canonicalCollectionSlug: "rationality"}, // posts from the rationality a-z collection (some of which are not tagged rationality)
       ]
     }
   }

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -88,6 +88,14 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
       positiveReviewVoteCount: {$gte: 1},
     }
   }
+  if (algorithm.lwRationalityOnly) {
+    return {
+      $or: [
+        {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}},
+        {canonicalCollectionSlug: "rationality"},
+      ]
+    }
+  }
   if (algorithm.reviewNominations) {
     if (isEAForum) {
       return {postedAt: {$lt: new Date(`${(algorithm.reviewNominations as number) + 1}-01-01`)}}


### PR DESCRIPTION
On LessWrong, as part of the epistemics marathon, we are temporarily changing recommendations to focus on rationality content.

Also updating the analytics contexts in the recommendations section.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202804002332672) by [Unito](https://www.unito.io)
