### PR TITLE
Debate dialogue cleanup

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -96,8 +96,6 @@ const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, docum
   if (isDebatePost && placeholder === defaultEditorPlaceholder) {
     placeholder = debateEditorPlaceholder;
   }
-
-  console.log({ placeholder });
   
   // To make sure that the refs are populated we have to do two rendering passes
   const [layoutReady, setLayoutReady] = useState(false)

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -8,7 +8,7 @@ import { ckEditorUploadUrlSetting, ckEditorWebsocketUrlSetting } from '../../lib
 import { ckEditorUploadUrlOverrideSetting, ckEditorWebsocketUrlOverrideSetting } from '../../lib/instanceSettings';
 import { CollaborationMode } from './EditorTopBar';
 import { useLocation } from '../../lib/routeUtil';
-import { defaultEditorPlaceholder } from '../../lib/editor/make_editable';
+import { debateEditorPlaceholder, defaultEditorPlaceholder } from '../../lib/editor/make_editable';
 import { mentionPluginConfiguration } from "../../lib/editor/mentionsConfig";
 
 // Uncomment this line and the reference below to activate the CKEditor debugger
@@ -94,7 +94,7 @@ const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, docum
 
   const isDebatePost = !!debate;
   if (isDebatePost && placeholder === defaultEditorPlaceholder) {
-    placeholder = 'Enter your first dialogue comment here, add other participants as co-authors, then save this as a draft.\n\nOther participants will be able to participate by leaving comments on the draft, which will automatically be converted into dialogue responses.';
+    placeholder = debateEditorPlaceholder;
   }
 
   console.log({ placeholder });

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -90,7 +90,14 @@ const CKPostEditor = ({ data, collectionName, fieldName, onSave, onChange, docum
   const [collaborationMode,setCollaborationMode] = useState<CollaborationMode>(initialCollaborationMode);
 
   // Get the linkSharingKey, if it exists
-  const { query : { key } } = useLocation();
+  const { query : { key, debate } } = useLocation();
+
+  const isDebatePost = !!debate;
+  if (isDebatePost && placeholder === defaultEditorPlaceholder) {
+    placeholder = 'Enter your first dialogue comment here, add other participants as co-authors, then save this as a draft.\n\nOther participants will be able to participate by leaving comments on the draft, which will automatically be converted into dialogue responses.';
+  }
+
+  console.log({ placeholder });
   
   // To make sure that the refs are populated we have to do two rendering passes
   const [layoutReady, setLayoutReady] = useState(false)

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -268,9 +268,9 @@ const PostActions = ({post, closeMenu, classes}: {
             showIcon
             document={post}
             subscriptionType={subscriptionTypes.newDebateComments}
-            subscribeMessage="Subscribe to debate"
-            unsubscribeMessage="Unsubscribe from debate"
-            tooltip="Notifies you when there is new activity in the debate"
+            subscribeMessage="Subscribe to dialogue"
+            unsubscribeMessage="Unsubscribe from dialogue"
+            tooltip="Notifies you when there is new activity in the dialogue"
           />
         }
 

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -133,7 +133,7 @@ const UsersMenu = ({classes}: {
                 <MenuItem>New Post</MenuItem>
               </Link>}
               {userCanPost(currentUser) && !isEAForum && userCanCreateField(currentUser, postSchema['debate']) && <Link to={`/newPost?debate=true`}>
-                <MenuItem>New Debate</MenuItem>
+                <MenuItem>New Dialogue</MenuItem>
               </Link>}
             </div>
             {showNewButtons && !currentUser.allCommentingDisabled && <MenuItem onClick={()=>openDialog({componentName:"NewShortformDialog"})}>

--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -144,21 +144,21 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Subscribed to Debates (as a reader)"
+      title="Subscribed to Dialogues (as a reader)"
       collectionName="Posts"
       subscriptionType="newDebateComments"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any debates as a reader."
+      noSubscriptionsMessage="You are not subscribed to any dialogues as a reader."
     />
 
     <SubscriptionsList
-      title="Subscribed to Debates (as a participant)"
+      title="Subscribed to Dialogues (as a participant)"
       collectionName="Posts"
       subscriptionType="newDebateReplies"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any debates as a participant."
+      noSubscriptionsMessage="You are not subscribed to any dialogues as a participant."
     />
 
     <SubscriptionsList

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1316,11 +1316,11 @@ const schema: SchemaType<DbUser> = {
     ...notificationTypeSettingsField(),
   },
   notificationDebateCommentsOnSubscribedPost: {
-    label: "New debate content in a debate I'm subscribed to",
+    label: "New dialogue content in a dialogue I'm subscribed to",
     ...notificationTypeSettingsField({ batchingFrequency: 'daily' })
   },
   notificationDebateReplies: {
-    label: "New debate content in a debate I'm participating in",
+    label: "New dialogue content in a dialogue I'm participating in",
     ...notificationTypeSettingsField()
   },
 

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -48,6 +48,11 @@ export const defaultEditorPlaceholder = isEAForum ?
 We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).
 You can switch between rich text and markdown in your user settings.`
 
+export const debateEditorPlaceholder = 
+`Enter your first dialogue comment here, add other participants as co-authors, then save this as a draft.
+
+Other participants will be able to participate by leaving comments on the draft, which will automatically be converted into dialogue responses.`;
+
 const defaultOptions: MakeEditableOptions = {
   // Determines whether to use the comment editor configuration (e.g. Toolbars)
   commentEditor: false,

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -274,7 +274,7 @@ export const NewDebateCommentNotification = registerNotificationType({
   userSettingField: "notificationDebateCommentsOnSubscribedPost",
   async getMessage({documentType, documentId}: GetMessageProps) {
     let document = await getDocument(documentType, documentId) as DbComment;
-    return await commentGetAuthorName(document) + ' left a new reply on the debate "' + await getCommentParentTitle(document) + '"';
+    return await commentGetAuthorName(document) + ' left a new reply on the dialogue "' + await getCommentParentTitle(document) + '"';
   },
   getIcon() {
     return <CommentsIcon style={iconStyles}/>
@@ -288,7 +288,7 @@ export const NewDebateReplyNotification = registerNotificationType({
   userSettingField: "notificationDebateReplies",
   async getMessage({documentType, documentId}: GetMessageProps) {
     let document = await getDocument(documentType, documentId) as DbComment;
-    return await commentGetAuthorName(document) + ' left a new reply on the debate "' + await getCommentParentTitle(document) + '"';
+    return await commentGetAuthorName(document) + ' left a new reply on the dialogue "' + await getCommentParentTitle(document) + '"';
   },
   getIcon() {
     return <CommentsIcon style={iconStyles}/>

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -45,7 +45,7 @@ if (forumTypeSetting.get() === "EAForum") {
 
 getCollectionHooks("Posts").createValidate.add(function DebateMustHaveCoauthor(validationErrors, { document }) {
   if (document.debate && !document.coauthorStatuses?.length) {
-    throw new Error('Debate must have at least one co-author!');
+    throw new Error('Dialogue must have at least one co-author!');
   }
 
   return validationErrors;

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -214,13 +214,13 @@ export const NewDebateCommentNotification = serverRegisterNotificationType({
   canCombineEmails: true,
   emailSubject: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     if (notifications.length > 1) {
-      return `${notifications.length} debate replies on debates you subscribed to`;
+      return `${notifications.length} dialogue replies on dialogues you subscribed to`;
     } else {
       const comment = await Comments.findOne(notifications[0].documentId);
       if (!comment) throw Error(`Can't find comment for notification: ${notifications[0]}`)
       const author = await Users.findOne(comment.userId);
-      if (!author) throw Error(`Can't find author for new debate comment notification: ${notifications[0]}`)
-      return `${author.displayName} replied in a debate you subscribed to`;
+      if (!author) throw Error(`Can't find author for new dialogue comment notification: ${notifications[0]}`)
+      return `${author.displayName} replied in a dialogue you subscribed to`;
     }
   },
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
@@ -237,13 +237,13 @@ export const NewDebateReplyNotification = serverRegisterNotificationType({
   canCombineEmails: true,
   emailSubject: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     if (notifications.length > 1) {
-      return `${notifications.length} replies on debates you're participanting in'`;
+      return `${notifications.length} replies on dialogues you're participanting in'`;
     } else {
       const comment = await Comments.findOne(notifications[0].documentId);
       if (!comment) throw Error(`Can't find comment for notification: ${notifications[0]}`)
       const author = await Users.findOne(comment.userId);
-      if (!author) throw Error(`Can't find author for new debate comment notification: ${notifications[0]}`)
-      return `${author.displayName} replied in a debate you're participanting in`;
+      if (!author) throw Error(`Can't find author for new dialogue comment notification: ${notifications[0]}`)
+      return `${author.displayName} replied in a dialogue you're participanting in`;
     }
   },
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -238,6 +238,10 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   }
   if (!voteTypes[voteType]) throw new Error(`Invalid vote type in performVoteServer: ${voteType}`);
 
+  if (collectionName === "Comments" && (document as DbComment).debateResponse) {
+    throw new Error("Cannot vote on dialogue responses");
+  }
+
   if (collectionName==="Revisions" && (document as DbRevision).collectionName!=='Tags')
     throw new Error("Revisions are only voteable if they're revisions of tags");
   


### PR DESCRIPTION
Rename debate to dialogue everywhere that's user-facing, block voting on dialogue responses on the server (since otherwise it can be done via API, via GreaterWrong, etc), and add more helpful instructions in the post editor placeholder/hint text for dialogues.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204444662353048) by [Unito](https://www.unito.io)
