### PR TITLE
Spotlight duration and minor styling updates.

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -15,6 +15,7 @@ import { useCurrentUser } from '../common/withUser';
 export const descriptionStyles = theme => ({
   ...postBodyStyles(theme),
   ...theme.typography.body2,
+  textShadow: `0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}`,
   '& p': {
     marginTop: ".5em",
     marginBottom: ".5em"

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -15,7 +15,10 @@ import { useCurrentUser } from '../common/withUser';
 export const descriptionStyles = theme => ({
   ...postBodyStyles(theme),
   ...theme.typography.body2,
-  textShadow: `0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, `
+  '& p': {
+    marginTop: ".5em",
+    marginBottom: ".5em"
+  },
 })
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
@@ -49,10 +49,13 @@ export const SpotlightsPage = ({classes}: {
     </SingleColumnSection>;
   }
 
+  const totalUpcomingDuration = upcomingSpotlights.reduce((total, spotlight) => total + spotlight.duration, 0);
+
+  const totalDraftDuration = draftSpotlights.reduce((total, spotlight) => total + spotlight.duration, 0);
+
   return <SingleColumnSection>
-    <SectionTitle title={'Spotlights'} />
+    <SectionTitle title={'New Spotlight'} />
     <div className={classes.form}>
-      <Typography variant="body2">New Spotlight</Typography>
       <SpotlightEditorStyles>
         <WrappedSmartForm
           collection={Spotlights}
@@ -61,9 +64,13 @@ export const SpotlightsPage = ({classes}: {
       </SpotlightEditorStyles>
     </div>
     {loading && <Loading/>}
-    <SectionTitle title="Upcoming Spotlights"/>
+    <SectionTitle title="Upcoming Spotlights">
+      <div>Total: {totalUpcomingDuration} days</div>
+    </SectionTitle>
     {upcomingSpotlights.map(spotlight => <SpotlightItem key={spotlight._id} spotlight={spotlight} refetchAllSpotlights={refetch} showAdminInfo/>)}
-    <SectionTitle title="Draft Spotlights"/>
+    <SectionTitle title="Draft Spotlights">
+      <div>Total: {totalDraftDuration} days</div>
+    </SectionTitle>
     {draftSpotlights.map(spotlight => <SpotlightItem key={spotlight._id} spotlight={spotlight} refetchAllSpotlights={refetch} showAdminInfo/>)}
   </SingleColumnSection>
 }


### PR DESCRIPTION
Shows the total duration of all spotlights in the "upcoming" and "draft" sections. Also tweaks the styling of the SpotlightItems to have less paragraph padding (see Immoral Mazes for example). Updates the text shadow

![](https://user-images.githubusercontent.com/3246710/193538730-8294811e-573d-480d-8495-d48ebaac7e52.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203089466506158) by [Unito](https://www.unito.io)
