### PR TITLE
Fix crosspost TOC comment count

### DIFF
--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -1,6 +1,7 @@
 import type { ApolloError } from "@apollo/client";
 import { useForeignApolloClient } from "./useForeignApolloClient";
 import { useSingle, UseSingleProps } from "../../lib/crud/withSingle";
+import { postGetCommentCountStr } from "../../lib/collections/posts/helpers";
 
 export type PostWithForeignId = {
   fmCrosspost: {
@@ -16,6 +17,13 @@ export const isPostWithForeignId =
     !!post.fmCrosspost.isCrosspost &&
     typeof post.fmCrosspost.hostedHere === "boolean" &&
     !!post.fmCrosspost.foreignPostId;
+
+const hasTableOfContents =
+  <
+    Post extends PostWithForeignId,
+    WithContents extends Post & {tableOfContents: {sections: any[]}}
+  >(post: Post): post is WithContents =>
+    "tableOfContents" in post && Array.isArray((post as WithContents).tableOfContents?.sections);
 
 /**
  * Load foreign crosspost data from the foreign site
@@ -49,10 +57,21 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
     // If this post was crossposted from elsewhere then we want to take most of the fields from
     // our local copy (for correct links/ids/etc.) but we need to override a few specific fields
     // to actually get the correct content and some metadata that isn't denormalized across sites
-    const overrideFields = ["contents", "tableOfContents", "url", "readTimeMinutes"];
+    const overrideFields = ["contents", "tableOfContents", "url", "readTimeMinutes"] as const;
     combinedPost = {...foreignPost, ...localPost} as Post & FragmentTypes[FragmentTypeName];
     for (const field of overrideFields) {
       combinedPost[field] = foreignPost?.[field] ?? localPost[field];
+    }
+    // We just took the table of contents from the foreign version, but we want to use the local comment count
+    if (hasTableOfContents(combinedPost)) {
+      combinedPost.tableOfContents = {
+        ...combinedPost.tableOfContents,
+        sections: combinedPost.tableOfContents.sections.map((section) =>
+          section.anchor === "comments"
+            ? {...section, title: postGetCommentCountStr(localPost as unknown as PostsBase)}
+            : section
+        ),
+      };
     }
   }
 


### PR DESCRIPTION
When displaying a crosspost on the foreign site, we show the TOC as generated on the site where the post was created. This includes the comment count, which will be wrong when displayed on the foreign site. This PR replaces the comment count with the correct local number.

It's also now possible to test crosspost PRs locally by starting two servers with `yarn ea-start` and `yarn ea-start-xpost-dev`, then the two sites will be available at `localhost:3000` and `localhost:4000`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203133181749503) by [Unito](https://www.unito.io)
