### PR TITLE
fix type issue from two PRs with conflicting assumptions

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -92,7 +92,7 @@ const PostsEditForm = ({ documentId, classes }: {
   return (
     <div className={classes.postForm}>
       <HeadTags title={document.title} />
-      <Components.PostsAcceptTos currentUser={currentUser} />
+      {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
       <NoSsr>
         <WrappedSmartForm
           collection={Posts}


### PR DESCRIPTION
Recent PRs to add support for [anonymous link-sharing](https://github.com/ForumMagnum/ForumMagnum/pull/4927) and a [new ToS](https://github.com/ForumMagnum/ForumMagnum/pull/6215/files#diff-1760ab6a36c559ac11e2b48fb15eff6bb8158ecda3fa8c56c8be29ff1f9cd4f8R103) were merged in, but together they generated a type error, where `PostsAcceptTos` requires a non-null `currentUser` but the anonymous link-sharing post created the possibility of a null `currentUser` at that point in the control flow (the tests for the first one had passed a couple days ago, and the second one was merged in after that, is my current theory for how that happened).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203477842651432) by [Unito](https://www.unito.io)
