### PR TITLE
fix spotlight item used to get next spotlight item position

### DIFF
--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -25,8 +25,6 @@ addCronJob({
     const msSincePromotion = now.valueOf() - lastPromotionDate.valueOf();
     const daysSincePromotion = Math.floor(msSincePromotion / MS_IN_DAY);
 
-    console.log({ daysSincePromotion, currentSpotlight });
-
     if (daysSincePromotion < currentSpotlight.duration) {
       return;
     }
@@ -39,8 +37,6 @@ addCronJob({
     const promoteIndex = lastSpotlightPosition > currentSpotlightPosition
       ? positionAscOrderedSpotlights.indexOf(currentSpotlight) + 1
       : 0;
-
-    console.log({ promoteIndex, positionAscOrderedSpotlights })
 
     const { position: positionToPromote } = positionAscOrderedSpotlights[promoteIndex];
 

--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -25,6 +25,8 @@ addCronJob({
     const msSincePromotion = now.valueOf() - lastPromotionDate.valueOf();
     const daysSincePromotion = Math.floor(msSincePromotion / MS_IN_DAY);
 
+    console.log({ daysSincePromotion, currentSpotlight });
+
     if (daysSincePromotion < currentSpotlight.duration) {
       return;
     }
@@ -35,8 +37,10 @@ addCronJob({
     // If we have any further spotlight items after the current one, promote the next one
     // Otherwise, roll over to the start
     const promoteIndex = lastSpotlightPosition > currentSpotlightPosition
-      ? positionAscOrderedSpotlights.indexOf(lastSpotlightByPosition) + 1
+      ? positionAscOrderedSpotlights.indexOf(currentSpotlight) + 1
       : 0;
+
+    console.log({ promoteIndex, positionAscOrderedSpotlights })
 
     const { position: positionToPromote } = positionAscOrderedSpotlights[promoteIndex];
 


### PR DESCRIPTION
Noticed some errors being thrown locally when running a dev server by the new spotlight cron job.  Turns out it was using the wrong spotlight item to get the current spotlight item's index, in order to get the next spotlight item's position.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203076959328456) by [Unito](https://www.unito.io)
