### PR TITLE
Properly display "0" for number input fields

### DIFF
--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -42,7 +42,6 @@ const MuiTextField = ({
     })
   }
 
-
   return <TextField
     variant={variant || 'standard'}
     select={select}

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -42,10 +42,14 @@ const MuiTextField = ({
     })
   }
 
+  const zeroSafeValue = value === 0 
+    ? 0 
+    : (value||"")
+
   return <TextField
     variant={variant || 'standard'}
     select={select}
-    value={value||""}
+    value={zeroSafeValue}
     defaultValue={defaultValue}
     label={label}
     onChange={onChange}

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -42,12 +42,11 @@ const MuiTextField = ({
     })
   }
 
-  const safeValue = (value === undefined || value === null) ? "" : value
 
   return <TextField
     variant={variant || 'standard'}
     select={select}
-    value={safeValue}
+    value={value ?? ""}
     defaultValue={defaultValue}
     label={label}
     onChange={onChange}

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -42,14 +42,12 @@ const MuiTextField = ({
     })
   }
 
-  const zeroSafeValue = value === 0 
-    ? 0 
-    : (value||"")
+  const safeValue = (value === undefined || value === null) ? "" : value
 
   return <TextField
     variant={variant || 'standard'}
     select={select}
-    value={zeroSafeValue}
+    value={safeValue}
     defaultValue={defaultValue}
     label={label}
     onChange={onChange}


### PR DESCRIPTION
Current our form component converts falsey values into an empty string. This PR fixes this for the case of "0" integers. It is plausible we should fix it in some more general way but I'm not sure what work the conversion was doing that I might accidentally break.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203034020537487) by [Unito](https://www.unito.io)
