### PR TITLE
Remove notices about two features being new now that they are no longer new

### DIFF
--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -236,7 +236,6 @@ const PostsAnalyticsPage = ({ classes }) => {
         <PostsAnalyticsInner post={post} classes={classes} />
       </NoSsr>
       <Typography variant="body1" className={classes.viewingNotice} component='div'>
-        <p>This feature is new. <Link to='/contact'>Let us know what you think.</Link></p>
         <p><em>Post statistics are only viewable by {isEAForum && "authors and"} admins</em></p>
       </Typography>
     </SingleColumnSection>

--- a/packages/lesswrong/components/shortform/ShortformPage.tsx
+++ b/packages/lesswrong/components/shortform/ShortformPage.tsx
@@ -16,7 +16,7 @@ const ShortformPage = ({classes}: {
   return (
     <SingleColumnSection>
       <div className={classes.column}>
-        <SectionTitle title="Shortform Content [Beta]"/>
+        <SectionTitle title="Shortform Content"/>
         <ShortformThreadList />
       </div>
     </SingleColumnSection>
@@ -30,4 +30,3 @@ declare global {
     ShortformPage: typeof ShortformPageComponent
   }
 }
-


### PR DESCRIPTION
Changes the Shortform page and the post analytics page.