### PR TITLE
Sequences use PostsItem again, checkbox refactor

### DIFF
--- a/packages/lesswrong/components/posts/PostReadCheckbox.tsx
+++ b/packages/lesswrong/components/posts/PostReadCheckbox.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import CheckBoxTwoToneIcon from '@material-ui/icons/CheckBoxTwoTone';
+import { forumTypeSetting } from '../../lib/instanceSettings';
+import { useItemsRead } from '../common/withRecordPostView';
+import { useNamedMutation } from '../../lib/crud/withMutation';
+import classNames from 'classnames';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    cursor: "pointer",
+  },
+  read: {
+    color: forumTypeSetting.get() === "EAForum"
+      ? theme.palette.primary.main
+      : theme.palette.primary.light,
+  },
+  unread: {
+    color: theme.palette.grey[400],
+  },
+});
+
+export const PostReadCheckbox = ({classes, post, width=12}: {
+  classes: ClassesType,
+  post: PostsBase,
+  width?: number
+}) => {
+  const { LWTooltip } = Components
+  const {postsRead, setPostRead} = useItemsRead();
+
+  const isRead = post.isRead || postsRead[post._id];
+
+  const {mutate: markAsReadOrUnread} = useNamedMutation<{
+    postId: string, isRead: boolean,
+  }>({
+    name: 'markAsReadOrUnread',
+    graphqlArgs: {postId: 'String', isRead: 'Boolean'},
+  });
+  
+  const handleMarkAsRead = () => {
+    void markAsReadOrUnread({
+      postId: post._id,
+      isRead: true,
+    });
+    setPostRead(post._id, true);
+  }
+
+  const handleMarkAsUnread = () => {
+    void markAsReadOrUnread({
+      postId: post._id,
+      isRead: false,
+    });
+    setPostRead(post._id, false);
+  }
+
+  if (isRead) {
+    return <LWTooltip title="Mark as unread">
+      <CheckBoxTwoToneIcon 
+        className={classNames(classes.root, classes.read)} 
+        style={{width}}
+        onClick={handleMarkAsUnread}
+      />
+    </LWTooltip>
+  } else {
+    return <LWTooltip title="Mark as read">
+      <CheckBoxOutlineBlankIcon 
+        className={classNames(classes.root, classes.unread)} 
+        style={{width}} 
+        onClick={handleMarkAsRead} 
+      />
+    </LWTooltip>
+
+  }
+}
+
+const PostReadCheckboxComponent = registerComponent('PostReadCheckbox', PostReadCheckbox, {styles});
+
+declare global {
+  interface ComponentTypes {
+    PostReadCheckbox: typeof PostReadCheckboxComponent
+  }
+}
+

