### PR TITLE
[EA Forum only] logged out users can sign up for forum digest

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -17,6 +17,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import TextField from '@material-ui/core/TextField';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
+// mailchimp link to sign up for the EA Forum's digest
 const eaForumDigestSubscribeURL = "https://effectivealtruism.us8.list-manage.com/subscribe/post?u=52b028e7f799cca137ef74763&amp;id=7457c7ff3e&amp;f_id=0086c5e1f0"
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -261,7 +262,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       {forumTypeSetting.get() === 'EAForum' ? <form action={eaForumDigestSubscribeURL} method="post" className={classes.digestForm}>
         <TextField label="Email address" name="EMAIL" required className={classes.digestFormInput} />
         <Button variant="contained" type="submit" color="primary" className={classes.digestFormSubmitBtn}>
-          Submit
+          Sign up
         </Button>
       </form> : <div className={classes.loginForm}>
         <WrappedLoginForm startingState="signup" />

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -14,8 +14,10 @@ import CheckRounded from '@material-ui/icons/CheckRounded'
 import withErrorBoundary from '../common/withErrorBoundary'
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import TextField from '@material-ui/core/TextField';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
+const eaForumDigestSubscribeURL = "https://effectivealtruism.us8.list-manage.com/subscribe/post?u=52b028e7f799cca137ef74763&amp;id=7457c7ff3e&amp;f_id=0086c5e1f0"
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -41,6 +43,24 @@ const styles = (theme: ThemeType): JssStyles => ({
   loginForm: {
     margin: "0 auto -4px",
     maxWidth: 252,
+  },
+  digestForm: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    columnGap: 30,
+    rowGap: '14px',
+    padding: '20px 50px 20px 20px',
+    [theme.breakpoints.down('xs')]: {
+      padding: 10
+    }
+  },
+  digestFormInput: {
+    flexGrow: 1
+  },
+  digestFormSubmitBtn: {
+    minHeight: 0,
+    boxShadow: 'none'
   },
   message: {
     display: "flex",
@@ -238,9 +258,14 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     );
     return <AnalyticsWrapper branch="logged-out">
       {subscribeTextNode}
-      <div className={classes.loginForm}>
+      {forumTypeSetting.get() === 'EAForum' ? <form action={eaForumDigestSubscribeURL} method="post" className={classes.digestForm}>
+        <TextField label="Email address" name="EMAIL" required className={classes.digestFormInput} />
+        <Button variant="contained" type="submit" color="primary" className={classes.digestFormSubmitBtn}>
+          Submit
+        </Button>
+      </form> : <div className={classes.loginForm}>
         <WrappedLoginForm startingState="signup" />
-      </div>
+      </div>}
       {adminUiMessage}
     </AnalyticsWrapper>
   } else if (!userHasEmailAddress(currentUser) || adminBranch===1) {


### PR DESCRIPTION
This PR allows logged out users to sign up for the EA Forum's digest. We didn't do anything to reduce the number of sign ups from bots, because Ollie and I were not sure if that would actually be an issue. 

<img width="600" alt="Screen Shot 2022-10-26 at 1 14 48 PM" src="https://user-images.githubusercontent.com/9057804/198093668-5627d981-7d3c-45c2-b493-6d3991394b2d.png">
