### PR TITLE
fix EA Forum post item audio icon height

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -117,7 +117,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   audio: {
     marginLeft: 6,
     "& svg": {
-      width: 15,
+      height: 13,
       margin: "3px -8px 0 3px",
     },
   },


### PR DESCRIPTION
Before:
<img width="707" alt="Screen Shot 2023-03-21 at 5 10 05 PM" src="https://user-images.githubusercontent.com/9057804/226742159-22bd14a2-cdfb-43da-9fab-5b99c7ef1073.png">

-----
After:
<img width="707" alt="Screen Shot 2023-03-21 at 5 11 30 PM" src="https://user-images.githubusercontent.com/9057804/226742180-64b70f38-78f3-4f81-8c73-5225ea74c16c.png">
