### PR TITLE
Add max-width property to figures in posts

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -265,6 +265,7 @@ const baseBodyStyles = (theme: ThemeType): JssStyles => ({
     ...tableHeadingStyles(theme)
   },
   '& figure': {
+    maxWidth: '100%',
     margin: '1em auto',
     textAlign: "center"
   },


### PR DESCRIPTION
Fixes https://github.com/ForumMagnum/ForumMagnum/issues/6196.

We allow custom widths on figures (including tables) in CKEditor. This has footgun potential if the fixed width exceeds the parent width, which has come up several times now (most recent instance pictured below, others [here](https://cea-core.slack.com/archives/C01Q279LKCK/p1624651025009900) and [here](https://cea-core.slack.com/archives/C02U2783GUC/p1663038306658959)).

This PR adds a max-width property to fix that.

<img width="1736" alt="image" src="https://user-images.githubusercontent.com/25752873/204895460-ae26ce29-1c5e-4c0f-a8bc-b3c109d49dc0.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203468621301885) by [Unito](https://www.unito.io)
