### PR TITLE
Stop recaptcha from running on the server

### DIFF
--- a/packages/lesswrong/client.js
+++ b/packages/lesswrong/client.js
@@ -10,7 +10,7 @@ import './client/ga';
 import './client/datadogStart';
 
 // Then import google reCaptcha v3
-import './client/reCaptcha'
+import './client/reCaptchaStart'
 
 // Then do the rest
 import './client/autoRefresh';

--- a/packages/lesswrong/client/reCaptcha.ts
+++ b/packages/lesswrong/client/reCaptcha.ts
@@ -1,4 +1,5 @@
 import { getCookiePreferences } from '../lib/cookies/utils';
+import { isServer } from '../lib/executionEnvironment';
 import { reCaptchaSiteKeySetting } from '../lib/publicSettings';
 
 let reCaptchaInitialized = false;
@@ -9,7 +10,7 @@ let reCaptchaInitialized = false;
  * but it will still work outside GDPR countries at least.
  */
 export async function initReCaptcha() {
-  if (reCaptchaInitialized) {
+  if (isServer || reCaptchaInitialized) {
     return;
   }
 
@@ -30,5 +31,3 @@ export async function initReCaptcha() {
 
   reCaptchaInitialized = true;
 }
-
-void initReCaptcha();

--- a/packages/lesswrong/client/reCaptchaStart.ts
+++ b/packages/lesswrong/client/reCaptchaStart.ts
@@ -1,0 +1,3 @@
+import { initReCaptcha } from "./reCaptcha";
+
+void initReCaptcha();


### PR DESCRIPTION
The `initReCaptcha` function was running on import which caused it to run on the server when it shouldn't

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204544175364068) by [Unito](https://www.unito.io)
