### PR TITLE
Flag UI on moderation page

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -78,6 +78,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   loadMore: {
     paddingLeft: 12,
     paddingTop: 12
+  },
+  flagged: {
+    color: theme.palette.error.main
   }
 });
 
@@ -160,9 +163,9 @@ const ModerationDashboard = ({ classes }: {
         <div className={classNames({ [classes.hidden]: currentView !== 'sunshineNewUsers' })}>
           <div className={classes.toc}>
             {usersToReview.map(user => {
-              return <div key={user._id} className={classes.tocListing}>
+              return <div key={user._id} className={classNames(classes.tocListing, {[classes.flagged]: user.sunshineFlagged})}>
                 <a href={`${location.pathname}${location.search ?? ''}#${user._id}`}>
-                  {user.displayName}
+                  {user.displayName} 
                 </a>
               </div>
             })}

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -9,7 +9,6 @@ import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
 import { hideScrollBars } from '../../themes/styleUtils';
 import { getReasonForReview } from '../../lib/collections/moderatorActions/helpers';
-import { ContentSummaryRows } from './ModeratorUserInfo/ContentSummaryRows';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -142,6 +141,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
     ...hideScrollBars
   },
+  flagged: {
+    border: theme.palette.border.intense,
+    borderColor: theme.palette.error.main
+  }
 })
 
 const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
@@ -232,7 +235,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   const renderExpand = !!(posts?.length || comments?.length)
   
   return (
-    <div className={classes.root}>
+    <div className={classNames(classes.root, {[classes.flagged]:user.sunshineFlagged})}>
       {basicInfoRow}
       <div className={classes.columns}>
         <div className={classes.infoColumn}>


### PR DESCRIPTION
I kept finding it annoying to scan for the non-flagged users on the /moderation page, which made it harder to get at least some user-processing done at times when I didn't have the spoons for serious mod processing.

Hard to share a screenshot without exposing semi-private mod information, but basically makes the names of the flagged users in the table-of-contents red, and gives a red border to flagged user info-boxes

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203747906391745) by [Unito](https://www.unito.io)
