### PR TITLE
[EA Forum only] fix post item three dots menu and replace bell icon

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -5,6 +5,8 @@ import SpeakerWaveIcon from "@heroicons/react/24/solid/SpeakerWaveIcon";
 import BookmarkIcon from "@heroicons/react/24/solid/BookmarkIcon";
 import StarIcon from "@heroicons/react/24/solid/StarIcon";
 import UserIcon from "@heroicons/react/24/solid/UserIcon";
+import BellOutlineIcon from "@heroicons/react/24/outline/BellIcon";
+import BellIcon from "@heroicons/react/24/solid/BellIcon";
 import LinkIcon from "@heroicons/react/20/solid/LinkIcon";
 import BookmarkOutlineIcon from "@heroicons/react/24/outline/BookmarkIcon";
 import StarOutlineIcon from "@heroicons/react/24/outline/StarIcon";
@@ -17,6 +19,8 @@ import MuiBookmarkBorderIcon from "@material-ui/icons/BookmarkBorder";
 import MuiStarIcon from "@material-ui/icons/Star";
 import MuiStarBorderIcon from "@material-ui/icons/StarBorder";
 import MuiPersonIcon from "@material-ui/icons/Person";
+import MuiNotificationsIcon from '@material-ui/icons/Notifications';
+import MuiNotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import MuiLinkIcon from "@material-ui/icons/Link";
 import NotesIcon from '@material-ui/icons/Notes';
 import { PinIcon } from "../icons/pinIcon";
@@ -39,6 +43,8 @@ export type ForumIconName =
   "Star" |
   "StarBorder" |
   "User" |
+  "Bell" |
+  "BellBorder" |
   "Link" |
   "Pin" |
   "Close" |
@@ -56,6 +62,8 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Star: MuiStarIcon,
     StarBorder: MuiStarBorderIcon,
     User: MuiPersonIcon,
+    Bell: MuiNotificationsIcon,
+    BellBorder: MuiNotificationsNoneIcon,
     Link: MuiLinkIcon,
     Pin: StickyIcon,
     Close: CloseIcon,
@@ -72,6 +80,8 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Star: StarIcon,
     StarBorder: StarOutlineIcon,
     User: UserIcon,
+    Bell: BellIcon,
+    BellBorder: BellOutlineIcon,
     Link: LinkIcon,
     Pin: PinIcon,
     Close: CloseIcon,

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -15,8 +15,6 @@ import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import { Link } from '../../lib/reactRouterWrapper';
 
 import Button from '@material-ui/core/Button';
-import NotificationsIcon from '@material-ui/icons/Notifications';
-import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Search from '@material-ui/icons/Search';
@@ -339,7 +337,8 @@ const Community = ({classes}: {
     });
   }
   
