### PR TITLE
Fix grey styling of "read more" in comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -15,7 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: "100%",
     overflowX: "hidden",
     overflowY: "hidden",
-    '& .read-more a, & .read-more a:hover': {
+    '& .read-more-button a, & .read-more-button a:hover': {
       textShadow:"none",
       backgroundImage: "none"
     },
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   root: {
     position: "relative",
-    '& .read-more': {
+    '& .read-more-button': {
       fontSize: ".85em",
       color: theme.palette.grey[600]
     }

--- a/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
+++ b/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
@@ -6,7 +6,7 @@ import { tagGetUrl } from '../../lib/collections/tags/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    "& a.read-more": {
+    "& a.read-more-button": {
       fontSize: ".85em",
       color: theme.palette.grey[600]
     },
@@ -24,12 +24,12 @@ const TagPreviewDescription = ({tag, classes}: {
   if (!tag) return null
   
   const highlight = truncate(tag.description?.htmlHighlight, 1, "paragraphs",
-    '... <a class="read-more" href="#">(read more)</a>')
+    '... <a class="read-more-button" href="#">(read more)</a>')
 
   if (tag.description?.htmlHighlight) {
     return <div
       onClick={(ev: React.SyntheticEvent) => {
-        if ((ev.target as any)?.className==="read-more") {
+        if ((ev.target as any)?.className==="read-more-button") {
           history.push(tagGetUrl(tag));
         }
       }}


### PR DESCRIPTION
Bug was introduced in https://github.com/ForumMagnum/ForumMagnum/pull/5922/commits/02265d3e1988da1327c8c52596d65d39327b545c which changed a CSS class name but missed some styling that was attached to it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203246867607266) by [Unito](https://www.unito.io)
