### PR TITLE
Enable improved tag editing in post edit form for drafts

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -52,7 +52,7 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     fragmentName: "TagFragment",
     limit: 100,
   });
-  
+
   if (loading) return <Loading/>
   if (!results) return null
   
@@ -76,10 +76,14 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     );
   }
   
+  const onMultiselectUpdate = (changes: { tagRelevance: string[] }) => {
+    updateValuesWithArray([...changes.tagRelevance, ...selectedSubforumTagIds]);
+  };
+  
   /**
    * When a tag is selected, add both it and its parent to the list of tags.
    */
-  const onTagSelected = (tag: {tagId: string, tagName: string, parentTagId?: string}, existingTagIds: Array<string>) => {
+  const onTagSelected = async (tag: {tagId: string, tagName: string, parentTagId?: string}, existingTagIds: Array<string>) => {
     updateValuesWithArray(
       [
         tag.tagId,
@@ -96,45 +100,34 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     updateValuesWithArray(existingTagIds.filter((thisTagId) => thisTagId !== tag.tagId))
   }
 
-  if (formType === "edit") {
-    return <FooterTagList
-      post={document}
-      hideScore
-      hidePostTypeTag
-      showCoreTags
-      link={false}
-    />
-  } else {
-    return (
-      <div className={classes.root}>
-        {showSubforumSection && (
-          <>
-            <h3 className={classNames(classes.subforumHeader, classes.header)}>Topics with subforums</h3>
-            <p className={classes.subforumExplanation}>
-              Your post is more likely to be seen by the right people if you post it in the relevant subforum. Subforums are broad topics with a dedicated community and space for general discussion.
-            </p>
-            <TagsChecklist
-              tags={subforumTags}
-              selectedTagIds={selectedTagIds}
-              onTagSelected={onTagSelected}
-              onTagRemoved={onTagRemoved}
-              displaySelected={"highlight"}
-            />
-            <h3 className={classes.header}>Other topics</h3>
-          </>
-        )}
-        <TagsChecklist tags={coreTags} selectedTagIds={selectedTagIds} onTagSelected={onTagSelected} />
-        <TagMultiselect
-          path={path}
-          placeholder={placeholder ?? `+ Add ${taggingNamePluralCapitalSetting.get()}`}
-          value={selectedTagIds.filter((tagId) => !selectedSubforumTagIds.includes(tagId))}
-          updateCurrentValues={(changes) => {
-            updateValuesWithArray([...changes.tagRelevance, ...selectedSubforumTagIds])
-          }}
-        />
-      </div>
-    );
-  }
+  return (
+    <div className={classes.root}>
+      {showSubforumSection && (
+        <>
+          <h3 className={classNames(classes.subforumHeader, classes.header)}>Topics with subforums</h3>
+          <p className={classes.subforumExplanation}>
+            Your post is more likely to be seen by the right people if you post it in the relevant subforum. Subforums
+            are broad topics with a dedicated community and space for general discussion.
+          </p>
+          <TagsChecklist
+            tags={subforumTags}
+            selectedTagIds={selectedTagIds}
+            onTagSelected={onTagSelected}
+            onTagRemoved={onTagRemoved}
+            displaySelected={"highlight"}
+          />
+          <h3 className={classes.header}>Other topics</h3>
+        </>
+      )}
+      <TagsChecklist tags={coreTags} selectedTagIds={selectedTagIds} onTagSelected={onTagSelected} />
+      <TagMultiselect
+        path={path}
+        placeholder={placeholder ?? `+ Add ${taggingNamePluralCapitalSetting.get()}`}
+        value={selectedTagIds.filter((tagId) => !selectedSubforumTagIds.includes(tagId))}
+        updateCurrentValues={onMultiselectUpdate}
+      />
+    </div>
+  );
 }
 
 const FormComponentPostEditorTaggingComponent = registerComponent("FormComponentPostEditorTagging", FormComponentPostEditorTagging, {styles});

--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -138,7 +138,6 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
       </div>
     );
   }
-
 }
 
 const FormComponentPostEditorTaggingComponent = registerComponent("FormComponentPostEditorTagging", FormComponentPostEditorTagging, {styles});

--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -100,34 +100,45 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     updateValuesWithArray(existingTagIds.filter((thisTagId) => thisTagId !== tag.tagId))
   }
 
