### PR TITLE
Add mutation debug loggers, format gql to avoid breaking syntax highlighting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# reformated some gql queries to stop them breaking syntax highlighting
+acf755ffe14fc57cc9f6c05ef0f04414de085dd7

--- a/packages/lesswrong/lib/vulcan-core/default_mutations.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_mutations.ts
@@ -1,6 +1,7 @@
 import { Utils, getTypeName } from '../vulcan-lib';
 import { userCanDo, userOwns } from '../vulcan-users/permissions';
 import isEmpty from 'lodash/isEmpty';
+import { loggerConstructor } from '../utils/logging';
 
 export interface MutationOptions<T extends DbObject> {
   newCheck?: (user: DbUser|null, document: T|null) => Promise<boolean>|boolean,
@@ -23,6 +24,7 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
   type T = ObjectsByCollectionName[N];
   const typeName = getTypeName(collectionName);
   const mutationOptions: MutationOptions<T> = {...defaultOptions, ...options};
+  const logger = loggerConstructor(`mutations-${collectionName.toLowerCase()}`)
 
   const mutations: any = {};
 
@@ -51,6 +53,7 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
       },
 
       async mutation(root: void, { data }, context: ResolverContext) {
+        logger('create mutation()')
         const collection = context[collectionName];
 
         // check if current user can pass check function; else throw error
@@ -113,6 +116,7 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
       },
 
       async mutation(root: void, { selector, data }, context: ResolverContext) {
+        logger('update mutation()')
         const collection = context[collectionName];
 
         if (isEmpty(selector)) {
@@ -215,6 +219,7 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
       },
 
       async mutation(root: void, { selector }, context: ResolverContext) {
+        logger('delete mutation()')
         const collection = context[collectionName];
 
         if (isEmpty(selector)) {

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/graphqlTemplates.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/graphqlTemplates.ts
@@ -50,12 +50,12 @@ export const mainTypeTemplate = ({ typeName, description, interfaces, fields }: 
   description?: string,
   interfaces: string[],
   fields: SchemaGraphQLFieldDescription[],
-}) =>
-`# ${description}
-type ${typeName} ${interfaces.length ? `implements ${interfaces.join(', ')} ` : ''}{
-${convertToGraphQL(fields, '  ')}
-}
-`;
+}) => (
+  `# ${description}
+  type ${typeName} ${interfaces.length ? `implements ${interfaces.join(', ')} ` : ''}{
+  ${convertToGraphQL(fields, '  ')}
+  }
+`);
 
 /* ------------------------------------- Selector Types ------------------------------------- */
 
@@ -81,12 +81,13 @@ type MovieSelectorInput {
 see https://www.opencrud.org/#sec-Data-types
 
 */
-export const selectorInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) =>
+export const selectorInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) => (
 `input ${typeName}SelectorInput {
   AND: [${typeName}SelectorInput]
   OR: [${typeName}SelectorInput]
 ${convertToGraphQL(fields, '  ')}
-}`;
+}`
+);
 
 /*
 
@@ -98,13 +99,14 @@ type MovieSelectorUniqueInput {
 }
 
 */
-export const selectorUniqueInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) =>
+export const selectorUniqueInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) => (
 `input ${typeName}SelectorUniqueInput {
   _id: String
   documentId: String # OpenCRUD backwards compatibility
   slug: String
 ${convertToGraphQL(fields, '  ')}
-}`;
+}`
+);
 
 /*
 
@@ -116,11 +118,12 @@ enum MovieOrderByInput {
 }
 
 */
-export const orderByInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) =>
+export const orderByInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) => (
 `enum ${typeName}OrderByInput {
   foobar
   ${fields.join('\n  ')}
-}`;
+}`
+);
 
 /* ------------------------------------- Query Types ------------------------------------- */
 
@@ -159,14 +162,15 @@ type SingleMovieInput {
 }
 
 */
-export const singleInputTemplate = ({ typeName }: {typeName: string}) =>
+export const singleInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Single${typeName}Input {
   selector: ${typeName}SelectorUniqueInput
   # Whether to enable caching for this query
   enableCache: Boolean
   # Return null instead of throwing MissingDocumentError
   allowNull: Boolean
-}`;
+}`
+);
 
 /*
 
@@ -180,7 +184,7 @@ type MultiMovieInput {
 }
 
 */
-export const multiInputTemplate = ({ typeName }: {typeName: string}) =>
+export const multiInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Multi${typeName}Input {
   # A JSON object that contains the query terms used to fetch data
   terms: JSON,
@@ -202,7 +206,8 @@ export const multiInputTemplate = ({ typeName }: {typeName: string}) =>
   before: String
   first: Int
   last: Int
-}`;
+}`
+);
 
 /* ------------------------------------- Query Output Types ------------------------------------- */
 
@@ -215,10 +220,11 @@ type SingleMovieOuput{
 }
 
 */
-export const singleOutputTemplate = ({ typeName }: {typeName: string}) =>
+export const singleOutputTemplate = ({ typeName }: {typeName: string}) => (
 `type Single${typeName}Output{
   result: ${typeName}
-}`;
+}`
+);
 
 /*
 
@@ -230,11 +236,12 @@ type MultiMovieOuput{
 }
 
 */
