### PR TITLE
Disable useEffect to fix infinite loop in useCookiePreferences

### DIFF
--- a/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
+++ b/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
@@ -42,15 +42,16 @@ export function useCookiePreferences(): {
 
   // If the user had not given explicit consent, but the value of COOKIE_PREFERENCES_COOKIE is different to what we are
   // using in the code (fallbackPreferences), update the cookie. This is so that Google Tag Manager handles it correctly.
-  useEffect(() => {
-    if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
+  // TODO this is causing an infinite loop somehow, reenable once we figure out why.
+  // useEffect(() => {
+  //   if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
 
-    if (JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
-      setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/" });
-      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
+  //   if (JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
+  //     setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/" });
+  //     void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
+  //   }
+  // // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
   
   const updateCookiePreferences = useCallback(
     (newPreferences: CookieType[]) => {


### PR DESCRIPTION
There is an infinite loop happening somehow involving this code path. I haven't been able to reproduce it, but commenting it out should stop it at least, and the behaviour in Google Tag Manager that this is supposed to trigger is disabled currently anyway

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204534744604089) by [Unito](https://www.unito.io)
