### PR TITLE
Truncate subtags list in topic page

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -117,6 +117,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
     borderTop: theme.palette.border.extraFaint,
     borderBottom: theme.palette.border.extraFaint,
   },
+  relatedTag : {
+    display: '-webkit-box',
+    "-webkit-line-clamp": 2,
+    "-webkit-box-orient": 'vertical',
+    overflow: 'hidden',
+  },
   relatedTagLink : {
     color: theme.palette.lwTertiary.dark
   },

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -7,12 +7,15 @@ import { tagPostTerms } from './TagPage';
 import { taggingNameCapitalSetting, taggingNamePluralCapitalSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
-  relatedTag: {
-    display: "flex",
+  relatedTagWrapper: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
     fontSize: "1.1rem",
     color: theme.palette.grey[900],
+    display: '-webkit-box',
+    "-webkit-line-clamp": 2,
+    "-webkit-box-orient": 'vertical',
+    overflow: 'hidden',
   },
   relatedTagLink : {
     color: theme.palette.lwTertiary.dark
@@ -81,8 +84,8 @@ const TagPreview = ({tag, loading, classes, showCount=true, showRelatedTags=true
       <TagPreviewDescription tag={tag}/>
       {showRelatedTags && (tag.parentTag || tag.subTags.length) ?
         <div className={classes.relatedTags}>
-          {tag.parentTag && <div className={classes.relatedTag}>Parent topic:&nbsp;<Link className={classes.relatedTagLink} to={tagGetUrl(tag.parentTag)}>{tag.parentTag.name}</Link></div>}
-          {tag.subTags.length ? <div className={classes.relatedTag}><span>Sub-{tag.subTags.length > 1 ? taggingNamePluralCapitalSetting.get() : taggingNameCapitalSetting.get()}:&nbsp;{tag.subTags.map((subTag, idx) => {
+          {tag.parentTag && <div className={classes.relatedTagWrapper}>Parent topic:&nbsp;<Link className={classes.relatedTagLink} to={tagGetUrl(tag.parentTag)}>{tag.parentTag.name}</Link></div>}
+          {tag.subTags.length ? <div className={classes.relatedTagWrapper}><span>Sub-{tag.subTags.length > 1 ? taggingNamePluralCapitalSetting.get() : taggingNameCapitalSetting.get()}:&nbsp;{tag.subTags.map((subTag, idx) => {
             return <><Link key={idx} className={classes.relatedTagLink} to={tagGetUrl(subTag)}>{subTag.name}</Link>{idx < tag.subTags.length - 1 ? <>,&nbsp;</>: <></>}</>
           })}</span></div> : <></>}
         </div> : <></>


### PR DESCRIPTION
This is required now because we're about to add a bunch of subtags to the Animal Welfare topic. In the long run I think we should make it so that all tags with lots of subtags are subforum, which will then have a box in the sidebar showing all the subtags (this is still so be decided). But this change is just to stop the topic page looking bad while subforums are in development

![Screenshot 2022-11-17 at 15 09 20](https://user-images.githubusercontent.com/77623106/202483961-0d1a7414-6320-4f6b-8c98-227e521a837a.png)
![Screenshot 2022-11-17 at 15 11 17](https://user-images.githubusercontent.com/77623106/202483970-f2894305-7c30-414f-af15-bf441ef9acbf.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203393507104721) by [Unito](https://www.unito.io)
