### PR TITLE
Fix stale recommendations bug

### DIFF
--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -87,6 +87,7 @@ const variadicFunctions = {
  */
 abstract class Query<T extends DbObject> {
   protected syntheticFields: Record<string, Type> = {};
+  protected joinedFields: Record<string, 0 | 1 | boolean> = {};
   protected nameSubqueries = true;
   protected isIndex = false;
 
@@ -233,7 +234,7 @@ abstract class Query<T extends DbObject> {
       }
     }
 
-    if (this.getField(field) || this.syntheticFields[field]) {
+    if (this.getField(field) || this.syntheticFields[field] || this.joinedFields[field]) {
       return `"${field}"`;
     }
 

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -167,12 +167,12 @@ const allRecommendablePosts = async ({currentUser, algorithm}: {
 }): Promise<Array<DbPost>> => {
   if (Posts.isPostgres()) {
     const joinHook = algorithm.onlyUnread && currentUser
-      ? `LEFT JOIN "ReadStatuses" rs ON rs."postId" = "Posts"._id AND rs."userId" = '${currentUser._id}' AND rs."isRead" = FALSE`
+      ? `LEFT JOIN "ReadStatuses" rs ON rs."postId" = "Posts"._id AND rs."userId" = '${currentUser._id}' AND rs."isRead" IS TRUE` // only include the isRead = true rows so we can filter them out via null comparison
       : undefined;
     const query = new SelectQuery(
-      new SelectQuery(Posts.getTable(), recommendablePostFilter(algorithm), {}, {joinHook}),
+      new SelectQuery(Posts.getTable(), {...recommendablePostFilter(algorithm), ...(joinHook ? {isRead: null} : {})}, {}, {joinHook, joinedFields: {...(joinHook ? {isRead: 1} : {})}}),
       {},
-      {projection: scoreRelevantFields},
+      {projection: {...scoreRelevantFields}},
     );
     return Posts.executeQuery(query) as Promise<DbPost[]>;
   } else {

--- a/packages/lesswrong/server/weightedList.ts
+++ b/packages/lesswrong/server/weightedList.ts
@@ -90,7 +90,7 @@ export class WeightedList
     if (typeof weight !== typeof 1) {
       throw new Error('Weight must be numeric (got ' + (weight as any).toString() + ')');
     }
-    if (weight <= 0)  {
+    if (weight < 0)  {
       throw new Error('Weight must be >= 0 (got ' + weight + ')');
     }
 


### PR DESCRIPTION
This is _a_ way to fix this bug, if @oetherington thinks it's basically acceptable then I will clean up the code a bit before merging

The reason this is not straightforward is because `SelectQuery` only expects to select fields from the table it is given, not from a table that is joined to that table. This PR adds a way to explicitly include fields from a joined table

I tried various other tricks to try and get it to select the joined field, including nested queries, but this was the only way I could get it to work. Things I don't like about this way:
 - it requires explicitly setting stuff that could be implicit
 - it loses some type safety by allowing the joined field to be any string

The basic problem is that 
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203696443688633) by [Unito](https://www.unito.io)
