### PR TITLE
fix zIndex on close button on spotlight item (curatedContentItem)

### DIFF
--- a/packages/lesswrong/components/recommendations/CuratedContentItem.tsx
+++ b/packages/lesswrong/components/recommendations/CuratedContentItem.tsx
@@ -49,7 +49,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: 'absolute',
     color: theme.palette.grey[300],
     top: 0,
-    right: 0
+    right: 0,
+    zIndex: theme.zIndexes.curatedContentItemCloseButton,
   },
   content: {
     padding: 16,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -21,6 +21,7 @@ export const zIndexes = {
   sequenceBanner: 0,
   singleColumnSection: 1,
   curatedContentItem: 1,
+  curatedContentItemCloseButton: 2,
   commentsMenu: 2,
   sequencesPageContent: 2,
   sequencesImageScrim: 2,


### PR DESCRIPTION
Currently the close button on the spotLight item doesn't work because it's lower z-index than the overall card. This fixes that.