### PR TITLE
Remove styling for altAccounts to fix bug

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -47,9 +47,7 @@ export const UserReviewStatus = ({classes, user}: {
 
     {firstClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: <a href={firstClientId?.firstSeenReferrer}>{firstClientId?.firstSeenReferrer}</a></div>}
     {firstClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: <Link to={firstClientId?.firstSeenLandingPage}>{firstClientId?.firstSeenLandingPage}</Link></div>}
-    {(firstClientId?.userIds?.length??0) > 1 && <div className={classes.qualitySignalRow}>
-      <AltAccountInfo user={user}/>
-    </div>}
+    {(firstClientId?.userIds?.length??0) > 1 && <AltAccountInfo user={user}/>}
     <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
   </div>;
 }


### PR DESCRIPTION
My altAccounts UI was accidentally in a css styling that hid the lower half of it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204427555530668) by [Unito](https://www.unito.io)
