### PR TITLE
Event banner: get higher resolution images because retina

### DIFF
--- a/packages/lesswrong/components/ea-forum/EventBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EventBanner.tsx
@@ -15,8 +15,8 @@ const mobileImageId = eventBannerMobileImageSetting.get()
 const desktopImageId = eventBannerDesktopImageSetting.get()
 const featuredPost = eventBannerLinkSetting.get()
 
-const mobileImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH},h_${bannerHeight}/${mobileImageId}`
-const desktopImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH},h_${bannerHeight}/${desktopImageId}`
+const mobileImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${mobileImageId}`
+const desktopImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${desktopImageId}`
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   link: {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203043665804550) by [Unito](https://www.unito.io)
