### PR TITLE
Clearer draft posts in new user info

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -14,7 +14,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: 600
   },
   deleted: {
-    color: theme.palette.grey[400]
+    opacity: .6,
+    '&&': {
+      fontWeight: 400
+    }
   },
   default: {
     color: theme.palette.grey[900],

--- a/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
@@ -11,7 +11,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     whiteSpace: "nowrap"
   },
   draft: {
-    color: theme.palette.grey[400]
+    opacity: .6,
+    '&&': {
+      fontWeight: 400
+    }
   },
   default: {
     color: theme.palette.grey[900],


### PR DESCRIPTION
When I made "new content" in the New User card show up as bold green, I accidentally got rid of the ability to easily scan for draft comments. This reworks the styling so you can identify drafts that are new-since-last-reviewed.

<img width="318" alt="image" src="https://user-images.githubusercontent.com/3246710/226498612-0c57229f-df5b-49df-a603-aa5786c77a2b.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204222197420808) by [Unito](https://www.unito.io)
