### PR TITLE
Fix redirect loop in the editor for secondary authors

### DIFF
--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React, { useState, } from 'react';
 import { useCurrentUser } from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil';
-import { getPostCollaborateUrl, canUserEditPost, postGetEditUrl, isNotHostedHere } from '../../lib/collections/posts/helpers';
+import { getPostCollaborateUrl, canUserEditPostMetadata, postGetEditUrl, isNotHostedHere } from '../../lib/collections/posts/helpers';
 import { editorStyles, ckEditorStyles } from '../../themes/stylePiping'
 import NoSSR from 'react-no-ssr';
 import { isMissingDocumentError } from '../../lib/utils/errorUtil';
@@ -82,7 +82,7 @@ const PostCollaborationEditor = ({ classes }: {
 
   // If you're the primary author, an admin, or have edit permissions, redirect to the main editor (rather than the
   // collab editor) so you can edit metadata etc
-  if (canUserEditPost(currentUser, post)) {
+  if (canUserEditPostMetadata(currentUser, post)) {
       return <PermanentRedirect url={postGetEditUrl(post._id, false, post.linkSharingKey)}/>
   }
 

--- a/packages/lesswrong/components/posts/MoveToDraft.tsx
+++ b/packages/lesswrong/components/posts/MoveToDraft.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import React, { useCallback } from 'react';
-import { canUserEditPost } from '../../lib/collections/posts/helpers';
+import { canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
 import { useCurrentUser } from '../common/withUser';
 import MenuItem from '@material-ui/core/MenuItem';
 
@@ -21,7 +21,7 @@ const MoveToDraft = ({ post }: {
     })
   }, [updatePost, post])
 
-  if (!post.draft && currentUser && canUserEditPost(currentUser, post)) {
+  if (!post.draft && currentUser && canUserEditPostMetadata(currentUser, post)) {
     return <div onClick={handleMoveToDraft}>
       <MenuItem>
         Move to Draft

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib
 import { useSingle } from '../../lib/crud/withSingle';
 import { useMessages } from '../common/withMessages';
 import { Posts } from '../../lib/collections/posts';
-import { postGetPageUrl, postGetEditUrl, getPostCollaborateUrl, isNotHostedHere } from '../../lib/collections/posts/helpers';
+import { postGetPageUrl, postGetEditUrl, getPostCollaborateUrl, isNotHostedHere, canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
 import { userIsSharedOn } from '../../lib/collections/users/helpers';
 import { useLocation, useNavigation } from '../../lib/routeUtil'
 import NoSsr from '@material-ui/core/NoSsr';
@@ -58,7 +58,7 @@ const PostsEditForm = ({ documentId, classes }: {
 
   // If we only have read access to this post, but it's shared with us,
   // redirect to the collaborative editor.
-  if (document && !canUserEditPost(currentUser, document)) {
+  if (document && !canUserEditPostMetadata(currentUser, document)) {
     return <Components.PermanentRedirect url={getPostCollaborateUrl(documentId, false, query.key)} status={302}/>
   }
   

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -58,11 +58,7 @@ const PostsEditForm = ({ documentId, classes }: {
 
   // If we only have read access to this post, but it's shared with us,
   // redirect to the collaborative editor.
-  if (document
-    && document.userId!==currentUser._id
-    && document.sharingSettings
-    && !userCanDo(currentUser, 'posts.edit.all')
-  ) {
+  if (document && !canUserEditPost(currentUser, document)) {
     return <Components.PermanentRedirect url={getPostCollaborateUrl(documentId, false, query.key)} status={302}/>
   }
   

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -6,7 +6,7 @@ import { userCanDo } from '../../../lib/vulcan-users/permissions';
 import { userGetDisplayName, userIsSharedOn } from '../../../lib/collections/users/helpers'
 import { userCanMakeAlignmentPost } from '../../../lib/alignment-forum/users/helpers'
 import { useCurrentUser } from '../../common/withUser'
-import { canUserEditPost } from '../../../lib/collections/posts/helpers';
+import { canUserEditPostMetadata } from '../../../lib/collections/posts/helpers';
 import { useSetAlignmentPost } from "../../alignment-forum/withSetAlignmentPost";
 import { useItemsRead } from '../../common/withRecordPostView';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -178,7 +178,7 @@ const PostActions = ({post, closeMenu, classes}: {
   const isRead = (post._id in postsRead) ? postsRead[post._id] : post.isRead;
   
   let editLink: React.ReactNode|null = null;
-  const isEditor = canUserEditPost(currentUser,post);
+  const isEditor = canUserEditPostMetadata(currentUser,post);
   const isShared = userIsSharedOn(currentUser, post);
   if (isEditor || isShared) {
     const link = isEditor ? {pathname:'/editPost', search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`} : {pathname:'/collaborateOnPost', search:`?${qs.stringify({postId: post._id})}`}
@@ -209,7 +209,7 @@ const PostActions = ({post, closeMenu, classes}: {
   
   return (
       <div className={classes.actions}>
-        { canUserEditPost(currentUser,post) && post.isEvent && <Link to={{pathname:'/newPost', search:`?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`}}>
+        { canUserEditPostMetadata(currentUser,post) && post.isEvent && <Link to={{pathname:'/newPost', search:`?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`}}>
           <MenuItem>
             <ListItemIcon>
               <EditIcon />
@@ -218,7 +218,7 @@ const PostActions = ({post, closeMenu, classes}: {
           </MenuItem>
         </Link>}
         {editLink}
-        { forumTypeSetting.get() === 'EAForum' && canUserEditPost(currentUser, post) && <Link
+        { forumTypeSetting.get() === 'EAForum' && canUserEditPostMetadata(currentUser, post) && <Link
           to={{pathname: '/postAnalytics', search: `?${qs.stringify({postId: post._id})}`}}
         >
           <MenuItem>

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -3,7 +3,7 @@ import { createCollection } from '../../vulcan-lib';
 import { userOwns, userCanDo } from '../../vulcan-users/permissions';
 import { addUniversalFields, getDefaultResolvers } from '../../collectionUtils'
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
-import { canUserEditPost, userIsPostGroupOrganizer } from './helpers';
+import { canUserEditPostMetadata, userIsPostGroupOrganizer } from './helpers';
 import { makeEditable } from '../../editor/make_editable';
 import { formGroups } from './formGroups';
 
@@ -26,7 +26,7 @@ const options: MutationOptions<DbPost> = {
       return true
     }
     
-    return canUserEditPost(user, document) || await userIsPostGroupOrganizer(user, document)
+    return canUserEditPostMetadata(user, document) || await userIsPostGroupOrganizer(user, document)
     // note: we can probably get rid of the userIsPostGroupOrganizer call since that's now covered in canUserEditPost, but the implementation is slightly different and isn't otherwise part of the PR that restrutured canUserEditPost
   },
 

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -182,7 +182,10 @@ export const userIsPostGroupOrganizer = async (user: UsersMinimumInfo|DbUser|nul
   return !!group && group.organizerIds.some(id => id === user._id);
 }
 
-export const canUserEditPost = (currentUser: UsersCurrent|DbUser|null, post: PostsBase|DbPost): boolean => {
+/**
+ * Whether the user can make updates to the post document (including both the main post body and most other post fields)
+ */
+export const canUserEditPostMetadata = (currentUser: UsersCurrent|DbUser|null, post: PostsBase|DbPost): boolean => {
   if (!currentUser) return false;
 
   const organizerIds = (post as PostsBase)?.group?.organizerIds;

--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -1,7 +1,7 @@
 import { randomSecret } from '../../lib/random';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { Posts } from '../../lib/collections/posts/collection';
-import { canUserEditPost } from '../../lib/collections/posts/helpers';
+import { canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
 import { Revisions } from '../../lib/collections/revisions/collection';
 import { isCollaborative } from '../../components/editor/EditorFormComponent';
 import { defineQuery, defineMutation } from '../utils/serverGraphqlUtil';
@@ -151,7 +151,7 @@ defineMutation({
     }
     
     // Must have write access to the post
-    if (!canUserEditPost(currentUser, post)) {
+    if (!canUserEditPostMetadata(currentUser, post)) {
       throw new Error("You don't have write access to this post");
     }
     


### PR DESCRIPTION
The full version (with metadata) and the collaborative version (body only) of the post editor redirect to each other, reflecting whether you have sufficient permissions to edit the metadata or not. However the redirect conditions didn't always match, which can cause a redirect loop (seen here: https://sentry.io/organizations/lesswrong/discover/lesswrong:d15779b356e3442d837c0e5de83e16b0/?environment=production&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=1301611&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29). Change the redirect condition in `PostsEditForm` to use the recently introduced `canUserEditPost` utility function, making it match the redirect in the other direction.

NOTE: The previous change gave explicitly-shared secondary authors the ability to edit post metadata (including clicking the Publish button), without fully exposing that in the UI. This is now fully exposed in the UI. There is also a difference between explicitly-shared users with edit access, and link-shared users with edit access: only explicitly-shared users can edit metadata and publish. This seems unintuitive.

Slack: https://app.slack.com/client/T3ERD8FQT/CJUN2UAFN/thread/CJUN2UAFN-1663715029.265129
Introduced in: https://github.com/ForumMagnum/ForumMagnum/pull/5706/commits/4d46c49a5c7432233bcaea718fac8cba6006a3c6



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203018648864211) by [Unito](https://www.unito.io)
