### PR TITLE
Info icon with tooltip mentioning advanced search features on tabbed search page

### DIFF
--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -85,6 +85,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "center",
     marginBottom: 15,
     gap: '16px',
+    [theme.breakpoints.down('xs')]: {
+      marginBottom: 12,
+    },
   },
   searchInputArea: {
     flex: 1,
@@ -94,9 +97,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 48,
     border: theme.palette.border.slightlyIntense2,
     borderRadius: 3,
-    [theme.breakpoints.down('xs')]: {
-      marginBottom: 12,
-    },
     "& .ais-SearchBox": {
       display: 'inline-block',
       position: 'relative',
@@ -132,6 +132,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('sm')]: {
       display: "none",
     },
+  },
+  infoIcon: {
+    fontSize: 20,
+    fill: theme.palette.grey[800],
   },
   tabs: {
     margin: '0 auto 20px',
@@ -363,7 +367,7 @@ const SearchPageTabbed = ({classes}:{
             title={`"Quotes" and -minus signs are supported.`}
             className={classes.searchHelp}
           >
-            <InfoIcon />
+            <InfoIcon className={classes.infoIcon}/>
           </LWTooltip>
         </div>
         

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -10,6 +10,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import SearchIcon from '@material-ui/icons/Search';
+import InfoIcon from '@material-ui/icons/Info';
 import moment from 'moment';
 
 const hitsPerPage = 10
@@ -79,11 +80,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   searchIcon: {
     marginLeft: 12
   },
+  searchBoxRow: {
+    display: "flex",
+    alignItems: "center",
+    marginBottom: 15,
+    gap: '16px',
+  },
   searchInputArea: {
+    flex: 1,
     display: "flex",
     alignItems: "center",
     maxWidth: 625,
-    marginBottom: 15,
     height: 48,
     border: theme.palette.border.slightlyIntense2,
     borderRadius: 3,
@@ -119,6 +126,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       "-webkit-appearance": "none",
       cursor: "text",
       ...theme.typography.body2,
+    },
+  },
+  searchHelp: {
+    [theme.breakpoints.down('sm')]: {
+      display: "none",
     },
   },
   tabs: {
@@ -228,8 +240,10 @@ const SearchPageTabbed = ({classes}:{
   )
   const [searchState, setSearchState] = useState<ExpandedSearchState>(qs.parse(location.search.slice(1)))
 
-  const { ErrorBoundary, ExpandedUsersSearchHit, ExpandedPostsSearchHit, ExpandedCommentsSearchHit,
-    ExpandedTagsSearchHit, ExpandedSequencesSearchHit, Typography } = Components
+  const {
+    ErrorBoundary, ExpandedUsersSearchHit, ExpandedPostsSearchHit, ExpandedCommentsSearchHit,
+    ExpandedTagsSearchHit, ExpandedSequencesSearchHit, Typography, LWTooltip
+  } = Components
     
   // we try to keep the URL synced with the search state
   const updateUrl = (search: ExpandedSearchState, tags: Array<string>) => {
@@ -337,12 +351,20 @@ const SearchPageTabbed = ({classes}:{
       </div>
 
       <div className={classes.resultsColumn}>
-        <div className={classes.searchInputArea}>
-          <SearchIcon className={classes.searchIcon}/>
-          {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
-            * null is the only option that actually suppresses the extra X button.
-          // @ts-ignore */}
-          <SearchBox defaultRefinement={query.query} reset={null} focusShortcuts={[]} autoFocus={true} />
+        <div className={classes.searchBoxRow}>
+          <div className={classes.searchInputArea}>
+            <SearchIcon className={classes.searchIcon}/>
+            {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
+              * null is the only option that actually suppresses the extra X button.
+            // @ts-ignore */}
+            <SearchBox defaultRefinement={query.query} reset={null} focusShortcuts={[]} autoFocus={true} />
+          </div>
+          <LWTooltip
+            title={`"Quotes" and -minus signs are supported.`}
+            className={classes.searchHelp}
+          >
+            <InfoIcon />
+          </LWTooltip>
         </div>
         
         <Tabs

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -401,6 +401,7 @@ declare global {
     forumType: ForumTypeString,
     
     breakpoints: {
+      /** Down is *inclusive* - down(sm) will go up to the md breakpoint */
       down:  (breakpoint: BreakpointName|number)=>string,
       up: (breakpoint: BreakpointName|number)=>string,
       values: Record<BreakpointName,number>,


### PR DESCRIPTION
The relevant line is `"Quotes" and -minus signs are supported.`. PR best viewed with whitespace off.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203797018070141) by [Unito](https://www.unito.io)
