### PR TITLE
Improve spotlight styles

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -16,9 +16,19 @@ export const descriptionStyles = theme => ({
   ...postBodyStyles(theme),
   ...theme.typography.body2,
   textShadow: `0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 16px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 32px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}, 0 0 64px ${theme.palette.grey[0]}`,
+  lineHeight: '1.65rem',
   '& p': {
     marginTop: ".5em",
-    marginBottom: ".5em"
+    marginBottom: ".5em",
+    '&:first-child': {
+      marginTop: 0,
+    },
+    'style~&': {
+      marginTop: 0,
+    },
+    '&:last-child': {
+      marginBottom: 0,
+    }
   },
 })
 
@@ -55,7 +65,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   content: {
     padding: 16,
     paddingRight: 35,
-    paddingBottom: 0,
     display: "flex",
     // overflow: "hidden",
     flexDirection: "column",
@@ -79,10 +88,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 12
   },
   description: {
-    marginTop: 8,
+    marginTop: 7,
+    marginBottom: 13,
     ...descriptionStyles(theme),
     position: "relative",
-    lineHeight: '1.65rem',
     [theme.breakpoints.down('xs')]: {
       display: "none"
     }
@@ -153,15 +162,22 @@ const styles = (theme: ThemeType): JssStyles => ({
       minHeight: "unset"
     },
     '& .ck.ck-content.ck-editor__editable': {
-      ...theme.typography.body2,
+      ...descriptionStyles(theme) 
+    },
+    '& .EditorFormComponent-ckEditorStyles .ck.ck-content': {
+      marginLeft: 0,
+    },
+    '& .ck.ck-editor__editable_inline': {
+      padding: 0,
+      border: "none !important",
     },
     '& .form-submit button': {
       position: "absolute",
       bottom: 0,
-      right: 0,
+      right: -38,
       background: theme.palette.background.translucentBackground,
       marginLeft: 12,
-      opacity: .5,
+      opacity: .75,
       '&:hover': {
         opacity: 1
       }
@@ -174,6 +190,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingRight: 16,
     paddingTop: 8,
     paddingBottom: 8
+  },
+  metaData: {
+    textAlign: "right",
+    paddingTop: 6,
+    paddingBottom: 12
   }
 });
 
@@ -221,7 +242,7 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
               {spotlight.customTitle ?? spotlight.document.title}
             </Link>
             <span className={classes.editDescriptionButton}>
-              {userCanDo(currentUser, 'spotlights.edit.all') && <LWTooltip title="Edit Spotlight">
+              {showAdminInfo && userCanDo(currentUser, 'spotlights.edit.all') && <LWTooltip title="Edit Spotlight">
                 <EditIcon className={classes.editButtonIcon} onClick={() => setEditDescription(!editDescription)}/>
               </LWTooltip>}
             </span>
@@ -248,11 +269,11 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
               />
             }
           </div>
+          <SpotlightStartOrContinueReading spotlight={spotlight} />
         </div>
         {spotlight.spotlightImageId && <div className={classes.image}>
           <CloudinaryImage publicId={spotlight.spotlightImageId} />
         </div>}
-        <SpotlightStartOrContinueReading spotlight={spotlight} />
         {hideBanner && <div className={classes.closeButtonWrapper}>
           <LWTooltip title="Hide this item for the next month" placement="right">
             <Button className={classes.closeButton} onClick={hideBanner}>
@@ -261,23 +282,25 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
           </LWTooltip>
         </div>}
         <div className={classes.editAllButton}>
