### PR TITLE
Be consistent about which <NoSSR> we use

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
       { name: "@material-ui/core/Typography", message: "Don't use material-UI's Typography component; use Components.LWTypography or JSS styles" },
       { name: "@material-ui/core/Dialog", message: "Don't use material-UI's Dialog component directly, use LWDialog instead" },
       { name: "@material-ui/core/Popper", importNames: ["Popper"], message: "Don't use material-UI's Popper component directly, use LWPopper instead" },
+      { name: "@material-ui/core/NoSsr", importNames: ["Popper"], message: "Don't use @material-ui/core/NoSsr/NoSsr; use react-no-ssr instead" },
       { name: "react-router", message: "Don't import react-router, use lib/reactRouterWrapper" },
       { name: "react-router-dom", message: "Don't import react-router-dom, use lib/reactRouterWrapper" },
     ],

--- a/packages/lesswrong/components/editor/DraftJSEditor.tsx
+++ b/packages/lesswrong/components/editor/DraftJSEditor.tsx
@@ -19,7 +19,7 @@ import createLinkifyPlugin from './draftjs-plugins/linkifyPlugin'
 import ImageButton from './draftjs-plugins/image/ImageButton';
 import { Map } from 'immutable';
 import { createBlockStyleButton, ItalicButton, BoldButton, UnderlineButton, BlockquoteButton } from 'draft-js-buttons';
-import NoSsr from '@material-ui/core/NoSsr';
+import NoSSR from 'react-no-ssr';
 import { isClient } from '../../lib/executionEnvironment';
 import * as _ from 'underscore';
 
@@ -166,7 +166,7 @@ class DraftJSEditor extends Component<DraftJSEditorProps,{}> {
 
     return (
       <div>
-        <NoSsr>
+        <NoSSR>
         <div className={this.props.className} onClick={this.focus}>
           <Editor
             editorState={editorState}
@@ -182,7 +182,7 @@ class DraftJSEditor extends Component<DraftJSEditorProps,{}> {
         </div>
         <InlineToolbar />
         <AlignmentTool />
-        </NoSsr>
+        </NoSSR>
       </div>
     )
   }

--- a/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
+++ b/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import * as _ from 'underscore';
 import { useMulti } from '../../lib/crud/withMulti';
-import NoSsr from '@material-ui/core/NoSsr';
+import NoSSR from 'react-no-ssr';
 
 const styles = (theme: ThemeType): JssStyles => ({
   
@@ -38,14 +38,14 @@ const TagFlagToggleList = ({ value, path }: {
   });
 
   if (loading) return <Loading />
-  return <NoSsr><div className="multi-select-buttons">
+  return <NoSSR><div className="multi-select-buttons">
     {results?.map(({_id}) => {
       const selected = value && value.includes(_id);
       return <a key={_id} onClick={() => handleClick(_id)}>
         <TagFlagItem documentId={_id} style={selected ? "grey" : "white"} showNumber={false} />
       </a>
     })}
-  </div></NoSsr>
+  </div></NoSSR>
 }
 
 (TagFlagToggleList as any).contextTypes = {

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import NoSsr from '@material-ui/core/NoSsr'
+import NoSSR from 'react-no-ssr';
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
@@ -233,9 +233,9 @@ const PostsAnalyticsPage = ({ classes }: {
           Note 2: Data collection began on {dataCollectionFirstDay}.
         </em>
       </Typography>}
-      <NoSsr>
+      <NoSSR>
         <PostsAnalyticsInner post={post} classes={classes} />
-      </NoSsr>
+      </NoSSR>
       <Typography variant="body1" className={classes.viewingNotice} component='div'>
         <p><em>Post statistics are only viewable by {isEAForum && "authors and"} admins</em></p>
       </Typography>

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -5,7 +5,7 @@ import { useMessages } from '../common/withMessages';
 import { Posts } from '../../lib/collections/posts';
 import { postGetPageUrl, postGetEditUrl, getPostCollaborateUrl, isNotHostedHere, canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
 import { useLocation, useNavigation } from '../../lib/routeUtil'
-import NoSsr from '@material-ui/core/NoSsr';
+import NoSSR from 'react-no-ssr';
 import { styles } from './PostsNewForm';
 import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
@@ -95,7 +95,7 @@ const PostsEditForm = ({ documentId, classes }: {
     <div className={classes.postForm}>
       <HeadTags title={document.title} />
       {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
-      <NoSsr>
+      <NoSSR>
         <WrappedSmartForm
           collection={Posts}
           documentId={documentId}
@@ -141,7 +141,7 @@ const PostsEditForm = ({ documentId, classes }: {
            */
           addFields={document.isEvent ? [] : ['tagRelevance']}
         />
-      </NoSsr>
+      </NoSSR>
     </div>
   );
 }

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -6,7 +6,7 @@ import pick from 'lodash/pick';
 import React from 'react';
 import { useCurrentUser } from '../common/withUser'
 import { useLocation, useNavigation } from '../../lib/routeUtil';
-import NoSsr from '@material-ui/core/NoSsr';
+import NoSSR from 'react-no-ssr';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useDialog } from "../common/withDialog";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
@@ -213,7 +213,7 @@ const PostsNewForm = ({classes}: {
     <div className={classes.postForm}>
       <RecaptchaWarning currentUser={currentUser}>
         <Components.PostsAcceptTos currentUser={currentUser} />
-        <NoSsr>
+        <NoSSR>
           <WrappedSmartForm
             collection={Posts}
             mutationFragment={getFragment('PostsPage')}
@@ -234,7 +234,7 @@ const PostsNewForm = ({classes}: {
               FormSubmit: NewPostsSubmit
             }}
           />
-        </NoSsr>
+        </NoSSR>
       </RecaptchaWarning>
     </div>
   );

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
-import NoSsr from '@material-ui/core/NoSsr';
+import NoSSR from 'react-no-ssr';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { getNewSnoozeUntilContentCount } from './ModeratorActions';
 
@@ -50,9 +50,9 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   </div>
   
   return <div className={classes.root}>
-    <NoSsr>
+    <NoSSR>
       <SunshineNewUsersInfo user={user} currentUser={currentUser} refetch={refetch}/>
-    </NoSsr>
+    </NoSSR>
   </div>
 }
 

--- a/packages/lesswrong/server/usedMuiStyles.ts
+++ b/packages/lesswrong/server/usedMuiStyles.ts
@@ -47,7 +47,6 @@ const getUsedMuiStyles = () => {
     MuiMenu: require("@material-ui/core/Menu/Menu").styles,
     MuiMenuItem: require("@material-ui/core/MenuItem/MenuItem").styles,
     MuiModal: require("@material-ui/core/Modal/Modal").styles,
-    MuiNoSsr: require("@material-ui/core/NoSsr/NoSsr").styles,
     MuiOutlinedInput: require("@material-ui/core/OutlinedInput/OutlinedInput").styles,
     MuiPaper: require("@material-ui/core/Paper/Paper").styles,
     MuiPopover: require("@material-ui/core/Popover/Popover").styles,


### PR DESCRIPTION
We had `<NoSSR>` components from `react-no-ssr` and from `@material-ui/core` and were split 50/50 between them. Also split 50/50 between being capitalized as `NoSsr` or `NoSSR` (orthogonal to which import was used). Make it consistent, using only the react-no-ssr one, capitalized `NoSSR`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203841381024678) by [Unito](https://www.unito.io)
