### PR TITLE
Add Review to Alignment Forum

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
@@ -5,6 +5,7 @@ import { userCanDo } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import AddIcon from '@material-ui/icons/Add';
+import { reviewIsActive, REVIEW_YEAR } from '../../lib/reviewUtils';
 
 const styles = (theme: ThemeType): JssStyles => ({
   frontpageSequencesGridList: {
@@ -17,7 +18,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const AlignmentForumHome = ({classes}: {
   classes: ClassesType
 }) => {
-  const { SingleColumnSection, SectionTitle, SequencesGridWrapper, PostsList2, SectionButton, RecentDiscussionThreadsList, CuratedSequences } = Components
+  const { SingleColumnSection, SectionTitle, FrontpageReviewWidget, PostsList2, SectionButton, RecentDiscussionThreadsList, CuratedSequences } = Components
   const currentUser = useCurrentUser();
 
   let recentPostsTerms = {view: 'new', limit: 10, forum: true, af: true}
@@ -30,6 +31,9 @@ const AlignmentForumHome = ({classes}: {
           <CuratedSequences />
         </div>
       </SingleColumnSection>
+      {reviewIsActive() && <SingleColumnSection>
+        <FrontpageReviewWidget reviewYear={REVIEW_YEAR}/>
+      </SingleColumnSection>}
       <SingleColumnSection>
         <SectionTitle title="AI Alignment Posts">
           { currentUser && userCanDo(currentUser, "posts.alignment.new") && 

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -8,6 +8,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: '1em',
     paddingLeft: '1em',
     textTransform: 'uppercase',
+    color: theme.palette.header.text,
     borderLeft: theme.palette.border.appBarSubtitleDivider,
   },
 });

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -11,7 +11,6 @@ import moment from 'moment';
 import { eligibleToNominate, getReviewPhase, getReviewTitle, ReviewYear, REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../lib/reviewUtils';
 import { userIsAdmin } from '../../lib/vulcan-users';
 
-const isLW = forumTypeSetting.get() === "LessWrong"
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -53,14 +52,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   activeProgress: {
-    backgroundColor: theme.palette.review.activeProgress,
+    backgroundColor: theme.palette.review.activeProgress, // ea-forum look here
   },
   coloredProgress: {
     position: 'absolute',
     top: 0,
     left: 0,
     height: '100%',
-    backgroundColor: theme.palette.review.progressBar
+    backgroundColor: theme.palette.review.progressBar // ea-forum look here
   },
   nominationDate: {},
   actionButtonRow: {

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -53,14 +53,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   activeProgress: {
-    backgroundColor: isLW ? theme.palette.review.activeProgress : theme.palette.primary.main,
+    backgroundColor: theme.palette.review.activeProgress,
   },
   coloredProgress: {
     position: 'absolute',
     top: 0,
     left: 0,
     height: '100%',
-    backgroundColor: isLW ? theme.palette.review.progressBar :  theme.palette.lwTertiary.main,
+    backgroundColor: theme.palette.review.progressBar
   },
   nominationDate: {},
   actionButtonRow: {

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { eligibleToNominate, getReviewPhase, getReviewTitle, ReviewYear, REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../lib/reviewUtils';
 import { userIsAdmin } from '../../lib/vulcan-users';
 
+const isLW = forumTypeSetting.get() === "LessWrong"
 const isEAForum = forumTypeSetting.get() === "EAForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -52,14 +53,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   activeProgress: {
-    backgroundColor: isEAForum ? theme.palette.primary.main : theme.palette.review.activeProgress,
+    backgroundColor: isLW ? theme.palette.review.activeProgress : theme.palette.primary.main,
   },
   coloredProgress: {
     position: 'absolute',
     top: 0,
     left: 0,
     height: '100%',
-    backgroundColor: isEAForum ? theme.palette.lwTertiary.main : theme.palette.review.progressBar,
+    backgroundColor: isLW ? theme.palette.review.progressBar :  theme.palette.lwTertiary.main,
   },
   nominationDate: {},
   actionButtonRow: {

--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -52,14 +52,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   activeProgress: {
-    backgroundColor: theme.palette.review.activeProgress, // ea-forum look here
+    backgroundColor: isEAForum ? theme.palette.primary.main : theme.palette.review.activeProgress,
   },
   coloredProgress: {
     position: 'absolute',
     top: 0,
     left: 0,
     height: '100%',
-    backgroundColor: theme.palette.review.progressBar // ea-forum look here
+    backgroundColor: isEAForum ? theme.palette.lwTertiary.main : theme.palette.review.progressBar,
   },
   nominationDate: {},
   actionButtonRow: {

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -80,7 +80,6 @@ export function getReviewThreshold(): Number {
 
 /** Is there an active review taking place? */
 export function reviewIsActive(): boolean {
-  if (!(isLWForum || isEAForum)) return false
   return getReviewPhase() !== "COMPLETE"
 }
 

--- a/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
@@ -40,6 +40,10 @@ export const alignmentForumTheme: SiteThemeSpecification = {
       light: "#7986cb",
       contrastText: shadePalette.grey[0],
     },
+    review: {
+      activeProgress: "rgba(63,81,181, .5)",
+      progressBar: "rgba(63,81,181, 1)"
+    },
     lwTertiary: {
       main:  shadePalette.type === "dark" ? "#7799a4" : "#607e88",
       dark:  shadePalette.type === "dark" ? "#7799a4" : "#607e88",


### PR DESCRIPTION
After discussing with Oli it seemed probably net-positive to put the Review widget on the Alignment Forum. The Widget and Review Page already seems to work as expected (it filters for AF posts just by virtue of being on the Alignment Forum).

<img width="886" alt="image" src="https://user-images.githubusercontent.com/3246710/211180571-edff5a8f-6750-4be7-a0c4-566e27b47186.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203668207941147) by [Unito](https://www.unito.io)
