### PR TITLE
[EA Forum only] fix post count on user profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -269,6 +269,16 @@ const EAUsersProfile = ({terms, slug, classes}: {
     enableTotal: false,
     skip: !user
   })
+  
+  // count posts here rather than using user.postCount,
+  // because the latter doesn't include posts where the user is a coauthor
+  const { totalCount: userPostsCount } = useMulti({
+    terms: {view: 'userPosts', userId: user?._id, limit: 0},
+    collectionName: "Posts",
+    fragmentName: 'PostsMinimumInfo',
+    enableTotal: true,
+    skip: !user
+  })
 
   const { SunshineNewUsersProfileInfo, SingleColumnSection, LWTooltip, EAUsersProfileTags,
     SettingsButton, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
@@ -467,7 +477,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
   return <div>
     <HeadTags
       description={metaDescription}
-      noIndex={(!user.postCount && !user.commentCount) || user.karma <= 0 || user.noindex}
+      noIndex={(!userPostsCount && !user.commentCount) || user.karma <= 0 || user.noindex}
       image={user.profileImageId && `https://res.cloudinary.com/cea/image/upload/c_crop,g_custom,q_auto,f_auto/${user.profileImageId}.jpg`}
     />
     <AnalyticsContext pageContext="userPage">
@@ -575,10 +585,10 @@ const EAUsersProfile = ({terms, slug, classes}: {
         
         <EAUsersProfileTabbedSection tabs={bioSectionTabs} />
         
-        {!!user.postCount && <div className={classes.section}>
+        {!!userPostsCount && <div className={classes.section}>
           <div className={classes.sectionHeadingRow}>
             <Typography variant="headline" className={classes.sectionHeading}>
-              Posts <div className={classes.sectionHeadingCount}>{user.postCount}</div>
+              Posts <div className={classes.sectionHeadingCount}>{userPostsCount}</div>
             </Typography>
             <SettingsButton onClick={() => setShowPostSetttings(!showPostSettings)}
               label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`} />

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -277,7 +277,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
       view: 'userPosts',
       userId: user?._id,
       authorIsUnreviewed: currentUser?.isAdmin ? null : false,
-      limit: 1
+      limit: 0
     },
     collectionName: "Posts",
     fragmentName: 'PostsMinimumInfo',
@@ -590,10 +590,10 @@ const EAUsersProfile = ({terms, slug, classes}: {
         
         <EAUsersProfileTabbedSection tabs={bioSectionTabs} />
         
-        {!!userPostsCount && <div className={classes.section}>
+        {!!(userPostsCount || user.postCount) && <div className={classes.section}>
           <div className={classes.sectionHeadingRow}>
             <Typography variant="headline" className={classes.sectionHeading}>
-              Posts <div className={classes.sectionHeadingCount}>{userPostsCount}</div>
+              Posts <div className={classes.sectionHeadingCount}>{(userPostsCount || user.postCount)}</div>
             </Typography>
             <SettingsButton onClick={() => setShowPostSettings(!showPostSettings)}
               label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`} />

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -260,7 +260,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
   }, [currentUser, user])
   
   // show/hide the "Posts" section sort/filter settings
-  const [showPostSettings, setShowPostSetttings] = useState(false)
+  const [showPostSettings, setShowPostSettings] = useState(false)
   
   const { results: userOrganizesGroups, loadMoreProps: userOrganizesGroupsLoadMoreProps } = useMulti({
     terms: {view: 'userOrganizesGroups', userId: user?._id, limit: 300},
@@ -273,7 +273,12 @@ const EAUsersProfile = ({terms, slug, classes}: {
   // count posts here rather than using user.postCount,
   // because the latter doesn't include posts where the user is a coauthor
   const { totalCount: userPostsCount } = useMulti({
-    terms: {view: 'userPosts', userId: user?._id, limit: 0},
+    terms: {
+      view: 'userPosts',
+      userId: user?._id,
+      authorIsUnreviewed: currentUser?.isAdmin ? null : false,
+      limit: 1
+    },
     collectionName: "Posts",
     fragmentName: 'PostsMinimumInfo',
     enableTotal: true,
@@ -590,7 +595,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
             <Typography variant="headline" className={classes.sectionHeading}>
               Posts <div className={classes.sectionHeadingCount}>{userPostsCount}</div>
             </Typography>
-            <SettingsButton onClick={() => setShowPostSetttings(!showPostSettings)}
+            <SettingsButton onClick={() => setShowPostSettings(!showPostSettings)}
               label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`} />
           </div>
           {showPostSettings && <PostsListSettings

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -294,7 +294,7 @@ export function useMulti<
   const { query: locationQuery, location } = useLocation();
   const { history } = useNavigation();
 
-  const defaultLimit = ((locationQuery && queryLimitName && parseInt(locationQuery[queryLimitName])) ?? (terms && terms.limit) ?? initialLimit)
+  let defaultLimit: number = (((locationQuery && queryLimitName && parseInt(locationQuery[queryLimitName])) || terms.limit) ?? initialLimit)
   const [ limit, setLimit ] = useState(defaultLimit);
   const [ lastTerms, setLastTerms ] = useState(_.clone(terms));
   

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -294,7 +294,7 @@ export function useMulti<
   const { query: locationQuery, location } = useLocation();
   const { history } = useNavigation();
 
-  const defaultLimit = ((locationQuery && queryLimitName && parseInt(locationQuery[queryLimitName])) || (terms && terms.limit) || initialLimit)
+  const defaultLimit = ((locationQuery && queryLimitName && parseInt(locationQuery[queryLimitName])) ?? (terms && terms.limit) ?? initialLimit)
   const [ limit, setLimit ] = useState(defaultLimit);
   const [ lastTerms, setLastTerms ] = useState(_.clone(terms));
   


### PR DESCRIPTION
Count the user's posts rather than rely on `user.postCount`, because the latter doesn't include posts that the user coauthored.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203248853856142) by [Unito](https://www.unito.io)
