### PR TITLE
Fix image position in Firefox for `PostsItemIntroSequence`

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
@@ -88,8 +88,12 @@ export const styles = (theme: ThemeType): JssStyles=> ({
     flexGrow: 1,
   },
   sequenceImage: {
+    // In an ideal world, this would be `height: "100%"`. This works fine in Chrome, but
+    // a bug in Firefox means that this breaks the `width: "auto"` on the image
+    // resulting in a bad mis-positioning. Hard-coding the height is a hack, but it's a
+    // hack that works. See https://stackoverflow.com/questions/46480358
+    height: 76,
     position: "absolute",
-    height: "100%",
     marginTop: 0,
     marginBottom: 0,
     overflow: 'hidden',

--- a/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
@@ -8,6 +8,9 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { KARMA_WIDTH } from './LWPostsItem';
 
+const IMAGE_WIDTH = 292;
+const IMAGE_HEIGHT = 96;
+
 export const styles = (theme: ThemeType): JssStyles=> ({
   root: {
     position: "relative",
@@ -88,17 +91,14 @@ export const styles = (theme: ThemeType): JssStyles=> ({
     flexGrow: 1,
   },
   sequenceImage: {
-    // In an ideal world, this would be `height: "100%"`. This works fine in Chrome, but
-    // a bug in Firefox means that this breaks the `width: "auto"` on the image
-    // resulting in a bad mis-positioning. Hard-coding the height is a hack, but it's a
-    // hack that works. See https://stackoverflow.com/questions/46480358
-    height: 76,
     position: "absolute",
+    height: "100%",
     marginTop: 0,
     marginBottom: 0,
     overflow: 'hidden',
     right: 0,
     bottom: 0,
+    aspectRatio: `${IMAGE_WIDTH}/${IMAGE_HEIGHT}`,
 
     // Overlay a white-to-transparent gradient over the image
     "&:after": {
@@ -198,7 +198,7 @@ const PostsItemIntroSequence = ({
 
           {withImage && sequence.gridImageId && <div className={classes.sequenceImage}>
             <img className={classes.sequenceImageImg}
-              src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
+              src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_${IMAGE_HEIGHT},q_auto,w_${IMAGE_WIDTH}/v1/${
                 sequence.gridImageId
               }`}
             />


### PR DESCRIPTION
`PostsItemIntroSequence` can optionally display a sequence image and the positioning of this image is currently pretty badly broken in Firefox due to a bug with the interaction between `height: 100%` and `width: auto`. This can be seen, for instance, in the introduction section of [the existential risk topic page](https://forum.effectivealtruism.org/topics/existential-risk?tab=wiki).

How it should look (in Chrome):
<img width="750" alt="Screenshot 2023-04-18 at 17 44 52" src="https://user-images.githubusercontent.com/5075628/232854812-1074e639-6ca0-4a9b-8d51-b5fea7ee1b73.png">

Currently in Firefox:
<img width="769" alt="Screenshot 2023-04-18 at 17 44 44" src="https://user-images.githubusercontent.com/5075628/232854765-e18150cb-1cb9-4c0d-917d-8507a8eceb49.png">

After this change:
<img width="781" alt="Screenshot 2023-04-18 at 18 15 18" src="https://user-images.githubusercontent.com/5075628/232854899-1886244a-35da-4946-9528-6b6e2cf5287e.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204426430263270) by [Unito](https://www.unito.io)
