### PR TITLE
Allow coauthors to access post analytics

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -6,7 +6,7 @@ import { useLocation } from '../../../lib/routeUtil';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { userCanDo } from '../../../lib/vulcan-users/permissions';
-import { userCanEdit, userGetDisplayName, userGetProfileUrlFromSlug } from "../../../lib/collections/users/helpers";
+import { userCanEditUser, userGetDisplayName, userGetProfileUrlFromSlug } from "../../../lib/collections/users/helpers";
 import { userGetEditUrl } from '../../../lib/vulcan-users/helpers';
 import { separatorBulletStyles } from '../../common/SectionFooter';
 import { taglineSetting } from '../../common/HeadTags';
@@ -560,13 +560,13 @@ const EAUsersProfile = ({terms, slug, classes}: {
                 </DialogGroup>
               </div>
             }
-            {userCanEdit(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
+            {userCanEditUser(currentUser, user) && <Link to={`/profile/${user.slug}/edit`}>
               Edit Profile
             </Link>}
             {currentUser && currentUser._id === user._id && <Link to="/manageSubscriptions">
               Manage Subscriptions
             </Link>}
-            {userCanEdit(currentUser, user) && <Link to={userGetEditUrl(user)}>
+            {userCanEditUser(currentUser, user) && <Link to={userGetEditUrl(user)}>
               Account Settings
             </Link>}
             {currentUser && currentUser._id === user._id && <a href="/logout">

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -9,12 +9,12 @@ import { useSingle } from '../../lib/crud/withSingle'
 import { forumTypeSetting } from '../../lib/instanceSettings'
 import { useLocation, useServerRequestStatus } from '../../lib/routeUtil'
 import { Components, registerComponent } from '../../lib/vulcan-lib'
-import { userOwns } from '../../lib/vulcan-users'
 import { useCurrentUser } from '../common/withUser'
 import { usePostAnalytics } from './usePostAnalytics'
 import { Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { requireCssVar } from '../../themes/cssVars';
 import moment from 'moment'
+import { canUserEditPostMetadata } from '../../lib/collections/posts/helpers'
 
 const isEAForum = forumTypeSetting.get()
 
@@ -199,8 +199,7 @@ const PostsAnalyticsPage = ({ classes }) => {
   }
 
   if (
-    !userOwns(currentUser, postReturn.document) &&
-    !currentUser.isAdmin &&
+    !canUserEditPostMetadata(currentUser, postReturn.document) &&
     !currentUser.groups?.includes('sunshineRegiment')
   ) {
     if (serverRequestStatus) serverRequestStatus.status = 403

--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -3,7 +3,7 @@ import { Components, getFragment, registerComponent } from '../../lib/vulcan-lib
 import React from 'react';
 import { useCurrentUser } from '../common/withUser';
 import Users from '../../lib/vulcan-users';
-import { userCanEdit, userGetProfileUrl } from '../../lib/collections/users/helpers';
+import { userCanEditUser, userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { Link } from '../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../lib/instanceSettings';
@@ -69,7 +69,13 @@ const EditProfileForm = ({classes}: {
     );
   }
   // current user doesn't have edit permission
-  if (!userCanEdit(currentUser, terms.documentId ? {_id: terms.documentId} : {slug: terms.slug})) {
+  if (!userCanEditUser(currentUser,
+    terms.documentId ?
+      {_id: terms.documentId} :
+      // HasSlugType wants a bunch of fields we don't have (schemaVersion, _id),
+      // but userCanEdit won't use them
+      {slug: terms.slug, __collectionName: 'Users'} as HasSlugType
+  )) {
     return <div className={classes.root}>
       Sorry, you do not have permission to do this at this time.
     </div>

--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib
 import { useMessages } from '../common/withMessages';
 import React from 'react';
 import Users from '../../lib/collections/users/collection';
-import { getUserEmail, userCanEdit, userGetDisplayName, userGetProfileUrl} from '../../lib/collections/users/helpers';
+import { getUserEmail, userCanEditUser, userGetDisplayName, userGetProfileUrl} from '../../lib/collections/users/helpers';
 import Button from '@material-ui/core/Button';
 import { useCurrentUser } from '../common/withUser';
 import { useNavigation } from '../../lib/routeUtil';
@@ -61,8 +61,13 @@ const UsersEditForm = ({terms, classes}: {
       </div>
     );
   }
-  if (!userCanEdit(currentUser,
-    terms.documentId ? {_id: terms.documentId} : {slug: terms.slug})) {
+  if (!userCanEditUser(currentUser,
+    terms.documentId ?
+      {_id: terms.documentId} :
+      // HasSlugType wants some fields we don't have (schemaVersion, _id), but
+      // userCanEdit won't use them
+      {slug: terms.slug, __collectionName: 'Users'} as HasSlugType
+  )) {
     return <span>Sorry, you do not have permission to do this at this time.</span>
   }
 

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
-import { userCanEdit, userGetDisplayName, userGetProfileUrl, userGetProfileUrlFromSlug } from "../../lib/collections/users/helpers";
+import { userCanEditUser, userGetDisplayName, userGetProfileUrl, userGetProfileUrlFromSlug } from "../../lib/collections/users/helpers";
 import { userGetEditUrl } from '../../lib/vulcan-users/helpers';
 import { DEFAULT_LOW_KARMA_THRESHOLD } from '../../lib/collections/posts/views'
 import StarIcon from '@material-ui/icons/Star'
@@ -266,7 +266,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
                 subscribeMessage="Subscribe to posts"
                 unsubscribeMessage="Unsubscribe from posts"
               /> }
-              {userCanEdit(currentUser, user) && <Link to={userGetEditUrl(user)}>
+              {userCanEditUser(currentUser, user) && <Link to={userGetEditUrl(user)}>
                 Account Settings
               </Link>}
             </Typography>

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -300,8 +300,12 @@ export const userUseMarkdownPostEditor = (user: UsersCurrent|null): boolean => {
   return user.markDownPostEditor
 }
 
-export const userCanEdit = (currentUser, user) => {
-  return userOwns(currentUser, user) || userCanDo(currentUser, 'users.edit.all')
+export const userCanEditUser = (currentUser: UsersCurrent|DbUser|null, user: HasIdType|HasSlugType|UsersMinimumInfo|DbUser) => {
+  // We allow users to call this function with basically "pretend" user objects
+  // as the second argument. We know from inspecting userOwns that those pretend
+  // user objects are safe, but if userOwns allowed them it would make the type
+  // checks much less safe.
+  return userOwns(currentUser, user as UsersMinimumInfo|DbUser) || userCanDo(currentUser, 'users.edit.all')
 }
 
 interface UserLocation {

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -89,7 +89,7 @@ export const userCanDo = (user: UsersProfile|DbUser|null, actionOrActions: strin
 };
 
 // Check if a user owns a document
-export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: HasUserIdType|DbUser|UsersMinimumInfo|DbObject): boolean {
+export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: HasUserIdType|DbUser|UsersMinimumInfo): boolean {
   if (!user) {
     // not logged in
     return false;

--- a/packages/lesswrong/server/resolvers/analyticsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/analyticsResolvers.ts
@@ -1,9 +1,9 @@
 import { PostAnalyticsResult } from "../../components/posts/usePostAnalytics";
 import { forumTypeSetting } from "../../lib/instanceSettings";
-import { userOwns } from "../../lib/vulcan-users";
 import { getAnalyticsConnection } from "../analytics/postgresConnection";
 import { addGraphQLQuery, addGraphQLResolvers, addGraphQLSchema } from "../vulcan-lib";
 import  camelCase  from "lodash/camelCase";
+import { canUserEditPostMetadata } from "../../lib/collections/posts/helpers";
 
 /**
  * Based on an analytics query, returns a function that runs that query
@@ -142,7 +142,10 @@ addGraphQLResolvers({
         throw new Error("Permission denied");
       }
       // Maybe check for karma level here?
-      if (!userOwns(currentUser, post) && !currentUser.isAdmin && !currentUser.groups.includes("sunshineRegiment")) {
+      if (
+        !canUserEditPostMetadata(currentUser, post) &&
+        !currentUser.groups.includes("sunshineRegiment")
+      ) {
         throw new Error("Permission denied");
       }
 


### PR DESCRIPTION
Also refactor userCanEditUser — previously the name and (absent) types were very ambiguous.

You may want to look at this PR commit-by-commit.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203358436921680) by [Unito](https://www.unito.io)
