### PR TITLE
Fix "bug" in ClickAwayListener

### DIFF
--- a/packages/lesswrong/components/common/LWClickAwayListener.tsx
+++ b/packages/lesswrong/components/common/LWClickAwayListener.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib/components';
+// eslint-disable-next-line no-restricted-imports
+import ClickAwayListener, { ClickAwayListenerProps } from '@material-ui/core/ClickAwayListener';
+
+/**
+ * Wrapped to ensure that "onClick" is the default mouse event.
+ * Without it, this would be a "onMouseUp" event, which happens BEFORE "onClick",
+ * and resulted in some annoying behavior. Also MUI v5 defaults this to "onClick".
+ */
+const LWClickAwayListener = ({children, ...props}: {
+  children: React.ReactNode,
+} & ClickAwayListenerProps) => {
+  return (
+    <ClickAwayListener mouseEvent="onClick" {...props}>
+      {children}
+    </ClickAwayListener>
+  );
+}
+
+const LWClickAwayListenerComponent = registerComponent('LWClickAwayListener', LWClickAwayListener);
+
+declare global {
+  interface ComponentTypes {
+    LWClickAwayListener: typeof LWClickAwayListenerComponent
+  }
+}

--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useCallback, useState } from 'react';
 import { Components } from '../../lib/vulcan-lib';
-import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { hookToHoc } from '../../lib/hocUtils';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useOnNavigate } from './NavigationEventSender';
@@ -50,8 +49,10 @@ export const DialogManager = ({children}: {
     if (closeOnNavigate) closeDialog()
   })
 
+  const { LWClickAwayListener } = Components
+
   const modal = isOpen && <ModalComponent {...componentProps} onClose={closeDialog} />
