### PR TITLE
Fix crosspost events

### DIFF
--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -17,6 +17,33 @@ export const isPostWithForeignId =
     typeof post.fmCrosspost.hostedHere === "boolean" &&
     !!post.fmCrosspost.foreignPostId;
 
+// If this post was crossposted from elsewhere then we want to take most of the fields from
+// our local copy (for correct links/ids/etc.) but we need to override a few specific fields
+// to actually get the correct content and some metadata that isn't denormalized across sites
+const overrideFields = [
+  "contents",
+  "tableOfContents",
+  "url",
+  "readTimeMinutes",
+  "activateRSVPs",
+  "eventType",
+  "startTime",
+  "endTime",
+  "localStartTime",
+  "localEndTime",
+  "mongoLocation",
+  "googleLocation",
+  "location",
+  "contactInfo",
+  "eventRegistrationLink",
+  "joinEventLink",
+  "onlineEvent",
+  "globalEvent",
+  "facebookLink",
+  "meetupLink",
+  "website",
+] as const;
+
 /**
  * Load foreign crosspost data from the foreign site
  */
@@ -46,10 +73,6 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
 
   let combinedPost: (Post & FragmentTypes[FragmentTypeName]) | undefined;
   if (!localPost.fmCrosspost.hostedHere) {
-    // If this post was crossposted from elsewhere then we want to take most of the fields from
-    // our local copy (for correct links/ids/etc.) but we need to override a few specific fields
-    // to actually get the correct content and some metadata that isn't denormalized across sites
-    const overrideFields = ["contents", "tableOfContents", "url", "readTimeMinutes"];
     combinedPost = {...foreignPost, ...localPost} as Post & FragmentTypes[FragmentTypeName];
     for (const field of overrideFields) {
       combinedPost[field] = foreignPost?.[field] ?? localPost[field];

--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -17,9 +17,12 @@ export const isPostWithForeignId =
     typeof post.fmCrosspost.hostedHere === "boolean" &&
     !!post.fmCrosspost.foreignPostId;
 
-// If this post was crossposted from elsewhere then we want to take most of the fields from
-// our local copy (for correct links/ids/etc.) but we need to override a few specific fields
-// to actually get the correct content and some metadata that isn't denormalized across sites
+/**
+ * If this post was crossposted from elsewhere then we want to take some of the fields from
+ * our local copy (for correct links/ids/etc.), but we want to override many of the fields with foreign
+ * data, to keep the origin post as the source of truth, and get some metadata that isn't 
+ * denormalized across sites.
+ */
 const overrideFields = [
   "contents",
   "tableOfContents",

--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -28,23 +28,6 @@ const overrideFields = [
   "tableOfContents",
   "url",
   "readTimeMinutes",
-  "activateRSVPs",
-  "eventType",
-  "startTime",
-  "endTime",
-  "localStartTime",
-  "localEndTime",
-  "mongoLocation",
-  "googleLocation",
-  "location",
-  "contactInfo",
-  "eventRegistrationLink",
-  "joinEventLink",
-  "onlineEvent",
-  "globalEvent",
-  "facebookLink",
-  "meetupLink",
-  "website",
 ] as const;
 
 /**

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostComments.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostComments.tsx
@@ -29,7 +29,8 @@ const PostsPageCrosspostComments = ({classes}: {classes: ClassesType}) => {
   const commentsText = comments === 0
     ? "Click to view."
     : `Click to view ${comments} comment${comments === 1 ? "" : "s"}.`;
-  const link = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", `posts/${foreignPost._id}`);
+  const base = foreignPost.isEvent ? "events" : "posts";
+  const link = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", `${base}/${foreignPost._id}`);
 
   const {Typography} = Components;
   return (

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostComments.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostComments.tsx
@@ -5,6 +5,7 @@ import {
   fmCrosspostBaseUrlSetting,
 } from "../../../lib/instanceSettings";
 import { useCrosspostContext } from "./PostsPageCrosspostWrapper";
+import { postGetPageUrl } from "../../../lib/collections/posts/helpers";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -29,8 +30,7 @@ const PostsPageCrosspostComments = ({classes}: {classes: ClassesType}) => {
   const commentsText = comments === 0
     ? "Click to view."
     : `Click to view ${comments} comment${comments === 1 ? "" : "s"}.`;
-  const base = foreignPost.isEvent ? "events" : "posts";
-  const link = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", `${base}/${foreignPost._id}`);
+  const link = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", postGetPageUrl(foreignPost));
 
   const {Typography} = Components;
   return (

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1273,7 +1273,7 @@ const schema: SchemaType<DbPost> = {
     insertableBy: ['members'],
     control: "FMCrosspostControl",
     group: formGroups.advancedOptions,
-    hidden: !fmCrosspostSiteNameSetting.get(),
+    hidden: (props) => !fmCrosspostSiteNameSetting.get() || props.eventForm,
     ...schemaDefaultValue({
       isCrosspost: false,
     }),

--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -68,7 +68,7 @@ const updateCrosspost = async (postId: string, denormalizedData: DenormalizedCro
 
 export const handleCrosspostUpdate = async (document: DbPost, data: Partial<DbPost>) => {
   if (
-    denormalizedFieldKeys.some((key) => data[key] !== undefined) &&
+    denormalizedFieldKeys.some((key) => data[key] !== undefined && data[key] !== document[key]) &&
     document.fmCrosspost?.foreignPostId
   ) {
     const denormalizedData = denormalizedFieldKeys.reduce(

--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -9,6 +9,10 @@ import { crosspostUserAgent } from "../../lib/apollo/links";
 import { denormalizedFieldKeys, DenormalizedCrosspostData, extractDenormalizedData } from "./denormalizedFields";
 
 export const performCrosspost = async <T extends Crosspost>(post: T): Promise<T> => {
+  if (post.isEvent) {
+    throw new Error("Events cannot be crossposted");
+  }
+
   if (!post.fmCrosspost || !post.userId || post.draft) {
     return post;
   }
@@ -67,6 +71,10 @@ const updateCrosspost = async (postId: string, denormalizedData: DenormalizedCro
 }
 
 export const handleCrosspostUpdate = async (document: DbPost, data: Partial<DbPost>) => {
+  if (document.isEvent || data.isEvent) {
+    throw new Error("Events cannot be crossposted");
+  }
+
   if (
     denormalizedFieldKeys.some((key) => data[key] !== undefined && data[key] !== document[key]) &&
     document.fmCrosspost?.foreignPostId

--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -1,0 +1,26 @@
+import { hasStringParam, hasBooleanParam } from "./validationHelpers";
+import { pick } from "underscore";
+
+/**
+ * In general, we try to keep a single source of truth for all post data that's
+ * crossposted on the original server and let the foreign server make graphql
+ * requests when it needs access to this.
+ *
+ * Some fields have to be denormalized across sites though for various reasons -
+ * these are defined here.
+ */
+export const denormalizedFieldKeys = [
+  "draft",
+  "deletedDraft",
+  "title",
+] as const;
+
+export const isValidDenormalizedData = (payload: unknown): payload is DenormalizedCrosspostData =>
+  hasBooleanParam(payload, "draft") &&
+  hasBooleanParam(payload, "deletedDraft") &&
+  hasStringParam(payload, "title");
+
+export type DenormalizedCrosspostData = Pick<DbPost, typeof denormalizedFieldKeys[number]>;
+
+export const extractDenormalizedData = <T extends DenormalizedCrosspostData>(data: T) =>
+  pick(data, ...denormalizedFieldKeys);

--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -1,5 +1,5 @@
 import { hasStringParam, hasBooleanParam } from "./validationHelpers";
-import { pick } from "underscore";
+import pick from "lodash/pick";
 
 /**
  * In general, we try to keep a single source of truth for all post data that's

--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -6,19 +6,24 @@ import { pick } from "underscore";
  * crossposted on the original server and let the foreign server make graphql
  * requests when it needs access to this.
  *
- * Some fields have to be denormalized across sites though for various reasons -
- * these are defined here.
+ * Some fields have to be denormalized across sites and these are defined here. In
+ * general, a field needs to be denormalized if it's used by PostsList2 or
+ * in database selectors (but these rules aren't strict).
+ *
+ * When adding a new field here, make sure to also update isValidDenormalizedData
  */
 export const denormalizedFieldKeys = [
   "draft",
   "deletedDraft",
   "title",
+  "isEvent",
 ] as const;
 
 export const isValidDenormalizedData = (payload: unknown): payload is DenormalizedCrosspostData =>
   hasBooleanParam(payload, "draft") &&
   hasBooleanParam(payload, "deletedDraft") &&
-  hasStringParam(payload, "title");
+  hasStringParam(payload, "title") &&
+  hasBooleanParam(payload, "isEvent");
 
 export type DenormalizedCrosspostData = Pick<DbPost, typeof denormalizedFieldKeys[number]>;
 

--- a/packages/lesswrong/server/fmCrosspost/resolvers.ts
+++ b/packages/lesswrong/server/fmCrosspost/resolvers.ts
@@ -32,6 +32,8 @@ export const makeCrossSiteRequest = async <T extends {}>(
   });
   const json = await result.json();
   if (json.status !== expectedStatus) {
+    // eslint-disable-next-line no-console
+    console.error("Cross-site request failed:", json);
     throw new ApiError(500, onErrorMessage);
   }
   return json;

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -37,17 +37,20 @@ export const validateUpdateCrosspostPayload = (payload: unknown): payload is Upd
   return true;
 }
 
-export type CrosspostPayload = {
+export type CrosspostPayload = DenormalizedCrosspostData & {
   localUserId: string,
   foreignUserId: string,
+  postId: string,
 }
 
 export const validateCrosspostPayload = (payload: unknown): payload is CrosspostPayload => {
   if (
     !hasStringParam(payload, "localUserId") ||
-    !hasStringParam(payload, "foreignUserId")
+    !hasStringParam(payload, "foreignUserId") ||
+    !hasStringParam(payload, "postId") ||
+    !isValidDenormalizedData(payload)
   ) {
-    throw new MissingParametersError(["localUserId", "foreignUserId"], payload);
+    throw new MissingParametersError(["localUserId", "foreignUserId", "postId", ...denormalizedFieldKeys], payload);
   }
   return true;
 }

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -1,4 +1,6 @@
 import { MissingParametersError } from "./errors";
+import { denormalizedFieldKeys, DenormalizedCrosspostData, isValidDenormalizedData } from "./denormalizedFields";
+import { hasStringParam } from "./validationHelpers";
 
 export type ConnectCrossposterArgs = {
   token: string,
@@ -7,19 +9,6 @@ export type ConnectCrossposterArgs = {
 export type ConnectCrossposterPayload = {
   userId: string,
 }
-
-const hasBooleanParam = (payload: unknown, param: string) =>
-  payload &&
-  typeof payload === "object" &&
-  param in payload &&
-  typeof payload[param] === "boolean";
-
-const hasStringParam = (payload: unknown, param: string) =>
-  payload &&
-  typeof payload === "object" &&
-  param in payload &&
-  typeof payload[param] === "string" &&
-  payload[param].length;
 
 export const validateConnectCrossposterPayload = (payload: unknown): payload is ConnectCrossposterPayload => {
   if (!hasStringParam(payload, "userId")) {
@@ -39,21 +28,11 @@ export const validateUnlinkCrossposterPayload = (payload: unknown): payload is U
   return true;
 }
 
-export type UpdateCrosspostPayload = {
-  postId: string,
-  draft: boolean,
-  deletedDraft: boolean,
-  title: string,
-}
+export type UpdateCrosspostPayload = DenormalizedCrosspostData & { postId: string }
 
 export const validateUpdateCrosspostPayload = (payload: unknown): payload is UpdateCrosspostPayload => {
-  if (
-    !hasStringParam(payload, "postId") ||
-    !hasBooleanParam(payload, "draft") ||
-    !hasBooleanParam(payload, "deletedDraft") ||
-    !hasStringParam(payload, "title")
-  ) {
-    throw new MissingParametersError(["postId", "draft", "draftDeleted", "title"], payload);
+  if (!hasStringParam(payload, "postId") || !isValidDenormalizedData(payload)) {
+    throw new MissingParametersError(["postId", ...denormalizedFieldKeys], payload);
   }
   return true;
 }
@@ -73,4 +52,4 @@ export const validateCrosspostPayload = (payload: unknown): payload is Crosspost
   return true;
 }
 
-export type Crosspost = Pick<DbPost, "_id" | "title" | "userId" | "fmCrosspost" | "draft">;
+export type Crosspost = Pick<DbPost, "_id" | "userId" | "fmCrosspost" | typeof denormalizedFieldKeys[number]>;

--- a/packages/lesswrong/server/fmCrosspost/validationHelpers.ts
+++ b/packages/lesswrong/server/fmCrosspost/validationHelpers.ts
@@ -1,0 +1,12 @@
+export const hasBooleanParam = (payload: unknown, param: string) =>
+  payload &&
+  typeof payload === "object" &&
+  param in payload &&
+  typeof payload[param] === "boolean";
+
+export const hasStringParam = (payload: unknown, param: string) =>
+  payload &&
+  typeof payload === "object" &&
+  param in payload &&
+  typeof payload[param] === "string" &&
+  payload[param].length;


### PR DESCRIPTION
Crossposting events currently doesn't work correctly - the crossposting happens, but the foreign site thinks it's just a normal post. Most of the work in this PR is just generalizing the way that denormalized fields are handled so that we can simply add new denormalized fields to the `denormalizedFieldKeys` array in the future (as we do with `isEvent` here).

We also need to add a _ton_ of fields to `overrideFields` on the frontend to make sure we fetch all the normalized data correctly. Part of me feels like this could move directly onto the schema like `overrideOnForeignCrosspost: true` or something, but then it becomes a lot less localized and more difficult to reason about. I'm not 100% either way.

Note that, even with these changes, crossposted events still won't show up on when searching on the `/events` page, but I think fixing that (if we think it's worth fixing) is complex enough to warrant a separate PR as it will involve denormalizing even more data.

It's also now possible to test crosspost PRs locally by starting two servers with `yarn ea-start` and `yarn ea-start-xpost-dev`, then the two sites will be available at `localhost:3000` and `localhost:4000`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203135194958302) by [Unito](https://www.unito.io)
