### PR TITLE
Fix the notification drawer open/close animations

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -125,7 +125,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
   return (
     <div className={classes.root}>
       <Components.ErrorBoundary>
-        {open && <SwipeableDrawer
+        <SwipeableDrawer
           open={open}
           anchor="right"
           onClose={() => setIsOpen(false)}
@@ -170,7 +170,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
             <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />
             <Components.NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser}/>
           </div>}
-        </SwipeableDrawer>}
+        </SwipeableDrawer>
       </Components.ErrorBoundary>
     </div>
   )


### PR DESCRIPTION
Bug was introduced in: [https://github.com/ForumMagnum/ForumMagnum/commit/668e4cb6eb4e3966299a9a4499d980d879d58cb9#diff-a768b8236f6e93117a2214[…]9f6c946f4c6de725a452e38R122](https://github.com/ForumMagnum/ForumMagnum/commit/668e4cb6eb4e3966299a9a4499d980d879d58cb9#diff-a768b8236f6e93117a2214503b6be2f2b74527e1d9f6c946f4c6de725a452e38R122)

The bug is that `SwipeableDrawer` does things even if `open` is false (eg it could be mid-way through a close animation), so conditionally removing it from the page is incorrect.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203126860388372) by [Unito](https://www.unito.io)
