### PR TITLE
[EA Forum only] hide xpost reading time on post items

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -286,9 +286,9 @@ const EAPostsItem = ({classes, ...props}: EAPostsListProps) => {
                   <div>
                     {' · '}
                     <PostsItemDate post={post} noStyles includeAgo />
-                    <span className={classes.readTime}>
+                    {(!post.fmCrosspost?.isCrosspost || post.fmCrosspost.hostedHere) && <span className={classes.readTime}>
                       {' · '}{post.readTimeMinutes || 1}m read
-                    </span>
+                    </span>}
                   </div>
                   <div className={classes.audio}>
                     {hasAudio && <ForumIcon icon="VolumeUp" />}


### PR DESCRIPTION
For now, we are hiding the reading time on post items for crossposts, because they will always say "1 min". Once crossposting is reworked, and we have the correct reading time, we can readd it.

<img width="701" alt="Screen Shot 2023-04-05 at 9 25 00 PM" src="https://user-images.githubusercontent.com/9057804/230249540-83664614-03e4-4af5-9cca-45f8ff012d17.png">

Addresses https://github.com/ForumMagnum/ForumMagnum/issues/6880

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204344405658383) by [Unito](https://www.unito.io)
