### PR TITLE
Run yarn-run-generate for the new createdAt setup

### DIFF
--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -13,7 +13,6 @@ interface AdvisorRequestsCollection extends CollectionBase<DbAdvisorRequest, "Ad
 interface DbAdvisorRequest extends DbObject {
   __collectionName?: "AdvisorRequests"
   userId: string
-  createdAt: Date
   timezone: string
   availability: string
   questions: string
@@ -21,6 +20,7 @@ interface DbAdvisorRequest extends DbObject {
   previousExperience: string
   selectedAdvisors: Array<string>
   referrer: string
+  createdAt: Date
 }
 
 interface BansCollection extends CollectionBase<DbBan, "Bans"> {
@@ -28,13 +28,13 @@ interface BansCollection extends CollectionBase<DbBan, "Bans"> {
 
 interface DbBan extends DbObject {
   __collectionName?: "Bans"
-  createdAt: Date
   expirationDate: Date
   userId: string
   ip: string
   reason: string
   comment: string
   properties: any /*{"definitions":[{"blackbox":true}]}*/
+  createdAt: Date
 }
 
 interface BooksCollection extends CollectionBase<DbBook, "Books"> {
@@ -42,7 +42,6 @@ interface BooksCollection extends CollectionBase<DbBook, "Books"> {
 
 interface DbBook extends DbObject {
   __collectionName?: "Books"
-  createdAt: Date
   postedAt: Date
   title: string
   subtitle: string
@@ -54,6 +53,7 @@ interface DbBook extends DbObject {
   hideProgressBar: boolean
   showChapters: boolean
   contents: EditableFieldContents
+  createdAt: Date
 }
 
 interface ChaptersCollection extends CollectionBase<DbChapter, "Chapters"> {
@@ -61,13 +61,13 @@ interface ChaptersCollection extends CollectionBase<DbChapter, "Chapters"> {
 
 interface DbChapter extends DbObject {
   __collectionName?: "Chapters"
-  createdAt: Date
   title: string
   subtitle: string
   number: number
   sequenceId: string
   postIds: Array<string>
   contents: EditableFieldContents
+  createdAt: Date
 }
 
 interface CollectionsCollection extends CollectionBase<DbCollection, "Collections"> {
@@ -75,7 +75,6 @@ interface CollectionsCollection extends CollectionBase<DbCollection, "Collection
 
 interface DbCollection extends DbObject {
   __collectionName?: "Collections"
-  createdAt: Date
   userId: string
   title: string
   slug: string
@@ -83,6 +82,7 @@ interface DbCollection extends DbObject {
   firstPageLink: string
   hideStartReadingButton: boolean
   contents: EditableFieldContents
+  createdAt: Date
 }
 
 interface CommentsCollection extends CollectionBase<DbComment, "Comments"> {
@@ -92,7 +92,6 @@ interface DbComment extends DbObject {
   __collectionName?: "Comments"
   parentCommentId: string
   topLevelCommentId: string
-  createdAt: Date
   postedAt: Date
   author: string
   postId: string
@@ -116,6 +115,7 @@ interface DbComment extends DbObject {
   promotedByUserId: string
   promotedAt: Date
   hideKarma: boolean
+  createdAt: Date
   legacy: boolean
   legacyId: string
   legacyPoll: boolean
@@ -153,13 +153,13 @@ interface ConversationsCollection extends CollectionBase<DbConversation, "Conver
 
 interface DbConversation extends DbObject {
   __collectionName?: "Conversations"
-  createdAt: Date
   title: string
   participantIds: Array<string>
   latestActivity: Date
   af: boolean
   messageCount: number
   archivedByIds: Array<string>
+  createdAt: Date
 }
 
 interface DatabaseMetadataCollection extends CollectionBase<DbDatabaseMetadata, "DatabaseMetadata"> {
@@ -169,6 +169,7 @@ interface DbDatabaseMetadata extends DbObject {
   __collectionName?: "DatabaseMetadata"
   name: string
   value: any /*{"definitions":[{"blackbox":true}]}*/
+  createdAt: Date
 }
 
 interface DebouncerEventsCollection extends CollectionBase<DbDebouncerEvents, "DebouncerEvents"> {
@@ -184,6 +185,7 @@ interface DbDebouncerEvents extends DbObject {
   upperBoundTime: Date
   key: string
   pendingEvents: Array<any /*{"definitions":[{"blackbox":true}]}*/>
+  createdAt: Date
 }
 
 interface EmailTokensCollection extends CollectionBase<DbEmailTokens, "EmailTokens"> {
@@ -196,6 +198,7 @@ interface DbEmailTokens extends DbObject {
   userId: string
   usedAt: Date
   params: any /*{"definitions":[{"blackbox":true}]}*/
+  createdAt: Date
 }
 
 interface FeaturedResourcesCollection extends CollectionBase<DbFeaturedResource, "FeaturedResources"> {
@@ -208,6 +211,7 @@ interface DbFeaturedResource extends DbObject {
   ctaText: string
   ctaUrl: string
   expiresAt: Date
+  createdAt: Date
 }
 
 interface GardenCodesCollection extends CollectionBase<DbGardenCode, "GardenCodes"> {
@@ -215,7 +219,6 @@ interface GardenCodesCollection extends CollectionBase<DbGardenCode, "GardenCode
 
 interface DbGardenCode extends DbObject {
   __collectionName?: "GardenCodes"
-  createdAt: Date
   code: string
   title: string
   userId: string
@@ -227,6 +230,7 @@ interface DbGardenCode extends DbObject {
   hidden: boolean
   deleted: boolean
   afOnly: boolean
+  createdAt: Date
   contents: EditableFieldContents
   pingbacks: any /*{"definitions":[{}]}*/
 }
@@ -236,13 +240,13 @@ interface LWEventsCollection extends CollectionBase<DbLWEvent, "LWEvents"> {
 
 interface DbLWEvent extends DbObject {
   __collectionName?: "LWEvents"
-  createdAt: Date
   userId: string
   name: string
   documentId: string
   important: boolean
   properties: any /*{"definitions":[{"blackbox":true}]}*/
   intercom: boolean
+  createdAt: Date
 }
 
 interface LegacyDataCollection extends CollectionBase<DbLegacyData, "LegacyData"> {
@@ -253,6 +257,7 @@ interface DbLegacyData extends DbObject {
   objectId: string
   collectionName: string
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
+  createdAt: Date
 }
 
 interface LocalgroupsCollection extends CollectionBase<DbLocalgroup, "Localgroups"> {
@@ -260,7 +265,6 @@ interface LocalgroupsCollection extends CollectionBase<DbLocalgroup, "Localgroup
 
 interface DbLocalgroup extends DbObject {
   __collectionName?: "Localgroups"
-  createdAt: Date
   name: string
   organizerIds: Array<string>
   lastActivity: Date
@@ -280,6 +284,7 @@ interface DbLocalgroup extends DbObject {
   inactive: boolean
   deleted: boolean
   contents: EditableFieldContents
+  createdAt: Date
 }
 
 interface MessagesCollection extends CollectionBase<DbMessage, "Messages"> {
@@ -288,10 +293,10 @@ interface MessagesCollection extends CollectionBase<DbMessage, "Messages"> {
 interface DbMessage extends DbObject {
   __collectionName?: "Messages"
   userId: string
-  createdAt: Date
   conversationId: string
   noEmail: boolean
   contents: EditableFieldContents
+  createdAt: Date
 }
 
 interface MigrationsCollection extends CollectionBase<DbMigration, "Migrations"> {
@@ -303,6 +308,7 @@ interface DbMigration extends DbObject {
   started: Date
   finished: Date
   succeeded: boolean
+  createdAt: Date
 }
 
 interface NotificationsCollection extends CollectionBase<DbNotification, "Notifications"> {
@@ -311,7 +317,6 @@ interface NotificationsCollection extends CollectionBase<DbNotification, "Notifi
 interface DbNotification extends DbObject {
   __collectionName?: "Notifications"
   userId: string
-  createdAt: Date
   documentId: string
   documentType: string
   extraData: any /*{"definitions":[{"blackbox":true}]}*/
@@ -323,6 +328,7 @@ interface DbNotification extends DbObject {
   viewed: boolean
   emailed: boolean
   waitingForBatch: boolean
+  createdAt: Date
 }
 
 interface PetrovDayLaunchsCollection extends CollectionBase<DbPetrovDayLaunch, "PetrovDayLaunchs"> {
@@ -330,10 +336,10 @@ interface PetrovDayLaunchsCollection extends CollectionBase<DbPetrovDayLaunch, "
 
 interface DbPetrovDayLaunch extends DbObject {
   __collectionName?: "PetrovDayLaunchs"
-  createdAt: Date
   launchCode: string
   hashedLaunchCode: string
   userId: string
+  createdAt: Date
 }
 
 interface PodcastEpisodesCollection extends CollectionBase<DbPodcastEpisode, "PodcastEpisodes"> {
@@ -345,6 +351,7 @@ interface DbPodcastEpisode extends DbObject {
   title: string
   episodeLink: string
   externalEpisodeId: string
+  createdAt: Date
 }
 
 interface PodcastsCollection extends CollectionBase<DbPodcast, "Podcasts"> {
@@ -355,6 +362,7 @@ interface DbPodcast extends DbObject {
   title: string
   applePodcastLink: string | null
   spotifyPodcastLink: string | null
+  createdAt: Date
 }
 
 interface PostRelationsCollection extends CollectionBase<DbPostRelation, "PostRelations"> {
@@ -362,11 +370,11 @@ interface PostRelationsCollection extends CollectionBase<DbPostRelation, "PostRe
 
 interface DbPostRelation extends DbObject {
   __collectionName?: "PostRelations"
-  createdAt: Date
   type: string
   sourcePostId: string
   targetPostId: string
   order: number
+  createdAt: Date
 }
 
 interface PostsCollection extends CollectionBase<DbPost, "Posts"> {
@@ -374,7 +382,6 @@ interface PostsCollection extends CollectionBase<DbPost, "Posts"> {
 
 interface DbPost extends DbObject {
   __collectionName?: "Posts"
-  createdAt: Date
   postedAt: Date
   modifiedAt: Date
   url: string
@@ -437,6 +444,7 @@ interface DbPost extends DbObject {
   onlyVisibleToEstablishedAccounts: boolean
   votingSystem: string
   podcastEpisodeId: string | null
+  createdAt: Date
   voteCount: number
   baseScore: number
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
@@ -540,7 +548,6 @@ interface RSSFeedsCollection extends CollectionBase<DbRSSFeed, "RSSFeeds"> {
 interface DbRSSFeed extends DbObject {
   __collectionName?: "RSSFeeds"
   userId: string
-  createdAt: Date
   ownedByUser: boolean
   displayFullContent: boolean
   nickname: string
@@ -548,6 +555,7 @@ interface DbRSSFeed extends DbObject {
   status: string
   rawFeed: any /*{"definitions":[{}]}*/
   setCanonicalUrl: boolean
+  createdAt: Date
 }
 
 interface ReadStatusesCollection extends CollectionBase<DbReadStatus, "ReadStatuses"> {
@@ -560,6 +568,7 @@ interface DbReadStatus extends DbObject {
   userId: string
   isRead: boolean
   lastUpdated: Date
+  createdAt: Date
 }
 
 interface ReportsCollection extends CollectionBase<DbReport, "Reports"> {
@@ -574,10 +583,10 @@ interface DbReport extends DbObject {
   link: string
   claimedUserId: string
   description: string
-  createdAt: Date
   closedAt: Date
   markedAsSpam: boolean
   reportedAsSpam: boolean
+  createdAt: Date
 }
 
 interface ReviewVotesCollection extends CollectionBase<DbReviewVote, "ReviewVotes"> {
@@ -585,7 +594,6 @@ interface ReviewVotesCollection extends CollectionBase<DbReviewVote, "ReviewVote
 
 interface DbReviewVote extends DbObject {
   __collectionName?: "ReviewVotes"
-  createdAt: Date
   userId: string
   postId: string
   qualitativeScore: number
@@ -594,6 +602,7 @@ interface DbReviewVote extends DbObject {
   year: string
   dummy: boolean
   reactions: Array<string>
+  createdAt: Date
 }
 
 interface RevisionsCollection extends CollectionBase<DbRevision, "Revisions"> {
@@ -618,6 +627,7 @@ interface DbRevision extends DbObject {
   html: string
   wordCount: number
   changeMetrics: any /*{"definitions":[{"blackbox":true}]}*/
+  createdAt: Date
   voteCount: number
   baseScore: number
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
@@ -630,7 +640,6 @@ interface SequencesCollection extends CollectionBase<DbSequence, "Sequences"> {
 
 interface DbSequence extends DbObject {
   __collectionName?: "Sequences"
-  createdAt: Date
   userId: string
   title: string
   gridImageId: string
@@ -643,6 +652,7 @@ interface DbSequence extends DbObject {
   hidden: boolean
   hideFromAuthorPage: boolean
   contents: EditableFieldContents
+  createdAt: Date
   af: boolean
 }
 
@@ -651,13 +661,13 @@ interface SubscriptionsCollection extends CollectionBase<DbSubscription, "Subscr
 
 interface DbSubscription extends DbObject {
   __collectionName?: "Subscriptions"
-  createdAt: Date
   userId: string
   state: "subscribed" | "suppressed"
   documentId: string
   collectionName: CollectionNameString
   deleted: boolean
   type: "newComments" | "newShortform" | "newPosts" | "newRelatedQuestions" | "newEvents" | "newReplies" | "newTagPosts"
+  createdAt: Date
 }
 
 interface TagFlagsCollection extends CollectionBase<DbTagFlag, "TagFlags"> {
@@ -665,11 +675,11 @@ interface TagFlagsCollection extends CollectionBase<DbTagFlag, "TagFlags"> {
 
 interface DbTagFlag extends DbObject {
   __collectionName?: "TagFlags"
-  createdAt: Date
   name: string
   deleted: boolean
   slug: string
   order: number
+  createdAt: Date
   contents: EditableFieldContents
 }
 
@@ -678,13 +688,13 @@ interface TagRelsCollection extends CollectionBase<DbTagRel, "TagRels"> {
 
 interface DbTagRel extends DbObject {
   __collectionName?: "TagRels"
-  createdAt: Date
   tagId: string
   postId: string
   deleted: boolean
   userId: string
   afBaseScore: number
   afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
+  createdAt: Date
   voteCount: number
   baseScore: number
   extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/
@@ -697,7 +707,6 @@ interface TagsCollection extends CollectionBase<DbTag, "Tags"> {
 
 interface DbTag extends DbObject {
   __collectionName?: "Tags"
-  createdAt: Date
   name: string
   slug: string
   oldSlugs: Array<string>
@@ -728,6 +737,7 @@ interface DbTag extends DbObject {
   postsDefaultSortOrder: string
   canVoteOnRels: Array<string>
   isSubforum: boolean
+  createdAt: Date
   description: EditableFieldContents
   subforumWelcomeText: EditableFieldContents
   parentTagId: string
@@ -740,7 +750,6 @@ interface DbUser extends DbObject {
   __collectionName?: "Users"
   username: string
   emails: Array<any /*{"definitions":[{}]}*/>
-  createdAt: Date
   isAdmin: boolean
   profile: any /*{"definitions":[{"blackbox":true}]}*/
   services: any /*{"definitions":[{"blackbox":true}]}*/
@@ -990,6 +999,7 @@ interface DbUser extends DbObject {
   howOthersCanHelpMe: EditableFieldContents
   howICanHelpOthers: EditableFieldContents
   biography: EditableFieldContents
+  createdAt: Date
   recommendationSettings: {
     frontpage: {
       method: string,
@@ -1048,6 +1058,7 @@ interface DbVote extends DbObject {
   isUnvote: boolean
   votedAt: Date
   documentIsAf: boolean
+  createdAt: Date
 }
 
 interface CollectionsByName {

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -10,7 +10,6 @@
 interface UsersDefaultFragment { // fragment on Users
   readonly username: string,
   readonly emails: Array<any /*{"definitions":[{}]}*/>,
-  readonly createdAt: Date,
   readonly isAdmin: boolean,
   readonly services: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly displayName: string,
@@ -25,7 +24,6 @@ interface UsersDefaultFragment { // fragment on Users
 }
 
 interface LWEventsDefaultFragment { // fragment on LWEvents
-  readonly createdAt: Date,
   readonly userId: string,
   readonly name: string,
   readonly documentId: string,
@@ -75,7 +73,6 @@ interface emailHistoryFragment { // fragment on LWEvents
 }
 
 interface PostRelationsDefaultFragment { // fragment on PostRelations
-  readonly createdAt: Date,
   readonly type: string,
   readonly sourcePostId: string,
   readonly targetPostId: string,
@@ -83,7 +80,6 @@ interface PostRelationsDefaultFragment { // fragment on PostRelations
 }
 
 interface LocalgroupsDefaultFragment { // fragment on Localgroups
-  readonly createdAt: Date,
   readonly name: string,
   readonly organizerIds: Array<string>,
   readonly lastActivity: Date,
@@ -105,7 +101,6 @@ interface LocalgroupsDefaultFragment { // fragment on Localgroups
 }
 
 interface TagsDefaultFragment { // fragment on Tags
-  readonly createdAt: Date,
   readonly name: string,
   readonly slug: string,
   readonly oldSlugs: Array<string>,
@@ -141,7 +136,6 @@ interface TagsDefaultFragment { // fragment on Tags
 }
 
 interface TagRelsDefaultFragment { // fragment on TagRels
-  readonly createdAt: Date,
   readonly tagId: string,
   readonly postId: string,
   readonly deleted: boolean,
@@ -151,7 +145,6 @@ interface TagRelsDefaultFragment { // fragment on TagRels
 }
 
 interface PostsDefaultFragment { // fragment on Posts
-  readonly createdAt: Date,
   readonly postedAt: Date,
   readonly modifiedAt: Date,
   readonly url: string,
@@ -217,7 +210,6 @@ interface PostsDefaultFragment { // fragment on Posts
 }
 
 interface BooksDefaultFragment { // fragment on Books
-  readonly createdAt: Date,
   readonly postedAt: Date,
   readonly title: string,
   readonly subtitle: string,
@@ -231,7 +223,6 @@ interface BooksDefaultFragment { // fragment on Books
 }
 
 interface CollectionsDefaultFragment { // fragment on Collections
-  readonly createdAt: Date,
   readonly userId: string,
   readonly title: string,
   readonly slug: string,
@@ -241,7 +232,6 @@ interface CollectionsDefaultFragment { // fragment on Collections
 }
 
 interface SequencesDefaultFragment { // fragment on Sequences
-  readonly createdAt: Date,
   readonly userId: string,
   readonly title: string,
   readonly gridImageId: string,
@@ -273,7 +263,6 @@ interface VotesDefaultFragment { // fragment on Votes
 interface CommentsDefaultFragment { // fragment on Comments
   readonly parentCommentId: string,
   readonly topLevelCommentId: string,
-  readonly createdAt: Date,
   readonly postedAt: Date,
   readonly author: string,
   readonly postId: string,
@@ -301,7 +290,6 @@ interface CommentsDefaultFragment { // fragment on Comments
 
 interface RSSFeedsDefaultFragment { // fragment on RSSFeeds
   readonly userId: string,
-  readonly createdAt: Date,
   readonly ownedByUser: boolean,
   readonly displayFullContent: boolean,
   readonly nickname: string,
@@ -965,7 +953,6 @@ interface WithVoteRevision { // fragment on Revisions
 
 interface NotificationsDefaultFragment { // fragment on Notifications
   readonly userId: string,
-  readonly createdAt: Date,
   readonly documentId: string,
   readonly documentType: string,
   readonly extraData: any /*{"definitions":[{"blackbox":true}]}*/,
@@ -994,7 +981,6 @@ interface NotificationsList { // fragment on Notifications
 }
 
 interface ConversationsDefaultFragment { // fragment on Conversations
-  readonly createdAt: Date,
   readonly title: string,
   readonly participantIds: Array<string>,
   readonly latestActivity: Date,
@@ -1005,7 +991,6 @@ interface ConversationsDefaultFragment { // fragment on Conversations
 
 interface MessagesDefaultFragment { // fragment on Messages
   readonly userId: string,
-  readonly createdAt: Date,
   readonly conversationId: string,
   readonly noEmail: boolean,
 }
@@ -1086,7 +1071,6 @@ interface ReportsDefaultFragment { // fragment on Reports
   readonly link: string,
   readonly claimedUserId: string,
   readonly description: string,
-  readonly createdAt: Date,
   readonly closedAt: Date,
   readonly markedAsSpam: boolean,
   readonly reportedAsSpam: boolean,
@@ -1173,7 +1157,6 @@ interface TagFlagEditFragment extends TagFlagFragment { // fragment on TagFlags
 }
 
 interface TagFlagsDefaultFragment { // fragment on TagFlags
-  readonly createdAt: Date,
   readonly name: string,
   readonly deleted: boolean,
   readonly slug: string,
@@ -1211,7 +1194,6 @@ interface GardenCodeFragmentEdit { // fragment on GardenCodes
 }
 
 interface GardenCodesDefaultFragment { // fragment on GardenCodes
-  readonly createdAt: Date,
   readonly code: string,
   readonly title: string,
   readonly userId: string,
@@ -1226,7 +1208,6 @@ interface GardenCodesDefaultFragment { // fragment on GardenCodes
 }
 
 interface BansDefaultFragment { // fragment on Bans
-  readonly createdAt: Date,
   readonly expirationDate: Date,
   readonly userId: string,
   readonly ip: string,
@@ -1248,7 +1229,6 @@ interface BansAdminPageFragment { // fragment on Bans
 }
 
 interface ChaptersDefaultFragment { // fragment on Chapters
-  readonly createdAt: Date,
   readonly title: string,
   readonly subtitle: string,
   readonly number: number,
@@ -1257,7 +1237,6 @@ interface ChaptersDefaultFragment { // fragment on Chapters
 }
 
 interface ReviewVotesDefaultFragment { // fragment on ReviewVotes
-  readonly createdAt: Date,
   readonly userId: string,
   readonly postId: string,
   readonly qualitativeScore: number,
@@ -1684,7 +1663,6 @@ interface SunshineTagFragment extends TagFragment { // fragment on Tags
 
 interface AdvisorRequestsDefaultFragment { // fragment on AdvisorRequests
   readonly userId: string,
-  readonly createdAt: Date,
   readonly timezone: string,
   readonly availability: string,
   readonly questions: string,
@@ -1708,7 +1686,6 @@ interface AdvisorRequestsMinimumInfo { // fragment on AdvisorRequests
 }
 
 interface SubscriptionsDefaultFragment { // fragment on Subscriptions
-  readonly createdAt: Date,
   readonly userId: string,
   readonly state: "subscribed" | "suppressed",
   readonly documentId: string,
@@ -2191,7 +2168,6 @@ interface UsersCrosspostInfo { // fragment on Users
 }
 
 interface PetrovDayLaunchsDefaultFragment { // fragment on PetrovDayLaunchs
-  readonly createdAt: Date,
   readonly launchCode: string,
   readonly hashedLaunchCode: string,
   readonly userId: string,

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -417,6 +417,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
         updateType: 'initial',
         commitMessage,
         changeMetrics,
+        createdAt: editedAt,
       };
       const firstRevision = await createMutator({
         collection: Revisions,
@@ -477,6 +478,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
           updateType,
           commitMessage,
           changeMetrics,
+          createdAt: editedAt,
         }
         const newRevisionDoc = await createMutator({
           collection: Revisions,


### PR DESCRIPTION
A recent PR (I think #5654?) made some changes relating to createdAt, but I think didn't run `yarn run generate`. This PR just does that without worrying about introducing any other features.

It seems to introduce some errors I haven't thought through yet.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202986379706705) by [Unito](https://www.unito.io)
