### PR TITLE
Secondary post authors in collab editor can access version history

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -202,9 +202,10 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     />
     {!hideControls && <Components.EditorTypeSelect value={contents} setValue={wrappedSetContents} isCollaborative={isCollaborative(document, fieldName)}/>}
     {!hideControls && collectionName==="Posts" && fieldName==="contents" && !!document._id &&
-    <Components.PostVersionHistoryButton
-      postId={document._id}
-    />
+      <Components.PostVersionHistoryButton
+        post={document}
+        postId={document._id}
+      />
     }
   </div>
 }

--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -114,6 +114,10 @@ const PostCollaborationEditor = ({ classes }: {
           isCollaborative={true}
           accessLevel={post.myEditorAccess as CollaborativeEditingAccessLevel}
         />
+        <Components.PostVersionHistoryButton
+          post={post}
+          postId={postId}
+        />
       </NoSSR>
     </ContentStyles>
   </SingleColumnSection>

--- a/packages/lesswrong/lib/collections/revisions/collection.ts
+++ b/packages/lesswrong/lib/collections/revisions/collection.ts
@@ -4,6 +4,7 @@ import { addUniversalFields, getDefaultResolvers } from '../../collectionUtils'
 import { userCanDo, membersGroup } from '../../vulcan-users/permissions';
 import { extractVersionsFromSemver } from '../../editor/utils';
 import { makeVoteable } from '../../make_voteable';
+import { getCollaborativeEditorAccess, accessLevelCan } from '../posts/collabEditingPermissions';
 
 export const Revisions: RevisionsCollection = createCollection({
   collectionName: 'Revisions',
@@ -26,13 +27,10 @@ Revisions.checkAccess = async (user: DbUser|null, revision: DbRevision, context:
   if ((user && user._id) === revision.userId) return true
   if (userCanDo(user, 'posts.view.all')) return true
   
-  if (revision.draft) {
-    return false;
-  }
-  
   // not sure why some revisions have no collectionName,
   // but this will cause an error below so just exclude them
   if (!revision.collectionName) return false
+  const collectionName = revision.collectionName;
   
   // Get the document that this revision is a field of, and check for access to
   // it. This is necessary for correctly handling things like posts' draft
@@ -44,13 +42,27 @@ Revisions.checkAccess = async (user: DbUser|null, revision: DbRevision, context:
   // ResolverContext, use a findOne query; this is slow, but doesn't come up
   // in any contexts where speed matters.
   const { major: majorVersion } = extractVersionsFromSemver(revision.version)
-  const collectionName= revision.collectionName;
-  const documentId = revision.documentId;
   const collection = getCollection(collectionName);
+  const documentId = revision.documentId;
   const document = context
     ? await context.loaders[collectionName].load(documentId)
     : await collection.findOne(documentId);
   
+  if (revision.collectionName === "Posts") {
+    const collabEditorAccess = await getCollaborativeEditorAccess({
+      formType: "edit",
+      post: document,
+      user: user,
+      useAdminPowers: true,
+    });
+    if (accessLevelCan(collabEditorAccess, "read")) {
+      return true;
+    }
+  }
+  
+  if (revision.draft) {
+    return false;
+  }
   
   // Everyone who can see the post can get access to non-draft revisions
   if (!await collection.checkAccess(user, document, context)) {


### PR DESCRIPTION
Co-authored-by: jpaddison3 <jp@centreforeffectivealtruism.org>

Useful for recovering if CkEditor crashes. Also makes the "restore this revision" button in the revision-history popup conditionally visible based on whether you have permission to use it (as opposed to only having read or comment access).