### PR TITLE
some UI improvements around subforum threads/discussions

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/EAModerationGuidelinesContent.ts
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/EAModerationGuidelinesContent.ts
@@ -10,7 +10,7 @@ const generalGuidelines = `
 export const subforumGuidelines = `
   <p><em>Guidelines:</em></p>
   <ul>
-    <li>Subforum threads will only appear in the feed below, and in "Recent Discussion" on the frontpage for other members</li>
+    <li>Subforum discussions will only appear in the feed below, and in "Recent Discussion" on the frontpage for other members</li>
     <li>Feel free to put in (much) less effort than you would when writing a post</li>
     <li>Still try to be clear, on-topic, and kind</li>
   </ul>

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -7,10 +7,21 @@ import { nofollowKarmaThreshold } from '../../lib/publicSettings';
 import { useForeignCrosspost, isPostWithForeignId, PostWithForeignId } from "../hooks/useForeignCrosspost";
 import { useForeignApolloClient } from "../hooks/useForeignApolloClient";
 import { captureException }from "@sentry/core";
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   highlightContinue: {
     marginTop:theme.spacing.unit*2
+  },
+  smallerFonts: {
+    fontSize: '1.1rem',
+    lineHeight: '1.7em',
+    '& h1, & h2, & h3': {
+      fontSize: "1.4rem",
+    },
+    '& li': {
+      fontSize: '1.1rem'
+    }
   }
 })
 
