### PR TITLE
[EA] More sans serif

### DIFF
--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -8,6 +8,7 @@ import { isMobile } from '../../lib/utils/isMobile'
 import { CommentTreeOptions } from './commentTree';
 import { coreTagIconMap } from '../tagging/CoreTagIcon';
 import { metaNoticeStyles } from './CommentsItem/CommentsItemMeta';
+import { isEAForum } from '../../lib/instanceSettings';
 
 export const SINGLE_LINE_PADDING_TOP = 5
 
@@ -24,6 +25,7 @@ export const singleLineStyles = (theme: ThemeType): JssStyles => ({
   paddingRight: theme.spacing.unit,
   color: theme.palette.text.dim60,
   whiteSpace: "nowrap",
+  fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
 })
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/ea-forum/EATermsOfUsePage.tsx
+++ b/packages/lesswrong/components/ea-forum/EATermsOfUsePage.tsx
@@ -32,6 +32,7 @@ const styles = (theme: ThemeType) => ({
     textAlign: "center",
     margin: 30 - PADDING,
     padding: PADDING,
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
   heading: {
     paddingTop: 20,

--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import type { Hit } from 'react-instantsearch-core';
 import LocalLibraryIcon from '@material-ui/icons/LocalLibrary';
 import { Snippet } from 'react-instantsearch-dom';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -18,6 +19,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.postStyle,
     fontSize: "1.25rem",
     ...theme.typography.smallCaps,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
     marginRight: 8,
     textDecoration: "none",
     "& a:hover": {

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from "@apollo/client";
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { userHasNewTagSubscriptions } from "../../lib/betas";
 import { subscriptionTypes } from '../../lib/collections/subscriptions/schema';
@@ -359,7 +359,10 @@ const TagPage = ({classes}: {
              */}
             {tag.subTags.length ? <div className={classes.relatedTag}><span>Sub-{tag.subTags.length > 1 ? taggingNamePluralCapitalSetting.get() : taggingNameCapitalSetting.get()}:&nbsp;{
                 tag.subTags.map((subTag, idx) => {
-                return <><Link key={idx} className={classes.relatedTagLink} to={tagGetUrl(subTag)}>{subTag.name}</Link>{idx < tag.subTags.length - 1 ? <>,&nbsp;</>: <></>}</>
+                return <Fragment key={idx}>
+                  <Link className={classes.relatedTagLink} to={tagGetUrl(subTag)}>{subTag.name}</Link>
+                  {idx < tag.subTags.length - 1 ? <>,&nbsp;</>: <></>}
+                </Fragment>
               })}</span>
             </div> : <></>}
           </div>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -126,6 +126,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',
     overflow: 'hidden',
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
   relatedTagLink : {
     color: theme.palette.lwTertiary.dark

--- a/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
@@ -59,6 +59,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     ...theme.typography.headline,
+    fontFamily: theme.palette.fonts.sansSerifStack,
     color: theme.palette.text.alwaysWhite,
     marginTop: 0,
     fontSize: 40,

--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -5,7 +5,7 @@ import Button from "@material-ui/core/Button";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import TextField from "@material-ui/core/TextField";
-import { forumTypeSetting, siteNameWithArticleSetting } from "../../lib/instanceSettings";
+import { isEAForum, siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useMessages } from "../common/withMessages";
 import { getUserEmail } from "../../lib/collections/users/helpers";
@@ -30,8 +30,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   sectionHelperText: {
     color: theme.palette.grey[600],
-    fontStyle: 'italic',
     fontSize: '1rem',
+    ...theme.typography.italic,
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
     "& a": {
       color: theme.palette.primary.main,
     },
@@ -102,7 +103,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
         // string in the likely event that someone already had an email and
         // wasn't shown the set email field
         ...(!getUserEmail(currentUser) && {email: emailInput.current?.value}),
-        acceptedTos: forumTypeSetting.get() === "EAForum",
+        acceptedTos: isEAForum,
       }})
     } catch (err) {
       if (/duplicate key error/.test(err.toString?.())) {
@@ -159,7 +160,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
         />
       </div>}
 
-      {forumTypeSetting.get() === 'EAForum' && <div className={classes.section}>
+      {isEAForum && <div className={classes.section}>
         <Typography variant='display1' gutterBottom>Would you like to get digest emails?</Typography>
         <Typography variant='body1' className={classes.sectionHelperText} gutterBottom>
           The EA Forum Digest is a weekly summary of the best content, curated by the EA Forum team.
@@ -176,7 +177,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
       </div>}
       {/* TODO: Something about bio? */}
       <div className={classes.submitButtonSection}>
-        {forumTypeSetting.get() === "EAForum" &&
+        {isEAForum &&
           <Typography variant="body1" className={classnames(classes.sectionHelperText, classes.tosText)} gutterBottom>
             I agree to the <TosLink />, including my content being available
             under a <LicenseLink /> license.


### PR DESCRIPTION
This PR switches some more serif fonts to sans-serif. It probably doesn't need a full design review, but FYI @agnesstenlund.

- Date on the terms of service page
<img width="701" alt="Screenshot 2023-05-02 at 12 14 41" src="https://user-images.githubusercontent.com/5075628/235655844-56a27567-3148-47f7-9df0-aa1628fd9652.png">

- Sub-topic/parent topic on the tage page:
<img width="513" alt="Screenshot 2023-05-02 at 12 14 54" src="https://user-images.githubusercontent.com/5075628/235655957-d27444c0-c611-4d0d-9f04-101ed585dc6d.png">

- Karma and time in single-line versions of answers (ie; in recent discussions):
<img width="395" alt="Screenshot 2023-05-02 at 12 25 34" src="https://user-images.githubusercontent.com/5075628/235656046-a33affc8-77cb-49c9-8499-da7e418160ec.png">

- Topic titles on "subforum" page (I don't know what we call this now subforums are dead?):
<img width="683" alt="Screenshot 2023-05-02 at 12 28 00" src="https://user-images.githubusercontent.com/5075628/235656163-4d3e1c21-a1de-417f-bb5c-a3ab8374c7b6.png">

- Sequence titles in search results:
<img width="537" alt="Screenshot 2023-05-02 at 12 30 01" src="https://user-images.githubusercontent.com/5075628/235656237-1f9d16b6-0a28-43ac-957a-538ddda41af6.png">

- Profile completion page for new users (I also removed the italics - awaiting controversy):
<img width="804" alt="Screenshot 2023-05-02 at 12 36 46" src="https://user-images.githubusercontent.com/5075628/235656306-cd78dec7-eb6b-4b2f-ac27-a7ce00d4c3cb.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204513592864765) by [Unito](https://www.unito.io)
