### PR TITLE
Disallow strong voting on your own comments

### DIFF
--- a/packages/lesswrong/lib/collections/comments/voting.ts
+++ b/packages/lesswrong/lib/collections/comments/voting.ts
@@ -9,5 +9,10 @@ const customBaseScoreReadAccess = (user: DbUser|null, comment: DbComment) => {
 
 makeVoteable(Comments, {
   timeDecayScoresCronjob: true,
-  customBaseScoreReadAccess
+  customBaseScoreReadAccess,
+  userCanVoteOn: (user: DbUser|null, comment: DbComment, voteType: string) => {
+    if (!user) return false;
+    if (comment.userId === user._id && ["bigUpvote", "bigDownvote"].includes(voteType)) return false;
+    return true;
+  }
 });

--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -5,7 +5,7 @@ import GraphQLJSON from 'graphql-type-json';
 interface CollectionVoteOptions {
   timeDecayScoresCronjob: boolean,
   customBaseScoreReadAccess?: (user: DbUser|null, object: any) => boolean
-  userCanVoteOn?: (user: DbUser, document: DbVoteableType) => boolean|Promise<boolean>,
+  userCanVoteOn?: (user: DbUser, document: DbVoteableType, voteType: string) => boolean|Promise<boolean>,
 }
 
 export const VoteableCollections: Array<CollectionBase<DbVoteableType>> = [];

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -75,7 +75,7 @@ function addVoteMutations(collection: CollectionBase<DbVoteableType>) {
         if (!document) throw new Error("No such document ID");
 
         const {userCanVoteOn} = VoteableCollectionOptions[collection.collectionName] ?? {};
-        if (userCanVoteOn && !(await userCanVoteOn(currentUser, document))) {
+        if (userCanVoteOn && !(await userCanVoteOn(currentUser, document, voteType))) {
           throw new Error("You do not have permission to vote on this");
         }
 


### PR DESCRIPTION
Disallow both strong upvoting and downvoting on your own comments. There is no need for any UI side change because it already says "You do not have permission to vote on this" when you try to do it, which I think makes it fairly obvious