### PR TITLE
Add sample rate settings for datadog tracing

### DIFF
--- a/packages/lesswrong/client.js
+++ b/packages/lesswrong/client.js
@@ -6,8 +6,9 @@ import './client/start';
 // Make sure to register settings before everything else
 import './client/publicSettings'
 
-// Then import the google analytics stuff
+// Then import google analytics and datadog
 import './client/ga';
+import './client/datadogRum';
 
 // Then import google reCaptcha v3
 import './client/reCaptcha'

--- a/packages/lesswrong/client/clientStartup.ts
+++ b/packages/lesswrong/client/clientStartup.ts
@@ -1,4 +1,3 @@
-import './datadogRum';
 import { runStartupFunctions } from '../lib/executionEnvironment';
 
 async function clientStartup() {

--- a/packages/lesswrong/client/datadogRum.ts
+++ b/packages/lesswrong/client/datadogRum.ts
@@ -1,6 +1,9 @@
 import { datadogRum } from '@datadog/browser-rum';
 import { getDatadogUser } from '../lib/collections/users/helpers';
 import { forumTypeSetting } from '../lib/instanceSettings';
+import { ddRumSampleRate, ddSessionReplaySampleRate, ddTracingSampleRate } from '../lib/publicSettings';
+
+console.log(ddRumSampleRate.get())
 
 datadogRum.init({
   applicationId: '2e902643-baff-466d-8882-db60acbdf13b',
@@ -9,8 +12,9 @@ datadogRum.init({
   service:'eaforum-client',
   env: ddEnv,
   // version: '1.0.0',
-  sampleRate: 100,
-  sessionReplaySampleRate: 100,
+  tracingSampleRate: ddTracingSampleRate.get(),
+  sampleRate: ddRumSampleRate.get(),
+  sessionReplaySampleRate: ddSessionReplaySampleRate.get(),
   trackInteractions: true,
   trackResources: true,
   trackLongTasks: true,
@@ -21,7 +25,7 @@ datadogRum.init({
     "https://forum-staging.effectivealtruism.org"
     // TODO add LW domains here if they want to use datadog
   ]
-});
+})
 
 export function configureDatadogRum(user: UsersCurrent | UsersEdit | DbUser | null) {
   if (forumTypeSetting.get() !== 'EAForum') return

--- a/packages/lesswrong/client/datadogRum.ts
+++ b/packages/lesswrong/client/datadogRum.ts
@@ -3,8 +3,6 @@ import { getDatadogUser } from '../lib/collections/users/helpers';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { ddRumSampleRate, ddSessionReplaySampleRate, ddTracingSampleRate } from '../lib/publicSettings';
 
-console.log(ddRumSampleRate.get())
-
 datadogRum.init({
   applicationId: '2e902643-baff-466d-8882-db60acbdf13b',
   clientToken: 'puba413e9fd2759b4b17c1909d396ba122a',

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -105,3 +105,7 @@ export const annualReviewVotingResultsPostPath = new DatabasePublicSetting<strin
 export const moderationEmail = new DatabasePublicSetting<string>('moderationEmail', "ERROR: NO MODERATION EMAIL SET")
 
 export const crosspostKarmaThreshold = new DatabasePublicSetting<number | null>('crosspostKarmaThreshold', 100);
+
+export const ddTracingSampleRate = new DatabasePublicSetting<number>('datadog.tracingSampleRate', 100) // Sample rate for backend traces, between 0 and 100
+export const ddRumSampleRate = new DatabasePublicSetting<number>('datadog.rumSampleRate', 100) // Sample rate for backend traces, between 0 and 100
+export const ddSessionReplaySampleRate = new DatabasePublicSetting<number>('datadog.sessionReplaySampleRate', 100) // Sample rate for backend traces, between 0 and 100


### PR DESCRIPTION
See also this [credentials PR](https://github.com/centre-for-effective-altruism/ForumCredentials/pull/11), description copied from there:

> Real User Monitoring is moderately expensive, $1.80/1k sesssions and we have about 20k sessions/day (~$1000/month overall), so we may want to sample it down a bit. I have left the rate at 100% initially to see if it ends up being useful for debugging individual user issues, but if not we're not getting much value out of it we can reduce it to like 10%

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203594881396109) by [Unito](https://www.unito.io)