@@ -33,6 +44,7 @@ const HighlightBody = ({
   setExpanded,
   expandedLoading,
   expandedDocument,
+  smallerFonts,
   classes,
 }: {
   post: PostsList,
@@ -42,6 +54,7 @@ const HighlightBody = ({
   setExpanded: (value: boolean) => void,
   expandedLoading: boolean,
   expandedDocument?: PostsExpandedHighlight,
+  smallerFonts?: boolean,
   classes: ClassesType,
 }) => {
   const { htmlHighlight = "", wordCount = 0 } = post.contents || {};
@@ -51,7 +64,7 @@ const HighlightBody = ({
     ev.preventDefault();
   }, [setExpanded]);
 
-  return <Components.ContentStyles contentType="postHighlight">
+  return <Components.ContentStyles contentType="postHighlight" className={classNames({[classes.smallerFonts]: smallerFonts})}>
     <Components.LinkPostMessage post={post} />
     <Components.ContentItemTruncated
       maxLengthWords={maxLengthWords}
@@ -76,10 +89,11 @@ const HighlightBody = ({
   </Components.ContentStyles>
 }
 
-const ForeignPostsHighlightBody = ({post, maxLengthWords, forceSeeMore=false, loading, classes}: {
+const ForeignPostsHighlightBody = ({post, maxLengthWords, forceSeeMore=false, smallerFonts, loading, classes}: {
   post: PostsList & PostWithForeignId,
   maxLengthWords: number,
   forceSeeMore?: boolean,
+  smallerFonts?: boolean,
   loading: boolean,
   classes: ClassesType,
 }) => {
@@ -98,6 +112,7 @@ const ForeignPostsHighlightBody = ({post, maxLengthWords, forceSeeMore=false, lo
       post,
       maxLengthWords,
       forceSeeMore,
+      smallerFonts,
       expanded,
       setExpanded,
       expandedLoading,
@@ -106,10 +121,11 @@ const ForeignPostsHighlightBody = ({post, maxLengthWords, forceSeeMore=false, lo
     }} />
 }
 
-const ForeignPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
+const ForeignPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, smallerFonts, classes}: {
   post: PostsList & PostWithForeignId,
   maxLengthWords: number,
   forceSeeMore?: boolean,
+  smallerFonts?: boolean,
   classes: ClassesType,
 }) => {
   const {loading, error, combinedPost} = useForeignCrosspost(post, foreignFetchProps);
@@ -118,14 +134,15 @@ const ForeignPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classe
     captureException(error);
   }
   return error
-    ? <LocalPostsHighlight {...{post, maxLengthWords, forceSeeMore, classes}} />
-    : <ForeignPostsHighlightBody {...{post, maxLengthWords, forceSeeMore, loading, classes}} />;
+    ? <LocalPostsHighlight {...{post, maxLengthWords, forceSeeMore, smallerFonts, classes}} />
+    : <ForeignPostsHighlightBody {...{post, maxLengthWords, forceSeeMore, smallerFonts, loading, classes}} />;
 }
 
-const LocalPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
+const LocalPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, smallerFonts, classes}: {
   post: PostsList,
   maxLengthWords: number,
   forceSeeMore?: boolean,
+  smallerFonts?: boolean,
   classes: ClassesType,
 }) => {
   const [expanded, setExpanded] = useState(false);
@@ -139,6 +156,7 @@ const LocalPostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}
     post,
     maxLengthWords,
     forceSeeMore,
+    smallerFonts,
     expanded,
     setExpanded,
     expandedLoading,
@@ -151,6 +169,7 @@ const PostsHighlight = ({post, ...rest}: {
   post: PostsList,
   maxLengthWords: number,
   forceSeeMore?: boolean,
+  smallerFonts?: boolean,
   classes: ClassesType,
 }) => isPostWithForeignId(post)
   ? <ForeignPostsHighlight post={post} {...rest} />

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -154,7 +154,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
         </div>
         <div className={classes.subforumTitleText}>
           <Link to={tagGetSubforumUrl(tag)} className={classes.subforumTitle}>{tag.name}</Link>
-          <div className={classes.subforumSubtitle}>subforum discussion</div>
+          <div className={classes.subforumSubtitle}>Subforum discussion</div>
         </div>
       </div> : <Link to={tagGetDiscussionUrl(tag)} className={classes.title}>
         {tag.name}

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -29,6 +29,39 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "block",
     fontSize: "1.75rem",
   },
+  subforumTitleRow: {
+    display: 'flex',
+    columnGap: 7,
+    marginBottom: 8,
+    '& svg': {
+      height: 20,
+      width: 20,
+      fill: theme.palette.grey[700]
+    }
+  },
+  subforumIcon: {
+    marginTop: 2
+  },
+  subforumTitleText: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    columnGap: 12
+  },
+  subforumTitle: {
+    color: theme.palette.grey[900],
+    fontFamily: theme.typography.postStyle.fontFamily,
+    fontSize: 20,
+    lineHeight: '25px',
+  },
+  subforumSubtitle: {
+    color: theme.palette.grey[600],
+    fontFamily: theme.typography.fontFamily,
+    fontSize: 13,
+    lineHeight: '18px',
+    marginTop: 4,
+    marginLeft: 1
+  },
   tag: {
     paddingTop: 18,
     paddingLeft: 16,
@@ -67,7 +100,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   tagCommentType?: TagCommentType,
   classes: ClassesType
 }) => {
-  const { CommentsNode, ContentItemBody, ContentStyles } = Components;
+  const { CommentsNode, ContentItemBody, ContentStyles, TopTagIcon } = Components;
   const isSubforum = tagCommentType === "SUBFORUM"
 
   const [truncated, setTruncated] = useState(true);
@@ -115,9 +148,17 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   
   return <div className={classes.root}>
     <div className={classes.tag}>
-      <Link to={isSubforum ? tagGetSubforumUrl(tag): tagGetDiscussionUrl(tag)} className={classes.title}>
-        {tag.name}{isSubforum && " Subforum"}
-      </Link>
+      {isSubforum ? <div className={classes.subforumTitleRow}>
+        <div className={classes.subforumIcon}>
+          <TopTagIcon tag={tag} />
+        </div>
+        <div className={classes.subforumTitleText}>
+          <Link to={tagGetSubforumUrl(tag)} className={classes.subforumTitle}>{tag.name}</Link>
+          <div className={classes.subforumSubtitle}>subforum discussion</div>
+        </div>
+      </div> : <Link to={tagGetDiscussionUrl(tag)} className={classes.title}>
+        {tag.name}
+      </Link>}
       
       <div className={classes.metadata}>
         {!isSubforum && <span>{metadataWording}</span>}
@@ -146,6 +187,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
               comment={comment.item}
               childComments={comment.children}
               key={comment.item._id}
+              showParentDefault
             />
           </div>
         )}

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -54,6 +54,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       opacity: 1
     },
   },
+  smallerMeta: {
+    '& .PostsItemMeta-info': {
+      fontSize: '1rem'
+    }
+  },
   showHighlight: {
     opacity: 0,
   },
