### PR TITLE
Remove broken search-refinement UI in AF search bar

### DIFF
--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -22,20 +22,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('xs')]: {
       top: forumTypeSetting.get() === 'EAForum' ? 78 : 48,
     },
-    "& .ais-CurrentRefinements": {
-      display: 'inline-block',
-      position: 'absolute',
-      padding: '0px 16px',
-      top: 16
-    },
-    "& .ais-CurrentRefinements-item": {
-      border: theme.palette.border.slightlyIntense2,
-      borderRadius: 20,
-      padding: '8px',
-    },
-    "& .ais-CurrentRefinements-label": {
-      marginRight: 5
-    },
   },
   searchResults: {
     overflow:"scroll",
@@ -89,7 +75,6 @@ const SearchBarResults = ({closeSearch, currentQuery, classes}: {
 
   return <div className={classes.root}>
     <div className={classes.searchResults}>
-        <CurrentRefinements />
         <Components.ErrorBoundary>
           <div className={classes.list}>
             <Index indexName={getAlgoliaIndexName("Users")}>


### PR DESCRIPTION
Removes the broken "af: true" button shown in this screenshot.

<img width="478" alt="Screen Shot 2023-01-12 at 7 34 24 PM" src="https://user-images.githubusercontent.com/101191/213364960-cd01b723-da7e-41ae-9b7c-4b9fc62b118f.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203778975319947) by [Unito](https://www.unito.io)
