### PR TITLE
[WIP] Post-summarizer language model integration, first prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
     "mongodb": "^3.6.3",
     "mz": "^2.7.0",
     "nodemailer": "^6.6.1",
+    "openai": "^3.1.0",
     "papaparse": "^4.6.2",
     "passport": "^0.5.2",
     "passport-auth0": "^1.4.0",

--- a/packages/lesswrong/components/languageModels/PostSummaryAction.tsx
+++ b/packages/lesswrong/components/languageModels/PostSummaryAction.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { useDialog } from '../common/withDialog';
+import { useSingle } from '../../lib/crud/withSingle';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import MenuItem from '@material-ui/core/MenuItem';
+
+const styles = (theme: ThemeType) => ({
+})
+
+const PostSummaryAction = ({post, classes}: {
+  post: PostsList,
+  classes: ClassesType,
+}) => {
+  const { openDialog } = useDialog();
+  
+  const showPostSummary = () => {
+    openDialog({
+      componentName: "PostSummaryDialog",
+      componentProps: { post },
+    });
+  }
+  
+  return <MenuItem onClick={showPostSummary}>
+    Summarize
+  </MenuItem>
+}
+
+const PostSummaryDialog = ({post, onClose, classes}: {
+  post: PostsList,
+  onClose?: ()=>void,
+  classes: ClassesType,
+}) => {
+  const { Loading, LWDialog } = Components;
+  const { document: postWithSummary, loading } = useSingle({
+    collectionName: "Posts",
+    fragmentName: "PostWithGeneratedSummary",
+    documentId: post._id,
+  });
+  
+  return <LWDialog open={true} onClose={onClose}>
+    <DialogTitle>{post.title}</DialogTitle>
+    <DialogContent>
+      {loading && <Loading/>}
+      {postWithSummary && postWithSummary.languageModelSummary}
+    </DialogContent>
+  </LWDialog>
+}
+
+const PostSummaryActionComponent = registerComponent('PostSummaryAction', PostSummaryAction, {styles});
+const PostSummaryDialogComponent = registerComponent('PostSummaryDialog', PostSummaryDialog, {styles});
+
+declare global {
+  interface ComponentTypes {
+    PostSummaryAction: typeof PostSummaryActionComponent
+    PostSummaryDialog: typeof PostSummaryDialogComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -22,6 +22,7 @@ import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema
 import { useDialog } from '../../common/withDialog';
 import { forumTypeSetting, taggingNamePluralCapitalSetting } from '../../../lib/instanceSettings';
 import { forumSelect } from '../../../lib/forumTypeUtils';
+import { userHasAutosummarize } from '../../../lib/betas';
 
 // We use a context here vs. passing in a boolean prop because we'd need to pass through ~4 layers of hierarchy
 export const AllowHidingFrontPagePostsContext = React.createContext<boolean>(false)
@@ -282,6 +283,10 @@ const PostActions = ({post, closeMenu, classes}: {
             Edit {taggingNamePluralCapitalSetting.get()}
           </MenuItem>
         </div>
+        
+        {userHasAutosummarize(currentUser)
+          && <Components.PostSummaryAction post={post}/>}
+        
         { isRead
           ? <div onClick={handleMarkAsUnread}>
               <MenuItem>

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -32,6 +32,8 @@ export const userCanUseSharing = (user: UsersCurrent|DbUser|null): boolean => mo
 export const userHasNewTagSubscriptions =  isEAForum ? shippedFeature : disabled
 export const userHasDefaultProfilePhotos = disabled
 
+export const userHasAutosummarize = adminOnly
+
 export const userHasThemePicker = isEAForum ? adminOnly : shippedFeature;
 
 export const userHasSideComments = isEAForum ? optInOnly : shippedFeature;

--- a/packages/lesswrong/lib/collections/languageModelCache/collection.ts
+++ b/packages/lesswrong/lib/collections/languageModelCache/collection.ts
@@ -1,0 +1,30 @@
+import { createCollection } from '../../vulcan-lib';
+import { addUniversalFields } from '../../collectionUtils'
+import { ensureIndex } from '../../collectionIndexUtils';
+
+const schema: SchemaType<DbTagFlag> = {
+  prompt: {
+    type: String,
+  },
+  model: {
+    type: String,
+  },
+  result: {
+    type: String,
+  },
+}
+
+export const LanguageModelCache: LanguageModelCacheCollection = createCollection({
+  collectionName: 'LanguageModelCache',
+  typeName: 'LanguageModelCache',
+  schema,
+  logChanges: false,
+});
+
+addUniversalFields({
+  collection: LanguageModelCache,
+});
+
+ensureIndex(LanguageModelCache, {model:1, prompt:1, _id:1});
+
+export default LanguageModelCache;

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -576,3 +576,10 @@ registerFragment(`
     sideComments
   }
 `);
+
+registerFragment(`
+  fragment PostWithGeneratedSummary on Post {
+    _id
+    languageModelSummary
+  }
+`);

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2363,6 +2363,14 @@ const schema: SchemaType<DbPost> = {
     type: Object,
     foreignKey: 'Comments',
   },
+  
+  languageModelSummary: {
+    type: String,
+    optional: true,
+    hidden: true,
+    canRead: ['admins'],
+    // Implementation in postSummaryResolver.ts
+  },
 };
 
 /* subforum-related fields */

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -681,6 +681,8 @@ importComponent("PrefixedInput", () => require('../components/form-components/Pr
 importComponent("PodcastEpisodeInput", () => require('../components/form-components/PodcastEpisodeInput'));
 importComponent("ThemeSelect", () => require('../components/form-components/ThemeSelect'));
 
+importComponent(["PostSummaryAction","PostSummaryDialog"], () => require('../components/languageModels/PostSummaryAction'));
+
 importComponent(["CommentOnSelectionPageWrapper","SelectedTextToolbar","CommentOnSelectionContentWrapper"], () => require('../components/comments/CommentOnSelection'));
 importComponent("PopupCommentEditor", () => require('../components/comments/PopupCommentEditor'));
 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -292,6 +292,18 @@ interface DbLWEvent extends DbObject {
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
 }
 
+interface LanguageModelCacheCollection extends CollectionBase<DbLanguageModelCache, "LanguageModelCache"> {
+}
+
+interface DbLanguageModelCache extends DbObject {
+  __collectionName?: "LanguageModelCache"
+  prompt: string
+  model: string
+  result: string
+  createdAt: Date
+  legacyData: any /*{"definitions":[{"blackbox":true}]}*/
+}
+
 interface LegacyDataCollection extends CollectionBase<DbLegacyData, "LegacyData"> {
 }
 
@@ -1244,6 +1256,7 @@ interface CollectionsByName {
   FeaturedResources: FeaturedResourcesCollection
   GardenCodes: GardenCodesCollection
   LWEvents: LWEventsCollection
+  LanguageModelCache: LanguageModelCacheCollection
   LegacyData: LegacyDataCollection
   Localgroups: LocalgroupsCollection
   Messages: MessagesCollection
@@ -1288,6 +1301,7 @@ interface ObjectsByCollectionName {
   FeaturedResources: DbFeaturedResource
   GardenCodes: DbGardenCode
   LWEvents: DbLWEvent
+  LanguageModelCache: DbLanguageModelCache
   LegacyData: DbLegacyData
   Localgroups: DbLocalgroup
   Messages: DbMessage

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -269,6 +269,8 @@ interface UsersDefaultFragment { // fragment on Users
   readonly commentingOnOtherUsersDisabled: boolean,
   readonly conversationsDisabled: boolean,
   readonly acknowledgedNewUserGuidelines: boolean | null,
+  readonly experiencedIn: Array<string>,
+  readonly interestedIn: Array<string>,
   readonly afPostCount: number,
   readonly afCommentCount: number,
   readonly afSequenceCount: number,
@@ -650,6 +652,7 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly moderationStyle: string,
   readonly hideCommentKarma: boolean,
   readonly commentCount: number,
+  readonly languageModelSummary: string,
   readonly subforumTagId: string,
   readonly af: boolean,
   readonly afDate: Date,
@@ -1175,6 +1178,11 @@ interface HighlightWithHash_contents { // fragment on Revisions
 interface PostSideComments { // fragment on Posts
   readonly _id: string,
   readonly sideComments: any,
+}
+
+interface PostWithGeneratedSummary { // fragment on Posts
+  readonly _id: string,
+  readonly languageModelSummary: string,
 }
 
 interface CommentsList { // fragment on Comments
@@ -2892,6 +2900,7 @@ interface FragmentTypes {
   WithVotePost: WithVotePost
   HighlightWithHash: HighlightWithHash
   PostSideComments: PostSideComments
+  PostWithGeneratedSummary: PostWithGeneratedSummary
   CommentsList: CommentsList
   ShortformComments: ShortformComments
   CommentWithRepliesFragment: CommentWithRepliesFragment
@@ -3069,6 +3078,7 @@ interface CollectionNamesByFragmentName {
   WithVotePost: "Posts"
   HighlightWithHash: "Posts"
   PostSideComments: "Posts"
+  PostWithGeneratedSummary: "Posts"
   CommentsList: "Comments"
   ShortformComments: "Comments"
   CommentWithRepliesFragment: "Comments"
@@ -3197,5 +3207,5 @@ interface CollectionNamesByFragmentName {
   SuggestAlignmentComment: "Comments"
 }
 
-type CollectionNameString = "AdvisorRequests"|"Bans"|"Books"|"Chapters"|"ClientIds"|"Collections"|"CommentModeratorActions"|"Comments"|"Conversations"|"DatabaseMetadata"|"DebouncerEvents"|"EmailTokens"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"LegacyData"|"Localgroups"|"Messages"|"Migrations"|"ModerationTemplates"|"ModeratorActions"|"Notifications"|"PetrovDayLaunchs"|"PodcastEpisodes"|"Podcasts"|"PostRelations"|"Posts"|"RSSFeeds"|"ReadStatuses"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Spotlights"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"UserTagRels"|"Users"|"Votes"
+type CollectionNameString = "AdvisorRequests"|"Bans"|"Books"|"Chapters"|"ClientIds"|"Collections"|"CommentModeratorActions"|"Comments"|"Conversations"|"DatabaseMetadata"|"DebouncerEvents"|"EmailTokens"|"FeaturedResources"|"GardenCodes"|"LWEvents"|"LanguageModelCache"|"LegacyData"|"Localgroups"|"Messages"|"Migrations"|"ModerationTemplates"|"ModeratorActions"|"Notifications"|"PetrovDayLaunchs"|"PodcastEpisodes"|"Podcasts"|"PostRelations"|"Posts"|"RSSFeeds"|"ReadStatuses"|"Reports"|"ReviewVotes"|"Revisions"|"Sequences"|"Spotlights"|"Subscriptions"|"TagFlags"|"TagRels"|"Tags"|"UserTagRels"|"Users"|"Votes"
 

--- a/packages/lesswrong/lib/generated/viewTypes.ts
+++ b/packages/lesswrong/lib/generated/viewTypes.ts
@@ -13,6 +13,7 @@ type EmailTokensViewName = never
 type FeaturedResourcesViewName = "activeResources";
 type GardenCodesViewName = "usersPrivateGardenCodes"|"publicGardenCodes"|"gardenCodeByCode";
 type LWEventsViewName = "adminView"|"postVisits"|"emailHistory"|"gatherTownUsers";
+type LanguageModelCacheViewName = never
 type LegacyDataViewName = never
 type LocalgroupsViewName = "userOrganizesGroups"|"userActiveGroups"|"userInactiveGroups"|"all"|"nearby"|"single"|"local"|"online";
 type MessagesViewName = "messagesConversation"|"conversationPreview";
@@ -56,6 +57,7 @@ interface ViewTermsByCollectionName {
   FeaturedResources: FeaturedResourcesViewTerms
   GardenCodes: GardenCodesViewTerms
   LWEvents: LWEventsViewTerms
+  LanguageModelCache: ViewTermsBase
   LegacyData: ViewTermsBase
   Localgroups: LocalgroupsViewTerms
   Messages: MessagesViewTerms

--- a/packages/lesswrong/lib/index.ts
+++ b/packages/lesswrong/lib/index.ts
@@ -172,6 +172,9 @@ import './collections/featuredResources/fragments'
 // Votes
 import './collections/votes';
 
+// Language-Model Cache
+import './collections/languageModelCache/collection';
+
 // Spotlights
 import './collections/spotlights/collection';
 import './collections/spotlights/fragments';

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -146,8 +146,10 @@ import './server/fmCrosspost/routes';
 
 import './server/spotlightCron';
 
-import './server/codegen/generateTypes';
+import './server/languageModels/languageModelIntegration';
+import './server/languageModels/postSummaryResolver';
 
+import './server/codegen/generateTypes';
 import './server/styleGeneration';
 
 // Algolia Search Integration

--- a/packages/lesswrong/server/languageModels/languageModelIntegration.ts
+++ b/packages/lesswrong/server/languageModels/languageModelIntegration.ts
@@ -1,0 +1,207 @@
+import { Configuration as OpenAIApiConfiguration, OpenAIApi } from "openai";
+import { Tags } from '../../lib/collections/tags/collection';
+import { dataToMarkdown } from '../editor/conversionUtils';
+import drop from 'lodash/drop';
+
+// Put your OpenAI API key here. TODO: Make this an instance setting.
+const openAIApiKey:string|null = null;
+
+let openAIApi: OpenAIApi|null = null;
+async function getOpenAI(): Promise<OpenAIApi|null> {
+  if (!openAIApi && openAIApiKey) {
+    openAIApi = new OpenAIApi(new OpenAIApiConfiguration({
+      apiKey: openAIApiKey,
+    }));
+  }
+  return openAIApi;
+}
+
+type LanguageModelAPI = "disabled"|"stub"|"openai";
+type LanguageModelClassificationTask = "isSpam"|"isFrontpage";
+type LanguageModelGenerationTask = "summarize"|"authorFeedback";
+type LanguageModelTask = LanguageModelClassificationTask|LanguageModelGenerationTask;
+
+type LanguageModelConfig = {
+  template: string,
+  task: LanguageModelTask,
+  api: LanguageModelAPI,
+  model: string,
+}
+
+type LanguageModelJob = LanguageModelConfig & {
+  maxTokens: number
+  inputs: Record<string,string>
+}
+
+/**
+ * canDoLanguageModelTask: Returns true if we're configured with an API key,
+ * prompts and anything else necessary to perform a language-model-based task.
+ * If this is false, UI for corresponding language-model-based features should
+ * not be displayed on the client.
+ *
+ * (Attempting to run language-model tasks may still fail even if this returned
+ * true, eg if we get an error from the OpenAI API).
+ */
+export async function canDoLanguageModelTask(task: LanguageModelTask, context: ResolverContext): Promise<boolean> {
+  const config = await getLMConfigForTask(task, context);
+  return (config && config.api!=="disabled");
+}
+
+function taskToWikiSlug(task: LanguageModelTask): string {
+  return `lm-config-${task.toLowerCase()}`;
+}
+
+/**
+ * Given a language-model task type, retrieve a corresponding template. Uses the
+ * text of an admin-only wiki page, formatted as Markdown.
+ */
+async function getLMConfigForTask(task: LanguageModelTask, context: ResolverContext): Promise<LanguageModelConfig> {
+  const wikiPageSlug = taskToWikiSlug(task);
+  const tag = await Tags.findOne({slug: wikiPageSlug});
+  
+  if (tag) {
+    return tagToLMConfig(tag, task);
+  } else {
+    return {
+      task,
+      api: "stub",
+      template: "Test ${input}", //eslint-disable-line no-template-curly-in-string
+      model: "stub-model",
+    };
+  }
+}
+
+function tagToLMConfig(tag: DbTag, task: LanguageModelTask): LanguageModelConfig {
+  if (!tag) throw new Error("Tag not found");
+  const descriptionMarkdown = dataToMarkdown(tag.description?.originalContents?.data, tag.description?.originalContents?.type);
+  const lines = descriptionMarkdown.trim().split('\n');
+  
+  let api: LanguageModelAPI = "disabled";
+  let model = "stub";
+  let template = "";
+  for (let i=0; i<lines.length; i++) {
+    const line = lines[i];
+    if (line.trim()==="") {
+      template = drop(lines,i+1).join("\n");
+      break;
+    }
+    
+    const [_headerLine,headerName,headerValue] = line.match(/^([a-zA-Z0-9_]+):\s*([^\s]*)\s*$/)
+    switch(headerName.toLowerCase()) {
+      case "api":
+        api = headerValue as LanguageModelAPI;
+        break;
+      case "model":
+        model = headerValue;
+        break;
+    }
+  }
+  
+  return { api, model, task, template };
+}
+
+/**
+ * Given a template for a language-model task, which is in markdown, and a set
+ * of key-value pairs, find instances of "${key}" in the text and substitute
+ * them.
+ *
+ * This is NOT safe for SQL, HTML rendering, or anything else that's sensitive
+ * to quoting. It is intended only for use with language-model prompting.
+ */
+function substituteIntoTemplate(template: string, inputs: Record<string,string>): string {
+  let result = template;
+  
+  for (let key of Object.keys(inputs)) {
+    result = result.replace(new RegExp("\\${"+key+"}", "g"), inputs[key]);
+  }
+  
+  return result;
+}
+
+/**
+ * Perform a binary-classification task using a language model. The provided
+ * input is the text that is being classified; it does *not* include the wrapping
+ * template, which is admin-configurable and loaded from the database.
+ */
+export async function languageModelClassify({taskName, inputs, context}: {
+  taskName: LanguageModelClassificationTask,
+  inputs: Record<string,string>,
+  context: ResolverContext,
+}): Promise<boolean|"maybe"> {
+  const lmConfig = await getLMConfigForTask(taskName, context);
+  const continuation = await languageModelExecute({
+    template: lmConfig.template,
+    inputs,
+    task: lmConfig.task,
+    api: lmConfig.api,
+    model: lmConfig.model,
+    maxTokens: 1,
+  });
+  const tokenizedContinuation = continuation.split(/\s+/);
+  const firstToken = tokenizedContinuation[0];
+  
+  if (firstToken.toLowerCase()==="yes")
+    return true;
+  else if (firstToken.toLowerCase()==="no")
+    return false;
+  else
+    return "maybe";
+}
+
+/**
+ * Perform a text-generation task using a language model. The provided input is
+ the text that is being classified; it does *not* include the wrapping template,
+ * which is admin-configurable and loaded from the database.
+ */
+export async function languageModelGenerateText({taskName, inputs, maxTokens, context}: {
+  taskName: LanguageModelGenerationTask,
+  inputs: Record<string,string>,
+  maxTokens: number,
+  context: ResolverContext,
+}): Promise<string> {
+  const lmConfig = await getLMConfigForTask(taskName, context);
+  const continuation = await languageModelExecute({
+    template: lmConfig.template,
+    inputs,
+    task: lmConfig.task,
+    api: lmConfig.api,
+    model: lmConfig.model,
+    maxTokens,
+  });
+  return continuation;
+}
+
+async function languageModelExecute(job: LanguageModelJob): Promise<string> {
+  // TODO: Check and populate the cache
+  
+  switch(job.api) {
+    default: {
+      throw new Error(`Invalid language model API: ${job.api}`);
+    }
+    case "disabled": {
+      throw new Error(`Language model not available for job type: ${job.task}`);
+    }
+    case "stub": {
+      return `Placeholder language model. Template was: ${JSON.stringify(job.template)}.\n\nInputs were: ${JSON.stringify(job.inputs)}.`;
+      break;
+    }
+    case "openai": {
+      const api = await getOpenAI();
+      if (!api) throw new Error("OpenAI API not configured");
+      const prompt = substituteIntoTemplate(job.template, job.inputs);
+      console.log(`Prompting with: ${JSON.stringify(prompt)}`);
+      const response = await api.createCompletion({
+        model: job.model,
+        prompt: prompt,
+        max_tokens: job.maxTokens,
+        //temperature: 0.7,
+        //top_p: 1,
+        //frequency_penalty: 0,
+        //presence_penalty: 0,
+      });
+      const topResult = response.data.choices[0].text;
+      if (topResult) return topResult;
+      else throw new Error("API did not return a top result");
+    }
+  }
+}

--- a/packages/lesswrong/server/languageModels/postSummaryResolver.ts
+++ b/packages/lesswrong/server/languageModels/postSummaryResolver.ts
@@ -1,0 +1,27 @@
+import { Posts } from '../../lib/collections/posts/collection';
+import { augmentFieldsDict } from '../../lib/utils/schemaUtils'
+import { dataToMarkdown } from '../editor/conversionUtils';
+import { languageModelGenerateText } from './languageModelIntegration';
+
+augmentFieldsDict(Posts, {
+  languageModelSummary: {
+    resolveAs: {
+      type: "String",
+      resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<string> => {
+        const markdownPostBody = dataToMarkdown(post.contents?.originalContents?.data, post.contents?.originalContents?.type);
+        const authorName = "Authorname"; //TODO
+        
+        return await languageModelGenerateText({
+          taskName: "summarize",
+          inputs: {
+            title: post.title,
+            author: authorName,
+            text: markdownPostBody,
+          },
+          maxTokens: 1000,
+          context
+        });
+      }
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,7 +4851,7 @@ axios@^0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
-axios@^0.26.1:
+axios@^0.26.0, axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
@@ -8326,6 +8326,15 @@ form-data@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -12282,6 +12291,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+openai@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-3.1.0.tgz#13bfb228cf777155b882c2deb3a03bc5094cb7b3"
+  integrity sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==
+  dependencies:
+    axios "^0.26.0"
+    form-data "^4.0.0"
 
 opentracing@>=0.12.1:
   version "0.14.7"


### PR DESCRIPTION
First prototype of a language-model integration feature. The feature itself does not work well (both because of the caveats, and because GPT-3 isn't quite up to the task), but this lays groundwork for other language-model integration experiments, and might be fun to play around with.

UI-wise, this is an admin-only feature which adds a "Summarize" button to the post-actions menu (ie, the triple-dot icon on post-items and post-pages). This takes the post body, combines it with some prompt text, feeds it to the OpenAI API, and shows you the result.

The way this is configured is via an admin-only wiki page named "LM Config Summarize". I have created this in the dev DB; the feature will not work unless it exists. It looks like this:

```
api: openai
model: text-davinci-003

${title}
by ${author}

${text}

======

Please summarize the post above in a paragraph.
```

Editing the first two lines changes the API that's used for the language model; the remainder is a template used to control how the text is prompted.

Limitations:
 * The post and prompt must fit within a size limit of ~4k tokens or you'll get a server-side error that gives you no client-side feedback. It doesn't truncate yet.
 * I tried it on a few posts and spotted major factual errors in some of the summaries.
 * You will need to provide your own OpenAI API key by editing `languageModelIntegration.ts`. (This will probably turn into a database-setting or an instance-setting.)
 * There is some piping for caching results, but they are not yet actually cached
