### PR TITLE
run linting, typechecking, and tests in parallel

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -20,8 +20,5 @@ jobs:
     - name: yarn install
       run: yarn install
 
-    - name: yarn run lint
-      run: yarn run lint
-
     - name: yarn run test-ci
       run: yarn run test-ci

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start-af-dev-db": "./build.js --no-clear -run --watch --mongoUrlFile ../LessWrong-Credentials/connectionStrings/dev-db.txt --settings ../LessWrong-Credentials/settings-local-dev-af-devdb.json",
     "start-af-prod-db": "./build.js --no-clear -run --watch --mongoUrlFile ../LessWrong-Credentials/connectionStrings/prod-db.txt --settings ../LessWrong-Credentials/settings-local-dev-af-proddb.json",
     "test": "jest --forceExit",
-    "test-ci": "jest --forceExit --ci",
+    "test-ci": "./scripts/test_ci.js",
     "test-watch": "jest --watchAll",
     "encrypt-credentials": "tar czf credentials.tar.gz --exclude '.git/*' -C ../ ./LessWrong-Credentials; travis encrypt-file credentials.tar.gz --add; rm credentials.tar.gz",
     "generate": "scripts/generateTypes.sh",

--- a/scripts/test_ci.js
+++ b/scripts/test_ci.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const ChildProcess = require('child_process');
+const { promisify } = require('util');
+
+const exec = promisify(ChildProcess.exec);
+
+const lintProcess = exec('yarn run --silent eslint 2>&1').catch(e => e);
+const tscProcess = exec('yarn run --silent tsc').catch(e => e);
+const testProcess = exec('yarn jest --forceExit --ci 2>&1').catch(e => e);
+
+Promise.all([lintProcess, tscProcess, testProcess]).then(results => {
+  results
+    .filter(result => result.stdout)
+    .forEach(result => console.log(result.stdout));
+
+  // Exit with failure status if any of eslint, tsc, or jest returned failure
+  const exitCode = results.find(r => r.code)?.code ?? 0;
+
+  process.exit(exitCode);
+});


### PR DESCRIPTION
There isn't really any reason to run the lint/typecheck and test operations in sequence.  Run them in parallel!