### PR TITLE
Don't zoom or show groups on HomepageCommunityMap

### DIFF
--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -254,7 +254,7 @@ const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', includeIna
           mapOptions={userLocation.known ? {center: userLocation, zoom: 5} : {zoom: 1}}
           keywordSearch={keywordSearch}
           hideLegend
-          showUsers={false}
+          showUsersByDefault={false}
         />
       </div>
     </div>

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -168,7 +168,7 @@ const CommunityHome = ({classes}: {
           <Components.CommunityMapWrapper
             terms={mapEventTerms}
             mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
-            showUsers
+            showUsersByDefault
           />
             <SingleColumnSection>
               <SectionTitle title={title} />

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -64,7 +64,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 
 // Make these variables have file-scope references to avoid rerending the scripts or map
 const defaultCenter = {lat: 39.5, lng: -43.636047}
-const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', defaultShowGroups, defaultShowUsers, showHideMap = false, hideLegend, petrovButton }: {
+const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', showGroupsByDefault, showUsersByDefault, showHideMap = false, hideLegend, petrovButton }: {
   groupTerms: LocalgroupsViewTerms,
   eventTerms?: PostsViewTerms,
   keywordSearch?: string,
@@ -73,8 +73,8 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   zoom: number,
   classes: ClassesType,
   className?: string,
-  defaultShowUsers?: boolean,
-  defaultShowGroups?: boolean,
+  showUsersByDefault?: boolean,
+  showGroupsByDefault?: boolean,
   showHideMap?: boolean,
   hideLegend?: boolean,
   petrovButton?: boolean,
@@ -93,8 +93,8 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   )
 
   const [ showEvents, setShowEvents ] = useState(true)
-  const [ showGroups, setShowGroups ] = useState(!!defaultShowGroups)
-  const [ showUsers, setShowUsers ] = useState(!!defaultShowUsers)
+  const [ showGroups, setShowGroups ] = useState(!!showGroupsByDefault)
+  const [ showUsers, setShowUsers ] = useState(!!showUsersByDefault)
   const [ showMap, setShowMap ] = useState(true)
 
   const [ viewport, setViewport ] = useState({

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -64,7 +64,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 
 // Make these variables have file-scope references to avoid rerending the scripts or map
 const defaultCenter = {lat: 39.5, lng: -43.636047}
-const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', showUsers, showHideMap = false, hideLegend, petrovButton }: {
+const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindows = [], center = defaultCenter, zoom = 2, classes, className = '', defaultShowGroups, defaultShowUsers, showHideMap = false, hideLegend, petrovButton }: {
   groupTerms: LocalgroupsViewTerms,
   eventTerms?: PostsViewTerms,
   keywordSearch?: string,
@@ -73,7 +73,8 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   zoom: number,
   classes: ClassesType,
   className?: string,
-  showUsers?: boolean,
+  defaultShowUsers?: boolean,
+  defaultShowGroups?: boolean,
   showHideMap?: boolean,
   hideLegend?: boolean,
   petrovButton?: boolean,
@@ -92,8 +93,8 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   )
 
   const [ showEvents, setShowEvents ] = useState(true)
-  const [ showGroups, setShowGroups ] = useState(true)
-  const [ showIndividuals, setShowIndividuals ] = useState(!!showUsers)
+  const [ showGroups, setShowGroups ] = useState(!!defaultShowGroups)
+  const [ showUsers, setShowUsers ] = useState(!!defaultShowUsers)
   const [ showMap, setShowMap ] = useState(true)
 
   const [ viewport, setViewport ] = useState({
@@ -124,6 +125,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     collectionName: "Localgroups",
     fragmentName: "localGroupsHomeFragment",
     limit: 500,
+    skip: !showGroups
   })
   // filter the list of groups if the user has typed in a keyword
   let visibleGroups = groups
@@ -138,7 +140,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     collectionName: "Users",
     fragmentName: "UsersMapEntry",
     limit: 500,
-    skip: !showIndividuals
+    skip: !showUsers
   })
 
   const isEAForum = forumTypeSetting.get() === 'EAForum';
@@ -147,19 +149,19 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     return <React.Fragment>
       {showEvents && <LocalEventsMapMarkers events={events} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
       {showGroups && <LocalGroupsMapMarkers groups={visibleGroups} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
-      {showIndividuals && <Components.PersonalMapLocationMarkers users={users} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
+      {showUsers && <Components.PersonalMapLocationMarkers users={users} handleClick={handleClick} handleClose={handleClose} openWindows={openWindows} />}
       {!hideLegend && <div className={classes.mapButtons}>
         <Components.CommunityMapFilter 
           showHideMap={showHideMap} 
           toggleEvents={() => setShowEvents(!showEvents)} showEvents={showEvents}
           toggleGroups={() => setShowGroups(!showGroups)} showGroups={showGroups}
-          toggleIndividuals={() => setShowIndividuals(!showIndividuals)} 
-          showIndividuals={showIndividuals}
+          toggleIndividuals={() => setShowUsers(!showUsers)} 
+          showIndividuals={showUsers}
           setShowMap={setShowMap}
         />
       </div>}
     </React.Fragment>
-  }, [showEvents, events, handleClick, handleClose, openWindows, showGroups, visibleGroups, showIndividuals, users, classes.mapButtons, showHideMap, hideLegend])
+  }, [showEvents, events, handleClick, handleClose, openWindows, showGroups, visibleGroups, showUsers, users, classes.mapButtons, showHideMap, hideLegend])
 
   if (!showMap) return null
 

