### PR TITLE
Fix agreement voting on subforums

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -8,6 +8,7 @@ import { forumTypeSetting } from "../../instanceSettings";
 import GraphQLJSON from 'graphql-type-json';
 import { commentGetPageUrlFromDB } from './helpers';
 import { tagCommentTypes } from './types';
+import { getVotingSystemNameForDocument } from '../../voting/votingSystems';
 
 
 export const moderationOptionsGroup: FormGroup = {
@@ -411,14 +412,8 @@ const schema: SchemaType<DbComment> = {
   votingSystem: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: async (comment: DbComment, args: void, context: ResolverContext) => {
-      if (comment?.tagId) return "twoAxis"; // Discussion and subforum comments are both allowed agree/disagree votes
-
-      if (!comment?.postId) {
-        return "default";
-      }
-      const post = await context.loaders.Posts.load(comment.postId);
-      return post.votingSystem || "default";
+    resolver: (comment: DbComment, args: void, context: ResolverContext): Promise<string> => {
+      return getVotingSystemNameForDocument(comment, context)
     }
   }),
   // Legacy: Boolean used to indicate that post was imported from old LW database

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -260,14 +260,21 @@ export function getVotingSystems(): VotingSystem[] {
   return Object.keys(votingSystems).map(k => votingSystems[k]!);
 }
 
-export async function getVotingSystemForDocument(document: VoteableType, context: ResolverContext) {
+export async function getVotingSystemNameForDocument(document: VoteableType, context: ResolverContext): Promise<string> {
+  if ((document as DbComment).tagId) {
+    return "twoAxis";
+  }
   if ((document as DbComment).postId) {
     const post = await context.loaders.Posts.load((document as DbComment).postId);
     if (post?.votingSystem) {
-      return await getVotingSystemByName(post.votingSystem);
+      return post.votingSystem;
     }
   }
-  return getDefaultVotingSystem();
+  return "default";
+}
+
+export async function getVotingSystemForDocument(document: VoteableType, context: ResolverContext) {
+  return getVotingSystemByName(await getVotingSystemNameForDocument(document, context));
 }
 
 


### PR DESCRIPTION
`getVotingSystemForDocument` would previously return the default voting system so agreement votes would be ignored

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203481267548313) by [Unito](https://www.unito.io)
