### PR TITLE
Add score boost for subforum comments

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -5,7 +5,7 @@ import { combineIndexWithDefaultViewIndex, ensureIndex } from '../../collectionI
 import type { FilterMode, FilterSettings, FilterTag } from '../../filterSettings';
 import { forumTypeSetting } from '../../instanceSettings';
 import { defaultVisibilityTags } from '../../publicSettings';
-import { defaultScoreModifiers, timeDecayExpr } from '../../scoring';
+import { postScoreModifiers, timeDecayExpr } from '../../scoring';
 import { viewFieldAllowAny, viewFieldNullOrMissing } from '../../vulcan-lib';
 import { Posts } from './collection';
 import { postStatuses, startHerePostIdSetting } from './constants';
@@ -340,7 +340,7 @@ function filterSettingsToParams(filterSettings: FilterSettings): any {
               else: 0
             }}
           )),
-          ...defaultScoreModifiers(),
+          ...postScoreModifiers(),
           ...frontpageSoftFilter,
         ]},
         ...tagsSoftFiltered.map(t => (

--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -3,15 +3,35 @@ import { DatabasePublicSetting } from './publicSettings';
 const timeDecayFactorSetting = new DatabasePublicSetting<number>('timeDecayFactor', 1.15)
 const frontpageBonusSetting = new DatabasePublicSetting<number>('frontpageScoreBonus', 10)
 const curatedBonusSetting = new DatabasePublicSetting<number>('curatedScoreBonus', 10)
+const subforumCommentBoostSetting = new DatabasePublicSetting<number>('subforumCommentScoreBonus', 20);
+const subforumCommentBoostHoursSetting = new DatabasePublicSetting<number>('subforumCommentScoreBonusHours', 8);
 
 export const TIME_DECAY_FACTOR = timeDecayFactorSetting;
 // Basescore bonuses for various categories
 export const FRONTPAGE_BONUS = frontpageBonusSetting;
 export const CURATED_BONUS = curatedBonusSetting;
 
+const getSubforumScoreBoost = () => {
+  return {
+    magnitude: subforumCommentBoostSetting.get(),
+    durationHours: subforumCommentBoostHoursSetting.get(),
+  };
+}
+
+const getSubforumCommentBonus = (item: VoteableType) => {
+  if ("tagCommentType" in item && item["tagCommentType"] === "SUBFORUM") {
+    const {magnitude, durationHours} = getSubforumScoreBoost();
+    const createdAt = (item as any).createdAt ?? new Date();
+    const ageHours = (Date.now() - createdAt.getTime()) / 3600000;
+    const factor = -magnitude / (durationHours * durationHours);
+    const bias = factor * (ageHours - durationHours) * (ageHours + durationHours);
+    return Math.max(0, bias);
+  }
+  return 0;
+}
 
 // NB: If you want to change this algorithm, make sure to also change the
-// timeDecayExpr function below
+// modifier functions below
 export const recalculateScore = (item: VoteableType) => {
   // Age Check
   if ((item as any).postedAt) {
@@ -23,7 +43,10 @@ export const recalculateScore = (item: VoteableType) => {
     // use baseScore if defined, if not just use 0
     let baseScore = item.baseScore || 0;
 
-    baseScore = baseScore + (((item as any).frontpageDate ? FRONTPAGE_BONUS.get() : 0) + ((item as any).curatedDate ? CURATED_BONUS.get() : 0));
+    const frontpageBonus = (item as any).frontpageDate ? FRONTPAGE_BONUS.get() : 0;
+    const curatedBonus = (item as any).curatedDate ? CURATED_BONUS.get() : 0;
+    const subforumBonus = getSubforumCommentBonus(item);
+    baseScore = baseScore + frontpageBonus + curatedBonus + subforumBonus;
 
     // HN algorithm
     const newScore = Math.round((baseScore / Math.pow(ageInHours + 2, TIME_DECAY_FACTOR.get()))*1000000)/1000000;
@@ -49,9 +72,55 @@ export const timeDecayExpr = () => {
   ]}
 }
 
-export const defaultScoreModifiers = () => {
+export const postScoreModifiers = () => {
   return [
     {$cond: {if: "$frontpageDate", then: FRONTPAGE_BONUS.get(), else: 0}},
     {$cond: {if: "$curatedDate", then: CURATED_BONUS.get(), else: 0}}
+  ];
+};
+
+export const commentScoreModifiers = () => {
+  const {magnitude, durationHours} = getSubforumScoreBoost();
+
+  // (Date.now() - createdAt.getTime()) / 3600000
+  const ageHoursExpr = {
+    $divide: [
+      {
+        $subtract: [
+          new Date(),
+          "$createdAt",
+        ],
+      },
+      3600000,
+    ],
+  };
+
+  // -magnitude / (durationHours * durationHours);
+  const factorExpr = {
+    $multiply: [
+      {
+        $divide: [
+          {$subtract: [0, magnitude]},
+          durationHours * durationHours,
+        ],
+      },
+    ],
+  };
+
+  // factor * (ageHours - durationHours) * (ageHours + durationHours)
+  const biasExpr = {
+    $multiply: [
+      factorExpr,
+      {$subtract: [ageHoursExpr, durationHours]},
+      {$add: [ageHoursExpr, durationHours]},
+    ],
+  };
+
+  return [
+    {$cond: {
+      if: {tagCommentType: "SUBFORUM"},
+      then: {$max: [0, biasExpr]},
+      else: 0,
+    }},
   ];
 };

--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -2,7 +2,7 @@ import { DatabasePublicSetting } from './publicSettings';
 
 /**
  * We apply a score boost to subforum comments using the formula:
- *   max(b, m * (1 - (x / d) ** p))
+ *   max(b, m * (1 - ((x / d) ** p)))
  * where b is the base (the minimum boost received after the duration
  * has expired), m is the magnitude (the maximum boost when the comment
  * is first posted), d is the duration in hours, p is the exponent
@@ -45,7 +45,7 @@ const getSubforumCommentBonus = (item: VoteableType) => {
     const {base, magnitude, duration, exponent} = getSubforumScoreBoost();
     const createdAt = (item as any).createdAt ?? new Date();
     const ageHours = (Date.now() - createdAt.getTime()) / 3600000;
-    return Math.max(base, magnitude * (1 - (ageHours / duration) ** exponent));
+    return Math.max(base, magnitude * (1 - ((ageHours / duration) ** exponent)));
   }
   return 0;
 }

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -1,5 +1,11 @@
 import { getCollection, Vulcan } from "./vulcan-lib";
-import { recalculateScore, timeDecayExpr, defaultScoreModifiers, TIME_DECAY_FACTOR } from '../lib/scoring';
+import {
+  recalculateScore,
+  timeDecayExpr,
+  postScoreModifiers,
+  commentScoreModifiers,
+  TIME_DECAY_FACTOR,
+} from '../lib/scoring';
 import * as _ from 'underscore';
 
 /*
@@ -70,7 +76,15 @@ const getCollectionProjections = (collectionName: CollectionNameString) => {
       baseScore: { // Add optional bonuses to baseScore of posts
         $add: [
           "$baseScore",
-          ...defaultScoreModifiers(),
+          ...postScoreModifiers(),
+        ],
+      },
+    },
+    Comments: {
+      baseScore: { // Add optional bonuses to baseScore of comments
+        $add: [
+          "$baseScore",
+          ...commentScoreModifiers(),
         ],
       },
     },


### PR DESCRIPTION
This is a first pass at improving the "magic" sorting for subforum comments. It took longer than expected due to experimenting with a few different methods, but I think this is definitely the cleanest I found, and it should make it relatively straight forward to make further tweaks to the algorithm, which I'm sure we'll want to do as this is still very simplistic. Here, we're taking advantage of the fact that the `score` field for subforum comments is never actually used anywhere else, so we can just change the formula for calculating it without needing to add a new field.

For now, all we're doing is adding a karma boost for the first N-hours after the comment is posted with a quadratic drop-off:
<img width="726" alt="Screenshot 2022-11-29 at 11 27 39" src="https://user-images.githubusercontent.com/5075628/204517503-f43f86b6-584e-4170-b491-6610a3e0b7a8.png">

The parameters are configurable with database settings, but I've set the defaults to a 20 point karma boost that lasts for 8 hours (with the dropoff, obviously), as shown in the graph above.

If we're happy with this, then we probably want to set the default sorting back to 'magic', but I've not done that in this PR yet so we can check if the algorithms actually any good or not first.

It may also be desirable to add some constant boost to comments, even after the time period has run out. We can do this by just changing the `0` constant used in the `max` expressions to some positive karma value (this isn't currently configurable, but if we want to do this then I'll add another database setting).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203457526195778) by [Unito](https://www.unito.io)
