### PR TITLE
Fix sending of curation emails on LW

### DIFF
--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -189,17 +189,12 @@ export class EventDebouncer<KeyType = string>
     }
   }
   
-  _dispatchEvent = async (key: KeyType, events: string[]) => {
-    try {
-      if (!isAnyTest) {
-        //eslint-disable-next-line no-console
-        console.log(`Handling ${events.length} grouped ${this.name} events`);
-      }
-      await this.callback(key, events);
-    } catch(e) {
+  _dispatchEvent = async (key: KeyType, events: string[]|null) => {
+    if (!isAnyTest) {
       //eslint-disable-next-line no-console
-      console.error(e);
+      console.log(`Handling ${events?.length} grouped ${this.name} events`);
     }
+    await this.callback(key, events||[]);
   };
 }
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -248,9 +248,15 @@ const curationEmailDelay = new EventDebouncer({
     // Still curated? If it was un-curated during the 20 minute delay, don't
     // send emails.
     if (post?.curatedDate) {
+      //eslint-disable-next-line no-console
+      console.log(`Sending curation emails`);
+
       // Email only non-admins (admins get emailed immediately, without the
       // delay).
       let usersToEmail = await findUsersToEmail({'emailSubscribedToCurated': true, isAdmin: false});
+
+      //eslint-disable-next-line no-console
+      console.log(`Found ${usersToEmail.length} users to email`);
       await sendPostByEmail(usersToEmail, postId, "you have the \"Email me new posts in Curated\" option enabled");
     } else {
       //eslint-disable-next-line no-console


### PR DESCRIPTION
Slack thread: https://app.slack.com/client/T3ERD8FQT/CJUN2UAFN/thread/CJUN2UAFN-1680045850.371559?cdn_fallback=1

The bug is introduced in a1de8c79d7b275619fb73de31c8b8f56ec1282df. Prior to this, if `EventDebouncer.recordEvent` is called with optional parameter `data` omitted, the resulting entry in the `debouncerEvents` collection has `pendingEvents: [null]`. This case is used by `curationEmailDelay`, which sends the non-admin version of the curation email 20 minutes after admins get it. That event-type doesn't use the data field because the post ID is already in the `key` field. However if the `pendingEvents` field is missing (as opposed empty or having a null in it), then when `_dispatchEvent` runs `console.log(``Handling ${events.length} grouped ${this.name} events)` it throws:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at EventDebouncer._dispatchEvent (/usr/src/app/packages/lesswrong/server/debouncer.ts:196:40)
    at dispatchEvent (/usr/src/app/packages/lesswrong/server/debouncer.ts:242:24)
    at dispatchPendingEvents (/usr/src/app/packages/lesswrong/server/debouncer.ts:274:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This made it into AWS logs ([https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faw[…]640183359866334600458958648398774292](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Felasticbeanstalk$252FLesswrongexpress-env$252Fvar$252Flog$252Feb-docker$252Fcontainers$252Feb-current-app$252Fstdouterr.log/log-events/i-0cf7d4aff2de841fc$3Fstart$3D1679452020241$26refEventId$3D37453031578782110181640183359866334600458958648398774292)) not didn't make it into Sentry, because it's wrapped in a try-catch block that calls console.error but doesn't do anything else with it.

Fix this on the handling side, by making `_dispatchEvent` not crash if `events` isn't an array.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204287925780408) by [Unito](https://www.unito.io)
