### PR TITLE
flag user from sunshine post item

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -94,10 +94,10 @@ const SunshineNewPostsItem = ({post, classes}: {
   }
 
   const lastManualUserFlag = post.user?.moderatorActions.find(action => action.type === MANUAL_FLAG_ALERT);
+  const isUserAlreadyFlagged = post.user?.needsReview || lastManualUserFlag?.active;
 
   const handleFlagUser = async () => {
-    const isAlreadyFlagged = lastManualUserFlag?.active;
-    if (isAlreadyFlagged) return;
+    if (isUserAlreadyFlagged) return;
 
     await createModeratorAction({
       data: {
@@ -128,7 +128,7 @@ const SunshineNewPostsItem = ({post, classes}: {
               <Button onClick={handleDelete}>
                 <ClearIcon className={classes.icon} /> Draft
               </Button>
-              <Button onClick={handleFlagUser}>
+              <Button onClick={handleFlagUser} disabled={isUserAlreadyFlagged}>
                 <VisibilityOutlinedIcon className={classes.icon} /> Flag User
               </Button>
             </div>
@@ -145,7 +145,7 @@ const SunshineNewPostsItem = ({post, classes}: {
                 <FormatDate date={post.postedAt}/>
               </MetaInfo>
               {post.commentCount && <MetaInfo>
-                <Link to={`postGetPageUrl(post)#comments`}>
+                <Link to={`${postGetPageUrl(post)}#comments`}>
                   {post.commentCount} comments
                 </Link>
               </MetaInfo>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -107,6 +107,8 @@ const SunshineNewPostsItem = ({post, refetch, classes}: {
       }
     });
     
+    // We need to refetch to make sure the "Flag User" button gets disabled
+    // The backend state only gets changed in a moderator action callback, so apollo doesn't handle it for us by updating the cache
     refetch();
   }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -11,7 +11,10 @@ import Button from '@material-ui/core/Button';
 import PersonIcon from '@material-ui/icons/Person'
 import HomeIcon from '@material-ui/icons/Home';
 import ClearIcon from '@material-ui/icons/Clear';
+import VisibilityOutlinedIcon from '@material-ui/icons/VisibilityOutlined';
 import { Posts } from '../../lib/collections/posts';
+import { useCreate } from '../../lib/crud/withCreate';
+import { MANUAL_FLAG_ALERT } from '../../lib/collections/moderatorActions/schema';
 
 const styles = (theme: ThemeType): JssStyles => ({
   icon: {
@@ -50,6 +53,11 @@ const SunshineNewPostsItem = ({post, classes}: {
     collectionName: "Posts",
     fragmentName: 'PostsList',
   });
+
+  const { create: createModeratorAction } = useCreate({
+    collectionName: 'ModeratorActions',
+    fragmentName: 'ModeratorActionsDefaultFragment'
+  });
   
   const handlePersonal = () => {
     void updatePost({
@@ -85,6 +93,20 @@ const SunshineNewPostsItem = ({post, classes}: {
     }
   }
 
+  const lastManualUserFlag = post.user?.moderatorActions.find(action => action.type === MANUAL_FLAG_ALERT);
+
+  const handleFlagUser = async () => {
+    const isAlreadyFlagged = lastManualUserFlag?.active;
+    if (isAlreadyFlagged) return;
+
+    await createModeratorAction({
+      data: {
+        type: MANUAL_FLAG_ALERT,
+        userId: post.userId,
+      }
+    });
+  }
+
   const { MetaInfo, LinkPostMessage, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, FormatDate, FooterTagList, Typography, ContentStyles, SmallSideVote } = Components
   const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
   const { html: userGuidelinesHtml = "" } = post.user?.moderationGuidelines || {}
@@ -96,7 +118,7 @@ const SunshineNewPostsItem = ({post, classes}: {
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
           <FooterTagList post={post} showCoreTags/>
-          <div className={classes.buttonRow}>
+            <div className={classes.buttonRow}>
               <Button onClick={handlePersonal}>
                 <PersonIcon className={classes.icon} /> Personal
               </Button>
@@ -105,6 +127,9 @@ const SunshineNewPostsItem = ({post, classes}: {
               </Button>}
               <Button onClick={handleDelete}>
                 <ClearIcon className={classes.icon} /> Draft
+              </Button>
+              <Button onClick={handleFlagUser}>
+                <VisibilityOutlinedIcon className={classes.icon} /> Flag User
               </Button>
             </div>
             <Typography variant="title" className={classes.title}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -42,8 +42,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const SunshineNewPostsItem = ({post, classes}: {
+const SunshineNewPostsItem = ({post, refetch, classes}: {
   post: SunshinePostsList,
+  refetch: () => void,
   classes: ClassesType
 }) => {
   const currentUser = useCurrentUser();
@@ -105,6 +106,8 @@ const SunshineNewPostsItem = ({post, classes}: {
         userId: post.userId,
       }
     });
+    
+    refetch();
   }
 
   const { MetaInfo, LinkPostMessage, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, FormatDate, FooterTagList, Typography, ContentStyles, SmallSideVote } = Components

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
@@ -14,7 +14,7 @@ const SunshineNewPostsList = ({ terms, classes }: {
   terms: PostsViewTerms,
   classes: ClassesType,
 }) => {
-  const { results, totalCount } = useMulti({
+  const { results, totalCount, refetch } = useMulti({
     terms,
     collectionName: "Posts",
     fragmentName: 'SunshinePostsList',
@@ -31,7 +31,7 @@ const SunshineNewPostsList = ({ terms, classes }: {
         </SunshineListTitle>
         {results.map(post =>
           <div key={post._id} >
-            <SunshineNewPostsItem post={post}/>
+            <SunshineNewPostsItem post={post} refetch={refetch}/>
           </div>
         )}
       </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -58,7 +58,7 @@ const SunshineNewUserPostsList = ({posts, user, classes}: {
                   <FormatDate date={post.postedAt}/>
                 </MetaInfo>
                 {post.commentCount && <MetaInfo>
-                  <Link to={`postGetPageUrl(post)#comments`}>
+                  <Link to={`${postGetPageUrl(post)}#comments`}>
                     {post.commentCount} comments
                   </Link>
                 </MetaInfo>}

--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -6,13 +6,15 @@ export const RECENTLY_DOWNVOTED_CONTENT_ALERT = 'recentlyDownvotedContentAlert';
 export const LOW_AVERAGE_KARMA_COMMENT_ALERT = 'lowAverageKarmaCommentAlert';
 export const LOW_AVERAGE_KARMA_POST_ALERT = 'lowAverageKarmaPostAlert';
 export const NEGATIVE_KARMA_USER_ALERT = 'negativeUserKarmaAlert';
+export const MANUAL_FLAG_ALERT = 'manualFlag';
 
 export const MODERATOR_ACTION_TYPES = {
   [RATE_LIMIT_ONE_PER_DAY]: 'Rate Limit (1 / day)',
   [RECENTLY_DOWNVOTED_CONTENT_ALERT]: 'Recently Downvoted Content',
   [LOW_AVERAGE_KARMA_COMMENT_ALERT]: 'Low Average Karma Comments',
   [LOW_AVERAGE_KARMA_POST_ALERT]: 'Low Average Karma Posts',
-  [NEGATIVE_KARMA_USER_ALERT]: 'Negative Karma User'
+  [NEGATIVE_KARMA_USER_ALERT]: 'Negative Karma User',
+  [MANUAL_FLAG_ALERT]: 'Manually Flagged'
 };
 
 /**

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -531,8 +531,7 @@ registerFragment(`
       }
 
       moderatorActions {
-        active
-        type
+        ...ModeratorActionDisplay
       }
     }
   }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -530,6 +530,7 @@ registerFragment(`
         html
       }
 
+      needsReview
       moderatorActions {
         ...ModeratorActionDisplay
       }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -529,6 +529,11 @@ registerFragment(`
         _id
         html
       }
+
+      moderatorActions {
+        active
+        type
+      }
     }
   }
 `)

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -330,7 +330,7 @@ interface ModeratorActionsCollection extends CollectionBase<DbModeratorAction, "
 interface DbModeratorAction extends DbObject {
   __collectionName?: "ModeratorActions"
   userId: string
-  type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert"
+  type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "manualFlag"
   endedAt: Date | null
   createdAt: Date
 }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1132,17 +1132,12 @@ interface SunshinePostsList_user extends UsersMinimumInfo { // fragment on Users
   readonly bannedUserIds: Array<string>,
   readonly moderatorAssistance: boolean,
   readonly moderationGuidelines: SunshinePostsList_user_moderationGuidelines|null,
-  readonly moderatorActions: Array<SunshinePostsList_user_moderatorActions>,
+  readonly moderatorActions: Array<ModeratorActionDisplay>,
 }
 
 interface SunshinePostsList_user_moderationGuidelines { // fragment on Revisions
   readonly _id: string,
   readonly html: string,
-}
-
-interface SunshinePostsList_user_moderatorActions { // fragment on ModeratorActions
-  readonly active: boolean,
-  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "manualFlag",
 }
 
 interface WithVotePost { // fragment on Posts

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1132,11 +1132,17 @@ interface SunshinePostsList_user extends UsersMinimumInfo { // fragment on Users
   readonly bannedUserIds: Array<string>,
   readonly moderatorAssistance: boolean,
   readonly moderationGuidelines: SunshinePostsList_user_moderationGuidelines|null,
+  readonly moderatorActions: Array<SunshinePostsList_user_moderatorActions>,
 }
 
 interface SunshinePostsList_user_moderationGuidelines { // fragment on Revisions
   readonly _id: string,
   readonly html: string,
+}
+
+interface SunshinePostsList_user_moderatorActions { // fragment on ModeratorActions
+  readonly active: boolean,
+  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "manualFlag",
 }
 
 interface WithVotePost { // fragment on Posts
@@ -2728,7 +2734,7 @@ interface SpotlightEditQueryFragment extends SpotlightMinimumInfo { // fragment 
 
 interface ModeratorActionsDefaultFragment { // fragment on ModeratorActions
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert",
+  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "manualFlag",
   readonly endedAt: Date | null,
 }
 
@@ -2736,7 +2742,7 @@ interface ModeratorActionDisplay { // fragment on ModeratorActions
   readonly _id: string,
   readonly user: UsersMinimumInfo|null,
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert",
+  readonly type: "rateLimitOnePerDay" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "manualFlag",
   readonly active: boolean,
   readonly createdAt: Date,
   readonly endedAt: Date | null,

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1132,6 +1132,7 @@ interface SunshinePostsList_user extends UsersMinimumInfo { // fragment on Users
   readonly bannedUserIds: Array<string>,
   readonly moderatorAssistance: boolean,
   readonly moderationGuidelines: SunshinePostsList_user_moderationGuidelines|null,
+  readonly needsReview: boolean,
   readonly moderatorActions: Array<ModeratorActionDisplay>,
 }
 


### PR DESCRIPTION
Makes it possible to flag users when reviewing their posts.
<img width="487" alt="image" src="https://user-images.githubusercontent.com/2136984/199119272-3c4aba14-13c0-4060-8c44-1169e4f4c638.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203274281315749) by [Unito](https://www.unito.io)
