### PR TITLE
Fix hidden descriptions on mobile library

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -17,6 +17,7 @@ const sequenceHighlights: CoreReadingCollection = {
   summary: `<div>How can we think better on purpose? Why should we think better on purpose?<br/>
     Read up on the core concepts that underly the LessWrong community.
     </div>`,
+  hideSummaryOnMobile: true,
   imageUrl: "https://res.cloudinary.com/lesswrong-2-0/image/upload/v1660339717/coverimage-05_qvc8ca.png",
   imageWidth: 200,
   color: "#757AA7",

--- a/packages/lesswrong/components/sequences/CollectionsItem.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsItem.tsx
@@ -123,6 +123,11 @@ export const CollectionsItem = ({classes, showCloseIcon, collection}: {
     path: "/"
   });
 
+  const description = <ContentItemBody
+    dangerouslySetInnerHTML={{__html: collection.summary}}
+    description={`sequence ${collection.id}`}
+  />
+
   return <div className={classNames(classes.root, {[classes.small]:collection.small})}>
     <LinkCard to={collection.url} className={classes.linkCard}>
       <div className={classes.content}>
@@ -133,18 +138,9 @@ export const CollectionsItem = ({classes, showCloseIcon, collection}: {
           {collection.subtitle}
         </div>}
         <ContentStyles contentType="postHighlight" className={classes.description}>
-          <div className={classes.desktop}>
-            <ContentItemBody
-              dangerouslySetInnerHTML={{__html: collection.summary}}
-              description={`sequence ${collection.id}`}
-            />
-          </div>
-          <div className={classes.mobile}>
-            {collection.mobileSummary && <ContentItemBody
-              dangerouslySetInnerHTML={{__html: collection.mobileSummary}}
-              description={`sequence ${collection.id}`}
-            />}
-          </div>
+          {collection.hideSummaryOnMobile ? <div className={classes.desktop}>
+            {description}
+          </div> : description}
         </ContentStyles>
         {firstPost && <div className={classes.firstPost}>
           First Post: <LWTooltip title={<PostsPreviewTooltipSingle postId={firstPost.postId}/>} tooltip={false}>

--- a/packages/lesswrong/components/sequences/CollectionsItem.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsItem.tsx
@@ -77,13 +77,8 @@ const styles = (theme: ThemeType): JssStyles => ({
       width: "100%"
     }
   },
-  desktop: {
+  hideOnMobile: {
     [theme.breakpoints.down('xs')]: {
-      display: "none"
-    }
-  },
-  mobile: {
-    [theme.breakpoints.up('sm')]: {
       display: "none"
     }
   },
@@ -138,7 +133,7 @@ export const CollectionsItem = ({classes, showCloseIcon, collection}: {
           {collection.subtitle}
         </div>}
         <ContentStyles contentType="postHighlight" className={classes.description}>
-          {collection.hideSummaryOnMobile ? <div className={classes.desktop}>
+          {collection.hideSummaryOnMobile ? <div className={classes.hideOnMobile}>
             {description}
           </div> : description}
         </ContentStyles>

--- a/packages/lesswrong/components/sequences/LWCoreReading.tsx
+++ b/packages/lesswrong/components/sequences/LWCoreReading.tsx
@@ -20,7 +20,7 @@ export interface CoreReadingCollection {
   id: string,
   userId: string,
   summary: string,
-  mobileSummary?: string,
+  hideSummaryOnMobile?: boolean,
   imageId?: string,
   imageWidth?: number,
   imageUrl?: string,


### PR DESCRIPTION
A previous PR to display the Sequences Highlights on frontpage accidentally broke the mobile display for the library page, which users the same component. (It was important for the frontpage display to hide the collection description on mobile, but we don't want that behavior in the library) 

This changes the mechanism for hiding it. I've done a resize test on both home page and /library.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202811052590828) by [Unito](https://www.unito.io)
