### PR TITLE
More font-weight + sentence case tweaks

### DIFF
--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -149,7 +149,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   localGroupsBtn: {
     textTransform: 'none',
-    fontSize: 12
+    fontSize: 13
   },
   localGroupsBtnIcon: {
     fontSize: 15,
@@ -181,7 +181,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eventsPageLink: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.text.invertedBackgroundText,
-    fontSize: 13,
+    fontSize: 14,
     padding: '8px 16px',
     borderRadius: 4,
     marginTop: 10

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -23,6 +23,7 @@ import Search from '@material-ui/icons/Search';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Chip from '@material-ui/core/Chip';
+import { isEAForum } from '../../lib/instanceSettings';
 
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -149,7 +150,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   localGroupsBtn: {
     textTransform: 'none',
-    fontSize: 13
+    fontSize: isEAForum ? 13 : 12,
   },
   localGroupsBtnIcon: {
     fontSize: 15,
@@ -181,7 +182,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eventsPageLink: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.text.invertedBackgroundText,
-    fontSize: 14,
+    fontSize: isEAForum ? 14 : 13,
     padding: '8px 16px',
     borderRadius: 4,
     marginTop: 10

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -10,6 +10,7 @@ import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';
 import { useTracking } from '../../../lib/analyticsEvents';
 import { truncate } from '../../../lib/editor/ellipsize';
+import { isEAForum } from '../../../lib/instanceSettings';
 import type { BasicDoc, SearchBoxProvided, StateResultsProvided } from 'react-instantsearch-core';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -49,7 +50,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   fullMapLink: {
     color: theme.palette.primary.main,
     ...theme.typography.commentStyle,
-    fontSize: 14,
+    fontSize: isEAForum ? 14 : 13,
     margin: '0 5px'
   },
   noResults: {

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -49,7 +49,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   fullMapLink: {
     color: theme.palette.primary.main,
     ...theme.typography.commentStyle,
-    fontSize: 13,
+    fontSize: 14,
     margin: '0 5px'
   },
   noResults: {

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -85,8 +85,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     alignItems: 'baseline',
   },
   localGroupName: {
-    ...theme.typography.headline,
+    ...theme.typography.headerStyle,
     fontSize: 18,
+    fontWeight: 700,
     display: '-webkit-box',
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -6,6 +6,7 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@material-ui/core/Button';
 import { requireCssVar } from '../../../themes/cssVars';
+import { isEAForum } from '../../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -85,9 +86,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     alignItems: 'baseline',
   },
   localGroupName: {
-    ...theme.typography.headerStyle,
+    ...theme.typography[isEAForum ? "headerStyle" : "headline"],
     fontSize: 18,
-    fontWeight: 700,
+    fontWeight: isEAForum ? 700 : undefined,
     display: '-webkit-box',
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -90,8 +90,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     }
   },
   onlineGroupName: {
-    ...theme.typography.headline,
-    fontSize: 20,
+    ...theme.typography.headerStyle,
+    fontWeight: 700,
+    fontSize: 18,
   },
   inactiveGroupTag: {
     color: theme.palette.grey[500],
@@ -126,6 +127,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     color: theme.palette.primary.main,
     padding: '10px 14px',
     borderRadius: 4,
+    fontSize: 14,
   },
   postGroupsCTA: {
     textAlign: 'center',
@@ -203,7 +205,7 @@ const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, cl
               </div>
               <div className={classes.onlineGroupJoin}>
                 <Link to={`/groups/${group._id}`} className={classes.onlineGroupBtn}>
-                  Learn More
+                  Learn more
                 </Link>
               </div>
             </div>

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -6,6 +6,8 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@material-ui/core/Button';
 import { requireCssVar } from '../../../themes/cssVars';
+import { isEAForum } from '../../../lib/instanceSettings';
+import { preferredHeadingCase } from '../../../lib/forumTypeUtils';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -89,11 +91,15 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
       whiteSpace: 'normal'
     }
   },
-  onlineGroupName: {
-    ...theme.typography.headerStyle,
-    fontWeight: 700,
-    fontSize: 18,
-  },
+  onlineGroupName: isEAForum ? {
+      ...theme.typography.headerStyle,
+      fontWeight: 700,
+      fontSize: 18,
+    }
+    : {
+      ...theme.typography.headline,
+      fontSize: 20,
+    },
   inactiveGroupTag: {
     color: theme.palette.grey[500],
     marginRight: 10
@@ -127,7 +133,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     color: theme.palette.primary.main,
     padding: '10px 14px',
     borderRadius: 4,
-    fontSize: 14,
+    fontSize: isEAForum ? 14 : theme.typography.commentStyle.fontSize,
   },
   postGroupsCTA: {
     textAlign: 'center',
@@ -205,7 +211,7 @@ const OnlineGroups = ({keywordSearch, includeInactive, toggleIncludeInactive, cl
               </div>
               <div className={classes.onlineGroupJoin}>
                 <Link to={`/groups/${group._id}`} className={classes.onlineGroupBtn}>
-                  Learn more
+                  {preferredHeadingCase("Learn More")}
                 </Link>
               </div>
             </div>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -500,7 +500,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
         </div>}
 
         <Components.Typography variant="headline" className={classes.eventsHeadline}>
-          Upcoming Events
+          Upcoming events
         </Components.Typography>
         {upcomingEventsList}
 

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -500,7 +500,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
         </div>}
 
         <Components.Typography variant="headline" className={classes.eventsHeadline}>
-          Upcoming events
+          {preferredHeadingCase("Upcoming Events")}
         </Components.Typography>
         {upcomingEventsList}
 

--- a/packages/lesswrong/components/posts/EventsUpcoming.tsx
+++ b/packages/lesswrong/components/posts/EventsUpcoming.tsx
@@ -7,7 +7,7 @@ const EventsUpcoming = () => {
 
   return (
     <SingleColumnSection>
-      <SectionTitle title="Upcoming Events"/>
+      <SectionTitle title="Upcoming events"/>
       <PostsList2 terms={terms}/>
     </SingleColumnSection>
   )

--- a/packages/lesswrong/components/posts/EventsUpcoming.tsx
+++ b/packages/lesswrong/components/posts/EventsUpcoming.tsx
@@ -1,5 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
+import { preferredHeadingCase } from '../../lib/forumTypeUtils';
 
 const EventsUpcoming = () => {
   const { SingleColumnSection, SectionTitle, PostsList2 } = Components
@@ -7,7 +8,7 @@ const EventsUpcoming = () => {
 
   return (
     <SingleColumnSection>
-      <SectionTitle title="Upcoming events"/>
+      <SectionTitle title={preferredHeadingCase("Upcoming Events")} />
       <PostsList2 terms={terms}/>
     </SingleColumnSection>
   )

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -35,6 +35,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   secondaryInfo: {
     fontSize: '1.4rem',
+    fontWeight: isEAForum ? 450 : undefined,
     fontFamily: theme.typography.uiSecondary.fontFamily,
   },
   groupLinks: {
@@ -46,6 +47,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.text.dim3,
     whiteSpace: "no-wrap",
     display: "inline-block",
+    fontWeight: isEAForum ? 450 : undefined,
     fontSize: theme.typography.body2.fontSize,
     "@media print": { display: "none" },
   },


### PR DESCRIPTION
Sentence case + small font size and weight changes to:
- Post header additional info
- Connect page
---
Before
![Screenshot 2023-03-02 at 17 45 42](https://user-images.githubusercontent.com/13235378/222495553-44dce259-eb28-4810-b3a5-d920040eeb6a.png)

After
![Screenshot 2023-03-02 at 17 45 06](https://user-images.githubusercontent.com/13235378/222495597-c397080d-0742-4692-aea9-d775396d36dc.png)

---

Before
![Screenshot 2023-03-02 at 17 46 34](https://user-images.githubusercontent.com/13235378/222495957-fa01d8f1-6850-4348-92ba-2b6da28ae467.png)


After
![Screenshot 2023-03-02 at 17 47 11](https://user-images.githubusercontent.com/13235378/222495930-549ba4d0-f396-432a-ad26-2ee5a49d0626.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204099973327274) by [Unito](https://www.unito.io)
