### PR TITLE
Upgrade dataloader to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "cookie-parser": "^1.4.3",
     "crypto-js": "^3.1.9-1",
     "csso": "^5.0.5",
-    "dataloader": "^1.4.0",
+    "dataloader": "^2.2.2",
     "dd-trace": "^3.5.0",
     "deepmerge": "^1.2.0",
     "draft-convert": "^2.1.2",

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -7,7 +7,7 @@ import { postCanEditHideCommentKarma, postGetPageUrl, postGetEmailShareUrl, post
 import { postStatuses, postStatusLabels } from './constants';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { TagRels } from "../tagRels/collection";
-import { getWithLoader } from '../../loaders';
+import { loadByIds, getWithLoader } from '../../loaders';
 import { formGroups } from './formGroups';
 import SimpleSchema from 'simpl-schema'
 import { DEFAULT_QUALITATIVE_VOTE } from '../reviewVotes/schema';
@@ -877,7 +877,7 @@ const schema: SchemaType<DbPost> = {
       const { currentUser } = context;
       const tagRelevanceRecord:Record<string, number> = post.tagRelevance || {}
       const tagIds = Object.entries(tagRelevanceRecord).filter(([id, score]) => score && score > 0).map(([id]) => id)
-      const tags = await context.loaders.Tags.loadMany(tagIds)
+      const tags = await loadByIds(context, "Tags", tagIds);
       return await accessFilterMultiple(currentUser, context.Tags, tags, context)
     }
   }),
