### PR TITLE
fix tooltip text for disagree button

### DIFF
--- a/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
@@ -54,7 +54,7 @@ const AgreementVoteAxis = ({ document, hideKarma=false, voteProps, classes }: {
   return <>
     <span className={classes.agreementSection}>
       <LWTooltip
-        title={<div><b>Agreement: Downvote</b><br />How much do you <b>agree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong upvote, click-and-hold.<br />(Click twice on mobile)</em></div>}
+        title={<div><b>Agreement: Downvote</b><br />How much do you <b>disagree</b> with this, separate from whether you think it's a good comment?<br /><em>For strong downvote, click-and-hold.<br />(Click twice on mobile)</em></div>}
         placement="bottom"
       >
         <AxisVoteButton


### PR DESCRIPTION
The tooltip for the disagree button has the wrong text on it.

![](https://user-images.githubusercontent.com/2136984/192348145-badb313a-ff66-454c-83e1-e84553a77e2b.png)

Fixed:
![](https://user-images.githubusercontent.com/2136984/192348806-f53b73cc-153f-470f-9c65-2926e7e821da.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203050632407304) by [Unito](https://www.unito.io)
