### PR TITLE
Prevent form inputs from clearing after accepting the TOS

### DIFF
--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -51,7 +51,6 @@ const PostsAcceptTos = ({currentUser, classes}: {
       acceptedTos: true,
     });
     const accepted = result?.data?.updateUser?.data?.acceptedTos;
-    console.log(result, accepted);
     if (accepted) {
       flash("Thank you for accepting the terms of use");
       setAccepted(true);

--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState, useCallback } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
-import { forumTypeSetting } from "../../lib/instanceSettings";
+import { isEAForum } from "../../lib/instanceSettings";
 import { gql, useMutation } from "@apollo/client";
 import { useMessages } from "../common/withMessages";
 import { Link } from "../../lib/reactRouterWrapper";
@@ -37,11 +37,12 @@ const PostsAcceptTos = ({currentUser, classes}: {
   classes: ClassesType,
 }) => {
   const [loading, setLoading] = useState(false);
+  const [accepted, setAccepted] = useState(currentUser.acceptedTos);
   const [acceptTos] = useMutation(gql`
     mutation AcceptTos {
       UserAcceptTos
     }
-  `, {refetchQueries: ['getCurrentUser']})
+  `);
   const {flash} = useMessages();
 
   const onAccept = useCallback(async () => {
@@ -54,13 +55,14 @@ const PostsAcceptTos = ({currentUser, classes}: {
     const accepted = result?.data?.UserAcceptTos;
     if (accepted) {
       flash("Thank you for accepting the terms of use");
+      setAccepted(true);
     } else {
       flash("Error: Something went wrong, please try again");
       setLoading(false);
     }
   }, [loading, setLoading, flash, acceptTos]);
 
-  if (forumTypeSetting.get() !== "EAForum" || currentUser.acceptedTos) {
+  if (!isEAForum || accepted) {
     return null;
   }
 

--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useCallback } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { isEAForum } from "../../lib/instanceSettings";
-import { gql, useMutation } from "@apollo/client";
+import { useUpdateCurrentUser } from "../hooks/useUpdateCurrentUser";
 import { useMessages } from "../common/withMessages";
 import { Link } from "../../lib/reactRouterWrapper";
 import Checkbox from '@material-ui/core/Checkbox';
@@ -38,11 +38,7 @@ const PostsAcceptTos = ({currentUser, classes}: {
 }) => {
   const [loading, setLoading] = useState(false);
   const [accepted, setAccepted] = useState(currentUser.acceptedTos);
-  const [acceptTos] = useMutation(gql`
-    mutation AcceptTos {
-      UserAcceptTos
-    }
-  `);
+  const updateCurrentUser = useUpdateCurrentUser();
   const {flash} = useMessages();
 
   const onAccept = useCallback(async () => {
@@ -51,8 +47,11 @@ const PostsAcceptTos = ({currentUser, classes}: {
     }
 
     setLoading(true);
-    const result = await acceptTos();
-    const accepted = result?.data?.UserAcceptTos;
+    const result = await updateCurrentUser({
+      acceptedTos: true,
+    });
+    const accepted = result?.data?.updateUser?.data?.acceptedTos;
+    console.log(result, accepted);
     if (accepted) {
       flash("Thank you for accepting the terms of use");
       setAccepted(true);
@@ -60,7 +59,7 @@ const PostsAcceptTos = ({currentUser, classes}: {
       flash("Error: Something went wrong, please try again");
       setLoading(false);
     }
-  }, [loading, setLoading, flash, acceptTos]);
+  }, [loading, setLoading, flash, updateCurrentUser]);
 
   if (!isEAForum || accepted) {
     return null;

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -593,9 +593,20 @@ export class Form<T extends DbObject> extends Component<SmartFormProps,FormState
 
   */
   UNSAFE_componentWillReceiveProps(nextProps: SmartFormProps) {
-    const needReset = !!RESET_PROPS.find(prop => !isEqual(this.props[prop], nextProps[prop]));
-    if (needReset) {
-      this.setState(getInitialStateFromProps(nextProps));
+    for (const prop of RESET_PROPS) {
+      const prev = this.props[prop];
+      const next = nextProps[prop];
+      if (!isEqual(prev, next)) {
+        if (
+          prop === "currentUser" &&
+          prev._id === next._id &&
+          prev.acceptedTos !== next.acceptedTos
+        ) {
+          continue;
+        }
+        this.setState(getInitialStateFromProps(nextProps));
+        break;
+      }
     }
   }
 

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -29,8 +29,8 @@ import { getAdminTeamAccount } from './commentCallbacks';
 const MINIMUM_APPROVAL_KARMA = 5
 
 if (forumTypeSetting.get() === "EAForum") {
-  const checkTosAccepted = <T extends Partial<DbPost>>(currentUser: DbUser | null, post: T, oldPost?: DbPost): T => {
-    if (post.draft === false && !post.shortform && (!oldPost || oldPost.draft) && !currentUser?.acceptedTos) {
+  const checkTosAccepted = <T extends Partial<DbPost>>(currentUser: DbUser | null, post: T): T => {
+    if (post.draft === false && !post.shortform && !currentUser?.acceptedTos) {
       throw new Error(TOS_NOT_ACCEPTED_ERROR);
     }
     return post;
@@ -39,7 +39,7 @@ if (forumTypeSetting.get() === "EAForum") {
     (post: DbPost, currentUser) => checkTosAccepted(currentUser, post),
   );
   getCollectionHooks("Posts").updateBefore.add(
-    (post, {oldDocument: oldPost, currentUser}) => checkTosAccepted(currentUser, post, oldPost),
+    (post, {currentUser}) => checkTosAccepted(currentUser, post),
   );
 }
 

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -162,6 +162,7 @@ addGraphQLResolvers({
       // Don't want to return the whole object without more permission checking
       return pick(updatedUser, 'username', 'slug', 'displayName', 'subscribedToCurated', 'usernameUnset')
     },
+    // TODO: Deprecated
     async UserAcceptTos(_root: void, _args: {}, {currentUser}: ResolverContext) {
       if (!currentUser) {
         throw new Error('Cannot accept terms of use while not logged in');
@@ -401,6 +402,7 @@ async function getEngagement (userId : string): Promise<{totalSeconds: number, e
 addGraphQLMutation(
   'NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!, email: String, acceptedTos: Boolean): NewUserCompletedProfile'
 )
+// TODO: Derecated
 addGraphQLMutation(
   'UserAcceptTos: Boolean'
 )


### PR DESCRIPTION
Currently, if you enter some text into the new post/edit post/new question/etc. pages and then click the checkbox to accept the TOS, all the text you entered will be deleted.

If you've already accepted the TOS, you can test this easily with `UPDATE "Users" SET "acceptedTos" = FALSE WHERE slug = '...'`.