### PR TITLE
Fix recent discussions not loading

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -127,7 +127,7 @@ const MixedTypeFeed = (args: {
       limit: firstPageSize,
     },
     fetchPolicy: "cache-and-network",
-    nextFetchPolicy: "cache-only",
+    nextFetchPolicy: "cache-first",
     ssr: true,
   });
   


### PR DESCRIPTION
Yesterday, Lizka noticed that "Recent Discussions" wasn't loading on the frontpage. It would correctly flash up on load from SSR, but would then disappear once we tried to refetch the data on the client because the data returned by Apollo was `undefined`. I began trying to debug the issue, but it resolved itself before I could find the cause. It seems to have come back again this morning though, and I managed to at least work out that it's some issue with the data not being fetchable from the client-side Apollo cache before the problem again resolved itself.

This change _seems_ to fix the issue, and it looks like `{ fetchPolicy: "cache-only", nextFetchPolicy: "cache-first" }` is the generally recommended way of doing paging with the cache (https://github.com/apollographql/apollo-client/issues/6916 and https://github.com/apollographql/apollo-client/issues/6907). The difference is that `cache-first` will make a network request if the data in the cache can't be used, whereas `cache-only` will just fail (https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies).

Unfortunately, I don't think this is actually testable though unless the bug comes back at some point (which does seem likely).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202933833628507) by [Unito](https://www.unito.io)
