### PR TITLE
Fix some styling bugs caused by Great Divergence

### DIFF
--- a/packages/lesswrong/components/editor/CKCommentEditor.tsx
+++ b/packages/lesswrong/components/editor/CKCommentEditor.tsx
@@ -11,13 +11,14 @@ import { mentionPluginConfiguration } from "../../lib/editor/mentionsConfig";
 // Uncomment the import and the line below to activate the debugger
 // import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 
-const CKCommentEditor = ({ data, collectionName, fieldName, onSave, onChange, onInit }: {
+const CKCommentEditor = ({ data, collectionName, fieldName, onSave, onChange, onInit, placeholder }: {
   data?: any,
   collectionName: CollectionNameString,
   fieldName: string,
   onSave?: any,
   onChange?: any,
   onInit?: any,
+  placeholder?: string,
 }) => {
   const webSocketUrl = ckEditorWebsocketUrlOverrideSetting.get() || ckEditorWebsocketUrlSetting.get();
   const ckEditorCloudConfigured = !!webSocketUrl;
@@ -51,7 +52,7 @@ const CKCommentEditor = ({ data, collectionName, fieldName, onSave, onChange, on
           }
         },
         initialData: data || "",
-        placeholder: defaultEditorPlaceholder,
+        placeholder: placeholder ?? defaultEditorPlaceholder,
         mention: mentionPluginConfiguration
       }}
       data={data}

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -56,7 +56,7 @@ const refreshDisplayMode = ( editor, sidebarElement ) => {
 }
 
 
-const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, documentId, userId, formType, onInit, classes, isCollaborative, accessLevel }: {
+const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, documentId, userId, formType, onInit, classes, isCollaborative, accessLevel, placeholder }: {
   data?: any,
   collectionName: CollectionNameString,
   fieldName: string,
@@ -71,6 +71,7 @@ const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, docum
   // If this is the contents field of a collaboratively-edited post, the access level the
   // logged in user has. Otherwise undefined.
   accessLevel?: CollaborativeEditingAccessLevel,
+  placeholder?: string,
   classes: ClassesType,
 }) => {
   const { EditorTopBar } = Components;
@@ -179,7 +180,7 @@ const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, docum
           container: presenceListRef.current
         },
         initialData: initData,
