### PR TITLE
Update git clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Forum Magnum is built on top of a number major open-source libraries.
 Clone our repo:
 
 ```
-git clone git@github.com:ForumMagnum/ForumMagnum.git
+git clone https://github.com/ForumMagnum/ForumMagnum.git
 ```
 
 Install dependencies:


### PR DESCRIPTION
Previous instructions would cause a 'Permission Denied' error when trying to clone the repo, whereas the new URL is the one suggested for use by GitHub.

Please let me know if I've missed something and there was a reason for the original though!



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203085199999026) by [Unito](https://www.unito.io)