@@ -98,6 +103,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "block",
     fontSize: "1.75rem",
   },
+  smallerTitle: {
+    fontSize: '1.5rem',
+    lineHeight: '1.6em'
+  },
   actions: {
     "& .PostActionsButton-icon": {
       fontSize: "1.5em",
@@ -116,6 +125,7 @@ const RecentDiscussionThread = ({
   comments, refetch,
   expandAllThreads: initialExpandAllThreads,
   maxLengthWords,
+  smallerFonts,
   classes,
 }: {
   post: PostsRecentDiscussion,
@@ -123,6 +133,7 @@ const RecentDiscussionThread = ({
   refetch: any,
   expandAllThreads?: boolean,
   maxLengthWords?: number,
+  smallerFonts?: boolean,
   classes: ClassesType,
 }) => {
   const [highlightVisible, setHighlightVisible] = useState(false);
@@ -183,19 +194,19 @@ const RecentDiscussionThread = ({
           <div className={classes.postItem}>
             {post.group && <PostsGroupDetails post={post} documentId={post.group._id} inRecentDiscussion={true} />}
             <div className={classes.titleAndActions}>
-              <Link to={postGetPageUrl(post)} className={classes.title}>
+              <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})}>
                 {post.title}
               </Link>
               <div className={classes.actions}>
                 <PostActionsButton post={post} vertical />
               </div>
             </div>
-            <div className={classes.threadMeta} onClick={showHighlight}>
+            <div className={classNames(classes.threadMeta, {[classes.smallerMeta]: smallerFonts})} onClick={showHighlight}>
               <PostsItemMeta post={post}/>
             </div>
           </div>
           <div className={highlightClasses}>
-            <PostsHighlight post={post} maxLengthWords={maxLengthWords ?? lastVisitedAt ? 50 : 170} />
+            <PostsHighlight post={post} maxLengthWords={maxLengthWords ?? lastVisitedAt ? 50 : 170} smallerFonts={smallerFonts} />
           </div>
         </div>
         <div className={classes.content}>

--- a/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/TagSubforumPage2.tsx
@@ -575,13 +575,13 @@ const TagSubforumPage2 = ({classes}: {
     <LWTooltip
       title={
         canPostDiscussion
-          ? "Create a thread which will only appear in this subforum"
-          : "You must be a member of this subforum to create a thread"
+          ? "Create a discussion which will only appear in this subforum"
+          : "You must be a member of this subforum to create a discussion"
       }
       className={classNames(classes.newPostLink, classes.newPostLinkHover)}
     >
       <SectionButton onClick={canPostDiscussion ? clickNewDiscussion : () => {}}>
-        <AddBoxIcon /> <span className={classes.hideOnMobile}>New</span>&nbsp;Thread
+        <AddBoxIcon /> <span className={classes.hideOnMobile}>New</span>&nbsp;Discussion
       </SectionButton>
     </LWTooltip>
   );
@@ -676,6 +676,7 @@ const TagSubforumPage2 = ({classes}: {
                   comments={post.recentComments}
                   maxLengthWords={50}
                   refetch={refetch}
+                  smallerFonts
                 />
               </div>
             ),


### PR DESCRIPTION
This PR includes a few things:
1. Rename subforum "thread" to "discussion"
2. When subforum threads appear in Recent Discussion, they should have a distinctive header so it's clear what they are
<img width="787" alt="Screen Shot 2022-12-20 at 11 16 13 AM" src="https://user-images.githubusercontent.com/9057804/208753311-de564465-fa40-4d71-8e6b-e86eb8f65eba.png">
<img width="379" alt="Screen Shot 2022-12-20 at 12 41 20 AM" src="https://user-images.githubusercontent.com/9057804/208753331-2f66cec9-cf15-4a6a-82b8-70524bdad862.png">
3. Decrease the font sizes for posts in the subforum feed, so that they don't feel larger/heavier than discussion threads (this will be iterated upon when we add titles to subforum threads)
<img width="733" alt="Screen Shot 2022-12-20 at 2 25 56 PM" src="https://user-images.githubusercontent.com/9057804/208753393-6cca8480-71a9-430b-aa81-2a048a1d0f56.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203590527405072) by [Unito](https://www.unito.io)
