### PR TITLE
Enable ignore rate limits

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -73,7 +73,7 @@ const PostsItemMeta = ({post, read, classes}: {
       </span>}
 
       <span className={classes.info}>
-        <PostsUserAndCoauthors post={post}/>
+        <PostsUserAndCoauthors post={post} showMarkers />
       </span>
 
       { afBaseScore && <span className={classes.info}>

--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
@@ -1,7 +1,6 @@
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import React from 'react';
 import ModeCommentIcon from '@material-ui/icons/ModeComment';
-import DebateIcon from '@material-ui/icons/Forum';
 import classNames from 'classnames';
 import type { PopperPlacementType } from '@material-ui/core/Popper'
 import { usePostsUserAndCoauthors } from './usePostsUserAndCoauthors';
@@ -15,6 +14,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('xs')]: {
       maxWidth: 160
     },
+  },
+  userMarkers: {
+    marginLeft: 4,
   },
   lengthUnlimited: {
     display: "inline",
@@ -37,17 +39,26 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const PostsUserAndCoauthors = ({post, abbreviateIfLong=false, classes, simple=false, tooltipPlacement = "left", newPromotedComments}: {
+const PostsUserAndCoauthors = ({
+  post,
+  abbreviateIfLong=false,
+  classes,
+  simple=false,
+  tooltipPlacement="left",
+  newPromotedComments,
+  showMarkers,
+}: {
   post: PostsList | SunshinePostsList,
   abbreviateIfLong?: boolean,
   classes: ClassesType,
   simple?: boolean,
   tooltipPlacement?: PopperPlacementType,
-  newPromotedComments?: boolean
+  newPromotedComments?: boolean,
+  showMarkers?: boolean,
 }) => {
   const {isAnon, topCommentAuthor, authors} = usePostsUserAndCoauthors(post);
 
-  const { UsersName, UserNameDeleted } = Components
+  const {UsersName, UserNameDeleted, UserCommentMarkers} = Components
 
   if (isAnon)
     return <UserNameDeleted/>;
@@ -57,6 +68,9 @@ const PostsUserAndCoauthors = ({post, abbreviateIfLong=false, classes, simple=fa
       <React.Fragment key={author._id}>
         {i > 0 ? ", " : ""}
         <UsersName user={author} simple={simple} tooltipPlacement={tooltipPlacement}/>
+        {showMarkers &&
+          <UserCommentMarkers user={author} className={classes.userMarkers} />
+        }
       </React.Fragment>
     )
     }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -105,6 +105,7 @@ registerFragment(`
     
     hideAuthor
     moderationStyle
+    ignoreRateLimits
     submitToFrontpage
     shortform
     onlyVisibleToLoggedIn

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { arrayOfForeignKeysField, foreignKeyField, googleLocationToMongoLocation, resolverOnlyField, denormalizedField, denormalizedCountOfReferences, accessFilterMultiple, accessFilterSingle } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 import { PostRelations } from "../postRelations/collection"
-import { postCanEditHideCommentKarma, postGetPageUrl, postGetEmailShareUrl, postGetTwitterShareUrl, postGetFacebookShareUrl, postGetDefaultStatus, getSocialPreviewImage } from './helpers';
+import { postCanEditHideCommentKarma, postGetPageUrl, postGetEmailShareUrl, postGetTwitterShareUrl, postGetFacebookShareUrl, postGetDefaultStatus, getSocialPreviewImage, canUserEditPostMetadata } from './helpers';
 import { postStatuses, postStatusLabels } from './constants';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { TagRels } from "../tagRels/collection";
@@ -2326,6 +2326,18 @@ const schema: SchemaType<DbPost> = {
         ];
       }
     },
+  },
+
+  ignoreRateLimits: {
+    type: Boolean,
+    optional: true,
+    nullable: true,
+    tooltip: "Allow users that moderators have rate-limited to comment freely on this post",
+    group: formGroups.moderationGroup,
+    canRead: ["guests"],
+    canCreate: ["members"],
+    canUpdate: [canUserEditPostMetadata],
+    order: 60
   },
   
   // On a post, do not show comment karma

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2342,6 +2342,7 @@ const schema: SchemaType<DbPost> = {
     type: Boolean,
     optional: true,
     nullable: true,
+    hidden: isEAForum,
     tooltip: "Allow users that moderators have rate-limited to comment freely on this post",
     group: formGroups.moderationGroup,
     canRead: ["guests"],

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -637,6 +637,7 @@ interface DbPost extends DbObject {
   sideCommentsCache: any /*{"definitions":[{}]}*/
   sideCommentVisibility: string
   moderationStyle: string
+  ignoreRateLimits: boolean | null
   hideCommentKarma: boolean
   commentCount: number
   debate: boolean | null

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -650,6 +650,7 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly sideCommentsCache: any /*{"definitions":[{}]}*/,
   readonly sideCommentVisibility: string,
   readonly moderationStyle: string,
+  readonly ignoreRateLimits: boolean | null,
   readonly hideCommentKarma: boolean,
   readonly commentCount: number,
   readonly languageModelSummary: string,
@@ -894,6 +895,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly afSticky: boolean,
   readonly hideAuthor: boolean,
   readonly moderationStyle: string,
+  readonly ignoreRateLimits: boolean | null,
   readonly submitToFrontpage: boolean,
   readonly shortform: boolean,
   readonly onlyVisibleToLoggedIn: boolean,
@@ -1291,6 +1293,7 @@ interface PostWithGeneratedSummary { // fragment on Posts
 interface PostWithRateLimit { // fragment on Posts
   readonly _id: string,
   readonly postSpecificRateLimit: Date,
+  readonly sideComments: any,
 }
 
 interface CommentsList { // fragment on Comments

--- a/packages/lesswrong/server/callbacks/rateLimits.ts
+++ b/packages/lesswrong/server/callbacks/rateLimits.ts
@@ -81,6 +81,11 @@ async function enforcePostRateLimit (user: DbUser) {
 }
 
 async function enforceCommentRateLimit(user: DbUser, comment: DbComment) {
+  const post = await Posts.findOne({_id:comment.postId})
+  if (post?.ignoreRateLimits) {
+    return
+  }
+
   const rateLimit = await rateLimitDateWhenUserNextAbleToComment(user);
   if (rateLimit) {
     const {nextEligible, rateLimitType:_} = rateLimit;


### PR DESCRIPTION
This adds a field to posts, "ignoreRateLimits", which... lets it ignore rate limits.

For the immediate future this is available in the moderationGuidelines section for all users. I think it's likely we actually want to make this require 50 karma or something, but, for now I want to ship a maximally lenient version.

@jpaddison3 it's hidden on EA Forum for now.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204465011708319) by [Unito](https://www.unito.io)
