### PR TITLE
Recompute afCommentCount whenever comments move to/from AF

### DIFF
--- a/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/alignmentCommentCallbacks.ts
@@ -24,7 +24,13 @@ export async function recalculateAFCommentMetadata(postId: string|null) {
     collection:Posts,
     documentId: postId,
     set: {
+      // Needs to be recomputed after anything moves to/from AF; can't be handled
+      // incrementally by simpler callbacks because a comment being removed from
+      // AF might mean an unrelated comment is now the newest.
       afLastCommentedAt:new Date(lastCommentedAt),
+      // Needs to be recomputed after anything moves to/from AF because those
+      // moves are using raw updates.
+      afCommentCount: afComments.length,
     },
     unset: {},
     validate: false,


### PR DESCRIPTION
Should fix an issue where, if a comment is promoted to AF and brings its parents in a thread along with it, those comments don't get included in the comment count displayed on AF.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203777808097563) by [Unito](https://www.unito.io)
