### PR TITLE
[EA Forum only] add next batch of job ads

### DIFF
--- a/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
@@ -176,22 +176,66 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
+type EAGOccupation =
+  'Academic research'|
+  'Operations'|
+  'Entrepreneurship'|
+  'Policymaking/Civil service'|
+  'EA community building/community management'|
+  'AI safety technical research'|
+  'Software development/Software engineering'|
+  'People management'|
+  'Education'|
+  'Global health & development'|
+  'Improving institutional decision making'|
+  'Earning to give'|
+  'AI strategy & policy'|
+  'Project management/ Program management'|
+  'Healthcare/Medicine'|
+  'Technology'|
+  'Grantmaking'|
+  'Information security'|
+  'Climate change mitigation'|
+  'Global coordination & peace-building'|
+  'Consulting'|
+  'Alternative proteins'|
+  'Global mental health & well-being'|
+  'Nuclear security'|
+  'Politics'|
+  'Writing'|
+  'Event production'|
+  'Product management'|
+  'Wild animal welfare'|
+  'Biosecurity'|
+  'Philanthropy'|
+  'Farmed animal welfare'|
+  'Communications/Marketing'|
+  'HR/People operations'|
+  'Global priorities research'|
+  'Journalism'|
+  'Finance/Accounting'|
+  'User experience design/research'|
+  'Data science/Data visualization'|
+  'Counselling/Social work'|
+  'Graphic design'|
+  'S-risk'
+
 type JobAdData = {
-  standardApplyBtn?: boolean, // set to show the "Apply now" button instead of "Yes, I'm interested"
-  occupationName?: string,    // used to match on EAG experience + interests
-  interestedIn?: string,      // used to match on EAG interests
-  tagId?: string,             // used to match on a topic
-  logo: string,
-  occupation: string,         // text displayed in the tooltip
-  feedbackLinkPrefill: string,
-  bitlyLink: string,          // bitly link to the job ad page
+  standardApplyBtn?: boolean,        // set to show the "Apply now" button instead of "Yes, I'm interested"
+  eagOccupations?: EAGOccupation[],  // used to match on EAG experience + interests
+  interestedIn?: EAGOccupation[],    // used to match on EAG interests
+  tagId?: string,                    // used to match on a topic
+  logo: string,                      // url for org logo
+  occupation: string,                // text displayed in the tooltip
+  feedbackLinkPrefill: string,       // url param used to prefill part of the feedback form
+  bitlyLink: string,                 // bitly link to the job ad page
   role: string,
-  insertThe?: boolean,        // set if you want to insert a "the" before the org name
+  insertThe?: boolean,               // set if you want to insert a "the" before the org name
   org: string,
-  orgLink: string,
+  orgLink: string,                   // internal link on the org name
   salary?: string,
   location: string,
-  deadline?: moment.Moment,   // not displayed, only used to hide the ad after this date
+  deadline?: moment.Moment,          // not displayed, only used to hide the ad after this date
   getDescription: (classes: ClassesType) => JSX.Element
 }
 
