### PR TITLE
Increase unit test jest timeout

### DIFF
--- a/packages/lesswrong/unitTests/unitTestSetup.ts
+++ b/packages/lesswrong/unitTests/unitTestSetup.ts
@@ -1,6 +1,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
+jest.setTimeout(20000);
+
 beforeAll(() => {
   chai.should();
   chai.use(chaiAsPromised);


### PR DESCRIPTION
The schema check unit test sometimes spuriously fails in CI due to hitting the 15 second jest timeout but I've not been able to reproduce the failure locally. This PR is an effort to try to fix it by increasing the timeout from 15 to 20 seconds. This may or may not fix the problem, but since the failures seem to be random I figure we may as well try this before spending a ton of time trying to debug it properly.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203846126372413) by [Unito](https://www.unito.io)
