### PR TITLE
Spotlights history on Recommendations page

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const RecommendationsPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { ConfigurableRecommendationsList, RecommendationsPageCuratedList } = Components;
+  const { ConfigurableRecommendationsList, RecommendationsPageCuratedList, SpotlightHistory  } = Components;
 
   return (
     <AnalyticsContext pageSectionContext={"recommendationsPage"} capturePostItemOnMount>
+      {forumTypeSetting.get() === "LessWrong" && <SpotlightHistory/>}
       <RecommendationsPageCuratedList/>
       <ConfigurableRecommendationsList configName="recommendationspage" />
     </AnalyticsContext>

--- a/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
@@ -5,12 +5,6 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { userCanDo } from '../../lib/vulcan-users';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = (theme: ThemeType): JssStyles => ({
-  root: {
-
-  }
-});
-
 export const SpotlightHistory = ({classes}: {
   classes: ClassesType,
 }) => {
@@ -39,7 +33,7 @@ export const SpotlightHistory = ({classes}: {
   </SingleColumnSection>;
 }
 
-const SpotlightHistoryComponent = registerComponent('SpotlightHistory', SpotlightHistory, {styles});
+const SpotlightHistoryComponent = registerComponent('SpotlightHistory', SpotlightHistory);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { Link } from '../../lib/reactRouterWrapper';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { userCanDo } from '../../lib/vulcan-users';
+import { useCurrentUser } from '../common/withUser';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+
+  }
+});
+
+export const SpotlightHistory = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const { SingleColumnSection, SectionTitle, SpotlightItem, LoadMore } = Components
+
+  const currentUser = useCurrentUser()
+
+  const { results: spotlights = [], loadMoreProps } = useMulti({
+    collectionName: 'Spotlights',
+    fragmentName: 'SpotlightDisplay',
+    terms: {
+      view: "mostRecentlyPromotedSpotlights",
+      limit: 1
+    },
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'network-only',
+    itemsPerPage: 50
+  });
+
+  const title = userCanDo(currentUser, 'spotlights.edit.all') ? <Link to={"/spotlights"}>Spotlights</Link> : <div>Spotlights</div>
+
+  return <SingleColumnSection className={classes.root}>
+    <SectionTitle title={title}/>
+    {spotlights.map(spotlight => <SpotlightItem key={spotlight._id} spotlight={spotlight}/>)}
+    <LoadMore {...loadMoreProps}/>
+  </SingleColumnSection>;
+}
+
+const SpotlightHistoryComponent = registerComponent('SpotlightHistory', SpotlightHistory, {styles});
+
+declare global {
+  interface ComponentTypes {
+    SpotlightHistory: typeof SpotlightHistoryComponent
+  }
+}
+

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -665,6 +665,7 @@ importComponent("RecommendationsPage", () => require('../components/recommendati
 importComponent("CuratedPostsList", () => require('../components/recommendations/CuratedPostsList'));
 importComponent("RecommendationsPageCuratedList", () => require('../components/recommendations/RecommendationsPageCuratedList'));
 importComponent("RecommendationsAndCurated", () => require('../components/recommendations/RecommendationsAndCurated'));
+importComponent("SpotlightHistory", () => require('../components/spotlights/SpotlightHistory'));
 importComponent("SpotlightItem", () => require('../components/spotlights/SpotlightItem'));
 importComponent("SpotlightEditorStyles", () => require('../components/spotlights/SpotlightEditorStyles'));
 


### PR DESCRIPTION
I kept wanting click the "recommendations" header on the frontpage to get to the spotlights page. I also separately think the Recommendations page should mirror whatever's in the Recommendations section, and thirdly think it'll be somewhat convenient for users to occasionally be able to check what a recent spotlight was if they didn't finish reading it and forgot what it was.

So... I made a quick update to the Recommendations page to include a spotlight section, and when you click on the spotlight-section-title if you're an admin/sunshine it takes you to the /spotlights page.

![](https://user-images.githubusercontent.com/3246710/192878427-c8f18fe0-1577-4e8e-8118-d9c9b938fa8a.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203068373639285) by [Unito](https://www.unito.io)
