### PR TITLE
fix chapter editing permission for users who own a sequence

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -131,7 +131,7 @@ const SequencesPage = ({ documentId, classes }: {
 
   const canEdit = userCanDo(currentUser, 'sequences.edit.all') || (userCanDo(currentUser, 'sequences.edit.own') && userOwns(currentUser, document))
   const canCreateChapter = userCanDo(currentUser, 'chapters.new.all')
-  const canEditChapter = userCanDo(currentUser, 'chapters.edit.all')
+  const canEditChapter = userCanDo(currentUser, 'chapters.edit.all') || canEdit
   const { html = "" } = document.contents || {}
 
   if (!canEdit && document.draft)


### PR DESCRIPTION
Users need to be able to edit chapters in sequences that they own, so as to be able to add posts to them (since adding posts to sequences routes through editing chapters).

Need to verify that this is compatible with the other intended changes in https://github.com/ForumMagnum/ForumMagnum/pull/6839

<img width="765" alt="image" src="https://user-images.githubusercontent.com/2136984/230211053-f14e8e3f-904d-44af-8f5a-1d9587ab34f7.png">
