### PR TITLE
Fix comment voting bugs

### DIFF
--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -67,7 +67,7 @@ registerVotingSystem({
   getCommentVotingComponent: () => Components.TwoAxisVoteOnComment,
   addVoteClient: ({voteType, document, oldExtendedScore, extendedVote, currentUser}: {voteType: string|null, document: VoteableTypeClient, oldExtendedScore, extendedVote: any, currentUser: UsersCurrent}): any => {
     const newAgreementPower = calculateVotePower(currentUser.karma, extendedVote?.agreement||"neutral");
-    const oldApprovalVoteCount = ("approvalVoteCount" in oldExtendedScore) ? oldExtendedScore.approvalVoteCount : document.voteCount;
+    const oldApprovalVoteCount = (oldExtendedScore && "approvalVoteCount" in oldExtendedScore) ? oldExtendedScore.approvalVoteCount : document.voteCount;
     const newVoteIncludesApproval = (voteType&&voteType!=="neutral");
     
     return {
@@ -80,7 +80,7 @@ registerVotingSystem({
     const oldVoteAgreement: string | undefined = cancelledExtendedVote?.agreement;
     const oldVoteIncludesAgreement = (oldVoteAgreement && oldVoteAgreement!=="neutral");
     const oldAgreementPower = oldVoteIncludesAgreement ? calculateVotePower(currentUser.karma, oldVoteAgreement) : 0;
-    const oldApprovalVoteCount = ("approvalVoteCount" in oldExtendedScore) ? oldExtendedScore.approvalVoteCount : document.voteCount;
+    const oldApprovalVoteCount = (oldExtendedScore && "approvalVoteCount" in oldExtendedScore) ? oldExtendedScore.approvalVoteCount : document.voteCount;
     const oldVoteIncludesApproval = (voteType&&voteType!=="neutral");
     
     return {


### PR DESCRIPTION
from slack:
>voting on comments appears to be a bit broken right now:
> - on posts I can do one vote (up/down, or agree/disagree), but then I can’t change it after that (or add both an agree and and upvote)
> - on subforums I can’t vote on threads at all, and I have the same problem as above voting on the replies to posts

This fixes the acute problem, although there are still some bugs in the new client side voting thing. If you cast a lot of votes quickly you can end up with a number that doesn't make sense