### PR TITLE
fix issues with backfilled tagrels

### DIFF
--- a/packages/lesswrong/server/scripts/backfillParentTags.ts
+++ b/packages/lesswrong/server/scripts/backfillParentTags.ts
@@ -10,7 +10,7 @@ const backfillParentTags = async (parentTagSlug: string) => {
   for (const childTag of childTags) {
     // For use in determine what already exists - no need to add
     const parentTagRelPostIds = (await TagRels.find({tagId: parentTag._id}).fetch()).map(rel => rel.postId);
-    const childTagRelPostIds = (await TagRels.find({tagId: childTag._id}).fetch())
+    const childTagRelPostIds = (await TagRels.find({tagId: childTag._id, baseScore: {$gt: 0}}).fetch())
       .filter(rel => !parentTagRelPostIds.includes(rel.postId))
       .map(rel => rel.postId);
     const parentTagRelIds = childTagRelPostIds.map(_ => randomId())

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -84,12 +84,9 @@ export const createVote = ({ document, collectionName, voteType, extendedVote, u
   user: DbUser|UsersCurrent,
   voteId?: string,
 }): Partial<DbVote> => {
-  if (!document.userId)
-    throw new Error("Voted-on document does not have an author userId?");
-
-  const coauthors = collectionName === "Posts"
-    ? getConfirmedCoauthorIds(document as DbPost)
-    : [];
+  let authorIds = document.userId ? [document.userId] : []
+  if (collectionName === "Posts")
+    authorIds = authorIds.concat(getConfirmedCoauthorIds(document as DbPost))
 
   return {
     // when creating a vote from the server, voteId can sometimes be undefined
@@ -102,7 +99,7 @@ export const createVote = ({ document, collectionName, voteType, extendedVote, u
     extendedVoteType: extendedVote,
     power: getVotePower({user, voteType, document}),
     votedAt: new Date(),
-    authorIds: [document.userId, ...coauthors],
+    authorIds,
     cancelled: false,
     documentIsAf: !!(document.af),
   }


### PR DESCRIPTION
I ran into two issues when working with posts in [this topic](https://forum.effectivealtruism.org/topics/criticism-of-work-in-effective-altruism):

1. I noticed some had the newly created "criticism of work in ea" parent tag, but not the original "criticism of ea orgs" child tag. The `backfillParentTags` script is supposed to only apply the parent tag to posts tagged with the child tag. The bug seems to be that it wasn't excluding tags that had been unapplied to the post.
2. I tried to downvote the parent tag since it was misapplied, but ran into the error `Voted-on document does not have an author userId?`. I think it's actually fine that `TagRels` can have no `userId`? I don't know what it means for a `TagRel` to have an "author". So I just made this a valid case and removed the error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204535138512429) by [Unito](https://www.unito.io)
