### PR TITLE
[EA] Even more sans serif

### DIFF
--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -7,8 +7,12 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
+import { isEAForum } from '../../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  subtitle: {
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+  },
   deleteWithoutTrace: {
     marginRight:"auto"
   },
@@ -63,7 +67,7 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
           What is your reason for deleting this comment?
         </DialogTitle>
         <DialogContent>
-          <p><em>
+          <p className={classes.subtitle}><em>
             (If you delete without a trace, the reason will be sent to the
             author of the comment privately. Otherwise it will be publicly
             displayed below the comment.)

--- a/packages/lesswrong/components/common/CookieBanner/CookiePolicy.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookiePolicy.tsx
@@ -33,6 +33,7 @@ const styles = (theme: ThemeType) => ({
     textAlign: "center",
     margin: 30 - PADDING,
     padding: PADDING,
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
   heading: {
     paddingTop: 20,

--- a/packages/lesswrong/components/common/CookieBanner/CookieTable.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookieTable.tsx
@@ -10,6 +10,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 8,
     fontWeight: 600,
     fontSize: "1.2rem",
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
   tableContainer: {
     borderTopLeftRadius: theme.borderRadius.default,

--- a/packages/lesswrong/components/ea-forum/users/EAGApplicationImportForm.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAGApplicationImportForm.tsx
@@ -21,6 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     maxWidth: 1000,
     margin: '0 auto',
+    fontFamily: theme.palette.fonts.sansSerifStack,
     '& input.geosuggest__input': {
       width: '100%'
     }
@@ -472,7 +473,7 @@ const EAGApplicationImportForm = ({classes}: {
           <Typography variant="display3" className={classes.heading} gutterBottom>
             Welcome to the &#10024; <span className={classes.loggedOutMessageHighlight}>Effective Altruism Forum</span> &#10024;
           </Typography>
-          <Typography variant="body1" className={classes.loggedOutMessage}>
+          <Typography variant="body2" className={classes.loggedOutMessage}>
             <a href={`/auth/auth0?returnTo=${pathname}`} className={classes.loggedOutLink}>Login</a> or <a href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`} className={classes.loggedOutLink}>Sign Up</a> to
             import information from your EA Global application to your EA Forum profile.
           </Typography>
@@ -482,20 +483,20 @@ const EAGApplicationImportForm = ({classes}: {
   }
     
   const body = !importedData ? <>
-    <Typography variant="body1" className={classes.noAppText}>
+    <Typography variant="body2" className={classes.noAppText}>
       Sorry, we found no EA Global applications matching your EA Forum account's email address.
     </Typography>
-    <Typography variant="body1" className={classes.subheading}>
+    <Typography variant="body2" className={classes.subheading}>
       If you feel that this is in error, please <Link to="/contact" className={classes.contactUs}>contact us</Link>.
     </Typography>
   </> : <>
-    <Typography variant="body1" className={classes.subheading}>
+    <Typography variant="body2" className={classes.subheading}>
       We've found your application data from {event}.
     </Typography>
     
     <AnalyticsContext pageSectionContext="overwriteCallout">
       <div className={classes.callout}>
-        <Typography variant="body1" className={classes.overwriteText}>
+        <Typography variant="body2" className={classes.overwriteText}>
           Would you like to overwrite your EA Forum profile data?
         </Typography>
         <div>
@@ -506,7 +507,7 @@ const EAGApplicationImportForm = ({classes}: {
           >
             Overwrite and Submit
           </button>
-          <Typography variant="body1" className={classes.overwriteBtnAltText}>
+          <Typography variant="body2" className={classes.overwriteBtnAltText}>
             or see details and make changes below
           </Typography>
         </div>

--- a/packages/lesswrong/components/tagging/TagRevisionItemFullMetadata.tsx
+++ b/packages/lesswrong/components/tagging/TagRevisionItemFullMetadata.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { Revisions } from '../../lib/collections/revisions/collection';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   tagName: {
@@ -13,6 +14,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 8,
     display: "block",
     fontSize: "1.75rem",
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   metadata: {
     color: theme.palette.grey[800],

--- a/packages/lesswrong/components/users/UsersViewABTests.tsx
+++ b/packages/lesswrong/components/users/UsersViewABTests.tsx
@@ -5,13 +5,20 @@ import { useCurrentUser } from '../common/withUser';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import Select from '@material-ui/core/Select';
 import * as _ from 'underscore';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType) => ({
   explanatoryText: {
     ...theme.typography.body1,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   abTestsTable: {
     ...theme.typography.body1,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
     marginTop: 24,
     "& th": {
       textAlign: "left",


### PR DESCRIPTION
This PR fixes more places with serif fonts on the EA forum:

- Tag edit titles in recent discussions
<img width="531" alt="Screenshot 2023-05-10 at 21 43 01" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/f18a6035-1598-4406-99cb-eab1117b26e7">

- Delete comment popup
<img width="575" alt="Screenshot 2023-05-10 at 21 29 47" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/3896258b-446d-44f7-9308-d759a62ac71c">

- A/B test page
<img width="784" alt="Screenshot 2023-05-10 at 21 26 15" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/59843bd3-51be-4ba3-b431-0957d740982d">

- The date on the cookie notice page (to match the date on the terms of use page)
<img width="310" alt="Screenshot 2023-05-10 at 21 41 17" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/a4a4879e-9ff3-4697-9275-13f86c2c86c1">

- Section headings for the cookie table
<img width="179" alt="Screenshot 2023-05-10 at 21 38 16" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/5d4b9b3a-4c56-4a87-95b5-8b01d0e114a0">

- EAG import page
<img width="688" alt="Screenshot 2023-05-10 at 21 35 47" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/693cc1cb-1809-46df-b2c1-cdcae57c5951">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204574705208863) by [Unito](https://www.unito.io)
