### PR TITLE
Return 200 rather than 500 errors from crossposting

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/resolvers.ts
+++ b/packages/lesswrong/server/fmCrosspost/resolvers.ts
@@ -66,7 +66,7 @@ export const makeCrossSiteRequest = async <RouteName extends ValidatedPostRouteN
   // Assertion is safe because either we got a result or we threw an error or returned
   const json = await result!.json();
   const validatedResponse = route.responseValidator.decode(json);
-  if (isLeft(validatedResponse)) {
+  if (isLeft(validatedResponse) || 'error' in json) {
     // eslint-disable-next-line no-console
     console.error("Cross-site request failed:", json);
     let errorMessage = onErrorMessage;

--- a/packages/lesswrong/server/fmCrosspost/routes.ts
+++ b/packages/lesswrong/server/fmCrosspost/routes.ts
@@ -76,9 +76,10 @@ export const addCrosspostRoutes = (app: Application) => {
       } catch (e) {
           // eslint-disable-next-line no-console
         console.error('Error when making cross-site GET request', { route: route.path, error: e });
+        const errorCode = e instanceof ApiError ? e.code : 501;
         return res
-          .status(e instanceof ApiError ? e.code : 501)
-          .send({error: e.message ?? "An unknown error occurred"})
+          .status(200)
+          .send({error: {message: e.message ?? "An unknown error occurred", code: errorCode}})
       }
 
       const decodedResponse = route.responseValidator.decode(response);
@@ -86,7 +87,7 @@ export const addCrosspostRoutes = (app: Application) => {
       if (isLeft(decodedResponse)) {
           // eslint-disable-next-line no-console
         console.error('Invalid response body when making cross-site GET request', { response, errors: decodedResponse.left.flatMap(e => e.context) });
-        return res.status(501).send({ error: 'An unknown error occurred' });
+        return res.status(200).send({ error: {message: 'An unknown error occurred' , code: 501 }});
       }
 
       return res.send(response);
@@ -108,9 +109,10 @@ export const addCrosspostRoutes = (app: Application) => {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error('Error when making cross-site POST request', { route: route.path, error: e });
+        const errorCode = e instanceof ApiError ? e.code : 501;
         return res
-          .status(e instanceof ApiError ? e.code : 501)
-          .send({error: e.message ?? "An unknown error occurred"})
+          .status(200)
+          .send({error: {message: e.message ?? "An unknown error occurred", code: errorCode }})
       }
 
       const decodedResponse = route.responseValidator.decode(response);
@@ -118,7 +120,7 @@ export const addCrosspostRoutes = (app: Application) => {
       if (isLeft(decodedResponse)) {
         // eslint-disable-next-line no-console
         console.error('Invalid response body when making cross-site GET request', { response, errors: decodedResponse.left.flatMap(e => e.context) });
-        return res.status(501).send({ error: 'An unknown error occurred' });
+        return res.status(200).send({ error: {message: 'An unknown error occurred', code: 501 }});
       }
 
       return res.send(response);


### PR DESCRIPTION
This is to stop crossposting errors from causing the elastic beanstalk health check to fail.

It turns out just changing the response code to 200 already worked, because the response is validated anyway so it still shows a nice error message if you return a malformed response with a 200 status code. I have also added an explicit check for 'error' in the response just in case