### PR TITLE
Fix missing crosspost bodies due to null-vs-empty-string distinction with cheerio parsing

### DIFF
--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -331,6 +331,6 @@ export const userIsPostCoauthor = (user: UsersMinimumInfo|DbUser|null, post: DbP
   return userIds.indexOf(user._id) >= 0;
 }
 
-export const isNotHostedHere = (post: PostsPage) => {
+export const isNotHostedHere = (post: PostsPage|DbPost) => {
   return post?.fmCrosspost?.isCrosspost && !post?.fmCrosspost?.hostedHere
 }


### PR DESCRIPTION
Before the bug: Side-comment generation attempts to parse `null` using cheerio, generating an exception, which is swallowed. (Mostly swallowed. It showed up in Sentry I think.) The annotated HTML used by side-comments is null, so side-comments are disabled.

After the bug: Side-comment generation handles the `null` case by treating it as empty-string. The annotated HTML used by side-comments is empty-string, which takes precedence over the cross-post fetching code.

The fix: Handle the crosspost-with-missing-body case directly in the `sideComments` resolver.