### PR TITLE
Add read-time to BooksProgressBar and collection

### DIFF
--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -53,6 +53,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
+const WORDS_PER_MINUTE = 300;
+const WORDS_PER_HOUR = WORDS_PER_MINUTE * 60;
+const WORDS_PER_PAGE = 500;
+
 const BooksProgressBar = ({ book, classes }: {
   book: BookPageFragment,
   classes: ClassesType
@@ -68,9 +72,9 @@ const BooksProgressBar = ({ book, classes }: {
 
   const postsReadText = `${readPosts.length} / ${totalPosts} posts read`;
   const totalWordCount = bookPosts.reduce((i, post) => i + (post.contents?.wordCount || 0), 0)
-  const readTime = totalWordCount > 18000 ? `${(totalWordCount/18000).toFixed(1)} hour` : `${Math.round(totalWordCount/300)} min`
+  const readTime = totalWordCount > WORDS_PER_HOUR ? `${(totalWordCount/WORDS_PER_HOUR).toFixed(1)} hour` : `${Math.round(totalWordCount/WORDS_PER_MINUTE)} min`
   const postsReadTooltip = <div>
-    <div>{totalWordCount.toLocaleString()} words, {Math.round(totalWordCount / 500)} pages</div>
+    <div>{totalWordCount.toLocaleString()} words, {Math.round(totalWordCount / WORDS_PER_PAGE)} pages</div>
     <div>Approximately {readTime} read</div>
   </div>
 

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -63,10 +63,16 @@ const BooksProgressBar = ({ book, classes }: {
 
   const bookPosts = book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts));
   // Check whether the post is marked as read either on the server or in the client-side context
-  const readPosts = bookPosts.filter(post => post.isRead || clientPostsRead[post._id]).length;
+  const readPosts = bookPosts.filter(post => post.isRead || clientPostsRead[post._id]);
   const totalPosts = bookPosts.length;
 
-  const postsReadText = `${readPosts} / ${totalPosts} posts read`;
+  const postsReadText = `${readPosts.length} / ${totalPosts} posts read`;
+  const totalWordCount = bookPosts.reduce((i, post) => i + (post.contents?.wordCount || 0), 0)
+  const readTime = totalWordCount > 18000 ? `${(totalWordCount/18000).toFixed(1)} hour` : `${Math.round(totalWordCount/300)} min`
+  const postsReadTooltip = <div>
+    <div>{totalWordCount.toLocaleString()} words, {Math.round(totalWordCount / 500)} pages</div>
+    <div>Approximately {readTime} read</div>
+  </div>
 
   if (book.hideProgressBar) return null
 
@@ -83,7 +89,7 @@ const BooksProgressBar = ({ book, classes }: {
       }
     </div>
     <div className={classNames(classes.sequence, classes.progressText)}>
-      {postsReadText}
+      <LWTooltip title={postsReadTooltip}>{postsReadText}</LWTooltip>
       <LoginToTrack className={classes.loginText}>
         login to track progress
       </LoginToTrack>

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -103,12 +103,12 @@ const CollectionsPage = ({ documentId, classes }: {
     // props
     const ButtonUntyped = Button as any;
     
-    // secret wordcount for admin convenience 
+    // hidden wordcount logged for admin convenience 
     // we don't show to users because it'd be too intimidating
     // (more info in BooksProgressBar for users)
     const posts = collection.books.flatMap(book => book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts)))
     const wordCount = posts.reduce((i, post) => i + (post?.contents?.wordCount || 0), 0)
-    console.log({wordCount})
+    console.log(`${wordCount} words`)
 
     return (<ErrorBoundary><div className={classes.root}>
       <ToCColumn 

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -108,6 +108,7 @@ const CollectionsPage = ({ documentId, classes }: {
     // (more info in BooksProgressBar for users)
     const posts = collection.books.flatMap(book => book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts)))
     const wordCount = posts.reduce((i, post) => i + (post?.contents?.wordCount || 0), 0)
+    // eslint-disable-next-line no-console
     console.log(`${wordCount.toLocaleString()} words`)
 
     return (<ErrorBoundary><div className={classes.root}>

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -103,6 +103,13 @@ const CollectionsPage = ({ documentId, classes }: {
     // props
     const ButtonUntyped = Button as any;
     
+    // secret wordcount for admin convenience 
+    // we don't show to users because it'd be too intimidating
+    // (more info in BooksProgressBar for users)
+    const posts = collection.books.flatMap(book => book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts)))
+    const wordCount = posts.reduce((i, post) => i + (post?.contents?.wordCount || 0), 0)
+    console.log({wordCount})
+
     return (<ErrorBoundary><div className={classes.root}>
       <ToCColumn 
         tableOfContents={<CollectionTableOfContents collection={document}/>}

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -108,7 +108,7 @@ const CollectionsPage = ({ documentId, classes }: {
     // (more info in BooksProgressBar for users)
     const posts = collection.books.flatMap(book => book.sequences.flatMap(sequence => sequence.chapters.flatMap(chapter => chapter.posts)))
     const wordCount = posts.reduce((i, post) => i + (post?.contents?.wordCount || 0), 0)
-    console.log(`${wordCount} words`)
+    console.log(`${wordCount.toLocaleString()} words`)
 
     return (<ErrorBoundary><div className={classes.root}>
       <ToCColumn 


### PR DESCRIPTION
This adds wordcount, and approximate pagecount and read-time, to Books and Collections. For books, it's (somewhat) hidden behind a tooltip. For collections it's only shown in the console log, to avoid looking too intimidating.

<img width="913" alt="image" src="https://user-images.githubusercontent.com/3246710/228776696-a9c148cf-8af6-4deb-b732-876622c38c04.png">

<img width="467" alt="image" src="https://user-images.githubusercontent.com/3246710/228777303-d88e9e56-dada-4c1c-a9e8-44a1691d0d01.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204298143568771) by [Unito](https://www.unito.io)
