### PR TITLE
Clean up collaborateOnPost redirect/permissions bugs

### DIFF
--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -9,6 +9,7 @@ import { isMissingDocumentError } from '../../lib/utils/errorUtil';
 import type { CollaborativeEditingAccessLevel } from '../../lib/collections/posts/collabEditingPermissions';
 import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
 import { useQuery, gql } from '@apollo/client';
+import { userCanDo } from '../../lib/vulcan-users';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -76,7 +77,7 @@ const PostCollaborationEditor = ({ classes }: {
   
   // If you're the primary author, or an admin, redirect to the main editor (rather than the
   // collab editor) so you can edit metadata etc
-  if (post.userId === currentUser._id || currentUser.isAdmin) {
+  if (post.userId === currentUser._id || userCanDo(currentUser, 'posts.edit.all')) {
     return <PermanentRedirect url={postGetEditUrl(post._id, false, post.linkSharingKey)}/>
   }
 

--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -164,7 +164,7 @@ const PostSharingSettingsDialog = ({postId, linkSharingKey, initialSharingSettin
     setIsChanged(true);
   };
   
-  const collabEditorLink = getPostCollaborateUrl(postId, false, post.linkSharingKey)
+  const collabEditorLink = getPostCollaborateUrl(postId, false, linkSharingKey)
   
   return <LWDialog open={true}>
     <div className={classes.sharingSettingsDialog}>

--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -13,6 +13,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import PropTypes from 'prop-types';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
 import { moderationEmail } from '../../lib/publicSettings';
+import { getPostCollaborateUrl } from '../../lib/collections/posts/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   linkSharingPreview: {
@@ -163,8 +164,7 @@ const PostSharingSettingsDialog = ({postId, linkSharingKey, initialSharingSettin
     setIsChanged(true);
   };
   
-  const linkPrefix = getSiteUrl().slice(0,-1);
-  const collabEditorLink = `${linkPrefix}/collaborateOnPost?postId=${postId}&key=${linkSharingKey}`
+  const collabEditorLink = getPostCollaborateUrl(postId, false, post.linkSharingKey)
   
   return <LWDialog open={true}>
     <div className={classes.sharingSettingsDialog}>

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -90,7 +90,7 @@ const PostsEditForm = ({ documentId, classes }: {
   
   // If we have access to the post but only readonly access and only because
   // it's published, don't show the edit form.
-  if (document.userId !== currentUser?._id && !userIsSharedOn(currentUser, document) && !userIsAdmin(currentUser)) {
+  if (document.userId !== currentUser._id && !userIsSharedOn(currentUser, document) && !userIsAdmin(currentUser)) {
     return <Components.ErrorAccessDenied/>
   }
   
@@ -107,7 +107,7 @@ const PostsEditForm = ({ documentId, classes }: {
   
   return (
     <div className={classes.postForm}>
-      <HeadTags title={document?.title} />
+      <HeadTags title={document.title} />
       <NoSsr>
         <WrappedSmartForm
           collection={Posts}

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib
 import { useSingle } from '../../lib/crud/withSingle';
 import { useMessages } from '../common/withMessages';
 import { Posts } from '../../lib/collections/posts';
-import { postGetPageUrl, postGetEditUrl } from '../../lib/collections/posts/helpers';
+import { postGetPageUrl, postGetEditUrl, getPostCollaborateUrl } from '../../lib/collections/posts/helpers';
 import { userIsSharedOn } from '../../lib/collections/users/helpers';
 import { useLocation, useNavigation } from '../../lib/routeUtil'
 import NoSsr from '@material-ui/core/NoSsr';
@@ -12,7 +12,7 @@ import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
-import { userCanDo, userIsAdmin } from '../../lib/vulcan-users/permissions';
+import { userCanDo } from '../../lib/vulcan-users/permissions';
 
 const PostsEditForm = ({ documentId, classes }: {
   documentId: string,
@@ -31,7 +31,7 @@ const PostsEditForm = ({ documentId, classes }: {
   const { params } = location; // From withLocation
   const isDraft = document && document.draft;
 
-  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, ForeignCrosspostEditForm, HeadTags } = Components
+  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags } = Components
   
   const saveDraftLabel: string = ((post) => {
     if (!post) return "Save Draft"
@@ -69,7 +69,7 @@ const PostsEditForm = ({ documentId, classes }: {
   // If we don't have access at all but a link-sharing key was provided, redirect to the
   // collaborative editor
   if (!document && !loading && query?.key) {
-    return <Components.PermanentRedirect url={`/collaborateOnPost?postId=${documentId}&key=${query.key}`} status={302}/>
+    return <Components.PermanentRedirect url={getPostCollaborateUrl(documentId, false, query.key)} status={302}/>
   }
   
   // If the post has a link-sharing key which is not in the URL, redirect to add

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -12,7 +12,7 @@ import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
-import { userIsAdmin } from '../../lib/vulcan-users/permissions';
+import { userCanDo, userIsAdmin } from '../../lib/vulcan-users/permissions';
 
 const PostsEditForm = ({ documentId, classes }: {
   documentId: string,
@@ -61,8 +61,7 @@ const PostsEditForm = ({ documentId, classes }: {
   if (document
     && document.userId!==currentUser._id
     && document.sharingSettings
-    && !userIsAdmin(currentUser)
-    && !currentUser.groups?.includes('sunshineRegiment')
+    && !userCanDo(currentUser, 'posts.edit.all')
   ) {
     return <Components.PermanentRedirect url={`/collaborateOnPost?postId=${documentId}${query.key ? "&key="+query.key : ""}`} status={302}/>
   }
@@ -90,7 +89,7 @@ const PostsEditForm = ({ documentId, classes }: {
   
   // If we have access to the post but only readonly access and only because
   // it's published, don't show the edit form.
-  if (document.userId !== currentUser._id && !userIsSharedOn(currentUser, document) && !userIsAdmin(currentUser)) {
+  if (document.userId !== currentUser._id && !userIsSharedOn(currentUser, document) && !userCanDo(currentUser, 'posts.edit.all')) {
     return <Components.ErrorAccessDenied/>
   }
   

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -63,7 +63,7 @@ const PostsEditForm = ({ documentId, classes }: {
     && document.sharingSettings
     && !userCanDo(currentUser, 'posts.edit.all')
   ) {
-    return <Components.PermanentRedirect url={`/collaborateOnPost?postId=${documentId}${query.key ? "&key="+query.key : ""}`} status={302}/>
+    return <Components.PermanentRedirect url={getPostCollaborateUrl(documentId, false, query.key)} status={302}/>
   }
   
   // If we don't have access at all but a link-sharing key was provided, redirect to the

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -118,6 +118,15 @@ export const postGetPageUrl = function(post: PostsMinimumForGetPageUrl, isAbsolu
   return `${prefix}/posts/${post._id}/${post.slug}`;
 };
 
+export const getPostCollaborateUrl = function (postId: string, isAbsolute=false, linkSharingKey?: string): string {
+  const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
+  if (linkSharingKey) {
+    return `${prefix}/collaborateOnPost?postId=${postId}&key=${linkSharingKey}`;
+  } else {
+    return `${prefix}/collaborateOnPost?postId=${postId}`;
+  }
+}
+
 export const postGetEditUrl = function(postId: string, isAbsolute=false, linkSharingKey?: string): string {
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
   if (linkSharingKey) {

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components } from './vulcan-lib/components';
 import Conversations from './collections/conversations/collection';
 import { Posts } from './collections/posts';
-import { postGetAuthorName } from './collections/posts/helpers';
+import { getPostCollaborateUrl, postGetAuthorName } from './collections/posts/helpers';
 import { Comments } from './collections/comments/collection';
 import { commentGetAuthorName } from './collections/comments/helpers';
 import { TagRels } from './collections/tagRels/collection';
@@ -299,7 +299,10 @@ export const PostSharedWithUserNotification = registerNotificationType({
     documentId: string|null,
     extraData: any
   }): string => {
-    return `/collaborateOnPost?postId=${documentId}`;
+    if (!documentId) {
+      throw new Error("PostSharedWithUserNotification documentId is missing")
+    }
+    return getPostCollaborateUrl(documentId, false)
   }
 });
 

--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -92,11 +92,14 @@ defineQuery({
     //  * Link-sharing is enabled and the post doesn't have a link-sharing key
     //  * Link-sharing is enabled and this user has provided the correct key in
     //    the past
+    //  * The logged-in user is the post author
     if (
-      (post?.shareWithUsers && _.contains(post.shareWithUsers, currentUser._id))
+      (post.shareWithUsers && _.contains(post.shareWithUsers, currentUser._id))
       || (linkSharingEnabled(post)
           && (!post.linkSharingKey || constantTimeCompare(post.linkSharingKey, linkSharingKey)))
       || (linkSharingEnabled(post) && _.contains(post.linkSharingKeyUsedBy, currentUser._id))
+      || currentUser._id === post.userId
+      || currentUser.isAdmin
     ) {
       // Add the user to linkSharingKeyUsedBy, if not already there
       if (!post.linkSharingKeyUsedBy || !_.contains(post.linkSharingKeyUsedBy, currentUser._id)) {

--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -93,6 +93,7 @@ defineQuery({
     //  * Link-sharing is enabled and this user has provided the correct key in
     //    the past
     //  * The logged-in user is the post author
+    //  * The logged in user is an admin
     if (
       (post.shareWithUsers && _.contains(post.shareWithUsers, currentUser._id))
       || (linkSharingEnabled(post)

--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -11,6 +11,7 @@ import { updateMutator } from '../vulcan-lib/mutators';
 import { pushRevisionToCkEditor } from './ckEditorWebhook';
 import * as _ from 'underscore';
 import crypto from 'crypto';
+import { userCanDo } from '../../lib/vulcan-users';
 
 export function generateLinkSharingKey(): string {
   return randomSecret();
@@ -93,14 +94,14 @@ defineQuery({
     //  * Link-sharing is enabled and this user has provided the correct key in
     //    the past
     //  * The logged-in user is the post author
-    //  * The logged in user is an admin
+    //  * The logged in user is an admin or moderator (or otherwise has edit permissions)
     if (
       (post.shareWithUsers && _.contains(post.shareWithUsers, currentUser._id))
       || (linkSharingEnabled(post)
           && (!post.linkSharingKey || constantTimeCompare(post.linkSharingKey, linkSharingKey)))
       || (linkSharingEnabled(post) && _.contains(post.linkSharingKeyUsedBy, currentUser._id))
       || currentUser._id === post.userId
-      || currentUser.isAdmin
+      || userCanDo(currentUser, 'posts.edit.all')
     ) {
       // Add the user to linkSharingKeyUsedBy, if not already there
       if (!post.linkSharingKeyUsedBy || !_.contains(post.linkSharingKeyUsedBy, currentUser._id)) {


### PR DESCRIPTION
This fixes some permissions-issues and confusing redirects that surround collaborative editing.

There are two pages for editing posts – the PostsEditForm and the PostCollaborationEditor. The former is for people who have the permission to edit all the other post-related fields (i.e. post authors and admins). The latter is for people who've been shared on the post for collaborative editing (and doesn't allow for the ability to actually submit changes so they appear publicly)

The goal here is that:


1. Whenever you should have full edit permissions on a post, you should always get redirected to /editPost. 
1. Whenever you don't have full edit permissions on a post, you get redirected to /collaborateOnPost



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202976287822865) by [Unito](https://www.unito.io)
