### PR TITLE
Fix SSR by replacing strawpoll blocks in contentitembody

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -1,12 +1,10 @@
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
-import React, { useCallback } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { commentExcerptFromHTML } from '../../../lib/editor/ellipsize'
 import { useCurrentUser } from '../../common/withUser'
 import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
 import type { ContentStyleType } from '../../common/ContentStyles';
-import ReactDOMServer from 'react-dom/server';
-import { useLocation } from '../../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   commentStyling: {
@@ -44,33 +42,8 @@ const CommentBody = ({ comment, classes, collapsed, truncated, postPage }: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const { pathname } = useLocation();
-  const { ContentItemBody, CommentDeletedMetadata, ContentStyles, StrawPollLoggedOut } = Components
+  const { ContentItemBody, CommentDeletedMetadata, ContentStyles } = Components
   const { html = "" } = comment.contents || {}
-
-  const replaceStrawPollEmbed = useCallback((htmlString, isLoggedIn, pathname) => {
-    if (!isLoggedIn) {
-      const parser = new DOMParser();
-      const htmlDoc = parser.parseFromString(htmlString, "text/html");
-      const strawpollEmbeds = htmlDoc.getElementsByClassName("strawpoll-embed");
-
-      for (const embed of Array.from(strawpollEmbeds)) {
-        if (embed && embed.parentNode) {
-          const replacementDiv = ReactDOMServer.renderToString(<StrawPollLoggedOut pathname={pathname} />);
-          const tempDiv = htmlDoc.createElement("div");
-          tempDiv.innerHTML = replacementDiv;
-
-          if (!tempDiv.firstElementChild) continue;
-
-          embed.parentNode.replaceChild(tempDiv.firstElementChild, embed);
-        }
-      }
-
-      return htmlDoc.documentElement.outerHTML;
-    }
-
-    return htmlString;
-  }, [StrawPollLoggedOut]);
 
   const bodyClasses = classNames(
     { [classes.commentStyling]: !comment.answer,
@@ -82,7 +55,6 @@ const CommentBody = ({ comment, classes, collapsed, truncated, postPage }: {
   if (collapsed) { return null }
 
   const innerHtml = truncated ? commentExcerptFromHTML(comment, currentUser, postPage) : html
-  const cleanedHtml = replaceStrawPollEmbed(innerHtml, !!currentUser, pathname);
 
   let contentType: ContentStyleType;
   if (comment.answer) {
@@ -97,7 +69,7 @@ const CommentBody = ({ comment, classes, collapsed, truncated, postPage }: {
     <ContentStyles contentType={contentType} className={classes.root}>
       <ContentItemBody
         className={bodyClasses}
-        dangerouslySetInnerHTML={{__html: cleanedHtml }}
+        dangerouslySetInnerHTML={{__html: innerHtml }}
         description={`comment ${comment._id}`}
         nofollow={(comment.user?.karma || 0) < nofollowKarmaThreshold.get()}
       />

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 import { captureException }from '@sentry/core';
 import { isServer } from '../../lib/executionEnvironment';
 import { linkIsExcludedFromPreview } from '../linkPreview/HoverPreviewLink';
+import withUser from './withUser';
+import { withLocation } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   scrollIndicatorWrapper: {
@@ -70,15 +72,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-interface ContentItemBodyProps extends WithStylesProps {
-  dangerouslySetInnerHTML: { __html: string },
-  className?: string,
-  description?: string,
+interface ExternalProps {
+  dangerouslySetInnerHTML: { __html: string };
+  className?: string;
+  description?: string;
   // Only Implemented for Tag Hover Previews
-  noHoverPreviewPrefetch?: boolean,
-  nofollow?: boolean,
-  idInsertions?: Record<string,React.ReactNode>
+  noHoverPreviewPrefetch?: boolean;
+  nofollow?: boolean;
+  idInsertions?: Record<string, React.ReactNode>;
 }
+interface ContentItemBodyProps extends ExternalProps, WithStylesProps, WithUserProps, WithLocationProps {}
 interface ContentItemBodyState {
   updatedElements: boolean,
 }
@@ -125,6 +128,7 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
       this.markScrollableLaTeX();
       this.markHoverableLinks();
       this.markElicitBlocks();
+      this.hideStrawPollLoggedOut();
       this.applyIdInsertions();
       this.setState({updatedElements: true})
     } catch(e) {
@@ -291,6 +295,20 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
       }
     }
   }
+
+  hideStrawPollLoggedOut = () => {
+    const { currentUser } = this.props;
+    const { location } = this.props;
+    const { pathname } = location;
+
+    if(!currentUser && this.bodyRef?.current) {
+      const strawpollBlocks = this.htmlCollectionToArray(this.bodyRef.current.getElementsByClassName("strawpoll-embed"));
+      for (const strawpollBlock of strawpollBlocks) {
+        const replacementElement = <Components.StrawPollLoggedOut pathname={pathname}/>
+        this.replaceElement(strawpollBlock, replacementElement)
+      }
+    }
+  }
   
   applyIdInsertions = () => {
     if (!this.props.idInsertions) return;
@@ -327,7 +345,13 @@ const addNofollowToHTML = (html: string): string => {
   return html.replace(/<a /g, '<a rel="nofollow" ')
 }
 
-const ContentItemBodyComponent = registerComponent('ContentItemBody', ContentItemBody, {styles});
+const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
+  styles,
+  hocs: [
+    withUser,
+    withLocation
+  ],
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
@@ -1,20 +1,15 @@
-import React, { useCallback, useMemo } from 'react';
+import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
 import { useSingle } from '../../../lib/crud/withSingle';
-import { useCurrentUser } from '../../common/withUser';
 import mapValues from 'lodash/mapValues';
 import type { SideCommentMode } from '../PostActions/SetSideCommentVisibility';
-import { useLocation } from '../../../lib/routeUtil';
-import ReactDOMServer from 'react-dom/server';
 
 const PostBody = ({post, html, sideCommentMode}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
   html: string,
   sideCommentMode?: SideCommentMode
 }) => {
-  const currentUser = useCurrentUser();
-  const { pathname } = useLocation();
   const includeSideComments = sideCommentMode && sideCommentMode!=="hidden";
 
   const { document, loading } = useSingle({
@@ -24,38 +19,11 @@ const PostBody = ({post, html, sideCommentMode}: {
     skip: !includeSideComments,
   });
   
-  const { ContentItemBody, SideCommentIcon, StrawPollLoggedOut } = Components;
+  const { ContentItemBody, SideCommentIcon } = Components;
   const nofollow = (post.user?.karma || 0) < nofollowKarmaThreshold.get();
   
-  const replaceStrawPollEmbed = useCallback((htmlString, isLoggedIn, pathname) => {
-    if (!isLoggedIn) {
-      const parser = new DOMParser();
-      const htmlDoc = parser.parseFromString(htmlString, "text/html");
-      const strawpollEmbeds = htmlDoc.getElementsByClassName("strawpoll-embed");
-
-      for (const embed of Array.from(strawpollEmbeds)) {
-        if (embed && embed.parentNode) {
-          const replacementDiv = ReactDOMServer.renderToString(<StrawPollLoggedOut pathname={pathname} />);
-          const tempDiv = htmlDoc.createElement("div");
-          tempDiv.innerHTML = replacementDiv;
-
-          if (!tempDiv.firstElementChild) continue;
-
-          embed.parentNode.replaceChild(tempDiv.firstElementChild, embed);
-        }
-      }
-
-      return htmlDoc.documentElement.outerHTML;
-    }
-
-    return htmlString;
-  }, [StrawPollLoggedOut]);
-
-  const cleanedHtml = useMemo(() => replaceStrawPollEmbed(html, !!currentUser, pathname), [currentUser, html, pathname, replaceStrawPollEmbed]);
-  const cleanedSideCommentHtml = useMemo(() => replaceStrawPollEmbed(document?.sideComments?.html || "", !!currentUser, pathname), [currentUser, document?.sideComments?.html, pathname, replaceStrawPollEmbed]);
-  
   if (includeSideComments && document?.sideComments) {
-    const htmlWithIDs = cleanedSideCommentHtml;
+    const htmlWithIDs = document.sideComments.html;
     const sideComments = sideCommentMode==="highKarma"
       ? document.sideComments.highKarmaCommentsByBlock
       : document.sideComments.commentsByBlock;
@@ -71,7 +39,7 @@ const PostBody = ({post, html, sideCommentMode}: {
   }
   
   return <ContentItemBody
-    dangerouslySetInnerHTML={{__html: cleanedHtml}}
+    dangerouslySetInnerHTML={{__html: html}}
     description={`post ${post._id}`}
     nofollow={nofollow}
   />


### PR DESCRIPTION
The way we were doing this before (manually in PostBody and CommentBody) was causing an SSR mismatch

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204422452213173) by [Unito](https://www.unito.io)
