### PR TITLE
users should be able to add the community topic filter to their frontpage

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -6,7 +6,7 @@ import { forumTypeSetting, taggingNamePluralCapitalSetting } from '../../lib/ins
 import { useMulti } from '../../lib/crud/withMulti';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
-import { shouldHideTag } from '../../lib/collections/tags/permissions';
+import { shouldHideTagForVoting } from '../../lib/collections/tags/permissions';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -52,7 +52,7 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
   if (loading) return <Loading/>
   if (!coreTags) return null
   
-  const coreTagsToDisplay = coreTags.filter(tag => tag.isSubforum && !shouldHideTag(currentUser, tag));
+  const coreTagsToDisplay = coreTags.filter(tag => tag.isSubforum && !shouldHideTagForVoting(currentUser, tag));
   
   const selectedTagIds = Object.keys(value||{})
   const selectedCoreTagIds = showCoreTopicSection ? selectedTagIds.filter(tagId => coreTagsToDisplay.find(tag => tag._id === tagId)) : []
@@ -124,6 +124,7 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
           placeholder={placeholder ?? `+ Add ${taggingNamePluralCapitalSetting.get()}`}
           value={selectedTagIds.filter((tagId) => !selectedCoreTagIds.includes(tagId))}
           updateCurrentValues={onMultiselectUpdate}
+          isVotingContext
         />
       </div>
     );

