### PR TITLE
Add ?directConnection to `yarn start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc --noEmit --skipLibCheck",
     "eslint": "eslint --max-warnings 0 --cache --ext .jsx,js,tsx,ts packages",
     "build": "./build.js",
-    "start": "NODE_OPTIONS=--max_old_space_size=8192 ./build.js --no-clear -run -watch --settings settings.json",
+    "start": "NODE_OPTIONS=--max_old_space_size=8192 ./build.js --no-clear -run -watch --mongoUrl mongodb://127.0.0.1:27017/?directConnection=true --settings settings.json",
     "start-dev-db": "./build.js --no-clear -run --watch --mongoUrlFile ../LessWrong-Credentials/connectionStrings/dev-db.txt --settings ../LessWrong-Credentials/settings-local-dev-devdb.json",
     "start-prod-db": "./build.js --no-clear -run --watch --mongoUrlFile ../LessWrong-Credentials/connectionStrings/prod-db.txt --settings ../LessWrong-Credentials/settings-local-dev-proddb.json",
     "start-local-db": "PORT=4000 ./build.js --no-clear -run --watch --mongoUrl mongodb://127.0.0.1:27017/?directConnection=true --settings ./settings-test.json",


### PR DESCRIPTION
This fixes #6016 (kinda). Before this change, `yarn start` would not actually connect to my local mongod server, instead erroring with

```
2022-11-09T17:21:58.815Z: Failed to connect to mongodb:  MongoServerSelectionError: connect ECONNREFUSED ::1:27017
    at Timeout._onTimeout (/Users/austin/Code/ForumMagnum/node_modules/mongodb/lib/core/sdam/topology.js:438:30)
    at listOnTimeout (node:internal/timers:564:17)
    at processTimers (node:internal/timers:507:7) {
  reason: TopologyDescription {
    type: 'Unknown',
    setName: null,
    maxSetVersion: null,
    maxElectionId: null,
    servers: Map(1) { 'localhost:27017' => [ServerDescription] },
    stale: false,
    compatible: true,
    compatibilityError: null,
    logicalSessionTimeoutMinutes: null,
    heartbeatFrequencyMS: 10000,
    localThresholdMS: 15,
    commonWireVersion: null
  }
}
node --inspect -r source-map-support/register -- ./build/... exited (1)
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203339178248280) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203339178248280
