### PR TITLE
Final day warning

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -367,6 +367,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
       showLoadMore={false}
       terms={{
         view:"reviewVoting",
+        minPositiveVoteCount: getReviewPhase() === "NOMINATIONS" ? 1 : 2,
         before: `${REVIEW_YEAR+1}-01-01`,
         ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
         limit: 3,

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -124,6 +124,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+function isLastDay(date: moment.Moment) {
+  return date.diff(new Date()) < (24 * 60 * 60 * 1000)
+}
+
 /**
  * Get the algorithm for review recommendations
  *
@@ -308,10 +312,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
       </LWTooltip>
     </div>
   </div>
-
-  function isLastDay(date: moment.Moment) {
-    return date.diff(new Date()) < (24 * 60 * 60 * 1000)
-  }
 
   const nominationPhaseButtons = <div className={classes.actionButtonRow}>
     {showFrontpageItems && !isLastDay(nominationEndDate) && <LatestReview/>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -116,6 +116,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.commentStyle,
     fontSize: 14,
     color: theme.palette.grey[500]
+  },
+  nominationTimeRemaining: {
+    marginRight: "auto",
+    marginLeft: 4,
+    textAlign: "left"
   }
 })
 
@@ -204,6 +209,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Posts with at least one positive vote proceed to the Review Phase.</li>
       </ul>
       <div>If you've been actively reading {siteNameWithArticleSetting.get()} before now, but didn't register an account, reach out to us on intercom.</div>
+      {activeRange === "NOMINATIONS" && <div><em>{nominationEndDate.fromNow()} remaining</em></div>}
     </div> :
     <div>
       <div>Cast initial votes for the {REVIEW_YEAR} Review.</div>
@@ -213,6 +219,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Any user registered before {REVIEW_YEAR} can nominate posts for review</li>
         <li>Posts will need at least two positive votes to proceed to the Review Phase.</li>
       </ul>
+      {activeRange === "NOMINATIONS" && <div><em>{nominationEndDate.fromNow()} remaining</em></div>}
     </div>
 
   const reviewTooltip = isEAForum ?
@@ -222,6 +229,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Write reviews of posts nominated for the {REVIEW_NAME_IN_SITU}</li>
         <li>Only posts with at least one review are eligible for the final vote</li>
       </ul>
+      {activeRange === "REVIEWS" && <div><em>{reviewEndDate.fromNow()} remaining</em></div>}
     </> :
     <>
       <div>Review posts for the {REVIEW_YEAR} Review (Opens {nominationEndDate.clone().format('MMM Do')})</div>
@@ -229,6 +237,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Write reviews of posts nominated for the {REVIEW_YEAR} Review</li>
         <li>Only posts with at least one review are eligible for the final vote</li>
       </ul>
+      {activeRange === "REVIEWS" && <div><em>{reviewEndDate.fromNow()} remaining</em></div>}
     </>
 
   const voteTooltip = isEAForum ?
@@ -238,6 +247,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Look over nominated posts and vote on them</li>
         <li>Any user registered before {nominationStartDate.format('MMM Do')} can vote in the review</li>
       </ul>
+      {activeRange === "REVIEWS" && <div><em>{voteEndDate.fromNow()} remaining</em></div>}
     </> :
     <>
       <div>Cast your final votes for the {REVIEW_YEAR} Review. (Opens {reviewEndDate.clone().format('MMM Do')})</div>
@@ -246,6 +256,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
         <li>Any user registered before {REVIEW_YEAR} can vote in the review</li>
         <li>The end result will be compiled into a canonical sequence and best-of {REVIEW_YEAR} book</li>
       </ul>
+      {activeRange === "REVIEWS" && <div><em>{voteEndDate.fromNow()} remaining</em></div>}
     </>
 
   const dateFraction = (fractionDate: moment.Moment, startDate: moment.Moment, endDate: moment.Moment) => {
@@ -298,8 +309,14 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
     </div>
   </div>
 
-const nominationPhaseButtons = <div className={classes.actionButtonRow}>
-    {showFrontpageItems && <LatestReview/>}
+  const oneDayLeftOfNominations = nominationEndDate.diff(new Date()) < (24 * 60 * 60 * 1000)
+
+  const nominationPhaseButtons = <div className={classes.actionButtonRow}>
+    {showFrontpageItems && !oneDayLeftOfNominations && <LatestReview/>}
+    {showFrontpageItems && oneDayLeftOfNominations && <span className={classNames(classes.nominationTimeRemaining, classes.timeRemaining)}>
+      <div>{nominationEndDate.fromNow()} remaining to cast nomination votes</div>
+      <div>(posts need two votes to proceed)</div>
+    </span>}
     {allPhaseButtons}
     <LWTooltip className={classes.buttonWrapper} title={`Nominate posts you previously upvoted.`}>
       <Link to={`/votesByYear/${REVIEW_YEAR}`} className={classes.actionButton}>
@@ -330,8 +347,10 @@ const nominationPhaseButtons = <div className={classes.actionButtonRow}>
   </div>
 
   const reviewAndVotingPhaseButtons = <div>
-    {/* TODO: make the time-remaining show up correctly throughout the review */}
     {/* If there's less than 24 hours remaining, show the remaining time */}
+    {reviewEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
+      {reviewEndDate.fromNow()} remaining
+    </span>}
     {voteEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
       {voteEndDate.fromNow()} remaining
     </span>}

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -346,7 +346,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
     </LWTooltip>}
   </div>
 
