### PR TITLE
Fix subforum feed margins

### DIFF
--- a/packages/lesswrong/components/comments/CommentFrame.tsx
+++ b/packages/lesswrong/components/comments/CommentFrame.tsx
@@ -113,7 +113,25 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const CommentFrame = ({comment, treeOptions, onClick, id, nestingLevel, hasChildren, highlighted, isSingleLine, isChild, isNewComment, isReplyToAnswer, hoverPreview, shortform, showPinnedOnProfile, children, classes}: {
+const CommentFrame = ({
+  comment,
+  treeOptions,
+  onClick,
+  id,
+  nestingLevel,
+  hasChildren,
+  highlighted,
+  isSingleLine,
+  isChild,
+  isNewComment,
+  isReplyToAnswer,
+  hoverPreview,
+  shortform,
+  showPinnedOnProfile,
+  children,
+  className,
+  classes
+}: {
   comment: CommentsList,
   treeOptions: CommentTreeOptions,
   onClick?: (event: any)=>void,
@@ -131,6 +149,7 @@ const CommentFrame = ({comment, treeOptions, onClick, id, nestingLevel, hasChild
   showPinnedOnProfile?: boolean,
   
   children: React.ReactNode,
+  className?: string,
   classes: ClassesType,
 }) => {
   const { condensed, postPage } = treeOptions;
@@ -139,6 +158,7 @@ const CommentFrame = ({comment, treeOptions, onClick, id, nestingLevel, hasChild
     "comments-node",
     nestingLevelToClass(nestingLevel, classes),
     classes.node,
+    className,
     {
       "af":comment.af,
       [classes.highlightAnimation]: highlighted,
@@ -184,7 +204,7 @@ const nestingLevelToClass = (nestingLevel: number, classes: ClassesType): string
 }
 
 
-const CommentFrameComponent = registerComponent('CommentFrame', CommentFrame, {styles});
+const CommentFrameComponent = registerComponent('CommentFrame', CommentFrame, {styles, stylePriority: -1});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -24,6 +24,7 @@ export interface CommentWithRepliesProps {
   initialMaxChildren?: number;
   commentNodeProps?: Partial<CommentsNodeProps>;
   startExpanded?: boolean;
+  className?: string;
   classes: ClassesType;
 }
 
@@ -34,6 +35,7 @@ const CommentWithReplies = ({
   initialMaxChildren = 3,
   commentNodeProps,
   startExpanded,
+  className,
   classes,
 }: CommentWithRepliesProps) => {
   const { hash: focusCommentId } = useLocation();
@@ -89,6 +91,7 @@ const CommentWithReplies = ({
       expandByDefault={startExpanded}
       {...commentNodeProps}
       treeOptions={treeOptions}
+      className={className}
     />
   );
 };

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -71,6 +71,7 @@ export interface CommentsNodeProps {
   showParentDefault?: boolean,
   noAutoScroll?: boolean,
   displayTagIcon?: boolean,
+  className?: string,
   classes: ClassesType,
 }
 /**
@@ -103,6 +104,7 @@ const CommentsNode = ({
   showParentDefault=false,
   noAutoScroll=false,
   displayTagIcon=false,
+  className,
   classes,
 }: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
@@ -223,6 +225,7 @@ const CommentsNode = ({
       hoverPreview={hoverPreview}
       shortform={shortform}
       showPinnedOnProfile={showPinnedOnProfile}
+      className={className}
     >
       {comment._id && <div ref={scrollTargetRef}>
         {isSingleLine

--- a/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
@@ -57,6 +57,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 16,
     padding: "0px 8px 8px 8px",
   },
+  shortformComment: {
+    '&&': {
+      marginTop: 0,
+      marginBottom: 32,
+    }
+  },
   centerChild: {
     display: "flex",
     justifyContent: "center",
@@ -136,7 +142,6 @@ const SubforumSubforumTab = ({tag, userTagRel, layout, isSubscribed, classes}: {
   const commentNodeProps = {
     treeOptions: {
       postPage: true,
-      showPostTitle: false,
       refetch,
       tag,
     },
@@ -254,6 +259,7 @@ const SubforumSubforumTab = ({tag, userTagRel, layout, isSubscribed, classes}: {
               comment={comment}
               commentNodeProps={commentNodeProps}
               initialMaxChildren={5}
+              className={classes.shortformComment}
             />
           ),
         },


### PR DESCRIPTION
Previously:
![image](https://user-images.githubusercontent.com/10352319/217590652-ecadf8f8-ed28-4ada-aa22-4a4a896dc44a.png)
Too small margins. Now they're all 32px.

Coauthored with @s-cheng

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203930648132696) by [Unito](https://www.unito.io)
