### PR TITLE
Add Log out to user profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -552,6 +552,9 @@ const EAUsersProfile = ({terms, slug, classes}: {
             {userCanEdit(currentUser, user) && <Link to={userGetEditUrl(user)}>
               Account Settings
             </Link>}
+            {currentUser && currentUser._id === user._id && <a href="/logout">
+              Log out
+            </a>}
           </Typography>
         </div>
         


### PR DESCRIPTION
It's currently not easy to log out on mobile because you have to hover over your user name to do it. I've added it to the user profile as well to make this easier. I think it makes sense to have this on desktop too, I would expect there to be a log out button somewhere on the profile page

<img width="391" alt="Screenshot 2022-09-05 at 16 06 08" src="https://user-images.githubusercontent.com/77623106/188478984-b9005da1-413c-46fe-80f1-b5609b2d66f9.png">
<img width="868" alt="Screenshot 2022-09-05 at 16 06 17" src="https://user-images.githubusercontent.com/77623106/188478988-774f2a2d-6581-4b7d-b5fe-c95e54cb6b94.png">
