### PR TITLE
don't ask for user location on frontpage

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -337,7 +337,7 @@ const Layout = ({currentUser, children, classes}: {
                 stayAtTop={Boolean(currentRoute?.fullscreen)}
               />}
               {/* enable during ACX Everywhere */}
-              {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap/></span>}
+              {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap requestUserLocation={false}/></span>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
               
               <div className={classNames(classes.standaloneNavFlex, {

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -337,7 +337,7 @@ const Layout = ({currentUser, children, classes}: {
                 stayAtTop={Boolean(currentRoute?.fullscreen)}
               />}
               {/* enable during ACX Everywhere */}
-              {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap requestUserLocation={false}/></span>}
+              {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap dontAskUserLocation={true}/></span>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
               
               <div className={classNames(classes.standaloneNavFlex, {

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
@@ -134,7 +134,8 @@ const LocalEventMapMarkerWrappersComponent = registerComponent("LocalEventMapMar
 });
 
 
-export const HomepageCommunityMap = ({classes}: {
+export const HomepageCommunityMap = ({requestUserLocation, classes}: {
+  requestUserLocation?: boolean,
   classes: ClassesType,
 }) => {
   const { LocalEventMapMarkerWrappers, HomepageMapFilter } = Components
@@ -142,7 +143,7 @@ export const HomepageCommunityMap = ({classes}: {
   const currentUser = useCurrentUser()
  
   // this is unused in this component, but for Meetup Month it seems good to force the prompt to enter location.
-  useUserLocation(currentUser)
+  useUserLocation(currentUser, !requestUserLocation)
 
   const [ viewport, setViewport ] = useState({
     latitude: defaultCenter.lat,

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
@@ -134,8 +134,8 @@ const LocalEventMapMarkerWrappersComponent = registerComponent("LocalEventMapMar
 });
 
 
-export const HomepageCommunityMap = ({requestUserLocation = true, classes}: {
-  requestUserLocation?: boolean,
+export const HomepageCommunityMap = ({dontAskUserLocation = false, classes}: {
+  dontAskUserLocation?: boolean,
   classes: ClassesType,
 }) => {
   const { LocalEventMapMarkerWrappers, HomepageMapFilter } = Components
@@ -143,7 +143,7 @@ export const HomepageCommunityMap = ({requestUserLocation = true, classes}: {
   const currentUser = useCurrentUser()
  
   // this is unused in this component, but for Meetup Month it seems good to force the prompt to enter location.
-  useUserLocation(currentUser, !requestUserLocation)
+  useUserLocation(currentUser, dontAskUserLocation)
 
   const [ viewport, setViewport ] = useState({
     latitude: defaultCenter.lat,

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
@@ -134,7 +134,7 @@ const LocalEventMapMarkerWrappersComponent = registerComponent("LocalEventMapMar
 });
 
 
-export const HomepageCommunityMap = ({requestUserLocation, classes}: {
+export const HomepageCommunityMap = ({requestUserLocation = true, classes}: {
   requestUserLocation?: boolean,
   classes: ClassesType,
 }) => {


### PR DESCRIPTION
Don't ask for the user location on the frontpage when rendering the community map.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204368865091039) by [Unito](https://www.unito.io)
