### PR TITLE
Show online events where mongoLocation is null

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1035,6 +1035,7 @@ Posts.addView("nearbyEvents", (terms: PostsViewTerms) => {
             }
           }
         },
+        {$and: [{mongoLocation: {$exists: false}}, {onlineEvent: true}]},
         {globalEvent: true} // also include events that are open to everyone around the world
       ]
     },

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -970,7 +970,13 @@ Posts.addView("globalEvents", (terms: PostsViewTerms) => {
   
   let query = {
     selector: {
-      globalEvent: true,
+      $or: [
+        {globalEvent: true},
+        {$and: [
+          {onlineEvent: true},
+          {mongoLocation: {$exists: false}},
+        ]},
+      ],
       isEvent: true,
       groupId: null,
       eventType: terms.eventType ? {$in: terms.eventType} : null,


### PR DESCRIPTION
Bug reported for smalls. Some events (such as https://forum.effectivealtruism.org/events/e9zLaDDNupnciRhvy/presentation-and-discussion) are not showing up on the events page.

Suprisingly, it looks like this is actually just a legit bug in the selector that wasn't caused by the Postgres migration. When filtering by location, we include events that are either within the user's configured distance or are marked as `globalEvent`. Many online events, however, have a null `mongoLocation` and so are never returned. The change here is to include events with a null `mongoLocation`, but only if they're also marked as `onlineEvent`.

Maybe the hope was that such events would also be marked as `globalEvent`, but empirically that is often not the case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204486450463250) by [Unito](https://www.unito.io)
