### PR TITLE
Make community read more default to posts tab

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -5,6 +5,7 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import moment from '../../lib/moment-timezone';
 import { useTimezone } from '../common/withTimezone';
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../../lib/collections/tags/collection';
+import { tagGetUrl } from '../../lib/collections/tags/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
 
@@ -34,7 +35,7 @@ const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
           <AnalyticsContext listContext={"communityPosts"}>
             <PostsList2 terms={recentPostsTerms} showLoadMore={false} />
             <SectionFooter>
-              <Link to={"/topics/community"}>Read more</Link>
+              <Link to={tagGetUrl({slug: 'community'}, {tab: "posts"})}>Read more</Link>
             </SectionFooter>
           </AnalyticsContext>
       </SingleColumnSection>

--- a/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
@@ -148,7 +148,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
 
 const subforumTabs = ["posts", "wiki"] as const
 type SubforumTab = typeof subforumTabs[number]
-const defaultTab: SubforumTab = "posts"
+const defaultTab: SubforumTab = "wiki"
 
 const TagSubforumPage2 = ({classes}: {
   classes: ClassesType


### PR DESCRIPTION
Initially the "Read more" took you to the wiki tab, as a result of merging these two PRs at the same time:
 - https://github.com/ForumMagnum/ForumMagnum/pull/6663 (which changes the default tab to wiki)
 - https://github.com/ForumMagnum/ForumMagnum/pull/6653 (which adds the link without explicitly setting the tab)

Then @s-cheng merged this [PR](https://github.com/ForumMagnum/ForumMagnum/pull/6668) to fix it by making the default tab "posts", which fixed the acute problem (thanks Sarah!)
 - https://github.com/ForumMagnum/ForumMagnum/pull/6668

I think we do actually want the default tab to be "wiki" though. Initially it was "posts" ("subforum") but we changed it to wiki because people complained about links in posts/other topics taking you to the subforum tab, whereas when they were written they were intended to take you to the wiki article. Another consideration is that we want links on google to go to the wiki page by default

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203945467759801) by [Unito](https://www.unito.io)
