### PR TITLE
Remove Credentials repo before restarting server

### DIFF
--- a/scripts/runProduction.sh
+++ b/scripts/runProduction.sh
@@ -7,6 +7,7 @@ set -ex
 
 # lw-look here: you must define GITHUB_CREDENTIALS_REPO_USER in your AWS EBS config
 echo "Cloning credentials repo"
+rm -rf Credentials/
 git clone https://$GITHUB_CREDENTIALS_REPO_USER:$GITHUB_CREDENTIALS_REPO_PAT@github.com/$GITHUB_CREDENTIALS_REPO_NAME.git Credentials
 
 # Decrypt credentials if encrypted


### PR DESCRIPTION
This was causing an error when we tried changing the postgres password because a cached version of Credentials was being used

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203578855443735) by [Unito](https://www.unito.io)
