### PR TITLE
Move crosspost comments below comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -160,7 +160,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
       {newForm && (!currentUser || !post || userIsAllowedToComment(currentUser, post, postAuthor)) && !post?.draft &&
         <div id="posts-thread-new-comment" className={classes.newComment}>
           <div className={classes.newCommentLabel}>New Comment</div>
-          {post?.isEvent && post?.rsvps?.length && (
+          {post?.isEvent && (post?.rsvps?.length > 0) && (
             <div className={classes.newCommentSublabel}>
               Everyone who RSVP'd to this event will be notified.
             </div>
@@ -176,7 +176,6 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
       {currentUser && post && !userIsAllowedToComment(currentUser, post, postAuthor) &&
         <Components.CantCommentExplanation post={post}/>
       }
-      <Components.PostsPageCrosspostComments />
       <Components.CommentsList
         treeOptions={{
           highlightDate: highlightDate,
@@ -189,6 +188,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
       />
+      <Components.PostsPageCrosspostComments />
     </div>
   );
 }


### PR DESCRIPTION
On LessWrong's end, it was feeling too prominent for EA comments to be the very first thing you saw in the comment's feed.

(Theoretically this could be forum-gated, but... seemed fair if we were lowering the prominence of EAF comments that EAF lower the prominence of ours :P)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203075934975682) by [Unito](https://www.unito.io)
