### PR TITLE
fix localgroup banner img cropping

### DIFF
--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -117,12 +117,13 @@ const formPreviewSizeByImageType = {
   }
 }
 
-const ImageUpload = ({name, document, updateCurrentValues, clearField, label, classes}: {
+const ImageUpload = ({name, document, updateCurrentValues, clearField, label, croppingAspectRatio, classes}: {
   name: string,
   document: Object,
   updateCurrentValues: Function,
   clearField: Function,
   label: string,
+  croppingAspectRatio?: number,
   classes: ClassesType
 }) => {
   const theme = useTheme();
@@ -173,7 +174,8 @@ const ImageUpload = ({name, document, updateCurrentValues, clearField, label, cl
             }
         }
       },
-      ...cloudinaryArgs
+      ...cloudinaryArgs,
+      ...(croppingAspectRatio ? {croppingAspectRatio} : {})
     }, setImageInfo);
   }
   

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -238,7 +238,10 @@ const schema: SchemaType<DbLocalgroup> = {
     insertableBy: ['members'],
     label: "Banner Image",
     control: "ImageUpload",
-    tooltip: "Recommend 1640x856 px, 1.91:1 aspect ratio (same as Facebook)"
+    tooltip: "Recommend 1640x856 px, 1.91:1 aspect ratio (same as Facebook)",
+    form: {
+      croppingAspectRatio: 1.91
+    }
   },
   
   inactive: {


### PR DESCRIPTION
A while back, we changed localgroup banner images from being full width to using fixed dimensions, and at the time I updated the `croppingAspectRatio` to match. But currently most banner images are still full width and use the new wider aspect ratio, so I'm fixing the localgroup case by just passing in a custom `croppingAspectRatio`.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203202265719335) by [Unito](https://www.unito.io)
