### PR TITLE
Small fix: Avoid line-break on "Promote to Front Page" 

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -93,6 +93,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     flexWrap: "wrap",
+    'align-items': "center",
   },
   collaborativeRedirectLink: {
     color:  theme.palette.secondary.main

--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
@@ -40,7 +40,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   submitToFrontpage: {
     display: "flex",
     alignItems: "center",
-    maxWidth: 200,
+    maxWidth: 400,
     [theme.breakpoints.down('sm')]: {
       width: "100%",
       maxWidth: "none",


### PR DESCRIPTION
### Before
![CleanShot 2023-01-12 at 23 35 02@2x](https://user-images.githubusercontent.com/13235378/212203872-c87c0f23-001f-457b-a794-e51013c7cc08.jpg)

### After
![CleanShot 2023-01-12 at 23 34 47@2x](https://user-images.githubusercontent.com/13235378/212203885-ce60ca4b-499c-4321-9b79-bd3ecf37b2e3.jpg)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203717721584115) by [Unito](https://www.unito.io)
