### PR TITLE
check email field for password resets

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -261,7 +261,7 @@ const authenticationResolvers = {
     },
     async resetPassword(root: void, { email }: {email: string}, context: ResolverContext) {
       if (!email) throw Error("Email is required for resetting passwords")
-      const user = (await Users.findOne({'emails.address': email})) ?? (await Users.findOne({email}));
+      const user = (await Users.findOne({email})) ?? (await Users.findOne({'emails.address': email}));
       if (!user) throw Error("Can't find user with given email address")
       const tokenLink = await ResetPasswordToken.generateLink(user._id)
       const emailSucceeded = await wrapAndSendEmail({

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -261,7 +261,7 @@ const authenticationResolvers = {
     },
     async resetPassword(root: void, { email }: {email: string}, context: ResolverContext) {
       if (!email) throw Error("Email is required for resetting passwords")
-      const user = await Users.findOne({'emails.address': email})
+      const user = (await Users.findOne({'emails.address': email})) ?? (await Users.findOne({email}));
       if (!user) throw Error("Can't find user with given email address")
       const tokenLink = await ResetPasswordToken.generateLink(user._id)
       const emailSucceeded = await wrapAndSendEmail({


### PR DESCRIPTION
ACX Meetup Organizer accounts were created with an `email` field, but the existing password reset functionality only checks the `emails[].address` field.  This means that organizers who had accounts created for them are unable to recover those accounts.

This is a patch to check both fields.  Long-term, we should migrate away from the `emails` field entirely.