### PR TITLE
Add PostsTagsList to All Posts Timeblock

### DIFF
--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -7,6 +7,7 @@ import { useTimezone } from '../common/withTimezone';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import type { ContentTypeString } from './PostsPage/ContentType';
 import filter from 'lodash/filter';
+import { useLocation } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -68,7 +69,7 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
   startDate: moment.Moment,
   hideIfEmpty: boolean,
   timeframe: TimeframeType,
-  displayShortform: any,
+  displayShortform?: boolean,
   classes: ClassesType,
   includeTags?: boolean,
 }) => {
@@ -77,7 +78,9 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
   const { timezone } = useTimezone();
 
   const [tagFilter, setTagFilter] = useState<string|null>(null)
-  
+  const {query} = useLocation()
+  const displayPostsTagsList = query.limit
+
   const { results: posts, totalCount, loading, loadMoreProps } = useMulti({
     terms,
     collectionName: "Posts",
@@ -169,7 +172,7 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
               `this ${timeBlock}`
             }
           </div> }
-          <PostsTagsList posts={posts ?? null} currentFilter={tagFilter} handleFilter={handleTagFilter} expandedMinCount={0}/>
+          {displayPostsTagsList && <PostsTagsList posts={posts ?? null} currentFilter={tagFilter} handleFilter={handleTagFilter} expandedMinCount={0}/>}
           {postGroups.map(({name, filteredPosts, label}) => {
             if (filteredPosts?.length > 0) return <div key={name}>
               <div

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -6,6 +6,7 @@ import { timeframeToTimeBlock, TimeframeType } from './timeframeUtils'
 import { useTimezone } from '../common/withTimezone';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import type { ContentTypeString } from './PostsPage/ContentType';
+import filter from 'lodash/filter';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -74,6 +75,8 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
   const [noShortform, setNoShortform] = useState(false);
   const [noTags, setNoTags] = useState(false);
   const { timezone } = useTimezone();
+
+  const [tagFilter, setTagFilter] = useState<string|null>(null)
   
   const { results: posts, totalCount, loading, loadMoreProps } = useMulti({
     terms,
@@ -82,6 +85,16 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
     enableTotal: true,
     itemsPerPage: 50,
   });
+
+  const filteredPosts = tagFilter ? filter(posts, post => post.tags.map(tag=>tag._id).includes(tagFilter)) : posts
+
+  const handleTagFilter = (tagId: string) => {
+    if (tagFilter === tagId) { 
+      setTagFilter(null)
+    } else {
+      setTagFilter(tagId)
+    }
+  }
 
   useEffect(() => {
     if (!loading && timeBlockLoadComplete) {
@@ -108,10 +121,10 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
   }
 
   const render = () => {
-    const { PostsItem2, LoadMore, ShortformTimeBlock, TagEditsTimeBlock, ContentType, Divider, Typography } = Components
+    const { PostsItem2, LoadMore, ShortformTimeBlock, TagEditsTimeBlock, ContentType, Divider, Typography, PostsTagsList } = Components
     const timeBlock = timeframeToTimeBlock[timeframe]
 
-    const noPosts = !loading && (!posts || (posts.length === 0))
+    const noPosts = !loading && (!filteredPosts || (filteredPosts.length === 0))
     // The most recent timeBlock is hidden if there are no posts or shortforms
     // on it, to avoid having an awkward empty partial timeBlock when it's close
     // to midnight.
@@ -121,7 +134,7 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
 
     const postGroups = postTypes.map(type => ({
       ...type,
-      posts: posts?.filter(type.postIsType) || []
+      filteredPosts: filteredPosts?.filter(type.postIsType) || []
     }))
 
     return (
@@ -156,23 +169,23 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
               `this ${timeBlock}`
             }
           </div> }
-
-          {postGroups.map(({name, posts, label}) => {
-            if (posts?.length > 0) return <div key={name}>
+          <PostsTagsList posts={posts ?? null} currentFilter={tagFilter} handleFilter={handleTagFilter} expandedMinCount={0}/>
+          {postGroups.map(({name, filteredPosts, label}) => {
+            if (filteredPosts?.length > 0) return <div key={name}>
               <div
                 className={name === 'frontpage' ? classes.frontpageSubtitle : classes.otherSubtitle}
               >
                 <ContentType type={name} label={label} />
               </div>
               <div className={classes.posts}>
-                {posts.map((post, i) =>
-                  <PostsItem2 key={post._id} post={post} index={i} dense showBottomBorder={i < posts!.length -1}/>
+                {filteredPosts.map((post, i) =>
+                  <PostsItem2 key={post._id} post={post} index={i} dense showBottomBorder={i < filteredPosts!.length -1}/>
                 )}
               </div>
             </div>
           })}
 
-          {(posts && posts.length < totalCount!) && <div className={classes.loadMore}>
+          {(filteredPosts && filteredPosts.length < totalCount!) && <div className={classes.loadMore}>
             <LoadMore
               {...loadMoreProps}
             />

--- a/packages/lesswrong/components/tagging/PostsTagsList.tsx
+++ b/packages/lesswrong/components/tagging/PostsTagsList.tsx
@@ -41,11 +41,17 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 type TagWithCount = TagPreviewFragment & {count:number}
 
-export const PostsTagsList = ({classes, posts, currentFilter, handleFilter}:{
+// This is designed to be used with list of posts, to show a list of all the tags currently
+// included among that list of posts, and allow users to filter the post list to only show 
+// those tags.
+export const PostsTagsList = ({classes, posts, currentFilter, handleFilter, expandedMinCount=3, defaultMax=6}:{
   classes: ClassesType,
   posts: PostsList[]|null,
-  currentFilter: string|null,
-  handleFilter: (string) => void
+  currentFilter: string|null, // the current tag being filtered on the post list
+  handleFilter: (string) => void, // function to update which tag is being filtered
+  expandedMinCount?: number // when showing more tags, this is the number
+  // of posts each tag needs to have to be included
+  defaultMax?: number // default number of tags to show
 }) => {
   const { LWTooltip } = Components
 
@@ -56,10 +62,6 @@ export const PostsTagsList = ({classes, posts, currentFilter, handleFilter}:{
     ...tag,
     count: allTags.filter(t => t._id === tag._id).length
   }))
-
-  const defaultMax = 6 // default number of tags to show
-  const expandedMinCount = 3 // when showing more tags, this is the number
-  // of posts each tag needs to have to be included
 
   const [max, setMax] = useState<number>(defaultMax)
   const sortedTagsWithCount = sortBy(tagsWithCount, tag => -tag.count)


### PR DESCRIPTION
This might be a controversial idea, but seemed easy to just whip up a PR to showcase it. If either @darkruby501 or @jpaddison3 don't like it, can either give up on it or forum-gate.

But, after creating my PostsTagsList for the LW Review, I found myself wishing I could use it in some other contexts. I think it'd be reasonable to have it on the AllPosts page, so you can see what the tag distribution each month was, and possibly filter tags if you want:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/3246710/216761036-b018094b-7385-45b9-95e6-f7eea50de1fb.png">

You might want instead to do some fancier thing that has something more like fully-fledged tag-filters. A problem with the current implementation is it only shows you the post-totals for the posts that you've already loaded. 

I think it might make sense to only show this if you've set a custom limit in the url, i.e. by clicking on a month (which sets the limit to 100), which would only show the tag-filters on pages that have loaded a substantial number of posts, so it feels less like it's cluttering the default experience.

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/3246710/216761136-46c2c356-8a78-45e2-898c-e5f02dbc7ffb.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203897585715049) by [Unito](https://www.unito.io)
