### PR TITLE
Add _id to contents in HighlightWithHash fragment to fix caching bug

### DIFF
--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -580,6 +580,7 @@ registerFragment(`
   fragment HighlightWithHash on Post {
     _id
     contents {
+      _id
       htmlHighlightStartingAtHash(hash: $hash)
     }
   }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1244,6 +1244,7 @@ interface HighlightWithHash { // fragment on Posts
 }
 
 interface HighlightWithHash_contents { // fragment on Revisions
+  readonly _id: string,
   readonly htmlHighlightStartingAtHash: string,
 }
 


### PR DESCRIPTION
In today's episode of why I hate Apollo: we currently have a bug where hovering over a link in a post preview will crash the entire recent discussions section if it's an internal link to a heading in that post. This is due to the fragment not containing the revision id. (You can test this on the dev database using the post http://localhost:3000/posts/fzRHvwwe2Jcz3sEHB/coauthor-voting-test).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204299594282647) by [Unito](https://www.unito.io)
