### PR TITLE
Fix awful mobile view of posts list settings to be somewhat less awful

### DIFF
--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -104,6 +104,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     background: theme.palette.panelBackground.default,
     padding: isEAForum ? "16px 24px 16px 24px" : "12px 24px 8px 12px",
     borderRadius: theme.borderRadius.default,
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: "column",
+      flexWrap: "nowrap",
+    },
   },
   hidden: {
     display: "none", // Uses CSS to show/hide


### PR DESCRIPTION
NB: this affects LW, @darkruby501. I doubt you will find it controversial.

Currently:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/10352319/225656447-2ef690cd-957f-49d4-aa41-28a08dd9175e.png">

<img width="316" alt="image" src="https://user-images.githubusercontent.com/10352319/225656650-adf99679-1970-48cb-8da6-93fcec6e216f.png">

After this PR (the EA screenshot includes redesign):

<img width="336" alt="image" src="https://user-images.githubusercontent.com/10352319/225657720-c3acca3f-1034-4da1-b13b-75bb9b4d594d.png">

<img width="332" alt="image" src="https://user-images.githubusercontent.com/10352319/225657085-7d904684-2f67-4775-9f37-4bdd8e772e62.png">

@agnesstenlund you may want to look at this and go, "oh god this needs work". This goal of this PR is to make this less awful on the margin.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204195481855044) by [Unito](https://www.unito.io)
