### PR TITLE
Styling improvements for New User and New Post in sunshine sidear

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -115,10 +115,10 @@ const SunshineNewPostsItem = ({post, classes}: {
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
+          <FooterTagList post={post} />
           <CoreTagsChecklist post={post} onSetTagsSelected={(selectedTags) => {
             setSelectedTags(selectedTags);
           }}/>
-          <FooterTagList post={post} />
           <div className={classes.buttonRow}>
               <Button onClick={handlePersonal}>
                 <PersonIcon className={classes.icon} /> Personal

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -147,8 +147,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   snooze10: {
     color: theme.palette.primary.main,
-    fontSize: 32,
-    marginTop: 2
+    fontSize: 34,
+    marginTop: 4
   },
   permissionsButton: {
     fontSize: 10,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -46,7 +46,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 8
+  },
+  permissionsRow: {
+    display: "flex",
+    alignItems: "center",
+    marginBottom: 8,
+    marginTop: 8
   },
   disabled: {
     opacity: .2,
@@ -142,7 +147,21 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   snooze10: {
-    color: theme.palette.primary.main
+    color: theme.palette.primary.main,
+    fontSize: 28
+  },
+  permissionsButton: {
+    fontSize: 10,
+    padding: 6,
+    paddingTop: 3,
+    paddingBottom: 3,
+    border: theme.palette.border.commentBorder,
+    borderRadius: 2,
+    marginRight: 10,
+    cursor: "pointer"
+  },
+  permissionDisabled: {
+    border: "none"
   }
 })
 
@@ -405,48 +424,26 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               </div>
             </div>
             <div className={classes.row}>
-              <LWTooltip title={`${user.postingDisabled ? "Enable" : "Disable"} this user's ability to create posts`}>
-                <Button onClick={handleDisablePosting} variant={user.postingDisabled ? "flat" : "outlined"}>
-                  Posts
-                </Button>
-              </LWTooltip>
-              <LWTooltip title={`${user.allCommentingDisabled ? "Enable" : "Disable"} this user's to comment (including their own shortform)`}>
-                <Button onClick={handleDisableAllCommenting} variant={user.allCommentingDisabled ? "flat" : "outlined"}>
-                  All Comments
-                </Button>
-              </LWTooltip>
-              <LWTooltip title={`${user.commentingOnOtherUsersDisabled ? "Enable" : "Disable"} this user's ability to comment on other people's posts`}>
-                <Button onClick={handleDisableCommentingOnOtherUsers} variant={user.commentingOnOtherUsersDisabled ? "flat" : "outlined"}>
-                  Other Comments
-                </Button>
-              </LWTooltip>
-              <LWTooltip title={`${user.conversationsDisabled ? "Enable" : "Disable"} this user's ability to start new private conversations`}>
-                <Button onClick={handleDisableConversations} variant={user.conversationsDisabled ? "flat" : "outlined"}>
-                  Conversations
-                </Button>
-              </LWTooltip>
-            </div>
-            <div className={classes.row}>
               <div className={classes.row}>
-                <LWTooltip title="Approve">
-                  <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>
-                </LWTooltip>
-                <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)">
+                <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)" placement="top">
                   <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
                 </LWTooltip>
                 <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)">
                   <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
                 </LWTooltip>
-                <LWTooltip title="Ban for 3 months">
+                <LWTooltip title="Approve" placement="top">
+                  <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>
+                </LWTooltip>
+                <LWTooltip title="Ban for 3 months" placement="top">
                   <RemoveCircleOutlineIcon className={classes.modButton} onClick={handleBan} />
                 </LWTooltip>
-                <LWTooltip title="Purge (delete and ban)">
+                <LWTooltip title="Purge (delete and ban)" placement="top">
                   <DeleteForeverIcon className={classes.modButton} onClick={handlePurge} />
                 </LWTooltip>
                 <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
                     <div>Flag this user for more review</div>
                     <div><em>(This will not remove them from sidebar)</em></div>
