### PR TITLE
Fix ui bugs for notes field

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -61,7 +61,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 4,
     marginTop: 8,
     marginBottom: 8,
-    ...hideScrollBars
+    ...hideScrollBars,
+    '& *': {
+      ...hideScrollBars
+    }
   },
 });
 
@@ -429,7 +432,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         disableUnderline
         placeholder="Notes for other moderators"
         multiline
-        rowsMax={5}
+        rows={5}
       />
     </div>
     {moderatorActionLog}


### PR DESCRIPTION
Due to some changes introduced in #5932 (I think), the MUI Input field was rendering three textfields and failing to hide two of them (as intended). 

This problem goes away if you change rowsMax to rows (instead rendering a different field), which requires also changing how scrollbar-hidden works. @oetherington is working on a more comprehensive solution.