### PR TITLE
Comment-permalink doesn't inherit a hash from the current URL

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/useCommentLink.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/useCommentLink.tsx
@@ -53,8 +53,8 @@ export const useCommentLink = ({
     event.preventDefault();
     history.replace({
       ...location,
-      search:
-      qs.stringify({...query, commentId: comment._id}),
+      search: qs.stringify({...query, commentId: comment._id}),
+      hash: null,
     });
 
     if (scrollIntoView) {


### PR DESCRIPTION
A user reported:

> A somewhat common sequence of actions is "click lw post" –> "press comments (adding #comments to the URL)" –> "press the URL to a specific comment (adding ?comment-id to the URL)" –> "copy paste my current URL to share a link to the comment".
The problem is that #comments is still at the end of the URL, so when someone follows that link, they go to the top of the comment-section. It's totally invisible that there's a specific comment above the post. Maybe they'll read the top comment instead, thinking that the link led to that. Or maybe they'll just think that the sender of the link failed to link to a specific comment, and close the tab.
> Example of a fix: When you click the link to a specific comment, that removes #comment from the end of the current URL.

This makes it so that comment-permalinks no longer inherit the hash portion of the URL.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204607663189314) by [Unito](https://www.unito.io)
