### PR TITLE
fix permission on suggestForAlignmentUsers causing graphql errors

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -786,7 +786,7 @@ const schema: SchemaType<DbComment> = {
       collectionName: "Users",
       type: "User"
     }),
-    canRead: ['members'],
+    canRead: ['guests'],
     canUpdate: ['members', 'alignmentForum', 'alignmentForumAdmins'],
     optional: true,
     label: "Suggested for Alignment by",


### PR DESCRIPTION
We've had this error in the logs for a long time:
`Cannot return null for non-nullable field Comment.suggestForAlignmentUsers`

The issue seems to be that canRead for was set to 'members' rather than 'guests', which meant that it returned null (rather than an empty array), meanwhile arrayOfForeignKeysField defines the graphql field type to be non-nullable.

Apart from log spam, the result is that the "There are ${n} comments pending acceptance to the Alignment Forum.  View them on LessWrong." message wasn't showing up for anyone who was logged out.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204535770213073) by [Unito](https://www.unito.io)
