### PR TITLE
Curation improvements

### DIFF
--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -57,6 +57,10 @@ const FILTERS_ALL: ForumOptions<Partial<Record<Filters, SettingsOption>>> = {
       label: "Frontpage",
       tooltip: "Posts about research and other work in high-impact cause areas."
     },
+    curated: {
+      label: "Curated",
+      tooltip: "Posts chosen by the moderation team to be well written and important (approximately 3 per week)"
+    },
     questions: {
       label: "Questions",
       tooltip: "Open questions and answers, ranging from newcomer questions to important unsolved scientific problems."

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
+import { useCurrentUser } from '../common/withUser';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   loadMorePadding: {
@@ -13,6 +15,8 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
   belowFold?: boolean,
   classes: ClassesType,
 }) => {
+  const currentUser = useCurrentUser();
+
   const { results, loadMoreProps, showLoadMore } = useMulti({
     terms,
     collectionName: "Posts",
@@ -29,8 +33,13 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
   const curatedDate = curatedResults ? new Date(curatedResults[0]?.curatedDate) : new Date();
   const twoAndAHalfDaysAgo = new Date(new Date().getTime()-(2.5*24*60*60*1000));
 
-  if (!belowFold && (curatedDate > twoAndAHalfDaysAgo)) return null
-  
+  if (
+    (!belowFold && (curatedDate > twoAndAHalfDaysAgo)) ||
+    (forumTypeSetting.get() === "EAForum" && !currentUser?.isAdmin)
+  ) {
+    return null
+  }
+
   const { SunshineListTitle, SunshineCuratedSuggestionsItem, MetaInfo, FormatDate, LoadMore } = Components
     
   if (results && results.length) {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -154,8 +154,8 @@ addFieldsDict(Posts, {
     control: 'datetime',
     optional: true,
     viewableBy: ['guests'],
-    insertableBy: ['sunshineRegiment', 'admins'],
-    editableBy: ['sunshineRegiment', 'admins'],
+    editableBy: isEAForum ? ['admins'] : ['sunshineRegiment', 'admins'],
+    insertableBy: isEAForum ? ['admins'] : ['sunshineRegiment', 'admins'],
     group: formGroups.adminOptions,
   },
   // metaDate: Date at which the post was marked as meta (null or false if it
@@ -797,8 +797,8 @@ addFieldsDict(Posts, {
     foreignKey: "Users",
     optional: true,
     viewableBy: ['guests'],
-    editableBy: ['sunshineRegiment', 'admins'],
-    insertableBy: ['sunshineRegiment', 'admins'],
+    editableBy: isEAForum ? ['admins'] : ['sunshineRegiment', 'admins'],
+    insertableBy: isEAForum ? ['admins'] : ['sunshineRegiment', 'admins'],
     group: formGroups.adminOptions,
     label: "Curated Review UserId"
   },


### PR DESCRIPTION
This branch has two improvements to curations on the EA forum after talking with Lizka.

First, it restricts the ability to approve curated posts to admins (sunshine regiment can still suggest), and second, it adds a "curated" option to the all posts page settings (like on LessWrong):
![Screenshot 2022-08-24 at 15 55 24](https://user-images.githubusercontent.com/5075628/186451430-072b6d3e-efd0-4754-8e4e-ea5b8125646f.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202859247143411) by [Unito](https://www.unito.io)
