### PR TITLE
Use a darker color palette for progress bars on the EA forum

### DIFF
--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import classNames from 'classnames';
 import { useItemsRead } from '../common/withRecordPostView';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -18,8 +19,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 2,
   },
   read: {
-    backgroundColor: theme.palette.primary.light,
-    border: theme.palette.primary.main,
+    ...(
+      forumTypeSetting.get() === "EAForum"
+        ? {
+          backgroundColor: theme.palette.primary.main,
+          border: theme.palette.primary.dark,
+        }
+        : {
+          backgroundColor: theme.palette.primary.light,
+          border: theme.palette.primary.main,
+        }
+    ),
     opacity: .6
   },
   bookProgress: {

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -5,6 +5,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import CheckBoxTwoToneIcon from '@material-ui/icons/CheckBoxTwoTone';
 import { useItemsRead } from '../common/withRecordPostView';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -20,7 +21,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   read: {
     width: 12,
-    color: theme.palette.primary.light,
+    color: forumTypeSetting.get() === "EAForum"
+      ? theme.palette.primary.main
+      : theme.palette.primary.light,
     marginRight: 10,
     position: "relative",
     top: -1


### PR DESCRIPTION
The collections page progess bars are currently using the "light" colour palette. Max has requested for the EA forum to use the "main" colour palette instead. LessWrong is unaffected.

<img width="777" alt="Screenshot 2022-08-17 at 12 34 09" src="https://user-images.githubusercontent.com/5075628/185114598-f93ff27b-2f19-4b04-b61e-ca2ae1876566.png">