-        placeholder: defaultEditorPlaceholder,
+        placeholder: placeholder ?? defaultEditorPlaceholder,
         mention: mentionPluginConfiguration
       }}
     />}

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -68,7 +68,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     padding: 0,
     pointerEvents: 'auto',
     '& textarea': {
-      marginTop: 4,
+      marginTop: 0,
       maxHeight: commentMinimalistEditorHeight,
       '&:focus': {
         maxHeight: '128px',
@@ -102,11 +102,6 @@ export const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   commentMinimalistEditorHeight: {
-    // // minHeight: commentMinimalistEditorHeight,
-    // '& .ck.ck-content': {
-    //   minHeight: commentMinimalistEditorHeight,
-    // },
-    // marginTop: 4,
     '& .ck-editor__editable': {
       maxHeight: "300px"
     },
@@ -131,6 +126,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     position: "absolute",
     top: 0,
     color: theme.palette.grey[500],
+    whiteSpace: "pre-wrap",
     // Without this pointerEvent code, there's a weird thing where if you try to click the placeholder text, instead of focusing on the editor element, it... doesn't. This is overriding something habryka did to make spoiler tags work. We discussed this for awhile and this seemed like the best option.
     pointerEvents: "none",
     "& *": {
@@ -200,6 +196,12 @@ export interface SerializedEditorContents {
   value: any,
 }
 
+export interface FormProps {
+  commentMinimalistStyle?: boolean
+  editorHintText?: string
+  maxHeight?: boolean
+}
+
 interface EditorProps {
   ref?: MutableRefObject<Editor|null>,
   currentUser: UsersCurrent|null,
@@ -209,7 +211,7 @@ interface EditorProps {
   collectionName: CollectionNameString,
   fieldName: string,
   initialEditorType: EditorTypeString,
-  formProps?: { commentMinimalistStyle: boolean },
+  formProps?: FormProps,
   
   // Whether to use the CkEditor collaborative editor, ie, this is the
   // contents field of a shared post.
@@ -485,6 +487,7 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
         collectionName, fieldName,
         formType: formType,
         userId: currentUser?._id,
+        placeholder: this.props.placeholder ?? undefined,
         onChange: (event, editor) => {
           // The getData call needs to be wrapped in a closure to avoid `this` reference errors
           this.throttledSetCkEditor(() => editor.getData());
@@ -531,7 +534,7 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
       { this.renderPlaceholder(!value, false) }
       <Components.ContentStyles contentType={contentType}  className={classNames({[classes.commentBodyStylesMinimalist]: formProps?.commentMinimalistStyle})}>
         <Input
-          className={classNames(classes.markdownEditor, this.getBodyStyles(), {[classes.questionWidth]: questionStyles}
+          className={classNames(classes.markdownEditor, this.getBodyStyles(), {[classes.questionWidth]: questionStyles, [classes.commentBodyStylesMinimalist]: formProps?.commentMinimalistStyle}
           )}
           value={value}
           onChange={(ev) => {

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -4,7 +4,7 @@ import { editableCollectionsFieldOptions } from '../../lib/editor/make_editable'
 import { getLSHandlers, getLSKeyPrefix } from './localStorageHandlers'
 import { userCanCreateCommitMessages } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
-import { Editor, EditorChangeEvent, getUserDefaultEditor, getInitialEditorContents, getBlankEditorContents, EditorContents, isBlank, serializeEditorContents, EditorTypeString, styles } from './Editor';
+import { Editor, EditorChangeEvent, getUserDefaultEditor, getInitialEditorContents, getBlankEditorContents, EditorContents, isBlank, serializeEditorContents, EditorTypeString, styles, FormProps } from './Editor';
 import withErrorBoundary from '../common/withErrorBoundary';
 import PropTypes from 'prop-types';
 import * as _ from 'underscore';
@@ -24,7 +24,7 @@ export function isCollaborative(post, fieldName: string): boolean {
 export const EditorFormComponent = ({form, formType, formProps, document, name, fieldName, value, hintText, placeholder, label, commentStyles, classes}: {
   form: any,
   formType: "edit"|"new",
-  formProps: any,
+  formProps: FormProps,
   document: any,
   name: any,
   fieldName: any,

--- a/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
+++ b/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
@@ -13,23 +13,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const forumHintText: ForumOptions<JSX.Element> = {
-  LessWrong: <div>
-    <div>Write your thoughts here! What have you been thinking about?</div>
-    <div>Exploratory, draft-stage, rough, and rambly thoughts are all welcome on Shortform.</div>
-  </div>,
-  AlignmentForum: <div>
-    <div>Write your thoughts here! What have you been thinking about?</div>
-    <div>Exploratory, draft-stage, rough, and rambly thoughts are all welcome on Shortform.</div>
-  </div>,
-  EAForum: <div>
-    <div>Write your brief or quickly written post here.</div>
-    <div>Exploratory, draft-stage, rough, and off-the-cuff thoughts are all welcome on Shortform.</div>
-  </div>,
-  default: <div>
-    <div>Write your brief or quickly written post here.</div>
-    <div>Exploratory, draft-stage, rough, and off-the-cuff thoughts are all welcome on Shortform.</div>
-  </div>
+const forumHintText: ForumOptions<string> = {
+  LessWrong: "Write your thoughts here! What have you been thinking about\nExploratory, draft-stage, rough, and rambly thoughts are all welcome on Shortform.",
+  AlignmentForum: "Write your thoughts here! What have you been thinking about?\nExploratory, draft-stage, rough, and rambly thoughts are all welcome on Shortform.",
+  EAForum: "Write your brief or quickly written post here.\nExploratory, draft-stage, rough, and off-the-cuff thoughts are all welcome on Shortform.",
+  default: "Write your brief or quickly written post here.\nExploratory, draft-stage, rough, and off-the-cuff thoughts are all welcome on Shortform."
 }
 
 const ShortformSubmitForm = ({ successCallback, classes }: {

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -35,11 +35,15 @@ export interface MakeEditableOptions {
   label?: string,
   order?: number,
   hideControls?: boolean,
-  hintText?: any,
+  hintText?: string,
   pingbacks?: boolean,
   revisionsHaveCommitMessages?: boolean,
   hidden?: boolean,
 }
+
+export const defaultEditorPlaceholder = `Write here. Select text for formatting options.
+We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).
+You can switch between rich text and markdown in your user settings.`
 
 const defaultOptions: MakeEditableOptions = {
   // Determines whether to use the comment editor configuration (e.g. Toolbars)
@@ -63,20 +67,10 @@ const defaultOptions: MakeEditableOptions = {
   },
   fieldName: "",
   order: 0,
-  hintText: (
-    <div>
-      <div>Write here. Select text for formatting options.</div>
-      <div>We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).</div>
-      <div>You can switch between rich text and markdown in your user settings.</div>
-    </div>
-  ),
+  hintText: defaultEditorPlaceholder,
   pingbacks: false,
   revisionsHaveCommitMessages: false,
 }
-
-export const defaultEditorPlaceholder = `Write here. Select text for formatting options.
-We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).
-You can switch between rich text and markdown in your user settings.`
 
 export const editableCollections = new Set<CollectionNameString>()
 export const editableCollectionsFields: Record<CollectionNameString,Array<string>> = {} as any;


### PR DESCRIPTION
This does the following:
 - makes non-default placeholder text work again (for the whole site)
 - fixes the styling of the comment box in the mobile view of subforums

![Screenshot 2022-09-27 at 13 18 56](https://user-images.githubusercontent.com/77623106/192548858-4492b414-c7c8-4998-8de5-dc8b55725092.png)


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203056693645708) by [Unito](https://www.unito.io)