@@ -199,7 +243,7 @@ type JobAdData = {
 // (also used in the confirmation email, so links in the description need to be absolute)
 export const JOB_AD_DATA: Record<string, JobAdData> = {
   'ai-policy-govai': {
-    occupationName: 'AI strategy & policy',
+    eagOccupations: ['AI strategy & policy'],
     tagId: 'u3Xg8MjDe2e6BvKtv', // AI Governance
     logo: 'https://80000hours.org/wp-content/uploads/2021/12/centre-for-the-governance-of-ai-160x160.jpeg',
     occupation: 'AI governance & policy',
@@ -211,7 +255,7 @@ export const JOB_AD_DATA: Record<string, JobAdData> = {
     orgLink: '/topics/centre-for-the-governance-of-ai',
     salary: '£9,000 - £12,000 stipend',
     location: 'Oxford, UK (Flexible)',
-    deadline: moment("01-16-2023", "MM-DD-YYYY"),
+    deadline: moment("01-15-2023", "MM-DD-YYYY"),
     getDescription: (classes: ClassesType) => <>
       <div className={classes.description}>
         In this fellowship at the <a href="https://www.governance.ai" target="_blank" rel="noopener noreferrer" className={classes.link}>
@@ -232,8 +276,226 @@ export const JOB_AD_DATA: Record<string, JobAdData> = {
       </div>
     </>
   },
+  'communications-cea-2': {
+    eagOccupations: ['Communications/Marketing', 'EA community building/community management', 'Writing'],
+    tagId: 'mPDquzDnkBkgi2iKR', // Marketing
+    logo: 'https://80000hours.org/wp-content/uploads/2022/12/CEA-160x160.png',
+    occupation: 'communications/marketing',
+    feedbackLinkPrefill: 'Communications+Specialist+at+CEA',
+    bitlyLink: "https://efctv.org/3H0m0q5", // https://www.centreforeffectivealtruism.org/careers/communications-specialist
+    role: 'Communications Specialist',
+    insertThe: true,
+    org: 'Centre for Effective Altruism',
+    orgLink: '/topics/centre-for-effective-altruism-1',
+    salary: '£49k - £77k',
+    location: 'Remote',
+    deadline: moment("01-15-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        <a href="https://www.centreforeffectivealtruism.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          CEA
+        </a> is looking to hire multiple people to improve how we communicate core EA ideas effectively and accurately,
+        including by working closely with other orgs in the EA and related communities.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates:
+        <ul>
+          <li>Have a strong understanding of EA ideas</li>
+          <li>Have clear, nuanced, and compelling writing</li>
+          <li>Can autonomously develop and implement communication campaigns around particular events or themes</li>
+        </ul>
+      </div>
+    </>
+  },
+  'communications-cea': {
+    eagOccupations: ['Communications/Marketing'],
+    tagId: 'mPDquzDnkBkgi2iKR', // Marketing
+    logo: 'https://80000hours.org/wp-content/uploads/2022/12/CEA-160x160.png',
+    occupation: 'communications/marketing',
+    feedbackLinkPrefill: 'Social+Media+Specialist+at+CEA',
+    bitlyLink: "https://efctv.org/3vTkVtP", // https://www.centreforeffectivealtruism.org/careers/social-media-specialist
+    role: 'Social Media Specialist',
+    insertThe: true,
+    org: 'Centre for Effective Altruism',
+    orgLink: '/topics/centre-for-effective-altruism-1',
+    salary: '£49k - £77k',
+    location: 'Remote',
+    deadline: moment("01-15-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        You'll be working at <a href="https://www.centreforeffectivealtruism.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          CEA
+        </a> to develop a social media strategy for effective altruism and work with EA organisations and spokespeople to implement it.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates have:
+        <ul>
+          <li>Familiarity with EA ideas</li>
+          <li>Clear, nuanced, and compelling writing</li>
+          <li>Sound judgement about the risks and benefits of different communications strategies and tactics</li>
+        </ul>
+      </div>
+    </>
+  },
+  'global-priorities-research-gpi-fellowship': {
+    eagOccupations: ['Global priorities research', 'Academic research'],
+    tagId: 'xsiR75hLgHBgtosDy', // Global priorities research
+    logo: 'https://80000hours.org/wp-content/uploads/2022/12/Global-priorities-institute-160x160.jpeg',
+    occupation: 'research',
+    feedbackLinkPrefill: 'Summer+Fellow+at+GPI',
+    bitlyLink: "https://efctv.org/3W8JbTN", // https://globalprioritiesinstitute.org/oxford-global-priorities-fellowship/
+    role: 'Summer Fellow',
+    insertThe: true,
+    org: 'Global Priorities Institute',
+    orgLink: '/topics/global-priorities-institute',
+    salary: '£5k stipend',
+    location: 'Oxford, UK',
+    deadline: moment("01-15-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        In this four-week fellowship with <a href="https://globalprioritiesinstitute.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          GPI
+        </a>, participants will learn about <span className={classes.link}>
+          <Components.HoverPreviewLink href={makeAbsolute("/topics/global-priorities-research")} innerHTML="global priorities research"/>
+        </span> and develop a new research project under the guidance of a supervisor.
+      </div>
+      <div className={classes.description}>
+        Applicants must:
+        <ul>
+          <li>Be a current Master's or PhD student in philosophy or economics (or an early career postdoc/faculty)</li>
+          <li>Be available from 12 June 2023 to 7 July 2023 to visit Oxford</li>
+          <li>Be able and willing to develop a new research project related to global priorities research during that time</li>
+        </ul>
+      </div>
+    </>
+  },
+  'ops-malaria-consortium': {
+    eagOccupations: ['Global health & development', 'Operations'],
+    tagId: 'sWcuTyTB5dP3nas2t', // Global health and development
+    logo: 'https://80000hours.org/wp-content/uploads/2019/11/Malaria-Consortium-160x160.png',
+    occupation: 'global health & development',
+    feedbackLinkPrefill: 'Administrative+Assistant+at+Malaria+Consortium',
+    bitlyLink: "https://efctv.org/3Gz7eW9", // https://malariaconsortium.current-vacancies.com/Jobs/Advert/2934672?cid=2061&t=Administrative-Assistant
+    role: 'Part-time Administrative Assistant',
+    org: 'Malaria Consortium',
+    orgLink: '/topics/malaria-consortium',
+    salary: '£28,814',
+    location: 'London, UK',
+    deadline: moment("01-15-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        <a href="https://www.malariaconsortium.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          Malaria Consortium
+        </a> is a British charity that works on preventing, controlling, and treating <span className={classes.link}>
+          <Components.HoverPreviewLink href={makeAbsolute("/topics/malaria")} innerHTML="malaria"/>
+        </span> and other communicable diseases in Africa and Asia.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates have:
+        <ul>
+          <li>5 A*-C GCSEs, including English Language and Mathematics</li>
+          <li>Administrative and Operations experience, particularly supporting use of policies and process</li>
+          <li>Experience working in a diverse environment and across cultures, especially Asia and Africa</li>
+        </ul>
+      </div>
+    </>
+  },
+  'program-management-malaria-consortium': {
+    eagOccupations: ['Global health & development', 'Project management/ Program management', 'Communications/Marketing'],
+    tagId: 'sWcuTyTB5dP3nas2t', // Global health and development
+    logo: 'https://80000hours.org/wp-content/uploads/2019/11/Malaria-Consortium-160x160.png',
+    occupation: 'global health & development',
+    feedbackLinkPrefill: 'Programme+Design+and+Development+Specialist+at+Malaria+Consortium',
+    bitlyLink: "https://efctv.org/3GA1j33", // https://malariaconsortium.current-vacancies.com/Jobs/Advert/2694751?cid=2061&t=Programme-Design-and-Development-Specialist
+    role: 'Programme Design and Development Specialist',
+    org: 'Malaria Consortium',
+    orgLink: '/topics/malaria-consortium',
+    salary: '£44,859',
+    location: 'London, UK',
+    deadline: moment("01-31-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        <a href="https://www.malariaconsortium.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          Malaria Consortium
+        </a> is a British charity that works on preventing, controlling, and treating <span className={classes.link}>
+          <Components.HoverPreviewLink href={makeAbsolute("/topics/malaria")} innerHTML="malaria"/>
+        </span> and other communicable diseases in Africa and Asia.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates have:
+        <ul>
+          <li>A Masters in Public Health, Epidemiology, Development Studies or similar fields, or equivalent practical experience</li>
+          <li>Experience in leading the design and writing of successful competitive proposals and tenders for public health programming for commercial bids and for grants</li>
+          <li>Experience in managing international health programmes in developing countries</li>
+        </ul>
+      </div>
+    </>
+  },
+  'ops-arc': {
+    eagOccupations: ['Operations', 'AI safety technical research'],
+    tagId: 'NNdytpR2E4jYKQCNd', // Operations
+    logo: 'https://80000hours.org/wp-content/uploads/2022/01/robotarm_big-160x160.png',
+    occupation: 'operations',
+    feedbackLinkPrefill: 'Operations+Officer+at+ARC',
+    bitlyLink: "https://efctv.org/3CGeuOI", // https://jobs.lever.co/alignment.org/78d8684f-e6f1-4d2a-a220-99d5622422ac
+    role: 'Operations Officer',
+    insertThe: true,
+    org: 'Alignment Research Center',
+    orgLink: '/topics/alignment-research-center',
+    location: 'Berkeley, CA',
+    deadline: moment("01-28-2023", "MM-DD-YYYY"),
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        <a href="https://alignment.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          ARC
+        </a> is a non-profit research organization focused on <span className={classes.link}>
+          <Components.HoverPreviewLink href={makeAbsolute("/topics/ai-alignment")} innerHTML="AI alignment"/>
+        </span>. As part of a new team within ARC, your role will be to build, operate, and maintain systems
+        to help them do their work efficiently and effectively.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates:
+        <ul>
+          <li>Are highly organized and adaptable</li>
+          <li>Have strong managerial skills and the ability to think strategically in order to guide and support a growing team</li>
+          <li>Have a strong interest in AI and AI safety and a strong drive to contribute and make a difference</li>
+        </ul>
+      </div>
+    </>
+  },
+  'ai-research-arc': {
+    eagOccupations: ['AI safety technical research'],
+    tagId: 'oNiQsBHA3i837sySD', // AI safety
+    logo: 'https://80000hours.org/wp-content/uploads/2022/01/robotarm_big-160x160.png',
+    occupation: 'AI safety',
+    feedbackLinkPrefill: 'Researcher,+Model+Evaluations+at+ARC',
+    bitlyLink: "https://efctv.org/3ZqYEkV", // https://jobs.lever.co/alignment.org/51cce9d1-73c7-461c-9d37-4ec1da07a863
+    role: 'Researcher, Model Evaluations',
+    insertThe: true,
+    org: 'Alignment Research Center',
+    orgLink: '/topics/alignment-research-center',
+    location: 'Berkeley, CA',
+    getDescription: (classes: ClassesType) => <>
+      <div className={classes.description}>
+        <a href="https://alignment.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
+          ARC
+        </a> is a non-profit research organization focused on <span className={classes.link}>
+          <Components.HoverPreviewLink href={makeAbsolute("/topics/ai-alignment")} innerHTML="AI alignment"/>
+        </span>. The evaluations project is a new team within ARC building capability evaluations for
+        advanced ML models, which can enable labs to make measurable safety commitments.
+      </div>
+      <div className={classes.description}>
+        Ideal candidates have:
+        <ul>
+          <li>A solid working knowledge of language model capabilities and modern ML</li>
+          <li>A good understanding of alignment risk, in order to identify core risks and translate abstract stories about risk into concrete measurements of existing models</li>
+          <li>Strong basic coding skills (able to design and build a system for managing experiments and data)</li>
+        </ul>
+      </div>
+    </>
+  },
   'biosecurity-warwick': {
-    interestedIn: 'Biosecurity',
+    interestedIn: ['Biosecurity'],
     tagId: 'aELNHEKtcZtMwEkdK', // Biosecurity
     logo: 'https://80000hours.org/wp-content/uploads/2022/12/Warwick-University-160x160.png',
     occupation: 'biosecurity',
@@ -258,36 +520,6 @@ export const JOB_AD_DATA: Record<string, JobAdData> = {
           <li>At least an upper second class UK honours degree or international equivalent</li>
           <li>Evidence of English language capability</li>
           <li>Two strong academic references</li>
-        </ul>
-      </div>
-    </>
-  },
-  'communications-cea': {
-    occupationName: 'Communications/Marketing',
-    tagId: 'mPDquzDnkBkgi2iKR', // Marketing
-    logo: 'https://80000hours.org/wp-content/uploads/2022/12/CEA-160x160.png',
-    occupation: 'communications/marketing',
-    feedbackLinkPrefill: 'Social+Media+Specialist+at+CEA',
-    bitlyLink: "https://efctv.org/3vTkVtP", // https://www.centreforeffectivealtruism.org/careers/social-media-specialist
-    role: 'Social Media Specialist',
-    insertThe: true,
-    org: 'Centre for Effective Altruism',
-    orgLink: '/topics/centre-for-effective-altruism-1',
-    salary: '£49k - £77k',
-    location: 'Remote',
-    deadline: moment("01-16-2023", "MM-DD-YYYY"),
-    getDescription: (classes: ClassesType) => <>
-      <div className={classes.description}>
-        You'll be working at <a href="https://www.centreforeffectivealtruism.org" target="_blank" rel="noopener noreferrer" className={classes.link}>
-          CEA
-        </a> to develop a social media strategy for effective altruism and work with EA organisations and spokespeople to implement it.
-      </div>
-      <div className={classes.description}>
-        Ideal candidates have:
-        <ul>
-          <li>Familiarity with EA ideas</li>
-          <li>Clear, nuanced, and compelling writing</li>
-          <li>Sound judgement about the risks and benefits of different communications strategies and tactics</li>
         </ul>
       </div>
     </>

--- a/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
@@ -95,7 +95,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 18,
     lineHeight: '24px',
     color: theme.palette.grey[700],
-    margin: '3px 0'
+    margin: '3px 0 5px'
   },
   link: {
     color: theme.palette.primary.main
@@ -104,7 +104,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     flexWrap: 'wrap',
     columnGap: 30,
-    rowGap: '3px'
+    rowGap: '5px'
   },
   metadata: {
     display: 'flex',
@@ -115,6 +115,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   metadataIcon: {
     fontSize: 12,
+  },
+  deadline: {
+    fontWeight: 600,
+    color: theme.palette.primary.dark
   },
   readMore: {
     display: 'flex',
@@ -176,6 +180,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
+// list of options from EAG
 type EAGOccupation =
   'Academic research'|
   'Operations'|
@@ -667,6 +672,14 @@ const TargetedJobAd = ({ad, onDismiss, onExpand, onInterested, onUninterested, c
             <LocationIcon className={classes.metadataIcon} />
             {adData.location}
           </div>
+          {
+            // display the deadline when it's within 2 days away
+            adData.deadline &&
+            moment().add(2, 'days').isSameOrAfter(adData.deadline, 'day') &&
+            <div className={classNames(classes.metadata, classes.deadline)}>
+              Apply by {adData.deadline.format('MMM Do')}
+            </div>
+          }
         </div>
         {!expanded ? <button onClick={handleExpand} className={classes.readMore}>
           <ChevronRight className={classes.readMoreIcon} /> Expand

--- a/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
@@ -10,6 +10,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { JOB_AD_DATA } from './TargetedJobAd';
 import union from 'lodash/union';
+import intersection from 'lodash/intersection';
 
 const HIDE_JOB_AD_COOKIE = 'hide_job_ad'
 
@@ -53,17 +54,18 @@ const TargetedJobAdSection = () => {
     
     for (let jobName in JOB_AD_DATA) {
       // skip any jobs where the deadline to apply has passed
-      if (JOB_AD_DATA[jobName].deadline?.isBefore(moment())) {
+      const deadline = JOB_AD_DATA[jobName].deadline
+      if (deadline && moment().isAfter(deadline, 'day')) {
         continue
       }
       
-      const occupationName = JOB_AD_DATA[jobName].occupationName
+      const eagOccupations = JOB_AD_DATA[jobName].eagOccupations
       const interestedIn = JOB_AD_DATA[jobName].interestedIn
       const occupationTag = JOB_AD_DATA[jobName].tagId
       const jobAdState = userJobAds[jobName]?.state
       // check if the ad fits the user's interests
-      const userIsMatch = (occupationName && userEAGInterests.includes(occupationName)) ||
-        (interestedIn && currentUser.interestedIn?.includes(interestedIn)) ||
+      const userIsMatch = intersection(userEAGInterests, eagOccupations).length ||
+        intersection(currentUser.interestedIn, interestedIn).length ||
         (occupationTag && userTags.includes(occupationTag))
       // make sure the user hasn't already clicked "interested" or "uninterested" for this ad
       const shouldShowAd = !jobAdState || ['seen', 'expanded'].includes(jobAdState)


### PR DESCRIPTION
Add six new job ads to the rotation, plus display the deadline when it's within two days from now.

<img width="708" alt="Screen Shot 2023-01-12 at 8 30 17 PM" src="https://user-images.githubusercontent.com/9057804/212216516-0593ff71-1483-421b-848b-c4102d676bc1.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203718160144346) by [Unito](https://www.unito.io)
