### PR TITLE
[EA Forum only] disable side-comments and comment-on-selection

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -22,7 +22,7 @@ const isEAForum = forumTypeSetting.get() === 'EAForum'
 // Features in progress                                                     //
 //////////////////////////////////////////////////////////////////////////////
 
-export const userHasCommentOnSelection = shippedFeature;
+export const userHasCommentOnSelection = isEAForum ? disabled : shippedFeature;
 export const userCanEditTagPortal = isEAForum ? moderatorOnly : adminOnly;
 export const userHasBoldPostItems = disabled
 export const userHasEAHomeHandbook = adminOnly
@@ -36,7 +36,7 @@ export const userHasAutosummarize = adminOnly
 
 export const userHasThemePicker = isEAForum ? adminOnly : shippedFeature;
 
-export const userHasSideComments = shippedFeature;
+export const userHasSideComments = isEAForum ? disabled : shippedFeature;
 
 export const userHasShortformTags = isEAForum ? shippedFeature : disabled;
 


### PR DESCRIPTION
We [enabled them](https://github.com/ForumMagnum/ForumMagnum/pull/6680) a month ago, but as per @SharangP's suggestion we are going to disable them (at least for now, will likely revisit in the future).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204228263467340) by [Unito](https://www.unito.io)
