### PR TITLE
Update review route

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -346,6 +346,13 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     ? 'Moderator Comment (Invisible)'
     : 'Moderator Comment';
   
+  const getReviewLink = (year) => {
+    if (year === "2018" || year === "2019") {
+      return `/reviews/${year}`
+    }
+    return `/reviewVoting/${year}`
+  }
+
   return (
     <AnalyticsContext pageElementContext="commentItem" commentId={comment._id}>
       <div className={classNames(
@@ -427,7 +434,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               {`Nomination for ${comment.nominatedForReview} Review`}
             </Link>}
 
-            {comment.reviewingForReview && <Link to={`/reviews/${comment.reviewingForReview}`} className={classes.metaNotice}>
+            {comment.reviewingForReview && <Link to={getReviewLink(comment.reviewingForReview)} className={classes.metaNotice}>
               {`Review for ${isEAForum && comment.reviewingForReview === '2020' ? 'the Decade' : comment.reviewingForReview} Review`}
             </Link>}
           </div>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -346,7 +346,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     ? 'Moderator Comment (Invisible)'
     : 'Moderator Comment';
   
-  const getReviewLink = (year) => {
+  const getReviewLink = (year: string) => {
     // We changed our review page in 2018 and 2019. In 2020 we came up with a page that we'll
     // hopefully stick with for awhile.
     if (year === "2018" || year === "2019") {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -347,6 +347,8 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     : 'Moderator Comment';
   
   const getReviewLink = (year) => {
+    // We changed our review page in 2018 and 2019. In 2020 we came up with a page that we'll
+    // hopefully stick with for awhile.
     if (year === "2018" || year === "2019") {
       return `/reviews/${year}`
     }


### PR DESCRIPTION
The route for the "Review for 20XX" UI element on CommentsItem previously linked to `/reviews/${year}`. That route format was basically deprecated going forward, but we need to continue supporting it for the 2018 and 2019 reviews.