### PR TITLE
Roll out subforums v2

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -153,7 +153,7 @@ const Layout = ({currentUser, children, classes}: {
   const [hideNavigationSidebar,setHideNavigationSidebar] = useState(!!(currentUser?.hideNavigationSidebar));
   const theme = useTheme();
   const { currentRoute, params: { slug }, pathname} = useLocation();
-  const isSubforum = subforumSlugsSetting.get().includes(slug);
+  const isSubforum = subforumSlugsSetting.get().includes(slug); // FIXME remove this hack and find a way to always use the isSubforum field on the tag
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useUpdate } from '../lib/crud/withUpdate';
 import { Helmet } from 'react-helmet';
 import classNames from 'classnames'
 import { useTheme } from './themes/useTheme';
-import { useLocation } from '../lib/routeUtil';
+import { subforumSlugsSetting, useLocation } from '../lib/routeUtil';
 import { AnalyticsContext } from '../lib/analyticsEvents'
 import { UserContext } from './common/withUser';
 import { TimezoneWrapper } from './common/withTimezone';
@@ -15,10 +15,8 @@ import { pBodyStyle } from '../themes/stylePiping';
 import { DatabasePublicSetting, googleTagManagerIdSetting } from '../lib/publicSettings';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { globalStyles } from '../themes/globalStyles/globalStyles';
-import type { ToCData, ToCSection } from '../server/tableOfContents';
 import { ForumOptions, forumSelect } from '../lib/forumTypeUtils';
 import { userCanDo } from '../lib/vulcan-users/permissions';
-import { getUserEmail } from "../lib/collections/users/helpers";
 import { DisableNoKibitzContext } from './users/UsersNameDisplay';
 
 export const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 0)
