### PR TITLE
LW migrate posts, comments, tags, revisions, readstatuses, votes, etc

### DIFF
--- a/packages/lesswrong/lib/collections/commentModeratorActions/collection.ts
+++ b/packages/lesswrong/lib/collections/commentModeratorActions/collection.ts
@@ -7,7 +7,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const CommentModeratorActions: CommentModeratorActionsCollection = createCollection({
   collectionName: 'CommentModeratorActions',
   typeName: 'CommentModeratorAction',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('CommentModeratorActions'),
   mutations: getDefaultMutations('CommentModeratorActions'),

--- a/packages/lesswrong/lib/collections/comments/collection.ts
+++ b/packages/lesswrong/lib/collections/comments/collection.ts
@@ -46,7 +46,7 @@ interface ExtendedCommentsCollection extends CommentsCollection {
 export const Comments: ExtendedCommentsCollection = createCollection({
   collectionName: 'Comments',
   typeName: 'Comment',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Comments'),
   mutations: getDefaultMutations('Comments', commentMutationOptions),

--- a/packages/lesswrong/lib/collections/postRelations/collection.ts
+++ b/packages/lesswrong/lib/collections/postRelations/collection.ts
@@ -6,7 +6,7 @@ import { forumTypeSetting } from '../../instanceSettings';
 export const PostRelations: PostRelationsCollection = createCollection({
   collectionName: 'PostRelations',
   typeName: 'PostRelation',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('PostRelations'),
   logChanges: true,

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -48,7 +48,7 @@ interface ExtendedPostsCollection extends PostsCollection {
 export const Posts: ExtendedPostsCollection = createCollection({
   collectionName: 'Posts',
   typeName: 'Post',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Posts'),
   mutations: getDefaultMutations('Posts', options),

--- a/packages/lesswrong/lib/collections/readStatus/collection.ts
+++ b/packages/lesswrong/lib/collections/readStatus/collection.ts
@@ -43,7 +43,7 @@ const schema: SchemaType<DbReadStatus> = {
 export const ReadStatuses: ReadStatusesCollection = createCollection({
   collectionName: "ReadStatuses",
   typeName: "ReadStatus",
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   logChanges: false,
 });

--- a/packages/lesswrong/lib/collections/revisions/collection.ts
+++ b/packages/lesswrong/lib/collections/revisions/collection.ts
@@ -13,7 +13,7 @@ export const PLAINTEXT_DESCRIPTION_LENGTH = 2000
 export const Revisions: RevisionsCollection = createCollection({
   collectionName: 'Revisions',
   typeName: 'Revision',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Revisions'),
   // No mutations (revisions are insert-only immutable, and are created as a

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -75,7 +75,7 @@ const options: MutationOptions<DbTagFlag> = {
 export const TagFlags: TagFlagsCollection = createCollection({
   collectionName: 'TagFlags',
   typeName: 'TagFlag',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('TagFlags'),
   mutations: getDefaultMutations('TagFlags', options),

--- a/packages/lesswrong/lib/collections/tagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/tagRels/collection.ts
@@ -82,7 +82,7 @@ const schema: SchemaType<DbTagRel> = {
 export const TagRels: TagRelsCollection = createCollection({
   collectionName: 'TagRels',
   typeName: 'TagRel',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('TagRels'),
   mutations: getDefaultMutations('TagRels', {

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -22,7 +22,7 @@ export const EA_FORUM_COMMUNITY_TOPIC_ID = 'ZCihBFp5P64JCvQY6'
 export const Tags: ExtendedTagsCollection = createCollection({
   collectionName: 'Tags',
   typeName: 'Tag',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Tags'),
   mutations: getDefaultMutations('Tags', {

--- a/packages/lesswrong/lib/collections/userTagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/userTagRels/collection.ts
@@ -70,7 +70,7 @@ const schema: SchemaType<DbUserTagRel> = {
 export const UserTagRels: UserTagRelsCollection = createCollection({
   collectionName: 'UserTagRels',
   typeName: 'UserTagRel',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('UserTagRels'),
   mutations: getDefaultMutations('UserTagRels', {

--- a/packages/lesswrong/lib/collections/votes/collection.ts
+++ b/packages/lesswrong/lib/collections/votes/collection.ts
@@ -7,7 +7,7 @@ import { userIsAdminOrMod } from '../../vulcan-users/permissions';
 export const Votes: VotesCollection = createCollection({
   collectionName: 'Votes',
   typeName: 'Vote',
-  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'mongo',
+  collectionType: forumTypeSetting.get() === 'EAForum' ? 'pg' : 'switching',
   schema,
   resolvers: getDefaultResolvers('Votes'),
 });

--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -93,6 +93,7 @@ export async function timedFunc<O>(label: string, func: () => O) {
   } finally {
     const endTime = new Date();
     const runtime = endTime.valueOf() - startTime.valueOf();
+    // eslint-disable-next-line no-console
     console.log(`${label} took ${runtime} ms`);
   }
   return result;

--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -84,3 +84,16 @@ Utils.slugIsUsed = async (collectionName: CollectionNameString, slug: string): P
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export async function timedFunc<O>(label: string, func: () => O) {
+  const startTime = new Date();
+  let result: O;
+  try {
+    result = await func();
+  } finally {
+    const endTime = new Date();
+    const runtime = endTime.valueOf() - startTime.valueOf();
+    console.log(`${label} took ${runtime} ms`);
+  }
+  return result;
+}

--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -85,6 +85,17 @@ export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Logs how long it takes for a function to execute.  See usage example below.
+ * 
+ * Original:
+ * 
+ * `await sql.none(compiled.sql, compiled.args));`
+ * 
+ * Wrapped:
+ * 
+ * `await timedFunc('sql.none', () => sql.none(compiled.sql, compiled.args));`
+ */
 export async function timedFunc<O>(label: string, func: () => O) {
   const startTime = new Date();
   let result: O;

--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -167,7 +167,7 @@ export async function triggerAutomodIfNeededForUser(user: DbUser) {
     // Sort by createdAt descending so that `.find` returns the most recent one matching the condition
     ModeratorActions.find({ userId }, { sort: { createdAt: -1 } }).fetch(),
     Comments.find({ userId }, { sort: { postedAt: -1 }, limit: 20 }).fetch(),
-    Posts.find({ userId, isEvent: false, draft: false }, { sort: { postedAt: -1 }, limit: 20 }).fetch()
+    Posts.find({ userId, isEvent: false, draft: false }, { sort: { postedAt: -1 }, limit: 20, projection: { postedAt: 1, baseScore: 1 } }).fetch()
   ]);
 
   const voteableContent = [...latestComments, ...latestPosts].sort((a, b) => b.postedAt.valueOf() - a.postedAt.valueOf());

--- a/packages/lesswrong/server/scripts/migrateCollections.ts
+++ b/packages/lesswrong/server/scripts/migrateCollections.ts
@@ -15,6 +15,8 @@ import { DatabaseMetadata } from "../../lib/collections/databaseMetadata/collect
 import { LWEvents } from "../../lib/collections/lwevents";
 import { inspect } from "util";
 import { CollectionFilters } from './collectionMigrationFilters';
+import { timedFunc } from "../../lib/helpers";
+import Posts from "../../lib/collections/posts/collection";
 
 type Transaction = ITask<{}>;
 
@@ -25,9 +27,18 @@ const extractObjectId = (value: Record<string, any>): Record<string, any> => {
   return value;
 }
 
+
+const sanitizeNullTerminatingChars = (value: DbRevision['originalContents']) => {
+  if (value.type !== 'markdown') return value;
+  value.data = value.data.replace(/\0/g, '');
+  return value;
+}
+
+const VALID_POST_ID_LENGTHS = new Set([17, 24]);
+
 // Custom formatters to fix data integrity issues on a per-collection basis
 // A place for nasty hacks to live...
-const formatters: Partial<Record<CollectionNameString, (document: DbObject) => DbObject>> = {
+const formatters: Partial<Record<CollectionNameString, (document: DbObject) => DbObject | Promise<DbObject | undefined>>> = {
   Posts: (post: DbPost): DbPost => {
     const scoreThresholds = [2, 30, 45, 75, 125, 200] as const;
     for (const threshold of scoreThresholds) {
@@ -94,6 +105,54 @@ const formatters: Partial<Record<CollectionNameString, (document: DbObject) => D
       spotlight.showAuthor = false;
     }
     return spotlight;
+  },
+  Comments: (comment: DbComment): DbComment => {
+    if (comment.contents?.originalContents) {
+      comment.contents.originalContents = sanitizeNullTerminatingChars(comment.contents.originalContents);
+    }
+    return comment;
+  },
+  Messages: (message: DbMessage): DbMessage => {
+    if (message.contents?.originalContents) {
+      message.contents.originalContents = sanitizeNullTerminatingChars(message.contents.originalContents);
+    }
+    return message;
+  },
+  Revisions: (revision: DbRevision): DbRevision => {
+    if (revision.originalContents) {
+      revision.originalContents = sanitizeNullTerminatingChars(revision.originalContents);
+    }
+    return revision;
+  },
+  ReadStatuses: async (readStatus: DbReadStatus): Promise<DbReadStatus | undefined> => {
+    if (readStatus.postId && !VALID_POST_ID_LENGTHS.has(readStatus.postId.length)) {
+      const maybeSlug = readStatus.postId;
+      if (maybeSlug !== 'null' && maybeSlug !== 'undefined') {
+        console.log(`ReadStatus with invalid postId ${maybeSlug}, checking if it's a slug`);
+        const postBySlug = await Posts.findOne({ slug: maybeSlug });
+        if (postBySlug) {
+          console.log(`Found post with slug ${maybeSlug}, id: ${postBySlug._id}`);
+          readStatus.postId = postBySlug._id;
+        } else {
+          // These cases are annoying to handle via collection query filters, so just filter them out here
+          return undefined;
+        }
+      } else {
+        return undefined;
+      }
+    }
+    return readStatus;
+  },
+  Votes: (vote: DbVote): DbVote => {
+    if (typeof vote.userId !== 'string') {
+      if (!('_str' in vote.userId)) {
+        throw new Error(`Unrecognized vote userId: ${JSON.stringify(vote.userId)}`);
+      }
+
+      // @ts-ignore - LW had some legacy imported data where userId was an object shaped like { _str: string }
+      vote.userId = vote.userId._str;
+    }
+    return vote;
   }
 };
 
@@ -195,6 +254,8 @@ const makeCollectionFilter = (collectionName: string) => {
 const isNonIdSortField = (collectionName: string) => {
   switch (collectionName) {
     case 'EmailTokens': return false;
+    case 'Posts': return false;
+    case 'ReadStatuses': return false;
     default: return true;
   }
 };
@@ -203,8 +264,6 @@ const getCollectionSortField = (collectionName: string) => {
   switch (collectionName) {
     case 'DebouncerEvents': return 'delayTime';
     case 'Migrations': return 'started';
-    case 'ReadStatuses': return 'lastUpdated';
-    case 'Revisions': return 'editedAt';
     case 'Votes': return 'votedAt';
     default: return 'createdAt';
   }
@@ -264,10 +323,11 @@ const copyData = async (
         const end = count + documents.length;
         console.log(`.........Migrating '${collection.getName()}' documents ${count}-${end} of ${totalCount}`);
         count += batchSize;
-        const query = new InsertQuery(table, documents.map(formatter), {}, {conflictStrategy: "ignore"});
+        const formattedDocuments = (await Promise.all(documents.map(formatter))).filter((doc): doc is DbObject => !!doc);
+        const query = new InsertQuery(table, formattedDocuments, {}, {conflictStrategy: "ignore"});
         const compiled = query.compile();
         try {
-          await sql.none(compiled.sql, compiled.args);
+          await timedFunc('sql.none', () => sql.none(compiled.sql, compiled.args));
         } catch (e) {
           console.log(documents);
           console.error(e);


### PR DESCRIPTION
In `Comments`, `Messages`, and `Revisions`, we had a few records with null-terminating characters (`\u0000`) which can't be represented as a string, and therefore couldn't be inserted into the `jsonb`-typed `contents` field in postgres.

In `ReadStatuses`, we had some records with `postId` values that weren't actual post IDs.  Some of those were post slugs, for some reason, which meant those are recoverable; others were random junk.  (Some of them were the string "null", which unfortunately is also a valid post slug.  I chose to exclude those, since that post was a draft and I doubt that's what those ReadStatuses were actually meant to point at.)

In `Votes` we had some imported agentFoundations votes which had `userId` shaped like `{ _str: $userId }`.

Collections in dev were migrated according to the most convenient available sort field:
`CommentModeratorActions`: `createdAt`
`Comments`: `createdAt` (created a new index for this)
`PostRelations`: `createdAt`
`Posts`: `_id` (would've preferred to use `createdAt`, but can't create a new index since we already have 64, and didn't feel comfortable dropping an existing one, given what's happened in the past)
`ReadStatuses`: `_id` (don't have `createdAt`, since they're created with a raw upsert)
`Revisions`: `createdAt` (created a new index for this)
`TagFlags`: `createdAt`
`TagRels`: `createdAt`
`Tags`: `createdAt`
`UserTagRels`: `createdAt`
`Votes`: `votedAt`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204473235276280) by [Unito](https://www.unito.io)
