### PR TITLE
Hide "this comment will not be visible"

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -31,7 +31,7 @@ const CommentBottomCaveats = ({comment, classes}: {
       </div>
     }
     { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
-    { commentIsHidden(comment) && <Components.MetaInfo>
+    { commentIsHidden(comment) && !comment.rejected && <Components.MetaInfo>
       [This comment will not be visible to other users until the moderation
       team checks it for spam or norm violations.]
     </Components.MetaInfo>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -140,6 +140,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     }
   }
   const handleReview = () => {
+    const newNotes = getModSignatureWithNote(`Approved`)+notes;
     if (canReview) {
       void updateUser({
         selector: {_id: user._id},
@@ -148,7 +149,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
           reviewedByUserId: currentUser._id,
           reviewedAt: new Date(),
           needsReview: false,
-          sunshineNotes: notes,
+          sunshineNotes: newNotes,
           snoozedUntilContentCount: null
         }
       })
@@ -224,6 +225,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   }
   
   const handlePurge = () => {
+    const newNotes = getModSignatureWithNote("Purge") + notes;
     if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
       void updateUser({
         selector: {_id: user._id},
@@ -236,7 +238,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
           needsReview: false,
           reviewedAt: new Date(),
           banned: moment().add(1000, 'years').toDate(),
-          sunshineNotes: notes
+          sunshineNotes: newNotes
         }
       })
       setNotes( getModSignatureWithNote("Purge")+notes )
@@ -244,16 +246,16 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   }
   
   const handleFlag = () => {
+    const flagStatus = user.sunshineFlagged ? "Unflag" : "Flag"
+    const newNotes =  getModSignatureWithNote(flagStatus)+notes
     void updateUser({
       selector: {_id: user._id},
       data: {
         sunshineFlagged: !user.sunshineFlagged,
-        sunshineNotes: notes
+        sunshineNotes: newNotes
       }
     })
-    
-    const flagStatus = user.sunshineFlagged ? "Unflag" : "Flag"
-    setNotes( getModSignatureWithNote(flagStatus)+notes )
+    setNotes(newNotes)
   }
   
   const handleDisablePosting = () => {


### PR DESCRIPTION
Once a comment has been rejected, it no longer makes sense to say "this comment will be hidden", because in the circumstances where you can actually see the comment it's, well, visible. (And should have a rejection reason listed)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204632763423053) by [Unito](https://www.unito.io)
