### PR TITLE
Fix comment count in "highlighting new comments since" message

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -7,7 +7,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
 import { useCurrentUser } from '../common/withUser';
-import type { CommentTreeNode } from '../../lib/utils/unflatten';
+import { unflattenComments, CommentTreeNode } from '../../lib/utils/unflatten';
 import classNames from 'classnames';
 import * as _ from 'underscore';
 
@@ -73,16 +73,18 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
   totalComments: number,
   loadMoreComments: any,
   loadingMoreComments: boolean,
-  comments: Array<CommentTreeNode<CommentsList>>,
+  comments: CommentsList[],
   parentAnswerId?: string,
   startThreadTruncated?: boolean,
   newForm: boolean,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
+  const commentTree = unflattenComments(comments);
+  
   const [highlightDate,setHighlightDate] = useState<Date|undefined>(post?.lastVisitedAt && new Date(post.lastVisitedAt));
   const [anchorEl,setAnchorEl] = useState<HTMLElement|null>(null);
-  const newCommentsSinceDate = highlightDate ? _.filter(comments, comment => new Date(comment.item.postedAt).getTime() > new Date(highlightDate).getTime()).length : 0;
+  const newCommentsSinceDate = highlightDate ? _.filter(comments, comment => new Date(comment.postedAt).getTime() > new Date(highlightDate).getTime()).length : 0;
   const now = useCurrentTime();
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -184,7 +186,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
           tag: tag,
         }}
         totalComments={totalComments}
-        comments={comments}
+        comments={commentTree}
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
       />

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
-import { unflattenComments } from "../../lib/utils/unflatten";
 
 const PostsCommentsThread = ({ post, terms, newForm=true }: {
   post?: PostsDetails,
@@ -22,10 +21,9 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
     return null;
   }
 
-  const nestedComments = unflattenComments(results);
   return (
     <Components.CommentsListSection
-      comments={nestedComments}
+      comments={results}
       loadMoreComments={loadMore}
       totalComments={totalCount as number}
       commentCount={(results && results.length) || 0}

--- a/packages/lesswrong/components/tagging/TagDiscussionSection.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { unflattenComments } from "../../lib/utils/unflatten";
 import { useMulti } from '../../lib/crud/withMulti';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -25,13 +24,12 @@ const TagDiscussionSection = ({classes, tag}: {
     enableTotal: true,
   });
   
-  const nestedComments = !!results && unflattenComments(results);
-  
-  if (!nestedComments) return null
+  if (!results)
+    return null
   
   return (
     <CommentsListSection
-      comments={nestedComments} tag={tag ? tag : undefined}
+      comments={results} tag={tag ? tag : undefined}
       loadMoreComments={loadMore}
       totalComments={totalCount as number}
       commentCount={(results?.length) || 0}


### PR DESCRIPTION
On post pages, there's a message that says "Highlighting [n] new comment since [date]". It only counted new root comments. Make it count all new comments.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203357109395411) by [Unito](https://www.unito.io)
