### PR TITLE
[EA Forum only] truncate profile tag list

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -150,9 +150,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     fill: theme.palette.grey[600],
     marginRight: 4
   },
-  tags: {
-    marginTop: 20,
-  },
   btns: {
     display: 'flex',
     columnGap: 20,
@@ -226,6 +223,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
     collectionName: "Users",
     fragmentName: 'UsersProfile',
     enableTotal: false,
+    fetchPolicy: 'cache-and-network'
   });
   const user = getUserFromResults(results)
   
@@ -272,7 +270,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
     skip: !user
   })
 
-  const { SunshineNewUsersProfileInfo, SingleColumnSection, LWTooltip, FooterTag,
+  const { SunshineNewUsersProfileInfo, SingleColumnSection, LWTooltip, EAUsersProfileTags,
     SettingsButton, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
     PostsList2, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
     Typography, ContentStyles, FormatDate, EAUsersProfileTabbedSection, PostsListSettings, LoadMore,
@@ -516,9 +514,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
               {user.website}
             </a>}
           </ContentStyles>
-          {user.profileTagIds && <div className={classes.tags}>
-            {user.profileTags.map(tag => <FooterTag key={tag._id} tag={{...tag, core: false}} />)}
-          </div>}
+          {user.profileTagIds && <EAUsersProfileTags tags={user.profileTags} />}
           {currentUser?._id != user._id && <div className={classes.btns}>
             <NewConversationButton
               user={user}

--- a/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTags.tsx
+++ b/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTags.tsx
@@ -38,7 +38,7 @@ const EAUsersProfileTags = ({tags, classes}: {
     <div className={classes.root}>
       {visibleTags.map(tag => <FooterTag key={tag._id} tag={{...tag, core: false}} />)}
       {meritsCollapse && <button onClick={() => setCollapsed(!collapsed)} className={classes.btn}>
-        Show {collapsed ? `${tags.length - MAX_TAGS} more` : 'less'}
+        {collapsed ? `${tags.length - MAX_TAGS} more` : 'Show less'}
       </button>}
     </div>
   )

--- a/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTags.tsx
+++ b/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTags.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Components, registerComponent } from '../../../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    marginTop: 20
+  },
+  btn: {
+    fontFamily: theme.typography.fontFamily,
+    background: 'none',
+    color: theme.palette.grey[500],
+    fontSize: 12,
+    padding: 0,
+    marginLeft: 5,
+    '&:hover': {
+      opacity: 0.5
+    },
+  }
+})
+
+const MAX_TAGS = 4
+
+const EAUsersProfileTags = ({tags, classes}: {
+  tags: Array<TagBasicInfo>,
+  classes: ClassesType,
+}) => {
+  const [collapsed, setCollapsed] = useState(true)
+
+  const { FooterTag } = Components
+  
+  if (!tags.length) return null
+  
+  // we only show up to 4 tags by default
+  const meritsCollapse = tags.length > MAX_TAGS
+  const visibleTags = (meritsCollapse && collapsed) ? tags.slice(0, MAX_TAGS) : tags
+  
+  return (
+    <div className={classes.root}>
+      {visibleTags.map(tag => <FooterTag key={tag._id} tag={{...tag, core: false}} />)}
+      {meritsCollapse && <button onClick={() => setCollapsed(!collapsed)} className={classes.btn}>
+        Show {collapsed ? `${tags.length - MAX_TAGS} more` : 'less'}
+      </button>}
+    </div>
+  )
+}
+
+const EAUsersProfileTagsComponent = registerComponent(
+  'EAUsersProfileTags', EAUsersProfileTags, {styles}
+);
+
+declare global {
+  interface ComponentTypes {
+    EAUsersProfileTags: typeof EAUsersProfileTagsComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -28,6 +28,7 @@ if (forumTypeSetting.get() === 'EAForum') {
   importComponent("EAGApplicationImportForm", () => require('../components/ea-forum/users/EAGApplicationImportForm'))
   importComponent("EAUsersProfile", () => require('../components/ea-forum/users/EAUsersProfile'))
   importComponent("EAUsersProfileTabbedSection", () => require('../components/ea-forum/users/modules/EAUsersProfileTabbedSection'))
+  importComponent("EAUsersProfileTags", () => require('../components/ea-forum/users/modules/EAUsersProfileTags'))
   importComponent("AdvisorsPage", () => require('../components/ea-forum/advice/AdvisorsPage'))
   importComponent("AdvisorsRequestPage", () => require('../components/ea-forum/advice/AdvisorsRequestPage'))
   importComponent("AdvisorCard", () => require('../components/ea-forum/advice/AdvisorCard'))


### PR DESCRIPTION
We have some users [enthusiastically](https://forum.effectivealtruism.org/users/jakubkraus07-gmail-com) adding topics to their profiles, so now we're only showing the first 4 by default. Also fixed an issue you wouldn't see the updated topics list until after a refresh.

![](https://user-images.githubusercontent.com/9057804/194130418-801c5344-ef7f-451e-a6d1-c360696dae92.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203110077863494) by [Unito](https://www.unito.io)
