### PR TITLE
Users can self-deactivate

### DIFF
--- a/packages/lesswrong/lib/collections/users/formGroups.ts
+++ b/packages/lesswrong/lib/collections/users/formGroups.ts
@@ -68,4 +68,10 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     order: 120,
     label: 'My Activity'
   },
+  deactivate: {
+    order: 130,
+    name: "deactivate",
+    label: "Deactivate Account",
+    startCollapsed: true,
+  }
 }

--- a/packages/lesswrong/lib/collections/users/permissions.ts
+++ b/packages/lesswrong/lib/collections/users/permissions.ts
@@ -1,5 +1,5 @@
 import Users from '../users/collection'
-import { userCanDo } from '../../vulcan-users/permissions';
+import { userCanDo, userOwns } from '../../vulcan-users/permissions';
 import { sunshineRegimentGroup } from '../../permissions';
 
 const sunshineRegimentActions = [
@@ -9,6 +9,6 @@ const sunshineRegimentActions = [
 sunshineRegimentGroup.can(sunshineRegimentActions);
 
 Users.checkAccess = async (user: DbUser|null, document: DbUser, context: ResolverContext|null): Promise<boolean> => {
-  if (document && document.deleted) return userCanDo(user, 'users.view.deleted')
+  if (document && document.deleted && !userOwns(user, document)) return userCanDo(user, 'users.view.deleted')
   return true
 };

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1009,10 +1009,11 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     defaultValue: false,
     canRead: ['guests'],
-    canUpdate: ['admins'],
-    label: 'Delete this user',
+    canUpdate: ['members', 'admins'],
+    label: 'Deactivate',
+    tooltip: "Your posts will be marked as '[Anonymous]'. (They will still be visible so other commenters' content and context will be preserved)",
     control: 'checkbox',
-    group: formGroups.adminOptions,
+    group: formGroups.deactivate,
   },
 
   // voteBanned: All future votes of this user have weight 0

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1011,7 +1011,7 @@ const schema: SchemaType<DbUser> = {
     canRead: ['guests'],
     canUpdate: ['members', 'admins'],
     label: 'Deactivate',
-    tooltip: "Your posts will be marked as '[Anonymous]'. (They will still be visible so other commenters' content and context will be preserved)",
+    tooltip: "Your posts and comments will be listed as '[Anonymous]', and your user profile won't accessible.",
     control: 'checkbox',
     group: formGroups.deactivate,
   },


### PR DESCRIPTION
This makes it so users can deactivate their own accounts instead of having to message an admin.

Also fixes a bug where deactivated users couldn't edit their profile (so that they can reactivate their account if they want)

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/3246710/193480199-2079f6dd-e139-4408-a35d-b0ecc972efa8.png">
