### PR TITLE
revert class name generation change

### DIFF
--- a/packages/lesswrong/client/themeProvider.tsx
+++ b/packages/lesswrong/client/themeProvider.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { jssPreset } from '@material-ui/core/styles';
+import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
 import { create } from 'jss';
 import type { AbstractThemeOptions } from '../themes/themeNames';
 import { ThemeContextProvider } from '../components/themes/useTheme';
-import { generateClassName } from '../lib/utils/generateClassName';
 
 export function wrapWithMuiTheme (app: React.ReactNode, themeOptions: AbstractThemeOptions) {
+  const generateClassName = createGenerateClassName({
+    dangerouslyUseGlobalCSS: true
+  });
+
   const jss = create({
     ...jssPreset(),
     insertionPoint: document.getElementById("jss-insertion-point") as HTMLElement,

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -456,7 +456,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         disableUnderline
         placeholder="Notes for other moderators"
         multiline
-        rowsMax={5}
+        rows={5}
       />
     </div>
     {moderatorActionLog}

--- a/packages/lesswrong/server/material-ui/themeProvider.tsx
+++ b/packages/lesswrong/server/material-ui/themeProvider.tsx
@@ -3,7 +3,7 @@ import JssProvider from 'react-jss/lib/JssProvider';
 import { SheetsRegistry } from 'react-jss/lib/jss';
 import { ThemeContextProvider } from '../../components/themes/useTheme';
 import { AbstractThemeOptions } from '../../themes/themeNames';
-import { generateClassName } from '../../lib/utils/generateClassName';
+import { createGenerateClassName } from '@material-ui/core/styles';
 
 export const wrapWithMuiTheme = <Context extends {sheetsRegistry?: SheetsRegistry}>(
   app: React.ReactNode,
@@ -12,6 +12,9 @@ export const wrapWithMuiTheme = <Context extends {sheetsRegistry?: SheetsRegistr
 ): React.ReactElement => {
   const sheetsRegistry = new SheetsRegistry();
   context.sheetsRegistry = sheetsRegistry;
+  const generateClassName = createGenerateClassName({
+    dangerouslyUseGlobalCSS: true
+  });
 
   return (
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/5995 seems to have introduced a bug where any page with certain components on it (including Material UI's `Input`, which is used for sunshineNotes, and also apparently most text forms??) became impossible to interact with.