### PR TITLE
Add icon to expanded comment on homepage, better no-icon view

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -33,6 +33,14 @@ export const styles = (theme: ThemeType): JssStyles => ({
   subforumTop: {
     paddingTop: 4,
   },
+  tagIcon: {
+    marginRight: 6,
+    '& svg': {
+      width: 15,
+      height: 15,
+      fill: theme.palette.grey[600],
+    },
+  },
   body: {
     borderStyle: "none",
     padding: 0,
@@ -331,7 +339,11 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
     )
   }
   
-  const { ShowParentComment, CommentsItemDate, CommentUserName, CommentShortformIcon, CommentDiscussionIcon, SmallSideVote, LWTooltip, PostsPreviewTooltipSingle, ReviewVotingWidget, LWHelpIcon } = Components
+  const {
+    ShowParentComment, CommentsItemDate, CommentUserName, CommentShortformIcon,
+    CommentDiscussionIcon, SmallSideVote, LWTooltip, PostsPreviewTooltipSingle, ReviewVotingWidget,
+    LWHelpIcon, TopTagIcon
+  } = Components
 
   if (!comment) {
     return null;
@@ -409,7 +421,11 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
         </div>
         <div className={classes.body}>
           {showCommentTitle && <div className={classes.title}>
-            <CommentDiscussionIcon comment={comment} />
+            {(displayTagIcon && tag) ? <span className={classes.tagIcon}>
+              <TopTagIcon tag={tag} />
+            </span> : <CommentDiscussionIcon
+              comment={comment}
+            />}
             {comment.title}
           </div>}
           <div className={classNames(classes.meta, {
@@ -419,7 +435,6 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               <div className={classes.usernameSpacing}>○</div>
             }
             {post && <CommentShortformIcon comment={comment} post={post} />}
-            {displayTagIcon && <span>TODO</span>}
             {!showCommentTitle && <CommentDiscussionIcon comment={comment} small />}
             {parentCommentId!=comment.parentCommentId && parentAnswerId!=comment.parentCommentId &&
               <ShowParentComment

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -7,6 +7,7 @@ import { commentGetKarma } from '../../lib/collections/comments/helpers'
 import { isMobile } from '../../lib/utils/isMobile'
 import { styles as commentsItemStyles } from './CommentsItem/CommentsItem';
 import { CommentTreeOptions } from './commentTree';
+import { topTagIconMap } from '../tagging/TopTagIcon';
 
 export const SINGLE_LINE_PADDING_TOP = 5
 
@@ -163,8 +164,8 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   const { ShowParentComment, CommentUserName, CommentShortformIcon, PostsItemComments, ContentStyles, LWPopper, CommentsNode, TopTagIcon } = Components
 
   const displayHoverOver = hover && (comment.baseScore > -5) && !isMobile() && enableHoverPreview
-
   const renderHighlight = (comment.baseScore > -5) && !comment.deleted
+  const actuallyDisplayTagIcon = !!(displayTagIcon && comment.tag && topTagIconMap[comment.tag.slug])
 
   return (
     <div className={classes.root} {...eventHandlers}>
@@ -176,8 +177,8 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
         })}
       >
         {post && <div className={classes.shortformIcon}><CommentShortformIcon comment={comment} post={post} simple={true} /></div>}
-        {displayTagIcon && comment.tag && <div className={classes.tagIcon}>
-          <TopTagIcon tag={comment.tag} /* className={classes.tagIcon} */ />
+        {actuallyDisplayTagIcon && <div className={classes.tagIcon}>
+          <TopTagIcon tag={comment.tag} />
         </div>}
 
         {parentCommentId!=comment.parentCommentId && <span className={classes.parentComment}>

--- a/packages/lesswrong/components/tagging/TopTagIcon.tsx
+++ b/packages/lesswrong/components/tagging/TopTagIcon.tsx
@@ -17,7 +17,7 @@ import { forumSelect } from '../../lib/forumTypeUtils';
 
 // Mapping from tag slug to icon
 // Don't want to fight the type system about the type of the MUI icon
-const topTagIconMap = forumSelect<Record<string, any>>({
+export const topTagIconMap = forumSelect<Record<string, any>>({
   EAForum: {
     biosecurity: DnaIcon,
     'existential-risk': MushroomCloudIcon,


### PR DESCRIPTION
Fix embarrassing oversight, as well as more minor oversight. Here are both changes in one view:

<img width="963" alt="image" src="https://user-images.githubusercontent.com/10352319/213223543-e04fbc79-c972-4adb-8dd3-37ad97a5db90.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203774583281319) by [Unito](https://www.unito.io)