--- a/packages/lesswrong/components/posts/PostReadCheckbox.tsx
+++ b/packages/lesswrong/components/posts/PostReadCheckbox.tsx
@@ -28,6 +28,7 @@ export const PostReadCheckbox = ({classes, post, width=12}: {
 }) => {
   const { LWTooltip } = Components
   const {postsRead, setPostRead} = useItemsRead();
+  
 
   const isRead = post.isRead || postsRead[post._id];
 
@@ -38,20 +39,12 @@ export const PostReadCheckbox = ({classes, post, width=12}: {
     graphqlArgs: {postId: 'String', isRead: 'Boolean'},
   });
   
-  const handleMarkAsRead = () => {
+  const handleSetIsRead = (isRead) => {
     void markAsReadOrUnread({
       postId: post._id,
-      isRead: true,
+      isRead: isRead,
     });
-    setPostRead(post._id, true);
-  }
-
-  const handleMarkAsUnread = () => {
-    void markAsReadOrUnread({
-      postId: post._id,
-      isRead: false,
-    });
-    setPostRead(post._id, false);
+    setPostRead(post._id, isRead);
   }
 
   if (isRead) {
@@ -59,7 +52,7 @@ export const PostReadCheckbox = ({classes, post, width=12}: {
       <CheckBoxTwoToneIcon 
         className={classNames(classes.root, classes.read)} 
         style={{width}}
-        onClick={handleMarkAsUnread}
+        onClick={() => handleSetIsRead(false)}
       />
     </LWTooltip>
   } else {
@@ -67,10 +60,9 @@ export const PostReadCheckbox = ({classes, post, width=12}: {
       <CheckBoxOutlineBlankIcon 
         className={classNames(classes.root, classes.unread)} 
         style={{width}} 
-        onClick={handleMarkAsRead} 
+        onClick={() => handleSetIsRead(true)}
       />
     </LWTooltip>
-
   }
 }
 

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -19,6 +19,11 @@ export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
 
 export const styles = (theme: ThemeType): JssStyles => ({
+  row: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between"
+  },
   root: {
     position: "relative",
     [theme.breakpoints.down('xs')]: {
@@ -295,6 +300,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   isRead: {
     // this is just a placeholder, enabling easier theming.
+  },
+  checkbox: {
+    marginRight: 10
   }
 })
 
@@ -320,7 +328,6 @@ const PostsItem2 = ({
   defaultToShowComments=false,
   sequenceId, 
   chapter,
-  index,
   terms,
   resumeReading,
   dismissRecommendation,
@@ -341,7 +348,8 @@ const PostsItem2 = ({
   curatedIconLeft=false,
   strikethroughTitle=false,
   translucentBackground=false,
-  forceSticky=false
+  forceSticky=false,
+  showReadCheckbox=false
 }: {
   /** post: The post displayed.*/
   post: PostsList,
@@ -390,7 +398,8 @@ const PostsItem2 = ({
   curatedIconLeft?: boolean,
   strikethroughTitle?: boolean
   translucentBackground?: boolean,
-  forceSticky?: boolean
+  forceSticky?: boolean,
+  showReadCheckbox?: boolean
 }) => {
   const [showComments, setShowComments] = React.useState(defaultToShowComments);
   const [readComments, setReadComments] = React.useState(false);
@@ -438,7 +447,7 @@ const PostsItem2 = ({
   const { PostsItemComments, PostsItemKarma, PostsTitle, PostsUserAndCoauthors, LWTooltip, 
     PostsPageActions, PostsItemIcons, PostsItem2MetaInfo, PostsItemTooltipWrapper,
     BookmarkButton, PostsItemDate, PostsItemNewCommentsWrapper, AnalyticsTracker,
-    AddToCalendarButton, PostsItemReviewVote, ReviewPostButton } = (Components as ComponentTypes)
+    AddToCalendarButton, PostsItemReviewVote, ReviewPostButton, PostReadCheckbox } = (Components as ComponentTypes)
 
   const postLink = postGetPageUrl(post, false, sequenceId || chapter?.sequenceId);
   const postEditLink = `/editPost?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`
@@ -468,7 +477,11 @@ const PostsItem2 = ({
   const reviewCountsTooltip = `${post.nominationCount2019 || 0} nomination${(post.nominationCount2019 === 1) ? "" :"s"} / ${post.reviewCount2019 || 0} review${(post.nominationCount2019 === 1) ? "" :"s"}`
 
   return (
-      <AnalyticsContext pageElementContext="postItem" postId={post._id} isSticky={isSticky(post, terms)}>
+    <AnalyticsContext pageElementContext="postItem" postId={post._id} isSticky={isSticky(post, terms)}>
+      <div className={classes.row}>
+        {showReadCheckbox && <div className={classes.checkbox}>
+          <PostReadCheckbox post={post} width={14} />
+        </div>}
         <div className={classNames(
           classes.root,
           {
@@ -476,7 +489,7 @@ const PostsItem2 = ({
             [classes.translucentBackground]: translucentBackground,
             [classes.bottomBorder]: showBottomBorder,
             [classes.commentsBackground]: renderComments,
-            [classes.isRead]: isRead
+            [classes.isRead]: isRead && !showReadCheckbox  // readCheckbox and post-title read-status don't aesthetically match
           })}
         >
           <PostsItemTooltipWrapper
@@ -503,7 +516,7 @@ const PostsItem2 = ({
                     <PostsTitle
                       postLink={post.draft ? postEditLink : postLink}
                       post={post}
-                      read={isRead}
+                      read={isRead && !showReadCheckbox} // readCheckbox and post-title read-status don't aesthetically match
                       sticky={isSticky(post, terms) || forceSticky}
                       showQuestionTag={showQuestionTag}
                       showDraftTag={showDraftTag}
@@ -513,7 +526,6 @@ const PostsItem2 = ({
                     />
                   </AnalyticsTracker>
                 </span>
-
 
                 {(resumeReading?.sequence || resumeReading?.collection) &&
                   <div className={classes.subtitle}>
@@ -615,7 +627,8 @@ const PostsItem2 = ({
             />
           </div>}
         </div>
-      </AnalyticsContext>
+      </div>
+    </AnalyticsContext>
   )
 };
 

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -39,7 +39,7 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
   }, []);
 
   const { ChaptersEditForm, ChapterTitle, SectionFooter,
-    SectionButton, ContentItemBody, ContentStyles, SequencesSmallPostLink } = Components
+    SectionButton, ContentItemBody, ContentStyles, PostsItem2 } = Components
   const html = chapter.contents?.html || ""
   if (edit) return (
     <ChaptersEditForm
@@ -56,7 +56,6 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
   <div>
     <div className={classes.title}>
       {chapter.title && <ChapterTitle title={chapter.title} large/>}
-      {canEdit && editButton}
     </div>
       {html && <ContentStyles contentType="post" className={classes.description}>
         <ContentItemBody
@@ -66,7 +65,11 @@ const ChaptersItem = ({ chapter, canEdit, classes }: {
       </ContentStyles>}
       <div className={classes.posts}>
         <AnalyticsContext chapter={chapter._id} capturePostItemOnMount>
-          {chapter.posts.map(post => <SequencesSmallPostLink key={chapter._id + post._id} sequenceId={chapter.sequenceId} post={post} large placement="bottom-end"/>)}
+          {chapter.posts.map(post => { 
+            return <div key={chapter._id + post._id}>
+              <PostsItem2 sequenceId={chapter.sequenceId} post={post} showReadCheckbox/>
+            </div>
+          })}
         </AnalyticsContext>
       </div>
       {!chapter.title && canEdit && <SectionFooter>{editButton}</SectionFooter>}

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -26,20 +26,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 10,
     marginTop: 10
   },
-  read: {
-    width: 12,
-    color: forumTypeSetting.get() === "EAForum"
-      ? theme.palette.primary.main
-      : theme.palette.primary.light,
-    marginRight: 10,
+  checkbox: {
     position: "relative",
-    top: -1
-  },
-  unread: {
-    width: 12,
-    color: theme.palette.grey[400],
-    marginRight: 10,
-    top: -1
+    top: -1,
+    marginRight: 10
   }
 });
 
@@ -50,17 +40,13 @@ const SequencesSmallPostLink = ({classes, post, sequenceId, large, placement="le
   large?: boolean,
   placement?: PopperPlacementType | undefined
 }) => {
-  const { LWTooltip, PostsPreviewTooltip } = Components
-
-  const { postsRead: clientPostsRead } = useItemsRead();
-
-  const isPostRead = post.isRead || clientPostsRead[post._id];
-
-  const icon = isPostRead ? <CheckBoxTwoToneIcon className={classes.read} /> : <CheckBoxOutlineBlankIcon className={classes.unread}/>
+  const { LWTooltip, PostsPreviewTooltip, PostReadCheckbox } = Components
 
   return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement={placement} inlineBlock={false} flip>
         <Link to={postGetPageUrl(post, false, sequenceId)} className={classNames(classes.title, {[classes.large]: large})}>
-          {icon} {post.title}
+          <div className={classes.checkbox}>
+            <PostReadCheckbox post={post} /> {post.title}
+          </div>
         </Link>
       </LWTooltip>
 }

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -28,7 +28,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   checkbox: {
     position: "relative",
-    top: -1,
+    top: 1,
     marginRight: 10
   }
 });
@@ -42,13 +42,16 @@ const SequencesSmallPostLink = ({classes, post, sequenceId, large, placement="le
 }) => {
   const { LWTooltip, PostsPreviewTooltip, PostReadCheckbox } = Components
 
-  return  <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement={placement} inlineBlock={false} flip>
-        <Link to={postGetPageUrl(post, false, sequenceId)} className={classNames(classes.title, {[classes.large]: large})}>
-          <div className={classes.checkbox}>
-            <PostReadCheckbox post={post} /> {post.title}
-          </div>
-        </Link>
-      </LWTooltip>
+  return <div className={classNames(classes.title, {[classes.large]: large})}>
+    <span className={classes.checkbox}>
+      <PostReadCheckbox post={post} />
+    </span>
+    <LWTooltip tooltip={false} clickable={true} title={<PostsPreviewTooltip post={post} postsList/>} placement={placement} inlineBlock={false} flip>
+      <Link to={postGetPageUrl(post, false, sequenceId)}>
+        {post.title}
+      </Link>
+    </LWTooltip>
+  </div>
 }
 
 const SequencesSmallPostLinkComponent = registerComponent("SequencesSmallPostLink", SequencesSmallPostLink, {styles});

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -232,6 +232,7 @@ importComponent("PostsListSortDropdown", () => require('../components/posts/Post
 importComponent("PostsItemTooltipWrapper", () => require('../components/posts/PostsItemTooltipWrapper'));
 importComponent("PostsItem2MetaInfo", () => require('../components/posts/PostsItem2MetaInfo'));
 importComponent("PostsTitle", () => require('../components/posts/PostsTitle'));
+importComponent("PostReadCheckbox", () => require('../components/posts/PostReadCheckbox'))
 importComponent("PostsPreviewTooltip", () => require('../components/posts/PostsPreviewTooltip'));
 importComponent("PostsPreviewTooltipSingle", () => require('../components/posts/PostsPreviewTooltipSingle'));
 importComponent("PostsPreviewTooltipSingleWithComment", () => require('../components/posts/PostsPreviewTooltipSingle'));

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -215,7 +215,6 @@ const tagIsWholeParagraph = (tag?: cheerio.TagElement): boolean => {
   // Ensure that the tag is inside a 'p' element and that all the text in that 'p' is in tags of
   // the same type as our base tag
   const para = cheerio(tag).closest('p');
-  console.log("cheerio", {para, tag})
   if (!para || para.text().trim() !== para.find(tag.name).text().trim()) {
     return false;
   }

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -215,7 +215,8 @@ const tagIsWholeParagraph = (tag?: cheerio.TagElement): boolean => {
   // Ensure that the tag is inside a 'p' element and that all the text in that 'p' is in tags of
   // the same type as our base tag
   const para = cheerio(tag).closest('p');
-  if (para.length < 1 || para.text().trim() !== para.find(tag.name).text().trim()) {
+  console.log("cheerio", {para, tag})
+  if (!para || para.text().trim() !== para.find(tag.name).text().trim()) {
     return false;
   }
 

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -116,7 +116,8 @@ export const baseTheme: BaseThemeSpecification = {
         },
         largeChapterTitle: {
           fontSize: '1.4rem',
-          margin: "1.5em 0 .2em 0"
+          margin: "1.5em 0 .5em 0",
+          color: palette.grey[800]
         },
         smallText: {
           fontFamily: palette.fonts.sansSerifStack,


### PR DESCRIPTION
A few people complained about the move to using SequencesSmallPostLink on Sequences pages. This reverts to using PostsItem2, but adds an optional checkbox for PostsItem2 so that reading a sequence still gives more sense of forward progression.

At the same time, refactors the checkboxes into their own component, shared between PostsItem2 and SequencesSmallPostLink, and lets people click on the checkbox to mark as read or unread. (A few people had asked for this too)

Note: I considered having the checkbox housed within the "border" of the PostsItem, but then the combination of checkbox + karma felt a bit cluttered.

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/3246710/197303428-91a08a85-88e9-4ecc-b09a-14607d0e62f6.png">
