### PR TITLE
Allow specific (classic) posts to have the type 3 player

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -37,8 +37,6 @@ const POST_DESCRIPTION_EXCLUSIONS: RegExp[] = [
   /acknowledgements/i
 ];
 
-const TYPE_III_DATE_CUTOFF = new Date('2023-05-01')
-
 /** Get a og:description-appropriate description for a post */
 export const getPostDescription = (post: {contents?: {plaintextDescription: string | null} | null, shortform: boolean, user: {displayName: string} | null}) => {
   if (post.contents?.plaintextDescription) {
@@ -178,10 +176,7 @@ const PostsPage = ({post, refetch, classes}: {
 
   // Show the podcast player if the user opened it on another post, hide it if they closed it (and by default)
   const [showEmbeddedPlayer, setShowEmbeddedPlayer] = useState(showEmbeddedPlayerCookie);
-  const allowTypeIIIPlayer =
-    allowTypeIIIPlayerSetting.get() &&
-    new Date(post.postedAt) >= TYPE_III_DATE_CUTOFF &&
-    isPostAllowedType3Audio(post);
+  const allowTypeIIIPlayer = allowTypeIIIPlayerSetting.get() && isPostAllowedType3Audio(post);
 
   const toggleEmbeddedPlayer = post.podcastEpisode || allowTypeIIIPlayer ? () => {
     const action = showEmbeddedPlayer ? "close" : "open";

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser } from '../../common/withUser';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { useRecordPostView } from '../../hooks/useRecordPostView';
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
-import {PublicInstanceSetting, forumTitleSetting, forumTypeSetting, isEAForum} from '../../../lib/instanceSettings';
+import {forumTitleSetting, forumTypeSetting, isEAForum} from '../../../lib/instanceSettings';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import { viewNames } from '../../comments/CommentsViews';
 import classNames from 'classnames';
@@ -23,8 +23,6 @@ import { PostsPageContext } from './PostsPageContext';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import Helmet from 'react-helmet';
 import { SHOW_PODCAST_PLAYER_COOKIE } from '../../../lib/cookies/cookies';
-
-const allowTypeIIIPlayerSetting = new PublicInstanceSetting<boolean>('allowTypeIIIPlayer', false, "optional")
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -176,7 +174,7 @@ const PostsPage = ({post, refetch, classes}: {
 
   // Show the podcast player if the user opened it on another post, hide it if they closed it (and by default)
   const [showEmbeddedPlayer, setShowEmbeddedPlayer] = useState(showEmbeddedPlayerCookie);
-  const allowTypeIIIPlayer = allowTypeIIIPlayerSetting.get() && isPostAllowedType3Audio(post);
+  const allowTypeIIIPlayer = isPostAllowedType3Audio(post);
 
   const toggleEmbeddedPlayer = post.podcastEpisode || allowTypeIIIPlayer ? () => {
     const action = showEmbeddedPlayer ? "close" : "open";

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, siteUrlSetting } from '../../instanceSettings';
+import { PublicInstanceSetting, forumTypeSetting, siteUrlSetting } from '../../instanceSettings';
 import { getOutgoingUrl, getSiteUrl } from '../../vulcan-lib/utils';
 import { mongoFindOne } from '../../mongoQueries';
 import { userOwns, userCanDo } from '../../vulcan-users/permissions';
@@ -350,6 +350,7 @@ export const postGetPrimaryTag = (post: PostsListWithVotes, includeNonCore = fal
   return typeof result === "object" ? result : undefined;
 }
 
+const allowTypeIIIPlayerSetting = new PublicInstanceSetting<boolean>('allowTypeIIIPlayer', false, "optional")
 const type3DateCutoffSetting = new DatabasePublicSetting<string>('type3.cutoffDate', '2023-05-01')
 const type3ExplicitlyAllowedPostIdsSetting = new DatabasePublicSetting<string[]>('type3.explicitlyAllowedPostIds', [])
 
@@ -357,6 +358,8 @@ const type3ExplicitlyAllowedPostIdsSetting = new DatabasePublicSetting<string[]>
  * Whether the post is allowed AI generated audio
  */
 export const isPostAllowedType3Audio = (post: PostsBase|DbPost): boolean => {
+  if (!allowTypeIIIPlayerSetting.get()) return false
+
   try {
     const TYPE_III_DATE_CUTOFF = new Date(type3DateCutoffSetting.get())
     const TYPE_III_ALLOWED_POST_IDS = type3ExplicitlyAllowedPostIdsSetting.get()

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -4,7 +4,7 @@ import { mongoFindOne } from '../../mongoQueries';
 import { userOwns, userCanDo } from '../../vulcan-users/permissions';
 import { userGetDisplayName, userIsSharedOn } from '../users/helpers';
 import { postStatuses, postStatusLabels } from './constants';
-import { cloudinaryCloudNameSetting } from '../../publicSettings';
+import { DatabasePublicSetting, cloudinaryCloudNameSetting } from '../../publicSettings';
 import Localgroups from '../localgroups/collection';
 import moment from '../../moment-timezone';
 import { max } from "underscore";
@@ -350,19 +350,32 @@ export const postGetPrimaryTag = (post: PostsListWithVotes, includeNonCore = fal
   return typeof result === "object" ? result : undefined;
 }
 
+const type3DateCutoffSetting = new DatabasePublicSetting<string>('type3.cutoffDate', '2023-05-01')
+const type3ExplicitlyAllowedPostIdsSetting = new DatabasePublicSetting<string[]>('type3.explicitlyAllowedPostIds', [])
+
 /**
  * Whether the post is allowed AI generated audio
  */
 export const isPostAllowedType3Audio = (post: PostsBase|DbPost): boolean => {
-  return (
-    !post.draft &&
-    !post.authorIsUnreviewed &&
-    !post.rejected &&
-    !post.podcastEpisodeId &&
-    !post.isEvent &&
-    !post.question &&
-    !post.debate &&
-    !post.shortform &&
-    post.status === postStatuses.STATUS_APPROVED
-  );
+  try {
+    const TYPE_III_DATE_CUTOFF = new Date(type3DateCutoffSetting.get())
+    const TYPE_III_ALLOWED_POST_IDS = type3ExplicitlyAllowedPostIdsSetting.get()
+
+    return (
+      (new Date(post.postedAt) >= TYPE_III_DATE_CUTOFF || TYPE_III_ALLOWED_POST_IDS.includes(post._id)) &&
+      !post.draft &&
+      !post.authorIsUnreviewed &&
+      !post.rejected &&
+      !post.podcastEpisodeId &&
+      !post.isEvent &&
+      !post.question &&
+      !post.debate &&
+      !post.shortform &&
+      post.status === postStatuses.STATUS_APPROVED
+    );
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+    return false
+  }
 }


### PR DESCRIPTION
We wanted to include posts from [this sequence](https://forum.effectivealtruism.org/sequences/dg852CXinRkieekxZ) in the initial rollout of AI audio (otherwise only posts after 2023-05-01 are included). Unfortunately the way the sequences architecture is set up doesn't make this completely straightforward (you can't just get a sequenceId from the post), so I have opted to just match against a list of post ids. I've added the ones we want as a setting (of which there are about 50). A benefit of this slightly hacky approach is that we can easily allow arbitrary posts in future

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204684918914943) by [Unito](https://www.unito.io)