-  const { CommunityBanner, LocalGroups, OnlineGroups, CommunityMembers, GroupFormLink, DistanceUnitToggle } = Components
+  const { CommunityBanner, LocalGroups, OnlineGroups, CommunityMembers, GroupFormLink,
+          DistanceUnitToggle, ForumIcon } = Components
   
   const handleChangeTab = (e: React.ChangeEvent, value: string) => {
     setTab(value)
@@ -427,8 +426,8 @@ const Community = ({classes}: {
             <div className={classes.notifications}>
               <Button variant="text" color="primary" onClick={openEventNotificationsForm} className={classes.notificationsBtn}>
                 {currentUser?.nearbyEventsNotifications ?
-                  <NotificationsIcon className={classes.notificationsIcon} /> :
-                  <NotificationsNoneIcon className={classes.notificationsIcon} />
+                  <ForumIcon icon="Bell" className={classes.notificationsIcon} /> :
+                  <ForumIcon icon="BellBorder" className={classes.notificationsIcon} />
                 } Notify me
               </Button>
             </div>

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -4,8 +4,6 @@ import { useUserLocation } from '../../lib/collections/users/helpers';
 import { useCurrentUser } from '../common/withUser';
 import { createStyles } from '@material-ui/core/styles';
 import FilterIcon from '@material-ui/icons/FilterList';
-import NotificationsIcon from '@material-ui/icons/Notifications';
-import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import { useDialog } from '../common/withDialog'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { useUpdate } from '../../lib/crud/withUpdate';
@@ -314,7 +312,7 @@ const EventsHome = ({classes}: {
     setDistance(unit === 'mi' ? Math.round(distance * 0.621371) : Math.round(distance / 0.621371))
   }
   
-  const { HighlightedEventCard, EventCards, Loading, DistanceUnitToggle, MenuItem } = Components
+  const { HighlightedEventCard, EventCards, Loading, DistanceUnitToggle, MenuItem, ForumIcon } = Components
   
   // on the EA Forum, we insert some special event cards (ex. Intro VP card)
   let numSpecialCards = currentUser ? 1 : 2
@@ -475,7 +473,9 @@ const EventsHome = ({classes}: {
             
             <div className={classes.notifications}>
               <Button variant="text" color="primary" onClick={openEventNotificationsForm} className={classes.notificationsBtn}>
-                {currentUser?.nearbyEventsNotifications ? <NotificationsIcon className={classes.notificationsIcon} /> : <NotificationsNoneIcon className={classes.notificationsIcon} />} Notify me
+                {currentUser?.nearbyEventsNotifications ?
+                  <ForumIcon icon="Bell" className={classes.notificationsIcon} /> :
+                  <ForumIcon icon="BellBorder" className={classes.notificationsIcon} />} Notify me
               </Button>
             </div>
           </div>

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -1,11 +1,9 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useMulti } from '../../lib/crud/withMulti';
 import React, { useState } from 'react';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import Badge from '@material-ui/core/Badge';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import AllIcon from '@material-ui/icons/Notifications';
 import ClearIcon from '@material-ui/icons/Clear';
 import PostsIcon from '@material-ui/icons/Description';
 import CommentsIcon from '@material-ui/icons/ModeComment';
@@ -83,7 +81,7 @@ const NotificationsMenu = ({ unreadPrivateMessages, open, setIsOpen, hasOpened, 
   const notificationCategoryTabs: Array<{ name: string, icon: ()=>React.ReactNode, terms: NotificationsViewTerms }> = [
     {
       name: "All Notifications",
-      icon: () => (<AllIcon classes={{root: classes.icon}}/>),
+      icon: () => (<Components.ForumIcon icon="Bell" className={classes.icon}/>),
       terms: {view: "userNotifications"},
     },
     {

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import Badge from '@material-ui/core/Badge';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 import IconButton from '@material-ui/core/IconButton';
-import NotificationsIcon from '@material-ui/icons/Notifications';
-import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import * as _ from 'underscore';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -39,6 +37,7 @@ const NotificationsMenuButton = ({ unreadNotifications, open, toggle, currentUse
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
+  const { ForumIcon } = Components
   const buttonClass = open ? classes.buttonOpen : classes.buttonClosed;
 
   return (
@@ -50,7 +49,7 @@ const NotificationsMenuButton = ({ unreadNotifications, open, toggle, currentUse
         classes={{ root: buttonClass }}
         onClick={toggle}
       >
-        {(unreadNotifications>0) ? <NotificationsIcon /> : <NotificationsNoneIcon />}
+        {(unreadNotifications>0) ? <ForumIcon icon="Bell" /> : <ForumIcon icon="BellBorder" />}
       </IconButton>
     </Badge>
   )

--- a/packages/lesswrong/components/notifications/NotifyMeButton.tsx
+++ b/packages/lesswrong/components/notifications/NotifyMeButton.tsx
@@ -1,6 +1,4 @@
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import NotificationsIcon from '@material-ui/icons/Notifications';
-import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import classNames from 'classnames';
 import React from 'react';
 import * as _ from 'underscore';
@@ -155,8 +153,8 @@ const NotifyMeButton = ({
     {loading
       ? <Components.Loading/>
       : (isSubscribed()
-        ? <NotificationsIcon />
-        : <NotificationsNoneIcon />
+        ? <Components.ForumIcon icon="Bell" />
+        : <Components.ForumIcon icon="BellBorder" />
       )
     }
   </ListItemIcon>

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -314,7 +314,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
                 */}
               <SecondaryInfo />
             </div>
-            <a> {/* The `a` tag prevents clicks from navigating to the post */}
+            <a onClick={(e) => e.stopPropagation()}> {/* The `a` tag prevents clicks from navigating to the post */}
               <PostsItemTrailingButtons
                 {...{
                   post,

--- a/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
+++ b/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
@@ -39,8 +39,6 @@ const PostActionsButton = ({post, vertical, classes}: {
   const { PopperCard, PostActions, LWClickAwayListener } = Components
   if (!currentUser) return null;
 
-  const placement = isEAForum ? "left-start" : "right-start";
-
   return <div className={classes.root}>
     <div ref={anchorEl}>
       <Icon className={classes.icon} onClick={() => handleSetOpen(!isOpen)}/>
@@ -48,7 +46,7 @@ const PostActionsButton = ({post, vertical, classes}: {
     <PopperCard
       open={isOpen}
       anchorEl={anchorEl.current}
-      placement={placement}
+      placement="right-start"
       allowOverflow
     >
       {/*FIXME: ClickAwayListener doesn't handle portals correctly, which winds up making submenus inoperable. But we do still need clickaway to close.*/}

--- a/packages/lesswrong/components/tagging/TagNotificationSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagNotificationSettings.tsx
@@ -1,7 +1,5 @@
 import React, { useRef, useState } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
-import NotificationsNoneIcon from "@material-ui/icons/NotificationsNone";
-import NotificationsIcon from "@material-ui/icons/Notifications";
 import Checkbox from '@material-ui/core/Checkbox';
 import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
 import IconButton from "@material-ui/core/IconButton";
@@ -74,7 +72,7 @@ const TagNotificationSettings = ({
   const [open, setOpen] = useState(false);
   const { flash } = useMessages();
 
-  const { LWClickAwayListener, LWPopper, Typography, Loading, NotifyMeButton } = Components;
+  const { LWClickAwayListener, LWPopper, Typography, Loading, NotifyMeButton, ForumIcon } = Components;
 
   const isSubforum = !!(tag.isSubforum && userTagRel)
   const allowSubforumMenu = false // TODO - enable this when we have proper notifications for shortform
@@ -177,9 +175,9 @@ const TagNotificationSettings = ({
           <div style={!isFrontpageSubscribed ? {display: 'none'} : {}}>
             <IconButton onClick={() => setOpen(!open)} className={classes.notificationsButton}>
               {(!userTagRel.subforumEmailNotifications && !isSubscribedToPosts) ? (
-                <NotificationsNoneIcon />
+                <ForumIcon icon="BellBorder" />
               ) : (
-                <NotificationsIcon />
+                <ForumIcon icon="Bell" />
               )}
             </IconButton>
           </div>

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -10,7 +10,6 @@ import { Tags } from './collections/tags/collection';
 import Messages from './collections/messages/collection';
 import Localgroups from './collections/localgroups/collection';
 import Users from './collections/users/collection';
-import AllIcon from '@material-ui/icons/Notifications';
 import PostsIcon from '@material-ui/icons/Description';
 import CommentsIcon from '@material-ui/icons/ModeComment';
 import EventIcon from '@material-ui/icons/Event';
@@ -180,7 +179,7 @@ export const PostApprovedNotification = registerNotificationType({
     return 'Your post "' + document.title + '" has been approved';
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 
@@ -214,7 +213,7 @@ export const NewEventNotification = registerNotificationType({
       return await postGetAuthorName(document as DbPost) + ' has created a new event';
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 
@@ -236,7 +235,7 @@ export const NewGroupPostNotification = registerNotificationType({
       return await postGetAuthorName(document as DbPost) + ' has created a new post in a group';
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 
@@ -340,7 +339,7 @@ export const NewUserNotification = registerNotificationType({
     return document.displayName + ' just signed up!';
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 
@@ -382,7 +381,7 @@ export const EmailVerificationRequiredNotification = registerNotificationType({
     return "Verify your email address to activate email subscriptions.";
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 
@@ -396,7 +395,7 @@ export const PostSharedWithUserNotification = registerNotificationType({
     return `${name} shared their ${document.draft ? "draft" : "post"} "${document.title}" with you`;
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
   getLink: ({documentType, documentId, extraData}: {
     documentType: string|null,
@@ -423,7 +422,7 @@ export const AlignmentSubmissionApprovalNotification = registerNotificationType(
     } else throw new Error("documentType must be post or comment!")
   },
   getIcon() {
-    return <AllIcon style={iconStyles} />
+    return <Components.ForumIcon icon="Bell" style={iconStyles} />
   },
 });
 


### PR DESCRIPTION
A few things in this PR:
1. Fixes an issue where clicking on a menu item in the post item three dots menu navigates to the post page rather than letting you ex. bookmark the post
2. Reverts the placement of the post item three dots menu to appear to the right of the icon, to make it more usable on mobile
3. Replaces the bell (notification) icon with the HeroIcons version, to be more consistent with our new icons:

<img width="481" alt="Screen Shot 2023-03-24 at 8 40 55 PM" src="https://user-images.githubusercontent.com/9057804/227669041-2590c9ef-283f-4e4f-b1f5-785f49d49955.png">
