### PR TITLE
Add workaround for collaborative editing link sharing

### DIFF
--- a/packages/lesswrong/lib/collections/users/collection.ts
+++ b/packages/lesswrong/lib/collections/users/collection.ts
@@ -15,6 +15,7 @@ export const Users: ExtendedUsersCollection = createCollection({
   collectionName: 'Users',
   typeName: 'User',
   schema,
+  // FIXME: switching this to postgres will cause `insertHashedLoginToken` to fail at the moment because $addToSet hasn't yet been implemented
   resolvers: getDefaultResolvers('Users'),
   mutations: getDefaultMutations('Users', {
     editCheck: (user: DbUser|null, document: DbUser) => {


### PR DESCRIPTION
$addToSet hasn't been implemented in postgres yet, so fall back to doing the array spreading trick for now

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203656432056991) by [Unito](https://www.unito.io)
