### PR TITLE
Defend against scenario where foreign forum is down when rendering crossposted post

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -45,7 +45,7 @@ const PostsPageCrosspostWrapper = ({post, refetch, fetchProps}: {
   } = useForeignCrosspost(post, fetchProps);
 
   const { Error404, Loading, PostsPage } = Components;
-  // If we get a error fetching the foreing xpost data, that should not stop us
+  // If we get a error fetching the foreign xpost data, that should not stop us
   // from rendering the post if we have it locally
   if (error && !post.fmCrosspost.hostedHere && !isMissingDocumentError(error) && !isOperationNotAllowedError(error)) {
     throw new Error(error.message);

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -45,12 +45,12 @@ const PostsPageCrosspostWrapper = ({post, refetch, fetchProps}: {
   } = useForeignCrosspost(post, fetchProps);
 
   const { Error404, Loading, PostsPage } = Components;
-  if (error && !isMissingDocumentError(error) && !isOperationNotAllowedError(error)) {
+  // If we get a error fetching the foreing xpost data, that should not stop us
+  // from rendering the post if we have it locally
+  if (error && !post.fmCrosspost.hostedHere && !isMissingDocumentError(error) && !isOperationNotAllowedError(error)) {
     throw new Error(error.message);
   } else if (loading) {
     return <div><Loading/></div>
-  // If we get a (functionally) 404 error, that should not stop us from
-  // rendering the post if we have it locally
   } else if (!post.fmCrosspost.hostedHere && !foreignPost && !post.draft) {
     return <Error404/>
   }


### PR DESCRIPTION
Follow-on to #6097.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203375234767702) by [Unito](https://www.unito.io)
