### PR TITLE
Rename "Needs Vote", add tooltip

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -19,6 +19,7 @@ import Card from '@material-ui/core/Card';
 import { randomId } from '../../lib/random';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
+const isLW = forumTypeSetting.get() === 'LessWrong'
 
 const styles = (theme: ThemeType): JssStyles => ({
   grid: {
@@ -571,20 +572,20 @@ const ReviewVotingPage = ({classes}: {
                 disableUnderline
                 >
                 {getReviewPhase() === "NOMINATIONS" && <MenuItem value={'needsPreliminaryVote'}>
-                  <LWTooltip title="Prioritizes posts with at least one Review, which you haven't yet voted on">
-                    <span><span className={classes.sortBy}>Sort by</span> Magic</span>
+                  <LWTooltip placement="left" title="Prioritizes posts with at least one Review, which you haven't yet voted on">
+                    <span><span className={classes.sortBy}>Sort by</span> Prioritized</span>
                   </LWTooltip>
                 </MenuItem>}
                 <MenuItem value={'lastCommentedAt'}>
                   <span className={classes.sortBy}>Sort by</span> Last Commented
                 </MenuItem>
-                <MenuItem value={'reviewVoteScoreHighKarma'}>
+                {getReviewPhase() === "REVIEWS" && <MenuItem value={'reviewVoteScoreHighKarma'}>
                   <span className={classes.sortBy}>Sort by</span> Vote Total (1000+ Karma Users)
-                </MenuItem>
-                <MenuItem value={'reviewVoteScoreAllKarma'}>
+                </MenuItem>}
+                {getReviewPhase() === "REVIEWS" && <MenuItem value={'reviewVoteScoreAllKarma'}>
                   <span className={classes.sortBy}>Sort by</span> Vote Total (All Users)
-                </MenuItem>
-                {!isEAForum && <MenuItem value={'reviewVoteScoreAF'}>
+                </MenuItem>}
+                {getReviewPhase() === "REVIEWS" && isLW && <MenuItem value={'reviewVoteScoreAF'}>
                   <span className={classes.sortBy}>Sort by</span> Vote Total (Alignment Forum Users)
                 </MenuItem>}
                 <MenuItem value={'yourVote'}>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -571,7 +571,9 @@ const ReviewVotingPage = ({classes}: {
                 disableUnderline
                 >
                 {getReviewPhase() === "NOMINATIONS" && <MenuItem value={'needsPreliminaryVote'}>
-                  <span className={classes.sortBy}>Sort by</span> Needs Vote
+                  <LWTooltip title="Prioritizes posts with at least one Review, which you haven't yet voted on">
+                    <span><span className={classes.sortBy}>Sort by</span> Magic</span>
+                  </LWTooltip>
                 </MenuItem>}
                 <MenuItem value={'lastCommentedAt'}>
                   <span className={classes.sortBy}>Sort by</span> Last Commented


### PR DESCRIPTION
– changes the name of "Needs Vote" sorting option to not be misleading, and include a tooltip
– removes "sort by vote total" except during the Review Phase
– changes AF vote total sorting to require being on LW, rather than Not EA Forum (since if other non-EA-forum Forum Magnum sites want to do a review they wouldn't be able to use AF karma)

<img width="485" alt="image" src="https://user-images.githubusercontent.com/3246710/205401184-025cb8cd-b71a-4968-b1b6-a4ebede2ab92.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203484266597388) by [Unito](https://www.unito.io)
