### PR TITLE
EA Left menu redesign

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/FeaturedResourceBanner.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/FeaturedResourceBanner.tsx
@@ -14,7 +14,7 @@ import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   card: {
-    margin: '1em 0 1em 1em',
+    margin: '1.5em 0 1em 1em',
     padding: '2em',
     boxShadow: theme.palette.boxShadow.featuredResourcesCard,
     display: 'flex',

--- a/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
@@ -22,7 +22,7 @@ const styles = ((theme: ThemeType): JssStyles => ({
     paddingLeft: 62,
     paddingBottom: 5,
     ...theme.typography.body2,
-    color: theme.palette.grey[800],
+    color: theme.palette.grey[isEAForum ? 600 : 800],
   },
   subItem: {
     textTransform: 'capitalize',

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -13,6 +13,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   selected: {
     '& $icon': {
       opacity: 1,
+      color: isEAForum ? theme.palette.grey[1000] : undefined,
     },
     '& $navText': {
       color: theme.palette.grey[isEAForum ? 1000 : 900],
@@ -30,21 +31,31 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "center",
     justifyContent: "space-around",
     flexDirection: "column",
+    ...(isEAForum
+      ? {
+        color: theme.palette.grey[600],
+        "&:hover": {
+          opacity: 1,
+          color: theme.palette.grey[800],
+        },
+      }
+      : {}),
   },
   icon: {
     display: "block",
-    opacity: .45,
+    opacity: isEAForum ? 1 : 0.45,
     width: smallIconSize,
     height: smallIconSize,
     '& svg': {
       width: smallIconSize,
       height: smallIconSize,
       fill: isEAForum ? undefined : "currentColor",
+      color: isEAForum ? "inherit" : undefined,
     }
   },
   navText: {
     ...theme.typography.body2,
-    color: theme.palette.grey[700],
+    color: isEAForum ? "inherit" : theme.palette.grey[700],
     fontSize: '.8rem',
   },
   homeIcon: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -16,7 +16,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       color: isEAForum ? 'white' : undefined,
     },
     '& $navText': {
-      color: isEAForum ? 'white' : theme.palette.grey [900],
+      color: isEAForum ? 'white' : theme.palette.grey[900],
       fontWeight: 600,
     },
     backgroundColor: theme.palette.grey[400]

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -5,6 +5,7 @@ import { useLocation } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import Tooltip from '@material-ui/core/Tooltip';
 import { MenuTabRegular } from './menuTabs';
+import { isEAForum } from '../../../lib/instanceSettings';
 
 const smallIconSize = 23
 
@@ -14,7 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       opacity: 1,
     },
     '& $navText': {
-      color: theme.palette.grey[900],
+      color: theme.palette.grey[isEAForum ? 1000 : 900],
       fontWeight: 600,
     },
     backgroundColor: theme.palette.grey[400]

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -13,10 +13,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   selected: {
     '& $icon': {
       opacity: 1,
-      color: isEAForum ? theme.palette.grey[1000] : undefined,
+      color: isEAForum ? 'white' : undefined,
     },
     '& $navText': {
-      color: theme.palette.grey[isEAForum ? 1000 : 900],
+      color: isEAForum ? 'white' : theme.palette.grey [900],
       fontWeight: 600,
     },
     backgroundColor: theme.palette.grey[400]

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -39,7 +39,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& svg': {
       width: smallIconSize,
       height: smallIconSize,
-      fill: "currentColor",
+      fill: isEAForum ? undefined : "currentColor",
     }
   },
   navText: {
@@ -70,15 +70,23 @@ const TabNavigationFooterItem = ({tab, classes}: TabNavigationFooterItemProps) =
     ({to, ...rest}: { to: string, className: string }) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
     : Link;
 
+  const isSelected = pathname === tab.link;
+  const hasIcon = tab.icon || tab.iconComponent || tab.selectedIconComponent;
+  const IconComponent = isSelected
+    ? tab.selectedIconComponent ?? tab.iconComponent
+    : tab.iconComponent;
+
   return <Tooltip placement='top' title={tab.tooltip || ''}>
     <Element
       to={tab.link}
-      className={classNames(classes.navButton, {[classes.selected]: pathname === tab.link})}
+      className={classNames(classes.navButton, {
+        [classes.selected]: isSelected,
+      })}
     >
-      {(tab.icon || tab.iconComponent) && <span
+      {hasIcon && <span
         className={classNames(classes.icon, {[classes.homeIcon]: tab.id === 'home'})}
       >
-        {tab.iconComponent && <tab.iconComponent />}
+        {IconComponent && <IconComponent />}
         {tab.icon && tab.icon}
       </span>}
       {tab.subItem ?

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -84,6 +84,9 @@ const styles = (theme: ThemeType): JssStyles => ({
       top: -1,
     }
   },
+  tooltip: {
+    maxWidth: isEAForum ? 190 : undefined,
+  },
 })
 
 type TabNavigationItemProps = {
@@ -114,7 +117,11 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
     ? tab.selectedIconComponent ?? tab.iconComponent
     : tab.iconComponent;
 
-  return <LWTooltip placement='right-start' title={tab.tooltip || ''}>
+  return <LWTooltip
+    placement='right-start'
+    title={tab.tooltip || ''}
+    className={classes.tooltip}
+  >
     <MenuItemLink
       onClick={handleClick}
       // We tried making this [the 'component' of the underlying material-UI

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -20,7 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       opacity: 1,
     },
     '& $navText': {
-      color: theme.palette.grey[900],
+      color: theme.palette.grey[isEAForum ? 1000 : 900],
       fontWeight: 600,
     },
   },
@@ -66,6 +66,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       transform: iconTransform,
     },
   },
