### PR TITLE
Add migration for missing debates fields in users table

### DIFF
--- a/packages/lesswrong/server/migrations/20230405T104221.debate_fields_hotfix.ts
+++ b/packages/lesswrong/server/migrations/20230405T104221.debate_fields_hotfix.ts
@@ -3,14 +3,14 @@ import { addField, dropField } from "./meta/utils"
 
 export const up = async ({db}: MigrationContext) => {
   if (Users.isPostgres()) {
-    addField(db, Users, "notificationDebateCommentsOnSubscribedPost");
-    addField(db, Users, "notificationDebateReplies");
+    await addField(db, Users, "notificationDebateCommentsOnSubscribedPost");
+    await addField(db, Users, "notificationDebateReplies");
   }
 }
 
 export const down = async ({db}: MigrationContext) => {
   if (Users.isPostgres()) {
-    dropField(db, Users, "notificationDebateCommentsOnSubscribedPost");
-    dropField(db, Users, "notificationDebateReplies");
+    await dropField(db, Users, "notificationDebateCommentsOnSubscribedPost");
+    await dropField(db, Users, "notificationDebateReplies");
   }
 }

--- a/packages/lesswrong/server/migrations/20230405T104221.debate_fields_hotfix.ts
+++ b/packages/lesswrong/server/migrations/20230405T104221.debate_fields_hotfix.ts
@@ -1,0 +1,16 @@
+import Users from "../../lib/vulcan-users"
+import { addField, dropField } from "./meta/utils"
+
+export const up = async ({db}: MigrationContext) => {
+  if (Users.isPostgres()) {
+    addField(db, Users, "notificationDebateCommentsOnSubscribedPost");
+    addField(db, Users, "notificationDebateReplies");
+  }
+}
+
+export const down = async ({db}: MigrationContext) => {
+  if (Users.isPostgres()) {
+    dropField(db, Users, "notificationDebateCommentsOnSubscribedPost");
+    dropField(db, Users, "notificationDebateReplies");
+  }
+}


### PR DESCRIPTION
These fields don't currently exist in Postgres due to a bug in commit cbc0699227622f1f85799d0815460c6e898a16f8.

This is preventing logins with Google, which just result in a blank page with a 500 error message.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204338517416228) by [Unito](https://www.unito.io)
