### PR TITLE
Rollout posts page recommendations to all users

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -15,7 +15,7 @@ import { userHasSideComments } from '../../../lib/betas';
 import { forumSelect } from '../../../lib/forumTypeUtils';
 import { welcomeBoxes } from './WelcomeBox';
 import { useABTest } from '../../../lib/abTestImpl';
-import { postsPageRecommendationsABTest, welcomeBoxABTest } from '../../../lib/abTests';
+import { welcomeBoxABTest } from '../../../lib/abTests';
 import { useDialog } from '../../common/withDialog';
 import { useMulti } from '../../../lib/crud/withMulti';
 import { SideCommentMode, SideCommentVisibilityContextType, SideCommentVisibilityContext } from '../../dropdowns/posts/SetSideCommentVisibility';
@@ -274,7 +274,6 @@ const PostsPage = ({post, refetch, classes}: {
   const sectionData = (post as PostsWithNavigationAndRevision).tableOfContentsRevision || (post as PostsWithNavigation).tableOfContents;
   const htmlWithAnchors = sectionData?.html || post.contents?.html;
 
-  const recommendationsTestGroup = useABTest(postsPageRecommendationsABTest);
   const showRecommendations = isEAForum &&
     !post.shortform &&
     !post.draft &&
@@ -282,8 +281,7 @@ const PostsPage = ({post, refetch, classes}: {
     !post.question &&
     !post.debate &&
     !post.isEvent &&
-    !sequenceId &&
-    recommendationsTestGroup === "recommended";
+    !sequenceId;
 
   const commentId = query.commentId || params.commentId
 

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -98,18 +98,3 @@ export const slowerFrontpageABTest = new ABTest({
     },
   },
 });
-
-export const postsPageRecommendationsABTest = new ABTest({
-  name: "postsPageRecommendations",
-  description: "Puts recommendations on the posts page",
-  groups: {
-    control: {
-      description: "No recommendations on the posts page",
-      weight: 9,
-    },
-    recommended: {
-      description: "Recommendations on the posts page",
-      weight: 1,
-    },
-  },
-});


### PR DESCRIPTION
This PR removes the AB test for posts page recommendations and rolls the feature out to all users. This should probably be merged after #7239.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204671482797510) by [Unito](https://www.unito.io)
