### PR TITLE
Moderator comment count

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -109,12 +109,14 @@ const ConversationPage = ({ documentId, terms, currentUser, classes }: {
   if (loading || (loadingTemplate && query.templateCommentId)) return <Loading />
   if (!conversation) return <Error404 />
 
+  const showModInboxLink = userCanDo(currentUser, 'conversations.view.all') && conversation.moderator
+
   return (
     <SingleColumnSection>
       <div className={classes.conversationSection}>
         <div className={classes.row}>
           <Typography variant="body2" className={classes.backButton}><Link to="/inbox"> Go back to Inbox </Link></Typography>
-          {userCanDo(currentUser, 'conversations.view.all') && conversation.moderator && <Typography variant="body2" className={classes.backButton}>
+          {showModInboxLink && <Typography variant="body2" className={classes.backButton}>
             <Link to="/moderatorInbox"> Moderator Inbox </Link>
           </Typography>}
         </div>

--- a/packages/lesswrong/components/messaging/InboxNavigation.tsx
+++ b/packages/lesswrong/components/messaging/InboxNavigation.tsx
@@ -7,11 +7,11 @@ import qs from 'qs'
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 // The Navigation for the Inbox components
-const InboxNavigation = ({classes, terms, currentUser, title="Your Conversations"}: {
+const InboxNavigation = ({classes, terms, currentUser, title=<>Your Conversations</>}: {
   classes: ClassesType,
   terms: ConversationsViewTerms,
   currentUser: UsersCurrent,
-  title?: String
+  title?: JSX.Element
 }) => {
   const location = useLocation();
   const { query } = location;

--- a/packages/lesswrong/components/messaging/ModeratorInboxWrapper.tsx
+++ b/packages/lesswrong/components/messaging/ModeratorInboxWrapper.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useLocation } from '../../lib/routeUtil';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const ModeratorInboxWrapper = () => {
   const { ErrorAccessDenied } = Components
@@ -16,8 +17,8 @@ const ModeratorInboxWrapper = () => {
     return <ErrorAccessDenied/>
   }
   const showArchive = query.showArchive === "true"
-  const terms: ConversationsViewTerms = {view: 'moderatorConversations', showArchive};
-  return <Components.InboxNavigation terms={terms} currentUser={currentUser} title="Moderator Conversations"/>
+  const terms: ConversationsViewTerms = {view: 'moderatorConversations', showArchive, userId: query.userId};
+  return <Components.InboxNavigation terms={terms} currentUser={currentUser} title={<Link to="/moderatorInbox">Moderator Conversations</Link>}/>
 }
 
 const ModeratorInboxWrapperComponent = registerComponent('ModeratorInboxWrapper', ModeratorInboxWrapper);

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorMessageCount.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorMessageCount.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { Link } from '../../lib/reactRouterWrapper';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import EmailIcon from '@material-ui/icons/Email';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    ...theme.typography.body2,
+    color: theme.palette.grey[600],
+    cursor: "pointer",
+    position: "relative",
+    top: 2
+  },
+  icon: {
+    height: 13,
+    position: "relative",
+    top: 1
+  }
+});
+
+export const ModeratorMessageCount = ({classes, userId}: {
+  userId: string,
+  classes: ClassesType,
+}) => {
+  const { LWTooltip } = Components
+  const { loading, totalCount } = useMulti({
+    terms: {view: "moderatorConversations", userId},
+    collectionName: "Conversations",
+    fragmentName: 'conversationIdFragment',
+    fetchPolicy: 'cache-and-network',
+    enableTotal: true
+  });
+
+  return <LWTooltip title={`Moderator Conversation Count`}>
+    <Link className={classes.root} to={`/moderatorInbox?userId=${userId}`}>
+      {loading && "..."} {totalCount} <EmailIcon className={classes.icon}/>
+    </Link>
+  </LWTooltip>
+}
+
+const ModeratorMessageCountComponent = registerComponent('ModeratorMessageCount', ModeratorMessageCount, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ModeratorMessageCount: typeof ModeratorMessageCountComponent
+  }
+}
+

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -369,7 +369,7 @@ const SunshineNewUsersInfo = ({ user, classes }: {
   const commentKarmaPreviews = comments ? _.sortBy(comments, contentSort) : []
   const postKarmaPreviews = posts ? _.sortBy(posts, contentSort) : []
 
-  const { MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, Typography, SunshineSendMessageWithDefaults, UsersNameWrapper } = Components
+  const { MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, Typography, SunshineSendMessageWithDefaults, UsersNameWrapper, ModeratorMessageCount } = Components
 
   const hiddenPostCount = user.maxPostCount - user.postCount
   const hiddenCommentCount = user.maxCommentCount - user.commentCount
@@ -450,6 +450,7 @@ const SunshineNewUsersInfo = ({ user, classes }: {
                 </LWTooltip>
               </div>
               <div className={classes.row}>
+                <ModeratorMessageCount userId={user._id} />
                 <SunshineSendMessageWithDefaults user={user} tagSlug={defaultModeratorPMsTagSlug.get()}/>
               </div>
             </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -70,7 +70,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
         className={classes.sendMessageButton}
         onClick={(ev) => setAnchorEl(ev.currentTarget)}
       >
-        Start Message
+        New Message
       </span>
       <Menu
         onClick={() => setAnchorEl(null)}
@@ -79,7 +79,7 @@ const SunshineSendMessageWithDefaults = ({ user, tagSlug, classes }: {
       >
         <MenuItem value={0}>
           <NewConversationButton user={user} currentUser={currentUser} includeModerators>
-            Start a message
+            New Message
           </NewConversationButton>
         </MenuItem>
         {defaultResponses && defaultResponses.map((comment, i) =>

--- a/packages/lesswrong/lib/collections/conversations/views.ts
+++ b/packages/lesswrong/lib/collections/conversations/views.ts
@@ -25,9 +25,10 @@ Conversations.addDefaultView(function (terms: ConversationsViewTerms) {
 
 // notifications for the site moderation team
 Conversations.addView("moderatorConversations", function (terms: ConversationsViewTerms) {
+  const participantIds = terms.userId ? {participantIds: terms.userId} : {}
   const showArchivedFilter = terms.showArchive ? {} : {archivedByIds: {$ne: terms.userId}}
   return {
-    selector: {moderator: true, messageCount: {$gt: 0}, ...showArchivedFilter},
+    selector: {moderator: true, messageCount: {$gt: 0}, ...showArchivedFilter, ...participantIds},
     options: {sort: {latestActivity: -1}}
   };
 });

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -470,6 +470,7 @@ importComponent("PostKarmaWithPreview", () => require('../components/sunshineDas
 importComponent("SunshineNewCommentsList", () => require('../components/sunshineDashboard/SunshineNewCommentsList'));
 importComponent("SunshineReportedContentList", () => require('../components/sunshineDashboard/SunshineReportedContentList'));
 importComponent("SunshineReportedItem", () => require('../components/sunshineDashboard/SunshineReportedItem'));
+importComponent("ModeratorMessageCount", () => require('../components/sunshineDashboard/ModeratorMessageCount'));
 importComponent("SunshineCuratedSuggestionsItem", () => require('../components/sunshineDashboard/SunshineCuratedSuggestionsItem'));
 importComponent("SunshineCuratedSuggestionsList", () => require('../components/sunshineDashboard/SunshineCuratedSuggestionsList'));
 importComponent("SunshineNewTagsList", () => require('../components/sunshineDashboard/SunshineNewTagsList'));


### PR DESCRIPTION
Adds a moderator-comment count to the SunshineNewUsersInfo, which is also a link to a /moderatorInbox page filtered to show conversations with the user-in-question:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/3246710/195446172-9b75304c-e924-4b6e-956a-364d7a73e2ed.png">
