### PR TITLE
Review karma-vote UI

### DIFF
--- a/packages/lesswrong/components/review/KarmaVoteStripe.tsx
+++ b/packages/lesswrong/components/review/KarmaVoteStripe.tsx
@@ -1,0 +1,54 @@
+import classNames from 'classnames';
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    height: "100%",
+    width: 6,
+    background: theme.palette.grey[405],
+  },
+  bigUpvote: {
+    background: theme.palette.primary.dark
+  },
+  smallUpvote: {
+    background: theme.palette.primary.light
+  },
+  bigDownvote: {
+    background: theme.palette.error.dark
+  },
+  smallDownvote: {
+    background: theme.palette.error.light
+  },
+});
+
+const voteMap = {
+  'bigDownvote': 'a strong (karma) downvote',
+  'smallDownvote': 'a (karma) downvote',
+  'smallUpvote': 'a (karma) upvote',
+  'bigUpvote': 'a strong (karma) upvote'
+}
+
+export const KarmaVoteStripe = ({classes, post}: {
+  classes: ClassesType,
+  post: PostsListWithVotes
+}) => {
+  const { LWTooltip } = Components
+  if (!post.currentUserVote) return null
+
+  return <LWTooltip title={`You previously gave this post ${voteMap[post.currentUserVote]}`} placement="left" inlineBlock={false}>
+    <div className={classNames(classes.root, classes[post.currentUserVote])}/>
+  </LWTooltip>
+}
+
+const KarmaVoteStripeComponent = registerComponent('KarmaVoteStripe', KarmaVoteStripe, {styles});
+
+declare global {
+  interface ComponentTypes {
+    KarmaVoteStripe: typeof KarmaVoteStripeComponent
+  }
+}
+

--- a/packages/lesswrong/components/review/KarmaVoteStripe.tsx
+++ b/packages/lesswrong/components/review/KarmaVoteStripe.tsx
@@ -1,6 +1,6 @@
-import classNames from 'classnames';
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -6,8 +6,6 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import type { SyntheticQualitativeVote } from './ReviewVotingPage';
 import { postGetCommentCount } from "../../lib/collections/posts/helpers";
 import { eligibleToNominate, getCostData, ReviewPhase, ReviewYear } from '../../lib/reviewUtils';
-import indexOf from 'lodash/indexOf'
-import pullAt from 'lodash/pullAt'
 import { voteTextStyling } from './PostsItemReviewVote';
 import { useRecordPostView } from '../hooks/useRecordPostView';
 import { commentBodyStyles } from '../../themes/stylePiping';
