### PR TITLE
Add expiry date to cookie preferences and handle reCaptcha cookies

### DIFF
--- a/packages/lesswrong/client/reCaptcha.ts
+++ b/packages/lesswrong/client/reCaptcha.ts
@@ -1,7 +1,34 @@
+import { getCookiePreferences } from '../lib/cookies/utils';
 import { reCaptchaSiteKeySetting } from '../lib/publicSettings';
 
-// Load and run ReCaptcha script on client
-const script = document.createElement('script')
-script.src = `https://www.google.com/recaptcha/api.js?render=${reCaptchaSiteKeySetting.get()}`
-document.body.appendChild(script)
+let reCaptchaInitialized = false;
 
+/**
+ * Check for cookie preferences and initialize ReCaptcha if analytics cookies are allowed.
+ * Unfortunately checking for cookie preferences makes it a lot less useful for preventing spam,
+ * but it will still work outside GDPR countries at least.
+ */
+export async function initReCaptcha() {
+  if (reCaptchaInitialized) {
+    return;
+  }
+
+  const { cookiePreferences } = await getCookiePreferences();
+
+  const analyticsCookiesAllowed = cookiePreferences.includes("analytics");
+
+  if (!analyticsCookiesAllowed) {
+    // eslint-disable-next-line no-console
+    console.log("Not initializing ReCaptcha because analytics cookies are not allowed");
+    return;
+  }
+
+  // Load and run ReCaptcha script on client
+  const script = document.createElement('script');
+  script.src = `https://www.google.com/recaptcha/api.js?render=${reCaptchaSiteKeySetting.get()}`;
+  document.body.appendChild(script);
+
+  reCaptchaInitialized = true;
+}
+
+void initReCaptcha();

--- a/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
+++ b/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
@@ -1,10 +1,14 @@
 import { useCookies } from "react-cookie";
 import { CookieSetOptions } from "universal-cookie/cjs/types";
 import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cookiePreferencesChangedCallbacks } from "../../lib/cookies/callbacks";
 import { getExplicitConsentRequiredAsync, getExplicitConsentRequiredSync } from "../common/CookieBanner/geolocation";
 import { useTracking } from "../../lib/analyticsEvents";
