### PR TITLE
Add AFLibraryPage [Alignment Forum only]

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AFLibraryPage.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFLibraryPage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { AnalyticsContext } from "../../lib/analyticsEvents";
+
+const styles = (theme: ThemeType): JssStyles => ({
+  pageTitle: {
+    ...theme.typography.headerStyle,
+    fontWeight: "bold",
+    textTransform: "uppercase",
+    borderTopStyle: "solid",
+    borderTopWidth: 4,
+    paddingTop: 10,
+    lineHeight: 1,
+    marginTop: 0,
+  }
+});
+
+export const AFLibraryPage = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const { SingleColumnSection, SectionTitle, Divider, SequencesNewButton, SequencesGridWrapper, Typography } = Components
+
+  return <div className={classes.root}>
+    <AnalyticsContext pageContext="sequencesHome">
+      <SingleColumnSection>
+        <Typography variant="display3" className={classes.pageTitle}>The Library</Typography>
+      </SingleColumnSection>
+      <SingleColumnSection>
+        <SectionTitle title="Curated Sequences" />
+        <div className={classes.sequencesGridWrapperWrapper}>
+          <SequencesGridWrapper
+            terms={{'view':'curatedSequences', limit:100}}
+            itemsPerPage={24}
+            showAuthor={true}
+            showLoadMore={true}
+          />
+        </div>
+      </SingleColumnSection>
+      <Divider />
+      <SingleColumnSection>
+        <SectionTitle  title="Community Sequences" >
+          <SequencesNewButton />
+        </SectionTitle>
+        <div className={classes.sequencesGridWrapperWrapper}>
+          <SequencesGridWrapper
+            terms={{'view':'communitySequences', limit:12}}
+            itemsPerPage={24}
+            showAuthor={true}
+            showLoadMore={true}
+          />
+        </div>
+      </SingleColumnSection>
+    </AnalyticsContext>
+  </div>;
+}
+
+const AFLibraryPageComponent = registerComponent('AFLibraryPage', AFLibraryPage, {styles});
+
+declare global {
+  interface ComponentTypes {
+    AFLibraryPage: typeof AFLibraryPageComponent
+  }
+}
+

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -613,6 +613,7 @@ importComponent("PetrovDayLossScreen", () => require('../components/seasonal/Pet
 importComponent("CoronavirusFrontpageWidget", () => require('../components/seasonal/CoronavirusFrontpageWidget'));
 // importComponent("AprilFools2022", () => require('../components/seasonal/AprilFools2022'));
 
+importComponent("AFLibraryPage", () => require('../components/alignment-forum/AFLibraryPage'));
 importComponent("AFApplicationForm", () => require('../components/alignment-forum/AFApplicationForm'));
 importComponent("AFNonMemberInitialPopup", () => require('../components/alignment-forum/AFNonMemberInitialPopup'));
 importComponent("AFNonMemberSuccessPopup", () => require('../components/alignment-forum/AFNonMemberSuccessPopup'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1011,9 +1011,9 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       title: "2019 Reviews",
     },
     {
-      name: 'sequencesHome',
+      name: 'library',
       path: '/library',
-      componentName: 'LibraryPage',
+      componentName: 'AFLibraryPage',
       enableResourcePrefetch: true,
       title: "The Library"
     },


### PR DESCRIPTION
It used to work fine for AF to share a library with LW, but when I added the new hardcoded collections on LW I forgot to ensure they didn't appear on AF.

This PR adds a new AFLibraryPage component so they can afford to move in different directions. (I weakly think this is preferable to adding a forum-gate within a single Library page, but could be argued otherwise)