### PR TITLE
minor updates on how we handle deleted comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -29,6 +29,8 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const getCommentDescription = (comment: CommentWithRepliesFragment) => {
+  if (comment.deleted) return '[Comment deleted]'
+
   return `Comment ${comment.user ? 
     `by ${comment.user.displayName} ` : 
     ''

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -212,7 +212,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
 
   const { postPage, showCollapseButtons, tag, post, refetch, hideReply, showPostTitle, singleLineCollapse, hideReviewVoteButtons, moderatedCommentId } = treeOptions;
 
-  const showCommentTitle = !!(commentAllowTitle(comment) && comment.title && !showEditState)
+  const showCommentTitle = !!(commentAllowTitle(comment) && comment.title && !comment.deleted && !showEditState)
 
   const showReply = (event: React.MouseEvent) => {
     event.preventDefault();

--- a/packages/lesswrong/server/akismet.ts
+++ b/packages/lesswrong/server/akismet.ts
@@ -96,8 +96,8 @@ getCollectionHooks("Comments").newAfter.add(async function checkCommentForSpamWi
             // NOTE: This mutation has no user attached. This interacts with commentsDeleteSendPMAsync so that the PM notification of a deleted comment appears to come from themself.
             set: {
               deleted: true,
-              deletedDate: new Date(), 
-              deletedReason: "Your comment has been marked as spam by the Akismet spam integration. We've sent you a PM with the content. If this deletion seems wrong to you, please send us a message on Intercom (the icon in the bottom-right of the page)"
+              deletedDate: new Date(),
+              deletedReason: "This comment has been marked as spam by the Akismet spam integration. We've sent the poster a PM with the content. If this deletion seems wrong to you, please send us a message on Intercom (the icon in the bottom-right of the page)."
             },
             validate: false,
           });


### PR DESCRIPTION
A few updates based on a report from Lizka:

1. Don't show the title of a deleted comment
2. Don't include the text of a deleted comment in the header meta description
3. Update the default Akismet deleted message to be less confusing