### PR TITLE
Reduce count of events in sidebar

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/EventsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/EventsList.tsx
@@ -16,7 +16,7 @@ const EventsList = ({currentUser, onClick}) => {
       view: 'nearbyEvents',
       lat: lat,
       lng: lng,
-      limit: isEAForum ? 4 : 7,
+      limit: 4,
     }
     return <span>
       <AnalyticsContext pageSubSectionContext="menuEventsList">
@@ -28,11 +28,11 @@ const EventsList = ({currentUser, onClick}) => {
   const eventsListTerms: PostsViewTerms = {
     view: 'events',
     globalEvent: false,
-    limit: isEAForum ? 1 : 3,
+    limit: isEAForum ? 1 : 2,
   }
   const globalTerms: PostsViewTerms = {
     view: 'globalEvents',
-    limit: isEAForum ? 3 : 4,
+    limit: isEAForum ? 3 : 2,
   }
   return <span>
     <AnalyticsContext pageSubSectionContext="menuEventsList">


### PR DESCRIPTION
This used to be like 3, and I think went up to 4 during the pandemic due to some weirdness in how online events worked. I have no idea how it got up to 7, that seems like a silly number.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202859889525580) by [Unito](https://www.unito.io)
