### PR TITLE
Highlight new comments/posts on sunshine info

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -26,25 +26,30 @@ const styles = (theme: ThemeType): JssStyles => ({
   titleDisplay: {
     display: "block"
   },
+  highlight: {
+    color: theme.palette.primary.main,
+    fontWeight: 600
+  }
 })
 
 
-const CommentKarmaWithPreview = ({ comment, classes, displayTitle }: {
+const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }: {
   comment: CommentsListWithParentMetadata,
   classes: ClassesType,
-  displayTitle: boolean
+  displayTitle: boolean,
+  reviewedAt: Date
 }) => {
   const { hover, anchorEl, eventHandlers } = useHover();
-  const { LWPopper, CommentsNode, MetaInfo } = Components
+  const { LWPopper, CommentsNode } = Components
 
   if (!comment) return null 
 
   return <span className={classNames(classes.root, {[classes.titleDisplay]: displayTitle})} {...eventHandlers}>
-    <Link className={comment.deleted ? classes.deleted : classes.default}
+    <Link className={classNames({[classes.highlight]: comment.postedAt > reviewedAt, [classes.deleted]: comment.deleted, [classes.default]: !comment.deleted})}
       to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}
     >
       <span className={displayTitle ? classes.scoreTitleFormat : null}>{comment.baseScore} </span>
-      {displayTitle && <MetaInfo>{comment.post?.title}</MetaInfo> }
+      {displayTitle && comment.post?.title }
     </Link>
     <LWPopper
         open={hover}

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/ContentSummaryRows.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/ContentSummaryRows.tsx
@@ -85,7 +85,7 @@ export const ContentSummaryRows = ({classes, comments, posts, user, loading}: {
           <DescriptionIcon className={classes.hoverPostIcon}/>
         </span>
       </LWTooltip>
-      {postKarmaPreviews.map(post => <PostKarmaWithPreview key={post._id} post={post} displayTitle={contentDisplay === "titles"}/>)}
+      {postKarmaPreviews.map(post => <PostKarmaWithPreview key={post._id} post={post} reviewedAt={user.reviewedAt} displayTitle={contentDisplay === "titles"}/>)}
       { hiddenPostCount ? <span> ({hiddenPostCount} drafted)</span> : null}
     </div>
 
@@ -94,7 +94,7 @@ export const ContentSummaryRows = ({classes, comments, posts, user, loading}: {
         { user.commentCount || 0 }
       </LWTooltip>
       <MessageIcon className={classes.icon}/>
-      {commentKarmaPreviews.map(comment => <CommentKarmaWithPreview key={comment._id} comment={comment} displayTitle={contentDisplay === "titles"}/>)}
+      {commentKarmaPreviews.map(comment => <CommentKarmaWithPreview key={comment._id} reviewedAt={user.reviewedAt} comment={comment} displayTitle={contentDisplay === "titles"}/>)}
       { hiddenCommentCount ? <span> ({hiddenCommentCount} deleted)</span> : null}
       </div>
   </div>;

--- a/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
@@ -22,24 +22,30 @@ const styles = (theme: ThemeType): JssStyles => ({
   scoreTitleFormat: {
     width: 20,
     display: "inline-block"
+  },
+  highlight: {
+    color: theme.palette.primary.main,
+    fontWeight: 600
   }
 })
 
 
-const PostKarmaWithPreview = ({ post, classes, displayTitle }: {
+const PostKarmaWithPreview = ({ post, classes, displayTitle, reviewedAt }: {
   post: SunshinePostsList,
   classes: ClassesType,
-  displayTitle: boolean
+  displayTitle: boolean,
+  reviewedAt: Date
 }) => {
   const { hover, anchorEl, eventHandlers } = useHover();
   const { LWPopper, PostsPreviewTooltip, MetaInfo } = Components
 
   return <span className={classNames(classes.root, {[classes.titleDisplay]: displayTitle})} {...eventHandlers}>
-    <Link className={post.draft ? classes.draft : classes.default} to={postGetPageUrl(post)}>
+    <Link className={classNames({[classes.highlight]: post.postedAt > reviewedAt, [classes.draft]: post.draft, [classes.default]: !post.draft})}
+      to={postGetPageUrl(post)}>
       <span className={displayTitle ? classes.scoreTitleFormat : null}>
         {post.baseScore} 
       </span>
-      {displayTitle && <MetaInfo>{post.title}</MetaInfo>}
+      {displayTitle && post.title}
     </Link>
     <LWPopper
         open={hover}


### PR DESCRIPTION
Make it easier to skim for newer content in the moderator sidebar/page

<img width="499" alt="image" src="https://user-images.githubusercontent.com/3246710/221273998-2ca9c7b4-8d53-4342-83d9-2f2af2abaf1d.png">

<img width="522" alt="image" src="https://user-images.githubusercontent.com/3246710/221274027-6b3b77a3-fc5d-4b67-91ba-262811e720ea.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204042294687164) by [Unito](https://www.unito.io)
