### PR TITLE
Sequence Banner image sizing

### DIFF
--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -58,7 +58,7 @@ const cloudinaryArgsByImageType = {
   bannerImageId: {
     minImageHeight: 300,
     minImageWidth: 700,
-    croppingAspectRatio: 1.91,
+    croppingAspectRatio: 4.7,
     croppingDefaultSelectionRatio: 1,
     uploadPreset: cloudinaryUploadPresetBannerSetting.get(),
   },

--- a/packages/lesswrong/components/sequences/SequencesNewForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNewForm.tsx
@@ -84,6 +84,14 @@ export const styles = (theme: ThemeType): JssStyles => ({
         position: "absolute !important",
         left: 0,
         maxWidth: "100%",
+        '& img': {
+          width: "100% !important",
+          height: "380px !important",
+        },
+        '& .ImageUpload-root': {
+          marginLeft: '0 !important',
+          paddingTop: '0 !important'
+        },
   
         [theme.breakpoints.down('sm')]: {
           marginTop: 40,

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -66,7 +66,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: theme.spacing.unit * 4,
     position: 'relative',
     backgroundColor: theme.palette.panelBackground.default,
-    marginTop: -200,
+    marginTop: -127,
     zIndex: theme.zIndexes.sequencesPageContent,
     [theme.breakpoints.down('sm')]: {
       marginTop: -100,


### PR DESCRIPTION
A few things were wrong with sequence banner images:
– the crop ratio was way off, making it hard to size images correctly so you could easily see the most interesting bits
– the sequence-text overlapped a lot with the image in a way that also tended to blot out the most interesting bits in the middle
– the sequence editor sizing was just... broken somehow.

Here's the new resulting image:
![](https://user-images.githubusercontent.com/3246710/194288089-b1527cfd-5555-4cd5-84d6-20125423dfe6.png)

Compared to before:
![](https://user-images.githubusercontent.com/3246710/194288336-a9037499-a4ec-44d6-b123-712b5e3b6dff.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203114573810684) by [Unito](https://www.unito.io)