--- a/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, keywordSearch, showHideMap, hideLegend, defaultShowUsers, defaultShowGroups=true, petrovButton}: {
+const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, keywordSearch, showHideMap, hideLegend, showUsersByDefault, showGroupsByDefault=true, petrovButton}: {
   className?: string,
   groupQueryTerms?: LocalgroupsViewTerms,
   currentUserLocation?: any,
@@ -11,8 +11,8 @@ const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, m
   terms?: PostsViewTerms,
   keywordSearch?: string,
   showHideMap?: boolean,
-  defaultShowUsers?: boolean,
-  defaultShowGroups?: boolean,
+  showUsersByDefault?: boolean,
+  showGroupsByDefault?: boolean,
   petrovButton?: any,
 }) => {
   const { CommunityMap } = Components;
@@ -26,8 +26,8 @@ const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, m
       showHideMap={showHideMap}
       petrovButton={petrovButton}
       hideLegend={hideLegend}
-      defaultShowUsers={defaultShowUsers}
-      defaultShowGroups={defaultShowGroups}
+      showUsersByDefault={showUsersByDefault}
+      showGroupsByDefault={showGroupsByDefault}
       {...mapOptions}
     />
   )

--- a/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, keywordSearch, showHideMap, hideLegend, showUsers, petrovButton}: {
+const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, mapOptions, terms, keywordSearch, showHideMap, hideLegend, defaultShowUsers, defaultShowGroups=true, petrovButton}: {
   className?: string,
   groupQueryTerms?: LocalgroupsViewTerms,
   currentUserLocation?: any,
@@ -11,7 +11,8 @@ const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, m
   terms?: PostsViewTerms,
   keywordSearch?: string,
   showHideMap?: boolean,
-  showUsers?: boolean,
+  defaultShowUsers?: boolean,
+  defaultShowGroups?: boolean,
   petrovButton?: any,
 }) => {
   const { CommunityMap } = Components;
@@ -25,7 +26,8 @@ const CommunityMapWrapper = ({className, groupQueryTerms, currentUserLocation, m
       showHideMap={showHideMap}
       petrovButton={petrovButton}
       hideLegend={hideLegend}
-      showUsers={showUsers}
+      defaultShowUsers={defaultShowUsers}
+      defaultShowGroups={defaultShowGroups}
       {...mapOptions}
     />
   )

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -18,7 +18,10 @@ export const HomepageCommunityMap = ({classes}: {
   const { CommunityMapWrapper } = Components
   
   const currentUser = useCurrentUser()
-  const currentUserLocation = useUserLocation(currentUser)
+ 
+  // this is unused, but for Meetup Month it seems good to force the prompt to enter location.
+  useUserLocation(currentUser)
+
   const mapEventTerms: PostsViewTerms = {
     view: 'events',
     filters: [],
@@ -27,7 +30,7 @@ export const HomepageCommunityMap = ({classes}: {
   return <div className={classes.root}>
     <CommunityMapWrapper
       terms={mapEventTerms}
-      mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
+      defaultShowGroups={false}
     />
   </div>;
 }

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -19,7 +19,7 @@ export const HomepageCommunityMap = ({classes}: {
   
   const currentUser = useCurrentUser()
  
-  // this is unused, but for Meetup Month it seems good to force the prompt to enter location.
+  // this is unused in this component, but for Meetup Month it seems good to force the prompt to enter location.
   useUserLocation(currentUser)
 
   const mapEventTerms: PostsViewTerms = {

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -30,7 +30,7 @@ export const HomepageCommunityMap = ({classes}: {
   return <div className={classes.root}>
     <CommunityMapWrapper
       terms={mapEventTerms}
-      defaultShowGroups={false}
+      showGroupsByDefault={false}
     />
   </div>;
 }


### PR DESCRIPTION
Adds a "showGroupsByDefault" field to the map, which is true by default to match existing usage but can be overridden. Changes the HomepageCommunityMap to only show events, and use the default map positioning which looks nicer.

Leaves in the request for user's location because we want to nudge people to opt into that this week.


<img width="1321" alt="image" src="https://user-images.githubusercontent.com/3246710/186991098-c094d746-fba4-499a-9f8c-6b0e3afef48c.png">
