### PR TITLE
Attempt to debug frontpage algorithm job

### DIFF
--- a/packages/lesswrong/server/useractivities/cron.ts
+++ b/packages/lesswrong/server/useractivities/cron.ts
@@ -31,9 +31,10 @@ async function assertTableIntegrity(dataDb: SqlClient) {
   if (dateCombinations.length > 1) {
     // eslint-disable-next-line no-console
     console.error(`UserActivities table has rows with different start and end dates. Dropping rows to fix this.`);
-    console.error('Incorrect date combinations and their counts:');
-    for (const dateCombo of dateCombinations.slice(1)) {
-      console.error(`startDate: ${dateCombo.startDate}, endDate: ${dateCombo.endDate}, count: ${dateCombo.count}`);
+    console.error('Date combinations and their counts:');
+    for (let i = 0; i < dateCombinations.length; i++) {
+      const dateCombo = dateCombinations[i];
+      console.error(`(${i === 0 ? "correct" : "incorrect"}) startDate: ${dateCombo.startDate}, endDate: ${dateCombo.endDate}, count: ${dateCombo.count}`);
       // get first 10 user ids with this date combo
       const userIds = (await dataDb.any(`
         SELECT "visitorId"
@@ -56,10 +57,11 @@ async function assertTableIntegrity(dataDb: SqlClient) {
     const { startDate: mostCommonStartDate, endDate: mostCommonEndDate } = dateCombinations[0];
 
     // Step 1.1: Delete rows with different startDate and endDate, keeping the most common combination
-    await dataDb.none(`
-      DELETE FROM "UserActivities"
-      WHERE "startDate" <> $1 OR "endDate" <> $2;
-    `, [mostCommonStartDate, mostCommonEndDate]);
+    // FIXME currently there is a bug where rows get dropped, add this back in when that is fixed
+    // await dataDb.none(`
+    //   DELETE FROM "UserActivities"
+    //   WHERE "startDate" <> $1 OR "endDate" <> $2;
+    // `, [mostCommonStartDate, mostCommonEndDate]);
   }
 
   // Step 2: Check if the array of activity has the correct length for each row
@@ -106,10 +108,11 @@ async function assertTableIntegrity(dataDb: SqlClient) {
     };
   }
 
-  await dataDb.none(`
-    DELETE FROM "UserActivities"
-    WHERE array_length("activityArray", 1) <> $1;
-  `, [correctActivityLengthInt]);
+  // FIXME currently there is a bug where rows get dropped, add this back in when that is fixed
+  // await dataDb.none(`
+  //   DELETE FROM "UserActivities"
+  //   WHERE array_length("activityArray", 1) <> $1;
+  // `, [correctActivityLengthInt]);
 }
 
 
@@ -292,13 +295,21 @@ async function concatNewActivity({dataDb, newActivityData, prevStartDate, update
  *    All of these arrays will be the same length (i.e. we zero-pad as necessary)
  *  - Rows from inactive users will be deleted
  */
-export async function updateUserActivities(props?: {updateStartDate?: Date, updateEndDate?: Date}) {
+export async function updateUserActivities(props?: {updateStartDate?: Date, updateEndDate?: Date, randomWait?: boolean}) {
   const dataDb = await getSqlClientOrThrow();
   if (!dataDb) {
     throw new Error("updateUserActivities: couldn't get database connection");
   };
   if (!UserActivities.isPostgres()) {
     console.log("updateUserActivities: only supported on Postgres");
+  }
+
+  if (props?.randomWait) {
+    // sleep for random amount of time up to 10 seconds
+    // FIXME remove once we have a better solution for not running this function twice
+    const sleepTime = Math.random() * 10000;
+    console.log(`Sleeping for ${sleepTime.toFixed(0)}ms before updating user activity to avoid multiple jobs running at the same time`)
+    await new Promise((resolve) => setTimeout(resolve, Math.random() * 10000));
   }
 
   await assertTableIntegrity(dataDb);
@@ -363,7 +374,7 @@ addCronJob({
   name: 'updateUserActivitiesCron',
   interval: 'every 3 hours',
   async job() {
-    await updateUserActivities();
+    await updateUserActivities({randomWait: true});
   }
 });
 


### PR DESCRIPTION
There is a bug in the frontpage algorithm job where rows get dropped by the `assertTableIntegrity` function due to having the wrong start and end date, this doesn't happen on every run, but like 30% of the time. Currently the algorithm is pretty broken because of this so I have set the parameters to effectively disable it

I think I've tracked this down to being caused by the job running twice every time, and sometimes the second job does `assertTableIntegrity` when the first job is halfway through updating the rows. I've added a random wait to test this theory, and also stopped actually deleting rows in assertTableIntegrity so that I can set the parameters back to the right values. I'm around 70% confident that this will fix the problem. If it does then I may try and track down why the job is running twice, and also try to guard against this in a neater way (such as with locks)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204371480077079) by [Unito](https://www.unito.io)
