### PR TITLE
EAF redesign fixes, incl. fix expanding frontpage filter settings and post title truncation

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -110,7 +110,9 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
   
   const changeShowTagFilterSettingsDesktop = () => {
     setFilterSettingsVisibleDesktop(!filterSettingsVisibleDesktop)
-    void updateCurrentUser({hideFrontpageFilterSettingsDesktop: filterSettingsVisibleDesktop})
+    if (!isEAForum) {
+      void updateCurrentUser({hideFrontpageFilterSettingsDesktop: filterSettingsVisibleDesktop})
+    }
     
     captureEvent("filterSettingsClicked", {
       settingsVisible: !filterSettingsVisibleDesktop,

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -126,6 +126,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 4,
     display: "flex",
     alignItems: "center",
+    padding: '10px 0',
     "& svg": {
       height: 18,
       marginRight: 1,

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -272,8 +272,6 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
                 Wrapper={TitleWrapper}
                 read={isRead && !showReadCheckbox}
                 isLink={false}
-                {/* TODO: mobile and desktop disagree */}
-                wrap
                 className={classes.title}
               />
               <div className={classes.meta}>

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -79,10 +79,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     fontFamily: theme.palette.fonts.sansSerifStack,
     marginBottom: 2,
     [theme.breakpoints.up("sm")]: {
-      whiteSpace: "nowrap",
-      overflow: "hidden",
-      textOverflow: "ellipsis",
-      display: "block",
+      display: "flex",
       maxWidth: "100%",
     },
     [theme.breakpoints.down("xs")]: {
@@ -275,6 +272,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
                 Wrapper={TitleWrapper}
                 read={isRead && !showReadCheckbox}
                 isLink={false}
+                {/* TODO: mobile and desktop disagree */}
                 wrap
                 className={classes.title}
               />

--- a/packages/lesswrong/components/posts/PostActions/SetSideCommentVisibility.tsx
+++ b/packages/lesswrong/components/posts/PostActions/SetSideCommentVisibility.tsx
@@ -6,6 +6,8 @@ import ChatBubbleOutline from '@material-ui/icons/ChatBubbleOutline';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Check from '@material-ui/icons/Check';
 import classNames from 'classnames';
+import { userHasSideComments } from '../../../lib/betas';
+import { useCurrentUser } from '../../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   check: {
@@ -54,13 +56,14 @@ export const SideCommentVisibilityContext = createContext<SideCommentVisibilityC
 const SetSideCommentVisibility = ({classes}: {
   classes: ClassesType
 }) => {
+  const currentUser = useCurrentUser()
   const sideCommentVisibility = useContext(SideCommentVisibilityContext);
   const { LWTooltip, MenuItem } = Components;
   
   // If in a context that isn't a post page (eg, the triple-dot menu on posts in
   // a post list), this context won't be there and this option doesn't apply, so
   // hide it.
-  if (!sideCommentVisibility)
+  if (!sideCommentVisibility || !userHasSideComments(currentUser))
     return null;
   
   const {sideCommentMode, setSideCommentMode} = sideCommentVisibility;

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -65,6 +65,13 @@ const styles = (theme: ThemeType): JssStyles => ({
       color: theme.palette.text.normal,
     }
   },
+  titleDesktopEllipsis: isEAForum ? {
+    [theme.breakpoints.up("sm")]: {
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    },
+  } : {},
   hideSmDown: { // TODO FIX NAME
     [theme.breakpoints.down('xs')]: {
       display: "none",
@@ -173,7 +180,10 @@ const PostsTitle = ({
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
         <CuratedIcon hasColor />
       </span>}
-      {isLink ? <Link to={url}>{title}</Link> : title }
+      {/* TODO: mobile and desktop disagree */}
+      <span className={!wrap && classes.titleDesktopEllipsis}>
+        {isLink ? <Link to={url}>{title}</Link> : title }
+      </span>
       {showIcons && <span className={classes.hideSmDown}>
         <PostsItemIcons post={post} hideCuratedIcon={curatedIconLeft} hidePersonalIcon={!showPersonalIcon}/>
       </span>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -66,13 +66,19 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   titleDesktopEllipsis: isEAForum ? {
+    '&:hover': {
+      opacity: 0.5
+    },
+    '& a': {
+      opacity: 1
+    },
     [theme.breakpoints.up("sm")]: {
       whiteSpace: "nowrap",
       overflow: "hidden",
       textOverflow: "ellipsis",
     },
   } : {},
-  hideSmDown: { // TODO FIX NAME
+  hideXsDown: {
     [theme.breakpoints.down('xs')]: {
       display: "none",
     }
@@ -180,11 +186,10 @@ const PostsTitle = ({
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
         <CuratedIcon hasColor />
       </span>}
-      {/* TODO: mobile and desktop disagree */}
       <span className={!wrap && classes.titleDesktopEllipsis}>
         {isLink ? <Link to={url}>{title}</Link> : title }
       </span>
-      {showIcons && <span className={classes.hideSmDown}>
+      {showIcons && <span className={classes.hideXsDown}>
         <PostsItemIcons post={post} hideCuratedIcon={curatedIconLeft} hidePersonalIcon={!showPersonalIcon}/>
       </span>}
     </span>


### PR DESCRIPTION
This PR has a few fixes:
1. Fixes the "Customize feed" closing when you try to expand it on desktop
2. Properly hides the "Side-comments" menu item when it's disabled for the site
3. Increases the click area for the post item comment icon, to make it easier to click
4. Post title truncation makes room for icons, fixing this issue:

<img width="698" alt="Screen Shot 2023-03-23 at 1 59 03 AM" src="https://user-images.githubusercontent.com/9057804/227116998-50928c20-b4be-4ca8-810b-be411422562e.png">
