### PR TITLE
Return recommendations to lesswrong

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -60,6 +60,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   posts: {
     boxShadow: theme.palette.boxShadow.default,
+  },
+  curated: {
+    marginTop: 12
   }
 });
 
@@ -134,7 +137,7 @@ const RecommendationsAndCurated = ({
     const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
     const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
     
-    const renderRecommendations = !settings.hideFrontpage && forumTypeSetting.get() !== "LessWrong" // temporarily hiding from LessWrong during ACX Everywhere season
+    const renderRecommendations = !settings.hideFrontpage
 
     const bookmarksLimit = (settings.hideFrontpage && settings.hideContinueReading) ? 6 : 3 
 
@@ -180,7 +183,9 @@ const RecommendationsAndCurated = ({
                 <RecommendationsList algorithm={frontpageRecommendationSettings} />
               </AnalyticsContext>
             }
-            {forumTypeSetting.get() !== "EAForum" && <CuratedPostsList />}
+            {forumTypeSetting.get() !== "EAForum" && <div className={classes.curated}>
+              <CuratedPostsList />
+            </div>}
           </div>
         </div>
 


### PR DESCRIPTION
We had removed them during ACX Everywhere. Returning them now, and adding a little spacing to help distinguish curated from recommendation posts.

<img width="939" alt="image" src="https://user-images.githubusercontent.com/3246710/189252718-eea37c71-6ba2-45a6-b7a0-4a699bdebcf9.png">
