### PR TITLE
show user id on users profiles to admins

### DIFF
--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -40,10 +40,6 @@ const styles = (theme: ThemeType): JssStyles => ({
       margin: 0,
     }
   },
-  title: {
-    display: 'flex',
-    alignItems: 'center'
-  },
   usernameTitle: {
     fontSize: "3rem",
     ...theme.typography.display3,
@@ -250,10 +246,8 @@ const UsersProfileFn = ({terms, slug, classes}: {
         <AnalyticsContext pageContext={"userPage"}>
           {/* Bio Section */}
           <SingleColumnSection>
-            <div className={classes.title}>
-              <div className={classes.usernameTitle}>
-                {username}
-              </div>
+            <div className={classes.usernameTitle}>
+              {username}
             </div>
             <Typography variant="body2" className={classes.userInfo}>
               { renderMeta() }

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -37,11 +37,20 @@ const styles = (theme: ThemeType): JssStyles => ({
       margin: 0,
     }
   },
+  title: {
+    display: 'flex',
+    alignItems: 'center'
+  },
   usernameTitle: {
     fontSize: "3rem",
     ...theme.typography.display3,
     ...theme.typography.postStyle,
     marginTop: 0,
+  },
+  userIdTitle: {
+    ...theme.typography.postStyle,
+    paddingLeft: 12,
+    paddingTop: 6
   },
   userInfo: {
     display: "flex",
@@ -70,7 +79,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   bio: {
     marginTop: theme.spacing.unit*3,
   },
-  title: {
+  postsTitle: {
     cursor: "pointer"
   },
   // Dark Magick
@@ -239,8 +248,13 @@ const UsersProfileFn = ({terms, slug, classes}: {
         <AnalyticsContext pageContext={"userPage"}>
           {/* Bio Section */}
           <SingleColumnSection>
-            <div className={classes.usernameTitle}>
-              {username}
+            <div className={classes.title}>
+              <div className={classes.usernameTitle}>
+                {username}
+              </div>
+              {currentUser?.isAdmin && <div className={classes.userIdTitle}>
+                {`userId: ${user._id}`}
+              </div>}
             </div>
             <Typography variant="body2" className={classes.userInfo}>
               { renderMeta() }
@@ -312,7 +326,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
           }
           {/* Posts Section */}
           <SingleColumnSection>
-            <div className={classes.title} onClick={() => setShowSettings(!showSettings)}>
+            <div className={classes.postsTitle} onClick={() => setShowSettings(!showSettings)}>
               <SectionTitle title={"Posts"}>
                 <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
               </SectionTitle>

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -20,6 +20,9 @@ import { separatorBulletStyles } from '../common/SectionFooter';
 import { taglineSetting } from '../common/HeadTags';
 import { SORT_ORDER_OPTIONS } from '../../lib/collections/posts/sortOrderOptions';
 import { nofollowKarmaThreshold } from '../../lib/publicSettings';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import { useMessages } from '../common/withMessages';
+import CopyIcon from '@material-ui/icons/FileCopy'
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -46,11 +49,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.display3,
     ...theme.typography.postStyle,
     marginTop: 0,
-  },
-  userIdTitle: {
-    ...theme.typography.postStyle,
-    paddingLeft: 12,
-    paddingTop: 6
   },
   userInfo: {
     display: "flex",
@@ -88,6 +86,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   userMetaInfo: {
     display: "inline-flex"
   },
+  copyIcon: {
+    fontSize: 14
+  }
 })
 
 export const getUserFromResults = <T extends UsersMinimumInfo>(results: Array<T>|null|undefined): T|null => {
@@ -103,6 +104,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const [showSettings, setShowSettings] = useState(false);
 
   const currentUser = useCurrentUser();
+  const { flash } = useMessages();
   
   const {loading, results} = useMulti({
     terms,
@@ -184,7 +186,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, LocalGroupsList,
       PostsListSettings, PostsList2, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
       SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
-      Typography, ContentStyles, ReportUserButton } = Components
+      Typography, ContentStyles, ReportUserButton, LWTooltip } = Components
 
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
@@ -252,12 +254,18 @@ const UsersProfileFn = ({terms, slug, classes}: {
               <div className={classes.usernameTitle}>
                 {username}
               </div>
-              {currentUser?.isAdmin && <div className={classes.userIdTitle}>
-                {`userId: ${user._id}`}
-              </div>}
             </div>
             <Typography variant="body2" className={classes.userInfo}>
               { renderMeta() }
+              { currentUser?.isAdmin &&
+                <div>
+                  <LWTooltip title="Click to copy userId" placement="right">
+                    <CopyToClipboard text={user._id} onCopy={()=>flash({messageString:"userId copied!"})}>
+                      <CopyIcon className={classes.copyIcon} />
+                    </CopyToClipboard>
+                  </LWTooltip>
+                </div>
+              }
               { currentUser?.isAdmin &&
                 <div>
                   <DialogGroup


### PR DESCRIPTION
It's often pretty annoying to need to go into a DB client to fetch a user's id from their slug.  Just add a "copy to clipboard" icon next to `Register RSS` (already an admin-only option).

<img width="811" alt="image" src="https://user-images.githubusercontent.com/2136984/207964854-c1e6acf2-d03f-44fa-a2f9-71b95425dea8.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203558310382418) by [Unito](https://www.unito.io)
