### PR TITLE
Fix logout on server refresh

### DIFF
--- a/packages/lesswrong/lib/SwitchingCollection.ts
+++ b/packages/lesswrong/lib/SwitchingCollection.ts
@@ -240,7 +240,7 @@ class SwitchingCollection<T extends DbObject> {
    * are searching by primary key, and the network overhead is minimal as the
    * database and server instances are both in the same AWS region.
    */
-  startPolling(): void {
+  startPolling(): Promise<void> {
     const poll = async () => {
       const {collectionName} = this.mongoCollection.options as any;
       const {read, write} = await getCollectionLockType(collectionName);
@@ -249,7 +249,7 @@ class SwitchingCollection<T extends DbObject> {
       setTimeout(poll, SwitchingCollection.POLL_RATE_SECONDS * 1000);
     }
 
-    void poll();
+    return poll();
   }
 }
 

--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -109,7 +109,7 @@ const initSettings = () => {
   return refreshSettingsCaches();
 }
 
-const initPostgres = () => {
+const initPostgres = async () => {
   if (Collections.some(collection => collection instanceof PgCollection || collection instanceof SwitchingCollection)) {
     // eslint-disable-next-line no-console
     console.log("Building postgres tables");
@@ -122,11 +122,13 @@ const initPostgres = () => {
 
   // eslint-disable-next-line no-console
   console.log("Initializing switching collections from lock table");
+  const polls: Promise<void>[] = [];
   for (const collection of Collections) {
     if (collection instanceof SwitchingCollection) {
-      collection.startPolling();
+      polls.push(collection.startPolling());
     }
   }
+  await Promise.all(polls);
 }
 
 const executeServerWithArgs = async ({shellMode, command}: CommandLineArguments) => {
@@ -160,7 +162,7 @@ export const initServer = async (commandLineArguments?: CommandLineArguments) =>
   await initDatabases(args);
   await initSettings();
   require('../server.ts');
-  initPostgres();
+  await initPostgres();
   return args;
 }
 


### PR DESCRIPTION
We currently have in issue on dev where the user appears to be logged out when the server restarts, but is logged in after refreshing. This is caused by the page making the new request before the `SwitchingCollection` has had a change to poll the value in `mongo2pg_lock` meaning it thinks it's still a `MongoCollection` even after being migrated. The fix here is just to wait for the first poll to finish before allowing the server to start listening for requests.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203920886786302) by [Unito](https://www.unito.io)
