### PR TITLE
[EA Forum only] clean up the sidebar links

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/EventsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/EventsList.tsx
@@ -16,7 +16,7 @@ const EventsList = ({currentUser, onClick}) => {
       view: 'nearbyEvents',
       lat: lat,
       lng: lng,
-      limit: 4,
+      limit: isEAForum ? 2 : 4,
     }
     return <span>
       <AnalyticsContext pageSubSectionContext="menuEventsList">
@@ -28,16 +28,16 @@ const EventsList = ({currentUser, onClick}) => {
   const eventsListTerms: PostsViewTerms = {
     view: 'events',
     globalEvent: false,
-    limit: isEAForum ? 1 : 2,
+    limit: 2,
   }
   const globalTerms: PostsViewTerms = {
     view: 'globalEvents',
-    limit: isEAForum ? 3 : 2,
+    limit: 2,
   }
   return <span>
     <AnalyticsContext pageSubSectionContext="menuEventsList">
       <TabNavigationEventsList onClick={onClick} terms={globalTerms} />
-      <TabNavigationEventsList onClick={onClick} terms={eventsListTerms} />
+      {!isEAForum && <TabNavigationEventsList onClick={onClick} terms={eventsListTerms} />}
     </AnalyticsContext>
   </span>
 }

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -316,21 +316,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnMobileStandalone: false,
       showOnCompressed: true
     }, {
-      id: 'local-groups',
-      title: 'Local Groups',
-      link: '/community',
-      subItem: true,
-    }, {
-      id: 'online-groups',
-      title: 'Online Groups',
-      link: '/community#online',
-      subItem: true,
-    }, {
-      id: 'community-members',
-      title: 'Community Members',
-      link: '/community#individuals',
-      subItem: true,
-    }, {
       id: 'advice',
       title: 'Book a 1:1 [BETA]',
       link: `/advice`,

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -340,7 +340,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       subItem: true,
     }, {
       id: 'about',
-      title: 'About the Forum',
+      title: 'How to use the Forum',
       link: '/about',
       subItem: true,
       compressedIconComponent: Info,

--- a/packages/lesswrong/components/form-components/TagMultiselect.tsx
+++ b/packages/lesswrong/components/form-components/TagMultiselect.tsx
@@ -33,18 +33,19 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCount=false, updateCurrentValues }: {
+const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCount=false, startWithBorder=false, updateCurrentValues }: {
   value: Array<string>,
   path: string,
   classes: ClassesType,
   label?: string,
   placeholder?: string,
   hidePostCount?: boolean,
+  startWithBorder?: boolean,
   updateCurrentValues<T extends {}>(values: T): void,
 }) => {
   const { SingleTagItem, TagsSearchAutoComplete, ErrorBoundary } = Components
 
-  const [focused, setFocused] = useState(false)
+  const [focused, setFocused] = useState(startWithBorder)
 
   const addTag = (id: string) => {
     if (!value.includes(id)) {

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -5,7 +5,8 @@ import { RefinementListExposed, RefinementListProvided, SearchState } from 'reac
 import { Hits, Configure, InstantSearch, SearchBox, Pagination, connectRefinementList, ToggleRefinement, NumericMenu, connectStats, ClearRefinements } from 'react-instantsearch-dom';
 import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient, AlgoliaIndexCollectionName, collectionIsAlgoliaIndexed } from '../../lib/algoliaUtil';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
-import { taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { Link } from '../../lib/reactRouterWrapper';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import SearchIcon from '@material-ui/icons/Search';
@@ -67,10 +68,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[600],
     marginBottom: 6
   },
+  mapLink: {
+    color: theme.palette.primary.main,
+    padding: 1,
+    marginTop: 30
+  },
   resultsColumn: {
     flex: '1 1 0',
   },
-
   searchIcon: {
     marginLeft: 12
   },
@@ -181,6 +186,7 @@ const TagsRefinementList = ({ tagsFilter, setTagsFilter }:
     path="tags"
     placeholder={`Filter by ${taggingNamePluralSetting.get()}`}
     hidePostCount
+    startWithBorder
     updateCurrentValues={(values: {tags?: Array<string>}) => {
       setTagsFilter && setTagsFilter(values.tags)
     }}
@@ -324,6 +330,10 @@ const SearchPageTabbed = ({classes}:{
           value={true}
         />}
         <ClearRefinements />
+        
+        {tab === 'Users' && forumTypeSetting.get() === 'EAForum' && <div className={classes.mapLink}>
+          <Link to="/community#individuals">View community map</Link>
+        </div>}
       </div>
 
       <div className={classes.resultsColumn}>


### PR DESCRIPTION
We're going down to two events in the sidebar, and removing the links to the Community page sections. The feature banner isn't quite visible above the fold yet though.

![](https://user-images.githubusercontent.com/9057804/198188023-859445fe-a43f-40d3-a005-f33f2d322277.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203253848439495) by [Unito](https://www.unito.io)
