### PR TITLE
Exclude april fools day posts from recommendations

### DIFF
--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -16,7 +16,8 @@ interface ExtendedTagsCollection extends TagsCollection {
   toAlgolia: (tag: DbTag) => Promise<Array<AlgoliaDocument>|null>
 }
 
-export const EA_FORUM_COMMUNITY_TOPIC_ID = 'ZCihBFp5P64JCvQY6'
+export const EA_FORUM_COMMUNITY_TOPIC_ID = 'ZCihBFp5P64JCvQY6';
+export const EA_FORUM_APRIL_FOOLS_DAY_TOPIC_ID = '4saLTjJHsbduczFti';
 
 export const Tags: ExtendedTagsCollection = createCollection({
   collectionName: 'Tags',


### PR DESCRIPTION
This PR just handles the frontpage recommendations section. Post page recommendations are handled separately in the `posts-page-recommendations` branch.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204491599442865) by [Unito](https://www.unito.io)
