### PR TITLE
fix displaying groups on the standalone groups map

### DIFF
--- a/packages/lesswrong/components/localGroups/GroupsMap.tsx
+++ b/packages/lesswrong/components/localGroups/GroupsMap.tsx
@@ -18,6 +18,7 @@ const GroupsMap = () => {
     groupTerms={{view: "all"}}
     zoom={parseInt(query?.zoom) || 1}
     initialOpenWindows={[]}
+    showGroupsByDefault
     hideLegend
     {...center}
   />


### PR DESCRIPTION
Someone from the EA Germany group asked me why there are no stars on the [standalone groups map](https://forum.effectivealtruism.org/groups-map?zoom=4&lat=51&lng=10). Turns out there was a bit of refactoring that missed that component.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203571805318348) by [Unito](https://www.unito.io)
