### PR TITLE
Add duration, customTitle and customSubtitle to Spotlights

### DIFF
--- a/packages/lesswrong/components/spotlights/CurrentSpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/CurrentSpotlightItem.tsx
@@ -5,12 +5,6 @@ import { useTracking } from '../../lib/analyticsEvents';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-const styles = (theme: ThemeType): JssStyles => ({
-  root: {
-
-  }
-});
-
 const HIDE_SPOTLIGHT_ITEM_PREFIX = 'hide_spotlight_item_';
 
 export const CurrentSpotlightItem = ({classes}: {
@@ -43,12 +37,13 @@ export const CurrentSpotlightItem = ({classes}: {
     captureEvent("spotlightItemHideItemClicked", { document: spotlight.document })
   }, [setCookie, cookieName, spotlight, captureEvent]);  
 
-  return <div className={classes.root}>
-    {spotlight && !isHidden && <SpotlightItem key={spotlight._id} spotlight={spotlight} hideBanner={hideBanner}/>}
-  </div>;
+  if (spotlight && !isHidden) {
+    return <SpotlightItem key={spotlight._id} spotlight={spotlight} hideBanner={hideBanner}/>
+  }
+  return null
 }
 
-const CurrentSpotlightItemComponent = registerComponent('CurrentSpotlightItem', CurrentSpotlightItem, {styles});
+const CurrentSpotlightItemComponent = registerComponent('CurrentSpotlightItem', CurrentSpotlightItem);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/spotlights/SpotlightEditorStyles.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightEditorStyles.tsx
@@ -16,7 +16,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       '& .input-spotlightImageId': {
         width: "66%"
       },
-      '& .input-documentId, & .input-documentType, & .input-position, & .input-draft': {
+      '& .input-documentId, & .input-documentType, & .input-position, & .input-draft, & .input-duration, & .input-customTitle, & .input-customSubtitle': {
         width: "calc(33% - 12px)",
         overflow: "hidden",
         marginRight: 12

--- a/packages/lesswrong/components/spotlights/SpotlightEditorStyles.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightEditorStyles.tsx
@@ -16,9 +16,13 @@ const styles = (theme: ThemeType): JssStyles => ({
       '& .input-spotlightImageId': {
         width: "66%"
       },
-      '& .input-documentId, & .input-documentType, & .input-position, & .input-draft, & .input-duration, & .input-customTitle, & .input-customSubtitle': {
+      '& .input-documentId, & .input-documentType, & .input-position, & .input-draft, & .input-duration, & .input-customTitle, & .input-customSubtitle, & .input-draft': {
         width: "calc(33% - 12px)",
         overflow: "hidden",
+        marginRight: 12
+      },
+      '& .input-lastPromotedAt': {
+        width: "calc(33% - 12px)",
         marginRight: 12
       },
       '& .form-submit': {

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -9,6 +9,7 @@ import Spotlights from '../../lib/collections/spotlights/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import { Components, getFragment, registerComponent } from '../../lib/vulcan-lib';
 import { userCanDo } from '../../lib/vulcan-users';
+import { DEFAULT_ACTIVE_DAYS } from '../../server/spotlightCron';
 import { postBodyStyles } from '../../themes/stylePiping';
 import { useCurrentUser } from '../common/withUser';
 
@@ -240,6 +241,8 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
   // But, also, the real proper fix here is to integrate continue reading here.
   const firstPostUrl = spotlight.firstPost && postGetPageUrl(spotlight.firstPost, false, spotlight.documentType === "Sequence" ? spotlight.documentId : undefined)
 
+  const duration = spotlight.duration || DEFAULT_ACTIVE_DAYS
+
   const onUpdate = () => {
     setEdit(false);
     refetchAllSpotlights?.();
@@ -318,6 +321,9 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
             {spotlight.draft && <MetaInfo>[Draft]</MetaInfo>}
             <MetaInfo>{spotlight.position}</MetaInfo>
             <MetaInfo><FormatDate date={spotlight.lastPromotedAt} format="YYYY-MM-DD"/></MetaInfo>
+            <LWTooltip title={`This will be on the frontpage for ${duration} days when it rotates in`}>
+              <MetaInfo>{duration} days</MetaInfo>
+            </LWTooltip>
           </div>
         }
       </div>}

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -9,7 +9,6 @@ import Spotlights from '../../lib/collections/spotlights/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import { Components, getFragment, registerComponent } from '../../lib/vulcan-lib';
 import { userCanDo } from '../../lib/vulcan-users';
-import { DEFAULT_ACTIVE_DAYS } from '../../server/spotlightCron';
 import { postBodyStyles } from '../../themes/stylePiping';
 import { useCurrentUser } from '../common/withUser';
 
@@ -241,7 +240,7 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
   // But, also, the real proper fix here is to integrate continue reading here.
   const firstPostUrl = spotlight.firstPost && postGetPageUrl(spotlight.firstPost, false, spotlight.documentType === "Sequence" ? spotlight.documentId : undefined)
 
-  const duration = spotlight.duration || DEFAULT_ACTIVE_DAYS
+  const duration = spotlight.duration
 
   const onUpdate = () => {
     setEdit(false);

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -87,8 +87,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       }
     }
   },
+  postPadding: {
+    paddingBottom: 12
+  },
   description: {
-    marginTop: 14,
+    marginTop: 8,
     ...descriptionStyles(theme),
     position: "relative",
     lineHeight: '1.65rem',
@@ -103,6 +106,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     lineHeight: "1.2em",
     display: "flex",
     alignItems: "center"
+  },
+  subtitle: {
+    ...theme.typography.postStyle,
+    fontSize: 15,
+    color: theme.palette.grey[700],
+    marginTop: -1,
+    fontStyle: "italic"
   },
   image: {
     '& img': {
@@ -238,10 +248,10 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
   return <AnalyticsTracker eventType="spotlightItem" captureOnMount captureOnClick={false}>
     <div className={classes.root}>
       <div className={classes.spotlightItem}>
-        <div className={classes.content}>
+        <div className={classNames(classes.content, {[classes.postPadding]: spotlight.documentType === "Post"})}>
           <div className={classes.title}>
             <Link to={url}>
-              {spotlight.document.title}
+              {spotlight.customTitle ?? spotlight.document.title}
             </Link>
             <span className={classes.editDescriptionButton}>
               {userCanDo(currentUser, 'spotlights.edit.all') && <LWTooltip title="Edit Spotlight">
@@ -249,6 +259,9 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
               </LWTooltip>}
             </span>
           </div>
+          {spotlight.customSubtitle && <div className={classes.subtitle}>
+            {spotlight.customSubtitle}
+          </div>}
           <div className={classes.description}>
             {editDescription ? 
               <div className={classes.editDescription}>

--- a/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
@@ -54,7 +54,7 @@ export const SpotlightsPage = ({classes}: {
       <SpotlightEditorStyles>
         <WrappedSmartForm
           collection={Spotlights}
-          mutationFragment={getFragment('SpotlightsDefaultFragment')}
+          mutationFragment={getFragment('SpotlightEditQueryFragment')}
         />
       </SpotlightEditorStyles>
     </div>

--- a/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
@@ -44,7 +44,9 @@ export const SpotlightsPage = ({classes}: {
   const draftSpotlights = spotlightsInDisplayOrder.filter(spotlight => spotlight.draft)
 
   if (!userCanDo(currentUser, 'spotlights.edit.all')) {
-    return <div>You must be logged in as an admin to use this page.</div>;
+    return <SingleColumnSection>
+      <Typography variant="body2">You must be logged in as an admin to use this page.</Typography>
+    </SingleColumnSection>;
   }
 
   return <SingleColumnSection>

--- a/packages/lesswrong/lib/collections/spotlights/collection.ts
+++ b/packages/lesswrong/lib/collections/spotlights/collection.ts
@@ -13,24 +13,24 @@ export const Spotlights: SpotlightsCollection = createCollection({
 
 addUniversalFields({ collection: Spotlights });
 
-// makeEditable({
-//   collection: Spotlights,
-//   options: {
-//     fieldName: "description",
-//     commentEditor: true,
-//     commentStyles: true,
-//     hideControls: true,
-//     getLocalStorageId: (spotlight) => {
-//       if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
-//       return {id: `spotlight:create`, verify:true}
-//     },
-//     permissions: {
-//       viewableBy: ['guests'],
-//       editableBy: ['admins', 'sunshineRegiment'],
-//       insertableBy: ['admins', 'sunshineRegiment']
-//     },
-//     order: 100
-//   }
-// });
+makeEditable({
+  collection: Spotlights,
+  options: {
+    fieldName: "description",
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    getLocalStorageId: (spotlight) => {
+      if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
+      return {id: `spotlight:create`, verify:true}
+    },
+    permissions: {
+      viewableBy: ['guests'],
+      editableBy: ['admins', 'sunshineRegiment'],
+      insertableBy: ['admins', 'sunshineRegiment']
+    },
+    order: 100
+  }
+});
 
 export default Spotlights;

--- a/packages/lesswrong/lib/collections/spotlights/collection.ts
+++ b/packages/lesswrong/lib/collections/spotlights/collection.ts
@@ -13,24 +13,24 @@ export const Spotlights: SpotlightsCollection = createCollection({
 
 addUniversalFields({ collection: Spotlights });
 
-makeEditable({
-  collection: Spotlights,
-  options: {
-    fieldName: "description",
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    getLocalStorageId: (spotlight) => {
-      if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
-      return {id: `spotlight:create`, verify:true}
-    },
-    permissions: {
-      viewableBy: ['guests'],
-      editableBy: ['admins', 'sunshineRegiment'],
-      insertableBy: ['admins', 'sunshineRegiment']
-    },
-    order: 60
-  }
-});
+// makeEditable({
+//   collection: Spotlights,
+//   options: {
+//     fieldName: "description",
+//     commentEditor: true,
+//     commentStyles: true,
+//     hideControls: true,
+//     getLocalStorageId: (spotlight) => {
+//       if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
+//       return {id: `spotlight:create`, verify:true}
+//     },
+//     permissions: {
+//       viewableBy: ['guests'],
+//       editableBy: ['admins', 'sunshineRegiment'],
+//       insertableBy: ['admins', 'sunshineRegiment']
+//     },
+//     order: 100
+//   }
+// });
 
 export default Spotlights;

--- a/packages/lesswrong/lib/collections/spotlights/fragments.ts
+++ b/packages/lesswrong/lib/collections/spotlights/fragments.ts
@@ -9,6 +9,8 @@ registerFragment(`
     draft
     position
     lastPromotedAt
+    customTitle
+    customSubtitle
   }
 `)
 

--- a/packages/lesswrong/lib/collections/spotlights/fragments.ts
+++ b/packages/lesswrong/lib/collections/spotlights/fragments.ts
@@ -11,6 +11,7 @@ registerFragment(`
     lastPromotedAt
     customTitle
     customSubtitle
+    duration
   }
 `)
 

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -162,39 +162,13 @@ const schema: SchemaType<DbSpotlight> = {
       }
     }
   },
-  duration: {
-    type: Number,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 40,
-    ...schemaDefaultValue(3),
-  },
-  customTitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 50,
-    optional: true,
-    nullable: true
-  },
-  customSubtitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 60,
-    optional: true,
-    nullable: true
-  },
   lastPromotedAt: {
     type: Date,
     control: "datetime",
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 70,
+    order: 40,
     // Default to the epoch date if not specified
     ...schemaDefaultValue(new Date(0)),
   },
@@ -203,7 +177,7 @@ const schema: SchemaType<DbSpotlight> = {
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 80,
+    order: 50,
     ...schemaDefaultValue(true),
   },
   spotlightImageId: {
@@ -214,8 +188,34 @@ const schema: SchemaType<DbSpotlight> = {
     control: "ImageUpload",
     optional: true,
     nullable: true,
+    order: 60,
+  },
+  duration: {
+    type: Number,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 70,
+    ...schemaDefaultValue(3),
+  },
+  customTitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 80,
+    optional: true,
+    nullable: true
+  },
+  customSubtitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
     order: 90,
-  }
+    optional: true,
+    nullable: true
+  },
 };
   
 export default schema;

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -162,13 +162,40 @@ const schema: SchemaType<DbSpotlight> = {
       }
     }
   },
+
+  duration: {
+    type: Number,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 40,
+    ...schemaDefaultValue(3),
+  },
+  customTitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 50,
+    optional: true,
+    nullable: true
+  },
+  customSubtitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 60,
+    optional: true,
+    nullable: true
+  },
   lastPromotedAt: {
     type: Date,
     control: "datetime",
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 40,
+    order: 70,
     // Default to the epoch date if not specified
     ...schemaDefaultValue(new Date(0)),
   },
@@ -177,7 +204,7 @@ const schema: SchemaType<DbSpotlight> = {
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 50,
+    order: 80,
     ...schemaDefaultValue(true),
   },
   spotlightImageId: {
@@ -188,34 +215,8 @@ const schema: SchemaType<DbSpotlight> = {
     control: "ImageUpload",
     optional: true,
     nullable: true,
-    order: 60,
-  },
-  duration: {
-    type: Number,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 70,
-    ...schemaDefaultValue(3),
-  },
-  customTitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 80,
-    optional: true,
-    nullable: true
-  },
-  customSubtitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
     order: 90,
-    optional: true,
-    nullable: true
-  },
+  }
 };
   
 export default schema;

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -162,13 +162,39 @@ const schema: SchemaType<DbSpotlight> = {
       }
     }
   },
