### PR TITLE
dont save email html in lwevents

### DIFF
--- a/packages/lesswrong/components/notifications/EmailPreview.tsx
+++ b/packages/lesswrong/components/notifications/EmailPreview.tsx
@@ -39,7 +39,7 @@ export const EmailPreview = ({email, sentDate, classes}: {
       <span className={classes.headerName}>To: </span>
       <span className={classes.headerContent}>{email.to}</span>
     </div>
-    <iframe className={classes.emailBodyFrame} srcDoc={email.html}/>
+    {email.html && <iframe className={classes.emailBodyFrame} srcDoc={email.html}/>}
     <div className={classes.emailTextVersion}>
       {email.text}
     </div>

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -292,9 +292,13 @@ export async function sendEmail(renderedEmail: RenderedEmail): Promise<boolean>
 }
 
 export async function logSentEmail(renderedEmail: RenderedEmail, user: DbUser | null, additionalFields: any) {
+  // Remove the html, which is very large and bloats LWEvents
+  // We still have the text content of the email, which is sufficient for email history
+  const { html, ...emailFields } = renderedEmail;
+
   // Replace user (object reference) in renderedEmail so we can log it in LWEvents
   const emailJson = {
-    ...renderedEmail,
+    ...emailFields,
     user: user?._id,
   };
   // Log in LWEvents table


### PR DESCRIPTION
Saving the html version of every single email we send has been enormously bloating LWEvents.  (We send e.g. many copies of every single curated post to everyone who's subscribed to curated posts.)

The only thing we were even using it for was for displaying in `/debug/emailHistory`, and if necessary we could externalize the logic to render the html into a script so we could do it on demand.  (This could give us something different if any of the relevant components or logic had changed since the email was sent, but we also have 15 days of log retention in Mailgun, so 🤷.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204652805861189) by [Unito](https://www.unito.io)
