### PR TITLE
Make label for all posts page community setting consistent with other labels

### DIFF
--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -218,7 +218,7 @@ const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, curren
             </QueryLink>
           </Tooltip>
 
-          {isEAForum && <Tooltip title={<div><div>By default, Community posts are hidden from the Frontpage list</div><div>Toggle to hide them here too.</div></div>} placement="left-start">
+          {isEAForum && <Tooltip title={<div><div>By default, Community posts are hidden.</div><div>Toggle to show them.</div></div>} placement="left-start">
             <QueryLink
               className={classes.checkboxGroup}
               onClick={() => setSetting('hideCommunity', !currentHideCommunity)}

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -226,9 +226,9 @@ const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, curren
               merge
               rel="nofollow"
             >
-              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentHideCommunity}/>
+              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={!currentHideCommunity}/>
               <MetaInfo className={classes.checkboxLabel}>
-                Hide Community
+                Show Community
               </MetaInfo>
             </QueryLink>
           </Tooltip>}

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -218,7 +218,7 @@ const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, curren
             </QueryLink>
           </Tooltip>
 
-          {isEAForum && <Tooltip title={<div><div>By default, Community posts are hidden.</div><div>Toggle to show them.</div></div>} placement="left-start">
+          {isEAForum && <Tooltip title={<div><div>By default, Community posts are shown.</div><div>Toggle to hide them.</div></div>} placement="left-start">
             <QueryLink
               className={classes.checkboxGroup}
               onClick={() => setSetting('hideCommunity', !currentHideCommunity)}


### PR DESCRIPTION
Requested by Lizka on Slack. It now matches the other checkbox labels, and doesn't mention the frontpage.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204097565097300) by [Unito](https://www.unito.io)
