### PR TITLE
Debouncer events pg improvements

### DIFF
--- a/packages/lesswrong/server/manualMigrations/migrationUtils.ts
+++ b/packages/lesswrong/server/manualMigrations/migrationUtils.ts
@@ -378,6 +378,7 @@ const getNextBatchByCreatedAt = <T extends DbObject>({
     } else if (filter.createdAt.$gte) {
       const gt = Math.max(filter.createdAt.$gte.getTime() - 1, 0);
       greaterThan = new Date(Math.max(greaterThan.getTime(), gt));
+      delete filter.createdAt.$gte;
     } else {
       throw new Error(`Unsupported createdAt filter in getNextBatchByCreatedAt: ${JSON.stringify(filter)}`);
     }

--- a/packages/lesswrong/server/manualMigrations/migrationUtils.ts
+++ b/packages/lesswrong/server/manualMigrations/migrationUtils.ts
@@ -373,13 +373,13 @@ const getNextBatchByCreatedAt = <T extends DbObject>({
   const lastRow = lastRows[lastRows.length - 1] as unknown as HasCreatedAtType;
   let greaterThan = lastRow.createdAt;
   if (filter && "createdAt" in filter) {
-    if (filter.$gt) {
-      greaterThan = new Date(Math.max(greaterThan.getTime(), filter.$gt.getTime()));
-    } else if (filter.$gte) {
-      const gt = Math.max(filter.$gte.getTime() - 1, 0);
+    if (filter.createdAt.$gt) {
+      greaterThan = new Date(Math.max(greaterThan.getTime(), filter.createdAt.$gt.getTime()));
+    } else if (filter.createdAt.$gte) {
+      const gt = Math.max(filter.createdAt.$gte.getTime() - 1, 0);
       greaterThan = new Date(Math.max(greaterThan.getTime(), gt));
     } else {
-      throw new Error("Unsupported createdAt filter in getNextBatchByCreatedAt");
+      throw new Error(`Unsupported createdAt filter in getNextBatchByCreatedAt: ${JSON.stringify(filter)}`);
     }
     delete filter.createdAt;
   }

--- a/packages/lesswrong/server/manualMigrations/migrationUtils.ts
+++ b/packages/lesswrong/server/manualMigrations/migrationUtils.ts
@@ -292,7 +292,7 @@ export async function dropUnusedField(collection, fieldName) {
 const getBatchSort = <T extends DbObject>(useCreatedAt: boolean) =>
   (useCreatedAt
     ? {createdAt: 1}
-    : {_id: 1}) as Record<keyof T, 1>; // It's the callers responsability to ensure the sort by a field that actally exists
+    : {_id: 1}) as Record<keyof T, 1>; // It's the callers responsibility to ensure the sort field actally exists
 
 const getFirstBatchById = async <T extends DbObject>({
   collection,
@@ -381,12 +381,14 @@ const getNextBatchByCreatedAt = <T extends DbObject>({
     } else {
       throw new Error(`Unsupported createdAt filter in getNextBatchByCreatedAt: ${JSON.stringify(filter)}`);
     }
-    delete filter.createdAt;
   }
   return collection.find(
     {
-      createdAt: {$gt: greaterThan},
       ...filter,
+      createdAt: {
+        ...filter?.createdAt,
+        $gt: greaterThan,
+      },
     },
     {
       sort: getBatchSort(true),
@@ -427,7 +429,7 @@ export async function forEachDocumentBatchInCollection<T extends DbObject>({
 }: {
   collection: CollectionBase<T>,
   batchSize?: number,
-  filter?: MongoSelector<DbObject> | null,
+  filter?: MongoSelector<T> | null,
   callback: (batch: T[]) => void | Promise<void>,
   loadFactor?: number,
   useCreatedAt?: boolean,

--- a/packages/lesswrong/server/scripts/migrateCollections.ts
+++ b/packages/lesswrong/server/scripts/migrateCollections.ts
@@ -68,6 +68,9 @@ const formatters: Partial<Record<CollectionNameString, (document: DbObject) => D
   },
   DebouncerEvents: (event: DbDebouncerEvents): DbDebouncerEvents => {
     extractObjectId(event);
+    if (typeof event.createdAt === "number") {
+      event.createdAt = new Date(event.createdAt);
+    }
     if (typeof event.delayTime === "number") {
       event.delayTime = new Date(event.delayTime);
     }


### PR DESCRIPTION
A couple of problems came up whilst migrating DebouncerEvents to Postgres on staging and prod that didn't happen in dev. This PR fixes them:

- Sometimes createdAt is an int instead of a date
- Some of the selectors in getNextBatchByCreatedAt are wrong

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204055608269261) by [Unito](https://www.unito.io)
