### PR TITLE
Fix a bug that caused editors in forms to not clear if submitted during the autosave delay window

### DIFF
--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -127,7 +127,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const autosaveInterval = 3000; //milliseconds
+const autosaveInterval = 15000; //milliseconds
 const checkImgErrsInterval = 500; //milliseconds
 const ckEditorName = forumTypeSetting.get() === 'EAForum' ? 'EA Forum Docs' : 'LessWrong Docs'
 
@@ -448,10 +448,9 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
           // bypass throttling. These cases don't have the performance
           // implications that motivated having throttling in the first place,
           // and this prevents a timing bug with form-clearing on submit.
-          const data: string = editor.getData();
-          if (isBlank({type: "ckEditorMarkup", value: data}) || isBlank(this.props.value)) {
+          if (!editor.data.model.hasContent(editor.model.document.getRoot('main'))) {
             this.throttledSetCkEditor.cancel();
-            this.setContents("ckEditorMarkup", data);
+            this.setContents("ckEditorMarkup", editor.getData());
           } else {
             this.throttledSetCkEditor(() => editor.getData())
           }

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -127,7 +127,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const autosaveInterval = 15000; //milliseconds
+const autosaveInterval = 3000; //milliseconds
 const checkImgErrsInterval = 500; //milliseconds
 const ckEditorName = forumTypeSetting.get() === 'EAForum' ? 'EA Forum Docs' : 'LessWrong Docs'
 


### PR DESCRIPTION
Bug introduced in: https://github.com/ForumMagnum/ForumMagnum/commit/f0cb371a81e0bfc89eb4fc158183612871e44bd9

Caused by a subtle timing interaction between rerenders causing CkEditor to update its contents, and CkEditor onChange events reporting state changes. Deferring setValue() can cause exogenous editor changes to get reverted.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202950500656787) by [Unito](https://www.unito.io)
