### PR TITLE
Comment edits decrement snooze count

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -423,13 +423,15 @@ getCollectionHooks("Comments").createAsync.add(async ({document}: CreateCallback
   await triggerReviewIfNeeded(document.userId);
 })
 
-getCollectionHooks("Comments").updateAsync.add(async function updatedCommentMaybeTriggerReview ({oldDocument, currentUser}: UpdateCallbackProperties<DbComment>) {
-  currentUser?.snoozedUntilContentCount && await updateMutator({
+getCollectionHooks("Comments").updateAsync.add(async function updatedCommentMaybeTriggerReview ({currentUser}: UpdateCallbackProperties<DbComment>) {
+  if (!currentUser) return;
+  currentUser.snoozedUntilContentCount && await updateMutator({
     collection: Users,
     documentId: currentUser._id,
     set: {
       snoozedUntilContentCount: currentUser.snoozedUntilContentCount - 1,
     },
+    validate: false,
   })
-  await triggerReviewIfNeeded(oldDocument.userId)
+  await triggerReviewIfNeeded(currentUser._id)
 });


### PR DESCRIPTION
We've had instances of spammers getting around moderation by creating unobjectionable comments, then editing them to contain spam. This PR causes those edits to contribute to the 'snooze' counter, the same as creating new posts and comments.

Fixes https://github.com/ForumMagnum/ForumMagnum/issues/4948

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203631351792292) by [Unito](https://www.unito.io)
