### PR TITLE
add back the ability to hide moderator comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentFrame.tsx
+++ b/packages/lesswrong/components/comments/CommentFrame.tsx
@@ -155,7 +155,7 @@ const CommentFrame = ({comment, treeOptions, onClick, id, nestingLevel, hasChild
       [classes.condensed]: condensed,
       [classes.shortformTop]: postPage && shortform && (nestingLevel===1),
       [classes.hoverPreview]: hoverPreview,
-      [classes.moderatorHat]: comment.moderatorHat,
+      [classes.moderatorHat]: comment.hideModeratorHat ? false : comment.moderatorHat,
       [classes.promoted]: comment.promoted
     }
   )

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -311,15 +311,15 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
    * 1) it has the moderatorHat
    * 2) the user is either an admin, or the moderatorHat isn't deliberately hidden
    */
-  // const showModeratorCommentAnnotation = comment.moderatorHat && (
-  //   userIsAdmin(currentUser)
-  //     ? true
-  //     : !comment.hideModeratorHat
-  //   );
+  const showModeratorCommentAnnotation = comment.moderatorHat && (
+    userIsAdmin(currentUser)
+      ? true
+      : !comment.hideModeratorHat
+    );
   
-  // const moderatorCommentAnnotation = comment.hideModeratorHat
-  //   ? 'Moderator Comment (Invisible)'
-  //   : 'Moderator Comment';
+  const moderatorCommentAnnotation = comment.hideModeratorHat
+    ? 'Moderator Comment (Invisible)'
+    : 'Moderator Comment';
   
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>
@@ -385,8 +385,8 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               scrollIntoView={scrollIntoView}
               scrollOnClick={postPage && !isParentComment}
             />
-            {comment.moderatorHat && <span className={classes.moderatorHat}>
-              Moderator Comment
+            {showModeratorCommentAnnotation && <span className={classes.moderatorHat}>
+              {moderatorCommentAnnotation}
             </span>}
             <SmallSideVote
               document={comment}

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -47,6 +47,7 @@ registerFragment(`
     shortform
     lastSubthreadActivity
     moderatorHat
+    hideModeratorHat
     nominatedForReview
     reviewingForReview
     promoted

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -597,6 +597,7 @@ const schema: SchemaType<DbComment> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     ...schemaDefaultValue(false),
+    hidden: true
   },
 
   /**
@@ -613,6 +614,7 @@ const schema: SchemaType<DbComment> = {
       if (!newDocument.moderatorHat) return null;
       return newDocument.hideModeratorHat;
     },
+    hidden: true
   },
 
   // whether this comment is pinned on the author's profile

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1202,6 +1202,7 @@ interface CommentsList { // fragment on Comments
   readonly shortform: boolean,
   readonly lastSubthreadActivity: Date,
   readonly moderatorHat: boolean,
+  readonly hideModeratorHat: boolean | null,
   readonly nominatedForReview: string,
   readonly reviewingForReview: string,
   readonly promoted: boolean,


### PR DESCRIPTION
Adds back the ability to make "invisible" mod comments that was originally introduced in https://github.com/ForumMagnum/ForumMagnum/pull/5992 and later removed for breaking crossposts.  Now that we're using a regular REST API to fetch crosspost data instead of a GraphQL query which throws errors on unknown fields (like a newly-added `hideModeratorHat` which one forum has deployed but the other doesn't), this should be safe.

This needs needs the EA forum to deploy last week's PR for using that new API, though it should be safe for LW to deploy this (since the EA forum has deployed the route itself, and LW is already using the new API, so won't break if we add a new field).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203414603091674) by [Unito](https://www.unito.io)
