### PR TITLE
Add geolocation to cookie banner (plus other cleanup)

### DIFF
--- a/packages/lesswrong/client/datadogRum.ts
+++ b/packages/lesswrong/client/datadogRum.ts
@@ -2,21 +2,19 @@ import { datadogRum } from '@datadog/browser-rum';
 import { getDatadogUser } from '../lib/collections/users/helpers';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { ddRumSampleRate, ddSessionReplaySampleRate, ddTracingSampleRate } from '../lib/publicSettings';
-import { Cookies } from 'react-cookie';
-import { COOKIE_PREFERENCES_COOKIE } from '../lib/cookies/cookies';
+import { getCookiePreferences } from '../lib/cookies/utils';
 
 let datadogInitialized = false;
 
-export function initDatadog() {
-  const cookies = new Cookies();
+export async function initDatadog() {
+  const { cookiePreferences } = await getCookiePreferences();
 
-  const allowedCookies = cookies.get(COOKIE_PREFERENCES_COOKIE) || ["necessary"];
-  const analyticsCookiesAllowed = allowedCookies.includes("analytics");
+  const analyticsCookiesAllowed = cookiePreferences.includes("analytics");
 
   if (forumTypeSetting.get() !== 'EAForum') return
   if (!analyticsCookiesAllowed) {
     // eslint-disable-next-line no-console
-    console.warn("Not initializing datadog because analytics cookies are not allowed")
+    console.log("Not initializing datadog because analytics cookies are not allowed")
     return
   }
 

--- a/packages/lesswrong/client/datadogStart.ts
+++ b/packages/lesswrong/client/datadogStart.ts
@@ -1,3 +1,3 @@
 import { initDatadog } from "./datadogRum";
 
-initDatadog();
+void initDatadog();

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -22,8 +22,7 @@ import { DisableNoKibitzContext } from './users/UsersNameDisplay';
 import { LayoutOptions, LayoutOptionsContext } from './hooks/useLayoutOptions';
 // enable during ACX Everywhere
 import { HIDE_MAP_COOKIE } from './seasonal/HomepageMap/HomepageMapFilter';
-import { useCookiesWithConsent } from './hooks/useCookiesWithConsent';
-import { COOKIE_PREFERENCES_COOKIE } from '../lib/cookies/cookies';
+import { useCookiePreferences } from './hooks/useCookiesWithConsent';
 
 export const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 0)
 const petrovAfterTime = new DatabasePublicSetting<number>('petrov.afterTime', 0)
@@ -181,7 +180,12 @@ const Layout = ({currentUser, children, classes}: {
   const theme = useTheme();
   const { currentRoute, params: { slug }, pathname} = useLocation();
   const layoutOptionsState = React.useContext(LayoutOptionsContext);
-  const [cookies] = useCookiesWithConsent()
+  const { explicitConsentGiven: cookieConsentGiven, explicitConsentRequired: cookieConsentRequired } = useCookiePreferences();
+  const showCookieBanner = cookieConsentRequired === true && !cookieConsentGiven;
+
+  // enable during ACX Everywhere
+  // const [cookies] = useCookiesWithConsent()
+  // const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !cookies[HIDE_MAP_COOKIE]
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",
@@ -276,12 +280,6 @@ const Layout = ({currentUser, children, classes}: {
         && currentTime < afterTime
     }
 
-    // enable during ACX Everywhere
-    // const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !cookies[hideMapCookieName]
-
-    // cookies[COOKIE_PREFERENCES_COOKIE] is a list of allowed cookie types, if it doesn't exist, that means the user has not yet made a choice
-    const showCookieBanner = !cookies[COOKIE_PREFERENCES_COOKIE]
-
     return (
       <AnalyticsContext path={pathname}>
       <UserContext.Provider value={currentUser}>
@@ -306,7 +304,9 @@ const Layout = ({currentUser, children, classes}: {
               <AnalyticsPageInitializer/>
               <NavigationEventSender/>
               {/* Only show intercom after they have accepted cookies */}
-              {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}
+              <NoSSR>
+                {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}
+              </NoSSR>
 
               <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
               {/* Google Tag Manager i-frame fallback */}

--- a/packages/lesswrong/components/common/CookieBanner/CookieBanner.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookieBanner.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import Button from "@material-ui/core/Button";
 import classNames from "classnames";
 import { useDialog } from "../withDialog";
-import { useUpdateCookiePreferences } from "../../hooks/useCookiesWithConsent";
+import { useCookiePreferences } from "../../hooks/useCookiesWithConsent";
 
 const styles = (theme: ThemeType) => ({
   bannerContainer: {
@@ -71,7 +71,7 @@ const styles = (theme: ThemeType) => ({
 
 const CookieBanner = ({ classes }: { classes: ClassesType }) => {
   const { openDialog } = useDialog();
-  const [_, updateCookiePreferences] = useUpdateCookiePreferences();
+  const { updateCookiePreferences } = useCookiePreferences();
   
   const handleAcceptAll = () => {
     updateCookiePreferences(["necessary", "functional", "analytics"]);

--- a/packages/lesswrong/components/common/CookieBanner/CookieDialog.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookieDialog.tsx
@@ -5,9 +5,8 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import Checkbox from "@material-ui/core/Checkbox";
 import classNames from "classnames";
 import Button from "@material-ui/core/Button";
-import { CookieType, CookiesTable, isValidCookieTypeArray } from "../../../lib/cookies/utils";
-import { useUpdateCookiePreferences } from "../../hooks/useCookiesWithConsent";
-import { COOKIE_PREFERENCES_COOKIE } from "../../../lib/cookies/cookies";
+import { CookieType, CookiesTable } from "../../../lib/cookies/utils";
+import { useCookiePreferences } from "../../hooks/useCookiesWithConsent";
 
 const styles = (theme: ThemeType) => ({
   dialog: {
@@ -154,11 +153,8 @@ const CookieCategory = ({
 const CookieDialog = ({ onClose, classes }: { onClose?: () => void; classes: ClassesType }) => {
   const { LWDialog, Typography } = Components;
 
-  const [cookies, updateCookiePreferences] = useUpdateCookiePreferences();
-  const existingCookiePreferences = isValidCookieTypeArray(cookies[COOKIE_PREFERENCES_COOKIE])
-    ? cookies[COOKIE_PREFERENCES_COOKIE]
-    : ["necessary"];
-  const [allowedCookies, setAllowedCookies] = useState<CookieType[]>(existingCookiePreferences);
+  const { cookiePreferences, updateCookiePreferences } = useCookiePreferences();
+  const [allowedCookies, setAllowedCookies] = useState<CookieType[]>(cookiePreferences);
 
   const saveAndClose = useCallback(() => {
     updateCookiePreferences(allowedCookies);

--- a/packages/lesswrong/components/common/CookieBanner/geolocation.ts
+++ b/packages/lesswrong/components/common/CookieBanner/geolocation.ts
@@ -1,0 +1,126 @@
+import { isServer } from "../../../lib/executionEnvironment";
+import { isEAForum } from "../../../lib/instanceSettings";
+
+const GDPR_COUNTRY_CODES: string[] = [
+  "AT", // Austria
+  "BE", // Belgium
+  "BG", // Bulgaria
+  "HR", // Croatia
+  "CY", // Cyprus
+  "CZ", // Czech Republic
+  "DK", // Denmark
+  "EE", // Estonia
+  "FI", // Finland
+  "FR", // France
+  "DE", // Germany
+  "GR", // Greece
+  "HU", // Hungary
+  "IE", // Ireland
+  "IT", // Italy
+  "LV", // Latvia
+  "LT", // Lithuania
+  "LU", // Luxembourg
+  "MT", // Malta
+  "NL", // Netherlands
+  "PL", // Poland
+  "PT", // Portugal
+  "RO", // Romania
+  "SK", // Slovakia
+  "SI", // Slovenia
+  "ES", // Spain
+  "SE", // Sweden
+  "GB", // United Kingdom
+];
+
+function getCountryCodeFromLocalStorage(): string | null {
+  const cachedCountryCode = localStorage.getItem('countryCode');
+  const cachedTimestamp = localStorage.getItem('countryCodeTimestamp');
+
+  if (!cachedCountryCode || !cachedTimestamp) {
+    return null;
+  }
+
+  const currentTime = new Date().getTime();
+  const timeDifference = currentTime - parseInt(cachedTimestamp);
+
+  // 24 hours
+  const cacheTTL = 24 * 60 * 60 * 1000;
+  if (timeDifference > cacheTTL) {
+    localStorage.removeItem('countryCode');
+    localStorage.removeItem('countryCodeTimestamp');
+    return null;
+  }
+
+  return cachedCountryCode;
+}
+
+function setCountryCodeToLocalStorage(countryCode: string) {
+  const timestamp = new Date().getTime();
+  localStorage.setItem('countryCode', countryCode);
+  localStorage.setItem('countryCodeTimestamp', timestamp.toString());
+}
+
+function getCachedUserCountryCode() {
+  if (isServer) return null;
+
+  const cachedCountryCode = getCountryCodeFromLocalStorage();
+  if (cachedCountryCode) {
+    return cachedCountryCode;
+  }
+  return null;
+}
+
+async function getUserCountryCode({ signal }: { signal?: AbortSignal } = {}): Promise<string | null> {
+  if (isServer) return null;
+
+  const cachedCountryCode = getCachedUserCountryCode();
+  if (cachedCountryCode) {
+    return cachedCountryCode;
+  }
+
+  const response = await fetch('https://ipapi.co/json/', { signal });
+
+  if (!response.ok) {
+    throw new Error(`Error fetching user country: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  const countryCode = data.country;
+  setCountryCodeToLocalStorage(countryCode);
+  return countryCode;
+}
+
+export function getExplicitConsentRequiredSync(): boolean | "unknown" {
+  if (isServer) return "unknown";
+  if (!isEAForum) return false;
+
+  const cachedCountryCode = getCachedUserCountryCode();
+  if (cachedCountryCode) {
+    return GDPR_COUNTRY_CODES.includes(cachedCountryCode);
+  }
+  return "unknown";
+}
+
+export async function getExplicitConsentRequiredAsync(): Promise<boolean | "unknown"> {
+  if (isServer) return "unknown";
+  if (!isEAForum) return false;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const countryCode = await getUserCountryCode({ signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (countryCode) {
+      return GDPR_COUNTRY_CODES.includes(countryCode);
+    }
+    return true;
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    // If there is any error (such as due to timing out), assume consent IS required
+    return true;
+  }
+}
+

--- a/packages/lesswrong/components/common/IntercomWrapper.tsx
+++ b/packages/lesswrong/components/common/IntercomWrapper.tsx
@@ -6,7 +6,7 @@ import { getUserEmail } from "../../lib/collections/users/helpers";
 import { useLocation } from '../../lib/routeUtil';
 import withErrorBoundary from './withErrorBoundary'
 import Intercom from '../../lib/vendor/react-intercom';
-import { useCheckCookieConsent } from '../hooks/useCookiesWithConsent';
+import { useCookiePreferences } from '../hooks/useCookiesWithConsent';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 
@@ -29,15 +29,15 @@ const IntercomWrapper = ({classes}: {
   const currentUser = useCurrentUser();
   const { currentRoute } = useLocation();
 
-  const { checkCookieConsent } = useCheckCookieConsent()
-  const functionalCookiesAllowed = checkCookieConsent(['functional'])
+  const { cookiePreferences } = useCookiePreferences()
+  const functionalCookiesAllowed = cookiePreferences.includes('functional')
   
   if (currentRoute?.standalone) {
     return null;
   }
   if (!functionalCookiesAllowed) {
     // eslint-disable-next-line no-console
-    console.warn("Not showing Intercom because functional cookies are not allowed")
+    console.log("Not showing Intercom because functional cookies are not allowed")
     return null;
   }
   

--- a/packages/lesswrong/components/common/hocTypes.ts
+++ b/packages/lesswrong/components/common/hocTypes.ts
@@ -85,8 +85,4 @@ interface WithUpdatePostProps {
   updatePost: WithUpdateFunction<PostsCollection>
 }
 
-interface WithCheckCookieConsentProps {
-  checkCookieConsent: (types: CookieType[]) => boolean,
-}
-
 }

--- a/packages/lesswrong/lib/cookies/callbacks.ts
+++ b/packages/lesswrong/lib/cookies/callbacks.ts
@@ -9,7 +9,7 @@ export const cookiePreferencesChangedCallbacks = new CallbackChainHook<CookieTyp
  * There is no way to turn it off without reloading currently (see https://github.com/DataDog/browser-sdk/issues/1008)
  */
 cookiePreferencesChangedCallbacks.add((cookiePreferences) => {
-  initDatadog();
+  void initDatadog();
 });
 /**
  * Send a cookie_preferences_changed event to Google Tag Manager, which triggers google analytics and hotjar to start

--- a/packages/lesswrong/lib/cookies/callbacks.ts
+++ b/packages/lesswrong/lib/cookies/callbacks.ts
@@ -15,6 +15,11 @@ cookiePreferencesChangedCallbacks.add((cookiePreferences) => {
  * Send a cookie_preferences_changed event to Google Tag Manager, which triggers google analytics and hotjar to start
  */
 cookiePreferencesChangedCallbacks.add((cookiePreferences) => {
-  // @ts-ignore
-  window.dataLayer.push({ event: "cookie_preferences_changed" }); // Must match event name in Google Tag Manager
+  const dataLayer = (window as any).dataLayer
+  if (!dataLayer) {
+    // eslint-disable-next-line no-console
+    console.warn("Trying to call gtag before dataLayer has been initialized")
+  } else {
+    dataLayer.push({ event: "cookie_preferences_changed" })
+  }
 });

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -14,12 +14,6 @@ export const TIMEZONE_COOKIE = registerCookie({
   description: "Stores the user's timezone",
 });
 
-export const COOKIE_PREFERENCES_COOKIE = registerCookie({
-  name: "cookie_preferences", // Must match variable in Google Tag Manager
-  type: "necessary",
-  description: "Stores the user's cookie preferences",
-});
-
 export const THEME_COOKIE = registerCookie({ name: "theme", type: "necessary", description: "Stores the user's theme preferences" });
 
 // Third party cookies

--- a/packages/lesswrong/lib/cookies/utils.ts
+++ b/packages/lesswrong/lib/cookies/utils.ts
@@ -1,8 +1,23 @@
+import { Cookies } from "react-cookie";
 import { TupleSet, UnionOf } from "../utils/typeGuardUtils";
-import { CallbackChainHook } from "../vulcan-lib";
+import { getExplicitConsentRequiredAsync } from "../../components/common/CookieBanner/geolocation";
+
+export const CookiesTable: Record<string, CookieSignature> = {};
 
 const CookieTypes = new TupleSet(["necessary", "functional", "analytics"] as const)
 export type CookieType = UnionOf<typeof CookieTypes>;
+
+export const COOKIE_PREFERENCES_COOKIE = registerCookie({
+  name: "cookie_preferences", // Must match variable in Google Tag Manager
+  type: "necessary",
+  description: "Stores the current cookie preferences (set by the user, or automatically if outside a country subject to GDPR)",
+});
+
+export const COOKIE_CONSENT_TIMESTAMP_COOKIE = registerCookie({
+  name: "cookie_consent_timestamp",
+  type: "necessary",
+  description: "Stores the time at which the user set their cookie preferences (once this is set the cookie preferences will never be changed automatically)",
+});
 
 export type CookieSignature = {
   name: string;
@@ -19,8 +34,6 @@ export type CookieSignatureMinimum = Omit<CookieSignature, 'maxExpires' | 'match
   matches?: (name: string) => boolean;
   maxExpires?: string;
 }
-
-export const CookiesTable: Record<string, CookieSignature> = {};
 
 export const isValidCookieTypeArray = (types?: string[] | null): types is CookieType[] => {
   if (!types) return false;
@@ -42,7 +55,31 @@ export function isCookieAllowed(name: string, cookieTypesAllowed: CookieType[]):
   throw new Error(`Unknown cookie: ${name}, you must register it with registerCookie`);
 }
 
-// TODO add forum gating (here and everywhere)
+/**
+ * Non-hook version of useCookiePreferences for use outside of React. Returns the list of
+ * allowed cookie types and whether the user has given explicit consent (if they are outside
+ * the EU, this will always be true)
+ */
+export async function getCookiePreferences(): Promise<{
+  cookiePreferences: CookieType[];
+  explicitConsentGiven: boolean;
+}> {
+  const cookies = new Cookies();
+  const preferencesValue = cookies.get(COOKIE_PREFERENCES_COOKIE);
+  const consentTimestamp = cookies.get(COOKIE_CONSENT_TIMESTAMP_COOKIE);
+  const explicitConsentGiven = !!consentTimestamp && isValidCookieTypeArray(preferencesValue);
+
+  const explicitConsentRequired = await getExplicitConsentRequiredAsync();
+  const fallbackPreferences: CookieType[] = explicitConsentRequired
+    ? ["necessary"]
+    : ["necessary", "functional", "analytics"];
+  const cookiePreferences = explicitConsentGiven
+    ? preferencesValue
+    : fallbackPreferences;
+
+  return { cookiePreferences, explicitConsentGiven };
+}
+
 export function registerCookie(cookie: CookieSignatureMinimum): string {
   if (cookie.name in CookiesTable && CookiesTable[cookie.name] !== cookie) {
     throw new Error(`Two cookies with the same name: ${cookie.name}`);


### PR DESCRIPTION
In this PR:
 - forum gating
 - geolocation gating
 - logging an analytics event when a user accepts/declines
 - some other refactoring

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204497406590711) by [Unito](https://www.unito.io)
