### PR TITLE
Fix old review vote display

### DIFF
--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -239,7 +239,8 @@ const ReviewVoteTableRow = (
   // otherwise use the qualitative score display. 
   const qualitativeScore = post.currentUserReviewVote?.qualitativeScore;
   const qualitativeScoreDisplay = qualitativeScore ? getCostData({costTotal})[qualitativeScore].value : "";
-  const userReviewVote = post.currentUserReviewVote?.quadraticScore ?? qualitativeScoreDisplay;
+  // note: this needs to be ||, not ??, because quadraticScore defaults to 0 rather than null
+  const userReviewVote = post.currentUserReviewVote?.quadraticScore || qualitativeScoreDisplay;
 
   // TODO: debug reviewCount = null
   return <AnalyticsContext pageElementContext="voteTableRow">


### PR DESCRIPTION
Robert had suggested a code refactor for this that used `??` instead of `||`, but `||` was actually important here so that we didn't use the default `0` for quadraticVote

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203653880626696) by [Unito](https://www.unito.io)
