### PR TITLE
Don't double check document permissions after checking collab permissions

### DIFF
--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -6,6 +6,7 @@ import { Revisions } from '../../lib/collections/revisions/collection';
 import { isCollaborative } from '../../components/editor/EditorFormComponent';
 import { defineQuery, defineMutation } from '../utils/serverGraphqlUtil';
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
+import { restrictViewableFields } from '../../lib/vulcan-users/permissions';
 import { revisionIsChange } from '../editor/make_editable_callbacks';
 import { updateMutator } from '../vulcan-lib/mutators';
 import { pushRevisionToCkEditor } from './ckEditorWebhook';
@@ -112,7 +113,7 @@ defineQuery({
       }
       
       // Return the post
-      const filteredPost = await accessFilterSingle(currentUser, Posts, post, context);
+      const filteredPost = restrictViewableFields(currentUser, Posts, post);
       return filteredPost;
     } else {
       throw new Error("Invalid postId or not shared with you");


### PR DESCRIPTION
We currently have a bug where draft posts that are publically editable are inaccessible the first time they're accessed with a sharing key. This is what happens:

* The user visits the `collaborateOnPost` page with a valid sharing key
* We validate this at lines 100 and 101 which evaluate to true
* We add the user to the `linkSharingKeyUsedBy` array in mongo at line 108, but don't update our `post` local variable
* We filter the post with `accessFilterSingle` which fails because the post is a draft and hasn't been explicitly shared with the user
* The endpoint returns `null` so we display a "You don't have permission" message
* The next time the user visits the page the filter will work because they'll have been added to the `linkSharingKeyUsedBy` array already. Note that we can't simply just do `post = await Posts.rawUpdateOne(...` at line 108 because `rawUpdateOne` returns the number of matched documents, not the updated document.

The simple fix here seems to just be to use `restrictViewableFields` instead of `accessFilterSingle`. This should be safe since we've already applied the special rules for collab post visibility before we get here.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203072759672488) by [Unito](https://www.unito.io)
