### PR TITLE
update moderator comment background color

### DIFF
--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -319,7 +319,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     newCommentFormModerationGuidelines: shades.greyAlpha(.07),
     commentNodeEven: shades.grey[120],
     commentNodeOdd: shades.grey[25],
-    commentModeratorHat: "#5f9b651c",
+    commentModeratorHat: "#ecf2ed",
     commentHighlightAnimation: shades.grey[300],
     postsItemExpandedComments: shades.grey[50],
     metaculusBackground: "#2c3947",


### PR DESCRIPTION
I noticed that the moderator comment hoverover is too transparent, so I replaced the color. Hopefully it looks the same.

- - -
Before:

![](https://user-images.githubusercontent.com/9057804/196303974-ad4817a1-face-4aa6-b31d-871c049f4d2d.png)

- - -
After:

![](https://user-images.githubusercontent.com/9057804/196304073-7d397a6b-802f-49ef-9de2-5137ce04bb3b.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203187825160269) by [Unito](https://www.unito.io)
