### PR TITLE
Fix table of contenets for highlights and eaHandbook

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -28,10 +28,10 @@ const petrovAfterTime = new DatabasePublicSetting<number>('petrov.afterTime', 0)
 // like to include
 const standaloneNavMenuRouteNames: ForumOptions<string[]> = {
   'LessWrong': [
-    'home', 'allPosts', 'questions', 'library', 'Shortform', 'Sequences', 'collections', 'nominations', 'reviews', 'highlights'
+    'home', 'allPosts', 'questions', 'library', 'Shortform', 'Sequences', 'collections', 'nominations', 'reviews',
   ],
   'AlignmentForum': ['alignment.home', 'library', 'allPosts', 'questions', 'Shortform'],
-  'EAForum': ['home', 'allPosts', 'questions', 'Shortform', 'eaLibrary', 'handbook', 'advice', 'advisorRequest', 'tagsSubforum'],
+  'EAForum': ['home', 'allPosts', 'questions', 'Shortform', 'eaLibrary', 'advice', 'advisorRequest', 'tagsSubforum'],
   'default': ['home', 'allPosts', 'questions', 'Community', 'Shortform',],
 }
 


### PR DESCRIPTION
Removes the normal sidebar, allowing the collection page to display properly with it's new ToC.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203537654348270) by [Unito](https://www.unito.io)
