### PR TITLE
Improve schema test

### DIFF
--- a/packages/lesswrong/server/scripts/makeMigrations.ts
+++ b/packages/lesswrong/server/scripts/makeMigrations.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { acceptMigrations, migrationsPath } from './acceptMigrations';
 import { existsSync } from 'node:fs';
-import { forumTypeSetting, ForumTypeString } from '../../lib/instanceSettings';
+import { ForumTypeString } from '../../lib/instanceSettings';
 
 const ROOT_PATH = path.join(__dirname, "../../../");
 const acceptedSchemePath = (rootPath: string) => path.join(rootPath, "schema/accepted_schema.sql");
@@ -124,17 +124,20 @@ export const makeMigrations = async ({
   generateMigrations=true,
   rootPath=ROOT_PATH,
   forumType,
+  silent=false,
 }: {
   writeSchemaChangelog: boolean,
   writeAcceptedSchema: boolean,
   generateMigrations: boolean,
   rootPath: string,
   forumType?: ForumTypeString,
+  silent?: boolean,
 }) => {
-  console.log(`=== Checking for schema changes ===`);
+  const log = silent ? (...args: any[]) => {} : console.log;
+  log(`=== Checking for schema changes ===`);
   // Get the most recent accepted schema hash from `schema_changelog.json`
   const {acceptsSchemaHash: acceptedHash, acceptedByMigration, timestamp} = await acceptMigrations({write: writeSchemaChangelog, rootPath});
-  console.log(`-- Using accepted hash ${acceptedHash}`);
+  log(`-- Using accepted hash ${acceptedHash}`);
 
   const currentHashes: Partial<Record<CollectionNameString, string>> = {};
   let schemaFileContents = "";
@@ -186,7 +189,7 @@ export const makeMigrations = async ({
     }
   }
 
-  console.log("=== Done ===");
+  log("=== Done ===");
 }
 
 Vulcan.makeMigrations = makeMigrations;

--- a/packages/lesswrong/unitTests/schemacheck.test.ts
+++ b/packages/lesswrong/unitTests/schemacheck.test.ts
@@ -14,7 +14,7 @@ describe('Schema check', () => {
       rootPath,
       forumType: "EAForum",
     });
-  }, 15000);
+  });
   it('accpeted_schema.sql overall hash matches most recent changelog item', async () => {
     const acceptedSchemaPath = path.join(rootPath, "schema/accepted_schema.sql");
     const acceptedData = await readFile(acceptedSchemaPath);

--- a/packages/lesswrong/unitTests/schemacheck.test.ts
+++ b/packages/lesswrong/unitTests/schemacheck.test.ts
@@ -13,6 +13,7 @@ describe('Schema check', () => {
       generateMigrations: false,
       rootPath,
       forumType: "EAForum",
+      silent: true,
     });
   });
   it('accpeted_schema.sql overall hash matches most recent changelog item', async () => {


### PR DESCRIPTION
Two improvements for the schema check unit test:

- Hide the `console.log`s if the test passes
- Remove the custom timeout, which is actually 5 seconds shorter than the default timeout that we use and is often the cause of spurious test failures. It's possible that we actually need to add a custom time out that's 5-10 seconds _longer_ than the default in order to stop the failures, but we should try this out first.