### PR TITLE
More EA redesign improvements

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -88,7 +88,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down("xs")]: {
       display: "-webkit-box",
       "-webkit-box-orient": "vertical",
-      "-webkit-line-clamp": 2,
+      "-webkit-line-clamp": 3,
     },
   },
   meta: {

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -73,16 +73,11 @@ export const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     fontFamily: theme.palette.fonts.sansSerifStack,
     marginBottom: 2,
-    display: "-webkit-box",
-    "-webkit-box-orient": "vertical",
-    "-webkit-line-clamp": 2,
-    [theme.breakpoints.down("xs")]: {
-      "-webkit-line-clamp": 3,
-    },
-  },
-  titleOverflow: {
+    whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
+    display: "block",
+    maxWidth: "100%",
   },
   meta: {
     display: "flex",

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -192,10 +192,15 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
     renderComments,
     commentTerms,
     condensedAndHiddenComments,
+    isRepeated,
     analyticsProps,
   } = usePostsItem(props);
   const {onClick} = useClickableCell(postLink);
   const authorExpandContainer = useRef(null);
+
+  if (isRepeated) {
+    return null;
+  }
 
   const {
     PostsTitle, PostsItemDate, ForumIcon, BookmarkButton, PostsItemKarma, FooterTag,

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -3,7 +3,6 @@ import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { usePostsItem, PostsItemConfig } from "./usePostsItem";
 import { SoftUpArrowIcon } from "../icons/softUpArrowIcon";
-import { HashLink } from "../common/HashLink";
 import { Link } from "../../lib/reactRouterWrapper";
 import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import withErrorBoundary from "../common/withErrorBoundary";
@@ -20,24 +19,14 @@ export const styles = (theme: ThemeType): JssStyles => ({
   readCheckbox: {
     minWidth: 24,
   },
-  container: {
-    position: "relative",
-    flexGrow: 1,
-    maxWidth: "100%",
+  expandedCommentsWrapper: {
     display: "flex",
-    alignItems: "center",
+    flexDirection: "column",
+    minWidth: "100%",
+    maxWidth: "100%",
     background: theme.palette.grey[0],
     border: `1px solid ${theme.palette.grey[100]}`,
     borderRadius: theme.borderRadius.default,
-    padding: `8px 12px 8px 0`,
-    fontFamily: theme.palette.fonts.sansSerifStack,
-    fontWeight: 500,
-    fontSize: 13,
-    color: theme.palette.grey[600],
-    cursor: "pointer",
-    [theme.breakpoints.down("xs")]: {
-      paddingRight: 12,
-    },
     "&:hover": {
       background: theme.palette.grey[50],
       border: `1px solid ${theme.palette.grey[250]}`,
@@ -47,6 +36,22 @@ export const styles = (theme: ThemeType): JssStyles => ({
     },
     "&:hover .PostsItemTrailingButtons-archiveButton": {
       opacity: 0.2,
+    },
+  },
+  container: {
+    position: "relative",
+    flexGrow: 1,
+    maxWidth: "100%",
+    display: "flex",
+    alignItems: "center",
+    padding: `8px 12px 8px 0`,
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontWeight: 500,
+    fontSize: 13,
+    color: theme.palette.grey[600],
+    cursor: "pointer",
+    [theme.breakpoints.down("xs")]: {
+      paddingRight: 12,
     },
   },
   karma: {
@@ -121,6 +126,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
       height: 18,
       marginRight: 1,
     },
+    "&:hover": {
+      color: theme.palette.grey[800],
+      opacity: 1,
+    },
   },
   newComments: {
     fontWeight: 700,
@@ -147,6 +156,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
       display: "none",
     },
   },
+  expandedComments: {
+    padding: "0 12px 8px",
+  },
 });
 
 export type EAPostsListProps = PostsItemConfig & {
@@ -158,7 +170,6 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
     post,
     postLink,
     tagRel,
-    commentsLink,
     commentCount,
     hasUnreadComments,
     primaryTag,
@@ -177,6 +188,10 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
     isRead,
     showReadCheckbox,
     tooltipPlacement,
+    toggleComments,
+    renderComments,
+    commentTerms,
+    condensedAndHiddenComments,
     analyticsProps,
   } = usePostsItem(props);
   const {onClick} = useClickableCell(postLink);
@@ -185,18 +200,18 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
   const {
     PostsTitle, PostsItemDate, ForumIcon, BookmarkButton, PostsItemKarma, FooterTag,
     TruncatedAuthorsList, PostsItemTagRelevance, PostsItemTooltipWrapper,
-    PostsItemTrailingButtons, PostReadCheckbox,
+    PostsItemTrailingButtons, PostReadCheckbox, PostsItemNewCommentsWrapper,
   } = Components;
 
   const SecondaryInfo = () => (
     <>
-      <HashLink to={commentsLink} className={classNames(
+      <a onClick={toggleComments} className={classNames(
         classes.comments,
         {[classes.newComments]: hasUnreadComments},
       )}>
         <ForumIcon icon="Comment" />
         {commentCount}
-      </HashLink>
+      </a>
       <div className={classes.bookmark}>
         <a> {/* The `a` tag prevents clicks from navigating to the post */}
           <BookmarkButton post={post} className={classes.bookmarkIcon} />
@@ -219,84 +234,98 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
             <PostReadCheckbox post={post} width={14} />
           </div>
         }
-        <div className={classes.container} onClick={onClick}>
-          <div className={classes.karma}>
-            {tagRel
-              ? <div className={classes.tagRelWrapper}>
-                <PostsItemTagRelevance tagRel={tagRel} post={post} />
-              </div>
-              : <>
-                <div className={classes.voteArrow}>
-                  <SoftUpArrowIcon />
+        <div className={classes.expandedCommentsWrapper}>
+          <div className={classes.container} onClick={onClick}>
+            <div className={classes.karma}>
+              {tagRel
+                ? <div className={classes.tagRelWrapper}>
+                  <PostsItemTagRelevance tagRel={tagRel} post={post} />
                 </div>
-                <PostsItemKarma post={post} />
-              </>
-            }
-          </div>
-          <div className={classes.details}>
-            <PostsTitle
-              {...{
-                post,
-                sticky,
-                showDraftTag,
-                showPersonalIcon,
-                strikethroughTitle,
-              }}
-              Wrapper={TitleWrapper}
-              read={isRead && !showReadCheckbox}
-              isLink={false}
-              curatedIconLeft={false}
-              iconsOnLeft
-              wrap
-              className={classes.title}
-            />
-            <div className={classes.meta}>
-              <div className={classes.metaLeft} ref={authorExpandContainer}>
-                <TruncatedAuthorsList
-                  post={post}
-                  expandContainer={authorExpandContainer}
-                />
-                <div>
-                  {' · '}
-                  <PostsItemDate post={post} noStyles includeAgo />
-                  <span className={classes.readTime}>
-                    {' · '}{post.readTimeMinutes || 1}m read
-                  </span>
-                </div>
-                <div className={classes.audio}>
-                  {hasAudio && <ForumIcon icon="VolumeUp" />}
-                </div>
-              </div>
-              <div className={classNames(
-                classes.secondaryContainer,
-                classes.onlyMobile,
-              )}>
-                <SecondaryInfo />
-              </div>
-            </div>
-          </div>
-          <div className={classNames(classes.secondaryContainer, classes.hideOnMobile)}>
-            <div className={classes.tag}>
-              {primaryTag && !showReadCheckbox &&
-                <FooterTag tag={primaryTag} smallText />
+                : <>
+                  <div className={classes.voteArrow}>
+                    <SoftUpArrowIcon />
+                  </div>
+                  <PostsItemKarma post={post} />
+                </>
               }
             </div>
-            <SecondaryInfo />
+            <div className={classes.details}>
+              <PostsTitle
+                {...{
+                  post,
+                  sticky,
+                  showDraftTag,
+                  showPersonalIcon,
+                  strikethroughTitle,
+                }}
+                Wrapper={TitleWrapper}
+                read={isRead && !showReadCheckbox}
+                isLink={false}
+                curatedIconLeft={false}
+                iconsOnLeft
+                wrap
+                className={classes.title}
+              />
+              <div className={classes.meta}>
+                <div className={classes.metaLeft} ref={authorExpandContainer}>
+                  <TruncatedAuthorsList
+                    post={post}
+                    expandContainer={authorExpandContainer}
+                  />
+                  <div>
+                    {' · '}
+                    <PostsItemDate post={post} noStyles includeAgo />
+                    <span className={classes.readTime}>
+                      {' · '}{post.readTimeMinutes || 1}m read
+                    </span>
+                  </div>
+                  <div className={classes.audio}>
+                    {hasAudio && <ForumIcon icon="VolumeUp" />}
+                  </div>
+                </div>
+                <div className={classNames(
+                  classes.secondaryContainer,
+                  classes.onlyMobile,
+                )}>
+                  <SecondaryInfo />
+                </div>
+              </div>
+            </div>
+            <div className={classNames(classes.secondaryContainer, classes.hideOnMobile)}>
+              <div className={classes.tag}>
+                {primaryTag && !showReadCheckbox &&
+                  <FooterTag tag={primaryTag} smallText />
+                }
+              </div>
+              <SecondaryInfo />
+            </div>
+            <a> {/* The `a` tag prevents clicks from navigating to the post */}
+              <PostsItemTrailingButtons
+                {...{
+                  post,
+                  showTrailingButtons,
+                  showMostValuableCheckbox,
+                  showDismissButton,
+                  showArchiveButton,
+                  resumeReading,
+                  onDismiss,
+                  onArchive,
+                }}
+              />
+            </a>
           </div>
-          <a> {/* The `a` tag prevents clicks from navigating to the post */}
-            <PostsItemTrailingButtons
-              {...{
-                post,
-                showTrailingButtons,
-                showMostValuableCheckbox,
-                showDismissButton,
-                showArchiveButton,
-                resumeReading,
-                onDismiss,
-                onArchive,
-              }}
-            />
-          </a>
+          {renderComments &&
+            <div className={classes.expandedComments}>
+              <PostsItemNewCommentsWrapper
+                terms={commentTerms}
+                post={post}
+                treeOptions={{
+                  highlightDate: post.lastVisitedAt,
+                  condensed: condensedAndHiddenComments,
+                }}
+              />
+            </div>
+          }
         </div>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -78,11 +78,18 @@ export const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     fontFamily: theme.palette.fonts.sansSerifStack,
     marginBottom: 2,
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    display: "block",
-    maxWidth: "100%",
+    [theme.breakpoints.up("sm")]: {
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      display: "block",
+      maxWidth: "100%",
+    },
+    [theme.breakpoints.down("xs")]: {
+      display: "-webkit-box",
+      "-webkit-box-orient": "vertical",
+      "-webkit-line-clamp": 2,
+    },
   },
   meta: {
     display: "flex",

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -94,14 +94,22 @@ const getTitle = (
   if (timeframe === 'monthly') {
     return startDate.format('MMMM YYYY');
   }
+
+  if (isEAForum) {
+    const result = size === 'smUp'
+      ? startDate.format('ddd, Do MMM YYYY')
+      : startDate.format('dddd, Do MMMM YYYY');
+    if (timeframe === 'weekly') {
+      return `Week of ${result}`;
+    }
+    return isToday(startDate) ? result.replace(/.*,/, "Today,") : result;
+  }
+
   const result = size === 'smUp'
     ? startDate.format('ddd, MMM Do YYYY')
     : startDate.format('dddd, MMMM Do YYYY');
   if (timeframe === 'weekly') {
     return `Week Of ${result}`;
-  }
-  if (isEAForum && isToday(startDate)) {
-    return result.replace(/.*,/, "Today,");
   }
   return result;
 }

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -97,8 +97,8 @@ const getTitle = (
 
   if (isEAForum) {
     const result = size === 'smUp'
-      ? startDate.format('ddd, Do MMM YYYY')
-      : startDate.format('dddd, Do MMMM YYYY');
+      ? startDate.format('ddd, D MMM YYYY')
+      : startDate.format('dddd, D MMMM YYYY');
     if (timeframe === 'weekly') {
       return `Week of ${result}`;
     }

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -111,7 +111,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "block",
     fontSize: "1.75rem",
     ...(isEAForum ? {
-      fontSize: 18,
+      fontSize: 22,
       fontWeight: 600,
       lineHeight: 1.25,
       fontFamily: theme.palette.fonts.sansSerifStack,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
@@ -1,6 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import classNames from 'classnames';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -14,7 +15,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   content: {
     ...theme.typography.postStyle,
     overflow: "hidden",
-    lineHeight: "1.2rem"
+    lineHeight: "1.2rem",
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
   hover: {
     backgroundColor: theme.palette.grey[50]

--- a/packages/lesswrong/lib/collections/posts/sortOrderOptions.tsx
+++ b/packages/lesswrong/lib/collections/posts/sortOrderOptions.tsx
@@ -12,7 +12,7 @@ export const SORT_ORDER_OPTIONS: { [key: string]: SettingsOption; } = {
   },
   top: { label: 'Top' },
   topAdjusted: {
-    label: isEAForum ? 'Top (inflation adjusted)' : 'Top (Inflation Adjusted)',
+    label: isEAForum ? 'Top (inflation-adjusted)' : 'Top (Inflation Adjusted)',
     tooltip: 'Posts with the highest karma relative to those posted around the same time',
   },
   recentComments: { label: isEAForum ? 'Recent comments' : 'Recent Comments' },


### PR DESCRIPTION
Changes in this PR:

- Limit post titles to a single line
<img width="780" alt="Screenshot 2023-03-20 at 23 06 22" src="https://user-images.githubusercontent.com/5075628/226484932-a9e5471e-c169-46c5-aeb7-0dd8b2279c5b.png">

- Make comments expandable (this required an extra level of div nesting, so the diff looks a lot worse than it actually is)
<img width="834" alt="Screenshot 2023-03-20 at 23 06 43" src="https://user-images.githubusercontent.com/5075628/226484947-8ebe75f6-c8c3-4957-bb2a-5f05acc39e85.png">

- Fix the casing and date format on the all posts page (requested by Lizka)
<img width="331" alt="Screenshot 2023-03-21 at 12 30 20" src="https://user-images.githubusercontent.com/5075628/226606553-c7ba9626-c7d7-4689-85eb-4e20125137e1.png">
<img width="257" alt="Screenshot 2023-03-21 at 12 30 10" src="https://user-images.githubusercontent.com/5075628/226606561-8441aec5-c028-4d65-a529-b2e8a6b48b3d.png">

- Sans serif for sunshine sidebar post titles
<img width="236" alt="Screenshot 2023-03-20 at 23 06 59" src="https://user-images.githubusercontent.com/5075628/226484953-15adb2bc-6498-4e75-8ecb-aa0da3796133.png">

- Add a hyphen to "inflation-adjusted" (as requested by Lizka)
<img width="206" alt="Screenshot 2023-03-21 at 12 21 41" src="https://user-images.githubusercontent.com/5075628/226604585-5729bace-6bae-4ad0-b645-a113788bc9cf.png">

- Fix a bug where curated posts could be shown twice in the posts list
