### PR TITLE
Fix curated star color

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -30,9 +30,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   curatedIcon: {
     fontSize: "1.2rem",
-    color: isEAForum ? theme.palette.primary.main : theme.palette.icon.dim4,
+    color: isEAForum ? theme.palette.icon.dim55 : theme.palette.icon.dim4,
     position: "relative",
     top: isEAForum ? 2 : 3,
+  },
+  curatedIconColor: {
+    color: theme.palette.primary.main,
   },
   question: {
     fontSize: "1.2rem",
@@ -60,13 +63,19 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-export const CuratedIcon = ({classes}:{classes:ClassesType}) => {
+export const CuratedIcon = ({hasColor, classes}:{
+  hasColor?: boolean,
+  classes: ClassesType
+}) => {
   const { LWTooltip, ForumIcon } = Components;
 
   return <span className={classes.postIcon}>
       <LWTooltip title={<div>Curated <div><em>(click to view all curated posts)</em></div></div>} placement="bottom-start">
         <Link to={curatedUrl}>
-          <ForumIcon icon="Star" className={classes.curatedIcon}/>
+          <ForumIcon icon="Star" className={classNames(
+            classes.curatedIcon,
+            {[classes.curatedIconColor]: hasColor && isEAForum},
+          )}/>
         </Link>
       </LWTooltip>
     </span>

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -171,7 +171,7 @@ const PostsTitle = ({
       [classes.strikethroughTitle]: strikethroughTitle
     }, className)}>
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
-        <CuratedIcon/>
+        <CuratedIcon hasColor />
       </span>}
       {isLink ? <Link to={url}>{title}</Link> : title }
       {showIcons && <span className={classes.hideSmDown}>


### PR DESCRIPTION
This PR changes the curated star so that it's blue when it's on the left, but grey when it's on the right.
<img width="797" alt="Screenshot 2023-03-21 at 21 03 12" src="https://user-images.githubusercontent.com/5075628/226741200-4ffa19dd-289a-4d3e-bee7-dc3816a67dbc.png">
<img width="797" alt="Screenshot 2023-03-21 at 21 03 10" src="https://user-images.githubusercontent.com/5075628/226741204-41c1a1e4-1e3f-45c9-a5e6-89f160bcdfdc.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204230739737930) by [Unito](https://www.unito.io)