-export const multiOutputTemplate = ({ typeName }: {typeName: string}) =>
+export const multiOutputTemplate = ({ typeName }: {typeName: string}) => (
 `type Multi${typeName}Output{
   results: [${typeName}]
   totalCount: Int
-}`;
+}`
+);
 
 /* ------------------------------------- Mutation Types ------------------------------------- */
 
@@ -245,8 +252,9 @@ Mutation for creating a new document
 createMovie(input: CreateMovieInput) : MovieOutput
 
 */
-export const createMutationTemplate = ({ typeName }: {typeName: string}) =>
-`create${typeName}(data: Create${typeName}DataInput!) : ${typeName}Output`;
+export const createMutationTemplate = ({ typeName }: {typeName: string}) => (
+  `create${typeName}(data: Create${typeName}DataInput!) : ${typeName}Output`
+);
 
 /*
 
@@ -255,8 +263,9 @@ Mutation for updating an existing document
 updateMovie(input: UpdateMovieInput) : MovieOutput
 
 */
-export const updateMutationTemplate = ({ typeName }: {typeName: string}) =>
-`update${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
+export const updateMutationTemplate = ({ typeName }: {typeName: string}) => (
+  `update${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`
+);
 
 /*
 
@@ -265,8 +274,9 @@ Mutation for updating an existing document; or creating it if it doesn't exist y
 upsertMovie(input: UpsertMovieInput) : MovieOutput
 
 */
-export const upsertMutationTemplate = ({ typeName }: {typeName: string}) =>
-`upsert${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`;
+export const upsertMutationTemplate = ({ typeName }: {typeName: string}) => (
+  `upsert${typeName}(selector: ${typeName}SelectorUniqueInput!, data: Update${typeName}DataInput! ) : ${typeName}Output`
+);
 
 /*
 
@@ -275,8 +285,9 @@ Mutation for deleting an existing document
 deleteMovie(input: DeleteMovieInput) : MovieOutput
 
 */
-export const deleteMutationTemplate = ({ typeName }: {typeName: string}) =>
-`delete${typeName}(selector: ${typeName}SelectorUniqueInput!) : ${typeName}Output`;
+export const deleteMutationTemplate = ({ typeName }: {typeName: string}) => (
+  `delete${typeName}(selector: ${typeName}SelectorUniqueInput!) : ${typeName}Output`
+);
 
 /* ------------------------------------- Mutation Input Types ------------------------------------- */
 
@@ -291,10 +302,11 @@ type CreateMovieInput {
 }
 
 */
-export const createInputTemplate = ({ typeName }: {typeName: string}) =>
+export const createInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Create${typeName}Input{
   data: Create${typeName}DataInput!
-}`;
+}`
+);
 
 /*
 
@@ -306,11 +318,12 @@ type UpdateMovieInput {
 }
 
 */
-export const updateInputTemplate = ({ typeName }: {typeName: string}) =>
+export const updateInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Update${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
   data: Update${typeName}DataInput!
-}`;
+}`
+);
 
 /*
 
@@ -324,11 +337,12 @@ type UpsertMovieInput {
 }
 
 */
-export const upsertInputTemplate = ({ typeName }: {typeName: string}) =>
+export const upsertInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Upsert${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
   data: Update${typeName}DataInput!
-}`;
+}`
+);
 
 /*
 
@@ -339,10 +353,11 @@ type DeleteMovieInput {
 }
 
 */
-export const deleteInputTemplate = ({ typeName }: {typeName: string}) =>
+export const deleteInputTemplate = ({ typeName }: {typeName: string}) => (
 `input Delete${typeName}Input{
   selector: ${typeName}SelectorUniqueInput!
-}`;
+}`
+);
 
 /*
 
@@ -354,10 +369,11 @@ type CreateMovieDataInput {
 }
 
 */
-export const createDataInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) =>
+export const createDataInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) => (
 `input Create${typeName}DataInput {
 ${convertToGraphQL(fields, '  ')}
-}`;
+}`
+);
 
 /*
 
@@ -369,10 +385,11 @@ type UpdateMovieDataInput {
 }
 
 */
-export const updateDataInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) =>
+export const updateDataInputTemplate = ({ typeName, fields }: { typeName: string, fields: SchemaGraphQLFieldDescription[] }) => (
 `input Update${typeName}DataInput {
 ${convertToGraphQL(fields, '  ')}
-}`;
+}`
+);
 
 /* ------------------------------------- Mutation Output Type ------------------------------------- */
 
@@ -385,10 +402,11 @@ type MovieOutput {
 }
 
 */
-export const mutationOutputTemplate = ({ typeName }: {typeName: string}) =>
+export const mutationOutputTemplate = ({ typeName }: {typeName: string}) => (
 `type ${typeName}Output{
   data: ${typeName}
-}`;
+}`
+);
 
 /* ------------------------------------- Mutation Queries ------------------------------------- */
 
@@ -412,11 +430,12 @@ export const upsertClientTemplate = ({ typeName, fragmentName, extraVariablesStr
   typeName: string,
   fragmentName: string,
   extraVariablesString?: string,
-}) =>
+}) => (
 `mutation upsert${typeName}($selector: ${typeName}SelectorUniqueInput!, $data: Update${typeName}DataInput!, ${extraVariablesString || ''}) {
   upsert${typeName}(selector: $selector, data: $data) {
     data {
       ...${fragmentName}
     }
   }
-}`;
+}`
+);


### PR DESCRIPTION
Small quality of life improvements for devs. My syntax highlighter didn't like some graphql files, I'm guessing it applies to other VSCodes as well. Note the fun `.git-blame-ignore-revs`, ([documentation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)) which is maybe overkill here, but which I was excited to try out.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203832561106031) by [Unito](https://www.unito.io)
