### PR TITLE
Fix tests 2023-02-15

### DIFF
--- a/packages/lesswrong/integrationTests/metatest.tests.ts
+++ b/packages/lesswrong/integrationTests/metatest.tests.ts
@@ -13,7 +13,7 @@ describe('Utils', () => {
     });
     it("user is in no groups by default", async () => {
       const user = await createDummyUser();
-      (Object.keys(user) as any).should.not.include('groups')
+      expect(user.groups).toBe(null);
     });
     it("user can be added to a group", async () => {
       const testGroups = ['randomGroupName']

--- a/packages/lesswrong/integrationTests/moderation.server.tests.ts
+++ b/packages/lesswrong/integrationTests/moderation.server.tests.ts
@@ -194,7 +194,7 @@ describe('User moderation fields --', () => {
   
   it("new trusted users do not have a moderationStyle", async () => {
     const user = await createDummyUser({groups:["trustLevel1"]})
-    expect(user.moderationStyle).to.equal(undefined)
+    expect(user.moderationStyle).to.equal(null)
   });
   it("non-trusted users can set their moderationStyle", async () => {
     const user = await createDummyUser()

--- a/packages/lesswrong/integrationTests/voting.tests.ts
+++ b/packages/lesswrong/integrationTests/voting.tests.ts
@@ -200,8 +200,8 @@ describe('Voting', function() {
         coauthorStatuses: [ { userId: coauthor._id, confirmed: true, } ],
       });
 
-      expect(author.karma).toBe(undefined);
-      expect(coauthor.karma).toBe(undefined);
+      expect(author.karma).toBe(null);
+      expect(coauthor.karma).toBe(null);
 
       await performVoteServer({ documentId: post._id, voteType: 'smallUpvote', collection: Posts, user: voter, skipRateLimits: false });
       await waitUntilCallbacksFinished();

--- a/packages/lesswrong/lib/sql/UpdateQuery.ts
+++ b/packages/lesswrong/lib/sql/UpdateQuery.ts
@@ -178,9 +178,8 @@ class UpdateQuery<T extends DbObject> extends Query<T> {
       const resolvedField = this.resolveFieldName(field);
       return format(resolvedField, updateValue);
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.warn(`Field "${field}" is not recognized - is it missing from the schema?`, e);
-      return [];
+      // @ts-ignore
+      throw new Error(`Field "${field}" is not recognized - is it missing from the schema?`, {cause: e});
     }
   }
 

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -30,6 +30,10 @@ voteCallbacks.cancelAsync.add(function cancelVoteKarma({newDocument, vote}: Vote
 
 
 voteCallbacks.castVoteAsync.add(async function incVoteCount ({newDocument, vote}: VoteDocTuple) {
+  if (vote.voteType === "neutral") {
+    return;
+  }
+
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {
@@ -38,6 +42,10 @@ voteCallbacks.castVoteAsync.add(async function incVoteCount ({newDocument, vote}
 });
 
 voteCallbacks.cancelAsync.add(async function cancelVoteCount ({newDocument, vote}: VoteDocTuple) {
+  if (vote.voteType === "neutral") {
+    return;
+  }
+
   const field = vote.voteType + "Count"
 
   if (newDocument.userId !== vote.userId) {


### PR DESCRIPTION
A few fixes for tests that seem to have been broken in various Postgres migrations. The tests didn't fail on any particular migration branch, but there seems to be some interaction where they fail when the migrations are all merged together.

This includes pulling some of the code from #6611 to prevent errors from running the same queries concurently on multiple threads (which Jest does).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203976951017643) by [Unito](https://www.unito.io)
