### PR TITLE
Stop subforum comments from showing up in recent discussion

### DIFF
--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -11,6 +11,7 @@ import { forumTypeSetting, taggingNamePluralSetting, taggingNameSetting } from '
 import { SORT_ORDER_OPTIONS, SettingsOption } from '../posts/sortOrderOptions';
 import omit from 'lodash/omit';
 import { formGroups } from './formGroups';
+import { TagCommentType } from '../comments/schema';
 
 addGraphQLSchema(`
   type TagContributor {
@@ -245,6 +246,7 @@ export const schema: SchemaType<DbTag> = {
         score: {$gt:0},
         deletedPublic: false,
         postedAt: {$gt: timeCutoff},
+        tagCommentType: TagCommentType.Discussion,
         ...(af ? {af:true} : {}),
       }, {
         limit: tagCommentsLimit,

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -16,6 +16,7 @@ import { getCollectionHooks, CreateCallbackProperties } from '../mutationCallbac
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { ensureIndex } from '../../lib/collectionUtils';
 import { triggerReviewIfNeeded } from "./sunshineCallbackUtils";
+import { TagCommentType } from '../../lib/collections/comments/schema';
 
 
 const MINIMUM_APPROVAL_KARMA = 5
@@ -89,7 +90,7 @@ getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations 
     await Posts.rawUpdateOne(comment.postId, {
       $set: {lastCommentedAt: new Date()},
     });
-  } else if (comment.tagId) {
+  } else if (comment.tagId && comment.tagCommentType === TagCommentType.Discussion) {
     await Tags.rawUpdateOne(comment.tagId, {
       $set: {lastCommentedAt: new Date()},
     });

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -17,6 +17,7 @@ import mapValues from 'lodash/mapValues';
 import take from 'lodash/take';
 import filter from 'lodash/filter';
 import * as _ from 'underscore';
+import { TagCommentType } from '../../lib/collections/comments/schema';
 
 addGraphQLSchema(`
   type TagUpdates {
@@ -57,6 +58,7 @@ addGraphQLResolvers({
         postedAt: {$lt: before, $gt: after},
         topLevelCommentId: null,
         tagId: {$exists: true, $ne: null},
+        tagCommentType: TagCommentType.Discussion,
       }).fetch();
       
       const userIds = _.uniq([...tagRevisions.map(tr => tr.userId), ...rootComments.map(rc => rc.userId)])


### PR DESCRIPTION
This is something I missed in #5638

I am fairly soon going to make it so that subforum comments _do_ show up in recent discussion for members of the subforum, which will probably involve refactoring this. But this is more important so it makes sense to merge it straight away



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202976031445303) by [Unito](https://www.unito.io)
