### PR TITLE
fix missing import

### DIFF
--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -276,6 +276,8 @@ importComponent("ReportPostMenuItem", () => require('../components/posts/ReportP
 importComponent("PostsItemDate", () => require('../components/posts/PostsItemDate'));
 importComponent("ElicitBlock", () => require('../components/posts/ElicitBlock'));
 
+importComponent("SetSideCommentVisibility", () => require('../components/posts/PostActions/SetSideCommentVisibility'));
+
 importComponent("UserPageTitle", () => require('../components/titles/UserPageTitle'));
 importComponent("SequencesPageTitle", () => require('../components/titles/SequencesPageTitle'));
 importComponent("PostsPageHeaderTitle", () => require('../components/titles/PostsPageTitle'));


### PR DESCRIPTION
Missing import was breaking post actions in SunshineNewUsersProfileInfo (and possibly in other places).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203460778229124) by [Unito](https://www.unito.io)
