### PR TITLE
mergeAccounts removes duplicate emails and displayNames

### DIFF
--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -368,7 +368,7 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
         await Users.rawUpdateOne(
           {_id: sourceUserId},
           {$set: {
-            'emails.0': newEmail
+            'emails.0': {address: newEmail, verified: source.emails[0].verified}
           }}
         );
       }

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -343,8 +343,6 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log()
-    // eslint-disable-next-line no-console
     console.log("%c Error changing slugs", "color: red")
     // eslint-disable-next-line no-console
     console.log(err)
@@ -353,14 +351,14 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
   // if the two accounts share an email address, change the sourceUser email to "+old"
   try {
     if (!dryRun) {
+      const splitEmail = sourceUser.email.split("@")
+      const newEmail = `${splitEmail[0]}+old@${splitEmail[1]}` 
       if (sourceUser.email === targetUser.email) {
-        const splitEmail = sourceUser.email.split("@")
-        const updatedEmail = `${splitEmail[0]}+old@${splitEmail[1]}` 
         // appending "+old" should still allow the email to work if need be
         await Users.rawUpdateOne(
           {_id: sourceUserId},
           {$set: {
-            email: updatedEmail
+            email: newEmail
           }}
         );
       }
@@ -370,16 +368,30 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
         await Users.rawUpdateOne(
           {_id: sourceUserId},
           {$set: {
-            'emails.0': '${sourceEmailsEmail}-old'
+            'emails.0': newEmail
           }}
         );
       }
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log()
-    // eslint-disable-next-line no-console
     console.log("%c Error changing emails", "color: red")
+    // eslint-disable-next-line no-console
+    console.log(err)
+  }
+
+  // if the two accounts share a displayName, change the sourceUSer to " (Old)"
+  try {
+    if (!dryRun) {
+      if (sourceUser.displayName === targetUser.displayName) {
+        const newDisplayName = sourceUser.displayName + " (Old)"
+        await Users.rawUpdateOne({_id: sourceUserId}, {$set: { email: newDisplayName}}
+        );
+      }
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log("%c Error changing displayName", "color: red")
     // eslint-disable-next-line no-console
     console.log(err)
   }

--- a/scripts/mergeUsers.sh
+++ b/scripts/mergeUsers.sh
@@ -33,4 +33,4 @@ TARGET_ID=${@:$OPTIND+1:1}
 
 echo "Merging user $SOURCE_ID into $TARGET_ID"
 
-scripts/serverShellCommand.sh "Vulcan.mergeAccounts('$SOURCE_ID', '$TARGET_ID', false)"
+scripts/serverShellCommand.sh "Vulcan.mergeAccounts({sourceUserId:'$SOURCE_ID', targetUserId:'$TARGET_ID', dryRun:false})"


### PR DESCRIPTION
People often end up with duplicate accounts sharing an email, and it'd be helpful if we could merge those in a way that actually removes the duplication so they can then actually edit their accounts without throwing validation errors.

This PR also makes it so that the mergeAccounts function specifies sourceUserId and targetUserId, because I frequently had to go looking up which was which, which I found annoying. (I personally access the command by searching my command line history, and grab the last instance of it). So, now it looks like:

```
scripts/serverShellCommand.sh "Globals.mergeAccounts({sourceUserId:'vperH823EjMoAnzAz', targetUserId:'bneALscHnCXsr8QRu', dryRun:false})"
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203050878789260) by [Unito](https://www.unito.io)
