### PR TITLE
LessWrong specific warning for posts and comment moderation

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -15,6 +15,8 @@ import { afNonMemberDisplayInitialPopup, afNonMemberSuccessHandling } from "../.
 import ArrowForward from '@material-ui/icons/ArrowForward';
 import { TagCommentType } from '../../lib/collections/comments/types';
 import { commentDefaultToAlignment } from '../../lib/collections/comments/helpers';
+import { isLW } from '../../lib/instanceSettings';
+import { Link } from '../../lib/reactRouterWrapper';
 
 export type CommentFormDisplayMode = "default" | "minimalist"
 
@@ -121,7 +123,7 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
   const isMinimalist = replyFormStyle === "minimalist"
   const [showGuidelines, setShowGuidelines] = useState(false)
   const [loading, setLoading] = useState(false)
-  const { ModerationGuidelinesBox, WrappedSmartForm, RecaptchaWarning, Loading } = Components
+  const { ModerationGuidelinesBox, WrappedSmartForm, RecaptchaWarning, Loading, ContentStyles } = Components
   
   const { openDialog } = useDialog();
   const { mutate: updateComment } = useUpdate({
@@ -230,9 +232,18 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
     <div className={classNames(isMinimalist ? classes.rootMinimalist : classes.root, {[classes.loadingRoot]: loading})} onFocus={onFocusCommentForm}>
       <RecaptchaWarning currentUser={currentUser}>
         <div className={padding ? classNames({[classes.form]: !isMinimalist, [classes.formMinimalist]: isMinimalist}) : undefined}>
-          {commentWillBeHidden && <div className={classes.modNote}><em>
-            A moderator will need to review your account before your comments will show up.
-          </em></div>}
+          {commentWillBeHidden && <div className={classes.modNote}>
+            <ContentStyles contentType="comment">
+              <em>
+                {isLW ? <>
+                  LessWrong is raising our moderation standards for new comments.<br/>
+                  See <Link to="/posts/kyDsgQGHoLkXz6vKL/lw-team-is-adjusting-moderation-policy?commentId=CFS4ccYK3rwk6Z7Ac">this FAQ</Link> to ensure your comments are approved.
+                </>
+                : <>A moderator will need to review your account before your comments will show up.</>
+                }          
+              </em>
+            </ContentStyles>
+          </div>}
           <div onFocus={(ev) => {
             afNonMemberDisplayInitialPopup(currentUser, openDialog)
             ev.preventDefault()

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -8,12 +8,12 @@ import { EditorState, convertFromRaw, convertToRaw } from 'draft-js'
 import Select from '@material-ui/core/Select';
 import * as _ from 'underscore';
 import { isClient } from '../../lib/executionEnvironment';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import type { CollaborativeEditingAccessLevel } from '../../lib/collections/posts/collabEditingPermissions';
 import FormLabel from '@material-ui/core/FormLabel';
 import {checkEditorValid} from './validation'
 
-const postEditorHeight = 250;
+const postEditorHeight = isEAForum ? 250 : 500;
 const questionEditorHeight = 150;
 const commentEditorHeight = 100;
 const commentMinimalistEditorHeight = 28;
@@ -604,7 +604,7 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
     const showPlaceholder = !(draftJSValue?.getCurrentContent && draftJSValue.getCurrentContent().hasText())
     const {className, contentType} = this.getBodyStyles();
 
-    return <div>
+    return <div clas>
       { this.renderPlaceholder(showPlaceholder, false) }
       {draftJSValue && <Components.ContentStyles contentType={contentType}><Components.DraftJSEditor
         editorState={draftJSValue}

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -604,7 +604,7 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
     const showPlaceholder = !(draftJSValue?.getCurrentContent && draftJSValue.getCurrentContent().hasText())
     const {className, contentType} = this.getBodyStyles();
 
-    return <div clas>
+    return <div>
       { this.renderPlaceholder(showPlaceholder, false) }
       {draftJSValue && <Components.ContentStyles contentType={contentType}><Components.DraftJSEditor
         editorState={draftJSValue}

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -102,11 +102,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
     color:  theme.palette.secondary.main
   },
   modNote: {
-    [theme.breakpoints.up('sm')]: {
-      paddingLeft: 20,
-      paddingRight: 20,
-      paddingBottom: 20
-    }
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: 20,
+    },
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20
   }
 })
 

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -7,13 +7,14 @@ import React from 'react';
 import { useCurrentUser } from '../common/withUser'
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import NoSSR from 'react-no-ssr';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, isLW } from '../../lib/instanceSettings';
 import { useDialog } from "../common/withDialog";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import { useUpdate } from "../../lib/crud/withUpdate";
 import { useSingle } from '../../lib/crud/withSingle';
 import type { SubmitToFrontpageCheckboxProps } from './SubmitToFrontpageCheckbox';
 import type { PostSubmitProps } from './PostSubmit';
+import { Link } from '../../lib/reactRouterWrapper';
 
 // Also used by PostsEditForm
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -99,6 +100,13 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   collaborativeRedirectLink: {
     color:  theme.palette.secondary.main
+  },
+  modNote: {
+    [theme.breakpoints.up('sm')]: {
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingBottom: 20
+    }
   }
 })
 
@@ -162,7 +170,7 @@ const PostsNewForm = ({classes}: {
     skip: !templateId,
   });
   
-  const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox, RecaptchaWarning, SingleColumnSection, Typography, Loading } = Components
+  const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox, RecaptchaWarning, SingleColumnSection, Typography, Loading, ContentStyles } = Components
   const userHasModerationGuidelines = currentUser && currentUser.moderationGuidelines && currentUser.moderationGuidelines.originalContents
   const af = forumTypeSetting.get() === 'AlignmentForum'
   const debateForm = !!(query && query.debate);
@@ -183,7 +191,7 @@ const PostsNewForm = ({classes}: {
   }
   const eventForm = query && query.eventForm
   
-  if (query.subforumTagId) {
+  if (query?.subforumTagId) {
     prefilledProps = {
       ...prefilledProps,
       subforumTagId: query.subforumTagId,
@@ -214,10 +222,19 @@ const PostsNewForm = ({classes}: {
     </div>
   }
 
+  // on LW, show a moderation message to users who haven't been approved yet
+  const postWillBeHidden = isLW && !currentUser.reviewedByUserId
+
   return (
     <div className={classes.postForm}>
       <RecaptchaWarning currentUser={currentUser}>
         <Components.PostsAcceptTos currentUser={currentUser} />
+        {postWillBeHidden && <ContentStyles contentType="comment" className={classes.modNote}>
+          <em>
+            LessWrong is raising our moderation standards for new posts.<br/>
+            See <Link to="/posts/kyDsgQGHoLkXz6vKL/lw-team-is-adjusting-moderation-policy?commentId=CFS4ccYK3rwk6Z7Ac">this FAQ</Link> to ensure your post is approved.
+          </em>
+        </ContentStyles>}
         <NoSSR>
           <WrappedSmartForm
             collection={Posts}


### PR DESCRIPTION
This PR makes it a bit more clear on LessWrong that comments and posts will be subject to more scrutiny than usual to new users.

It shouldn't have visible effects on EA Forum.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/3246710/230670381-5ceb733b-095d-4bf0-8107-8aebc3a8e635.png">

<img width="869" alt="image" src="https://user-images.githubusercontent.com/3246710/230672241-a0f7119c-7383-48ba-a03d-b95ec189e24e.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204356571295583) by [Unito](https://www.unito.io)
