### PR TITLE
only moderate negative karma users who were recently active

### DIFF
--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -70,10 +70,10 @@ function isActiveNegativeKarmaUser(user: DbUser, voteableItems: (DbComment | DbP
     // Not enough engagement to make a judgment
     if (voteableItems.length < 5) return false;
 
-    const oneWeekAgo = moment().subtract(7, 'days').toDate();
+    const oneMonthAgo = moment().subtract(1, 'month').toDate();
   
     // If the user hasn't posted in a while, we don't care if someone's been voting on their old content
-    if (voteableItems.every(item => item.postedAt < oneWeekAgo)) return false;
+    if (voteableItems.every(item => item.postedAt < oneMonthAgo)) return false;
 
     return user.karma < -5;
 }


### PR DESCRIPTION
Occassionally we'll get a user in the moderation queue due to the `NEGATIVE_KARMA_USER_ALERT` moderator action, when they haven't been active on the site in years, because someone recently downvoted one of their posts or comments, and they were either already at negative karma or that tipped them over.  These users are pretty pointless to moderate since they aren't active on the site.

Changes this so that we only trigger the rule if they have:
- enough posts and comments that them being a "negative karma user" is meaningful
- any recent posts at all

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203525510787726) by [Unito](https://www.unito.io)
