### PR TITLE
Change default rate limit expiry to three weeks (21 days)

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -311,7 +311,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   const applyModeratorAction = async (type: AllRateLimitTypes) => {
 
     const endDate = new Date();
-    endDate.setDate(endDate.getDate() + 60);
+    endDate.setDate(endDate.getDate() + 21);
 
     await createModeratorAction({
       data: {

--- a/packages/lesswrong/server/callbacks/rateLimits.ts
+++ b/packages/lesswrong/server/callbacks/rateLimits.ts
@@ -8,7 +8,6 @@ import { getModeratorRateLimit, getTimeframeForRateLimit, userHasActiveModerator
 import moment from 'moment';
 import Users from '../../lib/collections/users/collection';
 import { captureEvent } from '../../lib/analyticsEvents';
-import { isEAForum } from '../../lib/instanceSettings';
 
 
 const postIntervalSetting = new DatabasePublicSetting<number>('forum.postInterval', 30) // How long users should wait between each posts, in seconds


### PR DESCRIPTION
Also removed unused import

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204640168209195) by [Unito](https://www.unito.io)