+import moment from "moment";
+import { DatabasePublicSetting } from "../../lib/publicSettings";
+
+export const debugCookieBannerSetting = new DatabasePublicSetting<boolean>('debugCookieBanner', false);
 
 /**
  * Fetches the current cookie preferences and allows the user to update them.
@@ -42,24 +46,36 @@ export function useCookiePreferences(): {
 
   // If the user had not given explicit consent, but the value of COOKIE_PREFERENCES_COOKIE is different to what we are
   // using in the code (fallbackPreferences), update the cookie. This is so that Google Tag Manager handles it correctly.
-  // TODO this is causing an infinite loop somehow, reenable once we figure out why.
-  // useEffect(() => {
-  //   if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
+  const autoUpdateCount = useRef<number>(0);
+  useEffect(() => {
+    if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
 
-  //   if (JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
-  //     setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/" });
-  //     void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
-  //   }
-  // // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
+    if (isValidCookieTypeArray(preferencesCookieValue) && JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
+      // Apoologies for this bit of debugging in prod, but this previously caused an infinie loop
+      // sometimes and I haven't been able to reproduce this locally.
+      if (autoUpdateCount.current > 2 && debugCookieBannerSetting.get()) {
+        captureEvent("cookieBannerDebug", {
+          subtype: "autoUpdate",
+          cookiePreferences,
+          preferencesCookieValue,
+        })
+        return;
+      }
+      autoUpdateCount.current++;
+
+      setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/", expires: moment().add(2, 'years').toDate() });
+      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
   
   const updateCookiePreferences = useCallback(
     (newPreferences: CookieType[]) => {
       captureEvent("cookiePreferencesUpdated", {
         cookiePreferences: newPreferences,
       })
-      setCookie(COOKIE_CONSENT_TIMESTAMP_COOKIE, new Date(), { path: "/" });
-      setCookie(COOKIE_PREFERENCES_COOKIE, newPreferences, { path: "/" });
+      setCookie(COOKIE_CONSENT_TIMESTAMP_COOKIE, new Date(), { path: "/", expires: moment().add(2, 'years').toDate() });
+      setCookie(COOKIE_PREFERENCES_COOKIE, newPreferences, { path: "/", expires: moment().add(2, 'years').toDate() });
       void cookiePreferencesChangedCallbacks.runCallbacks({iterator: newPreferences, properties: []});
     },
     [captureEvent, setCookie]

--- a/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
+++ b/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
@@ -1,14 +1,11 @@
 import { useCookies } from "react-cookie";
 import { CookieSetOptions } from "universal-cookie/cjs/types";
 import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { cookiePreferencesChangedCallbacks } from "../../lib/cookies/callbacks";
 import { getExplicitConsentRequiredAsync, getExplicitConsentRequiredSync } from "../common/CookieBanner/geolocation";
 import { useTracking } from "../../lib/analyticsEvents";
 import moment from "moment";
-import { DatabasePublicSetting } from "../../lib/publicSettings";
-
-export const debugCookieBannerSetting = new DatabasePublicSetting<boolean>('debugCookieBanner', true);
 
 /**
  * Fetches the current cookie preferences and allows the user to update them.
@@ -46,31 +43,16 @@ export function useCookiePreferences(): {
 
   // If the user had not given explicit consent, but the value of COOKIE_PREFERENCES_COOKIE is different to what we are
   // using in the code (fallbackPreferences), update the cookie. This is so that Google Tag Manager handles it correctly.
-  const autoUpdateCount = useRef<number>(0);
-  useEffect(() => {
-    if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
+  // TODO this is causing an infinite loop somehow, reenable once we figure out why.
+  // useEffect(() => {
+  //   if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
 
-    if (isValidCookieTypeArray(preferencesCookieValue) && JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
-      autoUpdateCount.current++;
-      // Apoologies for this bit of debugging in prod, but this previously caused an infinie loop
-      // sometimes and I haven't been able to reproduce this locally.
-      if (debugCookieBannerSetting.get() && autoUpdateCount.current > 2) {
-        if (autoUpdateCount.current > 10) return; // Stop logging these if it's really stuck in an infinite loop
-
-        captureEvent("cookieBannerDebug", {
-          subtype: "autoUpdate",
-          autoUpdateCount: autoUpdateCount.current,
-          cookiePreferences,
-          preferencesCookieValue,
-        })
-        return;
-      }
-
-      setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/", expires: moment().add(2, 'years').toDate() });
-      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
+  //   if (JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
+  //     setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/", expires: moment().add(2, 'years').toDate()  });
+  //     void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
+  //   }
+  // // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
   
   const updateCookiePreferences = useCallback(
     (newPreferences: CookieType[]) => {

--- a/packages/lesswrong/lib/cookies/callbacks.ts
+++ b/packages/lesswrong/lib/cookies/callbacks.ts
@@ -2,15 +2,17 @@ import { Cookies } from "react-cookie";
 import { initDatadog } from "../../client/datadogRum";
 import { CallbackChainHook } from "../vulcan-lib";
 import { ALL_COOKIES, CookieType, isCookieAllowed } from "./utils";
+import { initReCaptcha } from "../../client/reCaptcha";
 
 export const cookiePreferencesChangedCallbacks = new CallbackChainHook<CookieType[], []>("cookiePreferencesChanged");
 /**
- * (Re)-initialise datadog RUM with the current cookie preferences.
+ * (Re)-initialise datadog RUM and ReCaptcha with the current cookie preferences.
  * NOTE: this will not turn it OFF if they have previously accepted and are now rejecting analytics cookies, it will only turn it ON if they are now accepting.
  * There is no way to turn it off without reloading currently (see https://github.com/DataDog/browser-sdk/issues/1008)
  */
 cookiePreferencesChangedCallbacks.add((cookiePreferences) => {
   void initDatadog();
+  void initReCaptcha();
 });
 
 /**

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -141,6 +141,7 @@ registerCookie({
 
 registerCookie({
   name: "_hjSessionUser_[*]",
+  matches: (name: string) => name.startsWith("_hjSessionUser_"),
   type: "functional",
   thirdPartyName: "Hotjar",
   description:
@@ -201,3 +202,14 @@ registerCookie({
   thirdPartyName: "Google",
   description: "This cookie name is associated with Google. It is set by Google to identify the user and is used in support of the Google Identity application.",
 });
+
+// Google Recaptcha
+registerCookie({
+  name: "(various)",
+  type: "analytics",
+  thirdPartyName: "Google ReCaptcha",
+  description: "Google ReCaptcha may set a number of cookies under the 'google.com' domain in order to check for suspicious activity. " +
+               "The full list of known possible cookies are: __Secure-3PSIDCC, __Secure-1PSIDCC, SIDCC, __Secure-3PAPISID, SSID, " +
+               "__Secure-1PAPISID, HSID, __Secure-3PSID, __Secure-1PSID, SID, SAPISID, APISID, NID, OTZ, 1P_JAR, AEC, DV, __Secure-ENID",
+});
+


### PR DESCRIPTION
The things here are:
 - There was no expiry date set on COOKIE_CONSENT_TIMESTAMP_COOKIE or  COOKIE_PREFERENCES_COOKIE which meant they expired when the browser was closed, I've added an expiry date
 - There were a bunch of cookies being set under the .google.com domain by google recaptcha, only when you log in (I previously thought these were to do with the actual google login). It would be nice if we could mark these as essential but the [advice](https://measuredcollective.com/gdpr-recaptcha-how-to-stay-compliant-with-gdpr/) is that they are fairly strongly unessential. I have made it so you need to accept cookies for recaptcha to work

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204537616639694) by [Unito](https://www.unito.io)
