### PR TITLE
migrate trivial collections

### DIFF
--- a/packages/lesswrong/lib/collections/advisorRequests/collection.ts
+++ b/packages/lesswrong/lib/collections/advisorRequests/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const AdvisorRequests: AdvisorRequestsCollection = createCollection({
   collectionName: 'AdvisorRequests',
   typeName: 'AdvisorRequest',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('AdvisorRequests'),
   mutations: getDefaultMutations('AdvisorRequests'),

--- a/packages/lesswrong/lib/collections/bans/collection.ts
+++ b/packages/lesswrong/lib/collections/bans/collection.ts
@@ -25,7 +25,7 @@ const options: MutationOptions<DbBan> = {
 export const Bans: BansCollection = createCollection({
   collectionName: 'Bans',
   typeName: 'Ban',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Bans'),
   mutations: getDefaultMutations('Bans', options),

--- a/packages/lesswrong/lib/collections/emailTokens/collection.ts
+++ b/packages/lesswrong/lib/collections/emailTokens/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const EmailTokens: EmailTokensCollection = createCollection({
   collectionName: 'EmailTokens',
   typeName: 'EmailTokens',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
 });
 

--- a/packages/lesswrong/lib/collections/featuredResources/collection.ts
+++ b/packages/lesswrong/lib/collections/featuredResources/collection.ts
@@ -6,7 +6,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const FeaturedResources: FeaturedResourcesCollection = createCollection({
   collectionName: 'FeaturedResources',
   typeName: 'FeaturedResource',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('FeaturedResources'),
 });

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -186,7 +186,7 @@ const schema: SchemaType<DbGardenCode> = {
 export const GardenCodes: GardenCodesCollection = createCollection({
   collectionName: 'GardenCodes',
   typeName: 'GardenCode',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('GardenCodes'),
   mutations: getDefaultMutations('GardenCodes'), //, options),

--- a/packages/lesswrong/lib/collections/legacyData/collection.ts
+++ b/packages/lesswrong/lib/collections/legacyData/collection.ts
@@ -15,7 +15,7 @@ const schema: SchemaType<DbLegacyData> = {
 export const LegacyData: LegacyDataCollection = createCollection({
   collectionName: "LegacyData",
   typeName: "LegacyData",
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema
 });
 

--- a/packages/lesswrong/lib/collections/moderationTemplates/collection.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/collection.ts
@@ -8,7 +8,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const ModerationTemplates: ModerationTemplatesCollection = createCollection({
   collectionName: 'ModerationTemplates',
   typeName: 'ModerationTemplate',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('ModerationTemplates'),
   mutations: getDefaultMutations('ModerationTemplates'),

--- a/packages/lesswrong/lib/collections/petrovDayLaunchs/collection.ts
+++ b/packages/lesswrong/lib/collections/petrovDayLaunchs/collection.ts
@@ -6,7 +6,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const PetrovDayLaunchs: PetrovDayLaunchsCollection = createCollection({
   collectionName: 'PetrovDayLaunchs',
   typeName: 'PetrovDayLaunch',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema
 });
 

--- a/packages/lesswrong/lib/collections/podcastEpisodes/collection.ts
+++ b/packages/lesswrong/lib/collections/podcastEpisodes/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const PodcastEpisodes: PodcastEpisodesCollection = createCollection({
   collectionName: 'PodcastEpisodes',
   typeName: 'PodcastEpisode',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('PodcastEpisodes'),
   mutations: getDefaultMutations('PodcastEpisodes', {

--- a/packages/lesswrong/lib/collections/podcasts/collection.ts
+++ b/packages/lesswrong/lib/collections/podcasts/collection.ts
@@ -6,7 +6,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const Podcasts: PodcastsCollection = createCollection({
   collectionName: 'Podcasts',
   typeName: 'Podcast',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Podcasts')
 });

--- a/packages/lesswrong/lib/collections/reports/collection.ts
+++ b/packages/lesswrong/lib/collections/reports/collection.ts
@@ -8,7 +8,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 const Reports: ReportsCollection = createCollection({
   collectionName: 'Reports',
   typeName: 'Report',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Reports'),
   mutations: getDefaultMutations('Reports'),

--- a/packages/lesswrong/lib/collections/rssfeeds/collection.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/collection.ts
@@ -27,7 +27,7 @@ const options: MutationOptions<DbRSSFeed> = {
 export const RSSFeeds: RSSFeedsCollection = createCollection({
   collectionName: 'RSSFeeds',
   typeName: 'RSSFeed',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('RSSFeeds'),
   mutations: getDefaultMutations('RSSFeeds', options),

--- a/packages/lesswrong/lib/collections/spotlights/collection.ts
+++ b/packages/lesswrong/lib/collections/spotlights/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const Spotlights: SpotlightsCollection = createCollection({
   collectionName: 'Spotlights',
   typeName: 'Spotlight',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Spotlights'),
   mutations: getDefaultMutations('Spotlights')

--- a/packages/lesswrong/server/scripts/migrateCollections.ts
+++ b/packages/lesswrong/server/scripts/migrateCollections.ts
@@ -215,7 +215,6 @@ const copyData = async (
   if (createdSince) {
     console.log(`...(using createdSince = ${createdSince})`);
   }
-  console.log(`...Copying data for collections ${collections.join(', ')}`);
   for (const collection of collections) {
     console.log(`......${collection.getName()}`);
     const table = collection.getPgCollection().table;

--- a/packages/lesswrong/server/scripts/migrateCollections.ts
+++ b/packages/lesswrong/server/scripts/migrateCollections.ts
@@ -88,6 +88,13 @@ const formatters: Partial<Record<CollectionNameString, (document: DbObject) => D
     extractObjectId(metadata);
     return metadata;
   },
+  Spotlights: (spotlight: DbSpotlight): DbSpotlight => {
+    extractObjectId(spotlight);
+    if (!spotlight.hasOwnProperty('showAuthor')) {
+      spotlight.showAuthor = false;
+    }
+    return spotlight;
+  }
 };
 
 type DbObjectWithLegacyData = DbObject & {legacyData?: any};
@@ -208,6 +215,7 @@ const copyData = async (
   if (createdSince) {
     console.log(`...(using createdSince = ${createdSince})`);
   }
+  console.log(`...Copying data for collections ${collections.join(', ')}`);
   for (const collection of collections) {
     console.log(`......${collection.getName()}`);
     const table = collection.getPgCollection().table;
@@ -218,7 +226,7 @@ const copyData = async (
     }).count();
 
     if (totalCount < 1) {
-      return;
+      continue;
     }
 
     const formatter = getCollectionFormatter(collection);


### PR DESCRIPTION
See the EA forum version of this PR: https://github.com/ForumMagnum/ForumMagnum/pull/6237

We already did the `Migrations` collection, though.

Also, fixing a bug in the `migrateCollections` script, which does an early `return` out of the loop over collections in `copyData` if there are no records in that collection, instead of a `continue`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204419759297265) by [Unito](https://www.unito.io)
