### PR TITLE
properly hide comments when hideUnreviewedAuthorComments is active

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { commentIsHidden } from '../../lib/collections/comments/helpers';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useSingle } from '../../lib/crud/withSingle';
 import { forumTypeSetting } from '../../lib/instanceSettings';
@@ -57,6 +58,9 @@ const CommentPermalink = ({ documentId, post, classes }: {
   if (!comment) {return null}
 
   if (!documentId) return null
+  
+  // if the site is currently hiding comments by unreviewed authors, check if we need to hide this comment
+  if (commentIsHidden(comment)) return null
 
   const ogUrl = post ? postGetPageUrl(post, true) : undefined // open graph
   const canonicalUrl = post ? post.canonicalSource || ogUrl : undefined

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useCurrentTime } from '../../../lib/utils/timeUtil';
-import { hideUnreviewedAuthorCommentsSettings } from '../../../lib/publicSettings';
+import { commentIsHidden } from '../../../lib/collections/comments/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   blockedReplies: {
@@ -15,9 +15,6 @@ const CommentBottomCaveats = ({comment, classes}: {
 }) => {
   const now = useCurrentTime();
   const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > now;
-  const hideSince = hideUnreviewedAuthorCommentsSettings.get()
-  const commentHidden = hideSince && new Date(hideSince) < new Date(comment.postedAt) &&
-    comment.authorIsUnreviewed
   
   return <>
     { blockedReplies &&
@@ -26,7 +23,7 @@ const CommentBottomCaveats = ({comment, classes}: {
       </div>
     }
     { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
-    { commentHidden && <Components.MetaInfo>
+    { commentIsHidden(comment) && <Components.MetaInfo>
       [This comment will not be visible to other users until the moderation
       team checks it for spam or norm violations.]
     </Components.MetaInfo>

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -6,6 +6,7 @@ import { userCanDo } from '../../vulcan-users/permissions';
 import { userGetDisplayName } from "../users/helpers";
 import { tagGetCommentLink } from '../tags/helpers';
 import { TagCommentType } from './types';
+import { hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
 
 // Get a comment author's name
 export async function commentGetAuthorName(comment: DbComment): Promise<string> {
@@ -90,3 +91,11 @@ export const commentGetKarma = (comment: CommentsList|DbComment): number => {
 }
 
 export const commentAllowTitle = (comment: {tagCommentType: TagCommentType, parentCommentId?: string}): boolean => comment?.tagCommentType === 'SUBFORUM' && !comment?.parentCommentId
+
+/**
+ * If the site is currently hiding comments by unreviewed authors, check if we need to hide this comment.
+ */
+export const commentIsHidden = (comment: CommentsList|DbComment) => {
+  const hideSince = hideUnreviewedAuthorCommentsSettings.get()
+  return hideSince && new Date(hideSince) < new Date(comment.postedAt) && comment.authorIsUnreviewed
+}

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -32,6 +32,7 @@ import Tags from '../lib/collections/tags/collection';
 import { subforumGetSubscribedUsers } from '../lib/collections/tags/helpers';
 import UserTagRels from '../lib/collections/userTagRels/collection';
 import { REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD } from '../lib/reviewUtils';
+import { commentIsHidden } from '../lib/collections/comments/helpers';
 
 // Callback for a post being published. This is distinct from being created in
 // that it doesn't fire on draft posts, and doesn't fire on posts that are awaiting
@@ -360,8 +361,7 @@ getCollectionHooks("ReviewVotes").newAsync.add(async function PositiveReviewVote
   }
 })
 
-// add new comment notification callback on comment submit
-getCollectionHooks("Comments").newAsync.add(async function CommentsNewNotifications(comment: DbComment) {
+const sendNewCommentNotifications = async (comment: DbComment) => {
   const post = comment.postId ? await Posts.findOne(comment.postId) : null;
   
   if (post?.isEvent) {
@@ -469,6 +469,21 @@ getCollectionHooks("Comments").newAsync.add(async function CommentsNewNotificati
       documentType: "comment",
       documentId: comment._id,
     });
+  }
+}
+
+// add new comment notification callback on comment submit
+getCollectionHooks("Comments").newAsync.add(async function commentsNewNotifications(comment: DbComment) {
+  // if the site is currently hiding comments by unreviewed authors, do not send notifications if this comment should be hidden
+  if (commentIsHidden(comment)) return
+  
+  sendNewCommentNotifications(comment)
+});
+
+getCollectionHooks("Comments").editAsync.add(async function commentsPublishedNotifications(comment: DbComment, oldComment: DbComment) {
+  // if the site is currently hiding comments by unreviewed authors, send the proper "new comment" notifications once the comment author is reviewed
+  if (commentIsHidden(oldComment) && !commentIsHidden(comment)) {
+    sendNewCommentNotifications(comment)
   }
 });
 


### PR DESCRIPTION
We got some [reports](https://cea-core.slack.com/archives/C038J512SD8/p1679565600710829) of comments from unreviewed users getting votes, which means they were not always being properly hidden. This PR stops them from appearing via permalink, and stops the relevant notifications from being sent until after the user is reviewed (when `hideUnreviewedAuthorComments` is active).