### PR TITLE
Add middleware to redirect bots to a different environment

### DIFF
--- a/.github/workflows/deployEAProd.yaml
+++ b/.github/workflows/deployEAProd.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        environment: [EAForum-Production-2]
+        environment: [EAForum-Production-2, EAForum-Api]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -44,6 +44,7 @@ import { inspect } from "util";
 import { renderJssSheetPreloads } from './utils/renderJssSheetImports';
 import { datadogMiddleware } from './datadog/datadogMiddleware';
 import { Sessions } from '../lib/collections/sessions';
+import { botRedirectMiddleware } from './botRedirect';
 
 const loadClientBundle = () => {
   const bundlePath = path.join(__dirname, "../../client/js/bundle.js");
@@ -134,6 +135,7 @@ export function startWebserver() {
   addClientIdMiddleware(addMiddleware);
   app.use(datadogMiddleware);
   app.use(pickerMiddleware);
+  app.use(botRedirectMiddleware);
   
   //eslint-disable-next-line no-console
   console.log("Starting ForumMagnum server. Versions: "+JSON.stringify(process.versions));

--- a/packages/lesswrong/server/botRedirect.ts
+++ b/packages/lesswrong/server/botRedirect.ts
@@ -36,8 +36,8 @@ const getBaseUrl = () => {
  *
  * This function inspects the user agent and path of incoming requests. If the user agent matches
  * a certain pattern and the bot site redirect setting is enabled, it redirects the request to
- * the bot site. The redirect is a 307 (temporary) redirect to try and prevent search engines
- * from permanently indexing the bot site if we mess this up
+ * the bot site. The redirect is a 307 (temporary) redirect to try and prevent search engines and
+ * browser caches from permanently saving the bot site if we mess this up
  */
 export const botRedirectMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const userAgent = req.headers["user-agent"];

--- a/packages/lesswrong/server/botRedirect.ts
+++ b/packages/lesswrong/server/botRedirect.ts
@@ -42,14 +42,9 @@ const getBaseUrl = () => {
 export const botRedirectMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const userAgent = req.headers["user-agent"];
   const botSiteBaseUrl = getBaseUrl();
-
-  if (!botSiteRedirectEnabledSetting.get() || !botSiteBaseUrl || !userAgent) {
-    return next();
-  }
-
   const userAgentRegexes = botSiteUserAgentRegexesSetting.get();
 
-  if (!userAgentRegexes) {
+  if (!botSiteRedirectEnabledSetting.get() || !botSiteBaseUrl || !userAgent || !userAgentRegexes) {
     return next();
   }
 

--- a/packages/lesswrong/server/botRedirect.ts
+++ b/packages/lesswrong/server/botRedirect.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from 'express';
+import { DatabasePublicSetting } from '../lib/publicSettings';
+import { combineUrls } from './vulcan-lib';
+
+const botSitUrlSetting = new DatabasePublicSetting<string|null>('botSiteUrl', null);
+
+export const botRedirectMiddleware = (req: Request, res: Response, next: AnyBecauseTodo) => {
+  // TODO; inspect for user agent
+  // const blockedFromEverythingBots
+  // const blockedFromGraphqlAndAllPostsBots
+  // Redirect bots to the bot site
+  // TODO; add protocol if not already present
+  const botSiteBaseUrl = botSitUrlSetting.get();
+  if (!botSiteBaseUrl) {
+    return next();
+  }
+  const botSiteUrl = combineUrls(botSiteBaseUrl, req.originalUrl);
+  res.redirect(307, botSiteUrl);
+}

--- a/packages/lesswrong/server/botRedirect.ts
+++ b/packages/lesswrong/server/botRedirect.ts
@@ -1,19 +1,61 @@
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import { DatabasePublicSetting } from '../lib/publicSettings';
-import { combineUrls } from './vulcan-lib';
+import { combineUrls } from '../lib/vulcan-lib/utils';
+import { PublicInstanceSetting } from '../lib/instanceSettings';
 
-const botSitUrlSetting = new DatabasePublicSetting<string|null>('botSiteUrl', null);
+/** Url of the bot site to redirect to, e.g. https://forum-bots.effectivealtruism.org (must include the http(s)://) */
+const botSiteUrlSetting = new DatabasePublicSetting<string|null>('botSite.url', null);
+/** e.g.
+ * {
+ *   '.*': [ // matches all paths
+ *     '.*python.*',
+ *     ...
+ *   ],
+ *   '/allPosts/?.*|/graphql/?.*': [ // Matches any path starting with /allPosts/ or /graphql/
+ *     '.*python.*',
+ *     ...
+ *   ],
+ * }
+*/
+const botSiteUserAgentRegexesSetting = new DatabasePublicSetting<Record<string, string[]> | null>('botSite.userAgentRegexes', null);
 
-export const botRedirectMiddleware = (req: Request, res: Response, next: AnyBecauseTodo) => {
-  // TODO; inspect for user agent
-  // const blockedFromEverythingBots
-  // const blockedFromGraphqlAndAllPostsBots
-  // Redirect bots to the bot site
-  // TODO; add protocol if not already present
-  const botSiteBaseUrl = botSitUrlSetting.get();
-  if (!botSiteBaseUrl) {
+const botSiteRedirectEnabledSetting = new PublicInstanceSetting<boolean>('botSite.redirectEnabled', false, 'optional');
+
+/**
+ * Middleware function to redirect bot requests to a separate bot site.
+ *
+ * This function inspects the user agent and path of incoming requests. If the user agent matches
+ * a certain pattern and the bot site redirect setting is enabled, it redirects the request to
+ * the bot site. The redirect is a 307 (temporary) redirect to try and prevent search engines
+ * from permanently indexing the bot site if we mess this up
+ */
+export const botRedirectMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const userAgent = req.headers["user-agent"];
+  const botSiteBaseUrl = botSiteUrlSetting.get();
+
+  if (!botSiteRedirectEnabledSetting.get() || !botSiteBaseUrl || !userAgent) {
     return next();
   }
-  const botSiteUrl = combineUrls(botSiteBaseUrl, req.originalUrl);
-  res.redirect(307, botSiteUrl);
+
+  const userAgentRegexes = botSiteUserAgentRegexesSetting.get();
+
+  if (!userAgentRegexes) {
+    return next();
+  }
+
+  // Check each path and associated user agent regexes
+  for (let path in userAgentRegexes) {
+    const pathRegex = new RegExp(path);
+
+    // If request URL matches path and user agent matches any regex, redirect to bot site
+    if (pathRegex.test(req.url)) {
+      const regexes = userAgentRegexes[path];
+      if (regexes.some(regex => new RegExp(regex).test(userAgent))) {
+        const botSiteUrl = combineUrls(botSiteBaseUrl, req.url);
+        return res.redirect(307, botSiteUrl);
+      }
+    }
+  }
+
+  next();
 }

--- a/packages/lesswrong/server/botRedirect.ts
+++ b/packages/lesswrong/server/botRedirect.ts
@@ -21,6 +21,16 @@ const botSiteUserAgentRegexesSetting = new DatabasePublicSetting<Record<string, 
 
 const botSiteRedirectEnabledSetting = new PublicInstanceSetting<boolean>('botSite.redirectEnabled', false, 'optional');
 
+const getBaseUrl = () => {
+  const botSiteBaseUrl = botSiteUrlSetting.get();
+  if (botSiteBaseUrl && !botSiteBaseUrl.startsWith('http://') && !botSiteBaseUrl.startsWith('https://')) {
+    // eslint-disable-next-line no-console
+    console.error("Invalid botSiteBaseUrl configuration: URL must start with http:// or https://");
+    return null;
+  }
+  return botSiteBaseUrl;
+}
+
 /**
  * Middleware function to redirect bot requests to a separate bot site.
  *
@@ -31,7 +41,7 @@ const botSiteRedirectEnabledSetting = new PublicInstanceSetting<boolean>('botSit
  */
 export const botRedirectMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const userAgent = req.headers["user-agent"];
-  const botSiteBaseUrl = botSiteUrlSetting.get();
+  const botSiteBaseUrl = getBaseUrl();
 
   if (!botSiteRedirectEnabledSetting.get() || !botSiteBaseUrl || !userAgent) {
     return next();


### PR DESCRIPTION
We have created a separate environment (see [here](https://forum-bots.effectivealtruism.org/)) for bots to use to try and mitigate some of the site stability issues we have been having recently. This PR adds an automatic redirect based on the user agent of the request. 

There are 3 new settings introduced to configure this behaviour:

Database public settings:
- `botSite.url`: This is the URL of the site where the bots are redirected
- `botSite.userAgentRegexes`: This is a record where the keys are regex patterns matching request paths and the values are arrays of regex patterns matching user agents (see code for an example if this is confusing)

Public instance settings (required because the bot site shares a db with the production site)
- `botSite.redirectEnabled`

I have gone with a blacklist rather than a whitelist (on @s-cheng 's suggestion), because the risk of blocking someone that we shouldn't seems higher than the other way around

To do after merging this:
 - Create the list of regexes to block
 - Write a post explaining this (probably before turning it on to be polite to people who run bots)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204601330013078) by [Unito](https://www.unito.io)
