### PR TITLE
Fix ordering of chapters in sequences

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -40,6 +40,7 @@ const schema: SchemaType<DbSequence> = {
       resolver: async (sequence: DbSequence, args: void, context: ResolverContext): Promise<Array<DbChapter>> => {
         const chapters = await context.Chapters.find(
           {sequenceId: sequence._id},
+          {sort: {number: 1}},
         ).fetch();
         return await accessFilterMultiple(context.currentUser, context.Chapters, chapters, context);
       }


### PR DESCRIPTION
Fixes the bug reported by Jesse on Slack where sequence chapters are shown in the wrong order on the collections page.

This happens because the collections page uses the `CollectionsPageFragment` which bypasses the sorting done by the `SequenceChapters` view and uses the default database ordering, which seemed to work fine in Mongo but breaks after copying the data to Postgres with a non-deterministic insert order.