### PR TITLE
SequencesSmallPostLink on SequencesPage

### DIFF
--- a/packages/lesswrong/components/common/SectionTitle.tsx
+++ b/packages/lesswrong/components/common/SectionTitle.tsx
@@ -40,6 +40,7 @@ const getAnchorId = (anchor: string|undefined, title: React.ReactNode) => {
   }
 }
 
+// This is meant to be used as the primary section title for the central page layout (normally used in conjunction with SingleColumnSection)
 const SectionTitle = ({children, classes, className, title, noTopMargin, anchor}: {
   children?: React.ReactNode,
   classes: ClassesType,

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -21,7 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
     alignItems: "center",
-    fontSize: "1.3rem",
+    ...theme.typography.postsItemTitle,
     [theme.breakpoints.down('xs')]: {
       whiteSpace: "unset",
       lineHeight: "1.8rem",

--- a/packages/lesswrong/components/sequences/ChapterTitle.tsx
+++ b/packages/lesswrong/components/sequences/ChapterTitle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { forumTypeSetting } from '../../lib/instanceSettings';
+import { registerComponent } from '../../lib/vulcan-lib';
+
+const isEAForum = forumTypeSetting.get() === "EAForum"
+
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    fontSize: isEAForum ? "1.25rem" : "1.4em",
+    fontStyle: isEAForum ? "unset" : "italic",
+    margin: "1em 0",
+  }
+});
+
+const ChapterTitle = ({classes, title}: {
+  classes: ClassesType,
+  title?: string
+}) => {
+  if (!title) return null
+  return  <div className={classes.root}>{title}</div>
+}
+
+const ChapterTitleComponent = registerComponent("ChapterTitle", ChapterTitle, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ChapterTitle: typeof ChapterTitleComponent
+  }
+}
+

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -5,20 +5,22 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 const styles = (theme: ThemeType): JssStyles => ({
   description: {
     marginLeft: 10,
-    marginBottom: 8,
+    marginBottom: 24,
     marginTop: 16
   },
   subtitle: {
-    fontSize: 20,
+    fontSize: "1.16em",
     lineHeight: 1.1,
     fontStyle: "italic",
-    marginTop: 20,
+    marginTop: 12,
   },
   posts: {
-    [theme.breakpoints.down('sm')]: {
       paddingLeft: 8,
       paddingRight: 8
-    }
+  },
+  title: {
+    display: "flex",
+    justifyContent: "space-between"
   }
 });
 
@@ -36,8 +38,8 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
     setEdit(false);
   }, []);
 
