### PR TITLE
Fix source-mapping in browser

### DIFF
--- a/build.js
+++ b/build.js
@@ -109,6 +109,7 @@ build({
   bundle: true,
   target: "es6",
   sourcemap: true,
+  sourcesContent: true,
   outfile: clientOutfilePath,
   minify: isProduction,
   banner: {
@@ -159,6 +160,7 @@ build({
   outfile: `./${outputDir}/server/js/serverBundle.js`,
   platform: "node",
   sourcemap: true,
+  sourcesContent: true,
   minify: false,
   run: cliopts.run && serverCli,
   onStart: (config, changedFiles, ctx) => {


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/commit/03f4ce9289b6be07e2f67e92096f35f37f45014f#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R167 switched from our fork of Estrella to mainline-version Estrella. This lost a workaround that had been applied to the fork, to make source-mapping work. Meanwhile the upstream/upgraded version made some other changes to source-mapping, which caused there to be a right-way-to-do-it. The right way to do it being "pass an option to unbreak the silly defaults".