### PR TITLE
[EA Forum only] update profile imgs in search results, fix position of voting tooltips

### DIFF
--- a/packages/lesswrong/components/search/ExpandedUsersSearchHit.tsx
+++ b/packages/lesswrong/components/search/ExpandedUsersSearchHit.tsx
@@ -66,13 +66,16 @@ const ExpandedUsersSearchHit = ({hit, classes}: {
   hit: Hit<any>,
   classes: ClassesType,
 }) => {
-  const { FormatDate, ProfilePhoto, ForumIcon } = Components
+  const { FormatDate, UsersProfileImage, ForumIcon } = Components
   const user = hit as AlgoliaUser
 
   return <div className={classes.root}>
     <Link to={`${userGetProfileUrl(user)}?from=search_page`} className={classes.link}>
       <div className={classes.profilePhotoCol}>
-        <ProfilePhoto user={user} noLink />
+        <UsersProfileImage
+          user={user}
+          size={36}
+          fallback="initials" />
       </div>
       <div>
         <div className={classes.displayNameRow}>

--- a/packages/lesswrong/components/users/UsersProfileImage.tsx
+++ b/packages/lesswrong/components/users/UsersProfileImage.tsx
@@ -68,6 +68,9 @@ const InitialFallback: FC<{
   className?: string,
   classes: ClassesType,
 }> = memo(({displayName, size, className, classes}) => {
+  // this shouldn't happen but somehow exists in our dev env
+  if (!displayName) return null
+  
   const initials = displayName.split(/[\s-_.()]/).map((s) => s?.[0]?.toUpperCase());
   const text = initials.filter((s) => s?.length).join("").slice(0, 3);
   const background = userBackground(displayName);
@@ -106,7 +109,10 @@ const InitialFallback: FC<{
 });
 
 const UsersProfileImage = ({user, size, fallback="initials", className, classes}: {
-  user?: UsersMinimumInfo,
+  user?: {
+    profileImageId?: string,
+    displayName: string
+  },
   size: number,
   fallback?: ProfileImageFallback,
   className?: string,

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -41,7 +41,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: '1rem',
     backgroundColor: theme.palette.panelBackground.default,
     transition: 'opacity 150ms cubic-bezier(0.4, 0, 1, 1) 0ms',
-    marginLeft: 0
+    marginLeft: 0,
+    paddingTop: isEAForum ? 12 : 0
   },
 })
 


### PR DESCRIPTION
A couple small fixes in this PR:
1. Updated the user search results tab to use the new profile img component, so now it's more colorful :)
<img width="300" alt="Screen Shot 2023-05-22 at 2 38 26 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/a24baeb9-beea-48db-8fc3-1070ea236cb1">

-----
2. Adjusted the position of the voting tooltip hover text so that it's better aligned (below is how it looked before the fix, now it's vertically centered with the karma)
<img width="109" alt="Screen Shot 2023-05-21 at 4 00 53 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/8de0a6ec-cdd7-41ca-9a26-1b0303fd3e5e">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204649212005591) by [Unito](https://www.unito.io)
