### PR TITLE
Postgres migration transactions

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -1,4 +1,16 @@
 require("ts-node/register");
-require("./packages/lesswrong/server/migrations/meta/umzug")
-  .createMigrator()
-  .then((migrator) => migrator.runAsCLI().finally(process.exit));
+const { createSqlConnection } = require("./packages/lesswrong/server/sqlConnection");
+const { createMigrator }  = require("./packages/lesswrong/server/migrations/meta/umzug");
+
+(async () => {
+  try {
+    const db = await createSqlConnection();
+    await db.tx(async (transaction) => {
+      const migrator = await createMigrator(transaction);
+      await migrator.runAsCLI();
+    });
+  } finally {
+    // Call exit manually as the Postgres thread pool stalls the exit for ~10 seconds
+    process.exit(1);
+  }
+})();

--- a/migrate.js
+++ b/migrate.js
@@ -9,8 +9,11 @@ const { createMigrator }  = require("./packages/lesswrong/server/migrations/meta
       const migrator = await createMigrator(transaction);
       await migrator.runAsCLI();
     });
-  } finally {
-    // Call exit manually as the Postgres thread pool stalls the exit for ~10 seconds
+  } catch (e) {
+    console.error("An error occurred while running migrations:", e);
     process.exit(1);
+  } finally {
+    // Call exit manually as the Postgres thread pool can stall the exit for ~10 seconds
+    process.exit(0);
   }
 })();

--- a/packages/lesswrong/server/migrations/meta/PgStorage.ts
+++ b/packages/lesswrong/server/migrations/meta/PgStorage.ts
@@ -60,7 +60,7 @@ class PgStorage implements UmzugStorage<MigrationContext> {
    */
   async executed({context}: Pick<MigrationParams<MigrationContext>, "context">): Promise<string[]> {
     const {db} = context;
-    const result: {name: string}[] = await db.any("SELECT name FROM migration_log ORDER BY end_time DESC");
+    const result: {name: string}[] = await db.any("SELECT name FROM migration_log ORDER BY name DESC");
     return result.map(({name}) => name);
   }
 }

--- a/packages/lesswrong/server/migrations/meta/umzug.ts
+++ b/packages/lesswrong/server/migrations/meta/umzug.ts
@@ -1,7 +1,6 @@
 import { Umzug } from "@centreforeffectivealtruism/umzug";
 import { readFileSync } from "fs";
 import { createHash } from "crypto";
-import { createSqlConnection } from "../../sqlConnection";
 import PgStorage from "./PgStorage";
 
 declare global {
@@ -19,9 +18,7 @@ declare global {
 
 const root = "./packages/lesswrong/server/migrations";
 
-export const createMigrator = async () => {
-  const db = await createSqlConnection();
-
+export const createMigrator = async (db: SqlClient) => {
   const storage = new PgStorage();
   await storage.setupEnvironment(db);
 


### PR DESCRIPTION
This PR adds the two features that we discussed on the initial migrations PR:

1. Each migration run now takes place inside a single transaction, so a failed migration with revert any previous successful migrations as well.
2. Migration ordering is enforced. Trying to run migrations out of order will result in a prompt being shown to the user where they can choose to either exit the migration run to fix the problem manually, force the migration to be executed anyway (strongly discouraged in prod, but almost certainly userful on dev), or automatically rename the out-of-order migration file to the current timestamp. In the deploy pipeline, we'll always want to choose the first option, so we can just run `yes n | yarn migrate up`, for instance.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203199912568647) by [Unito](https://www.unito.io)
