### PR TITLE
Add eventProps option to Link, and use to always capture furtherContext in CommentsItemDate

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -84,7 +84,7 @@ const CommentsItemDate = ({comment, post, tag, classes, scrollOnClick, scrollInt
       [classes.answerDate]: comment.answer,
     })}>
       {scrollOnClick ? <a rel="nofollow" href={url} onClick={handleLinkClick}>{ date } </a>
-        : <Link rel="nofollow" to={url}>{ date }</Link>
+        : <Link rel="nofollow" to={url} eventProps={{furtherContext: "dateIcon"}} >{ date }</Link>
       }
     </span>
   );

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -29,7 +29,7 @@ export const withRouter = (WrappedComponent) => {
 
 type LinkProps = Omit<HashLinkProps, 'to'> & {
   to: HashLinkProps['to'] | null
-  eventProps?: Record<string, any>
+  eventProps?: Record<string, string>
 };
 
 const isLinkValid = (props: LinkProps): props is HashLinkProps => {

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -29,6 +29,7 @@ export const withRouter = (WrappedComponent) => {
 
 type LinkProps = Omit<HashLinkProps, 'to'> & {
   to: HashLinkProps['to'] | null
+  eventProps?: Record<string, any>
 };
 
 const isLinkValid = (props: LinkProps): props is HashLinkProps => {
@@ -36,7 +37,7 @@ const isLinkValid = (props: LinkProps): props is HashLinkProps => {
 };
 
 export const Link = (props: LinkProps) => {
-  const { captureEvent } = useTracking({eventType: "linkClicked", eventProps: {to: props.to}})
+  const { captureEvent } = useTracking({eventType: "linkClicked", eventProps: {to: props.to, ...(props.eventProps ?? {})}})
   const handleClick = (e) => {
     captureEvent(undefined, {buttonPressed: e.button})
     props.onMouseDown && props.onMouseDown(e)


### PR DESCRIPTION
Previously `furtherContext: "dateIcon"` would only be set if `scrollOnClick` was true (which in practice means when clicked on from the post page), which means it was impossible to measure how often this was being clicked outside the posts page

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203989509940726) by [Unito](https://www.unito.io)
