### PR TITLE
Fix topAdjusted sort

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -488,6 +488,24 @@ Posts.addView("top", (terms: PostsViewTerms) => ({
 //   }
 // );
 
+// Used by "topAdjusted" sort
+ensureIndex(Posts,
+  augmentForDefaultView({ postedAt: 1, baseScore: 1, maxBaseScore: 1 }),
+  {
+    name: "posts.sort_by_topAdjusted",
+    partialFilterExpression: {
+      status: postStatuses.STATUS_APPROVED,
+      draft: false,
+      unlisted: false,
+      isFuture: false,
+      shortform: false,
+      authorIsUnreviewed: false,
+      hiddenRelatedQuestion: false,
+      isEvent: false,
+    },
+  }
+);
+
 Posts.addView("new", (terms: PostsViewTerms) => ({
   options: {sort: setStickies(sortings.new, terms)}
 }))

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -233,7 +233,7 @@ abstract class Query<T extends DbObject> {
       }
     }
 
-    if (this.getField(field)) {
+    if (this.getField(field) || this.syntheticFields[field]) {
       return `"${field}"`;
     }
 

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -536,7 +536,7 @@ abstract class Query<T extends DbObject> {
     if (op === "$arrayElemAt") {
       const [array, index] = expr[op];
       if (typeof array !== "string" || array[0] !== "$" || typeof index !== "number") {
-        throw new Error("Invalid arguments to $arrayElemAt");
+        throw new Error(`Invalid arguments to $arrayElemAt: ${JSON.stringify(expr[op])}`);
       }
       const tokens = array.split(".");
       const field = tokens[0][0] === "$" ? tokens[0].slice(1) : tokens[0];

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -62,7 +62,7 @@ const variadicFunctions = {
   $min: "LEAST",
   $max: "GREATEST",
   $ifNull: "COALESCE",
-};
+} as const;
 
 /**
  * Query is the base class of the query builder which defines a number of common

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -532,6 +532,7 @@ abstract class Query<T extends DbObject> {
       return [...this.compileExpression(array), "@> {", ...this.compileExpression(value), "}"];
     }
 
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/
     if (op === "$arrayElemAt") {
       const [array, index] = expr[op];
       let field;

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -58,6 +58,12 @@ const arithmeticOps = {
   ...comparisonOps,
 };
 
+const variadicFunctions = {
+  $min: "LEAST",
+  $max: "GREATEST",
+  $ifNull: "COALESCE",
+};
+
 /**
  * Query is the base class of the query builder which defines a number of common
  * functionalities (such as compiling artitrary expressions or selectors), as well
@@ -507,8 +513,8 @@ abstract class Query<T extends DbObject> {
       return ["SUM(", ...this.compileExpression(expr[op]), ")"];
     }
 
-    if (op === "$min" || op === "$max") {
-      const func = op === "$min" ? "LEAST" : "GREATEST";
+    if (variadicFunctions[op]) {
+      const func = variadicFunctions[op];
       const args = expr[op].map((value: any) => this.compileExpression(value));
       let prefix = `${func}(`;
       let result: Atom<T>[] = [];

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -535,6 +535,7 @@ abstract class Query<T extends DbObject> {
     if (op === "$arrayElemAt") {
       const [array, index] = expr[op];
       let field;
+      // e.g. "$cats"
       if (typeof array === "string" || array[0] === "$") {
         const tokens = array.split(".");
         const field = tokens[0][0] === "$" ? tokens[0].slice(1) : tokens[0];

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -358,6 +358,21 @@ describe("SelectQuery", () => {
       expectedArgs: [6, 3],
     },
     {
+      name: "can build select query with $ifNull",
+      getQuery: () => new SelectQuery(testTable, {a: 3}, {}, {
+        addFields: {
+          k: {
+            $ifNull: [
+              "$a",
+              4,
+            ],
+          },
+        },
+      }),
+      expectedSql: 'SELECT "TestCollection".* , COALESCE( "a" , $1 ) AS "k" FROM "TestCollection" WHERE "a" = $2',
+      expectedArgs: [4, 3],
+    },
+    {
       name: "can build select with date diff",
       getQuery: () => new SelectQuery<DbTestObject>(testTable, {a: 3}, {}, {
         addFields: {


### PR DESCRIPTION
Another airport fix.

This one fixes sorting by `topAdjusted` (and some other minor bugs too). It includes:

- Implementing `$ifNull`
- Better handling of `$arrayElemAt` (this is still a bit janky and can almost certainly be further improved in the future, but for now I just want to kill this bug ASAP)
- Making synthetic field names resolvable
- A better index for `topAdjusted` (still isn't perfect, but it's better than what we were using before)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203634886862408) by [Unito](https://www.unito.io)
