### PR TITLE
Remove sticky positioning from reviewLeaderboard

### DIFF
--- a/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
+++ b/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
@@ -13,10 +13,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: 16,
     paddingBottom: 10,
     border: theme.palette.border.commentBorder,
-    marginBottom: 16,
-    position: "sticky",
-    top: -48,
-    zIndex: theme.zIndexes.reviewLeaderboard
+    marginBottom: 16
   },
   username: {
     width: 160,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -40,7 +40,6 @@ export const zIndexes = {
   singleLineCommentHover: 4,
   questionPageWhitescreen: 4,
   footerNav: 4,
-  reviewLeaderboard: 5,
   textbox: 5,
   styledMapPopup: 6,
   nextUnread: 999,


### PR DESCRIPTION
Turned out this created a horrible interaction when you expanded the list, and was a dumb idea. Reverting it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203761737828272) by [Unito](https://www.unito.io)
