### PR TITLE
coauthors cannot award karma to themselves or other post authors, plus fixes to recomputeKarma

### DIFF
--- a/packages/lesswrong/lib/collections/votes/schema.ts
+++ b/packages/lesswrong/lib/collections/votes/schema.ts
@@ -119,7 +119,7 @@ const schema: SchemaType<DbVote> = {
     ...schemaDefaultValue(false),
   },
   
-  // Whether this is an unvote.
+  // Whether this is an unvote. This data is unreliable on the EA Forum for old votes (around 2019).
   isUnvote: {
     type: Boolean,
     canRead: ['guests'],

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -13,7 +13,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
  * @param {object} collection - The collection the item belongs to
  * @param {string} operation - The operation being performed
  */
-const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
+export const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
 voteCallbacks.castVoteAsync.add(function updateKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
   // Only update user karma if the operation isn't done by one of the item's current authors.
   // We don't want to let any of the authors give themselves or another author karma for this item.

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -15,15 +15,17 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
  */
 const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
 voteCallbacks.castVoteAsync.add(function updateKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
-  // only update karma is the operation isn't done by the item's author
-  if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
+  // Only update user karma if the operation isn't done by one of the item's current authors.
+  // We don't want to let any of the authors give themselves or another author karma for this item.
+  if (!vote.authorIds.includes(vote.userId) && collectionsThatAffectKarma.includes(vote.collectionName)) {
     void Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {karma: vote.power}});
   }
 });
 
 voteCallbacks.cancelAsync.add(function cancelVoteKarma({newDocument, vote}: VoteDocTuple, collection: CollectionBase<DbVoteableType>, user: DbUser) {
-  // only update karma is the operation isn't done by the item's author
-  if (newDocument.userId !== vote.userId && collectionsThatAffectKarma.includes(vote.collectionName)) {
+  // Only update user karma if the operation isn't done by one of the item's authors at the time of the original vote.
+  // We expect vote.authorIds here to be the same as the authorIds of the original vote.
+  if (!vote.authorIds.includes(vote.userId) && collectionsThatAffectKarma.includes(vote.collectionName)) {
     void Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {karma: -vote.power}});
   }
 });

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -455,19 +455,12 @@ async function recomputeKarma(userId: string) {
     cancelled: false,
     collectionName: {$in: collectionsThatAffectKarma}
   };
-  if (Votes.isPostgres()) {
-    selector["legacyData.legacy"] = {$ne: true};
-  } else {
-    selector.legacy = {$ne: true};
-  }
   const allTargetVotes = await Votes.find(selector).fetch()
-  const totalNonLegacyKarma = sumBy(allTargetVotes, vote => {
+  const karma = sumBy(allTargetVotes, vote => {
     // a doc author cannot give karma to themselves or any other authors for that doc
     return vote.authorIds.includes(vote.userId) ? 0 : vote.power
   })
-  // @ts-ignore FIXME: This legacyKarma field is correct for EAF, but unknown for other forums
-  const totalKarma = totalNonLegacyKarma + (user.legacyData?.legacyKarma || 0)
-  return totalKarma
+  return karma
 }
 
 Vulcan.getTotalKarmaForUser = recomputeKarma

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -9,6 +9,7 @@ import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 import sumBy from 'lodash/sumBy';
 import { ConversationsRepo, LocalgroupsRepo, VotesRepo } from '../repos';
 import Localgroups from '../../lib/collections/localgroups/collection';
+import { collectionsThatAffectKarma } from '../callbacks/votingCallbacks';
 
 const transferOwnership = async ({documentId, targetUserId, collection, fieldName = "userId"}) => {
   await updateMutator({
@@ -452,7 +453,7 @@ async function recomputeKarma(userId: string) {
     authorIds: user._id,
     userId: {$ne: user._id},
     cancelled: false,
-    collectionName: {$in: ["Posts", "Comments", "Revisions"]}
+    collectionName: {$in: collectionsThatAffectKarma}
   };
   if (Votes.isPostgres()) {
     selector["legacyData.legacy"] = {$ne: true};


### PR DESCRIPTION
EAF is re-evaluating how we calculate karma, and we found that recalculating karma for all users would cause lots of discrepancies from their current karma values. (See Table 6 in [this dashboard](https://app.hex.tech/9e4abdcd-b18c-49ca-acfc-3ec5249ddb1a/hex/19c39d4d-f783-4dab-8899-5ad8c54ee9b6/draft/logic).) While investigating this discrepancy, I discovered some bugs in `recomputeKarma()` and one bug that allowed post coauthor votes to award karma to all the post's authors. (I also found additional discrepancies that could not be explained by these, so I expect there are other voting-related bugs remaining.)

I haven't dug this deep into our voting before, so it's possible that some of these are not bugs and are intentional.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204255914003327) by [Unito](https://www.unito.io)
