### PR TITLE
Update algolia cron to 7 days

### DIFF
--- a/packages/lesswrong/server/search/algoliaCron.ts
+++ b/packages/lesswrong/server/search/algoliaCron.ts
@@ -7,7 +7,7 @@ const algoliaAutoSyncIndexesSetting = new DatabasePublicSetting<boolean>('algoli
 
 addCronJob({
   name: 'updateAlgoliaIndex',
-  interval: 'every 24 hours',
+  interval: 'every 7 days',
   job: async () => {
     if (algoliaAutoSyncIndexesSetting.get()) {
       await algoliaExportAll();


### PR DESCRIPTION
JP had previously commented that running the algolia script every day cost $500 a month, and didn't seem super necessary. This seems true, but also seems like running it once a week is worth the cost. 

I _think_ this updates the script correctly but I'm a little sketched out by the english language string used for the interval field.