### PR TITLE
Fix the account-edit form for cross-user editing

### DIFF
--- a/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
@@ -10,7 +10,7 @@ import { gql } from '@apollo/client';
 import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
 import { capitalize } from '../../lib/vulcan-lib/utils';
 import { useCreate } from '../../lib/crud/withCreate';
-import { useSingle } from '../../lib/crud/withSingle';
+import { useSingle, DocumentIdOrSlug } from '../../lib/crud/withSingle';
 import { useDelete } from '../../lib/crud/withDelete';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { getSchema } from '../../lib/utils/getSchema';
@@ -170,8 +170,11 @@ const FormWrapperEdit = (props: WrappedSmartFormProps&{schema: any}) => {
   const { queryFragment, mutationFragment } = getFragments("edit", props);
   const { extraVariables = {}, extraVariablesValues } = props
   
+  const selector: DocumentIdOrSlug = props.documentId
+    ? {documentId: props.documentId}
+    : {slug: props.slug}
   const { document, loading } = useSingle({
-    documentId: props.documentId,
+    ...selector,
     collectionName: props.collectionName,
     fragment: queryFragment,
     extraVariables,


### PR DESCRIPTION
The vulcan-forms refactoring PR (https://github.com/ForumMagnum/ForumMagnum/pull/6878) broken the edit-user form when editing users other than yourself (but not when editing yourself). This is because, when switching from the `withSingle` HoC to the `useSingle` hook, there was a case that `withSingle` handled that `useSingle` didn't: when no documentId is passed, but a slug is passed instead. Tightening the typechecking on both the `useSingle` and `FormWrapper` components confirmed that `UsersEditForm` and `EditProfileForm` were affected, but nothing else in the codebase was.

Fix by extending `useSingle` to be able to take a slug.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204427311388790) by [Unito](https://www.unito.io)
