### PR TITLE
don't update revisions, and don't save new ones for webhook events with no diff or no data

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -270,7 +270,7 @@ export async function dataToCkEditor(data, type) {
  * is just to find the first place where this occurs and then to ignore to the end of
  * the document.
  */
-export async function dataToWordCount(data, type) {
+export async function dataToWordCount(data, type): Promise<number> {
   try {
     const markdown = dataToMarkdown(data, type) ?? "";
     const withoutFootnotes = markdown

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -68,11 +68,21 @@ function versionIsDraft(semver: string, collectionName: CollectionNameString) {
 
 ensureIndex(Revisions, {documentId: 1, version: 1, fieldName: 1, editedAt: 1})
 
-export async function buildRevision({ originalContents, currentUser, dataWithDiscardedSuggestions }:{
-  originalContents: DbRevision["originalContents"],
-  currentUser: DbUser,
-  dataWithDiscardedSuggestions?: string
-}) {
+interface BuildRevisionParams {
+  originalContents: DbRevision['originalContents'];
+  currentUser: DbUser;
+  dataWithDiscardedSuggestions?: string;
+}
+
+export interface BuiltRevision  {
+  html: string;
+  wordCount: number;
+  originalContents: DbRevision['originalContents'];
+  editedAt: Date;
+  userId: string;
+}
+
+export async function buildRevision({ originalContents, currentUser, dataWithDiscardedSuggestions }: BuildRevisionParams): Promise<BuiltRevision> {
   const { data, type } = originalContents;
   const readerVisibleData = dataWithDiscardedSuggestions ?? data
   const html = await dataToHTML(readerVisibleData, type, !currentUser.isAdmin)


### PR DESCRIPTION
We occasionally experience issues where ckEditor sends us autosave info via webhook which clobbers user documents with "empty" revisions.  Sometimes these have non-breaking spaces in them, so that's why I'm using word count rather than `data.length`.  Regardless, this basically sucks as a user experience, and if you want to delete the entire contents of your post I don't think it's crazy to expect users to click "save" (and for them to be correspondingly less upset by the editor failing to autosave the "delete everything" operation, than by it accidentally deleting everything!)