### PR TITLE
Enforce node version

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [15.x]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [15.x]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -304,5 +304,8 @@
     "graphql": "^14.5.8",
     "graphql-tools": "^4.0.7",
     "ts-node": "^10.9.1"
+  },
+  "engines": {
+    "node": "15.x"
   }
 }


### PR DESCRIPTION
We just had an issue where a dev was using the wrong node version for development, which let a bug creep through to deployment. It's incredibly easy to accidentally use the wrong node version, but also quite easy to have yarn prevent you from doing so. Let's have yarn help us.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203116672882084) by [Unito](https://www.unito.io)
