### PR TITLE
add audio to suggest curated

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -11,9 +11,21 @@ import PlusOneIcon from '@material-ui/icons/PlusOne';
 import UndoIcon from '@material-ui/icons/Undo';
 import StarIcon from '@material-ui/icons/Star';
 import ClearIcon from '@material-ui/icons/Clear';
+import VolumeUpIcon from '@material-ui/icons/VolumeUp';
 import * as _ from 'underscore';
 
-const SunshineCuratedSuggestionsItem = ({post}: {
+const styles = (theme: ThemeType): JssStyles => ({
+  audioIcon: {
+    width: 14,
+    color: theme.palette.grey[500],
+    position: "relative",
+    top: 2
+  }
+});
+
+
+const SunshineCuratedSuggestionsItem = ({classes, post}: {
+  classes: ClassesType,
   post: PostsList
 }) => {
   const currentUser = useCurrentUser();
@@ -92,6 +104,7 @@ const SunshineCuratedSuggestionsItem = ({post}: {
           {post.postedAt && <Components.SidebarInfo>
             <Components.FormatDate date={post.postedAt}/>
           </Components.SidebarInfo>}
+          {post.podcastEpisodeId && <VolumeUpIcon className={classes.audioIcon}/>}
         </div>
         <Components.SidebarInfo>
           Endorsed by { post.suggestForCuratedUsernames }
@@ -118,7 +131,7 @@ const SunshineCuratedSuggestionsItem = ({post}: {
   )
 }
 
-const SunshineCuratedSuggestionsItemComponent = registerComponent('SunshineCuratedSuggestionsItem', SunshineCuratedSuggestionsItem, {
+const SunshineCuratedSuggestionsItemComponent = registerComponent('SunshineCuratedSuggestionsItem', SunshineCuratedSuggestionsItem, {styles, 
   hocs: [withErrorBoundary]
 });
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -17,6 +17,7 @@ import * as _ from 'underscore';
 const styles = (theme: ThemeType): JssStyles => ({
   audioIcon: {
     width: 14,
+    height: 14,
     color: theme.palette.grey[500],
     position: "relative",
     top: 2

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -64,7 +64,7 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
     return null
   }
 
-  const { SunshineListTitle, SunshineCuratedSuggestionsItem, MetaInfo, FormatDate, LoadMore } = Components
+  const { SunshineListTitle, SunshineCuratedSuggestionsItem, MetaInfo, FormatDate, LoadMore, LWTooltip } = Components
     
   if (results && results.length) {
     return (
@@ -74,7 +74,9 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
           <MetaInfo>
             <FormatDate date={curatedDate}/>
           </MetaInfo>
-          <VolumeUpIcon className={classNames(classes.audioIcon, {[classes.audioOnly]: audioOnly})} onClick={() => setAudioOnly(!audioOnly)}/>
+          <LWTooltip title="Filter to only show audio">
+            <VolumeUpIcon className={classNames(classes.audioIcon, {[classes.audioOnly]: audioOnly})} onClick={() => setAudioOnly(!audioOnly)}/>
+          </LWTooltip>
         </SunshineListTitle>
         {results.map(post =>
           <div key={post._id} >

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -1,13 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useCurrentUser } from '../common/withUser';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   loadMorePadding: {
     paddingLeft: 16,
   },
+  audioIcon: {
+    width: 14,
+    height: 14,
+    color: theme.palette.grey[500],
+    cursor: "pointer",
+    '&:hover': {
+      opacity: .5
+    }
+  },
+  audioOnly: {
+    color: theme.palette.primary.main
+  }
 });
 
 const shouldShow = (belowFold: boolean, curatedDate: Date, currentUser: UsersCurrent | null) => {
@@ -26,8 +40,12 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
 }) => {
   const currentUser = useCurrentUser();
 
+  const [audioOnly, setAudioOnly] = useState<boolean>(false)
+
   const { results, loadMoreProps, showLoadMore } = useMulti({
-    terms,
+    terms: {
+      ...terms, audioOnly
+    },
     collectionName: "Posts",
     fragmentName: 'PostsList',
     enableTotal: true,
@@ -40,7 +58,7 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
     fragmentName: 'PostsList',
   });
   const curatedDate = curatedResults ? new Date(curatedResults[0]?.curatedDate) : new Date();
-  const twoAndAHalfDaysAgo = new Date(new Date().getTime()-(2.5*24*60*60*1000));
+
 
   if (!shouldShow(!!belowFold, curatedDate, currentUser)) {
     return null
@@ -56,10 +74,11 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
           <MetaInfo>
             <FormatDate date={curatedDate}/>
           </MetaInfo>
+          <VolumeUpIcon className={classNames(classes.audioIcon, {[classes.audioOnly]: audioOnly})} onClick={() => setAudioOnly(!audioOnly)}/>
         </SunshineListTitle>
         {results.map(post =>
           <div key={post._id} >
-            <SunshineCuratedSuggestionsItem post={post}/>
+            <SunshineCuratedSuggestionsItem post={post} />
           </div>
         )}
         {showLoadMore && <div className={classes.loadMorePadding}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -65,32 +65,28 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes }:{
   }
 
   const { SunshineListTitle, SunshineCuratedSuggestionsItem, MetaInfo, FormatDate, LoadMore, LWTooltip } = Components
-    
-  if (results && results.length) {
-    return (
-      <div className={classes.root}>
-        <SunshineListTitle>
-          Suggestions for Curated
-          <MetaInfo>
-            <FormatDate date={curatedDate}/>
-          </MetaInfo>
-          <LWTooltip title="Filter to only show audio">
-            <VolumeUpIcon className={classNames(classes.audioIcon, {[classes.audioOnly]: audioOnly})} onClick={() => setAudioOnly(!audioOnly)}/>
-          </LWTooltip>
-        </SunshineListTitle>
-        {results.map(post =>
-          <div key={post._id} >
-            <SunshineCuratedSuggestionsItem post={post} />
-          </div>
-        )}
-        {showLoadMore && <div className={classes.loadMorePadding}>
-          <LoadMore {...loadMoreProps}/>
-        </div>}
-      </div>
-    )
-  } else {
-    return null
-  }
+  
+  return (
+    <div className={classes.root}>
+      <SunshineListTitle>
+        Suggestions for Curated
+        <MetaInfo>
+          <FormatDate date={curatedDate}/>
+        </MetaInfo>
+        <LWTooltip title="Filter to only show audio">
+          <VolumeUpIcon className={classNames(classes.audioIcon, {[classes.audioOnly]: audioOnly})} onClick={() => setAudioOnly(!audioOnly)}/>
+        </LWTooltip>
+      </SunshineListTitle>
+      {results?.map(post =>
+        <div key={post._id} >
+          <SunshineCuratedSuggestionsItem post={post} />
+        </div>
+      )}
+      {showLoadMore && <div className={classes.loadMorePadding}>
+        <LoadMore {...loadMoreProps}/>
+      </div>}
+    </div>
+  )
 }
 
 const SunshineCuratedSuggestionsListComponent = registerComponent('SunshineCuratedSuggestionsList', SunshineCuratedSuggestionsList, {styles})

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -131,6 +131,8 @@ registerFragment(`
       organizerIds
     }
 
+    podcastEpisodeId
+
     # deprecated
     nominationCount2018
     reviewCount2018
@@ -322,7 +324,6 @@ registerFragment(`
 
     # Crossposting
     fmCrosspost
-    podcastEpisodeId
   }
 `);
 

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -61,7 +61,8 @@ declare global {
     includeArchived?: boolean,
     includeDraftEvents?: boolean
     includeShared?: boolean
-    distance?: number
+    distance?: number,
+    audioOnly?: boolean
   }
 }
 
@@ -1193,9 +1194,11 @@ ensureIndex(Posts,
   { name: "posts.sunshineNewUsersPosts" }
 );
 
-Posts.addView("sunshineCuratedSuggestions", function () {
+Posts.addView("sunshineCuratedSuggestions", function (terms) {
+  const audio = terms.audioOnly ? {podcastEpisodeId: {$exists: true}} : {}
   return {
     selector: {
+      ...audio,
       suggestForCuratedUserIds: {$exists:true, $ne: []},
       reviewForCuratedUserId: {$exists:false}
     },

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -717,6 +717,13 @@ interface MessagesDefaultFragment { // fragment on Messages
   readonly noEmail: boolean,
 }
 
+interface SessionsDefaultFragment { // fragment on Sessions
+  readonly _id: string,
+  readonly session: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly expires: Date | null,
+  readonly lastModified: Date | null,
+}
+
 interface RSSFeedsDefaultFragment { // fragment on RSSFeeds
   readonly userId: string,
   readonly ownedByUser: boolean,
@@ -866,6 +873,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly finalReviewVoteScoreAF: number,
   readonly finalReviewVotesAF: Array<number>,
   readonly group: PostsBase_group|null,
+  readonly podcastEpisodeId: string | null,
   readonly nominationCount2018: number,
   readonly reviewCount2018: number,
   readonly nominationCount2019: number,
@@ -991,7 +999,6 @@ interface PostsDetails extends PostsListBase { // fragment on Posts
     hostedHere: boolean | null,
     foreignPostId: string | null,
   } | null,
-  readonly podcastEpisodeId: string | null,
 }
 
 interface PostsDetails_canonicalSequence { // fragment on Sequences
@@ -2890,13 +2897,6 @@ interface CronHistoriesDefaultFragment { // fragment on CronHistories
   readonly result: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
-interface SessionsDefaultFragment { // fragment on Sessions
-  readonly _id: string,
-  readonly session: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly expires: Date | null,
-  readonly lastModified: Date | null,
-}
-
 interface SuggestAlignmentComment extends CommentsList { // fragment on Comments
   readonly post: PostsMinimumInfo|null,
   readonly suggestForAlignmentUserIds: Array<string>,
@@ -2929,6 +2929,7 @@ interface FragmentTypes {
   ClientIdsDefaultFragment: ClientIdsDefaultFragment
   ConversationsDefaultFragment: ConversationsDefaultFragment
   MessagesDefaultFragment: MessagesDefaultFragment
+  SessionsDefaultFragment: SessionsDefaultFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
   RevisionsDefaultFragment: RevisionsDefaultFragment
   ModeratorActionsDefaultFragment: ModeratorActionsDefaultFragment
@@ -3085,7 +3086,6 @@ interface FragmentTypes {
   ModerationTemplatesDefaultFragment: ModerationTemplatesDefaultFragment
   ModerationTemplateFragment: ModerationTemplateFragment
   CronHistoriesDefaultFragment: CronHistoriesDefaultFragment
-  SessionsDefaultFragment: SessionsDefaultFragment
   SuggestAlignmentComment: SuggestAlignmentComment
 }
 
@@ -3110,6 +3110,7 @@ interface CollectionNamesByFragmentName {
   ClientIdsDefaultFragment: "ClientIds"
   ConversationsDefaultFragment: "Conversations"
   MessagesDefaultFragment: "Messages"
+  SessionsDefaultFragment: "Sessions"
   RSSFeedsDefaultFragment: "RSSFeeds"
   RevisionsDefaultFragment: "Revisions"
   ModeratorActionsDefaultFragment: "ModeratorActions"
@@ -3266,7 +3267,6 @@ interface CollectionNamesByFragmentName {
   ModerationTemplatesDefaultFragment: "ModerationTemplates"
   ModerationTemplateFragment: "ModerationTemplates"
   CronHistoriesDefaultFragment: "CronHistories"
-  SessionsDefaultFragment: "Sessions"
   SuggestAlignmentComment: "Comments"
 }
 


### PR DESCRIPTION
This has curated suggestion items let you know if there's existing audio for the post, and let's you filter the list to show only posts with audio:

<img width="306" alt="image" src="https://user-images.githubusercontent.com/3246710/218282178-6c02304a-2d44-448b-90b7-6df3020d4597.png">

<img width="297" alt="image" src="https://user-images.githubusercontent.com/3246710/218282258-28b86515-0a59-4f15-aba7-8a24bd1785d6.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203951917547416) by [Unito](https://www.unito.io)
