### PR TITLE
Moderator pm UI

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSendMessageWithDefaults.tsx
@@ -4,12 +4,10 @@ import Menu from '@material-ui/core/Menu';
 import { Link } from "../../lib/reactRouterWrapper";
 import EditIcon from "@material-ui/icons/Edit";
 import {Components, registerComponent} from "../../lib/vulcan-lib";
-import { useTagBySlug } from '../tagging/useTag'
 import { useMulti } from "../../lib/crud/withMulti";
 import { useCurrentUser } from '../common/withUser';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import type { TemplateQueryStrings } from '../messaging/NewConversationButton'
-import { tagGetDiscussionUrl } from '../../lib/collections/tags/helpers';
 import { commentBodyStyles } from '../../themes/stylePiping';
 
 const MODERATION_TEMPLATES_URL = "/admin/moderationTemplates"
@@ -34,10 +32,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     boxShadow: theme.palette.boxShadow.sunshineSendMessage,
   },
   sendMessageButton: {
+    marginTop: 8,
     padding: 8,
+    paddingTop: 6,
     height: 32,
     wordBreak: "keep-all",
     fontSize: "1rem",
+    border: theme.palette.border.faint,
+    borderRadius: 2,
     color: theme.palette.grey[500],
     '&:hover': {
       backgroundColor: theme.palette.grey[200]
@@ -52,8 +54,7 @@ const SunshineSendMessageWithDefaults = ({ user, embedConversation, classes }: {
 }) => {
   
   const { ContentItemBody, LWTooltip, NewConversationButton } = Components
-  
-  
+
   const currentUser = useCurrentUser()
   const [anchorEl, setAnchorEl] = useState<any>(null);
   

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -45,17 +45,17 @@ export const SunshineUserMessages = ({classes, user, currentUser}: {
   });
 
   return <div className={classes.root}>
-    {results?.map(conversation => <Link to={`/inbox/${conversation._id}`} key={conversation._id}>
-      <LWTooltip title={`${conversation.messageCount} messages in this conversation`}>
+    {results?.map(conversation => <LWTooltip title={`${conversation.messageCount} messages in this conversation`} key={conversation._id}>
+      <Link to={`/inbox/${conversation._id}`}>
         <MetaInfo><EmailIcon className={classes.icon}/> {conversation.messageCount}</MetaInfo>
-      </LWTooltip>
-      <span className={classes.title}>
-        Conversation with{" "} 
-        {conversation.participants?.map(participant => {
-          if (participant._id !== user._id) return <UsersName simple user={participant} key={`${conversation._id}${user._id}`}/>
-        })}
-      </span>
-    </Link>)}
+        <span className={classes.title}>
+          Conversation with{" "} 
+          {conversation.participants?.map(participant => {
+            if (participant._id !== user._id) return <UsersName simple user={participant} key={`${conversation._id}${user._id}`}/>
+          })}
+        </span>
+      </Link>
+    </LWTooltip>)}
     <SunshineSendMessageWithDefaults 
         user={user} 
         embedConversation={embedConversation}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -1,12 +1,22 @@
 import React, { useState } from 'react';
 import { useTracking } from '../../lib/analyticsEvents';
+import { useMulti } from '../../lib/crud/withMulti';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
+import EmailIcon from '@material-ui/icons/Email';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: JssStyles) => ({
   row: {
     display: "flex",
     alignItems: "center"
+  },
+  icon: {
+    height: 13,
+    width: 13,
+    position: "relative",
+    top: 2,
+    marginRight: 3,
   }
 })
 
@@ -15,7 +25,7 @@ export const SunshineUserMessages = ({classes, user, currentUser}: {
   classes: ClassesType,
   currentUser: UsersCurrent,
 }) => {
-  const { ModeratorMessageCount, SunshineSendMessageWithDefaults, NewMessageForm } = Components
+  const { SunshineSendMessageWithDefaults, NewMessageForm, UsersName, LWTooltip, MetaInfo } = Components
   const [embeddedConversationId, setEmbeddedConversationId] = useState<string | undefined>();
   const [templateQueries, setTemplateQueries] = useState<TemplateQueryStrings | undefined>();
 
@@ -26,14 +36,30 @@ export const SunshineUserMessages = ({classes, user, currentUser}: {
     setTemplateQueries(templateQueries)
   }
 
+  const { results } = useMulti({
+    terms: {view: "moderatorConversations", userId: user._id},
+    collectionName: "Conversations",
+    fragmentName: 'conversationsListFragment',
+    fetchPolicy: 'cache-and-network',
+    enableTotal: true
+  });
+
   return <div className={classes.root}>
-    <div className={classes.row}>
-      <ModeratorMessageCount userId={user._id} />
-      <SunshineSendMessageWithDefaults 
+    {results?.map(conversation => <Link to={`/inbox/${conversation._id}`} key={conversation._id}>
+      <LWTooltip title={`${conversation.messageCount} messages in this conversation`}>
+        <MetaInfo><EmailIcon className={classes.icon}/> {conversation.messageCount}</MetaInfo>
+      </LWTooltip>
+      <span className={classes.title}>
+        Conversation with{" "} 
+        {conversation.participants?.map(participant => {
+          if (participant._id !== user._id) return <UsersName simple user={participant} key={`${conversation._id}${user._id}`}/>
+        })}
+      </span>
+    </Link>)}
+    <SunshineSendMessageWithDefaults 
         user={user} 
         embedConversation={embedConversation}
       />
-    </div>
     {embeddedConversationId && <div>
       <NewMessageForm 
         conversationId={embeddedConversationId} 


### PR DESCRIPTION
Replaces the "here's the total number of conversations" UI in the UsersReviewInfoCard, with a more specific list of individual mod conversations, which includes a direct link to each conversation.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/3246710/222830553-83ac3bd2-8e0b-4616-8fef-84d8153c6a7d.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204109652776465) by [Unito](https://www.unito.io)
