### PR TITLE
Revert "Fix the notification drawer open/close animations"

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -125,7 +125,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
   return (
     <div className={classes.root}>
       <Components.ErrorBoundary>
-        <SwipeableDrawer
+        {open && <SwipeableDrawer
           open={open}
           anchor="right"
           onClose={() => setIsOpen(false)}
@@ -170,7 +170,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
             <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />
             <Components.NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser}/>
           </div>}
-        </SwipeableDrawer>
+        </SwipeableDrawer>}
       </Components.ErrorBoundary>
     </div>
   )


### PR DESCRIPTION
Turns out the MUI code that makes the notification drawer stay just off the edge of the screen wasn't very good.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203375795143263) by [Unito](https://www.unito.io)
