### PR TITLE
Fix white-on-white text in the community map popup in dark mode

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -26,7 +26,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     boxShadow: theme.palette.boxShadow.default,
     
     "& .mapboxgl-popup-content": {
-      background: theme.palette.background.default,
+      background: theme.palette.panelBackground.default,
     },
   },
   communityMap: {},

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -24,6 +24,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     },
     position: "relative",
     boxShadow: theme.palette.boxShadow.default,
+    
+    "& .mapboxgl-popup-content": {
+      background: theme.palette.background.default,
+    },
   },
   communityMap: {},
   mapButton: {

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -28,6 +28,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     "& .mapboxgl-popup-content": {
       background: theme.palette.panelBackground.default,
     },
+    "& .StyledMapPopup-markerPageLink": {
+      color: theme.palette.text.normal,
+    },
   },
   communityMap: {},
   mapButton: {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202879502405576) by [Unito](https://www.unito.io)
