### PR TITLE
User Dashboard expand all comments, and display rejection reasons more nicely

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -109,7 +109,7 @@ const CommentsNode = ({
 }: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
-  const [collapsed, setCollapsed] = useState(comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene');
+  const [collapsed, setCollapsed] = useState(!expandByDefault && (comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene'));
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
   const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, noHash } = treeOptions;
 

--- a/packages/lesswrong/components/sunshineDashboard/ContentRejectionDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ContentRejectionDialog.tsx
@@ -3,9 +3,10 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Paper from '@material-ui/core/Paper';
 import TextField from '@material-ui/core/TextField';
 import classNames from 'classnames';
-import React, { ChangeEventHandler, useState } from 'react';
+import React, { useState } from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
+import Card from '@material-ui/core/Card'
 
 const styles = (theme: ThemeType): JssStyles => ({
   dialogContent: {
@@ -27,6 +28,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   hideModalTextField: {
     display: 'none'
+  },
+  card: {
+    padding: 12,
+    width: 500,
   }
 });
 
@@ -34,7 +39,7 @@ const ContentRejectionDialog = ({classes, rejectContent}: {
   classes: ClassesType,
   rejectContent: (reason: string) => void,
 }) => {
-  const { LWTooltip } = Components;
+  const { LWTooltip, ContentItemBody, ContentStyles } = Components;
 
   const [selections, setSelections] = useState<Record<string,boolean>>({});
   const [hideTextField, setHideTextField] = useState(true);
@@ -71,13 +76,19 @@ const ContentRejectionDialog = ({classes, rejectContent}: {
   const dialogContent = <div className={classes.rejectionCheckboxes}>
     {Object.entries(rejectionReasons).map(([label, description]) => {
       return <span key={`rejection-reason-${label}`}>
-        <Checkbox
-          checked={selections[label]}
-          onChange={(_, checked) => composeRejectedReason(label, checked)}
-          className={classes.checkbox}
-        />
-        <LWTooltip title={description}>
-          {label}
+        <LWTooltip placement="right-end" tooltip={false} title={<Card className={classes.card}>
+          <ContentStyles contentType='comment'>
+            <ContentItemBody dangerouslySetInnerHTML={{__html: description || ""}} />
+          </ContentStyles>
+        </Card>}>
+          <div>
+            <Checkbox
+              checked={selections[label]}
+              onChange={(_, checked) => composeRejectedReason(label, checked)}
+              className={classes.checkbox}
+            />
+            {label}
+          </div>
         </LWTooltip>
       </span>
     })}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -46,6 +46,7 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
                 post: comment.post || undefined,
                 showPostTitle: true,
               }}
+              expandByDefault
               comment={comment}
             />)}
     </div>


### PR DESCRIPTION
Two minor UI improvements to the New User dashboard.

I'm not 100% sure if it's right to use "expandByDefault" to force comments to not be collapsed. I think in most cases where we'd want comments expanded by default, we also want them un-collapsed by default. The alternative is to build a separate "uncollapse by default". I think the terminology here is a bit confusing and annoying (I think what expandByDefault normally means is 'not-truncate-by-default', and it's unfortunate that expand is a reasonable antonym for "not expanded" and "not truncated")

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204445403449587) by [Unito](https://www.unito.io)
