### PR TITLE
fix a bug that can prevent publishing an event

### DIFF
--- a/packages/lesswrong/server/notificationCallbacksHelpers.tsx
+++ b/packages/lesswrong/server/notificationCallbacksHelpers.tsx
@@ -15,6 +15,7 @@ import * as _ from 'underscore';
 import { createMutator } from './vulcan-lib/mutators';
 import { createAnonymousContext } from './vulcan-lib/query';
 import keyBy from 'lodash/keyBy';
+import UsersRepo, { MongoNearLocation } from './repos/UsersRepo';
 
 /**
  * Return a list of users (as complete user objects) subscribed to a given
@@ -77,10 +78,8 @@ import keyBy from 'lodash/keyBy';
   }
 }
 
-export type MongoNearLocation = number[] | { type: "Point", coordinates: number[] }
-
 export async function getUsersWhereLocationIsInNotificationRadius(location: MongoNearLocation): Promise<Array<DbUser>> {
-  return await Users.aggregate([
+  return Users.isPostgres() ? new UsersRepo().getUsersWhereLocationIsInNotificationRadius(location) : await Users.aggregate([
     {
       "$geoNear": {
         "near": location, 

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -16,6 +16,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
   }
   
   getUsersWhereLocationIsInNotificationRadius(location: MongoNearLocation): Promise<Array<DbUser>> {
+    // the notification radius is in miles, so we convert the EARTH_DISTANCE from meters to miles
     return this.any(`
       SELECT *
       FROM "Users"

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -1,6 +1,7 @@
 import AbstractRepo from "./AbstractRepo";
 import Users from "../../lib/collections/users/collection";
 
+export type MongoNearLocation = { type: "Point", coordinates: number[] }
 export default class UsersRepo extends AbstractRepo<DbUser> {
   constructor() {
     super(Users);
@@ -12,5 +13,21 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
       FROM "Users"
       WHERE "services"->'resume'->'loginTokens' @> ('[{"hashedToken": "' || $1 || '"}]')::JSONB
     `, [hashedToken]);
+  }
+  
+  getUsersWhereLocationIsInNotificationRadius(location: MongoNearLocation): Promise<Array<DbUser>> {
+    return this.any(`
+      SELECT *
+      FROM "Users"
+      WHERE (
+        EARTH_DISTANCE(
+          LL_TO_EARTH(
+            ("nearbyEventsNotificationsMongoLocation"->'coordinates'->0)::FLOAT8,
+            ("nearbyEventsNotificationsMongoLocation"->'coordinates'->1)::FLOAT8
+          ),
+          LL_TO_EARTH($1, $2)
+        ) * 0.000621371
+      ) < "nearbyEventsNotificationsRadius"
+    `, [location.coordinates[0], location.coordinates[1]])
   }
 }


### PR DESCRIPTION
Co-authored with @oetherington 

We were investigating a different event-related bug and ran into this one, where we weren't properly handling `$geoNear` for PG. It threw a user-facing error and prevented the event from being created.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203980231106780) by [Unito](https://www.unito.io)
