### PR TITLE
Fix misaligned single-line comments

### DIFF
--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -65,9 +65,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   karma: {
     display:"inline-block",
     textAlign: "center",
-    width: 30,
     paddingTop: SINGLE_LINE_PADDING_TOP,
     paddingRight: SINGLE_LINE_PADDING_TOP,
+    flexGrow: 0,
+    flexShrink: 0,
   },
   date: {
     display:"inline-block",


### PR DESCRIPTION
Fix single-line comments looking jankily misaligned when some of the comments have short bodies. This is caused by having used a flex-box without paying attention to grow/shrink behavior.

Before:

![Screenshot 2023-04-10 at 18 14 15](https://user-images.githubusercontent.com/101191/231029878-448dc199-a866-4178-998e-087aed3ce941.png)

After:

![Screenshot 2023-04-10 at 18 14 27](https://user-images.githubusercontent.com/101191/231029907-de4a00e6-b113-4141-ab54-a64a0bf33469.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204368634001806) by [Unito](https://www.unito.io)
