### PR TITLE
Always show core subforums in sidebar

### DIFF
--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -47,7 +47,8 @@ ensureIndex(Tags, {deleted: 1, userId: 1, createdAt: 1});
 Tags.addView("currentUserSubforums", (terms: TagsViewTerms, _, context?: ResolverContext) => {
   return {
     selector: {
-      _id: {$in: context?.currentUser?.profileTagIds ?? []},
+      // Always show core subforums
+      $or: [{_id: {$in: context?.currentUser?.profileTagIds ?? []}}, {core: true}],
       isSubforum: true
     },
     options: {sort: {createdAt: -1}},


### PR DESCRIPTION
I've been finishing off [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/6165) for the sidebar redesign but this is all that is needed before we take the banner down. Merging this so as not to block that