### PR TITLE
Avoid rendering frontpage node unless it's actually needed

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -44,8 +44,8 @@ const EAHome = () => {
         <FrontpageReviewWidget reviewYear={REVIEW_YEAR}/>
       </SingleColumnSection>}
       
-      <EAHomeMainContent frontpageNode={
-        <>
+      <EAHomeMainContent FrontpageNode={
+        () => <>
           <HomeLatestPosts />
           <EAHomeCommunityPosts />
           {!reviewIsActive() && <RecommendationsAndCurated configName="frontpageEA" />}

--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ComponentType, useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { AnalyticsContext, captureEvent } from '../../lib/analyticsEvents';
 import classNames from 'classnames';
@@ -134,8 +134,8 @@ type TopicsBarTab = {
  * which includes the topics bar and the topic-specific tabs.
  * The "Frontpage" tab content comes from EAHome.
  */
-const EAHomeMainContent = ({frontpageNode, classes}:{
-  frontpageNode: ReactNode,
+const EAHomeMainContent = ({FrontpageNode, classes}:{
+  FrontpageNode: ComponentType,
   classes: ClassesType
 }) => {
   // we use the widths of the tabs window and the underlying topics bar
@@ -270,7 +270,7 @@ const EAHomeMainContent = ({frontpageNode, classes}:{
         </SingleColumnSection>
       </AnalyticsContext>
 
-      {activeTab.name === 'Frontpage' ? frontpageNode : <AnalyticsContext pageSectionContext="topicSpecificPosts">
+      {activeTab.name === 'Frontpage' ? <FrontpageNode /> : <AnalyticsContext pageSectionContext="topicSpecificPosts">
         <SingleColumnSection>
           <SectionTitle title="New & upvoted" noTopMargin>
             <Link to={`/topics/${activeTab.slug}`} className={classes.learnMoreLink}>View more</Link>


### PR DESCRIPTION
This is what I meant by my PR comment on #6797 - we currently always render the `frontpageNode` even when it's not actually used. This PR changes it to render only when displayed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204203525515822) by [Unito](https://www.unito.io)
