### PR TITLE
Subforums mixed type feed

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -26,14 +26,14 @@ const getQuery = ({resolverName, resolverArgs, fragmentArgs, sortKeyType, render
   renderers: any,
 }) => {
   const fragmentsUsed = _.filter(Object.keys(renderers).map(r => renderers[r].fragmentName), f=>f);
-  const queryArgsList=["$limit: Int", "$cutoff: Date", "$offset: Int",
+  const queryArgsList=["$limit: Int", `$cutoff: ${sortKeyType}`, "$offset: Int",
     ...(resolverArgs ? Object.keys(resolverArgs).map(k => `$${k}: ${resolverArgs[k]}`) : []),
     ...(fragmentArgs ? Object.keys(fragmentArgs).map(k => `$${k}: ${fragmentArgs[k]}`) : []),
   ];
   const resolverArgsList=["limit: $limit", "cutoff: $cutoff", "offset: $offset",
     ...(resolverArgs ? Object.keys(resolverArgs).map(k => `${k}: $${k}`) : []),
   ];
-  
+
   return gql`
     query ${resolverName}Query(${queryArgsList.join(", ")}) {
       ${resolverName}(${resolverArgsList.join(", ")}) {

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -32,9 +32,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const PostsListSortDropdown = ({classes, value, sortingParam="sortedBy"}:{
+const defaultOptions = Object.keys(TAG_POSTS_SORT_ORDER_OPTIONS)
+
+const PostsListSortDropdown = ({classes, value, options=defaultOptions, sortingParam="sortedBy"}:{
   classes: ClassesType,
   value: string
+  options?: string[],
   sortingParam?: string,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
@@ -48,7 +51,7 @@ const PostsListSortDropdown = ({classes, value, sortingParam="sortedBy"}:{
       anchorEl={anchorEl}
       onClose={()=>setAnchorEl(null)}
     >
-      {Object.keys(TAG_POSTS_SORT_ORDER_OPTIONS).map(sorting => (
+      {options.map(sorting => (
         <QueryLink key={sorting} query={{[sortingParam]:sorting}} merge>
           <MenuItem value={sorting} onClick={()=>setAnchorEl(null)}>
             {TAG_POSTS_SORT_ORDER_OPTIONS[sorting].label}

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -32,7 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const defaultOptions = Object.keys(TAG_POSTS_SORT_ORDER_OPTIONS)
+const defaultOptions = Object.keys(TAG_POSTS_SORT_ORDER_OPTIONS);
 
 const PostsListSortDropdown = ({classes, value, options=defaultOptions, sortingParam="sortedBy"}:{
   classes: ClassesType,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -118,7 +118,7 @@ const RecentDiscussionThread = ({
   classes,
 }: {
   post: PostsRecentDiscussion,
-  comments: Array<CommentsList>,
+  comments?: Array<CommentsList>,
   refetch: any,
   expandAllThreads?: boolean,
   classes: ClassesType,
@@ -150,7 +150,7 @@ const RecentDiscussionThread = ({
   const { PostsGroupDetails, PostsItemMeta, CommentsNode, PostsHighlight, PostsPageActions } = Components
 
   const lastCommentId = comments && comments[0]?._id
-  const nestedComments = unflattenComments(comments);
+  const nestedComments = unflattenComments(comments ?? []);
 
   const lastVisitedAt = markedAsVisitedAt || post.lastVisitedAt
 
@@ -196,9 +196,9 @@ const RecentDiscussionThread = ({
             <PostsHighlight post={post} maxLengthWords={lastVisitedAt ? 50 : 170} />
           </div>
         </div>
-        {nestedComments.length ? <div className={classes.content}>
+        <div className={classes.content}>
           <div className={classes.commentsList}>
-            {nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
+            {!!nestedComments.length && nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
               <div key={comment.item._id}>
                 <CommentsNode
                   treeOptions={treeOptions}
@@ -212,7 +212,7 @@ const RecentDiscussionThread = ({
               </div>
             )}
           </div>
-        </div> : null}
+        </div>
       </div>
     </AnalyticsContext>
   )

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -21,6 +21,8 @@ import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import AddBoxIcon from "@material-ui/icons/AddBox";
 import qs from "qs";
+import startCase from "lodash/startCase";
+import { subforumSortingTypes } from "../../lib/subforumSortings";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -458,6 +460,7 @@ const TagSubforumPage2 = ({classes}: {
       enableGuidelines: false,
       displayMode: "minimalist" as const,
     };
+    const sortBy = query.sortedBy ?? "new";
     return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
       <div className={classes.feedHeader}>
         <div className={classes.feedHeaderButtons}>
@@ -474,15 +477,13 @@ const TagSubforumPage2 = ({classes}: {
         firstPageSize={10}
         pageSize={20}
         refetchRef={refetchRef}
-        resolverName="SubforumFeed"
-        sortKeyType="Date"
+        resolverName={`Subforum${startCase(sortBy)}Feed`}
+        sortKeyType={subforumSortingTypes[sortBy]}
         resolverArgs={{
-          sort: 'String',
           tagId: 'String!',
           af: 'Boolean',
         }}
         resolverArgsValues={{
-          sort: query.sortedBy,
           tagId: tag._id,
           af: false,
         }}
@@ -496,7 +497,7 @@ const TagSubforumPage2 = ({classes}: {
                 <RecentDiscussionThread
                   key={post._id}
                   post={{...post, recentComments: []}}
-                  comments={[]}
+                  comments={undefined}
                   refetch={refetch}
                 />
               </div>

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -155,7 +155,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   tableOfContentsWrapper: {
     padding: 24,
-  }
+  },
+  feedPostWrapper: {
+    marginTop: 32,
+  },
 });
 
 export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
@@ -462,12 +465,14 @@ const TagSubforumPage2 = ({classes}: {
         tagSubforumPosts: {
           fragmentName: "PostsList",
           render: (post: PostsList) => (
-            <RecentDiscussionThread
-              key={post._id}
-              post={{...post, recentComments: []}}
-              comments={[]}
-              refetch={refetch}
-            />
+            <div className={classes.feedPostWrapper}>
+              <RecentDiscussionThread
+                key={post._id}
+                post={{...post, recentComments: []}}
+                comments={[]}
+                refetch={refetch}
+              />
+            </div>
           )
         },
         tagSubforumComments: {

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -50,9 +50,6 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   contentGivenImage: {
     marginTop: 185,
-    [theme.breakpoints.down('sm')]: {
-      marginTop: 130,
-    },
   },
   imageContainer: {
     position: 'absolute',

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -19,6 +19,7 @@ import { forumTypeSetting, taggingNameCapitalSetting, taggingNamePluralCapitalSe
 import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
+import AddBoxIcon from "@material-ui/icons/AddBox";
 import qs from "qs";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
@@ -156,6 +157,18 @@ export const styles = (theme: ThemeType): JssStyles => ({
   tableOfContentsWrapper: {
     padding: 24,
   },
+  feedWrapper: {
+    padding: "0 10px",
+  },
+  feedHeader: {
+    display: "flex",
+    marginBottom: -16,
+  },
+  feedHeaderButtons: {
+    display: "flex",
+    flexGrow: 1,
+    columnGap: 16,
+  },
   feedPostWrapper: {
     marginTop: 32,
   },
@@ -184,7 +197,7 @@ const TagSubforumPage2 = ({classes}: {
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography,
     TagPageButtonRow, RightSidebarColumn, SubscribeButton, CloudinaryImage2, TagIntroSequence,
     SectionTitle, TagTableOfContents, ContentStyles, SidebarSubtagsBox, MixedTypeFeed,
-    CommentWithReplies, RecentDiscussionThread,
+    SectionButton, CommentWithReplies, RecentDiscussionThread,
   } = Components;
   const currentUser = useCurrentUser();
   const { history } = useNavigation();
@@ -445,49 +458,63 @@ const TagSubforumPage2 = ({classes}: {
       enableGuidelines: false,
       displayMode: "minimalist" as const,
     };
-    return <MixedTypeFeed
-      firstPageSize={10}
-      pageSize={20}
-      refetchRef={refetchRef}
-      resolverName="SubforumFeed"
-      sortKeyType="Date"
-      resolverArgs={{
-        tagId: 'String!',
-        af: 'Boolean',
-      }}
-      resolverArgsValues={{
-        tagId: tag._id,
-        af: false,
-      }}
-      fragmentArgs={{}}
-      fragmentArgsValues={{}}
-      renderers={{
-        tagSubforumPosts: {
-          fragmentName: "PostsList",
-          render: (post: PostsList) => (
-            <div className={classes.feedPostWrapper}>
-              <RecentDiscussionThread
-                key={post._id}
-                post={{...post, recentComments: []}}
-                comments={[]}
-                refetch={refetch}
+    console.log("sort", query.sortedBy);
+    return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
+      <div className={classes.feedHeader}>
+        <div className={classes.feedHeaderButtons}>
+          <SectionButton>
+            <AddBoxIcon /> New Post
+          </SectionButton>
+          <SectionButton>
+            <AddBoxIcon /> New Discussion
+          </SectionButton>
+        </div>
+        <PostsListSortDropdown value={query.sortedBy} />
+      </div>
+      <MixedTypeFeed
+        firstPageSize={10}
+        pageSize={20}
+        refetchRef={refetchRef}
+        resolverName="SubforumFeed"
+        sortKeyType="Date"
+        resolverArgs={{
+          tagId: 'String!',
+          af: 'Boolean',
+        }}
+        resolverArgsValues={{
+          tagId: tag._id,
+          af: false,
+        }}
+        fragmentArgs={{}}
+        fragmentArgsValues={{}}
+        renderers={{
+          tagSubforumPosts: {
+            fragmentName: "PostsList",
+            render: (post: PostsList) => (
+              <div className={classes.feedPostWrapper}>
+                <RecentDiscussionThread
+                  key={post._id}
+                  post={{...post, recentComments: []}}
+                  comments={[]}
+                  refetch={refetch}
+                />
+              </div>
+            )
+          },
+          tagSubforumComments: {
+            fragmentName: "CommentWithRepliesFragment",
+            render: (comment: CommentWithRepliesFragment) => (
+              <CommentWithReplies
+                key={comment._id}
+                comment={comment}
+                commentNodeProps={commentNodeProps}
+                initialMaxChildren={5}
               />
-            </div>
-          )
-        },
-        tagSubforumComments: {
-          fragmentName: "CommentWithRepliesFragment",
-          render: (comment: CommentWithRepliesFragment) => (
-            <CommentWithReplies
-              key={comment._id}
-              comment={comment}
-              commentNodeProps={commentNodeProps}
-              initialMaxChildren={5}
-            />
-          )
-        },
-      }}
-    />
+            )
+          },
+        }}
+      />
+    </div>
   }
 
   return (
@@ -523,7 +550,7 @@ const TagSubforumPage2 = ({classes}: {
           }
           header={headerComponent}
         >
-          {tab === "wiki" ? wikiComponent : <p className={classes.centralColumn}><SubforumFeed /></p>}
+          {tab === "wiki" ? wikiComponent : <SubforumFeed />}
         </RightSidebarColumn>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -21,7 +21,7 @@ import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import AddBoxIcon from "@material-ui/icons/AddBox";
 import qs from "qs";
-import { isSubforumSorting, SubforumSorting, subforumSortingToResolverName, subforumSortingTypes } from "../../lib/subforumSortings";
+import { isSubforumSorting, SubforumSorting, subforumSortings, subforumSortingToResolverName, subforumSortingTypes } from "../../lib/subforumSortings";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -470,7 +470,7 @@ const TagSubforumPage2 = ({classes}: {
             <AddBoxIcon /> New Discussion
           </SectionButton>
         </div>
-        <PostsListSortDropdown value={query.sortedBy} />
+        <PostsListSortDropdown value={query.sortedBy} options={subforumSortings} />
       </div>
       <MixedTypeFeed
         firstPageSize={10}

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -181,7 +181,7 @@ const TagSubforumPage2 = ({classes}: {
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography,
     TagPageButtonRow, RightSidebarColumn, SubscribeButton, CloudinaryImage2, TagIntroSequence,
     SectionTitle, TagTableOfContents, ContentStyles, SidebarSubtagsBox, MixedTypeFeed,
-    CommentWithReplies,
+    CommentWithReplies, RecentDiscussionThread,
   } = Components;
   const currentUser = useCurrentUser();
   const { history } = useNavigation();
@@ -459,12 +459,23 @@ const TagSubforumPage2 = ({classes}: {
       fragmentArgs={{}}
       fragmentArgsValues={{}}
       renderers={{
+        tagSubforumPosts: {
+          fragmentName: "PostsList",
+          render: (post: PostsList) => (
+            <RecentDiscussionThread
+              key={post._id}
+              post={{...post, recentComments: []}}
+              comments={[]}
+              refetch={refetch}
+            />
+          )
+        },
         tagSubforumComments: {
           fragmentName: "CommentWithRepliesFragment",
           render: (comment: CommentWithRepliesFragment) => (
             <CommentWithReplies
-              comment={comment}
               key={comment._id}
+              comment={comment}
               commentNodeProps={commentNodeProps}
               initialMaxChildren={5}
             />

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -464,6 +464,8 @@ const TagSubforumPage2 = ({classes}: {
       displayMode: "minimalist" as const,
     };
     const sortBy: SubforumSorting = isSubforumSorting(query.sortedBy) ? query.sortedBy : defaultSubforumSorting;
+    const maxAgeHours = 18;
+    const commentsLimit = (currentUser && currentUser.isAdmin) ? 4 : 3;
     return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
       <div className={classes.feedHeader}>
         <div className={classes.feedHeaderButtons}>
@@ -490,17 +492,23 @@ const TagSubforumPage2 = ({classes}: {
           tagId: tag._id,
           af: false,
         }}
-        fragmentArgs={{}}
-        fragmentArgsValues={{}}
+        fragmentArgs={{
+          maxAgeHours: 'Int',
+          commentsLimit: 'Int',
+        }}
+        fragmentArgsValues={{
+          maxAgeHours,
+          commentsLimit,
+        }}
         renderers={{
           tagSubforumPosts: {
-            fragmentName: "PostsList",
-            render: (post: PostsList) => (
+            fragmentName: "PostsRecentDiscussion",
+            render: (post: PostsRecentDiscussion) => (
               <div className={classes.feedPostWrapper}>
                 <RecentDiscussionThread
                   key={post._id}
-                  post={{...post, recentComments: []}}
-                  comments={undefined}
+                  post={{...post}}
+                  comments={post.recentComments}
                   refetch={refetch}
                 />
               </div>

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -458,7 +458,6 @@ const TagSubforumPage2 = ({classes}: {
       enableGuidelines: false,
       displayMode: "minimalist" as const,
     };
-    console.log("sort", query.sortedBy);
     return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
       <div className={classes.feedHeader}>
         <div className={classes.feedHeaderButtons}>
@@ -478,10 +477,12 @@ const TagSubforumPage2 = ({classes}: {
         resolverName="SubforumFeed"
         sortKeyType="Date"
         resolverArgs={{
+          sort: 'String',
           tagId: 'String!',
           af: 'Boolean',
         }}
         resolverArgsValues={{
+          sort: query.sortedBy,
           tagId: tag._id,
           af: false,
         }}

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -21,8 +21,7 @@ import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import AddBoxIcon from "@material-ui/icons/AddBox";
 import qs from "qs";
-import startCase from "lodash/startCase";
-import { subforumSortingTypes } from "../../lib/subforumSortings";
+import { isSubforumSorting, SubforumSorting, subforumSortingToResolverName, subforumSortingTypes } from "../../lib/subforumSortings";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -460,7 +459,7 @@ const TagSubforumPage2 = ({classes}: {
       enableGuidelines: false,
       displayMode: "minimalist" as const,
     };
-    const sortBy = query.sortedBy ?? "new";
+    const sortBy: SubforumSorting = isSubforumSorting(query.sortedBy) ? query.sortedBy : "new";
     return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
       <div className={classes.feedHeader}>
         <div className={classes.feedHeaderButtons}>
@@ -477,7 +476,7 @@ const TagSubforumPage2 = ({classes}: {
         firstPageSize={10}
         pageSize={20}
         refetchRef={refetchRef}
-        resolverName={`Subforum${startCase(sortBy)}Feed`}
+        resolverName={`Subforum${subforumSortingToResolverName(sortBy)}Feed`}
         sortKeyType={subforumSortingTypes[sortBy]}
         resolverArgs={{
           tagId: 'String!',

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -21,7 +21,14 @@ import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import AddBoxIcon from "@material-ui/icons/AddBox";
 import qs from "qs";
-import { isSubforumSorting, SubforumSorting, subforumSortings, subforumSortingToResolverName, subforumSortingTypes } from "../../lib/subforumSortings";
+import {
+  defaultSubforumSorting,
+  isSubforumSorting,
+  SubforumSorting,
+  subforumSortings,
+  subforumSortingToResolverName,
+  subforumSortingTypes,
+} from "../../lib/subforumSortings";
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -459,7 +466,7 @@ const TagSubforumPage2 = ({classes}: {
       enableGuidelines: false,
       displayMode: "minimalist" as const,
     };
-    const sortBy: SubforumSorting = isSubforumSorting(query.sortedBy) ? query.sortedBy : "new";
+    const sortBy: SubforumSorting = isSubforumSorting(query.sortedBy) ? query.sortedBy : defaultSubforumSorting;
     return <div className={classNames(classes.centralColumn, classes.feedWrapper)}>
       <div className={classes.feedHeader}>
         <div className={classes.feedHeaderButtons}>

--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -19,7 +19,7 @@ export const closeDatabaseConnection = async () => {
 export const isAnyQueryPending = () => (inProgressQueries > 0);
 
 const disableAllWrites = false;
-const logQueries = false;
+const logQueries = true;
 const debugQueryBatches = false;
 let inProgressQueries = 0;
 let onBatchFinished: Promise<void>|null = null;

--- a/packages/lesswrong/lib/mongoCollection.ts
+++ b/packages/lesswrong/lib/mongoCollection.ts
@@ -19,7 +19,7 @@ export const closeDatabaseConnection = async () => {
 export const isAnyQueryPending = () => (inProgressQueries > 0);
 
 const disableAllWrites = false;
-const logQueries = true;
+const logQueries = false;
 const debugQueryBatches = false;
 let inProgressQueries = 0;
 let onBatchFinished: Promise<void>|null = null;

--- a/packages/lesswrong/lib/subforumSortings.ts
+++ b/packages/lesswrong/lib/subforumSortings.ts
@@ -13,6 +13,8 @@ export const subforumSortingTypes = {
 
 export type SubforumSorting = keyof typeof subforumSortingTypes;
 
+export const defaultSubforumSorting: SubforumSorting = "magic";
+
 export const subforumSortings = Object.keys(subforumSortingTypes) as SubforumSorting[];
 
 export const subforumSortingToResolverName = (sort: SubforumSorting) =>

--- a/packages/lesswrong/lib/subforumSortings.ts
+++ b/packages/lesswrong/lib/subforumSortings.ts
@@ -1,8 +1,14 @@
+/**
+ * This is the one-source-of-truth for sortings that are available on subforums.
+ * As well as defining the GraphQL types for sorting, this also defines the order
+ * in which the options are shown in the dropdown list.
+ */
 export const subforumSortingTypes = {
-  recentComments: "Date",
+  magic: "Float",
   new: "Date",
   old: "Date",
   top: "Int",
+  recentComments: "Date",
 } as const;
 
 export type SubforumSorting = keyof typeof subforumSortingTypes;

--- a/packages/lesswrong/lib/subforumSortings.ts
+++ b/packages/lesswrong/lib/subforumSortings.ts
@@ -1,0 +1,9 @@
+export const subforumSortingTypes = {
+  new: "Date",
+  old: "Date",
+  top: "Int",
+} as const;
+
+export const subforumSortings = Object.keys(subforumSortingTypes);
+
+export type SubforumSorting = keyof typeof subforumSortingTypes;

--- a/packages/lesswrong/lib/subforumSortings.ts
+++ b/packages/lesswrong/lib/subforumSortings.ts
@@ -1,9 +1,16 @@
 export const subforumSortingTypes = {
+  recentComments: "Date",
   new: "Date",
   old: "Date",
   top: "Int",
 } as const;
 
-export const subforumSortings = Object.keys(subforumSortingTypes);
-
 export type SubforumSorting = keyof typeof subforumSortingTypes;
+
+export const subforumSortings = Object.keys(subforumSortingTypes) as SubforumSorting[];
+
+export const subforumSortingToResolverName = (sort: SubforumSorting) =>
+  sort[0].toUpperCase() + sort.slice(1);
+
+export const isSubforumSorting = (sort: string): sort is SubforumSorting =>
+  (subforumSortings as string []).includes(sort);

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -19,7 +19,13 @@ import take from 'lodash/take';
 import filter from 'lodash/filter';
 import * as _ from 'underscore';
 import { recordSubforumView } from '../../lib/collections/userTagRels/helpers';
-import { SubforumSorting, subforumSortings, subforumSortingToResolverName, subforumSortingTypes } from '../../lib/subforumSortings';
+import {
+  defaultSubforumSorting,
+  SubforumSorting,
+  subforumSortings,
+  subforumSortingToResolverName,
+  subforumSortingTypes,
+} from '../../lib/subforumSortings';
 
 type SubforumFeedSort = {
   posts: SubquerySortField<DbPost, keyof DbPost>,
@@ -52,8 +58,7 @@ const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
     },
   }
 
-  const defaultFeedSorting = "new";
-  return feedSortings[sort ?? defaultFeedSorting] ?? feedSortings[defaultFeedSorting];
+  return feedSortings[sort ?? defaultSubforumSorting] ?? feedSortings[defaultSubforumSorting];
 }
 
 const createSubforumFeedResolver = <SortKeyType>(sorting: SubforumFeedSort) => async ({

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -1,5 +1,5 @@
 import { addGraphQLResolvers, addGraphQLQuery, addGraphQLSchema, addGraphQLMutation } from '../../lib/vulcan-lib/graphql';
-import { mergeFeedQueries, defineFeedResolver, viewBasedSubquery, StaticSortField, DynamicSortField, SortDirection } from '../utils/feedUtil';
+import { mergeFeedQueries, defineFeedResolver, viewBasedSubquery, SubquerySortField, SortDirection } from '../utils/feedUtil';
 import { Comments } from '../../lib/collections/comments/collection';
 import { Revisions } from '../../lib/collections/revisions/collection';
 import { Tags } from '../../lib/collections/tags/collection';
@@ -21,19 +21,18 @@ import * as _ from 'underscore';
 import { recordSubforumView } from '../../lib/collections/userTagRels/helpers';
 import { SubforumSorting, subforumSortings, subforumSortingToResolverName, subforumSortingTypes } from '../../lib/subforumSortings';
 
-// type SubforumFeedItem = DbComment | DbPost;
-// type SubforumFeedStaticSort = StaticSortField<SubforumFeedItem, keyof SubforumFeedItem>;
-// type SubforumFeedDynamicSort = DynamicSortField<SubforumFeedItem, Date, keyof SubforumFeedItem>;
-// type SubforumFeedSort = SubforumFeedStaticSort | SubforumFeedDynamicSort;
-
 type SubforumFeedSort = {
-  posts: StaticSortField<DbPost, keyof DbPost>,
-  comments: StaticSortField<DbComment, keyof DbComment>,
+  posts: SubquerySortField<DbPost, keyof DbPost>,
+  comments: SubquerySortField<DbComment, keyof DbComment>,
   sortDirection?: SortDirection,
 }
 
 const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
   const feedSortings: Record<SubforumSorting, SubforumFeedSort> = {
+    magic: {
+      posts: { sortField: "score" },
+      comments: { sortField: "score" },
+    },
     new: {
       posts: { sortField: "postedAt" },
       comments: { sortField: "postedAt" },
@@ -51,7 +50,6 @@ const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
       posts: { sortField: "lastCommentedAt" },
       comments: { sortField: "lastSubthreadActivity" },
     },
-    // magic: 0, // score - probably needs more
   }
 
   const defaultFeedSorting = "new";

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -25,8 +25,10 @@ type SubforumFeedStaticSort = StaticSortField<SubforumFeedItem, keyof SubforumFe
 type SubforumFeedDynamicSort = DynamicSortField<SubforumFeedItem, Date, keyof SubforumFeedItem>;
 type SubforumFeedSort = SubforumFeedStaticSort | SubforumFeedDynamicSort;
 
+type SubforumSorting = "new" | "old" | "top";
+
 const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
-  const feedSortings: Record<string, SubforumFeedSort> = {
+  const feedSortings: Record<SubforumSorting, SubforumFeedSort> = {
     // relevance: 0, // Does this even make sense here?
     // magic: 0, // score - probably needs more
     // recentComments: 0, // lastCommentedAt

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -93,6 +93,8 @@ const createSubforumFeedResolver = <SortKeyType>(sorting: SubforumFeedSort) => a
       context,
       selector: {
         tagId,
+        tagCommentType: "SUBFORUM",
+        topLevelCommentId: {$exists: false},
         ...(af ? {af: true} : undefined),
       },
     }),

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -34,12 +34,6 @@ type SubforumFeedSort = {
 
 const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
   const feedSortings: Record<SubforumSorting, SubforumFeedSort> = {
-    // relevance: 0, // Does this even make sense here?
-    // magic: 0, // score - probably needs more
-    recentComments: {
-      posts: { sortField: "lastCommentedAt" },
-      comments: { sortField: "lastSubthreadActivity" },
-    },
     new: {
       posts: { sortField: "postedAt" },
       comments: { sortField: "postedAt" },
@@ -53,6 +47,11 @@ const getSubforumFeedSorting = (sort?: string): SubforumFeedSort => {
       posts: { sortField: "baseScore" },
       comments: { sortField: "baseScore" },
     },
+    recentComments: {
+      posts: { sortField: "lastCommentedAt" },
+      comments: { sortField: "lastSubthreadActivity" },
+    },
+    // magic: 0, // score - probably needs more
   }
 
   const defaultFeedSorting = "new";

--- a/packages/lesswrong/server/utils/feedUtil.ts
+++ b/packages/lesswrong/server/utils/feedUtil.ts
@@ -111,7 +111,7 @@ export function defineFeedResolver<CutoffType>({name, resolver, args, cutoffType
 }) {
   addGraphQLSchema(`
     type ${name}QueryResults {
-      cutoff: Date
+      cutoff: ${cutoffTypeGraphQL}
       endOffset: Int!
       results: [${name}EntryType!]
     }


### PR DESCRIPTION
This PR implements the mixed type feed for the new subforum page. Most of the code is just refactoring the `MixedTypeFeed` GraphQL queries to allow more arbitrary sorting than is needed for the recent discussions section.

Fow now, the "New Post" and "New Discussion" buttons don't do anything since I'm not sure exactly how we want to handle this - I think it makes sense to do that in a separate PR anyway. (Also, maybe they should have different icons).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203420879434471) by [Unito](https://www.unito.io)
