### PR TITLE
Fix various sunshine bugs + rate limits prevent further warning-flags

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -13,6 +13,7 @@ import type { CommentWithModeratorActions } from './CommentsReviewInfoCard';
 const styles = (theme: ThemeType): JssStyles => ({
   page: {
     width: '90%',
+    maxWidth: 1800,
     margin: 'auto',
     [theme.breakpoints.down('sm')]: {
       width: '100%',

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -111,8 +111,6 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   
   const handleNotes = () => {
     if (notes != user.sunshineNotes) {
-      console.log(notes, user.sunshineNotes)
-      console.log("handleNotes")
       void updateUser({
         selector: {_id: user._id},
         data: {

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -65,6 +65,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 4,
     marginTop: 8,
     marginBottom: 8,
+    minHeight: 250,
     ...hideScrollBars,
     '& *': {
       ...hideScrollBars
@@ -110,6 +111,8 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   
   const handleNotes = () => {
     if (notes != user.sunshineNotes) {
+      console.log(notes, user.sunshineNotes)
+      console.log("handleNotes")
       void updateUser({
         selector: {_id: user._id},
         data: {
@@ -315,7 +318,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         endedAt: endDate
       }
     });
-
+    
     const existingRateLimits = user.moderatorActions.filter(modAction => rateLimitSet.has(modAction.type)) ?? [];
     for (const rateLimit of existingRateLimits) {
       void endRateLimit(rateLimit._id)

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -16,9 +16,8 @@ import { MODERATOR_ACTION_TYPES, RateLimitType, rateLimits, rateLimitSet } from 
 import FlagIcon from '@material-ui/icons/Flag';
 import Input from '@material-ui/core/Input';
 import { getCurrentContentCount, UserContentCountPartial } from '../../lib/collections/moderatorActions/helpers';
-import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import { hideScrollBars } from '../../themes/styleUtils';
-import { getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
+import { getNewModActionNotes, getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
 import Menu from '@material-ui/core/Menu'
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
@@ -308,7 +307,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
 
     const endDate = new Date();
     endDate.setDate(endDate.getDate() + 60);
-    
+
     await createModeratorAction({
       data: {
         type,
@@ -316,7 +315,8 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         endedAt: endDate
       }
     });
-    
+
+    setNotes( getNewModActionNotes(currentUser.displayName, type, notes) )
     const existingRateLimits = user.moderatorActions.filter(modAction => rateLimitSet.has(modAction.type)) ?? [];
     for (const rateLimit of existingRateLimits) {
       void endRateLimit(rateLimit._id)

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -5,10 +5,15 @@ import { Link } from '../../../lib/reactRouterWrapper'
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 16,
-    fontStyle: "italic"
+    fontStyle: "italic",
+    wordBreak: "break-all"
   },
   accountFlag: {
   },
+  qualitySignalRow: {
+    maxHeight: 20,
+    overflow: "hidden"
+  }
 });
 
 export const UserReviewStatus = ({classes, user}: {
@@ -40,8 +45,8 @@ export const UserReviewStatus = ({classes, user}: {
     {user.nullifyVotes && <div className={classes.accountFlag}>Previous votes deleted</div>}
     {user.deleteContent && <div className={classes.accountFlag}>Content purged</div>}
 
-    {firstClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: {firstClientId?.firstSeenReferrer}</div>}
-    {firstClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: {firstClientId?.firstSeenLandingPage}</div>}
+    {firstClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: <a href={firstClientId?.firstSeenReferrer}>{firstClientId?.firstSeenReferrer}</a></div>}
+    {firstClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: <Link to={firstClientId?.firstSeenLandingPage}>{firstClientId?.firstSeenLandingPage}</Link></div>}
     {(firstClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
       <em><Link to={`/moderation/altAccounts?slug=${user.slug}`}>Alternate accounts detected</Link></em>
     </div>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -5,6 +5,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import EmailIcon from '@material-ui/icons/Email';
 import { Link } from '../../lib/reactRouterWrapper';
+import uniq from 'lodash/uniq'
 
 const styles = (theme: JssStyles) => ({
   row: {
@@ -50,8 +51,10 @@ export const SunshineUserMessages = ({classes, user, currentUser}: {
         <MetaInfo><EmailIcon className={classes.icon}/> {conversation.messageCount}</MetaInfo>
         <span className={classes.title}>
           Conversation with{" "} 
-          {conversation.participants?.map(participant => {
-            if (participant._id !== user._id) return <UsersName simple user={participant} key={`${conversation._id}${user._id}`}/>
+          {conversation.participants.filter(participant => participant._id !== user._id).map(participant => {
+            return <MetaInfo key={`${conversation._id}${user._id}`}>
+              <UsersName simple user={participant}/>
+            </MetaInfo>
           })}
         </span>
       </Link>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -5,7 +5,6 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import EmailIcon from '@material-ui/icons/Email';
 import { Link } from '../../lib/reactRouterWrapper';
-import uniq from 'lodash/uniq'
 
 const styles = (theme: JssStyles) => ({
   row: {

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -236,7 +236,6 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
         <div className={classes.infoColumn}>
           <div>
             <ModeratorActions user={user} currentUser={currentUser} refetch={refetch} comments={comments} posts={posts}/>
-            <UserReviewStatus user={user}/>
           </div>
         </div>
         <div className={classes.contentColumn}>

--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -97,7 +97,7 @@ export function getReasonForReview(user: DbUser | SunshineUsersList, override?: 
   if (override) return 'override';
 
   const fullyReviewed = user.reviewedByUserId && !user.snoozedUntilContentCount;
-  const neverReviewed = !user.reviewedByUserId;
+  const neverReviewed = !user.reviewedByUserId && !user.reviewedAt;
   const snoozed = user.reviewedByUserId && user.snoozedUntilContentCount;
 
   if (fullyReviewed) return 'alreadyApproved';

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -10,6 +10,7 @@ import { Components } from '../../vulcan-lib';
 import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
 import moment from 'moment';
+import { MODERATOR_ACTION_TYPES } from '../moderatorActions/schema';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -525,6 +526,13 @@ export const getSignature = (name: string) => {
 export const getSignatureWithNote = (name: string, note: string) => {
   return `${getSignature(name)}: ${note}\n`;
 };
+
+export function getNewModActionNotes(responsibleAdminName: string, modActionType: DbModeratorAction["type"], sunshineNotes: string) {
+  const modActionDescription = MODERATOR_ACTION_TYPES[modActionType];
+  const newNote = getSignatureWithNote(responsibleAdminName, ` "${modActionDescription}"`);
+  const oldNotes = sunshineNotes ?? '';
+  return `${newNote}${oldNotes}`;
+}
 
 export const userCanVote = (user: UsersMinimumInfo|DbUser|null): PermissionResult => {
   // If the user is null, then returning true from this function is still valid;

--- a/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
@@ -1,5 +1,5 @@
-import { isActionActive, MODERATOR_ACTION_TYPES } from '../../lib/collections/moderatorActions/schema';
-import { getSignatureWithNote } from '../../lib/collections/users/helpers';
+import { isActionActive } from '../../lib/collections/moderatorActions/schema';
+import { getNewModActionNotes } from '../../lib/collections/users/helpers';
 import { loggerConstructor } from '../../lib/utils/logging';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { triggerReviewIfNeeded } from './sunshineCallbackUtils';
@@ -19,10 +19,8 @@ getCollectionHooks('ModeratorActions').createAsync.add(async function updateNote
   const moderatedUser = await context.loaders.Users.load(moderatedUserId);
   // In the case where there isn't a currentUser, that means that the moderator action was created using automod (via callback) rather than being manually applied
   const responsibleAdminName = currentUser?.displayName ?? 'Automod';
-  const modActionDescription = MODERATOR_ACTION_TYPES[newDocument.type];
-  const newNote = getSignatureWithNote(responsibleAdminName, ` "${modActionDescription}"`);
-  const oldNotes = moderatedUser.sunshineNotes ?? '';
-  const updatedNotes = `${newNote}${oldNotes}`;
+
+  const updatedNotes = getNewModActionNotes(responsibleAdminName, newDocument.type, moderatedUser.sunshineNotes)
 
   void context.Users.rawUpdateOne({ _id: moderatedUserId }, { $set: { sunshineNotes: updatedNotes } });
 });

--- a/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
@@ -25,4 +25,6 @@ getCollectionHooks('ModeratorActions').createAsync.add(async function updateNote
   const updatedNotes = `${newNote}${oldNotes}`;
 
   void context.Users.rawUpdateOne({ _id: moderatedUserId }, { $set: { sunshineNotes: updatedNotes } });
+  console.log("notes", updatedNotes)
+
 });

--- a/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
@@ -25,6 +25,4 @@ getCollectionHooks('ModeratorActions').createAsync.add(async function updateNote
   const updatedNotes = `${newNote}${oldNotes}`;
 
   void context.Users.rawUpdateOne({ _id: moderatedUserId }, { $set: { sunshineNotes: updatedNotes } });
-  console.log("notes", updatedNotes)
-
 });

--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -68,7 +68,7 @@ export function isRecentlyDownvotedContent(voteableItems: (DbComment | DbPost)[]
 
 function isActiveNegativeKarmaUser(user: DbUser, voteableItems: (DbComment | DbPost)[]) {
     // Not enough engagement to make a judgment
-    // if (voteableItems.length < 3) return false;
+    if (voteableItems.length < 5) return false;
 
     const oneMonthAgo = moment().subtract(1, 'month').toDate();
   

--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -175,6 +175,7 @@ export async function triggerAutomodIfNeededForUser(user: DbUser) {
   if (userModeratorActions.filter(isActionActive).some(action => rateLimitSet.has(action.type) )) {
     // if a mod has already given them a rate limit, they don't need to have any new actions applied to them
     // TODO: if we build any more complicated mod action rules, this will need to be updated
+    // eaforum-look-here
     return
   }
   const activeNegativeKarmaUser = isActiveNegativeKarmaUser(user, voteableContent);

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -60,10 +60,10 @@ voteCallbacks.castVoteAsync.add(async function updateNeedsReview (document: Vote
 });
 
 voteCallbacks.castVoteAsync.add(async function checkAutomod ({newDocument, vote}: VoteDocTuple) {
+  if (forumTypeSetting.get() === 'LessWrong') {
+    void triggerAutomodIfNeeded(newDocument.userId)
+  }
   if (vote.collectionName === 'Comments') {
-    if (forumTypeSetting.get() === 'LessWrong') {
-      void triggerAutomodIfNeeded(newDocument.userId)
-    }
     void triggerCommentAutomodIfNeeded(newDocument, vote);
   }
 });


### PR DESCRIPTION
This PR fixes various bugs:

– fixes a display bug where typing in the notes field caused the "conversations with this user" UI to replicate endlessly. This was due to _two_ issues, and we only fixed one of them. One issue is that typing into the notes field makes lots of calls to the DB that cause the component to refreshed (I think it might be correct to make all the calls to the DB, but not sure why the component refreshed). The second problem was a bug in the UI code that I don't quite understand, but changing from the manual function I'd previously written to using the filter function fixes it.

– referral links were sometimes really long and displayed weird. This truncates them but also makes them into actual links you can click if you want, or right-click to copy link.

– the "negative karma user" flag was previously only triggering when people voted on comments, which I think was just a straightforward mistake.

And changes functionality:

– if a user is already rate limited, further flags from the "downvoted content, low quality comments and negative karma users" shouldn't trigger, since the point of those was to elevate the user to consider for a rate limit. (@jpaddison3 I don't know if you're using this feature in a way this would break. I'm merging it for now because we need it but can do a followup forum-gate if you want)


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204426497931471) by [Unito](https://www.unito.io)
