### PR TITLE
Fix hydration errors related to 'load more' button

### DIFF
--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { queryIsUpdating } from './queryStatusUtils'
 import {useTracking} from "../../lib/analyticsEvents";
 import { LoadMoreCallback } from '../../lib/crud/withMulti';
+import { useIsFirstRender } from "../hooks/useIsFirstRender";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -64,6 +65,13 @@ const LoadMore = ({ loadMore, count, totalCount, className=null, loadingClassNam
   afterPostsListMarginTop?: boolean,
 }) => {
   const { captureEvent } = useTracking()
+
+  /**
+   * To avoid hydration errors, set loading to false if this is the initial render and we have
+   * a non-zero count that graphql cached during SSR.
+   */
+  const isFirstRender = useIsFirstRender();
+  loading = loading && !(isFirstRender && (count ?? 0) > 0);
 
   const { Loading } = Components
   const handleClickLoadMore = event => {

--- a/packages/lesswrong/components/hooks/useIsFirstRender.tsx
+++ b/packages/lesswrong/components/hooks/useIsFirstRender.tsx
@@ -1,0 +1,8 @@
+import { useRef } from "react";
+
+export const useIsFirstRender = () => {
+  const isFirstRender = useRef(true);
+  const {current} = isFirstRender;
+  isFirstRender.current = false;
+  return current;
+}


### PR DESCRIPTION
I did this fix because I've got an inkling that it might be a/the cause of a more complex bug I'm trying to figure out. It'll also be nice to get rid of these nasty console errors though. I'm not 100% sure that this is the cause of _all_ the hydration errors we have, but it does seem to fix all of the ones that I can easily reproduce on localhost.

The bug itself is dependant on SSR time, so in order to reproduce locally you may need to slow down your local server. This can be done easily by adding `await new Promise(resolve => setTimeout(resolve, 5000));` to `server/vulcan-lib/apollo-ssr/renderPage.tsx` at line 176 before we create `App`.

The issue is that we fetch data from the DB during SSR and render it, then once we're on the client we refetch the data over the network. This means that we call `LoadMore` with our initial data, but also with `loading` set to true, so we render a `Loader` which we didn't do on the server. The fix here is just to set loading to false if we're in the initial render and we have a non-zero count saved from SSR. This also comes with the nice benefit that we no longer flash a `Loader` when the page first loads.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202892867109276) by [Unito](https://www.unito.io)
