### PR TITLE
[EA Forum only] temporarily stop sending "event updated" emails

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -133,6 +133,11 @@ export async function postsNewNotifications (post: DbPost) {
 postPublishedCallback.add(postsNewNotifications);
 
 function eventHasRelevantChangeForNotification(oldPost: DbPost, newPost: DbPost) {
+  // TODO: We have a bug that sends users way too many of these emails,
+  //       and I might not have time to debug this today but I think it's pretty bad to spam email users,
+  //       so adding this as a temp fix
+  if (forumTypeSetting.get() === 'EAForum') return false
+  
   if (!!oldPost.mongoLocation !== !!newPost.mongoLocation) {
     //Location added or removed
     return true;


### PR DESCRIPTION
We've gotten multiple reports of being spammed by these emails, so I'm temporarily stopping them until I have time to debug it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203715767696837) by [Unito](https://www.unito.io)
