### PR TITLE
fix users getting lost when removed from the review queue

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -188,8 +188,14 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
       selector: {_id: user._id},
       data: {
         needsReview: false,
-        reviewedByUserId: null, // this is necessary so that their next post/comment won't appear without being approved by a moderator
-        reviewedAt: new Date(), // this is necessary so it shows up that they appear in the "recently reviewed" list
+        // this is necessary so that their next post/comment won't appear without being approved by a moderator
+        reviewedByUserId: null,
+        /* 
+         * this is necessary so it shows up that they appear in the "recently reviewed" list
+         * for users who've been reviewed before, we update the date.  for users we haven't, we don't.
+         * see comment in `getReasonForReview` for more details
+         */
+        reviewedAt: user.reviewedAt ? new Date() : null,
         sunshineNotes: newNotes
       }
     })    

--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -106,12 +106,19 @@ export function getReasonForReview(user: DbUser | SunshineUsersList, override?: 
   if (override) return 'override';
 
   const fullyReviewed = user.reviewedByUserId && !user.snoozedUntilContentCount;
-  const neverReviewed = !user.reviewedByUserId && !user.reviewedAt;
+  /**
+   * This covers several cases
+   * 1) never reviewed users
+   * 2) users who were removed from the review queue and weren't previously reviewed
+   * 3) users who were removed from the review queue and *were* previously reviewed
+   * 1 & 2 look indistinguishable, 3 will have a non-null reviewedAt date
+   */ 
+  const unreviewed = !user.reviewedByUserId;
   const snoozed = user.reviewedByUserId && user.snoozedUntilContentCount;
 
   if (fullyReviewed) return 'alreadyApproved';
 
-  if (neverReviewed) {
+  if (unreviewed) {
     if (user.mapLocation && isEAForum) return 'mapLocation';
     if (user.postCount) return 'firstPost';
     if (user.commentCount) return 'firstComment';

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -72,10 +72,6 @@ voteCallbacks.cancelAsync.add(async function cancelVoteCount ({newDocument, vote
   }
 });
 
-voteCallbacks.castVoteAsync.add(async function updateNeedsReview (document: VoteDocTuple) {
-  return triggerReviewIfNeeded(document.vote.userId)
-});
-
 voteCallbacks.castVoteAsync.add(async function checkAutomod ({newDocument, vote}: VoteDocTuple) {
   if (forumTypeSetting.get() === 'LessWrong') {
     void triggerAutomodIfNeeded(newDocument.userId)


### PR DESCRIPTION
This is a bunch of spaghetti and we're probably going to overhaul it imminently, but right now we have some users getting "lost" when removed from the review queue.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204606732152965) by [Unito](https://www.unito.io)
