### PR TITLE
Tagging on post new/edit form

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -31,7 +31,7 @@ const PostsEditForm = ({ documentId, classes }: {
   const { params } = location; // From withLocation
   const isDraft = document && document.draft;
 
-  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags, ForeignCrosspostEditForm } = Components
+  const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags, ForeignCrosspostEditForm, FooterTagList, CoreTagsChecklist } = Components
   
   const saveDraftLabel: string = ((post) => {
     if (!post) return "Save Draft"
@@ -88,13 +88,19 @@ const PostsEditForm = ({ documentId, classes }: {
   }
   
   const EditPostsSubmit = (props) => {
-    return <div className={classes.formSubmit}>
-      {!document.isEvent && <SubmitToFrontpageCheckbox {...props} />}
-      <PostSubmit
-        saveDraftLabel={saveDraftLabel} 
-        feedbackLabel={"Get Feedback"}
-        {...props}
-      />
+    return <div>
+      <div className={classes.tags}>
+        <h3>Post Tags</h3>
+        <FooterTagList post={document} showCoreTags/>
+      </div>
+      <div className={classes.formSubmit}>
+        {!document.isEvent && <SubmitToFrontpageCheckbox {...props} />}
+        <PostSubmit
+          saveDraftLabel={saveDraftLabel} 
+          feedbackLabel={"Get Feedback"}
+          {...props}
+        />
+      </div>
     </div>
   }
   

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -138,7 +138,7 @@ const prefillFromTemplate = (template: PostsEdit) => {
 
 const PostsNewForm = ({classes}: {
     classes: ClassesType,
-  }, context) => {
+  }) => {
   const { query } = useLocation();
   const { history } = useNavigation();
   const currentUser = useCurrentUser();

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -12,6 +12,7 @@ import { useDialog } from "../common/withDialog";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { useSingle } from '../../lib/crud/withSingle';
+import { groupLayoutStyles } from '../vulcan-forms/FormGroup';
 
 // Also used by PostsEditForm
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -96,6 +97,11 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   collaborativeRedirectLink: {
     color:  theme.palette.secondary.main
+  },
+  tags: {
+    ...groupLayoutStyles(theme).formSection,
+    padding: 16,
+    paddingBottom: 12
   }
 })
 
@@ -132,7 +138,7 @@ const prefillFromTemplate = (template: PostsEdit) => {
 
 const PostsNewForm = ({classes}: {
     classes: ClassesType,
-  }) => {
+  }, context) => {
   const { query } = useLocation();
   const { history } = useNavigation();
   const currentUser = useCurrentUser();
@@ -159,7 +165,7 @@ const PostsNewForm = ({classes}: {
     skip: !templateId,
   });
   
-  const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox, RecaptchaWarning, SingleColumnSection, Typography, Loading } = Components
+  const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox, RecaptchaWarning, SingleColumnSection, Typography, Loading, CoreTagsChecklist } = Components
   const userHasModerationGuidelines = currentUser && currentUser.moderationGuidelines && currentUser.moderationGuidelines.originalContents
   const af = forumTypeSetting.get() === 'AlignmentForum'
   const prefilledProps = templateDocument ? prefillFromTemplate(templateDocument) : {
@@ -193,9 +199,24 @@ const PostsNewForm = ({classes}: {
   }
 
   const NewPostsSubmit = (props) => {
-    return <div className={classes.formSubmit}>
-      {!eventForm && <SubmitToFrontpageCheckbox {...props} />}
-      <PostSubmit {...props} />
+    const {document, updateCurrentValues, submitForm } = props;
+
+    return <div>
+      <div className={classes.tags} onClick={async () => {
+        if (!document.title || !document.title.length) {
+          flash("Please give this post a title before sharing.");
+          return;
+        }
+        await updateCurrentValues({ draft: true });
+        await submitForm(null, {redirectToEditor: true});
+      }}>
+        <h3>Post Tags</h3>
+        <CoreTagsChecklist />
+      </div>
+      <div className={classes.formSubmit}>
+        {!eventForm && <SubmitToFrontpageCheckbox {...props} />}
+        <PostSubmit {...props} />
+      </div>
     </div>
   }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -39,7 +39,6 @@ const SunshineNewPostsItem = ({post, classes}: {
   post: SunshinePostsList,
   classes: ClassesType
 }) => {
-  const [selectedTags, setSelectedTags] = useState<Record<string,boolean>>({});
   const currentUser = useCurrentUser();
   const {eventHandlers, hover, anchorEl} = useHover();
   
@@ -47,28 +46,8 @@ const SunshineNewPostsItem = ({post, classes}: {
     collectionName: "Posts",
     fragmentName: 'PostsList',
   });
-  const [addTagsMutation] = useMutation(gql`
-    mutation addTagsMutation($postId: String, $tagIds: [String]) {
-      addTags(postId: $postId, tagIds: $tagIds)
-    }
-  `);
-
-  const applyTags = () => {
-    const tagsApplied: Array<string> = [];
-    for (let tagId of Object.keys(selectedTags)) {
-      if (selectedTags[tagId])
-        tagsApplied.push(tagId);
-    }
-    void addTagsMutation({
-      variables: {
-        postId: post._id,
-        tagIds: tagsApplied,
-      }
-    });
-  }
   
   const handlePersonal = () => {
-    applyTags();
     void updatePost({
       selector: { _id: post._id},
       data: {
@@ -80,8 +59,6 @@ const SunshineNewPostsItem = ({post, classes}: {
   }
 
   const handlePromote = () => {
-    applyTags();
-    
     void updatePost({
       selector: { _id: post._id},
       data: {
@@ -94,7 +71,6 @@ const SunshineNewPostsItem = ({post, classes}: {
   
   const handleDelete = () => {
     if (confirm("Are you sure you want to move this post to the author's draft?")) {
-      applyTags();
       window.open(userGetProfileUrl(post.user), '_blank');
       void updatePost({
         selector: { _id: post._id},
@@ -115,10 +91,7 @@ const SunshineNewPostsItem = ({post, classes}: {
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <FooterTagList post={post} />
-          <CoreTagsChecklist post={post} onSetTagsSelected={(selectedTags) => {
-            setSelectedTags(selectedTags);
-          }}/>
+          <FooterTagList post={post} showCoreTags/>
           <div className={classes.buttonRow}>
               <Button onClick={handlePersonal}>
                 <PersonIcon className={classes.icon} /> Personal

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import Checkbox from '@material-ui/core/Checkbox';
+import { tagStyle } from './FooterTag';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -17,19 +18,21 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   tag: {
-    minWidth: "25%",
-    display: "inline-block",
-    ...theme.typography.commentStyle,
-    marginRight: 16,
-    color: theme.palette.grey[600],
-    marginTop: 4
+    ...tagStyle(theme),
+    backgroundColor: "unset",
+    color: theme.palette.grey[400],
+    border: theme.palette.border.extraFaint,
+    '&:hover': {
+      border: theme.palette.border.grey300,
+      color: theme.palette.grey[800]
+    }
   }
-});
+}); 
 
-const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
-  onSetTagsSelected: (selectedTags: Record<string,boolean>)=>void,
+const CoreTagsChecklist = ({onTagSelected, classes, existingTagIds=[] }: {
+  onTagSelected?: (props: {tagId: string, tagName: string})=>void,
   classes: ClassesType,
-  post: PostsList|SunshinePostsList
+  existingTagIds?: Array<string|undefined>
 }) => {
   const { results, loading } = useMulti({
     terms: {
@@ -40,25 +43,20 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
     limit: 100,
   });
   
-  const { Loading } = Components;
-  const [selections, setSelections] = useState<Record<string,boolean>>({});
-  if (loading)
-    return <Loading/>
-  
-  return <div className={classes.root}>
-    {results?.map(tag => <span key={tag._id} className={classes.tag}>
-      <Checkbox
-        className={classes.checkbox}
-        checked={selections[tag._id]}
-        onChange={(event, checked) => {
-          const newSelections = {...selections, [tag._id]: checked};
-          setSelections(newSelections);
-          onSetTagsSelected(newSelections);
-        }}
-      />
-      {tag.name}
-    </span>)}
-  </div>
+  const { Loading, LWTooltip } = Components;
+  if (loading) return <Loading/>
+
+  const unusedCoreTags = results?.filter(tag => !existingTagIds.includes(tag._id))
+
+  const handleOnTagSelected = (tag) => onTagSelected ? onTagSelected({tagId:tag._id, tagName:tag.name}) : undefined
+
+  return <>
+    {unusedCoreTags?.map(tag => <LWTooltip key={tag._id} title={<div>Click to assign <em>{tag.name}</em> tag</div>}>
+      <div className={classes.tag} onClick={() => handleOnTagSelected(tag)}>
+        {tag.name}
+      </div>
+    </LWTooltip>)}
+  </>
 }
 
 

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -1085,6 +1085,7 @@ class Form<T extends DbObject> extends Component<any,any> {
     revertLabel: this.props.revertLabel,
     cancelCallback: this.props.cancelCallback,
     revertCallback: this.props.revertCallback,
+    submitForm: this.submitForm,
     updateCurrentValues: this.updateCurrentValues,
     formType: this.getFormType(),
     document: this.getDocument(),

--- a/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
@@ -43,7 +43,7 @@ const FormGroupHeaderComponent = registerComponent('FormGroupHeader', FormGroupH
   styles: headerStyles
 });
 
-const groupLayoutStyles = (theme: ThemeType): JssStyles => ({
+export const groupLayoutStyles = (theme: ThemeType): JssStyles => ({
   formSection: {
     fontFamily: theme.typography.fontFamily,
     border: theme.palette.border.grey400,

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -94,6 +94,7 @@ Tags.addView('coreTags', (terms: TagsViewTerms) => {
     },
     options: {
       sort: {
+        defaultOrder: -1,
         name: 1
       }
     },

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -396,7 +396,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
   tag: {
     background: shades.grey[200],
     border: `solid 1px ${shades.grey[200]}`,
-    coreTagBorder: shades.greyBorder("1px", .12),
+    coreTagBorder: shades.greyBorder("1px", .15),
     text: shades.greyAlpha(.9),
     boxShadow: `1px 2px 5px ${shades.boxShadowColor(.2)}`,
     hollowTagBackground: shades.grey[0],


### PR DESCRIPTION
This allows authors to tag their post before they publish this. I'm hoping this a) streamlines some work from moderators, reducing how much time we have to spend tagging new posts, and b) allows tag-filtering to work more reliably (some people complained that even though they have AI posts set to "hidden", they still end up seeing a bunch every day because it's often several hours before a moderator ensures the post is tagged properly.

Some less obvious things:

A) This bundles "CoreTagsChecklist" into "FooterTagList", so that they use one unified UI. I already had found CoreTagsChecklist + FooterTagList a somewhat annoying UI for the sunshine sidebar, and would expect users who're self-tagging to also find it annoying.

B) The tag list appears in the custom form-submit component, because that's the only way I could get it listed _above_ the submit button, and it felt awkward for it to be below the submit button.

C) You can't actually create tags for on a "new" post edit form, because the post doesn't exist yet, and doesn't have an _id. So instead, I create a dummy component that, when you click on it, saves the post and switches you over into the editor-view (similar to how sharing a post works)

D) To get 'C' to work, I had to pass the 'submitForm' function into 'getFormSubmitProps'. Weirdly, the form-submit component doesn't automatically have access to this, in either the props or the context (I guess it relies on some html magic? Robert and I both looked at this and were pretty confused, if I missed something here and should wire this differently let me know)

<img width="824" alt="image" src="https://user-images.githubusercontent.com/3246710/194680805-12766c7a-b7d3-4e2c-8807-9bbf40884aee.png">
