### PR TITLE
[EA Forum only] enable cropping for event images

### DIFF
--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -79,7 +79,8 @@ const cloudinaryArgsByImageType = {
   eventImageId: {
     minImageHeight: 270,
     minImageWidth: 480,
-    cropping: false,
+    croppingAspectRatio: 1.78,
+    croppingDefaultSelectionRatio: 1.78,
     uploadPreset: cloudinaryUploadPresetEventImageSetting.get()
   },
   spotlightImageId: {


### PR DESCRIPTION
I don't remember why this wasn't enabled before, but Alex ran into issues with the auto-cropping so I'm just enabling users to crop.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203350191985938) by [Unito](https://www.unito.io)
