### PR TITLE
opening side comments resizes toc

### DIFF
--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -104,12 +104,14 @@ const SideCommentIcon = ({commentIds, post, classes}: {
   // icon again when it's pinned open, it closes, and stays closed until
   // you move the mouse away and re-hover the same elmeent.
   const [pinned, setPinned] = useState<"open"|"closed"|"auto">("auto")
-  
+  // TODO: I can't tell under what circumstances this actually gets called
   const onClick = () => {
     if (pinned==="open") {
       setPinned("closed");
+      setSideCommentsActive(false)
     } else {
       setPinned("open");
+      setSideCommentsActive(true)
       //setSideCommentsActive(true);
     }
   }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useContext } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useNavigation, useSubscribedLocation } from '../../../lib/routeUtil';
 import { postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
@@ -22,6 +22,7 @@ import { useMulti } from '../../../lib/crud/withMulti';
 import { SideCommentMode, SideCommentVisibilityContextType, SideCommentVisibilityContext } from '../PostActions/SetSideCommentVisibility';
 import { PostsPageContext } from './PostsPageContext';
 import Helmet from 'react-helmet';
+import { SidebarsContext } from '../../common/SidebarsWrapper';
 
 const allowTypeIIIPlayerSetting = new PublicInstanceSetting<boolean>('allowTypeIIIPlayer', false, "optional")
 
@@ -292,11 +293,18 @@ const PostsPage = ({post, refetch, classes}: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDebateResponseLink, commentId]);
 
+  const {setSideCommentsActive} = useContext(SidebarsContext)!;
+
   const onClickCommentOnSelection = useCallback((html: string) => {
+    setSideCommentsActive(true)
     openDialog({
       componentName:"ReplyCommentDialog",
       componentProps: {
-        post, initialHtml: html
+        post, initialHtml: html,
+        // TODO: figure out how to actually pass an onClose callback, because this wasn't it
+        onClose: () => { 
+          setSideCommentsActive(false) 
+        }
       },
       noClickawayCancel: true,
     })

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -5,6 +5,7 @@ import { SidebarsContext } from '../../common/SidebarsWrapper';
 import classNames from 'classnames';
 
 const DEFAULT_TOC_MARGIN = 100
+const SIDE_COMMENT_TOC_MARGIN = 35
 const MAX_TOC_WIDTH = 270
 const MIN_TOC_WIDTH = 200
 
@@ -41,10 +42,28 @@ export const styles = (theme: ThemeType): JssStyles => ({
       display: 'block'
     }
   },
-  sideCommentsActive: {
-    gridTemplateColumns: `
-      1fr minmax(200px,270px) minmax(10px,25px) minmax(min-content,720px) minmax(10px, 25px) min-content 350px 1fr !important
-    `
+  tocActivatedSidecomments: {
+    // Check for support for template areas before applying
+    '@supports (grid-template-areas: "title")': {
+      display: 'grid',
+      gridTemplateColumns: `
+        .15fr
+        minmax(${MIN_TOC_WIDTH}px, ${MAX_TOC_WIDTH}px)
+        minmax(0px, ${SIDE_COMMENT_TOC_MARGIN}px)
+        minmax(min-content, ${MAX_COLUMN_WIDTH}px)
+        minmax(0px, ${SIDE_COMMENT_TOC_MARGIN}px)
+        min-content
+        10px
+        1.5fr
+      `,
+      gridTemplateAreas: `
+        "... ... .... title   .... ....... .... ..."
+        "... toc gap1 content gap2 welcome gap3 ..."
+      `,
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'block'
+    }
   },
   toc: {
     '@supports (grid-template-areas: "title")': {
@@ -121,14 +140,14 @@ export const ToCColumn = ({tableOfContents, header, welcomeBox, children, classe
   classes: ClassesType,
   welcomeBox?: React.ReactNode,
 }) => {
-  const {sideCommentsActive} = useContext(SidebarsContext)!;
+  const sideProps = useContext(SidebarsContext)!;
   
   return (
     <div className={classNames(
       classes.root,
       {
-        [classes.tocActivated]: !!tableOfContents || !!welcomeBox,
-        [classes.sideCommentsActive]: sideCommentsActive,
+        [classes.tocActivated]: (!!tableOfContents || !!welcomeBox) && !sideProps.sideCommentsActive,
+        [classes.tocActivatedSidecomments]: (!!tableOfContents || !!welcomeBox) && sideProps.sideCommentsActive
       }
     )}>
       <div className={classes.header}>


### PR DESCRIPTION
I successfully got it to resize the ToC when side comments are opened, but not when they are closed. I'm not sure if there's an existing onClose callback functionality or similar for openDialog.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204509788781294) by [Unito](https://www.unito.io)
