### PR TITLE
Link to subforum from topic page and vice versa

### DIFF
--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -88,7 +88,7 @@ const TagPageButtonRow = ({ tag, editing, setEditing, className, classes }: {
 }) => {
   const { openDialog } = useDialog();
   const currentUser = useCurrentUser();
-  const { LWTooltip, NotifyMeButton, TagDiscussionButton, ContentItemBody } = Components;
+  const { LWTooltip, NotifyMeButton, TagDiscussionButton, TagSubforumButton, ContentItemBody } = Components;
   const { tag: beginnersGuideContentTag } = useTagBySlug("tag-cta-popup", "TagFragment")
 
   const numFlags = tag.tagFlagsIds?.length
@@ -169,7 +169,8 @@ const TagPageButtonRow = ({ tag, editing, setEditing, className, classes }: {
       />
     </LWTooltip>}
     <div className={classes.button}>
-      <TagDiscussionButton tag={tag} hideLabelOnMobile />
+      {tag.isSubforum ?
+        <TagSubforumButton tag={tag} /> : <TagDiscussionButton tag={tag} hideLabelOnMobile />}
     </div>
     {!userHasNewTagSubscriptions(currentUser) && <LWTooltip
       className={classes.helpImprove}

--- a/packages/lesswrong/components/tagging/TagSubforumButton.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumButton.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { registerComponent } from '../../lib/vulcan-lib';
+import { Link } from "../../lib/reactRouterWrapper";
+import CommentOutlinedIcon from "@material-ui/icons/ModeCommentOutlined";
+import { tagGetSubforumUrl } from "../../lib/collections/tags/helpers";
+import { AnalyticsContext } from "../../lib/analyticsEvents";
+
+const styles = (theme: ThemeType): JssStyles => ({
+  discussionButton: {
+    ...theme.typography.commentStyle,
+    ...theme.typography.body2,
+    color: theme.palette.grey[700],
+    display: "flex",
+    alignItems: "center",
+    marginLeft: "auto"
+  },
+  discussionButtonIcon: {
+    height: 20,
+    width: 20,
+    marginRight: 4,
+    cursor: "pointer",
+    color: theme.palette.grey[700]
+  },
+  discussionCount: {
+    [theme.breakpoints.down('sm')]: {
+      alignSelf: "flex-start" //appears to low when there's no label
+    }
+  },
+  hideOnMobile: {
+    marginRight: 2,
+    [theme.breakpoints.down('sm')]: { //optimized or tag paye
+      display: "none"
+    }
+  }
+});
+
+
+const TagSubforumButton = ({
+  tag,
+  classes,
+}: {
+  tag: TagPageFragment | TagPageWithRevisionFragment;
+  classes: ClassesType;
+}) => {
+  const url = tagGetSubforumUrl(tag);
+  return (
+    <AnalyticsContext pageElementContext="subforumLink" resourceUrl={url}>
+      <Link className={classes.discussionButton} to={tagGetSubforumUrl(tag)}>
+        <CommentOutlinedIcon className={classes.discussionButtonIcon} />
+        <span className={classes.hideOnMobile}>Subforum</span>
+        <span className={classes.discussionCount}>&nbsp;{`(${tag.subforumUnreadMessagesCount})`}</span>
+      </Link>
+    </AnalyticsContext>
+  );
+};
+
+const TagSubforumButtonComponent = registerComponent("TagSubforumButton", TagSubforumButton, {styles});
+
+declare global {
+  interface ComponentTypes {
+    TagSubforumButton: typeof TagSubforumButtonComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -7,6 +7,9 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import classNames from "classnames";
 import { subforumDefaultSorting } from "../../lib/collections/comments/views";
 import truncateTagDescription from "../../lib/utils/truncateTagDescription";
+import { Link } from "../../lib/reactRouterWrapper";
+import { tagGetUrl } from "../../lib/collections/tags/helpers";
+import { taggingNameSetting } from "../../lib/instanceSettings";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -24,7 +27,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: '100%',
     [theme.breakpoints.up("lg")]: {
       margin: 0,
-    }
+    },
+    [theme.breakpoints.down("md")]: {
+      marginBottom: 0,
+    },
   },
   stickToBottom: {
     marginTop: "auto",
@@ -65,7 +71,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user: UsersProfile }) => {
-  const { Error404, Loading, SubforumCommentsThread, SectionTitle, SingleColumnSection, Typography, ContentStyles, ContentItemBody } = Components;
+  const { Error404, Loading, SubforumCommentsThread, SectionTitle, SingleColumnSection, Typography, ContentStyles, ContentItemBody, LWTooltip } = Components;
 
   const { params, query } = useLocation();
   const { slug } = params;
@@ -100,13 +106,22 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
     </div>
   ) : <></>;
 
+  const titleComponent = <>
+    <LWTooltip title={`To ${taggingNameSetting.get()} page`} placement="top-start" className={classes.tooltip}>
+      <Link to={tagGetUrl(tag)}>
+        {tag.name}
+      </Link>
+    </LWTooltip>
+    {" "}Subforum
+  </>
+
   return (
     <div className={classes.root}>
       <div className={classNames(classes.columnSection, classes.stickToBottom, classes.aside)}>
         {welcomeBoxComponent}
       </div>
       <SingleColumnSection className={classNames(classes.columnSection, classes.fullWidth)}>
-        <SectionTitle title={`${tag.name} Subforum`} className={classes.title} />
+        <SectionTitle title={titleComponent} className={classes.title} />
         <AnalyticsContext pageSectionContext="commentsSection">
           <SubforumCommentsThread
             tag={tag}

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -89,7 +89,7 @@ export const TagSubforumPage = ({ classes, user }: { classes: ClassesType; user:
     );
   }
 
-  const welcomeBoxComponent = tag.subforumWelcomeText ? (
+  const welcomeBoxComponent = tag.subforumWelcomeText?.html ? (
     <div className={classes.welcomeBox}>
       <ContentStyles contentType="comment">
         <ContentItemBody

--- a/packages/lesswrong/components/tagging/TagSubforumPage.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage.tsx
@@ -7,11 +7,10 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import classNames from "classnames";
 import { subforumDefaultSorting } from "../../lib/collections/comments/views";
 import startCase from "lodash/startCase";
-import { siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 import { Link } from "../../lib/reactRouterWrapper";
 import { tagGetUrl } from "../../lib/collections/tags/helpers";
-import { taggingNameSetting } from "../../lib/instanceSettings";
+import { taggingNameSetting, siteNameWithArticleSetting } from "../../lib/instanceSettings";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -182,6 +182,7 @@ registerFragment(`
     ...TagWithFlagsFragment
     tableOfContents
     postsDefaultSortOrder
+    subforumUnreadMessagesCount
     contributors(limit: $contributorsLimit) {
       totalCount
       contributors {
@@ -208,6 +209,7 @@ registerFragment(`
     ...TagWithFlagsAndRevisionFragment
     tableOfContents(version: $version)
     postsDefaultSortOrder
+    subforumUnreadMessagesCount
     contributors(limit: $contributorsLimit, version: $version) {
       totalCount
       contributors {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -514,6 +514,7 @@ importComponent("TagFlagItem", () => require('../components/tagging/TagFlagItem'
 importComponent("TagContributorsList", () => require('../components/tagging/TagContributorsList'));
 importComponent("TagDiscussionSection", () => require('../components/tagging/TagDiscussionSection'));
 importComponent("TagDiscussionButton", () => require('../components/tagging/TagDiscussionButton'));
+importComponent("TagSubforumButton", () => require('../components/tagging/TagSubforumButton'));
 importComponent("SubforumCommentsThread", () => require('../components/tagging/SubforumCommentsThread'));
 importComponent("AllPostsPageTagRevisionItem", () => require('../components/tagging/AllPostsPageTagRevisionItem'));
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1998,6 +1998,7 @@ interface TagWithFlagsAndRevisionFragment extends TagRevisionFragment { // fragm
 interface TagPageFragment extends TagWithFlagsFragment { // fragment on Tags
   readonly tableOfContents: any,
   readonly postsDefaultSortOrder: string,
+  readonly subforumUnreadMessagesCount: number,
   readonly contributors: any,
 }
 
@@ -2008,6 +2009,7 @@ interface AllTagsPageFragment extends TagWithFlagsFragment { // fragment on Tags
 interface TagPageWithRevisionFragment extends TagWithFlagsAndRevisionFragment { // fragment on Tags
   readonly tableOfContents: any,
   readonly postsDefaultSortOrder: string,
+  readonly subforumUnreadMessagesCount: number,
   readonly contributors: any,
 }
 


### PR DESCRIPTION
From the topic page to the subforum, we (JP and I) decided to just replace the discussion link since:


* Tag discussion is rarely used
* It could be confusing for people to have both, Yonatan mentioned being confused about the purpose of the subforums given that tag discussion exists. My impression is that we want Discussion to be about the wiki article but this isn't clearly communicated to users atm

I think it would be good (for all tags, not just subforums) to move "Discussion" to the side bar and call it "Wiki article discussion" or something, but for the existing subforums we have I think it's fine to just remove it entirely (there is 1 discussion comment on Software Engineering and 0 on Bioethics)

![](https://user-images.githubusercontent.com/77623106/194863756-d513fc79-157b-43f5-b0d4-95fe9a406c43.png)

From the subforum to the topic page:

![](https://user-images.githubusercontent.com/77623106/194863901-b93e06ad-fe9b-4fd3-a2cd-71a1167b494b.png)

I don't love this way of doing it, I think it looks a bit odd for only part of the title to be a link (but if we made the whole thing a link it would appear that it was linking to the subforum). I tried doing this instead, which I think looks better, but it doesn't show up on mobile so I think the title link is better overall:

![](https://user-images.githubusercontent.com/77623106/194865288-db6a53b3-8c07-4aaa-a591-f4f721c2c60b.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203133726638511) by [Unito](https://www.unito.io)
