### PR TITLE
Moderation page link

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import * as _ from 'underscore';
 import { postGetCommentCountStr } from '../../lib/collections/posts/helpers';
 import { CommentsNewFormProps } from './CommentsNewForm';
+import { Link } from '../../lib/reactRouterWrapper';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 
@@ -85,6 +86,8 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
   const currentUser = useCurrentUser();
   const commentTree = unflattenComments(comments);
   
+  const { LWTooltip, CommentsList, PostsPageCrosspostComments, MetaInfo, Row } = Components
+
   const [highlightDate,setHighlightDate] = useState<Date|undefined>(post?.lastVisitedAt && new Date(post.lastVisitedAt));
   const [anchorEl,setAnchorEl] = useState<HTMLElement|null>(null);
   const newCommentsSinceDate = highlightDate ? _.filter(comments, comment => new Date(comment.postedAt).getTime() > new Date(highlightDate).getTime()).length : 0;
@@ -182,7 +185,7 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         <Components.CantCommentExplanation post={post}/>
       }
       { totalComments ? renderTitleComponent() : null }
-      <Components.CommentsList
+      <CommentsList
         treeOptions={{
           highlightDate: highlightDate,
           post: post,
@@ -195,7 +198,14 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
       />
-      <Components.PostsPageCrosspostComments />
+      <PostsPageCrosspostComments />
+      <LWTooltip title="View deleted comments and banned users">
+        <Row justifyContent="flex-end">
+          <Link to="/moderation">
+            <MetaInfo>Moderation Log</MetaInfo>
+          </Link>
+        </Row>
+      </LWTooltip>
     </div>
   );
 }

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -7,14 +7,17 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
 import { useCurrentUser } from '../common/withUser';
-import { unflattenComments, CommentTreeNode } from '../../lib/utils/unflatten';
+import { unflattenComments } from '../../lib/utils/unflatten';
 import classNames from 'classnames';
 import * as _ from 'underscore';
 import { postGetCommentCountStr } from '../../lib/collections/posts/helpers';
 import { CommentsNewFormProps } from './CommentsNewForm';
 import { Link } from '../../lib/reactRouterWrapper';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
+
+const isEAForum = forumTypeSetting.get() === 'EAForum';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -199,13 +202,13 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         parentAnswerId={parentAnswerId}
       />
       <PostsPageCrosspostComments />
-      <Row justifyContent="flex-end">
+      {!isEAForum && <Row justifyContent="flex-end">
         <LWTooltip title="View deleted comments and banned users">
           <Link to="/moderation">
             <MetaInfo>Moderation Log</MetaInfo>
           </Link>
         </LWTooltip>
-      </Row>
+      </Row>}
     </div>
   );
 }

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -199,13 +199,13 @@ const CommentsListSection = ({post, tag, commentCount, loadMoreCount, totalComme
         parentAnswerId={parentAnswerId}
       />
       <PostsPageCrosspostComments />
-      <LWTooltip title="View deleted comments and banned users">
-        <Row justifyContent="flex-end">
+      <Row justifyContent="flex-end">
+        <LWTooltip title="View deleted comments and banned users">
           <Link to="/moderation">
             <MetaInfo>Moderation Log</MetaInfo>
           </Link>
-        </Row>
-      </LWTooltip>
+        </LWTooltip>
+      </Row>
     </div>
   );
 }

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -13,7 +13,7 @@ import * as _ from 'underscore';
 import { postGetCommentCountStr } from '../../lib/collections/posts/helpers';
 import { CommentsNewFormProps } from './CommentsNewForm';
 import { Link } from '../../lib/reactRouterWrapper';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { isEAForum } from '../../lib/instanceSettings';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -17,7 +17,6 @@ import { isEAForum } from '../../lib/instanceSettings';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 
-const isEAForum = forumTypeSetting.get() === 'EAForum';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
@@ -126,6 +126,7 @@ const deletedCommentColumns: Column[] = [
 const usersBannedFromPostsColumns: Column[] = [
   {
     name: 'user',
+    label: "Author",
     component: UserDisplay,
   },
   {

--- a/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
@@ -147,7 +147,12 @@ const usersBannedFromUsersColumns: Column[] = [
   },
   {
     name:'bannedUserIds',
-    label:'Banned Users',
+    label:'Banned From Frontpage',
+    component: BannedUsersDisplay
+  },
+  {
+    name:'bannedPersonalUserIds',
+    label:'Banned from Personal Posts',
     component: BannedUsersDisplay
   },
 ]
@@ -185,7 +190,7 @@ const ModerationLog = ({classes}: {
             options={{
               fragmentName: 'UsersBannedFromPostsModerationLog',
               terms: {view: "postsWithBannedUsers"},
-              limit: 10,
+              limit: 20,
               enableTotal: true
             }}
             showEdit={false}
@@ -200,7 +205,7 @@ const ModerationLog = ({classes}: {
             options={{
               fragmentName: 'UsersBannedFromUsersModerationLog',
               terms: {view: "usersWithBannedUsers"},
-              limit: 10,
+              limit: 20,
               enableTotal: true
             }}
             showEdit={false}

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -250,6 +250,7 @@ registerFragment(`
     slug
     displayName
     bannedUserIds
+    bannedPersonalUserIds
   }
 `)
 

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -110,7 +110,7 @@ Users.addView('LWUsersAdmin', (terms: UsersViewTerms) => ({
 Users.addView("usersWithBannedUsers", function () {
   return {
     selector: {
-      $or: [{bannedPersonalUserIds: {exists:true}}, {bannedUserIds: {$exists: true}}]
+      $or: [{bannedPersonalUserIds: {$ne:null}}, {bannedUserIds: {$ne:null}}]
     },
   }
 })

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -110,7 +110,7 @@ Users.addView('LWUsersAdmin', (terms: UsersViewTerms) => ({
 Users.addView("usersWithBannedUsers", function () {
   return {
     selector: {
-      bannedUserIds: {$exists: true}
+      $or: [{bannedPersonalUserIds: {exists:true}}, {bannedUserIds: {$exists: true}}]
     },
   }
 })

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2439,6 +2439,7 @@ interface UsersBannedFromUsersModerationLog { // fragment on Users
   readonly slug: string,
   readonly displayName: string,
   readonly bannedUserIds: Array<string>,
+  readonly bannedPersonalUserIds: Array<string>,
 }
 
 interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users


### PR DESCRIPTION
Adds a link to the moderation page at the bottom of post pages.

My guess is EAForum doesn't currently want this (they had previously hidden the moderation page from non-admins since it otherwise wasn't very discoverable and some people found it jarring to find out their moderation decisions were public). I can either forum-gate this for EA Forum, or remove the admin-gate for the /moderation page. 

Also fixes a bug in the /moderation page where people who'd only banned users from their personal blogposts weren't showing up. 

<img width="740" alt="image" src="https://user-images.githubusercontent.com/3246710/216762640-535e4170-cb3a-479a-8ec9-e0cb6a009d36.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203897826008742) by [Unito](https://www.unito.io)
