### PR TITLE
Fix invalid 'source' in mergeAccounts script

### DIFF
--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -368,7 +368,7 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
         await Users.rawUpdateOne(
           {_id: sourceUserId},
           {$set: {
-            'emails.0': {address: newEmail, verified: source.emails[0].verified}
+            'emails.0': {address: newEmail, verified: sourceEmailsEmail ? sourceEmailsEmail.verified : false}
           }}
         );
       }


### PR DESCRIPTION
Currently causing a type error on master.