### PR TITLE
Reset mongo client

### DIFF
--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -9,9 +9,9 @@ export const setDatabaseConnection = (_client, _db) => {
 export const getDatabase = () => db;
 export const getMongoClient = () => client
 export const databaseIsConnected = () => (db !== null);
-export const closeDatabaseConnection = () => {
+export const closeDatabaseConnection = async () => {
   if (client) {
-    client.close();
+    await client.close();
     client = null;
     db = null;
   }

--- a/packages/lesswrong/server/logging.ts
+++ b/packages/lesswrong/server/logging.ts
@@ -63,7 +63,7 @@ export const addSentryMiddlewares = (addConnectHandler: (handler: any)=>void) =>
 }
 
 const gigabytes = 1024*1024*1024;
-const consoleLogMemoryUsageThreshold = new DatabaseServerSetting<number>("consoleLogMemoryUsage", 1.5*gigabytes);
+export const consoleLogMemoryUsageThreshold = new DatabaseServerSetting<number>("consoleLogMemoryUsage", 1.5*gigabytes);
 const sentryErrorMemoryUsageThreshold = new DatabaseServerSetting<number>("sentryErrorMemoryUsage", 2.1*gigabytes);
 const memoryUsageCheckInterval = new DatabaseServerSetting<number>("memoryUsageCheckInterval", 2000);
 

--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -10,6 +10,7 @@ import { Globals } from '../lib/vulcan-lib/config';
 import process from 'process';
 import chokidar from 'chokidar';
 import fs from 'fs';
+import { consoleLogMemoryUsageThreshold } from './logging';
 
 async function setMongoClient(mongoUrl: string) {
   const priorClient = getMongoClient();
@@ -61,7 +62,10 @@ async function serverStartup() {
 
   onStartup(() => {
     setInterval(async () => {
-      await setMongoClient(commandLineArguments.mongoUrl);
+      const memoryUsage = process.memoryUsage()?.heapTotal;
+      if (memoryUsage > consoleLogMemoryUsageThreshold.get() * 2) {
+        await setMongoClient(commandLineArguments.mongoUrl);
+      }
     }, 10000);
   });
   

--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -1,5 +1,5 @@
 import { MongoClient } from 'mongodb';
-import { setDatabaseConnection } from '../lib/mongoCollection';
+import { getMongoClient, setDatabaseConnection } from '../lib/mongoCollection';
 import { runStartupFunctions, isAnyTest, onStartup } from '../lib/executionEnvironment';
 import { refreshSettingsCaches } from './loadDatabaseSettings';
 import { getCommandLineArguments } from './commandLine';
@@ -12,6 +12,7 @@ import chokidar from 'chokidar';
 import fs from 'fs';
 
 async function setMongoClient(mongoUrl: string) {
+  const priorClient = getMongoClient();
   try {
     // eslint-disable-next-line no-console
     console.log("Connecting to mongodb");
@@ -25,6 +26,9 @@ async function setMongoClient(mongoUrl: string) {
     await client.connect();
     const db = client.db(undefined, { returnNonCachedInstance: true });
     setDatabaseConnection(client, db);
+    if (priorClient) {
+      void priorClient.close();
+    }
   } catch(err) {
     // eslint-disable-next-line no-console
     console.error("Failed to connect to mongodb: ", err);

--- a/packages/lesswrong/testing/testMain.ts
+++ b/packages/lesswrong/testing/testMain.ts
@@ -72,6 +72,6 @@ export function testStartup() {
     await waitUntilCallbacksFinished();
   });
   afterAll(async () => {
-    closeDatabaseConnection();
+    await closeDatabaseConnection();
   });
 }


### PR DESCRIPTION
Quick & dirty patch to see if reassigning the Mongo client every 10 minutes mitigates the memory leak (since current best guess is that something in the client gets into a bad state and begins to retain all the response info).

Not sure about a couple things here:


1. Whether we do in fact want to use the `returnNonCachedInstance` flag
1. Whether we should be attempting to close the existing client either before or after spinning a new one up



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202937135416915) by [Unito](https://www.unito.io)
