### PR TITLE
fix topics bar fade on iOS Safari

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -38,7 +38,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       height: '100%',
       width: 50,
       content: "''",
-      background: `linear-gradient(to right, ${theme.palette.background.default}, transparent)`,
+      background: `linear-gradient(to right, ${theme.palette.background.default}, ${theme.palette.background.transparent})`,
       pointerEvents: 'none',
       zIndex: 1
     }
@@ -51,7 +51,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       height: '100%',
       width: 50,
       content: "''",
-      background: `linear-gradient(to left, ${theme.palette.background.default}, transparent)`,
+      background: `linear-gradient(to left, ${theme.palette.background.default}, ${theme.palette.background.transparent})`,
       pointerEvents: 'none'
     }
   },

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -294,6 +294,9 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     diffDeleted: "#f0d3d3",
     usersListItem: shades.greyAlpha(.05),
     primaryDim: '#e2f1f4',
+    // this is used to address a specific iOS Safari-related issue with linear-gradient:
+    // https://stackoverflow.com/questions/70446857/safari-linear-gradient
+    transparent: shades.inverseGreyAlpha(0),
   },
   panelBackground: {
     default: shades.grey[0],

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -372,6 +372,7 @@ declare global {
       diffDeleted: ColorString,
       usersListItem: ColorString,
       primaryDim: ColorString,
+      transparent: ColorString,
     },
     header: {
       text: ColorString,

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -185,6 +185,7 @@ export const darkModeTheme: UserThemeSpecification = {
       diffInserted: "#205120",
       diffDeleted: "#b92424",
       primaryDim: "#28383e",
+      transparent: 'transparent'
     },
     border: {
       itemSeparatorBottom: shadePalette.greyBorder("1px", .2),


### PR DESCRIPTION
Fixes [this issue](https://stackoverflow.com/questions/70446857/safari-linear-gradient) with linear-gradient on Safari on old iPhones

<img width="312" alt="Screen Shot 2023-03-16 at 4 45 23 PM" src="https://user-images.githubusercontent.com/9057804/225748700-b2368490-f669-44c0-8664-a89a332bd05e.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204199000456546) by [Unito](https://www.unito.io)
