### PR TITLE
Expired rate limit returns to queue

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -1,6 +1,5 @@
 import { foreignKeyField, resolverOnlyField } from '../../utils/schemaUtils'
 import { TupleSet, UnionOf } from '../../utils/typeGuardUtils';
-import { userOwns } from '../../vulcan-users/permissions';
 
 export const RATE_LIMIT_ONE_PER_DAY = 'rateLimitOnePerDay';
 export const RATE_LIMIT_ONE_PER_THREE_DAYS = 'rateLimitOnePerThreeDays';

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -14,6 +14,7 @@ import './server/rss-integration/cron';
 import './server/rss-integration/callbacks';
 import './server/karmaInflation/cron';
 import './server/useractivities/cron';
+import './server/users/cron'
 import './server/database-import/force_batch_update_scores';
 import './server/database-import/cleanup_scripts';
 import './server/robots';

--- a/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
+++ b/packages/lesswrong/server/scripts/mongoQueryToSQL.ts
@@ -1,12 +1,12 @@
 import SelectQuery from "../../lib/sql/SelectQuery";
 import Table from "../../lib/sql/Table";
-import { getCollectionByTableName, Globals } from "../vulcan-lib";
+import { getCollection, Globals } from "../vulcan-lib";
 
 /**
  * Translates a mongo find query to SQL for debugging purposes.  Requires a server running because the query builder uses collections, etc.
  */
 Globals.findToSQL = ({ tableName, selector, options }: { tableName: CollectionNameString, selector: AnyBecauseTodo, options?: MongoFindOptions<DbObject> }) => {
-  const table = Table.fromCollection(getCollectionByTableName(tableName));
+  const table = Table.fromCollection(getCollection(tableName));
   const select = new SelectQuery<DbObject>(table, selector, options);
   const { sql, args } = select.compile();
   // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/users/cron.ts
+++ b/packages/lesswrong/server/users/cron.ts
@@ -28,6 +28,7 @@ addCronJob({
       })
       
       // log the action
+      // eslint-disable-next-line no-console
       console.log('// Users with expired rate limits:', userIdsWithExpiringRateLimits); // eslint-disable-line
     }
   }

--- a/packages/lesswrong/server/users/cron.ts
+++ b/packages/lesswrong/server/users/cron.ts
@@ -14,7 +14,7 @@ addCronJob({
   
   
     const startOfDay = moment(new Date()).subtract(1, 'days').toDate()
-    const endOfDay = moment(new Date()).add(1, 'days').toDate()
+    const endOfDay = new Date() 
     
     const rateLimitsExpiringToday = await ModeratorActions.find({type: {$in: allRateLimits}, endedAt: {$gte: startOfDay, $lt: endOfDay}}).fetch();
     const userIdsWithExpiringRateLimits = rateLimitsExpiringToday.map((action) => action.userId);

--- a/packages/lesswrong/server/users/cron.ts
+++ b/packages/lesswrong/server/users/cron.ts
@@ -1,22 +1,22 @@
 import { addCronJob } from '../cronUtil';
 import Users from "../../lib/collections/users/collection";
-import * as _ from 'underscore';
 import { ModeratorActions } from "../../lib/collections/moderatorActions";
+import { allRateLimits } from "../../lib/collections/moderatorActions/schema";
+import { getSignatureWithNote } from "../../lib/collections/users/helpers";
+import * as _ from 'underscore';
 import moment from 'moment';
-import {allRateLimits} from "../../lib/collections/moderatorActions/schema";
-import {getNewModActionNotes, getSignatureWithNote} from "../../lib/collections/users/helpers";
 
 
 addCronJob({
   name: 'expiredRateLimitsReturnToReviewQueue',
-  interval: 'every 1 minute',
+  interval: 'every 24 hours',
   async job() {
   
   
     const startOfDay = moment(new Date()).subtract(1, 'days').toDate()
     const endOfDay = moment(new Date()).add(1, 'days').toDate()
     
-    const rateLimitsExpiringToday = await ModeratorActions.find({type: "rateLimit", endedAt: [{$gte: startOfDay}, {$lt: endOfDay}, ]}).fetch();
+    const rateLimitsExpiringToday = await ModeratorActions.find({type: {$in: allRateLimits}, endedAt: {$gte: startOfDay, $lt: endOfDay}}).fetch();
     const userIdsWithExpiringRateLimits = rateLimitsExpiringToday.map((action) => action.userId);
     const usersWithExpiringRateLimits = await Users.find({_id: {$in: userIdsWithExpiringRateLimits}}).fetch();
     

--- a/packages/lesswrong/server/users/cron.ts
+++ b/packages/lesswrong/server/users/cron.ts
@@ -1,0 +1,34 @@
+import { addCronJob } from '../cronUtil';
+import Users from "../../lib/collections/users/collection";
+import * as _ from 'underscore';
+import { ModeratorActions } from "../../lib/collections/moderatorActions";
+import moment from 'moment';
+import {allRateLimits} from "../../lib/collections/moderatorActions/schema";
+import {getNewModActionNotes, getSignatureWithNote} from "../../lib/collections/users/helpers";
+
+
+addCronJob({
+  name: 'expiredRateLimitsReturnToReviewQueue',
+  interval: 'every 1 minute',
+  async job() {
+  
+  
+    const startOfDay = moment(new Date()).subtract(1, 'days').toDate()
+    const endOfDay = moment(new Date()).add(1, 'days').toDate()
+    
+    const rateLimitsExpiringToday = await ModeratorActions.find({type: "rateLimit", endedAt: [{$gte: startOfDay}, {$lt: endOfDay}, ]}).fetch();
+    const userIdsWithExpiringRateLimits = rateLimitsExpiringToday.map((action) => action.userId);
+    const usersWithExpiringRateLimits = await Users.find({_id: {$in: userIdsWithExpiringRateLimits}}).fetch();
+    
+    if (!_.isEmpty(usersWithExpiringRateLimits)) {
+      
+      usersWithExpiringRateLimits.map(async user => {
+        const updatedNotes = `${getSignatureWithNote('Automod', "Rate limit expired")}${user.sunshineNotes}`
+        await Users.rawUpdateOne({_id: user._id}, {$set: {needsReview: true, sunshineNotes: updatedNotes}})
+      })
+      
+      // log the action
+      console.log('// Users with expired rate limits:', userIdsWithExpiringRateLimits); // eslint-disable-line
+    }
+  }
+});

--- a/packages/lesswrong/server/users/cron.ts
+++ b/packages/lesswrong/server/users/cron.ts
@@ -13,8 +13,8 @@ addCronJob({
   async job() {
   
   
-    const startOfDay = moment(new Date()).subtract(1, 'days').toDate()
-    const endOfDay = new Date() 
+    const endOfDay = new Date()
+    const startOfDay = moment(endOfDay).subtract(1, 'days').toDate()
     
     const rateLimitsExpiringToday = await ModeratorActions.find({type: {$in: allRateLimits}, endedAt: {$gte: startOfDay, $lt: endOfDay}}).fetch();
     const userIdsWithExpiringRateLimits = rateLimitsExpiringToday.map((action) => action.userId);


### PR DESCRIPTION
LessWrong has decided that we'll have rate limits expire by default after three weeks (so they don't persist indefinitely), but when they do so, the user gets returned to the review queue and we can do a quick little assessment of whether it should be reapplied.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204640281484759) by [Unito](https://www.unito.io)