-  const { ChaptersEditForm, SectionTitle, SectionFooter,
-    SectionButton, SequencesPostsList, ContentItemBody, ContentStyles } = Components
+  const { ChaptersEditForm, ChapterTitle, SectionFooter,
+    SectionButton, ContentItemBody, ContentStyles, SequencesSmallPostLink } = Components
   const html = chapter.contents?.html || ""
   if (edit) return (
     <ChaptersEditForm
@@ -52,9 +54,11 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
 
   return (
     <div>
-      {chapter.title && <SectionTitle title={chapter.title}>
+     
+      {chapter.title && <div className={classes.title}>
+        <ChapterTitle title={chapter.title}/>
         {canEdit && editButton}
-      </SectionTitle>}
+      </div>}
       {html && <ContentStyles contentType="post" className={classes.description}>
         <ContentItemBody
           dangerouslySetInnerHTML={{__html: html}}
@@ -63,7 +67,7 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
       </ContentStyles>}
       <div className={classes.posts}>
         <AnalyticsContext chapter={chapter._id} capturePostItemOnMount>
-          <SequencesPostsList posts={chapter.posts} chapter={chapter} />
+          {chapter.posts.map(post => <SequencesSmallPostLink key={chapter._id + post._id} sequenceId={chapter.sequenceId} post={post} large/>)}
         </AnalyticsContext>
       </div>
       {!chapter.title && canEdit && <SectionFooter>{editButton}</SectionFooter>}

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -5,6 +5,8 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import classNames from 'classnames';
 
+const isEAForum = forumTypeSetting.get() === "EAForum"
+
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 40,
@@ -87,10 +89,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 125,
     objectFit: "cover"
   },
-  chapterTitle: {
-    fontSize: "1.25rem !important",
-    margin: "8px 0 -8px 0 !important",
-  },
   postIcon: {
     height: 12,
     width: 12,
@@ -112,7 +110,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: "45%",
     display: "flex",
     flexDirection: "column",
-    justifyContent: forumTypeSetting.get() === "EAForum" ? "flex-start" : "center",
+    justifyContent: isEAForum ? "flex-start" : "center",
     maxHeight: 600,
     [theme.breakpoints.down('xs')]: {
       width: "100%",
@@ -147,12 +145,11 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
   showChapters?: boolean,
   classes: ClassesType,
 }) => {
-  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, SectionTitle, LWTooltip } = Components
+  const { UsersName, ContentStyles, SequencesSmallPostLink, ContentItemTruncated, LWTooltip, ChapterTitle } = Components
 
   const [expanded, setExpanded] = useState<boolean>(false)
 
   const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
-
 
   const posts = sequence.chapters?.flatMap(chapter => chapter.posts ?? []) ?? []
   const totalWordcount = posts.reduce((prev, curr) => prev + (curr?.contents?.wordCount || 0), 0)
@@ -207,7 +204,7 @@ export const LargeSequencesItem = ({sequence, showAuthor=false, showChapters=fal
       <div className={classes.right}>
         {sequence.chapters?.flatMap(({posts, title}, index) =>
           <React.Fragment key={index}>
-            {showChapters && title && <SectionTitle title={title} className={classes.chapterTitle} noTopMargin />}
+            <ChapterTitle title={title}/>
             {posts.map((post) => (
               <SequencesSmallPostLink
                 key={sequence._id + post._id}

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -37,7 +37,7 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
   sequence: SequencesPageFragment|null,
   showAuthor?: boolean
 }) => {
-  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip } = Components
+  const { SequencesSmallPostLink, Loading, ContentStyles, ContentItemTruncated, UsersName, LWTooltip, ChapterTitle } = Components
 
   const { results: chapters, loading: chaptersLoading } = useMulti({
     terms: {
@@ -74,13 +74,16 @@ export const SequencesHoverOver = ({classes, sequence, showAuthor=true}: {
     </ContentStyles>
     {/* show a loading spinner if either sequences hasn't loaded or chapters haven't loaded */}
     {(!sequence || (!chapters && chaptersLoading)) && <Loading/>}
-    {sequence && posts.map(post => 
-      <SequencesSmallPostLink 
-        key={sequence._id + post._id} 
-        post={post}
-        sequenceId={sequence._id}
-      />
-    )}
+    {sequence && chapters?.flatMap(chapter => {
+      return <div>
+        <ChapterTitle title={chapter.title}/>
+        {chapter.posts.map(post => <SequencesSmallPostLink 
+          key={sequence._id + post._id} 
+          post={post}
+          sequenceId={sequence._id}
+        />)}
+      </div>
+    })}
     <LWTooltip title={<div> ({totalWordcount.toLocaleString("en-US")} words)</div>}>
       <div className={classes.wordcount}>{Math.round(totalWordcount / 300)} min read</div>
     </LWTooltip>

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -6,6 +6,7 @@ import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import CheckBoxTwoToneIcon from '@material-ui/icons/CheckBoxTwoTone';
 import { useItemsRead } from '../common/withRecordPostView';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -18,6 +19,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "center",
     marginBottom: 6,
     marginTop: 6
+  },
+  large: {
+    ...theme.typography.postsItemTitle,
+    marginBottom: 10,
+    marginTop: 10
   },
   read: {
     width: 12,
@@ -36,10 +42,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const SequencesSmallPostLink = ({classes, post, sequenceId}: {
+const SequencesSmallPostLink = ({classes, post, sequenceId, large}: {
   classes: ClassesType,
   post: PostsList,
-  sequenceId: string
+  sequenceId: string,
+  large?: boolean
 }) => {
   const { LWTooltip, PostsPreviewTooltip } = Components
 
@@ -49,8 +56,8 @@ const SequencesSmallPostLink = ({classes, post, sequenceId}: {
 
   const icon = isPostRead ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
 
-  return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement="left-start" inlineBlock={false}>
-        <Link to={postGetPageUrl(post, false, sequenceId)} className={classes.title}>
+  return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement="left-start" inlineBlock={false} flip>
+        <Link to={postGetPageUrl(post, false, sequenceId)} className={classNames(classes.title, {[classes.large]: large})}>
           {icon} {post.title}
         </Link>
       </LWTooltip>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -532,6 +532,7 @@ importComponent("SequencesPost", () => require('../components/sequences/Sequence
 importComponent("SequencesGridItem", () => require('../components/sequences/SequencesGridItem'));
 importComponent("LargeSequencesItem", () => require('../components/sequences/LargeSequencesItem'));
 importComponent("SequencesHoverOver", () => require('../components/sequences/SequencesHoverOver'));
+importComponent("ChapterTitle", () => require('../components/sequences/ChapterTitle'));
 importComponent("SequencesSmallPostLink", () => require('../components/sequences/SequencesSmallPostLink'));
 importComponent("ChaptersItem", () => require('../components/sequences/ChaptersItem'));
 importComponent("ChaptersList", () => require('../components/sequences/ChaptersList'));

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -102,6 +102,9 @@ export const baseTheme: BaseThemeSpecification = {
           fontSize: '1.1rem',
           lineHeight: '1.5rem',
         },
+        postsItemTitle: {
+          fontSize: "1.3rem"
+        },
         smallText: {
           fontFamily: palette.fonts.sansSerifStack,
           fontWeight: 400,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -368,6 +368,7 @@ declare global {
       display2: JssStyles,
       display3: JssStyles,
       display4: JssStyles,
+      postsItemTitle: JssStyles,
       body1: JssStyles,
       body2: JssStyles,
       headline: JssStyles,


### PR DESCRIPTION
The primary goal of this PR is to change SequencesPage to use SequencesSmallPostLink instead of PostsItem2.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3246710/185871040-de1409f9-eb72-4d10-a46c-ba58c53267f5.png">
