### PR TITLE
Do not return 404 if the foreign x-post was moved to draft, but the post was hosted here

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -49,7 +49,9 @@ const PostsPageCrosspostWrapper = ({post, refetch, fetchProps}: {
     throw new Error(error.message);
   } else if (loading) {
     return <div><Loading/></div>
-  } else if (!foreignPost && !post.draft) {
+  // If we get a (functionally) 404 error, that should not stop us from
+  // rendering the post if we have it locally
+  } else if (!post.fmCrosspost.hostedHere && !foreignPost && !post.draft) {
     return <Error404/>
   }
 


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203369087791905) by [Unito](https://www.unito.io)
