### PR TITLE
[EA Forum only] followup UI tweaks after removing post item bookmark icon

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -250,7 +250,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
       </a>
       {currentUser && <div className={classes.postActions}>
         <InteractionWrapper classes={classes}>
-          <PostActionsButton post={post} popperPlacement="left-start" />
+          <PostActionsButton post={post} popperPlacement="left-start" vertical />
         </InteractionWrapper>
       </div>}
     </>

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -8,6 +8,7 @@ import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { useClickableCell } from "../common/useClickableCell";
+import { useCurrentUser } from "../common/withUser";
 
 export const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -144,8 +145,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   postActions: {
     minWidth: 20,
+    marginLeft: -5,
+    "& .PostActionsButton-icon": {
+      fontSize: 20,
+    },
     "&:hover .PostActionsButton-icon": {
-      color: theme.palette.grey[800],
+      color: theme.palette.grey[700],
     },
   },
   hideOnMobile: {
@@ -222,6 +227,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
   } = usePostsItem(props);
   const {onClick} = useClickableCell(postLink);
   const authorExpandContainer = useRef(null);
+  const currentUser = useCurrentUser()
 
   if (isRepeated) {
     return null;
@@ -242,11 +248,11 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
         <ForumIcon icon="Comment" />
         {commentCount}
       </a>
-      <div className={classes.postActions}>
+      {currentUser && <div className={classes.postActions}>
         <InteractionWrapper classes={classes}>
           <PostActionsButton post={post} popperPlacement="left-start" />
         </InteractionWrapper>
-      </div>
+      </div>}
     </>
   );
 

--- a/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
+++ b/packages/lesswrong/components/posts/PostActions/PostActionsButton.tsx
@@ -13,7 +13,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   icon: {
     verticalAlign: 'middle',
-    color: isEAForum ? theme.palette.grey[500] : undefined,
+    color: isEAForum ? theme.palette.grey[400] : undefined,
     cursor: "pointer",
   },
   popper: {


### PR DESCRIPTION
Addressing @agnesstenlund's comments in https://github.com/ForumMagnum/ForumMagnum/pull/7033, as well as adjusting the post item for logged out users (who can't see the three dots menu)

Logged in view:
<img width="720" alt="Screen Shot 2023-04-27 at 2 51 35 PM" src="https://user-images.githubusercontent.com/9057804/234965739-8911e85d-d7e8-4b6d-8146-54f1f3dbbf09.png">

-----
Logged out view:
<img width="720" alt="Screen Shot 2023-04-27 at 2 42 53 PM" src="https://user-images.githubusercontent.com/9057804/234965782-3854f667-df4d-49e7-bec1-479a1df1cf7c.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204490813164384) by [Unito](https://www.unito.io)
