### PR TITLE
make cloudinary urls use https

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -54,8 +54,11 @@ async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): 
     api_key: apiKey,
     api_secret: apiSecret,
     quality: 'auto',
-    fetch_format: 'auto'
+    fetch_format: 'auto',
+    secure: true
   });
+
+  console.log({ autoQualityFormatUrl, originalUrl: result.secure_url });
   
   await Images.rawInsert({
     originalUrl: oldUrl,

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -57,8 +57,6 @@ async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): 
     fetch_format: 'auto',
     secure: true
   });
-
-  console.log({ autoQualityFormatUrl, originalUrl: result.secure_url });
   
   await Images.rawInsert({
     originalUrl: oldUrl,


### PR DESCRIPTION
Apparently cloudinary's `url` manipulation spits out an `http` url by default (😡).  Didn't notice any issues in testing because they get auto-upgraded, mostly, but now there's a case in prod where it isn't being auto-upgraded.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204101353297904) by [Unito](https://www.unito.io)
