### PR TITLE
Fix casting of deep JSON strings

### DIFF
--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -239,9 +239,13 @@ abstract class Query<T extends DbObject> {
       if (fieldType instanceof ArrayType && !this.isIndex) {
         throw new NonScalarArrayAccessError(first, rest);
       } else if (fieldType) {
-        return `("${first}"` +
+        const hint = this.getTypeHint(typeHint);
+        const result = `("${first}"` +
           rest.map((element) => element.match(/^\d+$/) ? `[${element}]` : `->'${element}'`).join("") +
-          `)${this.getTypeHint(typeHint)}`;
+          `)${hint}`;
+        return hint === "::TEXT"
+          ? result.replace(/->(?!.*->)/, "->>")
+          : result;
       }
     }
 

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -166,6 +166,12 @@ describe("SelectQuery", () => {
       expectedArgs: [3],
     },
     {
+      name: "can build select query with json fields with a string result",
+      getQuery: () => new SelectQuery(testTable, {"c.d.e": "test"}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ("c"->\'d\'->>\'e\')::TEXT = $1',
+      expectedArgs: ["test"],
+    },
+    {
       name: "can build select query with array fields",
       getQuery: () => new SelectQuery(testTable, {"c.0": 3}),
       expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ("c"[0])::INTEGER = $1',


### PR DESCRIPTION
This should fix the following bug reported on intercom:
> For some reason urls to my website both with https:// in front or even adding a www don’t seem to work

The bug due to incorrect casting of JSON strings when retrieved from inside a deep JSON object in Postgres. Previously we generated `("fmCrosspost"->'foreignPostId')::TEXT`, but this should be `("fmCrosspost"->>'foreignPostId')::TEXT` otherwise the cast to `TEXT` adds quotes around the actual string value. The cast to `TEXT` isn't technically needed anymore, but it doesn't hurt and removing it will make the code more complicated.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203789663692948) by [Unito](https://www.unito.io)
