### PR TITLE
turn commentOnSelection span into a div for safari reader mode

### DIFF
--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -161,16 +161,16 @@ const CommentOnSelectionContentWrapper = ({onClickComment, children}: {
   onClickComment: (html: string)=>void,
   children: React.ReactNode,
 }) => {
-  const wrapperSpanRef = useRef<HTMLSpanElement|null>(null);
+  const wrapperDivRef = useRef<HTMLDivElement|null>(null);
   const currentUser = useCurrentUser();
   
   useEffect(() => {
-    if (wrapperSpanRef.current) {
-      let modifiedSpan = (wrapperSpanRef.current as any)
-      modifiedSpan.onClickComment = onClickComment;
+    if (wrapperDivRef.current) {
+      let modifiedDiv = (wrapperDivRef.current as any)
+      modifiedDiv.onClickComment = onClickComment;
       
       return () => {
-        modifiedSpan.onClickComment = null;
+        modifiedDiv.onClickComment = null;
       }
     }
   }, [onClickComment]);
@@ -179,9 +179,9 @@ const CommentOnSelectionContentWrapper = ({onClickComment, children}: {
     return <>{children}</>;
   }
   
-  return <span className="commentOnSelection" ref={wrapperSpanRef}>
+  return <div className="commentOnSelection" ref={wrapperDivRef}>
     {children}
-  </span>
+  </div>
 }
 
 /**


### PR DESCRIPTION
Safari's reader mode can't handle post bodies being inside a `span` for comment-on-selection.  Changing that to a `div` fixes it, without any (obvious to me) side effects.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203942329172659) by [Unito](https://www.unito.io)
