### PR TITLE
Refactor moderator actions

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
+import { useLocation } from '../../lib/routeUtil';
 import { useMulti } from '../../lib/crud/withMulti';
 
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
@@ -112,7 +113,9 @@ const ModerationDashboard = ({ classes }: {
           <div className={classes.toc}>
             {usersToReview?.map(user => {
               return <div key={user._id} className={classes.tocListing}>
-                {user.displayName}
+                <a href={`/admin/moderation#${user._id}`}>
+                  {user.displayName}
+                </a>
               </div>
             })}
             <div className={classes.loadMore}>
@@ -150,7 +153,7 @@ const ModerationDashboard = ({ classes }: {
           {usersToReview && allUsers && <>
             <div className={classNames({ [classes.hidden]: view === 'allUsers' })}>
               {usersToReview.map(user =>
-                <div key={user._id}>
+                <div key={user._id} id={user._id}>
                   <UsersReviewInfoCard user={user} refetch={refetch} currentUser={currentUser}/>
                 </div>
               )}

--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -9,7 +9,10 @@ import { useCurrentUser } from '../common/withUser';
 const styles = (theme: ThemeType): JssStyles => ({
   page: {
     width: '90%',
-    margin: 'auto'
+    margin: 'auto',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+    }
   },
   topBar: {
     position: "sticky",
@@ -40,9 +43,15 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "sticky",
     top: 64,
     paddingTop: 12,
+    [theme.breakpoints.down('md')]: {
+      display: "none"
+    }
   },
   main: {
-    width: "calc(100% - 230px)"
+    width: "calc(100% - 230px)",
+    [theme.breakpoints.down('md')]: {
+      width: "100%"
+    }
   },
   tocListing: {
     paddingTop: 4,

--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -149,14 +149,14 @@ const ModerationDashboard = ({ classes }: {
           </div>
           {usersToReview && allUsers && <>
             <div className={classNames({ [classes.hidden]: view === 'allUsers' })}>
-              {usersToReview?.map(user =>
+              {usersToReview.map(user =>
                 <div key={user._id}>
                   <UsersReviewInfoCard user={user} refetch={refetch} currentUser={currentUser}/>
                 </div>
               )}
             </div>
             <div className={classNames({ [classes.hidden]: view === 'sunshineNewUsers' })}>
-              {allUsers?.map(user =>
+              {allUsers.map(user =>
                 <div key={user._id}>
                   <UsersReviewInfoCard user={user} refetch={refetchAllUsers} currentUser={currentUser}/>
                 </div>

--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
-import { useLocation } from '../../lib/routeUtil';
 import { useMulti } from '../../lib/crud/withMulti';
 
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
@@ -85,7 +84,7 @@ const ModerationDashboard = ({ classes }: {
   const currentUser = useCurrentUser();
 
   const [view, setView] = useState<'sunshineNewUsers' | 'allUsers'>('sunshineNewUsers');
-  
+
   const { results: usersToReview, count, loadMoreProps, refetch, loading } = useMulti({
     terms: {view: "sunshineNewUsers", limit: 10},
     collectionName: "Users",

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -81,7 +81,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   user: SunshineUsersList,
   classes: ClassesType,
   currentUser: UsersCurrent,
-  refetch?: () => void,
+  refetch: () => void,
   comments: Array<CommentsListWithParentMetadata>|undefined,
   posts: Array<SunshinePostsList>|undefined,
 }) => {
@@ -316,7 +316,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
 
     setNotes(newNotes);
     // If we have a efetch to ensure the button displays (toggled on/off) properly 
-    refetch && refetch();
+    refetch();
   }
 
   const actionRow = <div className={classes.row}>
@@ -392,6 +392,15 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   </div>
 
   return <div>
+    {actionRow}
+    {permissionsRow}
+    <div>
+      <LWTooltip title={`${mostRecentRateLimit?.active ? "Un-rate-limit" : "Rate-limit"} this user's ability to post and comment`}>
+        <div className={classes.permissionsButton}onClick={handleRateLimit}>
+          {MODERATOR_ACTION_TYPES[RATE_LIMIT_ONE_PER_DAY]}
+        </div>
+      </LWTooltip>
+    </div>
     <div className={classes.notes}>
       <Input
         value={notes}
@@ -404,15 +413,6 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         multiline
         rowsMax={5}
       />
-    </div>
-    {actionRow}
-    {permissionsRow}
-    <div>
-      <LWTooltip title={`${mostRecentRateLimit?.active ? "Un-rate-limit" : "Rate-limit"} this user's ability to post and comment`}>
-        <div className={classes.permissionsButton}onClick={handleRateLimit}>
-          {MODERATOR_ACTION_TYPES[RATE_LIMIT_ONE_PER_DAY]}
-        </div>
-      </LWTooltip>
     </div>
     {moderatorActionLog}
   </div>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -1,0 +1,274 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import DoneIcon from '@material-ui/icons/Done';
+import SnoozeIcon from '@material-ui/icons/Snooze';
+import AddAlarmIcon from '@material-ui/icons/AddAlarm';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
+import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
+import classNames from 'classnames';
+import { useUpdate } from '../../lib/crud/withUpdate';
+import { useCreate } from '../../lib/crud/withCreate';
+import moment from 'moment';
+import { RATE_LIMIT_ONE_PER_DAY } from '../../lib/collections/moderatorActions/schema';
+import FlagIcon from '@material-ui/icons/Flag';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+
+  }
+});
+
+interface UserContentCountPartial {
+  postCount?: number,
+  commentCount?: number
+}
+
+export function getCurrentContentCount(user: UserContentCountPartial) {
+  const postCount = user.postCount ?? 0
+  const commentCount = user.commentCount ?? 0
+  return postCount + commentCount
+}
+
+export function getNewSnoozeUntilContentCount(user: UserContentCountPartial, contentCount: number) {
+  return getCurrentContentCount(user) + contentCount
+}
+
+export const ModeratorActions = ({classes, user, currentUser, refetch, setNotes, }: {
+  user: SunshineUsersList,
+  classes: ClassesType,
+  currentUser: UsersCurrent,
+  refetch: () => void
+}) => {
+  const { LWTooltip } = Components
+
+  const { mutate: updateUser } = useUpdate({
+    collectionName: "Users",
+    fragmentName: 'SunshineUsersList',
+  })
+
+  const { mutate: updateModeratorAction } = useUpdate({
+    collectionName: 'ModeratorActions',
+    fragmentName: 'ModeratorActionsDefaultFragment'
+  });
+
+  const { create: createModeratorAction } = useCreate({
+    collectionName: 'ModeratorActions',
+    fragmentName: 'ModeratorActionsDefaultFragment'
+  });
+
+  const canReview = !!(user.maxCommentCount || user.maxPostCount)
+
+  const getTodayString = () => {
+    const today = new Date();
+    return today.toLocaleString('default', { month: 'short', day: 'numeric'});
+  }
+
+  const signature = `${currentUser?.displayName}, ${getTodayString()}`
+  const signatureWithNote = (note:string) => {
+    return `${signature}: ${note}\n`
+  }
+
+  const handleReview = () => {
+    if (canReview) {
+      void updateUser({
+        selector: {_id: user._id},
+        data: {
+          sunshineFlagged: false,
+          reviewedByUserId: currentUser._id,
+          reviewedAt: new Date(),
+          needsReview: false,
+          sunshineNotes: notes,
+          snoozedUntilContentCount: null
+        }
+      })
+    }
+  }
+  
+  const handleSnooze = (contentCount: number) => {
+    const newNotes = signatureWithNote(`Snooze ${contentCount}`)+notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        needsReview: false,
+        reviewedAt: new Date(),
+        reviewedByUserId: currentUser!._id,
+        sunshineNotes: newNotes,
+        snoozedUntilContentCount: getNewSnoozeUntilContentCount(user, contentCount)
+      }
+    })
+    setNotes( newNotes )
+  }
+  
+  const banMonths = 3
+  
+  const handleBan = () => {
+    const newNotes = signatureWithNote("Ban") + notes;
+    if (confirm(`Ban this user for ${banMonths} months?`)) {
+      void updateUser({
+        selector: {_id: user._id},
+        data: {
+          sunshineFlagged: false,
+          reviewedByUserId: currentUser!._id,
+          voteBanned: true,
+          needsReview: false,
+          reviewedAt: new Date(),
+          banned: moment().add(banMonths, 'months').toDate(),
+          sunshineNotes: newNotes
+        }
+      })
+      setNotes( newNotes )
+    }
+  }
+  
+  const handlePurge = () => {
+    if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
+      void updateUser({
+        selector: {_id: user._id},
+        data: {
+          sunshineFlagged: false,
+          reviewedByUserId: currentUser!._id,
+          nullifyVotes: true,
+          voteBanned: true,
+          deleteContent: true,
+          needsReview: false,
+          reviewedAt: new Date(),
+          banned: moment().add(1000, 'years').toDate(),
+          sunshineNotes: notes
+        }
+      })
+      setNotes( signatureWithNote("Purge")+notes )
+    }
+  }
+  
+  const handleFlag = () => {
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        sunshineFlagged: !user.sunshineFlagged,
+        sunshineNotes: notes
+      }
+    })
+    
+    const flagStatus = user.sunshineFlagged ? "Unflag" : "Flag"
+    setNotes( signatureWithNote(flagStatus)+notes )
+  }
+  
+  const handleDisablePosting = () => {
+    const abled = user.postingDisabled ? 'enabled' : 'disabled';
+    const newNotes = signatureWithNote(`posting ${abled}`) + notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        postingDisabled: !user.postingDisabled,
+        sunshineNotes: newNotes
+      }
+    })
+    setNotes( newNotes )
+  }
+  
+  const handleDisableAllCommenting = () => {
+    const abled = user.allCommentingDisabled ? 'enabled' : 'disabled';
+    const newNotes = signatureWithNote(`all commenting ${abled}`) + notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        allCommentingDisabled: !user.allCommentingDisabled,
+        sunshineNotes: newNotes
+      }
+    })
+    setNotes( newNotes )
+  }
+  
+  const handleDisableCommentingOnOtherUsers = () => {
+    const abled = user.commentingOnOtherUsersDisabled ? 'enabled' : 'disabled'
+    const newNotes = signatureWithNote(`commenting on other's ${abled}`) + notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        commentingOnOtherUsersDisabled: !user.commentingOnOtherUsersDisabled,
+        sunshineNotes: newNotes
+      }
+    })
+    setNotes( newNotes )
+  }
+  
+  const handleDisableConversations = () => {
+    const abled = user.conversationsDisabled ? 'enabled' : 'disabled'
+    const newNotes = signatureWithNote(`conversations ${abled}`) + notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        conversationsDisabled: !user.conversationsDisabled,
+        sunshineNotes: newNotes
+      }
+    })
+    setNotes( newNotes )
+  }
+
+  const mostRecentRateLimit = user.moderatorActions.find(modAction => modAction.type === RATE_LIMIT_ONE_PER_DAY);
+
+  const handleRateLimit = async () => {
+    const addedOrRemoved = mostRecentRateLimit?.active ? 'removed' : 'added';
+    const newNotes = signatureWithNote(`rate limit ${addedOrRemoved}`) + notes;
+    await updateUser({
+      selector: { _id: user._id },
+      data: { sunshineNotes: newNotes }
+    });
+
+    // If we have an active rate limit, we want to disable it
+    if (mostRecentRateLimit?.active) {
+      await updateModeratorAction({
+        selector: { _id: mostRecentRateLimit._id },
+        data: { endedAt: new Date() }
+      });
+    } else {
+      // Otherwise, we want to create a new one
+      await createModeratorAction({
+        data: {
+          type: RATE_LIMIT_ONE_PER_DAY,
+          userId: user._id,
+        }
+      });
+    }
+
+    setNotes(newNotes);
+    // Refetch to ensure the button displays (toggled on/off) properly 
+    refetch();
+  }
+
+  return <div className={classes.row}>
+    <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)" placement="top">
+      <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
+    </LWTooltip>
+    <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)" placement="top">
+      <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
+    </LWTooltip>
+    <LWTooltip title="Approve" placement="top">
+      <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>
+    </LWTooltip>
+    <LWTooltip title="Ban for 3 months" placement="top">
+      <RemoveCircleOutlineIcon className={classes.modButton} onClick={handleBan} />
+    </LWTooltip>
+    <LWTooltip title="Purge (delete and ban)" placement="top">
+      <DeleteForeverIcon className={classes.modButton} onClick={handlePurge} />
+    </LWTooltip>
+    <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
+      <div>Flag this user for more review</div>
+      <div><em>(This will not remove them from sidebar)</em></div>
+    </div>} placement="top">
+      <div onClick={handleFlag} className={classes.modButton} >
+        {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
+      </div>
+    </LWTooltip>
+  </div>
+}
+
+const ModeratorActionsComponent = registerComponent('ModeratorActions', ModeratorActions, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ModeratorActions: typeof ModeratorActionsComponent
+  }
+}
+

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -1,25 +1,15 @@
 /* global confirm */
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useUpdate } from '../../lib/crud/withUpdate';
-import React, { useEffect, useState } from 'react';
-import moment from 'moment';
+import React, { useState } from 'react';
 import { useCurrentUser } from '../common/withUser';
 import withErrorBoundary from '../common/withErrorBoundary'
