### PR TITLE
revert algolia posts index ranking to default order (before the custom rankings)

### DIFF
--- a/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
+++ b/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
@@ -55,7 +55,7 @@ export const algoliaConfigureIndexes = async () => {
       'unordered(authorDisplayName)',
       'unordered(_id)',
     ],
-    ranking: ['typo','geo','words','filters','exact','proximity','attribute','custom'],
+    ranking: ['typo','geo','words','filters','proximity','attribute','exact','custom'],
     customRanking: [
       'asc(order)',
       'desc(baseScore)',


### PR DESCRIPTION
This is based on a report by Lizka, where she noticed that the search results would prioritize matching headings in the post body over matching on the post title. I agreed that we weigh matching a post title more. So I'm reverting us back to the default ranking order, as we think that gives us better results.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203184952762555) by [Unito](https://www.unito.io)
