### PR TITLE
Fix permanent discussion loading dots for logged out view

### DIFF
--- a/packages/lesswrong/components/common/LatestPostsDiscussion.tsx
+++ b/packages/lesswrong/components/common/LatestPostsDiscussion.tsx
@@ -21,15 +21,17 @@ const LatestPostsDiscussion = ({classes}: {
 }) => {
   const { Loading, ContentType, CommentsNode, LoadMore } = Components;
   const currentUser  = useCurrentUser();
+
+  const skip = !isEAForum || !currentUser?.profileTagIds?.length
   const subforumDiscussionCommentsQuery = useMulti({
     terms: {view: 'latestSubforumDiscussion', profileTagIds: currentUser?.profileTagIds, limit: 3},
     collectionName: "Comments",
     fragmentName: 'CommentWithRepliesFragment',
-    skip: !isEAForum || !currentUser?.profileTagIds?.length,
+    skip: skip,
   })
   const [loadMoreCalled, setLoadMoreCalled] = useState(false);
   
-  if (!isEAForum) {
+  if (skip) {
     return null;
   }
   if (subforumDiscussionCommentsQuery.loading) {


### PR DESCRIPTION
This is how it looked before:

![Screenshot 2023-01-20 at 17 47 51](https://user-images.githubusercontent.com/77623106/213772341-424c24e3-ca7c-44a6-8b47-2f610543c456.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203791931749992) by [Unito](https://www.unito.io)
