### PR TITLE
fix cdn https

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -44,14 +44,14 @@ async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): 
     }
   );
   // eslint-disable-next-line no-console
-  console.log(`Result of moving image: ${result.url}`);
+  console.log(`Result of moving image: ${result.secure_url}`);
   
   await Images.rawInsert({
     originalUrl: oldUrl,
-    cdnHostedUrl: result.url,
+    cdnHostedUrl: result.secure_url,
   });
   
-  return result.url;
+  return result.secure_url;
 }
 
 /// If an image has already been re-hosted, return its CDN URL. Otherwise null.


### PR DESCRIPTION
Some browsers do not display images from insecure URLs if the page is loaded over HTTPS. We were previously using the insecure URL, which would cause these images to not load.

To replicate:
1. Find an image online that uses srcset (I used the one from [this page](https://css-tricks.com/a-guide-to-the-responsive-images-syntax-in-html/#using-srcset))
2. Drag it into a comment
3. Post the comment
4. Wait for the hook to run and upload to cloudinary
5. Reload the page
6. Observe that the image in the comment is not visible

I think this was introduced by #6138 

This PR is just to prevent the issue going forward, we will need a separate PR to fix the old stuff that was migrated

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203619144301402) by [Unito](https://www.unito.io)
