### PR TITLE
Migrate LW 'Books', 'Chapters' and 'Collections' to Postgres: Part 1/2

### DIFF
--- a/packages/lesswrong/lib/collections/books/collection.ts
+++ b/packages/lesswrong/lib/collections/books/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const Books: BooksCollection = createCollection({
   collectionName: 'Books',
   typeName: 'Book',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Books'),
   mutations: getDefaultMutations('Books'),

--- a/packages/lesswrong/lib/collections/chapters/collection.ts
+++ b/packages/lesswrong/lib/collections/chapters/collection.ts
@@ -33,7 +33,7 @@ const options: MutationOptions<DbChapter> = {
 export const Chapters: ChaptersCollection = createCollection({
   collectionName: 'Chapters',
   typeName: 'Chapter',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Chapters'),
   mutations: getDefaultMutations('Chapters', options),

--- a/packages/lesswrong/lib/collections/collections/collection.ts
+++ b/packages/lesswrong/lib/collections/collections/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const Collections: CollectionsCollection = createCollection({
   collectionName: 'Collections',
   typeName: 'Collection',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Collections'),
   mutations: getDefaultMutations('Collections'),

--- a/packages/lesswrong/server/scripts/collectionMigrationFilters.ts
+++ b/packages/lesswrong/server/scripts/collectionMigrationFilters.ts
@@ -1,0 +1,32 @@
+export const CollectionFilters = {
+  Books: {
+    _id: {
+      $nin: [
+        '6Q3mmK9fhmdKaBrY3', 'Rx4hyKAWtog53QDGr', 'WduErZaMAQbNJTLcH', '85M373Ba5khcc2nhW', 'DrNyiLCoJDCyS3uk5', '3uNPScYM4QRGdSwD5', 'Z7ouzgFFo7a7FyfWw', 'YFbFiscrXRmkc4MR3', 'Qu3T4SEPJPTQSe5sg',
+        'yJAKGfRiL4G3gFez6', 'ahWKaYXSMztvTcxKT', 'Aj9mYd7DP5WyY36eQ', '48bqzCJSZbNuyjxpH', 'gXNG4q5QmA7c28gjm', 'Db6yctmze5bPEkNod', 'KRMRDYPZyuJ7iXypi', 'v6qSg7xJ4yrmZ7JeL', 'Xmb4uNGofwkZK8AHW',
+        'ZNDcjbf2YKiCYCEJr', '5Zo2ud7THof2Mp7T6', 'gP59pkF4DY6PuTBbw', 'j5MbdQtCspai4ASmw', 'aemgZa7d7vhNj6GvY', 'TtohJQBWapEhyhce3', 'A9NkrQZDN3rkujSKf', '3RqWcf6k3obJhR2Gn', 'FKqfyLN3K9JbWqcJR'
+      ]
+    }
+  },
+  Sequences: {
+    $nor: [
+      {
+        $and: [
+          {
+            _id: {
+              $in: [
+                "ni3zmxv472whorWuZ","abwJLsSMAt7AMwrsA","WhZyfSa9RtPXEBjrR","jGid58WsTTsYcHqKZ","DdEwjiHgu6T4YaKhn","ndw2bPx2jYCgSoZFc","nc8hB2fynFPRZYecn","9Z2oJgkf7nd4ejPC3","2qi7gyDXLz2EEr6sD",
+                "Srihgh6BPPpBcWoy4","ay6abSNrE9PCQuviy","GB2P6x9bZJue2NF8t","Nm7nCmn4P7XJ9Aarn","DgceNjEBefrqP3v8Z","QPgQWvdigqaZafmQX","gCX3je2BmvE3FvE43","2Pwz6nv3aWoqnYiQA","bt6yb3mwC2Fuc3WKN",
+                "dm4bhSKRABon7n8cX","wKJady82pK9tEgicw","EP69QjXWBokBKSTFv","LFy2F8uEm8m9CN33u","rNuPrZvabXe2MaZv8","3jqkTiAQkjKdCb6B7","prZQcis6iHp9fuRyj","DGBB8Bkx8ujk8dzhW","G3cMk7e5DH8s75tvf"
+              ],
+            },
+          },
+          {
+            isDeleted: true,
+          },
+        ],
+      },
+    ],
+  },
+
+};

--- a/packages/lesswrong/server/scripts/migrateCollections.ts
+++ b/packages/lesswrong/server/scripts/migrateCollections.ts
@@ -14,6 +14,7 @@ import { ObjectId } from "mongodb";
 import { DatabaseMetadata } from "../../lib/collections/databaseMetadata/collection";
 import { LWEvents } from "../../lib/collections/lwevents";
 import { inspect } from "util";
+import { CollectionFilters } from './collectionMigrationFilters';
 
 type Transaction = ITask<{}>;
 
@@ -170,9 +171,18 @@ const makeBatchFilter = (collectionName: string, createdSince?: Date) => {
 }
 
 const makeCollectionFilter = (collectionName: string) => {
-  return collectionName === "DatabaseMetadata"
-    ? { name: { $ne: "databaseId" } }
-    : {};
+  switch (collectionName) {
+    case "DatabaseMetadata":
+      return { name: { $ne: "databaseId" } };
+    case "Books":
+      return CollectionFilters['Books'];
+    case "Sequences":
+      return CollectionFilters['Sequences'];
+    case "Collections":
+      return { deleted: { $ne: true } };
+    default:
+      return {};
+  }
 }
 
 const copyDatabaseId = async (sql: Transaction) => {


### PR DESCRIPTION
See the EA forum version of this PR: https://github.com/ForumMagnum/ForumMagnum/pull/6120

LW also has some legacy test data in `Books`, `Collections`, and `Sequences` (the last of which isn't being migrated in this PR, but I figured it out while I working on the rest of it), which needs to be filtered out.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204417300804581) by [Unito](https://www.unito.io)
