### PR TITLE
ckeditor no longer in beta, updated EAF ckeditor placeholder text

### DIFF
--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -167,7 +167,7 @@ export type EditorTypeString = "html"|"markdown"|"draftJS"|"ckEditorMarkup";
 
 export const editorTypeToDisplay: Record<EditorTypeString,{name: string, postfix?:string}> = {
   html: {name: 'HTML', postfix: '[Admin Only]'},
-  ckEditorMarkup: {name: ckEditorName, postfix: '[Beta]'},
+  ckEditorMarkup: {name: ckEditorName},
   markdown: {name: 'Markdown'},
   draftJS: {name: 'Draft-JS'},
 }

--- a/packages/lesswrong/components/form-components/SocialPreviewUpload.tsx
+++ b/packages/lesswrong/components/form-components/SocialPreviewUpload.tsx
@@ -108,7 +108,7 @@ const buildPreviewFromDocument = (document: PostsEditWithLocalData): {descriptio
   const contentsType = originalContents.type
   if (!['html', 'ckEditorMarkup', 'markdown'].includes(contentsType)) {
     return {
-      description: `<Description preview not supported for this editor type (${originalContents.type}), switch to HTML, Markdown, or EA Forum Docs [Beta] to see the description preview>`,
+      description: `<Description preview not supported for this editor type (${originalContents.type}), switch to HTML, Markdown, or EA Forum Docs to see the description preview>`,
       fallbackImageUrl: null,
     };
   }

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -4,6 +4,7 @@ import { ContentType, getOriginalContents } from '../collections/revisions/schem
 import { accessFilterMultiple, addFieldsDict } from '../utils/schemaUtils';
 import SimpleSchema from 'simpl-schema'
 import { getWithLoader } from '../loaders';
+import { isEAForum } from '../instanceSettings';
 
 export const RevisionStorageType = new SimpleSchema({
   originalContents: {type: ContentType, optional: true},
@@ -41,7 +42,9 @@ export interface MakeEditableOptions {
   hidden?: boolean,
 }
 
-export const defaultEditorPlaceholder = `Write here. Select text for formatting options.
+export const defaultEditorPlaceholder = isEAForum ?
+`Write here. Select text to format it. Switch between rich text and markdown in your account settings.` :
+`Write here. Select text for formatting options.
 We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).
 You can switch between rich text and markdown in your user settings.`
 


### PR DESCRIPTION
This PR salvages one change from the [ckeditor button plugin branch](https://github.com/ForumMagnum/ForumMagnum/pull/6708) (our updated placeholder text), plus removes the [Beta] tag from the ckeditor option.

<img width="422" alt="Screen Shot 2023-03-24 at 3 53 27 PM" src="https://user-images.githubusercontent.com/9057804/227626065-5db82706-3740-47b6-98b2-2f6bc1058d82.png">
