### PR TITLE
dismiss user without review

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -16,6 +16,7 @@ import FlagIcon from '@material-ui/icons/Flag';
 import Input from '@material-ui/core/Input';
 import { isLowAverageKarmaContent } from '../../lib/collections/moderatorActions/helpers';
 import { sortBy } from 'underscore';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 
 const styles = (theme: ThemeType): JssStyles => ({
   row: {
@@ -176,6 +177,18 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
       selector: {_id: user._id},
       data: {
         needsReview: true,
+        sunshineNotes: newNotes
+      }
+    })    
+    setNotes( newNotes )
+  }
+
+  const handleRemoveNeedsReview = () => {
+    const newNotes = signatureWithNote("removed from review queue without snooze/approval") + notes;
+    void updateUser({
+      selector: {_id: user._id},
+      data: {
+        needsReview: false,
         sunshineNotes: newNotes
       }
     })    
@@ -345,6 +358,9 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     </LWTooltip>
     {!user.needsReview && <LWTooltip title="Return this user to the review queue">
       <VisibilityOutlinedIcon className={classes.modButton} onClick={handleNeedsReview}/>
+    </LWTooltip>}
+    {user.needsReview && <LWTooltip title="Remove this user from the review queue">
+      <VisibilityOffIcon className={classes.modButton} onClick={handleRemoveNeedsReview}/>
     </LWTooltip>}
   </div>
 


### PR DESCRIPTION
Sometimes we want to dismiss a user from the review queue without marking them as having been reviewed (which snoozing them would do), such as in the case of a new user with a post which either we or they have turned back into a draft after publishing.  (Maybe also for users who have not-obviously-spammy bios but haven't left any comments.). This gives us the opportunity to review their next published post before it goes live.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203261902334988) by [Unito](https://www.unito.io)
