### PR TITLE
Podcast Feature Highlight

### DIFF
--- a/packages/lesswrong/components/common/NewFeaturePulse.tsx
+++ b/packages/lesswrong/components/common/NewFeaturePulse.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    position: 'relative',
+  },
+  pulse: {
+    position: 'absolute',
+    left: '50%',
+    top: '50%',
+    transform: 'translate(-50%, -50%)',
+  }
+});
+
+const NewFeaturePulse = ({classes, children, dx=0, dy=0, width=50, height=50}: {
+  classes: ClassesType,
+  children: React.ReactNode,
+  dx?: number;
+  dy?: number;
+  width?: number;
+  height?: number;
+}) => { 
+  return <span className={ classes.root }>
+    <span className={classes.pulse}>
+      <svg style={{ position: 'relative', left: dx, top: dy }} width={width} height={height} viewBox={`-50 -50 100 100`}pointerEvents="none" xmlns="http://www.w3.org/2000/svg">
+        <circle id="circle" cx="0" cy="0" fill="none" opacity="0" r="10" stroke="#0c869b" strokeWidth="4">
+          <animate attributeName="r" from="25" to="50" dur="1.5s" begin="0s" repeatCount="2"/>
+          <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.3;1" dur='1.5s' repeatCount="2"/>
+        </circle>
+      </svg>
+    </span>
+    {children}
+  </span>
+ }
+
+const NewFeaturePulseComponent = registerComponent('NewFeaturePulse', NewFeaturePulse, { styles });
+
+declare global {
+  interface ComponentTypes {
+    NewFeaturePulse: typeof NewFeaturePulseComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -153,16 +153,16 @@ const PostsPagePostHeader = ({post, answers = [], toggleEmbeddedPlayer, hideMenu
     PostActionsButton, PostsVote, PostsGroupDetails, PostsTopSequencesNav,
     PostsPageEventData, FooterTagList, AddToCalendarButton, PostsPageTopTag, NewFeaturePulse} = Components;
   const [cookies, setCookie] = useCookies([PODCAST_TOOLTIP_SEEN_COOKIE]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps 
   const cachedTooltipSeen = useMemo(() => cookies[PODCAST_TOOLTIP_SEEN_COOKIE], []);
-  console.log("HAYYYYYYYY", cachedTooltipSeen)
 
   useEffect(() => {
     if(!cachedTooltipSeen) {
       setCookie(PODCAST_TOOLTIP_SEEN_COOKIE, true, {
         expires: moment().add(10, 'years').toDate(),
       });
-      console.log(cookies[PODCAST_TOOLTIP_SEEN_COOKIE])
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps 
   }, [])
   
   const feedLinkDescription = post.feed?.url && getHostname(post.feed.url)

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -127,6 +127,7 @@ importComponent("TagPageRevisionSelect", () => require('../components/revisions/
 importComponent("LWPopper", () => require('../components/common/LWPopper'));
 importComponent("LWTooltip", () => require('../components/common/LWTooltip'));
 importComponent("NewFeatureTooltip", () => require('../components/common/NewFeatureTooltip'));
+importComponent("NewFeaturePulse", () => require('../components/common/NewFeaturePulse'));
 importComponent("Typography", () => require('../components/common/Typography'));
 importComponent("PopperCard", () => require('../components/common/PopperCard'));
 importComponent("Footer", () => require('../components/common/Footer'));


### PR DESCRIPTION
This PR adds a `NewFeaturePulse` component, designed to draw user attention to icons, and adds it to the podcast icon on posts. The result is an animated surrounding circle that pulses twice when the page loads. This only happens once per user, handled via cookies.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/25752873/210617555-b8844295-a22c-4ebd-ba83-defa595fa711.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203650697950835) by [Unito](https://www.unito.io)
