### PR TITLE
Remove dev-gating of Subforums

### DIFF
--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -4,8 +4,6 @@ import { useLocation } from "../../lib/routeUtil";
 import { useTagBySlug } from "./useTag";
 import { isMissingDocumentError } from "../../lib/utils/errorUtil";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
-import { useSingle } from "../../lib/crud/withSingle";
-import { isProduction } from "../../lib/executionEnvironment";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,8 +33,7 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
     return <Loading />;
   }
 
-  // TODO-WH: remove isProduction flag here when we are ready to show this to users
-  if (isProduction || !tag || !tag.isSubforum) {
+  if (!tag || !tag.isSubforum) {
     return <Error404 />;
   }
 


### PR DESCRIPTION
We will want to show them on staging, and, for better or for worse, staging has `isProduction` set to true. I've checked, and there are no topics on production that have the `isSubforum` flag set to true.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202967649332943) by [Unito](https://www.unito.io)
