### PR TITLE
Block notifications from unreviewed users for subforum comments

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -448,9 +448,13 @@ getCollectionHooks("Comments").newAsync.add(async function CommentsNewNotificati
   }
   
   // 3. If this comment is in a subforum, notify members with email notifications enabled
-  if (comment.tagId && comment.tagCommentType === "SUBFORUM" && !comment.topLevelCommentId) {
-    const subforumSubscriberIds = (await subforumGetSubscribedUsers({ tagId: comment.tagId }))
-      .map((u) => u._id)
+  if (
+    comment.tagId &&
+    comment.tagCommentType === "SUBFORUM" &&
+    !comment.topLevelCommentId &&
+    !comment.authorIsUnreviewed // FIXME: make this more general, and possibly queue up notifications from unreviewed users to send once they are approved
+  ) {
+    const subforumSubscriberIds = (await subforumGetSubscribedUsers({ tagId: comment.tagId })).map((u) => u._id);
     const subforumSubscriberIdsMaybeNotify = (
       await UserTagRels.find({
         userId: { $in: subforumSubscriberIds },


### PR DESCRIPTION
Putting up this PR because it may take a while to figure out the correct policy on this, and in the meantime it's still important to stop notifications for spam comments on subforums (which we have seen a few of)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203713080775614) by [Unito](https://www.unito.io)