@@ -88,29 +86,9 @@ const styles = (theme: ThemeType) => ({
     background: theme.palette.grey[55],
     borderTop: theme.palette.border.faint,
   },
-  userVote: {
-    position: "absolute",
-    left: 0,
-    top: 0,
-    height: "100%",
-    width: 6,
-    background: theme.palette.grey[405],
-  },
   expandIcon: {
     color: theme.palette.grey[500],
     width: 36,
-  },
-  bigUpvote: {
-    background: theme.palette.primary.dark
-  },
-  smallUpvote: {
-    background: theme.palette.primary.light
-  },
-  bigDownvote: {
-    background: theme.palette.error.dark
-  },
-  smallDownvote: {
-    background: theme.palette.error.light
   },
   votes: {
     backgroundColor: theme.palette.grey[200],
@@ -190,7 +168,7 @@ const ReviewVoteTableRow = (
     voteTooltip: voteTooltipType
   }
 ) => {
-  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote, ReviewPostComments } = Components
+  const { PostsTitle, LWTooltip, PostsPreviewTooltip, MetaInfo, ReviewVotingButtons, PostsItemComments, PostsItem2MetaInfo, PostsItemReviewVote, ReviewPostComments, KarmaVoteStripe } = Components
 
   const currentUser = useCurrentUser()
 
@@ -204,13 +182,6 @@ const ReviewVoteTableRow = (
   const expanded = expandedPostId === post._id
 
   const currentUserIsAuthor = currentUser && (post.userId === currentUser._id || post.coauthors?.map(author => author?._id).includes(currentUser._id))
-
-  const voteMap = {
-    'bigDownvote': 'a strong (karma) downvote',
-    'smallDownvote': 'a (karma) downvote',
-    'smallUpvote': 'a (karma) upvote',
-    'bigUpvote': 'a strong (karma) upvote'
-  }
 
   const highVotes = post.reviewVotesHighKarma || []
   const allVotes = post.reviewVotesAllKarma || []
@@ -247,9 +218,7 @@ const ReviewVoteTableRow = (
   // TODO: debug reviewCount = null
   return <AnalyticsContext pageElementContext="voteTableRow">
     <div className={classNames(classes.root, {[classes.expanded]: expanded, [classes.votingPhase]: reviewPhase === "VOTING" })} onClick={markAsRead}>
-      {showKarmaVotes && post.currentUserVote && <LWTooltip title={`You previously gave this post ${voteMap[post.currentUserVote]}`} placement="left" inlineBlock={false}>
-          <div className={classNames(classes.userVote, classes[post.currentUserVote])}/>
-        </LWTooltip>}
+      {showKarmaVotes && <KarmaVoteStripe post={post}/>}
       <div className={classNames(classes.postVote, {[classes.postVoteVotingPhase]: reviewPhase === "VOTING"})}>
         <div className={classNames(classes.post, {[classes.postVotingPhase]: reviewPhase === "VOTING"})}>
           <LWTooltip title={<PostsPreviewTooltip post={post}/>} tooltip={false} flip={false}>

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -544,7 +544,7 @@ const ReviewVotingPage = ({classes}: {
                   <span className={classes.sortBy}>Sort by</span> Vote Total (Alignment Forum Users)
                 </MenuItem>}
                 <MenuItem value={'yourVote'}>
-                  <span className={classes.sortBy}>Sort by</span> Your Vote
+                  <span className={classes.sortBy}>Sort by</span> Your Review Vote
                 </MenuItem>
                 <MenuItem value={'yourKarmaVote'}>
                   <span className={classes.sortBy}>Sort by</span> Your Karma Vote

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -368,7 +368,8 @@ const ReviewVotingPage = ({classes}: {
         const post2Score = post2.currentUserReviewVote?.qualitativeScore || 0
         const post1QuadraticScore = post1.currentUserReviewVote?.quadraticScore || 0
         const post2QuadraticScore = post2.currentUserReviewVote?.quadraticScore || 0
-
+        const post1NotKarmaVoted = post1.currentUserVote === null 
+        const post2NotKarmaVoted = post2.currentUserVote === null
 
         if (sortPosts === "needsReview") {
           // This prioritizes posts with no reviews, which you highly upvoted
@@ -389,8 +390,6 @@ const ReviewVotingPage = ({classes}: {
         if (sortPosts === "needsFinalVote") {
           const post1NotReviewVoted = post1.currentUserReviewVote === null && post1.userId !== currentUser?._id
           const post2NotReviewVoted = post2.currentUserReviewVote === null && post2.userId !== currentUser?._id
-          const post1NotKarmaVoted = post1.currentUserVote === null 
-          const post2NotKarmaVoted = post2.currentUserVote === null
           if (post1NotReviewVoted && !post2NotReviewVoted) return -1
           if (post2NotReviewVoted && !post1NotReviewVoted) return 1
           if (post1Score < post2Score) return 1
@@ -410,6 +409,10 @@ const ReviewVotingPage = ({classes}: {
           if (post1Score < post2Score) return 1
           if (post1Score > post2Score) return -1
         }
+        if (sortPosts === "yourKarmaVote") {
+          if (post1NotKarmaVoted && !post2NotKarmaVoted) return 1
+          if (post2NotKarmaVoted && !post1NotKarmaVoted) return -1
+        }        
 
         if (post1[sortPosts] > post2[sortPosts]) return -1
         if (post1[sortPosts] < post2[sortPosts]) return 1
@@ -542,6 +545,9 @@ const ReviewVotingPage = ({classes}: {
                 </MenuItem>}
                 <MenuItem value={'yourVote'}>
                   <span className={classes.sortBy}>Sort by</span> Your Vote
+                </MenuItem>
+                <MenuItem value={'yourKarmaVote'}>
+                  <span className={classes.sortBy}>Sort by</span> Your Karma Vote
                 </MenuItem>
                 <MenuItem value={'reviewCount'}>
                   <span className={classes.sortBy}>Sort by</span> Review Count

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -81,6 +81,7 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
 
 export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
   const fallback = forumTypeSetting.get() === 'AlignmentForum' ? "afPostCommentsTop" : "postCommentsTop"
+  console.log("ASDFS", (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback)
   return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
 }
 

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -81,7 +81,6 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
 
 export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
   const fallback = forumTypeSetting.get() === 'AlignmentForum' ? "afPostCommentsTop" : "postCommentsTop"
-  console.log("ASDFS", (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback)
   return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
 }
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -769,6 +769,7 @@ importComponent("PostNominatedNotification", () => require('../components/review
 importComponent("SingleLineReviewsList", () => require('../components/review/SingleLineReviewsList'));
 
 importComponent("QuadraticVotingButtons", () => require('../components/review/QuadraticVotingButtons'))
+importComponent("KarmaVoteStripe", () => require('../components/review/KarmaVoteStripe'))
 importComponent("ReviewVoteTableRow", () => require('../components/review/ReviewVoteTableRow'))
 importComponent("ReviewVotingButtons", () => require('../components/review/ReviewVotingButtons'))
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -267,6 +267,14 @@ addRoute(
   },
 
   {
+    name: 'reviewQuickPage',
+    path: '/reviewQuickPage',
+    componentName: 'ReviewQuickPage',
+    title: "Review Quick Page",
+    subtitle: "Quick Review Page"
+  },
+
+  {
     name: "newLongformReviewForm",
     path: '/newLongformReview',
     title: "New Longform Review",
@@ -930,13 +938,6 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       name: 'reviews2019-old',
       path: '/reviews2019',
       redirect: () => `/reviews/2019`,
-    },
-    {
-      name: 'reviewQuickPage',
-      path: '/reviewQuickPage',
-      componentName: 'ReviewQuickPage',
-      title: "Review Quick Page",
-      subtitle: "Quick Review Page"
     },
     {
       name: 'library',


### PR DESCRIPTION
This PR 
– adds a "sort by karma vote" option to the /reviewVoting page
– changes the Quick Review Page UI to help highlight posts you've previously karma voted on, as follows: Instead of just grabbing the top 12 posts by AF Vote Total, it grabs the top 25 posts by Vote Total, and then sorts the ones you've voted on to the top. 
– fixes a random bug where the Quick Review Page wasn't loading on the Alignment Forum.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203761102119602) by [Unito](https://www.unito.io)
