### PR TITLE
Edit templates

### DIFF
--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { ModerationTemplates } from '../../lib/collections/moderationTemplates';
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
+import { useLocation } from '../../lib/routeUtil';
+import NoSSR from 'react-no-ssr';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -14,6 +16,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   deleted: {
     color: theme.palette.grey[500]
+  },
+  highlighted: {
+    border: theme.palette.border.intense
   }
 });
 
@@ -24,7 +29,9 @@ export const ModerationTemplateItem = ({classes, template}: {
   const { ContentItemBody, MetaInfo, WrappedSmartForm, BasicFormStyles, Row } = Components
   const [edit, setEdit] = useState<boolean>(false)
 
-  return <div className={classNames(classes.root, {[classes.deleted]: template.deleted})}>
+  const {hash} = useLocation()
+  
+  return <NoSSR><div className={classNames(classes.root, {[classes.deleted]: template.deleted, [classes.highlighted]: hash === `#${template._id}`})}>
     <Row>
       <h3>{template.name}{template.deleted && <> [Deleted]</>}</h3>
       <a onClick={() => setEdit(!edit)}><MetaInfo>Edit</MetaInfo></a>
@@ -48,7 +55,7 @@ export const ModerationTemplateItem = ({classes, template}: {
           </p>
         </div>
     }
-  </div>
+  </div></NoSSR>
 }
 
 const ModerationTemplateItemComponent = registerComponent('ModerationTemplateItem', ModerationTemplateItem, {styles});

--- a/packages/lesswrong/components/sunshineDashboard/ContentRejectionDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ContentRejectionDialog.tsx
@@ -7,6 +7,8 @@ import React, { useState } from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card'
+import EditIcon from '@material-ui/icons/Edit'
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
   dialogContent: {
@@ -32,6 +34,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   card: {
     padding: 12,
     width: 500,
+  },
+  reason: {
+    '&:hover $editIcon': {
+      opacity: 1
+    }
+  },
+  editIcon: {
+    height: 12,
+    color: theme.palette.grey[500],
+    opacity: .3
   }
 });
 
@@ -74,23 +86,23 @@ const ContentRejectionDialog = ({classes, rejectContent}: {
   };
 
   const dialogContent = <div className={classes.rejectionCheckboxes}>
-    {Object.entries(rejectionReasons).map(([label, description]) => {
-      return <span key={`rejection-reason-${label}`}>
+    {results.map((template) => {
+      return <div key={`rejection-reason-${template.name}`} className={classes.reason}>
         <LWTooltip placement="right-end" tooltip={false} title={<Card className={classes.card}>
           <ContentStyles contentType='comment'>
-            <ContentItemBody dangerouslySetInnerHTML={{__html: description || ""}} />
+            <ContentItemBody dangerouslySetInnerHTML={{__html: template.contents?.html || ""}} />
           </ContentStyles>
         </Card>}>
           <div>
             <Checkbox
-              checked={selections[label]}
-              onChange={(_, checked) => composeRejectedReason(label, checked)}
+              checked={selections[template.name]}
+              onChange={(_, checked) => composeRejectedReason(template.name, checked)}
               className={classes.checkbox}
             />
-            {label}
+            {template.name} <Link to={`/admin/moderationTemplates#${template._id}`} target="_blank"><EditIcon className={classes.editIcon}/></Link>
           </div>
         </LWTooltip>
-      </span>
+      </div>
     })}
     <TextField
       id="comment-moderation-rejection-reason"

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -31,17 +31,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   vote: {
     marginRight: 10
   },
-  rejectedIcon: {
+  rejectButton: {
     marginLeft: 'auto',
-    marginTop: 4,
-    color: theme.palette.grey[500],
-    cursor: "pointer",
-  },
-  rejectedLabel: {
-    marginLeft: 'auto',
-    marginBottom: 2,
-    color: theme.palette.grey[500],
-    cursor: "pointer",
   }
 })
 


### PR DESCRIPTION
Makes a little "edit" button for each rejection reason template that links to the moderation-templates page. Also updates the templates page to make it easier to find the template you were linking to.

<img width="464" alt="image" src="https://user-images.githubusercontent.com/3246710/236984251-84e7140a-5a19-4dcd-94be-06f7e3274c47.png">


<img width="1204" alt="image" src="https://user-images.githubusercontent.com/3246710/236983941-eec374cb-74f2-4468-843f-04ebe77d434a.png">
