### PR TITLE
[EA Forum only] move bookmark icon out of post item, replace with three dots menu

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -144,8 +144,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   postActions: {
     minWidth: 20,
-    "&:hover": {
-      opacity: 0.5,
+    "&:hover .PostActionsButton-icon": {
+      color: theme.palette.grey[800],
     },
   },
   hideOnMobile: {

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -142,16 +142,11 @@ export const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: 700,
     color: theme.palette.grey[1000],
   },
-  bookmark: {
+  postActions: {
     minWidth: 20,
     "&:hover": {
       opacity: 0.5,
     },
-  },
-  bookmarkIcon: {
-    fontSize: 18,
-    marginTop: 2,
-    color: theme.palette.grey[600],
   },
   hideOnMobile: {
     [theme.breakpoints.down("xs")]: {
@@ -233,7 +228,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
   }
 
   const {
-    PostsTitle, PostsItemDate, ForumIcon, BookmarkButton, PostsItemKarma, FooterTag,
+    PostsTitle, PostsItemDate, ForumIcon, PostActionsButton, PostsItemKarma, FooterTag,
     TruncatedAuthorsList, PostsItemTagRelevance, PostsItemTooltipWrapper,
     PostsItemTrailingButtons, PostReadCheckbox, PostsItemNewCommentsWrapper,
   } = Components;
@@ -247,9 +242,9 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
         <ForumIcon icon="Comment" />
         {commentCount}
       </a>
-      <div className={classes.bookmark}>
+      <div className={classes.postActions}>
         <InteractionWrapper classes={classes}>
-          <BookmarkButton post={post} className={classes.bookmarkIcon} />
+          <PostActionsButton post={post} popperPlacement="left-start" />
         </InteractionWrapper>
       </div>
     </>

--- a/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
+++ b/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
@@ -5,6 +5,7 @@ import MoreVertIcon from '@material-ui/icons/MoreVert';
 import { useCurrentUser } from '../../common/withUser';
 import { useTracking } from '../../../lib/analyticsEvents';
 import { isEAForum } from '../../../lib/instanceSettings';
+import { PopperPlacementType } from '@material-ui/core/Popper';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -12,6 +13,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   icon: {
     verticalAlign: 'middle',
+    color: isEAForum ? theme.palette.grey[500] : undefined,
     cursor: "pointer",
   },
   popper: {
@@ -20,8 +22,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const PostActionsButton = ({post, vertical, classes}: {
+const PostActionsButton = ({post, popperPlacement='right-start', vertical, classes}: {
   post: PostsList|SunshinePostsList,
+  popperPlacement?: PopperPlacementType,
   vertical?: boolean,
   classes: ClassesType,
 }) => {
@@ -46,7 +49,7 @@ const PostActionsButton = ({post, vertical, classes}: {
     <PopperCard
       open={isOpen}
       anchorEl={anchorEl.current}
-      placement="right-start"
+      placement={popperPlacement}
       allowOverflow
     >
       {/*FIXME: ClickAwayListener doesn't handle portals correctly, which winds up making submenus inoperable. But we do still need clickaway to close.*/}

--- a/packages/lesswrong/components/posts/PostsItemTrailingButtons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemTrailingButtons.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from "../../lib/vulcan-lib";
 import type { UsePostsItem } from "./usePostsItem";
 import ArchiveIcon from "@material-ui/icons/Archive";
 import CloseIcon from "@material-ui/icons/Close";
+import { isEAForum } from "../../lib/instanceSettings";
 
 export const MENU_WIDTH = 18;
 
@@ -86,21 +87,15 @@ const PostsItemTrailingButtons = ({
 
   return (
     <>
-      {
-        <div className={classes.actions}>
-          <DismissButton {...{showDismissButton, onDismiss}} />
-          {!resumeReading && <PostActionsButton post={post} vertical />}
-        </div>
-      }
-      {
-        <div className={classes.archiveButton}>
-          {showArchiveButton &&
-            <LWTooltip title={archiveDraftTooltip} placement="right">
-              <ArchiveIcon onClick={onArchive} />
-            </LWTooltip>
-          }
-        </div>
-      }
+      {(showDismissButton || resumeReading || !isEAForum) && <div className={classes.actions}>
+        <DismissButton {...{showDismissButton, onDismiss}} />
+        {!isEAForum && !resumeReading && <PostActionsButton post={post} vertical />}
+      </div>}
+      {showArchiveButton && <div className={classes.archiveButton}>
+        <LWTooltip title={archiveDraftTooltip} placement="right">
+          <ArchiveIcon onClick={onArchive} />
+        </LWTooltip>
+      </div>}
     </>
   );
 }


### PR DESCRIPTION
This PR moves the bookmark icon out of the EA Forum's post item into the three dots menu, and moves the three dots menu icon into the post item.

<img width="702" alt="Screen Shot 2023-04-26 at 12 12 24 PM" src="https://user-images.githubusercontent.com/9057804/234636898-069303f6-991d-4461-b6ed-e284704d1a3c.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204480829488979) by [Unito](https://www.unito.io)
