### PR TITLE
Moderators can reply to hidden comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { userIsAllowedToComment } from '../../../lib/collections/users/helpers';
-import { userCanDo } from '../../../lib/vulcan-users/permissions';
+import { userCanDo, userIsAdmin } from '../../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
 import withErrorBoundary from '../../common/withErrorBoundary';
 import { useCurrentUser } from '../../common/withUser';
@@ -237,7 +237,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
       // if you're banned.
       // @ts-ignore
       (!currentUser || userIsAllowedToComment(currentUser, treeOptions.post)) &&
-      !commentHidden
+      (!commentHidden || userIsAdmin(currentUser))
     )
 
     const showInlineCancel = showReplyState && isMinimalist

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -237,7 +237,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
       // if you're banned.
       // @ts-ignore
       (!currentUser || userIsAllowedToComment(currentUser, treeOptions.post)) &&
-      (!commentHidden || userIsAdmin(currentUser))
+      (!commentHidden || userCanDo(currentUser, 'posts.moderate.all'))
     )
 
     const showInlineCancel = showReplyState && isMinimalist


### PR DESCRIPTION
Makes it so moderators can reply to comments even if they'd normally be hidden

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204542190588141) by [Unito](https://www.unito.io)
