### PR TITLE
fix message input box loading for ssr with no template queries

### DIFF
--- a/packages/lesswrong/components/messaging/NewMessageForm.tsx
+++ b/packages/lesswrong/components/messaging/NewMessageForm.tsx
@@ -19,14 +19,17 @@ export const NewMessageForm = ({classes, conversationId, templateQueries, succes
 }) => {
   const { WrappedSmartForm, Loading, Error404 } = Components
 
+  const skip = !templateQueries?.templateCommentId;
+
   const { document: template, loading: loadingTemplate } = useSingle({
     documentId: templateQueries?.templateCommentId,
     collectionName: "Comments",
     fragmentName: 'CommentsList',
-    skip: !templateQueries
+    skip
   });
   
-  if (loadingTemplate) return <Loading/>
+  // For some reason loading returns true even if we're skipping the query?
+  if (!skip && loadingTemplate) return <Loading/>
   if (templateQueries?.templateCommentId && !template) return <Error404/>
 
   const templateHtml = template?.contents?.html && getDraftMessageHtml({html: template.contents.html, displayName: templateQueries?.displayName })


### PR DESCRIPTION
Couple issues here:
1. We shouldn't have been checking the existence of `templateQueries` for deciding whether to skip the template query, since it would always exist when `NewMessageForm` was rendered in the context of `ConversationPage` (unlike in `SunshineUserMessages`).  Check that a template ID exists instead, which is the thing we actually use to fetch it.
2. For some reason `useSingle` is returning `loading: true` even when `skip: true`, which meant that it would persistently show the loading state for the message box... but this only happened for server-side renders (i.e. the conversation page is loaded directly or in a new tab, rather than navigated-to).  Not actually sure what's going on there, and feels like a dangerous sort of thing to leave not figured out.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203239240524769) by [Unito](https://www.unito.io)
