### PR TITLE
Display non-review-votes vs 0-review-votes differently

### DIFF
--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -86,7 +86,6 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
   if (!canNominate(currentUser, post)) return null
 
   const voteIndex = newVote || post.currentUserReviewVote?.qualitativeScore || 0
-  console.log(voteIndex, post.title)
   const displayVote = getCostData({})[voteIndex]?.value
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
 

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -86,38 +86,15 @@ const PostsItemReviewVote = ({classes, post, marginRight=true}: {classes:Classes
   if (!canNominate(currentUser, post)) return null
 
   const voteIndex = newVote || post.currentUserReviewVote?.qualitativeScore || 0
+  console.log(voteIndex, post.title)
   const displayVote = getCostData({})[voteIndex]?.value
   const nominationsPhase = getReviewPhase() === "NOMINATIONS"
-
-  // TODO: if we want to switch to hoverover without click, use this
-  // const voteWidget = <Card className={classes.card}>
-  //   <ReviewVotingWidget post={post} setNewVote={setNewVote}/>
-  //   <ReviewPostButton
-  //     post={post}
-  //     year={REVIEW_YEAR+""}
-  //     reviewMessage={<LWTooltip title={`Write up your thoughts on what was good about a post, how it could be improved, and how you think stands the tests of time as part of the broader ${forumTitleSetting.get()} conversation`} placement="bottom">
-  //       <div className={classes.reviewButton}>Write a Review</div>
-  //     </LWTooltip>}
-  //   />
-  // </Card>;
-
-  // return (
-  //   <LWTooltip
-  //     title={voteWidget}
-  //     placement="right"
-  //     tooltip={false}
-  //     clickable>
-  //     <div className={classNames(classes.buttonWrapper, {[classes.marginRight]:marginRight})} onClick={(e) => setAnchorEl(e.target)}>
-  //       {displayVote ? <span className={classNames(classes.button, [classes[voteIndex]])}>{displayVote}</span> : "Vote"}
-  //     </div>
-  //   </LWTooltip>
-  // )
 
   return <div onMouseLeave={() => setAnchorEl(null)}>
 
     <LWTooltip title={`${nominationsPhase ? "Nominate this post by casting a preliminary vote" : "Update your vote"}`} placement="right">
       <div className={classNames(classes.buttonWrapper, {[classes.marginRight]:marginRight})} onClick={(e) => setAnchorEl(e.target)}>
-        {displayVote ? <span className={classNames(classes.button, [classes[voteIndex]])}>{displayVote}</span> : <span className={classes.voteButton}>Vote</span>}
+        {(voteIndex !== 0) ? <span className={classNames(classes.button, [classes[voteIndex]])}>{displayVote}</span> : <span className={classes.voteButton}>Vote</span>}
       </div>
     </LWTooltip>
 


### PR DESCRIPTION
Previously if you voted a post at "0", it wouldn't show up in the postslist, and would just say "vote". Now it is different:

<img width="804" alt="image" src="https://user-images.githubusercontent.com/3246710/205398309-94a73630-ec1c-46b2-95b5-5d918eaa6eaf.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203484217604758) by [Unito](https://www.unito.io)
