### PR TITLE
Subforum pinned comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -24,6 +24,7 @@ export interface CommentWithRepliesProps {
   markAsRead?: any;
   initialMaxChildren?: number;
   commentNodeProps?: Partial<CommentsNodeProps>;
+  startExpanded?: boolean;
   classes: ClassesType;
 }
 
@@ -34,13 +35,15 @@ const CommentWithReplies = ({
   markAsRead = () => {},
   initialMaxChildren = 3,
   commentNodeProps,
+  startExpanded,
   classes,
 }: CommentWithRepliesProps) => {
   const { hash: focusCommentId } = useLocation();
 
   const commentId = focusCommentId.slice(1) || null;
-  const startExpanded = comment.latestChildren.some(c => c._id === commentId)
-  
+
+  startExpanded ??= comment.latestChildren.some(c => c._id === commentId);
+
   const [maxChildren, setMaxChildren] = useState(startExpanded ? 500 : initialMaxChildren);
 
   if (!comment) return null;

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -627,7 +627,8 @@ const TagSubforumPage2 = ({classes}: {
                     showPostTitle: true,
                   },
                 }}
-                initialMaxChildren={5}
+                initialMaxChildren={3}
+                startExpanded={false}
               />
             )
           },

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -613,6 +613,24 @@ const TagSubforumPage2 = ({classes}: {
               />
             )
           },
+          tagSubforumStickyComments: {
+            fragmentName: "StickySubforumCommentFragment",
+            render: (comment: CommentWithRepliesFragment) => (
+              <CommentWithReplies
+                key={comment._id}
+                comment={{...comment, isPinnedOnProfile: true}}
+                commentNodeProps={{
+                  ...commentNodeProps,
+                  showPinnedOnProfile: true,
+                  treeOptions: {
+                    ...commentNodeProps.treeOptions,
+                    showPostTitle: true,
+                  },
+                }}
+                initialMaxChildren={5}
+              />
+            )
+          },
         }}
       />
     </div>

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -132,6 +132,15 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment StickySubforumCommentFragment on Comment {
+    ...CommentWithRepliesFragment
+    tag {
+      ...TagBasicInfo
+    }
+  }
+`);
+
+registerFragment(`
   fragment WithVoteComment on Comment {
     __typename
     _id

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -120,6 +120,15 @@ const schema: SchemaType<DbComment> = {
     hidden: true,
     ...schemaDefaultValue("DISCUSSION"),
   },
+  subforumStickyPriority: {
+    type: Number,
+    optional: true,
+    nullable: true,
+    canRead: ['guests'],
+    canCreate: ['sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    hidden: true,
+  },
   // The comment author's `_id`
   userId: {
     ...foreignKeyField({

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -124,6 +124,7 @@ interface DbComment extends DbObject {
   postId: string
   tagId: string
   tagCommentType: "SUBFORUM" | "DISCUSSION"
+  subforumStickyPriority: number | null
   userId: string
   userIP: string
   userAgent: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1275,6 +1275,10 @@ interface CommentsListWithParentMetadata extends CommentsList { // fragment on C
   readonly tag: TagBasicInfo|null,
 }
 
+interface StickySubforumCommentFragment extends CommentWithRepliesFragment { // fragment on Comments
+  readonly tag: TagBasicInfo|null,
+}
+
 interface WithVoteComment { // fragment on Comments
   readonly __typename: string,
   readonly _id: string,
@@ -2881,6 +2885,7 @@ interface FragmentTypes {
   DeletedCommentsMetaData: DeletedCommentsMetaData
   DeletedCommentsModerationLog: DeletedCommentsModerationLog
   CommentsListWithParentMetadata: CommentsListWithParentMetadata
+  StickySubforumCommentFragment: StickySubforumCommentFragment
   WithVoteComment: WithVoteComment
   CommentsListWithModerationMetadata: CommentsListWithModerationMetadata
   RevisionDisplay: RevisionDisplay
@@ -3057,6 +3062,7 @@ interface CollectionNamesByFragmentName {
   DeletedCommentsMetaData: "Comments"
   DeletedCommentsModerationLog: "Comments"
   CommentsListWithParentMetadata: "Comments"
+  StickySubforumCommentFragment: "Comments"
   WithVoteComment: "Comments"
   CommentsListWithModerationMetadata: "Comments"
   RevisionDisplay: "Revisions"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -369,6 +369,7 @@ interface CommentsDefaultFragment { // fragment on Comments
   readonly postId: string,
   readonly tagId: string,
   readonly tagCommentType: "SUBFORUM" | "DISCUSSION",
+  readonly subforumStickyPriority: number | null,
   readonly userId: string,
   readonly userIP: string,
   readonly userAgent: string,

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -95,6 +95,23 @@ const createSubforumFeedResolver = <SortKeyType>(sorting: SubforumFeedSort) => a
         tagId,
         tagCommentType: "SUBFORUM",
         topLevelCommentId: {$exists: false},
+        subforumStickyPriority: {$exists: false},
+        ...(af ? {af: true} : undefined),
+      },
+    }),
+    // Sticky subforum comments
+    viewBasedSubquery({
+      type: "tagSubforumStickyComments",
+      collection: Comments,
+      sortField: "subforumStickyPriority",
+      sortDirection: "asc",
+      sticky: true,
+      context,
+      selector: {
+        tagId,
+        tagCommentType: "SUBFORUM",
+        topLevelCommentId: {$exists: false},
+        subforumStickyPriority: {$exists: true},
         ...(af ? {af: true} : undefined),
       },
     }),
@@ -110,6 +127,7 @@ for (const sortBy of subforumSortings) {
     resultTypesGraphQL: `
       tagSubforumPosts: Post
       tagSubforumComments: Comment
+      tagSubforumStickyComments: Comment
     `,
     resolver: createSubforumFeedResolver(sorting),
   });


### PR DESCRIPTION
This PR implements pinned comments for subforums.

It uses a new `subforumStickyPriority` field (similar to how sticky post prioritisation works) which is used to set the index that the comment will be returned at. For our purposes we just want to set the value to `0`, but it could be used to add multiple stickied comments if needed in the future.

For the sake of expediting the process, this value currently needs to be set directly in the database, but if we use this in the future we could think about actually adding a proper UI.

For now, we're showing the name of the subforum next to the pin icon. This is probably redundant but it felt too bare without any text there. Maybe it could just say "Sticky" or "Pinned" instead? Or it could just stay as it is - I'm not going to lose sleep over it.

<img width="754" alt="Screenshot 2022-11-24 at 15 20 43" src="https://user-images.githubusercontent.com/5075628/203821728-19592c98-a931-48af-9d60-a71621332cf7.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203434763081297) by [Unito](https://www.unito.io)
