### PR TITLE
Fix comments item menu opacity

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -22,7 +22,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: theme.spacing.unit*1.5,
     paddingRight: theme.spacing.unit*1.5,
-    "&:hover $menu": {
+    "&:hover .CommentsItemMeta-menu": {
       opacity:1
     }
   },


### PR DESCRIPTION
Fixes a minor bug introduced in https://github.com/ForumMagnum/ForumMagnum/pull/6872 which moved the menu class from CommentsItem into CommentsItemMeta

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204339504065002) by [Unito](https://www.unito.io)
