### PR TITLE
Add meta tag for bing webmaster verification

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -7,6 +7,7 @@ import { PublicInstanceSetting } from '../../lib/instanceSettings';
 
 export const taglineSetting = new PublicInstanceSetting<string>('tagline', "A community blog devoted to refining the art of rationality", "warning")
 export const faviconUrlSetting = new PublicInstanceSetting<string>('faviconUrl', '/img/favicon.ico', "warning")
+export const bingValidationSetting = new PublicInstanceSetting<string | null>('bingValidation', null, "optional")
 const tabTitleSetting = new PublicInstanceSetting<string>('forumSettings.tabTitle', 'LessWrong', "warning")
 
 
@@ -31,6 +32,7 @@ const HeadTags = ({ogUrl: ogUrlProp, canonicalUrl: canonicalUrlProp, description
     const titleString = currentRoute?.title || titleProp || currentRoute?.subtitle;
 
     const rssUrl = `${getSiteUrl()}feed.xml`
+    const bingValidationString = bingValidationSetting.get()
 
     return (
       <React.Fragment>
@@ -47,6 +49,9 @@ const HeadTags = ({ogUrl: ogUrlProp, canonicalUrl: canonicalUrlProp, description
           <meta charSet='utf-8'/>
           <meta name='description' content={description}/>
           <meta name='viewport' content='width=device-width, initial-scale=1'/>
+
+          {/* required to use Bing's URL inspection tool: https://www.bing.com/webmasters/tools/urlinspection */}
+          {bingValidationString !== null && <meta name="msvalidate.01" content={bingValidationString} />}
 
           {/* twitter */}
           <meta name='twitter:card' content='summary_large_image'/>


### PR DESCRIPTION
Someone on the forum messaged me to say we aren't being shown in bing search results (or DuckDuckGo, which apparently uses bing). I've checked and this does indeed seem to be the case. I want to use the bing url inspection tool to see if we've been flagged as malware or something which requires verifying that we own the site

They give a couple of ways of verifying the site for this:
 - this meta tag thing
 - serving an XML file containing the same info
 - adding something to our DNS records

This seemed like the simplest + easiest to remember how to change if we need to in the future

I've already added the string to our prod instance settings