### PR TITLE
Fix hover-preview of single-line comments being also single line

### DIFF
--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -199,7 +199,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
               truncated
               nestingLevel={1}
               comment={comment}
-              treeOptions={{...treeOptions, hideReply: true, forceNotSingleLine: true}}
+              treeOptions={{...treeOptions, hideReply: true, forceSingleLine: false, forceNotSingleLine: true}}
               hoverPreview
             />
           </div>


### PR DESCRIPTION
A refactoring of comment-collapsing in the side-comments branch made the `forceSingleLine` option on `CommentsNode` part of `CommentTreeOptions`, making it heritable. Which is fine except that in `SingleLineComment`, the hover-preview inherits tree options from the comment that's being hovered. It explicitly handles this case by passing `forceNotSingleLine: true`... except that if both `forceSingleLine` and `forceNotSingleLine` are true, then `forceSingleLine` wins.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203454447813559) by [Unito](https://www.unito.io)
