### PR TITLE
Refactor subforum discussion section for loading many comments + fix bugs in setting lastSubthreadActivity and descendentCount

### DIFF
--- a/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
@@ -9,7 +9,7 @@ interface CommentOnPostWithRepliesProps extends CommentWithRepliesProps {
 
 const CommentOnPostWithReplies = (props: CommentOnPostWithRepliesProps) => {
   const {lastRead, markAsRead} = useMarkAsRead(props.post);
-  
+
   const {CommentWithReplies} = Components;
 
   return <CommentWithReplies {...props} lastRead={lastRead} markAsRead={markAsRead}/>

--- a/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useMarkAsRead } from "../common/withRecordPostView";
+import React, { useCallback, useState } from 'react';
+import { useRecordPostView } from "../common/withRecordPostView";
 import { CommentWithRepliesProps } from "./CommentWithReplies";
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
@@ -8,7 +8,14 @@ interface CommentOnPostWithRepliesProps extends CommentWithRepliesProps {
 }
 
 const CommentOnPostWithReplies = (props: CommentOnPostWithRepliesProps) => {
-  const {lastRead, markAsRead} = useMarkAsRead(props.post);
+  const post = props.post;
+  const [lastRead, setLastRead] = useState<Date>(post.lastVisitedAt);
+  const { recordPostView } = useRecordPostView(post);
+
+  const markAsRead = useCallback(async () => {
+    setLastRead(new Date());
+    recordPostView({ post });
+  }, [post, recordPostView]);
 
   const {CommentWithReplies} = Components;
 

--- a/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useMarkAsRead } from "../common/withRecordPostView";
+import { CommentWithRepliesProps } from "./CommentWithReplies";
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+
+interface CommentOnPostWithRepliesProps extends CommentWithRepliesProps {
+  post: PostsBase;
+}
+
+const CommentOnPostWithReplies = (props: CommentOnPostWithRepliesProps) => {
+  const {lastRead, markAsRead} = useMarkAsRead(props.post);
+  
+  const {CommentWithReplies} = Components;
+
+  return <CommentWithReplies {...props} lastRead={lastRead} markAsRead={markAsRead}/>
+};
+
+const CommentOnPostWithRepliesComponent = registerComponent(
+  'CommentOnPostWithReplies', CommentOnPostWithReplies
+);
+
+declare global {
+  interface ComponentTypes {
+    CommentOnPostWithReplies: typeof CommentOnPostWithRepliesComponent;
+  }
+}

--- a/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
@@ -3,12 +3,11 @@ import { useRecordPostView } from "../common/withRecordPostView";
 import { CommentWithRepliesProps } from "./CommentWithReplies";
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-interface CommentOnPostWithRepliesProps extends CommentWithRepliesProps {
+type CommentOnPostWithRepliesProps = Omit<CommentWithRepliesProps, 'lastRead' | 'markAsRead'> & {
   post: PostsBase;
 }
 
-const CommentOnPostWithReplies = (props: CommentOnPostWithRepliesProps) => {
-  const post = props.post;
+const CommentOnPostWithReplies = ({post, ...otherProps}: CommentOnPostWithRepliesProps) => {
   const [lastRead, setLastRead] = useState<Date>(post.lastVisitedAt);
   const { recordPostView } = useRecordPostView(post);
 
@@ -19,7 +18,7 @@ const CommentOnPostWithReplies = (props: CommentOnPostWithRepliesProps) => {
 
   const {CommentWithReplies} = Components;
 
-  return <CommentWithReplies {...props} lastRead={lastRead} markAsRead={markAsRead}/>
+  return <CommentWithReplies post={post} {...otherProps} lastRead={lastRead} markAsRead={markAsRead}/>
 };
 
 const CommentOnPostWithRepliesComponent = registerComponent(

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -46,7 +46,7 @@ const CommentPermalink = ({ documentId, post, classes }: {
     fragmentName: 'CommentWithRepliesFragment',
   });
   const refetch = data?.refetch;
-  const { Loading, Divider, CommentWithReplies, HeadTags } = Components;
+  const { Loading, Divider, CommentOnPostWithReplies, HeadTags } = Components;
 
   if (error || (!comment && !loading)) return <div>Comment not found</div>
   
@@ -67,7 +67,7 @@ const CommentPermalink = ({ documentId, post, classes }: {
       <div>
         <HeadTags ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl} 
         description={getCommentDescription(comment)} noIndex={true} />
-        <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
+        <CommentOnPostWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
       </div>
       {forumTypeSetting.get() !== 'EAForum' && <div className={classes.dividerMargins}><Divider /></div>}

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -67,7 +67,13 @@ const CommentPermalink = ({ documentId, post, classes }: {
       <div>
         <HeadTags ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl} 
         description={getCommentDescription(comment)} noIndex={true} />
-        <CommentOnPostWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
+        <CommentOnPostWithReplies key={comment._id} post={post} comment={comment} commentNodeProps={{
+          treeOptions: {
+            refetch,
+            showPostTitle: false,
+          },
+          expandByDefault: true,
+        }}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
       </div>
       {forumTypeSetting.get() !== 'EAForum' && <div className={classes.dividerMargins}><Divider /></div>}

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -2,8 +2,9 @@ import React, { useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { unflattenComments, addGapIndicators } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
-import { useRecordPostView } from '../common/withRecordPostView';
+import { useMarkAsRead, useRecordPostView } from '../common/withRecordPostView';
 import withErrorBoundary from '../common/withErrorBoundary';
+import { CommentsNodeProps } from './CommentsNode';
 
 const styles = (theme: ThemeType): JssStyles => ({
   showChildren: {
@@ -16,68 +17,81 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const CommentWithReplies = ({comment, post, refetch, showTitle=true, expandByDefault, classes}: {
-  comment: CommentWithRepliesFragment,
-  post: PostsBase,
-  refetch?: any,
-  showTitle?: boolean,
-  expandByDefault?: boolean,
-  classes: ClassesType,
-}) => {
-  const [markedAsVisitedAt,setMarkedAsVisitedAt] = useState<Date|null>(null);
-  const [maxChildren,setMaxChildren] = useState(3);
-  const { recordPostView } = useRecordPostView(post);
+export interface CommentWithRepliesProps {
+  comment: CommentWithRepliesFragment;
+  post?: PostsBase;
+  lastRead?: Date;
+  markAsRead?: any;
+  refetch?: any;
+  showTitle?: boolean;
+  expandByDefault?: boolean;
+  initialMaxChildren?: number;
+  passThroughProps?: Partial<CommentsNodeProps>;
+  classes: ClassesType;
+}
 
-  const markAsRead = useCallback(async () => {
-    setMarkedAsVisitedAt(new Date());
-    recordPostView({post})
-  }, [setMarkedAsVisitedAt, recordPostView, post]);
-
-  const { CommentsNode } = Components
-
-  if (!comment || !post)
-    return null;
-
-  const lastCommentId = comment.latestChildren[0]?._id
-
-  const renderedChildren = comment.latestChildren.slice(0, maxChildren)
-  const extraChildrenCount = (comment.latestChildren.length > renderedChildren.length) && (comment.latestChildren.length - renderedChildren.length)
-
-  let nestedComments = unflattenComments(renderedChildren)
-  if (extraChildrenCount > 0) {
-    nestedComments = addGapIndicators(nestedComments)
-  }
-
-  const lastVisitedAt = markedAsVisitedAt || post.lastVisitedAt
-
-  const showExtraChildrenButton = (extraChildrenCount>0) ? 
-    <a className={classes.showChildren} onClick={()=>setMaxChildren(500)}>
-      Showing 3 of {comment.latestChildren.length } replies (Click to show all)
-    </a> : null
-
+const CommentWithReplies = ({
+  comment,
+  post,
+  lastRead,
+  markAsRead = () => {},
+  refetch,
+  showTitle = true,
+  expandByDefault,
+  initialMaxChildren = 3,
+  passThroughProps,
+  classes,
+}: CommentWithRepliesProps) => {
+  const [maxChildren, setMaxChildren] = useState(initialMaxChildren);
+  
+  if (!comment) return null;
+  
+  const lastCommentId = comment.latestChildren[0]?._id;
+  
   const treeOptions: CommentTreeOptions = {
     lastCommentId,
     markAsRead: markAsRead,
-    highlightDate: lastVisitedAt,
+    highlightDate: lastRead,
     condensed: true,
     showPostTitle: showTitle,
     refetch,
     post,
   };
-  
-  return <CommentsNode
-    treeOptions={treeOptions}
-    noHash
-    startThreadTruncated={true}
-    nestingLevel={1}
-    comment={comment}
-    childComments={nestedComments}
-    key={comment._id}
-    shortform
-    expandByDefault={expandByDefault}
-    showExtraChildrenButton={showExtraChildrenButton}
-  />
-}
+
+  const { CommentsNode } = Components;
+
+  const renderedChildren = comment.latestChildren.slice(0, maxChildren);
+  const extraChildrenCount =
+    comment.latestChildren.length > renderedChildren.length && comment.latestChildren.length - renderedChildren.length;
+
+  let nestedComments = unflattenComments(renderedChildren);
+  if (extraChildrenCount > 0) {
+    nestedComments = addGapIndicators(nestedComments);
+  }
+
+  const showExtraChildrenButton =
+    extraChildrenCount > 0 ? (
+      <a className={classes.showChildren} onClick={() => setMaxChildren(maxChildren + 500)}>
+        Showing {maxChildren} of {comment.latestChildren.length} replies (Click to show all)
+      </a>
+    ) : null;
+
+  return (
+    <CommentsNode
+      treeOptions={treeOptions}
+      noHash
+      startThreadTruncated={true}
+      nestingLevel={1}
+      comment={comment}
+      childComments={nestedComments}
+      key={comment._id}
+      shortform
+      expandByDefault={expandByDefault}
+      showExtraChildrenButton={showExtraChildrenButton}
+      {...passThroughProps}
+    />
+  );
+};
 
 const CommentWithRepliesComponent = registerComponent(
   'CommentWithReplies', CommentWithReplies, {
@@ -88,7 +102,7 @@ const CommentWithRepliesComponent = registerComponent(
 
 declare global {
   interface ComponentTypes {
-    CommentWithReplies: typeof CommentWithRepliesComponent,
+    CommentWithReplies: typeof CommentWithRepliesComponent;
   }
 }
 

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -22,11 +22,8 @@ export interface CommentWithRepliesProps {
   post?: PostsBase;
   lastRead?: Date;
   markAsRead?: any;
-  refetch?: any;
-  showTitle?: boolean;
-  expandByDefault?: boolean;
   initialMaxChildren?: number;
-  passThroughProps?: Partial<CommentsNodeProps>;
+  commentNodeProps?: Partial<CommentsNodeProps>;
   classes: ClassesType;
 }
 
@@ -35,11 +32,8 @@ const CommentWithReplies = ({
   post,
   lastRead,
   markAsRead = () => {},
-  refetch,
-  showTitle = true,
-  expandByDefault,
   initialMaxChildren = 3,
-  passThroughProps,
+  commentNodeProps,
   classes,
 }: CommentWithRepliesProps) => {
   const [maxChildren, setMaxChildren] = useState(initialMaxChildren);
@@ -53,9 +47,9 @@ const CommentWithReplies = ({
     markAsRead: markAsRead,
     highlightDate: lastRead,
     condensed: true,
-    showPostTitle: showTitle,
-    refetch,
+    showPostTitle: true,
     post,
+    ...(commentNodeProps?.treeOptions || {}),
   };
 
   const { CommentsNode } = Components;
@@ -78,7 +72,6 @@ const CommentWithReplies = ({
 
   return (
     <CommentsNode
-      treeOptions={treeOptions}
       noHash
       startThreadTruncated={true}
       nestingLevel={1}
@@ -86,9 +79,9 @@ const CommentWithReplies = ({
       childComments={nestedComments}
       key={comment._id}
       shortform
-      expandByDefault={expandByDefault}
       showExtraChildrenButton={showExtraChildrenButton}
-      {...passThroughProps}
+      {...commentNodeProps}
+      treeOptions={treeOptions}
     />
   );
 };

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { unflattenComments, addGapIndicators } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
-import { useMarkAsRead, useRecordPostView } from '../common/withRecordPostView';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { CommentsNodeProps } from './CommentsNode';
 

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -34,6 +34,32 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
+export interface CommentsNodeProps {
+  treeOptions: CommentTreeOptions,
+  comment: CommentsList & {gapIndicator?: boolean},
+  startThreadTruncated?: boolean,
+  truncated?: boolean,
+  shortform?: any,
+  nestingLevel?: number,
+  expandAllThreads?:boolean,
+  expandByDefault?: boolean, // this determines whether this specific comment is expanded, without passing that expanded state to child comments
+  isChild?: boolean,
+  parentAnswerId?: string|null,
+  parentCommentId?: string,
+  showExtraChildrenButton?: any,
+  noHash?: boolean,
+  hoverPreview?: boolean,
+  forceSingleLine?: boolean,
+  forceNotSingleLine?: boolean,
+  childComments?: Array<CommentTreeNode<CommentsList>>,
+  loadChildrenSeparately?: boolean,
+  loadDirectReplies?: boolean,
+  showPinnedOnProfile?: boolean,
+  enableGuidelines?: boolean,
+  displayMode?: CommentFormDisplayMode,
+  classes: ClassesType,
+}
+
 const CommentsNode = ({
   treeOptions,
   comment,
@@ -58,31 +84,7 @@ const CommentsNode = ({
   enableGuidelines=true,
   displayMode="default",
   classes
-}: {
-  treeOptions: CommentTreeOptions,
-  comment: CommentsList & {gapIndicator?: boolean},
-  startThreadTruncated?: boolean,
-  truncated?: boolean,
-  shortform?: any,
-  nestingLevel?: number,
-  expandAllThreads?:boolean,
-  expandByDefault?: boolean, // this determines whether this specific comment is expanded, without passing that expanded state to child comments
-  isChild?: boolean,
-  parentAnswerId?: string|null,
-  parentCommentId?: string,
-  showExtraChildrenButton?: any,
-  noHash?: boolean,
-  hoverPreview?: boolean,
-  forceSingleLine?: boolean,
-  forceNotSingleLine?: boolean,
-  childComments?: Array<CommentTreeNode<CommentsList>>,
-  loadChildrenSeparately?: boolean,
-  loadDirectReplies?: boolean,
-  showPinnedOnProfile?: boolean,
-  enableGuidelines?: boolean,
-  displayMode?: CommentFormDisplayMode,
-  classes: ClassesType,
-}) => {
+}: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
   const [collapsed, setCollapsed] = useState(comment.deleted || comment.baseScore < KARMA_COLLAPSE_THRESHOLD);

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -42,7 +42,11 @@ export interface CommentsNodeProps {
   shortform?: any,
   nestingLevel?: number,
   expandAllThreads?:boolean,
-  expandByDefault?: boolean, // this determines whether this specific comment is expanded, without passing that expanded state to child comments
+  /**
+   * Determines whether this specific comment is expanded, without passing that
+   * expanded state to child comments
+   */
+  expandByDefault?: boolean,
   isChild?: boolean,
   parentAnswerId?: string|null,
   parentCommentId?: string,

--- a/packages/lesswrong/components/comments/CommentsTimeline.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimeline.tsx
@@ -82,7 +82,7 @@ const CommentsTimelineFn = ({
     );
   }
   
-  const passThroughProps = {
+  const commentNodeProps = {
     treeOptions: treeOptions,
     refetch: treeOptions.refetch,
     startThreadTruncated: startThreadTruncated,
@@ -105,7 +105,7 @@ const CommentsTimelineFn = ({
             refetch={treeOptions.refetch}
             comment={comment}
             key={comment._id}
-            passThroughProps={passThroughProps}
+            commentNodeProps={commentNodeProps}
             initialMaxChildren={5}
           />
         ))}

--- a/packages/lesswrong/components/comments/CommentsTimeline.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimeline.tsx
@@ -84,7 +84,6 @@ const CommentsTimelineFn = ({
   
   const commentNodeProps = {
     treeOptions: treeOptions,
-    refetch: treeOptions.refetch,
     startThreadTruncated: startThreadTruncated,
     parentCommentId: parentCommentId,
     parentAnswerId: parentAnswerId,
@@ -102,7 +101,6 @@ const CommentsTimelineFn = ({
         {loadingMoreComments ? <Components.Loading /> : <></>}
         {commentsToRender.map((comment) => (
           <CommentWithReplies
-            refetch={treeOptions.refetch}
             comment={comment}
             key={comment._id}
             commentNodeProps={commentNodeProps}

--- a/packages/lesswrong/components/comments/CommentsTimeline.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimeline.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import withErrorBoundary from '../common/withErrorBoundary';
 import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
+import { CommentFormDisplayMode } from './CommentsNewForm';
 
 const styles = (theme: ThemeType): JssStyles => ({
   button: {
@@ -32,7 +33,7 @@ const CommentsTimelineFn = ({
   classes,
 }: {
   treeOptions: CommentTreeOptions;
-  comments: Array<CommentTreeNode<CommentsList>>;
+  comments: CommentWithRepliesFragment[];
   commentCount: number;
   loadMoreCount: number,
   totalComments: number,
@@ -56,7 +57,7 @@ const CommentsTimelineFn = ({
       bodyRef.current?.scrollTo(0, bodyRef.current.scrollHeight);
   }, [currentHeight, userHasScrolled])
 
-  const { CommentsNode, Typography } = Components;
+  const { CommentWithReplies, Typography } = Components;
 
   const handleScroll = (e) => {
     const isAtBottom = Math.abs((e.target.scrollHeight - e.target.scrollTop) - e.target.clientHeight) < 10;
@@ -71,7 +72,7 @@ const CommentsTimelineFn = ({
       loadMoreComments(commentCount + loadMoreCount);
   }
 
-  const commentsToRender = useMemo(() => comments.reverse(), [comments]);
+  const commentsToRender = useMemo(() => comments.slice().reverse(), [comments]);
 
   if (!comments) {
     return (
@@ -80,26 +81,32 @@ const CommentsTimelineFn = ({
       </Typography>
     );
   }
+  
+  const passThroughProps = {
+    treeOptions: treeOptions,
+    refetch: treeOptions.refetch,
+    startThreadTruncated: startThreadTruncated,
+    parentCommentId: parentCommentId,
+    parentAnswerId: parentAnswerId,
+    forceSingleLine: forceSingleLine,
+    forceNotSingleLine: forceNotSingleLine,
+    shortform: (treeOptions.post as PostsBase)?.shortform,
+    isChild: defaultNestingLevel > 1,
+    enableGuidelines: false,
+    displayMode: "minimalist" as CommentFormDisplayMode,
+  }
 
   return (
     <Components.ErrorBoundary>
       <div className={classes.nestedScroll} ref={bodyRef} onScroll={handleScroll}>
         {loadingMoreComments ? <Components.Loading /> : <></>}
         {commentsToRender.map((comment) => (
-          <CommentsNode
-            treeOptions={treeOptions}
-            startThreadTruncated={startThreadTruncated}
-            comment={comment.item}
-            childComments={comment.children}
-            key={comment.item._id}
-            parentCommentId={parentCommentId}
-            parentAnswerId={parentAnswerId}
-            forceSingleLine={forceSingleLine}
-            forceNotSingleLine={forceNotSingleLine}
-            shortform={(treeOptions.post as PostsBase)?.shortform}
-            isChild={defaultNestingLevel > 1}
-            enableGuidelines={false}
-            displayMode={"minimalist"}
+          <CommentWithReplies
+            refetch={treeOptions.refetch}
+            comment={comment}
+            key={comment._id}
+            passThroughProps={passThroughProps}
+            initialMaxChildren={5}
           />
         ))}
       </div>

--- a/packages/lesswrong/components/comments/CommentsTimeline.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimeline.tsx
@@ -1,7 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import withErrorBoundary from '../common/withErrorBoundary';
-import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import { CommentFormDisplayMode } from './CommentsNewForm';
 
@@ -89,7 +88,6 @@ const CommentsTimelineFn = ({
     parentAnswerId: parentAnswerId,
     forceSingleLine: forceSingleLine,
     forceNotSingleLine: forceNotSingleLine,
-    shortform: (treeOptions.post as PostsBase)?.shortform,
     isChild: defaultNestingLevel > 1,
     enableGuidelines: false,
     displayMode: "minimalist" as CommentFormDisplayMode,

--- a/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
@@ -56,7 +56,7 @@ const CommentsTimelineSection = ({
   totalComments: number,
   loadMoreComments: any,
   loadingMoreComments: boolean,
-  comments: Array<CommentTreeNode<CommentsList>>,
+  comments: CommentWithRepliesFragment[],
   parentAnswerId?: string,
   startThreadTruncated?: boolean,
   newForm: boolean,

--- a/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
@@ -103,6 +103,7 @@ const CommentsTimelineSection = ({
         loadingMoreComments={loadingMoreComments}
       />
       {/* TODO add permissions check here */}
+      {/* TODO add sorting here */}
       {newForm && (
         <div id="posts-thread-new-comment" className={classes.newComment}>
           <Components.CommentsNewForm

--- a/packages/lesswrong/components/common/withRecordPostView.tsx
+++ b/packages/lesswrong/components/common/withRecordPostView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useCallback, useState } from 'react';
 import { useMutation, gql } from '@apollo/client';
 import { useCurrentUser } from './withUser';
 import { useNewEvents } from '../../lib/events/withNewEvents';
@@ -74,6 +74,18 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
   }, [postsRead, setPostRead, increasePostViewCount, currentUser, recordEvent]);
   
   return { recordPostView, isRead };
+}
+
+export const useMarkAsRead = (post: PostsBase): {lastRead: Date, markAsRead} => {
+  const [lastRead, setLastRead] = useState<Date>(post.lastVisitedAt);
+  const { recordPostView } = useRecordPostView(post);
+
+  const markAsRead = useCallback(async () => {
+    setLastRead(new Date());
+    recordPostView({ post });
+  }, [post, recordPostView]);
+  
+  return { lastRead, markAsRead };
 }
 
 export const withRecordPostView = hookToHoc(useRecordPostView);

--- a/packages/lesswrong/components/common/withRecordPostView.tsx
+++ b/packages/lesswrong/components/common/withRecordPostView.tsx
@@ -76,18 +76,6 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
   return { recordPostView, isRead };
 }
 
-export const useMarkAsRead = (post: PostsBase): {lastRead: Date, markAsRead} => {
-  const [lastRead, setLastRead] = useState<Date>(post.lastVisitedAt);
-  const { recordPostView } = useRecordPostView(post);
-
-  const markAsRead = useCallback(async () => {
-    setLastRead(new Date());
-    recordPostView({ post });
-  }, [post, recordPostView]);
-  
-  return { lastRead, markAsRead };
-}
-
 export const withRecordPostView = hookToHoc(useRecordPostView);
 
 export const useRecordTagView = (tag: TagFragment): {recordTagView: any, isRead: boolean} => {

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -51,7 +51,7 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
   // TODO: This doesn't quite work yet. Not sure why - Ray
   const markAsRead = () => {
     recordPostView({post, extraEventProperties: {type: "markAsRead"}})
-    setMarkedVisitedAt(new Date()) 
+    setMarkedVisitedAt(new Date())
   }
   
   const lastCommentId = results && results[0]?._id

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -46,7 +46,7 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
     limit: 5
   });
   
-  const { Loading, CommentsList, SubSection, CommentWithReplies, LoadMore, ContentStyles } = Components
+  const { Loading, CommentsList, SubSection, CommentOnPostWithReplies, LoadMore, ContentStyles } = Components
   
   // TODO: This doesn't quite work yet. Not sure why - Ray
   const markAsRead = () => {
@@ -93,7 +93,7 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
           forceSingleLine
         />
         : <div>
-          {results && results.map((comment) => <CommentWithReplies key={comment._id} comment={comment} post={post}/>)}
+          {results && results.map((comment) => <CommentOnPostWithReplies key={comment._id} comment={comment} post={post}/>)}
           <LoadMore {...loadMoreProps} />
         </div>}
       </SubSection>

--- a/packages/lesswrong/components/shortform/ShortformThreadList.tsx
+++ b/packages/lesswrong/components/shortform/ShortformThreadList.tsx
@@ -31,7 +31,11 @@ const ShortformThreadList = ({ classes }: {
       {results && results.map((comment, i) => {
         if (!comment.post) return null
         return <div key={comment._id} className={classes.shortformItem}>
-          <CommentOnPostWithReplies comment={comment} post={comment.post} refetch={refetch}/>
+          <CommentOnPostWithReplies comment={comment} post={comment.post} commentNodeProps={{
+            treeOptions: {
+              refetch
+            }
+          }}/>
         </div>
       })}
       <LoadMore {...loadMoreProps} />

--- a/packages/lesswrong/components/shortform/ShortformThreadList.tsx
+++ b/packages/lesswrong/components/shortform/ShortformThreadList.tsx
@@ -11,7 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const ShortformThreadList = ({ classes }: {
   classes: ClassesType,
 }) => {
-  const { LoadMore, CommentWithReplies, ShortformSubmitForm } = Components
+  const { LoadMore, CommentOnPostWithReplies, ShortformSubmitForm } = Components
   const { results, loadMoreProps, refetch } = useMulti({
     terms: {
       view: 'shortform',
@@ -31,7 +31,7 @@ const ShortformThreadList = ({ classes }: {
       {results && results.map((comment, i) => {
         if (!comment.post) return null
         return <div key={comment._id} className={classes.shortformItem}>
-          <CommentWithReplies comment={comment} post={comment.post} refetch={refetch}/>
+          <CommentOnPostWithReplies comment={comment} post={comment.post} refetch={refetch}/>
         </div>
       })}
       <LoadMore {...loadMoreProps} />

--- a/packages/lesswrong/components/tagging/SubforumCommentsThread.tsx
+++ b/packages/lesswrong/components/tagging/SubforumCommentsThread.tsx
@@ -22,7 +22,6 @@ const SubforumCommentsThread = ({ tag, terms, newForm=true }: {
     return null;
   }
 
-  // const nestedComments = unflattenComments(results);
   return (
     <Components.CommentsTimelineSection
       tag={tag}
@@ -31,7 +30,7 @@ const SubforumCommentsThread = ({ tag, terms, newForm=true }: {
       totalComments={totalCount as number}
       commentCount={(results && results.length) || 0}
       loadingMoreComments={loadingMore}
-      loadMoreCount={10}
+      loadMoreCount={50}
       newForm={newForm}
       refetch={refetch}
     />

--- a/packages/lesswrong/components/tagging/SubforumCommentsThread.tsx
+++ b/packages/lesswrong/components/tagging/SubforumCommentsThread.tsx
@@ -11,7 +11,7 @@ const SubforumCommentsThread = ({ tag, terms, newForm=true }: {
   const { loading, results, loadMore, loadingMore, totalCount, refetch } = useMulti({
     terms,
     collectionName: "Comments",
-    fragmentName: 'CommentsList',
+    fragmentName: 'CommentWithRepliesFragment',
     fetchPolicy: 'cache-and-network',
     enableTotal: true,
   });
@@ -22,11 +22,11 @@ const SubforumCommentsThread = ({ tag, terms, newForm=true }: {
     return null;
   }
 
-  const nestedComments = unflattenComments(results);
+  // const nestedComments = unflattenComments(results);
   return (
     <Components.CommentsTimelineSection
       tag={tag}
-      comments={nestedComments}
+      comments={results}
       loadMoreComments={loadMore}
       totalComments={totalCount as number}
       commentCount={(results && results.length) || 0}

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -95,7 +95,7 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
         <AnalyticsContext pageSectionContext="commentsSection">
           <SubforumCommentsThread
             tag={tag}
-            terms={{ tagId: tag._id, view: "tagSubforumComments", limit: 100 }}
+            terms={{ tagId: tag._id, view: "tagSubforumComments", limit: 10 }}
             newForm
           />
         </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -95,7 +95,7 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
         <AnalyticsContext pageSectionContext="commentsSection">
           <SubforumCommentsThread
             tag={tag}
-            terms={{ tagId: tag._id, view: "tagSubforumComments", limit: 10 }}
+            terms={{ tagId: tag._id, view: "tagSubforumComments", limit: 50, sortBy: "new" }}
             newForm
           />
         </AnalyticsContext>

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -501,7 +501,7 @@ ensureIndex(Comments,
 
 export const subforumSorting = {
   new: { postedAt: -1 },
-  recentDiscussion: { latestSubthreadActivity: -1 },
+  recentDiscussion: { lastSubthreadActivity: -1 },
 }
 
 Comments.addView('tagDiscussionComments', (terms: CommentsViewTerms) => ({

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -499,6 +499,11 @@ ensureIndex(Comments,
   { name: "comments.tagId" }
 );
 
+export const subforumSorting = {
+  new: { postedAt: -1 },
+  recentDiscussion: { latestSubthreadActivity: -1 },
+}
+
 Comments.addView('tagDiscussionComments', (terms: CommentsViewTerms) => ({
   selector: {
     tagId: terms.tagId,
@@ -507,12 +512,18 @@ Comments.addView('tagDiscussionComments', (terms: CommentsViewTerms) => ({
   },
 }));
 
-Comments.addView('tagSubforumComments', (terms: CommentsViewTerms) => ({
+Comments.addView('tagSubforumComments', ({tagId, sortBy="new"}: CommentsViewTerms) => {
+  const sorting = subforumSorting[sortBy] || subforumSorting.new
+  return {
   selector: {
-    tagId: terms.tagId,
-    tagCommentType: TagCommentType.Subforum as string
+    tagId: tagId,
+    tagCommentType: TagCommentType.Subforum as string,
+    topLevelCommentId: viewFieldNullOrMissing,
   },
-}));
+  options: {
+    sort: sorting,
+  },
+}});
 
 
 Comments.addView('moderatorComments', (terms: CommentsViewTerms) => ({

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -388,6 +388,7 @@ importComponent("ModeratorComments", () => require('../components/comments/Moder
 
 importComponent("CommentById", () => require('../components/comments/CommentById'));
 importComponent("CommentWithReplies", () => require('../components/comments/CommentWithReplies'));
+importComponent("CommentOnPostWithReplies", () => require('../components/comments/CommentOnPostWithReplies'));
 importComponent("CommentPermalink", () => require('../components/comments/CommentPermalink'));
 importComponent("RecentDiscussionThread", () => require('../components/recentDiscussion/RecentDiscussionThread'));
 importComponent("RecentDiscussionThreadsList", () => require('../components/recentDiscussion/RecentDiscussionThreadsList'));

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -385,7 +385,7 @@ getCollectionHooks("Comments").createBefore.add(async function SetTopLevelCommen
 getCollectionHooks("Comments").createAfter.add(async function UpdateDescendentCommentCounts (comment: DbComment) {
   const ancestorIds: string[] = await getCommentAncestorIds(comment);
   
-  await Comments.rawUpdateOne({ _id: {$in: ancestorIds} }, {
+  await Comments.rawUpdateMany({ _id: {$in: ancestorIds} }, {
     $set: {lastSubthreadActivity: new Date()},
     $inc: {descendentCount:1},
   });
@@ -397,7 +397,7 @@ getCollectionHooks("Comments").updateAfter.add(async function UpdateDescendentCo
   if (context.oldDocument.deleted !== context.newDocument.deleted) {
     const ancestorIds: string[] = await getCommentAncestorIds(comment);
     const increment = context.oldDocument.deleted ? 1 : -1;
-    await Comments.rawUpdateOne({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
+    await Comments.rawUpdateMany({_id: {$in: ancestorIds}}, {$inc: {descendentCount: increment}})
   }
   return comment;
 });


### PR DESCRIPTION
This fixes the following bugs:


* lastSubthreadActivity and descendentCount were not being set correctly on comments due to using rawUpdateOne instead of rawUpdateMany
* In the subforum discussion section it was possible for a reply to appear as a top level comment as we were just sorting by postedAt. This changes it to sort only the top comments by postedAt and use CommentWithReplies to render the replies

I was also planning to add an option for sorting by recent discussion in the subforum, this will involve fixing the problem of comment threads jumping to the bottom whenever you reply to them. The `CommentWithReplies` change turned out to be big enough that I think it's worth splitting that into a separate PR



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202979942318352) by [Unito](https://www.unito.io)
