### PR TITLE
Rearrange timeRemaining section on FrontpageReviewWidget

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -126,7 +126,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   timeRemaining: {
     ...theme.typography.commentStyle,
     fontSize: 14,
-    color: theme.palette.grey[500]
+    color: theme.palette.grey[500],
+    marginLeft: 12
   },
   nominationTimeRemaining: {
     marginRight: "auto",
@@ -134,7 +135,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     textAlign: "left"
   },
   reviewProgressBar: {
-    marginRight: "auto",
+    marginRight: 2,
     [theme.breakpoints.down('xs')]: {
       display: "none"
     }
@@ -361,10 +362,6 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true, reviewYear}: {
     {currentUser && currentUser.karma >= 1000 && <span className={classes.reviewProgressBar}>
       <UserReviewsProgressBar reviewYear={reviewYear}/>
     </span>}
-    {/* If there's less than 24 hours remaining, show the remaining time */}
-    {isLastDay(reviewEndDate) && <span className={classes.timeRemaining}>
-      {reviewEndDate.fromNow()} remaining
-    </span>}
     <LWTooltip title="A list of all reviews, with the top review-commenters ranked by total karma">
       <Link to={"/reviews"} className={classes.actionButton}>
         Review Leaderboard
@@ -380,6 +377,10 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true, reviewYear}: {
         Quick Review
       </Link>
     </LWTooltip>
+    {/* If there's less than 24 hours remaining, show the remaining time */}
+    {isLastDay(reviewEndDate) && <span className={classes.timeRemaining}>
+      {reviewEndDate.fromNow()} remaining
+    </span>}
   </div>
 
   const votingPhaseButtons = <div className={classes.actionButtonRow}>

--- a/packages/lesswrong/components/review/UserReviewsProgressBar.tsx
+++ b/packages/lesswrong/components/review/UserReviewsProgressBar.tsx
@@ -11,8 +11,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     alignItems: "center",
-    marginLeft: 4,
-    marginRight: 10
   },
   text: {
     ...theme.typography.body2,


### PR DESCRIPTION
Moves the timeRemaining to the right, so that it doesn't look as clunky next to the checkboxes

<img width="859" alt="image" src="https://user-images.githubusercontent.com/3246710/212562866-d1032c7c-2638-4b8b-b725-792ef4b3e338.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203754920464044) by [Unito](https://www.unito.io)
