### PR TITLE
Allow non-admin mods to see the moderation dashboard

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -7,7 +7,7 @@ import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { TupleSet, UnionOf } from '../../lib/utils/typeGuardUtils';
 
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { userIsAdmin } from '../../lib/vulcan-users/permissions';
+import { userIsAdminOrMod } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
 import type { CommentWithModeratorActions } from './CommentsReviewInfoCard';
 
@@ -150,7 +150,7 @@ const ModerationDashboard = ({ classes }: {
 
   const commentsWithActions = reduceCommentModeratorActions(commentModeratorActions);
 
-  if (!userIsAdmin(currentUser)) {
+  if (!userIsAdminOrMod(currentUser)) {
     return null;
   }
 

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -30,8 +30,13 @@ export const createGroup = (groupName: string): Group => {
   return userGroups[groupName];
 };
 
+type PermissionableUser = UsersMinimumInfo & {
+  readonly groups: Array<string>
+  readonly banned: Date
+}
+
 // get a list of a user's groups
-export const userGetGroups = (user: UsersProfile|DbUser|null): Array<string> => {
+export const userGetGroups = (user: PermissionableUser|DbUser|null): Array<string> => {
   if (!user) { // guests user
     return ['guests'];
   }
@@ -67,7 +72,7 @@ export const userGetActions = (user: UsersProfile|DbUser|null): Array<string> =>
 };
 
 // Check if a user is a member of a group
-export const userIsMemberOf = (user: UsersCurrent|UsersProfile|DbUser|null, group: PermissionGroups): boolean => {
+export const userIsMemberOf = (user: PermissionableUser|DbUser|null, group: PermissionGroups): boolean => {
   const userGroups = userGetGroups(user);
   for (let userGroup of userGroups) {
     if (userGroup === group)
@@ -129,6 +134,11 @@ export const userIsAdmin = function <T extends UsersMinimumInfo|DbUser|null>(use
 };
 
 export const isAdmin = userIsAdmin;
+
+export const userIsAdminOrMod = function <T extends PermissionableUser|DbUser|null> (user: T): user is Exclude<T, null> {
+  if (!user) return false;
+  return user.isAdmin || userIsMemberOf(user, 'sunshineRegiment');
+};
 
 // Check if a user can view a field
 export const userCanReadField = <T extends DbObject>(user: UsersCurrent|DbUser|null, field: CollectionFieldSpecification<T>, document: T): boolean => {


### PR DESCRIPTION
I believe this was an unintentional oversight. Also note the slight increase in type intelligence about `PermissionableUser` to allow any user fragment that has the requisite fields to be passed in.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203461667068555) by [Unito](https://www.unito.io)
