### PR TITLE
Include worldmodeling in recommendations

### DIFF
--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -90,7 +90,11 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
   }
   if (algorithm.lwRationalityOnly) {
     return {
-      "tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0} // rationality tag
+      $or: [
+        {"tagRelevance.Ng8Gice9KNkncxqcj": {$gt:0}}, // rationality tag
+        {"tagRelevance.3uE2pXvbcnS9nnZRE": {$gt:0}}, // world modeling tag
+      ]
+      
     }
   }
   if (algorithm.reviewNominations) {


### PR DESCRIPTION
A couple months ago Ruby and I made the frontpage recommendations section only show rationality posts. This adds world-modeling back into the mix. (The overall goal here is still to counterbalance the deluge of AI content and give new users better training data of what LessWrong is about)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203095749711773) by [Unito](https://www.unito.io)
