### PR TITLE
Remove voting and mapLocation triggers for review

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -1,5 +1,5 @@
 import moment from "moment";
-import { forumTypeSetting } from "../../instanceSettings";
+import { isEAForum } from "../../instanceSettings";
 import ModeratorActions from "./collection";
 import { MAX_ALLOWED_CONTACTS_BEFORE_FLAG, rateLimits, RateLimitType, RATE_LIMIT_ONE_PER_DAY, RATE_LIMIT_ONE_PER_FORTNIGHT, RATE_LIMIT_ONE_PER_MONTH, RATE_LIMIT_ONE_PER_THREE_DAYS, RATE_LIMIT_ONE_PER_WEEK } from "./schema";
 
@@ -102,8 +102,7 @@ export function getReasonForReview(user: DbUser | SunshineUsersList, override?: 
   if (fullyReviewed) return 'alreadyApproved';
 
   if (neverReviewed) {
-    if (user.voteCount > 20) return 'voteCount';
-    if (user.mapLocation) return 'mapLocation';
+    if (user.mapLocation && isEAForum) return 'mapLocation';
     if (user.postCount) return 'firstPost';
     if (user.commentCount) return 'firstComment';
     if (user.usersContactedBeforeReview?.length > MAX_ALLOWED_CONTACTS_BEFORE_FLAG) return 'contactedTooManyUsers';


### PR DESCRIPTION
This removes vote "voteCount > 20" trigger for new user review (for both EA Forum and LessWrong), and removes the mapLocation trigger for non-EAForum forums, since in practice I'd never seen that help with voter fraud detection.

(I think it'd be good to use the new ModerationAction callbacks to trigger for users with more specific sets of voter-fraud-warning-signs, but that should be handled separately from the way it's handled here)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204092261760368) by [Unito](https://www.unito.io)
