### PR TITLE
Fix merge accounts script in postgres

### DIFF
--- a/packages/lesswrong/lib/sql/UpdateQuery.ts
+++ b/packages/lesswrong/lib/sql/UpdateQuery.ts
@@ -171,7 +171,7 @@ class UpdateQuery<T extends DbObject> extends Query<T> {
         const {column, path} = this.buildJsonUpdatePath(field);
         return format(
           column,
-          ["JSONB_SET(", column, ",", path, ",", ...updateValue, ", TRUE)"],
+          ["JSONB_SET(", column, ",", path, "::TEXT[],", ...updateValue, ", TRUE)"],
         );
       }
 

--- a/packages/lesswrong/server/repos/ConversationsRepo.ts
+++ b/packages/lesswrong/server/repos/ConversationsRepo.ts
@@ -1,0 +1,16 @@
+import AbstractRepo from "./AbstractRepo";
+import Conversations from "../../lib/collections/conversations/collection";
+
+export default class ConversationsRepo extends AbstractRepo<DbConversation> {
+  constructor() {
+    super(Conversations);
+  }
+
+  moveUserConversationsToNewUser(oldUserId: string, newUserId: string): Promise<null> {
+    return this.none(`
+      UPDATE "Conversations"
+      SET "participantIds" = ARRAY_APPEND(ARRAY_REMOVE("participantIds", $1), $2)
+      WHERE ARRAY_POSITION("participantIds", $1) IS NOT NULL
+    `, [oldUserId, newUserId]);
+  }
+}

--- a/packages/lesswrong/server/repos/LocalgroupsRepo.ts
+++ b/packages/lesswrong/server/repos/LocalgroupsRepo.ts
@@ -1,0 +1,16 @@
+import AbstractRepo from "./AbstractRepo";
+import Localgroups from "../../lib/collections/localgroups/collection";
+
+export default class LocalgroupsRepo extends AbstractRepo<DbLocalgroup> {
+  constructor() {
+    super(Localgroups);
+  }
+
+  moveUserLocalgroupsToNewUser(oldUserId: string, newUserId: string): Promise<null> {
+    return this.none(`
+      UPDATE "Localgroups"
+      SET "organizerIds" = ARRAY_APPEND(ARRAY_REMOVE("organizerIds", $1), $2)
+      WHERE ARRAY_POSITION("organizerIds", $1) IS NOT NULL
+    `, [oldUserId, newUserId]);
+  }
+}

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -98,4 +98,12 @@ export default class VotesRepo extends AbstractRepo<DbVote> {
         "authorIds" @> ARRAY["userId"]
     `, [tagRevisionIds]);
   }
+
+  transferVotesTargetingUser(oldUserId: string, newUserId: string): Promise<null> {
+    return this.none(`
+      UPDATE "Votes"
+      SET "authorIds" = ARRAY_APPEND(ARRAY_REMOVE("authorIds", $1), $2)
+      WHERE ARRAY_POSITION("authorIds", $1) IS NOT NULL
+    `, [oldUserId, newUserId]);
+  }
 }

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -1,3 +1,4 @@
+import ConversationsRepo from "./ConversationsRepo";
 import DatabaseMetadataRepo from "./DatabaseMetadataRepo";
 import PostRelationsRepo from "./PostRelationsRepo";
 import PostsRepo from "./PostsRepo";
@@ -9,6 +10,7 @@ declare global {
 }
 
 const getAllRepos = () => ({
+  conversations: new ConversationsRepo(),
   databaseMetadata: new DatabaseMetadataRepo(),
   postRelations: new PostRelationsRepo(),
   posts: new PostsRepo(),
@@ -17,6 +19,7 @@ const getAllRepos = () => ({
 } as const);
 
 export {
+  ConversationsRepo,
   DatabaseMetadataRepo,
   PostRelationsRepo,
   PostsRepo,

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -1,5 +1,6 @@
 import ConversationsRepo from "./ConversationsRepo";
 import DatabaseMetadataRepo from "./DatabaseMetadataRepo";
+import LocalgroupsRepo from "./LocalgroupsRepo";
 import PostRelationsRepo from "./PostRelationsRepo";
 import PostsRepo from "./PostsRepo";
 import UsersRepo from "./UsersRepo";
@@ -12,6 +13,7 @@ declare global {
 const getAllRepos = () => ({
   conversations: new ConversationsRepo(),
   databaseMetadata: new DatabaseMetadataRepo(),
+  localgroups: new LocalgroupsRepo(),
   postRelations: new PostRelationsRepo(),
   posts: new PostsRepo(),
   users: new UsersRepo(),
@@ -21,6 +23,7 @@ const getAllRepos = () => ({
 export {
   ConversationsRepo,
   DatabaseMetadataRepo,
+  LocalgroupsRepo,
   PostRelationsRepo,
   PostsRepo,
   UsersRepo,

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -453,7 +453,9 @@ async function recomputeKarma(userId: string) {
     userId: {$ne: user._id},
     cancelled: false
   };
-  if (!Votes.isPostgres()) {
+  if (Votes.isPostgres()) {
+    selector["legacyData.legacy"] = {$ne: true};
+  } else {
     selector.legacy = {$ne: true};
   }
   const allTargetVotes = await Votes.find(selector).fetch()

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -448,12 +448,15 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}:{
 async function recomputeKarma(userId: string) {
   const user = await Users.findOne({_id: userId})
   if (!user) throw Error("Can't find user")
-  const allTargetVotes = await Votes.find({
+  const selector: Record<string, any> = {
     authorIds: user._id,
     userId: {$ne: user._id},
-    legacy: {$ne: true},
     cancelled: false
-  }).fetch()
+  };
+  if (!Votes.isPostgres()) {
+    selector.legacy = {$ne: true};
+  }
+  const allTargetVotes = await Votes.find(selector).fetch()
   const totalNonLegacyKarma = sumBy(allTargetVotes, vote => {
     return vote.power
   })

--- a/packages/lesswrong/unitTests/sql/UpdateQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/UpdateQuery.tests.ts
@@ -66,7 +66,7 @@ describe("UpdateQuery", () => {
     {
       name: "can set a value inside a JSON blob",
       getQuery: () => new UpdateQuery<DbTestObject>(testTable, {a: 3}, {$set: {"c.d.e": "hello world"}}),
-      expectedSql: `UPDATE "TestCollection" SET "c" = JSONB_SET( "c" , '{d, e}' , $1::TEXT , TRUE) WHERE "a" = $2 RETURNING "_id"`,
+      expectedSql: `UPDATE "TestCollection" SET "c" = JSONB_SET( "c" , '{d, e}' ::TEXT[], $1::TEXT , TRUE) WHERE "a" = $2 RETURNING "_id"`,
       expectedArgs: ["hello world", 3],
     },
     {


### PR DESCRIPTION
There are several queries in the `mergeAccounts` script that don't work properly in postgres. This PR fixes these issues.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203995349834364) by [Unito](https://www.unito.io)