--- a/packages/lesswrong/components/form-components/TagMultiselect.tsx
+++ b/packages/lesswrong/components/form-components/TagMultiselect.tsx
@@ -33,7 +33,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCount=false, startWithBorder=false, updateCurrentValues }: {
+const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCount=false, startWithBorder=false,isVotingContext, updateCurrentValues }: {
   value: Array<string>,
   path: string,
   classes: ClassesType,
@@ -41,6 +41,7 @@ const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCoun
   placeholder?: string,
   hidePostCount?: boolean,
   startWithBorder?: boolean,
+  isVotingContext?: boolean,
   updateCurrentValues(values): void,
 }) => {
   const { SingleTagItem, TagsSearchAutoComplete, ErrorBoundary } = Components
@@ -79,6 +80,7 @@ const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCoun
             clickAction={(id: string, tag: AlgoliaTag | null) => addTag(id, tag)}
             placeholder={placeholder}
             hidePostCount={hidePostCount}
+            isVotingContext={isVotingContext}
           />
         </div>
       </ErrorBoundary>

--- a/packages/lesswrong/components/search/TagsSearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/TagsSearchAutoComplete.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib'
 import { getAlgoliaIndexName } from '../../lib/algoliaUtil';
 
-const TagsSearchAutoComplete = ({clickAction, placeholder='Search for posts', hidePostCount=false}:{
+const TagsSearchAutoComplete = ({clickAction, placeholder='Search for posts', hidePostCount=false, isVotingContext}:{
   clickAction: (id: string, tag: AlgoliaTag | null) => void,
   placeholder?: string,
-  hidePostCount?: boolean
+  hidePostCount?: boolean,
+  isVotingContext?: boolean
 }) => {
   return <Components.SearchAutoComplete
     indexName={getAlgoliaIndexName("Tags")}
     clickAction={clickAction}
-    renderSuggestion={(hit: any) => <Components.TagSearchHit hit={hit} hidePostCount={hidePostCount} />}
+    renderSuggestion={(hit: any) => <Components.TagSearchHit hit={hit} hidePostCount={hidePostCount} isVotingContext={isVotingContext} />}
     placeholder={placeholder}
     noSearchPlaceholder='Tag ID'
   />

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -34,8 +34,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const AddTag = ({onTagSelected, classes}: {
+const AddTag = ({onTagSelected, isVotingContext, classes}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
+  isVotingContext?: boolean,
   classes: ClassesType,
 }) => {
   const { TagSearchHit, WrappedSmartForm } = Components
@@ -98,13 +99,15 @@ const AddTag = ({onTagSelected, classes}: {
         hitsPerPage={searchOpen ? 12 : 6}
       />
       <Hits hitComponent={({hit}) =>
-        <TagSearchHit hit={hit}
-            onClick={ev => {
-              onTagSelected({tagId: hit._id, tagName: hit.name});
-              ev.stopPropagation();
-            }}
-          />
-        }/>
+        <TagSearchHit
+          hit={hit}
+          onClick={ev => {
+            onTagSelected({tagId: hit._id, tagName: hit.name});
+            ev.stopPropagation();
+          }}
+          isVotingContext={isVotingContext}
+        />
+      }/>
     </InstantSearch>
     <Divider/>
     <Link target="_blank" to="/tags/all" className={classes.newTag}>

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -19,8 +19,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const AddTagButton = ({onTagSelected, classes, children}: {
+const AddTagButton = ({onTagSelected, isVotingContext, classes, children}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
+  isVotingContext?: boolean,
   classes: ClassesType,
   children?: ReactNode,
 }) => {
@@ -59,6 +60,7 @@ const AddTagButton = ({onTagSelected, classes, children}: {
               setIsOpen(false);
               onTagSelected({tagId, tagName});
             }}
+            isVotingContext={isVotingContext}
           />
         </Paper>
       </LWClickAwayListener>

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -179,7 +179,7 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false, s
       />
     )}
     { !hidePostTypeTag && postType }
-    {currentUser && !hideAddTag && <AddTagButton onTagSelected={onTagSelected} />}
+    {currentUser && !hideAddTag && <AddTagButton onTagSelected={onTagSelected} isVotingContext />}
     { isAwaiting && <Loading/>}
   </span>
 };

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useHover } from '../common/withHover';
 import { useCurrentUser } from '../common/withUser';
-import { shouldHideTag } from '../../lib/collections/tags/permissions';
+import { shouldHideTagForVoting } from '../../lib/collections/tags/permissions';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -31,10 +31,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const TagSearchHit = ({hit, onClick, hidePostCount=false, classes}: {
+const TagSearchHit = ({hit, onClick, hidePostCount=false, isVotingContext, classes}: {
   hit: any,
   onClick?: (ev: any) => void,
   hidePostCount?: boolean,
+  isVotingContext?: boolean,
   classes: ClassesType,
 }) => {
   const { PopperCard, TagPreview, Loading } = Components;
@@ -47,7 +48,9 @@ const TagSearchHit = ({hit, onClick, hidePostCount=false, classes}: {
   const {eventHandlers, hover, anchorEl} = useHover();
   const currentUser = useCurrentUser();
 
-  if (shouldHideTag(currentUser, tag ?? hit)) {
+  // Some tags are only allowed to be voted in by certain users, ex. mods & admins.
+  // However, users should still be able to find them in standard search, ex. frontpage filters.
+  if (isVotingContext && shouldHideTagForVoting(currentUser, tag ?? hit)) {
     return null;
   }
 

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -48,7 +48,8 @@ const TagSearchHit = ({hit, onClick, hidePostCount=false, isVotingContext, class
   const {eventHandlers, hover, anchorEl} = useHover();
   const currentUser = useCurrentUser();
 
-  // Some tags are only allowed to be voted in by certain users, ex. mods & admins.
+  // Some tags are only allowed to be voted on by certain users, ex. mods & admins
+  // - in these cases, other users should not be able to find them via search.
   // However, users should still be able to find them in standard search, ex. frontpage filters.
   if (isVotingContext && shouldHideTagForVoting(currentUser, tag ?? hit)) {
     return null;

--- a/packages/lesswrong/lib/collections/tags/permissions.ts
+++ b/packages/lesswrong/lib/collections/tags/permissions.ts
@@ -2,12 +2,12 @@ import { forumTypeSetting } from "../../instanceSettings";
 
 const adminOnlyTagSlugs = ["community"];
 
-export const shouldHideTag = (user: UsersCurrent | null, tag?: {slug: string}) => {
-  if (forumTypeSetting.get() !== "EAForum" || !user) {
+export const shouldHideTagForVoting = (user: UsersCurrent | null, tag?: {slug: string}) => {
+  if (forumTypeSetting.get() !== "EAForum") {
     return false;
   }
-  if (tag && !user.isAdmin && !user.groups?.includes("sunshineRegiment")) {
-    return adminOnlyTagSlugs.includes(tag.slug);
+  if (tag && adminOnlyTagSlugs.includes(tag.slug)) {
+    return user?.isAdmin || user?.groups?.includes("sunshineRegiment")
   }
   return false;
 }


### PR DESCRIPTION
When we restricted voting on the "Community" topic, we started excluding it from the search results list. However, that also meant that users who had removed it as a frontpage filter could not longer re-add it. Here I'm fixing that by only excluding topics from the search results list when we are in a voting context, because by default users should be able to search for and find those topics.

Also fixed a related bug that actually **did** allow logged out users to search for "Community" and apply it to their frontpage.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204102367460112) by [Unito](https://www.unito.io)