@@ -154,8 +152,9 @@ const Layout = ({currentUser, children, classes}: {
   const [disableNoKibitz, setDisableNoKibitz] = useState(false);
   const [hideNavigationSidebar,setHideNavigationSidebar] = useState(!!(currentUser?.hideNavigationSidebar));
   const theme = useTheme();
-  const location = useLocation();
-  const currentRoute = location.currentRoute
+  const { currentRoute, params: { slug }, pathname} = useLocation();
+  const isSubforum = subforumSlugsSetting.get().includes(slug);
+  
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",
     fragmentName: 'UsersCurrent',
@@ -205,14 +204,13 @@ const Layout = ({currentUser, children, classes}: {
     // FIXME: This is using route names, but it would be better if this was
     // a property on routes themselves.
 
-    const standaloneNavigation = !currentRoute ||
-      forumSelect(standaloneNavMenuRouteNames)
-        .includes(currentRoute?.name)
-    
+    const standaloneNavigation =
+      !currentRoute || forumSelect(standaloneNavMenuRouteNames).includes(currentRoute?.name) || isSubforum;
+
     const renderSunshineSidebar = currentRoute?.sunshineSidebar && (userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins'))
     
     const shouldUseGridLayout = standaloneNavigation
-    const unspacedGridLayout = currentRoute?.unspacedGrid
+    const unspacedGridLayout = currentRoute?.unspacedGrid || isSubforum
 
     const renderPetrovDay = () => {
       const currentTime = (new Date()).valueOf()
@@ -226,7 +224,7 @@ const Layout = ({currentUser, children, classes}: {
     }
     
     return (
-      <AnalyticsContext path={location.pathname}>
+      <AnalyticsContext path={pathname}>
       <UserContext.Provider value={currentUser}>
       <TimezoneWrapper>
       <ItemsReadContextWrapper>

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -67,6 +67,7 @@ const CommentPermalink = ({ documentId, post, classes }: {
       showPostTitle: false,
     },
     expandByDefault: true,
+    noAutoScroll: true
   };
 
   // NB: classes.root is not in the above styles, but is used by eaTheme

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -57,12 +57,12 @@ const CommentsItemDate = ({comment, post, tag, classes, scrollOnClick, scrollInt
   permalink?: boolean,
 }) => {
   const { history } = useNavigation();
-  const { location } = useLocation();
+  const { location, query } = useLocation();
   const { captureEvent } = useTracking();
 
   const handleLinkClick = (event: React.MouseEvent) => {
     event.preventDefault()
-    history.replace({...location, search: qs.stringify({commentId: comment._id})})
+    history.replace({...location, search: qs.stringify({...query, commentId: comment._id})})
     if(scrollIntoView) scrollIntoView();
     captureEvent("linkClicked", {buttonPressed: event.button, furtherContext: "dateIcon"})
   };

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -69,6 +69,7 @@ export interface CommentsNodeProps {
    * Default: false.  Currently only used in the comment moderation tab.
    */
   showParentDefault?: boolean,
+  noAutoScroll?: boolean,
   classes: ClassesType,
 }
 /**
@@ -98,6 +99,7 @@ const CommentsNode = ({
   enableGuidelines=true,
   karmaCollapseThreshold=KARMA_COLLAPSE_THRESHOLD,
   showParentDefault=false,
+  noAutoScroll=false,
   classes
 }: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
@@ -152,7 +154,7 @@ const CommentsNode = ({
 
   const {hash: commentHash} = useLocation();
   useEffect(() => {
-    if (comment && commentHash === ("#" + comment._id)) {
+    if (!noAutoScroll && comment && commentHash === ("#" + comment._id)) {
       setTimeout(() => { //setTimeout make sure we execute this after the element has properly rendered
         scrollIntoView()
       }, 0);

--- a/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
@@ -5,6 +5,7 @@ import { taggingNamePluralSetting } from "../../../lib/instanceSettings";
 import { useMulti } from "../../../lib/crud/withMulti";
 import MenuItem from "@material-ui/core/MenuItem";
 import { Link } from "../../../lib/reactRouterWrapper";
+import { tagGetSubforumUrl } from "../../../lib/collections/tags/helpers";
 
 const styles = ((theme: ThemeType): JssStyles => ({
   menuItem: {
@@ -63,7 +64,7 @@ const SubforumsList = ({ onClick, classes }) => {
               key={subforum._id}
               onClick={onClick}
               component={Link}
-              to={`/${taggingNamePluralSetting.get()}/${subforum.slug}/subforum`}
+              to={tagGetSubforumUrl(subforum)}
               classes={{ root: classes.menuItem }}
             >
               <TabNavigationSubItem className={classes.subItem}>

--- a/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { registerComponent, Components } from "../../../lib/vulcan-lib/components";
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
-import { taggingNamePluralSetting } from "../../../lib/instanceSettings";
 import { useMulti } from "../../../lib/crud/withMulti";
 import MenuItem from "@material-ui/core/MenuItem";
 import { Link } from "../../../lib/reactRouterWrapper";
@@ -68,10 +67,7 @@ const SubforumsList = ({ onClick, classes }) => {
               classes={{ root: classes.menuItem }}
             >
               <TabNavigationSubItem className={classes.subItem}>
-                {subforum.name}{" "}
-                {subforum.subforumUnreadMessagesCount ? (
-                  <span className={classes.unreadCount}>({subforum.subforumUnreadMessagesCount}) </span>
-                ) : null}
+                {subforum.name}
               </TabNavigationSubItem>
             </MenuItemUntyped>
           ))}

--- a/packages/lesswrong/components/tagging/TagPageRouter.tsx
+++ b/packages/lesswrong/components/tagging/TagPageRouter.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { subforumSlugsSetting, useLocation } from "../../lib/routeUtil";
+import { Components, registerComponent } from "../../lib/vulcan-lib";
+
+const TagPageRouter = () => {
+  const { params: { slug }} = useLocation();
+  const isSubforum = subforumSlugsSetting.get().includes(slug);
+
+  const {TagPage, TagSubforumPage2} = Components
+  return isSubforum ? <TagSubforumPage2/> : <TagPage/>
+}
+
+const TagPageRouterComponent = registerComponent("TagPageRouter", TagPageRouter);
+
+declare global {
+  interface ComponentTypes {
+    TagPageRouter: typeof TagPageRouterComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -379,8 +379,7 @@ const TagSubforumPage2 = ({classes}: {
   const isSubscribed = !!currentUser?.profileTagIds?.includes(tag._id)
 
   // if no sort order was selected, try to use the tag page's default sort order for posts
-  // TODO: possibly use tag.postsDefaultSortOrder as the fallback, initially though we do want subforum sorting to be different from the wiki post list sorting
-  const sortBy: SubforumSorting = isSubforumSorting(query.sortedBy) ? query.sortedBy : defaultSubforumSorting;
+  const sortBy: SubforumSorting = (isSubforumSorting(query.sortedBy) && query.sortedBy) || (isSubforumSorting(tag.postsDefaultSortOrder) && tag.postsDefaultSortOrder) || defaultSubforumSorting;
 
   const terms = {
     ...tagPostTerms(tag, query),

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -45,7 +45,7 @@ export const tagGetDiscussionUrl = (tag: {slug: string}, isAbsolute=false) => {
 }
 
 export const tagGetSubforumUrl = (tag: {slug: string}, isAbsolute=false) => {
-  const suffix = `/${tagUrlBase}/${tag.slug}`
+  const suffix = `/${tagUrlBase}/${tag.slug}?tab=subforum`
   return isAbsolute ? combineUrls(siteUrlSetting.get(), suffix) : suffix
 }
 

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -1,5 +1,7 @@
+import qs from "qs";
 import { forumSelect } from "../../forumTypeUtils";
 import { siteUrlSetting, taggingNameIsSet, taggingNamePluralSetting } from "../../instanceSettings";
+import { subforumSlugsSetting } from "../../routeUtil";
 import { combineUrls } from "../../vulcan-lib";
 import { TagCommentType } from "../comments/types";
 import Users from "../users/collection";
@@ -27,12 +29,12 @@ export const tagCreateUrl = `/${tagUrlBase}/create`
 export const tagGradingSchemeUrl = `/${tagUrlBase}/tag-grading-scheme`
 
 export const tagGetUrl = (tag: {slug: string}, urlOptions?: GetUrlOptions) => {
-  const { flagId, edit } = urlOptions || {};
+  // Assume links that are not explicitly for the subforum should go to the wiki tab (this may change in the future)
+  const urlSearchParams = subforumSlugsSetting.get().includes(tag.slug) ? {tab: "wiki", ...urlOptions} : urlOptions
+  const search = qs.stringify(urlSearchParams)
+
   const url = `/${tagUrlBase}/${tag.slug}`
-  if (flagId && edit) return `${url}?flagId=${flagId}&edit=${edit}`
-  if (flagId) return `${url}?flagId=${flagId}`
-  if (edit) return `${url}?edit=${edit}`
-  return url
+  return `${url}${search ? `?${search}` : ''}`
 }
 
 export const tagGetHistoryUrl = (tag: {slug: string}) => `${tagGetUrl(tag)}/history`
@@ -43,7 +45,7 @@ export const tagGetDiscussionUrl = (tag: {slug: string}, isAbsolute=false) => {
 }
 
 export const tagGetSubforumUrl = (tag: {slug: string}, isAbsolute=false) => {
-  const suffix = `/${tagUrlBase}/${tag.slug}/subforum`
+  const suffix = `/${tagUrlBase}/${tag.slug}`
   return isAbsolute ? combineUrls(siteUrlSetting.get(), suffix) : suffix
 }
 
@@ -54,7 +56,7 @@ export const tagGetCommentLink = ({tagSlug, commentId, tagCommentType = "DISCUSS
   isAbsolute?: boolean,
 }): string => {
   const base = tagCommentType === "DISCUSSION" ? tagGetDiscussionUrl({slug: tagSlug}, isAbsolute) : tagGetSubforumUrl({slug: tagSlug}, isAbsolute)
-  return commentId ? `${base}#${commentId}` : base
+  return commentId ? `${base}?commentId=${commentId}` : base
 }
 
 export const tagGetRevisionLink = (tag: DbTag|TagBasicInfo, versionNumber: string): string => {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -579,6 +579,7 @@ importComponent("SubforumMember", () => require('../components/tagging/SubforumM
 importComponent("SubforumNotificationSettings", () => require('../components/tagging/SubforumNotificationSettings'));
 importComponent("TagSubforumPage", () => require('../components/tagging/TagSubforumPage'));
 importComponent("TagSubforumPage2", () => require('../components/tagging/TagSubforumPage2'));
+importComponent("TagPageRouter", () => require('../components/tagging/TagPageRouter'));
 importComponent("RightSidebarColumn", () => require('../components/tagging/RightSidebarColumn'));
 importComponent("SidebarSubtagsBox", () => require('../components/tagging/SidebarSubtagsBox'));
 importComponent("SidebarMembersBox", () => require('../components/tagging/SidebarMembersBox'));

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -5,6 +5,9 @@ import { LocationContext, NavigationContext, ServerRequestStatusContext, Subscri
 import type { RouterLocation } from './vulcan-lib/routes';
 import * as _ from 'underscore';
 import { ForumOptions, forumSelect } from './forumTypeUtils';
+import { PublicInstanceSetting } from './instanceSettings';
+
+export const subforumSlugsSetting = new PublicInstanceSetting<string[]>('subforumTagSlugs', [], 'optional')
 
 // Given the props of a component which has withRouter, return the parsed query
 // from the URL.

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -5,9 +5,9 @@ import { LocationContext, NavigationContext, ServerRequestStatusContext, Subscri
 import type { RouterLocation } from './vulcan-lib/routes';
 import * as _ from 'underscore';
 import { ForumOptions, forumSelect } from './forumTypeUtils';
-import { PublicInstanceSetting } from './instanceSettings';
+import { DatabasePublicSetting } from './publicSettings';
 
-export const subforumSlugsSetting = new PublicInstanceSetting<string[]>('subforumTagSlugs', [], 'optional')
+export const subforumSlugsSetting = new DatabasePublicSetting<string[]>('subforumTagSlugs', [])
 
 // Given the props of a component which has withRouter, return the parsed query
 // from the URL.

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -7,6 +7,7 @@ import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from './reviewUtils';
 import { forumSelect } from './forumTypeUtils';
 import pickBy from 'lodash/pickBy';
 import qs from 'qs';
+import { subforumSlugsSetting } from './routeUtil';
 
 
 export const communityPath = '/community';
@@ -713,8 +714,8 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name: 'subforum',
       path: `/${taggingNamePluralSetting.get()}/:slug/subforum`,
       redirect: (routerLocation: RouterLocation) => {
-        console.log("routerLocation", routerLocation)
         const { params: {slug}, query, hash } = routerLocation
+        const isRouteSubforum = subforumSlugsSetting.get().includes(slug)
 
         const redirectQuery = pickBy({
           ...query,
@@ -722,7 +723,8 @@ const forumSpecificRoutes = forumSelect<Route[]>({
           commentId: query.commentId || hash?.slice(1)
         }, v => v)
 
-        return `/${taggingNamePluralSetting.get()}/${slug}?${qs.stringify(redirectQuery)}${hash}`
+        // If the route is not declared as a subforum but somehow the user has clicked on a subforum link, redirect to the /subforum2 path, which will always display like a subforum
+        return `/${taggingNamePluralSetting.get()}/${slug}${isRouteSubforum ? '' : '/subforum2'}?${qs.stringify(redirectQuery)}${hash}`
       }
     },
     {

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -377,7 +377,7 @@ if (taggingNameIsSet.get()) {
     {
       name: 'tagsSingleCustomName',
       path: `/${taggingNamePluralSetting.get()}/:slug`,
-      componentName: 'TagPage',
+      componentName: 'TagPageRouter',
       titleComponentName: 'TagPageTitle',
       subtitleComponentName: 'TagPageTitle',
       previewComponentName: 'TagHoverPreview',
@@ -710,8 +710,7 @@ const forumSpecificRoutes = forumSelect<Route[]>({
     {
       name: 'subforum',
       path: `/${taggingNamePluralSetting.get()}/:slug/subforum`,
-      componentName: 'TagSubforumPage',
-      fullscreen: true,
+      redirect: () => `/${taggingNamePluralSetting.get()}/:slug`
     },
     {
       name: 'tagsSubforum',

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -5,6 +5,8 @@ import { addRoute, PingbackDocument, RouterLocation, Route } from './vulcan-lib/
 import { onStartup } from './executionEnvironment';
 import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from './reviewUtils';
 import { forumSelect } from './forumTypeUtils';
+import pickBy from 'lodash/pickBy';
+import qs from 'qs';
 
 
 export const communityPath = '/community';
@@ -710,7 +712,18 @@ const forumSpecificRoutes = forumSelect<Route[]>({
     {
       name: 'subforum',
       path: `/${taggingNamePluralSetting.get()}/:slug/subforum`,
-      redirect: () => `/${taggingNamePluralSetting.get()}/:slug`
+      redirect: (routerLocation: RouterLocation) => {
+        console.log("routerLocation", routerLocation)
+        const { params: {slug}, query, hash } = routerLocation
+
+        const redirectQuery = pickBy({
+          ...query,
+          tab: "subforum",
+          commentId: query.commentId || hash?.slice(1)
+        }, v => v)
+
+        return `/${taggingNamePluralSetting.get()}/${slug}?${qs.stringify(redirectQuery)}${hash}`
+      }
     },
     {
       name: 'tagsSubforum',


### PR DESCRIPTION
 - Route topics that are subforums to the v2 subforum page
 - Redirect links to the v1 subforum to the v2 version
 - Switch over tag and comment links to point to the correct url
 - Some other small fixes that don't deserve their own PR
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203435533179907) by [Unito](https://www.unito.io)