+  selectedIcon: {
+    "& svg": {
+      color: isEAForum ? theme.palette.grey[1000] : undefined,
+    },
+  },
   navText: {
     ...theme.typography.body2,
     color: theme.palette.grey[800],
@@ -102,6 +107,12 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
     }
   }
 
+  const isSelected = pathname === tab.link;
+  const hasIcon = tab.icon || tab.iconComponent || tab.selectedIconComponent;
+  const IconComponent = isSelected
+    ? tab.selectedIconComponent ?? tab.iconComponent
+    : tab.iconComponent;
+
   return <LWTooltip placement='right-start' title={tab.tooltip || ''}>
     <MenuItemLink
       onClick={handleClick}
@@ -113,14 +124,15 @@ const TabNavigationItem = ({tab, onClick, classes}: TabNavigationItemProps) => {
       rootClass={classNames({
         [classes.navButton]: !tab.subItem,
         [classes.subItemOverride]: tab.subItem,
-        [classes.selected]: pathname === tab.link,
+        [classes.selected]: isSelected,
       })}
       disableTouchRipple
     >
-      {(tab.icon || tab.iconComponent) && <span
-        className={classNames(classes.icon, {[classes.homeIcon]: tab.id === 'home'})}
-      >
-        {tab.iconComponent && <tab.iconComponent />}
+      {hasIcon && <span className={classNames(classes.icon, {
+        [classes.selectedIcon]: isSelected,
+        [classes.homeIcon]: tab.id === 'home',
+      })}>
+        {IconComponent && <IconComponent />}
         {tab.icon && tab.icon}
       </span>}
       {tab.subItem ?

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -1,11 +1,18 @@
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import React from 'react';
-import { Link } from '../../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { useLocation } from '../../../lib/routeUtil';
 import { MenuTabRegular } from './menuTabs';
+import { isEAForum } from '../../../lib/instanceSettings';
+import { forumSelect } from '../../../lib/forumTypeUtils';
 
 export const iconWidth = 30
+
+const iconTransform = forumSelect({
+  LessWrong: "scale(0.8)",
+  EAForum: "scale(0.7)",
+  default: undefined,
+});
 
 const styles = (theme: ThemeType): JssStyles => ({
   selected: {
@@ -53,14 +60,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 28,
     marginRight: 16,
     display: "inline",
-    
     "& svg": {
-      fill: "currentColor",
+      fill: isEAForum ? undefined : "currentColor",
       color: theme.palette.icon.navigationSidebarIcon,
-      ...(theme.forumType === "LessWrong"
-        ? { transform: "scale(0.8)" }
-        : {}
-      ),
+      transform: iconTransform,
     },
   },
   navText: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -26,10 +26,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   navButton: {
     '&:hover': {
-      opacity:.6,
+      opacity: isEAForum ? 1 : 0.6,
+      color: isEAForum ? theme.palette.grey[800] : undefined,
       backgroundColor: 'transparent' // Prevent MUI default behavior of rendering solid background on hover
     },
-    
+    color: theme.palette.grey[isEAForum ? 600 : 800],
     ...(theme.forumType === "LessWrong"
       ? {
         paddingTop: 7,
@@ -62,7 +63,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "inline",
     "& svg": {
       fill: isEAForum ? undefined : "currentColor",
-      color: theme.palette.icon.navigationSidebarIcon,
+      color: isEAForum ? undefined : theme.palette.icon.navigationSidebarIcon,
       transform: iconTransform,
     },
   },
@@ -73,7 +74,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   navText: {
     ...theme.typography.body2,
-    color: theme.palette.grey[isEAForum ? 600 : 800],
+    color: "inherit",
     textTransform: "none !important",
   },
   homeIcon: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -73,7 +73,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   navText: {
     ...theme.typography.body2,
-    color: theme.palette.grey[800],
+    color: theme.palette.grey[isEAForum ? 600 : 800],
     textTransform: "none !important",
   },
   homeIcon: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -20,6 +20,7 @@ const styles = (theme: ThemeType): JssStyles => {
       justifyContent: "space-around",
       maxWidth: TAB_NAVIGATION_MENU_WIDTH,
       paddingTop: 15,
+      paddingLeft: isEAForum ? 6 : undefined,
     },
     navSidebarTransparent: {
       zIndex: 10,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -34,7 +34,6 @@ const styles = (theme: ThemeType): JssStyles => {
         ? {
           marginLeft: theme.spacing.unit * 2.5,
           marginTop: theme.spacing.unit * 2.5,
-
         }
         : {
           marginLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)) - 2,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -8,6 +8,7 @@ import menuTabs from './menuTabs'
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import { forumSelect } from '../../../lib/forumTypeUtils';
 import classNames from 'classnames';
+import { isEAForum } from '../../../lib/instanceSettings';
 
 export const TAB_NAVIGATION_MENU_WIDTH = 250
 
@@ -27,10 +28,18 @@ const styles = (theme: ThemeType): JssStyles => {
     },
     divider: {
       width: 50,
-      marginLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)) - 2,
-      marginTop: theme.spacing.unit*1.5,
-      marginBottom: theme.spacing.unit*2.5,
       borderBottom: theme.palette.border.normal,
+      marginBottom: theme.spacing.unit * 2.5,
+      ...(isEAForum
+        ? {
+          marginLeft: theme.spacing.unit * 2.5,
+          marginTop: theme.spacing.unit * 2.5,
+
+        }
+        : {
+          marginLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)) - 2,
+          marginTop: theme.spacing.unit * 1.5,
+        }),
     },
   }
 }

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -3,6 +3,10 @@ import { registerComponent } from '../../../lib/vulcan-lib';
 import classNames from 'classnames'
 import { iconWidth } from './TabNavigationItem'
 import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
+import { isEAForum } from '../../../lib/instanceSettings';
+
+const iconPadding = (theme: ThemeType) =>
+  isEAForum ? theme.spacing.unit / 2 : iconWidth + theme.spacing.unit * 2;
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -10,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "block",
     paddingBottom: theme.spacing.unit,
     // padding reflects how large an icon+padding is
-    paddingLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)),
+    paddingLeft: (theme.spacing.unit*2) + iconPadding(theme),
     color: theme.palette.grey[700],
     width:
       TAB_NAVIGATION_MENU_WIDTH - // base width

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -6,7 +6,7 @@ import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
 import { isEAForum } from '../../../lib/instanceSettings';
 
 const iconPadding = (theme: ThemeType) =>
