### PR TITLE
Fix pingbacks in Postgres

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -11,6 +11,7 @@ import { Posts } from './collection';
 import { postStatuses, startHerePostIdSetting } from './constants';
 import uniq from 'lodash/uniq';
 import { INITIAL_REVIEW_THRESHOLD, getPositiveVoteThreshold, QUICK_REVIEW_SCORE_THRESHOLD, ReviewPhase, REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD, VOTING_PHASE_REVIEW_THRESHOLD } from '../../reviewUtils';
+import { jsonArrayContainsSelector } from '../../utils/viewUtils';
 
 export const DEFAULT_LOW_KARMA_THRESHOLD = -10
 export const MAX_LOW_KARMA_THRESHOLD = -1000
@@ -1238,7 +1239,7 @@ ensureIndex(Posts,
 Posts.addView("pingbackPosts", (terms: PostsViewTerms) => {
   return {
     selector: {
-      "pingbacks.Posts": terms.postId,
+      ...jsonArrayContainsSelector(Posts, "pingbacks.Posts", terms.postId),
       baseScore: {$gt: 0}
     },
     options: {

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -157,3 +157,10 @@ function replaceSpecialFieldSelectors(selector: any): any {
   return result;
 }
 
+export const jsonArrayContainsSelector = <T extends DbObject>(
+  collection: CollectionBase<T>,
+  field: string,
+  value: any,
+) => collection.isPostgres()
+  ? {$expr: {$jsonArrayContains: [field, value]}}
+  : {[field]: value};

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -74,6 +74,12 @@ describe("SelectQuery", () => {
       expectedArgs: [3, "b"],
     },
     {
+      name: "can build select query with $jsonArrayContains operator",
+      getQuery: () => new SelectQuery(testTable, {$expr: {$jsonArrayContains: ["a.b.c.d", 3]}}),
+      expectedSql: `SELECT "TestCollection".* FROM "TestCollection" WHERE "a" @> (' { "b": { "c": { "d": ["' || $1 || '"] } } } ')::JSONB`,
+      expectedArgs: [3],
+    },
+    {
       name: "can build select query with nested boolean combiners",
       getQuery: () => new SelectQuery(testTable, {a: 3, $or: [{b: "hello"}, {c: {$exists: false}}]}),
       expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE ( "a" = $1 AND ( "b" = $2 OR "c" IS NULL ) )',


### PR DESCRIPTION
This PR fixes pingbacks on the EA Forum which were broken when we migrated posts to Postgres. The solution here is to add a new mongo-like operator that is only used when we're in Postgres which can correctly generate the SQL without requiring schemas for deep JSON objects. This is a bit of a hack, but it's also pretty rare in the code base.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203859716354875) by [Unito](https://www.unito.io)
