### PR TITLE
Fix frontpage mobile homepage map ui bug

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -82,6 +82,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   sunshine: {
     gridArea: 'sunshine'
   },
+  hideHomepageMapOnMobile: {
+    [theme.breakpoints.down('sm')]: {
+      display: "none"
+    }
+  },
   whiteBackground: {
     background: theme.palette.background.pageActiveAreaBackground,
   },
@@ -257,7 +262,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
         && currentTime < afterTime
     }
 
-    const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !isMobile() && !cookies.get(hideMapCookieName)
+    const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !cookies.get(hideMapCookieName)
       
     return (
       <AnalyticsContext path={location.pathname}>
@@ -305,7 +310,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                 standaloneNavigationPresent={standaloneNavigation}
                 toggleStandaloneNavigation={this.toggleStandaloneNavigation}
               />}
-              {renderCommunityMap && <HomepageCommunityMap/>}
+              {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap/></span>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
               <div className={shouldUseGridLayout ? classes.gridActivated : null}>
                 {standaloneNavigation && <div className={classes.navSidebar}>


### PR DESCRIPTION
Removes usage of `isMobile` which seems to be the problem. Replaces with breakpoints.

![image](https://user-images.githubusercontent.com/7250541/187977418-a20829a5-45f4-4e44-a412-3b7d93a98c7f.png)
