### PR TITLE
rename "promoted" comments to "pinned" comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -518,7 +518,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
             </span>}
           </div>
           {comment.promoted && comment.promotedByUser && <div className={classes.metaNotice}>
-            Promoted by {comment.promotedByUser.displayName}
+            Pinned by {comment.promotedByUser.displayName}
           </div>}
           {renderBodyOrEditor()}
           {!comment.deleted && !collapsed && renderCommentBottom()}

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -195,7 +195,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           {singleLinePostTitle && <span className={classes.postTitle}>{post?.title}</span>}
           { comment.nominatedForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Nomination</span>}
           { comment.reviewingForReview && !hideSingleLineMeta && <span className={classes.metaNotice}>Review</span>}
-          { comment.promoted && !hideSingleLineMeta && <span className={classes.metaNotice}>Promoted</span>}
+          { comment.promoted && !hideSingleLineMeta && <span className={classes.metaNotice}>Pinned</span>}
           {contentToRender}
         </ContentStyles>}
         {showDescendentCount && comment.descendentCount>0 && <PostsItemComments

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -164,7 +164,7 @@ const Answer = ({ comment, post, classes }: {
                 />
               </div>
               { comment.promotedByUser && <div className={classes.metaNotice}>
-                Promoted by {comment.promotedByUser.displayName}
+                Pinned by {comment.promotedByUser.displayName}
               </div>}
               { showEdit ?
                 <Components.CommentsEditForm

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -314,6 +314,7 @@ const schema: SchemaType<DbComment> = {
     optional: true,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
+    label: "Pinned"
   },
 
   promotedByUserId: {


### PR DESCRIPTION
This is just a quick change to make the UI feel more consistent, plus I thought it was weird for [this comment](https://forum.effectivealtruism.org/posts/99tnp7Jpts7Gssq7J/transitioning-to-an-advisory-role?commentId=gFmhPZwQXvxnsC6Ap#comments) to be marked as "promoted". It's possible there are two different use cases here and we should have both "pinned" and "promoted" comments, but since this feature is rarely used as-is that seems unlikely to be prioritized.

See more related discussion in [this slack thread](https://cea-core.slack.com/archives/CJY3ZKP62/p1676921967213059).

Old:
<img width="743" alt="Screen Shot 2023-02-20 at 10 51 41 AM" src="https://user-images.githubusercontent.com/9057804/220204438-0d7629bf-2f5a-48e5-9472-05c1ddf5c7c3.png">

-----
New:
<img width="743" alt="Screen Shot 2023-02-20 at 1 54 32 PM" src="https://user-images.githubusercontent.com/9057804/220204052-031015e0-1a21-4d1d-95e9-fa2c6f930ea5.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204009069511717) by [Unito](https://www.unito.io)
