### PR TITLE
Separate out untruncate and uncollapse comments (and make comment hoverpreviews "forceUnCollapsed")

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -72,7 +72,8 @@ const CommentPermalink = ({ documentId, post, classes }: {
       refetch,
       showPostTitle: false,
     },
-    expandByDefault: true,
+    forceUnTruncated: true,
+    forceUnCollapsed: true,
     noAutoScroll: true
   };
 

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -88,7 +88,8 @@ const CommentWithReplies = ({
       shortform
       showExtraChildrenButton={showExtraChildrenButton}
       expandAllThreads={startExpanded}
-      expandByDefault={startExpanded}
+      forceUnTruncated={startExpanded}
+      forceUnCollapsed={startExpanded}
       {...commentNodeProps}
       treeOptions={treeOptions}
       className={className}

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -45,7 +45,8 @@ export interface CommentsNodeProps {
    * Determines whether this specific comment is expanded, without passing that
    * expanded state to child comments
    */
-  expandByDefault?: boolean,
+  forceUnTruncated?: boolean,
+  forceUnCollapsed?: boolean,
   expandNewComments?: boolean,
   isChild?: boolean,
   parentAnswerId?: string|null,
@@ -88,7 +89,8 @@ const CommentsNode = ({
   shortform,
   nestingLevel=1,
   expandAllThreads,
-  expandByDefault,
+  forceUnTruncated,
+  forceUnCollapsed,
   expandNewComments=true,
   isChild,
   parentAnswerId,
@@ -109,7 +111,7 @@ const CommentsNode = ({
 }: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
-  const [collapsed, setCollapsed] = useState(!expandByDefault && (comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene'));
+  const [collapsed, setCollapsed] = useState(!forceUnCollapsed && (comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene'));
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
   const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, noHash } = treeOptions;
 
@@ -245,7 +247,7 @@ const CommentsNode = ({
             </AnalyticsContext>
           : <CommentsItem
               treeOptions={treeOptions}
-              truncated={isTruncated && !expandByDefault} // expandByDefault checked separately here, so isTruncated can also be passed to child nodes
+              truncated={isTruncated && !forceUnTruncated} // forceUnTruncated checked separately here, so isTruncated can also be passed to child nodes
               nestingLevel={updatedNestingLevel}
               parentCommentId={parentCommentId}
               parentAnswerId={parentAnswerId || (comment.answer && comment._id) || undefined}

--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -249,7 +249,7 @@ const SideCommentSingle = ({commentId, post, dontTruncateRoot=false, classes}: {
           hideActionsMenu: true,
           isSideComment: true,
         },
-        ...(dontTruncateRoot ? {expandByDefault: true} : {}),
+        ...(dontTruncateRoot ? {forceUnTruncated: true} : {}),
       }}
     />
   </div>

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -207,6 +207,7 @@ const PostsPreviewTooltip = ({ postsList, post, hash, classes, comment }: {
                 truncated
                 comment={renderedComment}
                 hoverPreview
+                forceUnCollapsed
               />
             </div>
           : loading

--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -60,7 +60,7 @@ const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }:
         placement={displayTitle ? "right-start" : "bottom-start"}
       >
       <div className={classes.commentPreview}>
-        <CommentsNode treeOptions={{showPostTitle: true}} comment={comment} expandByDefault/>
+        <CommentsNode treeOptions={{showPostTitle: true}} comment={comment} forceUnTruncated forceUnCollapsed/>
       </div>
     </LWPopper>
   </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -46,7 +46,8 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
                 post: comment.post || undefined,
                 showPostTitle: true,
               }}
-              expandByDefault
+              forceUnTruncated
+              forceUnCollapsed
               comment={comment}
             />)}
     </div>


### PR DESCRIPTION
So... last week I made a PR that used the "expandByDefault" flag (previously used to ensure comments weren't truncated) to also force comments to not be collapsed, because I needed some way to do that.

Then I turned around and immediately noticed a situation where I _do_ want them truncated, but don't want them collapsed.

So, this goes ahead and splits up that functionality, and makes comment hoverovers use the "forceUnCollapsed" flag but not the forceUnTruncated one.

I'm not thrilled with the names here but was lining them up to match with forceSingleline. Feel free to suggest alternatives. I capitalized both the "Un" and the "Collapsed" because otherwise the words blurred together too much for me.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204473123235832) by [Unito](https://www.unito.io)
