### PR TITLE
Karma alignment + Post title font size

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -15,7 +15,7 @@ export const postPageTitleStyles = (theme: ThemeType): JssStyles => ({
   color: theme.palette.text.primary,
   [theme.breakpoints.down('sm')]: isEAForum
     ? {
-      fontSize: '2.1rem',
+      fontSize: '2.3rem',
       marginTop: 20,
     }
     : {
@@ -23,7 +23,7 @@ export const postPageTitleStyles = (theme: ThemeType): JssStyles => ({
     },
   ...(isEAForum
     ? {
-      fontSize: '2.5rem',
+      fontSize: '3rem',
     }
     : {}),
 })

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -7,18 +7,16 @@ import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   upvote: {
-    marginBottom: -22
+    marginBottom: -21
   },
   downvote: {
-    marginTop: isEAForum ? -27 : -25,
+    marginTop: -28
   },
   voteScores: {
     margin:"15%",
   },
   voteScore: {
     color: theme.palette.grey[500],
-    paddingLeft: 1, // For some weird reason having this padding here makes it look more centered
-    lineHeight: isEAForum ? 1.2 : undefined,
     position: 'relative',
     zIndex: theme.zIndexes.postsVote,
     fontSize: '55%',

--- a/packages/lesswrong/components/votes/VoteArrowIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIcon.tsx
@@ -14,7 +14,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 'inherit',
     width: 'initial',
     height: 'initial',
-    marginTop: isEAForum ? 2 : undefined,
     padding: 0,
     '&:hover': {
       backgroundColor: 'transparent',


### PR DESCRIPTION
**Two fixes**
1. Karma alignment (affects LW too, since LW was also misaligned).
It's still not perfectly centered horizontally and I'm pulling my hair trying to fix it (says it still has 1px leftpadding after I removed the 1px leftpadding)
2. Post title size (has been bugging me that it's the same size as the h1 title inside of posts. We could make the headings smaller instead too, if this feels overly large)

### Before
<img width="789" alt="Screenshot 2023-04-20 at 12 56 25" src="https://user-images.githubusercontent.com/13235378/233358929-d2820cea-0e14-4c05-b826-d794686d154a.png">

### After
<img width="793" alt="Screenshot 2023-04-20 at 12 52 26" src="https://user-images.githubusercontent.com/13235378/233359170-d2bb95ce-f5de-45cc-945c-906ad85f7511.png">

### Karma with LW theme override
<img width="105" alt="Screenshot 2023-04-20 at 13 01 40" src="https://user-images.githubusercontent.com/13235378/233359962-9cf36a91-ccdf-4d30-988c-e0994928721b.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204440401374055) by [Unito](https://www.unito.io)
