### PR TITLE
Allow third party API users to authenticate via Auth0 access tokens.

### DIFF
--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -398,7 +398,7 @@ export const addAuthMiddlewares = (addConnectHandler) => {
       const info = null // not used
       auth0Strategy.userProfile(accessToken, (err, profile) => {
         if(profile) {
-          userHandler(accessToken, resumeToken, profile, (err, user) => {
+          void userHandler(accessToken, resumeToken, profile, (err, user) => {
             handleAuthenticate(req, res, next, err, user, info)
           })
         } else {

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -230,11 +230,11 @@ function createAccessTokenStrategy(auth0Strategy) {
   return new CustomStrategy((req, done) => {
     const accessToken = req.query['access_token']
     const resumeToken = "" // not used
-    if(typeof(accessToken) !== 'string') {
+    if (typeof(accessToken) !== 'string') {
       return done("Invalid token")
     } else {
       auth0Strategy.userProfile(accessToken, (err, profile) => {
-        if(profile) {
+        if (profile) {
           void accessTokenUserHandler(accessToken, resumeToken, profile, done)
         } else {
           return done("Invalid token")


### PR DESCRIPTION
This should allow GreaterWrong users to log in to EA Forum again.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204235263854497) by [Unito](https://www.unito.io)
