### PR TITLE
Fix missing space between author and title in EmailComment

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -127,6 +127,7 @@ const EmailComment = ({commentId, classes}: {
       </a>
       {" by "}
       <EmailUsername user={comment.user}/>
+      {" "}
       {comment.post && <a href={postGetPageUrl(comment.post, true)}>
         {comment.post.title}
       </a>}


### PR DESCRIPTION
Introduced in: [aafcfbad51520c9883c2e9602052483dddf998a8](https://github.com/ForumMagnum/ForumMagnum/commit/aafcfbad51520c9883c2e9602052483dddf998a8)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203860521514231) by [Unito](https://www.unito.io)
