### PR TITLE
add tags to default subscription types

### DIFF
--- a/packages/lesswrong/lib/collections/subscriptions/mutations.ts
+++ b/packages/lesswrong/lib/collections/subscriptions/mutations.ts
@@ -8,7 +8,8 @@ export const defaultSubscriptionTypeTable = {
   "Posts": subscriptionTypes.newComments,
   "Users": subscriptionTypes.newPosts,
   "Localgroups": subscriptionTypes.newEvents,
-  // TODO: Tags?
+  "Tags": subscriptionTypes.newTagPosts
+  // TODO: other subscription types?
 }
 
 export type DefaultSubscriptionType = keyof typeof defaultSubscriptionTypeTable;


### PR DESCRIPTION
Going to any tag page results in an error.  I think this is because of a missing value in `defaultSubscriptionTypeTable` for tags.  (In any case, adding the value for tags fixed it.)

We should type the `document` input for `useNotifyMe` more strictly, probably?

cc @oetherington (w.r.t. https://github.com/ForumMagnum/ForumMagnum/pull/6823)
<img width="1728" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/154e88a2-d26a-474e-aa62-e2bb00442c7f">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204680681986306) by [Unito](https://www.unito.io)
