### PR TITLE
admins can also copy userId from EAF profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -27,7 +27,9 @@ import LibraryAddIcon from '@material-ui/icons/LibraryAdd'
 import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
 import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
-
+import CopyToClipboard from 'react-copy-to-clipboard';
+import CopyIcon from '@material-ui/icons/FileCopy'
+import { useMessages } from '../../common/withMessages';
 
 const styles = (theme: ThemeType): JssStyles => ({
   section: {
@@ -181,6 +183,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 20,
     ...separatorBulletStyles(theme)
   },
+  copyLink: {
+    verticalAlign: 'text-top'
+  },
+  copyIcon: {
+    color: theme.palette.primary.main,
+    fontSize: 14,
+    cursor: 'pointer',
+    '&:hover': {
+      opacity: 0.5
+    }
+  },
   registerRssLink: {
     cursor: 'pointer',
     '&:hover': {
@@ -217,6 +230,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser()
+  const { flash } = useMessages()
   
   const {loading, results} = useMulti({
     terms,
@@ -549,6 +563,15 @@ const EAUsersProfile = ({terms, slug, classes}: {
             />
           </div>}
           <Typography variant="body2" className={classes.links}>
+            {currentUser?.isAdmin &&
+              <div>
+                <LWTooltip title="Click to copy userId" placement="bottom" className={classes.copyLink}>
+                  <CopyToClipboard text={user._id} onCopy={() => flash({messageString: "userId copied!"})}>
+                    <CopyIcon className={classes.copyIcon} />
+                  </CopyToClipboard>
+                </LWTooltip>
+              </div>
+            }
             {currentUser?.isAdmin &&
               <div className={classes.registerRssLink}>
                 <DialogGroup


### PR DESCRIPTION
To match functionality added to the LW user profile [earlier](https://github.com/ForumMagnum/ForumMagnum/pull/6302).

<img width="708" alt="Screen Shot 2023-01-13 at 5 19 18 PM" src="https://user-images.githubusercontent.com/9057804/212430258-e2fdb8e3-f83a-410c-b955-f1653b18798f.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203746748098306) by [Unito](https://www.unito.io)
