### PR TITLE
conversations missing participant ids crash the moderatorInbox

### DIFF
--- a/packages/lesswrong/lib/collections/conversations/permissions.ts
+++ b/packages/lesswrong/lib/collections/conversations/permissions.ts
@@ -25,5 +25,5 @@ sunshineRegimentGroup.can(sunshineRegimentActions);
 
 Conversations.checkAccess = async (user: DbUser|null, document: DbConversation, context: ResolverContext|null): Promise<boolean> => {
   if (!user || !document) return false;
-  return document.participantIds.includes(user._id) ? userCanDo(user, 'conversations.view.own') : userCanDo(user, `conversations.view.all`)
+  return document.participantIds?.includes(user._id) ? userCanDo(user, 'conversations.view.own') : userCanDo(user, `conversations.view.all`)
 };


### PR DESCRIPTION
Still need to debug what exactly happened to create a conversation without any participantIds, but it shouldn't cause all other conversations to fail to load (which is what currently happens).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204009092931211) by [Unito](https://www.unito.io)
