### PR TITLE
Fix unapprove user button not working

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -87,8 +87,9 @@ export interface UserContentCountPartial {
 }
 
 export function getCurrentContentCount(user: UserContentCountPartial) {
-  const postCount = user.postCount ?? 0
-  const commentCount = user.commentCount ?? 0
+  // Note: there's a bug somewhere that sometimes makes postCount or commentCount negative, which breaks things. Math.max ensures minimum of 0.
+  const postCount = Math.max(user.postCount ?? 0, 0)
+  const commentCount = Math.max(user.commentCount ?? 0, 0)
   return postCount + commentCount
 }
 


### PR DESCRIPTION
I'm not sure why, but sometimes a user accidentally has a negative postCount or commentCount, and because of how the unapprove user button checks the "snooze count", it wouldn't let you click on the button. This forces the postCount and commentCount to always  be at least zero.