@@ -1265,8 +1265,7 @@ const schema: SchemaType<DbPost> = {
       fieldName: 'coauthors',
       type: '[User!]!',
       resolver: async (post: DbPost, args: void, context: ResolverContext) =>  {
-        const loader = context.loaders['Users'];
-        const resolvedDocs = await loader.loadMany(
+        const resolvedDocs = await loadByIds(context, "Users",
           post.coauthorStatuses?.map(({ userId }) => userId) || []
         );
         return await accessFilterMultiple(context.currentUser, context['Users'], resolvedDocs, context);

--- a/packages/lesswrong/lib/collections/sequences/helpers.ts
+++ b/packages/lesswrong/lib/collections/sequences/helpers.ts
@@ -4,6 +4,7 @@ import { Books } from '../books/collection';
 import { Collections } from '../collections/collection';
 import { Sequences } from './collection';
 import { accessFilterMultiple } from '../../utils/schemaUtils';
+import { loadByIds } from '../../loaders';
 import keyBy from 'lodash/keyBy';
 import * as _ from 'underscore';
 
@@ -35,7 +36,7 @@ export const sequenceGetAllPostIDs = async (sequenceId: string, context: Resolve
   const validPostIds = _.filter(allPostIds, postId=>!!postId);
   
   // Filter by user access
-  const posts = await context.loaders.Posts.loadMany(validPostIds);
+  const posts = await loadByIds(context, "Posts", validPostIds);
   const accessiblePosts = await accessFilterMultiple(context.currentUser, context.Posts, posts, context);
   return accessiblePosts.map(post => post._id);
 }

--- a/packages/lesswrong/lib/loaders.ts
+++ b/packages/lesswrong/lib/loaders.ts
@@ -47,3 +47,35 @@ export async function getWithCustomLoader<T extends DbObject, ID>(context: Resol
 
   return await context.extraLoaders[loaderName].load(id);
 }
+
+/**
+ * Given an array of IDs, load the corresponding objects and return them in an
+ * array of the same length, with nulls for any IDs that don't exist.
+ *
+ * If the same ID is requested multiple times with the same ResolverContext, ie
+ * while assembling a response to the same HTTP request, the object will be
+ * fetched once and reused.
+ *
+ * This is a wrapper around `loadMany` on the underlying data loader, which
+ * simplifies calling it by translating any instances of `Error` in the result
+ * list to a single thrown exception.
+ */
+export async function loadByIds<N extends CollectionNameString>(context: ResolverContext, collectionName: N, ids: string[]): Promise<(ObjectsByCollectionName[N]|null)[]> {
+  const results = await context.loaders[collectionName].loadMany(ids);
+  
+  // The `dataloader` library returns an array of (result|null|Error), handling
+  // the case where loading a subset of objects threw an exception. If this
+  // happens, it probably means something has gone wrong with our connection to
+  // the database, and we don't want to return an array where some objects are
+  // relaced with Error, we just want to throw an exception for the whole batch.
+
+  // Check for any instances of Error in the results, and throw
+  for (let result of results) {
+    if (result instanceof Error) {
+      throw result;
+    }
+  }
+
+  // Downcast to remove Error from the possible results, and return
+  return results as Array<ObjectsByCollectionName[N]|null>;
+}

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -1,7 +1,7 @@
 import { addCallback, getCollection } from '../vulcan-lib';
 import { restrictViewableFields } from '../vulcan-users/permissions';
 import SimpleSchema from 'simpl-schema'
-import { getWithLoader } from "../loaders";
+import { loadByIds, getWithLoader } from "../loaders";
 import { isServer } from '../executionEnvironment';
 import { asyncFilter } from './asyncUtils';
 import type { GraphQLScalarType } from 'graphql';
@@ -54,9 +54,7 @@ const generateIdResolverMulti = <CollectionName extends CollectionNameString>({
     const { currentUser } = context
     const collection = context[collectionName] as unknown as CollectionBase<DbType>
 
-    const loader = context.loaders[collectionName] as DataLoader<string,DbType>;
-    const resolvedDocs: Array<DbType> = await loader.loadMany(keys)
-
+    const resolvedDocs: Array<DbType|null> = await loadByIds(context, collectionName, keys)
     return await accessFilterMultiple(currentUser, collection, resolvedDocs, context);
   }
 }

--- a/packages/lesswrong/lib/utils/typeGuardUtils.ts
+++ b/packages/lesswrong/lib/utils/typeGuardUtils.ts
@@ -51,3 +51,7 @@ export class TupleSet<T extends ReadonlyArray<string|number>> extends Set<string
 
 export type TupleOf<T extends TupleSet<any>> = T extends TupleSet<infer U> ? U : never;
 export type UnionOf<T extends TupleSet<any>> = TupleOf<T>[number];
+
+export function filterNonnull<T>(arr: (T|null|undefined)[]): T[] {
+  return arr.filter(x=>x!=null && x!==undefined) as T[];
+}

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Components } from '../vulcan-lib/components';
 import { calculateVotePower } from './voteTypes';
+import { loadByIds } from '../loaders';
+import { filterNonnull } from '../utils/typeGuardUtils';
 import sumBy from 'lodash/sumBy'
 import uniq from 'lodash/uniq';
 import keyBy from 'lodash/keyBy';
@@ -91,8 +93,8 @@ registerVotingSystem({
   },
   computeExtendedScore: async (votes: DbVote[], context: ResolverContext) => {
     const userIdsThatVoted = uniq(votes.map(v=>v.userId));
-    const usersThatVoted = await context.loaders.Users.loadMany(userIdsThatVoted);
-    const usersById = keyBy(usersThatVoted, u=>u._id);
+    const usersThatVoted = await loadByIds(context, "Users", userIdsThatVoted);
+    const usersById = keyBy(filterNonnull(usersThatVoted), u=>u._id);
     
     const result = {
       approvalVoteCount: votes.filter(v=>(v.voteType && v.voteType!=="neutral")).length,
@@ -171,8 +173,8 @@ registerVotingSystem({
   },
   computeExtendedScore: async (votes: DbVote[], context: ResolverContext) => {
     const userIdsThatVoted = uniq(votes.map(v=>v.userId));
-    const usersThatVoted = await context.loaders.Users.loadMany(userIdsThatVoted);
-    const usersById = keyBy(usersThatVoted, u=>u._id);
+    const usersThatVoted = await loadByIds(context, "Users", userIdsThatVoted);
+    const usersById = keyBy(filterNonnull(usersThatVoted), u=>u._id);
     
     const axisScores = fromPairs(reactBallotAxisNames.map(axis => {
       return [axis, sumBy(votes, v => getVoteAxisStrength(v, usersById, axis))];

--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -1,6 +1,7 @@
 import Conversations from '../../lib/collections/conversations/collection'
 import { SENT_MODERATOR_MESSAGE } from '../../lib/collections/moderatorActions/schema';
 import { userIsAdmin } from '../../lib/vulcan-users';
+import { loadByIds } from '../../lib/loaders';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { createMutator } from '../vulcan-lib';
 
@@ -25,7 +26,7 @@ getCollectionHooks("Messages").createAsync.add(async function updateUserNotesOnM
   const conversation = await context.loaders.Conversations.load(conversationId);
   if (conversation.moderator) {
     const [conversationParticipants, conversationMessageCount] = await Promise.all([
-      context.loaders.Users.loadMany(conversation.participantIds),
+      loadByIds(context, "Users", conversation.participantIds),
       // No need to fetch more than 2, we only care if this is the first message in the conversation
       context.Messages.find({ conversationId }, { limit: 2 }).count()
     ]);

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -10,6 +10,7 @@ import { Posts } from '../../lib/collections/posts';
 import { augmentFieldsDict, accessFilterMultiple } from '../../lib/utils/schemaUtils';
 import { compareVersionNumbers } from '../../lib/editor/utils';
 import { toDictionary } from '../../lib/utils/toDictionary';
+import { loadByIds } from '../../lib/loaders';
 import moment from 'moment';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
@@ -204,13 +205,13 @@ addGraphQLResolvers({
       }).fetch();
       
       const userIds = _.uniq([...tagRevisions.map(tr => tr.userId), ...rootComments.map(rc => rc.userId)])
-      const usersAll = await context.loaders.Users.loadMany(userIds)
+      const usersAll = await loadByIds(context, "Users", userIds)
       const users = await accessFilterMultiple(context.currentUser, Users, usersAll, context)
       const usersById = keyBy(users, u => u._id);
       
       // Get the tags themselves
       const tagIds = _.uniq([...tagRevisions.map(r=>r.documentId), ...rootComments.map(c=>c.tagId)]);
-      const tagsUnfiltered = await context.loaders.Tags.loadMany(tagIds);
+      const tagsUnfiltered = await loadByIds(context, "Tags", tagIds);
       const tags = await accessFilterMultiple(context.currentUser, Tags, tagsUnfiltered, context);
       
       return tags.map(tag => {
@@ -259,7 +260,7 @@ addGraphQLResolvers({
 
       // Get the tags themselves, keyed by the id
       const tagIds = _.uniq(tagRevisions.map(r=>r.documentId));
-      const tagsUnfiltered = (await context.loaders.Tags.loadMany(tagIds));
+      const tagsUnfiltered = await loadByIds(context, "Tags", tagIds);
       const tags = (await accessFilterMultiple(context.currentUser, Tags, tagsUnfiltered, context)).reduce( (acc, tag) => {
         acc[tag._id] = tag;
         return acc;
@@ -309,7 +310,7 @@ augmentFieldsDict(Tags, {
       }> => {
         const contributionStatsByUserId = await getContributorsList(tag, version||null);
         const contributorUserIds = Object.keys(contributionStatsByUserId);
-        const contributorUsersUnfiltered = await context.loaders.Users.loadMany(contributorUserIds);
+        const contributorUsersUnfiltered = await loadByIds(context, "Users", contributorUserIds);
         const contributorUsers = await accessFilterMultiple(context.currentUser, Users, contributorUsersUnfiltered, context);
         const usersById = keyBy(contributorUsers, u => u._id);
   

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -12,6 +12,8 @@ import { randomId } from '../lib/random';
 import { getConfirmedCoauthorIds } from '../lib/collections/posts/helpers';
 import { ModeratorActions } from '../lib/collections/moderatorActions/collection';
 import { RECEIVED_VOTING_PATTERN_WARNING } from '../lib/collections/moderatorActions/schema';
+import { loadByIds } from '../lib/loaders';
+import { filterNonnull } from '../lib/utils/typeGuardUtils';
 import moment from 'moment';
 import * as _ from 'underscore';
 import sumBy from 'lodash/sumBy'
@@ -466,8 +468,8 @@ export const recalculateDocumentScores = async (document: VoteableType, context:
   
   const userIdsThatVoted = uniq(votes.map(v=>v.userId));
   // make sure that votes associated with users that no longer exist get ignored for the AF score
-  const usersThatVoted = (await context.loaders.Users.loadMany(userIdsThatVoted))?.filter(u=>!!u);
-  const usersThatVotedById = keyBy(usersThatVoted, u=>u._id);
+  const usersThatVoted = await loadByIds(context, "Users", userIdsThatVoted);
+  const usersThatVotedById = keyBy(filterNonnull(usersThatVoted), u=>u._id);
   
   const afVotes = _.filter(votes, v=>userCanDo(usersThatVotedById[v.userId], "votes.alignment"));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6418,10 +6418,10 @@ dataloader@2.0.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
-dataloader@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz"
-  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+dataloader@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
+  integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
This crosses a major version; see https://github.com/graphql/dataloader/releases/tag/v2.0.0 for changes. The main change is that the timing of promise resolution has changed, in a way that avoids N+1 select in some cases. This also adds Typescript definitions, and changes how error handling works. We convert calls to loadMany to go through a wrapper, loadByIds, to change that error handling again to something friendlier.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204317164541382) by [Unito](https://www.unito.io)
