### PR TITLE
Fix memory leak in AF setting/clearing functions

### DIFF
--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
@@ -4,6 +4,7 @@ import { updateMutator } from '../../vulcan-lib';
 import { commentsAlignmentAsync } from '../../resolvers/alignmentForumMutations';
 import { getCollectionHooks } from '../../mutationCallbacks';
 import { asyncForeachSequential } from '../../../lib/utils/asyncUtils';
+import { getCommentAncestorIds, getCommentSubtree } from '../commentCallbacks';
 import * as _ from 'underscore';
 
 export async function recalculateAFCommentMetadata(postId: string|null) {
@@ -44,19 +45,18 @@ getCollectionHooks("Comments").newAsync.add(async function AlignmentCommentsNewO
 
 //TODO: Probably change these to take a boolean argument?
 const updateParentsSetAFtrue = async (comment: DbComment) => {
-  await Comments.rawUpdateOne({_id:comment.parentCommentId}, {$set: {af: true}});
-  const parent = await Comments.findOne({_id: comment.parentCommentId});
-  if (parent) {
-    await updateParentsSetAFtrue(parent)
+  const ancestorIds = await getCommentAncestorIds(comment);
+  if (ancestorIds.length > 0) {
+    await Comments.rawUpdateMany({_id: {$in: ancestorIds}}, {$set: {af: true}});
   }
 }
 
 const updateChildrenSetAFfalse = async (comment: DbComment) => {
-  const children = await Comments.find({parentCommentId: comment._id}).fetch();
-  await asyncForeachSequential(children, async (child) => {
-    await Comments.rawUpdateOne({_id:child._id}, {$set: {af: false}});
-    await updateChildrenSetAFfalse(child)
-  })
+  const subtreeComments: DbComment[] = await getCommentSubtree(comment);
+  if (subtreeComments.length > 0) {
+    const subtreeCommentIds: string[] = subtreeComments.map(c=>c._id);
+    await Comments.rawUpdateMany({_id: {$in: subtreeCommentIds}}, {$set: {af: false}});
+  }
 }
 
 async function CommentsAlignmentEdit (comment: DbComment, oldComment: DbComment) {

--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
@@ -4,7 +4,7 @@ import { updateMutator } from '../../vulcan-lib';
 import { commentsAlignmentAsync } from '../../resolvers/alignmentForumMutations';
 import { getCollectionHooks } from '../../mutationCallbacks';
 import { asyncForeachSequential } from '../../../lib/utils/asyncUtils';
-import { getCommentAncestorIds, getCommentSubtree } from '../commentCallbacks';
+import { getCommentAncestorIds, getCommentSubtree } from '../../utils/commentTreeUtils';
 import * as _ from 'underscore';
 
 export async function recalculateAFCommentMetadata(postId: string|null) {

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -45,7 +45,7 @@ export const getAdminTeamAccount = async () => {
 
 // Return the IDs of all ancestors of the given comment (not including the provided
 // comment itself).
-const getCommentAncestorIds = async (comment: DbComment): Promise<string[]> => {
+export const getCommentAncestorIds = async (comment: DbComment): Promise<string[]> => {
   const ancestorIds: string[] = [];
   
   let currentComment: DbComment|null = comment;
@@ -59,7 +59,7 @@ const getCommentAncestorIds = async (comment: DbComment): Promise<string[]> => {
 }
 
 // Return all comments in a subtree, given its root.
-export const getCommentSubtree = async (rootComment: DbComment, projection: any): Promise<any[]> => {
+export const getCommentSubtree = async (rootComment: DbComment, projection?: any): Promise<DbComment[]> => {
   const comments: DbComment[] = [rootComment];
   let visited = new Set<string>();
   let unvisited: string[] = [rootComment._id];

--- a/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
+++ b/packages/lesswrong/server/migrations/2021-04-28-populateCommentDescendentCounts.ts
@@ -1,5 +1,5 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
-import { getCommentSubtree } from '../callbacks/commentCallbacks';
+import { getCommentSubtree } from '../utils/commentTreeUtils';
 import { asyncForeachParallel } from '../../lib/utils/asyncUtils';
 import Comments from '../../lib/collections/comments/collection';
 import * as _ from 'underscore';

--- a/packages/lesswrong/server/utils/commentTreeUtils.ts
+++ b/packages/lesswrong/server/utils/commentTreeUtils.ts
@@ -1,0 +1,42 @@
+import { Comments } from '../../lib/collections/comments/collection';
+import * as _ from 'underscore';
+import { Globals } from '../vulcan-lib';
+
+// Return the IDs of all ancestors of the given comment (not including the provided
+// comment itself).
+export const getCommentAncestorIds = async (comment: DbComment): Promise<string[]> => {
+  const ancestorIds: string[] = [];
+  
+  let currentComment: DbComment|null = comment;
+  while (currentComment?.parentCommentId) {
+    currentComment = await Comments.findOne({_id: currentComment.parentCommentId});
+    if (currentComment)
+      ancestorIds.push(currentComment._id);
+  }
+  
+  return ancestorIds;
+}
+
+// Return all comments in a subtree, given its root.
+export const getCommentSubtree = async (rootComment: DbComment, projection?: any): Promise<DbComment[]> => {
+  const comments: DbComment[] = [rootComment];
+  let visited = new Set<string>();
+  let unvisited: string[] = [rootComment._id];
+  
+  while(unvisited.length > 0) {
+    const childComments = await Comments.find({parentCommentId: {$in: unvisited}}, projection).fetch();
+    for (let commentId of unvisited)
+      visited.add(commentId);
+    unvisited = [];
+    
+    for (let childComment of childComments) {
+      if (!visited.has(childComment._id)) {
+        comments.push(childComment);
+        unvisited.push(childComment._id);
+      }
+    }
+  }
+  
+  return comments;
+}
+Globals.getCommentSubtree = getCommentSubtree;

--- a/packages/lesswrong/server/utils/commentTreeUtils.ts
+++ b/packages/lesswrong/server/utils/commentTreeUtils.ts
@@ -10,8 +10,12 @@ export const getCommentAncestorIds = async (comment: DbComment): Promise<string[
   let currentComment: DbComment|null = comment;
   while (currentComment?.parentCommentId) {
     currentComment = await Comments.findOne({_id: currentComment.parentCommentId});
-    if (currentComment)
+    if (currentComment) {
+      if (ancestorIds.includes(currentComment._id)) {
+        throw new Error("Parent-comment reference cycle detected starting from "+comment._id);
+      }
       ancestorIds.push(currentComment._id);
+    }
   }
   
   return ancestorIds;


### PR DESCRIPTION
Fix a memory leak which periodically kills causes LW server instances to die, causing 504s. The problem is that `updateParentsSetAFtrue` can recurse infinitely if searching for a null `parentCommentId` returns a result, leaking at a rate of one stack-frame per mongodb roundtrip until the process dies.

Fix rewrites `updateParentsSetAFtrue` (and `updateChildrenSetAFfalse`, which was right next to it and looked a little sketchy) to use preexisting, safer utility functions for getting the comment ancestor-chain and descendents. (Then moves those utility functions into a new file to break an import-cycle, and armors `getCommentAncestorIds` against the possibility of parent-comment-reference cycles in the database.)

This bug was introduced in https://github.com/ForumMagnum/ForumMagnum/commit/e7d2dbf184249e30d2d14974322cc3faca3ec617 and has likely existed ever since, but may have been masked for most of its lifetime by fortunate coincidences about which comment gets returned when you make an unconstrained find-a-comment query.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202944851758246) by [Unito](https://www.unito.io)
