### PR TITLE
Improve crossposted questions

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -301,7 +301,11 @@ const PostsPage = ({post, refetch, classes}: {
     })
   }, [openDialog, post]);
 
-  const tableOfContents = sectionData
+  const isCrosspostedQuestion = post.question &&
+    post.fmCrosspost?.isCrosspost &&
+    !post.fmCrosspost?.hostedHere;
+
+  const tableOfContents = sectionData && !isCrosspostedQuestion
     ? <TableOfContents sectionData={sectionData} title={post.title} />
     : null;
   

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -305,10 +305,14 @@ const PostsPage = ({post, refetch, classes}: {
     post.fmCrosspost?.isCrosspost &&
     !post.fmCrosspost?.hostedHere;
 
+  // Hide the table of contents on questions that are foreign crossposts
+  // as we read ToC data from the foreign site and it includes answers
+  // which don't exists locally. TODO: Remove this gating when we finally
+  // rewrite crossposting.
   const tableOfContents = sectionData && !isCrosspostedQuestion
     ? <TableOfContents sectionData={sectionData} title={post.title} />
     : null;
-  
+
   const header = <>
     {!commentId && <>
       <HeadTags

--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -11,19 +11,22 @@ import pick from "lodash/pick";
  * in database selectors (but these rules aren't strict).
  *
  * When adding a new field here, make sure to also update isValidDenormalizedData
+ * and DenormalizedCrosspostValidator.
  */
 export const denormalizedFieldKeys = [
   "draft",
   "deletedDraft",
   "title",
   "isEvent",
+  "question",
 ] as const;
 
 export const isValidDenormalizedData = (payload: unknown): payload is DenormalizedCrosspostData =>
   hasBooleanParam(payload, "draft") &&
   hasBooleanParam(payload, "deletedDraft") &&
   hasStringParam(payload, "title") &&
-  hasBooleanParam(payload, "isEvent");
+  hasBooleanParam(payload, "isEvent") &&
+  hasBooleanParam(payload, "question");
 
 export type DenormalizedCrosspostData = Pick<DbPost, typeof denormalizedFieldKeys[number]>;
 

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -61,7 +61,8 @@ const DenormalizedCrosspostValidator = t.strict({
   draft: t.boolean,
   deletedDraft: t.boolean,
   title: t.string,
-  isEvent: t.boolean
+  isEvent: t.boolean,
+  question: t.boolean,
 });
 
 /**


### PR DESCRIPTION
This PR makes two changes:

- Denormalize the `question` field on posts for crossposts
- Hide the table of contents for foreign crossposted questions

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204572381085819) by [Unito](https://www.unito.io)
