### PR TITLE
Fix two common spurious console-error messages

### DIFF
--- a/packages/lesswrong/client/logging.ts
+++ b/packages/lesswrong/client/logging.ts
@@ -1,10 +1,8 @@
 import * as Sentry from '@sentry/browser';
 import * as SentryIntegrations from '@sentry/integrations';
-import { routerOnUpdate } from '../components/hooks/useOnNavigate';
-import type { RouterLocation } from '../lib/vulcan-lib/routes';
 import { captureEvent, AnalyticsUtil, userChangedCallback } from '../lib/analyticsEvents';
 import { browserProperties } from '../lib/utils/browserProperties';
-import { sentryUrlSetting, sentryReleaseSetting, sentryEnvironmentSetting, forumTypeSetting } from '../lib/instanceSettings';
+import { sentryUrlSetting, sentryReleaseSetting, sentryEnvironmentSetting } from '../lib/instanceSettings';
 import { getUserEmail } from "../lib/collections/users/helpers";
 import { devicePrefersDarkMode } from "../components/themes/usePrefersDarkMode";
 import { configureDatadogRum } from './datadogRum';
@@ -73,12 +71,6 @@ window.addEventListener('load', ev => {
   });
 });
 
-routerOnUpdate.add(({oldLocation, newLocation}: {oldLocation: RouterLocation, newLocation: RouterLocation}) => {
-  captureEvent("navigate", {
-    from: oldLocation.pathname,
-    to: newLocation.pathname,
-  });
-});
 
 // Put the tabId, which was injected into the page as a global variable, into
 // the analytics context vars. See apollo-ssr/renderPage.js

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -183,10 +183,10 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
   //  2) Hide the username on mobile so users with long usernames can still
   //     enter search queries
   // Called by SearchBar.
-  const setSearchOpen = (isOpen: boolean) => {
+  const setSearchOpen = useCallback((isOpen: boolean) => {
     if (isOpen) { captureEvent("searchToggle", {"open": isOpen}) }
     setSearchOpenState(isOpen);
-  }
+  }, [captureEvent]);
 
   const renderNavigationMenuButton = () => {
     // The navigation menu button either toggles a free floating sidebar, opens

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { routerOnUpdate } from '../hooks/useOnNavigate';
+import { useOnNavigate } from '../hooks/useOnNavigate';
 import { InstantSearch, SearchBox, connectMenu } from 'react-instantsearch-dom';
 import classNames from 'classnames';
 import SearchIcon from '@material-ui/icons/Search';
 import CloseIcon from '@material-ui/icons/Close';
 import Portal from '@material-ui/core/Portal';
-import { withLocation, withNavigation } from '../../lib/routeUtil';
+import { useNavigation } from '../../lib/routeUtil';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/algoliaUtil';
 import { forumTypeSetting } from '../../lib/instanceSettings';
@@ -98,139 +98,104 @@ const styles = (theme: ThemeType): JssStyles => ({
   },  
 })
 
