### PR TITLE
make coauthors field optional for graphql

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1282,7 +1282,7 @@ const schema: SchemaType<DbPost> = {
     type: Array,
     resolveAs: {
       fieldName: 'coauthors',
-      type: '[User!]!',
+      type: '[User!]',
       resolver: async (post: DbPost, args: void, context: ResolverContext) =>  {
         const resolvedDocs = await loadByIds(context, "Users",
           post.coauthorStatuses?.map(({ userId }) => userId) || []


### PR DESCRIPTION
Posts that (incorrectly) have `deletedDraft: true` while `draft: false` will fail to render for non-admin, non-owner users.
![image](https://github.com/ForumMagnum/ForumMagnum/assets/2136984/2bb807fc-8674-4b2e-983a-00df67ea4a78)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204566177525356) by [Unito](https://www.unito.io)
