### PR TITLE
fix sortable list typing

### DIFF
--- a/packages/lesswrong/components/form-components/sortableList.tsx
+++ b/packages/lesswrong/components/form-components/sortableList.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback} from 'react';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
+import type {SortEvent, SortEventWithTag} from 'react-sortable-hoc';
 import * as _ from 'underscore';
 
 export const makeSortableListComponent = ({renderItem}: {
@@ -18,11 +19,11 @@ export const makeSortableListComponent = ({renderItem}: {
     </span>
   });
   
-  const shouldCancelStart = (e) => {
+  const shouldCancelStart = (e: SortEvent | SortEventWithTag) => {
     // Cancel drag if the event target is a form field, so that if the draggable
     // things have form fields inside them, you can still click to focus them.
     const disabledElements = [ 'input', 'textarea', 'select', 'option', 'button', 'svg', 'path' ];
-    if (disabledElements.includes(e.target.tagName.toLowerCase())) {
+    if ('tagName' in e.target && disabledElements.includes(e.target.tagName.toLowerCase())) {
       return true; // Return true to cancel sorting
     } else {
       return false;


### PR DESCRIPTION
Addressing the [lint error](https://github.com/ForumMagnum/ForumMagnum/runs/8261432218?check_suite_focus=true).  I think this is a bug in eslint; Typescript itself has no problem recognizing them as valid imports in the same import from that module (without splitting out the separate `import type` for the two types).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202955236615244) by [Unito](https://www.unito.io)
