### PR TITLE
Console error fixes

### DIFF
--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -19,13 +19,13 @@ const EASequencesHome = ({classes}) => {
       <SectionTitle  title="Sequences" >
         <SequencesNewButton />
       </SectionTitle>
-      <Typography variant='body1' className={classes.description} gutterBottom>
-        <ContentStyles contentType="post">
+      <ContentStyles contentType="post">
+        <Typography variant='body1' className={classes.description} gutterBottom>
           Sequences are collections of posts on a common theme, or that build on each other. They
           help authors to develop ideas in ways that would be difficult in a single post. You can also
           add posts written by other people to a sequence if you think they should be read together.
-        </ContentStyles>
-      </Typography>
+        </Typography>
+      </ContentStyles>
       <div className={classes.sequencesGridWrapperWrapper}>
         <Components.SequencesGridWrapper
           terms={{'view': 'communitySequences', limit: 12}}

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -7,7 +7,6 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { tagStyle } from './FooterTag';
 import Input from '@material-ui/core/Input';
 import { Link } from '../../lib/reactRouterWrapper';
-import { isMobile } from '../../lib/utils/isMobile'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { userHasNewTagSubscriptions } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
@@ -97,7 +96,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 60,
     "-webkit-appearance": "none",
     "-moz-appearance": "textfield"
-  }
+  },
+  hideOnMobile: {
+    [theme.breakpoints.down('sm')]: {
+      display: "none",
+    },
+  },
+  hideOnDesktop: {
+    [theme.breakpoints.up('md')]: {
+      display: "none",
+    },
+  },
 });
 
 const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChangeMode, onRemove, description, classes}: {
@@ -177,12 +186,16 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
 
   return <span {...eventHandlers} className={classNames(classes.tag, {[classes.noTag]: !tagId})}>
     <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag?._id} tagName={tag?.name}>
-      {(tag && !isMobile()) ?
-        <Link to={tagGetUrl(tag)}>
-          {tagLabel}
-        </Link> :
-        tagLabel
-      }
+      {tag ? (
+        <>
+          <Link to={tagGetUrl(tag)} className={classes.hideOnMobile}>
+            {tagLabel}
+          </Link>
+          <span className={classes.hideOnDesktop}>
+            {tagLabel}
+          </span>
+        </>
+      ) : tagLabel}
       <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom-start">
         <div className={classes.filtering}>
           <div className={classes.filterRow}>

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -517,6 +517,8 @@ const TagSubforumPage2 = ({classes}: {
       <div className={classes.membersListLink}>
         {!membersCountLoading && <button className={classes.membersListLink} onClick={onClickMembersList}>{membersCount} members</button>}
       </div>
+      {/* TODO Tabs component below causes an SSR mismatch, because its subcomponent TabIndicator has its own styles.
+      Importing those into usedMuiStyles.ts didn't fix it; EV of further investigation didn't seem worth it for now. */}
       <Tabs
         value={tab}
         onChange={handleChangeTab}

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -535,7 +535,7 @@ const TagSubforumPage2 = ({classes}: {
     <ContentStyles contentType="tag" key={`welcome_box`}>
       <div className={classNames(classes.sidebarBoxWrapper, classes.sidebarBoxWrapperDefaultPadding)} dangerouslySetInnerHTML={{ __html: truncateTagDescription(tag.subforumWelcomeText.html, false)}} />
     </ContentStyles>
-  ) : <></>;
+  ) : null;
   const rightSidebarComponents = [
     welcomeBoxComponent,
     <SidebarMembersBox tag={tag} className={classes.sidebarBoxWrapper} key={`members_box`} />,

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -333,7 +333,6 @@ Comments.addView("defaultModeratorResponses", (terms: CommentsViewTerms) => {
     }
   };
 });
-ensureIndex(Comments, augmentForDefaultView({tagId:1}));
 
 
 Comments.addView('repliesToAnswer', (terms: CommentsViewTerms) => {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -161,7 +161,7 @@ importComponent("SubscribeWidget", () => require('../components/common/Subscribe
 importComponent("SubscribeDialog", () => require('../components/common/SubscribeDialog'));
 
 importComponent("HoverPreviewLink", () => require('../components/linkPreview/HoverPreviewLink'));
-importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview", "OWIDPreview", "MetaculusPreview", "ManifoldPreview", "MetaforecastPreview", "ArbitalPreview"], () => require('../components/linkPreview/PostLinkPreview'));
+importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview", "OWIDPreview", "MetaculusPreview", "ManifoldPreview", "MetaforecastPreview", "ArbitalPreview", "SequencePreview"], () => require('../components/linkPreview/PostLinkPreview'));
 importComponent("FootnotePreview", () => require('../components/linkPreview/FootnotePreview'));
 importComponent("LinkToPost", () => require('../components/linkPreview/LinkToPost'));
 


### PR DESCRIPTION
Fixing a few console errors:
1. missing key error on subforum page caused by empty fragment
2. validate DOM nesting error on sequences page
3. missing `importComponent` call for `SequencePreview`
4. `isMobile` causing SSR issues with Material UI on the homepage filter section — replaced with breakpoints
5. Removed a duplicate index on comments
6. Investigated but didn't fix an SSR issue with MUI Tabs; left a TODO comment here: https://github.com/ForumMagnum/ForumMagnum/commit/40a8c3e51adfd256ae6306f17b1a15b26efb4e56

Fixes #6192

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203526503968868) by [Unito](https://www.unito.io)
