### PR TITLE
Allow admins to override the calculated read time of posts

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentNumber.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentNumber.tsx
@@ -4,25 +4,19 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import mapValues from 'lodash/mapValues';
 
 class FormComponentNumber extends PureComponent<any> {
-
-  getChildContext() {
-    return {
-      ...this.context,
-      
-      // For some reason MuiTextField with type="number" constrains the input
-      // to a number, but then reports the result as a string, which causes
-      // form validation to fail because strings like "3" are not nunbers.
-      // Insert a mapping here to parse them first.
-      updateCurrentValues: (changes) => {
-        this.context.updateCurrentValues(mapValues(changes, n=>parseInt(n)));
-      }
-    };
-  }
-  
   render() {
     return <Components.MuiTextField
       type="number"
       {...this.props as any}
+      updateCurrentValues={
+        // MuiTextField returns a string - convert it into a number to avoid database errors
+        (values) => {
+          for (const key in values) {
+            values[key] = parseInt(values[key]);
+          }
+          this.props.updateCurrentValues(values);
+        }
+      }
     />
   }
 }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -124,7 +124,8 @@ const PostsPagePostHeader = ({post, classes}: {
   const { major } = extractVersionsFromSemver(post.version)
   const hasMajorRevision = major > 1
   const wordCount = post.contents?.wordCount || 0
-  
+  const readTime = post.readTimeMinutes ?? 1
+
   return <>
     {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}
     <AnalyticsContext pageSectionContext="topSequenceNavigation">
@@ -146,9 +147,8 @@ const PostsPagePostHeader = ({post, classes}: {
               </a>
             </LWTooltip>
           }
-          {/* NB: Currently display:none'd */}
-          {!!wordCount && !post.isEvent && <LWTooltip title={`${wordCount} words`}>
-            <span className={classes.wordCount}>{Math.floor(wordCount/200) || 1 } min read</span>
+          {!post.isEvent && <LWTooltip title={`${wordCount} words`}>
+            <span className={classes.wordCount}>{readTime} min read</span>
           </LWTooltip>}
           {!post.isEvent && <span className={classes.date}>
             <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -151,7 +151,13 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
 
 
   const posts = sequence.chapters?.flatMap(chapter => chapter.posts ?? []) ?? []
-  const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
+  const [
+    totalWordCount,
+    totalReadTime,
+  ] = posts.reduce(([wordCount, readTime], curr) => ([
+    wordCount + (curr?.contents?.wordCount ?? 0),
+    readTime + (curr?.readTimeMinutes ?? 0),
+  ]), [0, 0]);
 
   const highlight = sequence.contents?.htmlHighlight || ""
 
@@ -195,8 +201,8 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
               description={`sequence ${sequence._id}`}
             />
           </ContentStyles>}
-          <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>
-            <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read</div>
+          <LWTooltip title={<div> ({totalWordCount.toLocaleString("en-US")} words)</div>}>
+            <div className={classes.wordcount}>{totalReadTime} min read</div>
           </LWTooltip>
         </div>
       </div>

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -186,6 +186,7 @@ registerFragment(`
   fragment PostsListBase on Post {
     ...PostsBase
     ...PostsAuthors
+    readTimeMinutes
     moderationGuidelines {
       _id
       html
@@ -412,6 +413,7 @@ registerFragment(`
   fragment PostsEdit on Post {
     ...PostsPage
     coauthorStatuses
+    readTimeMinutesOverride
     moderationGuidelines {
       ...RevisionEdit
     }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -413,7 +413,30 @@ const schema: SchemaType<DbPost> = {
     editableBy: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
   },
-  
+
+  // By default, the read time for a post is calculated automatically from the word count.
+  // Sometimes this incorrect (often due to link posts, videos, etc.) so it can be overridden
+  // manually by setting this field.
+  readTimeMinutesOverride: {
+    type: Number,
+    optional: true,
+    canRead: ['guests'],
+    canCreate: ['admins'],
+    canUpdate: ['admins'],
+    group: formGroups.adminOptions,
+    control: 'FormComponentNumber',
+    label: 'Read time (minutes)',
+    tooltip: 'By default, this is calculated from the word count. Enter a value to override.',
+  },
+  readTimeMinutes: resolverOnlyField({
+    type: Number,
+    viewableBy: ['guests'],
+    resolver: ({readTimeMinutesOverride, contents}: DbPost) =>
+      Math.round(typeof readTimeMinutesOverride === "number"
+        ? readTimeMinutesOverride
+        : (contents?.wordCount ?? 0) / 250),
+  }),
+
   // DEPRECATED field for GreaterWrong backwards compatibility
   wordCount: resolverOnlyField({
     type: Number,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -355,6 +355,7 @@ interface DbPost extends DbObject {
   userId: string
   question: boolean
   authorIsUnreviewed: boolean
+  readTimeMinutesOverride: number
   submitToFrontpage: boolean
   hiddenRelatedQuestion: boolean
   originalPostRelationSourceId: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -171,6 +171,7 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly userId: string,
   readonly question: boolean,
   readonly authorIsUnreviewed: boolean,
+  readonly readTimeMinutesOverride: number,
   readonly submitToFrontpage: boolean,
   readonly hiddenRelatedQuestion: boolean,
   readonly originalPostRelationSourceId: string,
@@ -480,6 +481,7 @@ interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
 }
 
 interface PostsListBase extends PostsBase, PostsAuthors { // fragment on Posts
+  readonly readTimeMinutes: number,
   readonly moderationGuidelines: PostsListBase_moderationGuidelines|null,
   readonly customHighlight: PostsListBase_customHighlight|null,
   readonly lastPromotedComment: PostsListBase_lastPromotedComment|null,
@@ -665,6 +667,7 @@ interface PostsEdit extends PostsPage { // fragment on Posts
     confirmed: boolean,
     requested: boolean,
   }>,
+  readonly readTimeMinutesOverride: number,
   readonly moderationGuidelines: RevisionEdit|null,
   readonly contents: RevisionEdit|null,
   readonly customHighlight: RevisionEdit|null,


### PR DESCRIPTION
The estimated read times for the handbook (which are automatically calculated from the word count of posts) are currently massively overestimated due to a large number of link posts, some of which also contain videos. This PR adds an admin option to manually input a read time for posts.

I also moved the logic which calculates the value from the word count out of the individual react components and into a resolver-only field which also checks the override. It turns out that the posts page was assuming readers would read at 200 WPM, but the collection page assumed 300 WPM. Apparently the [average](https://www.sciencedirect.com/science/article/abs/pii/S0749596X19300786) is 238 WPM for non-fiction and 260 WPM for fiction, so I split this down the middle and used 250 WPM.

<img width="470" alt="Screenshot 2022-08-18 at 16 45 58" src="https://user-images.githubusercontent.com/5075628/185438198-89c8d12e-e8c0-4436-803a-d477cd6b7777.png">
