### PR TITLE
Fix moderator validation bug

### DIFF
--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -9,14 +9,15 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useDialog } from '../common/withDialog';
 
 // Button used to start a new conversation for a given user
-const NewConversationButton = ({ user, currentUser, children, templateCommentId, from }: {
+const NewConversationButton = ({ user, currentUser, children, templateCommentId, from, moderator }: {
   user: {
     _id: string
   },
   currentUser: UsersCurrent|null,
   templateCommentId?: string,
   from?: string,
-  children: any
+  children: any,
+  moderator?: boolean
 }) => {
   
   const { history } = useNavigation();
@@ -45,8 +46,15 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
   const newConversation = useCallback(async (search) =>  {
     const alignmentFields = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
 
+    let baseData = {
+      participantIds:[user._id, currentUser?._id], 
+      ...alignmentFields
+    }
+
+    const data = moderator ? { moderator: true, ...baseData} : {...baseData}
+
     const response = await createConversation({
-      data: {moderator: true, participantIds:[user._id, currentUser?._id], ...alignmentFields},
+      data: data,
     })
     const conversationId = response.data.createConversation.data._id
     history.push({pathname: `/inbox/${conversationId}`, ...search})

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -55,7 +55,7 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
     const response = await createConversation({data})
     const conversationId = response.data.createConversation.data._id
     history.push({pathname: `/inbox/${conversationId}`, ...search})
-  }, [createConversation, user, currentUser, history]);
+  }, [createConversation, user, currentUser, history, includeModerators]);
 
   const existingConversationCheck = () => {
     let searchParams: Array<string> = []

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -9,7 +9,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useDialog } from '../common/withDialog';
 
 // Button used to start a new conversation for a given user
-const NewConversationButton = ({ user, currentUser, children, templateCommentId, from, moderator }: {
+const NewConversationButton = ({ user, currentUser, children, templateCommentId, from, includeModerators }: {
   user: {
     _id: string
   },
@@ -17,7 +17,7 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
   templateCommentId?: string,
   from?: string,
   children: any,
-  moderator?: boolean
+  includeModerators?: boolean
 }) => {
   
   const { history } = useNavigation();
@@ -50,12 +50,9 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
       participantIds:[user._id, currentUser?._id], 
       ...alignmentFields
     }
-
     const data = moderator ? { moderator: true, ...baseData} : {...baseData}
 
-    const response = await createConversation({
-      data: data,
-    })
+    const response = await createConversation({data})
     const conversationId = response.data.createConversation.data._id
     history.push({pathname: `/inbox/${conversationId}`, ...search})
   }, [createConversation, user, currentUser, history]);

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -50,7 +50,7 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
       participantIds:[user._id, currentUser?._id], 
       ...alignmentFields
     }
-    const data = moderator ? { moderator: true, ...baseData} : {...baseData}
+    const data = includeModerators ? { moderator: true, ...baseData} : {...baseData}
 
     const response = await createConversation({data})
     const conversationId = response.data.createConversation.data._id

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -78,7 +78,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
         anchorEl={anchorEl}
       >
         <MenuItem value={0}>
-          <NewConversationButton user={user} currentUser={currentUser} moderator>
+          <NewConversationButton user={user} currentUser={currentUser} includeModerators>
             Start a message
           </NewConversationButton>
         </MenuItem>
@@ -90,7 +90,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
               </div>}
             >
               <MenuItem>
-                <NewConversationButton user={user} currentUser={currentUser} templateCommentId={comment._id} moderator>
+                <NewConversationButton user={user} currentUser={currentUser} templateCommentId={comment._id} includeModerators>
                   {getTitle(comment.contents?.plaintextMainText || null)}
                 </NewConversationButton>
               </MenuItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -78,7 +78,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
         anchorEl={anchorEl}
       >
         <MenuItem value={0}>
-          <NewConversationButton user={user} currentUser={currentUser}>
+          <NewConversationButton user={user} currentUser={currentUser} moderator>
             Start a message
           </NewConversationButton>
         </MenuItem>
@@ -90,7 +90,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
               </div>}
             >
               <MenuItem>
-                <NewConversationButton user={user} currentUser={currentUser} templateCommentId={comment._id}>
+                <NewConversationButton user={user} currentUser={currentUser} templateCommentId={comment._id} moderator>
                   {getTitle(comment.contents?.plaintextMainText || null)}
                 </NewConversationButton>
               </MenuItem>


### PR DESCRIPTION
I had accidentally put the moderator flag into all new conversations, instead of just ones from the sunshine sidebar, which broke non-admin ability to message users. This fixes it so it's only passed in from the sunshine sidebar.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1202998772001881) by [Unito](https://www.unito.io)
