### PR TITLE
Correctly remove theme cookie

### DIFF
--- a/packages/lesswrong/components/themes/useTheme.tsx
+++ b/packages/lesswrong/components/themes/useTheme.tsx
@@ -101,7 +101,7 @@ export const ThemeContextProvider = ({options, children}: {
     if (JSON.stringify(themeOptions) !== JSON.stringify(window.themeOptions)) {
       window.themeOptions = themeOptions;
       if (forumTypeSetting.get() === "EAForum") {
-        removeCookie(THEME_COOKIE_NAME);
+        removeCookie(THEME_COOKIE_NAME, {path: "/"});
       } else {
         setCookie(THEME_COOKIE_NAME, JSON.stringify(themeOptions), {
           path: "/",

--- a/packages/lesswrong/lib/crud/withUpdate.tsx
+++ b/packages/lesswrong/lib/crud/withUpdate.tsx
@@ -99,6 +99,7 @@ export const useUpdate = <CollectionName extends CollectionNameString>({ collect
   collectionName: CollectionName,
   fragmentName: FragmentName,
 }): {
+  /** Set a field to `null` to delete it */
   mutate: WithUpdateFunction<CollectionBase<ObjectsByCollectionName[CollectionName]>>,
   loading: boolean,
   error: ApolloError|undefined,


### PR DESCRIPTION
This was leading to a bug where EA Forum developers who had set a theme on the LW version of localhost could not leave that theme.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203796962370363) by [Unito](https://www.unito.io)
