### PR TITLE
Fix sequence links for sequences that aren't in collections

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -56,7 +56,7 @@ export const sequenceGetAllPosts = async (sequenceId: string, context: ResolverC
 
 const getSequenceCollectionBooks = async function(sequenceId: string) {
   const sequence = await Sequences.findOne({ _id: sequenceId });
-  if (!sequence) return;
+  if (!sequence?.canonicalCollectionSlug) return;
 
   const { canonicalCollectionSlug } = sequence;
 


### PR DESCRIPTION
Reported by Lizka. When a sequence is not in a collection, `canonicalCollectionSlug` will be undefined and `getSequenceCollectionBooks` will fetch a random collection. This can currently be seen on https://forum.effectivealtruism.org/s/JuwQwdLugR63ux2P8/p/dYiJLvcRJ4nk4xm3X which links to the EA handbook as the next post, despite not being in a relevant sequence.