### PR TITLE
Template message variable replacement

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -35,6 +35,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const getTemplateHtml = ({html, displayName, greetingName}) => {
+  if (!html) return
   let newHtml = html.replace(/.*\\\\/, "")
   if (displayName) {
     newHtml = newHtml.replace(/{{displayName}}/g, displayName)

--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -34,14 +34,14 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const getTemplateHtml = ({html, displayName, greetingName}) => {
+const getDraftMessageHtml = ({html, displayName, firstName}) => {
   if (!html) return
   let newHtml = html.replace(/.*\\\\/, "")
   if (displayName) {
     newHtml = newHtml.replace(/{{displayName}}/g, displayName)
   }
-  if (greetingName) {
-    newHtml = newHtml.replace(/{{greetingName}}/g, greetingName)
+  if (firstName) {
+    newHtml = newHtml.replace(/{{firstName}}/g, firstName)
   }
   return newHtml
 }
@@ -121,7 +121,7 @@ const ConversationPage = ({ documentId, terms, currentUser, classes }: {
   if (loading || (loadingTemplate && query.templateCommentId)) return <Loading />
   if (!conversation) return <Error404 />
 
-  const templateHtml = getTemplateHtml({html: template?.contents?.html, displayName: query.displayName, greetingName: query.greetingName })
+  const templateHtml = getDraftMessageHtml({html: template?.contents?.html, displayName: query.displayName, firstName: query.firstName })
 
   return (
     <SingleColumnSection>

--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -34,6 +34,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+const getTemplateHtml = ({html, displayName, greetingName}) => {
+  let newHtml = html.replace(/.*\\\\/, "")
+  if (displayName) {
+    newHtml = newHtml.replace(/{{displayName}}/g, displayName)
+  }
+  if (greetingName) {
+    newHtml = newHtml.replace(/{{greetingName}}/g, greetingName)
+  }
+  return newHtml
+}
+
 // The Navigation for the Inbox components
 const ConversationPage = ({ documentId, terms, currentUser, classes }: {
   documentId: string,
@@ -109,6 +120,8 @@ const ConversationPage = ({ documentId, terms, currentUser, classes }: {
   if (loading || (loadingTemplate && query.templateCommentId)) return <Loading />
   if (!conversation) return <Error404 />
 
+  const templateHtml = getTemplateHtml({html: template?.contents?.html, displayName: query.displayName, greetingName: query.greetingName })
+
   return (
     <SingleColumnSection>
       <div className={classes.conversationSection}>
@@ -131,7 +144,7 @@ const ConversationPage = ({ documentId, terms, currentUser, classes }: {
               contents: {
                 originalContents: {
                   type: "ckEditorMarkup",
-                  data: template?.contents?.html,
+                  data: templateHtml
                 }
               }
             }}

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -9,12 +9,12 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useDialog } from '../common/withDialog';
 
 // Button used to start a new conversation for a given user
-const NewConversationButton = ({ user, currentUser, children, templateCommentId, from, includeModerators }: {
+const NewConversationButton = ({ user, currentUser, children, from, includeModerators, templateQueries }: {
   user: {
     _id: string
   },
   currentUser: UsersCurrent|null,
-  templateCommentId?: string,
+  templateQueries?: object,
   from?: string,
   children: any,
   includeModerators?: boolean
@@ -59,13 +59,13 @@ const NewConversationButton = ({ user, currentUser, children, templateCommentId,
 
   const existingConversationCheck = (initiatingUser: UsersCurrent) => () => {
     let searchParams: Array<string> = []
-    if (templateCommentId) {
-      searchParams.push(qs.stringify({templateCommentId: templateCommentId}))
+    if (templateQueries) {
+      searchParams.push(qs.stringify(templateQueries))
     }
     if (from) {
       searchParams.push(`from=${from}`)
     }
-    const search = searchParams ? {search:`?${searchParams.join('&')}`} : {}
+    const search = searchParams.length > 0 ? {search:`?${searchParams.join('&')}`} : {}
     
     for (let conversation of (results ?? [])) {
       history.push({pathname: `/inbox/${conversation._id}`, ...search})

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -63,6 +63,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
   
   
   if (!(user && currentUser)) return null
+  const greetingName = user.displayName.split(" ")[0]
   
   return (
     <div className={classes.root}>
@@ -90,7 +91,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
               </div>}
             >
               <MenuItem>
-                <NewConversationButton user={user} currentUser={currentUser} templateCommentId={comment._id} includeModerators>
+                <NewConversationButton user={user} currentUser={currentUser} templateQueries={{templateCommentId: comment._id, greetingName, displayName: user.displayName}} includeModerators>
                   {getTitle(comment.contents?.plaintextMainText || null)}
                 </NewConversationButton>
               </MenuItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -63,7 +63,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
   
   
   if (!(user && currentUser)) return null
-  const greetingName = user.displayName.split(" ")[0]
+  const firstName = user.displayName.split(" ")[0]
   
   return (
     <div className={classes.root}>
@@ -91,7 +91,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
               </div>}
             >
               <MenuItem>
-                <NewConversationButton user={user} currentUser={currentUser} templateQueries={{templateCommentId: comment._id, greetingName, displayName: user.displayName}} includeModerators>
+                <NewConversationButton user={user} currentUser={currentUser} templateQueries={{templateCommentId: comment._id, firstName, displayName: user.displayName}} includeModerators>
                   {getTitle(comment.contents?.plaintextMainText || null)}
                 </NewConversationButton>
               </MenuItem>


### PR DESCRIPTION
This begins to actually replace the mod template message variables with their substance. (i.e. {{displayName}} turns into the user's display name).

<img width="683" alt="image" src="https://user-images.githubusercontent.com/3246710/195241496-39c553e9-ebce-41dd-9625-94d4294864ec.png">

compared to:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/3246710/195241232-ab72e212-8210-4a0d-8899-640257b7b4ac.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203147494390793) by [Unito](https://www.unito.io)
