### PR TITLE
Fix inifite reload loop caused by unstable DraftJS block keys

### DIFF
--- a/packages/lesswrong/lib/editor/utils.test.ts
+++ b/packages/lesswrong/lib/editor/utils.test.ts
@@ -67,19 +67,33 @@ describe("draftToHtml", () => {
   })
 })
 
-describe("htmlToDraft -> draftToHtml roundtrip testing", () => {
-  const tests = [
-    {description: "italics", html: "<p><em>Italic</em></p>"},
-    {description: "bold", html: "<p><strong>Bold</strong></p>"},
-    {description: "bold-italic", html: "<p><strong><em>BoldItalic</em></strong></p>"},
-    {description: "bullet-list", html: "<ul><li>first</li><li>second</li></ul>"},
-    {description: "link", html: `<p><a href="google.com"> Link </a></p>`}
-  ]
-  for (const t of tests) {
-    it(t.description, () => {
-      const draft = htmlToDraftServer(t.html)
-      const html = draftToHTML(convertFromRaw(draft))
-      html.should.equal(t.html)
-    })
-  }
-})
+describe("htmlToDraft", () => {
+  describe("draftToHtml roundtrip testing", () => {
+    const tests = [
+      {description: "italics", html: "<p><em>Italic</em></p>"},
+      {description: "bold", html: "<p><strong>Bold</strong></p>"},
+      {description: "bold-italic", html: "<p><strong><em>BoldItalic</em></strong></p>"},
+      {description: "bullet-list", html: "<ul><li>first</li><li>second</li></ul>"},
+      {description: "link", html: `<p><a href="google.com"> Link </a></p>`}
+    ]
+    for (const t of tests) {
+      it(t.description, () => {
+        const draft = htmlToDraftServer(t.html)
+        const html = draftToHTML(convertFromRaw(draft))
+        html.should.equal(t.html)
+      })
+    }
+  });
+
+  it("Server-side conversions are stable between calls", async () => {
+    const html = `
+      <h1>This is a sample heading</h1>
+      <p>This is some sample text.</p>
+      <h2>This is another sample heading</h2>
+      <p>This is some more sample text.</p>
+    `;
+    const draft1 = htmlToDraftServer(html);
+    const draft2 = htmlToDraftServer(html);
+    expect(draft1).toEqual(draft2);
+  });
+});

--- a/packages/lesswrong/lib/editor/utils.test.ts
+++ b/packages/lesswrong/lib/editor/utils.test.ts
@@ -96,4 +96,16 @@ describe("htmlToDraft", () => {
     const draft2 = htmlToDraftServer(html);
     expect(draft1).toEqual(draft2);
   });
+
+  it("Server-side stable ids are unique", async () => {
+    const html = `
+      <p>This is some sample text.</p>
+      <p>This is some sample text.</p>
+    `;
+    const draft1 = htmlToDraftServer(html);
+    const draft2 = htmlToDraftServer(html);
+    expect(draft1.blocks).toHaveLength(2);
+    expect(typeof draft1.blocks[0].key).toBe("string");
+    expect(draft1.blocks[0].key).not.toBe(draft2.blocks[1].key);
+  });
 });

--- a/packages/lesswrong/server/resolvers/revisionResolvers.ts
+++ b/packages/lesswrong/server/resolvers/revisionResolvers.ts
@@ -56,10 +56,15 @@ export function htmlToDraftServer(html: string): Draft.RawDraftContentState {
   // Apollo's ability to cache things and in some cases can lead to infinite refetch loops. Here, we
   // overwrite these ids with stable md5 hashes (sliced to 5 characters since this is what draftjs
   // likes).
+  const usedIds = new Set<string>();
   for (const block of raw?.blocks ?? []) {
     if (block.key) {
-      const hash = createHash("md5").update(block.text ?? "").digest("hex");
-      block.key = hash.slice(0, 5);
+      let hash = block.text ?? "";
+      do {
+        hash = createHash("md5").update(hash).digest("hex").slice(0, 5);
+      } while (usedIds.has(hash));
+      usedIds.add(hash);
+      block.key = hash;
     }
   }
 


### PR DESCRIPTION
Fixes #5942 

See the comment in the code for an explanation of why the bug happens.

The one thing we have to be careful about here is that `convertToRaw` doesn't make any internal references to ids once they're generated as this approach would leave these references dangling right now. From [the code](https://github.com/HubSpot/draft-convert/blob/master/src/convertFromHTML.js), this seems to be safe, but it's something to look out for in the future.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203294639619194) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203294639619194
