### PR TITLE
Remove EAPostsList tag

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -304,11 +304,15 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
               </div>
             </div>
             <div className={classNames(classes.secondaryContainer, classes.hideOnMobile)}>
+              {/*
+                * This is commented out for now as we'll likely experiment with
+                * adding it back in the future
               <div className={classes.tag}>
                 {primaryTag && !showReadCheckbox &&
                   <FooterTag tag={primaryTag} smallText />
                 }
               </div>
+                */}
               <SecondaryInfo />
             </div>
             <a> {/* The `a` tag prevents clicks from navigating to the post */}


### PR DESCRIPTION
This PR removes the tag from the `EAPostsList`. For now, I've just commented it out as we're likely to experiment with adding it back in the future.
<img width="850" alt="Screenshot 2023-03-21 at 18 28 00" src="https://user-images.githubusercontent.com/5075628/226706756-adbafbc9-cfa0-4e65-aa57-ec91b1f2e399.png">

