### PR TITLE
Allow users to see their own unreviewed comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -23,7 +23,12 @@ const CommentBottomCaveats = ({comment, classes}: {
       </div>
     }
     { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
-    { hideUnreviewedAuthorCommentsSettings.get() && comment.authorIsUnreviewed && <Components.MetaInfo>[This comment will not be shown publicly until its author has been reviewed by the moderation team.]</Components.MetaInfo> }
+    { hideUnreviewedAuthorCommentsSettings.get() && comment.authorIsUnreviewed &&
+      <Components.MetaInfo>
+        [This comment will not be visible to other users until the moderation
+        team checks it for spam or norm violations.]
+      </Components.MetaInfo>
+    }
   </>
 }
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useCurrentTime } from '../../../lib/utils/timeUtil';
+import { hideUnreviewedAuthorCommentsSettings } from '../../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   blockedReplies: {
@@ -22,6 +23,7 @@ const CommentBottomCaveats = ({comment, classes}: {
       </div>
     }
     { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
+    { hideUnreviewedAuthorCommentsSettings.get() && comment.authorIsUnreviewed && <Components.MetaInfo>[This comment will not be shown publicly until its author has been reviewed by the moderation team.]</Components.MetaInfo> }
   </>
 }
 

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -23,6 +23,7 @@ registerFragment(`
     deletedPublic
     deletedReason
     hideAuthor
+    authorIsUnreviewed
     user {
       ...UsersMinimumInfo
     }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1213,6 +1213,7 @@ interface CommentsList { // fragment on Comments
   readonly deletedPublic: boolean,
   readonly deletedReason: string,
   readonly hideAuthor: boolean,
+  readonly authorIsUnreviewed: boolean,
   readonly user: UsersMinimumInfo|null,
   readonly currentUserVote: string,
   readonly currentUserExtendedVote: any,


### PR DESCRIPTION
In the event we turn on "hideUnreviewedAuthorComments". This dramatically improves the experience from "wtf happened to my comment" to "oh, I guess I need to wait". It is nevertheless not beautiful.

<img width="789" alt="image" src="https://user-images.githubusercontent.com/10352319/212421661-738d227d-5799-40d9-ae28-7c41ade7c169.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203753740008359) by [Unito](https://www.unito.io)
