### PR TITLE
Disable createMutator validation when creating a crosspost

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/requestHandlers.ts
+++ b/packages/lesswrong/server/fmCrosspost/requestHandlers.ts
@@ -93,7 +93,7 @@ export const onCrosspostRequest = withApiErrorHandlers(async (req: Request, res:
   const {data: post} = await Utils.createMutator({
     document,
     collection: Posts,
-    validate: true,
+    validate: false,
     currentUser: user,
     context: {
       currentUser: user,


### PR DESCRIPTION
Crossposting is currently failing with the error `app.validation_error`. After digging into it deeper, it turns out that this is because `posts.userId` is defined in the schema as only being insertable by admins (it usually gets set by a callback after validation), so it fails when the account we crosspost _to_ is not an admin (we did test with a mix of admin/non-admin accounts, but evidently we only posted _from_ non-admins, not _to_ non-admins).

We could just adjust the schema to account for this, but my feeling is that it's better to just disable the validation here. This should be safe, since this code path is inside one of the API calls and we've already done a _ton_ of manual validation before we get here - if anything's not right, we'll have aborted already.

My main worry with making a special case in the schema is that this is a pretty niche field that's difficult to test locally, so it would be very easy for someone to make an innocent unrelated change to the permissions in 6 months time that breaks crossposting without them realising.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203030017571142) by [Unito](https://www.unito.io)
