### PR TITLE
Improve UI for adding draft posts to sequences

### DIFF
--- a/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
@@ -3,6 +3,9 @@ import React, { useCallback, useState } from 'react';
 import Chapters from '../../lib/collections/chapters/collection';
 import { useDialog } from '../common/withDialog';
 import Button from '@material-ui/core/Button';
+import isEqual from 'lodash/isEqual';
+import { useMessages } from "../common/withMessages";
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -17,6 +20,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     top: "-2.9em",
     right: "1.1em"
+  },
+  disabled: {
+    opacity: 0.3,
   }
 })
 //TODO: Manage chapter removal to remove the reference from all parent-sequences
@@ -29,15 +35,26 @@ const ChaptersEditForm = ({classes, documentId, postIds, successCallback, cancel
   cancelCallback: any,
 }) => {
   const { openDialog } = useDialog();
+  const [saved, setSaved] = useState(true);
+  const { flash } = useMessages();
+
+  const changeCallback = useCallback((doc: ChaptersFragment) => {
+    setSaved(isEqual(doc.postIds, postIds));
+  }, [postIds]);
+
 
   const showAddDraftPostDialog = () => {
-    openDialog({
-      componentName: "AddDraftPostDialog",
-      componentProps: {
-        documentId: documentId,
-        postIds: postIds,
-      }
-    });
+    if (saved) {
+      openDialog({
+        componentName: "AddDraftPostDialog",
+        componentProps: {
+          documentId: documentId,
+          postIds: postIds,
+        }
+      });
+    } else {
+      flash("Save your changes before adding draft posts.")
+    }
   }
 
   return (
@@ -48,11 +65,15 @@ const ChaptersEditForm = ({classes, documentId, postIds, successCallback, cancel
         documentId={documentId}
         successCallback={successCallback}
         cancelCallback={cancelCallback}
+        changeCallback={changeCallback}
         showRemove={true}
         queryFragment={getFragment('ChaptersEdit')}
         mutationFragment={getFragment('ChaptersEdit')}
       />
-      <Button color="primary" className={classes.addDraftButton} onClick={showAddDraftPostDialog}>Add draft post</Button>
+      <Button color="primary" className={classNames(
+        classes.addDraftButton,
+        {[classes.disabled]: !saved}
+      )} onClick={showAddDraftPostDialog}>Add draft post</Button>
     </div>
   )
 }


### PR DESCRIPTION
For historical/technical reasons, there's a UI to add posts to sequences and, beneath it, an Add Draft Post button to open a different UI, in a modal, to add *draft* posts to sequences. The UI to add posts allows you to add multiple posts and rearrange them before you save the new list of posts all at once. In contrast, the modal to add *draft* posts adds the post and saves the list immediately. Because of this, if you add/rearrange posts in the first UI and don't save yet, and then you add a draft post, the saving of the draft post uses the old list, overwriting the changes you previously made.

This PR prevents that by disabling the the Add Draft Post button when there are unsaved changes in the first UI. If the user clicks on the button anyway, an explanatory message "Save your changes before adding draft posts" appears.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204358646720912) by [Unito](https://www.unito.io)
