### PR TITLE
Cron history log spam

### DIFF
--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
@@ -218,7 +218,7 @@ SyncedCron._entryWrapper = function(entry: any) {
       // If we have a dup key error, another instance has already tried to run
       // this job.
       try {
-        jobHistory._id = await self._collection.rawInsert(jobHistory);
+        jobHistory._id = await self._collection.rawInsert(jobHistory, {quiet: true});
       } catch(e) {
         if (isDuplicateKeyError(self._collection, e)) {
           log.info('Not running "' + entry.name + '" again.');


### PR DESCRIPTION
The cron history code detects duplicate database entries by allowing the insert query to throw a duplciate key error which it then catches and handles. However, `PgCollection` also sees this error and logs it to the console before it gets caught by the cron code which leads to a lot of log spam. This PR adds a "quiet" mode so we can disable Postgres error logging for this query.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203860417886965) by [Unito](https://www.unito.io)
