### PR TITLE
Don't require the user to accept TOS to post a shortform

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -24,7 +24,7 @@ const MINIMUM_APPROVAL_KARMA = 5
 
 if (forumTypeSetting.get() === "EAForum") {
   const checkTosAccepted = <T extends Partial<DbPost>>(currentUser: DbUser | null, post: T, oldPost?: DbPost): T => {
-    if (post.draft === false && (!oldPost || oldPost.draft) && !currentUser?.acceptedTos) {
+    if (post.draft === false && !post.shortform && (!oldPost || oldPost.draft) && !currentUser?.acceptedTos) {
       throw new Error(TOS_NOT_ACCEPTED_ERROR);
     }
     return post;


### PR DESCRIPTION
This makes it so that accepting the TOS isn't required to create a shortform.

When testing, note that the bug only affects users who create their first shortform - adding a new shortform after the initial post is created bypasses this check anyway because its technically only adding a comment.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203844820934017) by [Unito](https://www.unito.io)
