### PR TITLE
Add note to README, postinstall.sh about perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Forum Magnum is built on top of a number major open-source libraries.
   * Node
     * see `.nvmrc` for the required node version
     * You can use [Node Version Manager](https://github.com/creationix/nvm) to install the appropriate version of Node
+  * Curl, Perl are optional, but needed to run some scripts and tests
 
 ### Installation
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -56,6 +56,16 @@ else
   echo
 fi
 
+echo -n "Checking for perl... "
+if which perl >/dev/null; then
+  echo "yes"
+else
+  echo "no"
+  echo "You do not have perl installed. The server will still run, you will not be able"
+  echo "to run makemigrations"
+  echo
+fi
+
 if [ ! -f settings.json ]; then
   echo "Creating settings.json"
   cp sample_settings.json settings.json


### PR DESCRIPTION
Note that postinstall will not fail your install for not having perl. The addition raises the salience of needing perl so you are better prepared for needing to write your first migration.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203497377055713) by [Unito](https://www.unito.io)
