### PR TITLE
unblock automatic self-voting for low karma users

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -371,6 +371,7 @@ getCollectionHooks("Comments").newAfter.add(async function LWCommentsNewUpvoteOw
     collection: Comments,
     user: commentAuthor,
     skipRateLimits: true,
+    selfVote: true
   })
   return {...comment, ...votedComment} as DbComment;
 });

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -112,6 +112,7 @@ getCollectionHooks("Posts").newAfter.add(async function LWPostsNewUpvoteOwnPost(
    collection: Posts,
    user: postAuthor,
    skipRateLimits: true,
+   selfVote: true
  })
  return {...post, ...votedPost} as DbPost;
 });

--- a/packages/lesswrong/server/callbacks/revisionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/revisionCallbacks.ts
@@ -25,6 +25,7 @@ afterCreateRevisionCallback.add(async ({revisionID}) => {
     voteType: 'smallUpvote',
     user,
     skipRateLimits: true,
+    selfVote: true
   })
 });
 

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -130,6 +130,7 @@ getCollectionHooks("TagRels").newAfter.add(async (tagRel: DbTagRel) => {
     collection: TagRels,
     user: tagCreator,
     skipRateLimits: true,
+    selfVote: true
   })
   await updatePostDenormalizedTags(tagRel.postId);
   return {...tagRel, ...votedTagRel} as DbTagRel;

--- a/packages/lesswrong/server/tagging/tagsGraphQL.ts
+++ b/packages/lesswrong/server/tagging/tagsGraphQL.ts
@@ -5,12 +5,13 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { performVoteServer } from '../voteServer';
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
 
-export const addOrUpvoteTag = async ({tagId, postId, currentUser, ignoreParent = false, context}: {
+export const addOrUpvoteTag = async ({tagId, postId, currentUser, ignoreParent = false, context, selfVote = false}: {
   tagId: string,
   postId: string,
   currentUser: DbUser,
   ignoreParent?: boolean,
   context: ResolverContext,
+  selfVote?: boolean,
 }): Promise<DbTagRel> => {
   // Validate that tagId and postId refer to valid non-deleted documents
   // and that this user can see both.
@@ -35,7 +36,7 @@ export const addOrUpvoteTag = async ({tagId, postId, currentUser, ignoreParent =
     // If the tag has a parent which has not been applied to this post, apply it
     if (!ignoreParent && tag?.parentTagId && !await TagRels.findOne({ tagId: tag.parentTagId, postId })) {
       // RECURSIVE CALL, should only ever go one level deep because we disallow chaining of parent tags (see packages/lesswrong/lib/collections/tags/schema.ts)
-      await addOrUpvoteTag({tagId: tag?.parentTagId, postId, currentUser, context});
+      await addOrUpvoteTag({tagId: tag?.parentTagId, postId, currentUser, context, selfVote: true});
     }
     return tagRel.data;
   } else {
@@ -47,6 +48,7 @@ export const addOrUpvoteTag = async ({tagId, postId, currentUser, ignoreParent =
       user: currentUser,
       toggleIfAlreadyVoted: false,
       skipRateLimits: true,
+      selfVote
     });
     // performVoteServer should be generic but it ain't, and returns a DbVoteableType
     return votedTagRel as DbTagRel;

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -199,7 +199,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
 }
 
 // Server-side database operation
-export const performVoteServer = async ({ documentId, document, voteType, extendedVote, collection, voteId = randomId(), user, toggleIfAlreadyVoted = true, skipRateLimits, context }: {
+export const performVoteServer = async ({ documentId, document, voteType, extendedVote, collection, voteId = randomId(), user, toggleIfAlreadyVoted = true, skipRateLimits, context, selfVote = false }: {
   documentId?: string,
   document?: DbVoteableType|null,
   voteType: string,
@@ -210,6 +210,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   toggleIfAlreadyVoted?: boolean,
   skipRateLimits: boolean,
   context?: ResolverContext,
+  selfVote?: boolean,
 }): Promise<{
   modifiedDocument: DbVoteableType,
   showVotingPatternWarning: boolean,
@@ -228,7 +229,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
 
   // Check whether the user is allowed to vote at all, in full generality
   const { fail: cannotVote } = userCanVote(user);
-  if (cannotVote) {
+  if (!selfVote && cannotVote) {
     throw new Error('User does not meet the requirements to vote.');
   }
 


### PR DESCRIPTION
Need to allow users who are blocked from voting (due to being new/low karma) to self-vote via e.g. callbacks on new comments/posts/tags.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204386384847658) by [Unito](https://www.unito.io)
