### PR TITLE
Moderated user and commment counts

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/CommentsReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentsReviewInfoCard.tsx
@@ -109,7 +109,7 @@ const getVoteDistribution = ({ allVotes }: { allVotes: { voteType: string }[] })
   }, voteCounts);
 }
 
-interface CommentWithModeratorActions {
+export interface CommentWithModeratorActions {
   comment: CommentsListWithModerationMetadata;
   actions: Omit<CommentModeratorActionDisplay, 'comment'>[];
 }

--- a/packages/lesswrong/components/sunshineDashboard/CommentsReviewTab.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentsReviewTab.tsx
@@ -1,7 +1,6 @@
-import uniqBy from 'lodash/uniqBy';
 import React from 'react';
-import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
+import type { CommentWithModeratorActions } from './CommentsReviewInfoCard';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -9,23 +8,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-export const CommentsReviewTab = ({classes}: {
+export const CommentsReviewTab = ({commentsWithActions, classes}: {
+  commentsWithActions: CommentWithModeratorActions[],
   classes: ClassesType,
 }) => {
   const { CommentsReviewInfoCard } = Components;
-
-  const { results = [] } = useMulti({
-    collectionName: 'CommentModeratorActions',
-    fragmentName: 'CommentModeratorActionDisplay',
-    terms: { view: 'activeCommentModeratorActions', limit: 10 }
-  });
-
-  const allComments = results.map(result => result.comment);
-  const uniqueComments = uniqBy(allComments, comment => comment._id);
-  const commentsWithActions = uniqueComments.map(comment => {
-    const actionsWithoutComment = results.filter(result => result.comment._id === comment._id).map(({ comment, ...remainingAction }) => remainingAction);
-    return { comment, actions: actionsWithoutComment };
-  });
 
   return <div className={classes.root}>
     {commentsWithActions.map(commentWithActions =>

--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames';
 import uniqBy from 'lodash/uniqBy';
-import React, { useState } from 'react';
+import qs from 'qs';
+import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
-import { TupleOf, TupleSet } from '../../lib/utils/typeGuardUtils';
-import qs from 'qs';
+import { TupleSet, UnionOf } from '../../lib/utils/typeGuardUtils';
 
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { userIsAdmin } from '../../lib/vulcan-users/permissions';
@@ -90,8 +90,6 @@ const ModeratorActionItem = ({ moderatorAction, classes }: {
   );
 };
 
-// type DashboardTabs = 'sunshineNewUsers' | 'allUsers' | 'moderatedComments';
-
 const reduceCommentModeratorActions = (commentModeratorActions: CommentModeratorActionDisplay[]): CommentWithModeratorActions[] => {
   const allComments = commentModeratorActions.map(action => action.comment);
   const uniqueComments = uniqBy(allComments, comment => comment._id);
@@ -104,7 +102,7 @@ const reduceCommentModeratorActions = (commentModeratorActions: CommentModerator
 };
 
 const tabs = new TupleSet(['sunshineNewUsers', 'allUsers', 'moderatedComments'] as const);
-type DashboardTabs = TupleOf<typeof tabs>[number]; // typeof tabs[number];// 'sunshineNewUsers' | 'allUsers' | 'moderatedComments';
+type DashboardTabs = UnionOf<typeof tabs>;
 
 const getCurrentView = (query: Record<string, string>): DashboardTabs => {
   const currentViewParam = query.view;
@@ -126,14 +124,13 @@ const ModerationDashboard = ({ classes }: {
   const { query, location } = useLocation();
   const currentView = getCurrentView(query);
 
-  // const [view, setView] = useState<DashboardTabs>(currentView);
-
   const changeView = (newView: DashboardTabs) => {
-    history.replace({
+    history.push({
       ...location,
       search: qs.stringify({
         view: newView
-      })
+      }),
+      hash: ''
     });
   };
   
@@ -172,7 +169,7 @@ const ModerationDashboard = ({ classes }: {
           <div className={classes.toc}>
             {usersToReview.map(user => {
               return <div key={user._id} className={classes.tocListing}>
-                <a href={`/admin/moderation#${user._id}`}>
+                <a href={`${location.pathname}${location.search ?? ''}#${user._id}`}>
                   {user.displayName}
                 </a>
               </div>
@@ -198,7 +195,7 @@ const ModerationDashboard = ({ classes }: {
           <div className={classes.toc}>
             {commentsWithActions.map(({ comment }) => {
               return <div key={comment._id} className={classes.tocListing}>
-                <a href={`/admin/moderation#${comment._id}`}>
+                <a href={`${location.pathname}${location.search ?? ''}#${comment._id}`}>
                   {`${comment.user?.displayName} on "${comment.post?.title}"`}
                 </a>
               </div>;

--- a/packages/lesswrong/lib/utils/typeGuardUtils.ts
+++ b/packages/lesswrong/lib/utils/typeGuardUtils.ts
@@ -1,0 +1,14 @@
+type Literal<T> = string extends T ? never : T;
+type Tuple<T extends ReadonlyArray<string>> = Literal<T[number]> extends never ? never : T;
+
+export class TupleSet<T extends ReadonlyArray<string>> extends Set<string> {
+  constructor(knownValues: Tuple<T>) {
+    super(knownValues);
+  }
+
+  has (value: string): value is T[number] {
+    return this.has(value);
+  }
+}
+
+export type TupleOf<T extends TupleSet<any>> = T extends TupleSet<infer U> ? U : never;

--- a/packages/lesswrong/lib/utils/typeGuardUtils.ts
+++ b/packages/lesswrong/lib/utils/typeGuardUtils.ts
@@ -1,14 +1,45 @@
 type Literal<T> = string extends T ? never : T;
 type Tuple<T extends ReadonlyArray<string>> = Literal<T[number]> extends never ? never : T;
 
+/**
+ * We fairly frequently encounter the following pattern:
+ * - we have some known set of literal values
+ * - we need to check some unknown value to see if it's one of them
+ * - we want to preserve type info (i.e. have that previous check act as a type guard)
+ * 
+ * Most ways of doing this in Typescript rely on type casts, which are fragile, since you can change something in one place but not another
+ * 
+ * The generic constraints here ensure that you can only pass in tuples with literal values known at compile-time, and not string arrays
+ * This ensures that the type guard works as intended and doesn't silently "break" if the set is instantiated with an insufficiently-typed set of values
+ * 
+ * Example usage:
+ * ```
+ * const tabs = new TupleSet(['sunshineNewUsers', 'allUsers', 'moderatedComments'] as const);
+ * type DashboardTabs = UnionOf<typeof tabs>;
+ * 
+ * const getCurrentView = (query: Record<string, string>): DashboardTabs => {
+ *  const tabQuery = query.view; // this is type `string`
+ *  if (tabs.has(tabQuery)) return tabQuery; // This is now type `DashboardTabs`
+ *  else return 'sunshineNewUsers';
+ * }
+ * ```
+ * 
+ * The following will cause a type error:
+ * ```
+ * const tabNames = ['sunshineNewUsers', 'allUsers', 'moderatedComments'];
+ * new TupleSet(tabNames); // tabNames is typed `string[]`
+ * new TupleSet(['sunshineNewUsers', 'allUsers', 'moderatedComments']); // missing `as const`
+ * ```
+ */
 export class TupleSet<T extends ReadonlyArray<string>> extends Set<string> {
   constructor(knownValues: Tuple<T>) {
     super(knownValues);
   }
 
   has (value: string): value is T[number] {
-    return this.has(value);
+    return super.has(value);
   }
 }
 
 export type TupleOf<T extends TupleSet<any>> = T extends TupleSet<infer U> ? U : never;
+export type UnionOf<T extends TupleSet<any>> = TupleOf<T>[number];


### PR DESCRIPTION
Now show remaining total remaining count of users and comments left in their respective moderation queues.  (Note that the comment count maybe slightly inaccurate in the future, as we add more CommentModeratorAction types, since it's counting the number of CommentModeratorAction items, and any individual comment could in theory have more than one action associated with it.)
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/2136984/200690673-a1196eb6-0f45-48a8-a116-ff8d5c767f8c.png">
