### PR TITLE
HTTP header updates

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
 
     access_log    /var/log/nginx/access.log;
 
+    server_tokens off;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -45,6 +45,7 @@ import { renderJssSheetPreloads } from './utils/renderJssSheetImports';
 import { datadogMiddleware } from './datadog/datadogMiddleware';
 import { Sessions } from '../lib/collections/sessions';
 import { botRedirectMiddleware } from './botRedirect';
+import { hstsMiddleware } from './hsts';
 
 const loadClientBundle = () => {
   const bundlePath = path.join(__dirname, "../../client/js/bundle.js");
@@ -136,7 +137,8 @@ export function startWebserver() {
   app.use(datadogMiddleware);
   app.use(pickerMiddleware);
   app.use(botRedirectMiddleware);
-  
+  app.use(hstsMiddleware);
+
   //eslint-disable-next-line no-console
   console.log("Starting ForumMagnum server. Versions: "+JSON.stringify(process.versions));
   

--- a/packages/lesswrong/server/expressServer.ts
+++ b/packages/lesswrong/server/expressServer.ts
@@ -1,3 +1,4 @@
 import express from 'express'
 
 export const app = express();
+app.disable("x-powered-by");

--- a/packages/lesswrong/server/hsts.ts
+++ b/packages/lesswrong/server/hsts.ts
@@ -1,0 +1,9 @@
+import type { Request, Response, NextFunction } from "express";
+
+export const hstsMiddleware = (_req: Request, res: Response, next: NextFunction) => {
+  res.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload",
+  );
+  next();
+}


### PR DESCRIPTION
This PR makes some small changes to our HTTP headers for SEO and general security reasons.

- We add an HSTS header
- We remove the "x-powered-by" header that Express adds
- We turn off nginx server_tokens, which disables the "server" header and removes the nginx version from error messages, etc.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204685032791575) by [Unito](https://www.unito.io)
