### PR TITLE
update wording for many votes posts need to go to review phase

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -209,7 +209,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Nominate a post by casting a <em>preliminary vote</em>, or vote on an existing nomination to help us prioritize it during the Review Phase.</li>
         <li>Any post from {REVIEW_YEAR} can be nominated</li>
         <li>Any user registered before {REVIEW_YEAR} can nominate posts for review</li>
-        <li>Posts will need at least one vote to proceed to the Review Phase.</li>
+        <li>Posts will need at least two positive votes to proceed to the Review Phase.</li>
       </ul>
     </div>
 

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -480,6 +480,12 @@ const ReviewVotingPage = ({classes}: {
       </p>
 
       <p className={classes.faqQuestion}>
+        <FaqCard linkText="How many votes are required for a nominated post to proceed to the Review Phase?">
+          <p>Posts will need at least two positive Preliminary Votes to proceed to the Review Phase.</p>
+        </FaqCard>
+      </p>
+
+      <p className={classes.faqQuestion}>
         <FaqCard linkText="Who is eligible?">
           <ul>
             <li>Any user registered before {REVIEW_YEAR} can vote on posts.</li>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -480,7 +480,7 @@ const ReviewVotingPage = ({classes}: {
       </p>
 
       <p className={classes.faqQuestion}>
-        <FaqCard linkText="How many votes are required for a nominated post to proceed to the Review Phase?">
+        <FaqCard linkText="How many votes does a post need to proceed to the Review Phase?">
           <p>Posts will need at least two positive Preliminary Votes to proceed to the Review Phase.</p>
         </FaqCard>
       </p>


### PR DESCRIPTION
We're going to require 2+ positive votes for posts to go to the review phase this year.  Update wording (& add a new FAQ entry) to reflect that.

<img width="715" alt="image" src="https://user-images.githubusercontent.com/2136984/205143204-4e20eb0b-bc57-42e3-93b1-c0cada779067.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203476502665797) by [Unito](https://www.unito.io)
