### PR TITLE
Fix sunshine sidebar causing various frontpage stuff to not load

### DIFF
--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -9,6 +9,7 @@ registerFragment(`
     topLevelCommentId
     descendentCount
     contents {
+      _id
       html
       plaintextMainText
     }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1189,6 +1189,7 @@ interface CommentsList { // fragment on Comments
 }
 
 interface CommentsList_contents { // fragment on Revisions
+  readonly _id: string,
   readonly html: string,
   readonly plaintextMainText: string,
 }


### PR DESCRIPTION
We said on Slack that we'd deprioritise this bug, but Lizka found another affected case today that was a lot more serious as it prevented us from interacting with some flagged content. I spent some more time digging in to it and I'm pretty sure this is the correct solution (it seems to fix the issue on local).

The problem is that we don't send the `_id` with the `contents` field on the `CommentsList` fragment, which means that the Apollo cache falls over when it tries to normalize the data.

0/10 would not debug again.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203166368566648) by [Unito](https://www.unito.io)
