### PR TITLE
Fix console warnings on the login form

### DIFF
--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -138,9 +138,9 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
   const { pathname } = useLocation()
   const { SignupSubscribeToCurated } = Components;
   const [reCaptchaToken, setReCaptchaToken] = useState<any>(null);
-  const [username, setUsername] = useState<string | undefined>(undefined)
-  const [password, setPassword] = useState<string | undefined>(undefined)
-  const [email, setEmail] = useState<string | undefined>(undefined)
+  const [username, setUsername] = useState<string>("")
+  const [password, setPassword] = useState<string>("")
+  const [email, setEmail] = useState<string>("")
   const { flash } = useMessages();
   const [currentAction, setCurrentAction] = useState<possibleActions>(startingState)
   const [subscribeToCurated, setSubscribeToCurated] = useState<boolean>(!['EAForum', 'AlignmentForum'].includes(forumTypeSetting.get()))


### PR DESCRIPTION
(LW specific, debug builds only) When you typed into one of the text fields on the login or signup form, you'd get a console warning about elements switching from unmanaged to managed, because the initial value given to the text input field was `undefined` but should have been `""`. Fix that by initializing the text boxes to `""` instead of `undefined`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204149797131079) by [Unito](https://www.unito.io)
