### PR TITLE
Fix deletion of multi-paragraph posts from Algolia

### DIFF
--- a/packages/lesswrong/lib/collections/posts/constants.ts
+++ b/packages/lesswrong/lib/collections/posts/constants.ts
@@ -7,7 +7,7 @@ import StarIcon from '@material-ui/icons/Star';
 import { forumTypeSetting } from '../../instanceSettings';
 
 export const postStatuses = {
-  STATUS_PENDING: 1,
+  STATUS_PENDING: 1, // Unused
   STATUS_APPROVED: 2,
   STATUS_REJECTED: 3,
   STATUS_SPAM: 4,

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -57,12 +57,6 @@ export const postIsApproved = function (post: DbPost): boolean {
   return post.status === postStatuses.STATUS_APPROVED;
 };
 
-// Check if a post is pending
-export const postIsPending = function (post: DbPost): boolean {
-  return post.status === postStatuses.STATUS_PENDING;
-};
-
-
 // Get URL for sharing on Twitter.
 export const postGetTwitterShareUrl = (post: DbPost): string => {
   return `https://twitter.com/intent/tweet?text=${ encodeURIComponent(post.title) }%20${ encodeURIComponent(postGetLink(post, true)) }`;


### PR DESCRIPTION
Previously: due to our algolia paragraph splitting, our code had to do some jiu-jitsu to get all the paragraphs it wanted to delete, when it tried to remove a post from algolia. That fanciness started failing apparenly, and we were not removing spam posts from algolia.

Turns out you can avoid that fanciness by typing `distinct: false` into your algolia query. Algolia will now return all the paragraphs, and then you can just delete them all.

While writing this we discovered: https://github.com/ForumMagnum/ForumMagnum/issues/5641, but declined to fix it at the same time as we ran out of pairing time and that one is much less important.

Coauthored with Jim.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202950551000154) by [Unito](https://www.unito.io)
