### PR TITLE
Disallow Seekport bot

### DIFF
--- a/packages/lesswrong/server/robots.ts
+++ b/packages/lesswrong/server/robots.ts
@@ -38,6 +38,9 @@ Disallow: /compare
 Disallow: /emailToken
 Disallow: /*?commentId=*
 Crawl-Delay: 2
+
+User-agent: SeekportBot
+Disallow: /
 `);
   }
 });


### PR DESCRIPTION
This is the bot that was causing trouble yesterday. We have already blocked all the ip addresses associated with it so this is just an extra layer of protection (which the bot may well ignore anyway)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202905747165799) by [Unito](https://www.unito.io)
