### PR TITLE
Add maintenance banner

### DIFF
--- a/packages/lesswrong/components/common/MaintenanceBanner.tsx
+++ b/packages/lesswrong/components/common/MaintenanceBanner.tsx
@@ -6,7 +6,7 @@ import { ExpandedDate } from "../common/FormatDate";
 import { siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { isMobile } from "../../lib/utils/isMobile";
 import classNames from "classnames";
-import { startCase } from "lodash";
+import startCase from "lodash/startCase";
 
 export const maintenanceTime = new DatabasePublicSetting<string | null>("maintenanceBannerTime", null);
 const explanationText = new DatabasePublicSetting<string>("maintenanceBannerExplanationText", "");

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -4,7 +4,7 @@ import { DatabasePublicSetting } from '../../lib/publicSettings'
 import { Components, registerComponent } from '../../lib/vulcan-lib'
 import { useCurrentUser } from '../common/withUser'
 import { reviewIsActive } from '../../lib/reviewUtils'
-import { maintenanceTime } from './MaintenanceBanner'
+import { maintenanceTime } from '../common/MaintenanceBanner'
 
 const eaHomeSequenceIdSetting = new PublicInstanceSetting<string | null>('eaHomeSequenceId', null, "optional") // Sequence ID for the EAHomeHandbook sequence
 const showSmallpoxSetting = new DatabasePublicSetting<boolean>('showSmallpox', false)

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -4,11 +4,13 @@ import { DatabasePublicSetting } from '../../lib/publicSettings'
 import { Components, registerComponent } from '../../lib/vulcan-lib'
 import { useCurrentUser } from '../common/withUser'
 import { reviewIsActive } from '../../lib/reviewUtils'
+import { maintenanceTime } from './MaintenanceBanner'
 
 const eaHomeSequenceIdSetting = new PublicInstanceSetting<string | null>('eaHomeSequenceId', null, "optional") // Sequence ID for the EAHomeHandbook sequence
 const showSmallpoxSetting = new DatabasePublicSetting<boolean>('showSmallpox', false)
 const showHandbookBannerSetting = new DatabasePublicSetting<boolean>('showHandbookBanner', false)
 const showEventBannerSetting = new DatabasePublicSetting<boolean>('showEventBanner', false)
+const showMaintenanceBannerSetting = new DatabasePublicSetting<boolean>('showMaintenanceBanner', false)
 
 const EAHome = () => {
   const currentUser = useCurrentUser();
@@ -19,8 +21,12 @@ const EAHome = () => {
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
   const shouldRenderEventBanner = showEventBannerSetting.get()
-  const shouldRenderMaintenanceBanner = true
   const shouldRenderSmallpox = showSmallpoxSetting.get()
+  // Only show the maintenance banner if the the current time is before the maintenance time (plus 5 minutes leeway),
+  // this is just so we don't have to rush to change the server settings as soon as the maintenance is done
+  const maintenanceTimeValue = maintenanceTime.get()
+  const isBeforeMaintenanceTime = maintenanceTimeValue && Date.now() < new Date(maintenanceTimeValue).getTime() + 5*60*1000
+  const shouldRenderMaintenanceBanner = showMaintenanceBannerSetting.get() && isBeforeMaintenanceTime
 
   return (
     <React.Fragment>

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -14,15 +14,17 @@ const EAHome = () => {
   const currentUser = useCurrentUser();
   const {
     RecentDiscussionFeed, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated,
-    SmallpoxBanner, StickiedPosts, EventBanner, FrontpageReviewWidget, SingleColumnSection
+    SmallpoxBanner, StickiedPosts, EventBanner, MaintenanceBanner, FrontpageReviewWidget, SingleColumnSection
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
   const shouldRenderEventBanner = showEventBannerSetting.get()
+  const shouldRenderMaintenanceBanner = true
   const shouldRenderSmallpox = showSmallpoxSetting.get()
 
   return (
     <React.Fragment>
+      {shouldRenderMaintenanceBanner && <MaintenanceBanner />}
       {shouldRenderSmallpox && <SmallpoxBanner/>}
       {shouldRenderEventBanner && <EventBanner />}
       

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -25,7 +25,7 @@ const EAHome = () => {
   // Only show the maintenance banner if the the current time is before the maintenance time (plus 5 minutes leeway),
   // this is just so we don't have to rush to change the server settings as soon as the maintenance is done
   const maintenanceTimeValue = maintenanceTime.get()
-  const isBeforeMaintenanceTime = maintenanceTimeValue && Date.now() < new Date(maintenanceTimeValue).getTime() + 5*60*1000
+  const isBeforeMaintenanceTime = maintenanceTimeValue && Date.now() < new Date(maintenanceTimeValue).getTime() + (5*60*1000)
   const shouldRenderMaintenanceBanner = showMaintenanceBannerSetting.get() && isBeforeMaintenanceTime
 
   return (

--- a/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
@@ -1,55 +1,51 @@
-import React from 'react'
-import { createStyles } from '@material-ui/core/styles'
-import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { SECTION_WIDTH } from '../common/SingleColumnSection';
-import { cloudinaryCloudNameSetting, DatabasePublicSetting } from '../../lib/publicSettings';
-import { Link } from '../../lib/reactRouterWrapper';
-import Button from '@material-ui/core/Button';
-import { useCurrentUser } from '../common/withUser';
+import React from "react";
+import { createStyles } from "@material-ui/core/styles";
+import { registerComponent, Components } from "../../lib/vulcan-lib";
+import { DatabasePublicSetting } from "../../lib/publicSettings";
+import { ExpandedDate } from "../common/FormatDate";
 
-// const eventBannerMobileImageSetting = new DatabasePublicSetting<string | null>('eventBannerMobileImage', null)
-// const eventBannerDesktopImageSetting = new DatabasePublicSetting<string | null>('eventBannerDesktopImage', null)
-// const eventBannerLinkSetting = new DatabasePublicSetting<string | null>('eventBannerLink', null)
+export const maintenanceTime = new DatabasePublicSetting<string | null>('maintenanceBannerTime', null)
+const explanationText = new DatabasePublicSetting<string>('maintenanceBannerExplanationText', '')
 
-const styles = createStyles((theme: ThemeType): JssStyles => ({
-  root: {
-    padding: 20,
-    width: '100%',
-    objectFit: 'cover',
-    ...theme.typography.display1,
-    marginTop: '0.5em',
-    border: theme.palette.border.commentBorder,
-    borderWidth: 2,
-    borderRadius: 2,
-    borderColor: theme.palette.primary.main,
-    background: theme.palette.background.pageActiveAreaBackground,
-  }
-}))
+const styles = createStyles(
+  (theme: ThemeType): JssStyles => ({
+    root: {
+      padding: 20,
+      width: "100%",
+      fontFamily: theme.typography.postStyle.fontFamily,
+      fontSize: "1.5rem",
+      marginTop: "0.5em",
+      border: theme.palette.border.commentBorder,
+      borderWidth: 2,
+      borderRadius: 2,
+      borderColor: theme.palette.error.main,
+      background: theme.palette.background.pageActiveAreaBackground,
+    },
+    buttonRow: {
+      marginLeft: "auto",
+      width: "fit-content",
+    },
+  })
+);
 
 const MaintenanceBanner = ({ classes }) => {
-  const currentUser = useCurrentUser()
-  const { SingleColumnSection } = Components
+  const maintenanceTimeValue = maintenanceTime.get()
+  if (!maintenanceTimeValue) return <></>;
+  const { SingleColumnSection } = Components;
 
-  return <SingleColumnSection className={classes.root}>
-    <div>
-      The EA Forum will be undergoing scheduled maintenance at TIME on DATE, we anticipate this will take around TIME
-    </div>
-    {currentUser ? <Button
-      type="submit"
-      id="new-comment-submit"
-      onClick={() => { }}
-    >
-      Dismiss
-    </Button> : <></>}
-  </SingleColumnSection>
-}
+  return (
+    <SingleColumnSection className={classes.root}>
+      <div>
+        The EA Forum will be undergoing scheduled maintenance on <ExpandedDate date={maintenanceTimeValue}/>{explanationText.get()}
+      </div>
+    </SingleColumnSection>
+  );
+};
 
-const MaintenanceBannerComponent = registerComponent(
-  'MaintenanceBanner', MaintenanceBanner, { styles },
-)
+const MaintenanceBannerComponent = registerComponent("MaintenanceBanner", MaintenanceBanner, { styles });
 
 declare global {
   interface ComponentTypes {
-    MaintenanceBanner: typeof MaintenanceBannerComponent
+    MaintenanceBanner: typeof MaintenanceBannerComponent;
   }
 }

--- a/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { createStyles } from '@material-ui/core/styles'
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { SECTION_WIDTH } from '../common/SingleColumnSection';
+import { cloudinaryCloudNameSetting, DatabasePublicSetting } from '../../lib/publicSettings';
+import { Link } from '../../lib/reactRouterWrapper';
+import Button from '@material-ui/core/Button';
+import { useCurrentUser } from '../common/withUser';
+
+// const eventBannerMobileImageSetting = new DatabasePublicSetting<string | null>('eventBannerMobileImage', null)
+// const eventBannerDesktopImageSetting = new DatabasePublicSetting<string | null>('eventBannerDesktopImage', null)
+// const eventBannerLinkSetting = new DatabasePublicSetting<string | null>('eventBannerLink', null)
+
+const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {
+    padding: 20,
+    width: '100%',
+    objectFit: 'cover',
+    ...theme.typography.display1,
+    marginTop: '0.5em',
+    border: theme.palette.border.commentBorder,
+    borderWidth: 2,
+    borderRadius: 2,
+    borderColor: theme.palette.primary.main,
+    background: theme.palette.background.pageActiveAreaBackground,
+  }
+}))
+
+const MaintenanceBanner = ({ classes }) => {
+  const currentUser = useCurrentUser()
+  const { SingleColumnSection } = Components
+
+  return <SingleColumnSection className={classes.root}>
+    <div>
+      The EA Forum will be undergoing scheduled maintenance at TIME on DATE, we anticipate this will take around TIME
+    </div>
+    {currentUser ? <Button
+      type="submit"
+      id="new-comment-submit"
+      onClick={() => { }}
+    >
+      Dismiss
+    </Button> : <></>}
+  </SingleColumnSection>
+}
+
+const MaintenanceBannerComponent = registerComponent(
+  'MaintenanceBanner', MaintenanceBanner, { styles },
+)
+
+declare global {
+  interface ComponentTypes {
+    MaintenanceBanner: typeof MaintenanceBannerComponent
+  }
+}

--- a/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/MaintenanceBanner.tsx
@@ -36,7 +36,7 @@ const MaintenanceBanner = ({ classes }) => {
   return (
     <SingleColumnSection className={classes.root}>
       <div>
-        The EA Forum will be undergoing scheduled maintenance on <ExpandedDate date={maintenanceTimeValue}/>{explanationText.get()}
+        The EA Forum will be undergoing scheduled maintenance on <ExpandedDate date={maintenanceTimeValue}/>{explanationText.get() || ''}
       </div>
     </SingleColumnSection>
   );

--- a/packages/lesswrong/components/form-components/TagSelect.tsx
+++ b/packages/lesswrong/components/form-components/TagSelect.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import withUser from '../common/withUser';
 import { useSingle } from '../../lib/crud/withSingle';

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -21,7 +21,7 @@ if (forumTypeSetting.get() === 'EAForum') {
   importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHandbook'));
   importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
   importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
-  importComponent("MaintenanceBanner", () => require('../components/ea-forum/MaintenanceBanner'));
+  importComponent("MaintenanceBanner", () => require('../components/common/MaintenanceBanner'));
   importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
   importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
   importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -21,6 +21,7 @@ if (forumTypeSetting.get() === 'EAForum') {
   importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHandbook'));
   importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
   importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
+  importComponent("MaintenanceBanner", () => require('../components/ea-forum/MaintenanceBanner'));
   importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
   importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
   importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))


### PR DESCRIPTION
I ended up making it non-dismissable for simplicity's sake, seeing as JP said we should only show it for a few hours before a short maintenance window anyway

There are 3 server settings you can set to make it show up:


* showMaintenanceBanner: boolean - it won't appear without this
* maintenanceBannerTime: string (which can be parsed by new Date(...), e.g. '2022-08-30T10:54:00Z') - the time at which the maintenance is scheduled, it won't appear if this is not set, or if the current time is more than 5 minutes after this
* maintenanceBannerExplanationText: string - arbitrary string to add to the end of the message, ", we anticipate this will take around 30 minutes" in the screenshot, optional

![](https://user-images.githubusercontent.com/77623106/187422577-f2e4daad-9a1f-4809-a577-54f831fbb95f.png)

![](https://user-images.githubusercontent.com/77623106/187422530-7d35f165-b572-49ff-bb6c-29de5d23b289.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202891138978236) by [Unito](https://www.unito.io)
