### PR TITLE
Fix links to post comments

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -120,7 +120,7 @@ const SunshineNewPostsItem = ({post, classes}: {
                 <FormatDate date={post.postedAt}/>
               </MetaInfo>
               {post.commentCount && <MetaInfo>
-                <Link to={`postGetPageUrl(post)#comments`}>
+                <Link to={`${postGetPageUrl(post)}#comments`}>
                   {post.commentCount} comments
                 </Link>
               </MetaInfo>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -58,7 +58,7 @@ const SunshineNewUserPostsList = ({posts, user, classes}: {
                   <FormatDate date={post.postedAt}/>
                 </MetaInfo>
                 {post.commentCount && <MetaInfo>
-                  <Link to={`postGetPageUrl(post)#comments`}>
+                  <Link to={`${postGetPageUrl(post)}#comments`}>
                     {post.commentCount} comments
                   </Link>
                 </MetaInfo>}


### PR DESCRIPTION
I totally forgot to actually run the function instead of literally linking people to "postGetPageUrl(post)#comments". Fixed.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203275001936264) by [Unito](https://www.unito.io)
