### PR TITLE
Remove unnecessary line from shortformFrontpage migration

### DIFF
--- a/packages/lesswrong/server/migrations/20230502T083210.add_shortformFrontpage.ts
+++ b/packages/lesswrong/server/migrations/20230502T083210.add_shortformFrontpage.ts
@@ -38,9 +38,6 @@ import { addField, dropField } from "./meta/utils"
 
 export const up = async ({db}: MigrationContext) => {
   if (Comments.isPostgres()) await addField(db, Comments, 'shortformFrontpage')
-
-  // Add default values for all existing comments
-  await db.any(`UPDATE "Comments" SET "shortformFrontpage" = TRUE;`)
 }
 
 export const down = async ({db}: MigrationContext) => {


### PR DESCRIPTION
Removes redundant (& slow) update operation which is already taken care of by Postgres when adding a new column with a `DEFAULT` value.