### PR TITLE
fix top margin on a groups/events pages

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -51,7 +51,7 @@ const allowedIncompletePaths: string[] = ["termsOfUse"];
 
 const styles = (theme: ThemeType): JssStyles => ({
   main: {
-    paddingTop: isEAForum ? 20 : 50,
+    paddingTop: theme.spacing.mainLayoutPaddingTop,
     paddingBottom: 15,
     marginLeft: "auto",
     marginRight: "auto",

--- a/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
@@ -7,7 +7,7 @@ import { Configure, InstantSearch } from 'react-instantsearch-dom';
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   map: {
     height: '100vh',
-    marginTop: -50,
+    marginTop: -20,
     [theme.breakpoints.down('sm')]: {
       marginTop: 0,
     },

--- a/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
@@ -7,7 +7,7 @@ import { Configure, InstantSearch } from 'react-instantsearch-dom';
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   map: {
     height: '100vh',
-    marginTop: -20,
+    marginTop: -theme.spacing.mainLayoutPaddingTop,
     [theme.breakpoints.down('sm')]: {
       marginTop: 0,
     },

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -21,13 +21,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},
   topSection: {
     [theme.breakpoints.up('md')]: {
-      marginTop: isEAForum ? -20 : -50,
+      marginTop: -theme.spacing.mainLayoutPaddingTop,
     }
   },
   topSectionMap: {
     height: 250,
     [theme.breakpoints.up('md')]: {
-      marginTop: isEAForum ? -20 : -50,
+      marginTop: -theme.spacing.mainLayoutPaddingTop,
     },
     [theme.breakpoints.down('sm')]: {
       marginLeft: -8,
@@ -36,7 +36,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   imageContainer: {
     [theme.breakpoints.up('md')]: {
-      marginTop: isEAForum ? -20 : -50,
+      marginTop: -theme.spacing.mainLayoutPaddingTop,
     },
     [theme.breakpoints.down('sm')]: {
       marginLeft: -8,

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -21,13 +21,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},
   topSection: {
     [theme.breakpoints.up('md')]: {
-      marginTop: -50,
+      marginTop: isEAForum ? -20 : -50,
     }
   },
   topSectionMap: {
     height: 250,
     [theme.breakpoints.up('md')]: {
-      marginTop: -50,
+      marginTop: isEAForum ? -20 : -50,
     },
     [theme.breakpoints.down('sm')]: {
       marginLeft: -8,
@@ -36,7 +36,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   imageContainer: {
     [theme.breakpoints.up('md')]: {
-      marginTop: -50,
+      marginTop: isEAForum ? -20 : -50,
     },
     [theme.breakpoints.down('sm')]: {
       marginLeft: -8,
@@ -57,9 +57,6 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginTop: 24,
     [theme.breakpoints.down('xs')]: {
       display: 'block',
-    },
-    [theme.breakpoints.up('md')]: {
-      marginTop: isEAForum ? 60 : undefined,
     },
   },
   inactiveGroupTag: {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser } from '../../common/withUser';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { useRecordPostView } from '../../hooks/useRecordPostView';
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
-import {forumTitleSetting, forumTypeSetting} from '../../../lib/instanceSettings';
+import {forumTitleSetting, forumTypeSetting, isEAForum} from '../../../lib/instanceSettings';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import { viewNames } from '../../comments/CommentsViews';
 import classNames from 'classnames';
@@ -108,7 +108,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   headerImageContainer: {
     paddingBottom: 15,
     [theme.breakpoints.up('md')]: {
-      marginTop: -50,
+      marginTop: isEAForum ? -20 : -50,
     },
     [theme.breakpoints.down('sm')]: {
       marginTop: -12,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -108,7 +108,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   headerImageContainer: {
     paddingBottom: 15,
     [theme.breakpoints.up('md')]: {
-      marginTop: isEAForum ? -20 : -50,
+      marginTop: -theme.spacing.mainLayoutPaddingTop,
     },
     [theme.breakpoints.down('sm')]: {
       marginTop: -12,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -83,6 +83,7 @@ export const baseTheme: BaseThemeSpecification = {
       spacing: {
         unit: spacingUnit,
         titleDividerSpacing,
+        mainLayoutPaddingTop: 50
       },
       borderRadius: {
         default: 0,

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -103,6 +103,9 @@ export const eaForumTheme: SiteThemeSpecification = {
       fontFamily: serifStack
     }
     return {
+      spacing: {
+        mainLayoutPaddingTop: 20
+      },
       borderRadius: {
         default: 6,
         small: 4,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -432,6 +432,7 @@ declare global {
     spacing: {
       unit: number,
       titleDividerSpacing: number,
+      mainLayoutPaddingTop: number,
     },
     borderRadius: {
       default: number,


### PR DESCRIPTION
When we updated the top padding in `Layout.tsx`, that affected some groups/events-related pages, since many of those try to offset the default padding to be flush with the top of the page. For example, see how [this event's](https://forum.effectivealtruism.org/events/dMLhFC6tkwCTG57TP/ea-anu-discussion-dinner) banner image is cut off at the top. This PR updates the spacing on those pages.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204356068911951) by [Unito](https://www.unito.io)
