### PR TITLE
fix a typo affecting a couple Sequences views

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/views.ts
+++ b/packages/lesswrong/lib/collections/sequences/views.ts
@@ -55,7 +55,7 @@ Sequences.addView("userProfilePrivate", function (terms: SequencesViewTerms) {
     },
     options: {
       sort: {
-        drafts: -1,
+        draft: -1,
         userProfileOrder: 1,
         createdAt: -1,
       }
@@ -71,7 +71,7 @@ Sequences.addView("userProfileAll", function (terms: SequencesViewTerms) {
     },
     options: {
       sort: {
-        drafts: -1,
+        draft: -1,
         hideFromAuthorPage: 1,
         userProfileOrder: 1,
         createdAt: -1
@@ -79,6 +79,7 @@ Sequences.addView("userProfileAll", function (terms: SequencesViewTerms) {
     },
   };
 });
+ensureIndex(Sequences, augmentForDefaultView({ userId: 1, draft: 1, hideFromAuthorPage: 1, userProfileOrder: 1 }))
 
 Sequences.addView("curatedSequences", function (terms: SequencesViewTerms) {
   return {


### PR DESCRIPTION
I guess we just had this typo in the views and never noticed until now...

Fixes [this asana issue](https://app.asana.com/0/628521446211730/1203657517138944/f)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203710517594313) by [Unito](https://www.unito.io)
