### PR TITLE
Add `forceCollectionType` instance setting

### DIFF
--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -123,6 +123,12 @@ export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'Les
 // Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum". Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.
 export const siteNameWithArticleSetting = new PublicInstanceSetting<string>('siteNameWithArticle', "LessWrong", "warning")
 
+/**
+ * By default, we switch between using Mongo or Postgres based on the forum type. This can make it difficult to
+ * test changes with different forum types to find regressions. Setting this to either "mongo" or "pg" will force
+ * all collections to be of that type whatever the forum type setting might be, making cross-forum testing much
+ * easier.
+ */
 export const forceCollectionTypeSetting = new PublicInstanceSetting<CollectionType|null>("forceCollectionType", null, "optional");
 
 /**

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -123,6 +123,8 @@ export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'Les
 // Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum". Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.
 export const siteNameWithArticleSetting = new PublicInstanceSetting<string>('siteNameWithArticle', "LessWrong", "warning")
 
+export const forceCollectionTypeSetting = new PublicInstanceSetting<CollectionType|null>("forceCollectionType", null, "optional");
+
 /**
  * Name of the tagging feature on your site. The EA Forum is going to try
  * calling them topics. You should set this setting with the lowercase singular

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -6,8 +6,8 @@ import { registerCollection } from './getCollection';
 import { addGraphQLCollection } from './graphql';
 import { camelCaseify } from './utils';
 import { pluralize } from './pluralize';
+import { forceCollectionTypeSetting } from '../instanceSettings';
 export * from './getCollection';
-import { loggerConstructor } from '../utils/logging'
 
 // When used in a view, set the query so that it returns rows where a field is
 // null or is missing. Equivalent to a search with mongo's `field:null`, except
@@ -26,9 +26,12 @@ export const getCollectionName = (typeName): CollectionNameString => pluralize(t
 // TODO: find more reliable way to get type name from collection name?
 export const getTypeName = (collectionName: CollectionNameString) => collectionName.slice(0, -1);
 
-export type CollectionType = "mongo" | "pg" | "switching";
+declare global {
+  type CollectionType = "mongo" | "pg" | "switching";
+}
 
 const pickCollectionType = (collectionType?: CollectionType) => {
+  collectionType = forceCollectionTypeSetting.get() ?? collectionType;
   switch (collectionType) {
   case "pg":
     return PgCollection;


### PR DESCRIPTION
It's currently difficult for EA Forum developers to test the site in LessWrong mode and vice versa because changing the `forumType` instance setting also changes the database type between Postgres and Mongo. This PR adds an optional instance setting called `forceCollectionType` of type `CollectionType` which can be used to separate this logic. That is, adding `"forceCollectionType": "pg"` as an instance setting for the EA Forum will allow us to set the `forumType` to `"LessWrong"` whilst still using Postgres, and LessWrong can use `"forceCollectionType": "mongo"` to test the site in EA Forum mode without needing all collections in Postgres.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204149385538374) by [Unito](https://www.unito.io)
