### PR TITLE
Post created flash message draft

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -243,7 +243,8 @@ const PostsNewForm = ({classes}: {
                 history.push(postGetEditUrl(post._id));
               } else {
                 history.push({pathname: postGetPageUrl(post)})
-                flash({ messageString: "Post created.", type: 'success'});
+                const postDescription = post.draft ? "Draft" : "Post";
+                flash({ messageString: `${postDescription} created.`, type: 'success'});
               }
             }}
             eventForm={eventForm}


### PR DESCRIPTION
When you create a new post from the new post page, a flash message appears saying "Post created." This includes when the new post is being saved as a draft with the Save Draft buttom. A user reported this as having scared them, since they thought they had created a non-draft post when they only meant to save a draft.

Change the message to say "Draft created" instead if it's a draft.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204607654941169) by [Unito](https://www.unito.io)