-  const withClickaway = isOpen && (noClickawayCancel ? modal : <ClickAwayListener onClickAway={closeDialog}>{modal}</ClickAwayListener>);
+  const withClickaway = isOpen && (noClickawayCancel ? modal : <LWClickAwayListener onClickAway={closeDialog}>{modal}</LWClickAwayListener>);
   return (
     <OpenDialogContext.Provider value={providedContext}>
       {children}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageActions.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import { useCurrentUser } from '../../common/withUser';
 import { useTracking } from '../../../lib/analyticsEvents';
-import ClickawayListener from '@material-ui/core/ClickAwayListener';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -25,35 +24,33 @@ const PostsPageActions = ({post, vertical, classes}: {
   vertical?: boolean,
   classes: ClassesType,
 }) => {
-  const [anchorEl, setAnchorEl] = useState<any>(null);
+  const anchorEl = useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const {captureEvent} = useTracking();
   const currentUser = useCurrentUser();
 
-  const handleClick = (e) => {
-    captureEvent("tripleDotClick", {open: true, itemType: "post", postId: post._id})
-    setAnchorEl(anchorEl ? null : e.target);
-  }
-
-  const handleClose = () => {
-    captureEvent("tripleDotClick", {open: false, itemType: "post"})
-    setAnchorEl(null);
+  const handleSetOpen = (open: boolean) => {
+    captureEvent("tripleDotClick", {open, itemType: "post", postId: post._id})
+    setIsOpen(open);
   }
 
   const Icon = vertical ? MoreVertIcon : MoreHorizIcon
-  const { PopperCard, PostActions } = Components
+  const { PopperCard, PostActions, LWClickAwayListener } = Components
   if (!currentUser) return null;
 
   return <div className={classes.root}>
-    <Icon className={classes.icon} onClick={handleClick}/> 
+    <div ref={anchorEl}>
+      <Icon className={classes.icon} onClick={() => handleSetOpen(!isOpen)}/>
+    </div>
     <PopperCard
-      open={Boolean(anchorEl)}
-      anchorEl={anchorEl}
+      open={isOpen}
+      anchorEl={anchorEl.current}
       placement="right-start"
-      allowOverflow      
+      allowOverflow
     >
-      <ClickawayListener onClickAway={handleClose}>
-        <PostActions post={post} closeMenu={handleClose}/>
-      </ClickawayListener>
+      <LWClickAwayListener onClickAway={() => handleSetOpen(false)}>
+        <PostActions post={post} closeMenu={() => handleSetOpen(false)}/>
+      </LWClickAwayListener>
     </PopperCard>
   </div>
 }

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -1,7 +1,6 @@
-import React, { useState }  from 'react';
+import React, { useRef, useState }  from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Paper from '@material-ui/core/Paper';
-import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { useCurrentUser } from '../common/withUser';
 import { userCanUseTags } from '../../lib/betas';
 import { useTracking } from "../../lib/analyticsEvents";
@@ -26,10 +25,10 @@ const AddTagButton = ({onTagSelected, classes, children}: {
   children?: any
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);
+  const anchorEl = useRef<HTMLAnchorElement|null>(null);
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking()
-  const { LWPopper, AddTag } = Components
+  const { LWPopper, AddTag, LWClickAwayListener } = Components
 
   if (!userCanUseTags(currentUser)) {
     return null;
@@ -37,33 +36,32 @@ const AddTagButton = ({onTagSelected, classes, children}: {
 
   return <a
     onClick={(ev) => {
-      setAnchorEl(ev.currentTarget);
       setIsOpen(true);
       captureEvent("addTagClicked")
     }}
     className={classes.addTagButton}
+    ref={anchorEl}
   >
     {children ? children : <span className={classes.defaultButton}>+ Add {taggingNameCapitalSetting.get()}</span>}
 
     <LWPopper
       open={isOpen}
-      anchorEl={anchorEl}
+      anchorEl={anchorEl.current}
       placement="bottom"
       allowOverflow
     >
-      <ClickAwayListener
+      <LWClickAwayListener
         onClickAway={() => setIsOpen(false)}
       >
         <Paper>
           <AddTag
             onTagSelected={({tagId, tagName}: {tagId: string, tagName: string}) => {
-              setAnchorEl(null);
               setIsOpen(false);
               onTagSelected({tagId, tagName});
             }}
           />
         </Paper>
-      </ClickAwayListener>
+      </LWClickAwayListener>
     </LWPopper>
   </a>;
 }

--- a/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Components, getFragment, registerComponent } from "../../lib/vulcan-lib";
 import NotificationsNoneIcon from "@material-ui/icons/NotificationsNone";
 import NotificationsIcon from "@material-ui/icons/Notifications";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import IconButton from "@material-ui/core/IconButton";
-import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import Paper from "@material-ui/core/Paper";
 import UserTagRels from "../../lib/collections/userTagRels/collection";
 import { useMulti } from "../../lib/crud/withMulti";
@@ -12,8 +11,10 @@ import { Link } from "../../lib/reactRouterWrapper";
 import { useRecordSubforumView } from "../hooks/useRecordSubforumView";
 
 const styles = (theme: ThemeType): JssStyles => ({
-  notificationsButton: {
+  notificationsButtonWrapper: {
     margin: "0 12px 0 0",
+  },
+  notificationsButton: {
     padding: 4,
   },
   popout: {
@@ -35,10 +36,10 @@ const SubforumNotificationSettings = ({
   currentUser: UsersCurrent;
   classes: ClassesType;
 }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const anchorEl = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
 
-  const { LWPopper, WrappedSmartForm, Typography, Loading } = Components;
+  const { LWClickAwayListener, LWPopper, WrappedSmartForm, Typography, Loading } = Components;
 
   const { loading, results, refetch } = useMulti({
     terms: { view: "single", tagId: tag._id, userId: currentUser._id },
@@ -63,38 +64,20 @@ const SubforumNotificationSettings = ({
   if (!userTagRel) return null
   if (loading) return null
 
-  const handleOpen = (event) => {
-    setOpen(true);
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = (e) => {
-    if (e && anchorEl?.contains(e.target)) {
-      return;
-    }
-    setOpen(false);
-  };
-
-  const handleToggle = (e) => {
-    if (open) {
-      handleClose(null); // When closing from toggle, force a close by not providing an event
-    } else {
-      handleOpen(e);
-    }
-  };
-
   return (
     <AnalyticsContext pageSection="subforumNotificationSettings">
       <div className={classes.root}>
-        <IconButton onClick={handleToggle} className={classes.notificationsButton}>
-          {(!userTagRel.subforumShowUnreadInSidebar && !userTagRel.subforumEmailNotifications) ? (
-            <NotificationsNoneIcon />
-          ) : (
-            <NotificationsIcon />
-          )}
-        </IconButton>
-        <LWPopper open={open} anchorEl={anchorEl} placement="bottom-end">
-          <ClickAwayListener onClickAway={handleClose}>
+        <div ref={anchorEl} className={classes.notificationsButtonWrapper}>
+          <IconButton onClick={() => setOpen(!open)} className={classes.notificationsButton}>
+            {(!userTagRel.subforumShowUnreadInSidebar && !userTagRel.subforumEmailNotifications) ? (
+              <NotificationsNoneIcon />
+            ) : (
+              <NotificationsIcon />
+            )}
+          </IconButton>
+        </div>
+        <LWPopper open={open} anchorEl={anchorEl.current} placement="bottom-end">
+          <LWClickAwayListener onClickAway={() => setOpen(false)}>
             <Paper className={classes.popout}>
               {loading ? (
                 <Loading />
@@ -113,7 +96,7 @@ const SubforumNotificationSettings = ({
                 </>
               )}
             </Paper>
-          </ClickAwayListener>
+          </LWClickAwayListener>
         </LWPopper>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -129,6 +129,7 @@ importComponent("LoadMore", () => require('../components/common/LoadMore'));
 importComponent("ReCaptcha", () => require('../components/common/ReCaptcha'));
 importComponent("DefaultStyleFormGroup", () => require('../components/common/DefaultStyleFormGroup'))
 importComponent("LinkCard", () => require('../components/common/LinkCard'));
+importComponent("LWClickAwayListener", () => require('../components/common/LWClickAwayListener'));
 importComponent("LWDialog", () => require('../components/common/LWDialog'));
 importComponent("Error404", () => require('../components/common/Error404'));
 importComponent("ErrorAccessDenied", () => require('../components/common/ErrorAccessDenied'));


### PR DESCRIPTION
The default for `ClickAwayListener` was to listen for mouseUp events, whereas most other components listen for onClick. This resulted in some fiddle logic you had to do to make it work correctly because mouseUp is fired before onClick, e.g. look at the logic that was in `packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx` before this change:

```Typescript
  const handleOpen = (event) => {
    setOpen(true);
    setAnchorEl(event.currentTarget);
  };

  const handleClose = (e) => {
    if (e && anchorEl?.contains(e.target)) {
      return;
    }
    setOpen(false);
  };

  const handleToggle = (e) => {
    if (open) {
      handleClose(null); // When closing from toggle, force a close by not providing an event
    } else {
      handleOpen(e);
    }
  };
```

If you clicked on the bell to close the popout `handleClose` would be called by the ClickAwayListener and then `handleToggle` would be called by the bell icon's `onClick`. This would result in the popout quickly closing and reopening if it wasn't for:
```Typescript
if (e && anchorEl?.contains(e.target)) {
      return;
    }
```

This PR wraps the MUI ClickAwayListener with on that uses `onClick` by default. In v5 of MUI `onClick` is the [default setting](https://mui.com/base/api/click-away-listener/) so presumably other people have run into this problem

I have tested all the ones I've changed apart from `withDialog`, because this is used in about 60 places. I have tested about 10 of those and they seem to work fine

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203254361045478) by [Unito](https://www.unito.io)
