### PR TITLE
Redesign post icon positioning

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -192,6 +192,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
     onArchive,
     resumeReading,
     strikethroughTitle,
+    curatedIconLeft,
     isRead,
     showReadCheckbox,
     tooltipPlacement,
@@ -269,12 +270,11 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
                   showDraftTag,
                   showPersonalIcon,
                   strikethroughTitle,
+                  curatedIconLeft,
                 }}
                 Wrapper={TitleWrapper}
                 read={isRead && !showReadCheckbox}
                 isLink={false}
-                curatedIconLeft={false}
-                iconsOnLeft
                 wrap
                 className={classes.title}
               />

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -36,7 +36,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   question: {
     fontSize: "1.2rem",
-    color: theme.palette.icon.dim4,
+    color: isEAForum ? theme.palette.icon.dim55 : theme.palette.icon.dim4,
     fontWeight: '600'
   },
   alignmentIcon: {
@@ -45,16 +45,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   linkIcon: {
-    color: theme.palette.icon.dim4,
     position: "relative",
     ...(isEAForum
       ? {
-        fontSize: "1rem",
+        fontSize: "1.2rem",
         top: 1,
+        color: theme.palette.icon.dim55,
       }
       : {
         fontSize: "1.2rem",
         top: 3,
+        color: theme.palette.icon.dim4,
       }),
   },
 });

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -8,7 +8,7 @@ import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   iconSet: {
-    marginLeft: isEAForum ? undefined : theme.spacing.unit,
+    marginLeft: isEAForum ? 6 : theme.spacing.unit,
     marginRight: isEAForum ? 2 : theme.spacing.unit,
     lineHeight: "1.0rem",
     '&:empty': {

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -113,7 +113,6 @@ const PostsTitle = ({
   showDraftTag=true, 
   wrap=false, 
   showIcons=true,
-  iconsOnLeft=false,
   isLink=true, 
   curatedIconLeft=true, 
   strikethroughTitle=false,
@@ -129,7 +128,6 @@ const PostsTitle = ({
   showDraftTag?: boolean,
   wrap?: boolean,
   showIcons?: boolean,
-  iconsOnLeft?: boolean,
   isLink?: boolean,
   curatedIconLeft?: boolean
   strikethroughTitle?: boolean
@@ -146,21 +144,14 @@ const PostsTitle = ({
     !pathname.includes('/events') && !pathname.includes('/groups') && !pathname.includes('/community');
 
   const url = postLink || postGetPageUrl(post)
-  
-  const PrimaryIcon = postIcon(post);
-  const secondaryIcons = showIcons && <span className={classes.hideSmDown}>
-    <PostsItemIcons
-      post={post}
-      hideCuratedIcon={curatedIconLeft}
-      hidePersonalIcon={!showPersonalIcon}
-    />
-  </span>
+
+  const Icon = postIcon(post);
 
   const title = <span>
     {sticky && <span className={classes.sticky}>
       <ForumIcon icon="Pin" className={classes.stickyIcon} />
     </span>}
-    {PrimaryIcon && <PrimaryIcon className={classes.primaryIcon}/>}
+    {Icon && <Icon className={classes.primaryIcon}/>}
 
     {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}
     {post.isFuture && <span className={classes.tag}>[Pending]</span>}
@@ -182,9 +173,10 @@ const PostsTitle = ({
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
         <CuratedIcon/>
       </span>}
-      {iconsOnLeft && secondaryIcons}
       {isLink ? <Link to={url}>{title}</Link> : title }
-      {!iconsOnLeft && secondaryIcons}
+      {showIcons && <span className={classes.hideSmDown}>
+        <PostsItemIcons post={post} hideCuratedIcon={curatedIconLeft} hidePersonalIcon={!showPersonalIcon}/>
+      </span>}
     </span>
   )
 

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -55,7 +55,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.icon.dim55,
     paddingRight: theme.spacing.unit,
     top: -2,
-    width: isEAForum ? 28 : "auto",
+    width: isEAForum ? 26 : "auto",
     position: "relative",
     verticalAlign: "middle",
   },

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { Comments } from "../../lib/collections/comments";
 import { styles as commentsItemStyles } from "../comments/CommentsItem/CommentsItem";
 import { nofollowKarmaThreshold } from '../../lib/publicSettings';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -32,7 +33,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   author: {
     display: 'inline-block',
     fontWeight: 600,
-    ...theme.typography.postStyle
+    ...theme.typography.postStyle,
+    ...(isEAForum
+      ? {
+        fontFamily: theme.palette.fonts.sansSerifStack,
+      }
+      : {}),
   },
   date: {
     display: 'inline-block',

--- a/packages/lesswrong/components/questions/AnswersList.tsx
+++ b/packages/lesswrong/components/questions/AnswersList.tsx
@@ -1,7 +1,7 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import { useLocation } from '../../lib/routeUtil';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -18,6 +18,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   answersSorting:{
     ...theme.typography.body1,
     color: theme.palette.text.secondary,
+    ...(isEAForum
+      ? {
+        fontFamily: theme.palette.fonts.sansSerifStack,
+      }
+      : {}),
   },
   loading: {
     opacity: .5,


### PR DESCRIPTION
This PR updates the position of icons in the post title to match the same logic as on production. This is mainly just reverting parts of commit 5c316e751b52992d4c4b8de81b0c32fb9aede817. This also fixes the current bug where the curated star isn't shown on mobile.
<img width="800" alt="Screenshot 2023-03-21 at 19 20 15" src="https://user-images.githubusercontent.com/5075628/226718139-8e32e5d1-90ac-4494-9666-a7690ed1a733.png">
<img width="802" alt="Screenshot 2023-03-21 at 19 23 06" src="https://user-images.githubusercontent.com/5075628/226719657-de1975e9-3ee2-4d75-9338-b610c54291ce.png">

Whilst I was looking at questions, I also went ahead and fixed the serif fonts in the answers section that should be sans-serif:
<img width="656" alt="Screenshot 2023-03-21 at 19 25 54" src="https://user-images.githubusercontent.com/5075628/226719747-289180da-c37e-4dd1-8f7f-f3ca40b03994.png">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204229583378376) by [Unito](https://www.unito.io)
