### PR TITLE
replace double arrows icon with gear icon on LW

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -76,7 +76,7 @@ const AllPostsPage = ({classes}: {classes: ClassesType}) => {
   const currentHideCommunity = (query.hideCommunity === 'true') || currentUser?.allPostsHideCommunity || false;
 
   const {
-    SingleColumnSection, SectionTitle, SortButton, PostsListSettings, HeadTags,
+    SingleColumnSection, SectionTitle, SortButton, SettingsButton, PostsListSettings, HeadTags,
     AllPostsList,
   } = Components;
 
@@ -91,7 +91,10 @@ const AllPostsPage = ({classes}: {classes: ClassesType}) => {
           >
             <div className={classes.title} onClick={toggleSettings}>
               <SectionTitle title={preferredHeadingCase("All Posts")}>
-                <SortButton label={formatSort(currentSorting)} />
+                {isEAForum ?
+                  <SortButton label={formatSort(currentSorting)} /> :
+                  <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
+                }
               </SectionTitle>
             </div>
           </Tooltip>

--- a/packages/lesswrong/components/posts/DraftsList.tsx
+++ b/packages/lesswrong/components/posts/DraftsList.tsx
@@ -93,8 +93,8 @@ const DraftsList = ({limit, title="My Drafts", userId, showAllDraftsLink=true, h
             </Components.SectionButton>
           </Link>
         </div>}
-        <div className={classes.sortButton} onClick={() => setShowSettings(!showSettings)}>
-          <Components.SortButton label={`Sorted by ${ sortings[currentSorting]}`}/>
+        <div className={classes.settingsButton} onClick={() => setShowSettings(!showSettings)}>
+          <Components.SettingsButton label={`Sorted by ${ sortings[currentSorting]}`}/>
         </div>
       </div>
     </Components.SectionTitle>}

--- a/packages/lesswrong/components/sequences/SequenceDraftsList.tsx
+++ b/packages/lesswrong/components/sequences/SequenceDraftsList.tsx
@@ -59,7 +59,7 @@ const SequenceDraftsList = ({limit, title="My Drafts", userId, classes, addDraft
     {(!results && loading) ? <Loading /> : <>
       <Components.SectionTitle title={title} noTopMargin={true}>
         <div onClick={() => setShowSettings(!showSettings)}>
-          <Components.SortButton label={`Sorted by ${ sortings[currentSorting]}`}/>
+          <Components.SettingsButton label={`Sorted by ${ sortings[currentSorting]}`}/>
         </div>
       </Components.SectionTitle>
       {showSettings && <Components.DraftsListSettings

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -185,7 +185,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const render = () => {
     const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, LocalGroupsList,
       PostsListSettings, PostsList2, NewConversationButton, TagEditsByUser, NotifyMeButton, DialogGroup,
-      SortButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
+      SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
       Typography, ContentStyles, ReportUserButton, LWTooltip } = Components
 
     if (loading) {
@@ -337,7 +337,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
           <SingleColumnSection>
             <div className={classes.postsTitle} onClick={() => setShowSettings(!showSettings)}>
               <SectionTitle title={"Posts"}>
-                <SortButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
+                <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
               </SectionTitle>
             </div>
             {showSettings && <PostsListSettings


### PR DESCRIPTION
Revert a bunch of places where we replaced the gear icon with the double arrows (up & down, indicating sort), to make sure LW no longer has the double arrows icon.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204506521200113) by [Unito](https://www.unito.io)
