### PR TITLE
Exclude Rejected Content from Search

### DIFF
--- a/packages/lesswrong/server/scripts/algoliaExport.ts
+++ b/packages/lesswrong/server/scripts/algoliaExport.ts
@@ -66,10 +66,10 @@ async function algoliaExport(collection: AlgoliaIndexedCollection<AlgoliaIndexed
 async function algoliaExportByCollectionName(collectionName: AlgoliaIndexCollectionName) {
   switch (collectionName) {
     case 'Posts':
-      await algoliaExport(Posts, {baseScore: {$gte: 0}, draft: {$ne: true}, status: postStatuses.STATUS_APPROVED})
+      await algoliaExport(Posts, {baseScore: {$gte: 0}, draft: {$ne: true}, status: postStatuses.STATUS_APPROVED, rejected: {$ne :true}, authorIsUnreviewed: {$ne: true}})
       break
     case 'Comments':
-      await algoliaExport(Comments, {baseScore: {$gt: 0}, deleted: {$ne: true}})
+      await algoliaExport(Comments, {baseScore: {$gt: 0}, deleted: {$ne: true}, rejected: {$ne: true}, authorIsUnreviewed: {$ne: true}})
       break
     case 'Users':
       await algoliaExport(Users, {deleted: {$ne: true}, deleteContent: {$ne: true}})

--- a/packages/lesswrong/server/scripts/algoliaExport.ts
+++ b/packages/lesswrong/server/scripts/algoliaExport.ts
@@ -17,7 +17,7 @@ import * as _ from 'underscore';
 import moment from 'moment';
 import take from 'lodash/take';
 
-async function algoliaExport(collection: AlgoliaIndexedCollection<AlgoliaIndexedDbObject>, selector?: {[attr: string]: any}, updateFunction?: any) {
+async function algoliaExport<T extends AlgoliaIndexedDbObject>(collection: AlgoliaIndexedCollection<T>, selector?: MongoSelector<T>, updateFunction?: any) {
   let client = getAlgoliaAdminClient();
   if (!client) return;
   
@@ -45,8 +45,8 @@ async function algoliaExport(collection: AlgoliaIndexedCollection<AlgoliaIndexed
     filter: computedSelector,
     batchSize: 100,
     loadFactor: 0.5,
-    callback: async (documents: AlgoliaIndexedDbObject[]) => {
-      await algoliaIndexDocumentBatch({ documents, collection, algoliaIndex, errors: totalErrors, updateFunction });
+    callback: async (documents: T[]) => {
+      await algoliaIndexDocumentBatch<T>({ documents, collection, algoliaIndex, errors: totalErrors, updateFunction });
       
       exportedSoFar += documents.length;
       // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -32,7 +32,7 @@ const USER_BIO_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS
 const TAG_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS;
 
 Comments.toAlgolia = async (comment: DbComment): Promise<Array<AlgoliaComment>|null> => {
-  if (comment.deleted || comment.rejected ) return null;
+  if (comment.deleted || comment.rejected || comment.authorIsUnreviewed ) return null;
   
   const algoliaComment: AlgoliaComment = {
     objectID: comment._id,

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -32,7 +32,7 @@ const USER_BIO_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS
 const TAG_MAX_SEARCH_CHARACTERS = COMMENT_MAX_SEARCH_CHARACTERS;
 
 Comments.toAlgolia = async (comment: DbComment): Promise<Array<AlgoliaComment>|null> => {
-  if (comment.deleted) return null;
+  if (comment.deleted || comment.rejected ) return null;
   
   const algoliaComment: AlgoliaComment = {
     objectID: comment._id,
@@ -180,6 +180,8 @@ Posts.toAlgolia = async (post: DbPost): Promise<Array<AlgoliaPost>|null> => {
   if (post.status !== postStatuses.STATUS_APPROVED)
     return null;
   if (post.authorIsUnreviewed)
+    return null;
+  if (post.rejected)
     return null;
   
   const tags = post.tagRelevance ? 


### PR DESCRIPTION
We now mark some comments and posts from users as rejected. These should not show on the main site but currently are still in search. This attempts to fix it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204510383359734) by [Unito](https://www.unito.io)
