### PR TITLE
Make map use three different colors

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -9,7 +9,7 @@ import { Helmet } from 'react-helmet'
 import * as _ from 'underscore';
 import { mapboxAPIKeySetting } from '../../lib/publicSettings';
 import { forumTypeSetting } from '../../lib/instanceSettings';
-import PersonIcon from '@material-ui/icons/PersonPin';
+import PersonIcon from '@material-ui/icons/Person';
 import classNames from 'classnames';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -137,8 +137,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     terms: {view: "usersMapLocations"},
     collectionName: "Users",
     fragmentName: "UsersMapEntry",
-    limit: 500,
-    skip: !showUsers
+    limit: 500
   })
 
   const isEAForum = forumTypeSetting.get() === 'EAForum';

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -137,7 +137,8 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     terms: {view: "usersMapLocations"},
     collectionName: "Users",
     fragmentName: "UsersMapEntry",
-    limit: 500
+    limit: 500,
+    skip: !showIndividuals
   })
 
   const isEAForum = forumTypeSetting.get() === 'EAForum';

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -33,7 +33,6 @@ export const HomepageCommunityMap = ({classes}: {
     <CommunityMapWrapper
       terms={mapEventTerms}
       mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
-      showUsers
     />
   </div>;
 }

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -7,6 +7,7 @@ import { useCurrentUser } from '../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
+    marginTop: 50,
     [theme.breakpoints.down('sm')]: {
       display: "none"
     }

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -421,10 +421,9 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
   eaForumGroupsMobileImg: '#e2f1f4',
   
   contrastText: shades.grey[0],
-  event: '#2b6a99',
-  group: '#588f27',
-  individual: '#3f51b5',
-  
+  event: 'rgba(67,151,71,.65)',
+  group: 'rgba(24,68,155,.65)',
+  individual: 'rgba(88,64,29,.65)',
   primary: {
     main: "#5f9b65",
     dark: "#426c46",

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -423,7 +423,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
   contrastText: shades.grey[0],
   event: 'rgba(67,151,71,.65)',
   group: 'rgba(24,68,155,.65)',
-  individual: 'rgba(88,64,29,.65)',
+  individual: 'rgba(90,90,90,.65)',
   primary: {
     main: "#5f9b65",
     dark: "#426c46",


### PR DESCRIPTION
Previously the map looks like this:
![](https://user-images.githubusercontent.com/3246710/186570559-bb14ae0b-51c3-4e89-a3ed-801b1024da10.png)

I don't like a couple things about this:


1. The individual-pins mostly aren't relevant and blow out everything else. 
1. The individual pins also feel bigger than they need to be.
1. When lots of pins are near each other, I can't tell how many there are, they look like a giant blob
1. The individuals and events are the same color(ish) and hard to tell apart.

When you turn off individuals, it looks like this:
![](https://user-images.githubusercontent.com/3246710/186560792-dad2858e-742b-4880-912d-21413c1bc89f.png)

This PR:
– changes the color of individuals
– makes individuals into a smaller icon
– hides individuals by default on the frontpage
– perhaps controversially, adds some translucency to icons so that when multiple of them are stacked on top of each other, there's more visual cue about the density being higher. (note: I slightly increased the opacity yesterday, Ruby, if you already looked at that)

[fake edit: I just noticed that we already manually set the opacity in the icon, I think for the same reason, so maybe it's better to do all opacity setting there]

Current new version (not sure these colors are great either)

![](https://user-images.githubusercontent.com/3246710/186571112-3b2d2cea-026c-4bb4-9140-f0864b19d4ac.png)

![](https://user-images.githubusercontent.com/3246710/186574517-d4a81e39-5d4e-4db9-9dda-339bffcafca9.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202861035294362) by [Unito](https://www.unito.io)
