### PR TITLE
Subforum notification updates

### DIFF
--- a/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
@@ -128,7 +128,7 @@ const SubforumNotificationSettings = ({
                     <Typography variant="body2">Upweight on frontpage</Typography>
                   </span>
                   <Typography variant="body2" className={classes.accountLink}>
-                    <Link to={"/account?highlightField=notificationSubforumUnread"}>Change batching and email vs on-site in account settings</Link>
+                    <Link to={"/account?highlightField=notificationSubscribedTagPost"}>Change batching and email vs on-site in account settings</Link>
                   </Typography>
                 </>
               )}

--- a/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
@@ -29,15 +29,18 @@ const styles = (theme: ThemeType): JssStyles => ({
   upweight: {
     display: "flex",
     alignItems: "center",
-    marginBottom: -3,
+    marginTop: -3,
     "& .MuiButtonBase-root": {
       padding: 6,
+    },
+    "& .Typography-root": {
+      cursor: "default",
     },
   },
   accountLink: {
     borderTop: "solid 1px",
     borderColor: theme.palette.grey[300],
-    margin: "0px 4px",
+    margin: "8px 4px 0px 4px",
     padding: "4px 4px 0px 4px",
     fontSize: 13,
     color: theme.palette.primary.main
@@ -55,11 +58,11 @@ const SubforumNotificationSettings = ({
   className?: string;
   classes: ClassesType;
 }) => {
-  const {filterSettings, setTagFilter, removeTagFilter} = useFilterSettings();
+  const {filterSettings, setTagFilter} = useFilterSettings();
   const anchorEl = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
 
-  const { LWClickAwayListener, LWPopper, WrappedSmartForm, FormComponentCheckbox, Typography, Loading } = Components;
+  const { LWClickAwayListener, LWPopper, WrappedSmartForm, Typography, Loading } = Components;
 
   const { loading, results, refetch } = useMulti({
     terms: { view: "single", tagId: tag._id, userId: currentUser._id },
@@ -113,10 +116,6 @@ const SubforumNotificationSettings = ({
                 <Loading />
               ) : (
                 <>
-                  <span className={classes.upweight}>
-                    <Checkbox checked={isFrontpageSubscribed} onChange={toggleIsFrontpageSubscribed} disableRipple />
-                    <Typography variant="body2">Upweight on frontpage</Typography>
-                  </span>
                   <WrappedSmartForm
                     collection={UserTagRels}
                     documentId={userTagRel?._id}
@@ -124,6 +123,10 @@ const SubforumNotificationSettings = ({
                     mutationFragment={getFragment("UserTagRelNotifications")}
                     autoSubmit
                   />
+                  <span className={classes.upweight}>
+                    <Checkbox checked={isFrontpageSubscribed} onChange={toggleIsFrontpageSubscribed} disableRipple />
+                    <Typography variant="body2">Upweight on frontpage</Typography>
+                  </span>
                   <Typography variant="body2" className={classes.accountLink}>
                     <Link to={"/account?highlightField=notificationSubforumUnread"}>Change batching and email vs on-site in account settings</Link>
                   </Typography>

--- a/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Components, getFragment, registerComponent } from "../../lib/vulcan-lib";
 import NotificationsNoneIcon from "@material-ui/icons/NotificationsNone";
 import NotificationsIcon from "@material-ui/icons/Notifications";
+import Checkbox from '@material-ui/core/Checkbox';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import IconButton from "@material-ui/core/IconButton";
 import Paper from "@material-ui/core/Paper";
@@ -9,6 +10,7 @@ import UserTagRels from "../../lib/collections/userTagRels/collection";
 import { useMulti } from "../../lib/crud/withMulti";
 import { Link } from "../../lib/reactRouterWrapper";
 import { useRecordSubforumView } from "../hooks/useRecordSubforumView";
+import { useFilterSettings } from '../../lib/filterSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   notificationsButton: {
@@ -23,6 +25,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& .form-input:last-child': {
       marginBottom: 4,
     }
+  },
+  upweight: {
+    display: "flex",
+    alignItems: "center",
+    marginBottom: -3,
+    "& .MuiButtonBase-root": {
+      padding: 6,
+    },
   },
   accountLink: {
     borderTop: "solid 1px",
@@ -45,10 +55,11 @@ const SubforumNotificationSettings = ({
   className?: string;
   classes: ClassesType;
 }) => {
+  const {filterSettings, setTagFilter, removeTagFilter} = useFilterSettings();
   const anchorEl = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
 
-  const { LWClickAwayListener, LWPopper, WrappedSmartForm, Typography, Loading } = Components;
+  const { LWClickAwayListener, LWPopper, WrappedSmartForm, FormComponentCheckbox, Typography, Loading } = Components;
 
   const { loading, results, refetch } = useMulti({
     terms: { view: "single", tagId: tag._id, userId: currentUser._id },
@@ -73,6 +84,16 @@ const SubforumNotificationSettings = ({
   if (!userTagRel) return null
   if (loading) return null
 
+  const filterSetting = filterSettings?.tags?.find(({tagId}) => tag._id === tagId);
+  const isFrontpageSubscribed = filterSetting?.filterMode === "Subscribed";
+
+  const toggleIsFrontpageSubscribed = () =>
+    setTagFilter({
+      tagId: tag._id,
+      tagName: tag.name,
+      filterMode: isFrontpageSubscribed ? 0 : "Subscribed",
+    });
+
   return (
     <AnalyticsContext pageSection="subforumNotificationSettings">
       <div className={className}>
@@ -92,6 +113,10 @@ const SubforumNotificationSettings = ({
                 <Loading />
               ) : (
                 <>
+                  <span className={classes.upweight}>
+                    <Checkbox checked={isFrontpageSubscribed} onChange={toggleIsFrontpageSubscribed} disableRipple />
+                    <Typography variant="body2">Upweight on frontpage</Typography>
+                  </span>
                   <WrappedSmartForm
                     collection={UserTagRels}
                     documentId={userTagRel?._id}

--- a/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/SubforumNotificationSettings.tsx
@@ -3,7 +3,7 @@ import { Components, getFragment, registerComponent } from "../../lib/vulcan-lib
 import NotificationsNoneIcon from "@material-ui/icons/NotificationsNone";
 import NotificationsIcon from "@material-ui/icons/Notifications";
 import Checkbox from '@material-ui/core/Checkbox';
-import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
 import IconButton from "@material-ui/core/IconButton";
 import Paper from "@material-ui/core/Paper";
 import UserTagRels from "../../lib/collections/userTagRels/collection";
@@ -11,25 +11,29 @@ import { useMulti } from "../../lib/crud/withMulti";
 import { Link } from "../../lib/reactRouterWrapper";
 import { useRecordSubforumView } from "../hooks/useRecordSubforumView";
 import { useFilterSettings } from '../../lib/filterSettings';
+import { useMessages } from "../common/withMessages";
+import { userIsDefaultSubscribed } from "../../lib/subscriptionUtil";
+import { useCreate } from "../../lib/crud/withCreate";
+import { max } from "underscore";
 
 const styles = (theme: ThemeType): JssStyles => ({
   notificationsButton: {
     padding: 4,
   },
   popout: {
-    padding: "1px 0px 4px 0px",
-    maxWidth: 250,
+    padding: "4px 0px 4px 0px",
+    maxWidth: 260,
     '& .form-input': {
-      marginTop: 12,
+      marginTop: 0,
     },
     '& .form-input:last-child': {
       marginBottom: 4,
     }
   },
-  upweight: {
+  checkbox: {
     display: "flex",
     alignItems: "center",
-    marginTop: -3,
+    marginRight: 24,
     "& .MuiButtonBase-root": {
       padding: 6,
     },
@@ -40,7 +44,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   accountLink: {
     borderTop: "solid 1px",
     borderColor: theme.palette.grey[300],
-    margin: "8px 4px 0px 4px",
+    margin: "4px 4px 0px 4px",
     padding: "4px 4px 0px 4px",
     fontSize: 13,
     color: theme.palette.primary.main
@@ -61,6 +65,7 @@ const SubforumNotificationSettings = ({
   const {filterSettings, setTagFilter} = useFilterSettings();
   const anchorEl = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
+  const { flash } = useMessages();
 
   const { LWClickAwayListener, LWPopper, WrappedSmartForm, Typography, Loading } = Components;
 
@@ -70,8 +75,47 @@ const SubforumNotificationSettings = ({
     fragmentName: "UserTagRelNotifications",
     fetchPolicy: "cache-and-network",
   });
-  const recordSubforumView = useRecordSubforumView({userId: currentUser._id, tagId: tag._id});
 
+  // This is all a mess because we had to launch subforums quickly, I can only apologize
+  // Get existing subscription, if there is one
+  const subscriptionType = "newTagPosts"
+  const { results: subscriptions, loading: loadingSubscriptions } = useMulti({
+    terms: {
+      view: "subscriptionState",
+      documentId: tag._id,
+      userId: currentUser?._id,
+      type: subscriptionType,
+      collectionName: "Tags",
+      limit: 1
+    },
+    collectionName: "Subscriptions",
+    fragmentName: 'SubscriptionState',
+    enableTotal: false,
+  });
+  const { create: createSubscription } = useCreate({
+    collectionName: 'Subscriptions',
+    fragmentName: 'SubscriptionState',
+  });
+
+  const getIsSubscribed = () => {
+    // Get the last element of the results array, which will be the most recent subscription
+    if (subscriptions && subscriptions.length > 0) {
+      // Get the newest subscription entry (Mingo doesn't enforce the limit:1)
+      const currentSubscription = max(subscriptions, result=>new Date(result.createdAt).getTime());
+
+      if (currentSubscription.state === "subscribed")
+        return true;
+      else if (currentSubscription.state === "suppressed")
+        return false;
+    }
+    return userIsDefaultSubscribed({
+      user: currentUser,
+      subscriptionType, collectionName: "Tags", document: tag
+    });
+  }
+  const isSubscribed = getIsSubscribed();
+
+  const recordSubforumView = useRecordSubforumView({userId: currentUser._id, tagId: tag._id});
   const userTagRel = results?.length ? results[0] : undefined;
   
   // This is to ensure the userTagRel exists, which it almost always should because it is created as a result of loading `SubforumCommentsThread`
@@ -97,6 +141,25 @@ const SubforumNotificationSettings = ({
       filterMode: isFrontpageSubscribed ? 0 : "Subscribed",
     });
 
+  const togglePostsSubscribed = async (e) => {
+    try {
+      e.preventDefault();
+      const subscriptionState = isSubscribed ? 'suppressed' : 'subscribed'
+      captureEvent("subscribeClicked", {state: subscriptionState})
+
+      const newSubscription = {
+        state: subscriptionState,
+        documentId: tag._id,
+        collectionName: "Tags",
+        type: subscriptionType,
+      } as const;
+
+      await createSubscription({data: newSubscription})
+    } catch(error) {
+      flash({messageString: error.message});
+    }
+  }
+
   return (
     <AnalyticsContext pageSection="subforumNotificationSettings">
       <div className={className}>
@@ -116,6 +179,10 @@ const SubforumNotificationSettings = ({
                 <Loading />
               ) : (
                 <>
+                  <span className={classes.checkbox}>
+                    <Checkbox checked={isSubscribed} onChange={togglePostsSubscribed} disableRipple />
+                    <Typography variant="body2">Notify me of new posts</Typography>
+                  </span>
                   <WrappedSmartForm
                     collection={UserTagRels}
                     documentId={userTagRel?._id}
@@ -123,12 +190,12 @@ const SubforumNotificationSettings = ({
                     mutationFragment={getFragment("UserTagRelNotifications")}
                     autoSubmit
                   />
-                  <span className={classes.upweight}>
+                  <span className={classes.checkbox}>
                     <Checkbox checked={isFrontpageSubscribed} onChange={toggleIsFrontpageSubscribed} disableRipple />
                     <Typography variant="body2">Upweight on frontpage</Typography>
                   </span>
                   <Typography variant="body2" className={classes.accountLink}>
-                    <Link to={"/account?highlightField=notificationSubscribedTagPost"}>Change batching and email vs on-site in account settings</Link>
+                    <Link to={"/account?highlightField=notificationSubscribedTagPost"}>Change notification batching and email vs on-site in account settings</Link>
                   </Typography>
                 </>
               )}

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -313,7 +313,7 @@ const TagSubforumPage2 = ({classes}: {
   })
 
   const { openDialog } = useDialog();
-  const { totalCount: membersCount } = useMulti({
+  const { totalCount: membersCount, loading: membersCountLoading } = useMulti({
     terms: {view: 'tagCommunityMembers', profileTagId: tag?._id, limit: 0},
     collectionName: 'Users',
     fragmentName: 'UsersProfile',
@@ -500,7 +500,7 @@ const TagSubforumPage2 = ({classes}: {
         {!!currentUser && !editing && (isSubscribed ? <SubforumNotificationSettings tag={tag} currentUser={currentUser} className={classes.notificationSettings} /> : <SubforumSubscribeSection tag={tag} className={classes.joinBtn} />)}
       </div>
       <div className={classes.membersListLink}>
-        <button className={classes.membersListLink} onClick={onClickMembersList}>{membersCount} members</button>
+        {!membersCountLoading && <button className={classes.membersListLink} onClick={onClickMembersList}>{membersCount} members</button>}
       </div>
       <Tabs
         value={tab}

--- a/packages/lesswrong/lib/collections/userTagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/userTagRels/collection.ts
@@ -46,7 +46,8 @@ const schema: SchemaType<DbUserTagRel> = {
     type: Boolean,
     nullable: false,
     optional: false,
-    control: "SubforumNotifications",
+    label: "Notify me of new discussions",
+    // control: "SubforumNotifications", // TODO: Possibly add this back in (it shows the batching settings in the menu)
     canRead: [userOwns, 'admins'],
     canCreate: ['members', 'admins'],
     canUpdate: [userOwns, 'admins'],

--- a/packages/lesswrong/lib/collections/userTagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/userTagRels/collection.ts
@@ -39,6 +39,7 @@ const schema: SchemaType<DbUserTagRel> = {
     canRead: [userOwns, 'admins'],
     canCreate: ['members', 'admins'],
     canUpdate: [userOwns, 'admins'],
+    hidden: true,
     ...schemaDefaultValue(true),
   },
   subforumEmailNotifications: {


### PR DESCRIPTION
Here are the changes to the subforum notification settings. It's very possible that I misunderstood what the actual desired behaviour should be - I presumed "Post notifications on/off" just meant the existing setting, but feel free to correct if wrong. I figured the best thing to do is probably just to create the PR and if I misunderstood you can correct me here rather than slowing everything down checking in slack. This whole notification setup seems kind of complicated and I don't really know what's going on 😅.

Also, recent feedback from Lizka about notifcations that should maybe influence whay we do here: "I joined. I really didn't want EG to appear in my profile. I knew I should fix that so I went to edit my profile, unchecked the topic there, realized that it probably also subscribed me on the frontpage -- also didn't want that, went to remove that off the frontpage; I was still subscribed (despite removing it in my profile) and unsubscribing was non-trivial and confusing".

<img width="760" alt="Screenshot 2022-11-24 at 16 57 34" src="https://user-images.githubusercontent.com/5075628/203837268-6c13aa57-71cf-4007-9a3d-d7c465e93710.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203435052329236) by [Unito](https://www.unito.io)
