### PR TITLE
Show correct read time and word count for dialogues

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -333,7 +333,7 @@ const PostsPage = ({post, refetch, classes}: {
             />
           </div>}
         <PostCoauthorRequest post={post} currentUser={currentUser} />
-        <PostsPagePostHeader post={post} answers={answers ?? []} toggleEmbeddedPlayer={toggleEmbeddedPlayer}/>
+        <PostsPagePostHeader post={post} answers={answers ?? []} toggleEmbeddedPlayer={toggleEmbeddedPlayer} dialogueResponses={debateResponses}/>
         </div>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -202,7 +202,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
     }
 
     return Math.max(1, Math.round(wordCount / 250));
-  }, [post, dialogueResponses]);
+  }, [post, dialogueResponses, wordCount]);
 
   const {
     answerCount,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -149,9 +149,10 @@ const getResponseCounts = (
 
 /// PostsPagePostHeader: The metadata block at the top of a post page, with
 /// title, author, voting, an actions menu, etc.
-const PostsPagePostHeader = ({post, answers = [], toggleEmbeddedPlayer, hideMenu, hideTags, classes}: {
+const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggleEmbeddedPlayer, hideMenu, hideTags, classes}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
   answers?: CommentsList[],
+  dialogueResponses?: CommentsList[],
   toggleEmbeddedPlayer?: () => void,
   hideMenu?: boolean,
   hideTags?: boolean,
@@ -178,8 +179,30 @@ const PostsPagePostHeader = ({post, answers = [], toggleEmbeddedPlayer, hideMenu
   const feedLink = post.feed?.url && `${getProtocol(post.feed.url)}//${getHostname(post.feed.url)}`;
   const { major } = extractVersionsFromSemver(post.version)
   const hasMajorRevision = major > 1
-  const wordCount = post.contents?.wordCount || 0
-  const readTime = post.readTimeMinutes ?? 1
+
+  const wordCount = useMemo(() => {
+    if (!post.debate || dialogueResponses.length === 0) {
+      return post.contents?.wordCount || 0;
+    }
+
+    return dialogueResponses.reduce((wordCount, response) => {
+      wordCount += response.contents?.wordCount ?? 0;
+      return wordCount;
+    }, 0);
+  }, [post, dialogueResponses]);
+
+  /**
+   * It doesn't make a ton of sense to fetch all the debate response comments in the resolver field, since we:
+   * 1. already have them here
+   * 2. need them to compute the word count in the debate case as well
+   */
+  const readTime = useMemo(() => {
+    if (!post.debate || dialogueResponses.length === 0) {
+      return post.readTimeMinutes ?? 1;
+    }
+
+    return Math.max(1, Math.round(wordCount / 250));
+  }, [post, dialogueResponses]);
 
   const {
     answerCount,


### PR DESCRIPTION
Dialogues would previously show `1 min read` (~0 words), because they were based on the post's contents' wordCount (which would be only the word count of the first dialogue response, because of how dialogues work).

This doesn't solve for showing read times in e.g. `EAPostsItem`, though, since you don't have all the comments that make up the dialogue contents there.  (That might have to be changed regardless when fixing the hover-over preview, which doesn't currently work for similar reasons.)

Not urgent, @jpaddison3 (if you want to think about this).

<img width="714" alt="image" src="https://user-images.githubusercontent.com/2136984/235030878-4c69747e-130f-49cf-88fe-9516d45a1dd7.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204492739799669) by [Unito](https://www.unito.io)
