### PR TITLE
Fix negative comment counts on question posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -124,10 +124,17 @@ const countAnswersAndDescendents = (answers: CommentsList[]) => {
 const getResponseCounts = (
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
   answers: CommentsList[],
-) => ({
-  answerCount: answers.length,
-  commentCount: post.commentCount - countAnswersAndDescendents(answers),
-});
+) => {
+  // answers may include some which are deleted:true, deletedPublic:true (in which
+  // case various fields are unpopulated and a deleted-item placeholder is shown
+  // in the UI). These deleted answers are *not* included in post.commentCount.
+  const nonDeletedAnswers = answers.filter(answer=>!answer.deleted);
+  
+  return {
+    answerCount: nonDeletedAnswers.length,
+    commentCount: post.commentCount - countAnswersAndDescendents(nonDeletedAnswers),
+  };
+};
 
 /// PostsPagePostHeader: The metadata block at the top of a post page, with
 /// title, author, voting, an actions menu, etc.


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/commit/b091f826c16a098d07d0e8d27f5ed561e88154c2 modified the post header on question posts to count answers and their replies separately from non-answer comments, with the comment count being

```
post.commentCount - countAnswersAndDescendents(answers)
```

The trick is that if an answer is deleted:true, deletedPublic:true, then it's in the answers list (as a deleted-answer placeholder), but not included in post.commentCount.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203574035516829) by [Unito](https://www.unito.io)
