### PR TITLE
Change wording of first post moderation

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -81,7 +81,7 @@ const PostBodyPrefix = ({post, query, classes}: {
     {post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>
       {currentUser?._id === post.userId
         ? "Because this is your first post, this post is awaiting moderator approval."
-        : "This post is unlisted and is still awaiting moderation.\nUsers' first posts need to go through moderation."
+        : "This post is unlisted and is still awaiting moderation.\nUsers' first posts need to be approved by a moderator."
       }
       <LWTooltip title={<p>
         New users' first posts on {siteNameWithArticleSetting.get()} are checked by moderators before they appear on the site.


### PR DESCRIPTION
Ruby found the old wording somewhat confusing.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204526745118499) by [Unito](https://www.unito.io)
