### PR TITLE
hideUnreviewedAuthorComments becomes a date after which we will hide comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -15,6 +15,9 @@ const CommentBottomCaveats = ({comment, classes}: {
 }) => {
   const now = useCurrentTime();
   const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > now;
+  const hideSince = hideUnreviewedAuthorCommentsSettings.get()
+  const commentHidden = hideSince && new Date(hideSince) < new Date(comment.postedAt) &&
+    comment.authorIsUnreviewed
   
   return <>
     { blockedReplies &&
@@ -23,11 +26,10 @@ const CommentBottomCaveats = ({comment, classes}: {
       </div>
     }
     { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
-    { hideUnreviewedAuthorCommentsSettings.get() && comment.authorIsUnreviewed &&
-      <Components.MetaInfo>
-        [This comment will not be visible to other users until the moderation
-        team checks it for spam or norm violations.]
-      </Components.MetaInfo>
+    { commentHidden && <Components.MetaInfo>
+      [This comment will not be visible to other users until the moderation
+      team checks it for spam or norm violations.]
+    </Components.MetaInfo>
     }
   </>
 }

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -221,7 +221,9 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
     return <span>Sorry, you do not have permission to comment at this time.</span>
   }
 
-  const commentWillBeHidden = hideUnreviewedAuthorCommentsSettings.get() && currentUser && !currentUser.isReviewed
+  const hideDate = hideUnreviewedAuthorCommentsSettings.get()
+  const commentWillBeHidden = hideDate && new Date(hideDate) < new Date() &&
+    currentUser && !currentUser.isReviewed
   const extraFormProps = isMinimalist ? {commentMinimalistStyle: true, editorHintText: "Reply..."} : {}
   const parentDocumentId = post?._id || tag?._id
   return (

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -29,12 +29,18 @@ Comments.addDefaultView((terms: CommentsViewTerms, _, context?: ResolverContext)
   const validFields = pick(terms, 'userId', 'authorIsUnreviewed');
 
   const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
+  const hideSince = hideUnreviewedAuthorCommentsSettings.get()
+  // When we're hiding unreviewed comments, we allow comments that meet any of:
+  //  * The author is reviewed
+  //  * The comment was posted before the hideSince date
+  //  * The comment was posted by the current user
   // We set `{$ne: true}` instead of `false` to allow for comments that haven't
   // had the default value set yet (ie: those created by the frontend
   // immediately prior to appearing)
-  const hideUnreviewedAuthorComments = hideUnreviewedAuthorCommentsSettings.get()
+  const hideNewUnreviewedAuthorComments = hideSince
     ? {$or: [
       {authorIsUnreviewed: {$ne: true}},
+      {postedAt: {$lt: new Date(hideSince)}},
       ...(context?.currentUser?._id ? [{userId: context?.currentUser?._id}] : [])]}
     : {}
   return ({
@@ -42,7 +48,7 @@ Comments.addDefaultView((terms: CommentsViewTerms, _, context?: ResolverContext)
       $or: [{$and: [{deleted: true}, {deletedPublic: true}]}, {deleted: false}],
       hideAuthor: terms.userId ? false : undefined,
       ...alignmentForum,
-      ...hideUnreviewedAuthorComments,
+      ...hideNewUnreviewedAuthorComments,
       ...validFields,
     },
     options: {
@@ -62,7 +68,7 @@ export function augmentForDefaultView(indexFields)
   return combineIndexWithDefaultViewIndex({
     viewFields: indexFields,
     prefix: {},
-    suffix: {authorIsUnreviewed: 1, deleted:1, deletedPublic:1, hideAuthor:1, userId:1, af:1},
+    suffix: {authorIsUnreviewed: 1, deleted:1, deletedPublic:1, hideAuthor:1, userId:1, af:1, postedAt:1},
   });
 }
 

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -34,10 +34,13 @@ Comments.addDefaultView((terms: CommentsViewTerms, _, context?: ResolverContext)
   //  * The author is reviewed
   //  * The comment was posted before the hideSince date
   //  * The comment was posted by the current user
+  // Do not run this on the client (ie: Mingo), because we will not have the
+  // resolver context, and return unreviewed comments to ensure cache is
+  // properly invalidated.
   // We set `{$ne: true}` instead of `false` to allow for comments that haven't
   // had the default value set yet (ie: those created by the frontend
   // immediately prior to appearing)
-  const hideNewUnreviewedAuthorComments = hideSince
+  const hideNewUnreviewedAuthorComments = (hideSince && bundleIsServer)
     ? {$or: [
       {authorIsUnreviewed: {$ne: true}},
       {postedAt: {$lt: new Date(hideSince)}},

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -59,7 +59,7 @@ export const ckEditorUploadUrlSetting = new DatabasePublicSetting<string | null>
 export const ckEditorWebsocketUrlSetting = new DatabasePublicSetting<string | null>('ckEditor.webSocketUrl', null) // Websocket URL for CKEditor (for collaboration)
 
 
-export const hideUnreviewedAuthorCommentsSettings = new DatabasePublicSetting<boolean>('hideUnreviewedAuthorComments', false) // Hide comments by unreviewed authors (prevents spam, but delays new user engagement)
+export const hideUnreviewedAuthorCommentsSettings = new DatabasePublicSetting<string | null>('hideUnreviewedAuthorComments', null) // Hide comments by unreviewed authors after date provided (prevents spam / flaming / makes moderation easier, but delays new user engagement)
 export const cloudinaryCloudNameSetting = new DatabasePublicSetting<string>('cloudinary.cloudName', 'lesswrong-2-0') // Cloud name for cloudinary hosting
 
 export const forumAllPostsNumDaysSetting = new DatabasePublicSetting<number>('forum.numberOfDays', 10) // Number of days to display in the timeframe view


### PR DESCRIPTION
Previously I was too worried about hiding comments which had gone live and received discussion before this setting was enabled. Now we will be able to set the date to the day we deploy the setting, and then only future comments will be hidden.

In order to make this efficient, I've added a `{postedAt:1}` to the default index.

Also: the prior behavior for new user comments was that they would be posted and then disappear into the void until a refresh. This PR fixes that with a bundleIsServer check.

*I am making the assumption that the only time `Comments.getParameters()` is called on the client is for Mingo.* I believe that is correct, but if I'm wrong it could allow people to see these comments.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203747307194311) by [Unito](https://www.unito.io)
