### PR TITLE
Minor spotlight fixes

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightHistory.tsx
@@ -26,7 +26,7 @@ export const SpotlightHistory = ({classes}: {
 
   const title = userCanDo(currentUser, 'spotlights.edit.all') ? <Link to={"/spotlights"}>Spotlight Items</Link> : <div>Spotlight Items</div>
 
-  return <SingleColumnSection className={classes.root}>
+  return <SingleColumnSection>
     <SectionTitle title={title}/>
     {spotlights.map(spotlight => <SpotlightItem key={spotlight._id} spotlight={spotlight}/>)}
     <LoadMore {...loadMoreProps}/>

--- a/packages/lesswrong/lib/collections/spotlights/permissions.ts
+++ b/packages/lesswrong/lib/collections/spotlights/permissions.ts
@@ -1,7 +1,9 @@
+import { sunshineRegimentGroup } from "../../permissions";
 import { adminsGroup } from "../../vulcan-users";
 
-const adminActions = [
+const actions = [
   'spotlights.edit.all',
 ];
 
-adminsGroup.can(adminActions);
+adminsGroup.can(actions);
+sunshineRegimentGroup.can(actions)


### PR DESCRIPTION
Allow sunshines to edit spotlights, and remove unused class that's currently breaking the /recommendations page



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203069577405780) by [Unito](https://www.unito.io)
