### PR TITLE
ChangeWidthOfReviewVotes

### DIFF
--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -113,7 +113,7 @@ const styles = (theme: ThemeType) => ({
   },
   votes: {
     backgroundColor: theme.palette.grey[200],
-    padding: 10,
+    padding: 8,
     alignSelf: "stretch",
     display: "flex",
     alignItems: "center",
@@ -126,14 +126,12 @@ const styles = (theme: ThemeType) => ({
     backgroundColor: "unset",
   },
   yourVote: {
-    marginLeft: 6,
     [theme.breakpoints.down('xs')]: {
       order: 0,
       marginRight: 10
     }
   },
   voteResults: {
-    width: 140,
     ...theme.typography.commentStyle,
     fontSize: 12,
     [theme.breakpoints.down('xs')]: {


### PR DESCRIPTION
During the review phase, all posts had an unnecessary 140 px width which looked super weird. I removed it, and checked how it looked in the other two phases. Seemed to be fine.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203551100684073) by [Unito](https://www.unito.io)