+  duration: {
+    type: Number,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 40,
+    ...schemaDefaultValue(3),
+  },
+  customTitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 50,
+    optional: true,
+    nullable: true
+  },
+  customSubtitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 60,
+    optional: true,
+    nullable: true
+  },
   lastPromotedAt: {
     type: Date,
     control: "datetime",
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 40,
+    order: 70,
     // Default to the epoch date if not specified
     ...schemaDefaultValue(new Date(0)),
   },
@@ -177,7 +203,7 @@ const schema: SchemaType<DbSpotlight> = {
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
-    order: 50,
+    order: 80,
     ...schemaDefaultValue(true),
   },
   spotlightImageId: {
@@ -188,34 +214,8 @@ const schema: SchemaType<DbSpotlight> = {
     control: "ImageUpload",
     optional: true,
     nullable: true,
-    order: 60,
-  },
-  duration: {
-    type: Number,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 70,
-    ...schemaDefaultValue(3),
-  },
-  customTitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 70,
-    optional: true,
-    nullable: true
-  },
-  customSubtitle: {
-    type: String,
-    canRead: ['guests'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    order: 70,
-    optional: true,
-    nullable: true
-  },
+    order: 90,
+  }
 };
   
 export default schema;

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -190,7 +190,32 @@ const schema: SchemaType<DbSpotlight> = {
     nullable: true,
     order: 60,
   },
