### PR TITLE
Send notification when added to conversation

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -27,6 +27,8 @@ import { RSVPType } from '../lib/collections/posts/schema';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { getSubscribedUsers, createNotifications, getUsersWhereLocationIsInNotificationRadius } from './notificationCallbacksHelpers'
 import moment from 'moment';
+import difference from 'lodash/difference';
+import Messages from '../lib/collections/messages/collection';
 
 // Callback for a post being published. This is distinct from being created in
 // that it doesn't fire on draft posts, and doesn't fire on posts that are awaiting
@@ -435,6 +437,17 @@ getCollectionHooks("Messages").newAsync.add(async function messageNewNotificatio
 
   // Create notification
   await createNotifications({userIds: recipientIds, notificationType: 'newMessage', documentType: 'message', documentId: message._id, noEmail: message.noEmail});
+});
+
+getCollectionHooks("Conversations").editAsync.add(async function conversationEditNotification(conversation: DbConversation, oldConversation: DbConversation) {
+  const newParticipantIds = difference(conversation.participantIds || [], oldConversation.participantIds || []);
+
+  if (newParticipantIds.length) {
+    // Notify newly added users of the most recent message
+    const mostRecentMessage = await Messages.findOne({conversationId: conversation._id}, {sort: {createdAt: -1}});
+    if (mostRecentMessage) // don't notify if there are no messages, they will still be notified when they receive the first message
+      await createNotifications({userIds: newParticipantIds, notificationType: 'newMessage', documentType: 'message', documentId: mostRecentMessage._id, noEmail: mostRecentMessage.noEmail});
+  }
 });
 
 export async function bellNotifyEmailVerificationRequired (user: DbUser) {


### PR DESCRIPTION
I'm just sending the standard "new message" notification because this is much simpler than creating a whole new notification type, lmk if you think it would be worth adding a new notification



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202927039940203) by [Unito](https://www.unito.io)
