### PR TITLE
[WIP] Add comment-on-selection toolbar

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -211,7 +211,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
   render () {
     const {currentUser, location, children, classes, theme, cookies} = this.props;
     const {hideNavigationSidebar} = this.state
-    const { NavigationStandalone, ErrorBoundary, Footer, Header, FlashMessages, AnalyticsClient, AnalyticsPageInitializer, NavigationEventSender, PetrovDayWrapper, NewUserCompleteProfile, HomepageCommunityMap } = Components
+    const { NavigationStandalone, ErrorBoundary, Footer, Header, FlashMessages, AnalyticsClient, AnalyticsPageInitializer, NavigationEventSender, PetrovDayWrapper, NewUserCompleteProfile, HomepageCommunityMap, CommentOnSelectionPageWrapper } = Components
 
     const showIntercom = (currentUser: UsersCurrent|null) => {
       if (currentUser && !currentUser.hideIntercom) {
@@ -280,6 +280,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
         },
       }}>
       <TableOfContentsContext.Provider value={this.setToC}>
+      <CommentOnSelectionPageWrapper>
         <div className={classNames("wrapper", classes.wrapper, {'alignment-forum': forumTypeSetting.get() === 'AlignmentForum'}) } id="wrapper">
           <DialogManager>
             <CommentBoxManager>
@@ -335,6 +336,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
             </CommentBoxManager>
           </DialogManager>
         </div>
+      </CommentOnSelectionPageWrapper>
       </TableOfContentsContext.Provider>
       </ItemsReadContext.Provider>
       </TimezoneContext.Provider>

--- a/packages/lesswrong/components/comments/ReplyCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/ReplyCommentDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { Link } from '../../lib/reactRouterWrapper';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  popup: {
+    position: "fixed",
+    background: theme.palette.panelBackground.default,
+    border: theme.palette.border.normal,
+    boxShadow: theme.palette.boxShadow.default,
+    bottom: 0,
+    right: 20,
+    width: 500,
+    height: 400,
+  },
+  heading: {
+    background: theme.palette.primary.dark,
+    padding: 8,
+  },
+  title: {
+    ...theme.typography.commentStyle,
+    color: theme.palette.text.invertedBackgroundText,
+    fontSize: "1.2rem"
+  },
+  closeButton: {
+    position: "absolute",
+    top: 4,
+    right: 4,
+    color: theme.palette.text.invertedBackgroundText,
+    cursor: "pointer",
+  },
+  form: {
+    padding: 8,
+  },
+})
+
+
+const ReplyCommentDialog = ({post, initialText, onClose, classes}: {
+  post: PostsBase,
+  initialText: string, //TODO
+  onClose?: ()=>void,
+  classes: ClassesType,
+}) => {
+  const { CommentsNewForm, Typography, LWDialog } = Components;
+  
+  const closeDialog = () => {
+    onClose?.();
+  }
+
+  return (
+    <div className={classes.popup}>
+      <div className={classes.heading}>
+        <div className={classes.title}>{post.title}</div>
+        <div className={classes.closeButton} onClick={closeDialog}>X</div>
+      </div>
+      <div className={classes.form}>
+        <CommentsNewForm
+          post={post}
+          padding={false}
+          successCallback={onClose}
+          enableGuidelines={false}
+          type="comment"
+        />
+      </div>
+    </div>
+  );
+}
+
+const ReplyCommentDialogComponent = registerComponent('ReplyCommentDialog', ReplyCommentDialog, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ReplyCommentDialog: typeof ReplyCommentDialogComponent
+  }
+}
+

