### PR TITLE
Apply tags from edit post page

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useHover } from '../common/withHover';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { useSingle } from '../../lib/crud/withSingle';
+import toDictionary from '../../lib/utils/toDictionary';
+import mapValues from 'lodash/mapValues';
+import { taggingNamePluralSetting } from '../../lib/instanceSettings';
+
+/**
+ * Edit tags on the new or edit post form. If it's the new form, use
+ * TagMultiSelect; a server-side callback will convert tags to tag-relevances.
+ * If it's the edit form, instead use FooterTagList, which has the same
+ * voting-on-tag-relevance as the post page. Styling doesn't match between these
+ * two, which is moderately unfortunate.
+ */
+const FormComponentPostEditorTagging = ({value, path, document, label, placeholder, formType, updateCurrentValues}: {
+  value: any,
+  path: string,
+  document: any,
+  label?: string,
+  placeholder?: string,
+  formType: "edit"|"new",
+  updateCurrentValues: any,
+}) => {
+  if (formType === "edit") {
+    return <Components.FooterTagList
+      post={document}
+      hideScore
+    />
+  } else {
+    return <Components.TagMultiselect
+      path={path} label={label}
+      placeholder={`Add ${taggingNamePluralSetting.get()}`}
+      
+      value={Object.keys(value||{})}
+      updateCurrentValues={(changes) => {
+        updateCurrentValues(
+          mapValues(
+            changes,
+            (arrayOfTagIds: string[]) => toDictionary(
+              arrayOfTagIds, tagId=>tagId, tagId=>1
+            )
+          )
+        )
+      }}
+    />
+  }
+}
+
+const FormComponentPostEditorTaggingComponent = registerComponent("FormComponentPostEditorTagging", FormComponentPostEditorTagging);
+
+declare global {
+  interface ComponentTypes {
+    FormComponentPostEditorTagging: typeof FormComponentPostEditorTaggingComponent
+  }
+}
+
+

