### PR TITLE
update NewPostEmail to include podcast info for posts with podcasts

### DIFF
--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -47,7 +47,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const getPodcastInfoElement = (podcastEpisode: PostsDetails_podcastEpisode) => {
-  const { podcast: { title, applePodcastLink, spotifyPodcastLink }, episodeLink, externalEpisodeId } = podcastEpisode;
+  const { podcast: { applePodcastLink, spotifyPodcastLink }, episodeLink, externalEpisodeId } = podcastEpisode;
   const episodeUrl = new URL(episodeLink);
 
   // episodeLink is something like https://www.buzzsprout.com/2037297/11391281-...
@@ -66,7 +66,7 @@ const getPodcastInfoElement = (podcastEpisode: PostsDetails_podcastEpisode) => {
   const externalDirectoryAvailability = !!spotifyLinkElement && !!appleLinkElement;
 
   return <p>
-    This post has been recorded as part of the {title}, and can be listened to on {buzzsproutLinkElement}.
+    Listen to the podcast recording version of this post on {buzzsproutLinkElement}.
     {externalDirectoryAvailability ? '  It is also available on ' + spotifyLinkElement + ' and ' + appleLinkElement + '.' : ''}
   </p>;
 };

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -100,11 +100,6 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
     </a> : "Online Event"
   }
 
-  let podcastInfo: JSX.Element | undefined;
-  if (document.podcastEpisode) {
-    podcastInfo = getPodcastInfoElement(document.podcastEpisode);
-  }
-
   return (<React.Fragment>
     <div className={classes.heading}>
       <h1>
@@ -131,8 +126,8 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
       </div>}
     </div>
 
-    {podcastInfo && <div className={classes.podcastRow}>
-      {podcastInfo}
+    {document.podcastEpisode && <div className={classes.podcastRow}>
+      {getPodcastInfoElement(document.podcastEpisode)}
       <hr />
     </div>}
     

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -66,8 +66,8 @@ const getPodcastInfoElement = (podcastEpisode: PostsDetails_podcastEpisode) => {
   const externalDirectoryAvailability = !!spotifyLinkElement && !!appleLinkElement;
 
   return <p>
-    Listen to the podcast recording version of this post on {buzzsproutLinkElement}.
-    {externalDirectoryAvailability ? '  It is also available on ' + spotifyLinkElement + ' and ' + appleLinkElement + '.' : ''}
+    Listen to the podcast version of this post on {buzzsproutLinkElement}.
+    {externalDirectoryAvailability ? ' You can also find it on ' + spotifyLinkElement + ' and ' + appleLinkElement + '.' : ''}
   </p>;
 };
 


### PR DESCRIPTION
Top row: new info (inserted in `NewPostEmail`).  Bottom row: old info (manually edited into the post body; won't be added to new posts going forward).  Both displayed for styling comparison.

![](https://user-images.githubusercontent.com/2136984/192648952-1f7a6562-3d3f-4814-9867-66ffba422f49.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203061107972590) by [Unito](https://www.unito.io)
