### PR TITLE
Subforum wiki sidebar

### DIFF
--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -10,7 +10,7 @@ import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    marginBottom: 0,
+    margin: "0 32px",
     display: "flex",
     flexDirection: "row",
     justifyContent: "center",
@@ -29,7 +29,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 3,
   },
   aside: {
-    width: "fit-content",
+    width: 380,
     [theme.breakpoints.down("md")]: {
       display: "none",
     },
@@ -41,7 +41,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderColor: theme.palette.secondary.main,
     borderWidth: 2,
     borderRadius: 3,
-    maxWidth: 380,
   },
   title: {
     textTransform: "capitalize",
@@ -50,7 +49,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   wikiSidebar: {
     marginTop: 84,
-    maxWidth: 380,
     gridColumnStart: 3,
     padding: '2em',
     backgroundColor: theme.palette.panelBackground.default,
@@ -90,21 +88,19 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
   }
 
   const welcomeBoxComponent = tag.subforumWelcomeText ? (
-    <div className={classes.aside}>
-      <div className={classes.welcomeBox}>
-        <ContentStyles contentType="comment">
-          <ContentItemBody
-            dangerouslySetInnerHTML={{ __html: tag.subforumWelcomeText?.html || "" }}
-            description={`${tag.name} subforum`}
-          />
-        </ContentStyles>
-      </div>
+    <div className={classes.welcomeBox}>
+      <ContentStyles contentType="comment">
+        <ContentItemBody
+          dangerouslySetInnerHTML={{ __html: tag.subforumWelcomeText?.html || "" }}
+          description={`${tag.name} subforum`}
+        />
+      </ContentStyles>
     </div>
   ) : <></>;
 
   return (
     <div className={classes.root}>
-      <div className={classNames(classes.columnSection, classes.stickToBottom)}>
+      <div className={classNames(classes.columnSection, classes.stickToBottom, classes.aside)}>
         {welcomeBoxComponent}
       </div>
       <SingleColumnSection className={classNames(classes.columnSection, classes.fullWidth)}>
@@ -116,14 +112,12 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
           />
         </AnalyticsContext>
       </SingleColumnSection>
-      <div className={classes.columnSection}>
+      <div className={classNames(classes.columnSection, classes.aside)}>
         {tag?.tableOfContents?.html &&
-          <div className={classes.aside}>
           <ContentStyles contentType="tag">
-            <div className={classNames(classes.wikiSidebar, classes.columnSection)} dangerouslySetInnerHTML={{ __html: truncateTagDescription(tag.tableOfContents.html, false) }}>
-            </div>
+            <div className={classNames(classes.wikiSidebar, classes.columnSection)} dangerouslySetInnerHTML={{ __html: truncateTagDescription(tag.tableOfContents.html, false) }} />
           </ContentStyles>
-        </div>}
+        }
       </div>
     </div>
   );

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useLocation } from "../../lib/routeUtil";
 import { useTagBySlug } from "./useTag";
@@ -6,29 +6,29 @@ import { isMissingDocumentError } from "../../lib/utils/errorUtil";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import classNames from "classnames";
 import { subforumDefaultSorting } from "../../lib/collections/comments/views";
+import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: 0,
     display: "flex",
     flexDirection: "row",
+    justifyContent: "center",
+    columnGap: 32,
     [theme.breakpoints.down("md")]: {
       flexDirection: "column",
     },
   },
   columnSection: {
-    marginBottom: 0,
-    width: "100%",
-  },
-  fullWidth: {
-    flex: 'none',
+    [theme.breakpoints.up("lg")]: {
+      margin: 0,
+    }
   },
   stickToBottom: {
     marginTop: "auto",
+    marginBottom: 3,
   },
