### PR TITLE
Make remove from queue prevent future posts from appearing

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -188,6 +188,8 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
       selector: {_id: user._id},
       data: {
         needsReview: false,
+        reviewedByUserId: null, // this is necessary so that their next post/comment won't appear without being approved by a moderator
+        reviewedAt: new Date(), // this is necessary so it shows up that they appear in the "recently reviewed" list
         sunshineNotes: newNotes
       }
     })    


### PR DESCRIPTION
This update from 'remove from queue' makes it (as originally intended) so that if applied to a user that's previously been approved, they no longer have the ability to make posts appear live without being approved by a moderator.

It also makes it so they properly appear in the recently-reviewed-users list, so it's easier to reverse the change if you want.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204356994402888) by [Unito](https://www.unito.io)
