### PR TITLE
Add sprout icon to post authors

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -4,8 +4,7 @@ import classNames from 'classnames';
 import moment from 'moment';
 import { isEAForum, siteNameWithArticleSetting } from '../../../lib/instanceSettings';
 import { DatabasePublicSetting } from '../../../lib/publicSettings';
-
-const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
+import { isNewUser } from '../../../lib/collections/users/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   author: {
@@ -62,33 +61,16 @@ const CommentUserName = ({comment, classes, simple = false, isPostAuthor, hideSp
       </span>
     );
   } else {
-    const karmaThreshold = newUserIconKarmaThresholdSetting.get()
-    // show the "new user" sprout icon if the author has low karma or joined less than a week ago
-    const showSproutIcon = (karmaThreshold && author.karma < karmaThreshold) ||
-                            moment(author.createdAt).isAfter(moment().subtract(1, 'week'))
+    const showSproutIcon = isNewUser(author)
     return <>
       <UsersName
         user={author}
         simple={simple}
+        allowNewUserIcon
+        showAuthorIcon={isPostAuthor}
         className={classNames(className, classes.author)}
         tooltipPlacement="bottom-start"
       />
-      {isEAForum && isPostAuthor && <LWTooltip
-          placement="bottom-start"
-          title="Post author"
-          className={classes.iconWrapper}
-        >
-          <ForumIcon icon="Author" className={classes.postAuthorIcon} />
-        </LWTooltip>
-      }
-      {showSproutIcon && !hideSprout && <LWTooltip
-          placement="bottom-start"
-          title={`${author.displayName} is either new on ${siteNameWithArticleSetting.get()} or doesn't have much karma yet.`}
-          className={classes.iconWrapper}
-        >
-          <ForumIcon icon="Sprout" className={classes.sproutIcon} />
-        </LWTooltip>
-      }
     </>
   }
 }

--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -1,10 +1,7 @@
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import React from 'react';
 import classNames from 'classnames';