-  const reviewAndVotingPhaseButtons = <div>
+  const reviewAndVotingPhaseButtons = <div className={classes.actionButtonRow}>
     {/* If there's less than 24 hours remaining, show the remaining time */}
     {reviewEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
       {reviewEndDate.fromNow()} remaining

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -309,11 +309,13 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
     </div>
   </div>
 
-  const oneDayLeftOfNominations = nominationEndDate.diff(new Date()) < (24 * 60 * 60 * 1000)
+  function isLastDay(date: moment.Moment) {
+    return date.diff(new Date()) < (24 * 60 * 60 * 1000)
+  }
 
   const nominationPhaseButtons = <div className={classes.actionButtonRow}>
-    {showFrontpageItems && !oneDayLeftOfNominations && <LatestReview/>}
-    {showFrontpageItems && oneDayLeftOfNominations && <span className={classNames(classes.nominationTimeRemaining, classes.timeRemaining)}>
+    {showFrontpageItems && !isLastDay(nominationEndDate) && <LatestReview/>}
+    {showFrontpageItems && isLastDay(nominationEndDate) && <span className={classNames(classes.nominationTimeRemaining, classes.timeRemaining)}>
       <div>{nominationEndDate.fromNow()} remaining to cast nomination votes</div>
       <div>(posts need two votes to proceed)</div>
     </span>}
@@ -348,10 +350,10 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
 
   const reviewAndVotingPhaseButtons = <div className={classes.actionButtonRow}>
     {/* If there's less than 24 hours remaining, show the remaining time */}
-    {reviewEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
+    {isLastDay(reviewEndDate) && <span className={classes.timeRemaining}>
       {reviewEndDate.fromNow()} remaining
     </span>}
-    {voteEndDate.diff(new Date()) < (24 * 60 * 60 * 1000) && <span className={classes.timeRemaining}>
+    {isLastDay(voteEndDate) && <span className={classes.timeRemaining}>
       {voteEndDate.fromNow()} remaining
     </span>}
     {eligibleToNominate(currentUser) &&

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -367,7 +367,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true}: {classes: Cla
       showLoadMore={false}
       terms={{
         view:"reviewVoting",
-        minPositiveVoteCount: getReviewPhase() === "NOMINATIONS" ? 1 : 2,
         before: `${REVIEW_YEAR+1}-01-01`,
         ...(isEAForum ? {} : {after: `${REVIEW_YEAR}-01-01`}),
         limit: 3,

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -10,6 +10,7 @@ import { viewFieldAllowAny, viewFieldNullOrMissing } from '../../vulcan-lib';
 import { Posts } from './collection';
 import { postStatuses, startHerePostIdSetting } from './constants';
 import uniq from 'lodash/uniq';
+import { getPositiveVoteThreshold, getReviewThreshold } from '../../reviewUtils';
 
 export const DEFAULT_LOW_KARMA_THRESHOLD = -10
 export const MAX_LOW_KARMA_THRESHOLD = -1000
@@ -59,7 +60,6 @@ declare global {
     includeDraftEvents?: boolean
     includeShared?: boolean
     distance?: number,
-    minPositiveVoteCount?: number
   }
 }
 
@@ -1359,7 +1359,8 @@ ensureIndex(Posts,
 Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
-      positiveReviewVoteCount: { $gte: terms.minPositiveVoteCount },
+      positiveReviewVoteCount: { $gte: getPositiveVoteThreshold() },
+      reviewCount: { $gte: getReviewThreshold() }
     },
     options: {
       // This sorts the posts deterministically, which is important for the
@@ -1382,8 +1383,8 @@ ensureIndex(Posts,
 Posts.addView("reviewFinalVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
-      reviewCount: { $gte: 1 },
-      positiveReviewVoteCount: { $gte: 1 }, // TODO: Ray thinks next year this should change to "has at least 4 points"
+      reviewCount: { $gte: getReviewThreshold() },
+      positiveReviewVoteCount: { $gte: getPositiveVoteThreshold() }
     },
     options: {
       // This sorts the posts deterministically, which is important for the

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -59,6 +59,7 @@ declare global {
     includeDraftEvents?: boolean
     includeShared?: boolean
     distance?: number,
+    minPositiveVoteCount?: number
   }
 }
 
@@ -1358,7 +1359,7 @@ ensureIndex(Posts,
 Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
-      positiveReviewVoteCount: { $gte: 1 },
+      positiveReviewVoteCount: { $gte: terms.minPositiveVoteCount },
     },
     options: {
       // This sorts the posts deterministically, which is important for the

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -33,6 +33,26 @@ export function getReviewPhase(): ReviewPhase | void {
   return
 }
 
+export function getPositiveVoteThreshold(): Number {
+  // During the nomination phase, posts require 1 positive reviewVote
+  // to appear in review post lists (so a single vote allows others to see it
+  // and get prompted to cast additional votes.
+  // 
+  // Starting in the review phase, posts require at least 2 votes, 
+  // ensuring the post is at least plausibly worth everyone's time to review
+  return getReviewPhase() === "NOMINATIONS" ? 1 : 2
+}
+
+export function getReviewThreshold(): Number {
+  // During the voting phase, only show posts with at least 1 review.
+  // (it's known that users can still go write reviews in the middle of the 
+  // voting phase to add them to lists, and I (Ray) think it's fine. Posts are 
+  // still penalized for not having been visible during the full voting period,
+  // and it seems fine for people who go out of their way to last-minute-review things
+  // to get them at least visible during part of the voting period)
+  return getReviewPhase() === "VOTING" ? 1 : 0
+}
+
 /** Is there an active review taking place? */
 export function reviewIsActive(): boolean {
   if (!(isLWForum || isEAForum)) return false
@@ -53,7 +73,7 @@ export function postEligibleForReview (post: PostsBase) {
 }
 
 export function postIsVoteable (post: PostsBase) {
-  return getReviewPhase() === "NOMINATIONS" || post.positiveReviewVoteCount > 0
+  return getReviewPhase() === "NOMINATIONS" || post.positiveReviewVoteCount >= getPositiveVoteThreshold()
 }
 
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -31,6 +31,7 @@ import Messages from '../lib/collections/messages/collection';
 import Tags from '../lib/collections/tags/collection';
 import { subforumGetSubscribedUsers } from '../lib/collections/tags/helpers';
 import UserTagRels from '../lib/collections/userTagRels/collection';
+import { getPositiveVoteThreshold } from '../lib/reviewUtils';
 
 // Callback for a post being published. This is distinct from being created in
 // that it doesn't fire on draft posts, and doesn't fire on posts that are awaiting
@@ -352,7 +353,7 @@ async function notifyRsvps(comment: DbComment, post: DbPost) {
 // This may have been sending out duplicate notifications in previous years, maybe just be because this was implemented partway into the review, and some posts slipped through that hadn't previously gotten voted on.
 getCollectionHooks("ReviewVotes").newAsync.add(async function PositiveReviewVoteNotifications(reviewVote: DbReviewVote) {
   const post = reviewVote.postId ? await Posts.findOne(reviewVote.postId) : null;
-  if (post && post.positiveReviewVoteCount > 1) {
+  if (post && post.positiveReviewVoteCount >= getPositiveVoteThreshold()) {
     const notifications = await Notifications.find({documentId:post._id, type: "postNominated" }).fetch()
     if (!notifications.length) {
       await createNotifications({userIds: [post.userId], notificationType: "postNominated", documentType: "post", documentId: post._id})

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -10,6 +10,7 @@ import { WeightedList } from './weightedList';
 import type { RecommendationsAlgorithm } from '../lib/collections/users/recommendationSettings';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import SelectQuery from "../lib/sql/SelectQuery";
+import { getPositiveVoteThreshold } from '../lib/reviewUtils';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -74,11 +75,12 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
       question: true
     }
   }
+  // NOTE: this section is currently unused and should probably be removed -Ray
   if (algorithm.reviewReviews) {
     if (isEAForum) {
       return {
         postedAt: {$lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)},
-        positiveReviewVoteCount: {$gte: 1}, // EA-forum look here
+        positiveReviewVoteCount: {$gte: getPositiveVoteThreshold()}, // EA-forum look here
       }
     }
     return {
@@ -86,7 +88,7 @@ const getInclusionSelector = (algorithm: RecommendationsAlgorithm) => {
         $gt: new Date(`${algorithm.reviewReviews}-01-01`),
         $lt: new Date(`${(algorithm.reviewReviews as number) + 1}-01-01`)
       },
-      positiveReviewVoteCount: {$gte: 1},
+      positiveReviewVoteCount: {$gte: getPositiveVoteThreshold()},
     }
   }
   if (algorithm.lwRationalityOnly) {


### PR DESCRIPTION
This makes it so that:
 – during the last day of each phase, there's a warning about the number of hours remaining.
 – makes it so that each phase of the review shows the right combination of posts, refactoring things to avoid magic numbers that had previously gotten out of sync.
 – fixes a minor UI issue.

<img width="836" alt="image" src="https://user-images.githubusercontent.com/3246710/207464833-0bd40cf2-e897-4e18-9134-ed34332d9d3c.png">

And, throughout the phase, the hoverover has an indication on how many hours are remaining

<img width="402" alt="image" src="https://user-images.githubusercontent.com/3246710/207464943-711f01e9-f2c0-4bfe-814b-056fb778f4ab.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203550276692339) by [Unito](https://www.unito.io)
