### PR TITLE
Add icons for new core tags

### DIFF
--- a/packages/lesswrong/components/tagging/TopTagIcon.tsx
+++ b/packages/lesswrong/components/tagging/TopTagIcon.tsx
@@ -31,6 +31,7 @@ export const topTagIconMap = forumSelect<Record<string, any>>({
     'animal-welfare': BirdIcon, // Replacing wild-animal-welfare and farmed-animal-welfare
     'effective-altruism-groups': PeopleIcon,
     'career-choice': ChoiceIcon,
+    'taking-action': ChoiceIcon, // Doesn't exist yet, but may be replacing career-choice
     'ai-risk': ChipIcon,
     'ai-safety': ChipIcon, // Replacing ai-risk
     'global-health-and-development': EarthIcon,

--- a/packages/lesswrong/components/tagging/TopTagIcon.tsx
+++ b/packages/lesswrong/components/tagging/TopTagIcon.tsx
@@ -20,14 +20,19 @@ import { forumSelect } from '../../lib/forumTypeUtils';
 export const topTagIconMap = forumSelect<Record<string, any>>({
   EAForum: {
     biosecurity: DnaIcon,
+    'biosecurity-and-pandemic-preparedness': DnaIcon, // Replacing biosecurity
     'existential-risk': MushroomCloudIcon,
+    'global-catastrophic-risk': MushroomCloudIcon, // (Possibly) replacing existential-risk
     'cause-prioritization': GlobeIcon,
     'moral-philosophy': ScrollIcon,
+    'philosophy': ScrollIcon, // Replacing moral-philosophy
     'wild-animal-welfare': BirdIcon,
     'farmed-animal-welfare': ChickenIcon,
+    'animal-welfare': BirdIcon, // Replacing wild-animal-welfare and farmed-animal-welfare
     'effective-altruism-groups': PeopleIcon,
     'career-choice': ChoiceIcon,
     'ai-risk': ChipIcon,
+    'ai-safety': ChipIcon, // Replacing ai-risk
     'global-health-and-development': EarthIcon,
     'policy': GavelIcon,
     'effective-giving': GiveIcon,


### PR DESCRIPTION
Not all of these are definitely going to be changed (Global Catastrophic Risk and Taking Action haven't been fully decided on yet), but as this will only be used for core tags there's no downside to adding them all now

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203789788301955) by [Unito](https://www.unito.io)
