### PR TITLE
set advanced options first and open by default

### DIFF
--- a/packages/lesswrong/lib/collections/posts/formGroups.ts
+++ b/packages/lesswrong/lib/collections/posts/formGroups.ts
@@ -50,13 +50,13 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     startCollapsed: true,
   },
   advancedOptions: {
-    order:40,
+    order:21,
     name: "advancedOptions",
     label: "Options",
-    startCollapsed: true,
+    // startCollapsed: true,
   },
   highlight: {
-    order: 21,
+    order: 22,
     name: "highlight",
     label: "Highlight",
     startCollapsed: true,

--- a/packages/lesswrong/lib/collections/posts/formGroups.ts
+++ b/packages/lesswrong/lib/collections/posts/formGroups.ts
@@ -50,9 +50,10 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     startCollapsed: true,
   },
   advancedOptions: {
-    order:21,
+    order:40,
     name: "advancedOptions",
     label: "Options",
+    startCollapsed: true,
   },
   highlight: {
     order: 22,
@@ -66,4 +67,9 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     label: "Audio",
     startCollapsed: true
   },
+  coauthors: {
+    order: 21,
+    name: "coauthors",
+    label: "Coauthors"
+  }
 };

--- a/packages/lesswrong/lib/collections/posts/formGroups.ts
+++ b/packages/lesswrong/lib/collections/posts/formGroups.ts
@@ -53,7 +53,6 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
     order:21,
     name: "advancedOptions",
     label: "Options",
-    // startCollapsed: true,
   },
   highlight: {
     order: 22,

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1218,7 +1218,7 @@ const schema: SchemaType<DbPost> = {
     optional: true,
     label: "Co-Authors",
     control: "CoauthorsListEditor",
-    group: formGroups.advancedOptions,
+    group: formGroups.coauthors,
   },
   'coauthorStatuses.$': {
     type: new SimpleSchema({


### PR DESCRIPTION
We've been getting a lot of requests from users via intercom to add other users as coauthors on their posts.  Let's try making the option much more visible.  (Edit: now in its own form group, so as not to draw additional attention to the crossposting feature, which we're not sure we want users to be thinking about "by default".)

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2136984/197656216-f62b741d-c661-4566-b00c-66749a7a92c7.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203231835889020) by [Unito](https://www.unito.io)
