### PR TITLE
Max old space size12800

### DIFF
--- a/scripts/runProduction.sh
+++ b/scripts/runProduction.sh
@@ -10,5 +10,5 @@ if [ -n "$TRANSCRYPT_SECRET" ]; then
     cd ..
 fi
 
-export NODE_OPTIONS="--max_old_space_size=5210 --heapsnapshot-signal=SIGUSR2"
+export NODE_OPTIONS="--max_old_space_size=12800 --heapsnapshot-signal=SIGUSR2"
 ./build.js -run --settings ./Credentials/$SETTINGS_FILE_NAME --production


### PR DESCRIPTION
Make this truly enormous, since possibly heap snapshots use the node heap itself!  Only for use on r6i.large instances, which have 16gb ram.