### PR TITLE
Fix LWTooltip eating its contents if no title is provided

### DIFF
--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -31,7 +31,7 @@ const LWTooltip = ({classes, className, children, title, placement="bottom-start
     title: typeof title=="string" ? title : undefined
   });
   
-  if (!title) return <>children</>
+  if (!title) return <>{children}</>
 
   return <span className={classNames({[classes.root]: inlineBlock}, className)} {...eventHandlers}>
     { /* Only render the LWPopper if this element has ever been hovered. (But

--- a/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
@@ -29,7 +29,7 @@ const LocalGroupsList = ({terms, children, classes, showNoResults=true, heading}
       <SectionTitle title={heading} />
       {children}
     </SingleColumnSection> :
-    <>children</>;
+    <>{children}</>;
 
   if (!results && loading) return <Loading />
 


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203850370498212) by [Unito](https://www.unito.io)
