### PR TITLE
fix reviewed by display for users who were removed from the review queue

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -23,7 +23,7 @@ export const UserReviewStatus = ({classes, user}: {
 
   const firstClientId = user.associatedClientIds?.[0];
   return <div className={classes.root}>
-    {user.reviewedAt
+    {(user.reviewedByUserId && user.reviewedAt)
       ? <div className={classes.reviewedAt}>Reviewed <FormatDate date={user.reviewedAt}/> ago by <UsersNameWrapper documentId={user.reviewedByUserId}/> ({approvalStatus})</div>
       : null 
     }


### PR DESCRIPTION
Broken because https://github.com/ForumMagnum/ForumMagnum/pull/6927 + showing the user name wrapper when `reviewedAt` exists, rather than both `reviewedAt` and `reviewedByUserId`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204368121055824) by [Unito](https://www.unito.io)
