### PR TITLE
Fix postsItem2 checkbox width

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -41,6 +41,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
     width: "100%",
     background: theme.palette.panelBackground.default,
   },
+  checkboxWidth: {
+    width: "calc(100% - 24px)"
+  },
   translucentBackground: {
     width: "100%",
     background: theme.palette.panelBackground.translucent,
@@ -491,6 +494,7 @@ const PostsItem2 = ({
           classes.root,
           {
             [classes.background]: !translucentBackground,
+            [classes.checkboxWidth]: showReadCheckbox,
             [classes.translucentBackground]: translucentBackground,
             [classes.bottomBorder]: showBottomBorder,
             [classes.commentsBackground]: renderComments,


### PR DESCRIPTION
Fixes the width issues that happen on sequence pages when you include the checkboxes:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/3246710/200481159-cd328266-1851-47da-b5b9-a484f5918ab4.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203318920920588) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203318920920588
