### PR TITLE
buildout - allow post authors to require approval on comments before others can reply

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -143,6 +143,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     top: 3
   },
+  pendingApproval: {
+    paddingLeft: 12
+  }
 })
 
 export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, setSingleLine, truncated, showPinnedOnProfile, parentAnswerId, enableGuidelines=true, displayMode, showParentDefault=false, classes }: {
@@ -173,6 +176,14 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   const currentUser = useCurrentUser();
 
   const { postPage, tag, post, refetch, hideReply, showPostTitle, singleLineCollapse, hideReviewVoteButtons, moderatedCommentId } = treeOptions;
+  const showCommentApprovalStatus = !!post?.requireCommentApproval && !(isChild || comment.parentCommentId);
+
+  console.log({ commentId: comment._id, isChild, parentCommentId });
+
+  const canReplyFromApprovalStatus = () => {
+    if (!post?.requireCommentApproval) return true;
+    return comment.commentApproval?.status === 'approved';
+  };
 
   const showReply = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -255,7 +266,8 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
       // here. We should do something more complicated to give client-side feedback
       // if you're banned.
       // @ts-ignore
-      (!currentUser || userIsAllowedToComment(currentUser, treeOptions.post))
+      (!currentUser || userIsAllowedToComment(currentUser, treeOptions.post)) &&
+      canReplyFromApprovalStatus()
     )
 
     const showInlineCancel = showReplyState && isMinimalist
@@ -393,6 +405,9 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               collection={Comments}
               hideKarma={post?.hideCommentKarma}
             />