-  return (
-    <div className={classes.root}>
-      {showSubforumSection && (
-        <>
-          <h3 className={classNames(classes.subforumHeader, classes.header)}>Topics with subforums</h3>
-          <p className={classes.subforumExplanation}>
-            Your post is more likely to be seen by the right people if you post it in the relevant subforum. Subforums
-            are broad topics with a dedicated community and space for general discussion.
-          </p>
-          <TagsChecklist
-            tags={subforumTags}
-            selectedTagIds={selectedTagIds}
-            onTagSelected={onTagSelected}
-            onTagRemoved={onTagRemoved}
-            displaySelected={"highlight"}
-          />
-          <h3 className={classes.header}>Other topics</h3>
-        </>
-      )}
-      <TagsChecklist tags={coreTags} selectedTagIds={selectedTagIds} onTagSelected={onTagSelected} />
-      <TagMultiselect
-        path={path}
-        placeholder={placeholder ?? `+ Add ${taggingNamePluralCapitalSetting.get()}`}
-        value={selectedTagIds.filter((tagId) => !selectedSubforumTagIds.includes(tagId))}
-        updateCurrentValues={onMultiselectUpdate}
-      />
-    </div>
-  );
+  if (!document.draft && formType === "edit") {
+    return <FooterTagList
+      post={document}
+      hideScore
+      hidePostTypeTag
+      showCoreTags
+      link={false}
+    />
+  } else {
+    return (
+      <div className={classes.root}>
+        {showSubforumSection && (
+          <>
+            <h3 className={classNames(classes.subforumHeader, classes.header)}>Topics with subforums</h3>
+            <p className={classes.subforumExplanation}>
+              Your post is more likely to be seen by the right people if you post it in the relevant subforum. Subforums
+              are broad topics with a dedicated community and space for general discussion.
+            </p>
+            <TagsChecklist
+              tags={subforumTags}
+              selectedTagIds={selectedTagIds}
+              onTagSelected={onTagSelected}
+              onTagRemoved={onTagRemoved}
+              displaySelected={"highlight"}
+            />
+            <h3 className={classes.header}>Other topics</h3>
+          </>
+        )}
+        <TagsChecklist tags={coreTags} selectedTagIds={selectedTagIds} onTagSelected={onTagSelected} />
+        <TagMultiselect
+          path={path}
+          placeholder={placeholder ?? `+ Add ${taggingNamePluralCapitalSetting.get()}`}
+          value={selectedTagIds.filter((tagId) => !selectedSubforumTagIds.includes(tagId))}
+          updateCurrentValues={onMultiselectUpdate}
+        />
+      </div>
+    );
+  }
+
 }
 
 const FormComponentPostEditorTaggingComponent = registerComponent("FormComponentPostEditorTagging", FormComponentPostEditorTagging, {styles});

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -11,7 +11,6 @@ import Card from '@material-ui/core/Card';
 import { Link } from '../../lib/reactRouterWrapper';
 import * as _ from 'underscore';
 import { forumSelect } from '../../lib/forumTypeUtils';
-import { filter } from 'underscore';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -71,6 +70,7 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false, s
     collectionName: "TagRels",
     fragmentName: "TagRelMinimumFragment", // Must match the fragment in the mutation
     limit: 100,
