### PR TITLE
Add link to mod inbox

### DIFF
--- a/packages/lesswrong/components/messaging/InboxNavigation.tsx
+++ b/packages/lesswrong/components/messaging/InboxNavigation.tsx
@@ -5,6 +5,8 @@ import { useUpdate } from '../../lib/crud/withUpdate';
 import { useMulti } from '../../lib/crud/withMulti';
 import qs from 'qs'
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { Link } from '../../lib/reactRouterWrapper';
+import { userCanDo } from '../../lib/vulcan-users';
 
 // The Navigation for the Inbox components
 const InboxNavigation = ({classes, terms, currentUser, title="Your Conversations"}: {
@@ -14,7 +16,7 @@ const InboxNavigation = ({classes, terms, currentUser, title="Your Conversations
   title?: String
 }) => {
   const location = useLocation();
-  const { query } = location;
+  const { currentRoute, query } = location;
   const { history } = useNavigation();
   
   const { results, loading, loadMoreProps } = useMulti({
@@ -43,14 +45,19 @@ const InboxNavigation = ({classes, terms, currentUser, title="Your Conversations
     history.push({...location, search: `?${qs.stringify({expanded: !expanded})}`})
   }
 
+  const showModeratorLink = userCanDo(currentUser, 'conversations.view.all') && currentRoute.name !== "moderatorInbox"
+
   return (
     <SingleColumnSection>
         <SectionTitle title={title}>
-          <SectionFooterCheckbox
-            onClick={expandCheckboxClick}
-            value={expanded}
-            label={"Expand"}
-          />
+          <SectionFooter>
+            <SectionFooterCheckbox
+              onClick={expandCheckboxClick}
+              value={expanded}
+              label={"Expand"}
+            />
+            {showModeratorLink && <Link to={"/moderatorInbox"}>Mod Inbox</Link>}
+          </SectionFooter>
         </SectionTitle>
         {results?.length ?
           results.map(conversation => <ConversationItem key={conversation._id} conversation={conversation} updateConversation={updateConversation} currentUser={currentUser} expanded={expanded}/>


### PR DESCRIPTION
It was a bit annoying to get to the /moderatorInbox page, and this adds a link on the /inbox page.

![](https://user-images.githubusercontent.com/3246710/195217474-f01a0997-456c-4052-b5e6-857a6d24f9b6.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203146922573777) by [Unito](https://www.unito.io)
