### PR TITLE
Fix null comparison bug in query builder

### DIFF
--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -251,6 +251,13 @@ abstract class Query<T extends DbObject> {
       }
     } else {
       const hint = unresolvedField.indexOf(".") > 0 && resolvedField.indexOf("::") < 0 ? this.getTypeHint(value) : "";
+      if (value === null) {
+        if (op === "=") {
+          return [`${resolvedField}${hint} IS NULL`];
+        } else if (op === "<>") {
+          return [`${resolvedField}${hint} IS NOT NULL`];
+        }
+      }
       return [`${resolvedField}${hint} ${op} `, new Arg(value)];
     }
   }

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -71,8 +71,8 @@ describe("SelectQuery", () => {
     },
     {
       name: "can build select query with comparison against null",
-      getQuery: () => new SelectQuery(testTable, {a: null}),
-      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" IS NULL',
+      getQuery: () => new SelectQuery(testTable, {a: null, b: {$eq: null}, c: {$ne: null}}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ( "a" IS NULL AND "b" IS NULL AND "c" IS NOT NULL )',
       expectedArgs: [],
     },
     {


### PR DESCRIPTION
Small bug in query builder selectors when using `{$eq: null}` or `{$ne: null}` which blocks migrating sequences. These currently get compiled as `"x" = NULL` and `"x" <> null`, but they should be `"x" IS NULL` and `"x" IS NOT NULL`.