### PR TITLE
hide "Subscribe to posts by <author>" from menu of deleted comment

### DIFF
--- a/packages/lesswrong/components/comments/CommentActions/CommentActions.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/CommentActions.tsx
@@ -52,7 +52,7 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       subscribeMessage="Subscribe to comment replies"
       unsubscribeMessage="Unsubscribe from comment replies"
     />
-    {comment.user?._id && (comment.user._id !== currentUser._id) &&
+    {comment.user?._id && (comment.user._id !== currentUser._id) && !comment.deleted &&
       <NotifyMeButton asMenuItem document={comment.user} showIcon
         subscribeMessage={"Subscribe to posts by "+userGetDisplayName(comment.user)}
         unsubscribeMessage={"Unsubscribe from posts by "+userGetDisplayName(comment.user)}


### PR DESCRIPTION
This allowed non-admin users to see the author of deleted comments, so we're removing that menu option.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204461975098820) by [Unito](https://www.unito.io)
