### PR TITLE
Add shorter timeout to graphiql requests

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -6,7 +6,7 @@ import { renderWithCache, getThemeOptionsFromReq } from './vulcan-lib/apollo-ssr
 
 import { pickerMiddleware } from './vendor/picker';
 import voyagerMiddleware from 'graphql-voyager/middleware/express';
-import { graphiqlMiddleware } from './vulcan-lib/apollo-server/graphiql';
+import { graphiqlTimeoutMiddleware, graphiqlUIMiddleware } from './vulcan-lib/apollo-server/graphiql';
 import getPlaygroundConfig from './vulcan-lib/apollo-server/playground';
 
 import { getExecutableSchema } from './vulcan-lib/apollo-server/initGraphQL';
@@ -169,6 +169,7 @@ export function startWebserver() {
 
   app.use('/graphql', express.json({ limit: '50mb' }));
   app.use('/graphql', express.text({ type: 'application/graphql' }));
+  app.use('/graphql', graphiqlTimeoutMiddleware)
   apolloServer.applyMiddleware({ app })
 
   addStaticRoute("/js/bundle.js", ({query}, req, res, context) => {
@@ -223,7 +224,7 @@ export function startWebserver() {
     endpointUrl: config.path,
   }));
   // Setup GraphiQL
-  app.use("/graphiql", graphiqlMiddleware({
+  app.use("/graphiql", graphiqlUIMiddleware({
     endpointURL: config.path,
     passHeader: "'Authorization': localStorage['Meteor.loginToken']", // eslint-disable-line quotes
   }));

--- a/packages/lesswrong/server/datadog/datadogMiddleware.ts
+++ b/packages/lesswrong/server/datadog/datadogMiddleware.ts
@@ -1,15 +1,6 @@
 import { getDatadogUser } from '../../lib/collections/users/helpers'
-import type { Request } from 'express';
+import { getIpFromRequest } from '../utils/httpUtil'
 import tracer from './tracer'
-
-export const getIpFromRequest = (req: Request): string => {
-  let ipOrIpArray = req.headers['x-forwarded-for'] || req.headers["x-real-ip"] || req.connection.remoteAddress || "unknown";
-  let ip = typeof ipOrIpArray === "object" ? ipOrIpArray[0] : ipOrIpArray as string;
-  if (ip.indexOf(",") >= 0) {
-    ip = ip.split(",")[0];
-  }
-  return ip;
-}
 
 /**
  * - Attach user info and IP address to the root span

--- a/packages/lesswrong/server/utils/httpUtil.ts
+++ b/packages/lesswrong/server/utils/httpUtil.ts
@@ -85,3 +85,12 @@ export function getAllCookiesFromReq(req: Request) {
     return new Cookies(untypedReq.cookies); // req.universalCookies;
   }
 }
+
+export const getIpFromRequest = (req: Request): string => {
+  let ipOrIpArray = req.headers['x-forwarded-for'] || req.headers["x-real-ip"] || req.connection.remoteAddress || "unknown";
+  let ip = typeof ipOrIpArray === "object" ? ipOrIpArray[0] : ipOrIpArray as string;
+  if (ip.indexOf(",") >= 0) {
+    ip = ip.split(",")[0];
+  }
+  return ip;
+}

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -21,13 +21,12 @@ import { captureException } from '@sentry/core';
 import { randomId } from '../../../lib/random';
 import { getPublicSettings, getPublicSettingsLoaded } from '../../../lib/settingsCache'
 import { ServerRequestStatusContextType } from '../../../lib/vulcan-core/appContext';
-import { getCookieFromReq, getPathFromReq } from '../../utils/httpUtil';
+import { getCookieFromReq, getIpFromRequest, getPathFromReq } from '../../utils/httpUtil';
 import { getThemeOptions, AbstractThemeOptions } from '../../../themes/themeNames';
 import { renderJssSheetImports } from '../../utils/renderJssSheetImports';
 import { DatabaseServerSetting } from '../../databaseSettings';
 import type { Request, Response } from 'express';
 import type { TimeOverride } from '../../../lib/utils/timeUtil';
-import { getIpFromRequest } from '../../datadog/datadogMiddleware';
 import { isEAForum } from '../../../lib/instanceSettings';
 import { frontpageAlgoCacheDisabled } from '../../../lib/scoring';
 


### PR DESCRIPTION
Requests from graphiql have been known to slow the site down, this adds a configurable shorter timeout to try and mitigate this somewhat (previously they had a 60 second timeout like all other request).

With graphql it's very hard to know how costly a request will be before you make it so I think this is about the best we can do without completely locking down the set of allowed queries

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204601932226495) by [Unito](https://www.unito.io)
