### PR TITLE
Yellow curated icon

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -36,7 +36,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: isEAForum ? 2 : 3,
   },
   curatedIconColor: {
-    color: theme.palette.primary.main,
+    color: isEAForum ? theme.palette.icon.yellow : theme.palette.primary.main,
   },
   question: {
     fontSize: "1.2rem",

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -252,6 +252,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     topAuthor: shades.grey[340],
     navigationSidebarIcon: shades.greyAlpha(1.0),
     sprout: '#69886e',
+    yellow: '#ffc500',
     
     commentsBubble: {
       commentCount: "#fff",

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -200,6 +200,7 @@ declare global {
       topAuthor: ColorString,
       navigationSidebarIcon: ColorString,
       sprout: ColorString,
+      yellow: ColorString,
       
       commentsBubble: {
         commentCount: ColorString,


### PR DESCRIPTION
**Why?**
At a glance curated posts look too much like pinned posts, which we think may lead to people ignoring them.

**Before**
![Screenshot 2023-05-03 at 14 30 04](https://user-images.githubusercontent.com/13235378/235916398-b37aea7f-9845-45e7-b532-7838c30747dc.png)

**After**
![Screenshot 2023-05-03 at 14 30 00](https://user-images.githubusercontent.com/13235378/235916353-95c446df-7a06-4ffb-a768-613e91321baa.png)

Dark mode

![Screenshot 2023-05-03 at 14 31 17](https://user-images.githubusercontent.com/13235378/235916745-ccff2cfc-8e27-4d17-8309-05e68410d496.png)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204522650370154) by [Unito](https://www.unito.io)
