### PR TITLE
Fix typos introduced by a single-to-double-quotes conversion hitting apostrophes

### DIFF
--- a/packages/lesswrong/components/tagging/usePersonalBlogpostInfo.tsx
+++ b/packages/lesswrong/components/tagging/usePersonalBlogpostInfo.tsx
@@ -4,10 +4,10 @@ import { ForumOptions, forumSelect } from "../../lib/forumTypeUtils";
 const lwafPersonalBlogpostInfo = {
   name: "Personal Blog",
   tooltip: <div>
-    <p><b>Personal Blogposts</b> are posts that don"t fit LessWrong"s Frontpage Guidelines. They get less visibility by default. The frontpage guidelines are:</p>
+    <p><b>Personal Blogposts</b> are posts that don't fit LessWrong's Frontpage Guidelines. They get less visibility by default. The frontpage guidelines are:</p>
     <ul>
       <li><em>Timelessness</em>. Will people still care about this in 5 years?</li>
-      <li><em>Avoid political topics</em>. They"re important to discuss sometimes, but we try to avoid it on LessWrong.</li>
+      <li><em>Avoid political topics</em>. They're important to discuss sometimes, but we try to avoid it on LessWrong.</li>
       <li><em>General Appeal</em>. Is this a niche post that only a small fraction of users will care about?</li>
     </ul>
   </div>


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/commit/da2686822264944f7b59f3e39bd0ee98308f0947

I did a few regex-searches looking for other instances of the same file but didn't find any outside of this file.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203525976937303) by [Unito](https://www.unito.io)
