### PR TITLE
Lighten pin icon

### DIFF
--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -37,7 +37,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingRight: 10,
     position: "relative",
     top: 2,
-    color: theme.palette.icon.maxIntensity,
+    color: theme.palette.icon.slightlyDim3,
   },
   primaryIcon: {
     color: theme.palette.icon.dim55,


### PR DESCRIPTION
On Lizka's request, I think this looks better on LW too so I haven't forum gated it

Before/after EA forum:
![](https://user-images.githubusercontent.com/77623106/195321982-19c76afe-7abf-427c-899b-94a85e32b7ae.png)
![](https://user-images.githubusercontent.com/77623106/195321976-55b005df-322f-4c3e-a72e-9b51e8c3fdd3.png)

Before/after LW:
<img width="838" alt="Screenshot 2022-10-12 at 11 42 06" src="https://user-images.githubusercontent.com/77623106/195322423-3e7a186c-6e0e-48d7-963d-1b7dc697a4ac.png">
<img width="838" alt="Screenshot 2022-10-12 at 11 42 13" src="https://user-images.githubusercontent.com/77623106/195322425-fd1f9b33-9428-4774-bee1-8ca3be94c99a.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203149747717316) by [Unito](https://www.unito.io)
