### PR TITLE
Add AF to review sample query

### DIFF
--- a/packages/lesswrong/lib/reviewVoteUpdate.ts
+++ b/packages/lesswrong/lib/reviewVoteUpdate.ts
@@ -174,3 +174,5 @@ export async function updateReviewVoteTotals (votePhase: reviewVotePhase) {
 //     reviewVoteScoreAF:1
 //   })
 //   .sort({reviewVoteScoreAllKarma:-1})
+
+// MAKE SURE TO UPDATE LIMIT OF QUERY IN UI

--- a/packages/lesswrong/lib/reviewVoteUpdate.ts
+++ b/packages/lesswrong/lib/reviewVoteUpdate.ts
@@ -163,6 +163,7 @@ export async function updateReviewVoteTotals (votePhase: reviewVotePhase) {
 //     _id:1, 
 //     userId:1, 
 //     author:1, 
+//     af: 1,
 //     reviewCount:1, 
 //     positiveReviewVoteCount:1, 
 //     reviewVotesAllKarma:1, 


### PR DESCRIPTION
reviewVoteUpdate.ts has a commented-out-query, designed to be run on NosqlBooster. I forgot to include the AF column, and wanted a bit of reminder text to help me avoid a footgun in NosqlBooster.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203778062260374) by [Unito](https://www.unito.io)
