### PR TITLE
Hide recommendations on events

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -281,6 +281,7 @@ const PostsPage = ({post, refetch, classes}: {
     !post.deletedDraft &&
     !post.question &&
     !post.debate &&
+    !post.isEvent &&
     !sequenceId &&
     recommendationsTestGroup === "recommended";
 


### PR DESCRIPTION
Hide recommendations on posts pages when the post is an event

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204637315044927) by [Unito](https://www.unito.io)
