### PR TITLE
Fix shortforms being hidden in recent discussion

### DIFF
--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -139,7 +139,7 @@ function getParameters<N extends CollectionNameString, T extends DbObject=Object
  * in that context, the specific-view needs something other than `undefined` to
  * replace the default-view's constraint with.)
  */
-function replaceSpecialFieldSelectors(selector: any): any {
+export function replaceSpecialFieldSelectors(selector: any): any {
   let result: any = {};
   for (let key of Object.keys(selector)) {
     if (_.isEqual(selector[key], viewFieldNullOrMissing)) {

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -3,8 +3,8 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { Tags } from '../../lib/collections/tags/collection';
 import { Revisions } from '../../lib/collections/revisions/collection';
 import { forumTypeSetting } from '../../lib/instanceSettings';
-import { filterModeIsSubscribed } from '../../lib/filterSettings';
 import Comments from '../../lib/collections/comments/collection';
+import { viewFieldAllowAny } from '../vulcan-lib';
 
 defineFeedResolver<Date>({
   name: "RecentDiscussionFeed",
@@ -46,9 +46,9 @@ defineFeedResolver<Date>({
             $or: [{isEvent: false}, {globalEvent: true}, {commentCount: {$gt: 0}}],
             lastCommentedAt: {$exists: true},
             hideFromRecentDiscussions: {$ne: true},
-            hiddenRelatedQuestion: undefined,
-            shortform: undefined,
-            groupId: undefined,
+            hiddenRelatedQuestion: viewFieldAllowAny,
+            shortform: viewFieldAllowAny,
+            groupId: viewFieldAllowAny,
             ...(af ? {af: true} : undefined),
           },
         }),

--- a/packages/lesswrong/server/utils/feedUtil.ts
+++ b/packages/lesswrong/server/utils/feedUtil.ts
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import { addGraphQLResolvers, addGraphQLQuery, addGraphQLSchema } from '../../lib/vulcan-lib/graphql';
 import { accessFilterMultiple } from '../../lib/utils/schemaUtils';
-import { getDefaultViewSelector, mergeSelectors } from '../../lib/utils/viewUtils';
+import { getDefaultViewSelector, mergeSelectors, replaceSpecialFieldSelectors } from '../../lib/utils/viewUtils';
 
 export type FeedSubquery<ResultType extends DbObject, SortKeyType> = {
   type: string,
@@ -243,7 +243,8 @@ async function queryWithCutoff<ResultType extends DbObject>({
     selector,
     cutoffSelector
   )
-  const resultsRaw = await collection.find(mergedSelector, {
+  const finalizedSelector = replaceSpecialFieldSelectors(mergedSelector);
+  const resultsRaw = await collection.find(finalizedSelector, {
     sort: sort as Partial<Record<keyof ResultType, number>>,
     limit,
   }).fetch();


### PR DESCRIPTION
TL;DR look at the code, `viewFieldAllowAny`.

***

In #6618, we introduced the concept of `mergeSelectors`, which fixed a bug with merging selectors with `$and` and `$or`. `mergeSelectors` replaced two[^1] places where we merged selectors. One place, in views, we used `_.merge`, which was a recursive merge, and also did some other fanciness. The other place was in `queryWithCutoff` in `feedUtil.ts`, where we were simply doing a spread merge, ie:

```ts
const merged = {
  ...selector1,
  ...selector2
}
```

In our `mergeSelectors` function, we used `_.merge` for the non-boolean-conjuctor parts of the selectors. It turns out the fanciness of `_.merge` introduced a bug. We were, in `recentDiscussionFeed.ts` relying on the non-fanciness of the spread method. Specifically, we were doing, in the end:

```ts
const merged = {
  ...{[stuff], shortform: false},
  ...{[stuff], shortform: undefined}
}
```

And relying on the second `shortform: undefined` to override `shortform: false`. In the new fanciness world, `_.merge` was saying: "oh, I'm merging an object with a real value with an object with an undefined one, I'll prefer the one with the real value", which was contrary to what we wanted.

We can fix this the same way the view system fixes this, by using a special object called `viewFieldAllowAny`, that says, basically, "remove this from the resulting selector". It must be post-processed, but we have a function for that.

[^1]: I think two, maybe three, but two _types_ of merges

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203913905212559) by [Unito](https://www.unito.io)
