### PR TITLE
Fix approval votecount tooltip

### DIFF
--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -67,8 +67,8 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
   const { OverallVoteButton, LWTooltip } = Components
 
   const collection = getCollection(voteProps.collectionName);
-  const agreementVoteCount = voteProps.document?.extendedScore?.agreementVoteCount || 0;
-  const approvalVoteCount = (voteProps.voteCount || 0) - agreementVoteCount
+  const agreementVoteCount = voteProps.document?.extendedScore?.agreementVoteCount ?? 0;
+  const approvalVoteCount = (voteProps.voteCount ?? 0) - agreementVoteCount
   const karma = voteProps.baseScore;
 
   let moveToAlignnmentUserId = ""

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -67,7 +67,8 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
   const { OverallVoteButton, LWTooltip } = Components
 
   const collection = getCollection(voteProps.collectionName);
-  const voteCount = voteProps.voteCount;
+  const agreementVoteCount = voteProps.document?.extendedScore?.agreementVoteCount || 0;
+  const approvalVoteCount = (voteProps.voteCount || 0) - agreementVoteCount
   const karma = voteProps.baseScore;
 
   let moveToAlignnmentUserId = ""
@@ -131,7 +132,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
             <LWTooltip title={'The author of this post has disabled karma visibility'}>
               <span>{' '}</span>
             </LWTooltip> :
-            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
+            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({approvalVoteCount} {approvalVoteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
               <span className={classes.voteScore}>
                 {karma}
               </span>


### PR DESCRIPTION
Currently the overall/approve voting tooltip shows approval + agreement voting, which is very confusing. This changes the display to only show total approval voting.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203326817222886) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203326817222886
