### PR TITLE
Enable side comments on EA forum (as opt in)

### DIFF
--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -4,6 +4,7 @@ import CommentIcon from '@material-ui/icons/ModeComment';
 import { userHasCommentOnSelection } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
 import { useOnNavigate } from '../hooks/useOnNavigate';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const selectedTextToolbarStyles = (theme: ThemeType): JssStyles => ({
   toolbar: {
@@ -17,6 +18,11 @@ const selectedTextToolbarStyles = (theme: ThemeType): JssStyles => ({
     
     "&:hover": {
       background: theme.palette.panelBackground.darken08,
+    },
+
+    // Hide on mobile to avoid horizontal scrolling
+    [theme.breakpoints.down('xs')]: {
+      display: isEAForum ? "none" : "initial",
     },
   },
 });

--- a/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
@@ -31,7 +31,7 @@ const PostBody = ({post, html, sideCommentMode}: {
       ? document.sideComments.highKarmaCommentsByBlock
       : document.sideComments.commentsByBlock;
     const sideCommentsMap = mapValues(sideComments, commentIds => <SideCommentIcon post={post} commentIds={commentIds}/>)
-    
+
     return <ContentItemBody
       dangerouslySetInnerHTML={{__html: htmlWithIDs}}
       key={`${post._id}_${sideCommentMode}`}

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -22,7 +22,7 @@ const isEAForum = forumTypeSetting.get() === 'EAForum'
 // Features in progress                                                     //
 //////////////////////////////////////////////////////////////////////////////
 
-export const userHasCommentOnSelection = isEAForum ? optInOnly : shippedFeature;
+export const userHasCommentOnSelection = shippedFeature;
 export const userCanEditTagPortal = isEAForum ? moderatorOnly : adminOnly;
 export const userHasBoldPostItems = disabled
 export const userHasEAHomeHandbook = adminOnly
@@ -36,7 +36,7 @@ export const userHasAutosummarize = adminOnly
 
 export const userHasThemePicker = isEAForum ? adminOnly : shippedFeature;
 
-export const userHasSideComments = isEAForum ? optInOnly : shippedFeature;
+export const userHasSideComments = shippedFeature;
 
 export const userHasShortformTags = isEAForum ? shippedFeature : disabled;
 

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -22,7 +22,7 @@ const isEAForum = forumTypeSetting.get() === 'EAForum'
 // Features in progress                                                     //
 //////////////////////////////////////////////////////////////////////////////
 
-export const userHasCommentOnSelection = isEAForum ? disabled : shippedFeature;
+export const userHasCommentOnSelection = isEAForum ? optInOnly : shippedFeature;
 export const userCanEditTagPortal = isEAForum ? moderatorOnly : adminOnly;
 export const userHasBoldPostItems = disabled
 export const userHasEAHomeHandbook = adminOnly


### PR DESCRIPTION
Co-authored-by: "Jonathan Mustin" <jcmustin@gmail.com>

The only problem we could find with side comments was that they introduce a horizontal scroll on mobile, so we just hide the button on mobile. This UI is required for the highlights project which will use the same toolbar

This PR makes side comments opt in, we could also just enable them fully if everyone. I don't anticipate any further changes before enabling them so this probably makes sense, but I thought people might want to try it on staging/prod before committing to enabling it fully

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203962583336773) by [Unito](https://www.unito.io)