-import DoneIcon from '@material-ui/icons/Done';
-import FlagIcon from '@material-ui/icons/Flag';
-import SnoozeIcon from '@material-ui/icons/Snooze';
-import AddAlarmIcon from '@material-ui/icons/AddAlarm';
-import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
-import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
 import DescriptionIcon from '@material-ui/icons/Description'
 import { useMulti } from '../../lib/crud/withMulti';
 import MessageIcon from '@material-ui/icons/Message'
 import * as _ from 'underscore';
 import { DatabasePublicSetting } from '../../lib/publicSettings';
-import Input from '@material-ui/core/Input';
-import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
+import { userCanDo } from '../../lib/vulcan-users';
 
 export const defaultModeratorPMsTagSlug = new DatabasePublicSetting<string>('defaultModeratorPMsTagSlug', "moderator-default-responses")
 
@@ -40,6 +30,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[700],
     position: "relative",
     top: 3
+  },
+  topRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
   },
   row: {
     display: "flex",
@@ -188,169 +183,7 @@ const SunshineNewUsersInfo = ({ user, classes }: {
 }) => {
   const currentUser = useCurrentUser();
 
-  const { mutate: updateUser } = useUpdate({
-    collectionName: "Users",
-    fragmentName: 'SunshineUsersList',
-  })
-
-  const [notes, setNotes] = useState(user.sunshineNotes || "")
   const [contentSort, setContentSort] = useState<'baseScore' | 'postedAt'>("baseScore")
-
-  const canReview = !!(user.maxCommentCount || user.maxPostCount)
-
-  const handleNotes = () => {
-    if (notes != user.sunshineNotes) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineNotes: notes
-        }
-      })
-    }
-  }
-
-  useEffect(() => {
-    return () => {
-      handleNotes();
-    }
-  });
-
-  const handleReview = () => {
-    if (canReview) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          reviewedAt: new Date(),
-          needsReview: false,
-          sunshineNotes: notes,
-          snoozedUntilContentCount: null
-        }
-      })
-    }
-  }
-
-  const handleSnooze = (contentCount: number) => {
-    const newNotes = signatureWithNote(`Snooze ${contentCount}`)+notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        needsReview: false,
-        reviewedAt: new Date(),
-        reviewedByUserId: currentUser!._id,
-        sunshineNotes: newNotes,
-        snoozedUntilContentCount: getNewSnoozeUntilContentCount(user, contentCount)
-      }
-    })
-    setNotes( newNotes )
-  }
-
-  const banMonths = 3
-
-  const handleBan = () => {
-    const newNotes = signatureWithNote("Ban") + notes;
-    if (confirm(`Ban this user for ${banMonths} months?`)) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          voteBanned: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(banMonths, 'months').toDate(),
-          sunshineNotes: newNotes
-        }
-      })
-      setNotes( newNotes )
-    }
-  }
-
-  const handlePurge = () => {
-    if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          nullifyVotes: true,
-          voteBanned: true,
-          deleteContent: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(1000, 'years').toDate(),
-          sunshineNotes: notes
-        }
-      })
-      setNotes( signatureWithNote("Purge")+notes )
-    }
-  }
-
-  const handleFlag = () => {
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        sunshineFlagged: !user.sunshineFlagged,
-        sunshineNotes: notes
-      }
-    })
-
-    const flagStatus = user.sunshineFlagged ? "Unflag" : "Flag"
-    setNotes( signatureWithNote(flagStatus)+notes )
-  }
-
-  const handleDisablePosting = () => {
-    const abled = user.postingDisabled ? 'enabled' : 'disabled';
-    const newNotes = signatureWithNote(`posting ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        postingDisabled: !user.postingDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-
-  const handleDisableAllCommenting = () => {
-    const abled = user.allCommentingDisabled ? 'enabled' : 'disabled';
-    const newNotes = signatureWithNote(`all commenting ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        allCommentingDisabled: !user.allCommentingDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-
-  const handleDisableCommentingOnOtherUsers = () => {
-    const abled = user.commentingOnOtherUsersDisabled ? 'enabled' : 'disabled'
-    const newNotes = signatureWithNote(`commenting on other's ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        commentingOnOtherUsersDisabled: !user.commentingOnOtherUsersDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-
-  const handleDisableConversations = () => {
-    const abled = user.conversationsDisabled ? 'enabled' : 'disabled'
-    const newNotes = signatureWithNote(`conversations ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        conversationsDisabled: !user.conversationsDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
 
   const { results: posts, loading: postsLoading } = useMulti({
     terms:{view:"sunshineNewUsersPosts", userId: user._id},
@@ -371,120 +204,39 @@ const SunshineNewUsersInfo = ({ user, classes }: {
   const commentKarmaPreviews = comments ? _.sortBy(comments, contentSort) : []
   const postKarmaPreviews = posts ? _.sortBy(posts, contentSort) : []
 
-  const { MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, Typography, SunshineSendMessageWithDefaults, UsersNameWrapper, ModeratorMessageCount } = Components
+  const { MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, Typography, SunshineSendMessageWithDefaults, UsersNameWrapper, ModeratorMessageCount, ModeratorActions } = Components
 
   const hiddenPostCount = user.maxPostCount - user.postCount
   const hiddenCommentCount = user.maxCommentCount - user.commentCount
 
-  if (!userCanDo(currentUser, "posts.moderate.all")) return null
-
-  const getTodayString = () => {
-    const today = new Date();
-    return today.toLocaleString('default', { month: 'short', day: 'numeric'});
-  }
-
-  const signature = `${currentUser?.displayName}, ${getTodayString()}`
-  const signatureWithNote = (note:string) => {
-    return `${signature}: ${note}\n`
-  }
-
-  const signAndDate = (sunshineNotes:string) => {
-    if (!sunshineNotes.match(signature)) {
-      const padding = !sunshineNotes ? ": " : ": \n\n"
-      return signature + padding + sunshineNotes
-    } 
-    return sunshineNotes
-  }
-
-  const handleClick = () => {
-    const signedNotes = signAndDate(notes)
-    if (signedNotes != notes) {
-      setNotes(signedNotes)
-    }
-  }
+  if (!currentUser || !userCanDo(currentUser, "posts.moderate.all")) return null
 
   return (
       <div className={classes.root}>
         <Typography variant="body2">
           <MetaInfo>
             <div className={classes.info}>
-              {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/></em></p> : null }
-              {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
+              <div className={classes.topRow}>
+                <div>
+                  {user.reviewedAt && <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/></em></p>}
+                  {user.banned && <p><em>Banned until <FormatDate date={user.banned}/></em></p>}
               
-              {user.associatedClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: {user.associatedClientId?.firstSeenReferrer}</div>}
-              {user.associatedClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: {user.associatedClientId?.firstSeenLandingPage}</div>}
-              {(user.associatedClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
-                <em>Alternate accounts detected</em>
-              </div>}
-              <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
-              
+                  {user.associatedClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: {user.associatedClientId?.firstSeenReferrer}</div>}
+                  {user.associatedClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: {user.associatedClientId?.firstSeenLandingPage}</div>}
+                  {(user.associatedClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
+                    <em>Alternate accounts detected</em>
+                  </div>}
+                  <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
+                </div>
+                <div className={classes.row}>
+                  <ModeratorMessageCount userId={user._id} />
+                  <SunshineSendMessageWithDefaults user={user} tagSlug={defaultModeratorPMsTagSlug.get()}/>
+                </div>
+              </div>              
               <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
               {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
-              <div className={classes.notes}>
-                <Input 
-                  value={notes} 
-                  fullWidth
-                  onChange={e => setNotes(e.target.value)}
-                  onClick={e => handleClick()}
-                  disableUnderline 
-                  placeholder="Notes for other moderators"
-                  multiline
-                />
-              </div>
             </div>
-            <div className={classes.row}>
-              <div className={classes.row}>
-                <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)" placement="top">
-                  <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
-                </LWTooltip>
-                <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)" placement="top">
-                  <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
-                </LWTooltip>
-                <LWTooltip title="Approve" placement="top">
-                  <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>
-                </LWTooltip>
-                <LWTooltip title="Ban for 3 months" placement="top">
-                  <RemoveCircleOutlineIcon className={classes.modButton} onClick={handleBan} />
-                </LWTooltip>
-                <LWTooltip title="Purge (delete and ban)" placement="top">
-                  <DeleteForeverIcon className={classes.modButton} onClick={handlePurge} />
-                </LWTooltip>
-                <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
-                    <div>Flag this user for more review</div>
-                    <div><em>(This will not remove them from sidebar)</em></div>
-                  </div>} placement="top">
-                  <div onClick={handleFlag} className={classes.modButton} >
-                    {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
-                  </div>
-                </LWTooltip>
-              </div>
-              <div className={classes.row}>
-                <ModeratorMessageCount userId={user._id} />
-                <SunshineSendMessageWithDefaults user={user} tagSlug={defaultModeratorPMsTagSlug.get()}/>
-              </div>
-            </div>
-            <div className={classes.permissionsRow}>
-              <LWTooltip title={`${user.postingDisabled ? "Enable" : "Disable"} this user's ability to create posts`}>
-                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.postingDisabled})} onClick={handleDisablePosting}>
-                  Posts
-                </div>
-              </LWTooltip>
-              <LWTooltip title={`${user.allCommentingDisabled ? "Enable" : "Disable"} this user's to comment (including their own shortform)`}>
-                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.allCommentingDisabled})} onClick={handleDisableAllCommenting}>
-                  All Comments
-                </div>
-              </LWTooltip>
-              <LWTooltip title={`${user.commentingOnOtherUsersDisabled ? "Enable" : "Disable"} this user's ability to comment on other people's posts`}>
-                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.commentingOnOtherUsersDisabled})} onClick={handleDisableCommentingOnOtherUsers}>
-                  Other Comments
-                </div>
-              </LWTooltip>
-              <LWTooltip title={`${user.conversationsDisabled ? "Enable" : "Disable"} this user's ability to start new private conversations`}>
-                <div className={classNames(classes.permissionsButton, {[classes.permissionDisabled]: user.conversationsDisabled})}onClick={handleDisableConversations}>
-                  Conversations
-                </div>
-              </LWTooltip>
-            </div>
+            <ModeratorActions user={user} currentUser={currentUser}/>
             <hr className={classes.hr}/>
             <div className={classes.votesRow}>
               <span>Votes: </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -236,7 +236,7 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
               {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
             </div>
-            <ModeratorActions user={user} currentUser={currentUser}/>
+            <ModeratorActions user={user} currentUser={currentUser} comments={comments} posts={posts}/>
             <hr className={classes.hr}/>
             <div className={classes.votesRow}>
               <span>Votes: </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -177,9 +177,10 @@ export function getNewSnoozeUntilContentCount(user: UserContentCountPartial, con
   return getCurrentContentCount(user) + contentCount
 }
 
-const SunshineNewUsersInfo = ({ user, classes }: {
+const SunshineNewUsersInfo = ({ user, classes, refetch }: {
   user: SunshineUsersList,
   classes: ClassesType,
+  refetch: () => void
 }) => {
   const currentUser = useCurrentUser();
 
@@ -236,7 +237,7 @@ const SunshineNewUsersInfo = ({ user, classes }: {
               <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
               {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
             </div>
-            <ModeratorActions user={user} currentUser={currentUser} comments={comments} posts={posts}/>
+            <ModeratorActions user={user} currentUser={currentUser} comments={comments} posts={posts} refetch={refetch}/>
             <hr className={classes.hr}/>
             <div className={classes.votesRow}>
               <span>Votes: </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -13,8 +13,6 @@ import { userCanDo } from '../../lib/vulcan-users';
 
 export const defaultModeratorPMsTagSlug = new DatabasePublicSetting<string>('defaultModeratorPMsTagSlug', "moderator-default-responses")
 
-export const getTitle = (s: string|null) => s ? s.split("\\")[0] : ""
-
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor: theme.palette.grey[50]
@@ -161,21 +159,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     border: "none"
   }
 })
-
-interface UserContentCountPartial {
-  postCount?: number,
-  commentCount?: number
-}
-
-export function getCurrentContentCount(user: UserContentCountPartial) {
-  const postCount = user.postCount ?? 0
-  const commentCount = user.commentCount ?? 0
-  return postCount + commentCount
-}
-
-export function getNewSnoozeUntilContentCount(user: UserContentCountPartial, contentCount: number) {
-  return getCurrentContentCount(user) + contentCount
-}
 
 const SunshineNewUsersInfo = ({ user, classes, refetch }: {
   user: SunshineUsersList,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -160,12 +160,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const SunshineNewUsersInfo = ({ user, classes, refetch }: {
+const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
   user: SunshineUsersList,
   classes: ClassesType,
-  refetch: () => void
+  refetch: () => void,
+  currentUser: UsersCurrent
 }) => {
-  const currentUser = useCurrentUser();
 
   const [contentSort, setContentSort] = useState<'baseScore' | 'postedAt'>("baseScore")
 
@@ -193,7 +193,7 @@ const SunshineNewUsersInfo = ({ user, classes, refetch }: {
   const hiddenPostCount = user.maxPostCount - user.postCount
   const hiddenCommentCount = user.maxCommentCount - user.commentCount
 
-  if (!currentUser || !userCanDo(currentUser, "posts.moderate.all")) return null
+  if (!userCanDo(currentUser, "posts.moderate.all")) return null
 
   return (
       <div className={classes.root}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -27,9 +27,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     background: theme.palette.panelBackground.sunshineFlaggedUser,
   }
 })
-const SunshineNewUsersItem = ({ user, classes }: {
+const SunshineNewUsersItem = ({ user, classes, refetch }: {
   user: SunshineUsersList,
-  classes: ClassesType
+  classes: ClassesType,
+  refetch: () => void,
 }) => {
   const { eventHandlers, hover, anchorEl } = useHover();
 
@@ -39,7 +40,7 @@ const SunshineNewUsersItem = ({ user, classes }: {
     <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <SunshineNewUsersInfo user={user} />
+          <SunshineNewUsersInfo user={user} refetch={refetch}/>
         </SidebarHoverOver>
         <div>
           <MetaInfo className={classes.info}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -27,10 +27,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     background: theme.palette.panelBackground.sunshineFlaggedUser,
   }
 })
-const SunshineNewUsersItem = ({ user, classes, refetch }: {
+const SunshineNewUsersItem = ({ user, classes, refetch, currentUser }: {
   user: SunshineUsersList,
   classes: ClassesType,
   refetch: () => void,
+  currentUser: UsersCurrent,
 }) => {
   const { eventHandlers, hover, anchorEl } = useHover();
 
@@ -40,7 +41,7 @@ const SunshineNewUsersItem = ({ user, classes, refetch }: {
     <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <SunshineNewUsersInfo user={user} refetch={refetch}/>
+          <SunshineNewUsersInfo user={user} refetch={refetch} currentUser={currentUser}/>
         </SidebarHoverOver>
         <div>
           <MetaInfo className={classes.info}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -19,7 +19,7 @@ const SunshineNewUsersList = ({ classes, terms }: {
   classes: ClassesType
 }) => {
   const currentUser = useCurrentUser();
-  const { results, totalCount, loadMoreProps } = useMulti({
+  const { results, totalCount, loadMoreProps, refetch } = useMulti({
     terms,
     collectionName: "Users",
     fragmentName: 'SunshineUsersList',
@@ -37,7 +37,7 @@ const SunshineNewUsersList = ({ classes, terms }: {
         </SunshineListTitle>
         {results.map(user =>
           <div key={user._id} >
-            <SunshineNewUsersItem user={user}/>
+            <SunshineNewUsersItem user={user} refetch={refetch}/>
           </div>
         )}
         <div className={classes.loadMore}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -2,7 +2,6 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
-import { useCurrentUser } from '../common/withUser';
 import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -14,11 +13,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const SunshineNewUsersList = ({ classes, terms }: {
+const SunshineNewUsersList = ({ classes, terms, currentUser }: {
   terms: UsersViewTerms,
-  classes: ClassesType
+  classes: ClassesType,
+  currentUser: UsersCurrent,
 }) => {
-  const currentUser = useCurrentUser();
   const { results, totalCount, loadMoreProps, refetch } = useMulti({
     terms,
     collectionName: "Users",
@@ -37,7 +36,7 @@ const SunshineNewUsersList = ({ classes, terms }: {
         </SunshineListTitle>
         {results.map(user =>
           <div key={user._id} >
-            <SunshineNewUsersItem user={user} refetch={refetch}/>
+            <SunshineNewUsersItem user={user} refetch={refetch} currentUser={currentUser}/>
           </div>
         )}
         <div className={classes.loadMore}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
 import NoSsr from '@material-ui/core/NoSsr';
 import { useUpdate } from '../../lib/crud/withUpdate';
-import { getNewSnoozeUntilContentCount } from './SunshineNewUsersInfo';
+import { getNewSnoozeUntilContentCount } from './ModeratorActions';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -21,7 +21,7 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
 
   const { SunshineNewUsersInfo, SectionButton } = Components
 
-  const { document: user } = useSingle({
+  const { document: user, refetch } = useSingle({
     documentId:userId,
     collectionName: "Users",
     fragmentName: 'SunshineUsersList',
@@ -43,7 +43,7 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
     })
   }
 
-  if (!userCanDo(currentUser, 'posts.moderate.all')) return null
+  if (!currentUser || !userCanDo(currentUser, 'posts.moderate.all')) return null
   
   if (user.reviewedByUserId && !user.snoozedUntilContentCount) return <div className={classes.root} onClick={unapproveUser}>
     <SectionButton>Unapprove</SectionButton>
@@ -51,7 +51,7 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   
   return <div className={classes.root}>
     <NoSsr>
-      <SunshineNewUsersInfo user={user}/>
+      <SunshineNewUsersInfo user={user} currentUser={currentUser} refetch={refetch}/>
     </NoSsr>
   </div>
 }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
@@ -9,12 +9,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const SunshineReportedContentList = ({ classes }: {
+const SunshineReportedContentList = ({ classes, currentUser }: {
   classes: ClassesType,
+  currentUser: UsersCurrent,
 }) => {
   const { SunshineListTitle, SunshineReportedItem, SunshineListCount, LoadMore } = Components
   
-  const { results, totalCount, loadMoreProps } = useMulti({
+  const { results, totalCount, loadMoreProps, refetch } = useMulti({
     terms: {view:"sunshineSidebarReports", limit: 30},
     collectionName: "Reports",
     fragmentName: 'unclaimedReportsList',
@@ -35,7 +36,9 @@ const SunshineReportedContentList = ({ classes }: {
           <div key={report._id} >
             <SunshineReportedItem
               report={report}
+              currentUser={currentUser}
               updateReport={updateReport}
+              refetch={refetch}
             />
           </div>
         )}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -3,7 +3,6 @@ import { useUpdate } from '../../lib/crud/withUpdate';
 import React from 'react';
 import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
-import { useCurrentUser } from '../common/withUser'
 import DoneIcon from '@material-ui/icons/Done';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { forumTypeSetting } from '../../lib/instanceSettings';
@@ -22,12 +21,14 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const SunshineReportedItem = ({report, updateReport, classes}: {
+const SunshineReportedItem = ({report, updateReport, classes, currentUser, refetch}: {
   report: any,
   updateReport: WithUpdateFunction<ReportsCollection>,
   classes: ClassesType,
+  currentUser: UsersCurrent,
+  refetch: () => void
 }) => {
-  const currentUser = useCurrentUser();
+
   const { hover, anchorEl, eventHandlers } = useHover();
   const { mutate: updateComment } = useUpdate({
     collectionName: "Comments",
@@ -99,7 +100,7 @@ const SunshineReportedItem = ({report, updateReport, classes}: {
               <PostsTitle post={post}/>
               <PostsHighlight post={post} maxLengthWords={600}/>
             </div>}
-            {reportedUser && <SunshineNewUsersInfo user={reportedUser}/>}
+            {reportedUser && <SunshineNewUsersInfo user={reportedUser} currentUser={currentUser} refetch={refetch}/>}
           </Typography>
         </SidebarHoverOver>
         {comment && <SunshineCommentsItemOverview comment={comment}/>}
@@ -110,7 +111,7 @@ const SunshineReportedItem = ({report, updateReport, classes}: {
           </>}
           {reportedUser && <div>
             <Link to={report.link} className={classes.reportedUser}>
-              <strong>{ reportedUser?.displayName }</strong>
+              <strong>{ reportedUser.displayName }</strong>
               <PersonOutlineIcon className={classes.reportedUserIcon}/>
             </Link>
           </div>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -32,6 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   sendMessageButton: {
     padding: 8,
     height: 32,
+    wordBreak: "keep-all",
     fontSize: "1rem",
     color: theme.palette.grey[500],
     '&:hover': {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -57,8 +57,8 @@ const SunshineSidebar = ({classes}: {classes: ClassesType}) => {
       {showInitialSidebar && <div className={classes.background}>
         <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
-        <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 10}}/>
-        <SunshineReportedContentList />
+        <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 10}} currentUser={currentUser}/>
+        <SunshineReportedContentList currentUser={currentUser}/>
         <SunshineNewTagsList />
         
         {/* alignmentForumAdmins see AF content above the fold */}
@@ -105,7 +105,7 @@ const SunshineSidebar = ({classes}: {classes: ClassesType}) => {
           <KeyboardArrowRightIcon/>
         </div>}
         { showUnderbelly && <div>
-          <SunshineNewUsersList terms={{view:"allUsers", limit: 30}} />
+          <SunshineNewUsersList terms={{view:"allUsers", limit: 30}} currentUser={currentUser} />
         </div>}
       </div>}
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -9,6 +9,9 @@ const styles = (theme: JssStyles) => ({
   row: {
     display: "flex",
     alignItems: "center"
+  },
+  messageForm: {
+    width: 500
   }
 })
 
@@ -37,7 +40,7 @@ export const SunshineUserMessages = ({classes, user}: {
         embedConversation={embedConversation}
       />
     </div>
-    {embeddedConversationId && <NewMessageForm 
+    {embeddedConversationId && <div className={classes.messageForm}><NewMessageForm 
       conversationId={embeddedConversationId} 
       templateQueries={templateQueries}
       successEvent={() => {
@@ -47,7 +50,7 @@ export const SunshineUserMessages = ({classes, user}: {
           moderatorConveration: true
         })
       }}
-    />}
+    /></div>}
   </div>;
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useTracking } from '../../lib/analyticsEvents';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { useCurrentUser } from '../common/withUser';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import {defaultModeratorPMsTagSlug} from "./SunshineNewUsersInfo";
 
@@ -15,14 +14,14 @@ const styles = (theme: JssStyles) => ({
   }
 })
 
-export const SunshineUserMessages = ({classes, user}: {
+export const SunshineUserMessages = ({classes, user, currentUser}: {
   user: SunshineUsersList,
   classes: ClassesType,
+  currentUser: UsersCurrent,
 }) => {
   const { ModeratorMessageCount, SunshineSendMessageWithDefaults, NewMessageForm } = Components
   const [embeddedConversationId, setEmbeddedConversationId] = useState<string | undefined>();
   const [templateQueries, setTemplateQueries] = useState<TemplateQueryStrings | undefined>();
-  const currentUser = useCurrentUser()
 
   const { captureEvent } = useTracking()
 
@@ -47,7 +46,7 @@ export const SunshineUserMessages = ({classes, user}: {
         successEvent={() => {
           captureEvent('messageSent', {
             conversationId: embeddedConversationId,
-            sender: currentUser?._id,
+            sender: currentUser._id,
             moderatorConveration: true
           })
         }}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -40,17 +40,19 @@ export const SunshineUserMessages = ({classes, user}: {
         embedConversation={embedConversation}
       />
     </div>
-    {embeddedConversationId && <div className={classes.messageForm}><NewMessageForm 
-      conversationId={embeddedConversationId} 
-      templateQueries={templateQueries}
-      successEvent={() => {
-        captureEvent('messageSent', {
-          conversationId: embeddedConversationId,
-          sender: currentUser?._id,
-          moderatorConveration: true
-        })
-      }}
-    /></div>}
+    {embeddedConversationId && <div className={classes.messageForm}>
+      <NewMessageForm 
+        conversationId={embeddedConversationId} 
+        templateQueries={templateQueries}
+        successEvent={() => {
+          captureEvent('messageSent', {
+            conversationId: embeddedConversationId,
+            sender: currentUser?._id,
+            moderatorConveration: true
+          })
+        }}
+      />
+    </div>}
   </div>;
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -9,9 +9,6 @@ import MessageIcon from '@material-ui/icons/Message'
 import * as _ from 'underscore';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
-import { LOW_AVERAGE_KARMA_COMMENT_ALERT, LOW_AVERAGE_KARMA_POST_ALERT, MODERATOR_ACTION_TYPES } from '../../lib/collections/moderatorActions/schema';
-import { isLowAverageKarmaContent } from '../../lib/collections/moderatorActions/helpers';
-
 
 export const getTitle = (s: string|null) => s ? s.split("\\")[0] : ""
 
@@ -220,31 +217,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
         <FormatDate date={user.createdAt}/>
       </MetaInfo>
     </div>
-
-
   </div>
-
-  const moderatorActionLogRow = <div>
-    {user.moderatorActions
-      .filter(moderatorAction => moderatorAction.active)
-      .map(moderatorAction => {
-        let averageContentKarma: number | undefined;
-        if (moderatorAction.type === LOW_AVERAGE_KARMA_COMMENT_ALERT) {
-          const mostRecentComments = _.sortBy(comments ?? [], 'postedAt').reverse();
-          ({ averageContentKarma } = isLowAverageKarmaContent(mostRecentComments ?? [], 'comment'));
-        } else if (moderatorAction.type === LOW_AVERAGE_KARMA_POST_ALERT) {
-          const mostRecentPosts = _.sortBy(posts ?? [], 'postedAt').reverse();
-          ({ averageContentKarma } = isLowAverageKarmaContent(mostRecentPosts ?? [], 'post'));
-        }
-
-        const suffix = typeof averageContentKarma === 'number' ? ` (${averageContentKarma})` : '';
-
-        return <div key={`${user._id}_${moderatorAction.type}`}>{`${MODERATOR_ACTION_TYPES[moderatorAction.type]}${suffix}`}</div>;
-      })
-    }
-  </div>
-
-  
 
   const votesRow = <div className={classes.votesRow}>
     <span>Votes: </span>
@@ -305,8 +278,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
       <div className={classes.columns}>
         <div className={classes.infoColumn}>
           <div>
-            <ModeratorActions user={user} currentUser={currentUser} refetch={refetch}/>
-            {moderatorActionLogRow}
+            <ModeratorActions user={user} currentUser={currentUser} refetch={refetch} comments={comments} posts={posts}/>
             {user.reviewedAt
               ? <div className={classes.reviewedAt}>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/></div>
               : null 

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -301,7 +301,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
           </div>
         </div>
         <div className={classes.messagesColumn}>
-          <SunshineUserMessages user={user}/>
+          <SunshineUserMessages user={user} currentUser={currentUser}/>
         </div>
       </div>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -116,6 +116,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   infoColumn: {
     width: '30%',
+    minWidth: 388,
     padding: 16,
     paddingTop: 12,
     borderRight: theme.palette.border.extraFaint,
@@ -146,10 +147,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   contentCollapsed: {
     maxHeight: 300,
     overflowY: "scroll",
-    cursor: "pointer",
-    '&:after': { 
-      content: '"<a>Expand</a>"',
-    }
+    cursor: "pointer"
   },
   contentSummaryRow: {
     display: "flex",

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -10,8 +10,6 @@ import * as _ from 'underscore';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
 
-export const getTitle = (s: string|null) => s ? s.split("\\")[0] : ""
-
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor: theme.palette.grey[0],

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -1,16 +1,8 @@
 /* global confirm */
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useUpdate } from '../../lib/crud/withUpdate';
 import React, { useState } from 'react';
-import moment from 'moment';
 import withErrorBoundary from '../common/withErrorBoundary'
-import DoneIcon from '@material-ui/icons/Done';
 import FlagIcon from '@material-ui/icons/Flag';
-import SnoozeIcon from '@material-ui/icons/Snooze';
-import AddAlarmIcon from '@material-ui/icons/AddAlarm';
-import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
-import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
 import DescriptionIcon from '@material-ui/icons/Description'
 import { useMulti } from '../../lib/crud/withMulti';
 import MessageIcon from '@material-ui/icons/Message'
@@ -21,7 +13,6 @@ import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 import { userGetProfileUrl} from '../../lib/collections/users/helpers';
 import { LOW_AVERAGE_KARMA_COMMENT_ALERT, LOW_AVERAGE_KARMA_POST_ALERT, MODERATOR_ACTION_TYPES, RATE_LIMIT_ONE_PER_DAY } from '../../lib/collections/moderatorActions/schema';
-import { useCreate } from '../../lib/crud/withCreate';
 import { isLowAverageKarmaContent } from '../../lib/collections/moderatorActions/helpers';
 
 
@@ -208,21 +199,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-interface UserContentCountPartial {
-  postCount?: number,
-  commentCount?: number
-}
-
-export function getCurrentContentCount(user: UserContentCountPartial) {
-  const postCount = user.postCount ?? 0
-  const commentCount = user.commentCount ?? 0
-  return postCount + commentCount
-}
-
-export function getNewSnoozeUntilContentCount(user: UserContentCountPartial, contentCount: number) {
-  return getCurrentContentCount(user) + contentCount
-}
-
 const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   user: SunshineUsersList,
   currentUser: UsersCurrent,
@@ -230,27 +206,11 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   classes: ClassesType,
 }) => {
   
-  const { mutate: updateUser } = useUpdate({
-    collectionName: "Users",
-    fragmentName: 'SunshineUsersList',
-  })
-
-  const { mutate: updateModeratorAction } = useUpdate({
-    collectionName: 'ModeratorActions',
-    fragmentName: 'ModeratorActionsDefaultFragment'
-  });
-
-  const { create: createModeratorAction } = useCreate({
-    collectionName: 'ModeratorActions',
-    fragmentName: 'ModeratorActionsDefaultFragment'
-  });
   
   const [notes, setNotes] = useState(user.sunshineNotes || "")
   const [contentSort, setContentSort] = useState<'baseScore' | 'postedAt'>("baseScore")
   const [contentExpanded, setContentExpanded] = useState<boolean>(false)
-  
-  const canReview = !!(user.maxCommentCount || user.maxPostCount)
-  
+    
   const handleNotes = () => {
     if (notes != user.sunshineNotes) {
       void updateUser({
@@ -260,174 +220,6 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
         }
       })
     }
-  }
-
-  const handleReview = () => {
-    if (canReview) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          reviewedAt: new Date(),
-          needsReview: false,
-          sunshineNotes: notes,
-          snoozedUntilContentCount: null
-        }
-      })
-    }
-  }
-  
-  const handleSnooze = (contentCount: number) => {
-    const newNotes = signatureWithNote(`Snooze ${contentCount}`)+notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        needsReview: false,
-        reviewedAt: new Date(),
-        reviewedByUserId: currentUser!._id,
-        sunshineNotes: newNotes,
-        snoozedUntilContentCount: getNewSnoozeUntilContentCount(user, contentCount)
-      }
-    })
-    setNotes( newNotes )
-  }
-  
-  const banMonths = 3
-  
-  const handleBan = () => {
-    const newNotes = signatureWithNote("Ban") + notes;
-    if (confirm(`Ban this user for ${banMonths} months?`)) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          voteBanned: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(banMonths, 'months').toDate(),
-          sunshineNotes: newNotes
-        }
-      })
-      setNotes( newNotes )
-    }
-  }
-  
-  const handlePurge = () => {
-    if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
-      void updateUser({
-        selector: {_id: user._id},
-        data: {
-          sunshineFlagged: false,
-          reviewedByUserId: currentUser!._id,
-          nullifyVotes: true,
-          voteBanned: true,
-          deleteContent: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(1000, 'years').toDate(),
-          sunshineNotes: notes
-        }
-      })
-      setNotes( signatureWithNote("Purge")+notes )
-    }
-  }
-  
-  const handleFlag = () => {
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        sunshineFlagged: !user.sunshineFlagged,
-        sunshineNotes: notes
-      }
-    })
-    
-    const flagStatus = user.sunshineFlagged ? "Unflag" : "Flag"
-    setNotes( signatureWithNote(flagStatus)+notes )
-  }
-  
-  const handleDisablePosting = () => {
-    const abled = user.postingDisabled ? 'enabled' : 'disabled';
-    const newNotes = signatureWithNote(`posting ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        postingDisabled: !user.postingDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-  
-  const handleDisableAllCommenting = () => {
-    const abled = user.allCommentingDisabled ? 'enabled' : 'disabled';
-    const newNotes = signatureWithNote(`all commenting ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        allCommentingDisabled: !user.allCommentingDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-  
-  const handleDisableCommentingOnOtherUsers = () => {
-    const abled = user.commentingOnOtherUsersDisabled ? 'enabled' : 'disabled'
-    const newNotes = signatureWithNote(`commenting on other's ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        commentingOnOtherUsersDisabled: !user.commentingOnOtherUsersDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-  
-  const handleDisableConversations = () => {
-    const abled = user.conversationsDisabled ? 'enabled' : 'disabled'
-    const newNotes = signatureWithNote(`conversations ${abled}`) + notes;
-    void updateUser({
-      selector: {_id: user._id},
-      data: {
-        conversationsDisabled: !user.conversationsDisabled,
-        sunshineNotes: newNotes
-      }
-    })
-    setNotes( newNotes )
-  }
-
-  const mostRecentRateLimit = user.moderatorActions.find(modAction => modAction.type === RATE_LIMIT_ONE_PER_DAY);
-
-  const handleRateLimit = async () => {
-    const addedOrRemoved = mostRecentRateLimit?.active ? 'removed' : 'added';
-    const newNotes = signatureWithNote(`rate limit ${addedOrRemoved}`) + notes;
-    await updateUser({
-      selector: { _id: user._id },
-      data: { sunshineNotes: newNotes }
-    });
-
-    // If we have an active rate limit, we want to disable it
-    if (mostRecentRateLimit?.active) {
-      await updateModeratorAction({
-        selector: { _id: mostRecentRateLimit._id },
-        data: { endedAt: new Date() }
-      });
-    } else {
-      // Otherwise, we want to create a new one
-      await createModeratorAction({
-        data: {
-          type: RATE_LIMIT_ONE_PER_DAY,
-          userId: user._id,
-        }
-      });
-    }
-
-    setNotes(newNotes);
-    // Refetch to ensure the button displays (toggled on/off) properly 
-    refetch();
   }
   
   const { results: posts, loading: postsLoading } = useMulti({
@@ -455,16 +247,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   const hiddenCommentCount = user.maxCommentCount - user.commentCount
   
   if (!userCanDo(currentUser, "posts.moderate.all")) return null
-  
-  const getTodayString = () => {
-    const today = new Date();
-    return today.toLocaleString('default', { month: 'short', day: 'numeric'});
-  }
-  
-  const signature = `${currentUser?.displayName}, ${getTodayString()}`
-  const signatureWithNote = (note:string) => {
-    return `${signature}: ${note}\n`
-  }
+
   
   const signAndDate = (sunshineNotes:string) => {
     if (!sunshineNotes.match(signature)) {
@@ -536,33 +319,6 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
       rowsMax={5}
     />
   </div>
-
-  const moderatorActionsRow = <div className={classes.row}>
-    <LWTooltip title="Snooze 10 (Appear in sidebar after 10 posts and/or comments)" placement="top">
-      <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
-    </LWTooltip>
-    <LWTooltip title="Snooze 1 (Appear in sidebar on next post or comment)" placement="top">
-      <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
-    </LWTooltip>
-    <LWTooltip title="Approve" placement="top">
-      <DoneIcon onClick={handleReview} className={classNames(classes.modButton, {[classes.canReview]: !classes.disabled })}/>
-    </LWTooltip>
-    <LWTooltip title="Ban for 3 months" placement="top">
-      <RemoveCircleOutlineIcon className={classes.modButton} onClick={handleBan} />
-    </LWTooltip>
-    <LWTooltip title="Purge (delete and ban)" placement="top">
-      <DeleteForeverIcon className={classes.modButton} onClick={handlePurge} />
-    </LWTooltip>
-    <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
-      <div>Flag this user for more review</div>
-      <div><em>(This will not remove them from sidebar)</em></div>
-    </div>} placement="top">
-      <div onClick={handleFlag} className={classes.modButton} >
-        {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
-      </div>
-    </LWTooltip>
-  </div>
-
   
   const permissionsRow = <div className={classes.permissionsRow}>
       <LWTooltip title={`${user.postingDisabled ? "Enable" : "Disable"} this user's ability to create posts`}>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -495,6 +495,7 @@ importComponent("SidebarAction", () => require('../components/sunshineDashboard/
 importComponent("SunshineListCount", () => require('../components/sunshineDashboard/SunshineListCount'));
 importComponent("UsersReviewInfoCard", () => require('../components/sunshineDashboard/UsersReviewInfoCard'));
 importComponent(["EmailHistory", "EmailHistoryPage"], () => require('../components/sunshineDashboard/EmailHistory'));
+importComponent("ModeratorActions", () => require('../components/sunshineDashboard/ModeratorActions'));
 
 importComponent("AddTag", () => require('../components/tagging/AddTag'));
 importComponent("NewTagsList", () => require('../components/tagging/NewTagsList'));

--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -1,5 +1,5 @@
 import Users from "../../lib/collections/users/collection";
-import { getCurrentContentCount } from '../../components/sunshineDashboard/SunshineNewUsersInfo';
+import { getCurrentContentCount } from '../../components/sunshineDashboard/ModeratorActions';
 import { Comments } from "../../lib/collections/comments";
 import { ModeratorActions } from "../../lib/collections/moderatorActions";
 import { createAdminContext, createMutator, updateMutator } from "../vulcan-lib";

--- a/packages/lesswrong/server/migrations/2022-08-11-snoozeUntilContentCount.ts
+++ b/packages/lesswrong/server/migrations/2022-08-11-snoozeUntilContentCount.ts
@@ -1,7 +1,7 @@
 import { registerMigration } from './migrationUtils';
 
 import { Users } from '../../lib/collections/users/collection';
-import { getNewSnoozeUntilContentCount } from '../../components/sunshineDashboard/SunshineNewUsersInfo';
+import { getNewSnoozeUntilContentCount } from '../../components/sunshineDashboard/ModeratorActions';
 
 registerMigration({
   name: "setSnoozeUntilContentCountValues",


### PR DESCRIPTION
Pulls out all the moderator actions into one component that can be shared between UsersReviewInfoCard and SunshineNewUsersInfo. 

Also adjusts the structure of UsersReviewInfoCard slightly.

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/3246710/197891867-b11e78b0-d2a1-4152-b880-e33e234aa45e.png">

<img width="541" alt="image" src="https://user-images.githubusercontent.com/3246710/197892141-39263379-1c6b-4c21-b603-ce95864ab332.png">

