### PR TITLE
Fix access denied styling

### DIFF
--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -18,7 +18,7 @@ const ErrorAccessDenied = () => {
       <Typography variant='body1'>
         Please log in to access this page.
       </Typography>
-      <Components.WrappedLoginForm/>
+      <Components.WrappedLoginForm startingState='login'/>
     </SingleColumnSection>
   }
 }

--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -4,7 +4,7 @@ import { useCurrentUser } from './withUser';
 import { useServerRequestStatus } from '../../lib/routeUtil'
 
 const ErrorAccessDenied = () => {
-  const { SingleColumnSection } = Components;
+  const { SingleColumnSection, Typography } = Components;
   const serverRequestStatus = useServerRequestStatus()
   const currentUser = useCurrentUser();
   if (serverRequestStatus) serverRequestStatus.status = 403
@@ -15,7 +15,9 @@ const ErrorAccessDenied = () => {
     </SingleColumnSection>
   } else {
     return <SingleColumnSection>
-      <div>Please log in to access this page.</div>
+      <Typography variant='body1'>
+        Please log in to access this page.
+      </Typography>
       <Components.WrappedLoginForm/>
     </SingleColumnSection>
   }

--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const PostCollaborationEditor = ({ classes }: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, Loading, ContentStyles, Typography, WrappedLoginForm } = Components
+  const { SingleColumnSection, Loading, ContentStyles, ErrorAccessDenied } = Components
   const currentUser = useCurrentUser();
   const [editorLoaded, setEditorLoaded] = useState(false)
 
@@ -59,12 +59,7 @@ const PostCollaborationEditor = ({ classes }: {
   // If logged out, show a login form. (Even if link-sharing is enabled, you still
   // need to be logged into LessWrong with some account.)
   if (!currentUser) {
-    return <SingleColumnSection>
-      <Typography variant="body1">
-        Please log in to access this draft
-      </Typography>
-      <WrappedLoginForm startingState='login'/>
-    </SingleColumnSection>
+    return <ErrorAccessDenied/>
   }
   
   // Error handling and loading state

--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const PostCollaborationEditor = ({ classes }: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, Loading, ContentStyles } = Components
+  const { SingleColumnSection, Loading, ContentStyles, Typography, WrappedLoginForm } = Components
   const currentUser = useCurrentUser();
   const [editorLoaded, setEditorLoaded] = useState(false)
 
@@ -59,12 +59,12 @@ const PostCollaborationEditor = ({ classes }: {
   // If logged out, show a login form. (Even if link-sharing is enabled, you still
   // need to be logged into LessWrong with some account.)
   if (!currentUser) {
-    return <Components.SingleColumnSection>
-      <div>
+    return <SingleColumnSection>
+      <Typography variant="body1">
         Please log in to access this draft
-      </div>
-      <Components.WrappedLoginForm/>
-    </Components.SingleColumnSection>
+      </Typography>
+      <WrappedLoginForm/>
+    </SingleColumnSection>
   }
   
   // Error handling and loading state
@@ -121,4 +121,3 @@ declare global {
     PostCollaborationEditor: typeof PostCollaborationEditorComponent
   }
 }
-

--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -63,7 +63,7 @@ const PostCollaborationEditor = ({ classes }: {
       <Typography variant="body1">
         Please log in to access this draft
       </Typography>
-      <WrappedLoginForm/>
+      <WrappedLoginForm startingState='login'/>
     </SingleColumnSection>
   }
   

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -198,7 +198,7 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
   </Components.ContentStyles>;
 }
 
-const WrappedLoginFormEA = ({startingState='login', classes}: WrappedLoginFormProps) => {
+const WrappedLoginFormEA = ({startingState, classes}: WrappedLoginFormProps) => {
   const { pathname } = useLocation()
   
   return <Components.ContentStyles contentType="commentExceptPointerEvents">

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -53,6 +53,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     justifyContent: 'space-between',
     '&.ea-forum': {
+      maxWidth: 400,
       justifyContent: 'space-around',
       padding: '8px 20px',
     }
@@ -197,7 +198,7 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
   </Components.ContentStyles>;
 }
 
-const WrappedLoginFormEA = ({startingState, classes}: WrappedLoginFormProps) => {
+const WrappedLoginFormEA = ({startingState='login', classes}: WrappedLoginFormProps) => {
   const { pathname } = useLocation()
   
   return <Components.ContentStyles contentType="commentExceptPointerEvents">


### PR DESCRIPTION
Previously the access denied pages were a bit of a mess on the lw-deploy branch, when viewed on the EA Forum view. The main issue was that there was no width to contain the login buttons, so they flexed across the whole dang page. Now we add a max width. While we're at it, replace some div'd text with Typography.

I also addressed my own PR comment and combined the access denied message in PostCollaborationEditor with ErrorAccessDenied.

![](https://user-images.githubusercontent.com/10352319/186974248-dc8259ab-e7f5-4cbf-b303-b40361f7e2fb.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202873012790743) by [Unito](https://www.unito.io)
