### PR TITLE
Make comment link copy to clipboard rather than changing url

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -210,7 +210,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
  *
  * Before adding more props to this, consider whether you should instead be adding a field to the CommentTreeOptions interface.
  */
-export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, setSingleLine, truncated, showPinnedOnProfile, parentAnswerId, enableGuidelines=true, showParentDefault=false, displayTagIcon=false, classes }: {
+export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, toggleCollapse, setSingleLine, truncated, showPinnedOnProfile, parentAnswerId, enableGuidelines=true, showParentDefault=false, displayTagIcon=false, classes }: {
   treeOptions: CommentTreeOptions,
   comment: CommentsList|CommentsListWithParentMetadata,
   nestingLevel: number,
@@ -218,7 +218,6 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   collapsed?: boolean,
   isParentComment?: boolean,
   parentCommentId?: string,
-  scrollIntoView?: ()=>void,
   toggleCollapse?: ()=>void,
   setSingleLine?: (singleLine: boolean)=>void,
   truncated: boolean,
@@ -481,11 +480,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
               [<span>{collapsed ? "+" : "-"}</span>]
             </a>}
             <CommentUserName comment={comment} className={classes.username}/>
-            <CommentsItemDate
-              comment={comment} post={post} tag={tag}
-              scrollIntoView={scrollIntoView}
-              scrollOnClick={postPage && !isParentComment}
-            />
+            <CommentsItemDate comment={comment} post={post} tag={tag} />
             {showModeratorCommentAnnotation && <span className={classes.moderatorHat}>
               {moderatorCommentAnnotation}
             </span>}

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -250,7 +250,6 @@ const CommentsNode = ({
               parentAnswerId={parentAnswerId || (comment.answer && comment._id) || undefined}
               toggleCollapse={toggleCollapse}
               key={comment._id}
-              scrollIntoView={scrollIntoView}
               setSingleLine={setSingleLine}
               displayTagIcon={displayTagIcon}
               { ...passedThroughItemProps}


### PR DESCRIPTION
Previously the intended behaviour was:
 - Follow the link (so the permalinked comment appears at the top of the page)
 - Scroll the permalinked comment into view (wasn't working)

Now the behaviour is:
 - Copy the link url

My guess is that this is usually what users expect to happen, and what they would want. There are some edge cases though where they may want to follow the link, e.g. when clicking through from recent discussion, or from a user profile. I decided to go with this simple version because I expect almost all clicks on these links are from post pages (since that's where most traffic is), and it's less confusing to just alway do the same thing