### PR TITLE
Fix subforum mobile styling issue

### DIFF
--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -16,10 +16,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     justifyContent: "center",
     columnGap: 32,
     [theme.breakpoints.down("md")]: {
+      margin: 0,
       flexDirection: "column",
     },
   },
   columnSection: {
+    maxWidth: '100%',
     [theme.breakpoints.up("lg")]: {
       margin: 0,
     }


### PR DESCRIPTION
Fixed an issue on mobile which caused the discussion section to extend offscreen.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203111863920502) by [Unito](https://www.unito.io)
