### PR TITLE
Remove flexWrapEndRow to Tag Filter Settings

### DIFF
--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -37,9 +37,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     cursor: "pointer",
     border: theme.palette.tag.border
   },
-  flexWrapEndGrow: {
-    flexGrow: 9999999,
-  },
   personalTooltip: {
     ...filteringStyles(theme),
   },
@@ -119,7 +116,6 @@ const TagFilterSettings = ({
           </AddTagButton>
       </LWTooltip>}
     </div>
-    <div className={classes.flexWrapEndGrow} />
   </span>
 }
 


### PR DESCRIPTION
I think the new frontpage filters look unacceptably bad by default:

![](https://user-images.githubusercontent.com/3246710/215292330-37baef94-d560-44a5-b430-79b79bbf228a.png)

If you remove the flexWrapEndRow div, it instead looks like this, which IMO is much better:
![](https://user-images.githubusercontent.com/3246710/215292335-4a12a1d1-4f59-413c-9101-9c6ba9bc7a0d.png)

And AFAICT I can add ~2 tags with some filtering and it still looks pretty reasonable, because of how the Personal Blog and "Add" buttons work:
![](https://user-images.githubusercontent.com/3246710/215292609-08502d26-38ad-4374-a68a-f2dfbc7cff98.png)

It's not until I add _three_ new tags that it starts looking weird. I agree this looks bad, but a) I honestly don't think it's _horrendously bad_ and meanwhile I predict only a teeny fraction of users are going to add 3 tags and see it looking like this in the first place.
![](https://user-images.githubusercontent.com/3246710/215292639-914dacc4-3d07-4077-ac85-ad7415252188.png)

(This might be different on the EA Forum that has fewer tags by default, I'm not sure what that ends up looking like, could imagine forum-gating a solution here)

I futzed around with some other options to see if there was a "get the best of both worlds" option but couldn't find anything that seemed better. (I do still think it's not crazy to just conditionally-display the flexWrapEndRow if there are 3+ tags or something, I don't think it's as madness inducing as jpaddison3 and jimrandomh think. I agree it's at least a _little_ madness inducing, so just proposing this simple change instead for now)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203850294874049) by [Unito](https://www.unito.io)
