### PR TITLE
More more EA redesign improvements

### DIFF
--- a/packages/lesswrong/components/collections/BigCollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/BigCollectionsCard.tsx
@@ -2,6 +2,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import type { CoreReadingCollection } from '../sequences/LWCoreReading';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -43,6 +44,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   author: {
     ...theme.typography.postStyle,
     marginBottom:theme.spacing.unit,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   media: {
     height:271,

--- a/packages/lesswrong/components/collections/CollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/CollectionsCard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import type { CoreReadingCollection } from '../sequences/LWCoreReading';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -34,6 +35,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderTop: `solid 4px ${theme.palette.text.maxIntensity}`, // This gets overwritten by a color from the DB
     paddingTop: theme.spacing.unit*1.5
   },
+  title: {
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+  },
   mergeTitle: {
     display: "inline",
     marginRight: 10,
@@ -45,6 +49,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.postStyle,
     marginBottom:theme.spacing.unit,
     display: "inline-block",
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   media: {
     '& img':{

--- a/packages/lesswrong/components/common/FlashMessages.tsx
+++ b/packages/lesswrong/components/common/FlashMessages.tsx
@@ -4,11 +4,13 @@ import classnames from 'classnames';
 import React from 'react';
 import Snackbar from '@material-ui/core/Snackbar';
 import Button from '@material-ui/core/Button';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     '& .MuiSnackbarContent-message': {
       color: theme.palette.text.maxIntensity,
+      fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
     },
   },
 });

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -307,7 +307,6 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
                   unreadNotifications={unreadNotifications}
                   toggle={handleNotificationToggle}
                   open={notificationOpen}
-                  currentUser={currentUser}
                 />}
               </div>
             </Toolbar>

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -1,12 +1,19 @@
 import React, { Component } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { withTracking } from "../../lib/analyticsEvents";
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { isEAForum } from '../../lib/instanceSettings';
 
-const isEAForum = forumTypeSetting.get() === 'EAForum'
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    "&:hover": {
+      opacity: isEAForum ? 1 : undefined,
+      color: isEAForum ? theme.palette.grey[800] : undefined,
+    },
+  },
+});
 
