### PR TITLE
Fix bad uses of 'useTheme' during SSR

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -4,7 +4,6 @@ import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { Link } from '../../lib/reactRouterWrapper';
 import NoSSR from 'react-no-ssr';
 import Headroom from '../../lib/react-headroom'
-import { useTheme } from '../themes/useTheme';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
@@ -149,7 +148,6 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking()
   const updateCurrentUser = useUpdateCurrentUser();
-  const theme = useTheme();
 
   const setNavigationOpen = (open: boolean) => {
     setNavigationOpenState(open);

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -5,7 +5,7 @@ import { useMulti } from '../../../lib/crud/withMulti';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@material-ui/core/Button';
-import { useTheme } from '../../themes/useTheme';
+import { requireCssVar } from '../../../themes/cssVars';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -150,6 +150,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   return Math.round(distanceUnit === 'mi' ? distanceInKm * 0.621371 : distanceInKm)
 }
 
+const defaultBackground = requireCssVar("palette", "panelBackground", "default");
+const dimBackground = requireCssVar("palette", "background", "primaryDim2");
+
 const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', includeInactive, toggleIncludeInactive, classes}: {
   keywordSearch: string,
   userLocation: {
@@ -163,7 +166,6 @@ const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', includeIna
   toggleIncludeInactive: MouseEventHandler,
   classes: ClassesType,
 }) => {
-  const theme = useTheme()
   const { CommunityMapWrapper, CloudinaryImage2 } = Components
 
   let groupsListTerms: LocalgroupsViewTerms = {}
@@ -211,9 +213,9 @@ const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', includeIna
       </div> : <div className={classes.localGroupsList}>
         {localGroups?.map(group => {
           const rowStyle = group.bannerImageId ? {
-            backgroundImage: `linear-gradient(to right, transparent, ${theme.palette.panelBackground.default} 140px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${group.bannerImageId})`
+            backgroundImage: `linear-gradient(to right, transparent, ${defaultBackground} 140px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${group.bannerImageId})`
           } : {
-            backgroundImage: `url(https://res.cloudinary.com/cea/image/upload/c_pad,h_80,w_140,q_auto,f_auto/ea-logo-square-1200x1200__1_.png), linear-gradient(to right, ${theme.palette.background.primaryDim2}, ${theme.palette.panelBackground.default} 140px)`
+            backgroundImage: `url(https://res.cloudinary.com/cea/image/upload/c_pad,h_80,w_140,q_auto,f_auto/ea-logo-square-1200x1200__1_.png), linear-gradient(to right, ${dimBackground}, ${defaultBackground} 140px)`
           }
           // the distance from the user's location to the group's location
           let distanceToGroup;

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -5,7 +5,7 @@ import { useMulti } from '../../../lib/crud/withMulti';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@material-ui/core/Button';
-import { useTheme } from '../../themes/useTheme';
+import { requireCssVar } from '../../../themes/cssVars';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -133,6 +133,8 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
 }))
 
+const defaultBackground = requireCssVar("palette", "panelBackground", "default");
+const dimBackground = requireCssVar("palette", "background", "primaryDim2");
 
 const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, classes}: {
   keywordSearch: string,
@@ -140,7 +142,6 @@ const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, cl
   toggleIncludeInactive: MouseEventHandler,
   classes: ClassesType,
 }) => {
-  const theme = useTheme()
   const { CloudinaryImage2 } = Components
   
   const { results, loading } = useMulti({
@@ -179,9 +180,9 @@ const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, cl
       <div className={classes.onlineGroupsList}>
         {onlineGroups?.map(group => {
           const rowStyle = group.bannerImageId ? {
-            backgroundImage: `linear-gradient(to right, transparent, ${theme.palette.panelBackground.default} 200px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_200,q_auto,f_auto/${group.bannerImageId})`
+            backgroundImage: `linear-gradient(to right, transparent, ${defaultBackground} 200px), url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_200,q_auto,f_auto/${group.bannerImageId})`
           } : {
-            backgroundImage: `url(https://res.cloudinary.com/cea/image/upload/c_pad,h_80,w_200,q_auto,f_auto/ea-logo-square-1200x1200__1_.png), linear-gradient(to right, ${theme.palette.background.primaryDim2}, ${theme.palette.panelBackground.default} 200px)`
+            backgroundImage: `url(https://res.cloudinary.com/cea/image/upload/c_pad,h_80,w_200,q_auto,f_auto/ea-logo-square-1200x1200__1_.png), linear-gradient(to right, ${dimBackground}, ${defaultBackground} 200px)`
           }
           
           return <div key={group._id} className={classes.onlineGroup}>

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -11,7 +11,6 @@ import { useTheme } from '../themes/useTheme';
 import { useDialog } from '../common/withDialog';
 import { useCurrentUser } from '../common/withUser';
 import { userHasDefaultProfilePhotos } from '../../lib/betas';
-import { requireCssVar } from '../../themes/cssVars';
 
 const cloudinaryUploadPresetGridImageSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetGridImage', 'tz0mgw2s')
 const cloudinaryUploadPresetBannerSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetBanner', 'navcjwf7')
@@ -117,8 +116,6 @@ const formPreviewSizeByImageType = {
     height: 234
   }
 }
-
-const primaryMain = requireCssVar("palette", "primary", "main");
 
 const ImageUpload = ({name, document, updateCurrentValues, clearField, label, croppingAspectRatio, classes}: {
   name: string,

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../themes/useTheme';
 import { useDialog } from '../common/withDialog';
 import { useCurrentUser } from '../common/withUser';
 import { userHasDefaultProfilePhotos } from '../../lib/betas';
+import { requireCssVar } from '../../themes/cssVars';
 
 const cloudinaryUploadPresetGridImageSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetGridImage', 'tz0mgw2s')
 const cloudinaryUploadPresetBannerSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetBanner', 'navcjwf7')
@@ -116,6 +117,8 @@ const formPreviewSizeByImageType = {
     height: 234
   }
 }
+
+const primaryMain = requireCssVar("palette", "primary", "main");
 
 const ImageUpload = ({name, document, updateCurrentValues, clearField, label, croppingAspectRatio, classes}: {
   name: string,

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -7,14 +7,13 @@ import classNames from 'classnames'
 import React from 'react'
 import { useSingle } from '../../lib/crud/withSingle'
 import { forumTypeSetting } from '../../lib/instanceSettings'
-import { Link } from '../../lib/reactRouterWrapper'
 import { useLocation, useServerRequestStatus } from '../../lib/routeUtil'
 import { Components, registerComponent } from '../../lib/vulcan-lib'
 import { userOwns } from '../../lib/vulcan-users'
 import { useCurrentUser } from '../common/withUser'
 import { usePostAnalytics } from './usePostAnalytics'
 import { Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
-import { useTheme } from '../themes/useTheme'
+import { requireCssVar } from '../../themes/cssVars';
 import moment from 'moment'
 
 const isEAForum = forumTypeSetting.get()
@@ -71,11 +70,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+const lineStroke = requireCssVar("palette", "primary", "main");
+
 function PostsAnalyticsGraphs (
   { classes, uniqueClientViewsSeries }: { classes: ClassesType, uniqueClientViewsSeries: { date: string, uniqueClientViews: number }[] | undefined }
 ) {
   const { Typography } = Components
-  const theme = useTheme();
   
   if (!uniqueClientViewsSeries?.length || uniqueClientViewsSeries.length === 1) {
     return (<Typography variant="body1" className={classes.notEnoughDataMessage}>
@@ -93,7 +93,7 @@ function PostsAnalyticsGraphs (
       type="monotone"
       dataKey="uniqueClientViews"
       name="Views by unique devices"
-      stroke={theme.palette.primary.main}
+      stroke={lineStroke}
       dot={false}
       activeDot={{ r: 8 }}
     />
@@ -249,3 +249,11 @@ declare global {
     PostsAnalyticsPage: typeof PostsAnalyticsPageComponent
   }
 }
+
+function useCssVar(arg0: string, arg1: string, arg2: string) {
+  throw new Error('Function not implemented.')
+}
+function useCssVar(arg0: string, arg1: string, arg2: string) {
+  throw new Error('Function not implemented.')
+}
+

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -249,11 +249,3 @@ declare global {
     PostsAnalyticsPage: typeof PostsAnalyticsPageComponent
   }
 }
-
-function useCssVar(arg0: string, arg1: string, arg2: string) {
-  throw new Error('Function not implemented.')
-}
-function useCssVar(arg0: string, arg1: string, arg2: string) {
-  throw new Error('Function not implemented.')
-}
-

--- a/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
@@ -2,17 +2,16 @@ import React, { useEffect, useRef } from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib';
 import { applePodcastIcon } from '../../icons/ApplePodcastIcon';
 import { spotifyPodcastIcon } from '../../icons/SpotifyPodcastIcon';
-import { useConcreteThemeOptions } from '../../themes/useTheme';
-import classNames from 'classnames';
 import { useEventListener } from '../../hooks/useEventListener';
 import { useTracking } from '../../../lib/analyticsEvents';
+import { requireCssVar } from '../../../themes/cssVars';
+
+const playerOpacity = requireCssVar("palette", "embeddedPlayer", "opacity");
 
 const styles = (): JssStyles => ({
   embeddedPlayer: {
-    marginBottom: '2px'
-  },
-  playerDarkMode: {
-    opacity: 0.85
+    marginBottom: '2px',
+    opacity: playerOpacity,
   },
   podcastIconList: {
     paddingLeft: '0px',
@@ -32,9 +31,6 @@ const PostsPodcastPlayer = ({ podcastEpisode, postId, classes }: {
   const mouseOverDiv = useRef(false);
   const divRef = useRef<HTMLDivElement | null>(null);
   const { captureEvent } = useTracking();
-
-  const themeOptions = useConcreteThemeOptions();
-  const isDarkMode = themeOptions.name === 'dark';
 
   // Embed a reference to the generated-per-episode buzzsprout script, which is
   // responsible for hydrating the player div (with the id
@@ -66,7 +62,7 @@ const PostsPodcastPlayer = ({ podcastEpisode, postId, classes }: {
   return <>
     <div
       id={`buzzsprout-player-${podcastEpisode.externalEpisodeId}`}
-      className={classNames(classes.embeddedPlayer, { [classes.playerDarkMode]: isDarkMode })}
+      className={classes.embeddedPlayer}
       ref={divRef}
       onMouseOver={() => setMouseOverDiv(true)}
       onMouseOut={() => setMouseOverDiv(false)}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
@@ -4,14 +4,11 @@ import { applePodcastIcon } from '../../icons/ApplePodcastIcon';
 import { spotifyPodcastIcon } from '../../icons/SpotifyPodcastIcon';
 import { useEventListener } from '../../hooks/useEventListener';
 import { useTracking } from '../../../lib/analyticsEvents';
-import { requireCssVar } from '../../../themes/cssVars';
 
-const playerOpacity = requireCssVar("palette", "embeddedPlayer", "opacity");
-
-const styles = (): JssStyles => ({
+const styles = (theme: ThemeType): JssStyles => ({
   embeddedPlayer: {
     marginBottom: '2px',
-    opacity: playerOpacity,
+    opacity: theme.palette.embeddedPlayer.opacity,
   },
   podcastIconList: {
     paddingLeft: '0px',

--- a/packages/lesswrong/components/search/ExpandedSequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/ExpandedSequencesSearchHit.tsx
@@ -6,7 +6,7 @@ import { Snippet } from 'react-instantsearch-dom';
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { userGetProfileUrlFromSlug } from '../../lib/collections/users/helpers';
 import { useNavigation } from '../../lib/routeUtil';
-import { useTheme } from '../themes/useTheme';
+import { requireCssVar } from '../../themes/cssVars';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -66,12 +66,14 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
 
+const translucentBackground = requireCssVar("palette", "panelBackground", "translucent3");
+const greyBackground = requireCssVar("palette", "grey", 0);
+
 const ExpandedSequencesSearchHit = ({hit, classes}: {
   hit: Hit<any>,
   classes: ClassesType,
 }) => {
   const { history } = useNavigation()
-  const theme = useTheme()
 
   const { FormatDate, UserNameDeleted } = Components
   const sequence: AlgoliaSequence = hit
@@ -81,7 +83,7 @@ const ExpandedSequencesSearchHit = ({hit, classes}: {
   }
   
   const style = sequence.bannerImageId ? {
-    background: `linear-gradient(to left, transparent, ${theme.palette.panelBackground.translucent3} 70px, ${theme.palette.grey[0]} 140px), no-repeat right url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${sequence.bannerImageId})`
+    background: `linear-gradient(to left, transparent, ${translucentBackground} 70px, ${greyBackground} 140px), no-repeat right url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${sequence.bannerImageId})`
   } : {}
 
   return <div className={classes.root} style={style}>

--- a/packages/lesswrong/components/search/ExpandedTagsSearchHit.tsx
+++ b/packages/lesswrong/components/search/ExpandedTagsSearchHit.tsx
@@ -5,7 +5,7 @@ import type { Hit } from 'react-instantsearch-core';
 import { Snippet } from 'react-instantsearch-dom';
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
-import { useTheme } from '../themes/useTheme';
+import { requireCssVar } from '../../themes/cssVars';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -56,15 +56,17 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const cloudinaryCloudName = cloudinaryCloudNameSetting.get()
 
+const translucentBackground = requireCssVar("palette", "panelBackground", "translucent3");
+const greyBackground = requireCssVar("palette", "grey", 0);
+
 const ExpandedTagsSearchHit = ({hit, classes}: {
   hit: Hit<any>,
   classes: ClassesType,
 }) => {
-  const theme = useTheme()
   const tag = hit as AlgoliaTag
-  
+
   const style = tag.bannerImageId ? {
-    background: `linear-gradient(to left, transparent, ${theme.palette.panelBackground.translucent3} 70px, ${theme.palette.grey[0]} 140px), no-repeat right url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${tag.bannerImageId})`
+    background: `linear-gradient(to left, transparent, ${translucentBackground} 70px, ${greyBackground} 140px), no-repeat right url(https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_crop,g_custom/c_fill,h_115,w_140,q_auto,f_auto/${tag.bannerImageId})`
   } : {}
 
   return <div className={classes.root} style={style}>

--- a/packages/lesswrong/components/themes/useTheme.tsx
+++ b/packages/lesswrong/components/themes/useTheme.tsx
@@ -17,8 +17,9 @@ type ThemeContextObj = {
 export const ThemeContext = React.createContext<ThemeContextObj|null>(null);
 
 /**
- * NOTE: The hooks in this file should NOT be used for dynamicly applying styles/colors/etc.
- * to components as this will have undesired results during SSR where we may or may not know
+ * You should NOT use the hooks in this file unless you _really_ know what you're doing - in
+ * particular, they should never be used for dynamically applying styles/colors/etc. to
+ * components as this will have undesired results during SSR where we may or may not know
  * which theme to use if the user has their theme set to "auto". For this use case you should
  * instead use `requireCssVar`.
  */

--- a/packages/lesswrong/components/themes/useTheme.tsx
+++ b/packages/lesswrong/components/themes/useTheme.tsx
@@ -16,6 +16,12 @@ type ThemeContextObj = {
 }
 export const ThemeContext = React.createContext<ThemeContextObj|null>(null);
 
+/**
+ * NOTE: The hooks in this file should NOT be used for dynamicly applying styles/colors/etc.
+ * to components as this will have undesired results during SSR where we may or may not know
+ * which theme to use if the user has their theme set to "auto". For this use case you should
+ * instead use `requireCssVar`.
+ */
 export const useTheme = (): ThemeType => {
   const themeContext = React.useContext(ThemeContext);
   if (!themeContext) throw "useTheme() used without the context available";

--- a/packages/lesswrong/components/votes/VoteAgreementIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteAgreementIcon.tsx
@@ -7,6 +7,7 @@ import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
 import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
+import { VoteColor, cssVoteColors } from './voteColors';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -127,7 +128,7 @@ export interface VoteArrowIconProps {
   solidArrow?: boolean,
   strongVoteDelay: number,
   orientation: "up"|"down"|"left"|"right",
-  color: "error"|"primary"|"secondary",
+  color: VoteColor,
   voted: boolean,
   eventHandlers: {
     handleMouseDown?: ()=>void,
@@ -154,7 +155,7 @@ const VoteAgreementIcon = ({ solidArrow, strongVoteDelay, orientation, color, vo
   const bigVoteAccentStyling = (upOrDown === "Downvote") ? classes.smallArrowBigVoted : classes.smallCheckBigVoted
   const bigVoteCompletedStyling = (upOrDown === "Downvote") ? classes.bigClearCompleted : classes.bigCheckCompleted
   const bigVoteStyling = (upOrDown === "Downvote") ? classes.bigClear : classes.bigCheck
-  
+
   return (
     <IconButton
       className={classNames(classes.root)}
@@ -179,7 +180,7 @@ const VoteAgreementIcon = ({ solidArrow, strongVoteDelay, orientation, color, vo
                 viewBox='6 6 12 12'
               />
               <PrimaryIcon
-                style={bigVoteCompleted ? {color: theme.palette[color].light} : {}}
+                style={bigVoteCompleted ? {color: cssVoteColors[color]} : {}}
                 className={classNames(bigVoteStyling, classes.noClickCatch, {
                   [bigVoteCompletedStyling]: bigVoteCompleted,
                   // [classes.bigCheckCompleted]: bigVoteCompleted,

--- a/packages/lesswrong/components/votes/VoteArrowIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIcon.tsx
@@ -5,7 +5,7 @@ import UpArrowIcon from '@material-ui/icons/KeyboardArrowUp';
 import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
-import { useTheme } from '../themes/useTheme';
+import { VoteColor, cssVoteColors } from './voteColors';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -67,7 +67,7 @@ export interface VoteArrowIconProps {
   strongVoteDelay: number,
   orientation: "up"|"down"|"left"|"right",
   enabled?: boolean,
-  color: "error"|"primary"|"secondary",
+  color: VoteColor,
   voted: boolean,
   eventHandlers: {
     handleMouseDown?: ()=>void,
@@ -84,7 +84,6 @@ export interface VoteArrowIconProps {
 const VoteArrowIcon = ({ solidArrow, strongVoteDelay, orientation, enabled = true, color, voted, eventHandlers, bigVotingTransition, bigVoted, bigVoteCompleted, alwaysColored, classes }: VoteArrowIconProps & {
   classes: ClassesType
 }) => {
-  const theme = useTheme();
   const Icon = solidArrow ? ArrowDropUpIcon : UpArrowIcon
   const { LWTooltip } = Components;
 
@@ -119,7 +118,7 @@ const VoteArrowIcon = ({ solidArrow, strongVoteDelay, orientation, enabled = tru
       <Transition in={!!(bigVotingTransition || bigVoted)} timeout={strongVoteDelay}>
         {(state) => (
           <UpArrowIcon
-            style={bigVoteCompleted ? {color: theme.palette[color].light} : undefined}
+            style={bigVoteCompleted ? {color: cssVoteColors[color]} : undefined}
             className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
             color={(bigVoted || bigVoteCompleted) ? color : 'inherit'}
             viewBox='6 6 12 12'

--- a/packages/lesswrong/components/votes/voteColors.ts
+++ b/packages/lesswrong/components/votes/voteColors.ts
@@ -1,0 +1,9 @@
+import { requireCssVar } from '../../themes/cssVars';
+
+const voteColors = ["error", "primary", "secondary"] as const;
+
+export type VoteColor = typeof voteColors[number];
+
+export const cssVoteColors = Object.fromEntries(
+  voteColors.map((color) => [color, requireCssVar("palette", color, "light")]),
+);

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -16,6 +16,7 @@ import type { ForumTypeString } from '../lib/instanceSettings';
 import { getForumTheme } from '../themes/forumTheme';
 import { usedMuiStyles } from './usedMuiStyles';
 import { minify } from 'csso';
+import { requestedCssVarsToString } from '../themes/cssVars';
 
 const generateMergedStylesheet = (themeOptions: ThemeOptions): Buffer => {
   importAllComponents();
@@ -45,12 +46,14 @@ const generateMergedStylesheet = (themeOptions: ThemeOptions): Buffer => {
   ReactDOM.renderToString(WrappedTree);
   const jssStylesheet = context.sheetsRegistry.toString()
   const theme = getForumTheme(themeOptions);
+  const cssVars = requestedCssVarsToString(theme);
   
   const mergedCSS = [
     draftjsStyles(theme),
     miscStyles(theme),
     jssStylesheet,
     ...theme.rawCSS,
+    cssVars,
   ].join("\n");
 
   const minifiedCSS = minify(mergedCSS).css;

--- a/packages/lesswrong/themes/cssVars.ts
+++ b/packages/lesswrong/themes/cssVars.ts
@@ -29,6 +29,8 @@ const getAtPath = <T extends {}>(data: T, path: ThemePath) => path.length < 2
  * For instance, if we want to use the theme value `theme.palette.panelBackground.dim`, we can do:
  * const background = requireCssVar("palette", "panelBackground", "dim");
  * const MyComponent = () => <div style={{background}} />;
+ * This will set the style to `{background: var(--palette-panelBackground-dim)}` which will be
+ * read from a theme-dependant stylesheet.
  *
  * NOTE: `requireCssVar` MUST be called at the top level of a file and not inside a component. It's
  * not a React hook!

--- a/packages/lesswrong/themes/cssVars.ts
+++ b/packages/lesswrong/themes/cssVars.ts
@@ -1,0 +1,46 @@
+import type { Theme as MuiThemeType } from '@material-ui/core/styles';
+
+const requestedCssVars = new Set<string>();
+
+const separator = ":";
+const pathToKey = (path: string[]) => path.join(separator);
+const keyToPath = (key: string) => key.split(separator);
+const keyToVar = (key: string) => "--" + key.replace(new RegExp(separator, "g"), "-");
+const keyToVarRef = (key: string) => `var(${keyToVar(key)})`;
+const getAtPath = <T extends {}>(data: T, path: string[]) => path.length < 2
+  ? data[path[0]]
+  : getAtPath(data[path[0]], path.slice(1));
+
+/**
+ * During SSR, we may not know which theme is currently being used if the user has their theme
+ * set to "auto", which can cause issues for components which need to include some specific
+ * styles conditionally. This function provides a work-around for this problem by exporting
+ * particular values from the theme as CSS variables, which will gracefully handle theme changes
+ * on the client side.
+ *
+ * For instance, if we want to use the theme value `theme.palette.panelBackground.dim`, we can do:
+ * const background = requireCssVar("palette", "panelBackground", "dim");
+ * const MyComponent = () => <div style={{background}} />;
+ *
+ * NOTE: `requireCssVar` MUST be called at the top level of a file and not inside a component. It's
+ * not a React hook!
+ */
+export const requireCssVar = (...path: string[]): string => {
+  const key = pathToKey(path);
+  requestedCssVars.add(key);
+  return keyToVarRef(key);
+}
+
+export const requestedCssVarsToString = (theme: MuiThemeType & ThemeType, selector = ":root"): string => {
+  const vars: string[] = [];
+  for (const key of requestedCssVars.values()) {
+    const value = getAtPath(theme, keyToPath(key));
+    if (value) {
+      vars.push(`${keyToVar(key)}: ${value};`);
+    } else {
+      // eslint-disable-next-line
+      console.warn("Warning: Invalid theme key:", key);
+    }
+  }
+  return `${selector} { ${vars.join("")} }`;
+}

--- a/packages/lesswrong/themes/cssVars.ts
+++ b/packages/lesswrong/themes/cssVars.ts
@@ -1,13 +1,21 @@
 import type { Theme as MuiThemeType } from '@material-ui/core/styles';
 
+type ThemePathItem = string | number;
+type ThemePath = ThemePathItem[];
+
 const requestedCssVars = new Set<string>();
 
+const parsePathItem = (item: string): ThemePathItem => {
+  const parsed = parseInt(item);
+  return Number.isNaN(parsed) ? item : parsed;
+}
+
 const separator = ":";
-const pathToKey = (path: string[]) => path.join(separator);
-const keyToPath = (key: string) => key.split(separator);
-const keyToVar = (key: string) => "--" + key.replace(new RegExp(separator, "g"), "-");
-const keyToVarRef = (key: string) => `var(${keyToVar(key)})`;
-const getAtPath = <T extends {}>(data: T, path: string[]) => path.length < 2
+const pathToKey = (path: ThemePath): string => path.join(separator);
+const keyToPath = (key: string): ThemePath => key.split(separator).map(parsePathItem);
+const keyToVar = (key: string): string => "--" + key.replace(new RegExp(separator, "g"), "-");
+const keyToVarRef = (key: string): string => `var(${keyToVar(key)})`;
+const getAtPath = <T extends {}>(data: T, path: ThemePath) => path.length < 2
   ? data[path[0]]
   : getAtPath(data[path[0]], path.slice(1));
 
@@ -25,7 +33,7 @@ const getAtPath = <T extends {}>(data: T, path: string[]) => path.length < 2
  * NOTE: `requireCssVar` MUST be called at the top level of a file and not inside a component. It's
  * not a React hook!
  */
-export const requireCssVar = (...path: string[]): string => {
+export const requireCssVar = (...path: ThemePath): string => {
   const key = pathToKey(path);
   requestedCssVars.add(key);
   return keyToVarRef(key);

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -428,6 +428,9 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     commentMarker: "#fef7a9",
     commentMarkerActive: "#fdf05d",
   },
+  embeddedPlayer: {
+    opacity: 1,
+  },
   
   commentParentScrollerHover: shades.greyAlpha(.075),
   tocScrollbarColors: `rgba(255,255,255,0) ${shades.grey[300]}`,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -372,6 +372,9 @@ declare global {
     intercom?: { //Optional. If omitted, use defaults from library.
       buttonBackground: ColorString,
     },
+    embeddedPlayer: {
+      opacity: number,
+    },
     group: ColorString,
     contrastText: ColorString,
     individual: ColorString,

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -183,6 +183,9 @@ export const darkModeTheme: UserThemeSpecification = {
     intercom: {
       buttonBackground: `${shadePalette.grey[400]} !important`,
     },
+    embeddedPlayer: {
+      opacity: 0.85,
+    },
     editor: {
       commentPanelBackground: shadePalette.grey[200],
       sideCommentEditorBackground: shadePalette.grey[100],


### PR DESCRIPTION
The simplest way to handle this seems to just be to not use `useTheme` in these contexts.

I added a `requireCssVar` function that provides a css variable for a particular theme item that will respect changes to the theme on the client side, and won't directly read the wrong theme during SSR.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203286431838161) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203286431838161
