### PR TITLE
Add script to create filtered readonly postgres user

### DIFF
--- a/scripts/create_filtered_readonly_user.sql
+++ b/scripts/create_filtered_readonly_user.sql
@@ -1,0 +1,33 @@
+-- This script creates a readonly user that is filtered to only access
+-- public information.
+-- The password is set using a psql variable:
+-- psql --set=filtered_readonly_password="some_secret_password" <conn parameters> -f ./scripts/create_filtered_readonly_user.sql
+
+DO
+$$BEGIN
+IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'filtered_readonly') THEN
+	REVOKE ALL ON ALL TABLES IN SCHEMA public FROM filtered_readonly;
+	DROP USER filtered_readonly;
+END IF;
+END$$;
+
+CREATE USER filtered_readonly WITH
+	NOCREATEDB NOSUPERUSER NOCREATEROLE NOINHERIT
+	PASSWORD :'filtered_readonly_password';
+
+GRANT SELECT ON "Books" TO filtered_readonly;
+GRANT SELECT ON "Chapters" TO filtered_readonly;
+GRANT SELECT ON "Collections" TO filtered_readonly;
+GRANT SELECT ON "Comments" TO filtered_readonly;
+GRANT SELECT ON "FeaturedResources" TO filtered_readonly;
+GRANT SELECT ON "Localgroups" TO filtered_readonly;
+GRANT SELECT ON "PodcastEpisodes" TO filtered_readonly;
+GRANT SELECT ON "Podcasts" TO filtered_readonly;
+GRANT SELECT ON "PostRelations" TO filtered_readonly;
+GRANT SELECT ON "Posts" TO filtered_readonly;
+GRANT SELECT ON "Revisions" TO filtered_readonly;
+GRANT SELECT ON "Sequences" TO filtered_readonly;
+GRANT SELECT ON "Spotlights" TO filtered_readonly;
+GRANT SELECT ON "TagFlags" TO filtered_readonly;
+GRANT SELECT ON "TagRels" TO filtered_readonly;
+GRANT SELECT ON "Tags" TO filtered_readonly;


### PR DESCRIPTION
This script creates a readonly user that is filtered to only access public information.

I _think_ this is the right stuff. I couldn't see any columns that we need to filter out, but I could be wrong. It's possible to do so, but it's really annoying.

The password is set using a psql variable:
`psql --set=filtered_readonly_password="some_secret_password" <conn parameters> -f ./scripts/create_filtered_readonly_user.sql`

I've created a user on the dev database with username `filtered_readonly` and password `pwd` for testing purposes.

