### PR TITLE
Fix presence list large number of users

### DIFF
--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -35,6 +35,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& .ck-presence-list__counter': {
       fontSize: '1rem !important',
       marginBottom: "0 !important",
+      display: "block !important", //doesn't hide when more than 1 user, helps in cases with many users present
     },
 
     "& .ck-tooltip": {
@@ -83,36 +84,37 @@ const EditorTopBar = ({presenceListRef, accessLevel, collaborationMode, setColla
 
   return <div className={classes.editorTopBar}>
     <div className={classes.presenceList} ref={presenceListRef}/>
-    
-    <Select
-      className={classes.collabModeSelect} disableUnderline
-      value={collaborationMode}
-      onChange={(e) => {
-        const newMode = e.target.value as CollaborationMode;
-        setCollaborationMode(newMode);
-      }}
-    >
-      <MenuItem value="Viewing" key="Viewing">
-        Viewing
-      </MenuItem>
-      <MenuItem value="Commenting" key="Commenting"
-        disabled={!accessLevelCan(accessLevel, "comment")}
+    <span>
+      <Select
+        className={classes.collabModeSelect} disableUnderline
+        value={collaborationMode}
+        onChange={(e) => {
+          const newMode = e.target.value as CollaborationMode;
+          setCollaborationMode(newMode);
+        }}
       >
-        Commenting
-      </MenuItem>
-      <MenuItem value="Editing" key="Editing"
-        disabled={!accessLevelCan(accessLevel, "edit")}
-      >
-        Editing
-      </MenuItem>
-    </Select>
-    
-    <LWTooltip title="Collaborative docs automatically save all changes">
-      <Button className={classes.saveStatus}>
-        Auto-Saved
-        {/*TODO: Make this track offline status etc*/}
-      </Button>
-    </LWTooltip>
+        <MenuItem value="Viewing" key="Viewing">
+          Viewing
+        </MenuItem>
+        <MenuItem value="Commenting" key="Commenting"
+          disabled={!accessLevelCan(accessLevel, "comment")}
+        >
+          Commenting
+        </MenuItem>
+        <MenuItem value="Editing" key="Editing"
+          disabled={!accessLevelCan(accessLevel, "edit")}
+        >
+          Editing
+        </MenuItem>
+      </Select>
+      
+      <LWTooltip title="Collaborative docs automatically save all changes">
+        <Button className={classes.saveStatus}>
+          Auto-Saved
+          {/*TODO: Make this track offline status etc*/}
+        </Button>
+      </LWTooltip>
+    </span>
   </div>
 }
 

--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -36,6 +36,13 @@ const styles = (theme: ThemeType): JssStyles => ({
       fontSize: '1rem !important',
       marginBottom: "0 !important",
       display: "block !important", //doesn't hide when more than 1 user, helps in cases with many users present
+      wordBreak: "normal !important"
+    },
+    
+    '& .ck-presence-list__list': {
+      "&:nth-child(3)": {
+        display: "none"
+      }
     },
 
     "& .ck-tooltip": {
@@ -67,6 +74,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   saveStatus: {
     '&:hover': {
       background: "unset"
+    },
+    [theme.breakpoints.down('xs')]: {
+      display: "none"
     }
   },
 });

--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -26,25 +26,27 @@ const styles = (theme: ThemeType): JssStyles => ({
       marginBottom: "0 !important",
       alignItems: "center !important",
     },
-
     '& .ck-user__name': {
       color: 'unset !important',
       fontFamily: theme.typography.commentStyle.fontFamily + '!important',
     },
-    
     '& .ck-presence-list__counter': {
       fontSize: '1rem !important',
       marginBottom: "0 !important",
       display: "block !important", //doesn't hide when more than 1 user, helps in cases with many users present
       wordBreak: "normal !important"
     },
-    
     '& .ck-presence-list__list': {
-      "&:nth-child(3)": {
-        display: "none"
+      flexWrap: "wrap"
+    },
+    '& .ck-presence-list__list-item:nth-child(n+4)': {
+      display:"none"
+    },
+    [theme.breakpoints.down('xs')]: {
+      '& .ck-presence-list__list-item:nth-child(n+3)': {
+        display:"none"
       }
     },
-
     "& .ck-tooltip": {
       transform: "initial !important",
       bottom: "initial !important",

--- a/packages/lesswrong/server/fmCrosspost/tokens.ts
+++ b/packages/lesswrong/server/fmCrosspost/tokens.ts
@@ -3,7 +3,6 @@ import jwt, { VerifyErrors } from "jsonwebtoken";
 import { MissingSecretError } from "./errors";
 
 const crosspostSigningKeySetting = new DatabaseServerSetting<string|null>("fmCrosspostSigningKey", null);
-console.log(crosspostSigningKeySetting)
 
 const getSecret = () => {
   const secret = crosspostSigningKeySetting.get();

--- a/packages/lesswrong/server/fmCrosspost/tokens.ts
+++ b/packages/lesswrong/server/fmCrosspost/tokens.ts
@@ -3,6 +3,7 @@ import jwt, { VerifyErrors } from "jsonwebtoken";
 import { MissingSecretError } from "./errors";
 
 const crosspostSigningKeySetting = new DatabaseServerSetting<string|null>("fmCrosspostSigningKey", null);
+console.log(crosspostSigningKeySetting)
 
 const getSecret = () => {
   const secret = crosspostSigningKeySetting.get();


### PR DESCRIPTION
Changed the presence list to have a maximum number of shown users, so it doesn't explode when there's lots of them. Also cleans up styling in other minor ways.

Here are two screenshots with four users:

![](https://user-images.githubusercontent.com/3246710/190511666-0d6d9b4a-7b97-4b46-bfe7-194a498ba426.png)

![](https://user-images.githubusercontent.com/3246710/190511709-f1fce597-ca43-4a9d-9bdc-f5e72a9410c2.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202991651098846) by [Unito](https://www.unito.io)
