### PR TITLE
Enforce 'IS TRUE/FALSE' over '= TRUE/FALSE' in postgres queries

### DIFF
--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -287,9 +287,9 @@ abstract class Query<T extends DbObject> {
       }
       else if (value === false) {
         if (op === "=") {
-          return [`${resolvedField}${hint} IS NOT TRUE`];
+          return [`${resolvedField}${hint} IS FALSE`];
         } else if (op === "<>") {
-          return [`${resolvedField}${hint} IS TRUE`];
+          return [`${resolvedField}${hint} IS NOT FALSE`];
         }
       }
       return [`${resolvedField}${hint} ${op} `, new Arg(value)];

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -278,6 +278,20 @@ abstract class Query<T extends DbObject> {
           return [`${resolvedField}${hint} IS NOT NULL`];
         }
       }
+      else if (value === true) {
+        if (op === "=") {
+          return [`${resolvedField}${hint} IS TRUE`];
+        } else if (op === "<>") {
+          return [`${resolvedField}${hint} IS NOT TRUE`];
+        }
+      }
+      else if (value === false) {
+        if (op === "=") {
+          return [`${resolvedField}${hint} IS NOT TRUE`];
+        } else if (op === "<>") {
+          return [`${resolvedField}${hint} IS TRUE`];
+        }
+      }
       return [`${resolvedField}${hint} ${op} `, new Arg(value)];
     }
   }

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -76,6 +76,18 @@ describe("SelectQuery", () => {
       expectedArgs: [],
     },
     {
+      name: "can build select query with comparison against true",
+      getQuery: () => new SelectQuery(testTable, {a: true, b: {$eq: true}, c: {$ne: true}}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ( "a" IS TRUE AND "b" IS TRUE AND "c" IS NOT TRUE )',
+      expectedArgs: [],
+    },
+    {
+      name: "can build select query with comparison against false",
+      getQuery: () => new SelectQuery(testTable, {a: false, b: {$eq: false}, c: {$ne: false}}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ( "a" IS FALSE AND "b" IS FALSE AND "c" IS NOT FALSE )',
+      expectedArgs: [],
+    },
+    {
       name: "can build select query with equal comparison",
       getQuery: () => new SelectQuery(testTable, {a: {$eq: 3}}),
       expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" = $1',


### PR DESCRIPTION
Per Will, it's preferable to always use (e.g.) `IS TRUE` over `= TRUE` in postgres. This PR replaces that automatically, in the same way as we already do for null cases.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203792267311289) by [Unito](https://www.unito.io)
