### PR TITLE
Edit post is always at top

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -220,6 +220,7 @@ const PostActions = ({post, closeMenu, classes}: {
   
   return (
       <div className={classes.actions}>
+        {editLink}
         { canUserEditPostMetadata(currentUser,post) && post.isEvent && <Link to={{pathname:'/newPost', search:`?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`}}>
           <MenuItem>
             <ListItemIcon>
@@ -228,7 +229,6 @@ const PostActions = ({post, closeMenu, classes}: {
             Duplicate Event
           </MenuItem>
         </Link>}
-        {editLink}
         { forumTypeSetting.get() === 'EAForum' && canUserEditPostMetadata(currentUser, post) && <Link
           to={{pathname: '/postAnalytics', search: `?${qs.stringify({postId: post._id})}`}}
         >


### PR DESCRIPTION
I kept accidentally duplicating my event while trying to edit it, which I found pretty annoying. Not sure how intentional putting the "duplicate event" button on top was but this seems like an improvement to me. Can ForumGate it if EA folk have strong preferences.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203542357000302) by [Unito](https://www.unito.io)
