### PR TITLE
Adds hideMap button to frontpage map (plus site customization clean up)

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -256,7 +256,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
         && currentTime < afterTime
     }
     
-    const renderCommunityMap = forumTypeSetting.get() === "LessWrong" && currentRoute?.name === 'home'
+    const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap)
       
     return (
       <AnalyticsContext path={location.pathname}>
@@ -304,7 +304,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                 standaloneNavigationPresent={standaloneNavigation}
                 toggleStandaloneNavigation={this.toggleStandaloneNavigation}
               />}
-              {renderCommunityMap && <HomepageCommunityMap />}
+              {renderCommunityMap && <HomepageCommunityMap/>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
               <div className={shouldUseGridLayout ? classes.gridActivated : null}>
                 {standaloneNavigation && <div className={classes.navSidebar}>

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -28,6 +28,7 @@ export const HomepageCommunityMap = ({classes}: {
     <CommunityMapWrapper
       terms={mapEventTerms}
       mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
+      showHideMap
     />
   </div>;
 }

--- a/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageCommunityMap.tsx
@@ -30,7 +30,6 @@ export const HomepageCommunityMap = ({classes}: {
   return <div className={classes.root}>
     <CommunityMapWrapper
       terms={mapEventTerms}
-      mapOptions={currentUserLocation.known && {center: currentUserLocation, zoom: 5}}
       showHideMap
       showGroupsByDefault={false}
     />

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1091,8 +1091,8 @@ addFieldsDict(Users, {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     order: 44,
-    group: formGroups.default,
-    hidden: true,
+    group: formGroups.siteCustomizations,
+    hidden: false,
     label: "Hide the frontpage map"
   },
 
@@ -1102,7 +1102,7 @@ addFieldsDict(Users, {
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
-    hidden: forumTypeSetting.get() === "EAForum",
+    hidden: true,
     label: "Hide the tagging progress bar",
     order: 45,
     group: formGroups.siteCustomizations
@@ -1116,7 +1116,7 @@ addFieldsDict(Users, {
     // canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     order: 46,
-    hidden: forumTypeSetting.get() === "EAForum",
+    hidden: true,
     group: formGroups.siteCustomizations,
     label: "Hide the frontpage book ad"
   },
@@ -1128,7 +1128,7 @@ addFieldsDict(Users, {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     order: 47,
-    hidden: forumTypeSetting.get() === "EAForum",
+    hidden: true,
     group: formGroups.siteCustomizations,
     label: "Hide the frontpage book ad"
   },
@@ -1559,6 +1559,7 @@ addFieldsDict(Users, {
     tooltip: "Restore the old Draft-JS based editor",
     group: formGroups.siteCustomizations,
     label: "Restore the previous WYSIWYG editor",
+    hidden: forumTypeSetting.get() !== "EAForum",
     order: 73,
   },
   walledGardenInvite: {


### PR DESCRIPTION
Primarily pass in the props for showing the hide map button frontpage map (and hide it when it is set)
plus clean up some unused fields in user site customizations