### PR TITLE
Show different messages for logged-out users viewing a crosspost fr a new account

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -18,7 +18,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   contentNotice: {
     ...theme.typography.contentNotice,
-    ...theme.typography.postStyle
+    ...theme.typography.postStyle,
+    maxWidth: 600,
   },
   infoIcon: {
     width: 16,
@@ -62,15 +63,18 @@ const PostBodyPrefix = ({post, query, classes}: {
 
     <AlignmentCrosspostMessage post={post} />
     <AlignmentPendingApprovalMessage post={post} />
-    
+
     {post.shortform && post.draft && <div className={classes.contentNotice}>
       This is a special post that holds your short-form writing. Because it's
       marked as a draft, your short-form posts will not be displayed. To un-draft
       it, pick Edit from the menu above, then click Publish.
     </div>}
-    
+
     {post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>
-      Because this is your first post, this post is awaiting moderator approval.
+      {currentUser?._id === post.userId
+        ? "Because this is your first post, this post is awaiting moderator approval."
+        : "This post is unlisted and is still awaiting moderation.\nUsers' first posts need to go through moderation."
+      }
       <LWTooltip title={<p>
         New users' first posts on {siteNameWithArticleSetting.get()} are checked by moderators before they appear on the site.
         Most posts will be approved within 24 hours; posts that are spam or that don't meet site


### PR DESCRIPTION
The approach here is just to show a more appropriate message rather than to do anything too fancy. I also added a `maxWidth` as it makes the wrapping a bit more sane with the longer message.

LessWrong as the author:
![Screenshot 2022-09-29 at 18 39 02](https://user-images.githubusercontent.com/5075628/193103617-0591b786-aba2-4840-b9d7-879a3ef87810.png)

LessWrong as a different user:
![Screenshot 2022-09-29 at 18 37 52](https://user-images.githubusercontent.com/5075628/193103650-a77419eb-8991-4350-acba-6c1a96ff37e3.png)

EA Forum as the author:
![Screenshot 2022-09-29 at 18 43 42](https://user-images.githubusercontent.com/5075628/193104661-a78ff469-a2db-4251-8e57-1f59cb4e1bc3.png)

EA Forum as a different user:
![Screenshot 2022-09-29 at 18 44 21](https://user-images.githubusercontent.com/5075628/193104680-307ab854-e4d0-4424-881a-34fd57adcb0f.png)

These posts still aren't visible to logged-out users, but I feel like this is potentially the correct behaviour anyway(?):
![Screenshot 2022-09-29 at 18 46 16](https://user-images.githubusercontent.com/5075628/193105070-a31c0329-1dd2-4a2d-b0cb-54f71d7b6ee5.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203075369278820) by [Unito](https://www.unito.io)