-          {userCanDo(currentUser, 'spotlights.edit.all') && <LWTooltip title="Edit Spotlight">
+          {showAdminInfo && userCanDo(currentUser, 'spotlights.edit.all') && <LWTooltip title="Edit Spotlight">
             <MoreVertIcon className={classNames(classes.editButtonIcon, classes.editAllButtonIcon)} onClick={() => setEdit(!edit)}/>
           </LWTooltip>}
         </div>
       </div>
-      {showAdminInfo && <div className={classes.form}>
-        {edit ? <SpotlightEditorStyles>
-           <WrappedSmartForm
-              collection={Spotlights}
-              documentId={spotlight._id}
-              mutationFragment={getFragment('SpotlightEditQueryFragment')}
-              queryFragment={getFragment('SpotlightEditQueryFragment')}
-              successCallback={onUpdate}
-            /> 
-          </SpotlightEditorStyles>
+      {showAdminInfo && <>
+        {edit ? <div className={classes.form}>
+            <SpotlightEditorStyles>
+            <WrappedSmartForm
+                collection={Spotlights}
+                documentId={spotlight._id}
+                mutationFragment={getFragment('SpotlightEditQueryFragment')}
+                queryFragment={getFragment('SpotlightEditQueryFragment')}
+                successCallback={onUpdate}
+              /> 
+            </SpotlightEditorStyles>
+          </div>
            :
-          <div>
+          <div className={classes.metaData}>
             {spotlight.draft && <MetaInfo>[Draft]</MetaInfo>}
             <MetaInfo>{spotlight.position}</MetaInfo>
             <MetaInfo><FormatDate date={spotlight.lastPromotedAt} format="YYYY-MM-DD"/></MetaInfo>
@@ -286,7 +309,7 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
             </LWTooltip>
           </div>
         }
-      </div>}
+      </>}
     </div>
   </AnalyticsTracker>
 }

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -173,14 +173,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
     '& .form-submit button': {
       position: "absolute",
-      bottom: 0,
-      right: -38,
-      background: theme.palette.background.translucentBackground,
-      marginLeft: 12,
-      opacity: .75,
-      '&:hover': {
-        opacity: 1
-      }
+      bottom: -38,
+      right: 0,
+      marginLeft: 12
     }
   },
   form: {

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -56,19 +56,19 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight}: {
   // in that collection it wouldn't provide the right 'next post')
   // But, also, the real proper fix here is to integrate continue reading here.
   const firstPost = readPosts.length === 0 && posts[0]
-  const firstPostSequence = spotlight.documentType === "Sequence" ? spotlight.documentId : undefined
+  const firstPostSequenceId = spotlight.documentType === "Sequence" ? spotlight.documentId : undefined
 
   if (firstPost) {
     return <div className={classes.firstPost}>
       First Post: <LWTooltip title={<PostsPreviewTooltip post={firstPost}/>} tooltip={false}>
-        <Link to={postGetPageUrl(firstPost, false, firstPostSequence)}>{firstPost.title}</Link>
+        <Link to={postGetPageUrl(firstPost, false, firstPostSequenceId)}>{firstPost.title}</Link>
       </LWTooltip>
     </div>
   } else {
     return <div>
     {posts.map(post => (
       <LWTooltip key={`${spotlight._id}-${post._id}`} title={<PostsPreviewTooltip post={post}/>} tooltip={false} flip={false}>
-        <Link to={postGetPageUrl(post)}>
+        <Link to={postGetPageUrl(post, false, firstPostSequenceId)}>
           <div className={classNames(classes.postProgressBox, {[classes.read]: post.isRead || clientPostsRead[post._id]})} />
         </Link>
       </LWTooltip>

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -10,9 +10,6 @@ import { postProgressBoxStyles } from '../sequences/BooksProgressBar';
 const styles = (theme: ThemeType): JssStyles => ({
   firstPost: {
     ...theme.typography.body2,
-    padding: 16,
-    paddingTop: 10,
-    paddingBottom: 12,
     fontSize: "1.1rem",
     ...theme.typography.commentStyle,
     position: "relative",
@@ -21,11 +18,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& a': {
       color: theme.palette.primary.main
     }
-  },
-  sequenceCheckmarks: {
-    padding: 16,
-    paddingTop: 10,
-    paddingBottom: 12,
   },
   postProgressBox: {
     ...postProgressBoxStyles(theme)
@@ -73,7 +65,7 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight}: {
       </LWTooltip>
     </div>
   } else {
-    return <div className={classes.sequenceCheckmarks}>
+    return <div>
     {posts.map(post => (
       <LWTooltip key={`${spotlight._id}-${post._id}`} title={<PostsPreviewTooltip post={post}/>} tooltip={false} flip={false}>
         <Link to={postGetPageUrl(post)}>


### PR DESCRIPTION
Makes the text-editor for the description match the exact styling of the displayed description, and does some other minor nice-to-have improvements for spotlight styling:

![](https://user-images.githubusercontent.com/3246710/194195163-4e2e3395-df42-4c07-864c-ac806165b0a5.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203112170972554) by [Unito](https://www.unito.io)
