### PR TITLE
Fixes to mobile view of subforums

### DIFF
--- a/packages/lesswrong/components/comments/CommentsTimeline.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimeline.tsx
@@ -52,8 +52,18 @@ const CommentsTimelineFn = ({
   // Scroll to the bottom when the page loads
   const currentHeight = bodyRef.current?.clientHeight;
   useEffect(() => {
-    if (!userHasScrolled && bodyRef.current)
+    if (!userHasScrolled && bodyRef.current) {
       bodyRef.current?.scrollTo(0, bodyRef.current.scrollHeight);
+
+      // For mobile: scroll the entire page to the bottom to stop the address bar from
+      // forcing the bottom off the end of the page. On desktop this just does nothing
+      // because the page fills the screen exactly
+      window.scrollTo({
+        top: 500,
+        // 'smooth' is to try and encourage it to scroll the address bar off the scree rather than overlaying it
+        behavior: 'smooth'
+      });
+    }
   }, [currentHeight, userHasScrolled])
 
   const { CommentWithReplies, Typography } = Components;

--- a/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
@@ -107,10 +107,14 @@ const CommentsTimelineSection = ({
   }, [])
 
   const recalculateTopAbsolutePosition = () => {
-    if (bodyRef.current && bodyRef.current.getBoundingClientRect().top !== topAbsolutePosition)
-      setTopAbsolutePosition(bodyRef.current.getBoundingClientRect().top)
+    if (!bodyRef.current) return
+
+    // We want the position relative to the top of the page, not the top of the viewport, so add window.scrollY
+    const newPos = bodyRef.current.getBoundingClientRect().top + window.scrollY
+    if (newPos !== topAbsolutePosition)
+      setTopAbsolutePosition(newPos)
   }
-  
+
   const {CommentsTimeline, InlineSelect, CommentsNewForm, Typography, SubforumSubscribeSection} = Components
 
   return (


### PR DESCRIPTION
This fixes two bugs:


* when you tapped in and out of the text box the timeline view could end up the wrong size due to not accounting for window.scrollY when measuring it's position
* the address bar pushed the text box off the end of the page



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203079720982588) by [Unito](https://www.unito.io)