--- a/packages/lesswrong/components/hooks/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/hooks/CommentOnSelection.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useContext, useState, useRef } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import CommentIcon from '@material-ui/icons/ModeComment';
+
+const selectedTextToolbarStyles = (theme: ThemeType): JssStyles => ({
+  root: {
+    background: "#aaa", //TODO
+    border: "1px solid black", //TODO
+    position: "absolute",
+    zIndex: 10000, //TODO
+    padding: 8,
+    marginTop: -32,
+    marginLeft: -32,
+  },
+  commentIcon: {
+  },
+});
+
+// CommentOnSelectionPageWrapper is used in Layout, and wraps the whole page
+// CommentOnSelectionContentWrapper wraps elements in which the content is selectable
+
+interface CommentOnSelectionContextType {
+}
+
+export const CommentOnSelectionContext = React.createContext<CommentOnSelectionContextType|null>(null);
+
+type SelectedTextToolbarState =
+    {open: false}
+  | {open: true, x: number, y: number}
+
+const CommentOnSelectionPageWrapper = ({children}: {
+  children: React.ReactNode
+}) => {
+  const { SelectedTextToolbar } = Components;
+  const [toolbarState,setToolbarState] = useState<SelectedTextToolbarState>({open: false});
+ 
+  useEffect(() => {
+    const selectionChangedHandler = (event) => {
+      const selection = document.getSelection();
+      const selectionText = selection+"";
+      
+      // Is this selection non-empty?
+      if (!selection || !selectionText?.length) {
+        setToolbarState({open: false});
+        return;
+      }
+      
+      // Determine whether this selection is fully wrapped in a single CommentOnSelectionWrapper
+      let commonWrapper: Node|null = null;
+      let hasCommonWrapper = true;
+      for (let i=0; i<selection.rangeCount; i++) {
+        const range = selection.getRangeAt(i);
+        const container = range.commonAncestorContainer;
+        const wrapper = nearestAncestorElementWith(
+          container,
+          n=>!!((n as any).onClickComment)
+        );
+        if (commonWrapper) {
+          if (container !== commonWrapper) {
+            hasCommonWrapper = false;
+          }
+        } else {
+          commonWrapper = wrapper;
+        }
+      }
+      
+      // Get the bounding box of the selection
+      const boundingRect = selection.getRangeAt(0).getBoundingClientRect();
+      
+      // Place the toolbar
+      const x = boundingRect.x + (boundingRect.width/2) + window.scrollX;
+      const y = boundingRect.y + window.scrollY;
+      setToolbarState({open: true, x,y});
+    };
+    document.addEventListener('selectionchange', selectionChangedHandler);
+    
+    return () => {
+      document.removeEventListener('selectionchange', selectionChangedHandler);
+    };
+  }, []);
+  
+  const onClickComment = (ev) => {
+    const firstSelectedNode = document.getSelection()?.anchorNode;
+    if (!firstSelectedNode) {
+      return;
+    }
+    const contentWrapper = nearestAncestorElementWith(
+      firstSelectedNode,
+      n=>!!((n as any).onClickComment)
+    );
+    if (!contentWrapper) {
+      return;
+    }
+    const selection = document.getSelection();
+    const selectionText = selection+"";
+    (contentWrapper as any).onClickComment(selectionText);
+  }
+  
+  return <CommentOnSelectionContext.Provider value={{}}>
+    {children}
+    {toolbarState.open && <SelectedTextToolbar
+      onClickComment={onClickComment}
+      x={toolbarState.x} y={toolbarState.y}
+    />}
+  </CommentOnSelectionContext.Provider>
+}
+
+const SelectedTextToolbar = ({onClickComment, x, y, classes}: {
+  onClickComment: (ev)=>void,
+  x: number, y: number,
+  classes: ClassesType,
+}) => {
+  return <div className={classes.root} style={{left: x, top: y}}>
+    <CommentIcon className={classes.commentIcon} onClick={ev => onClickComment(ev)}/>
+  </div>
+}
+
+
+const CommentOnSelectionContentWrapper = ({onClickComment, children}: {
+  onClickComment: (text: string)=>void,
+  children: React.ReactNode,
+}) => {
+  const wrapperSpanRef = useRef<HTMLSpanElement|null>(null);
+  
+  useEffect(() => {
+    if (wrapperSpanRef.current) {
+      let modifiedSpan = (wrapperSpanRef.current as any)
+      modifiedSpan.onClickComment = onClickComment;
+      
+      return () => {
+        modifiedSpan.onClickComment = null;
+      }
+    }
+  }, [onClickComment]);
+  
+  return <span className="commentOnSelection" ref={wrapperSpanRef}>
+    {children}
+  </span>
+}
+
+function nearestAncestorElementWith(start: Node, fn: (node: Node)=>boolean): Node|null {
+  let pos: Node|null = start;
+  while(pos && !fn(pos)) {
+    pos = pos.parentElement;
+  }
+  return pos;
+}
+
+
+
+const CommentOnSelectionPageWrapperComponent = registerComponent('CommentOnSelectionPageWrapper', CommentOnSelectionPageWrapper);
+const SelectedTextToolbarComponent = registerComponent(
+  'SelectedTextToolbar', SelectedTextToolbar,
+  {styles: selectedTextToolbarStyles}
+);
+const CommentOnSelectionContentWrapperComponent = registerComponent("CommentOnSelectionContentWrapper", CommentOnSelectionContentWrapper);
+
+declare global {
+  interface ComponentTypes {
+    CommentOnSelectionPageWrapper: typeof CommentOnSelectionPageWrapperComponent
+    SelectedTextToolbar: typeof SelectedTextToolbarComponent
+    CommentOnSelectionContentWrapper: typeof CommentOnSelectionContentWrapperComponent,
+  }
+}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useLocation } from '../../../lib/routeUtil';
 import { postGetPageUrl } from '../../../lib/collections/posts/helpers';
