### PR TITLE
fix form input layout

### DIFF
--- a/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
@@ -332,9 +332,11 @@ class FormComponent extends Component<any,any> {
     );
 
     if (this.props.tooltip) {
-      return <Components.LWTooltip title={this.props.tooltip} placement="left-start">
-        <div>{ formComponent }</div>
-      </Components.LWTooltip>
+      return <div>
+        <Components.LWTooltip title={this.props.tooltip} placement="left-start">
+          <div>{ formComponent }</div>
+        </Components.LWTooltip>
+      </div>
     } else {
       return formComponent;
     }


### PR DESCRIPTION
A recent change made it such that form inputs could become `inline-block` and end up next to each other. This fixes that.

<img width="669" alt="Screen Shot 2023-02-08 at 3 46 46 PM" src="https://user-images.githubusercontent.com/9057804/222497122-add32cdd-3264-481b-99e3-b4912b8fb5ec.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204099854253225) by [Unito](https://www.unito.io)