+            {showCommentApprovalStatus && <span className={classes.pendingApproval}>
+              {!comment.commentApproval ? 'Pending Approval - Replies Disabled' : ''}
+            </span>}
 
             {!isParentComment && renderMenu()}
             {post && <Components.CommentOutdatedWarning comment={comment} post={post}/>}

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 
+interface PartitionedComments {
+  approvedOrPending: CommentsList[];
+  rejected: CommentsList[];
+}
+
 const PostsCommentsThread = ({ post, terms, newForm=true }: {
   post?: PostsDetails,
   terms: CommentsViewTerms,
@@ -19,6 +24,44 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
     return <Components.Loading />;
   } else if (!results) {
     return null;
+  }
+
+  if (post?.requireCommentApproval && results) {
+    const approvedOrPendingComments: CommentsList[] = [];
+    const rejectedComments: CommentsList[] = [];
+
+    // results?.forEach((comment) => {
+    //   if (!comment.commentApproval || comment.commentApproval.status === 'approved') {
+    //     approvedOrPendingComments.push(comment);
+    //   } else {
+    //     rejectedComments.push(comment);
+    //   }
+    // });
+
+    return (
+      <>
+        <Components.CommentsListSection
+          comments={results}
+          loadMoreComments={loadMore}
+          totalComments={totalCount as number}
+          commentCount={(results.length) || 0}
+          loadingMoreComments={loadingMore}
+          post={post}
+          newForm={newForm}
+          approvalSection='approved'
+        />
+        <Components.CommentsListSection
+          comments={results}
+          loadMoreComments={loadMore}
+          totalComments={totalCount as number}
+          commentCount={(results.length) || 0}
+          loadingMoreComments={loadingMore}
+          post={post}
+          newForm={false}
+          approvalSection='rejected'
+        />
+      </>
+    );
   }
 
   return (

--- a/packages/lesswrong/lib/collections/commentApprovals/collection.ts
+++ b/packages/lesswrong/lib/collections/commentApprovals/collection.ts
@@ -1,0 +1,17 @@
+import schema from './schema';
+import { createCollection } from '../../vulcan-lib';
+import { addUniversalFields, getDefaultResolvers } from '../../collectionUtils'
+import { getDefaultMutations } from '../../vulcan-core/default_mutations';
+
+export const CommentApprovals: CommentApprovalsCollection = createCollection({
+  collectionName: 'CommentApprovals',
+  typeName: 'CommentApproval',
+  schema,
+  resolvers: getDefaultResolvers('CommentApprovals'),
+  mutations: getDefaultMutations('CommentApprovals'),
+  logChanges: true,
+});
+
+addUniversalFields({collection: CommentApprovals});
+
+export default CommentApprovals;

--- a/packages/lesswrong/lib/collections/commentApprovals/fragments.ts
+++ b/packages/lesswrong/lib/collections/commentApprovals/fragments.ts
@@ -1,0 +1,10 @@
+import { registerFragment } from '../../vulcan-lib';
+
+registerFragment(`
+  fragment CommentApprovalWithoutComment on CommentApproval {
+    _id
+    status
+    rejectionReason
+    createdAt
+  }
+`);

--- a/packages/lesswrong/lib/collections/commentApprovals/schema.ts
+++ b/packages/lesswrong/lib/collections/commentApprovals/schema.ts
@@ -1,0 +1,67 @@
+import { foreignKeyField } from '../../utils/schemaUtils'
+import { userOwns } from '../../vulcan-users/permissions';
+
+// export const DOWNVOTED_COMMENT_ALERT = 'downvotedCommentAlert';
+
+// export const COMMENT_MODERATOR_ACTION_TYPES = {
+//   [DOWNVOTED_COMMENT_ALERT]: 'Downvoted Comment'
+// };
+
+// /**
+//  * If the action hasn't ended yet (either no endedAt, or endedAt in the future), it's active.
+//  */
+// export const isCommentActionActive = (moderatorAction: DbCommentModeratorAction) => {
+//   return !moderatorAction.endedAt || moderatorAction.endedAt > new Date();
+// }
+
+const schema: SchemaType<DbCommentApproval> = {
+  commentId: {
+    ...foreignKeyField({
+      idFieldName: "commentId",
+      resolverName: "comment",
+      collectionName: "Comments",
+      type: "Comment",
+      nullable: false
+    }),
+    // TODO: figure out all permissions
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    canCreate: ['sunshineRegiment', 'admins'],
+    optional: true,
+  },
+  status: {
+    type: String,
+    // control: 'select',
+    allowedValues: ['approved', 'rejected'],
+    // options: () => Object.entries(COMMENT_MODERATOR_ACTION_TYPES).map(([value, label]) => ({ value, label })),
+    // TODO: figure out all permissions
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    canCreate: ['sunshineRegiment', 'admins'],
+  },
+  rejectionReason: {
+    type: String,
+    nullable: true,
+    optional: true,
+    // TODO: figure out all permissions
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    canCreate: ['sunshineRegiment', 'admins'],    
+  }
+  // endedAt: {
+  //   type: Date,
+  //   optional: true,
+  //   nullable: true,
+  //   canRead: [userOwns, 'sunshineRegiment', 'admins'],
+  //   canUpdate: ['sunshineRegiment', 'admins'],
+  //   canCreate: ['sunshineRegiment', 'admins'],
+  //   control: 'datetime',
+  // },
+  // active: resolverOnlyField({
+  //   type: Boolean,
+  //   canRead: [userOwns, 'sunshineRegiment', 'admins'],
+  //   resolver: (doc) => isCommentActionActive(doc)
+  // })
+};
+
+export default schema;

--- a/packages/lesswrong/lib/collections/commentApprovals/views.ts
+++ b/packages/lesswrong/lib/collections/commentApprovals/views.ts
@@ -1,0 +1,30 @@
+import { ensureIndex } from '../../collectionIndexUtils';
+import CommentApprovals from './collection';
+
+interface NoViewTerms extends ViewTermsBase {
+  view?: undefined;
+}
+
+// interface ActiveCommentModeratorActionsViewTerms extends ViewTermsBase {
+//   view: 'activeCommentModeratorActions';
+//   limit: number;
+// }
+
+// declare global {
+//   type CommentModeratorActionsViewTerms =
+//     | NoViewTerms
+//     | ActiveCommentModeratorActionsViewTerms
+// }
+
+// CommentApprovals.addView('activeCommentModeratorActions', function (terms: ActiveCommentModeratorActionsViewTerms) {
+//   return {
+//     selector: {
+//       $or: [
+//         { endedAt: { $exists: false } },
+//         { endedAt: null }
+//       ]
+//     },
+//     options: { sort: { createdAt: -1 }, limit: terms.limit }
+//   };
+// })
+ensureIndex(CommentApprovals, { commentId: 1, createdAt: -1 })

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -56,6 +56,9 @@ registerFragment(`
     directChildrenCount
     votingSystem
     isPinnedOnProfile
+    commentApproval {
+      ...CommentApprovalWithoutComment
+    }
   }
 `);
 

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -626,6 +626,15 @@ const schema: SchemaType<DbComment> = {
     ...schemaDefaultValue(false),
   },
   
+  commentApproval: resolverOnlyField({
+    type: 'CommentApproval',
+    graphQLtype: 'CommentApproval',
+    nullable: true,
+    canRead: ['guests'],
+    resolver: (comment, args, context) => {
+      return context.CommentApprovals.findOne({ commentId: comment._id });
+    }
+  })
 };
 
 /* Alignment Forum fields */

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -15,6 +15,7 @@ registerFragment(`
       qualitativeScore
     }
     userId
+    requireCommentApproval
   }
 `);
 

--- a/packages/lesswrong/lib/collections/posts/permissions.ts
+++ b/packages/lesswrong/lib/collections/posts/permissions.ts
@@ -1,7 +1,7 @@
 import { Posts } from './collection'
 import { postStatusLabels } from './constants'
 import { guestsGroup, membersGroup, adminsGroup, userCanDo, userOwns } from '../../vulcan-users/permissions';
-import { sunshineRegimentGroup, trustLevel1Group, canModeratePersonalGroup, canCommentLockGroup } from '../../permissions';
+import { sunshineRegimentGroup, trustLevel1Group, canModeratePersonalGroup, canCommentLockGroup, canRequireCommentApprovalGroup } from '../../permissions';
 import { userIsSharedOn } from '../users/helpers'
 import * as _ from 'underscore';
 import { userIsPostGroupOrganizer } from './helpers';
@@ -69,7 +69,8 @@ const sunshineRegimentActions = [
   'posts.suggestCurate',
   'posts.frontpage.all',
   'posts.moderate.all',
-  'posts.commentLock.all'
+  'posts.commentLock.all',
+  'posts.requireCommentApproval.all'
 ];
 sunshineRegimentGroup.can(sunshineRegimentActions);
 
@@ -77,3 +78,4 @@ sunshineRegimentGroup.can(sunshineRegimentActions);
 trustLevel1Group.can(['posts.moderate.own', 'posts.suggestCurate']);
 canModeratePersonalGroup.can(['posts.moderate.own.personal']);
 canCommentLockGroup.can(['posts.commentLock.own']);
+canRequireCommentApprovalGroup.can(['posts.requireCommentApproval.own']);

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -19,7 +19,7 @@ import GraphQLJSON from 'graphql-type-json';
 import * as _ from 'underscore';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
 import { userOwns } from '../../vulcan-users/permissions';
-import { userCanCommentLock, userCanModeratePost, userIsSharedOn } from '../users/helpers';
+import { userCanCommentLock, userCanModeratePost, userCanRequireCommentApproval, userIsSharedOn } from '../users/helpers';
 import { sequenceGetNextPostID, sequenceGetPrevPostID, sequenceContainsPost, getPrevPostIdFromPrevSequence, getNextPostIdFromNextSequence } from '../sequences/helpers';
 import { captureException } from '@sentry/core';
 import { userOverNKarmaFunc } from "../../vulcan-users";
@@ -2299,6 +2299,17 @@ const schema: SchemaType<DbPost> = {
   'recentComments.$': {
     type: Object,
     foreignKey: 'Comments',
+  },
+
+  requireCommentApproval: {
+    type: Boolean,
+    canRead: ['guests'],
+    group: formGroups.moderationGroup,
+    canUpdate: (currentUser: DbUser|null, document: DbPost) => userCanRequireCommentApproval(currentUser, document),
+    canCreate: (currentUser: DbUser|null) => userCanRequireCommentApproval(currentUser, null),
+    optional: true,
+    nullable: true,
+    control: "checkbox",
   },
 };
 

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -150,6 +150,19 @@ export const userCanCommentLock = (user: UsersCurrent|DbUser|null, post: PostsBa
   )
 }
 
