### PR TITLE
Add instapaper_body class to post body, so that Instapaper will detect it correctly

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -282,7 +282,7 @@ const PostsPage = ({post, refetch, classes}: {
           <PostsPodcastPlayer podcastEpisode={post.podcastEpisode} postId={post._id} />
         </div>}
         { post.isEvent && post.activateRSVPs &&  <RSVPs post={post} /> }
-        <ContentStyles contentType="post" className={classes.postContent}>
+        <ContentStyles contentType="post" className={classNames(classes.postContent, "instapaper_body")}>
           <PostBodyPrefix post={post} query={query}/>
           <AnalyticsContext pageSectionContext="postBody">
             <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>


### PR DESCRIPTION
Instapaper is a site that bookmarks and reformats posts for later reading. It has a complex and undocumented heuristic for detecting where the body of the post is. At some point recently (maybe related to comment-on-selection), its heuristic stopped correctly identifying LW post bodies, and some Instapaper users complained.

According to an email from Instapaper, adding the `instapaper_body` class to the element we want it to detect as the body should override the heuristic and make the body-extraction work correctly again.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203357013785153) by [Unito](https://www.unito.io)
