### PR TITLE
Fix UI jumps caused by expanding comment tree

### DIFF
--- a/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentOnPostWithReplies.tsx
@@ -1,24 +1,16 @@
-import React, { useCallback, useState } from 'react';
-import { useRecordPostView } from "../hooks/useRecordPostView";
+import React from 'react';
 import { CommentWithRepliesProps } from "./CommentWithReplies";
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-type CommentOnPostWithRepliesProps = Omit<CommentWithRepliesProps, 'lastRead' | 'markAsRead'> & {
+type CommentOnPostWithRepliesProps = CommentWithRepliesProps & {
   post: PostsBase;
 }
 
 const CommentOnPostWithReplies = ({post, ...otherProps}: CommentOnPostWithRepliesProps) => {
-  const [lastRead, setLastRead] = useState<Date>(post.lastVisitedAt);
-  const { recordPostView } = useRecordPostView(post);
-
-  const markAsRead = useCallback(async () => {
-    setLastRead(new Date());
-    recordPostView({ post });
-  }, [post, recordPostView]);
 
   const {CommentWithReplies} = Components;
 
-  return <CommentWithReplies post={post} {...otherProps} lastRead={lastRead} markAsRead={markAsRead}/>
+  return <CommentWithReplies post={post} {...otherProps} />
 };
 
 const CommentOnPostWithRepliesComponent = registerComponent(

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -21,7 +21,6 @@ export interface CommentWithRepliesProps {
   comment: CommentWithRepliesFragment;
   post?: PostsBase;
   lastRead?: Date;
-  markAsRead?: any;
   initialMaxChildren?: number;
   commentNodeProps?: Partial<CommentsNodeProps>;
   startExpanded?: boolean;
@@ -32,7 +31,6 @@ const CommentWithReplies = ({
   comment,
   post,
   lastRead,
-  markAsRead = () => {},
   initialMaxChildren = 3,
   commentNodeProps,
   startExpanded,
@@ -52,7 +50,6 @@ const CommentWithReplies = ({
   
   const treeOptions: CommentTreeOptions = {
     lastCommentId,
-    markAsRead: markAsRead,
     highlightDate: lastRead,
     condensed: true,
     showPostTitle: true,

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -7,7 +7,6 @@ import { AnalyticsContext } from "../../lib/analyticsEvents"
 import { CommentTreeNode, commentTreesEqual } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import { HIGHLIGHT_DURATION } from './CommentFrame';
-import type { CommentFormDisplayMode } from './CommentsNewForm';
 
 const KARMA_COLLAPSE_THRESHOLD = -4;
 
@@ -108,7 +107,7 @@ const CommentsNode = ({
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
   const [collapsed, setCollapsed] = useState(comment.deleted || comment.baseScore < karmaCollapseThreshold);
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
-  const { lastCommentId, condensed, postPage, post, highlightDate, markAsRead, scrollOnExpand, forceSingleLine, forceNotSingleLine, noHash, replyFormStyle="default" } = treeOptions;
+  const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, noHash } = treeOptions;
 
   const beginSingleLine = (): boolean => {
     // TODO: Before hookification, this got nestingLevel without the default value applied, which may have changed its behavior?
@@ -190,7 +189,6 @@ const CommentsNode = ({
   const handleExpand = async (event: React.MouseEvent) => {
     event.stopPropagation()
     if (isTruncated || isSingleLine) {
-      markAsRead && await markAsRead()
       setTruncated(false);
       setSingleLine(false);
       setTruncatedStateSet(true);

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -37,13 +37,6 @@ export interface CommentTreeOptions {
   lastCommentId?: string,
   
   /**
-   * Callback invoked when the comment is expanded. Typically marks the
-   * *post* as read (not just the individual comment, we don't track
-   * individual comment read statuses).
-   */
-  markAsRead?: ()=>void|Promise<void>,
-  
-  /**
    * If passed, comments are highlighted (with a bar on the left edge)
    * if they're newer than this date.
    */

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -411,7 +411,6 @@ const PostsItem2 = ({
 }) => {
   const [showComments, setShowComments] = React.useState(defaultToShowComments);
   const [readComments, setReadComments] = React.useState(false);
-  const [markedVisitedAt, setMarkedVisitedAt] = React.useState<Date|null>(null);
   const { isRead, recordPostView } = useRecordPostView(post);
 
   const currentUser = useCurrentUser();
@@ -425,11 +424,6 @@ const PostsItem2 = ({
     [post, recordPostView, setShowComments, showComments, setReadComments]
   );
 
-  const markAsRead = () => {
-    recordPostView({post, extraEventProperties: {type: "markAsRead"}})
-    setMarkedVisitedAt(new Date()) 
-  }
-
   const compareVisitedAndCommentedAt = (lastVisitedAt, lastCommentedAt) => {
     const newComments = lastVisitedAt < lastCommentedAt;
     return (isRead && newComments && !readComments)
@@ -437,12 +431,12 @@ const PostsItem2 = ({
 
   const hasUnreadComments = () => {
     const lastCommentedAt = postGetLastCommentedAt(post)
-    const lastVisitedAt = markedVisitedAt || post.lastVisitedAt
+    const lastVisitedAt = post.lastVisitedAt
     return compareVisitedAndCommentedAt(lastVisitedAt, lastCommentedAt)
   }
 
   const hasNewPromotedComments = () => {
-    const lastVisitedAt = markedVisitedAt || post.lastVisitedAt
+    const lastVisitedAt = post.lastVisitedAt
     const lastCommentPromotedAt = postGetLastCommentPromotedAt(post)
     return compareVisitedAndCommentedAt(lastVisitedAt, lastCommentPromotedAt)
   }
@@ -632,9 +626,8 @@ const PostsItem2 = ({
               terms={commentTerms}
               post={post}
               treeOptions={{
-                highlightDate: markedVisitedAt || post.lastVisitedAt,
+                highlightDate: post.lastVisitedAt,
                 condensed: condensedAndHiddenComments,
-                markAsRead: markAsRead,
               }}
             />
           </div>}

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -72,7 +72,6 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
 
   const [truncated, setTruncated] = useState(true);
   const [expandAllThreads, setExpandAllThreads] = useState(false);
-  const [readStatus, setReadStatus] = useState(false);
   const {recordTagView} = useRecordTagView(tag);
   const [markedAsVisitedAt, setMarkedAsVisitedAt] = useState<Date|null>(null);
   
@@ -81,15 +80,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   const nestedComments = useOrderPreservingArray(unflattenComments(comments), (comment) => comment._id);
   
   const onClickEventType = isSubforum ? "recentDiscussionSubforumClick" : "recentDiscussionTagClick"
-  const markAsRead = useCallback(
-    () => {
-      setReadStatus(true);
-      setMarkedAsVisitedAt(new Date());
-      setExpandAllThreads(true);
-      recordTagView({tag, extraEventProperties: {type: onClickEventType}})
-    },
-    [recordTagView, tag, onClickEventType]
-  );
+
   const clickExpandDescription = useCallback(() => {
     setTruncated(false);
     setExpandAllThreads(true);
@@ -104,7 +95,6 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
     refetch,
     scrollOnExpand: true,
     lastCommentId: lastCommentId,
-    markAsRead: markAsRead,
     highlightDate: lastVisitedAt,
     tag: tag,
     condensed: true,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -126,20 +126,17 @@ const RecentDiscussionThread = ({
   classes: ClassesType,
 }) => {
   const [highlightVisible, setHighlightVisible] = useState(false);
-  const [readStatus, setReadStatus] = useState(false);
   const [markedAsVisitedAt, setMarkedAsVisitedAt] = useState<Date|null>(null);
   const [expandAllThreads, setExpandAllThreads] = useState(false);
-  const { isRead, recordPostView } = useRecordPostView(post);
-  const [showSnippet] = useState(!isRead || post.commentCount === null); // This state should never change after mount, so we don't grab the setter from useState
+  const { recordPostView } = useRecordPostView(post);
 
   const markAsRead = useCallback(
     () => {
-      setReadStatus(true);
       setMarkedAsVisitedAt(new Date());
       setExpandAllThreads(true);
       recordPostView({post, extraEventProperties: {type: "recentDiscussionClick"}})
     },
-    [setReadStatus, setMarkedAsVisitedAt, setExpandAllThreads, recordPostView, post]
+    [setMarkedAsVisitedAt, setExpandAllThreads, recordPostView, post]
   );
   const showHighlight = useCallback(
     () => {
@@ -169,7 +166,6 @@ const RecentDiscussionThread = ({
   const treeOptions: CommentTreeOptions = {
     scrollOnExpand: true,
     lastCommentId: lastCommentId,
-    markAsRead: markAsRead,
     highlightDate: lastVisitedAt,
     refetch: refetch,
     condensed: true,

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Components, registerComponent} from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { unflattenComments } from '../../lib/utils/unflatten';
-import { useRecordPostView } from '../hooks/useRecordPostView';
 import { singleLineStyles } from '../comments/SingleLineComment';
 import { CONDENSED_MARGIN_BOTTOM } from '../comments/CommentFrame';
 
@@ -36,8 +35,6 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
   hideReviewVoteButtons?: boolean
   singleLineCollapse?: boolean
 }) => {
-  const [markedVisitedAt, setMarkedVisitedAt] = React.useState<Date|null>(null);
-  const { recordPostView } = useRecordPostView(post)
   const { loading, results, loadMoreProps } = useMulti({
     terms,
     collectionName: "Comments",
@@ -47,12 +44,6 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
   });
   
   const { Loading, CommentsList, SubSection, CommentOnPostWithReplies, LoadMore, ContentStyles } = Components
-  
-  // TODO: This doesn't quite work yet. Not sure why - Ray
-  const markAsRead = () => {
-    recordPostView({post, extraEventProperties: {type: "markAsRead"}})
-    setMarkedVisitedAt(new Date())
-  }
   
   const lastCommentId = results && results[0]?._id
   const nestedComments = results ? unflattenComments(results) : [];
@@ -80,12 +71,11 @@ const ReviewPostComments = ({ terms, classes, title, post, singleLine, placehold
         {singleLine ? <CommentsList
           treeOptions={{
             lastCommentId: lastCommentId,
-            highlightDate: markedVisitedAt || post.lastVisitedAt,
+            highlightDate: post.lastVisitedAt,
             hideSingleLineMeta: true,
             hideReviewVoteButtons: hideReviewVoteButtons,
             singleLineCollapse: singleLineCollapse,
             enableHoverPreview: false,
-            markAsRead: markAsRead,
             post: post,
             forceSingleLine: true
           }}


### PR DESCRIPTION
We have a `markAsRead` callback that gets triggered when you expand a comment tree. It primarily records a post view, but also triggers several UI changes at once — unread comment styling disappears for all comments on the post, the post highlight length can change, and longer comments are truncated to a single line, which can easily cause the comment you're looking at to jump off-screen.

I get the impression that some of this is a UI bug (the jumping offscreen in particular seems like it), but in any case the value add of recording a post view doesn't feel worth the swarm of UI updates, which all feel unexpected and unwanted to me as a user. This PR opts to remove that markAsRead callback entirely.

Note that there are two places where a local callback coincidentally called markAsRead gets used:
1. RecentDiscussionThread, in a click handler on PostsItemMeta
2. ReviewVoteTableRow component click handler
and also a markAsReadOrUnread callback in the PostActions dropdown, all of which are unaffected by this.

Fixes https://github.com/ForumMagnum/ForumMagnum/issues/5948

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203565704165962) by [Unito](https://www.unito.io)
