### PR TITLE
Fix log due to passing eventProps into DOM

### DIFF
--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -36,8 +36,8 @@ const isLinkValid = (props: LinkProps): props is HashLinkProps => {
   return typeof props.to === "string" || typeof props.to === "object";
 };
 
-export const Link = (props: LinkProps) => {
-  const { captureEvent } = useTracking({eventType: "linkClicked", eventProps: {to: props.to, ...(props.eventProps ?? {})}})
+export const Link = ({eventProps, ...props}: LinkProps) => {
+  const { captureEvent } = useTracking({eventType: "linkClicked", eventProps: {to: props.to, ...(eventProps ?? {})}})
   const handleClick = (e) => {
     captureEvent(undefined, {buttonPressed: e.button})
     props.onMouseDown && props.onMouseDown(e)


### PR DESCRIPTION
We were getting a log like this because `eventProps` was passed all the way through to the DOM element
```
React does not recognize the `eventProps` prop on a DOM element...
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1203996626197653) by [Unito](https://www.unito.io)
