### PR TITLE
Add analytics to frontpage shortform

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -53,14 +53,16 @@ const EAHome = () => {
           <HomeLatestPosts />
           {!currentUser?.hideCommunitySection && <EAHomeCommunityPosts />}
           {isEAForum && (
-            <SingleColumnSection>
-              <CommentsListCondensed
-                label={"Shortform"}
-                terms={shortformTerms}
-                initialLimit={5}
-                shortformButton
-              />
-            </SingleColumnSection>
+            <AnalyticsContext pageSectionContext="frontpageShortform">
+              <SingleColumnSection>
+                <CommentsListCondensed
+                  label={"Shortform"}
+                  terms={shortformTerms}
+                  initialLimit={5}
+                  shortformButton
+                />
+              </SingleColumnSection>
+            </AnalyticsContext>
           )}
           {!reviewIsActive() && <RecommendationsAndCurated configName="frontpageEA" />}
           <RecentDiscussionFeed

--- a/packages/lesswrong/components/shortform/ShortformListItem.tsx
+++ b/packages/lesswrong/components/shortform/ShortformListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import { SoftUpArrowIcon } from "../icons/softUpArrowIcon";
@@ -7,6 +7,7 @@ import { useHover } from "../common/withHover";
 import { isMobile } from "../../lib/utils/isMobile";
 import withErrorBoundary from "../common/withErrorBoundary";
 import moment from "moment";
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -83,7 +84,14 @@ const ShortformListItem = ({comment, hideTag, classes}: {
   hideTag?: boolean,
   classes: ClassesType,
 }) => {
+  const { captureEvent } = useTracking();
+
   const [expanded, setExpanded] = useState(false)
+  const wrappedSetExpanded = useCallback((value: boolean) => {
+    setExpanded(value);
+    captureEvent(value ? "shortformItemExpanded" : "shortformItemCollapsed");
+  }, [captureEvent, setExpanded]);
+
   const {eventHandlers, hover, anchorEl} = useHover({
     pageElementContext: "shortformItemTooltip",
     commentId: comment._id,
@@ -92,7 +100,7 @@ const ShortformListItem = ({comment, hideTag, classes}: {
   const treeOptions = {
     post: comment.post || undefined,
     showCollapseButtons: true,
-    onToggleCollapsed: () => setExpanded(!expanded),
+    onToggleCollapsed: () => wrappedSetExpanded(!expanded),
   };
 
   const {
@@ -119,7 +127,7 @@ const ShortformListItem = ({comment, hideTag, classes}: {
   return (
     <div
       className={classes.root}
-      onClick={() => setExpanded(true)}
+      onClick={() => wrappedSetExpanded(true)}
       {...eventHandlers}
     >
       <div className={classes.karma}>


### PR DESCRIPTION
Previously there were no analytics events for when a shortform was toggled open or closed

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204570208978787) by [Unito](https://www.unito.io)
