### PR TITLE
Cleanup from migrating subforum comments onto tag

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -485,15 +485,6 @@ ensureIndex(Comments,
   augmentForDefaultView({ reviewingForReview: 1, userId: 1, postId: 1 }),
   { name: "comments.reviews2018" }
 );
-
-// TODO remove (https://app.asana.com/0/0/1202945419128640/f)
-// renamed to tagDiscussionComments to better distinguish between comments on the tag subforum
-// we can delete this once we're confident browsers are no longer a bundle.js from before the rename (7 days after merge)
-Comments.addView('commentsOnTag', (terms: CommentsViewTerms) => ({
-  selector: {
-    tagId: terms.tagId,
-  },
-}));
 ensureIndex(Comments,
   augmentForDefaultView({tagId: 1}),
   { name: "comments.tagId" }
@@ -508,8 +499,7 @@ export const subforumDefaultSorting = "recentDiscussion"
 Comments.addView('tagDiscussionComments', (terms: CommentsViewTerms) => ({
   selector: {
     tagId: terms.tagId,
-    // TODO (https://app.asana.com/0/0/1202945419128640/f) Change != Subforum to == Discussion once all comments have been migrated
-    tagCommentType: {$ne: TagCommentType.Subforum as string}
+    tagCommentType: TagCommentType.Discussion as string
   },
 }));
 

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -20,7 +20,7 @@ const EmailCommentBatch = ({comments}:{comments: DbComment[]}) => {
   const { EmailComment, EmailCommentsOnPostHeader } = Components;
   const commentsOnPosts = filter(comments, comment => !!comment.postId)
   const commentsByPostId = groupBy(commentsOnPosts, (comment:DbComment)=>comment.postId);
-  const commentsOnTags = filter(comments, comment => !!comment.tagId && comment.tagCommentType !== TagCommentType.Subforum)
+  const commentsOnTags = filter(comments, comment => !!comment.tagId && comment.tagCommentType === TagCommentType.Discussion)
   const commentsByTagId = groupBy(commentsOnTags, (comment:DbComment)=>comment.tagId);
   
   return <div>


### PR DESCRIPTION
* Removed `commentsOnTag` view which is no longer used (hasn't been used for 3 weeks so should be safe to remove)
* Replace all checks for `!== TagCommentType.Subforum` with `=== TagCommentType.Discussion` as all comments are now one or the other



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203058444608204) by [Unito](https://www.unito.io)