-interface ExternalProps {
-  onSetIsActive: (active: boolean)=>void,
+const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
+  onSetIsActive: (active:boolean)=>void,
   searchResultsArea: any,
-}
-interface SearchBarProps extends ExternalProps, WithStylesProps, WithLocationProps, WithNavigationProps {
-}
+  classes: ClassesType
+}) => {
+  const [inputOpen,setInputOpen] = useState(false);
+  const [searchOpen,setSearchOpen] = useState(false);
+  const [currentQuery,setCurrentQuery] = useState("");
+  const { history } = useNavigation();
 
-interface SearchBarState {
-  inputOpen: boolean,
-  searchOpen: boolean,
-  currentQuery: string,
-}
-
-class SearchBar extends Component<SearchBarProps,SearchBarState> {
-  routerUpdateCallback: any
-  
-  constructor(props: SearchBarProps){
-    super(props);
-    this.state = {
-      inputOpen: false,
-      searchOpen: false,
-      currentQuery: "",
-    }
-  }
-
-  handleSubmit = () => {
-    const { history } = this.props
-    const { currentQuery } = this.state
+  const handleSubmit = () => {
     history.push({pathname: `/search`, search: `?${qs.stringify({query: currentQuery})}`});
-    this.closeSearch()
+    closeSearch()
   }
   
-  componentDidMount() {
-    let _this = this;
-    this.routerUpdateCallback = function closeSearchOnNavigate() {
-      _this.closeSearch();
-    };
-    routerOnUpdate.add(this.routerUpdateCallback);
+  useOnNavigate(() => {
+    closeSearch();
+  });
+
+
+  const openSearchResults = () => setSearchOpen(true);
+  const closeSearchResults = () => setSearchOpen(false);
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setInputOpen(false);
+    if (onSetIsActive)
+      onSetIsActive(false);
   }
 
-  componentWillUnmount() {
-    if (this.routerUpdateCallback) {
-      routerOnUpdate.remove(this.routerUpdateCallback);
-      this.routerUpdateCallback = null;
-    }
+  const handleSearchTap = () => {
+    setInputOpen(true);
+    setSearchOpen(!!currentQuery);
+    if (onSetIsActive)
+      onSetIsActive(true);
   }
 
-
-  openSearchResults = () => {
-    this.setState({searchOpen: true});
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') closeSearch();
+    if (event.keyCode === 13) handleSubmit()
   }
 
-  closeSearchResults = () => {
-    this.setState({searchOpen: false});
-  }
-
-  closeSearch = () => {
-    this.setState({searchOpen: false, inputOpen: false});
-    if (this.props.onSetIsActive)
-      this.props.onSetIsActive(false);
-  }
-
-  handleSearchTap = () => {
-    this.setState({inputOpen: true, searchOpen: !!this.state.currentQuery});
-    if (this.props.onSetIsActive)
-      this.props.onSetIsActive(true);
-  }
-
-  handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape') this.closeSearch();
-    if (event.keyCode === 13) this.handleSubmit()
-  }
-
-  queryStateControl = (searchState: any): void => {
-    if (searchState.query !== this.state.currentQuery) {
-      this.setState({currentQuery: searchState.query});
+  const queryStateControl = (searchState: any): void => {
+    if (searchState.query !== currentQuery) {
+      setCurrentQuery(searchState.query);
       if (searchState.query) {
-        this.openSearchResults();
+        openSearchResults();
       } else {
-        this.closeSearchResults();
+        closeSearchResults();
       }
     }
   }
 
-  render() {
-    const alignmentForum = forumTypeSetting.get() === 'AlignmentForum';
+  const alignmentForum = forumTypeSetting.get() === 'AlignmentForum';
+  const { SearchBarResults } = Components
 
-    const { searchResultsArea, classes } = this.props
-    const { searchOpen, inputOpen, currentQuery } = this.state
-    const { SearchBarResults } = Components
-
-    if(!isAlgoliaEnabled()) {
-      return <div>Search is disabled (Algolia App ID not configured on server)</div>
-    }
-
-    return <div className={classes.root} onKeyDown={this.handleKeyDown}>
-      <div className={classes.rootChild}>
-        <InstantSearch
-          indexName={getAlgoliaIndexName("Posts")}
-          searchClient={getSearchClient()}
-          onSearchStateChange={this.queryStateControl}
-        >
-          <div className={classNames(
-            classes.searchInputArea,
-            {"open": inputOpen},
-            {[classes.alignmentForum]: alignmentForum}
-          )}>
-            {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
-            <div onClick={this.handleSearchTap}>
-              <SearchIcon className={classes.searchIcon}/>
-              {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
-                * null is the only option that actually suppresses the extra X button.
-               // @ts-ignore */}
-              {inputOpen && <SearchBox reset={null} focusShortcuts={[]} autoFocus={true} />}
-            </div>
-            { searchOpen && <div className={classes.searchBarClose} onClick={this.closeSearch}>
-              <CloseIcon className={classes.closeSearchIcon}/>
-            </div>}
-            <div>
-              { searchOpen && <Portal container={searchResultsArea.current}>
-                  <SearchBarResults closeSearch={this.closeSearch} currentQuery={currentQuery} />
-                </Portal> }
-            </div>
-          </div>
-        </InstantSearch>
-      </div>
-    </div>
+  if(!isAlgoliaEnabled()) {
+    return <div>Search is disabled (Algolia App ID not configured on server)</div>
   }
+
+  return <div className={classes.root} onKeyDown={handleKeyDown}>
+    <div className={classes.rootChild}>
+      <InstantSearch
+        indexName={getAlgoliaIndexName("Posts")}
+        searchClient={getSearchClient()}
+        onSearchStateChange={queryStateControl}
+      >
+        <div className={classNames(
+          classes.searchInputArea,
+          {"open": inputOpen},
+          {[classes.alignmentForum]: alignmentForum}
+        )}>
+          {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
+          <div onClick={handleSearchTap}>
+            <SearchIcon className={classes.searchIcon}/>
+            {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
+              * null is the only option that actually suppresses the extra X button.
+             // @ts-ignore */}
+            {inputOpen && <SearchBox reset={null} focusShortcuts={[]} autoFocus={true} />}
+          </div>
+          { searchOpen && <div className={classes.searchBarClose} onClick={closeSearch}>
+            <CloseIcon className={classes.closeSearchIcon}/>
+          </div>}
+          <div>
+            { searchOpen && <Portal container={searchResultsArea.current}>
+                <SearchBarResults closeSearch={closeSearch} currentQuery={currentQuery} />
+              </Portal> }
+          </div>
+        </div>
+      </InstantSearch>
+    </div>
+  </div>
 }
 
-const SearchBarComponent = registerComponent<ExternalProps>("SearchBar", SearchBar, {
+const SearchBarComponent = registerComponent("SearchBar", SearchBar, {
   styles,
-  hocs: [withLocation, withErrorBoundary, withNavigation],
+  hocs: [withErrorBoundary],
+  areEqual: "auto",
 });
 
 declare global {

--- a/packages/lesswrong/components/hooks/useOnNavigate.tsx
+++ b/packages/lesswrong/components/hooks/useOnNavigate.tsx
@@ -4,11 +4,12 @@ import { CallbackChainHook  } from '../../lib/vulcan-lib/callbacks';
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { isClient } from '../../lib/executionEnvironment';
+import { captureEvent } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 
 let lastLocation: RouterLocation|null = null;
 
-export const routerOnUpdate = new CallbackChainHook<{oldLocation:RouterLocation|null,newLocation:RouterLocation},[]>("router.onUpdate");
+const routerOnUpdate = new CallbackChainHook<{oldLocation:RouterLocation|null,newLocation:RouterLocation},[]>("router.onUpdate");
 
 const NavigationEventSender = () => {
   const location = useSubscribedLocation();
@@ -20,6 +21,10 @@ const NavigationEventSender = () => {
       if (location.pathname !== lastLocation?.pathname) {
         // Don't send the callback on the initial pageload, only on post-load navigations
         if (lastLocation) {
+          captureEvent("navigate", {
+            from: lastLocation.pathname,
+            to: location.pathname,
+          });
           void routerOnUpdate.runCallbacks({
             iterator: {oldLocation: lastLocation, newLocation: location},
             properties: [],

--- a/packages/lesswrong/components/hooks/useOnNavigate.tsx
+++ b/packages/lesswrong/components/hooks/useOnNavigate.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { CallbackChainHook  } from '../../lib/vulcan-lib/callbacks';
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { isClient } from '../../lib/executionEnvironment';
@@ -8,8 +7,8 @@ import { captureEvent } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 
 let lastLocation: RouterLocation|null = null;
-
-const routerOnUpdate = new CallbackChainHook<{oldLocation:RouterLocation|null,newLocation:RouterLocation},[]>("router.onUpdate");
+type LocationChange = {oldLocation: RouterLocation|null, newLocation: RouterLocation};
+let onNavigateFunctions: Array<(locationChange: LocationChange)=>void> = [];
 
 const NavigationEventSender = () => {
   const location = useSubscribedLocation();
@@ -25,10 +24,10 @@ const NavigationEventSender = () => {
             from: lastLocation.pathname,
             to: location.pathname,
           });
-          void routerOnUpdate.runCallbacks({
-            iterator: {oldLocation: lastLocation, newLocation: location},
-            properties: [],
-          });
+          let change: LocationChange = {oldLocation: lastLocation, newLocation: location};
+          for(let cb of [...onNavigateFunctions]) {
+            cb(change);
+          }
         }
         lastLocation = _.clone(location);
       }
@@ -43,11 +42,11 @@ const NavigationEventSender = () => {
  * at the *start* of the navigation, ie, when the link is first clicked (but
  * before most of the stuff at the destination has loaded).
  */
-export function useOnNavigate(fn: ({oldLocation,newLocation}: {oldLocation: RouterLocation|null, newLocation: RouterLocation})=>void) {
+export function useOnNavigate(fn: (change: LocationChange)=>void) {
   useEffect(() => {
-    routerOnUpdate.add(fn);
+    onNavigateFunctions.push(fn);
     return () => {
-      routerOnUpdate.remove(fn);
+      onNavigateFunctions = onNavigateFunctions.filter(f=>f!==fn);
     };
   }, [fn]);
 }

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -1,41 +1,54 @@
-import '../components/alignment-forum/withSetAlignmentPost';
+import { importComponent } from './vulcan-lib';
+
+/**
+ * This file registers each component-containing file with a call to
+ * `importComponent`, providing the names of any components in that file, and a
+ * function that require()s it. This doesn't immediately cause that component
+ * file to be imported; instead, it stores that metadata in a table, and calls
+ * the function the first time the component is used (more specifically: the
+ * first time it's extracted from `Components`, which is a proxy class).
+ *
+ * This setup dates back to a time when file-imports in this codebase were
+ * slow (pre-esbuild) and might not be neessary anymore.
+ *
+ * Calls to `importComponent` never need to be forum-gated, and forum-gating
+ * here has no benefit; instead, site-specific components should check the
+ * forum type at time of use.
+ *
+ * The order of components in this file doesn't matter, and it isn't
+ * particularly organized.
+ */
+
+
+// A few directories have `index.ts` files containing `importComponent` calls
+// for only the things in that directory. Those are imported here. This is not
+// required and we mostly haven't been doing it.
 import '../components/posts/PostActions';
 import '../components/posts/PostsPage';
 import '../components/posts/TableOfContents';
-
 import '../components/vulcan-core/vulcan-core-components';
-import { forumTypeSetting } from './instanceSettings';
-// vulcan:forms
 import './vulcan-forms/components';
-import { importComponent } from './vulcan-lib';
 
-if(forumTypeSetting.get() === 'AlignmentForum') {
-  // HACK: At the top of the file because DeepScan false-positively warns about
-  // imports not at top level, and it re-detects it every time the line number
-  // changes. Putting it at the top makes its line number stable.
-  importComponent("AlignmentForumHome", () => require('../components/alignment-forum/AlignmentForumHome'));
-}
+importComponent("AlignmentForumHome", () => require('../components/alignment-forum/AlignmentForumHome'));
 
-if (forumTypeSetting.get() === 'EAForum') {
-  importComponent("EAHome", () => require('../components/ea-forum/EAHome'));
-  importComponent("EAHomeCommunityPosts", () => require('../components/ea-forum/EAHomeCommunityPosts'));
-  importComponent("EATermsOfUsePage", () => require('../components/ea-forum/EATermsOfUsePage'));
-  importComponent("EASequencesHome", () => require('../components/ea-forum/EASequencesHome'));
-  importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHandbook'));
-  importComponent("EAForumWrappedPage", () => require('../components/ea-forum/EAForumWrappedPage'));
-  importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
-  importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
-  importComponent("MaintenanceBanner", () => require('../components/common/MaintenanceBanner'));
-  importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
-  importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
-  importComponent("TargetedJobAdSection", () => require('../components/ea-forum/TargetedJobAdSection'))
-  importComponent("TargetedJobAd", () => require('../components/ea-forum/TargetedJobAd'))
-  importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))
-  importComponent("EAGApplicationImportForm", () => require('../components/ea-forum/users/EAGApplicationImportForm'))
-  importComponent("EAUsersProfile", () => require('../components/ea-forum/users/EAUsersProfile'))
-  importComponent("EAUsersProfileTabbedSection", () => require('../components/ea-forum/users/modules/EAUsersProfileTabbedSection'))
-  importComponent("EAUsersProfileTags", () => require('../components/ea-forum/users/modules/EAUsersProfileTags'))
-}
+importComponent("EAHome", () => require('../components/ea-forum/EAHome'));
+importComponent("EAHomeCommunityPosts", () => require('../components/ea-forum/EAHomeCommunityPosts'));
+importComponent("EATermsOfUsePage", () => require('../components/ea-forum/EATermsOfUsePage'));
+importComponent("EASequencesHome", () => require('../components/ea-forum/EASequencesHome'));
+importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHandbook'));
+importComponent("EAForumWrappedPage", () => require('../components/ea-forum/EAForumWrappedPage'));
+importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
+importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
+importComponent("MaintenanceBanner", () => require('../components/common/MaintenanceBanner'));
+importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
+importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
+importComponent("TargetedJobAdSection", () => require('../components/ea-forum/TargetedJobAdSection'))
+importComponent("TargetedJobAd", () => require('../components/ea-forum/TargetedJobAd'))
+importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))
+importComponent("EAGApplicationImportForm", () => require('../components/ea-forum/users/EAGApplicationImportForm'))
+importComponent("EAUsersProfile", () => require('../components/ea-forum/users/EAUsersProfile'))
+importComponent("EAUsersProfileTabbedSection", () => require('../components/ea-forum/users/modules/EAUsersProfileTabbedSection'))
+importComponent("EAUsersProfileTags", () => require('../components/ea-forum/users/modules/EAUsersProfileTags'))
 
 importComponent("ConversationTitleEditForm", () => require('../components/messaging/ConversationTitleEditForm'));
 importComponent("ConversationDetails", () => require('../components/messaging/ConversationDetails'));


### PR DESCRIPTION
On LW (but not EAF), the error `Missing component: TargetedJobAdSection` would appear in the client console. (Nothing is actually broken, though.) This was caused by unnecessary double-forum-gating in `components.ts`. Cleaned that up, and added a block-common to `components.ts` about why forum-gating isn't necessary in that file.

On all, the error `Async before callbacks should not return undefined. Please return the document/data instead` would appear 3x on client-navigation. This was caused by `useOnNavigate` using some janky Vulcan callbacks machinery that it didn't need, and passing `undefined` in a slot where some recently-introduced defensive programming wants to see a real value. Fix the error message by refactoring that area, replacing the Vulcan callback with a simple array.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204141271278168) by [Unito](https://www.unito.io)
