### PR TITLE
Increase Review Leaderboard default display to 10

### DIFF
--- a/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
+++ b/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
@@ -63,8 +63,11 @@ export const ReviewsLeaderboard = ({classes, reviews, reviewYear}: {
       totalKarma: userTuple[1].reduce((value, review) => value + review.baseScore - getSelfUpvotePower(user), 0),
       reviews: sortBy(userTuple[1], obj => -obj.baseScore)
   })})
+
+  const NUM_DEFAULT_REVIEWS = 10
+
   const sortedUserRows = sortBy(userRowsMapping, obj => -obj.totalKarma)
-  const truncatedRows = truncated ? sortedUserRows.slice(0,5) : sortedUserRows
+  const truncatedRows = truncated ? sortedUserRows.slice(0,NUM_DEFAULT_REVIEWS) : sortedUserRows
 
   const totalKarma = reviews?.reduce((v, r) => v + r.baseScore, 0)
 
@@ -95,7 +98,7 @@ export const ReviewsLeaderboard = ({classes, reviews, reviewYear}: {
         </Row>
       </div>
     })}
-    <a className={classes.showAll} onClick={() => setTruncated(!truncated)}>{truncated ? <>Show All Reviewers (5/{sortedUserRows.length})</> : "Show Fewer"}</a>
+    <a className={classes.showAll} onClick={() => setTruncated(!truncated)}>{truncated ? <>Show All Reviewers ({NUM_DEFAULT_REVIEWS}/{sortedUserRows.length})</> : "Show Fewer"}</a>
   </div>
 }
 


### PR DESCRIPTION
It seemed like noticing "You were in the top 10" might be motivating for people trying to climb the leaderboard. The top 5 mostly consists of LessWrong team, who professionally review things, so there were fewer opportunities to notice yourself there.

Only affects the Review/LessWrong.

<img width="837" alt="image" src="https://user-images.githubusercontent.com/3246710/214208147-5cdf7d9c-6990-4ef9-a01b-0cd2a7d34a2b.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203813129081953) by [Unito](https://www.unito.io)
