### PR TITLE
Revert "ChangeWidthOfReviewVotes"

### DIFF
--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -113,7 +113,7 @@ const styles = (theme: ThemeType) => ({
   },
   votes: {
     backgroundColor: theme.palette.grey[200],
-    padding: 8,
+    padding: 10,
     alignSelf: "stretch",
     display: "flex",
     alignItems: "center",
@@ -126,12 +126,14 @@ const styles = (theme: ThemeType) => ({
     backgroundColor: "unset",
   },
   yourVote: {
+    marginLeft: 6,
     [theme.breakpoints.down('xs')]: {
       order: 0,
       marginRight: 10
     }
   },
   voteResults: {
+    width: 140,
     ...theme.typography.commentStyle,
     fontSize: 12,
     [theme.breakpoints.down('xs')]: {


### PR DESCRIPTION
I.... was totally wrong to remove these lines, this code was doing an important thing. It looked wrong because I hadn't run the updateReviewVotes script yet, but once you do you want the line-length fixed to 140px.

Should have respected Arnold's Fence from 2021 which I'd forgotten the purpose of.

Reverts ForumMagnum/ForumMagnum#6296

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203566049030586) by [Unito](https://www.unito.io)
