### PR TITLE
Posts recommendations improvements

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -274,6 +274,7 @@ const PostsPage = ({post, refetch, classes}: {
 
   const recommendationsTestGroup = useABTest(postsPageRecommendationsABTest);
   const showRecommendations = isEAForum &&
+    !post.shortform &&
     !post.draft &&
     !post.deletedDraft &&
     !post.question &&

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -274,7 +274,10 @@ const PostsPage = ({post, refetch, classes}: {
 
   const recommendationsTestGroup = useABTest(postsPageRecommendationsABTest);
   const showRecommendations = isEAForum &&
+    !post.draft &&
+    !post.deletedDraft &&
     !post.question &&
+    !post.debate &&
     !sequenceId &&
     recommendationsTestGroup === "recommended";
 

--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
@@ -1,6 +1,5 @@
 import React, { FC, MouseEvent, useCallback } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
-import { useCurrentUser } from "../common/withUser";
 import { gql, useMutation } from "@apollo/client";
 import { useObserver } from "../hooks/useObserver";
 import { SoftUpArrowIcon } from "../icons/softUpArrowIcon";
@@ -48,17 +47,30 @@ const styles = (theme: ThemeType) => ({
     transform: "translateY(-2px)",
     color: theme.palette.grey[400],
   },
+  titleContainer: {
+    flexGrow: 1,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    display: "flex",
+    alignItems: "flex-start",
+    [theme.breakpoints.down("xs")]: {
+      whiteSpace: "unset",
+      flexDirection: "column",
+    },
+  },
   title: {
     fontSize: 16,
     fontWeight: 600,
     color: theme.palette.grey[1000],
     flexGrow: 1,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
   },
   author: {
     textAlign: "right",
     whiteSpace: "nowrap",
+    [theme.breakpoints.down("xs")]: {
+      marginTop: 4,
+    },
   },
   coauthors: {
     marginLeft: 3,
@@ -85,7 +97,6 @@ const PostsPageRecommendationItem = ({
 }) => {
   const postLink = postGetPageUrl(post, false, post.canonicalSequence?._id);
   const {onClick} = useClickableCell(postLink);
-  const currentUser = useCurrentUser();
   const [observeRecommendation] = useMutation(
     observeRecommendationMutation,
     {errorPolicy: "all"},
@@ -146,37 +157,38 @@ const PostsPageRecommendationItem = ({
           <SoftUpArrowIcon />
         </div>
       </div>
-      <div className={classes.title}>
+      <div className={classes.titleContainer}>
         <PostsTitle
           post={post}
           Wrapper={TitleWrapper}
           isLink={false}
           curatedIconLeft
+          className={classes.title}
         />
-      </div>
-      <div className={classes.author}>
-        <InteractionWrapper className={classes.interactionWrapper}>
-          <UsersName user={post.user} />
-          {post.coauthors.length > 0 &&
-            <LWTooltip
-              title={
-                <div>
-                  {post.coauthors.map((coauthor, i) =>
-                    <div key={i}>
-                      <UsersName user={coauthor} />
-                    </div>
-                  )}
-                </div>
-              }
-            >
-              <span className={classes.coauthors}>+{post.coauthors.length} more</span>
-            </LWTooltip>
-          }
-        </InteractionWrapper>
+        <div className={classes.author}>
+          <InteractionWrapper className={classes.interactionWrapper}>
+            <UsersName user={post.user} />
+            {post.coauthors.length > 0 &&
+              <LWTooltip
+                title={
+                  <div>
+                    {post.coauthors.map((coauthor, i) =>
+                      <div key={i}>
+                        <UsersName user={coauthor} />
+                      </div>
+                    )}
+                  </div>
+                }
+              >
+                <span className={classes.coauthors}>+{post.coauthors.length} more</span>
+              </LWTooltip>
+            }
+          </InteractionWrapper>
+        </div>
       </div>
       <div>
         <InteractionWrapper>
-          <PostActionsButton post={post} vertical />
+          <PostActionsButton post={post} vertical autoPlace />
         </InteractionWrapper>
       </div>
     </div>

--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
@@ -30,7 +30,7 @@ const styles = (theme: ThemeType) => ({
 const PostsPageRecommendationsList = ({
   title = "More posts like this",
   strategy = "moreFromTag",
-  bias = 1,
+  bias,
   features,
   forceLoggedOutView,
   classes,

--- a/packages/lesswrong/server/recommendations/CollabFilterStrategy.ts
+++ b/packages/lesswrong/server/recommendations/CollabFilterStrategy.ts
@@ -22,7 +22,7 @@ class CollabFilterStrategy extends FeatureStrategy {
   ): Promise<RecommendationResult> {
     const features: WeightedFeature[] = [
       {feature: "karma", weight: 0.8},
-      {feature: "curated", weight: 0.075},
+      {feature: "curated", weight: 0.06},
     ];
 
     if (this.weightByTagSimilarity) {


### PR DESCRIPTION
Changes in this PR:
 - Better payout of posts recommendations on mobile from [Agnes' design in slack](https://cea-core.slack.com/archives/C03G0AQ925P/p1683873865021309?thread_ts=1683802025.109309&cid=C03G0AQ925P)
 - Slightly less of a relevancy boost for curated posts (they already have a massive boost from the fact that they generally have super high karma)
 - More relevancy boost for tag similarity (this is actually a bug fix - it was meant to be 1.5, but it was actually 1 because of a default value for a React prop)
 - Hide recommendations on drafts, shortforms, debates and deleted posts

<img width="769" alt="Screenshot 2023-05-15 at 13 48 37" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4f004a92-2238-405b-861b-2214d065f5de">

<img width="433" alt="Screenshot 2023-05-15 at 13 50 29" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/945cefab-2d69-4a60-b431-56dad073d4aa">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204602046743876) by [Unito](https://www.unito.io)
