### PR TITLE
Less margin on collections page chapter titles

### DIFF
--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -89,6 +89,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   chapterTitle: {
     fontSize: "1.25rem !important",
+    margin: "8px 0 -8px 0 !important",
   },
   postIcon: {
     height: 12,
@@ -206,7 +207,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
       <div className={classes.right}>
         {sequence.chapters?.flatMap(({posts, title}, index) =>
           <React.Fragment key={index}>
-            {showChapters && title && <SectionTitle title={title} className={classes.chapterTitle} />}
+            {showChapters && title && <SectionTitle title={title} className={classes.chapterTitle} noTopMargin />}
             {posts.map((post) => (
               <SequencesSmallPostLink
                 key={sequence._id + post._id}


### PR DESCRIPTION
Jesse requested less margin on chapter titles on the collections page:

Before/after:
<img width="721" alt="Screenshot 2022-08-18 at 17 27 15" src="https://user-images.githubusercontent.com/5075628/185446678-e40cee85-a87c-4fc8-a019-5d6122a5bdad.png">
<img width="746" alt="Screenshot 2022-08-18 at 17 26 59" src="https://user-images.githubusercontent.com/5075628/185446692-917f46d7-a184-4354-9861-3ca97e1e2ff2.png">