-import moment from 'moment';
-import { isEAForum, siteNameWithArticleSetting } from '../../../lib/instanceSettings';
-import { DatabasePublicSetting } from '../../../lib/publicSettings';
-import { isNewUser } from '../../../lib/collections/users/helpers';
+import { isEAForum } from '../../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   author: {
@@ -45,7 +42,7 @@ const CommentUserName = ({comment, classes, simple = false, isPostAuthor, hideSp
   hideSprout?: boolean,
   className?: string
 }) => {
-  const { UserNameDeleted, UsersName, ForumIcon, LWTooltip } = Components
+  const { UserNameDeleted, UsersName } = Components
   const author = comment.user
   
   if (comment.deleted) {
@@ -61,13 +58,12 @@ const CommentUserName = ({comment, classes, simple = false, isPostAuthor, hideSp
       </span>
     );
   } else {
-    const showSproutIcon = isNewUser(author)
     return <>
       <UsersName
         user={author}
         simple={simple}
-        allowNewUserIcon
-        showAuthorIcon={isPostAuthor}
+        allowNewUserIcon={!hideSprout}
+        showAuthorIcon={isEAForum && isPostAuthor}
         className={classNames(className, classes.author)}
         tooltipPlacement="bottom-start"
       />

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -21,7 +21,7 @@ const PostsAuthors = ({classes, post}: {
   const { UsersName, PostsCoauthor, Typography } = Components
   return <Typography variant="body1" component="span" className={classes.root}>
     by <span className={classes.authorName}>
-      {!post.user || post.hideAuthor ? <Components.UserNameDeleted/> : <UsersName user={post.user} />}
+      {!post.user || post.hideAuthor ? <Components.UserNameDeleted/> : <UsersName user={post.user} allowNewUserIcon />}
       {post.coauthors?.map(coauthor =>
         <PostsCoauthor key={coauthor._id} post={post} coauthor={coauthor} />
       )}

--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -23,7 +23,7 @@ const PostsCoauthor = ({ post, coauthor }: {
     : UsersName;
   return (
     <>
-      , <Component user={coauthor} />
+      , <Component user={coauthor} {...(!isPending && {allowNewUserIcon: true})} />
     </>
   );
 }

--- a/packages/lesswrong/components/users/UsersName.tsx
+++ b/packages/lesswrong/components/users/UsersName.tsx
@@ -8,22 +8,23 @@ import React from 'react';
  * with deleted accounts, where the user object that comes back in a query is
  * null for non-admins).
  */
-const UsersName = ({user, documentId, nofollow=false, simple=false, tooltipPlacement = "left", className}: {
+const UsersName = ({user, documentId, nofollow=false, simple=false, tooltipPlacement = "left", className, ...otherProps}: {
   user?: UsersMinimumInfo|null|undefined,
   documentId?: string,
   /** Marks the link nofollow, so if it's spammy search engines won't crawl the user page. */
   nofollow?: boolean,
   /** Makes it not a link, and removes the tooltip. */
   simple?: boolean,
-
+  showAuthorIcon?: boolean,
+  allowNewUserIcon?: boolean,
   tooltipPlacement?: PopperPlacementType,
   /** Add an extra class/styling to the link */
   className?: string,
 }) => {
   if (user) {
-    return <Components.UsersNameDisplay user={user} nofollow={nofollow} simple={simple} tooltipPlacement={tooltipPlacement} className={className}/>
+    return <Components.UsersNameDisplay user={user} nofollow={nofollow} simple={simple} tooltipPlacement={tooltipPlacement} className={className} {...otherProps}/>
   } else if (documentId) {
-    return <Components.UsersNameWrapper documentId={documentId} nofollow={nofollow} simple={simple} className={className} />
+    return <Components.UsersNameWrapper documentId={documentId} nofollow={nofollow} simple={simple} className={className}  {...otherProps}/>
   } else {
     return <Components.UserNameDeleted />
   }

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { useCurrentUser } from '../common/withUser';
 import type { PopperPlacementType } from '@material-ui/core/Popper'
-import { isEAForum, siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   color: {

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -1,12 +1,13 @@
 import React, { useContext, createContext } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { userGetDisplayName, userGetProfileUrl } from '../../lib/collections/users/helpers';
+import { isNewUser, userGetDisplayName, userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useHover } from '../common/withHover'
 import classNames from 'classnames';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { useCurrentUser } from '../common/withUser';
 import type { PopperPlacementType } from '@material-ui/core/Popper'
+import { isEAForum, siteNameWithArticleSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   color: {
@@ -14,6 +15,20 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   noColor: {
     color: "inherit !important"
+  },
+  iconWrapper: {
+    marginLeft: 6,
+  },
+  postAuthorIcon: {
+    verticalAlign: 'text-bottom',
+    color: theme.palette.grey[500],
+    fontSize: 16,
+  },
+  sproutIcon: {
+    position: 'relative',
+    bottom: -2,
+    color: theme.palette.icon.sprout,
+    fontSize: 16,
   }
 })
 
@@ -24,11 +39,13 @@ export const DisableNoKibitzContext = createContext<DisableNoKibitzContextType >
  * Given a user (which may not be null), render the user name as a link with a
  * tooltip. This should not be used directly; use UsersName instead.
  */
-const UsersNameDisplay = ({user, color=false, nofollow=false, simple=false, classes, tooltipPlacement = "left", className}: {
+const UsersNameDisplay = ({user, color=false, nofollow=false, simple=false, showAuthorIcon=false, allowNewUserIcon=false, classes, tooltipPlacement = "left", className}: {
   user: UsersMinimumInfo|null|undefined,
   color?: boolean,
   nofollow?: boolean,
   simple?: boolean,
+  showAuthorIcon?: boolean,
+  allowNewUserIcon?: boolean,
   classes: ClassesType,
   tooltipPlacement?: PopperPlacementType,
   className?: string,
@@ -47,7 +64,7 @@ const UsersNameDisplay = ({user, color=false, nofollow=false, simple=false, clas
   if (!user || user.deleted) {
     return <Components.UserNameDeleted userShownToAdmins={user}/>
   }
-  const { UserTooltip, LWTooltip } = Components
+  const { UserTooltip, LWTooltip, ForumIcon } = Components
   
   const displayName = noKibitz ? "(hidden)" : userGetDisplayName(user);
   const colorClass = color?classes.color:classes.noColor;
@@ -58,16 +75,35 @@ const UsersNameDisplay = ({user, color=false, nofollow=false, simple=false, clas
     </span>
   }
 
-  return <span {...eventHandlers} className={className}>
-    <AnalyticsContext pageElementContext="userNameDisplay" userIdDisplayed={user._id}>
-    <LWTooltip title={<UserTooltip user={user}/>} placement={tooltipPlacement} inlineBlock={false}>
-      <Link to={userGetProfileUrl(user)} className={colorClass}
-        {...(nofollow ? {rel:"nofollow"} : {})}
+  const showNewUserIcon = allowNewUserIcon && isNewUser(user);
+  return <span className={className}>
+    <span {...eventHandlers}>
+      <AnalyticsContext pageElementContext="userNameDisplay" userIdDisplayed={user._id}>
+      <LWTooltip title={<UserTooltip user={user}/>} placement={tooltipPlacement} inlineBlock={false}>
+        <Link to={userGetProfileUrl(user)} className={colorClass}
+          {...(nofollow ? {rel:"nofollow"} : {})}
+        >
+          {displayName}
+        </Link>
+      </LWTooltip>
+      </AnalyticsContext>
+    </span>
+    {showAuthorIcon && <LWTooltip
+        placement="bottom-start"
+        title="Post author"
+        className={classes.iconWrapper}
       >
-        {displayName}
-      </Link>
-    </LWTooltip>
-    </AnalyticsContext>
+        <ForumIcon icon="Author" className={classes.postAuthorIcon} />
+      </LWTooltip>
+    }
+    {showNewUserIcon && <LWTooltip
+        placement="bottom-start"
+        title={`${user.displayName} is either new on ${siteNameWithArticleSetting.get()} or doesn't have much karma yet.`}
+        className={classes.iconWrapper}
+      >
+        <ForumIcon icon="Sprout" className={classes.sproutIcon} />
+      </LWTooltip>
+    }
   </span>
 }
 

--- a/packages/lesswrong/components/users/UsersNameWrapper.tsx
+++ b/packages/lesswrong/components/users/UsersNameWrapper.tsx
@@ -9,10 +9,12 @@ import React from 'react';
  * display their name. If the nofollow attribute is true OR the user has a
  * spam-risk score below 0.8, the user-page link will be marked nofollow.
  */
-const UsersNameWrapper = ({documentId, nofollow=false, simple=false, className}: {
+const UsersNameWrapper = ({documentId, nofollow=false, simple=false, className, ...otherProps}: {
   documentId: string,
   nofollow?: boolean,
   simple?: boolean,
+  showAuthorIcon?: boolean,
+  allowNewUserIcon?: boolean,
   className?: string,
 }) => {
   const { document, loading } = useSingle({
@@ -23,7 +25,7 @@ const UsersNameWrapper = ({documentId, nofollow=false, simple=false, className}:
   if (!document && loading) {
     return <Components.Loading />
   } else if (document) {
-    return <Components.UsersNameDisplay user={document} nofollow={nofollow || document.spamRiskScore<0.8} simple={simple} className={className}/>
+    return <Components.UsersNameDisplay user={document} nofollow={nofollow || document.spamRiskScore<0.8} simple={simple} className={className} {...otherProps}/>
   } else {
     return <Components.UserNameDeleted/>
   }

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -7,6 +7,10 @@ import React, { useEffect, useState } from 'react';
 import * as _ from 'underscore';
 import { getBrowserLocalStorage } from '../../../components/editor/localStorageHandlers';
 import { Components } from '../../vulcan-lib';
+import { DatabasePublicSetting } from '../../publicSettings';
+import moment from 'moment';
+
+const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
 // Get a user's display name (not unique, can take special characters and spaces)
 export const userGetDisplayName = (user: { username: string, fullName?: string, displayName: string } | null): string => {
@@ -33,6 +37,16 @@ export const userOwnsAndInGroup = (group: PermissionGroups) => {
   return (user: DbUser, document: HasUserIdType): boolean => {
     return userOwns(user, document) && userIsMemberOf(user, group)
   }
+}
+
+/**
+ * Count a user as "new" if they have low karma or joined less than a week ago
+ */
+export const isNewUser = (user: UsersMinimumInfo): boolean => {
+  const karmaThreshold = newUserIconKarmaThresholdSetting.get()
+  return (
+    (karmaThreshold && user.karma < karmaThreshold) || moment(user.createdAt).isAfter(moment().subtract(1, "week"))
+  );
 }
 
 export interface SharableDocument {


### PR DESCRIPTION
I have moved the icons down into the UsersNameDisplay component, which should make it easier to add the sprout icon to other places in future if we want to. I have only added it to post authors and coauthors for now

![Screenshot 2023-04-04 at 14 32 06](https://user-images.githubusercontent.com/77623106/229809579-603657fe-86ef-4f18-9b32-7c6081eb58a0.png)
![Screenshot 2023-04-04 at 14 32 34](https://user-images.githubusercontent.com/77623106/229809588-f2ce7830-1cbe-4b3a-9265-6359deb93d7f.png)
![Screenshot 2023-04-04 at 14 33 21](https://user-images.githubusercontent.com/77623106/229809594-b0abc803-559b-4dd9-9969-5ca15fb0d156.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204331207242035) by [Unito](https://www.unito.io)
