### PR TITLE
shift reading time to be below title, reduce author row fontsize

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -93,12 +93,6 @@ export const styles = (theme: ThemeType): JssStyles => ({
   tag: {
     margin: "0 5px 0 15px",
   },
-  readTime: {
-    minWidth: 75,
-    textAlign: "right",
-    whiteSpace: "nowrap",
-    paddingRight: 10,
-  },
   comments: {
     minWidth: 58,
     marginLeft: 4,
@@ -182,9 +176,6 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
 
   const SecondaryInfo = () => (
     <>
-      <div className={classes.readTime}>
-        {post.readTimeMinutes || 1}m read
-      </div>
       <HashLink to={commentsLink} className={classes.comments}>
         <ForumIcon icon="Comment" />
         {commentCount}
@@ -239,7 +230,12 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
           <div className={classes.meta}>
             <TruncatedAuthorsList
               post={post}
-              after={<>, <PostsItemDate post={post} noStyles includeAgo /></>}
+              after={<>
+                {' · '}
+                <PostsItemDate post={post} noStyles includeAgo />
+                {' · '}
+                {post.readTimeMinutes || 1}m read
+              </>}
             />
             <div className={classNames(
               classes.secondaryContainer,

--- a/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
+++ b/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
@@ -8,6 +8,7 @@ const styles = (_: ThemeType): JssStyles => ({
     overflowX: "hidden",
     whiteSpace: "nowrap",
     maxWidth: "100%",
+    fontSize: 13,
   },
   item: {},
   overflowContainer: {


### PR DESCRIPTION
Tiny PR done with JP:

- Move the read time next to the post date
- Change the font size of the text under the title from 14px to 13px
- Change the separator from a comma to a dot

Ideally we'd like to merge this ASAP to test on the beta site.

<img width="799" alt="Screenshot 2023-03-16 at 17 27 07" src="https://user-images.githubusercontent.com/5075628/225703462-5eddc2b0-20aa-4810-9a53-050d5f5a7378.png">
