### PR TITLE
Allow 'in' comparisons with an empty value array

### DIFF
--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -330,9 +330,11 @@ abstract class Query<T extends DbObject> {
           }
           const typeHint = this.getTypeHint(this.getField(fieldName));
           const hint = typeHint ?? "";
-          const args = value[comparer].flatMap((item: any) => [
-            ",", new Arg(item), hint,
-          ]).slice(1);
+          const args = value[comparer].length
+            ? value[comparer].flatMap((item: any) => [
+              ",", new Arg(item), hint,
+            ]).slice(1)
+            : [`SELECT NULL${hint}`];
           return [field, hint, "IN (", ...args, ")"];
 
         case "$exists":

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -118,6 +118,12 @@ describe("SelectQuery", () => {
       expectedArgs: [1, 2, 3],
     },
     {
+      name: "can build select query with in comparison with empty array",
+      getQuery: () => new SelectQuery(testTable, {a: {$in: []}}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" ::DOUBLE PRECISION IN ( SELECT NULL::DOUBLE PRECISION )',
+      expectedArgs: [],
+    },
+    {
       name: "can build select query with not-in comparison",
       getQuery: () => new SelectQuery(testTable, {a: {$nin: [1, 2, 3]}}),
       expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE NOT ( "a" ::DOUBLE PRECISION IN ( $1 ::DOUBLE PRECISION , $2 ::DOUBLE PRECISION , $3 ::DOUBLE PRECISION ) )',


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203626563247360) by [Unito](https://www.unito.io)
