### PR TITLE
If a comment request is missing post ID, throw an exception rather than generating a crazy-slow DB query

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -150,6 +150,8 @@ Comments.addView("postCommentsOld", (terms: CommentsViewTerms) => {
 // Uses same index as postCommentsNew
 
 Comments.addView("postCommentsNew", (terms: CommentsViewTerms) => {
+  if (!terms.postId)
+    throw new Error("Invalid postCommentsNew view: postId is required");
   return {
     selector: {
       postId: terms.postId,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203558824642214) by [Unito](https://www.unito.io)
