### PR TITLE
pass through index hint for enableTotal count queries

### DIFF
--- a/packages/lesswrong/lib/alignment-forum/comments/views.ts
+++ b/packages/lesswrong/lib/alignment-forum/comments/views.ts
@@ -14,7 +14,7 @@ Comments.addView("alignmentSuggestedComments", function (terms) {
     options: {
       sort: {
         postedAt: 1,
-      },
+      }, 
       hint: "comments.alignmentSuggestedComments",
     }
   }

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -97,6 +97,7 @@ type ViewQueryAndOptions<
     limit?: number
     skip?: number
     projection?: MongoProjection<T>
+    hint?: string
   }
 }
 
@@ -109,6 +110,7 @@ interface MergedViewQueryAndOptions<
     sort: MongoSort<T>
     limit: number
     skip?: number
+    hint?: string
   }
 }
 

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -65,7 +65,8 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
           // get total count of documents matching the selector
           // TODO: Make this handle synthetic fields
           if (saturated) {
-            data.totalCount = await Utils.Connectors.count(collection, parameters.selector);
+            const { hint } = parameters.options;
+            data.totalCount = await Utils.Connectors.count(collection, parameters.selector, { hint });
           } else {
             data.totalCount = viewableDocs.length;
           }
@@ -189,6 +190,7 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
     logger('aggregation pipeline', pipeline);
     return await collection.aggregate(pipeline).toArray();
   } else {
+    logger('queryFromViewParameters connector find', selector, terms, options);
     return await Utils.Connectors.find(collection,
       {
         ...selector,


### PR DESCRIPTION
We've had occassional issues where AF admins loading the front page of LW caused extremely slow queries (full table scans on `comments`).  After some investigation, I realized that the trigger was having 10 or more comments suggested for alignment, and some more digging revealed that default resolver logic wasn't passing through view-derived parameter options for the `count` query that only gets run when `enableTotal: true` and there are at least as many documents returned as the `limit`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203484348434834) by [Unito](https://www.unito.io)
