### PR TITLE
fix subforum sorting in the list layout view

### DIFF
--- a/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
@@ -138,6 +138,7 @@ const SubforumSubforumTab = ({tag, userTagRel, layout, isSubscribed, classes}: {
 
   // if no sort order was selected, try to use the tag page's default sort order for posts
   const sortBy: SubforumSorting = (isSubforumSorting(query.sortedBy) && query.sortedBy) || (isSubforumSorting(tag.postsDefaultSortOrder) && tag.postsDefaultSortOrder) || defaultSubforumSorting;
+  query.sortedBy = sortBy // make sure to set the default sorting if necessary
   
   const commentNodeProps = {
     treeOptions: {


### PR DESCRIPTION
Previously the post list wasn't respecting the default sort order (ex. when I tried to set Community's list to "Magic").

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203942661767003) by [Unito](https://www.unito.io)
