### PR TITLE
Make the beta site deploy based on ea-deploy

### DIFF
--- a/.github/workflows/deployEABeta.yaml
+++ b/.github/workflows/deployEABeta.yaml
@@ -3,7 +3,7 @@ concurrency: deploy-ea-beta
 on:
   workflow_dispatch:
   push:
-    branches: [ea-emoji-reacts]
+    branches: [ea-deploy]
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The audio stuff is all in the master branch (but only enabled on the beta site) so it's simpler to just deploy from ea-deploy

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204684526397964) by [Unito](https://www.unito.io)
