### PR TITLE
[EA Forum only] fix job ad bugs

### DIFF
--- a/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
@@ -257,7 +257,7 @@ const TargetedJobAd = ({
   
   // show the ad to any users interested in software engineering
   const showJobAd = currentUser && (userIds.includes(currentUser._id) || currentUser.profileTagIds?.includes(SOFTWARE_ENG_TAG_ID))
-  
+
   // track which users have seen the ad
   useEffect(() => {
     if (!loading && !count && showJobAd) {
@@ -265,7 +265,8 @@ const TargetedJobAd = ({
         data: {userId: currentUser._id, interestedInMetaculus: false}
       })
     }
-  }, [loading, count, currentUser, showJobAd, createJobAdView])
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, count, currentUser, showJobAd])
   
   const dismissJobAd = () => {
     captureEvent('hideJobAd')

--- a/packages/lesswrong/components/ea-forum/advice/AdvisorsPage.tsx
+++ b/packages/lesswrong/components/ea-forum/advice/AdvisorsPage.tsx
@@ -299,16 +299,16 @@ const AdvisorsPage = ({classes}: {
 
   const { SingleColumnSection, HeadTags, AdvisorCard, Loading, CommunityMemberCard } = Components
 
-  const { create: createAdvisorRequest } = useCreate({
-    collectionName: 'AdvisorRequests',
-    fragmentName: 'AdvisorRequestsMinimumInfo',
-  })
-  const { count } = useMulti({
-    terms: {view: 'requestsByUser', userId: currentUser?._id},
-    collectionName: 'AdvisorRequests',
-    fragmentName: 'AdvisorRequestsMinimumInfo',
-    skip: !currentUser
-  })
+  // const { create: createAdvisorRequest } = useCreate({
+  //   collectionName: 'AdvisorRequests',
+  //   fragmentName: 'AdvisorRequestsMinimumInfo',
+  // })
+  // const { count } = useMulti({
+  //   terms: {view: 'requestsByUser', userId: currentUser?._id},
+  //   collectionName: 'AdvisorRequests',
+  //   fragmentName: 'AdvisorRequestsMinimumInfo',
+  //   skip: !currentUser
+  // })
   
   const { results: communityMembers, loading: communityMembersLoading } = useMulti({
     terms: {view: 'tagCommunityMembers', profileTagId: TOPIC_ID, hasBio: true, limit: 50},
@@ -319,11 +319,11 @@ const AdvisorsPage = ({classes}: {
   const onRequest = async () => {
     captureEvent('advisorRequestBtnClicked')
     // track that the current user requested a chat
-    if (currentUser && !count) {
-      await createAdvisorRequest({
-        data: {userId: currentUser._id}
-      });
-    }
+    // if (currentUser && !count) {
+    //   await createAdvisorRequest({
+    //     data: {userId: currentUser._id}
+    //   });
+    // }
   }
   
   const handleJoin = () => {

--- a/packages/lesswrong/lib/collections/advisorRequests/permissions.ts
+++ b/packages/lesswrong/lib/collections/advisorRequests/permissions.ts
@@ -1,0 +1,8 @@
+import { membersGroup } from '../../vulcan-users/permissions';
+
+const membersActions = [
+  'advisorrequests.view.own',
+  'advisorrequests.new',
+  'advisorrequests.edit.own',
+];
+membersGroup.can(membersActions);

--- a/packages/lesswrong/lib/index.ts
+++ b/packages/lesswrong/lib/index.ts
@@ -126,6 +126,7 @@ import './collections/books/permissions';
 
 import './collections/advisorRequests/collection';
 import './collections/advisorRequests/fragments';
+import './collections/advisorRequests/permissions';
 import './collections/advisorRequests/views';
 
 


### PR DESCRIPTION
In trying to get this out before my vacation, apparently I didn't test it properly. The two fixes here are:

1. Added `permissions.ts` for `AdvisorRequests`, so now the tracking actually works for non-admins
2. Stopped creating duplicate documents per user due to extra calls to `createJobAdView()`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203389756015931) by [Unito](https://www.unito.io)
