### PR TITLE
Fix infinite loop when auto-updating users cookie preferences

### DIFF
--- a/packages/lesswrong/client/datadogRum.ts
+++ b/packages/lesswrong/client/datadogRum.ts
@@ -3,6 +3,7 @@ import { getDatadogUser } from '../lib/collections/users/helpers';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { ddRumSampleRate, ddSessionReplaySampleRate, ddTracingSampleRate } from '../lib/publicSettings';
 import { getCookiePreferences } from '../lib/cookies/utils';
+import { isServer } from '../lib/executionEnvironment';
 
 let datadogInitialized = false;
 
@@ -11,7 +12,7 @@ export async function initDatadog() {
 
   const analyticsCookiesAllowed = cookiePreferences.includes("analytics");
 
-  if (forumTypeSetting.get() !== 'EAForum') return
+  if (isServer || forumTypeSetting.get() !== 'EAForum') return
   if (!analyticsCookiesAllowed) {
     // eslint-disable-next-line no-console
     console.log("Not initializing datadog because analytics cookies are not allowed")

--- a/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
+++ b/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
@@ -1,11 +1,17 @@
 import { useCookies } from "react-cookie";
 import { CookieSetOptions } from "universal-cookie/cjs/types";
-import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
+import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, cookiePreferencesAutoUpdated, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cookiePreferencesChangedCallbacks } from "../../lib/cookies/callbacks";
 import { getExplicitConsentRequiredAsync, getExplicitConsentRequiredSync } from "../common/CookieBanner/geolocation";
 import { useTracking } from "../../lib/analyticsEvents";
 import moment from "moment";
+import { DatabasePublicSetting } from "../../lib/publicSettings";
+
+const disableCookiePreferenceAutoUpdateSetting = new DatabasePublicSetting<boolean>('disableCookiePreferenceAutoUpdate', false)
+/** Global variable storing the last time the cookie preferences were updated automatically, to prevent several instances
+ * of this hook from updating the cookie preferences at the same time. */
+let cookiePreferencesAutoUpdatedTime: Date | null = null
 
 /**
  * Fetches the current cookie preferences and allows the user to update them.
@@ -43,16 +49,21 @@ export function useCookiePreferences(): {
 
   // If the user had not given explicit consent, but the value of COOKIE_PREFERENCES_COOKIE is different to what we are
   // using in the code (fallbackPreferences), update the cookie. This is so that Google Tag Manager handles it correctly.
-  // TODO this is causing an infinite loop somehow, reenable once we figure out why.
-  // useEffect(() => {
-  //   if (explicitConsentRequired === "unknown" || explicitConsentGiven) return;
+  useEffect(() => {
+    // TODO: this was previously causing an infinite loop for an unknown reason, if this happens again, we should
+    // turn this setting on. Remove this once the bug is definitely fixed.
+    if (disableCookiePreferenceAutoUpdateSetting.get()) return
 
-  //   if (JSON.stringify(cookiePreferences) !== JSON.stringify(preferencesCookieValue)) {
-  //     setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/", expires: moment().add(2, 'years').toDate()  });
-  //     void cookiePreferencesChangedCallbacks.runCallbacks({iterator: cookiePreferences, properties: []});
-  //   }
-  // // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
+    const canAutoUpdate = cookiePreferencesAutoUpdatedTime === null || moment().diff(cookiePreferencesAutoUpdatedTime, 'seconds') > 30
+    if (!canAutoUpdate || explicitConsentRequired === "unknown" || explicitConsentGiven) return;
+
+    if (JSON.stringify(fallbackPreferences) !== JSON.stringify(preferencesCookieValue)) {
+      cookiePreferencesAutoUpdatedTime = new Date();
+      setCookie(COOKIE_PREFERENCES_COOKIE, cookiePreferences, { path: "/", expires: moment().add(2, 'years').toDate()  });
+      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: { cookiePreferences, explicitlyChanged: false }, properties: []});
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explicitConsentRequired, JSON.stringify(cookiePreferences), JSON.stringify(preferencesCookieValue), setCookie]);
   
   const updateCookiePreferences = useCallback(
     (newPreferences: CookieType[]) => {
@@ -61,7 +72,7 @@ export function useCookiePreferences(): {
       })
       setCookie(COOKIE_CONSENT_TIMESTAMP_COOKIE, new Date(), { path: "/", expires: moment().add(2, 'years').toDate() });
       setCookie(COOKIE_PREFERENCES_COOKIE, newPreferences, { path: "/", expires: moment().add(2, 'years').toDate() });
-      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: newPreferences, properties: []});
+      void cookiePreferencesChangedCallbacks.runCallbacks({iterator: { cookiePreferences: newPreferences, explicitlyChanged: true }, properties: []});
     },
     [captureEvent, setCookie]
   );

--- a/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
+++ b/packages/lesswrong/components/hooks/useCookiesWithConsent.ts
@@ -1,6 +1,6 @@
 import { useCookies } from "react-cookie";
 import { CookieSetOptions } from "universal-cookie/cjs/types";
-import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, cookiePreferencesAutoUpdated, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
+import { ALL_COOKIES, COOKIE_CONSENT_TIMESTAMP_COOKIE, COOKIE_PREFERENCES_COOKIE, CookieType, ONLY_NECESSARY_COOKIES, isCookieAllowed, isValidCookieTypeArray } from "../../lib/cookies/utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cookiePreferencesChangedCallbacks } from "../../lib/cookies/callbacks";
 import { getExplicitConsentRequiredAsync, getExplicitConsentRequiredSync } from "../common/CookieBanner/geolocation";


### PR DESCRIPTION
There is a `useEffect` inside `useCookiePreferences` which automatically updates the "cookie_preferences" cookie if the value is different to what is being used in the code. This was intended to be called when a user first visits the site (or, rarely, when they move countries), so if the user is in a GDPR country like the uk it should set the cookie to '["necessary"]', and if they are in e.g. the US it should set it to '["necessary", "functional", "analytics"]'. This is required because Google Tag Manager only has access to the "cookie_preferences" cookie to determine whether to trigger google analytics (i.e. it can't directly tell what country the user is in)

There was a bug in this where it would sometimes get stuck in an infinite loop of trying to update the cookie, and in doing so trigger hundreds of `page_view` events in google analytics, this only happened outside GDPR countries. Because of this I disabled this behaviour in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/7121) and the google analytics triggering has been broken since then (it is stuck on for all users, even if they have rejected cookies)

I haven't been able to reproduce the bug, but I think I have a reasonably good guess as to what was going on:
 - At the time this happened there were some bugs in the geolocation code, which meant:
   - Some requests were hitting a rate limit
   - There could be multiple calls to the geolocation api during a single page load, which meant some could hit the rate limit and fail while others could succeed
 - There were also several independent calls to `useCookiePreferences` which would (independently) try and automatically update the "cookie_preferences" cookie based on the value they got from the geolocation api
 - I think what was happening was two instances of the `useCookiePreferences` would try and set the "cookie_preferences" cookie to different values ('["necessary"]' and '["necessary", "functional", "analytics"]') and end causing an infinite loop when the value of the cookie fails to match the expected value. This would delete the google analytics cookie and retrigger it on every loop

This should be fixed in a number of ways now:
 - The geolocation code is now fixed by this [PR](https://github.com/ForumMagnum/ForumMagnum/pull/7110/files) (it is called at most once per page load and should never hit a rate limit now)
 - I have made it so no cookies are deleted if the update is triggered automatically
 - I have added a check that makes it so the cookie can only be updated every 30 seconds (in practice setting this to 2 seconds makes it so two instances of `useCookiePreferences` don't try to update it at the same time, 30s is just to be safe)
   - Even if the specific explanation above is wrong (fairly likely seeing as I couldn't reproduce the bug), there was definitely an infinite loop being caused in some way and this should fix that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204572433597831) by [Unito](https://www.unito.io)
