### PR TITLE
Emulate mongo behaviour when sorting nulls

### DIFF
--- a/packages/lesswrong/lib/sql/SelectQuery.ts
+++ b/packages/lesswrong/lib/sql/SelectQuery.ts
@@ -296,7 +296,10 @@ class SelectQuery<T extends DbObject> extends Query<T> {
       this.atoms.push("ORDER BY");
       const sorts: string[] = [];
       for (const field in sort) {
-        sorts.push(`${this.resolveFieldName(field)} ${sort[field] === 1 ? "ASC" : "DESC"}`);
+        const pgSorting = sort[field] === 1
+            ? "ASC NULLS FIRST"
+            : "DESC NULLS LAST"
+        sorts.push(`${this.resolveFieldName(field)} ${pgSorting}`);
       }
       this.atoms.push(sorts.join(", "));
     }

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -168,13 +168,13 @@ describe("SelectQuery", () => {
     {
       name: "can build select query with descending sort",
       getQuery: () => new SelectQuery<DbTestObject>(testTable, {a: 3}, {sort: {b: -1}}),
-      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC',
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC NULLS LAST',
       expectedArgs: [3],
     },
     {
       name: "can build select query with ascending sort",
       getQuery: () => new SelectQuery<DbTestObject>(testTable, {a: 3}, {sort: {b: 1}}),
-      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" ASC',
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" ASC NULLS FIRST',
       expectedArgs: [3],
     },
     {
@@ -192,7 +192,7 @@ describe("SelectQuery", () => {
     {
       name: "can build select query with multiple options",
       getQuery: () => new SelectQuery<DbTestObject>(testTable, {a: 3}, {sort: {b: -1}, limit: 10, skip: 20}),
-      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC LIMIT $2 OFFSET $3',
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC NULLS LAST LIMIT $2 OFFSET $3',
       expectedArgs: [3, 10, 20],
     },
     {

--- a/packages/lesswrong/unitTests/sql/pipeline.tests.ts
+++ b/packages/lesswrong/unitTests/sql/pipeline.tests.ts
@@ -20,7 +20,7 @@ describe("Pipeline", () => {
           $limit: 10,
         },
       ]).toQuery(),
-      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC LIMIT $2',
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC NULLS LAST LIMIT $2',
       expectedArgs: [3, 10],
     },
     {
@@ -45,7 +45,7 @@ describe("Pipeline", () => {
           },
         },
       ]).toQuery(),
-      expectedSql: 'SELECT * FROM ( SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC LIMIT $2 ) A WHERE "b" = $3',
+      expectedSql: 'SELECT * FROM ( SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1 ORDER BY "b" DESC NULLS LAST LIMIT $2 ) A WHERE "b" = $3',
       expectedArgs: [3, 10, "test"],
     },
   ]);


### PR DESCRIPTION
This is a quick airport fix.

Someone reported via email a few days ago that sorting `allPosts` by "All Time" and "Recent Comments" was broken. This fixes that, and probably some other bugs too.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203635072261309) by [Unito](https://www.unito.io)
