### PR TITLE
npe in moderation log

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
@@ -70,7 +70,7 @@ const DeletedByUserDisplay = ({column, document}) => {
 
 
 const BannedUsersDisplay = ({column, document}) => {
-  const bannedUsers = document[column.name]
+  const bannedUsers = document[column.name] ?? []
   return <div>
     { bannedUsers.map((userId) => <div key={userId}>
       <Components.UsersNameWrapper documentId={userId} nofollow />


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/2136984/192869803-7e69ea6c-8810-4783-b1f2-d161b4b47906.png)

For some reason this only happens when either opening the notifications sidebar, or opening and then closing karma notifications.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203068013127898) by [Unito](https://www.unito.io)
