### PR TITLE
Fix dialog voting bug

### DIFF
--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -238,7 +238,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   }
   if (!voteTypes[voteType]) throw new Error(`Invalid vote type in performVoteServer: ${voteType}`);
 
-  if (collectionName === "Comments" && (document as DbComment).debateResponse) {
+  if (!selfVote && collectionName === "Comments" && (document as DbComment).debateResponse) {
     throw new Error("Cannot vote on dialogue responses");
   }
 


### PR DESCRIPTION
We accidentally made it so dialog-participants couldn't submit a dialog post or comments, because it included a self-upvote that we'd mistakenly blocked. This fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204465820056794) by [Unito](https://www.unito.io)
