### PR TITLE
Deduplicate mixed type feeds

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -139,9 +139,10 @@ const MixedTypeFeed = (args: {
   // for the cutoff.
   const reachedEnd = (data && data[resolverName] && !data[resolverName].cutoff);
   
+  const keyFunc = (result) => `${result.type}_${result[result.type]?._id}`; // Get a unique key for each result. Used for sorting and deduplication.
+
   // maybeStartLoadingMore: Test whether the scroll position is close enough to
-  // the bottom that we should start loading the next page, and if so, start
-  // loading it.
+  // the bottom that we should start loading the next page, and if so, start loading it.
   const maybeStartLoadingMore = () => {
     // Client side, scrolled to near the bottom? Start loading if we aren't loading already.
     if (isClient
@@ -165,13 +166,18 @@ const MixedTypeFeed = (args: {
             if (!fetchMoreResult) {
               return prev;
             }
-            
+
+            // Deduplicate by removing repeated results from the newly fetched page. Ideally we
+            // would use cursor-based pagination to avoid this
+            const prevKeys = new Set(prev[resolverName].results.map(keyFunc));
+            const deduplicatedResults = fetchMoreResult[resolverName].results.filter(result => !prevKeys.has(keyFunc(result)));
+
             return {
               [resolverName]: {
                 __typename: fetchMoreResult[resolverName].__typename,
                 cutoff: fetchMoreResult[resolverName].cutoff,
                 endOffset: data[resolverName].endOffset,
-                results: [...prev[resolverName].results, ...fetchMoreResult[resolverName].results],
+                results: [...prev[resolverName].results, ...deduplicatedResults],
               }
             };
           }
@@ -188,7 +194,6 @@ const MixedTypeFeed = (args: {
   useOnPageScroll(maybeStartLoadingMore);
   
   const results = (data && data[resolverName]?.results) || [];
-  const keyFunc = (result) => `${result.type}_${result[result.type]?._id}`;
   const orderedResults = useOrderPreservingArray(results, keyFunc);
   return <div>
     {orderedResults.map((result) =>

--- a/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
+++ b/packages/lesswrong/components/hooks/useOrderPreservingArray.tsx
@@ -4,7 +4,8 @@ type OrderPreservingArrayPolicy = "prepend-new" | "append-new" | "interleave-new
 type IndexType = string | number;
 
 const arrayToIndexMap = (arr: IndexType[]): Record<IndexType, number> =>
-  Object.keys(arr).reduce(function (map, idx) {
+  Object.keys(arr).reduce(function (map, idxStr) {
+    const idx = parseInt(idxStr);
     map[arr[idx]] = idx;
     return map;
   }, {});


### PR DESCRIPTION
We have intermittently seen a bug where items in the recent discussion feed were duplicated. This should fix that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203412794552927) by [Unito](https://www.unito.io)
