### PR TITLE
script to delete user content when they request account deletion

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -147,6 +147,7 @@ import './server/fmCrosspost/crosspost';
 import './server/fmCrosspost/routes';
 
 import './server/exportUserData';
+import './server/deleteUserContent';
 
 import './server/spotlightCron';
 

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -43,6 +43,10 @@ export const getAdminTeamAccount = async () => {
   return account;
 }
 
+/**
+ * Don't send a PM to users if their comments are deleted with this reason.  Used for account deletion requests.
+ */
+export const noDeletionPmReason = 'Requested account deletion';
 
 getCollectionHooks("Comments").newValidate.add(async function createShortformPost (comment: DbComment, currentUser: DbUser) {
   if (comment.shortform && !comment.postId) {
@@ -207,7 +211,13 @@ getCollectionHooks("Comments").newValidate.add(function NewCommentsEmptyCheck (c
 });
 
 export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser: DbUser | undefined) {
-  if ((!comment.deletedByUserId || comment.deletedByUserId !== comment.userId) && comment.deleted && comment.contents?.html) {
+  const commentDeletedByAnotherUser =
+    (!comment.deletedByUserId || comment.deletedByUserId !== comment.userId)
+    && comment.deleted
+    && comment.contents?.html;
+
+  const noPmDeletionReason = comment.deletedReason === noDeletionPmReason;
+  if (commentDeletedByAnotherUser && !noPmDeletionReason) {
     const onWhat = comment.tagId
       ? (await Tags.findOne(comment.tagId))?.name
       : (comment.postId

--- a/packages/lesswrong/server/deleteUserContent.ts
+++ b/packages/lesswrong/server/deleteUserContent.ts
@@ -1,0 +1,61 @@
+import Comments from "../lib/collections/comments/collection";
+import Posts from "../lib/collections/posts/collection";
+import Users from "../lib/collections/users/collection";
+import { updateMutator } from './vulcan-lib';
+
+import { Globals } from "./vulcan-lib";
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+};
+
+/** Please ensure that we know that the user is who they say they are! */
+export const deleteUserContent = async (
+  selector: {_id?: string, slug?: string, email?: string},
+  outfile?: string,
+) => {
+  if (!selector._id && !selector.slug && !selector.email) {
+    throw new Error("Must specify either an _id, slug or email");
+  }
+
+  const user = await Users.findOne(selector);
+  if (!user) {
+    throw new Error("User not found: " + JSON.stringify(selector));
+  }
+
+  const userId = user._id;
+
+  const userComments = await Comments.find({ userId, deleted: false }).fetch();
+
+  for (const userComment of userComments) {
+    await updateMutator({
+      collection: Comments,
+      documentId: userComment._id,
+      set: {
+        deleted: true,
+        deletedPublic: true,
+        deletedByUserId: userId,
+        deletedReason: 'Requested account deletion'
+      }
+    });
+
+    await sleep(50);
+  }
+
+  const userPosts = await Posts.find({ userId, deletedDraft: false }).fetch();
+
+  for (const userPost of userPosts) {
+    await updateMutator({
+      collection: Posts,
+      documentId: userPost._id,
+      set: {
+        draft: true,
+        deletedDraft: true,
+      }
+    });
+
+    await sleep(50);
+  }
+};
+
+Globals.deleteUserContent = deleteUserContent;

--- a/packages/lesswrong/server/deleteUserContent.ts
+++ b/packages/lesswrong/server/deleteUserContent.ts
@@ -1,9 +1,7 @@
 import Comments from "../lib/collections/comments/collection";
 import Posts from "../lib/collections/posts/collection";
 import Users from "../lib/collections/users/collection";
-import { updateMutator } from './vulcan-lib';
-
-import { Globals } from "./vulcan-lib";
+import { Globals, updateMutator } from './vulcan-lib';
 
 const sleep = (ms: number) => {
   return new Promise((resolve) => { setTimeout(resolve, ms); });

--- a/packages/lesswrong/server/deleteUserContent.ts
+++ b/packages/lesswrong/server/deleteUserContent.ts
@@ -1,6 +1,7 @@
 import Comments from "../lib/collections/comments/collection";
 import Posts from "../lib/collections/posts/collection";
 import Users from "../lib/collections/users/collection";
+import { exportUserData } from "./exportUserData";
 import { Globals, updateMutator } from './vulcan-lib';
 
 const sleep = (ms: number) => {
@@ -14,6 +15,10 @@ export const deleteUserContent = async (
 ) => {
   if (!selector._id && !selector.slug && !selector.email) {
     throw new Error("Must specify either an _id, slug or email");
+  }
+
+  if (outfile) {
+    await exportUserData(selector, outfile);
   }
 
   const user = await Users.findOne(selector);


### PR DESCRIPTION
In the cases where we get users who want more than just account deactivation.

There's a couple open questions here:

- whether the comments should have `deletedPublic: true`, and if so, what the `deletedReason` should be
- whether we do in fact want to do this via `updateMutator` rather than e.g. `Collection.rawUpdateMany`.  I think we do, since that better preserves data integrity (i.e. callbacks get run as intended, etc).  Unfortunately this does make batch-updates impossible, which is why I also added a short sleep in between updates (to avoid hammering the server too hard).
- whether to do anything other than mark the user as `deleted` afterwards

Plausibly we also want to have this automatically run the `exportUserData` script first by default.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203833296611333) by [Unito](https://www.unito.io)
