### PR TITLE
Suggestion: Don't render recent discussion in SSR

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -5,6 +5,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib'
 import { useCurrentUser } from '../common/withUser'
 import { reviewIsActive } from '../../lib/reviewUtils'
 import { maintenanceTime } from '../common/MaintenanceBanner'
+import NoSSR from 'react-no-ssr'
 
 const eaHomeSequenceIdSetting = new PublicInstanceSetting<string | null>('eaHomeSequenceId', null, "optional") // Sequence ID for the EAHomeHandbook sequence
 const showSmallpoxSetting = new DatabasePublicSetting<boolean>('showSmallpox', false)
@@ -42,12 +43,14 @@ const EAHome = () => {
       
       <HomeLatestPosts />
       
-      {!reviewIsActive() && <RecommendationsAndCurated configName="frontpageEA" />}
-      <RecentDiscussionFeed
-        af={false}
-        commentsLimit={recentDiscussionCommentsPerPost}
-        maxAgeHours={18}
-      />
+      <NoSSR>
+        {!reviewIsActive() && <RecommendationsAndCurated configName="frontpageEA" />}
+        <RecentDiscussionFeed
+          af={false}
+          commentsLimit={recentDiscussionCommentsPerPost}
+          maxAgeHours={18}
+        />
+      </NoSSR>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
This gives a moderate performance benefit in loading the front page, and shouldn't really affect the user experience because recent discussion isn't in view when the page loads. The only difference is that you might see loading dots if you immediately (within half a second) scroll down to it

Using a local copy of the prod db it got the initial response down from 802ms to 559ms for a non-admin account (~30% reduction). In the real prod the page load time is a bit slower than this, I'm not sure why but I would assume due to the db network latency, so the effect may be more or less than this