### PR TITLE
fix admins/mods ability to vote on community tag

### DIFF
--- a/packages/lesswrong/lib/collections/tags/permissions.ts
+++ b/packages/lesswrong/lib/collections/tags/permissions.ts
@@ -7,7 +7,7 @@ export const shouldHideTagForVoting = (user: UsersCurrent | null, tag?: {slug: s
     return false;
   }
   if (tag && adminOnlyTagSlugs.includes(tag.slug)) {
-    return user?.isAdmin || user?.groups?.includes("sunshineRegiment")
+    return !user || (!user.isAdmin && !user.groups?.includes("sunshineRegiment"))
   }
   return false;
 }


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204125856401286) by [Unito](https://www.unito.io)
