### PR TITLE
Truncate subforum topics list

### DIFF
--- a/packages/lesswrong/components/tagging/subforums/SidebarSubtagsBox.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SidebarSubtagsBox.tsx
@@ -24,13 +24,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   removeButton: {
     float: "right",
   },
-  showMoreTagsLink: {
-
+  showAllSubtags: {
+    margin: "5px 0 0",
+    ...theme.typography.body2,
+    ...theme.typography.commentStyle,
+    color: theme.palette.lwTertiary.main,
   },
 });
 
 const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment | TagPageWithRevisionFragment; className?: string; classes: ClassesType }) => {
-  const { ContentStyles, FooterTag, AddTagButton, TagPreview, Loading, LoadMore } = Components;
+  const { ContentStyles, FooterTag, AddTagButton, TagPreview, Loading } = Components;
 
   const [isAwaiting, setIsAwaiting] = useState(false)
   const [showAllSubtags, setShowAllSubtags] = useState(false)
@@ -85,7 +88,7 @@ const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment |
   };
 
   const sortedSubtags = sortTags(subTags, (t) => t)
-  const visibleSubtags = showAllSubtags ? sortedSubtags : take(sortedSubtags, 8)
+  const visibleSubtags = showAllSubtags ? sortedSubtags : take(sortedSubtags, 7)
 
   return (
     <div className={classNames(className, classes.root)}>
@@ -108,7 +111,7 @@ const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment |
           />
         ))}
         {canEditSubtags && <AddTagButton onTagSelected={({ tagId: subTagId }) => setParentTag({ subTagId, parentTagId: tag._id })} />}
-        {!showAllSubtags && visibleSubtags.length < sortedSubtags.length && <div><LoadMore loadMore={() => setShowAllSubtags(true)} /></div>}
+        {!showAllSubtags && visibleSubtags.length < sortedSubtags.length && <div className={classes.showAllSubtags}><a onClick={() => setShowAllSubtags(true)}>Show All</a></div>}
         { isAwaiting && <Loading/>}
       </span>
     </div>

--- a/packages/lesswrong/components/tagging/subforums/SidebarSubtagsBox.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SidebarSubtagsBox.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import take from "lodash/take";
 import React, { useState } from "react";
 import { useSingle } from "../../../lib/crud/withSingle";
 import { useUpdate } from "../../../lib/crud/withUpdate";
@@ -23,12 +24,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   removeButton: {
     float: "right",
   },
+  showMoreTagsLink: {
+
+  },
 });
 
 const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment | TagPageWithRevisionFragment; className?: string; classes: ClassesType }) => {
-  const { ContentStyles, FooterTag, AddTagButton, TagPreview, Loading } = Components;
+  const { ContentStyles, FooterTag, AddTagButton, TagPreview, Loading, LoadMore } = Components;
 
   const [isAwaiting, setIsAwaiting] = useState(false)
+  const [showAllSubtags, setShowAllSubtags] = useState(false)
   const currentUser = useCurrentUser();
 
   // TODO: we fetch the tag twice (once in TagSubforumPage2 and once here) because we want to get more info about the subtags, which could slow down the main page if there are a lot of them.
@@ -79,6 +84,9 @@ const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment |
     );
   };
 
+  const sortedSubtags = sortTags(subTags, (t) => t)
+  const visibleSubtags = showAllSubtags ? sortedSubtags : take(sortedSubtags, 8)
+
   return (
     <div className={classNames(className, classes.root)}>
       <ContentStyles contentType="tag">
@@ -91,7 +99,7 @@ const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment |
           hideScore={true}
           popperCard={<WrappedTagPreview tag={tag} showRelatedTags={false} />}
         />
-        {sortTags(subTags, (t) => t).map((tag) => (
+        {visibleSubtags.map((tag) => (
           <FooterTag
             key={tag._id}
             tag={tag}
@@ -100,6 +108,7 @@ const SidebarSubtagsBox = ({ tag, className, classes }: { tag: TagPageFragment |
           />
         ))}
         {canEditSubtags && <AddTagButton onTagSelected={({ tagId: subTagId }) => setParentTag({ subTagId, parentTagId: tag._id })} />}
+        {!showAllSubtags && visibleSubtags.length < sortedSubtags.length && <div><LoadMore loadMore={() => setShowAllSubtags(true)} /></div>}
         { isAwaiting && <Loading/>}
       </span>
     </div>


### PR DESCRIPTION
For visual simplicity, this PR truncates the 'Posts in this space are about' section to the first 8 topics, with a 'show all' link to display the full list.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/25752873/213780694-90e57c63-b658-4241-bc87-70844b153c50.png">
<img width="499" alt="image" src="https://user-images.githubusercontent.com/25752873/213780760-fede4f0e-ed20-42e1-b735-8c50696f1674.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203792410532330) by [Unito](https://www.unito.io)
