### PR TITLE
Fix post-pages showing the newest version of post bodies when they should be showing a historical version

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -255,6 +255,8 @@ const PostsPage = ({post, refetch, classes}: {
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [post._id]);
   
+  const isOldVersion = query?.revision && post.contents;
+  
   const defaultSideCommentVisibility = userHasSideComments(currentUser)
     ? (post.sideCommentVisibility ?? "highKarma")
     : "hidden";
@@ -376,7 +378,7 @@ const PostsPage = ({post, refetch, classes}: {
             <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>
               {htmlWithAnchors && <PostBody
                 post={post} html={htmlWithAnchors}
-                sideCommentMode={sideCommentMode}
+                sideCommentMode={isOldVersion ? "hidden" : sideCommentMode}
               />}
             </CommentOnSelectionContentWrapper>
           </AnalyticsContext>


### PR DESCRIPTION
A user reported that old Sequences posts, which are supposed to have a version dropdown for viewing the old version without R:A-Z edits, no longer seemed to have the old versions accessible. There were two bugs both breaking this. The first was a data integrity issue, where in mongodb the `fieldName` on some `Revisions` was `["contents"]` rather than `"contents"`, which, when translated into postgres, caused those revisions to no longer show up in the history because they had the field name `"{contents}"`. I fixed that with a one-off SQL migration:

```
update "Revisions" set "fieldName"='contents' where "fieldName"='{contents}';
```

(I don't know whether any EA Forum posts have the same issue; it's worth a quick check with `select count(*) from "Revisions" where "fieldName"='{contents}';`)

The second issue was that when viewing an old version of a post with side-comments active, the post body was annotated with side comments using `sideCommentsCache`, which comes from the latest revision rather than the selected revision. This PR fixes _that_ issue by disabling side-comments when an old post version is selected.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204575026325147) by [Unito](https://www.unito.io)
