### PR TITLE
Prevent side-comment icons from causing horiz scroll on mobile

### DIFF
--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -19,6 +19,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderRadius: 8,
     color: theme.palette.icon.dim6,
     
+    [theme.breakpoints.down('xs')]: {
+      display: "none",
+    },
+    
     "@media print": {
       display: "none",
     },

--- a/packages/lesswrong/components/posts/PostActions/SetSideCommentVisibility.tsx
+++ b/packages/lesswrong/components/posts/PostActions/SetSideCommentVisibility.tsx
@@ -6,6 +6,7 @@ import Paper from '@material-ui/core/Paper';
 import ChatBubbleOutline from '@material-ui/icons/ChatBubbleOutline';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Check from '@material-ui/icons/Check';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   check: {
@@ -21,6 +22,20 @@ const styles = (theme: ThemeType): JssStyles => ({
     right: 12,
     top: 12,
     color: theme.palette.text.dim40,
+    
+    [theme.breakpoints.down('xs')]: {
+      display: "none",
+    }
+  },
+  showOnlyIfMobile: {
+    display: "none",
+    [theme.breakpoints.down('xs')]: {
+      display: "block",
+    },
+  },
+  largerScreenNeededNotice: {
+    padding: 8,
+    ...theme.typography.commentStyle,
   },
 });
 
@@ -51,6 +66,9 @@ const SetSideCommentVisibility = ({classes}: {
   
   const {sideCommentMode, setSideCommentMode} = sideCommentVisibility;
   const submenu = <Paper>
+    <span className={classNames(classes.showOnlyIfMobile, classes.largerScreenNeededNotice)}>
+      Side-comments require a larger screen
+    </span>
     {sideCommentModes.map(mode =>
       <MenuItem
         key={mode.name}
@@ -79,6 +97,9 @@ const SetSideCommentVisibility = ({classes}: {
       </ListItemIcon>
       <span className={classes.sideCommentsLabel}>
         Side-comments
+      </span>
+      <span className={classNames(classes.showOnlyIfMobile, classes.currentSelectionPreview)}>
+        Hidden
       </span>
       <span className={classes.currentSelectionPreview}>
         {sideCommentModes.find(mode=>mode.name===sideCommentMode)?.label}


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203777333851032) by [Unito](https://www.unito.io)
