### PR TITLE
Fix too much margin on filter mode cards

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -47,7 +47,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 4,
   },
   filtering: {
-    ...filteringStyles(theme)
+    ...filteringStyles(theme),
+    marginBottom: 4,
   },
   filterRow: {
     display: "flex",


### PR DESCRIPTION
Previously:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/10352319/206874330-1e104624-d293-4afc-9b8f-8489341c1857.png">

Now:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/10352319/206874345-3d3a7782-965f-4998-8537-d9a13de57096.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203527696864551) by [Unito](https://www.unito.io)
