### PR TITLE
Upgrade from node 18.12 to 18.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Node 18.12 is LTS
-FROM node:18.12.0
+# Node 18.x is LTS
+FROM node:18.15.0
 ENV IS_DOCKER=true
 # Transcrypt dependency
 RUN apt-get update && apt-get install -y bsdmainutils

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -3,17 +3,25 @@
 # version of nodejs, and warn about system issues that would cause problems.
 # This is run as a postinstall script from package.json.
 
+REQUIRED_NODE_MAJOR_VERSION=18
+
 echo -n "Checking for node... "
 if which node >/dev/null; then
   node --version 2>&1
   NODE_MAJOR_VERSION=$(node -p 'process.version.match(/^v(\d+)/)[1]')
-  if [ "$NODE_MAJOR_VERSION" -lt 14 ]; then
-    echo "Your version of nodejs is too old (we require 14+). You might want to use"
-    echo "Node Version Manager (nvm). For install instructions, see"
+  if [ "$NODE_MAJOR_VERSION" -lt "$REQUIRED_NODE_MAJOR_VERSION" ]; then
+    echo "Your version of nodejs is too old (we require 18.x). You might want to use Node"
+    echo "Version Manager (nvm). For install instructions, see"
     echo "    https://github.com/nvm-sh/nvm#installing-and-updating"
     echo "And then run:"
-    echo "    nvm use 14"
+    echo "    nvm install $REQUIRED_NODE_MAJOR_VERSION; nvm use $REQUIRED_NODE_MAJOR_VERSION"
     exit 1
+  elif [ "$NODE_MAJOR_VERSION" -gt "$REQUIRED_NODE_MAJOR_VERSION" ]; then
+    echo "Your version of nodejs is a newer major version than we use (we use 18.x); you"
+    echo "may encounter compatibility issues. To switch to node ${REQUIRED_NODE_MAJOR_VERSION}, use"
+    echo "    nvm install $REQUIRED_NODE_MAJOR_VERSION; nvm use $REQUIRED_NODE_MAJOR_VERSION"
+    echo "If you don't have nvm installed, see:"
+    echo "    https://github.com/nvm-sh/nvm#installing-and-updating"
   fi
 else
   echo "not found"


### PR DESCRIPTION
Nodejs changelog: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.15.0

The thing that actually prompted me to do this was wanting to get rid of the warning on startup that reads

```
(node:2658) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time (Use `node --trace-warnings ...` to show where the warning was created)
```

which is removed in node 18.13. There are also some CVEs in versions between 18.12 and 18.15, but none of them look likely to be relevant (given that our server doesn't do its own SSL termination).

Note that the corresponding version number on a *dev* machine isn't affected by this; to do that upgrade you'd run `nvm install 18.15; nvm use 18`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204140657546177) by [Unito](https://www.unito.io)
