### PR TITLE
don't try to submit contents in post edits when a podcaster is adding an episode

### DIFF
--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -307,6 +307,23 @@ export const deserializeEditorContents = (contents: SerializedEditorContents): E
   }
 }
 
+/**
+ * Editor's `submitData` is called in `EditorFormComponent`.
+ * Curently, the only situation where we (validly) won't have a ckEditorReference is if a podcaster is editing a post to add a podcast episode to it.
+ * 
+ * Podcasters don't have permissions to edit the contents of a post, so the editor itself isn't rendered (due to the field permissions).
+ * 
+ * Simply submitting the post was causing an error in `submitData`, since it expects a ckEditorReference if we're attempting to submit the contents of the post.
+ * We just shouldn't try to submit post contents if we'll blow up by doing so (or know that we can't ahead of time).
+ */
+export const shouldSubmitContents = (editorRef: Editor) => {
+  const editorType = editorRef.props.value.type;
+  const ckEditorReference = editorRef.state.ckEditorReference;
+
+  if (editorType !== 'ckEditorMarkup') return true;
+  return !!ckEditorReference;
+}
+
 export class Editor extends Component<EditorProps,EditorComponentState> {
   throttledSetCkEditor: any
   debouncedCheckMarkdownImgErrs: any

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -4,7 +4,7 @@ import { editableCollectionsFieldOptions } from '../../lib/editor/make_editable'
 import { getLSHandlers, getLSKeyPrefix } from './localStorageHandlers'
 import { userCanCreateCommitMessages } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
-import { Editor, EditorChangeEvent, getUserDefaultEditor, getInitialEditorContents, getBlankEditorContents, EditorContents, isBlank, serializeEditorContents, EditorTypeString, styles, FormProps } from './Editor';
+import { Editor, EditorChangeEvent, getUserDefaultEditor, getInitialEditorContents, getBlankEditorContents, EditorContents, isBlank, serializeEditorContents, EditorTypeString, styles, FormProps, shouldSubmitContents } from './Editor';
 import withErrorBoundary from '../common/withErrorBoundary';
 import PropTypes from 'prop-types';
 import * as _ from 'underscore';
@@ -128,7 +128,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   useEffect(() => {
     if (editorRef.current) {
       const cleanupSubmitForm = context.addToSubmitForm(async (submission) => {
-        if (editorRef.current)
+        if (editorRef.current && shouldSubmitContents(editorRef.current))
           return {
             ...submission,
             [fieldName]: await editorRef.current.submitData(submission)


### PR DESCRIPTION
Not 100% sure what caused the regression, since as far as I can tell none of the relevant (editor/contents) code has been changed since I wrote & tested the podcasters logic.

This stops us from trying to submit the `contents` of a post when editing it if it's a ckEditor post and we don't have a ckEditor reference.  The only time that currently comes up is if it's a podcaster editing the post, since they're the only group that have permissions to edit posts (as a collection, such that they can add a podcast episode) but don't have permissions to edit the contents of the post itself.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203396033599208) by [Unito](https://www.unito.io)