--- a/packages/lesswrong/components/form-components/TagMultiselect.tsx
+++ b/packages/lesswrong/components/form-components/TagMultiselect.tsx
@@ -30,7 +30,6 @@ const TagMultiselect = ({ value, path, classes, label, placeholder, updateCurren
   placeholder?: string,
   updateCurrentValues<T extends {}>(values: T): void,
 }) => {
-  
   const addTag = (id: string) => {
     if (!value.includes(id)) {
       value.push(id)

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -145,6 +145,14 @@ const PostsEditForm = ({ documentId, classes }: {
           version="draft"
           noSubmitOnCmdEnter
           repeatErrors
+          
+          {/*
+            * addFields includes tagRelevance because the field permissions on
+            * the schema say the user can't edit this field, but the widget
+            * "edits" the tag list via indirect operations (upvoting/downvoting
+            * relevance scores).
+            */}
+          addFields={document.isEvent ? [] : ['tagRelevance']}
         />
       </NoSsr>
     </div>

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -808,12 +808,21 @@ const schema: SchemaType<DbPost> = {
     }
   }),
   
-  // Denormalized, with manual callbacks. Mapping from tag ID to baseScore, ie Record<string,number>.
+  // Denormalized, with manual callbacks. Mapping from tag ID to baseScore, ie
+  // Record<string,number>. If submitted as part of a new-post submission, the
+  // submitter applies/upvotes relevance for any tags included as keys.
   tagRelevance: {
     type: Object,
     optional: true,
-    hidden: true,
+    insertableBy: ['members'],
+    editableBy: [],
     viewableBy: ['guests'],
+    
+    blackbox: true,
+    label: "Tags",
+    group: formGroups.advancedOptions,
+    control: "FormComponentPostEditorTagging",
+    hidden: (props) => props.eventForm,
   },
   
   "tagRelevance.$": {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -593,6 +593,7 @@ importComponent("PostsListEditor", () => require('../components/form-components/
 importComponent("ImageUpload", () => require('../components/form-components/ImageUpload'));
 importComponent("FMCrosspostControl", () => require('../components/form-components/FMCrosspostControl'));
 importComponent("ImageUploadDefaultsDialog", () => require('../components/form-components/ImageUploadDefaultsDialog'));
+importComponent("FormComponentPostEditorTagging", () => require('../components/form-components/FormComponentPostEditorTagging'));
 importComponent("SequencesListEditor", () => require('../components/form-components/SequencesListEditor'));
 importComponent("SequencesListEditorItem", () => require('../components/form-components/SequencesListEditorItem'));
 importComponent("SubmitButton", () => require('../components/form-components/SubmitButton'));

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -91,7 +91,7 @@ import './server/callbacks/localgroupCallbacks';
 import './server/callbacks/gardenCodeCallbacks';
 import './server/resolvers/commentResolvers';
 import './server/callbacks/postCallbacks';
-import './lib/collections/posts/validate';
+import './server/posts/validatePost';
 import './server/callbacks/chapterCallbacks';
 import './server/callbacks/sequenceCallbacks';
 import './server/callbacks/bookCallbacks';

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -13,6 +13,7 @@ import { postPublishedCallback } from '../notificationCallbacks';
 import moment from 'moment';
 import { triggerReviewIfNeeded } from "./sunshineCallbackUtils";
 import { performCrosspost, handleCrosspostUpdate } from "../fmCrosspost";
+import { addOrUpvoteTag } from '../tagging/tagsGraphQL';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
@@ -287,3 +288,25 @@ getCollectionHooks("Posts").updateBefore.add((
   data: Partial<DbPost>,
   {document}: UpdateCallbackProperties<DbPost>,
 ) => handleCrosspostUpdate(document, data));
+
+getCollectionHooks("Posts").createAfter.add(async (post: DbPost, props: CreateCallbackProperties<DbPost>) => {
+  const {currentUser, context} = props;
+  
+  if (post.tagRelevance) {
+    // Convert tag relevances in a new-post submission to creating new TagRel objects, and upvoting them.
+    console.log(JSON.stringify(post.tagRelevance));
+    const tagsToApply = Object.keys(post.tagRelevance);
+    post = {...post, tagRelevance: undefined};
+    
+    for (let tagId of tagsToApply) {
+      await addOrUpvoteTag({
+        tagId, postId: post._id,
+        currentUser: currentUser!,
+        context
+      });
+    }
+  }
+  
+  return post;
+});
+

--- a/packages/lesswrong/server/posts/validatePost.ts
+++ b/packages/lesswrong/server/posts/validatePost.ts
@@ -1,7 +1,7 @@
-import { registerCollectionValidator } from '../../../server/scripts/validateDatabase';
-import { createAdminContext } from '../../../server/vulcan-lib/query';
-import { Posts } from './collection';
-import { sequenceGetAllPosts } from '../sequences/helpers';
+import { registerCollectionValidator } from '../scripts/validateDatabase';
+import { createAdminContext } from '../vulcan-lib/query';
+import { Posts } from '../../lib/collections/posts/collection';
+import { sequenceGetAllPosts } from '../../lib/collections/sequences/helpers';
 import * as _ from 'underscore';
 
 registerCollectionValidator({

--- a/packages/lesswrong/server/tagging/tagsGraphQL.ts
+++ b/packages/lesswrong/server/tagging/tagsGraphQL.ts
@@ -5,7 +5,7 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { performVoteServer } from '../voteServer';
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
 
-const addOrUpvoteTag = async ({tagId, postId, currentUser, context}: {
+export const addOrUpvoteTag = async ({tagId, postId, currentUser, context}: {
   tagId: string,
   postId: string,
   currentUser: DbUser,


### PR DESCRIPTION
Adds tags to the new-post and edit post forms, in the Options section. Wired up so they get applied correctly, but needs some styling before it's ready to merge.

If it's a new post, uses `TagMultiselect`. If it's an existing post, uses `FooterTagList`, because that one handles all the complexity of relevance-voting in the case where you may be editing a post which has already had tags applied by other people. The visual mismatch between these two versions is unfortunate.