### PR TITLE
Add api key and fix thundering herd for ipapi

### DIFF
--- a/packages/lesswrong/components/common/CookieBanner/geolocation.ts
+++ b/packages/lesswrong/components/common/CookieBanner/geolocation.ts
@@ -1,6 +1,9 @@
 import { isServer } from "../../../lib/executionEnvironment";
 import { isEAForum } from "../../../lib/instanceSettings";
+import { DatabasePublicSetting } from "../../../lib/publicSettings";
 import { getBrowserLocalStorage } from "../../editor/localStorageHandlers";
+
+const ipApiKeySetting = new DatabasePublicSetting<string | null>('ipapi.apiKey', null);
 
 const GDPR_COUNTRY_CODES: string[] = [
   "AT", // Austria
@@ -75,6 +78,8 @@ function getCachedUserCountryCode() {
   return null;
 }
 
+let inFlightRequest: Promise<string | null> | null = null;
+
 async function getUserCountryCode({ signal }: { signal?: AbortSignal } = {}): Promise<string | null> {
   if (isServer) return null;
 
@@ -83,17 +88,37 @@ async function getUserCountryCode({ signal }: { signal?: AbortSignal } = {}): Pr
     return cachedCountryCode;
   }
 
-  const response = await fetch('https://ipapi.co/json/', { signal });
-
-  if (!response.ok) {
-    throw new Error(`Error fetching user country: ${response.statusText}`);
+  if (inFlightRequest) {
+    // If there's an in-flight request, wait for it to finish and return the result
+    const countryCode = await inFlightRequest;
+    return countryCode;
   }
 
-  const data = await response.json();
-  const countryCode = data.country;
-  setCountryCodeToLocalStorage(countryCode);
+  const apiKey = ipApiKeySetting.get();
+  const ipapiUrl = apiKey ? `https://ipapi.co/json/?key=${apiKey}` : 'https://ipapi.co/json/';
+
+  inFlightRequest = (async () => {
+    try {
+      const response = await fetch(ipapiUrl, { signal });
+
+      if (!response.ok) {
+        throw new Error(`Error fetching user country: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const countryCode = data.country;
+      setCountryCodeToLocalStorage(countryCode);
+      return countryCode;
+    } finally {
+      // Reset the in-flight request to null after completion
+      inFlightRequest = null;
+    }
+  })();
+
+  const countryCode = await inFlightRequest;
   return countryCode;
 }
+
 
 export function getExplicitConsentRequiredSync(): boolean | "unknown" {
   if (!isEAForum) return false;

--- a/packages/lesswrong/components/common/CookieBanner/geolocation.ts
+++ b/packages/lesswrong/components/common/CookieBanner/geolocation.ts
@@ -119,7 +119,6 @@ async function getUserCountryCode({ signal }: { signal?: AbortSignal } = {}): Pr
   return countryCode;
 }
 
-
 export function getExplicitConsentRequiredSync(): boolean | "unknown" {
   if (!isEAForum) return false;
   if (isServer) return "unknown";


### PR DESCRIPTION
We were getting a [rate limit response](https://ipapi.co/ratelimited/) on the unpaid plan. I did find a bug where multiple requests could be made per page load due to new requests being made when existing ones were in flight. This was only ~5 per page load though, so I still think this rate limit was spurious seeing as it should allow 30,000 requests per month (and we cache the response for 48 hours)

Anyway, this PR adds an api key for the paid plan (which allows 60,000 requests per month, and allows us to track usage). It also fixes the problem of having multiple requests in flight