### PR TITLE
Add "Comment Icon" for Users Awaiting Review

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/FirstContentIcons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/FirstContentIcons.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib';
+import DescriptionIcon from '@material-ui/icons/Description'
+import MessageIcon from '@material-ui/icons/Message'
+import classNames from "classnames";
+
+const styles = (theme: ThemeType): JssStyles => ({
+  icon: {
+    height: 13,
+    color: theme.palette.grey[500],
+    position: "relative",
+    top: 3
+  },
+  commentIcon: {
+    marginLeft: -6
+  },
+});
+
+export const FirstContentIcons = ({user, classes}: {
+  user: SunshineUsersList,
+  classes: ClassesType,
+}) => {
+  const showPostIcon = user.postCount > 0 && !user.reviewedByUserId
+  const showCommentIcon = user.commentCount > 0 && !user.reviewedByUserId
+  return <span>
+    {showPostIcon && <DescriptionIcon className={classes.icon}/>}
+    {showCommentIcon && <MessageIcon className={classNames(classes.icon, {[classes.commentIcon]:showPostIcon})}/>}
+  </span>;
+}
+
+const FirstContentIconsComponent = registerComponent('FirstContentIcons', FirstContentIcons, {styles});
+
+declare global {
+  interface ComponentTypes {
+    FirstContentIcons: typeof FirstContentIconsComponent
+  }
+}
+

--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { TupleSet, UnionOf } from '../../lib/utils/typeGuardUtils';
-import DescriptionIcon from '@material-ui/icons/Description'
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { userIsAdminOrMod } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
@@ -117,7 +116,7 @@ const getCurrentView = (query: Record<string, string>): DashboardTabs => {
 const ModerationDashboard = ({ classes }: {
   classes: ClassesType
 }) => {
-  const { UsersReviewInfoCard, CommentsReviewTab, LoadMore, Loading } = Components;
+  const { UsersReviewInfoCard, CommentsReviewTab, LoadMore, Loading, FirstContentIcons } = Components;
     
   const currentUser = useCurrentUser();
 
@@ -172,7 +171,7 @@ const ModerationDashboard = ({ classes }: {
               return <div key={user._id} className={classNames(classes.tocListing, {[classes.flagged]: user.sunshineFlagged})}>
                 <a href={`${location.pathname}${location.search ?? ''}#${user._id}`}>
                   {user.displayName} 
-                  {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon className={classes.icon}/>}
+                  <FirstContentIcons user={user}/>
                 </a>
               </div>
             })}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -5,7 +5,6 @@ import { Link } from '../../lib/reactRouterWrapper'
 
 import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
-import DescriptionIcon from '@material-ui/icons/Description'
 import FlagIcon from '@material-ui/icons/Flag'
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -35,8 +34,8 @@ const SunshineNewUsersItem = ({ user, classes, refetch, currentUser }: {
 }) => {
   const { eventHandlers, hover, anchorEl } = useHover();
 
-  const { SunshineListItem, SidebarHoverOver, SunshineNewUsersInfo, MetaInfo, FormatDate } = Components
-
+  const { SunshineListItem, SidebarHoverOver, SunshineNewUsersInfo, MetaInfo, FormatDate, FirstContentIcons } = Components
+  
   return (
     <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
       <SunshineListItem hover={hover}>
@@ -55,7 +54,7 @@ const SunshineNewUsersItem = ({ user, classes, refetch, currentUser }: {
           <MetaInfo className={classes.info}>
             <FormatDate date={user.createdAt}/>
           </MetaInfo>
-          {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon  className={classes.icon}/>}
+          <FirstContentIcons user={user}/>
           {user.sunshineFlagged && <FlagIcon className={classes.icon}/>}
           {!user.reviewedByUserId && <MetaInfo className={classes.info}>
             { getUserEmail(user) || "This user has no email" }

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -2,7 +2,6 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React, { useState } from 'react';
 import withErrorBoundary from '../common/withErrorBoundary'
 import FlagIcon from '@material-ui/icons/Flag';
-import DescriptionIcon from '@material-ui/icons/Description'
 import { useMulti } from '../../lib/crud/withMulti';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
@@ -152,7 +151,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   const {
     MetaInfo, FormatDate, SunshineUserMessages, LWTooltip, UserReviewStatus,
     SunshineNewUserPostsList, ContentSummaryRows, SunshineNewUserCommentsList, ModeratorActions,
-    UsersName, NewUserDMSummary
+    UsersName, NewUserDMSummary, FirstContentIcons
   } = Components
 
   const [contentExpanded, setContentExpanded] = useState<boolean>(false)
@@ -183,7 +182,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
     <div>
       <div className={classes.displayName}>
         <UsersName user={user}/>
-        {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon className={classes.icon}/>}
+        <FirstContentIcons user={user}/>
         {user.sunshineFlagged && <FlagIcon className={classes.icon}/>}
         {showReviewTrigger && <MetaInfo className={classes.legacyReviewTrigger}>{reviewTrigger}</MetaInfo>}
       </div>

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -131,6 +131,7 @@ Users.addView("sunshineNewUsers", function (terms: UsersViewTerms) {
         sunshineFlagged: -1,
         reviewedByUserId: 1,
         postCount: -1,
+        commentCount: -1,
         signUpReCaptchaRating: -1,
         createdAt: -1
       }

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -548,6 +548,7 @@ importComponent("SidebarInfo", () => require('../components/sunshineDashboard/Si
 importComponent("SidebarActionMenu", () => require('../components/sunshineDashboard/SidebarActionMenu'));
 importComponent("SidebarAction", () => require('../components/sunshineDashboard/SidebarAction'));
 importComponent("SunshineListCount", () => require('../components/sunshineDashboard/SunshineListCount'));
+importComponent("FirstContentIcons", () => require('../components/sunshineDashboard/FirstContentIcons'));
 importComponent("UsersReviewInfoCard", () => require('../components/sunshineDashboard/UsersReviewInfoCard'));
 importComponent("CommentsReviewTab", () => require('../components/sunshineDashboard/CommentsReviewTab'));
 importComponent("CommentsReviewInfoCard", () => require('../components/sunshineDashboard/CommentsReviewInfoCard'));


### PR DESCRIPTION
LessWrong is enabling review-required for new user's first comments. To go with this, we've added a comment icon in the same places that there's a post icon, to help us prioritizing reviewing users with new comments.

We've also added sorting to put these users higher up.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204334528936103) by [Unito](https://www.unito.io)


<img width="326" alt="Moderation Dashboard - LessWrong 2023-04-04 13-29-25" src="https://user-images.githubusercontent.com/7250541/229913048-f770adb7-c616-491e-aaaf-0e22eff0c405.png">

<img width="173" alt="Moderation Dashboard - LessWrong 2023-04-04 13-29-48" src="https://user-images.githubusercontent.com/7250541/229913105-92b1d8c0-3452-48d9-914a-3b43acea0894.png">

<img width="224" alt="LessWrong 2023-04-04 13-30-25" src="https://user-images.githubusercontent.com/7250541/229913274-98d4dc1a-9bc2-4560-99bd-4fa1c9d8741c.png">
