### PR TITLE
fix dropping a field thats not in the schema

### DIFF
--- a/packages/lesswrong/lib/sql/AddFieldQuery.ts
+++ b/packages/lesswrong/lib/sql/AddFieldQuery.ts
@@ -8,10 +8,10 @@ import Table from "./Table";
  * meant for use in migrations.
  */
 class AddFieldQuery<T extends DbObject> extends Query<T> {
-  constructor(table: Table<T>, fieldName: string) {
+  constructor(table: Table<T>, fieldName: string, skipValidation?: boolean) {
     const fields = table.getFields();
     const fieldType = fields[fieldName];
-    if (!fieldType) {
+    if (!skipValidation && !fieldType) {
       throw new Error(`Field "${fieldName}" does not exist in the schema`);
     }
     super(table, [

--- a/packages/lesswrong/lib/sql/DropFieldQuery.ts
+++ b/packages/lesswrong/lib/sql/DropFieldQuery.ts
@@ -8,14 +8,13 @@ import Table from "./Table";
  * - it's used in a reverse migration
  * - we are deleting an old field that has been deprecated for a while
  *
- * We may want to change this in the future if there are cases where we want to
- * drop a field that is not in the schema.
+ * To drop a field that's not in the schema, set the skipValidation flag.
  */
 class DropFieldQuery<T extends DbObject> extends Query<T> {
-  constructor(table: Table<T>, fieldName: string) {
+  constructor(table: Table<T>, fieldName: string, skipValidation?: boolean) {
     const fields = table.getFields();
     const fieldType = fields[fieldName];
-    if (!fieldType) {
+    if (!skipValidation && !fieldType) {
       throw new Error(`Field "${fieldName}" does not exist in the schema`);
     }
     super(table, [

--- a/packages/lesswrong/server/migrations/meta/utils.ts
+++ b/packages/lesswrong/server/migrations/meta/utils.ts
@@ -30,7 +30,7 @@ export const addRemovedField = async <T extends DbObject>(
   collection: PgCollection<T>,
   fieldName: string,
 ): Promise<void> => {
-  const {sql, args} = new AddFieldQuery(collection.getTable(), fieldName).compile();
+  const {sql, args} = new AddFieldQuery(collection.getTable(), fieldName, true).compile();
   await db.none(sql, args);
 }
 
@@ -54,7 +54,7 @@ export const dropRemovedField = async <T extends DbObject>(
   collection: PgCollection<T>,
   fieldName: string,
 ): Promise<void> => {
-  const {sql, args} = new DropFieldQuery(collection.getTable(), fieldName).compile();
+  const {sql, args} = new DropFieldQuery(collection.getTable(), fieldName, true).compile();
   await db.none(sql, args);
 }
 


### PR DESCRIPTION
When I tried to drop a field, the [migration](https://github.com/ForumMagnum/ForumMagnum/actions/runs/4866025205/jobs/8677068931?pr=7105) on staging gave me this error:

Error: Migration 20230502T160034.drop_noComicSans_from_Users.ts (up) failed: Original error: Field "noComicSans" does not exist in the schema

Hopefully this PR will fix that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204518808397947) by [Unito](https://www.unito.io)
