### PR TITLE
Fix Move to Personal Blog action

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1262,7 +1262,7 @@ const schema: SchemaType<DbPost> = {
             false,
           );
         }
-        return data.frontpageDate ?? oldDocument.frontpageDate;
+        return data.frontpageDate === undefined ? oldDocument.frontpageDate : data.frontpageDate;
       },
     }),
   },


### PR DESCRIPTION
"Move to Personal Blog" tries to set the `frontpageDate` to null, this was failing because the `??` operator would make it fall back to the previous date in this case