### PR TITLE
fix bug with numeric profile ids

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -66,6 +66,7 @@ import "./server/scripts/setUserTagFilters";
 import "./server/scripts/randomRecommendationSamples";
 import "./server/scripts/languageModels/generateTaggingPostSets";
 import "./server/scripts/languageModels/testModGPTOnComments";
+import "./server/scripts/mongoQueryToSQL";
 import './server/manualMigrations';
 import './server/manualMigrations/migrationsDashboardGraphql';
 

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -83,7 +83,9 @@ function createOAuthUserHandler<P extends Profile>(profilePath: string, getIdFro
       if (!profileId) {
         throw new Error('OAuth profile does not have a profile ID')
       }
-      let user = await Users.findOne({[`${profilePath}.id`]: profileId})
+      // TODO: We use a string representation of the profileId because we have Github IDs stored as strings but we get them as numbers
+      // And our query builder can't yet handle that case correctly
+      let user = await Users.findOne({[`${profilePath}.id`]: `${profileId}`})
       if (!user) {
         const email = profile.emails?.[0]?.value 
         

--- a/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
+++ b/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
@@ -1,0 +1,10 @@
+import SelectQuery from "../../lib/sql/SelectQuery";
+import Table from "../../lib/sql/Table";
+import { getCollectionByTableName, Globals } from "../vulcan-lib";
+
+Globals.findToSQL = ({ tableName, selector, options }: { tableName: CollectionNameString, selector: AnyBecauseTodo, options?: MongoFindOptions<DbObject> }) => {
+  const table = Table.fromCollection(getCollectionByTableName(tableName));
+  const select = new SelectQuery<DbObject>(table, selector, options);
+  const { sql, args } = select.compile();
+  console.log({ sql, args });
+};

--- a/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
+++ b/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
@@ -6,5 +6,6 @@ Globals.findToSQL = ({ tableName, selector, options }: { tableName: CollectionNa
   const table = Table.fromCollection(getCollectionByTableName(tableName));
   const select = new SelectQuery<DbObject>(table, selector, options);
   const { sql, args } = select.compile();
+  // eslint-disable-next-line no-console
   console.log({ sql, args });
 };

--- a/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
+++ b/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
@@ -2,6 +2,9 @@ import SelectQuery from "../../lib/sql/SelectQuery";
 import Table from "../../lib/sql/Table";
 import { getCollectionByTableName, Globals } from "../vulcan-lib";
 
+/**
+ * Translates a mongo find query to SQL for debugging purposes.  Requires a server running because the query builder uses collections, etc.
+ */
 Globals.findToSQL = ({ tableName, selector, options }: { tableName: CollectionNameString, selector: AnyBecauseTodo, options?: MongoFindOptions<DbObject> }) => {
   const table = Table.fromCollection(getCollectionByTableName(tableName));
   const select = new SelectQuery<DbObject>(table, selector, options);


### PR DESCRIPTION
For github logins specifically, we get back a number as a profile ID, and the query builder doesn't like that:
```
SQL Error for Users at position undefined:
cannot cast jsonb string to type integer:
`SELECT "Users".* FROM "Users" WHERE ("services"->'github'->'id')::INTEGER =  $1 LIMIT $2
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204592710372018) by [Unito](https://www.unito.io)
