### PR TITLE
Allow adding draft posts to sequences via canonicalSequenceId

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -26,7 +26,6 @@ import { crosspostKarmaThreshold } from '../../publicSettings';
 import { userHasSideComments } from '../../betas';
 import { getDefaultViewSelector } from '../../utils/viewUtils';
 import { Sequences } from '../sequences/collection';
-import { mongoFind } from '../../mongoQueries';
 
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
 
@@ -135,11 +134,11 @@ const schemaDefaultValueFmCrosspost = schemaDefaultValue({
   isCrosspost: false,
 })
 
-const sequenceIdIfPermitted = async (post, currentUser) => {
+const sequenceIdIfPermitted = async (post: DbPost|Partial<DbPost>, currentUser: DbUser|null) => {
   if (!post.canonicalSequenceId) return null;
 
   const sequence = await Sequences.findOne({ _id: post.canonicalSequenceId });
-  if (!Sequences.options.mutations.edit.check(currentUser, sequence)) return null;
+  if (!Sequences.checkEditAccess(currentUser, sequence)) return null;
 
   return post.canonicalSequenceId;
 }

--- a/packages/lesswrong/lib/collections/sequences/collection.ts
+++ b/packages/lesswrong/lib/collections/sequences/collection.ts
@@ -17,8 +17,7 @@ const options: MutationOptions<DbSequence> = {
   },
 
   editCheck: (user: DbUser|null, document: DbSequence|null) => {
-    if (!user || !document) return false;
-    return userOwns(user, document) ? userCanDo(user, 'sequences.edit.own') : userCanDo(user, `sequences.edit.all`)
+    return Sequences.checkEditAccess(user, document);
   },
 
   removeCheck: (user: DbUser|null, document: DbSequence|null) => {
@@ -29,7 +28,8 @@ const options: MutationOptions<DbSequence> = {
 
 interface ExtendedSequencesCollection extends SequencesCollection {
   // Functions in search/utils.ts
-  toAlgolia: (sequence: DbSequence) => Promise<Array<AlgoliaDocument>|null>
+  toAlgolia: (sequence: DbSequence) => Promise<Array<AlgoliaDocument>|null>,
+  checkEditAccess: (user: DbUser|null, sequence: DbSequence|null) => boolean
 }
 
 export const Sequences: ExtendedSequencesCollection = createCollection({

--- a/packages/lesswrong/lib/collections/sequences/permissions.ts
+++ b/packages/lesswrong/lib/collections/sequences/permissions.ts
@@ -40,3 +40,8 @@ Sequences.checkAccess = async (user, document) => {
     return false;
   }
 }
+
+Sequences.checkEditAccess = (user, document) => {
+  if (!user || !document) return false;
+  return userOwns(user, document) ? userCanDo(user, 'sequences.edit.own') : userCanDo(user, `sequences.edit.all`)
+}

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -24,7 +24,6 @@ import { updatePostDenormalizedTags } from '../tagging/tagCallbacks';
 import { sequenceContainsPost } from '../../lib/collections/sequences/helpers';
 import { Sequences } from '../../lib/collections/sequences/collection';
 import { Chapters } from '../../lib/collections/chapters/collection';
-import { mongoFind } from '../../lib/mongoQueries';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
@@ -436,9 +435,9 @@ async function addPostToSequence(post: DbPost, props: CreateCallbackProperties<D
   if (await sequenceContainsPost(post.canonicalSequenceId, post._id, context)) return post;
 
   const sequence = await Sequences.findOne({ _id: post.canonicalSequenceId });
-  if (!Sequences.options.mutations.edit.check(currentUser, sequence)) return null;
+  if (!Sequences.checkEditAccess(currentUser, sequence)) return null;
 
-  const chapters = await mongoFind("Chapters", {sequenceId: post.canonicalSequenceId}, {sort: {number: 1}});
+  const chapters = await Chapters.find({sequenceId: post.canonicalSequenceId}, {sort: {number: 1}}).fetch();
   const lastChapter = chapters.at(-1);
   if (!lastChapter) return post;
 


### PR DESCRIPTION
This PR enables people to add **draft** posts to sequences. The current UI for adding posts to sequences uses the Posts index to find posts, so it can't find the user's draft posts. After discussion with Robert and Raymond, we decided to use the existing post.canonicalSequenceId field.

post.canonicalSequenceId used to be only insertable/editable by admins, but now it's insertable/editable by members too. If you enter a sequenceId as a post's canonicalSequenceId, we use onCreate or onUpdate to check that it's a real sequenceId, and check that you have permission to edit that sequence (i.e., we check that either you own the sequence, or you have 'sequences.edit.all'). If those checks pass, the canonicalSequenceId keeps the value, otherwise it's null.

Then, we use createAfter and updateAfter hooks to check whether the post is already in the sequence. If it isn't, we add it to the latest chapter of the sequence. (We use these create/update-After callbacks, rather than onCreate/onUpdate, because onCreate doesn't know the id of the post because it hasn't been saved yet, so it can't add the postId to the sequence).

<img width="731" alt="canonicalSequenceId" src="https://user-images.githubusercontent.com/675520/217698852-4ca5f830-343e-43b5-8ed2-990323242b1f.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203934149671311) by [Unito](https://www.unito.io)
