### PR TITLE
Permission-gate fields when content is deleted

### DIFF
--- a/packages/lesswrong/lib/collections/comments/collection.ts
+++ b/packages/lesswrong/lib/collections/comments/collection.ts
@@ -1,6 +1,6 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib';
-import { userCanDo, userOwns, userIsAdmin } from '../../vulcan-users/permissions';
+import { userCanDo, userOwns } from '../../vulcan-users/permissions';
 import { userIsAllowedToComment } from '../users/helpers';
 import { mongoFindOne } from '../../mongoQueries';
 import { addUniversalFields, getDefaultResolvers } from '../../collectionUtils'
@@ -52,27 +52,6 @@ export const Comments: ExtendedCommentsCollection = createCollection({
   mutations: getDefaultMutations('Comments', commentMutationOptions),
   logChanges: true,
 });
-
-Comments.checkAccess = async (currentUser: DbUser|null, comment: DbComment, context: ResolverContext|null): Promise<boolean> => {
-  if (userIsAdmin(currentUser) || userOwns(currentUser, comment)) { // admins can always see everything, users can always see their own posts
-    return true;
-  } else {
-    return true;
-  }
-  
-  // NOTE: There used to be a special case here that would deny access (to non-
-  // admins) if comment.isDeleted was true. This was wrong in two cancelling
-  // ways: first, because we show UI on post pages indicating that a deleted
-  // comment used to be there, and denying access would hide that UI. And
-  // second, because the field is named `deleted`, not named `isDeleted`.
-  //
-  // What we ought to be doing is blocking access to specific fields (ie the
-  // contents field) if the comment is deleted and the user has access, but
-  // that's more complicated and we're not currently doing that. This means that
-  // sophisticated users can recover the contents of deleted comments. OTOH most
-  // deleted comments are getting saved by archive.org and in RSS readers
-  // anyways, so I'm not sure that matters much.
-}
 
 addUniversalFields({
   collection: Comments,

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -1,4 +1,4 @@
-import { userOwns } from '../../vulcan-users/permissions';
+import { documentIsNotDeleted, userOwns } from '../../vulcan-users/permissions';
 import { arrayOfForeignKeysField, foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences } from '../../utils/schemaUtils';
 import { mongoFindOne } from '../../mongoQueries';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
@@ -70,7 +70,7 @@ const schema: SchemaType<DbComment> = {
   author: {
     type: String,
     optional: true,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     onInsert: async (document, currentUser) => {
       // if userId is changing, change the author name too
       if (document.userId) {
@@ -141,7 +141,7 @@ const schema: SchemaType<DbComment> = {
       nullable: true,
     }),
     optional: true,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     hidden: true,
   },
@@ -413,7 +413,7 @@ const schema: SchemaType<DbComment> = {
   // DEPRECATED field for GreaterWrong backwards compatibility
   htmlBody: resolverOnlyField({
     type: String,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     resolver: (comment: DbComment, args: void, context: ResolverContext) => {
       const contents = comment.contents;
       if (!contents) return "";

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -17,7 +17,7 @@ import { fmCrosspostBaseUrlSetting, fmCrosspostSiteNameSetting, forumTypeSetting
 import { forumSelect } from '../../forumTypeUtils';
 import * as _ from 'underscore';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
-import { userOwns } from '../../vulcan-users/permissions';
+import { documentIsNotDeleted, userOwns } from '../../vulcan-users/permissions';
 import { userCanCommentLock, userCanModeratePost } from '../users/helpers';
 import { sequenceGetNextPostID, sequenceGetPrevPostID, sequenceContainsPost, getPrevPostIdFromPrevSequence, getNextPostIdFromNextSequence } from '../sequences/helpers';
 import { userOverNKarmaFunc } from "../../vulcan-users";
@@ -373,7 +373,7 @@ const schema: SchemaType<DbPost> = {
     type: String,
     denormalized: true,
     optional: true,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     onEdit: async (modifier, document, currentUser) => {
       // if userId is changing, change the author name too
       if (modifier.$set && modifier.$set.userId) {
@@ -392,7 +392,7 @@ const schema: SchemaType<DbPost> = {
     }),
     optional: true,
     control: 'text',
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: ['admins'],
     canCreate: ['admins'],
     tooltip: 'The user id of the author',
@@ -519,7 +519,7 @@ const schema: SchemaType<DbPost> = {
   // DEPRECATED field for GreaterWrong backwards compatibility
   htmlBody: resolverOnlyField({
     type: String,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     resolver: (post: DbPost, args: void, { Posts }: ResolverContext) => {
       const contents = post.contents;
       if (!contents) return "";
@@ -1291,7 +1291,7 @@ const schema: SchemaType<DbPost> = {
       },
       addOriginalField: true,
     },
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: ['sunshineRegiment', 'admins', userOverNKarmaFunc(MINIMUM_COAUTHOR_KARMA)],
     canCreate: ['sunshineRegiment', 'admins', userOverNKarmaFunc(MINIMUM_COAUTHOR_KARMA)],
     optional: true,
@@ -1352,7 +1352,7 @@ const schema: SchemaType<DbPost> = {
     }),
     optional: true,
     nullable: true,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: [allOf(userOwns, userPassesCrosspostingKarmaThreshold), 'admins'],
     canCreate: [userPassesCrosspostingKarmaThreshold, 'admins'],
     control: "FMCrosspostControl",
@@ -1800,7 +1800,7 @@ const schema: SchemaType<DbPost> = {
       collectionName: "Users",
       type: "User"
     }),
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     optional: true,
@@ -1823,7 +1823,7 @@ const schema: SchemaType<DbPost> = {
       type: "Localgroup",
       nullable: true,
     }),
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
     optional: true,
@@ -1993,7 +1993,7 @@ const schema: SchemaType<DbPost> = {
 
   mongoLocation: {
     type: Object,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     hidden: true,
     blackbox: true,
     optional: true,
@@ -2012,7 +2012,7 @@ const schema: SchemaType<DbPost> = {
       stringVersionFieldName: "location",
     },
     hidden: (props) => !props.eventForm,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     label: "Event Location",
@@ -2024,7 +2024,7 @@ const schema: SchemaType<DbPost> = {
 
   location: {
     type: String,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
     hidden: true,
@@ -2034,7 +2034,7 @@ const schema: SchemaType<DbPost> = {
   contactInfo: {
     type: String,
     hidden: (props) => !props.eventForm,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members'],
     label: "Contact Info",
@@ -2046,7 +2046,7 @@ const schema: SchemaType<DbPost> = {
   facebookLink: {
     type: String,
     hidden: (props) => !props.eventForm,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     label: "Facebook Event",
@@ -2060,7 +2060,7 @@ const schema: SchemaType<DbPost> = {
   meetupLink: {
     type: String,
     hidden: (props) => !props.eventForm,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     label: "Meetup.com Event",
@@ -2074,7 +2074,7 @@ const schema: SchemaType<DbPost> = {
   website: {
     type: String,
     hidden: (props) => !props.eventForm,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     control: "MuiTextField",
@@ -2089,7 +2089,7 @@ const schema: SchemaType<DbPost> = {
     optional: true,
     hidden: (props) => !props.eventForm || !isEAForum,
     label: "Event Image",
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members'],
     control: "ImageUpload",
@@ -2157,7 +2157,7 @@ const schema: SchemaType<DbPost> = {
   shareWithUsers: {
     type: Array,
     order: 15,
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     optional: true,

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -1,4 +1,4 @@
-import { userOwns } from '../vulcan-users/permissions';
+import { documentIsNotDeleted, userOwns } from '../vulcan-users/permissions';
 import { camelCaseify } from '../vulcan-lib/utils';
 import { ContentType, getOriginalContents } from '../collections/revisions/schema'
 import { accessFilterMultiple, addFieldsDict } from '../utils/schemaUtils';
@@ -69,7 +69,7 @@ const defaultOptions: MakeEditableOptions = {
   // }
   getLocalStorageId: null,
   permissions: {
-    canRead: ['guests'],
+    canRead: [documentIsNotDeleted],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members']
   },

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -114,6 +114,22 @@ export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: 
   }
 };
 
+export const documentIsNotDeleted = <T extends DbObject>(
+  user: PermissionableUser|DbUser|null,
+  document: T,
+) => {
+  // Admins and mods can see deleted content
+  if (userIsAdminOrMod(user)) {
+    return true;
+  }
+  // Unfortunately, different collections use different field names
+  // to represent "deleted-ness"
+  return !(
+    (document as unknown as DbComment).deleted ||
+    (document as unknown as DbPost).deletedDraft ||
+    (document as unknown as DbSequence).isDeleted
+  );
+}
 
 export const userOverNKarmaFunc = (n: number) => {
     return (user: UsersMinimumInfo|DbUser|null): boolean => {

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -93,8 +93,10 @@ export const userCanDo = (user: UsersProfile|DbUser|null, actionOrActions: strin
   return userIsAdmin(user) || intersection(authorizedActions, actions).length > 0;
 };
 
+export type OwnableDocument = HasUserIdType|DbUser|UsersMinimumInfo;
+
 // Check if a user owns a document
-export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: HasUserIdType|DbUser|UsersMinimumInfo): boolean {
+export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: OwnableDocument): boolean {
   if (!user) {
     // not logged in
     return false;
@@ -114,12 +116,16 @@ export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: 
   }
 };
 
-export const documentIsNotDeleted = <T extends DbObject>(
+export const documentIsNotDeleted = (
   user: PermissionableUser|DbUser|null,
-  document: T,
+  document: OwnableDocument,
 ) => {
   // Admins and mods can see deleted content
   if (userIsAdminOrMod(user)) {
+    return true;
+  }
+  // Authors can see their deleted content
+  if (userOwns(user, document)) {
     return true;
   }
   // Unfortunately, different collections use different field names


### PR DESCRIPTION
Currently, the body of deleted content is available in the Apollo cache that's embedded in the HTML during SSR. This is a long-standing problem, as is evidenced by Jim's comment in the code from mid-2021.

This PR adds a new permissions function to disallow this, but we still make the content available to admins, mods and the original author.

By default, I've applied this to all fields that use `make_editable`, but it's plausible that there's some reason I've not thought about that means we should restrict to to fewer fields, or apply it to more.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204535640179844) by [Unito](https://www.unito.io)
