### PR TITLE
Fix spurious bell-icon notifications when revisiting old tabs

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -14,6 +14,7 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import classNames from 'classnames';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { forumTypeSetting, PublicInstanceSetting } from '../../lib/instanceSettings';
+import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
 
 export const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 export const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
@@ -149,6 +150,8 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
   const {toc} = useContext(SidebarsContext)!;
   const { captureEvent } = useTracking()
   const updateCurrentUser = useUpdateCurrentUser();
+  const { unreadNotifications, unreadPrivateMessages } = useUnreadNotifications();
+  
 
   const setNavigationOpen = (open: boolean) => {
     setNavigationOpenState(open);
@@ -299,6 +302,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
                 {!currentUser && <UsersAccountMenu />}
                 {currentUser && <KarmaChangeNotifier currentUser={currentUser} />}
                 {currentUser && <NotificationsMenuButton
+                  unreadNotifications={unreadNotifications}
                   toggle={handleNotificationToggle}
                   open={notificationOpen}
                   currentUser={currentUser}
@@ -314,6 +318,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
           />
         </Headroom>
         {currentUser && <NotificationsMenu
+          unreadPrivateMessages={unreadPrivateMessages}
           open={notificationOpen}
           hasOpened={notificationHasOpened}
           setIsOpen={handleSetNotificationDrawerOpen}

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.ts
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { useQuery, gql } from '@apollo/client';
+import { useOnNavigate } from '../hooks/useOnNavigate';
+import { useOnFocusTab } from '../hooks/useOnFocusTab';
+import { useMulti } from '../../lib/crud/withMulti';
+import { useCurrentUser } from '../common/withUser';
+
+/**
+ * Get the number of unread notifications (the number displayed on the badge by
+ * the bell icon). Refreshes on navigation and on restoring a background tab.
+ *
+ * This uses the dedicated unreadNotificationCounts resolver, to deal with a
+ * particular subtlety: when refreshing after a navigation or tab focus, the
+ * value we have on the client for currentUser.lastNotificationsCheck is not
+ * necessarily up to date. In particular if you open a tab, leave it in the
+ * background for awhile while checking notifications in other tabs, then
+ * come back to the background tab, using the client-cached value for
+ * lastNotificationsCheck would cause a spurious unread-notification count.
+ */
+export function useUnreadNotifications(): {
+  unreadNotifications: number
+  unreadPrivateMessages: number
+} {
+  const currentUser = useCurrentUser();
+  
+  const { data, loading, refetch: refetchCounts } = useQuery(gql`
+    query UnreadNotificationCountQuery {
+      unreadNotificationCounts {
+        unreadNotifications
+        unreadPrivateMessages
+      }
+    }
+  `, {
+    ssr: true
+  });
+  
+  // Prefetch notifications. This matches the view that the notifications sidebar
+  // opens to by default (in `NotificationsMenu`); it isn't actually *used* here
+  // but having fetched it puts it into the cache, which saves a load-spinner
+  // in the crucial "click the notifications icon after site load" interaction.
+  const { refetch: refetchNotifications } = useMulti({
+    terms: {
+      view: "userNotifications",
+      userId: currentUser?._id,
+    },
+    collectionName: "Notifications",
+    fragmentName: 'NotificationsList',
+    limit: 20,
+    enableTotal: false,
+    skip: !currentUser?._id,
+  });
+  
+  const refetchBoth = useCallback(() => {
+    void refetchCounts();
+    void refetchNotifications();
+  }, [refetchCounts, refetchNotifications]);
+  useOnNavigate(refetchBoth);
+  useOnFocusTab(refetchBoth);
+
+  const unreadNotifications = data?.unreadNotifications ?? 0;
+  const unreadPrivateMessages = data?.unreadPrivateMessages ?? 0;
+  return { unreadNotifications, unreadPrivateMessages };
+}

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -65,28 +65,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
-  classes: ClassesType,
+const NotificationsMenu = ({ unreadPrivateMessages, open, setIsOpen, hasOpened, classes }: {
+  unreadPrivateMessages: number,
   open: boolean,
   setIsOpen: (isOpen: boolean) => void,
   hasOpened: boolean,
+  classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
   const [tab,setTab] = useState(0);
-  const { results } = useMulti({
-    terms: {
-      view: 'userNotifications',
-      userId: currentUser ? currentUser._id : "",
-      type: "newMessage"
-    },
-    collectionName: "Notifications",
-    fragmentName: 'NotificationsList',
-    limit: 20,
-    enableTotal: false,
-  });
 
   const [lastNotificationsCheck] = useState(currentUser?.lastNotificationsCheck ?? "");
-  const newMessages = results && _.filter(results, (x) => x.createdAt > lastNotificationsCheck);
   if (!currentUser) {
     return null;
   }
@@ -111,7 +100,7 @@ const NotificationsMenu = ({ classes, open, setIsOpen, hasOpened }: {
       icon: () => (
         <Badge
           classes={{ root: classes.badgeContainer, badge: classes.badge }}
-          badgeContent={(newMessages && newMessages.length) || ""}
+          badgeContent={unreadPrivateMessages>0 ? `${unreadPrivateMessages}` : ""}
         >
           <MailIcon classes={{root: classes.icon}} />
         </Badge>

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -1,14 +1,10 @@
 import React, { useCallback } from 'react';
 import Badge from '@material-ui/core/Badge';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { useMulti } from '../../lib/crud/withMulti';
-import { useOnNavigate } from '../hooks/useOnNavigate';
-import { useOnFocusTab } from '../hooks/useOnFocusTab';
 import IconButton from '@material-ui/core/IconButton';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import * as _ from 'underscore';
-import { useQuery, gql } from '@apollo/client';
 
 const styles = (theme: ThemeType): JssStyles => ({
   badgeContainer: {
@@ -36,40 +32,25 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const NotificationsMenuButton = ({ open, toggle, currentUser, classes }: {
+const NotificationsMenuButton = ({ unreadNotifications, open, toggle, currentUser, classes }: {
+  unreadNotifications: number,
   open: boolean,
   toggle: ()=>void,
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
-  const { data, loading, refetch } = useQuery(gql`
-    query UnreadNotificationCountQuery {
-      unreadNotificationsCount
-    }
-  `, {
-    ssr: true
-  });
-  const notificationCount = data?.unreadNotificationsCount ?? 0;
-  
-  useOnNavigate(useCallback(() => {
-    void refetch();
-  }, [refetch]));
-  useOnFocusTab(useCallback(() => {
-    void refetch();
-  }, [refetch]));
-
   const buttonClass = open ? classes.buttonOpen : classes.buttonClosed;
 
   return (
     <Badge
       classes={{ root: classes.badgeContainer, badge: classes.badge }}
-      badgeContent={(notificationCount>0) ? `${notificationCount}` : ""}
+      badgeContent={(unreadNotifications>0) ? `${unreadNotifications}` : ""}
     >
       <IconButton
         classes={{ root: buttonClass }}
         onClick={toggle}
       >
-        {(notificationCount>0) ? <NotificationsIcon /> : <NotificationsNoneIcon />}
+        {(unreadNotifications>0) ? <NotificationsIcon /> : <NotificationsNoneIcon />}
       </IconButton>
     </Badge>
   )

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -98,6 +98,7 @@ import './server/callbacks/commentCallbacks';
 import './server/callbacks/localgroupCallbacks';
 import './server/callbacks/gardenCodeCallbacks';
 import './server/resolvers/commentResolvers';
+import './server/resolvers/notificationResolvers';
 import './server/callbacks/postCallbacks';
 import './server/posts/validatePost';
 import './server/callbacks/chapterCallbacks';

--- a/packages/lesswrong/server/resolvers/notificationResolvers.ts
+++ b/packages/lesswrong/server/resolvers/notificationResolvers.ts
@@ -1,0 +1,24 @@
+import { defineQuery } from '../utils/serverGraphqlUtil';
+import { Notifications } from '../../lib/collections/notifications/collection';
+import { getDefaultViewSelector } from '../../lib/utils/viewUtils';
+
+defineQuery({
+  name: "unreadNotificationsCount",
+  resultType: "Int!",
+  fn: async (root: void, args: {}, context: ResolverContext): Promise<number> => {
+    const { currentUser } = context;
+    if (!currentUser)
+      return 0;
+    
+    const lastNotificationsCheck = currentUser.lastNotificationsCheck;
+    const notificationsCount = await Notifications.find({
+      ...getDefaultViewSelector("Notifications"),
+      userId: currentUser._id,
+      ...(lastNotificationsCheck && {
+        createdAt: {$gt: lastNotificationsCheck},
+      }),
+    }).count();
+    console.log(`notificationsCount=${notificationsCount}`);;
+    return notificationsCount;
+  }
+});


### PR DESCRIPTION
When you revisited an old tab, it would refresh your notifications (good) but not refresh your current-user object with its `lastNotificationsCheck` field; it would then use the stale last-checked date to decide that you had unread notifications, and show a number badge on the bell icon. This PR fixes that by moving the unread notifications count to a dedicated resolver, which always has an up to date `lastNotificationsCheck` because it runs server side.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203834707673252) by [Unito](https://www.unito.io)
