### PR TITLE
Add a maximum value for offset

### DIFF
--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -164,7 +164,7 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
   
   // Don't allow API requests with an offset provided >2000. This prevents some
   // extremely-slow queries.
-  if (terms.offset > maxAllowedSkip) {
+  if (terms.offset && (terms.offset > maxAllowedSkip)) {
     throw new Error("Exceeded maximum value for skip");
   }
   

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -4,6 +4,8 @@ import { asyncFilter } from '../utils/asyncUtils';
 import { loggerConstructor, logGroupConstructor } from '../utils/logging';
 import { describeTerms } from '../utils/viewUtils';
 
+const maxAllowedSkip = 2000;
+
 interface DefaultResolverOptions {
   cacheMaxAge: number
 }
@@ -159,6 +161,13 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
 const queryFromViewParameters = async <T extends DbObject>(collection: CollectionBase<T>, terms: ViewTermsBase, parameters: any): Promise<Array<T>> => {
   const logger = loggerConstructor(`views-${collection.collectionName.toLowerCase()}`)
   const selector = parameters.selector;
+  
+  // Don't allow API requests with an offset provided >2000. This prevents some
+  // extremely-slow queries.
+  if (options.skip > maxAllowedSkip) {
+    throw new Error("Exceeded maximum value for skip");
+  }
+  
   const options = {
     ...parameters.options,
     skip: terms.offset,

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -164,7 +164,7 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
   
   // Don't allow API requests with an offset provided >2000. This prevents some
   // extremely-slow queries.
-  if (options.skip > maxAllowedSkip) {
+  if (terms.offset > maxAllowedSkip) {
     throw new Error("Exceeded maximum value for skip");
   }
   


### PR DESCRIPTION
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203598713233724) by [Unito](https://www.unito.io)

We had an issue where a bot crawling the GreaterWrong front page clicking Next a bunch of times, led to GreaterWrong making API requests to us with very large `skip` parameters. These were rapid enough and slow enough to bring down the DB.

This adds a maximum value of 2000 to the `offset` parameter in graphql queries. I believe the offset is never used by ForumMagnum itself, only by third-party API users, which will now be limited in how many pages deep they can query.