### PR TITLE
Make algolia comment search work for subforums, topic discussion, events, groups

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -13,7 +13,7 @@ import { useMessages } from '../common/withMessages';
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberDisplayInitialPopup, afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import ArrowForward from '@material-ui/icons/ArrowForward';
-import { TagCommentType, commentDefaultToAlignment } from '../../lib/collections/comments/helpers';
+import { TagCommentType, commentDefaultToAlignment } from '../../lib/collections/comments/types';
 
 export type CommentFormDisplayMode = "default" | "minimalist"
 

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -13,7 +13,8 @@ import { useMessages } from '../common/withMessages';
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { afNonMemberDisplayInitialPopup, afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import ArrowForward from '@material-ui/icons/ArrowForward';
-import { TagCommentType, commentDefaultToAlignment } from '../../lib/collections/comments/types';
+import { TagCommentType } from '../../lib/collections/comments/types';
+import { commentDefaultToAlignment } from '../../lib/collections/comments/helpers';
 
 export type CommentFormDisplayMode = "default" | "minimalist"
 

--- a/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsTimelineSection.tsx
@@ -4,7 +4,7 @@ import { useCurrentUser } from '../common/withUser';
 import classNames from 'classnames';
 import * as _ from 'underscore';
 import { NEW_COMMENT_MARGIN_BOTTOM } from './CommentsListSection';
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 import type { Option } from '../common/InlineSelect';
 import { isEmpty } from 'underscore';
 import { useLocation, useNavigation } from '../../lib/routeUtil';

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -5,7 +5,7 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 
 const isEAForum = forumTypeSetting.get() === "EAForum"
 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -8,7 +8,7 @@ import { truncate } from '../../lib/editor/ellipsize';
 import { useRecordTagView } from '../common/withRecordPostView';
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { taggingNameCapitalSetting, taggingNameIsSet } from '../../lib/instanceSettings';
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 import { useOrderPreservingArray } from '../hooks/useOrderPreservingArray';
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -59,7 +59,7 @@ const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
     {showIcon && <LWTooltip title="Comment">
       <ChatBubbleOutlineIcon className={classes.icon}/>
     </LWTooltip>}
-    <Link to={url} onClick={(event: React.MouseEvent) => url && isLeftClick(event) && clickAction && clickAction()}>
+    <Link to={url} onClick={(event: React.MouseEvent) => isLeftClick(event) && clickAction && clickAction()}>
       <div>
         <Components.MetaInfo>{comment.authorDisplayName}</Components.MetaInfo>
         <Components.MetaInfo>{comment.baseScore} karma </Components.MetaInfo>

--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -4,7 +4,7 @@ import { Snippet } from 'react-instantsearch-dom';
 import type { Hit } from 'react-instantsearch-core';
 import React from 'react';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 import { tagGetCommentLink } from '../../lib/collections/tags/helpers';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 

--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -4,6 +4,9 @@ import { Snippet } from 'react-instantsearch-dom';
 import type { Hit } from 'react-instantsearch-core';
 import React from 'react';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
+import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { tagGetCommentLink } from '../../lib/collections/tags/helpers';
+import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -39,12 +42,24 @@ const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
 }) => {
   const comment = (hit as AlgoliaComment);
   const { LWTooltip } = Components
-  const url = "/posts/" + comment.postId + "/" + comment.postSlug + "#" + comment._id
+
+  let url = "";
+  if (comment.tagSlug && comment.tagCommentType) {
+    url = tagGetCommentLink(comment.tagSlug, comment._id, comment.tagCommentType as TagCommentType);
+  } else if (comment.postId && comment.postSlug) {
+    url = `${postGetPageUrl({
+      _id: comment.postId ?? "",
+      slug: comment.postSlug ?? "",
+      isEvent: comment.postIsEvent,
+      groupId: comment.postGroupId,
+    })}#${comment._id}`;
+  }
+
   return <div className={classes.root}>
     {showIcon && <LWTooltip title="Comment">
       <ChatBubbleOutlineIcon className={classes.icon}/>
     </LWTooltip>}
-    <Link to={url} onClick={(event: React.MouseEvent) => isLeftClick(event) && clickAction && clickAction()}>
+    <Link to={url} onClick={(event: React.MouseEvent) => url && isLeftClick(event) && clickAction && clickAction()}>
       <div>
         <Components.MetaInfo>{comment.authorDisplayName}</Components.MetaInfo>
         <Components.MetaInfo>{comment.baseScore} karma </Components.MetaInfo>

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -5,11 +5,7 @@ import { postGetPageUrl } from '../posts/helpers';
 import { userCanDo } from '../../vulcan-users/permissions';
 import { userGetDisplayName } from "../users/helpers";
 import { tagGetSubforumUrl } from '../tags/helpers';
-
-export enum TagCommentType {
-  Subforum = "SUBFORUM",
-  Discussion = "DISCUSSION",
-}
+import { TagCommentType } from './types';
 
 // Get a comment author's name
 export async function commentGetAuthorName(comment: DbComment): Promise<string> {

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -32,7 +32,6 @@ export async function commentGetPageUrlFromDB(comment: DbComment, isAbsolute = f
       return `${prefix}/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/discussion#${comment._id}`;
     } else {
       return `${prefix}${tagGetSubforumUrl(tag)}#${comment._id}`;
-      
     }
   } else {
     throw Error(`Unable to find document for comment: ${comment._id}`)

--- a/packages/lesswrong/lib/collections/comments/index.ts
+++ b/packages/lesswrong/lib/collections/comments/index.ts
@@ -4,4 +4,5 @@ import './schema';
 import './helpers';
 import './permissions';
 import './views';
-import './voting'
+import './voting';
+import './types';

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -1,7 +1,7 @@
 import { userOwns } from '../../vulcan-users/permissions';
 import { arrayOfForeignKeysField, foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences } from '../../utils/schemaUtils';
 import { mongoFindOne } from '../../mongoQueries';
-import { commentGetPageUrlFromDB, TagCommentType } from './helpers';
+import { commentGetPageUrlFromDB, TagCommentType } from './types';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { schemaDefaultValue } from '../../collectionUtils';
 import { Utils } from '../../vulcan-lib';

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -1,12 +1,13 @@
 import { userOwns } from '../../vulcan-users/permissions';
 import { arrayOfForeignKeysField, foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences } from '../../utils/schemaUtils';
 import { mongoFindOne } from '../../mongoQueries';
-import { commentGetPageUrlFromDB, TagCommentType } from './types';
+import { TagCommentType } from './types';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { schemaDefaultValue } from '../../collectionUtils';
 import { Utils } from '../../vulcan-lib';
 import { forumTypeSetting } from "../../instanceSettings";
 import GraphQLJSON from 'graphql-type-json';
+import { commentGetPageUrlFromDB } from './helpers';
 
 
 export const moderationOptionsGroup: FormGroup = {

--- a/packages/lesswrong/lib/collections/comments/types.ts
+++ b/packages/lesswrong/lib/collections/comments/types.ts
@@ -1,0 +1,4 @@
+export enum TagCommentType {
+  Subforum = "SUBFORUM",
+  Discussion = "DISCUSSION",
+}

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -6,7 +6,7 @@ import { hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
 import { ReviewYear } from '../../reviewUtils';
 import { viewFieldNullOrMissing } from '../../vulcan-lib';
 import { Comments } from './collection';
-import { TagCommentType } from './helpers';
+import { TagCommentType } from './types';
 
 declare global {
   interface CommentsViewTerms extends ViewTermsBase {

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -1,7 +1,7 @@
 import { forumSelect } from "../../forumTypeUtils";
 import { siteUrlSetting, taggingNameIsSet, taggingNamePluralSetting } from "../../instanceSettings";
 import { combineUrls } from "../../vulcan-lib";
-import { TagCommentType } from "../comments/helpers";
+import { TagCommentType } from "../comments/types";
 
 export const tagMinimumKarmaPermissions = forumSelect({
   // Topic spampocalypse defense

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -1,6 +1,7 @@
 import { forumSelect } from "../../forumTypeUtils";
 import { siteUrlSetting, taggingNameIsSet, taggingNamePluralSetting } from "../../instanceSettings";
 import { combineUrls } from "../../vulcan-lib";
+import { TagCommentType } from "../comments/helpers";
 
 export const tagMinimumKarmaPermissions = forumSelect({
   // Topic spampocalypse defense
@@ -29,18 +30,19 @@ export const tagGetUrl = (tag: {slug: string}, urlOptions?: GetUrlOptions) => {
   return url
 }
 
-export const tagGetDiscussionUrl = (tag: DbTag|TagBasicInfo) => {
-  return `/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/discussion`
+export const tagGetDiscussionUrl = (tag: {slug: string}, isAbsolute=false) => {
+  const suffix = `/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/discussion`
+  return isAbsolute ? combineUrls(siteUrlSetting.get(), suffix) : suffix
 }
 
-export const tagGetSubforumUrl = (tag: DbTag|TagBasicInfo, isAbsolute=false) => {
-  const suffix =  `/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/subforum`
-  if (isAbsolute) return combineUrls(siteUrlSetting.get(), suffix)
-  return suffix
+export const tagGetSubforumUrl = (tag: {slug: string}, isAbsolute=false) => {
+  const suffix = `/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/subforum`
+  return isAbsolute ? combineUrls(siteUrlSetting.get(), suffix) : suffix
 }
 
-export const tagGetCommentLink = (tag: DbTag|TagBasicInfo, commentId: string): string => {
-  return `/${taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'}/${tag.slug}/discussion#${commentId}`
+export const tagGetCommentLink = (tagSlug: string, commentId: string, tagCommentType: TagCommentType = TagCommentType.Discussion, isAbsolute=false): string => {
+  const base = tagCommentType === TagCommentType.Discussion ? tagGetDiscussionUrl({slug: tagSlug}, isAbsolute) : tagGetSubforumUrl({slug: tagSlug}, isAbsolute)
+  return `${base}#${commentId}`
 }
 
 export const tagGetRevisionLink = (tag: DbTag|TagBasicInfo, versionNumber: string): string => {

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -11,7 +11,7 @@ import { forumTypeSetting, taggingNamePluralSetting, taggingNameSetting } from '
 import { SORT_ORDER_OPTIONS, SettingsOption } from '../posts/sortOrderOptions';
 import omit from 'lodash/omit';
 import { formGroups } from './formGroups';
-import { TagCommentType } from '../comments/helpers';
+import { TagCommentType } from '../comments/types';
 
 addGraphQLSchema(`
   type TagContributor {

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -16,7 +16,7 @@ import { getCollectionHooks, CreateCallbackProperties } from '../mutationCallbac
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { ensureIndex } from '../../lib/collectionUtils';
 import { triggerReviewIfNeeded } from "./sunshineCallbackUtils";
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 
 
 const MINIMUM_APPROVAL_KARMA = 5

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -8,7 +8,8 @@ import './EmailPostAuthors';
 import './EmailContentItemBody';
 import filter from 'lodash/filter';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
-import { TagCommentType, commentGetPageUrl } from '../../lib/collections/comments/types';
+import { TagCommentType } from '../../lib/collections/comments/types';
+import { commentGetPageUrl } from '../../lib/collections/comments/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   comment: {

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -8,7 +8,7 @@ import './EmailPostAuthors';
 import './EmailContentItemBody';
 import filter from 'lodash/filter';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
-import { TagCommentType, commentGetPageUrl } from '../../lib/collections/comments/helpers';
+import { TagCommentType, commentGetPageUrl } from '../../lib/collections/comments/types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   comment: {

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -17,7 +17,7 @@ import mapValues from 'lodash/mapValues';
 import take from 'lodash/take';
 import filter from 'lodash/filter';
 import * as _ from 'underscore';
-import { TagCommentType } from '../../lib/collections/comments/helpers';
+import { TagCommentType } from '../../lib/collections/comments/types';
 
 addGraphQLSchema(`
   type TagUpdates {

--- a/packages/lesswrong/server/search/algoliaDocuments.d.ts
+++ b/packages/lesswrong/server/search/algoliaDocuments.d.ts
@@ -19,7 +19,13 @@ interface AlgoliaComment {
   postId?: string,
   postTitle?: string,
   postSlug?: string,
+  postSequenceId?: string,
+  postIsEvent?: boolean,
+  postGroupId?: string,
   body: string,
+  tagId?: string,
+  tagSlug?: string,
+  tagCommentType?: string,
 }
 
 interface AlgoliaSequence {

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -54,12 +54,26 @@ Comments.toAlgolia = async (comment: DbComment): Promise<Array<AlgoliaComment>|n
     algoliaComment.authorUserName = commentAuthor.username;
     algoliaComment.authorSlug = commentAuthor.slug;
   }
-  const parentPost = await Posts.findOne({_id: comment.postId});
-  if (parentPost) {
-    algoliaComment.postId = comment.postId;
-    algoliaComment.postTitle = parentPost.title;
-    algoliaComment.postSlug = parentPost.slug;
+
+  if (comment.postId) {
+    const parentPost = await Posts.findOne({_id: comment.postId});
+    if (parentPost) {
+      algoliaComment.postId = comment.postId;
+      algoliaComment.postTitle = parentPost.title;
+      algoliaComment.postSlug = parentPost.slug;
+      algoliaComment.postIsEvent = parentPost.isEvent;
+      algoliaComment.postGroupId = parentPost.groupId;
+    }
   }
+  if (comment.tagId) {
+    const tag = await Tags.findOne({_id: comment.tagId});
+    if (tag) {
+      algoliaComment.tagId = comment.tagId;
+      algoliaComment.tagCommentType = comment.tagCommentType;
+      algoliaComment.tagSlug = tag.slug;
+    }
+  }
+
   let body = ""
   if (comment.contents?.originalContents?.type) {
     const { data, type } = comment.contents.originalContents


### PR DESCRIPTION
Previously it only worked for posts.

Another way of doing this would be to put the url in the search hit, although that would introduce the possibility of the results getting out of sync if we change the url structure, which is why I didn't do that. I wouldn't mind changing to that way if anyone knows of any problems with the way I've done it (e.g. it costs more, adding more fields degrades the search quality)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203092851132284) by [Unito](https://www.unito.io)
