### PR TITLE
Sorted by UI: remove italic + change icon

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsListMeta.tsx
@@ -11,7 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
-    'align-items': 'center',
+    alignItems: 'center',
     color: theme.palette.grey[600]
   }
 })

--- a/packages/lesswrong/components/comments/CommentsListMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsListMeta.tsx
@@ -11,6 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
+    'align-items': 'center',
     color: theme.palette.grey[600]
   }
 })

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -286,7 +286,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
   })
 
   const { SunshineNewUsersProfileInfo, SingleColumnSection, LWTooltip, EAUsersProfileTags,
-    SettingsButton, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
+    SortButton, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
     PostsList2, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
     Typography, ContentStyles, FormatDate, EAUsersProfileTabbedSection, PostsListSettings, LoadMore,
     RecentComments, SectionButton, SequencesGridWrapper, ReportUserButton, DraftsList } = Components
@@ -596,7 +596,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
             <Typography variant="headline" className={classes.sectionHeading}>
               Posts <div className={classes.sectionHeadingCount}>{(userPostsCount || user.postCount)}</div>
             </Typography>
-            <SettingsButton onClick={() => setShowPostSettings(!showPostSettings)}
+            <SortButton onClick={() => setShowPostSettings(!showPostSettings)}
               label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`} />
           </div>
           {showPostSettings && <PostsListSettings

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -15,7 +15,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
   },
   iconWithLabel: {
-    marginRight: theme.spacing.unit,
     marginRight: 4,
     marginLeft: 4,
   },

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
-import Sort from '@material-ui/icons/Sort';
+import SwapVert from '@material-ui/icons/SwapVert';
 
 const styles = (theme: ThemeType): JssStyles => ({
   icon: {
@@ -34,11 +34,11 @@ const SettingsButton = ({classes, className, onClick, showIcon=true, label=""}: 
 }) => {
   if (label) {
     return <span className={classes.iconWithLabelGroup} onClick={onClick}>
-      {showIcon && <Sort className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
+      {showIcon && <SwapVert className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
       <span className={classes.label}>{ label }</span>
     </span>
   }
-  return <Sort className={classNames(classes.icon, className)} onClick={onClick}/>
+  return <SwapVert className={classNames(classes.icon, className)} onClick={onClick}/>
 }
 
 const SettingsButtonComponent = registerComponent('SettingsButton', SettingsButton, {styles});

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
-import Settings from '@material-ui/icons/Settings';
+import Sort from '@material-ui/icons/Sort';
 
 const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.grey[400],
+    width: 20,
+    height: 20,
   },
   iconWithLabelGroup: {
     display: "flex",
@@ -20,7 +22,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.body2,
     fontSize: 14,
     color: theme.palette.grey[600],
-    fontStyle: "italic"
   }
 })
 
@@ -33,11 +34,11 @@ const SettingsButton = ({classes, className, onClick, showIcon=true, label=""}: 
 }) => {
   if (label) {
     return <span className={classes.iconWithLabelGroup} onClick={onClick}>
-      {showIcon && <Settings className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
+      {showIcon && <Sort className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
       <span className={classes.label}>{ label }</span>
     </span>
   }
-  return <Settings className={classNames(classes.icon, className)} onClick={onClick}/>
+  return <Sort className={classNames(classes.icon, className)} onClick={onClick}/>
 }
 
 const SettingsButtonComponent = registerComponent('SettingsButton', SettingsButton, {styles});

--- a/packages/lesswrong/components/icons/SortButton.tsx
+++ b/packages/lesswrong/components/icons/SortButton.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
-import Settings from '@material-ui/icons/Settings';
+import SwapVert from '@material-ui/icons/SwapVert';
 
 const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.grey[600],
-    fontSize: 18
+    fontSize: 18,
   },
   iconWithLabelGroup: {
     display: "flex",
@@ -15,9 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
   },
   iconWithLabel: {
-    marginRight: theme.spacing.unit,
     marginRight: 4,
-    marginLeft: 4,
   },
   label: {
     ...theme.typography.body2,
@@ -26,7 +24,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const SettingsButton = ({classes, className, onClick, showIcon=true, label=""}: {
+const SortButton = ({classes, className, onClick, showIcon=true, label=""}: {
   classes: ClassesType,
   className?: string,
   onClick?: any,
@@ -35,17 +33,17 @@ const SettingsButton = ({classes, className, onClick, showIcon=true, label=""}: 
 }) => {
   if (label) {
     return <span className={classes.iconWithLabelGroup} onClick={onClick}>
-      {showIcon && <Settings className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
+      {showIcon && <SwapVert className={classNames(classes.icon, classes.iconWithLabel, className)}/>}
       <span className={classes.label}>{ label }</span>
     </span>
   }
-  return <Settings className={classNames(classes.icon, className)} onClick={onClick}/>
+  return <SwapVert className={classNames(classes.icon, className)} onClick={onClick}/>
 }
 
-const SettingsButtonComponent = registerComponent('SettingsButton', SettingsButton, {styles});
+const SortButtonComponent = registerComponent('SortButton', SortButton, {styles});
 
 declare global {
   interface ComponentTypes {
-    SettingsButton: typeof SettingsButtonComponent
+    SortButton: typeof SortButtonComponent
   }
 }

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -129,7 +129,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
     const { classes, currentUser } = this.props
     const { query } = this.props.location;
     const { showSettings } = this.state
-    const { SingleColumnSection, SectionTitle, SettingsButton, PostsListSettings, HeadTags } = Components
+    const { SingleColumnSection, SectionTitle, SortButton, PostsListSettings, HeadTags } = Components
 
     const currentTimeframe = query.timeframe || currentUser?.allPostsTimeframe || 'daily'
     const currentSorting = query.sortedBy    || currentUser?.allPostsSorting   || 'magic'
@@ -146,7 +146,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
             <Tooltip title={`${showSettings ? "Hide": "Show"} options for sorting and filtering`} placement="top-end">
               <div className={classes.title} onClick={this.toggleSettings}>
                 <SectionTitle title="All Posts">
-                  <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
+                  <SortButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
                 </SectionTitle>
               </div>
             </Tooltip>

--- a/packages/lesswrong/components/posts/DraftsList.tsx
+++ b/packages/lesswrong/components/posts/DraftsList.tsx
@@ -94,8 +94,8 @@ const DraftsList = ({limit, title="My Drafts", userId, showAllDraftsLink=true, h
             </Components.SectionButton>
           </Link>
         </div>}
-        <div className={classes.settingsButton} onClick={() => setShowSettings(!showSettings)}>
-          <Components.SettingsButton label={`Sorted by ${ sortings[currentSorting]}`}/>
+        <div className={classes.sortButton} onClick={() => setShowSettings(!showSettings)}>
+          <Components.SortButton label={`Sorted by ${ sortings[currentSorting]}`}/>
         </div>
       </div>
     </Components.SectionTitle>}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -181,7 +181,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const render = () => {
     const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, LocalGroupsList,
       PostsListSettings, PostsList2, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
-      SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
+      SortButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
       Typography, ContentStyles, ReportUserButton, LWTooltip } = Components
 
     if (loading) {
@@ -330,7 +330,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
           <SingleColumnSection>
             <div className={classes.postsTitle} onClick={() => setShowSettings(!showSettings)}>
               <SectionTitle title={"Posts"}>
-                <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
+                <SortButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
               </SectionTitle>
             </div>
             {showSettings && <PostsListSettings

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -207,6 +207,7 @@ importComponent("EditProfileForm", () => require('../components/users/EditProfil
 
 importComponent("OmegaIcon", () => require('../components/icons/OmegaIcon'));
 importComponent("SettingsButton", () => require('../components/icons/SettingsButton'));
+importComponent("SortButton", () => require('../components/icons/SortButton'));
 importComponent("KarmaIcon", () => require('../components/icons/KarmaIcon.tsx'));
 
 // posts


### PR DESCRIPTION
### Before
![CleanShot 2023-01-12 at 14 38 57](https://user-images.githubusercontent.com/13235378/212096443-fc3a375c-60c4-43e4-9451-bd9c8bc98ded.jpg)

### After
![CleanShot 2023-01-12 at 14 39 43](https://user-images.githubusercontent.com/13235378/212096454-14f8db54-eb21-490b-bccb-e9f561433355.jpg)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203713947945019) by [Unito](https://www.unito.io)

## Design recommendations
* **Remove italic:** You rarely see italic used on buttons, menu items, product labels. It's usually preferred to use lighter colors and smaller font sizes if you want to deemphasise something.
* **Change icon:** The `sort` icon seems more suitable than the settings cog (I prefer the up down icon even more (see Asana screenshot below) but there was none in the Mui library so I started with the one they call `Sort`)
![CleanShot 2023-01-12 at 14 48 36](https://user-images.githubusercontent.com/13235378/212097925-5d056dc6-c6f5-42e1-bc06-afa61fa605f0.jpg)

