### PR TITLE
Revert "Fix approval votecount tooltip"

### DIFF
--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -67,8 +67,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
   const { OverallVoteButton, LWTooltip } = Components
 
   const collection = getCollection(voteProps.collectionName);
-  const agreementVoteCount = voteProps.document?.extendedScore?.agreementVoteCount ?? 0;
-  const approvalVoteCount = (voteProps.voteCount ?? 0) - agreementVoteCount
+  const voteCount = voteProps.voteCount;
   const karma = voteProps.baseScore;
 
   let moveToAlignnmentUserId = ""
@@ -132,7 +131,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
             <LWTooltip title={'The author of this post has disabled karma visibility'}>
               <span>{' '}</span>
             </LWTooltip> :
-            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({approvalVoteCount} {approvalVoteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
+            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
               <span className={classes.voteScore}>
                 {karma}
               </span>


### PR DESCRIPTION
Reverts ForumMagnum/ForumMagnum#6035

Quoting myself:

> This PR is based on an incorrect understanding about how votes are stored in the DB. Voters who vote on approval and agreement only end up inserting 1 non-cancelled vote into the db. Therefore this vote will ignore their vote when counting approval votes.
>
> For simplicity I will revert this PR. I believe the correct approach is to add another denormalizedCountOfReferences.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203340241850254) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201302964208280/1203340241850254
