### PR TITLE
Prevent sending empty private messages

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
-import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useMulti } from '../../lib/crud/withMulti';
 import { conversationGetTitle } from '../../lib/collections/conversations/helpers';
@@ -9,7 +9,6 @@ import { useLocation } from '../../lib/routeUtil';
 import { useTracking } from '../../lib/analyticsEvents';
 import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import { userCanDo } from '../../lib/vulcan-users';
-import { getDraftMessageHtml } from '../../lib/collections/messages/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   conversationSection: {
@@ -33,15 +32,20 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-// The Navigation for the Inbox components
-const ConversationPage = ({ documentId, terms, currentUser, classes }: {
-  documentId: string,
-  terms: MessagesViewTerms,
+/**
+ * Page for viewing a private messages conversation. Typically invoked from
+ * ConversationWrapper, which takes care of the URL parsing.
+ */
+const ConversationPage = ({ conversationId, currentUser, classes }: {
+  conversationId: string,
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
   const { results, loading: loadingMessages } = useMulti({
-    terms,
+    terms: {
+      view: 'messagesConversation',
+      conversationId,
+    },
     collectionName: "Messages",
     fragmentName: 'messageListFragment',
     fetchPolicy: 'cache-and-network',
@@ -49,7 +53,7 @@ const ConversationPage = ({ documentId, terms, currentUser, classes }: {
     enableTotal: false,
   });
   const { document: conversation, loading: loadingConversation } = useSingle({
-    documentId,
+    documentId: conversationId,
     collectionName: "Conversations",
     fragmentName: 'conversationsListFragment',
   });

--- a/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
+++ b/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
@@ -1,15 +1,13 @@
-/*
-
-A component to configure the "Edit Title" form.
-
-*/
-
 import React from 'react';
 import { Components, registerComponent, getFragment } from "../../lib/vulcan-lib";
 import Conversations from '../../lib/collections/conversations/collection';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
+/**
+ * Form for editing the title of a private messages conversation and also for
+ * adding additional participants.
+ */
 const ConversationTitleEditForm = ({onClose, documentId}: {
   onClose?: ()=>void,
   documentId: string,

--- a/packages/lesswrong/components/messaging/ConversationWrapper.tsx
+++ b/packages/lesswrong/components/messaging/ConversationWrapper.tsx
@@ -3,14 +3,16 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil';
 
+/**
+ * A page with a private mesage conversation, with URL parameter parsing.
+ */
 const ConversationWrapper = () => {
   const currentUser = useCurrentUser()
   const { params } = useLocation();
   
   if (!currentUser) return <div>Log in to access private messages.</div>
-  const messagesTerms: MessagesViewTerms = {view: 'messagesConversation', conversationId: params._id};
 
-  return <Components.ConversationPage terms={messagesTerms} documentId={params._id} currentUser={currentUser} />
+  return <Components.ConversationPage conversationId={params._id} currentUser={currentUser} />
 }
 
 const ConversationWrapperComponent = registerComponent('ConversationWrapper', ConversationWrapper);

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -1,9 +1,3 @@
-/*
-
-Display of a single message in the Conversation Wrapper
-
-*/
-
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
@@ -11,7 +5,6 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import { useCurrentUser } from '../common/withUser';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { PROFILE_IMG_DIAMETER, PROFILE_IMG_DIAMETER_MOBILE } from './ProfilePhoto';
-
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -67,6 +60,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
+/**
+ * Display of a single message in the Conversation Wrapper
+*/
 const MessageItem = ({message, classes}: {
   message: messageListFragment,
   classes: ClassesType,
@@ -81,7 +77,7 @@ const MessageItem = ({message, classes}: {
   const colorClassName = classNames({[classes.whiteMeta]: isCurrentUser})
   const isEAForum = forumTypeSetting.get() === 'EAForum'
 
-  let profilePhoto
+  let profilePhoto: React.ReactNode|null = null;
   if (!isCurrentUser && isEAForum) {
     profilePhoto = <Components.ProfilePhoto user={message.user} className={classes.profileImg} />
   }

--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -4,6 +4,14 @@ import { userIsAdmin } from '../../lib/vulcan-users';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { createMutator } from '../vulcan-lib';
 
+getCollectionHooks("Messages").newValidate.add(function NewMessageEmptyCheck (message: DbMessage) {
+  const { data } = (message.contents && message.contents.originalContents) || {}
+  if (!data) {
+    throw new Error("You cannot send an empty message");
+  }
+  return message;
+});
+
 getCollectionHooks("Messages").createAsync.add(function unArchiveConversations({document}) {
   void Conversations.rawUpdateOne({_id:document.conversationId}, {$set: {archivedByIds: []}});
 });


### PR DESCRIPTION
Previously: If you clicked Submit on the private-message conversation page with a blank message, it would send an empty message; some-but-not-all display and notifications of this message would be suppressed due to it being empty.

Now: If you click Subnit on the private-message conversation page with a blank message, it says "You cannot send an empty message" (almost identical to how it's handled if you try to  submit an empty comment on a post page.)

Also fixed up some doc-comments, an implicit any, and an awkward indirect construction of `terms`, while I was in the neighborhood.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204139963091783) by [Unito](https://www.unito.io)
