### PR TITLE
Fix missing bullets in Google Docs publish-to-web paste

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/utils.ts
+++ b/packages/lesswrong/server/vulcan-lib/utils.ts
@@ -61,7 +61,6 @@ export const sanitize = function(s: string): string {
       li: [ 'footnote-item' ],
     },
     allowedStyles: {
-      ...(sanitizeHtml.defaults as any).allowedStyles, // TODO: prolly a noop
       figure: {
         'width': [/^(?:\d|\.)+(?:px|em|%)$/],
         'height': [/^(?:\d|\.)+(?:px|em|%)$/],

--- a/packages/lesswrong/server/vulcan-lib/utils.ts
+++ b/packages/lesswrong/server/vulcan-lib/utils.ts
@@ -61,7 +61,7 @@ export const sanitize = function(s: string): string {
       li: [ 'footnote-item' ],
     },
     allowedStyles: {
-      ...(sanitizeHtml.defaults as any).allowedStyles,
+      ...(sanitizeHtml.defaults as any).allowedStyles, // TODO: prolly a noop
       figure: {
         'width': [/^(?:\d|\.)+(?:px|em|%)$/],
         'height': [/^(?:\d|\.)+(?:px|em|%)$/],

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -514,7 +514,10 @@ export const ckEditorStyles = (theme: ThemeType): JssStyles => {
         '& .ck-annotation__user, & .ck-thread__user': {
           display: "none"
         },
-        '--ck-color-comment-count': theme.palette.primary.main
+        '--ck-color-comment-count': theme.palette.primary.main,
+        '& ol, & ul': {
+          listStyleType: "revert !important",
+        }
       },
       
       "--ck-color-base-background": theme.palette.editor.commentPanelBackground,

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -458,6 +458,9 @@ export const ckEditorStyles = (theme: ThemeType): JssStyles => {
         '& hr': {
           ...hrStyles(theme)
         },
+        '& ol, & ul': {
+          listStyleType: "revert !important",
+        },
       },
       '& .ck-placeholder:before': {
         whiteSpace: 'break-spaces'
@@ -515,9 +518,6 @@ export const ckEditorStyles = (theme: ThemeType): JssStyles => {
           display: "none"
         },
         '--ck-color-comment-count': theme.palette.primary.main,
-        '& ol, & ul': {
-          listStyleType: "revert !important",
-        }
       },
       
       "--ck-color-base-background": theme.palette.editor.commentPanelBackground,


### PR DESCRIPTION
This PR fixes an issue in copy-pasted content from Google Docs' publish-to-web view. That view uses an inline style of `list-style-type: none` on `ul`s and `ol`s to allow for their custom bullets, which, when pasted into CKEditor, caused bullets to look like indents.

Fixes https://github.com/ForumMagnum/ForumMagnum/issues/5531



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203084020603583) by [Unito](https://www.unito.io)
