### PR TITLE
don't trigger notifications for event updates on events with unset times

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -138,7 +138,6 @@ function eventHasRelevantChangeForNotification(oldPost: DbPost, newPost: DbPost)
   const oldLocation = oldPost.googleLocation?.geometry?.location;
   const newLocation = newPost.googleLocation?.geometry?.location;
   if (!!oldLocation !== !!newLocation) {
-    console.log({ oldLocation, newLocation }, '!!oldLocation !== !!newLocation');
     //Location added or removed
     return true;
   }
@@ -148,7 +147,6 @@ function eventHasRelevantChangeForNotification(oldPost: DbPost, newPost: DbPost)
     // dumb thing inside the mutation callback handlers mixes up null vs
     // undefined, causing callbacks to get a spurious change from null to
     // undefined which should not trigger a notification.
-    console.log({ oldLocation, newLocation }, 'oldLocation && newLocation && !_.isEqual(oldLocation, newLocation)');
     return true;
   }
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -135,7 +135,6 @@ export async function postsNewNotifications (post: DbPost) {
 postPublishedCallback.add(postsNewNotifications);
 
 function eventHasRelevantChangeForNotification(oldPost: DbPost, newPost: DbPost) {
-  console.log('in eventHasRelevantChangeForNotification');
   const oldLocation = oldPost.googleLocation?.geometry?.location;
   const newLocation = newPost.googleLocation?.geometry?.location;
   if (!!oldLocation !== !!newLocation) {
@@ -182,7 +181,6 @@ function eventHasRelevantChangeForNotification(oldPost: DbPost, newPost: DbPost)
 }
 
 getCollectionHooks("Posts").updateAsync.add(async function eventUpdatedNotifications ({document: newPost, oldDocument: oldPost}: {document: DbPost, oldDocument: DbPost}) {
-  console.log('in eventUpdatedNotifications callback');
   // don't bother notifying people about past or unscheduled events
   const isUpcomingEvent = newPost.startTime && moment().isBefore(moment(newPost.startTime))
   // only send notifications if the event was already published *before* being edited


### PR DESCRIPTION
This seems to be triggering because, when someone new RSVPs to an event without a defined endTime, the endTime on the old post is null but the endTime on the new post is undefined, and moment(null) is not the same as moment(undefined).  I'm guessing migrating posts changed something about how missing/null fields work here.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204543039575511) by [Unito](https://www.unito.io)
