### PR TITLE
EA New comment indicator

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -104,6 +104,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
       marginRight: 1,
     },
   },
+  newComments: {
+    fontWeight: 700,
+    color: theme.palette.grey[1000],
+  },
   bookmark: {
     minWidth: 20,
     "&:hover": {
@@ -138,6 +142,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
     tagRel,
     commentsLink,
     commentCount,
+    hasUnreadComments,
     primaryTag,
     hasAudio,
     sticky,
@@ -166,7 +171,10 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
 
   const SecondaryInfo = () => (
     <>
-      <HashLink to={commentsLink} className={classes.comments}>
+      <HashLink to={commentsLink} className={classNames(
+        classes.comments,
+        {[classes.newComments]: hasUnreadComments},
+      )}>
         <ForumIcon icon="Comment" />
         {commentCount}
       </HashLink>


### PR DESCRIPTION
This PR indicates which posts have unread comments in the posts list:

<img width="730" alt="Screenshot 2023-03-17 at 11 51 15" src="https://user-images.githubusercontent.com/5075628/225897306-dc0c9c88-9940-45a7-b4c4-21c8da3df35b.png">
<img width="732" alt="Screenshot 2023-03-17 at 11 50 32" src="https://user-images.githubusercontent.com/5075628/225897315-4b32b50d-2133-42c6-adfd-7a346100b526.png">

[Figma](https://www.figma.com/file/OD4vJlLuWriHqG1WJXY4LV/Q1.1-2023?node-id=1208-13531&t=ep269ockHaCP0JcT-0)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204203039431269) by [Unito](https://www.unito.io)
