### PR TITLE
Allow acceptsSchemaHash to use single quotes

### DIFF
--- a/packages/lesswrong/server/scripts/acceptMigrations.ts
+++ b/packages/lesswrong/server/scripts/acceptMigrations.ts
@@ -48,7 +48,7 @@ const getMigrationChangelogEntries = async (rootPath: string): Promise<SchemaCha
   for (const migrationFile of migrationFiles) {
     // NOTE: I'm using this regex hack rather than importing because esbuild doesn't support
     // dynamic imports, I would very much like to change this
-    const acceptsHashRegex = new RegExp(/^export const acceptsSchemaHash = "(.*)"/);
+    const acceptsHashRegex = new RegExp(/^export const acceptsSchemaHash = ["'](.*)["']/);
     const contents = (await readFile(migrationFile)).toString().split("\n");
     const acceptsHashLine = contents.find(line => acceptsHashRegex.test(line));
     


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203819946073465) by [Unito](https://www.unito.io)