+    fetchPolicy: 'cache-and-network',
   });
 
   const tagIds = (results||[]).map((tag) => tag._id)

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -872,7 +872,8 @@ const schema: SchemaType<DbPost> = {
     type: Object,
     optional: true,
     insertableBy: ['members'],
-    editableBy: [],
+    // This must be set to editable to allow the data to be sent from the edit form, but in practice it's always overwritten by updatePostDenormalizedTags
+    editableBy: [userOwns, 'sunshineRegiment', 'admins'],
     viewableBy: ['guests'],
     
     blackbox: true,

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -2,7 +2,7 @@ import { createMutator } from '../vulcan-lib';
 import { Posts } from '../../lib/collections/posts/collection';
 import { Comments } from '../../lib/collections/comments/collection';
 import Users from '../../lib/collections/users/collection';
-import { performVoteServer } from '../voteServer';
+import { clearVotesServer, performVoteServer } from '../voteServer';
 import { voteCallbacks, VoteDocTuple } from '../../lib/voting/vote';
 import Localgroups from '../../lib/collections/localgroups/collection';
 import { PostRelations } from '../../lib/collections/postRelations/index';
@@ -19,6 +19,8 @@ import { MOVED_POST_TO_DRAFT } from '../../lib/collections/moderatorActions/sche
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { captureException } from '@sentry/core';
 import { TOS_NOT_ACCEPTED_ERROR } from '../fmCrosspost/resolvers';
+import TagRels from '../../lib/collections/tagRels/collection';
+import { updatePostDenormalizedTags } from '../tagging/tagCallbacks';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
@@ -336,36 +338,80 @@ getCollectionHooks("Posts").updateBefore.add((
   {document}: UpdateCallbackProperties<DbPost>,
 ) => handleCrosspostUpdate(document, data));
 
+async function bulkApplyPostTags ({postId, tagsToApply, currentUser, context}: {postId: string, tagsToApply: string[], currentUser: DbUser, context: ResolverContext}) {
+  const applyOneTag = async (tagId: string) => {
+    try {
+      await addOrUpvoteTag({
+        tagId, postId,
+        currentUser: currentUser!,
+        ignoreParent: true,  // Parent tags are already applied by the post submission form, so if the parent tag isn't present the user must have manually removed it
+        context
+      });
+    } catch(e) {
+      // This can throw if there's a tag applied which doesn't exist, which
+      // can happen if there are issues with the Algolia index.
+      //
+      // If we fail to add a tag, capture the exception in Sentry but don't
+      // throw from the form-submission callback. From the user perspective
+      // letting this exception esscape would make posting appear to fail (but
+      // actually the post is created, minus some of its callbacks having
+      // completed).
+      captureException(e)
+    }
+  }
+  await Promise.all(tagsToApply.map(applyOneTag))
+}
+
+async function bulkRemovePostTags ({tagRels, currentUser, context}: {tagRels: DbTagRel[], currentUser: DbUser, context: ResolverContext}) {
+  const clearOneTag = async (tagRel: DbTagRel) => {
+    try {
+      await clearVotesServer({ document: tagRel, collection: TagRels, user: currentUser, context})
+    } catch(e) {
+      captureException(e)
+    }
+  }
+  await Promise.all(tagRels.map(clearOneTag))
+}
+
 getCollectionHooks("Posts").createAfter.add(async (post: DbPost, props: CreateCallbackProperties<DbPost>) => {
   const {currentUser, context} = props;
+  if (!currentUser) return post; // Shouldn't happen, but just in case
   
   if (post.tagRelevance) {
     // Convert tag relevances in a new-post submission to creating new TagRel objects, and upvoting them.
     const tagsToApply = Object.keys(post.tagRelevance);
     post = {...post, tagRelevance: undefined};
-    
-    for (let tagId of tagsToApply) {
-      try {
-        await addOrUpvoteTag({
-          tagId, postId: post._id,
-          currentUser: currentUser!,
-          ignoreParent: true,  // Parent tags are already applied by the post submission form, so if the parent tag isn't present the user must have manually removed it
-          context
-        });
-      } catch(e) {
-        // This can throw if there's a tag applied which doesn't exist, which
-        // can happen if there are issues with the Algolia index.
-        //
-        // If we fail to add a tag, capture the exception in Sentry but don't
-        // throw from the form-submission callback. From the user perspective
-        // letting this exception esscape would make posting appear to fail (but
-        // actually the post is created, minus some of its callbacks having
-        // completed).
-        captureException(e)
-      }
+    await bulkApplyPostTags({postId: post._id, tagsToApply, currentUser, context})
+  }
+
+  return post;
+});
+
+getCollectionHooks("Posts").updateAfter.add(async (post: DbPost, props: CreateCallbackProperties<DbPost>) => {
+  const {currentUser, context} = props;
+  if (!currentUser) return post; // Shouldn't happen, but just in case
+
+  if (post.tagRelevance) {
+    const existingTagRels = await TagRels.find({ postId: post._id, baseScore: {$gt: 0} }).fetch()
+    const existingTagIds = existingTagRels.map(tr => tr.tagId);
+
+    const formTagIds = Object.keys(post.tagRelevance);
+    const tagsToApply = formTagIds.filter(tagId => !existingTagIds.includes(tagId));
+    const tagsToRemove = existingTagIds.filter(tagId => !formTagIds.includes(tagId));
+
+    const applyPromise = bulkApplyPostTags({postId: post._id, tagsToApply, currentUser, context})
+    const removePromise = bulkRemovePostTags({tagRels: existingTagRels.filter(tagRel => tagsToRemove.includes(tagRel.tagId)), currentUser, context})
+
+    await Promise.all([applyPromise, removePromise])
+    if (tagsToApply.length || tagsToRemove.length) {
+      // Rebuild the tagRelevance field on the post. It's unfortunate that we have to do this extra (slow) step, but
+      // it's necessary because tagRelevance can depend on votes from other people so it's not that straightforward to
+      // work out the final state from the data we have here.
+      // This isn't necessary in the create case because we know there will be no existing tagRels when a post is created
+      await updatePostDenormalizedTags(post._id);
     }
   }
-  
+
   return post;
 });
 


### PR DESCRIPTION
Previously this UI only worked on post creation, now it works for editing drafts too (which is presumably how most time is spent editing posts).

I've made it still fall back to the FooterTagList for published posts because it includes information about all tagRel votes, not just ones done by the editing user, which is more likely to be necessary with posts that have been public for a while (and have had tags added by moderators)

There are edge cases with drafts where multiple people could vote on tags before it's published, in which case e.g. a tag may not be fully removed by changing it in the edit form, but I don't expect this to be that common

![Screenshot 2023-01-26 at 17 55 32](https://user-images.githubusercontent.com/77623106/214913690-2f76cb66-d474-44a7-8e2f-cacfae6c5701.png)
vs what it looks like for published posts:
![Screenshot 2023-01-26 at 18 02 19](https://user-images.githubusercontent.com/77623106/214913692-b2d63a43-b27d-4c7a-8acc-70a6a17d9592.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203839103075205) by [Unito](https://www.unito.io)
