### PR TITLE
Don't break words in username

### DIFF
--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -43,6 +43,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: '16px',
     fontWeight: 400,
     color: theme.palette.header.text,
+    wordBreak: 'break-word',
   },
   notAMember: {
     marginLeft: 5,


### PR DESCRIPTION
This always annoys me on mobile

Before
<img width="391" alt="Screenshot 2022-09-05 at 15 53 19" src="https://user-images.githubusercontent.com/77623106/188476398-238bfc8f-c25a-4b4f-9f35-70dadacfa722.png">

After (still doesn't overflow if the user has a really long username with no spaces):
<img width="391" alt="Screenshot 2022-09-05 at 15 53 54" src="https://user-images.githubusercontent.com/77623106/188476404-927b1a55-a244-443a-99d2-9d5713492bdc.png">
<img width="391" alt="Screenshot 2022-09-05 at 15 54 53" src="https://user-images.githubusercontent.com/77623106/188476406-ef0db7cc-3c73-4a4a-a020-ec4c7c20a985.png">