-
+  duration: {
+    type: Number,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 70,
+    ...schemaDefaultValue(3),
+  },
+  customTitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 70,
+    optional: true,
+    nullable: true
+  },
+  customSubtitle: {
+    type: String,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    order: 70,
+    optional: true,
+    nullable: true
+  },
 };
   
 export default schema;

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -665,9 +665,12 @@ interface DbSpotlight extends DbObject {
   documentId: string
   documentType: SpotlightDocumentType
   position: number
-  spotlightImageId: string | null
-  draft: boolean
   lastPromotedAt: Date
+  draft: boolean
+  spotlightImageId: string | null
+  duration: number
+  customTitle: string | null
+  customSubtitle: string | null
   createdAt: Date
   description: EditableFieldContents
 }
@@ -793,7 +796,7 @@ interface DbUser extends DbObject {
   noSingleLineComments: boolean
   noCollapseCommentsPosts: boolean
   noCollapseCommentsFrontpage: boolean
-  petrovOptOut: boolean
+  petrovOptOut: boolean | null
   hideNavigationSidebar: boolean
   currentFrontpageFilter: string
   frontpageFilterSettings: any /*{"definitions":[{"blackbox":true}]}*/

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -665,12 +665,12 @@ interface DbSpotlight extends DbObject {
   documentId: string
   documentType: SpotlightDocumentType
   position: number
-  lastPromotedAt: Date
-  draft: boolean
-  spotlightImageId: string | null
   duration: number
   customTitle: string | null
   customSubtitle: string | null
+  lastPromotedAt: Date
+  draft: boolean
+  spotlightImageId: string | null
   createdAt: Date
   description: EditableFieldContents
 }

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -665,14 +665,13 @@ interface DbSpotlight extends DbObject {
   documentId: string
   documentType: SpotlightDocumentType
   position: number
-  duration: number
-  customTitle: string | null
-  customSubtitle: string | null
   lastPromotedAt: Date
   draft: boolean
   spotlightImageId: string | null
+  duration: number
+  customTitle: string | null
+  customSubtitle: string | null
   createdAt: Date
-  description: EditableFieldContents
 }
 
 interface SubscriptionsCollection extends CollectionBase<DbSubscription, "Subscriptions"> {

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -672,6 +672,7 @@ interface DbSpotlight extends DbObject {
   customTitle: string | null
   customSubtitle: string | null
   createdAt: Date
+  description: EditableFieldContents
 }
 
 interface SubscriptionsCollection extends CollectionBase<DbSubscription, "Subscriptions"> {

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2605,12 +2605,12 @@ interface SpotlightsDefaultFragment { // fragment on Spotlights
   readonly documentId: string,
   readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Sequence","Collection","Post"]}]},"optional":false,"label":"Document type"}}]}*/,
   readonly position: number,
-  readonly lastPromotedAt: Date,
-  readonly draft: boolean,
-  readonly spotlightImageId: string | null,
   readonly duration: number,
   readonly customTitle: string | null,
   readonly customSubtitle: string | null,
+  readonly lastPromotedAt: Date,
+  readonly draft: boolean,
+  readonly spotlightImageId: string | null,
 }
 
 interface SpotlightMinimumInfo { // fragment on Spotlights
@@ -2623,6 +2623,7 @@ interface SpotlightMinimumInfo { // fragment on Spotlights
   readonly lastPromotedAt: Date,
   readonly customTitle: string | null,
   readonly customSubtitle: string | null,
+  readonly duration: number,
 }
 
 interface SpotlightDisplay extends SpotlightMinimumInfo { // fragment on Spotlights

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2626,8 +2626,15 @@ interface SpotlightMinimumInfo { // fragment on Spotlights
   readonly duration: number,
 }
 
+interface SpotlightTest { // fragment on Spotlights
+  readonly customTitle: string | null,
+  readonly customSubtitle: string | null,
+  readonly duration: number,
+}
+
 interface SpotlightDisplay extends SpotlightMinimumInfo { // fragment on Spotlights
   readonly document: SpotlightDisplay_document,
+  readonly description: SpotlightDisplay_description|null,
   readonly firstPost: SpotlightDisplay_firstPost|null,
 }
 
@@ -2637,6 +2644,10 @@ interface SpotlightDisplay_document { // fragment on Posts
   readonly slug: string,
 }
 
+interface SpotlightDisplay_description { // fragment on Revisions
+  readonly html: string,
+}
+
 interface SpotlightDisplay_firstPost { // fragment on Posts
   readonly _id: string,
   readonly title: string,
@@ -2644,6 +2655,7 @@ interface SpotlightDisplay_firstPost { // fragment on Posts
 }
 
 interface SpotlightEditQueryFragment extends SpotlightMinimumInfo { // fragment on Spotlights
+  readonly description: RevisionEdit|null,
 }
 
 interface SuggestAlignmentComment extends CommentsList { // fragment on Comments
@@ -2815,6 +2827,7 @@ interface FragmentTypes {
   UserVotes: UserVotes
   SpotlightsDefaultFragment: SpotlightsDefaultFragment
   SpotlightMinimumInfo: SpotlightMinimumInfo
+  SpotlightTest: SpotlightTest
   SpotlightDisplay: SpotlightDisplay
   SpotlightEditQueryFragment: SpotlightEditQueryFragment
   SuggestAlignmentComment: SuggestAlignmentComment
@@ -2978,6 +2991,7 @@ interface CollectionNamesByFragmentName {
   UserVotes: "Votes"
   SpotlightsDefaultFragment: "Spotlights"
   SpotlightMinimumInfo: "Spotlights"
+  SpotlightTest: "Spotlights"
   SpotlightDisplay: "Spotlights"
   SpotlightEditQueryFragment: "Spotlights"
   SuggestAlignmentComment: "Comments"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2605,12 +2605,12 @@ interface SpotlightsDefaultFragment { // fragment on Spotlights
   readonly documentId: string,
   readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Sequence","Collection","Post"]}]},"optional":false,"label":"Document type"}}]}*/,
   readonly position: number,
-  readonly duration: number,
-  readonly customTitle: string | null,
-  readonly customSubtitle: string | null,
   readonly lastPromotedAt: Date,
   readonly draft: boolean,
   readonly spotlightImageId: string | null,
+  readonly duration: number,
+  readonly customTitle: string | null,
+  readonly customSubtitle: string | null,
 }
 
 interface SpotlightMinimumInfo { // fragment on Spotlights
@@ -2628,7 +2628,6 @@ interface SpotlightMinimumInfo { // fragment on Spotlights
 
 interface SpotlightDisplay extends SpotlightMinimumInfo { // fragment on Spotlights
   readonly document: SpotlightDisplay_document,
-  readonly description: SpotlightDisplay_description|null,
   readonly firstPost: SpotlightDisplay_firstPost|null,
 }
 
@@ -2638,10 +2637,6 @@ interface SpotlightDisplay_document { // fragment on Posts
   readonly slug: string,
 }
 
-interface SpotlightDisplay_description { // fragment on Revisions
-  readonly html: string,
-}
-
 interface SpotlightDisplay_firstPost { // fragment on Posts
   readonly _id: string,
   readonly title: string,
@@ -2649,7 +2644,6 @@ interface SpotlightDisplay_firstPost { // fragment on Posts
 }
 
 interface SpotlightEditQueryFragment extends SpotlightMinimumInfo { // fragment on Spotlights
-  readonly description: RevisionEdit|null,
 }
 
 interface SuggestAlignmentComment extends CommentsList { // fragment on Comments

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -34,7 +34,7 @@ interface UsersDefaultFragment { // fragment on Users
   readonly noSingleLineComments: boolean,
   readonly noCollapseCommentsPosts: boolean,
   readonly noCollapseCommentsFrontpage: boolean,
-  readonly petrovOptOut: boolean,
+  readonly petrovOptOut: boolean | null,
   readonly hideNavigationSidebar: boolean,
   readonly currentFrontpageFilter: string,
   readonly frontpageFilterSettings: any /*{"definitions":[{"blackbox":true}]}*/,
@@ -2155,7 +2155,7 @@ interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBo
   readonly auto_subscribe_to_my_comments: boolean,
   readonly autoSubscribeAsOrganizer: boolean,
   readonly petrovPressedButtonDate: Date,
-  readonly petrovOptOut: boolean,
+  readonly petrovOptOut: boolean | null,
   readonly sortDraftsBy: string,
   readonly noindex: boolean,
   readonly paymentEmail: string,
@@ -2281,7 +2281,7 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly sortDraftsBy: string,
   readonly petrovPressedButtonDate: Date,
   readonly petrovLaunchCodeDate: Date,
-  readonly petrovOptOut: boolean,
+  readonly petrovOptOut: boolean | null,
   readonly lastUsedTimezone: string,
 }
 
@@ -2603,21 +2603,26 @@ interface UserVotes { // fragment on Votes
 
 interface SpotlightsDefaultFragment { // fragment on Spotlights
   readonly documentId: string,
-  readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Post","Sequence","Collection"]}]},"optional":false,"label":"Document type"}}]}*/,
+  readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Sequence","Collection","Post"]}]},"optional":false,"label":"Document type"}}]}*/,
   readonly position: number,
-  readonly spotlightImageId: string | null,
-  readonly draft: boolean,
   readonly lastPromotedAt: Date,
+  readonly draft: boolean,
+  readonly spotlightImageId: string | null,
+  readonly duration: number,
+  readonly customTitle: string | null,
+  readonly customSubtitle: string | null,
 }
 
 interface SpotlightMinimumInfo { // fragment on Spotlights
   readonly _id: string,
   readonly documentId: string,
-  readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Post","Sequence","Collection"]}]},"optional":false,"label":"Document type"}}]}*/,
+  readonly documentType: any /*{"definitions":[{"type":{"type":{"definitions":[{"allowedValues":["Sequence","Collection","Post"]}]},"optional":false,"label":"Document type"}}]}*/,
   readonly spotlightImageId: string | null,
   readonly draft: boolean,
   readonly position: number,
   readonly lastPromotedAt: Date,
+  readonly customTitle: string | null,
+  readonly customSubtitle: string | null,
 }
 
 interface SpotlightDisplay extends SpotlightMinimumInfo { // fragment on Spotlights

--- a/packages/lesswrong/lib/generated/viewTypes.ts
+++ b/packages/lesswrong/lib/generated/viewTypes.ts
@@ -27,7 +27,7 @@ type ReportsViewName = "allReports"|"unclaimedReports"|"claimedReports"|"adminCl
 type ReviewVotesViewName = "reviewVotesFromUser"|"reviewVotesForPost"|"reviewVotesForPostAndUser"|"reviewVotesAdminDashboard";
 type RevisionsViewName = "revisionsByUser"|"revisionsOnDocument";
 type SequencesViewName = "userProfile"|"userProfilePrivate"|"userProfileAll"|"curatedSequences"|"communitySequences";
-type SpotlightsViewName = never
+type SpotlightsViewName = "mostRecentlyPromotedSpotlights"|"spotlightsPage";
 type SubscriptionsViewName = "subscriptionState"|"subscriptionsOfType";
 type TagFlagsViewName = "allTagFlags";
 type TagRelsViewName = "postsWithTag"|"tagsOnPost";
@@ -65,7 +65,7 @@ interface ViewTermsByCollectionName {
   ReviewVotes: ReviewVotesViewTerms
   Revisions: RevisionsViewTerms
   Sequences: SequencesViewTerms
-  Spotlights: ViewTermsBase
+  Spotlights: SpotlightsViewTerms
   Subscriptions: SubscriptionsViewTerms
   TagFlags: TagFlagsViewTerms
   TagRels: TagRelsViewTerms
@@ -75,4 +75,4 @@ interface ViewTermsByCollectionName {
 }
 
 
-type NameOfCollectionWithViews = "AdvisorRequests"|"Chapters"|"Comments"|"Conversations"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"Localgroups"|"Messages"|"Notifications"|"PodcastEpisodes"|"PostRelations"|"Posts"|"RSSFeeds"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"Users"|"Votes"
+type NameOfCollectionWithViews = "AdvisorRequests"|"Chapters"|"Comments"|"Conversations"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"Localgroups"|"Messages"|"Notifications"|"PodcastEpisodes"|"PostRelations"|"Posts"|"RSSFeeds"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Spotlights"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"Users"|"Votes"

--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -2,7 +2,7 @@ import Spotlights from '../lib/collections/spotlights/collection';
 import { addCronJob } from './cronUtil';
 
 const MS_IN_DAY = 1000 * 60 * 60 * 24;
-const ACTIVE_DAYS = 3;
+const DEFAULT_ACTIVE_DAYS = 3;
 
 addCronJob({
   name: 'updatePromotedSpotlightItem',
@@ -26,7 +26,9 @@ addCronJob({
     const msSincePromotion = now.valueOf() - lastPromotionDate.valueOf();
     const daysSincePromotion = Math.floor(msSincePromotion / MS_IN_DAY);
 
-    if (daysSincePromotion < ACTIVE_DAYS) {
+    const duration = currentSpotlight.duration ?? DEFAULT_ACTIVE_DAYS
+
+    if (daysSincePromotion < duration) {
       return;
     }
 
@@ -45,7 +47,7 @@ addCronJob({
     // But doing it this way prevents a slow "walk" due to the cron job interval...
     // ...ensuring the promotion happens at around the same time, and each period length is still roughly constant
     const newPromotionDate = new Date(lastPromotionDate);
-    newPromotionDate.setDate(lastPromotionDate.getDate() + ACTIVE_DAYS);
+    newPromotionDate.setDate(lastPromotionDate.getDate() + DEFAULT_ACTIVE_DAYS);
 
     await Spotlights.rawUpdateOne({ position: positionToPromote, draft: false }, { $set: { lastPromotedAt: newPromotionDate } });
   }

--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -2,7 +2,7 @@ import Spotlights from '../lib/collections/spotlights/collection';
 import { addCronJob } from './cronUtil';
 
 const MS_IN_DAY = 1000 * 60 * 60 * 24;
-const DEFAULT_ACTIVE_DAYS = 3;
+export const DEFAULT_ACTIVE_DAYS = 3;
 
 addCronJob({
   name: 'updatePromotedSpotlightItem',

--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -2,7 +2,6 @@ import Spotlights from '../lib/collections/spotlights/collection';
 import { addCronJob } from './cronUtil';
 
 const MS_IN_DAY = 1000 * 60 * 60 * 24;
-export const DEFAULT_ACTIVE_DAYS = 3;
 
 addCronJob({
   name: 'updatePromotedSpotlightItem',
@@ -26,9 +25,7 @@ addCronJob({
     const msSincePromotion = now.valueOf() - lastPromotionDate.valueOf();
     const daysSincePromotion = Math.floor(msSincePromotion / MS_IN_DAY);
 
-    const duration = currentSpotlight.duration ?? DEFAULT_ACTIVE_DAYS
-
-    if (daysSincePromotion < duration) {
+    if (daysSincePromotion < currentSpotlight.duration) {
       return;
     }
 
@@ -47,7 +44,7 @@ addCronJob({
     // But doing it this way prevents a slow "walk" due to the cron job interval...
     // ...ensuring the promotion happens at around the same time, and each period length is still roughly constant
     const newPromotionDate = new Date(lastPromotionDate);
-    newPromotionDate.setDate(lastPromotionDate.getDate() + DEFAULT_ACTIVE_DAYS);
+    newPromotionDate.setDate(lastPromotionDate.getDate() + currentSpotlight.duration);
 
     await Spotlights.rawUpdateOne({ position: positionToPromote, draft: false }, { $set: { lastPromotedAt: newPromotionDate } });
   }


### PR DESCRIPTION
Adds custom titles and subtitles for spotlight items (the "Petrov Day" title in the example was originally a much longer "[LW Petrov Day 2022 (Monday, 9/26)](http://localhost:3000/posts/KTEciTeFwL2tTujZk/lw-petrov-day-2022-monday-9-26)").

Also adds a duration (measured in days), so that some spotlights can last longer or shorter than 3 days.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/3246710/192650654-8eda0c3e-13a4-4d75-af83-de3661ceaa1b.png">

<img width="836" alt="image" src="https://user-images.githubusercontent.com/3246710/192650943-0bf44bdc-4eff-47b7-8533-a979b0a69e16.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203060590064194) by [Unito](https://www.unito.io)
