### PR TITLE
Add user-agent to crossposting API requests

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -4,7 +4,7 @@ import { randomId } from "../../lib/random";
 import { Crosspost, UpdateCrosspostPayload, CrosspostPayload } from "./types";
 import { signToken } from "./tokens";
 import { apiRoutes, makeApiUrl } from "./routes";
-import { makeCrossSiteRequest } from "./resolvers";
+import { makeCrossSiteRequest, crosspostUserAgent } from "./resolvers";
 
 export const performCrosspost = async <T extends Crosspost>(post: T): Promise<T> => {
   if (!post.fmCrosspost || !post.userId || post.draft) {
@@ -36,6 +36,7 @@ export const performCrosspost = async <T extends Crosspost>(post: T): Promise<T>
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "User-Agent": crosspostUserAgent,
     },
     body: JSON.stringify({
       token,

--- a/packages/lesswrong/server/fmCrosspost/resolvers.ts
+++ b/packages/lesswrong/server/fmCrosspost/resolvers.ts
@@ -7,6 +7,8 @@ import { signToken } from "./tokens";
 import type { Request } from "express";
 import fetch from "node-fetch";
 
+export const crosspostUserAgent = "ForumMagnum/2.1";
+
 const getUserId = (req?: Request) => {
   const userId = req?.user?._id;
   if (!userId) {
@@ -25,6 +27,7 @@ export const makeCrossSiteRequest = async <T extends {}>(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "User-Agent": crosspostUserAgent,
     },
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
Relevant Slack thread: https://app.slack.com/client/T3ERD8FQT/C75BWSNBH/thread/C75BWSNBH-1663086521.834869

Adds a user-agent to crossposting API requests. This is something we want anyways (because it makes the requests distinctive in logs/Sentry), but also maybe works around a problem with an overzealous AWS firewall config.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202975927639748) by [Unito](https://www.unito.io)
