### PR TITLE
Add default sorting back in to core topic pages

### DIFF
--- a/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
@@ -96,11 +96,6 @@ const SubforumSubforumTab = ({
   }, [refetchRef]);
 
   const hideIntroPost = currentUser && userTagRel && !!userTagRel?.subforumHideIntroPost
-  
-  const clickNewShortform = useCallback(() => {
-    setNewShortformOpen(true)
-    captureEvent("newShortformClicked", {tagId: tag._id, tagName: tag.name, pageSectionContext: "tagHeader"})
-  }, [captureEvent, setNewShortformOpen, tag._id, tag.name])
 
   const { mutate: updateUserTagRel } = useUpdate({
     collectionName: 'UserTagRels',
@@ -225,7 +220,7 @@ const SubforumSubforumTab = ({
   </>;
 
   const terms = {
-    ...tagPostTerms(tag, query),
+    ...tagPostTerms(tag, {...query, sortedBy: sortBy}),
     limit: 10
   }
   const listLayoutComponent = (


### PR DESCRIPTION
Currently it's broken if there is no explicit sorting set

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204341550728192) by [Unito](https://www.unito.io)
