### PR TITLE
Enable auto as an option for LW users set their theme to

### DIFF
--- a/packages/lesswrong/themes/themeNames.ts
+++ b/packages/lesswrong/themes/themeNames.ts
@@ -52,6 +52,10 @@ export const themeMetadata: Array<ThemeMetadata> = forumTypeSetting.get() === "E
       name: "dark",
       label: "Dark Mode",
     },
+    {
+      name: "auto",
+      label: "Auto",
+    },
   ];
 
 export function isValidSerializedThemeOptions(options: string|object): options is string | AbstractThemeOptions {


### PR DESCRIPTION
Consider this, like, an open source contribution from a user who wants the feature.

I checked this out on an assortment of LW-specialized pages, but of course I can't do a perfect job testing without your data. However, I expect the combination of y'all already having dark mode, and us having caught the small issues with useTheme to make this very low risk.

This does *not* set the default to be auto. Just allows users (such as myself) to select it as an option from the dropdown.

![image](https://user-images.githubusercontent.com/10352319/203156261-cafd47c6-ad23-4563-bfc2-8bb527e64fc1.png)

The benefit of this is that I won't have to burn my eyes reading LW at 9pm hours after sundown, while also maintaining my nice, sunny UI during the day. About 50% of users have a computer that changes theme based on time of day according to my scientific poll:

![image](https://user-images.githubusercontent.com/10352319/203156776-149eba3b-af51-4590-bd34-ab96b8de90ce.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203415096340437) by [Unito](https://www.unito.io)
