### PR TITLE
make community posts section collapsable

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -13,6 +13,7 @@ import CommentIcon from "@heroicons/react/24/outline/ChatBubbleLeftIcon";
 import LightbulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
 import ChevronLeftIcon from "@heroicons/react/24/solid/ChevronLeftIcon";
 import ChevronRightIcon from "@heroicons/react/24/solid/ChevronRightIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import MuiVolumeUpIcon from "@material-ui/icons/VolumeUp";
 import MuiBookmarkIcon from "@material-ui/icons/Bookmark";
 import MuiBookmarkBorderIcon from "@material-ui/icons/BookmarkBorder";
@@ -44,7 +45,8 @@ export type ForumIconName =
   "Comment" |
   "Shortform" |
   "ChevronLeft" |
-  "ChevronRight";
+  "ChevronRight" |
+  "ChevronDown";
 
 const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
   default: {
@@ -61,6 +63,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Shortform: NotesIcon,
     ChevronLeft: ChevronLeftIcon,
     ChevronRight: ChevronRightIcon,
+    ChevronDown: ChevronDownIcon,
   },
   EAForum: {
     VolumeUp: SpeakerWaveIcon,
@@ -76,6 +79,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Shortform: LightbulbIcon,
     ChevronLeft: ChevronLeftIcon,
     ChevronRight: ChevronRightIcon,
+    ChevronDown: ChevronDownIcon,
   },
 };
 

--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
-import { AnalyticsContext } from '../../lib/analyticsEvents';
+import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import moment from '../../lib/moment-timezone';
+import { useCookies } from 'react-cookie';
 import { useTimezone } from '../common/withTimezone';
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../../lib/collections/tags/collection';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: 10
+  },
+  expandIcon: {
+    position: 'relative',
+    top: 2,
+    fontSize: 14,
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.palette.grey[800],
+    }
+  },
   readMoreLink: {
     fontSize: 14,
     color: theme.palette.grey[600],
@@ -14,9 +29,39 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+const SHOW_COMMUNITY_POSTS_SECTION_COOKIE = 'show_community_posts_section'
+
 const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
+  const [cookies, setCookie, removeCookie] = useCookies([SHOW_COMMUNITY_POSTS_SECTION_COOKIE])
+  // default to collapsing the section
+  const [sectionExpanded, setSectionExpanded] = useState(cookies[SHOW_COMMUNITY_POSTS_SECTION_COOKIE])
+  const { captureEvent } = useTracking()
   const { timezone } = useTimezone()
-  const { SingleColumnSection, PostsList2, SectionTitle, SectionFooter } = Components
+  
+  const toggleSectionVisibility = () => {
+    setSectionExpanded(!sectionExpanded)
+    
+    if (sectionExpanded) {
+      removeCookie(SHOW_COMMUNITY_POSTS_SECTION_COOKIE)
+      captureEvent('communityPostsSectionCollapsed')
+    } else {
+      setCookie(SHOW_COMMUNITY_POSTS_SECTION_COOKIE, "true", {expires: moment().add(10, 'years').toDate()})
+      captureEvent('communityPostsSectionExpanded')
+    }
+  }
+
+  const { SingleColumnSection, PostsList2, SectionTitle, LWTooltip, ForumIcon } = Components
+  
+  const titleNode = <div className={classes.title}>
+    Posts tagged community
+    <LWTooltip title={sectionExpanded ? 'Collapse' : 'Expand'}>
+      <ForumIcon
+        icon={sectionExpanded ? 'ChevronDown' : 'ChevronRight'}
+        onClick={toggleSectionVisibility}
+        className={classes.expandIcon}
+      />
+    </LWTooltip>
+  </div>
 
   const now = moment().tz(timezone)
   const dateCutoff = now.subtract(90, 'days').format("YYYY-MM-DD")
@@ -34,12 +79,12 @@ const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
   return (
     <AnalyticsContext pageSectionContext="communityPosts">
       <SingleColumnSection>
-        <SectionTitle title="Posts tagged community">
-          <Link to="/topics/community" className={classes.readMoreLink}>View more</Link>
+        <SectionTitle title={titleNode}>
+          {sectionExpanded && <Link to="/topics/community" className={classes.readMoreLink}>View more</Link>}
         </SectionTitle>
-        <AnalyticsContext listContext={"communityPosts"}>
+        {sectionExpanded && <AnalyticsContext listContext={"communityPosts"}>
           <PostsList2 terms={recentPostsTerms} showLoadMore={false} />
-        </AnalyticsContext>
+        </AnalyticsContext>}
       </SingleColumnSection>
     </AnalyticsContext>
   )

--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { AnalyticsContext, captureEvent } from '../../lib/analyticsEvents';
+import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import classNames from 'classnames';
 import { tagPostTerms } from '../tagging/TagPage';
 import { useMulti } from '../../lib/crud/withMulti';
@@ -175,6 +175,7 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
   const [activeTab, setActiveTab] = useState<TopicsBarTab>(frontpageTab)
   const [leftArrowVisible, setLeftArrowVisible] = useState(false)
   const [rightArrowVisible, setRightArrowVisible] = useState(true)
+  const { captureEvent } = useTracking()
   
   /**
    * When the topics bar is scrolled, hide/show the left/right arrows as necessary.


### PR DESCRIPTION
Now the "community posts" section of the frontpage will be collapsed by default. Users can click the arrow to expand it, which is saved in a cookie.

<img width="794" alt="Screen Shot 2023-03-17 at 5 12 01 PM" src="https://user-images.githubusercontent.com/9057804/226055402-7779824d-52e6-4922-95f5-8332346caaca.png">

-----
Upon expanding (no change from root redesign branch):

<img width="794" alt="Screen Shot 2023-03-17 at 5 12 12 PM" src="https://user-images.githubusercontent.com/9057804/226055889-9c94d0c9-b655-4d48-a3ec-a6e96285ca1b.png">