@@ -16,6 +16,7 @@ import { welcomeBoxes } from './WelcomeBox';
 import { useABTest } from '../../../lib/abTestImpl';
 import { welcomeBoxABTest } from '../../../lib/abTests';
 import { useCookies } from 'react-cookie';
+import { useDialog } from '../../common/withDialog';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -146,6 +147,7 @@ const PostsPage = ({post, refetch, classes}: {
 }) => {
   const location = useLocation();
   const currentUser = useCurrentUser();
+  const { openDialog } = useDialog();
   const { recordPostView } = useRecordPostView(post);
 
   const { captureEvent } = useTracking();
@@ -188,7 +190,8 @@ const PostsPage = ({post, refetch, classes}: {
   const { HeadTags, PostsPagePostHeader, PostsPagePostFooter, PostBodyPrefix,
     PostsCommentsThread, ContentItemBody, PostsPageQuestionContent, PostCoauthorRequest,
     CommentPermalink, AnalyticsInViewTracker, ToCColumn, WelcomeBox, TableOfContents, RSVPs,
-    PostsPodcastPlayer, AFUnreviewedCommentCount, CloudinaryImage2, ContentStyles
+    PostsPodcastPlayer, AFUnreviewedCommentCount, CloudinaryImage2, ContentStyles,
+    CommentOnSelectionContentWrapper
   } = Components
 
   useEffect(() => {
@@ -224,6 +227,16 @@ const PostsPage = ({post, refetch, classes}: {
   if (post.isEvent && post.eventImageId) {
     socialPreviewImageUrl = `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/c_fill,g_auto,ar_16:9/${post.eventImageId}`
   }
+  
+  const onClickCommentOnSelection = useCallback((text: string) => {
+    openDialog({
+      componentName:"ReplyCommentDialog",
+      componentProps: {
+        post, initialText: text
+      },
+      noClickawayCancel: true,
+    })
+  }, [openDialog, post]);
 
   const tableOfContents = sectionData
     ? <TableOfContents sectionData={sectionData} title={post.title} />
@@ -272,7 +285,9 @@ const PostsPage = ({post, refetch, classes}: {
         <ContentStyles contentType="post" className={classes.postContent}>
           <PostBodyPrefix post={post} query={query}/>
           <AnalyticsContext pageSectionContext="postBody">
-            { htmlWithAnchors && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`} nofollow={(post.user?.karma || 0) < nofollowKarmaThreshold.get()}/> }
+            <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>
+              { htmlWithAnchors && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`} nofollow={(post.user?.karma || 0) < nofollowKarmaThreshold.get()}/> }
+            </CommentOnSelectionContentWrapper>
           </AnalyticsContext>
         </ContentStyles>
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -393,6 +393,7 @@ importComponent("CommentById", () => require('../components/comments/CommentById
 importComponent("CommentWithReplies", () => require('../components/comments/CommentWithReplies'));
 importComponent("CommentOnPostWithReplies", () => require('../components/comments/CommentOnPostWithReplies'));
 importComponent("CommentPermalink", () => require('../components/comments/CommentPermalink'));
+importComponent("ReplyCommentDialog", () => require('../components/comments/ReplyCommentDialog'));
 importComponent("RecentDiscussionThread", () => require('../components/recentDiscussion/RecentDiscussionThread'));
 importComponent("RecentDiscussionThreadsList", () => require('../components/recentDiscussion/RecentDiscussionThreadsList'));
 importComponent("RecentDiscussionFeed", () => require('../components/recentDiscussion/RecentDiscussionFeed'));
@@ -628,6 +629,8 @@ importComponent("TagFlagToggleList", () => require('../components/form-component
 importComponent("SelectLocalgroup", () => require('../components/form-components/SelectLocalgroup'));
 importComponent("PrefixedInput", () => require('../components/form-components/PrefixedInput'));
 importComponent("PodcastEpisodeInput", () => require('../components/form-components/PodcastEpisodeInput'));
+
+importComponent(["CommentOnSelectionPageWrapper","SelectedTextToolbar","CommentOnSelectionContentWrapper"], () => require('../components/hooks/CommentOnSelection'));
 
 importComponent("HomepageCommunityMap", () => require('../components/seasonal/HomepageMap/HomepageCommunityMap'));
 importComponent("HomepageMapFilter", () => require('../components/seasonal/HomepageMap/HomepageMapFilter'));


### PR DESCRIPTION
In response to a conversation with Ruby about inline commenting, and the observation that commenting on something in the middle of a post is high-friction because you have to scroll away and lose your place. A prototype:

When you highlight text in a post, a little toolbar appears over the selection, with one button (a comment button). When you click the button, a comment editor appears in the bottom-right corner.

Future work:
* Decide whether this interaction is a good idea overall
* Prepopulate the comment editor with a blockquote of the selection
* Make the styling work
* Delay showing the toolbar until you release the mouse button