### PR TITLE
Brotli compress bundle.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const WebSocket = require('ws');
 const fetch = require("node-fetch");
 const crypto = require('crypto');
+const { zlib } = require("mz");
 
 const defaultServerPort = 3000;
 
@@ -72,12 +73,13 @@ const bundleDefinitions = {
   "serverPort": getServerPort(),
 };
 
+const clientOutfilePath = `./${outputDir}/client/js/bundle.js`;
 build({
   entryPoints: ['./packages/lesswrong/client/clientStartup.ts'],
   bundle: true,
   target: "es6",
   sourcemap: true,
-  outfile: `./${outputDir}/client/js/bundle.js`,
+  outfile: clientOutfilePath,
   minify: isProduction,
   banner: clientBundleBanner,
   treeShaking: "ignore-annotations",
@@ -92,6 +94,16 @@ build({
     if (buildResult?.errors?.length > 0) {
       console.log("Skipping browser refresh notification because there were build errors");
     } else {
+      // Creating brotli compressed version of bundle.js to save on client download size:
+      const brotliOutfilePath = `${clientOutfilePath}.br`;
+      // Always delete compressed version if it exists, to avoid stale files
+      if (fs.existsSync(brotliOutfilePath)) {
+        fs.unlinkSync(brotliOutfilePath);
+      }
+      if (isProduction) {
+        fs.writeFileSync(brotliOutfilePath, zlib.brotliCompressSync(fs.readFileSync(clientOutfilePath, 'utf8')));
+      }
+
       latestCompletedBuildId = inProgressBuildId;
       initiateRefresh();
     }


### PR DESCRIPTION
Statically compress the client bundle just after it is built when running in production, then check for this compressed version when serving the file. This gets it down from 2.1MB to 1.6MB.

Very long explanation of why I'm doing it this way:

"But Will," I hear you cry, "weren't we going to use a CDN to do the brotli compression for us? Thus compressing every response without requiring any code changes". Yes that was the plan, and some CDNs do claim to do brotli compression for you, but:


* There is only one which will actually _convert_ gzip to brotli, Cloudflare (based on [this](https://community.cloudflare.com/t/compression-with-gzip-and-brotli/297664)), and it's not suitable because it only caches based on file extension not MIME type
* From testing on Cloudfront it seems like it's quite hit and miss whether it actually applies compression even when the server returns uncompressed files
* They only tend to do compression when a file is cached, we don't want to couple together caching and compression necessarily

So I think trying to rely on a CDN to do all our compression is probably a dead end, and that we should just continue to handle it on our servers (note: the CDN still gives us the benefit of caching the compressed files, which saves time + cpu). To that end, I tried setting up nginx to do the compression, the same way we handle gzip. But I couldn't get this to work because it requires installing an nginx module, which is not straightforward to do on the nginx server that comes preinstalled on the instances that Elastic Beanstalk creates.

The other relevant info is that brotli has 11 levels of compression:


* 1-9 are fast enough (a few ms) to do stream compression with, and give ~15% greater compression than gzip. Any on the fly compression we could do (with a CDN or nginx or just using zlib inside our server) would use one of these levels
* 10 and 11 are much slower (~10 seconds) and give a much better compression ratio (~25% better than gzip)

bundle.js is about half of the total downloaded content when you load the front page, so just statically compressing it gets most of the value we would get from adding stream compression to everything.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202806026132575) by [Unito](https://www.unito.io)
