### PR TITLE
Exclude images and links from EA user bio preview

### DIFF
--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -74,7 +74,12 @@ const formatRole = (jobTitle?: string, organization?: string): string =>
     ? `${jobTitle} @ ${organization}`
     : (jobTitle || organization) ?? "";
 
-const formatBio = (bio?: string): string => htmlToText(bio ?? "");
+const formatBio = (bio?: string): string => htmlToText(bio ?? "", {
+  selectors: [
+    {selector: "a", options: {ignoreHref: true}},
+    {selector: "img", format: "skip"},
+  ],
+});
 
 const formatStat = (value?: number): string => {
   value ??= 0;


### PR DESCRIPTION
Tidy up the formatting of user bios in the new users hover-over by removing images and link hrefs.

Before:
<img width="293" alt="Screenshot 2023-04-26 at 12 39 12" src="https://user-images.githubusercontent.com/5075628/234564052-85d7aaff-a34d-4ef9-9968-01c4488f780f.png">

After:
<img width="293" alt="Screenshot 2023-04-26 at 12 39 17" src="https://user-images.githubusercontent.com/5075628/234564040-e7851ffe-d477-4e91-9c15-d6015c32827e.png">
