### PR TITLE
topics bar returns to the selected tab when clicking "back", and goes to Frontpage tab when clicking logo

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -6,6 +6,8 @@ import { tagPostTerms } from '../tagging/TagPage';
 import { useMulti } from '../../lib/crud/withMulti';
 import debounce from 'lodash/debounce';
 import { Link } from '../../lib/reactRouterWrapper';
+import { useLocation, useNavigation } from '../../lib/routeUtil';
+import qs from 'qs';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -203,7 +205,22 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
   const [activeTab, setActiveTab] = useState<TopicsBarTab>(frontpageTab)
   const [leftArrowVisible, setLeftArrowVisible] = useState(false)
   const [rightArrowVisible, setRightArrowVisible] = useState(true)
+  const { history } = useNavigation()
+  const { location, query } = useLocation()
   const { captureEvent } = useTracking()
+  
+  useEffect(() => {
+    if (coreTopics) {
+      // set the initial active tab based on the query,
+      // and update the tab if the user clicks on a new one
+      const activeTab = coreTopics.find(topic => topic.slug === query.tab)
+      if (activeTab) {
+        setActiveTab(activeTab)
+      } else {
+        setActiveTab(frontpageTab)
+      }
+    }
+  }, [coreTopics, query])
   
   /**
    * When the topics bar is scrolled, hide/show the left/right arrows as necessary.
@@ -256,7 +273,10 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
   }
   
   const handleTabClick = (tab) => {
-    setActiveTab(tab)
+    history.replace({
+      ...location,
+      search: qs.stringify({...query, tab: tab.slug}),
+    })
     captureEvent("topicsBarTabClicked", {topicsBarTabId: tab._id, topicsBarTabName: tab.shortName || tab.name})
   }
   

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -186,7 +186,7 @@ const PostsTitle = ({
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
         <CuratedIcon hasColor />
       </span>}
-      <span className={!wrap && classes.eaTitleDesktopEllipsis}>
+      <span className={!wrap ? classes.eaTitleDesktopEllipsis : undefined}>
         {isLink ? <Link to={url}>{title}</Link> : title }
       </span>
       {showIcons && <span className={classes.hideXsDown}>


### PR DESCRIPTION
This PR updates the topics bar to set the active tab via a query param. This allows us to return to the selected tab when the user clicks the back button, and to reset the tab to the Frontpage when clicking on the EA Forum logo.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204296064423690) by [Unito](https://www.unito.io)
