### PR TITLE
Remove bash strict-mode flags which broke deploying LW

### DIFF
--- a/scripts/runProduction.sh
+++ b/scripts/runProduction.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 echo "Running Production Site"
 
-set -eux
+# Not setting bash strict flags because set -u makes the script abort if some
+# variables are undefined, but those variables are optional.
+#set -eux
 
 # lw-look here: you must define GITHUB_CREDENTIALS_REPO_USER in your AWS EBS config
+echo "Cloning credentials repo"
 git clone https://$GITHUB_CREDENTIALS_REPO_USER:$GITHUB_CREDENTIALS_REPO_PAT@github.com/$GITHUB_CREDENTIALS_REPO_NAME.git Credentials
 
 # Decrypt credentials if encrypted
 if [ -n "$TRANSCRYPT_SECRET" ]; then
+    echo "Using transcrypt to decrypt credentials"
     cd Credentials
     transcrypt -c aes-256-cbc -p "$TRANSCRYPT_SECRET" -y
     cd ..
+else
+    echo "Not using transcrypt"
 fi
 
 # Run outstanding database migrations


### PR DESCRIPTION
`set -eux` makes `bash` stricter in various ways. One of those ways is that the script will abort and fail if it uses an environment variables that's undefined. Later in the script, we have

```if [ -n "$TRANSCRYPT_SECRET" ]; then```

which explicitly tests for whether an undefined environment variable, in a way that will interact with `set -u` to abort the script. That optional envvar is used by EA Forum, but not by LW. Oops.

Revert to minimum strictness for now (undoing that part of [this commit](https://github.com/ForumMagnum/ForumMagnum/commit/c88a92258c4c054ea2c0059236641b3eac401232)).