### PR TITLE
Restore missing useEffect hook

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import DoneIcon from '@material-ui/icons/Done';
 import SnoozeIcon from '@material-ui/icons/Snooze';
@@ -117,6 +117,12 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
       })
     }
   }
+
+  useEffect(() => {
+    return () => {
+      handleNotes();
+    }
+  });
 
   const signAndDate = (sunshineNotes:string) => {
     if (!sunshineNotes.match(signature)) {


### PR DESCRIPTION
This was accidentally lost during a [refactor](https://github.com/ForumMagnum/ForumMagnum/commit/7a1940b87fc4321e22f66f97511a42c98ac841f3). Adding it back in, which makes sunshine user notes less likely to get lost. (Note: with the hook restored, the notes still aren't perfectly preserved. It seems to reliably lose the last few characters. But, the currently live LW branch seems to reliably lose everything you typed)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203348618420846) by [Unito](https://www.unito.io)
