### PR TITLE
Process LaTeX for sanitized HTML

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -201,7 +201,7 @@ export async function ckEditorMarkupToHtml(markup: string): Promise<string> {
 export async function dataToHTML(data: AnyBecauseTodo, type: string, sanitizeData = false) {
   switch (type) {
     case "html":
-      return sanitizeData ? sanitize(data) : await mjPagePromise(data, trimLatexAndAddCSS)
+      return await mjPagePromise(sanitizeData ? sanitize(data) : data, trimLatexAndAddCSS)
     case "ckEditorMarkup":
       return await ckEditorMarkupToHtml(data)
     case "draftJS":


### PR DESCRIPTION
Currently if you are a non-admin and you give us HTML (for example as part of an RSS import) we don't process the HTML for LaTeX. 

I did this because I wasn't totally confident that MathJax wouldn't open up some weird XSS attack, but I think the risk is relatively low, and the benefits seem worth it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204541711102061) by [Unito](https://www.unito.io)
