### PR TITLE
Event banner: Get event image setting on render to allow for db setting updates

### DIFF
--- a/packages/lesswrong/components/ea-forum/EventBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EventBanner.tsx
@@ -11,12 +11,6 @@ const eventBannerLinkSetting = new DatabasePublicSetting<string | null>('eventBa
 
 const bannerHeight = 250
 const container = cloudinaryCloudNameSetting.get()
-const mobileImageId = eventBannerMobileImageSetting.get()
-const desktopImageId = eventBannerDesktopImageSetting.get()
-const featuredPost = eventBannerLinkSetting.get()
-
-const mobileImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${mobileImageId}`
-const desktopImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${desktopImageId}`
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   link: {
@@ -38,6 +32,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 
 const EventBanner = ({ classes }) => {
   const { SingleColumnSection } = Components
+
+  const mobileImageId = eventBannerMobileImageSetting.get()
+  const desktopImageId = eventBannerDesktopImageSetting.get()
+  const featuredPost = eventBannerLinkSetting.get()
+
+  const mobileImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${mobileImageId}`
+  const desktopImage = `https://res.cloudinary.com/${container}/image/upload/w_${SECTION_WIDTH*2},h_${bannerHeight*2}/${desktopImageId}`
   
   return <SingleColumnSection>
     <Link to={featuredPost} className={classes.link}>


### PR DESCRIPTION
I can't believe I wrote that bug.

Problem: we change the display of the homepage event banner based on a render-time setting.get() call. But we get the image ID from an initialization-time setting.get(). Thus image ID will only change on deploys, but the display of the banner will change ~5 minutes after the setting is updated in the DB.

This converts everything to be render-time, meaning we can deploy banner updates without deploys.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203043780289044) by [Unito](https://www.unito.io)
