### PR TITLE
Ban emojis in post titles

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -16,7 +16,7 @@ import { performCrosspost, handleCrosspostUpdate } from "../fmCrosspost/crosspos
 import { addOrUpvoteTag } from '../tagging/tagsGraphQL';
 import { userIsAdmin } from '../../lib/vulcan-users';
 import { MOVED_POST_TO_DRAFT, REJECTED_POST } from '../../lib/collections/moderatorActions/schema';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { isEAForum } from '../../lib/instanceSettings';
 import { captureException } from '@sentry/core';
 import { TOS_NOT_ACCEPTED_ERROR } from '../fmCrosspost/resolvers';
 import TagRels from '../../lib/collections/tagRels/collection';
@@ -28,7 +28,7 @@ import { getAdminTeamAccount } from './commentCallbacks';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
-if (forumTypeSetting.get() === "EAForum") {
+if (isEAForum) {
   const checkTosAccepted = <T extends Partial<DbPost>>(currentUser: DbUser | null, post: T): T => {
     if (post.draft === false && !post.shortform && !currentUser?.acceptedTos) {
       throw new Error(TOS_NOT_ACCEPTED_ERROR);
@@ -41,6 +41,14 @@ if (forumTypeSetting.get() === "EAForum") {
   getCollectionHooks("Posts").updateBefore.add(
     (post, {currentUser}) => checkTosAccepted(currentUser, post),
   );
+
+  const assertPostTitleHasNoEmojis = (post: DbPost) => {
+    if (/\p{Extended_Pictographic}/u.test(post.title)) {
+      throw new Error("Post titles cannot contain emojis");
+    }
+  }
+  getCollectionHooks("Posts").newSync.add(assertPostTitleHasNoEmojis);
+  getCollectionHooks("Posts").updateBefore.add(assertPostTitleHasNoEmojis);
 }
 
 getCollectionHooks("Posts").createValidate.add(function DebateMustHaveCoauthor(validationErrors, { document }) {
@@ -276,7 +284,7 @@ getCollectionHooks("Posts").updateAsync.add(async function sendRejectionPM({ new
     }
 
     // FYI EA Forum: Decide if you want this to always send emails the way you do for deletion. We think it's better not to.
-    const noEmail = forumTypeSetting.get() === "EAForum" 
+    const noEmail = isEAForum
     ? false 
     : !(!!postUser?.reviewedByUserId && !postUser.snoozedUntilContentCount)
   


### PR DESCRIPTION
You don't get to use that regex every day. It's a fun one.

<img width="804" alt="Screenshot 2023-05-18 at 23 56 08" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c19db1ac-194d-4fef-b15a-f8c60e5e8816">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204633037683998) by [Unito](https://www.unito.io)
