### PR TITLE
Fix "banned until" date format

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -28,7 +28,7 @@ export const UserReviewStatus = ({classes, user}: {
       : null 
     }
     {user.banned
-      ? <p><em>Banned until <FormatDate format="yyyy-mm-DD" date={user.banned}/></em></p>
+      ? <p><em>Banned until <FormatDate format="YYYY-MM-DD" date={user.banned}/></em></p>
       : null 
     }
 


### PR DESCRIPTION
Fixes a typo in the date formatting introduced in https://github.com/ForumMagnum/ForumMagnum/commit/6bf6ef52439ce57b87f16b087dc499240e827032  (`mm` is minutes, `MM` is months)


Screenshot of bug:
![image](https://user-images.githubusercontent.com/6978200/230728554-32fb1f29-2962-4736-9f21-05679cbcd8d3.png)

