### PR TITLE
Speed up query used by slow bot

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -170,24 +170,6 @@ const schema: SchemaType<DbComment> = {
     hidden: true,
   },
 
-  // GraphQL only fields
-
-  pageUrl: resolverOnlyField({
-    type: String,
-    canRead: ['guests'],
-    resolver: async (comment: DbComment, args: void, context: ResolverContext) => {
-      return await commentGetPageUrlFromDB(comment, true)
-    },
-  }),
-
-  pageUrlRelative: resolverOnlyField({
-    type: String,
-    canRead: ['guests'],
-    resolver: async (comment: DbComment, args: void, context: ResolverContext) => {
-      return await commentGetPageUrlFromDB(comment, false)
-    },
-  }),
-
   answer: {
     type: Boolean,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -2377,7 +2377,7 @@ const schema: SchemaType<DbUser> = {
   },
   subforumPreferredLayout: {
     type: String,
-    allowedValues: subforumLayouts,
+    allowedValues: Array.from(subforumLayouts),
     hidden: true, // only editable by changing the setting from the subforum page
     optional: true,
     canRead: [userOwns, 'admins'],


### PR DESCRIPTION
There is a bot hitting the site with a very slow query every 5 mins at the moment, which slows down the rest of the site by consuming a lot of cpu. The query the bot is running is something like this:
```
  comments(input: $input) {
    results {
      _id
      allVotes {
        authorIds
        createdAt
        extendedVoteType
        userId
        voteType
      }
      author
      baseScore
      extendedScore
      htmlBody
      lastSubthreadActivity
      parentCommentId
      pageUrl
      post {
        _id
        pageUrl
        postedAt
        score
        slug
        title
      }
      postVersion
      postedAt
      revisions {
        changeMetrics
        editedAt
        originalContents {
          data
          type
        }
        version
        wordCount
      }
      user {
        commentCount
        createdAt
        karma
        maxCommentCount
        maxPostCount
        postCount
        username
      }
      userId
      voteCount
      wordCount
    }
  }
```
The fields `pageUrl` and `revisions` were both causing 1 query per comment, which resulted in thousands of queries.

I have removed the `pageUrl` field as it wasn't being used anywhere. It's still accessible via the post (which doesn't result in additional queries as it is fetched via a dataloader) if necessary. For `revisions` I have added a getWithLoader to batch all the lookups into 1 query.

From testing this locally against the prod db fetching 4000 comments (I only ran the slow version once so as not to brick the site):
 - previously: 44s, ~8000 db queries
 - now: 7-10s, 4 db queries


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203837007771302) by [Unito](https://www.unito.io)
