### PR TITLE
Hide Unapproved Posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -182,15 +182,6 @@ const PostsPage = ({post, refetch, classes}: {
     return params.sequenceId || post?.canonicalSequenceId;
   }
 
-  const shouldHideAsSpam = () => {
-    // Logged-out users shouldn't be able to see spam posts
-    if (post.authorIsUnreviewed && !currentUser) {
-      return true;
-    }
-
-    return false;
-  }
-
   const { query, params } = location;
 
   const sortBy = query.answersSorting || "top";
@@ -224,10 +215,6 @@ const PostsPage = ({post, refetch, classes}: {
     });
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [post._id]);
-  
-  if (shouldHideAsSpam()) {
-    throw new Error("Logged-out users can't see unreviewed (possibly spam) posts");
-  }
   
   const defaultSideCommentVisibility = userHasSideComments(currentUser)
     ? (post.sideCommentVisibility ?? "highKarma")

--- a/packages/lesswrong/lib/collections/posts/permissions.ts
+++ b/packages/lesswrong/lib/collections/posts/permissions.ts
@@ -53,6 +53,8 @@ Posts.checkAccess = async (currentUser: DbUser|null, post: DbPost, context: Reso
     return true;
   } else if (post.isFuture || post.draft) {
     return false;
+  } else if (post.authorIsUnreviewed) {
+    return false
   } else {
     const status = _.findWhere(postStatusLabels, {value: post.status});
     if (!status) return false;


### PR DESCRIPTION
We were running into some posts from unapproved users, who were nonetheless getting comments. Previously, unapproved posts were hidden at the frontend client level, and the view level, but not the post permissions level. This hid unapproved posts from most places you might normally find them, but somehow people keep finding little edge cases and start commenting before admins have approved.

This PR puts logic into Posts.checkAccess. 

I've tested that this results in:
– the post author can see the post
– an admin can see the post
– a random user cannot see the post (this is a change from status quo)

– post author can see the post on their user profile
– an admin can see the post on their user profile
– a random user cannot see the post on their user profile (this is a change from status quo)

I removed the "shouldHideAsSpam" function from the client since it's now superfluous. 

The error message that you get if you try to navigate to an unapproved post without permission to view it is now a bit more confusing (it says "Sorry, you don't have access to this page. This is usually because the post in question has been removed by the author."). That messaging is slightly misleading (although not false). But, also, now that we're making it much harder to view the post, it shouldn't come up very often.