### PR TITLE
Fix class name generation

### DIFF
--- a/packages/lesswrong/client/themeProvider.tsx
+++ b/packages/lesswrong/client/themeProvider.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
+import { jssPreset } from '@material-ui/core/styles';
 import { create } from 'jss';
 import type { AbstractThemeOptions } from '../themes/themeNames';
 import { ThemeContextProvider } from '../components/themes/useTheme';
-
+import { generateClassName } from '../lib/utils/generateClassName';
 
 export function wrapWithMuiTheme (app: React.ReactNode, themeOptions: AbstractThemeOptions) {
-  const generateClassName = createGenerateClassName({
-    dangerouslyUseGlobalCSS: true
-  });
   const jss = create({
     ...jssPreset(),
     insertionPoint: document.getElementById("jss-insertion-point") as HTMLElement,
   });
-  
+
   return (
     <JssProvider jss={jss} generateClassName={generateClassName}>
       <ThemeContextProvider options={themeOptions}>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -429,7 +429,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         disableUnderline
         placeholder="Notes for other moderators"
         multiline
-        rows={5}
+        rowsMax={5}
       />
     </div>
     {moderatorActionLog}

--- a/packages/lesswrong/lib/utils/generateClassName.ts
+++ b/packages/lesswrong/lib/utils/generateClassName.ts
@@ -1,0 +1,6 @@
+import type { Rule, Stylesheet } from 'react-jss/lib/jss';
+
+export const generateClassName = (rule: Rule, styleSheet: Stylesheet): string => {
+  const prefix = styleSheet?.options?.classNamePrefix;
+  return prefix ? `${prefix}-${rule.key}` : rule.key;
+};

--- a/packages/lesswrong/server/material-ui/themeProvider.tsx
+++ b/packages/lesswrong/server/material-ui/themeProvider.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { createGenerateClassName } from '@material-ui/core/styles';
 import { SheetsRegistry } from 'react-jss/lib/jss';
 import { ThemeContextProvider } from '../../components/themes/useTheme';
 import { AbstractThemeOptions } from '../../themes/themeNames';
+import { generateClassName } from '../../lib/utils/generateClassName';
 
 export const wrapWithMuiTheme = <Context extends {sheetsRegistry?: SheetsRegistry}>(
   app: React.ReactNode,
@@ -12,9 +12,6 @@ export const wrapWithMuiTheme = <Context extends {sheetsRegistry?: SheetsRegistr
 ): React.ReactElement => {
   const sheetsRegistry = new SheetsRegistry();
   context.sheetsRegistry = sheetsRegistry;
-  const generateClassName = createGenerateClassName({
-    dangerouslyUseGlobalCSS: true
-  });
 
   return (
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
@@ -24,4 +21,3 @@ export const wrapWithMuiTheme = <Context extends {sheetsRegistry?: SheetsRegistr
     </JssProvider>
   );
 }
-


### PR DESCRIPTION
I think this _should_ fix the problems caused by JSS adding `-nnn` suffixes to some internal components. For now, I've just removed suffixes in all cases - it's theoretically possible that this could lead to collisions, but I can't see any case where this would happen unless we start having multiple components with exactly the same name which seems bad for a whole variety of different reasons.

If you think this could be too dangerous then let me know and we can just add some extra logic here. Either we could add a suffix for everything, or we could keep track of a dictionary of class names and only add a suffix (and maybe issue a console warning?) when we actually find a concrete collision.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203276862774143) by [Unito](https://www.unito.io)