-                  </div>}>
+                  </div>} placement="top">
                   <div onClick={handleFlag} className={classes.modButton} >
                     {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
                   </div>
@@ -455,6 +452,31 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               <div className={classes.row}>
                 <SunshineSendMessageWithDefaults user={user} tagSlug={defaultModeratorPMsTagSlug.get()}/>
               </div>
+            </div>
+            <div className={classes.permissionsRow}>
+              <div className={classNames(classes.permissionsbutton, classes.permissionDisabled)}>
+                Permissions:
+              </div>
+              <LWTooltip title={`${user.postingDisabled ? "Enable" : "Disable"} this user's ability to create posts`}>
+                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.postingDisabled})} onClick={handleDisablePosting}>
+                  Posts
+                </div>
+              </LWTooltip>
+              <LWTooltip title={`${user.allCommentingDisabled ? "Enable" : "Disable"} this user's to comment (including their own shortform)`}>
+                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.allCommentingDisabled})} onClick={handleDisableAllCommenting}>
+                  All Comments
+                </div>
+              </LWTooltip>
+              <LWTooltip title={`${user.commentingOnOtherUsersDisabled ? "Enable" : "Disable"} this user's ability to comment on other people's posts`}>
+                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.commentingOnOtherUsersDisabled})} onClick={handleDisableCommentingOnOtherUsers}>
+                  Other Comments
+                </div>
+              </LWTooltip>
+              <LWTooltip title={`${user.conversationsDisabled ? "Enable" : "Disable"} this user's ability to start new private conversations`}>
+                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.conversationsDisabled})}onClick={handleDisableConversations}>
+                  Conversations
+                </div>
+              </LWTooltip>
             </div>
             <hr className={classes.hr}/>
             <div className={classes.votesRow}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -425,11 +425,11 @@ const SunshineNewUsersInfo = ({ user, classes }: {
             </div>
             <div className={classes.row}>
               <div className={classes.row}>
+                <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)" placement="top">
+                  <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
+                </LWTooltip>
                 <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)" placement="top">
                   <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
-                </LWTooltip>
-                <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)">
-                  <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
                 </LWTooltip>
                 <LWTooltip title="Approve" placement="top">
                   <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -20,7 +20,6 @@ import { DatabasePublicSetting } from '../../lib/publicSettings';
 import Input from '@material-ui/core/Input';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
-import Button from '@material-ui/core/Button';
 
 const defaultModeratorPMsTagSlug = new DatabasePublicSetting<string>('defaultModeratorPMsTagSlug', "moderator-default-responses")
 
@@ -454,9 +453,6 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               </div>
             </div>
             <div className={classes.permissionsRow}>
-              <div className={classNames(classes.permissionsbutton, classes.permissionDisabled)}>
-                Permissions:
-              </div>
               <LWTooltip title={`${user.postingDisabled ? "Enable" : "Disable"} this user's ability to create posts`}>
                 <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.postingDisabled})} onClick={handleDisablePosting}>
                   Posts

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -147,14 +147,15 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   snooze10: {
     color: theme.palette.primary.main,
-    fontSize: 28
+    fontSize: 32,
+    marginTop: 2
   },
   permissionsButton: {
     fontSize: 10,
     padding: 6,
     paddingTop: 3,
     paddingBottom: 3,
-    border: theme.palette.border.commentBorder,
+    border: theme.palette.border.normal,
     borderRadius: 2,
     marginRight: 10,
     cursor: "pointer"


### PR DESCRIPTION
This makes the new permissions buttons in the sunshine sidebar a bit more aesthetic/convenient, and makes the snooze10 button more prominent.

![](https://user-images.githubusercontent.com/3246710/185773608-b622e810-0f7b-4ddd-95dd-4cd5febfe72c.png)

Also, reverses the order of the tags on new-post-items, so that the hoverovers aren't as annoying when I'm trying to move my cursor to the middle of the hoverover.

![](https://user-images.githubusercontent.com/3246710/185773624-e0689e11-a6b2-4d9a-84d9-85f9297c3de8.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202834851431261) by [Unito](https://www.unito.io)
