### PR TITLE
[EA Forum only] hide continue reading and bookmarks from home page

### DIFF
--- a/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
@@ -4,6 +4,7 @@ import { useCurrentUser } from '../common/withUser';
 import { Link } from '../../lib/reactRouterWrapper'
 import { getRecommendationSettings, archiveRecommendationsName } from './RecommendationsAlgorithmPicker'
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const ConfigurableRecommendationsList = ({configName}: {
   configName: string
@@ -34,7 +35,7 @@ const ConfigurableRecommendationsList = ({configName}: {
         </Link>
       </LWTooltip>}
     >
-      <SettingsButton onClick={toggleSettings}/>
+      {!isEAForum && <SettingsButton onClick={toggleSettings}/>}
     </SectionTitle>
     { settingsVisible &&
       <RecommendationsAlgorithmPicker

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -6,7 +6,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import deepmerge from 'deepmerge';
 import { useCurrentUser } from '../common/withUser';
 import { defaultAlgorithmSettings, RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import { ForumOptions, forumSelect } from '../../lib/forumTypeUtils';
 
 export const archiveRecommendationsName = forumTypeSetting.get() === 'EAForum' ? 'Forum Favorites' : 'Archive Recommendations'
@@ -46,6 +46,8 @@ export function getRecommendationSettings({settings, currentUser, configName}: {
   currentUser: UsersCurrent|null,
   configName: string,
 }): RecommendationsAlgorithm {
+  if (isEAForum) return defaultAlgorithmSettings
+  
   if (settings) {
     return {
       ...defaultAlgorithmSettings,

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -93,7 +93,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
     onChange(newSettings);
   }
   return <div className={classes.root}>
-    {['frontpage', 'frontpageEA'].includes(configName) && <span className={classes.settingGroup}>
+    {(configName === "frontpage") && <span className={classes.settingGroup}>
       <span className={classes.setting}>
         <SectionFooterCheckbox
           value={!settings.hideContinueReading}

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -136,17 +136,19 @@ const RecommendationsAndCurated = ({
       <div><em>(Click to see more recommendations)</em></div>
     </div>
 
-    const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
-    const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
+    const renderBookmarks = !isEAForum && ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
+    const renderContinueReading = !isEAForum && currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
     
     const renderRecommendations = !settings.hideFrontpage
 
-    const bookmarksLimit = (settings.hideFrontpage && settings.hideContinueReading) ? 6 : 3 
+    const bookmarksLimit = (settings.hideFrontpage && settings.hideContinueReading) ? 6 : 3
 
     return <SingleColumnSection className={classes.section}>
       <AnalyticsContext pageSectionContext="recommendations">
         <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
-          <Link to={"/recommendations"}>Recommendations</Link>
+          <Link to={"/recommendations"}>
+            {isEAForum ? 'Classic posts' : 'Recommendations'}
+          </Link>
         </LWTooltip>}>
           {currentUser &&
             <LWTooltip title="Customize your recommendations">

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -150,7 +150,7 @@ const RecommendationsAndCurated = ({
             {isEAForum ? 'Classic posts' : 'Recommendations'}
           </Link>
         </LWTooltip>}>
-          {currentUser &&
+          {!isEAForum && currentUser &&
             <LWTooltip title="Customize your recommendations">
               <SettingsButton showIcon={false} onClick={toggleSettings} label="Customize"/>
             </LWTooltip>


### PR DESCRIPTION
As per [this asana task](https://app.asana.com/0/628521446211730/1204155311038150/f), we're removing the "continue reading" and "bookmarks" portions of the "Recommendations" section on the home page, removing the customization options, and renaming it to be "Classic posts".

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204467013781286) by [Unito](https://www.unito.io)
