### PR TITLE
Minor UI improvements to new-user-queue

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { TupleSet, UnionOf } from '../../lib/utils/typeGuardUtils';
-
+import DescriptionIcon from '@material-ui/icons/Description'
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { userIsAdminOrMod } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
@@ -81,7 +81,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   flagged: {
     color: theme.palette.error.main
-  }
+  },
+  icon: {
+    height: 13,
+    color: theme.palette.grey[500],
+    position: "relative",
+    top: 3
+  },
 });
 
 const reduceCommentModeratorActions = (commentModeratorActions: CommentModeratorActionDisplay[]): CommentWithModeratorActions[] => {
@@ -166,6 +172,7 @@ const ModerationDashboard = ({ classes }: {
               return <div key={user._id} className={classNames(classes.tocListing, {[classes.flagged]: user.sunshineFlagged})}>
                 <a href={`${location.pathname}${location.search ?? ''}#${user._id}`}>
                   {user.displayName} 
+                  {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon className={classes.icon}/>}
                 </a>
               </div>
             })}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -37,7 +37,7 @@ const SunshineNewUserPostsList = ({posts, user, classes}: {
   classes: ClassesType,
   user: SunshineUsersList
 }) => {
-  const { MetaInfo, FormatDate, PostsTitle, SmallSideVote, PostActionsButton, ContentStyles } = Components
+  const { MetaInfo, FormatDate, PostsTitle, SmallSideVote, PostActionsButton, ContentStyles, LinkPostMessage } = Components
  
   if (!posts) return null
 
@@ -60,19 +60,22 @@ const SunshineNewUserPostsList = ({posts, user, classes}: {
                 <MetaInfo>
                   <FormatDate date={post.postedAt}/>
                 </MetaInfo>
-                {postGetCommentCount(post) && <MetaInfo>
+                <MetaInfo>
                   <Link to={`${postGetPageUrl(post)}#comments`}>
                     {postGetCommentCountStr(post)}
                   </Link>
-                </MetaInfo>}
+                </MetaInfo>
               </span>
             </div>
           </div>
           <PostActionsButton post={post} />
         </div>
-        {!post.draft && <ContentStyles contentType="postHighlight" className={classes.postBody}>
-          <div dangerouslySetInnerHTML={{__html: (post.contents?.html || "")}} />
-        </ContentStyles>}
+        {!post.draft && <div className={classes.postBody}>
+          <LinkPostMessage post={post}/>
+          <ContentStyles contentType="postHighlight">
+            <div dangerouslySetInnerHTML={{__html: (post.contents?.html || "")}} />
+          </ContentStyles>
+        </div>}
       </div>)}
     </div>
   )


### PR DESCRIPTION
– on the moderation page, puts an icon for "has posts that are awaiting review before appearing on the site" in the table-of-contents

– always shows the "number of comments" data for new user posts

– show linkpost message on new user posts.

<img width="892" alt="image" src="https://user-images.githubusercontent.com/3246710/214927011-9280cc7d-5901-4b20-8dac-e16b7922517a.png">
