### PR TITLE
Remove Crossposting message from AlignmentForum

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -12,8 +12,12 @@ import classNames from 'classnames';
 import * as _ from 'underscore';
 import { postGetCommentCountStr } from '../../lib/collections/posts/helpers';
 import { CommentsNewFormProps } from './CommentsNewForm';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
+
+const isLW = forumTypeSetting.get() === "LessWrong"
+const isEA = forumTypeSetting.get() === "EAForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -195,7 +199,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
       />
-      <Components.PostsPageCrosspostComments />
+      {(isEA || isLW) && <Components.PostsPageCrosspostComments />}
     </div>
   );
 }

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -7,7 +7,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
 import { useCurrentUser } from '../common/withUser';
-import { unflattenComments, CommentTreeNode } from '../../lib/utils/unflatten';
+import { unflattenComments } from '../../lib/utils/unflatten';
 import classNames from 'classnames';
 import * as _ from 'underscore';
 import { postGetCommentCountStr } from '../../lib/collections/posts/helpers';
@@ -16,8 +16,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 
-const isLW = forumTypeSetting.get() === "LessWrong"
-const isEA = forumTypeSetting.get() === "EAForum"
+const isAF = forumTypeSetting.get() === "AlignmentForum"
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -199,7 +198,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
       />
-      {(isEA || isLW) && <Components.PostsPageCrosspostComments />}
+      {!isAF && <Components.PostsPageCrosspostComments />}
     </div>
   );
 }


### PR DESCRIPTION
AlignmentForum deliberately didn't include a link to LessWrong to avoid looking weird, and it feels pretty bad to have it link to EA Forum but not LessWrong. I also just think it's actually good for forums to have somewhat more distinct cultures.