+export const userCanRequireCommentApproval = (user: UsersCurrent|DbUser|null, post: PostsBase|DbPost|null): boolean => {
+  if (userCanDo(user, "posts.requireCommentApproval.all")) {
+    return true
+  }
+  if (!user || !post) {
+    return false
+  }
+  return !!(
+    userCanDo(user, "posts.requireCommentApproval.own") &&
+    userOwns(user, post)
+  )
+}
+
 export const userIsBannedFromPost = (user: UsersMinimumInfo|DbUser, post: PostsDetails|DbPost, postAuthor: PostsAuthors_user|DbUser|null): boolean => {
   if (!post) return false;
   return !!(

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -100,6 +100,18 @@ interface DbCollection extends DbObject {
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
 }
 
+interface CommentApprovalsCollection extends CollectionBase<DbCommentApproval, "CommentApprovals"> {
+}
+
+interface DbCommentApproval extends DbObject {
+  __collectionName?: "CommentApprovals"
+  commentId: string
+  status: "approved" | "rejected"
+  rejectionReason: string | null
+  createdAt: Date
+  legacyData: any /*{"definitions":[{"blackbox":true}]}*/
+}
+
 interface CommentModeratorActionsCollection extends CollectionBase<DbCommentModeratorAction, "CommentModeratorActions"> {
 }
 
@@ -600,6 +612,7 @@ interface DbPost extends DbObject {
   moderationStyle: string
   hideCommentKarma: boolean
   commentCount: number
+  requireCommentApproval: boolean | null
   subforumTagId: string
   af: boolean
   afDate: Date
@@ -1226,6 +1239,7 @@ interface CollectionsByName {
   Chapters: ChaptersCollection
   ClientIds: ClientIdsCollection
   Collections: CollectionsCollection
+  CommentApprovals: CommentApprovalsCollection
   CommentModeratorActions: CommentModeratorActionsCollection
   Comments: CommentsCollection
   Conversations: ConversationsCollection
@@ -1270,6 +1284,7 @@ interface ObjectsByCollectionName {
   Chapters: DbChapter
   ClientIds: DbClientId
   Collections: DbCollection
+  CommentApprovals: DbCommentApproval
   CommentModeratorActions: DbCommentModeratorAction
   Comments: DbComment
   Conversations: DbConversation

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -642,6 +642,7 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly moderationStyle: string,
   readonly hideCommentKarma: boolean,
   readonly commentCount: number,
+  readonly requireCommentApproval: boolean | null,
   readonly subforumTagId: string,
   readonly af: boolean,
   readonly afDate: Date,
@@ -711,6 +712,7 @@ interface PostsMinimumInfo { // fragment on Posts
   readonly af: boolean,
   readonly currentUserReviewVote: PostsMinimumInfo_currentUserReviewVote|null,
   readonly userId: string,
+  readonly requireCommentApproval: boolean | null,
 }
 
 interface PostsMinimumInfo_currentUserReviewVote { // fragment on ReviewVotes
@@ -1209,6 +1211,7 @@ interface CommentsList { // fragment on Comments
   readonly directChildrenCount: number,
   readonly votingSystem: string,
   readonly isPinnedOnProfile: boolean,
+  readonly commentApproval: CommentApprovalWithoutComment|null,
 }
 
 interface CommentsList_contents { // fragment on Revisions
@@ -2801,6 +2804,19 @@ interface ModerationTemplateFragment { // fragment on ModerationTemplates
   readonly contents: RevisionEdit|null,
 }
 
+interface CommentApprovalsDefaultFragment { // fragment on CommentApprovals
+  readonly commentId: string,
+  readonly status: "approved" | "rejected",
+  readonly rejectionReason: string | null,
+}
+
+interface CommentApprovalWithoutComment { // fragment on CommentApprovals
+  readonly _id: string,
+  readonly status: "approved" | "rejected",
+  readonly rejectionReason: string | null,
+  readonly createdAt: Date,
+}
+
 interface SuggestAlignmentComment extends CommentsList { // fragment on Comments
   readonly post: PostsMinimumInfo|null,
   readonly suggestForAlignmentUserIds: Array<string>,
@@ -2984,6 +3000,8 @@ interface FragmentTypes {
   CommentModeratorActionDisplay: CommentModeratorActionDisplay
   ModerationTemplatesDefaultFragment: ModerationTemplatesDefaultFragment
   ModerationTemplateFragment: ModerationTemplateFragment
+  CommentApprovalsDefaultFragment: CommentApprovalsDefaultFragment
+  CommentApprovalWithoutComment: CommentApprovalWithoutComment
   SuggestAlignmentComment: SuggestAlignmentComment
 }
 
@@ -3159,8 +3177,10 @@ interface CollectionNamesByFragmentName {
   CommentModeratorActionDisplay: "CommentModeratorActions"
   ModerationTemplatesDefaultFragment: "ModerationTemplates"
   ModerationTemplateFragment: "ModerationTemplates"
+  CommentApprovalsDefaultFragment: "CommentApprovals"
+  CommentApprovalWithoutComment: "CommentApprovals"
   SuggestAlignmentComment: "Comments"
 }
 
-type CollectionNameString = "AdvisorRequests"|"Bans"|"Books"|"Chapters"|"ClientIds"|"Collections"|"CommentModeratorActions"|"Comments"|"Conversations"|"DatabaseMetadata"|"DebouncerEvents"|"EmailTokens"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"LegacyData"|"Localgroups"|"Messages"|"Migrations"|"ModerationTemplates"|"ModeratorActions"|"Notifications"|"PetrovDayLaunchs"|"PodcastEpisodes"|"Podcasts"|"PostRelations"|"Posts"|"RSSFeeds"|"ReadStatuses"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Spotlights"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"UserTagRels"|"Users"|"Votes"
+type CollectionNameString = "AdvisorRequests"|"Bans"|"Books"|"Chapters"|"ClientIds"|"Collections"|"CommentApprovals"|"CommentModeratorActions"|"Comments"|"Conversations"|"DatabaseMetadata"|"DebouncerEvents"|"EmailTokens"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"LegacyData"|"Localgroups"|"Messages"|"Migrations"|"ModerationTemplates"|"ModeratorActions"|"Notifications"|"PetrovDayLaunchs"|"PodcastEpisodes"|"Podcasts"|"PostRelations"|"Posts"|"RSSFeeds"|"ReadStatuses"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Spotlights"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"UserTagRels"|"Users"|"Votes"
 

--- a/packages/lesswrong/lib/generated/viewTypes.ts
+++ b/packages/lesswrong/lib/generated/viewTypes.ts
@@ -4,6 +4,7 @@ type BooksViewName = never
 type ChaptersViewName = "SequenceChapters";
 type ClientIdsViewName = never
 type CollectionsViewName = never
+type CommentApprovalsViewName = never
 type CommentModeratorActionsViewName = "activeCommentModeratorActions";
 type CommentsViewName = "commentReplies"|"postCommentsDeleted"|"allCommentsDeleted"|"postCommentsTop"|"afPostCommentsTop"|"postCommentsOld"|"postCommentsNew"|"postCommentsBest"|"postLWComments"|"profileRecentComments"|"allRecentComments"|"recentComments"|"afSubmissions"|"recentDiscussionThread"|"afRecentDiscussionThread"|"postsItemComments"|"sunshineNewCommentsList"|"questionAnswers"|"legacyIdComment"|"sunshineNewUsersComments"|"defaultModeratorResponses"|"repliesToAnswer"|"topShortform"|"shortform"|"repliesToCommentThread"|"shortformLatestChildren"|"nominations2018"|"nominations2019"|"reviews2018"|"reviews2019"|"reviews"|"tagDiscussionComments"|"tagSubforumComments"|"moderatorComments"|"alignmentSuggestedComments"|"rss";
 type ConversationsViewName = "moderatorConversations"|"userConversations"|"userGroupUntitledConversations";
@@ -47,6 +48,7 @@ interface ViewTermsByCollectionName {
   Chapters: ChaptersViewTerms
   ClientIds: ViewTermsBase
   Collections: ViewTermsBase
+  CommentApprovals: ViewTermsBase
   CommentModeratorActions: CommentModeratorActionsViewTerms
   Comments: CommentsViewTerms
   Conversations: ConversationsViewTerms

--- a/packages/lesswrong/lib/index.ts
+++ b/packages/lesswrong/lib/index.ts
@@ -187,6 +187,11 @@ import './collections/commentModeratorActions/index';
 // ModerationTemplates
 import './collections/moderationTemplates/index';
 
+// Comment approvals
+import './collections/commentApprovals/collection';
+import './collections/commentApprovals/views';
+import './collections/commentApprovals/fragments';
+
 // Internationalization
 import './i18n-en-us/en_US';
 

--- a/packages/lesswrong/lib/permissions.ts
+++ b/packages/lesswrong/lib/permissions.ts
@@ -8,3 +8,5 @@ export const canModeratePersonalGroup = createGroup("canModeratePersonal");
 export const canCommentLockGroup = createGroup("canCommentLock");
 export const tagManagerGroup = createGroup("tagManager");
 export const canSuggestCurationGroup = createGroup("canSuggestCuration");
+export const canRequireCommentApprovalGroup = createGroup("canRequireCommentApproval");
+

--- a/packages/lesswrong/lib/utils/unflatten.ts
+++ b/packages/lesswrong/lib/utils/unflatten.ts
@@ -88,3 +88,26 @@ export function commentTreesEqual<Fragment extends ThreadableCommentType>(a: Arr
   }
   return true;
 }
+
+export function flattenComments<T extends ThreadableCommentType>(commentTree: CommentTreeNode<T>[]): T[] {
+  // Shallow copy to avoid mutating the input
+  const commentTreeClone = [...commentTree];
+  
+  // Prevent cycles if we somehow have them
+  const seenCommentIds = new Set<string>();
+
+  // Results
+  const flattenedComments: T[] = [];
+
+  let nextNode: CommentTreeNode<T> | undefined;
+  // Assignment evaluates to true if an element is returned from `pop`, false otherwise
+  while (nextNode = commentTreeClone.pop()) {
+    if (!seenCommentIds.has(nextNode.item._id)) {
+      flattenedComments.push(nextNode.item);
+      seenCommentIds.add(nextNode.item._id);
+      commentTreeClone.push(...nextNode.children);
+    }
+  }
+
+  return flattenedComments;
+}


### PR DESCRIPTION
Design (mostly copied from the original spec):

- Posts have a setting that means top-level comments follow this new ontology
- Comments have a “pending, approved, rejected” status (`pending` is implicit; any comment on such a post without an explicit `commentApproval` of either `approved` or `rejected` will be considered `pending`).
- Comments Section has two sub-sections: Main Comments (pending & approved) + “Rejected Comments” (we need to figure out the name for the section...)
- Comments start out in Main Comments but pending and cannot be replied to. There is a visible indication on the post “this comment is pending, can’t be replied” for readers. For the author/mods, there should be really high visibility of pending comments via some system.
- If the author/mod approves a comment, it can be replied to. We might want UI that makes it clearer which comments can be replied to.
- If author/mod rejects the comment, they get a UI which lets them indicate reason and the comment is moved to the disapproved section, and has the reason displayed.
