### PR TITLE
Add AddFieldQuery class

### DIFF
--- a/packages/lesswrong/lib/sql/AddFieldQuery.ts
+++ b/packages/lesswrong/lib/sql/AddFieldQuery.ts
@@ -10,14 +10,14 @@ import Table from "./Table";
 class AddFieldQuery<T extends DbObject> extends Query<T> {
   constructor(table: Table, fieldName: string) {
     const fields = table.getFields();
-    const field = fields[fieldName];
-    if (!field) {
+    const fieldType = fields[fieldName];
+    if (!fieldType) {
       throw new Error(`Field "${fieldName}" does not exist in the schema`);
     }
     super(table, [
       "ALTER TABLE",
       table,
-      `ADD COLUMN "${fieldName}" ${field.toString()}`,
+      `ADD COLUMN "${fieldName}" ${fieldType.toString()}`,
     ]);
   }
 }

--- a/packages/lesswrong/lib/sql/AddFieldQuery.ts
+++ b/packages/lesswrong/lib/sql/AddFieldQuery.ts
@@ -1,0 +1,25 @@
+import Query from "./Query";
+import Table from "./Table";
+
+/**
+ * Builds a Postgres query to add a new field to a Postgres table.
+ * This assumes that the field already exists in the schema but
+ * has not been propogated to the database yet and, as such, is
+ * mainly meant for use in migrations.
+ */
+class AddFieldQuery<T extends DbObject> extends Query<T> {
+  constructor(table: Table, fieldName: string) {
+    const fields = table.getFields();
+    const field = fields[fieldName];
+    if (!field) {
+      throw new Error(`Field "${fieldName}" does not exist in the schema`);
+    }
+    super(table, [
+      "ALTER TABLE",
+      table,
+      `ADD COLUMN "${fieldName}" ${field.toString()}`,
+    ]);
+  }
+}
+
+export default AddFieldQuery;

--- a/packages/lesswrong/lib/sql/AddFieldQuery.ts
+++ b/packages/lesswrong/lib/sql/AddFieldQuery.ts
@@ -5,7 +5,7 @@ import Table from "./Table";
  * Builds a Postgres query to add a new field to a Postgres table.
  * This assumes that the field already exists in the schema but
  * has not been propogated to the database yet and, as such, is
- * mainly meant for use in migrations.
+ * meant for use in migrations.
  */
 class AddFieldQuery<T extends DbObject> extends Query<T> {
   constructor(table: Table, fieldName: string) {

--- a/packages/lesswrong/lib/sql/index.ts
+++ b/packages/lesswrong/lib/sql/index.ts
@@ -8,6 +8,7 @@ import "./UpdateQuery";
 import "./DeleteQuery";
 import "./CreateTableQuery";
 import "./CreateIndexQuery";
+import "./AddFieldQuery";
 import "./DropIndexQuery";
 import "./Pipeline";
 import "./PgCollection";


### PR DESCRIPTION
This should make writing migrations a lot quicker. After add field `foo` to collection `Bar`, we can just do
```
export const up = async ({db}: MigrationContext) => {
  const {sql} = new AddFieldQuery(Bar.table, "foo").compile();
  await db.none(sql);
}
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203466697968528) by [Unito](https://www.unito.io)
