### PR TITLE
Crosspost tooltip, message written by Lizka

### DIFF
--- a/packages/lesswrong/components/form-components/FMCrosspostControl.tsx
+++ b/packages/lesswrong/components/form-components/FMCrosspostControl.tsx
@@ -62,18 +62,16 @@ const FMCrosspostAccount = ({fmCrosspostUserId, classes}: {
   const link = `${fmCrosspostBaseUrlSetting.get()}users/${document?.slug}`;
 
   const {Loading} = Components;
-  return document && !loading
-    ? (
-      <div className={classes.crosspostMessage}>
-        This post will be crossposted to {fmCrosspostSiteNameSetting.get()} by
-        your account <a className={classes.link} href={link} target="_blank" rel="noreferrer">
-          {document.username}
-        </a>
-      </div>
-    )
-    : (
-      <Loading />
-    );
+  
+  if (!document || loading) {
+    return <Loading/>
+  }
+  return <div className={classes.crosspostMessage}>
+    This post will be crossposted to {fmCrosspostSiteNameSetting.get()} by
+    your account <a className={classes.link} href={link} target="_blank" rel="noreferrer">
+      {document.username}
+    </a>
+  </div>
 }
 
 /**

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1284,7 +1284,7 @@ const schema: SchemaType<DbPost> = {
     editableBy: [userOwns, 'admins'],
     insertableBy: ['members'],
     control: "FMCrosspostControl",
-    tooltip: fmCrosspostBaseUrlSetting.get() && ["https://forum.effectivealtruism.org", "https://forum.effectivealtruism.org/"].includes(fmCrosspostBaseUrlSetting.get()!) ?
+    tooltip: fmCrosspostBaseUrlSetting.get()?.includes("forum.effectivealtruism.org") ?
       "The EA Forum is for discussions that are relevant to doing good effectively. If you're not sure what this means, consider exploring the Forum's Frontpage before posting on it." :
       undefined,
     group: formGroups.advancedOptions,

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -13,7 +13,7 @@ import SimpleSchema from 'simpl-schema'
 import { DEFAULT_QUALITATIVE_VOTE } from '../reviewVotes/schema';
 import { getCollaborativeEditorAccess } from './collabEditingPermissions';
 import { getVotingSystems } from '../../voting/votingSystems';
-import { fmCrosspostSiteNameSetting, forumTypeSetting } from '../../instanceSettings';
+import { fmCrosspostBaseUrlSetting, fmCrosspostSiteNameSetting, forumTypeSetting } from '../../instanceSettings';
 import { forumSelect } from '../../forumTypeUtils';
 import GraphQLJSON from 'graphql-type-json';
 import * as _ from 'underscore';
@@ -1284,6 +1284,9 @@ const schema: SchemaType<DbPost> = {
     editableBy: [userOwns, 'admins'],
     insertableBy: ['members'],
     control: "FMCrosspostControl",
+    tooltip: fmCrosspostBaseUrlSetting.get() && ["https://forum.effectivealtruism.org", "https://forum.effectivealtruism.org/"].includes(fmCrosspostBaseUrlSetting.get()!) ?
+      "The EA Forum is for discussions that are relevant to doing good effectively. If you're not sure what this means, consider exploring the Forum's Frontpage before posting on it." :
+      undefined,
     group: formGroups.advancedOptions,
     order: 3,
     hidden: (props) => !fmCrosspostSiteNameSetting.get() || props.eventForm,


### PR DESCRIPTION
Only shows up when the target of the crossposting is the EA Forum. I couldn't think of a super elegant way to check for that, let me know if you think of a nicer one.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203281891282059) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203281891282059