-  welcomeBoxPadding: {
-    padding: "32px 32px 3px 32px",
-    marginLeft: "auto",
+  aside: {
     width: "fit-content",
     [theme.breakpoints.down("md")]: {
       display: "none",
@@ -48,6 +48,20 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 24,
     marginBottom: 10,
   },
+  wikiSidebar: {
+    marginTop: 84,
+    maxWidth: 380,
+    gridColumnStart: 3,
+    padding: '2em',
+    backgroundColor: theme.palette.panelBackground.default,
+    border: theme.palette.border.commentBorder,
+    '& a': {
+      color: theme.palette.primary,
+    },
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
+  }
 });
 
 export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user: UsersProfile }) => {
@@ -76,7 +90,7 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
   }
 
   const welcomeBoxComponent = tag.subforumWelcomeText ? (
-    <div className={classes.welcomeBoxPadding}>
+    <div className={classes.aside}>
       <div className={classes.welcomeBox}>
         <ContentStyles contentType="comment">
           <ContentItemBody
@@ -102,7 +116,15 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
           />
         </AnalyticsContext>
       </SingleColumnSection>
-      <div className={classes.columnSection}></div>
+      <div className={classes.columnSection}>
+        {tag?.tableOfContents?.html &&
+          <div className={classes.aside}>
+          <ContentStyles contentType="tag">
+            <div className={classNames(classes.wikiSidebar, classes.columnSection)} dangerouslySetInnerHTML={{ __html: truncateTagDescription(tag.tableOfContents.html, false) }}>
+            </div>
+          </ContentStyles>
+        </div>}
+      </div>
     </div>
   );
 };

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -139,6 +139,7 @@ registerFragment(`
   fragment TagSubforumFragment on Tag {
     ...TagPreviewFragment
     isSubforum
+    tableOfContents
     subforumWelcomeText {
       _id
       html

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1952,6 +1952,7 @@ interface TagPreviewFragment_description { // fragment on Revisions
 
 interface TagSubforumFragment extends TagPreviewFragment { // fragment on Tags
   readonly isSubforum: boolean,
+  readonly tableOfContents: any,
   readonly subforumWelcomeText: TagSubforumFragment_subforumWelcomeText|null,
 }
 

--- a/packages/lesswrong/lib/utils/truncateTagDescription.ts
+++ b/packages/lesswrong/lib/utils/truncateTagDescription.ts
@@ -1,0 +1,26 @@
+const truncateTagDescription = (htmlWithAnchors: string, withReadMore = true) => {
+  for (let matchString of [
+      'id="Further_reading"',
+      'id="Bibliography"',
+      'id="Related_entries"',
+      'class="footnotes"',
+    ]) {
+    if(htmlWithAnchors.includes(matchString)) {
+      const truncationLength = htmlWithAnchors.indexOf(matchString);
+      /**
+       * The `truncate` method used below uses a complicated criterion for what
+       * counts as a character. Here, we want to truncate at a known index in
+       * the string. So rather than using `truncate`, we can slice the string
+       * at the desired index, use `parseFromString` to clean up the HTML,
+       * and then append our footer 'read more' element.
+       */
+      return new DOMParser().parseFromString(
+          htmlWithAnchors.slice(0, truncationLength), 
+          'text/html'
+        ).body.innerHTML + (withReadMore ? "<span>...<p><a>(Read More)</a></p></span>" : "");
+    }
+  }
+  return htmlWithAnchors
+}
+
+export default truncateTagDescription;


### PR DESCRIPTION
This PR adds a right sidebar element on desktop which displays the topic's contents, excluding things like footnotes and references. As with the welcome box, it's removed on smaller screens.

This PR also includes changes from a recent run of yarn generate that didn't make it into master, in [this commit](https://github.com/ForumMagnum/ForumMagnum/commit/e4e0722de2c27b6a13f264a25f48127ca1d58a75).

![](https://user-images.githubusercontent.com/25752873/190210710-e55ae31b-4d36-4618-ad69-f6635482977b.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202983749947406) by [Unito](https://www.unito.io)
