### PR TITLE
Refactor views

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -8,6 +8,7 @@ import { forumTypeSetting } from "../../instanceSettings";
 import { commentAllowTitle, commentGetPageUrlFromDB } from './helpers';
 import { tagCommentTypes } from './types';
 import { getVotingSystemNameForDocument } from '../../voting/votingSystems';
+import { viewTermsToQuery } from '../../utils/viewUtils';
 
 
 export const moderationOptionsGroup: FormGroup = {
@@ -240,7 +241,7 @@ const schema: SchemaType<DbComment> = {
     viewableBy: ['guests'],
     resolver: async (comment: DbComment, args: void, context: ResolverContext) => {
       const { Comments } = context;
-      const params = Comments.getParameters({view:"shortformLatestChildren", topLevelCommentId: comment._id})
+      const params = viewTermsToQuery("Comments", {view:"shortformLatestChildren", topLevelCommentId: comment._id});
       return await Comments.find(params.selector, params.options).fetch()
     }
   }),

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -24,6 +24,7 @@ import { userOverNKarmaFunc } from "../../vulcan-users";
 import { allOf } from '../../utils/functionUtils';
 import { crosspostKarmaThreshold } from '../../publicSettings';
 import { userHasSideComments } from '../../betas';
+import { getDefaultViewSelector } from '../../utils/viewUtils';
 
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
 