-interface SubscribeWidgetProps extends WithTrackingProps {
-}
+interface SubscribeWidgetProps extends WithTrackingProps {}
+interface SubscribeWidgetProps extends WithStylesProps {}
 interface SubscribeWidgetState {
   dialogOpen: boolean,
   method: string,
@@ -28,7 +35,7 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
 
     return (
       <div>
-        <a onClick={() => this.openDialog("rss")}>
+        <a onClick={() => this.openDialog("rss")} className={this.props.classes.root}>
           <TabNavigationSubItem>Subscribe (RSS{!isEAForum && '/Email'})</TabNavigationSubItem>
         </a>
         { dialogOpen && <SubscribeDialog
@@ -42,6 +49,7 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
 }
 
 const SubscribeWidgetComponent = registerComponent("SubscribeWidget", SubscribeWidget, {
+  styles,
   hocs: [withTracking]
 });
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -52,7 +52,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingLeft: 0,
     paddingRight: 0,
     '&:hover': {
-      backgroundColor: 'transparent' // Prevent MUI default behavior of rendering solid background on hover
+      backgroundColor: 'transparent', // Prevent MUI default behavior of rendering solid background on hover
+      opacity: isEAForum ? 1 : undefined,
     }
   },
   icon: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -24,7 +24,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     whiteSpace: "nowrap",
     overflow: "hidden",
     '&:hover': {
-      opacity: .6
+      opacity: isEAForum ? 1 : 0.6,
+      color: isEAForum ? theme.palette.grey[800] : undefined,
     },
     boxSizing: "content-box"
   }

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -5,7 +5,8 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 const styles = (theme: ThemeType): JssStyles => ({
   description: {
     marginTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit*4,
+    marginBottom: `${theme.spacing.unit * 2}px !important`,
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
 })
 

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -54,9 +54,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     columnGap: 10,
     fontSize: 20,
     lineHeight: '30px',
-    fontWeight: '700',
+    fontWeight: '600',
     paddingBottom: 3,
     borderBottom: `3px solid ${theme.palette.primary.main}`,
+    fontFamily: theme.palette.fonts.sansSerifStack,
     [theme.breakpoints.down('xs')]: {
       columnGap: 8,
       fontSize: 18,
@@ -79,7 +80,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   sectionSubHeading: {
     fontSize: 16,
-    fontWeight: '700',
+    fontWeight: '600',
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
   inactiveGroup: {
     color: theme.palette.grey[500],
@@ -99,7 +101,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   username: {
     fontSize: 32,
     lineHeight: '42px',
-    marginBottom: 16
+    marginBottom: 16,
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontWeight: 500,
   },
   roleAndOrg: {
     fontSize: 16,

--- a/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
+++ b/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
@@ -12,6 +12,7 @@ export const eaUsersProfileSectionStyles = (theme: ThemeType) => ({
   padding: '24px 32px',
   marginBottom: 24,
   borderRadius: theme.borderRadius.default,
+  fontFamily: theme.palette.fonts.sansSerifStack,
   [theme.breakpoints.down('xs')]: {
     padding: 16,
   }
@@ -37,9 +38,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     columnGap: 10,
     fontSize: 20,
     lineHeight: '30px',
-    fontWeight: '700',
+    fontWeight: '600',
     paddingBottom: 3,
     borderBottom: `3px solid transparent`,
+    fontFamily: theme.palette.fonts.sansSerifStack,
     [theme.breakpoints.down('xs')]: {
       columnGap: 8,
       fontSize: 18,

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Badge from '@material-ui/core/Badge';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import IconButton from '@material-ui/core/IconButton';
-import * as _ from 'underscore';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   badgeContainer: {
@@ -13,12 +13,18 @@ const styles = (theme: ThemeType): JssStyles => ({
   badge: {
     backgroundColor: 'inherit',
     color: theme.palette.header.text,
-    fontFamily: 'freight-sans-pro, sans-serif',
-    fontSize: "12px",
     fontWeight: 500,
     right: "1px",
     top: "1px",
     pointerEvents: "none",
+    ...(isEAForum
+      ? {
+        fontSize: 10,
+      }
+      : {
+        fontFamily: "freight-sans-pro, sans-serif",
+        fontSize: 12,
+      }),
   },
   buttonOpen: {
     backgroundColor: theme.palette.buttons.notificationsBellOpen.background,
@@ -30,11 +36,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const NotificationsMenuButton = ({ unreadNotifications, open, toggle, currentUser, classes }: {
+const NotificationsMenuButton = ({ unreadNotifications, open, toggle, classes }: {
   unreadNotifications: number,
   open: boolean,
   toggle: ()=>void,
-  currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
   const { ForumIcon } = Components

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -75,9 +75,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     flexDirection: "column",
     justifyContent: "center",
     background: theme.palette.panelBackground.default,
-    borderRadius: isEAForum
-      ? `0 0 ${theme.borderRadius.small}px ${theme.borderRadius.small}px`
-      : undefined,
+    ...(isEAForum
+      ? {
+        borderRadius: `0 0 ${theme.borderRadius.small}px ${theme.borderRadius.small}px`,
+        fontFamily: theme.palette.fonts.sansSerifStack,
+      }
+      : {
+      }),
   },
   bookItemShadowStyle: {
     boxShadow: "none",
@@ -125,11 +129,7 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   classes: ClassesType,
   bookItemStyle?: boolean
 }) => {
-  const getSequenceUrl = () => {
-    return '/s/' + sequence._id
-  }
   const { LinkCard, SequencesHoverOver } = Components;
-  const url = getSequenceUrl()
 
   // The hoverover is adjusted so that it's title lines up with where the SequencesGridItem title would have been, to avoid seeing the title twice
   let positionAdjustment = -35

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -32,8 +32,16 @@ const styles = (theme: ThemeType): JssStyles => ({
 
   title: {
     fontSize: 16,
-    lineHeight: 1.0,
-    maxHeight: 32,
+    ...(isEAForum
+      ? {
+        lineHeight: 1.25,
+        maxHeight: 42,
+        minHeight: 42,
+      }
+      : {
+        lineHeight: 1.0,
+        maxHeight: 32,
+      }),
     paddingTop: 2,
     display: "-webkit-box",
     "-webkit-line-clamp": 2,

--- a/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHoverOver.tsx
@@ -4,6 +4,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card';
 import { Link } from '../../lib/reactRouterWrapper';
 import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -14,6 +15,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.body1,
     ...theme.typography.postStyle,
     ...theme.typography.smallCaps,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   description: {
     ...theme.typography.body2,
@@ -22,7 +26,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 8,
   },
   author: {
-    color: theme.palette.text.dim
+    color: theme.palette.text.dim,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   wordcount: {
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/votes/VoteArrowIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIcon.tsx
@@ -6,6 +6,7 @@ import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
 import { VoteColor, cssVoteColors } from './voteColors';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -13,6 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 'inherit',
     width: 'initial',
     height: 'initial',
+    marginTop: isEAForum ? 2 : undefined,
     padding: 0,
     '&:hover': {
       backgroundColor: 'transparent',


### PR DESCRIPTION
This PR fixes some more issues with the new redesign. I think the only remaining problems after this are caching for the frontpage topic feeds, and a few larger issues that are still waiting on designs.

- Fix the font for the notifications button
- Fix hover styles for menu subitems
- Fix cutoff sequence titles
- More typography fixes for the /library page
- Adjust vertical alignment of vote arrows
- Fix (all?) the serif text on the user profile page
- Fix serif text in the flash notification text