### PR TITLE
[EA Forum only] pin subforum organizers to the top of the members list

### DIFF
--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -59,7 +59,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   mobileImg: {
     display: 'none',
     height: 160,
-    backgroundColor: theme.palette.background.primaryDim2,
+    backgroundColor: theme.palette.background.primaryDim,
     justifyContent: 'center',
     alignItems: 'center',
     [theme.breakpoints.down('xs')]: {
@@ -151,7 +151,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }
 
 const defaultBackground = requireCssVar("palette", "panelBackground", "default");
-const dimBackground = requireCssVar("palette", "background", "primaryDim2");
+const dimBackground = requireCssVar("palette", "background", "primaryDim");
 
 const LocalGroups = ({keywordSearch, userLocation, distanceUnit='km', includeInactive, toggleIncludeInactive, classes}: {
   keywordSearch: string,

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -49,7 +49,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   mobileImg: {
     display: 'none',
     height: 160,
-    backgroundColor: theme.palette.background.primaryDim2,
+    backgroundColor: theme.palette.background.primaryDim,
     justifyContent: 'center',
     alignItems: 'center',
     [theme.breakpoints.down('xs')]: {
@@ -134,7 +134,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }))
 
 const defaultBackground = requireCssVar("palette", "panelBackground", "default");
-const dimBackground = requireCssVar("palette", "background", "primaryDim2");
+const dimBackground = requireCssVar("palette", "background", "primaryDim");
 
 const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, classes}: {
   keywordSearch: string,

--- a/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
+++ b/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
@@ -73,7 +73,7 @@ const SidebarMembersBox = ({tag, className, classes}: {
   const organizers: UsersProfile[] = []
   const otherMembers: UsersProfile[] = []
   members?.forEach(member => {
-    if (tag.subforumModeratorIds.includes(member._id)) {
+    if (tag.subforumModeratorIds?.includes(member._id)) {
       organizers.push(member)
     } else {
       otherMembers.push(member)

--- a/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
+++ b/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
@@ -59,7 +59,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const SidebarMembersBox = ({tag, className, classes}: {
-  tag: TagDetailsFragment,
+  tag: TagSubforumFragment,
   className?: string,
   classes: ClassesType,
 }) => {

--- a/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
+++ b/packages/lesswrong/components/tagging/SidebarMembersBox.tsx
@@ -59,7 +59,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const SidebarMembersBox = ({tag, className, classes}: {
-  tag: TagBasicInfo,
+  tag: TagDetailsFragment,
   className?: string,
   classes: ClassesType,
 }) => {
@@ -68,6 +68,16 @@ const SidebarMembersBox = ({tag, className, classes}: {
     collectionName: 'Users',
     fragmentName: 'UsersProfile',
     skip: !tag
+  })
+  
+  const organizers: UsersProfile[] = []
+  const otherMembers: UsersProfile[] = []
+  members?.forEach(member => {
+    if (tag.subforumModeratorIds.includes(member._id)) {
+      organizers.push(member)
+    } else {
+      otherMembers.push(member)
+    }
   })
   
   const { SubforumSubscribeSection, SubforumMember, Loading } = Components
@@ -80,7 +90,12 @@ const SidebarMembersBox = ({tag, className, classes}: {
       </h2>
       <div className={classes.scrollableList}>
         {loading && <Loading />}
-        {members?.map(user => {
+        {organizers?.map(user => {
+          return <div key={user._id} className={classes.user}>
+            <SubforumMember user={user} isOrganizer />
+          </div>
+        })}
+        {otherMembers?.map(user => {
           return <div key={user._id} className={classes.user}>
             <SubforumMember user={user} />
           </div>

--- a/packages/lesswrong/components/tagging/SubforumMember.tsx
+++ b/packages/lesswrong/components/tagging/SubforumMember.tsx
@@ -30,13 +30,29 @@ const styles = (theme: ThemeType): JssStyles => ({
     '-moz-box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),
     borderRadius: '50%',
   },
+  name: {
+    marginBottom: 4
+  },
   displayName: {
     fontSize: 16,
+    lineHeight: '22px',
     fontWeight: 700,
     display: '-webkit-box',
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',
     overflow: 'hidden',
+  },
+  userTags: {
+    display: 'flex',
+    marginBottom: 8
+  },
+  userTag: {
+    backgroundColor: theme.palette.background.primaryDim2,
+    color: theme.palette.primary.dark,
+    fontFamily: theme.typography.fontFamily,
+    fontSize: 11,
+    padding: '5px 11px',
+    borderRadius: 14
   },
   role: {
     fontFamily: theme.typography.fontFamily,
@@ -116,13 +132,13 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 
-const SubforumMember = ({user, classes}: {
+const SubforumMember = ({user, isOrganizer, classes}: {
   user: UsersProfile,
+  isOrganizer?: boolean,
   classes: ClassesType,
 }) => {
   const bioRef = useRef<HTMLDivElement>(null)
   
-  const currentUser = useCurrentUser()
   const meritsCollapse = useCheckMeritsCollapse({
     ref: bioRef,
     height: COLLAPSED_SECTION_HEIGHT
@@ -173,6 +189,11 @@ const SubforumMember = ({user, classes}: {
           {user.displayName}
         </Link>
       </Typography>
+      {isOrganizer && <div className={classes.userTags}>
+        <div className={classes.userTag}>
+          Organizer
+        </div>
+      </div>}
       {(user.jobTitle || user.organization) && <div className={classes.role}>
         {user.jobTitle} {user.organization ? `@ ${user.organization}` : ''}
       </div>}

--- a/packages/lesswrong/components/tagging/SubforumMember.tsx
+++ b/packages/lesswrong/components/tagging/SubforumMember.tsx
@@ -47,8 +47,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 8
   },
   userTag: {
-    backgroundColor: theme.palette.background.primaryDim2,
-    color: theme.palette.primary.dark,
+    backgroundColor: theme.palette.background.primaryDim,
+    color: theme.palette.text.primaryDarkOnDim,
     fontFamily: theme.typography.fontFamily,
     fontSize: 11,
     padding: '5px 11px',

--- a/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
+++ b/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
@@ -45,7 +45,7 @@ const SubforumMembersDialog = ({classes, onClose, tag}: {
   const organizers: UsersProfile[] = []
   const otherMembers: UsersProfile[] = []
   members?.forEach(member => {
-    if (tag.subforumModeratorIds.includes(member._id)) {
+    if (tag.subforumModeratorIds?.includes(member._id)) {
       organizers.push(member)
     } else {
       otherMembers.push(member)

--- a/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
+++ b/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
@@ -33,13 +33,23 @@ const styles = (theme: ThemeType): JssStyles => ({
 const SubforumMembersDialog = ({classes, onClose, tag}: {
   classes: ClassesType,
   onClose: () => void,
-  tag: TagBasicInfo,
+  tag: TagDetailsFragment,
 }) => {
   const { results: members, loading } = useMulti({
     terms: {view: 'tagCommunityMembers', profileTagId: tag?._id, limit: 100},
     collectionName: 'Users',
     fragmentName: 'UsersProfile',
     skip: !tag
+  })
+  
+  const organizers: UsersProfile[] = []
+  const otherMembers: UsersProfile[] = []
+  members?.forEach(member => {
+    if (tag.subforumModeratorIds.includes(member._id)) {
+      organizers.push(member)
+    } else {
+      otherMembers.push(member)
+    }
   })
   
   const { LWDialog, SubforumSubscribeSection, SubforumMember, Loading } = Components
@@ -52,7 +62,12 @@ const SubforumMembersDialog = ({classes, onClose, tag}: {
       </h2>
       <DialogContent>
         {loading && <Loading />}
-        {members?.map(user => {
+        {organizers?.map(user => {
+          return <div key={user._id} className={classes.user}>
+            <SubforumMember user={user} isOrganizer />
+          </div>
+        })}
+        {otherMembers?.map(user => {
           return <div key={user._id} className={classes.user}>
             <SubforumMember user={user} />
           </div>

--- a/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
+++ b/packages/lesswrong/components/tagging/SubforumMembersDialog.tsx
@@ -33,7 +33,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const SubforumMembersDialog = ({classes, onClose, tag}: {
   classes: ClassesType,
   onClose: () => void,
-  tag: TagDetailsFragment,
+  tag: TagSubforumFragment,
 }) => {
   const { results: members, loading } = useMulti({
     terms: {view: 'tagCommunityMembers', profileTagId: tag?._id, limit: 100},

--- a/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
@@ -21,7 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
     '@media (hover: hover)': {
       "&:hover": {
-        background: theme.palette.background.primaryDim2,
+        background: theme.palette.background.primaryDim,
       },
     },
   },

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -141,6 +141,7 @@ registerFragment(`
   fragment TagSubforumFragment on Tag {
     ...TagPreviewFragment
     isSubforum
+    subforumModeratorIds
     tableOfContents
     subforumWelcomeText {
       _id

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2039,6 +2039,7 @@ interface TagPreviewFragment_description { // fragment on Revisions
 
 interface TagSubforumFragment extends TagPreviewFragment { // fragment on Tags
   readonly isSubforum: boolean,
+  readonly subforumModeratorIds: Array<string>,
   readonly tableOfContents: any,
   readonly subforumWelcomeText: TagSubforumFragment_subforumWelcomeText|null,
 }

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -198,6 +198,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     alwaysWhite: "#fff",
     sequenceIsDraft: "rgba(100, 169, 105, 0.9)",
     sequenceTitlePlaceholder: shades.inverseGreyAlpha(0.5),
+    primaryDarkOnDim: '#085d6c', // text that is meant to be shown on the primaryDim background color
 
     eventMaybe: "#d59c00",
     
@@ -291,8 +292,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     diffInserted: "#d4ead4",
     diffDeleted: "#f0d3d3",
     usersListItem: shades.greyAlpha(.05),
-    primaryDim: '#d3edf2',
-    primaryDim2: '#e2f1f4',
+    primaryDim: '#e2f1f4',
   },
   panelBackground: {
     default: shades.grey[0],

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -55,8 +55,7 @@ export const eaForumTheme: SiteThemeSpecification = {
     },
     background: {
       default: shadePalette.type === 'light' ? '#f6f8f9' : shadePalette.grey[60],
-      primaryDim: '#d3edf2',
-      primaryDim2: '#e2f1f4',
+      primaryDim: '#e2f1f4',
     },
     header: {
       text: shadePalette.type === 'light' ? "rgba(0,0,0,.87)" : shadePalette.greyAlpha(.87),

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -142,6 +142,7 @@ declare global {
       alwaysWhite: ColorString,
       sequenceIsDraft: ColorString,
       sequenceTitlePlaceholder: ColorString,
+      primaryDarkOnDim: ColorString,
     
       reviewUpvote: ColorString,
       reviewDownvote: ColorString,
@@ -355,7 +356,6 @@ declare global {
       diffDeleted: ColorString,
       usersListItem: ColorString,
       primaryDim: ColorString,
-      primaryDim2: ColorString,
     },
     header: {
       text: ColorString,

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -162,6 +162,7 @@ export const darkModeTheme: UserThemeSpecification = {
   componentPalette: (shadePalette: ThemeShadePalette) => deepmerge({
     text: {
       alwaysWhite: '#fff',
+      primaryDarkOnDim: '#a8cad7',
       aprilFools: {
         orange: "#ff7144",
         yellow: "#ffba7d",
@@ -183,8 +184,7 @@ export const darkModeTheme: UserThemeSpecification = {
     background: {
       diffInserted: "#205120",
       diffDeleted: "#b92424",
-      primaryDim: "#303435",
-      primaryDim2: "#303435",
+      primaryDim: "#28383e",
     },
     border: {
       itemSeparatorBottom: shadePalette.greyBorder("1px", .2),


### PR DESCRIPTION
In the subforum members list, we're now always displaying the organizers at the top, and marking them with a tag.

<img width="345" alt="Screen Shot 2022-12-15 at 5 47 19 PM" src="https://user-images.githubusercontent.com/9057804/207987859-b6e40ec0-30cd-4688-b3f4-e9c67bd54c15.png">

Dark mode:
<img width="345" alt="Screen Shot 2022-12-15 at 7 13 25 PM" src="https://user-images.githubusercontent.com/9057804/207993320-ca7177a2-f48a-47a8-a65d-e53db6b4d4cc.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203566005132954) by [Unito](https://www.unito.io)
