### PR TITLE
Add useOrderPreservingArray hook and fix recent discussion jumping when you reply

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -4,6 +4,7 @@ import { useQuery, gql } from '@apollo/client';
 import { useOnPageScroll } from './withOnPageScroll';
 import { isClient } from '../../lib/executionEnvironment';
 import * as _ from 'underscore';
+import { useOrderPreservingArray } from '../hooks/useOrderPreservingArray';
 
 const loadMoreDistance = 500;
 
@@ -185,9 +186,13 @@ const MixedTypeFeed = (args: {
   // have been attached to the DOM, so we can''t test whether they reach the bottom.
   useEffect(maybeStartLoadingMore);
   useOnPageScroll(maybeStartLoadingMore);
+  
+  const results = (data && data[resolverName]?.results) || [];
+  const keyFunc = (result) => result[result.type]?._id;
+  const orderedResults = useOrderPreservingArray(results, keyFunc);
   return <div>
-    {data && data[resolverName]?.results && data[resolverName].results.map((result,i) =>
-      <div key={i}>
+    {orderedResults.map((result) =>
+      <div key={keyFunc(result)}>
         <RenderFeedItem renderers={renderers} item={result}/>
       </div>
     )}

--- a/packages/lesswrong/components/hooks/useOrderPreservingArray.test.tsx
+++ b/packages/lesswrong/components/hooks/useOrderPreservingArray.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useOrderPreservingArray } from "./useOrderPreservingArray";
+
+describe("useOrderPreservingArray", () => {
+  it("Prepends new elements when using prepend-new", () => {
+    const initialArray = [{ _id: "a" }, { _id: "b" }, { _id: "c" }];
+    const { result, rerender } = renderHook(
+      (array: any[]) => useOrderPreservingArray(array, (elem) => elem._id, "prepend-new"),
+      { initialProps: initialArray }
+    );
+    expect(result.current).toEqual(initialArray);
+
+    rerender([{ _id: "d" }, ...initialArray, { _id: "e" }]);
+    // should move new elements to the front but retain their order
+    expect(result.current).toEqual([{ _id: "d" }, { _id: "e" }, { _id: "a" }, { _id: "b" }, { _id: "c" }]);
+
+    // should move new element in the middle to the front, and update the contents of existing elements
+    rerender([{ _id: "d", k: "abc" }, { _id: "a" }, { _id: "b" }, { _id: "f" }, { _id: "c" }, { _id: "e" }]);
+    expect(result.current).toEqual([
+      { _id: "f" },
+      { _id: "d", k: "abc" },
+      { _id: "e" },
+      { _id: "a" },
+      { _id: "b" },
+      { _id: "c" },
+    ]);
+  });
+
+  it("Appends new elements when using append-new", () => {
+    const initialArray = [{ _id: "a" }, { _id: "b" }, { _id: "c" }];
+    const { result, rerender } = renderHook(
+      (array: any[]) => useOrderPreservingArray(array, (elem) => elem._id, "append-new"),
+      { initialProps: initialArray }
+    );
+    expect(result.current).toEqual(initialArray);
+
+    rerender([{ _id: "d" }, ...initialArray, { _id: "e" }]);
+    // should move new elements to the end but retain their order
+    expect(result.current).toEqual([{ _id: "a" }, { _id: "b" }, { _id: "c" }, { _id: "d" }, { _id: "e" }]);
+
+    // should move new element in the middle to the end, and update the contents of existing elements
+    rerender([{ _id: "d", k: "abc" }, { _id: "a" }, { _id: "c" }, { _id: "f" }, { _id: "b" }, { _id: "e" }]);
+    expect(result.current).toEqual([
+      { _id: "a" },
+      { _id: "b" },
+      { _id: "c" },
+      { _id: "d", k: "abc" },
+      { _id: "e" },
+      { _id: "f" },
+    ]);
+  });
+
+  it("Preserves order of existing elements when using interleave-new", () => {
+    const initialArray = [{ _id: "a" }, { _id: "b" }, { _id: "c" }];
+    const { result, rerender } = renderHook(
+      (array: any[]) => useOrderPreservingArray(array, (elem) => elem._id, "interleave-new"),
+      { initialProps: initialArray }
+    );
+    expect(result.current).toEqual(initialArray);
+
+    rerender([{ _id: "c" }, { _id: "d" }, { _id: "a" }, { _id: "e" }, { _id: "b" }]);
+    // a,b,c should be back in their original order, and d,e should be left in the same positions
+    expect(result.current).toEqual([{ _id: "a" }, { _id: "d" }, { _id: "b" }, { _id: "e" }, { _id: "c" }]);
+
+    rerender([{ _id: "c" }, { _id: "f" }, { _id: "h" }, { _id: "b" }]);
+    // a has been removed, but b and c should remain in the same relative order, and f and h should be left in the same positions
+    expect(result.current).toEqual([{ _id: "b" }, { _id: "f" }, { _id: "h" }, { _id: "c" }]);
+  });
+
+  it("Doesn't do any reordering when using no-reorder", () => {
+    const initialArray = [{ _id: "a" }, { _id: "b" }, { _id: "c" }];
+    const { result, rerender } = renderHook(
+      (array: any[]) => useOrderPreservingArray(array, (elem) => elem._id, "no-reorder"),
+      { initialProps: initialArray }
+    );
+    expect(result.current).toEqual(initialArray);
+
+    rerender([{ _id: "c" }, { _id: "d" }, { _id: "a" }, { _id: "e" }, { _id: "b" }]);
+    // everything is in the same order
+    expect(result.current).toEqual([{ _id: "c" }, { _id: "d" }, { _id: "a" }, { _id: "e" }, { _id: "b" }]);
+  });
+});

--- a/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
+++ b/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
@@ -1,0 +1,71 @@
+import { useMemo, useRef } from "react";
+
+type OrderPreservingArrayPolicy = "prepend-new" | "append-new" | "interleave-new" | "no-reorder";
+type IndexType = string | number;
+
+const arrayToIndexMap = (arr: IndexType[]): Record<IndexType, number> =>
+  Object.keys(arr).reduce(function (map, idx) {
+    map[arr[idx]] = idx;
+    return map;
+  }, {});
+
+const indexMapToArray = (map: Record<IndexType, number>): IndexType[] => {
+  const unsortedKeys = Object.keys(map);
+  const sortedKeys = unsortedKeys.sort((a, b) => map[a] - map[b]);
+  return sortedKeys;
+};
+
+function buildOrderIndexMap<T>(
+  array: T[],
+  keyFunc: (elem: T) => string | number,
+  policy: OrderPreservingArrayPolicy,
+  currentOrderingIndexMap: Record<IndexType, number>
+): Record<IndexType, number> {
+  const naiveOrdering = array.map(keyFunc);
+
+  if (policy === "no-reorder" || Object.keys(currentOrderingIndexMap).length === 0) {
+    return arrayToIndexMap(naiveOrdering);
+  }
+
+  if (policy === "append-new" || policy === "prepend-new") {
+    const newElems = naiveOrdering.filter((id) => currentOrderingIndexMap[id] === undefined);
+    return arrayToIndexMap([
+      ...(policy === "prepend-new" ? newElems : []),
+      ...indexMapToArray(currentOrderingIndexMap),
+      ...(policy === "append-new" ? newElems : []),
+    ]);
+  }
+
+  if (policy === "interleave-new") {
+    // fill the new ordering array:
+    // 1. leave new elements in the same index
+    // 2. insert current elements in the order they appear in the current ordering
+    const currentElems = naiveOrdering
+      .filter((id) => id in currentOrderingIndexMap)
+      .sort((a, b) => currentOrderingIndexMap[a] - currentOrderingIndexMap[b])
+      .reverse();
+    const newOrdering = naiveOrdering
+      .map((elem) => (elem in currentOrderingIndexMap ? currentElems.pop() : elem)) as IndexType[];
+    return arrayToIndexMap(newOrdering);
+  }
+  // Can't actually reach this line, but typescript can't work that out
+  return arrayToIndexMap(naiveOrdering);
+}
+
+export function useOrderPreservingArray<T>(
+  array: T[],
+  keyFunc: (elem) => string | number,
+  policy: OrderPreservingArrayPolicy = "interleave-new"
+): T[] {
+  const orderIndexMapRef = useRef<Record<IndexType, number>>({});
+
+  orderIndexMapRef.current = useMemo(
+    () => buildOrderIndexMap(array, keyFunc, policy, orderIndexMapRef.current),
+    [array, keyFunc, policy]
+  );
+
+  const sortedArray = array
+    .slice()
+    .sort((a, b) => orderIndexMapRef.current[keyFunc(a)] - orderIndexMapRef.current[keyFunc(b)]);
+  return sortedArray;
+}

--- a/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
+++ b/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
@@ -17,7 +17,7 @@ const indexMapToArray = (map: Record<IndexType, number>): IndexType[] => {
 
 function buildOrderIndexMap<T>(
   array: T[],
-  keyFunc: (elem: T) => string | number,
+  keyFunc: (elem: T) => IndexType,
   policy: OrderPreservingArrayPolicy,
   currentOrderingIndexMap: Record<IndexType, number>
 ): Record<IndexType, number> {
@@ -52,9 +52,21 @@ function buildOrderIndexMap<T>(
   return arrayToIndexMap(naiveOrdering);
 }
 
+/**
+ * Keeps elements that have already appeared in the array in the same order, useful for preventing reordering of elements when refetching.
+ *
+ * @param array
+ * @param keyFunc
+ * @param policy
+ *  - "prepend-new": New elements are prepended to the array, existing elements are kept in the same order
+ *  - "append-new": New elements are appended to the array, existing elements are kept in the same order
+ *  - "interleave-new": New elements are interleaved with the existing elements (see useOrderPreservingArray.test.tsx for example)
+ *  - "no-reorder": No reordering is done, useful for disabling this behavior without needing to call the hook conditionally
+ * @returns
+ */
 export function useOrderPreservingArray<T>(
   array: T[],
-  keyFunc: (elem) => string | number,
+  keyFunc: (elem) => IndexType,
   policy: OrderPreservingArrayPolicy = "interleave-new"
 ): T[] {
   const orderIndexMapRef = useRef<Record<IndexType, number>>({});

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -104,6 +104,7 @@ const RecentDiscussionFeed = ({
                 render: (tag: TagRecentDiscussion) => (
                   <RecentDiscussionTag
                     tag={tag}
+                    refetch={refetch}
                     comments={tag.recentComments}
                     expandAllThreads={expandAll}
                   />

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -57,8 +57,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const RecentDiscussionTag = ({ tag, comments, expandAllThreads: initialExpandAllThreads, classes }: {
+const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThreads: initialExpandAllThreads, classes }: {
   tag: TagRecentDiscussion,
+  refetch?: any,
   comments: Array<CommentsList>,
   expandAllThreads?: boolean
   classes: ClassesType
@@ -94,6 +95,7 @@ const RecentDiscussionTag = ({ tag, comments, expandAllThreads: initialExpandAll
     : descriptionHtml;
   
   const commentTreeOptions: CommentTreeOptions = {
+    refetch,
     scrollOnExpand: true,
     lastCommentId: lastCommentId,
     markAsRead: markAsRead,


### PR DESCRIPTION
This adds a hook `useOrderPreservingArray` to keep elements that have already been returned in the same order on refetch, and uses it in the Recent Discussion section on the front page so you can reply to comments without the post jumping to the top

The main purpose of this is to do the same thing in the subforum discussion section, but that is waiting on #5676 being merged



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202985086843718) by [Unito](https://www.unito.io)
