### PR TITLE
add emoji reaction voting system

### DIFF
--- a/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
@@ -28,12 +28,29 @@ const styles = (theme: ThemeType): JssStyles => ({
   voteButtonSelected: {
     background: theme.palette.grey[200],
   },
+  emojiReactionsAxisRoot: {
+    marginLeft: 10,
+  },
+  addReactionIcon: {
+    verticalAlign: 'text-bottom',
+    fontSize: 20,
+    cursor: "pointer",
+    '& g': {
+      fill: theme.palette.grey[500],
+    },
+    '@media (hover: hover)': {
+      "&:hover": {
+        '& g': {
+          fill: theme.palette.grey[300],
+        }
+      },
+    },
+  },
   scores: {
     display: 'inline-block',
     fontFamily: theme.typography.commentStyle.fontFamily,
     fontSize: 12,
     lineHeight: '12px',
-    marginLeft: 16
   },
   score: {
     display: "inline-flex",
@@ -41,7 +58,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: '6px 6px 4px',
     borderRadius: 3,
     border: theme.palette.border.extraFaint,
-    marginRight: 4,
+    marginLeft: 4,
   },
   icon: {
     color: theme.palette.text.slightlyDim,
@@ -52,7 +69,7 @@ interface EmojiReactionVoteOnCommentProps extends CommentVotingComponentProps {
   classes: ClassesType
 }
 
-const ReactionDisplay = ({reaction, voteProps, classes}: {
+const EmojiReaction = ({reaction, voteProps, classes}: {
   reaction: EmojiReaction,
   voteProps: VotingProps<VoteableTypeClient>,
   classes: ClassesType,
@@ -97,24 +114,32 @@ const BallotEmojiReaction = ({reaction, voteProps, classes}: {
   </div>
 }
 
-const EmojiReactionVoteOnComment = ({document, hideKarma=false, collection, votingSystem, classes}: EmojiReactionVoteOnCommentProps) => {
-  const voteProps = useVote(document, collection.options.collectionName, votingSystem)
+const EmojiReactionsAxis = ({voteProps, classes}: {
+  voteProps: VotingProps<VoteableTypeClient>,
+  classes: ClassesType,
+}) => {
   const { hover, anchorEl, eventHandlers } = useHover()
   
-  const { OverallVoteAxis, PopperCard } = Components
+  const { PopperCard } = Components
   
-  return <span className={classes.root} {...eventHandlers}>
-    <OverallVoteAxis
-      document={document}
-      hideKarma={hideKarma}
-      voteProps={voteProps}
-      hideTooltips
-    />
-    
+  // Only show the +reaction icon if there aren't any reactions yet.
+  // Icon borrowed from here: https://iconduck.com/icons/67395/emoji-add
+  const hasReactions = emojiReactions.some(reaction => voteProps.document?.extendedScore?.[reaction.name])
+  
+  return <span className={classes.emojiReactionsAxisRoot} {...eventHandlers}>
     <span className={classes.scores}>
       {emojiReactions.map(reaction =>
-        <ReactionDisplay key={reaction.name} reaction={reaction} voteProps={voteProps} classes={classes}/>
+        <EmojiReaction key={reaction.name} reaction={reaction} voteProps={voteProps} classes={classes}/>
       )}
+      {!hasReactions && <svg className={classNames("MuiSvgIcon-root", classes.addReactionIcon)} fill="none" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+        <g fill="#212121">
+          <path d="m13 7c0-3.31371-2.6863-6-6-6-3.31371 0-6 2.68629-6 6 0 3.3137 2.68629 6 6 6 .08516 0 .1699-.0018.25419-.0053-.11154-.3168-.18862-.6499-.22673-.9948l-.02746.0001c-2.76142 0-5-2.23858-5-5s2.23858-5 5-5 5 2.23858 5 5l-.0001.02746c.3449.03811.678.11519.9948.22673.0035-.08429.0053-.16903.0053-.25419z"/>
+          <path d="m7.11191 10.4982c.08367-.368.21246-.71893.38025-1.04657-.15911.03174-.32368.04837-.49216.04837-.74037 0-1.40506-.3212-1.86354-.83346-.18417-.20576-.50026-.22327-.70603-.03911-.20576.18417-.22327.50026-.03911.70603.64016.71524 1.57205 1.16654 2.60868 1.16654.03744 0 .07475-.0006.11191-.0018z"/>
+          <path d="m6 6c0 .41421-.33579.75-.75.75s-.75-.33579-.75-.75.33579-.75.75-.75.75.33579.75.75z"/>
+          <path d="m8.75 6.75c.41421 0 .75-.33579.75-.75s-.33579-.75-.75-.75-.75.33579-.75.75.33579.75.75.75z"/>
+          <path d="m15 11.5c0 1.933-1.567 3.5-3.5 3.5s-3.5-1.567-3.5-3.5 1.567-3.5 3.5-3.5 3.5 1.567 3.5 3.5zm-3-2c0-.27614-.2239-.5-.5-.5s-.5.22386-.5.5v1.5h-1.5c-.27614 0-.5.2239-.5.5s.22386.5.5.5h1.5v1.5c0 .2761.2239.5.5.5s.5-.2239.5-.5v-1.5h1.5c.2761 0 .5-.2239.5-.5s-.2239-.5-.5-.5h-1.5z"/>
+        </g>
+      </svg>}
     </span>
     
     {hover && <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom-start">
@@ -122,6 +147,21 @@ const EmojiReactionVoteOnComment = ({document, hideKarma=false, collection, voti
         {emojiReactions.map(react => <BallotEmojiReaction key={react.name} reaction={react} voteProps={voteProps} classes={classes}/>)}
       </div>
     </PopperCard>}
+  </span>
+}
+
+const EmojiReactionVoteOnComment = ({document, hideKarma=false, collection, votingSystem, classes}: EmojiReactionVoteOnCommentProps) => {
+  const voteProps = useVote(document, collection.options.collectionName, votingSystem)
+  
+  const { OverallVoteAxis } = Components
+  
+  return <span className={classes.root}>
+    <OverallVoteAxis
+      document={document}
+      hideKarma={hideKarma}
+      voteProps={voteProps}
+    />
+    <EmojiReactionsAxis voteProps={voteProps} classes={classes} />
   </span>
 }
 

--- a/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { CommentVotingComponentProps, EmojiReaction, emojiReactions } from '../../lib/voting/votingSystems';
+import { useVote, VotingProps } from './withVote';
+import { useHover } from '../common/withHover';
+import { useDialog } from '../common/withDialog';
+import { useCurrentUser } from '../common/withUser';
+import classNames from 'classnames';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+  },
+  hoverBallot: {
+    display: 'flex',
+    columnGap: 6,
+    padding: 6,
+  },
+  voteButton: {
+    padding: '3px 6px',
+    fontSize: 16,
+    cursor: "pointer",
+    "&:hover": {
+      background: theme.palette.background.primaryDim2,
+    },
+  },
+  voteButtonSelected: {
+    background: theme.palette.grey[200],
+  },
+  scores: {
+    display: 'inline-block',
+    fontFamily: theme.typography.commentStyle.fontFamily,
+    fontSize: 12,
+    lineHeight: '12px',
+    marginLeft: 16
+  },
+  score: {
+    display: "inline-flex",
+    columnGap: 4,
+    padding: '6px 6px 4px',
+    borderRadius: 3,
+    border: theme.palette.border.extraFaint,
+    marginRight: 4,
+  },
+  icon: {
+    color: theme.palette.text.slightlyDim,
+  }
+});
+
+interface EmojiReactionVoteOnCommentProps extends CommentVotingComponentProps {
+  classes: ClassesType
+}
+
+const ReactionDisplay = ({reaction, voteProps, classes}: {
+  reaction: EmojiReaction,
+  voteProps: VotingProps<VoteableTypeClient>,
+  classes: ClassesType,
+}) => {
+  const count = voteProps.document?.extendedScore?.[reaction.name] || 0
+  if (!count) return null
+
+  return <div className={classes.score}>
+    <span className={classes.icon}>{reaction.icon}</span>
+    <span>{count}</span>
+  </div>
+}
+
+const BallotEmojiReaction = ({reaction, voteProps, classes}: {
+  reaction: EmojiReaction,
+  voteProps: VotingProps<VoteableTypeClient>,
+  classes: ClassesType,
+}) => {
+  const isSelected = !!voteProps.document?.currentUserExtendedVote?.[reaction.name]
+  const { openDialog } = useDialog()
+  const currentUser = useCurrentUser()
+  
+  return <div className={classNames(classes.voteButton, {[classes.voteButtonSelected]: isSelected})} onClick={() => {
+    if (!currentUser) {
+      openDialog({
+        componentName: "LoginPopup",
+        componentProps: {}
+      })
+    } else {
+      voteProps.vote({
+        document: voteProps.document,
+        voteType: voteProps.document.currentUserVote || null,
+        extendedVote: {
+          ...voteProps.document.currentUserExtendedVote,
+          [reaction.name]: !isSelected,
+        },
+        currentUser,
+      })
+    }
+  }}>
+    {reaction.icon}
+  </div>
+}
+
+const EmojiReactionVoteOnComment = ({document, hideKarma=false, collection, votingSystem, classes}: EmojiReactionVoteOnCommentProps) => {
+  const voteProps = useVote(document, collection.options.collectionName, votingSystem)
+  const { hover, anchorEl, eventHandlers } = useHover()
+  
+  const { OverallVoteAxis, PopperCard } = Components
+  
+  return <span className={classes.root} {...eventHandlers}>
+    <OverallVoteAxis
+      document={document}
+      hideKarma={hideKarma}
+      voteProps={voteProps}
+      showBox={false}
+    />
+    
+    <span className={classes.scores}>
+      {emojiReactions.map(reaction =>
+        <ReactionDisplay key={reaction.name} reaction={reaction} voteProps={voteProps} classes={classes}/>
+      )}
+    </span>
+    
+    {hover && <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom-start">
+      <div className={classes.hoverBallot}>
+        {emojiReactions.map(react => <BallotEmojiReaction key={react.name} reaction={react} voteProps={voteProps} classes={classes}/>)}
+      </div>
+    </PopperCard>}
+  </span>
+}
+
+
+const EmojiReactionVoteOnCommentComponent = registerComponent('EmojiReactionVoteOnComment', EmojiReactionVoteOnComment, {styles});
+
+declare global {
+  interface ComponentTypes {
+    EmojiReactionVoteOnComment: typeof EmojiReactionVoteOnCommentComponent
+  }
+}
+

--- a/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
@@ -19,8 +19,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: '3px 6px',
     fontSize: 16,
     cursor: "pointer",
-    "&:hover": {
-      background: theme.palette.background.primaryDim2,
+    '@media (hover: hover)': {
+      "&:hover": {
+        background: theme.palette.background.primaryDim2,
+      },
     },
   },
   voteButtonSelected: {
@@ -106,7 +108,7 @@ const EmojiReactionVoteOnComment = ({document, hideKarma=false, collection, voti
       document={document}
       hideKarma={hideKarma}
       voteProps={voteProps}
-      showBox={false}
+      hideTooltips
     />
     
     <span className={classes.scores}>

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -52,17 +52,26 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBox=false }: {
+const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBox=false, hideTooltips=false }: {
   document: VoteableTypeClient,
   hideKarma?: boolean,
   voteProps: VotingProps<VoteableTypeClient>,
   classes: ClassesType,
   showBox?: boolean
+  hideTooltips?: boolean
 }) => {
   const currentUser = useCurrentUser();
   const {eventHandlers, hover} = useHover();
   
   if (!document) return null;
+  
+  // Wrap all LWTooltips so that we can hide them if necessary
+  const MaybeShowTooltip = (props) => {
+    if (hideTooltips) {
+      return props.children
+    }
+    return <LWTooltip {...props} />
+  }
 
   const { OverallVoteButton, LWTooltip } = Components
 
@@ -96,7 +105,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
   return (
     <span className={classes.vote} {...eventHandlers}>
       {!!af && forumTypeSetting.get() !== 'AlignmentForum' &&
-        <LWTooltip placement="bottom" title={<div>
+        <MaybeShowTooltip placement="bottom" title={<div>
             <p>AI Alignment Forum Karma</p>
             { moveToAfInfo }
         </div>}>
@@ -104,19 +113,19 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
             <span className={classes.secondarySymbol}>Ω</span>
             <span className={classes.secondaryScoreNumber}>{afBaseScore || 0}</span>
           </span>
-        </LWTooltip>
+        </MaybeShowTooltip>
       }
       {!af && (forumTypeSetting.get() === 'AlignmentForum') &&
-        <LWTooltip title="LessWrong Karma" placement="bottom">
+        <MaybeShowTooltip title="LessWrong Karma" placement="bottom">
           <span className={classes.secondaryScore}>
             <span className={classes.secondarySymbol}>LW</span>
             <span className={classes.secondaryScoreNumber}>{document.baseScore || 0}</span>
           </span>
-        </LWTooltip>
+        </MaybeShowTooltip>
       }
       {(forumTypeSetting.get() !== 'AlignmentForum' || !!af) &&
         <span className={classNames(classes.overallSection, {[classes.overallSectionBox]: showBox})}>
-          <LWTooltip
+          <MaybeShowTooltip
             title={<div><b>Overall Karma: Downvote</b><br />How much do you like this overall?<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
@@ -126,18 +135,18 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
               upOrDown="Downvote"
               {...voteProps}
             />
-          </LWTooltip>
+          </MaybeShowTooltip>
           {hideKarma ?
-            <LWTooltip title={'The author of this post has disabled karma visibility'}>
+            <MaybeShowTooltip title={'The author of this post has disabled karma visibility'}>
               <span>{' '}</span>
-            </LWTooltip> :
-            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
+            </MaybeShowTooltip> :
+            <MaybeShowTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
               <span className={classes.voteScore}>
                 {karma}
               </span>
-            </LWTooltip>
+            </MaybeShowTooltip>
           }
-          <LWTooltip
+          <MaybeShowTooltip
             title={<div><b>Overall Karma: Upvote</b><br />How much do you like this overall?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
@@ -147,7 +156,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
               upOrDown="Upvote"
               {...voteProps}
             />
-          </LWTooltip>
+          </MaybeShowTooltip>
         </span>
       }
     </span>

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -52,26 +52,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBox=false, hideTooltips=false }: {
+const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBox=false }: {
   document: VoteableTypeClient,
   hideKarma?: boolean,
   voteProps: VotingProps<VoteableTypeClient>,
   classes: ClassesType,
   showBox?: boolean
-  hideTooltips?: boolean
 }) => {
   const currentUser = useCurrentUser();
   const {eventHandlers, hover} = useHover();
   
   if (!document) return null;
-  
-  // Wrap all LWTooltips so that we can hide them if necessary
-  const MaybeShowTooltip = (props) => {
-    if (hideTooltips) {
-      return props.children
-    }
-    return <LWTooltip {...props} />
-  }
 
   const { OverallVoteButton, LWTooltip } = Components
 
@@ -105,7 +96,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
   return (
     <span className={classes.vote} {...eventHandlers}>
       {!!af && forumTypeSetting.get() !== 'AlignmentForum' &&
-        <MaybeShowTooltip placement="bottom" title={<div>
+        <LWTooltip placement="bottom" title={<div>
             <p>AI Alignment Forum Karma</p>
             { moveToAfInfo }
         </div>}>
@@ -113,19 +104,19 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
             <span className={classes.secondarySymbol}>Ω</span>
             <span className={classes.secondaryScoreNumber}>{afBaseScore || 0}</span>
           </span>
-        </MaybeShowTooltip>
+        </LWTooltip>
       }
       {!af && (forumTypeSetting.get() === 'AlignmentForum') &&
-        <MaybeShowTooltip title="LessWrong Karma" placement="bottom">
+        <LWTooltip title="LessWrong Karma" placement="bottom">
           <span className={classes.secondaryScore}>
             <span className={classes.secondarySymbol}>LW</span>
             <span className={classes.secondaryScoreNumber}>{document.baseScore || 0}</span>
           </span>
-        </MaybeShowTooltip>
+        </LWTooltip>
       }
       {(forumTypeSetting.get() !== 'AlignmentForum' || !!af) &&
         <span className={classNames(classes.overallSection, {[classes.overallSectionBox]: showBox})}>
-          <MaybeShowTooltip
+          <LWTooltip
             title={<div><b>Overall Karma: Downvote</b><br />How much do you like this overall?<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
@@ -135,18 +126,18 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
               upOrDown="Downvote"
               {...voteProps}
             />
-          </MaybeShowTooltip>
+          </LWTooltip>
           {hideKarma ?
-            <MaybeShowTooltip title={'The author of this post has disabled karma visibility'}>
+            <LWTooltip title={'The author of this post has disabled karma visibility'}>
               <span>{' '}</span>
-            </MaybeShowTooltip> :
-            <MaybeShowTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
+            </LWTooltip> :
+            <LWTooltip title={<div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount == 1 ? "Vote" : "Votes"})</div>} placement="bottom">
               <span className={classes.voteScore}>
                 {karma}
               </span>
-            </MaybeShowTooltip>
+            </LWTooltip>
           }
-          <MaybeShowTooltip
+          <LWTooltip
             title={<div><b>Overall Karma: Upvote</b><br />How much do you like this overall?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
           >
@@ -156,7 +147,7 @@ const OverallVoteAxis = ({ document, hideKarma=false, voteProps, classes, showBo
               upOrDown="Upvote"
               {...voteProps}
             />
-          </MaybeShowTooltip>
+          </LWTooltip>
         </span>
       }
     </span>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -299,6 +299,7 @@ importComponent("VoteOnComment", () => require('../components/votes/VoteOnCommen
 importComponent("TwoAxisVoteOnComment", () => require('../components/votes/TwoAxisVoteOnComment'));
 importComponent("AgreementVoteAxis", () => require('../components/votes/AgreementVoteAxis'));
 importComponent("ReactBallotVoteOnComment", () => require('../components/votes/ReactBallotVoteOnComment'));
+importComponent("EmojiReactionVoteOnComment", () => require('../components/votes/EmojiReactionVoteOnComment'));
 importComponent("PostsVote", () => require('../components/votes/PostsVote'));
 
 // Events

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -180,7 +180,7 @@ export const emojiReactions: EmojiReaction[] = [
   {name: "raised-hands", icon: "🙌"},
   {name: "enthusiasm", icon: "🎉"},
   {name: "empathy", icon: "❤️"},
-  {name: "star",   icon: "🌟"},
+  {name: "star", icon: "🌟"},
   {name: "surprise", icon: "😮"},
 ]
 const emojiReactionNames = emojiReactions.map(reaction => reaction.name)


### PR DESCRIPTION
We're focusing some effort on promoting Giving Tuesday / effective giving on the EA Forum. We're planning on running a "Where are you donating this year, and why?" open thread, and want to enable some good vibes by letting people react to comments.

I'd like to get this out soon to unblock Lizka. I mimicked the existing "react ballots" voting system and updated the UI.

<img width="431" alt="Screen Shot 2022-11-22 at 4 08 48 PM" src="https://user-images.githubusercontent.com/9057804/203423792-039d5a24-155a-4306-998c-82a28a326d35.png">

~~Unfortunately, the tooltips on the standard voting component are pretty annoyingly in the way of the first user to emoji react, but after that you can hover over the other reacts and add yours more easily. I might try to fix this interaction, could be a separate PR though.~~

I addressed this by just separating out the emoji reactions UI from the standard voting UI, since that was confusingly tied together anyway. Now you add the first reaction by clicking the "add reaction" icon instead.

<img width="404" alt="Screen Shot 2022-11-22 at 6 03 02 PM" src="https://user-images.githubusercontent.com/9057804/203439132-d5d14cb5-8fdc-4114-a9ec-f923c0a407ba.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203423113920122) by [Unito](https://www.unito.io)
