### PR TITLE
Fix printing with auto theme

### DIFF
--- a/packages/lesswrong/server/utils/renderJssSheetImports.ts
+++ b/packages/lesswrong/server/utils/renderJssSheetImports.ts
@@ -31,10 +31,14 @@ const renderLinkMainSheet = (url: string): string =>
 const renderImportForColorScheme = (url: string, colorScheme: string): string =>
   `@import url("${url}") screen and (prefers-color-scheme: ${colorScheme});\n`;
 
+const renderImportForPrint = (url: string): string =>
+  `@import url("${url}") print;\n`;
+
 export const renderAutoStyleImport = () => {
   const light = renderImportForColorScheme(stylesheetUrls.light, "light");
   const dark = renderImportForColorScheme(stylesheetUrls.dark, "dark");
-  return `<style id="${stylesId}">${light}${dark}</style>`;
+  const print = renderImportForPrint(stylesheetUrls.light);
+  return `<style id="${stylesId}">${light}${dark}${print}</style>`;
 }
 
 export const renderJssSheetImports = (themeOptions: AbstractThemeOptions): string => {


### PR DESCRIPTION
We're currently not loading any CSS when printing if the user's theme is set to "auto" because the CSS `@import`s which check `prefers-color-scheme` also specify `screen`.

This seems to be the correct thing to do, since the spec doesn't specify how `prefers-color-scheme` should work when printing, instead leaving it up to user agents to implement how they wish ([context](https://github.com/w3c/csswg-drafts/issues/3522#issuecomment-463300486)).

We can work around this by just adding a separate `@import` for printing that loads the light theme.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203307608606644) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203307608606644
