### PR TITLE
Fix HideRepeatedPostContext removing viewed curated posts from main post feed

### DIFF
--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -192,7 +192,7 @@ const PostsList2 = ({
 
       <div className={boxShadow ? classes.posts : null}>
         {orderedResults && orderedResults.map((post, i) => {
-          if (isPostRepeated(post._id)) {
+          if (isPostRepeated(post._id) || post._id in hiddenPosts) {
             return null;
           }
           addPost(post._id);
@@ -211,9 +211,7 @@ const PostsList2 = ({
             tooltipPlacement,
           };
 
-          if (!(post._id in hiddenPosts)) {
-            return <PostsItem2 key={post._id} {...props} />
-          }
+          return <PostsItem2 key={post._id} {...props} />
         })}
       </div>
       {showLoadMore && <SectionFooter>


### PR DESCRIPTION
This PR fixes a bug reported on Slack by Lizka.

We show curated posts at the top of the home page feed, but hide them if they've already been read (but always show at least one even it's already been read). This is done by using 2 `PostsList2` components (the first just for curated posts and the second for the main feed) which are both wrapped in a single `HideRepeatedPostsContext` which prevents any post from being displayed multiple times.

The bug here is that we register posts as being shown in the context _before_ checking if we should hide them because they're a curated post that's already been read. This means that a post that gets hidden from the curated posts lists because it's already been read will also be hidden from the main feed, even if it should ordinarily be shown.