### PR TITLE
Fix mark-as-unread in PostReadCheckbox

### DIFF
--- a/packages/lesswrong/components/posts/PostReadCheckbox.tsx
+++ b/packages/lesswrong/components/posts/PostReadCheckbox.tsx
@@ -30,7 +30,7 @@ export const PostReadCheckbox = ({classes, post, width=12}: {
   const {postsRead, setPostRead} = useItemsRead();
   
 
-  const isRead = post.isRead || postsRead[post._id];
+  const isRead = post && ((post._id in postsRead) ? postsRead[post._id] : post.isRead)
 
   const {mutate: markAsReadOrUnread} = useNamedMutation<{
     postId: string, isRead: boolean,


### PR DESCRIPTION
Caused by misinterpreting `postsRead` in `ItemsReadContextType` as a set, rather than a mappign where true, false, and missing are three distinct meanings.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203281300564029) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203281300564029
