### PR TITLE
Fix spotlight author mobile margin

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -91,7 +91,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   description: {
     marginTop: 7,
-    marginBottom: 13,
+    marginBottom: 10,
     ...descriptionStyles(theme),
     position: "relative",
     [theme.breakpoints.down('xs')]: {
@@ -125,7 +125,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   author: {
-    marginTop: -6,
+    marginTop: 4,
     color: theme.palette.grey[600],
   },
   authorName: {

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -8,7 +8,11 @@ import { useItemsRead } from '../hooks/useRecordPostView';
 import { postProgressBoxStyles } from '../sequences/BooksProgressBar';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  boxesRoot: {
+    marginTop: 4,
+  },
   firstPost: {
+    marginTop: 4,
     ...theme.typography.body2,
     fontSize: "1.1rem",
     ...theme.typography.commentStyle,
@@ -65,7 +69,7 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight}: {
       </LWTooltip>
     </div>
   } else {
-    return <div>
+    return <div className={classes.boxesRoot}>
     {posts.map(post => (
       <LWTooltip key={`${spotlight._id}-${post._id}`} title={<PostsPreviewTooltip post={post}/>} tooltip={false} flip={false}>
         <Link to={postGetPageUrl(post, false, firstPostSequenceId)}>
@@ -84,4 +88,3 @@ declare global {
     SpotlightStartOrContinueReading: typeof SpotlightStartOrContinueReadingComponent
   }
 }
-

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -61,6 +61,8 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight}: {
   // But, also, the real proper fix here is to integrate continue reading here.
   const firstPost = readPosts.length === 0 && posts[0]
   const firstPostSequenceId = spotlight.documentType === "Sequence" ? spotlight.documentId : undefined
+  
+  if (spotlight.documentType !== "Sequence" || !posts.length) return null;
 
   if (firstPost) {
     return <div className={classes.firstPost}>


### PR DESCRIPTION
Currently:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/10352319/218880680-05a28048-5076-4121-8bcb-ae9a4b9f744e.png">

New:

<img width="353" alt="image" src="https://user-images.githubusercontent.com/10352319/218880690-3c6786a2-8845-435b-8ee7-b75d31f13cac.png">

It's still a bit too tight, but I didn't feel like making a drastic change here.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203972060639705) by [Unito](https://www.unito.io)
