### PR TITLE
Fix pluralization of posts and comments in EA user tooltip

### DIFF
--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -135,11 +135,11 @@ const EAUserTooltipContent = ({user, classes}: {
         </div>
         <div className={classes.stat}>
           <div>{formatStat(postCount)}</div>
-          <div>Posts</div>
+          <div>{postCount === 1 ? "Post" : "Posts"}</div>
         </div>
         <div className={classes.stat}>
           <div>{formatStat(commentCount)}</div>
-          <div>Comments</div>
+          <div>{commentCount === 1 ? "Comment" : "Comments"}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The new user pop-over on the EA forum currently always pluralizes "posts" and "comments" even if the user only has one.

Before:
<img width="311" alt="Screenshot 2023-05-10 at 21 50 23" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/ea42243f-5d09-475b-9618-aaf3041a9bee">

After:
<img width="321" alt="Screenshot 2023-05-10 at 21 48 53" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c741dbe8-2efe-4198-b203-cde94467fc80">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204574780357189) by [Unito](https://www.unito.io)
