### PR TITLE
update community posts section "View more" styling, revert personal blogpost icon back to grey

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -7,7 +7,11 @@ import { useTimezone } from '../common/withTimezone';
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../../lib/collections/tags/collection';
 
 const styles = (theme: ThemeType): JssStyles => ({
-
+  readMoreLink: {
+    fontSize: 14,
+    color: theme.palette.grey[600],
+    fontWeight: 600
+  }
 })
 
 const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
@@ -30,13 +34,12 @@ const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
   return (
     <AnalyticsContext pageSectionContext="communityPosts">
       <SingleColumnSection>
-        <SectionTitle title="Posts tagged community"></SectionTitle>
-          <AnalyticsContext listContext={"communityPosts"}>
-            <PostsList2 terms={recentPostsTerms} showLoadMore={false} />
-            <SectionFooter>
-              <Link to={"/topics/community"}>Read more</Link>
-            </SectionFooter>
-          </AnalyticsContext>
+        <SectionTitle title="Posts tagged community">
+          <Link to="/topics/community" className={classes.readMoreLink}>View more</Link>
+        </SectionTitle>
+        <AnalyticsContext listContext={"communityPosts"}>
+          <PostsList2 terms={recentPostsTerms} showLoadMore={false} />
+        </AnalyticsContext>
       </SingleColumnSection>
     </AnalyticsContext>
   )

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -23,10 +23,16 @@ const styles = (theme: ThemeType): JssStyles => ({
     // not sure if this is best way to do this
     '&&': {
       fontSize: "1.2rem",
-      color: isEAForum ? theme.palette.primary.main : theme.palette.icon.dim4,
+      color: theme.palette.icon.dim4,
       position: "relative",
       top: 3,
     },
+  },
+  curatedIcon: {
+    fontSize: "1.2rem",
+    color: isEAForum ? theme.palette.primary.main : theme.palette.icon.dim4,
+    position: "relative",
+    top: isEAForum ? 2 : 3,
   },
   question: {
     fontSize: "1.2rem",
@@ -59,7 +65,7 @@ export const CuratedIcon = ({classes}:{classes:ClassesType}) => {
   return <span className={classes.postIcon}>
       <LWTooltip title={<div>Curated <div><em>(click to view all curated posts)</em></div></div>} placement="bottom-start">
         <Link to={curatedUrl}>
-          <ForumIcon icon="Star" className={classes.icon}/>
+          <ForumIcon icon="Star" className={classes.curatedIcon}/>
         </Link>
       </LWTooltip>
     </span>
@@ -77,8 +83,7 @@ const PostsItemIcons = ({post, classes, hideCuratedIcon, hidePersonalIcon}: {
   const { OmegaIcon, LWTooltip, CuratedIcon, ForumIcon } = Components;
 
   return <span className={classes.iconSet}>
-    {post.curatedDate && !hideCuratedIcon && 
-      <CuratedIcon/>}
+    {post.curatedDate && !hideCuratedIcon && <CuratedIcon/>}
     
     {post.question && <span className={classes.postIcon}>
       <LWTooltip title={<div>Question <div><em>(click to view all questions)</em></div></div>} placement="right">

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -6,13 +6,13 @@ import classNames from 'classnames';
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 import { useContinueReading } from './withContinueReading';
 import {AnalyticsContext, useTracking} from "../../lib/analyticsEvents";
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
 
 export const curatedUrl = "/recommendations"
 
 const styles = (theme: ThemeType): JssStyles => ({
-  section: {
+  section: isEAForum ? {} : {
     marginTop: -12,
   },
   continueReadingList: {


### PR DESCRIPTION
Before:

<img width="740" alt="Screen Shot 2023-03-17 at 4 13 17 PM" src="https://user-images.githubusercontent.com/9057804/226025582-a0c805eb-5c6b-4f21-b4b8-e82c0a804071.png">

-----
After (styling matches the "View more" links at the top of the topic-specific post lists, functionality is the same as before):

<img width="740" alt="Screen Shot 2023-03-17 at 4 15 11 PM" src="https://user-images.githubusercontent.com/9057804/226026297-80534fa3-e078-4e07-969e-d58b20374b45.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204207359211641) by [Unito](https://www.unito.io)
