### PR TITLE
set image quality to auto when mirroring image to cloudinary

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -44,19 +44,25 @@ async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): 
       cloud_name: cloudName,
       api_key: apiKey,
       api_secret: apiSecret,
-      transformation: {
-        quality: 'auto'
-      }
     }
   );
   logger(`Result of moving image: ${result.secure_url}`);
+
+  // Serve all images with automatic quality and format transformations to save on bandwidth
+  const autoQualityFormatUrl = cloudinary.v2.url(result.public_id, {
+    cloud_name: cloudName,
+    api_key: apiKey,
+    api_secret: apiSecret,
+    quality: 'auto',
+    fetch_format: 'auto'
+  });
   
   await Images.rawInsert({
     originalUrl: oldUrl,
-    cdnHostedUrl: result.secure_url,
+    cdnHostedUrl: autoQualityFormatUrl,
   });
   
-  return result.secure_url;
+  return autoQualityFormatUrl;
 }
 
 /// If an image has already been re-hosted, return its CDN URL. Otherwise null.

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -44,6 +44,9 @@ async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): 
       cloud_name: cloudName,
       api_key: apiKey,
       api_secret: apiSecret,
+      transformation: {
+        quality: 'auto'
+      }
     }
   );
   logger(`Result of moving image: ${result.secure_url}`);


### PR DESCRIPTION
We're serving totally uncompressed images to users, which causes two problems:
1. significantly runs up our Cloudinary bills, since they charge through the nose for bandwidth usage (& site traffic has been going up a bunch lately)
2. probably makes for a pretty slow loading experience for users with mediocre internet connections

This is the "bare-minimum level of effort" patch; we could also do [format optimization](https://cloudinary.com/documentation/image_optimization#how_to_optimize_image_format) if we want.  I've tested this change in dev and it works fine, though it's not retroactive and I'm not sure it's worth writing a migration.

Happy to forum-gate if the EA forum doesn't want this change (or wants to test it out first, and/or have a more fine-tuned optimization).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204042665650767) by [Unito](https://www.unito.io)
