### PR TITLE
Quiet log spam from x-post server not running

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/resolvers.ts
+++ b/packages/lesswrong/server/fmCrosspost/resolvers.ts
@@ -40,7 +40,6 @@ export const makeCrossSiteRequest = async <RouteName extends ValidatedPostRouteN
   } catch (e) {
     if (e.cause.code === 'ECONNREFUSED' && e.cause.port === 4000) {
       // We're testing locally, and the x-post server isn't running
-      // Slime
       return { document: {} }
     } else {
       throw e


### PR DESCRIPTION
I just created like a million test crossposts and now running the server without an x-post server running is a dumpster fire. This fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203868589167062) by [Unito](https://www.unito.io)
