### PR TITLE
Move new-user-info to shared UI

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -27,6 +27,12 @@ export const UserReviewStatus = ({classes, user}: {
       ? <p><em>Banned until <FormatDate date={user.banned}/></em></p>
       : null 
     }
+    {user.associatedClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: {user.associatedClientId?.firstSeenReferrer}</div>}
+    {user.associatedClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: {user.associatedClientId?.firstSeenLandingPage}</div>}
+    {(user.associatedClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
+      <em>Alternate accounts detected</em>
+    </div>}
+    <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
   </div>;
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -189,22 +189,14 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
 
   if (!userCanDo(currentUser, "posts.moderate.all")) return null
 
+  // All elements in this component should also appar in UsersReviewInfoCard
   return (
       <div className={classes.root}>
         <Typography variant="body2">
           <MetaInfo>
             <div className={classes.info}>
               <div className={classes.topRow}>
-                <div>
-                  <UserReviewStatus user={user}/>
-              
-                  {user.associatedClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: {user.associatedClientId?.firstSeenReferrer}</div>}
-                  {user.associatedClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: {user.associatedClientId?.firstSeenLandingPage}</div>}
-                  {(user.associatedClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
-                    <em>Alternate accounts detected</em>
-                  </div>}
-                  <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
-                </div>
+                <UserReviewStatus user={user}/>
                 <div className={classes.row}>
                   <ModeratorMessageCount userId={user._id} />
                   <SunshineSendMessageWithDefaults user={user}/>


### PR DESCRIPTION
This moves some UI about new users into a shared component between SunshineNewUsersInfo and UsersReviewInfoCard

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204035859778667) by [Unito](https://www.unito.io)
