### PR TITLE
Conditional rendering refactor in Layout

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -23,7 +23,6 @@ import { globalStyles } from '../themes/globalStyles/globalStyles';
 import type { ToCData, ToCSection } from '../server/tableOfContents';
 import { ForumOptions, forumSelect } from '../lib/forumTypeUtils';
 import { userCanDo } from '../lib/vulcan-users/permissions';
-import { HomepageCommunityMap } from './seasonal/HomepageCommunityMap';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 1631226712000)
@@ -242,18 +241,22 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
       forumSelect(standaloneNavMenuRouteNames)
         .includes(currentRoute?.name)
     
-    const showSunshineSidebar = currentRoute?.sunshineSidebar && (userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins'))
+    const renderSunshineSidebar = currentRoute?.sunshineSidebar && (userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins'))
         
     const shouldUseGridLayout = standaloneNavigation
 
-    const currentTime = new Date()
-    const beforeTime = petrovBeforeTime.get()
-    const afterTime = petrovAfterTime.get()
-
-    const renderPetrovDay = 
-      currentRoute?.name === "home"
-      && ['LessWrong', 'EAForum'].includes(forumTypeSetting.get())
-      && beforeTime < currentTime.valueOf() && currentTime.valueOf() < afterTime
+    const renderPetrovDay = () => {
+      const currentTime = (new Date()).valueOf()
+      const beforeTime = petrovBeforeTime.get()
+      const afterTime = petrovAfterTime.get()
+    
+      return currentRoute?.name === "home"
+        && ['LessWrong', 'EAForum'].includes(forumTypeSetting.get())
+        && beforeTime < currentTime 
+        && currentTime < afterTime
+    }
+    
+    const renderCommunityMap = forumTypeSetting.get() === "LessWrong" && currentRoute?.name === 'home'
       
     return (
       <AnalyticsContext path={location.pathname}>
@@ -301,8 +304,8 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                 standaloneNavigationPresent={standaloneNavigation}
                 toggleStandaloneNavigation={this.toggleStandaloneNavigation}
               />}
-              {forumTypeSetting.get() === "LessWrong" && currentRoute?.name === 'home' && <HomepageCommunityMap />}
-              {renderPetrovDay && <PetrovDayWrapper/>}
+              {renderCommunityMap && <HomepageCommunityMap />}
+              {renderPetrovDay() && <PetrovDayWrapper/>}
               <div className={shouldUseGridLayout ? classes.gridActivated : null}>
                 {standaloneNavigation && <div className={classes.navSidebar}>
                   <NavigationStandalone sidebarHidden={hideNavigationSidebar}/>
@@ -322,7 +325,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                   </ErrorBoundary>
                   <Footer />
                 </div>
-                {showSunshineSidebar && <div className={classes.sunshine}>
+                {renderSunshineSidebar && <div className={classes.sunshine}>
                   <Components.SunshineSidebar/>
                 </div>}
               </div>


### PR DESCRIPTION
This cleans up the conditional rendering Layout, with the convention that seems least-bad to me.

I think forum-specific rendering often ends up getting particularly cluttery, and conditional rendering gets cluttery. I think generally as soon as you end up with 2+ clauses in a condition, that condition should be moved out into a separate variable or function.

This also standardizes on "renderX" instead of a mix of "renderX" and "showX" (at least in this particular file)