### PR TITLE
Don't initialize mathjax on the server when running migrations

### DIFF
--- a/packages/lesswrong/server/editor/utils.ts
+++ b/packages/lesswrong/server/editor/utils.ts
@@ -1,7 +1,7 @@
 import pick from 'lodash/pick';
 import mjAPI from 'mathjax-node'
 import Revisions from '../../lib/collections/revisions/collection';
-import { isAnyTest } from '../../lib/executionEnvironment';
+import { isAnyTest, isMigrations } from '../../lib/executionEnvironment';
 
 export const trimLatexAndAddCSS = (dom: any, css: string) => {
   // Remove empty paragraphs
@@ -38,7 +38,7 @@ const MATHJAX_OPTIONS = {
   delayStartupTypeset: true,
 }
 
-if (!isAnyTest) {
+if (!isAnyTest && !isMigrations) {
   mjAPI.config({
     MathJax: MATHJAX_OPTIONS
   });


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203546286091065) by [Unito](https://www.unito.io)
