### PR TITLE
expand truncated and single-line comments after scrolling from See in context

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -153,11 +153,29 @@ const CommentsNode = ({
     }, HIGHLIGHT_DURATION*1000);
   }, []);
 
+  const handleExpand = async (event?: React.MouseEvent) => {
+    event?.stopPropagation()
+    if (isTruncated || isSingleLine) {
+      setTruncated(false);
+      setSingleLine(false);
+      setTruncatedStateSet(true);
+      if (scrollOnExpand) {
+        scrollIntoView("auto") // should scroll instantly
+      }
+    }
+  }
+
   const {hash: commentHash} = useSubscribedLocation();
   useEffect(() => {
     if (!noHash && !noAutoScroll && comment && commentHash === ("#" + comment._id)) {
       setTimeout(() => { //setTimeout make sure we execute this after the element has properly rendered
-        scrollIntoView()
+        // This check is redundant with the one in handleExpand, but I don't want to call scrollIntoView twice
+        if (isTruncated || isSingleLine) {
+          handleExpand()
+        }
+        else {
+          scrollIntoView()
+        }
       }, 0);
     }
     //No exhaustive deps because this is supposed to run only on mount
@@ -185,18 +203,6 @@ const CommentsNode = ({
 
     return isTruncated && !(expandNewComments && isNewComment);
   })();
-
-  const handleExpand = async (event: React.MouseEvent) => {
-    event.stopPropagation()
-    if (isTruncated || isSingleLine) {
-      setTruncated(false);
-      setSingleLine(false);
-      setTruncatedStateSet(true);
-      if (scrollOnExpand) {
-        scrollIntoView("auto") // should scroll instantly
-      }
-    }
-  }
 
   const { CommentFrame, SingleLineComment, CommentsItem, RepliesToCommentList, AnalyticsTracker } = Components
 

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -169,13 +169,8 @@ const CommentsNode = ({
   useEffect(() => {
     if (!noHash && !noAutoScroll && comment && commentHash === ("#" + comment._id)) {
       setTimeout(() => { //setTimeout make sure we execute this after the element has properly rendered
-        // This check is redundant with the one in handleExpand, but I don't want to call scrollIntoView twice
-        if (isTruncated || isSingleLine) {
-          handleExpand()
-        }
-        else {
-          scrollIntoView()
-        }
+        void handleExpand()
+        scrollIntoView()
       }, 0);
     }
     //No exhaustive deps because this is supposed to run only on mount


### PR DESCRIPTION
Truncated/single-line comments remain that way even when scrolling to them after clicking "See in context".

<img width="748" alt="image" src="https://user-images.githubusercontent.com/2136984/209412292-828371a5-e200-4736-a822-ca06c204ed76.png">

**Original Behavior (after clicking "See in context")**
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2136984/209412306-2f513a44-d430-4412-adab-fcb72198066d.png">

**New Behavior (after clicking "See in context")**
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2136984/209414114-c38b1f94-5a41-46cb-8574-bd0a718f5526.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203609311025327) by [Unito](https://www.unito.io)