@@ -2328,7 +2329,7 @@ const schema: SchemaType<DbPost> = {
       const { currentUser, Comments } = context;
       const timeCutoff = moment(post.lastCommentedAt).subtract(maxAgeHours, 'hours').toDate();
       const comments = await Comments.find({
-        ...Comments.defaultView({}).selector,
+        ...getDefaultViewSelector("Comments"),
         postId: post._id,
         score: {$gt:0},
         deletedPublic: false,

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -13,6 +13,7 @@ import omit from 'lodash/omit';
 import { formGroups } from './formGroups';
 import Comments from '../comments/collection';
 import UserTagRels from '../userTagRels/collection';
+import { getDefaultViewSelector } from '../../utils/viewUtils';
 
 addGraphQLSchema(`
   type TagContributor {
@@ -246,7 +247,7 @@ const schema: SchemaType<DbTag> = {
       const timeCutoff = moment(lastCommentTime).subtract(maxAgeHours, 'hours').toDate();
 
       const comments = await Comments.find({
-        ...Comments.defaultView({}).selector,
+        ...getDefaultViewSelector("Comments"),
         tagId: tag._id,
         score: {$gt:0},
         deletedPublic: false,

--- a/packages/lesswrong/lib/crud/cacheUpdates.ts
+++ b/packages/lesswrong/lib/crud/cacheUpdates.ts
@@ -1,7 +1,9 @@
 import { Utils } from '../vulcan-lib';
 import { getCollectionByTypeName } from '../vulcan-lib/getCollection';
 import { getMultiResolverName, findWatchesByTypeName, getUpdateMutationName, getCreateMutationName, getDeleteMutationName } from './utils';
+import { viewTermsToQuery } from '../utils/viewUtils';
 import type { ApolloClient, ApolloCache } from '@apollo/client';
+
 
 export const updateCacheAfterCreate = (typeName: string, client: ApolloClient<any>) => {
   const mutationName = getCreateMutationName(typeName);
@@ -74,7 +76,8 @@ const invalidateQuery = ({client, query, variables}: {
 
 const getParametersByTypeName = (terms, typeName) => {
   const collection = getCollectionByTypeName(typeName);
-  return collection.getParameters(terms /* apolloClient */);
+  const collectionName = collection.collectionName;
+  return viewTermsToQuery(collectionName, terms); //NOTE: this once passed apolloClient but doesn't anymore
 }
 
 export const handleDeleteMutation = ({ document, results, typeName }) => {

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -26,7 +26,6 @@ interface CollectionBase<
   addView: (viewName: string, view: ViewFunction<N>) => void
   defaultView: ViewFunction<N> //FIXME: This is actually nullable (but should just have a default)
   views: Record<string, ViewFunction<N>>
-  getParameters: (terms: ViewTermsByCollectionName[N], apolloClient?: any, context?: ResolverContext) => MergedViewQueryAndOptions<N,T>
   
   _schemaFields: SchemaType<T>
   _simpleSchema: any

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -8,12 +8,14 @@ import merge from 'lodash/merge';
 // 'Maximum documents per request'
 const maxDocumentsPerRequestSetting = new DatabasePublicSetting<number>('maxDocumentsPerRequest', 5000)
 
-// Given a view (which gets translated into a mongo query), provide a string
-// which describes what's being queried (ie the view name, and a list of
-// parameters that were attached, but not the values of those parameters). This
-// is attached to the mongodb query by putting a $comment in the selector, so
-// that when we see slow queries in the profiler, we can easily identify the
-// source.
+/**
+ * Given a view (which gets translated into a mongo query), provide a string
+ * which describes what's being queried (ie the view name, and a list of
+ * parameters that were attached, but not the values of those parameters). This
+ * is attached to the mongodb query by putting a $comment in the selector, so
+ * that when we see slow queries in the profiler, we can easily identify the
+ * source.
+ */
 export function describeTerms(terms: ViewTermsBase) {
   const viewName = terms.view || "defaultView";
   const otherTerms = Object.keys(terms).filter(key => key!=='view').join(',');
@@ -23,16 +25,30 @@ export function describeTerms(terms: ViewTermsBase) {
     return viewName;
 }
 
+/**
+ * Given a set of terms describing a view, translate them into a mongodb selector
+ * and options, which is ready to execute (but don't execute it yet).
+ */
 export function viewTermsToQuery<N extends CollectionNameString>(collectionName: N, terms: ViewTermsByCollectionName[N], apolloClient?: any, resolverContext?: ResolverContext) {
   const collection = getCollection(collectionName);
   return getParameters(collection, terms, apolloClient, resolverContext);
 }
 
+/**
+ * Return the default selector for a given collection. This is generally a filter
+ * which handles things like soft deletion, hidden drafts, etc; if you're building
+ * a query that doesn't pass through the views system, you probably want to use
+ * this selector as a starting point.
+ */
 export function getDefaultViewSelector<N extends CollectionNameString>(collectionName: N) {
   const viewQuery = viewTermsToQuery(collectionName, {})
   return replaceSpecialFieldSelectors(viewQuery.selector);
 }
 
+/**
+ * Given a set of terms describing a view, translate them into a mongodb selector
+ * and options, which is ready to execute (but don't execute it yet).
+ */
 function getParameters<N extends CollectionNameString, T extends DbObject=ObjectsByCollectionName[N]>(
   collection: CollectionBase<T>,
   terms: ViewTermsByCollectionName[N] = {},
@@ -113,12 +129,20 @@ function getParameters<N extends CollectionNameString, T extends DbObject=Object
   return parameters;
 }
 
+/**
+ * Take a selector, which is a mongodb selector except that some fields may be
+ * the special values `viewFieldNullOrMissing` or `viewFieldAllowAny`, and turn
+ * it into a mongodb selector without those special cases. (These special-case
+ * values exist to support merging a specific-view selector with a default view;
+ * in that context, the specific-view needs something other than `undefined` to
+ * replace the default-view's constraint with.)
+ */
 function replaceSpecialFieldSelectors(selector: any): any {
   let result: any = {};
   for (let key of Object.keys(selector)) {
     if (_.isEqual(selector[key], viewFieldNullOrMissing)) {
       // Put an explicit null in the selector. In mongodb-query terms, this means
-      // no constraint on the given field.
+      // the field must either contain the value null, or be missing.
       result[key] = null;
     } else if (_.isEqual(selector[key], viewFieldAllowAny)) {
       // Skip: The selector has a no-op in this field. Probably a specific view

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -1,3 +1,4 @@
+import { getCollection } from '../vulcan-lib/getCollection';
 
 // Given a view (which gets translated into a mongo query), provide a string
 // which describes what's being queried (ie the view name, and a list of
@@ -12,4 +13,15 @@ export function describeTerms(terms: ViewTermsBase) {
     return `${viewName}(${otherTerms})`;
   else
     return viewName;
+}
+
+export function viewTermsToQuery<N extends CollectionNameString>(collectionName: N, terms: ViewTermsByCollectionName[N], apolloClient?: any, resolverContext?: ResolverContext) {
+  const collection = getCollection(collectionName);
+  return collection.getParameters(terms, apolloClient, resolverContext);
+}
+
+export function getDefaultViewSelector<N extends CollectionNameString>(collectionName: N) {
+  const viewQuery = viewTermsToQuery(collectionName, {})
+  // TODO: Postprocess out viewFieldNullOrMissing
+  return viewQuery.selector;
 }

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -1,4 +1,12 @@
 import { getCollection } from '../vulcan-lib/getCollection';
+import { loggerConstructor } from './logging'
+import { viewFieldNullOrMissing, viewFieldAllowAny } from '../vulcan-lib/collections';
+import { DatabasePublicSetting } from '../publicSettings';
+import * as _ from 'underscore';
+import merge from 'lodash/merge';
+
+// 'Maximum documents per request'
+const maxDocumentsPerRequestSetting = new DatabasePublicSetting<number>('maxDocumentsPerRequest', 5000)
 
 // Given a view (which gets translated into a mongo query), provide a string
 // which describes what's being queried (ie the view name, and a list of
@@ -17,11 +25,100 @@ export function describeTerms(terms: ViewTermsBase) {
 
 export function viewTermsToQuery<N extends CollectionNameString>(collectionName: N, terms: ViewTermsByCollectionName[N], apolloClient?: any, resolverContext?: ResolverContext) {
   const collection = getCollection(collectionName);
-  return collection.getParameters(terms, apolloClient, resolverContext);
+  return getParameters(collection, terms, apolloClient, resolverContext);
 }
 
 export function getDefaultViewSelector<N extends CollectionNameString>(collectionName: N) {
   const viewQuery = viewTermsToQuery(collectionName, {})
   // TODO: Postprocess out viewFieldNullOrMissing
   return viewQuery.selector;
+}
+
+function getParameters<N extends CollectionNameString, T extends DbObject=ObjectsByCollectionName[N]>(
+  collection: CollectionBase<T>,
+  terms: ViewTermsByCollectionName[N] = {},
+  apolloClient?: any,
+  context?: ResolverContext
+): MergedViewQueryAndOptions<N,T> {
+  const collectionName = collection.collectionName;
+  const logger = loggerConstructor(`views-${collectionName.toLowerCase()}`)
+  logger('getParameters(), terms:', terms);
+
+  let parameters: any = {
+    selector: {},
+    options: {},
+  };
+
+  if (collection.defaultView) {
+    parameters = merge(
+      parameters,
+      collection.defaultView(terms, apolloClient, context)
+    );
+    logger('getParameters(), parameters after defaultView:', parameters)
+  }
+
+  // handle view option
+  if (terms.view && collection.views[terms.view]) {
+    const viewFn = collection.views[terms.view];
+    const view = viewFn(terms, apolloClient, context);
+    let mergedParameters = merge(parameters, view);
+
+    if (
+      mergedParameters.options &&
+      mergedParameters.options.sort &&
+      view.options &&
+      view.options.sort
+    ) {
+      // If both the default view and the selected view have sort options,
+      // don't merge them together; take the selected view's sort. (Otherwise
+      // they merge in the wrong order, so that the default-view's sort takes
+      // precedence over the selected view's sort.)
+      mergedParameters.options.sort = view.options.sort;
+    }
+    parameters = mergedParameters;
+    logger('getParameters(), parameters after defaultView and view:', parameters)
+  }
+
+  // sort using terms.orderBy (overwrite defaultView's sort)
+  if (terms.orderBy && !_.isEmpty(terms.orderBy)) {
+    parameters.options.sort = terms.orderBy;
+  }
+
+  // if there is no sort, default to sorting by createdAt descending
+  if (!parameters.options.sort) {
+    parameters.options.sort = { createdAt: -1 } as any;
+  }
+
+  // extend sort to sort posts by _id to break ties, unless there's already an id sort
+  // NOTE: always do this last to avoid overriding another sort
+  if (!(parameters.options.sort && typeof parameters.options.sort._id !== undefined)) {
+    parameters = merge(parameters, { options: { sort: { _id: -1 } } });
+  }
+
+  // remove any null fields (setting a field to null means it should be deleted)
+  _.keys(parameters.selector).forEach(key => {
+    if (_.isEqual(parameters.selector[key], viewFieldNullOrMissing)) {
+      parameters.selector[key] = null;
+    } else if (_.isEqual(parameters.selector[key], viewFieldAllowAny)) {
+      delete parameters.selector[key];
+    } else if (parameters.selector[key] === null || parameters.selector[key] === undefined) {
+      //console.log(`Warning: Null key ${key} in query of collection ${collectionName} with view ${terms.view}.`);
+      delete parameters.selector[key];
+    }
+  });
+  if (parameters.options.sort) {
+    _.keys(parameters.options.sort).forEach(key => {
+      if (parameters.options.sort[key] === null) {
+        delete parameters.options.sort[key];
+      }
+    });
+  }
+
+  // limit number of items to 1000 by default
+  const maxDocuments = maxDocumentsPerRequestSetting.get();
+  const limit = terms.limit || parameters.options.limit;
+  parameters.options.limit = !limit || limit < 1 || limit > maxDocuments ? maxDocuments : limit;
+
+  logger('getParameters(), final parameters:', parameters);
+  return parameters;
 }

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -2,7 +2,7 @@ import { Utils, getTypeName, getCollection } from '../vulcan-lib';
 import { restrictViewableFields } from '../vulcan-users/permissions';
 import { asyncFilter } from '../utils/asyncUtils';
 import { loggerConstructor, logGroupConstructor } from '../utils/logging';
-import { describeTerms } from '../utils/viewUtils';
+import { describeTerms, viewTermsToQuery } from '../utils/viewUtils';
 
 const maxAllowedSkip = 2000;
 
@@ -42,10 +42,11 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
         // get collection based on collectionName argument
         const collection = getCollection(collectionName);
 
-        // get selector and options from terms and perform Mongo query
-        const parameters = collection.getParameters(terms, {}, context);
+        // Get selector and options from terms and perform Mongo query
+        // Downcasts terms because there are collection-specific terms but this function isn't collection-specific
+        const parameters = viewTermsToQuery(collectionName, terms as any, {}, context);
         
-        const docs: Array<T> = await queryFromViewParameters(collection, terms, parameters);
+        const docs: Array<T> = await performQueryFromViewParameters(collection, terms, parameters);
         
         // Were there enough results to reach the limit specified in the query?
         const saturated = parameters.options.limit && docs.length>=parameters.options.limit;
@@ -158,7 +159,7 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
   };
 }
 
-const queryFromViewParameters = async <T extends DbObject>(collection: CollectionBase<T>, terms: ViewTermsBase, parameters: any): Promise<Array<T>> => {
+const performQueryFromViewParameters = async <T extends DbObject>(collection: CollectionBase<T>, terms: ViewTermsBase, parameters: any): Promise<Array<T>> => {
   const logger = loggerConstructor(`views-${collection.collectionName.toLowerCase()}`)
   const selector = parameters.selector;
   
@@ -199,7 +200,7 @@ const queryFromViewParameters = async <T extends DbObject>(collection: Collectio
     logger('aggregation pipeline', pipeline);
     return await collection.aggregate(pipeline).toArray();
   } else {
-    logger('queryFromViewParameters connector find', selector, terms, options);
+    logger('performQueryFromViewParameters connector find', selector, terms, options);
     return await Utils.Connectors.find(collection,
       {
         ...selector,

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -98,8 +98,7 @@ export const createCollection = <
     addGraphQLCollection(collection);
   }
 
-  // ------------------------------------- Default Fragment -------------------------------- //
-
+  // Default Fragment
   const defaultFragment = getDefaultFragmentText(collection, schema);
   if (defaultFragment) registerFragment(defaultFragment);
 

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -1,9 +1,6 @@
 import { MongoCollection } from '../mongoCollection';
 import PgCollection from '../sql/PgCollection';
 import SwitchingCollection from '../SwitchingCollection';
-import * as _ from 'underscore';
-import merge from 'lodash/merge';
-import { DatabasePublicSetting } from '../publicSettings';
 import { getDefaultFragmentText, registerFragment } from './fragments';
 import { registerCollection } from './getCollection';
 import { addGraphQLCollection } from './graphql';
@@ -11,9 +8,6 @@ import { camelCaseify } from './utils';
 import { pluralize } from './pluralize';
 export * from './getCollection';
 import { loggerConstructor } from '../utils/logging'
-
-// 'Maximum documents per request'
-const maxDocumentsPerRequestSetting = new DatabasePublicSetting<number>('maxDocumentsPerRequest', 5000)
 
 // When used in a view, set the query so that it returns rows where a field is
 // null or is missing. Equivalent to a search with mongo's `field:null`, except
@@ -109,90 +103,6 @@ export const createCollection = <
   const defaultFragment = getDefaultFragmentText(collection, schema);
   if (defaultFragment) registerFragment(defaultFragment);
 
-  // ------------------------------------- Parameters -------------------------------- //
-
-  collection.getParameters = ((terms: ViewTermsByCollectionName[N] = {}, apolloClient?: any, context?: ResolverContext): MergedViewQueryAndOptions<N,T> => {
-    const logger = loggerConstructor(`views-${collectionName.toLowerCase()}`)
-    logger('getParameters(), terms:', terms);
-
-    let parameters: any = {
-      selector: {},
-      options: {},
-    };
-
-    if (collection.defaultView) {
-      parameters = merge(
-        parameters,
-        collection.defaultView(terms, apolloClient, context)
-      );
-      logger('getParameters(), parameters after defaultView:', parameters)
-    }
-
-    // handle view option
-    if (terms.view && collection.views[terms.view]) {
-      const viewFn = collection.views[terms.view];
-      const view = viewFn(terms, apolloClient, context);
-      let mergedParameters = merge(parameters, view);
-
-      if (
-        mergedParameters.options &&
-        mergedParameters.options.sort &&
-        view.options &&
-        view.options.sort
-      ) {
-        // If both the default view and the selected view have sort options,
-        // don't merge them together; take the selected view's sort. (Otherwise
-        // they merge in the wrong order, so that the default-view's sort takes
-        // precedence over the selected view's sort.)
-        mergedParameters.options.sort = view.options.sort;
-      }
-      parameters = mergedParameters;
-      logger('getParameters(), parameters after defaultView and view:', parameters)
-    }
-
-    // sort using terms.orderBy (overwrite defaultView's sort)
-    if (terms.orderBy && !_.isEmpty(terms.orderBy)) {
-      parameters.options.sort = terms.orderBy;
-    }
-
-    // if there is no sort, default to sorting by createdAt descending
-    if (!parameters.options.sort) {
-      parameters.options.sort = { createdAt: -1 } as any;
-    }
-
-    // extend sort to sort posts by _id to break ties, unless there's already an id sort
-    // NOTE: always do this last to avoid overriding another sort
-    if (!(parameters.options.sort && typeof parameters.options.sort._id !== undefined)) {
-      parameters = merge(parameters, { options: { sort: { _id: -1 } } });
-    }
-
-    // remove any null fields (setting a field to null means it should be deleted)
-    _.keys(parameters.selector).forEach(key => {
-      if (_.isEqual(parameters.selector[key], viewFieldNullOrMissing)) {
-        parameters.selector[key] = null;
-      } else if (_.isEqual(parameters.selector[key], viewFieldAllowAny)) {
-        delete parameters.selector[key];
-      } else if (parameters.selector[key] === null || parameters.selector[key] === undefined) {
-        //console.log(`Warning: Null key ${key} in query of collection ${collectionName} with view ${terms.view}.`);
-        delete parameters.selector[key];
-      }
-    });
-    if (parameters.options.sort) {
-      _.keys(parameters.options.sort).forEach(key => {
-        if (parameters.options.sort[key] === null) {
-          delete parameters.options.sort[key];
-        }
-      });
-    }
-
-    // limit number of items to 1000 by default
-    const maxDocuments = maxDocumentsPerRequestSetting.get();
-    const limit = terms.limit || parameters.options.limit;
-    parameters.options.limit = !limit || limit < 1 || limit > maxDocuments ? maxDocuments : limit;
-
-    logger('getParameters(), final parameters:', parameters);
-    return parameters;
-  }) as any;
 
   registerCollection(collection);
 

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -11,6 +11,7 @@ import type { RecommendationsAlgorithm } from '../lib/collections/users/recommen
 import { forumTypeSetting } from '../lib/instanceSettings';
 import SelectQuery from "../lib/sql/SelectQuery";
 import { getPositiveVoteThreshold } from '../lib/reviewUtils';
+import { getDefaultViewSelector } from '../lib/utils/viewUtils';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
 
@@ -135,7 +136,7 @@ const recommendablePostFilter = (algorithm: RecommendationsAlgorithm) => {
   const recommendationFilter = {
     // Gets the selector from the default Posts view, which includes things like
     // excluding drafts and deleted posts
-    ...Posts.getParameters({}).selector,
+    ...getDefaultViewSelector("Posts"),
 
     // Only consider recommending posts if they hit the minimum base score. This has a big
     // effect on the size of the recommendable-post set, which needs to not be

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -9,6 +9,7 @@ import { getDefaultPostLocationFields } from '../posts/utils'
 import { addBlockIDsToHTML, getSideComments, matchSideComments } from '../sideComments';
 import { captureException } from '@sentry/core';
 import { getToCforPost } from '../tableOfContents';
+import { getDefaultViewSelector } from '../../lib/utils/viewUtils';
 import keyBy from 'lodash/keyBy';
 import GraphQLJSON from 'graphql-type-json';
 
@@ -81,7 +82,7 @@ augmentFieldsDict(Posts, {
         
         const now = new Date();
         const comments = await Comments.find({
-          ...Comments.defaultView({}).selector,
+          ...getDefaultViewSelector("Comments"),
           postId: post._id,
         }).fetch();
         

--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -12,6 +12,7 @@ import { addStaticRoute } from './vulcan-lib';
 import { accessFilterMultiple } from '../lib/utils/schemaUtils';
 import { getCommentParentTitle } from '../lib/notificationTypes';
 import { asyncForeachSequential } from '../lib/utils/asyncUtils';
+import { viewTermsToQuery } from '../lib/utils/viewUtils';
 
 
 Posts.addView('rss', Posts.views.new); // default to 'new' view for RSS feed
@@ -45,7 +46,7 @@ export const servePostRSS = async (terms: RSSTerms, url?: string) => {
   let karmaThreshold = terms.karmaThreshold = roundKarmaThreshold(parseInt(terms.karmaThreshold, 10));
   url = url || rssTermsToUrl(terms); // Default value is the custom rss feed computed from terms
   const feed = new RSS(getMeta(url));
-  let parameters = Posts.getParameters(terms);
+  let parameters = viewTermsToQuery("Posts", terms);
   delete parameters['options']['sort']['sticky'];
 
   parameters.options.limit = 10;
@@ -97,7 +98,7 @@ export const serveCommentRSS = async (terms: RSSTerms, url?: string) => {
   url = url || rssTermsToUrl(terms); // Default value is the custom rss feed computed from terms
   const feed = new RSS(getMeta(url));
 
-  let parameters = Comments.getParameters(terms);
+  let parameters = viewTermsToQuery("Comments", terms);
   parameters.options.limit = 50;
   const commentsCursor = await Comments.find(parameters.selector, parameters.options).fetch();
   const restrictedComments = await accessFilterMultiple(null, Comments, commentsCursor, null);

--- a/packages/lesswrong/server/sideComments.ts
+++ b/packages/lesswrong/server/sideComments.ts
@@ -2,6 +2,7 @@ import cheerio from 'cheerio';
 import { cheerioParse, cheerioParseAndMarkOffsets, tokenizeHtml } from './utils/htmlUtil';
 import { Comments } from '../lib/collections/comments/collection';
 import type { SideCommentsResolverResult } from '../lib/collections/posts/schema';
+import { getDefaultViewSelector } from '../lib/utils/viewUtils';
 import groupBy from 'lodash/groupBy';
 import some from 'lodash/some';
 
@@ -349,7 +350,7 @@ export async function getSideComments(context: ResolverContext, postId: string, 
   //const startTimeMs = new Date().getTime();
   
   const comments = await Comments.find({
-    ...Comments.defaultView({}).selector,
+    ...getDefaultViewSelector("Comments"),
     postId,
   }).fetch();
   

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -10,6 +10,7 @@ import { forumTypeSetting } from '../lib/instanceSettings';
 import { Utils } from '../lib/vulcan-lib';
 import { updateDenormalizedHtmlAttributions } from './tagging/updateDenormalizedHtmlAttributions';
 import { annotateAuthors } from './attributeEdits';
+import { getDefaultViewSelector } from '../lib/utils/viewUtils';
 
 export interface ToCAnswer {
   baseScore: number,
@@ -277,7 +278,7 @@ async function getTocAnswers (document: DbPost) {
 
 async function getTocComments (document: DbPost) {
   const commentSelector: any = {
-    ...Comments.defaultView({}).selector,
+    ...getDefaultViewSelector("Comments"),
     answer: false,
     parentAnswerId: null,
     postId: document._id

--- a/packages/lesswrong/server/utils/feedUtil.ts
+++ b/packages/lesswrong/server/utils/feedUtil.ts
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import { addGraphQLResolvers, addGraphQLQuery, addGraphQLSchema } from '../../lib/vulcan-lib/graphql';
 import { accessFilterMultiple } from '../../lib/utils/schemaUtils';
+import { getDefaultViewSelector } from '../../lib/utils/viewUtils';
 
 export type FeedSubquery<ResultType extends DbObject, SortKeyType> = {
   type: string,
@@ -230,7 +231,7 @@ async function queryWithCutoff<ResultType extends DbObject>({
   cutoff: any,
   sortDirection: SortDirection,
 }) {
-  const defaultViewSelector = collection.defaultView ? collection.defaultView({} as any).selector : {};
+  const collectionName = collection.collectionName;
   const {currentUser} = context;
 
   const sort = {[cutoffField]: sortDirection === "asc" ? 1 : -1, _id: 1};
@@ -238,7 +239,7 @@ async function queryWithCutoff<ResultType extends DbObject>({
     ? {[cutoffField]: {[sortDirection === "asc" ? "$gt" : "$lt"]: cutoff}}
     : {};
   const resultsRaw = await collection.find({
-    ...defaultViewSelector,
+    ...getDefaultViewSelector(collectionName),
     ...selector,
     ...cutoffSelector,
   }, {


### PR DESCRIPTION
Refactor the views system a bit. Makes various places around the code-base that get the default view, use the view system via a more purposeful entry point instead. This disarms a footgun which I ran into in another branch, which was the motivation for doing this now: the thing you got back from `Collection.getParameters({}).selector` was *almost* a ready-to-use mongodb selector, except it can have `viewFieldNullOrMissing` in it if the particular collection's default view contains that. Existing usages lucked out of hitting this case, but some new code did.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203618950006734) by [Unito](https://www.unito.io)
