### PR TITLE
Fix links inside moderation guidelines being unclickable if they also expand/collapse

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -111,14 +111,25 @@ const ModerationGuidelinesBox = ({classes, commentType = "post", documentId}: {
     fetchPolicy: "cache-first",
     fragmentName: isPost ? "PostsList" : "TagFragment",
   });
-  const isPostType = (document): document is PostsList => isPost && !!document
+  const isPostType = (document: PostsList|TagFragment): document is PostsList => isPost && !!document
   
   if (!document || loading) return null
 
   const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
+    // On click, toggle moderation-guidelines expansion. Event handler is only
+    // attached if they're long enough for expand/collapse to be a thing. Note
+    // that if the moderation guidelines contain a link, this could also be a
+    // link-click, in which case it's important not to preventDefault or
+    // stopPropagation.
+    
+    // Only toggle moderation-guidelines expansion on an unmodified left-click
+    // (ie not if this is an open-new-tab on a link)
+    if(e.altKey || e.shiftKey || e.ctrlKey || e.metaKey || e.button!==0) {
+      return;
+    }
+    
     setExpanded(!expanded)
+    
     if (currentUser) {
       const eventProperties = {
         userId: currentUser._id,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204140242205691) by [Unito](https://www.unito.io)
