### PR TITLE
Vendor react-intercom

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,6 @@
     "react-instantsearch": "^6.1.0",
     "react-instantsearch-core": "^6.8.1",
     "react-instantsearch-dom": "^6.8.1",
-    "react-intercom": "^1.0.13",
     "react-jss": "^8.1.0",
     "react-map-gl": "^5.2.9",
     "react-no-ssr": "^1.1.0",

--- a/packages/lesswrong/components/common/IntercomWrapper.tsx
+++ b/packages/lesswrong/components/common/IntercomWrapper.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from './withUser';
 import { getUserEmail } from "../../lib/collections/users/helpers";
 import { useLocation } from '../../lib/routeUtil';
 import withErrorBoundary from './withErrorBoundary'
-import Intercom from 'react-intercom';
+import Intercom from '../../lib/vendor/react-intercom';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 

--- a/packages/lesswrong/lib/vendor/react-intercom.js
+++ b/packages/lesswrong/lib/vendor/react-intercom.js
@@ -10,6 +10,7 @@ export const IntercomAPI = (...args) => {
   if (canUseDOM && window.Intercom) {
     window.Intercom.apply(null, args);
   } else {
+    // eslint-disable-next-line no-console
     console.warn('Intercom not initialized yet');
   }
 };
@@ -26,7 +27,7 @@ export default class Intercom extends Component {
 
     const {
       appID,
-      ...otherProps,
+      ...otherProps
     } = props;
 
     if (!appID || !canUseDOM) {
@@ -53,14 +54,14 @@ export default class Intercom extends Component {
     window.intercomSettings = { ...otherProps, app_id: appID };
 
     if (window.Intercom) {
-      window.Intercom('boot', otherProps);
+      window.Intercom('boot', otherProps); //eslint-disable-line babel/new-cap
     }
   }
 
   componentWillReceiveProps(nextProps) {
     const {
       appID,
-      ...otherProps,
+      ...otherProps
     } = nextProps;
 
     if (!canUseDOM) return;
@@ -70,10 +71,10 @@ export default class Intercom extends Component {
     if (window.Intercom) {
       if (this.loggedIn(this.props) && !this.loggedIn(nextProps)) {
         // Shutdown and boot each time the user logs out to clear conversations
-        window.Intercom('shutdown');
-        window.Intercom('boot', otherProps);
+        window.Intercom('shutdown'); //eslint-disable-line babel/new-cap
+        window.Intercom('boot', otherProps); //eslint-disable-line babel/new-cap
       } else {
-        window.Intercom('update', otherProps);
+        window.Intercom('update', otherProps); //eslint-disable-line babel/new-cap
       }
     }
   }
@@ -85,7 +86,7 @@ export default class Intercom extends Component {
   componentWillUnmount() {
     if (!canUseDOM || !window.Intercom) return false;
 
-    window.Intercom('shutdown');
+    window.Intercom('shutdown'); //eslint-disable-line babel/new-cap
 
     delete window.Intercom;
     delete window.intercomSettings;

--- a/packages/lesswrong/lib/vendor/react-intercom.js
+++ b/packages/lesswrong/lib/vendor/react-intercom.js
@@ -58,7 +58,7 @@ export default class Intercom extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       appID,
       ...otherProps

--- a/packages/lesswrong/lib/vendor/react-intercom.js
+++ b/packages/lesswrong/lib/vendor/react-intercom.js
@@ -1,0 +1,101 @@
+// react-intercom, vendored from https://github.com/nhagen/react-intercom/blob/master/src/index.js
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+const canUseDOM = !!(
+  (typeof window !== 'undefined' &&
+  window.document && window.document.createElement)
+);
+
+export const IntercomAPI = (...args) => {
+  if (canUseDOM && window.Intercom) {
+    window.Intercom.apply(null, args);
+  } else {
+    console.warn('Intercom not initialized yet');
+  }
+};
+
+export default class Intercom extends Component {
+  static propTypes = {
+    appID: PropTypes.string.isRequired,
+  };
+
+  static displayName = 'Intercom';
+
+  constructor(props) {
+    super(props);
+
+    const {
+      appID,
+      ...otherProps,
+    } = props;
+
+    if (!appID || !canUseDOM) {
+      return;
+    }
+
+    if (!window.Intercom) {
+      (function(w, d, id, s, x) {
+        function i() {
+            i.c(arguments);
+        }
+        i.q = [];
+        i.c = function(args) {
+            i.q.push(args);
+        };
+        w.Intercom = i;
+        s = d.createElement('script');
+        s.async = 1;
+        s.src = 'https://widget.intercom.io/widget/' + id;
+        d.head.appendChild(s);
+      })(window, document, appID);
+    }
+
+    window.intercomSettings = { ...otherProps, app_id: appID };
+
+    if (window.Intercom) {
+      window.Intercom('boot', otherProps);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      appID,
+      ...otherProps,
+    } = nextProps;
+
+    if (!canUseDOM) return;
+
+    window.intercomSettings = { ...otherProps, app_id: appID };
+
+    if (window.Intercom) {
+      if (this.loggedIn(this.props) && !this.loggedIn(nextProps)) {
+        // Shutdown and boot each time the user logs out to clear conversations
+        window.Intercom('shutdown');
+        window.Intercom('boot', otherProps);
+      } else {
+        window.Intercom('update', otherProps);
+      }
+    }
+  }
+
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  componentWillUnmount() {
+    if (!canUseDOM || !window.Intercom) return false;
+
+    window.Intercom('shutdown');
+
+    delete window.Intercom;
+    delete window.intercomSettings;
+  }
+
+  loggedIn(props) {
+    return props.email || props.user_id;
+  }
+
+  render() {
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8178,7 +8178,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.1, fbjs@^0.8.15, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.15:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -13091,13 +13091,6 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@15.5.8:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz"
-  integrity sha1-a3suFBCDvjjIWVqlH8VXdccZk5Q=
-  dependencies:
-    fbjs "^0.8.9"
-
 prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz"
@@ -13469,13 +13462,6 @@ react-instantsearch@^6.1.0:
     react-instantsearch-core "^6.8.2"
     react-instantsearch-dom "^6.8.2"
     react-instantsearch-native "^6.8.2"
-
-react-intercom@^1.0.13:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/react-intercom/-/react-intercom-1.0.15.tgz#29180aca961a319eaab88a66126e484e1abd428b"
-  integrity sha512-e4NhmearKjdxmu6EjiA0d29FqEXJUvWtyxo4ioipNsKBD7gZgvtyJMty9UhNRSf9RoPqtSX2Fw4ooy6Ld86ddw==
-  dependencies:
-    prop-types "15.5.8"
 
 react-is@16.10.2:
   version "16.10.2"


### PR DESCRIPTION
react-intercom produces a console warning about it using React's
componentWillReceiveProps, which is deprecated. Looking at the package
to see if it can be fixed with a version upgrade, I found that the
package (which lives at https://github.com/nhagen/react-intercom) has a
notice in its readme that says:

>> This package is no longer maintained
>
> This is an unofficial package, is not maintined by Intercom, and now should now be considered deprecated. I can not recommend using external dependencies to manage adding simple scripts to your page. Please refer to official Intercom documentation for installation instructions.
>
> Installing Intercom (and other similar third party scripts) is trivial without using a package like react-intercom. Using an unofficial dependency to do so may be convenient, but ultimately is not something I recommend. Unnecessary third party dependencies introduce unnecessary security risks and compatibility risk. If you'd like to maintain an internal version of this package, please fork this repo or use this package as a guide on how that can be done. Its easy!

So, vendored it, as the package author suggests. I then made the minimal changes to the vendored file for it to not have lint warnings, and not emit a browser-console warning about using an unsafe React function. (I don't think the React warning points at anything we care about.)