-  isEAForum ? theme.spacing.unit / 2 : iconWidth + theme.spacing.unit * 2;
+  isEAForum ? theme.spacing.unit / 2 : iconWidth + (theme.spacing.unit * 2);
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -15,7 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: theme.spacing.unit,
     // padding reflects how large an icon+padding is
     paddingLeft: (theme.spacing.unit*2) + iconPadding(theme),
-    color: theme.palette.grey[700],
+    color: theme.palette.grey[isEAForum ? 600 : 700],
     width:
       TAB_NAVIGATION_MENU_WIDTH - // base width
       ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft,

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -300,6 +300,12 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       divider: true,
       showOnCompressed: true,
     }, {
+      id: 'handbook',
+      title: 'The EA Handbook',
+      link: '/handbook',
+      tooltip: 'To help you learn the basics of Effective Altruism, we took some of the best writing and made this handbook. Think of it as the textbook you’d get in your first college course. It explains the core ideas of EA, so that you can start applying them to your own life.',
+      subItem: true,
+    }, {
       id: 'shortform',
       title: 'Shortform',
       link: '/shortform',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -264,9 +264,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       ${taggingNamePluralSetting.get()} in EA and collects posts tagged with those ${taggingNamePluralSetting.get()}.`,
       showOnMobileStandalone: true,
       showOnCompressed: true,
-    },{
-      id: 'subforumsList',
-      customComponentName: "SubforumsList",
     }, {
       id: 'library',
       title: 'Library',
@@ -275,24 +272,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       tooltip: "Core reading, and sequences of posts building on a common theme",
       showOnMobileStandalone: true,
       showOnCompressed: true,
-    }, {
-      id: 'handbook',
-      title: 'The EA Handbook',
-      link: '/handbook',
-      tooltip: "To help you learn the basics of Effective Altruism, we took some of the best writing and made this handbook. Think of it as the textbook you’d get in your first college course. It explains the core ideas of EA, so that you can start applying them to your own life.",
-      subItem: true,
-    }, {
-      id: 'replacing-guilt',
-      title: 'Replacing Guilt',
-      link: '/s/a2LBRPLhvwB83DSGq',
-      tooltip: "Nate Soares writes about replacing guilt with other feelings and finding better ways to motivate yourself, so you can build a better future without falling apart.",
-      subItem: true,
-    }, {
-      id: 'most-important-century',
-      title: 'Most Important Century',
-      link: '/s/isENJuPdB3fhjWYHd',
-      tooltip: `Holden Karnofsky argues that we may be living in the most important century ever — a time when our decisions could shape the future for billions of years to come.`,
-      subItem: true,
     }, {
       id: 'takeAction',
       title: 'Take action',
@@ -308,9 +287,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       tooltip: 'Upcoming events near you',
       showOnMobileStandalone: true,
       showOnCompressed: true
-    }, {
-      id: 'eventsList',
-      customComponentName: "EventsList",
     }, {
       id: 'community',
       title: 'Groups & people',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -13,10 +13,14 @@ import LocalOffer from '@material-ui/icons/LocalOffer';
 import Sort from '@material-ui/icons/Sort'
 import Info from '@material-ui/icons/Info';
 import LocalLibrary from '@material-ui/icons/LocalLibrary';
-import PlaylistAddCheck from '@material-ui/icons/PlaylistAddCheck';
-import VoiceChatIcon from '@material-ui/icons/VoiceChat';
-import EventIcon from '@material-ui/icons/Event';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
+import HomeIcon from "@heroicons/react/20/solid/HomeIcon";
+import ArchiveBoxIcon from "@heroicons/react/24/outline/ArchiveBoxIcon";
+import TagIcon from "@heroicons/react/24/outline/TagIcon";
+import BookOpenIcon from "@heroicons/react/24/outline/BookOpenIcon";
+import HeartIcon from "@heroicons/react/24/outline/HeartIcon";
+import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
+import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
 import { communityPath } from '../../../lib/routes';
 import { REVIEW_YEAR } from '../../../lib/reviewUtils';
 import { ForumOptions, preferredHeadingCase } from '../../../lib/forumTypeUtils';
@@ -65,7 +69,7 @@ export type MenuTabRegular = {
   mobileTitle?: string
   link: string
   icon?: React.ReactNode
-  iconComponent?: any // I tried
+  iconComponent?: React.ComponentType | React.FC<{className: string}>
   compressedIconComponent?: any
   tooltip?: React.ReactNode
   showOnMobileStandalone?: boolean
@@ -238,7 +242,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'home',
       title: 'Home',
       link: '/',
-      iconComponent: Home,
+      iconComponent: HomeIcon,
       tooltip: 'See recent posts on strategies for doing the most good, plus recent activity from all across the Forum.',
       showOnMobileStandalone: true,
       showOnCompressed: true,
@@ -246,7 +250,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'allPosts',
       title: 'All posts',
       link: '/allPosts',
-      iconComponent: Sort,
+      iconComponent: ArchiveBoxIcon,
       tooltip: 'See all posts, filtered and sorted by date, karma, and more.',
       showOnMobileStandalone: false,
       showOnCompressed: true,
@@ -255,7 +259,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       title: taggingNamePluralCapitalSetting.get(),
       mobileTitle: taggingNamePluralCapitalSetting.get(),
       link: `/${taggingNamePluralSetting.get()}/all`,
-      iconComponent: LocalOffer,
+      iconComponent: TagIcon,
       tooltip: `A sorted list of pages — “${taggingNamePluralCapitalSetting.get()}” — in the EA Forum Wiki, which explains 
       ${taggingNamePluralSetting.get()} in EA and collects posts tagged with those ${taggingNamePluralSetting.get()}.`,
       showOnMobileStandalone: true,
@@ -267,7 +271,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'library',
       title: 'Library',
       link: '/library',
-      iconComponent: LocalLibrary,
+      iconComponent: BookOpenIcon,
       tooltip: "Core reading, and sequences of posts building on a common theme",
       showOnMobileStandalone: true,
       showOnCompressed: true,
@@ -293,14 +297,14 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'takeAction',
       title: 'Take action',
       link: `/${taggingNamePluralSetting.get()}/take-action`,
-      iconComponent: PlaylistAddCheck,
+      iconComponent: HeartIcon,
       tooltip: "Opportunities to get involved with impactful work",
       loggedOutOnly: true
     }, {
       id: 'events',
       title: 'Events',
       link: '/events',
-      iconComponent: EventIcon,
+      iconComponent: CalendarIcon,
       tooltip: 'Upcoming events near you',
       showOnMobileStandalone: true,
       showOnCompressed: true
@@ -309,9 +313,9 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       customComponentName: "EventsList",
     }, {
       id: 'community',
-      title: 'Connect',
+      title: 'Groups & people',
       link: communityPath,
-      iconComponent: SupervisedUserCircleIcon,
+      iconComponent: UsersIcon,
       tooltip: 'Join a group near you or meet others online',
       showOnMobileStandalone: false,
       showOnCompressed: true

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -14,17 +14,26 @@ import Sort from '@material-ui/icons/Sort'
 import Info from '@material-ui/icons/Info';
 import LocalLibrary from '@material-ui/icons/LocalLibrary';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
-import HomeIcon from "@heroicons/react/20/solid/HomeIcon";
-import ArchiveBoxIcon from "@heroicons/react/24/outline/ArchiveBoxIcon";
-import TagIcon from "@heroicons/react/24/outline/TagIcon";
-import BookOpenIcon from "@heroicons/react/24/outline/BookOpenIcon";
-import HeartIcon from "@heroicons/react/24/outline/HeartIcon";
-import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
-import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
 import { communityPath } from '../../../lib/routes';
 import { REVIEW_YEAR } from '../../../lib/reviewUtils';
 import { ForumOptions, preferredHeadingCase } from '../../../lib/forumTypeUtils';
 import { taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../../lib/instanceSettings';
+
+// EA Forum menu icons
+import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
+import HomeSelectedIcon from "@heroicons/react/20/solid/HomeIcon";
+import AllPostsIcon from "@heroicons/react/24/outline/ArchiveBoxIcon";
+import AllPostsSelectedIcon from "@heroicons/react/24/solid/ArchiveBoxIcon";
+import TopicsIcon from "@heroicons/react/24/outline/TagIcon";
+import TopicsSelectedIcon from "@heroicons/react/24/solid/TagIcon";
+import LibraryIcon from "@heroicons/react/24/outline/BookOpenIcon";
+import LibrarySelectedIcon from "@heroicons/react/24/solid/BookOpenIcon";
+import TakeActionIcon from "@heroicons/react/24/outline/HeartIcon";
+import TakeActionSelectedIcon from "@heroicons/react/24/solid/HeartIcon";
+import EventsIcon from "@heroicons/react/24/outline/CalendarIcon";
+import EventsSelectedIcon from "@heroicons/react/24/solid/CalendarIcon";
+import GroupsIcon from "@heroicons/react/24/outline/UsersIcon";
+import GroupsSelectedIcon from "@heroicons/react/24/solid/UsersIcon";
 
 // The sidebar / bottom bar of the Forum contain 10 or so similar tabs, unique to each Forum. The
 // tabs can appear in
@@ -63,14 +72,17 @@ type MenuTabCustomComponent = {
   customComponentName: string
 }
 
+type MenuItemIcon = React.ComponentType | React.FC<{className?: string}>;
+
 export type MenuTabRegular = {
   id: string
   title: string
   mobileTitle?: string
   link: string
   icon?: React.ReactNode
-  iconComponent?: React.ComponentType | React.FC<{className?: string}>
-  compressedIconComponent?: any
+  iconComponent?: MenuItemIcon
+  selectedIconComponent?: MenuItemIcon
+  compressedIconComponent?: MenuItemIcon
   tooltip?: React.ReactNode
   showOnMobileStandalone?: boolean
   showOnCompressed?: boolean
@@ -243,6 +255,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       title: 'Home',
       link: '/',
       iconComponent: HomeIcon,
+      selectedIconComponent: HomeSelectedIcon,
       tooltip: 'See recent posts on strategies for doing the most good, plus recent activity from all across the Forum.',
       showOnMobileStandalone: true,
       showOnCompressed: true,
@@ -250,7 +263,8 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'allPosts',
       title: 'All posts',
       link: '/allPosts',
-      iconComponent: ArchiveBoxIcon,
+      iconComponent: AllPostsIcon,
+      selectedIconComponent: AllPostsSelectedIcon,
       tooltip: 'See all posts, filtered and sorted by date, karma, and more.',
       showOnMobileStandalone: false,
       showOnCompressed: true,
@@ -259,7 +273,8 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       title: taggingNamePluralCapitalSetting.get(),
       mobileTitle: taggingNamePluralCapitalSetting.get(),
       link: `/${taggingNamePluralSetting.get()}/all`,
-      iconComponent: TagIcon,
+      iconComponent: TopicsIcon,
+      selectedIconComponent: TopicsSelectedIcon,
       tooltip: `A sorted list of pages — “${taggingNamePluralCapitalSetting.get()}” — in the EA Forum Wiki, which explains 
       ${taggingNamePluralSetting.get()} in EA and collects posts tagged with those ${taggingNamePluralSetting.get()}.`,
       showOnMobileStandalone: true,
@@ -268,7 +283,8 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'library',
       title: 'Library',
       link: '/library',
-      iconComponent: BookOpenIcon,
+      iconComponent: LibraryIcon,
+      selectedIconComponent: LibrarySelectedIcon,
       tooltip: "Core reading, and sequences of posts building on a common theme",
       showOnMobileStandalone: true,
       showOnCompressed: true,
@@ -276,14 +292,16 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'takeAction',
       title: 'Take action',
       link: `/${taggingNamePluralSetting.get()}/take-action`,
-      iconComponent: HeartIcon,
+      iconComponent: TakeActionIcon,
+      selectedIconComponent: TakeActionSelectedIcon,
       tooltip: "Opportunities to get involved with impactful work",
       loggedOutOnly: true
     }, {
       id: 'events',
       title: 'Events',
       link: '/events',
-      iconComponent: CalendarIcon,
+      iconComponent: EventsIcon,
+      selectedIconComponent: EventsSelectedIcon,
       tooltip: 'Upcoming events near you',
       showOnMobileStandalone: true,
       showOnCompressed: true
@@ -291,7 +309,8 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'community',
       title: 'Groups & people',
       link: communityPath,
-      iconComponent: UsersIcon,
+      iconComponent: GroupsIcon,
+      selectedIconComponent: GroupsSelectedIcon,
       tooltip: 'Join a group near you or meet others online',
       showOnMobileStandalone: false,
       showOnCompressed: true

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -69,7 +69,7 @@ export type MenuTabRegular = {
   mobileTitle?: string
   link: string
   icon?: React.ReactNode
-  iconComponent?: React.ComponentType | React.FC<{className: string}>
+  iconComponent?: React.ComponentType | React.FC<{className?: string}>
   compressedIconComponent?: any
   tooltip?: React.ReactNode
   showOnMobileStandalone?: boolean

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -287,9 +287,6 @@ export const eaForumTheme: SiteThemeSpecification = {
           icon: {
             opacity: 1,
           },
-          navText: {
-            color: palette.grey[800]
-          }
         },
         TabNavigationFooterItem: {
           selected: {
@@ -299,11 +296,6 @@ export const eaForumTheme: SiteThemeSpecification = {
         TabNavigationCompressedItem: {
           icon: {
             opacity: 1
-          }
-        },
-        TabNavigationMenuSubItem: {
-          root: {
-            color: palette.grey[800]
           }
         },
         PostsPageTitle: {

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -279,12 +279,6 @@ export const eaForumTheme: SiteThemeSpecification = {
             backgroundColor: palette.grey[200],
           }
         },
-        TabNavigationMenu: {
-          divider: {
-            marginTop: 10,
-            marginBottom: 20,
-          }
-        },
         TabNavigationItem: {
           navButton: {
             paddingTop: 10,


### PR DESCRIPTION
This PR adds the new styles for the left-hand menu on the forum:
<img width="462" alt="Screenshot 2023-03-20 at 13 16 26" src="https://user-images.githubusercontent.com/5075628/226350133-ba445690-21e8-4d2d-869d-d1291df53b89.png">
<img width="462" alt="Screenshot 2023-03-20 at 13 16 33" src="https://user-images.githubusercontent.com/5075628/226350173-da02dacf-1208-47ea-a75b-e8fa7e2d3183.png">



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204215865270850) by [Unito](https://www.unito.io)
