### PR TITLE
Fix crosspost read times

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -59,11 +59,11 @@ const PostsPageCrosspostWrapper = ({post, refetch, fetchProps}: {
   };
 
   if (!contextValue.hostedHere) {
-    contextValue.combinedPost = {
-      ...document,
-      ...post,
-      contents: document?.contents ?? post.contents,
-    };
+    const overrideFields = ["contents", "readTimeMinutes"];
+    contextValue.combinedPost = {...document, ...post};
+    for (const field of overrideFields) {
+      contextValue.combinedPost[field] = document?.[field] ?? post[field];
+    }
   }
 
   return (

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -59,6 +59,11 @@ const PostsPageCrosspostWrapper = ({post, refetch, fetchProps}: {
   };
 
   if (!contextValue.hostedHere) {
+    /**
+     * If this post was crossposted from elsewhere then we want to take most of the fields from
+     * our local copy (for correct links/ids/etc.) but we need to override a few specific fields
+     * to actually get the correct content and some metadata that isn't denormalized across sites
+     */
     const overrideFields = ["contents", "readTimeMinutes"];
     contextValue.combinedPost = {...document, ...post};
     for (const field of overrideFields) {


### PR DESCRIPTION
This PR fixes read times for posts that are crossposted from elsewhere. It's possible (probable?) that more fields will need to be added to `overrideFields` in the future, but I'm not sure exactly which right now.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203050787101586) by [Unito](https://www.unito.io)
