### PR TITLE
Add missing param checks for getLocalTime

### DIFF
--- a/packages/lesswrong/server/mapsUtils.ts
+++ b/packages/lesswrong/server/mapsUtils.ts
@@ -10,6 +10,16 @@ export async function getLocalTime(time, googleLocation) {
     console.log("No Server-side Google Maps API key provided, can't resolve local time")
     return null
   }
+  if (!googleLocation) {
+    // eslint-disable-next-line no-console
+    console.log("No googleLocation provided")
+    return null
+  }
+  if (!time) {
+    // eslint-disable-next-line no-console
+    console.log("No time provided")
+    return null
+  }
   const googleMapsClient = new Client({});
 
   try {


### PR DESCRIPTION
I originally included this in https://github.com/ForumMagnum/ForumMagnum/pull/5512, but wanted to move it over into a separate PR so that the ACX migration PR could get merged safely without having to think too hard.

I don't actually remember how to replicate the situation where `googleLocation` or `time` are missing.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203069747846957) by [Unito](https://www.unito.io)
