### PR TITLE
Disable nginx buffering for pages with prefetching

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -279,6 +279,7 @@ export function startWebserver() {
     );
     
     if (prefetchResources) {
+      response.setHeader("X-Accel-Buffering", "no"); // force nginx to send start of response immediately
       response.status(200);
       response.write(prefetchPrefix);
     }


### PR DESCRIPTION
We send the start of the page with `<script defer src="/js/bundle.js...` before rendering the whole page so the browser starts downloading bundle.js straight away. At some point nginx started buffering this bit of the response so this stopped working so the browser had to wait for the whole page to load, this fixes it (I have tested in Elastic Beanstalk)

I think the proximate cause of this breaking was [this](https://github.com/ForumMagnum/ForumMagnum/pull/5447) change to allow compression, in that if I remove the header that allows compression it also stops nginx from buffering. Although I did test that at the time and confirmed that it was still working... I would guess the full explanation is something like "nginx buffers up to x bytes, and the compression change plus something else caused the size of the first part of the response to go below x", and/or that the recent changes to Elastic Beanstalk resulted in a slightly different version of nginx running



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202942753123089) by [Unito](https://www.unito.io)
