### PR TITLE
Allow LessWrong users to use react voting system

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1049,9 +1049,9 @@ const schema: SchemaType<DbPost> = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    canCreate: ['members', 'admins', 'sunshineRegiment'],
+    canCreate: isLW ? ['members'] : ['admins', 'sunshineRegiment'],
     canUpdate: [userOwnsAndOnLW, 'admins', 'sunshineRegiment'],
-    group: isLW ? formGroups.options : formGroups.adminOptions,
+    group: isLW ? formGroups.advancedOptions : formGroups.adminOptions,
     control: "select",
     form: {
       options: ({currentUser}:{currentUser: UsersCurrent}) => {

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -13,11 +13,11 @@ import SimpleSchema from 'simpl-schema'
 import { DEFAULT_QUALITATIVE_VOTE } from '../reviewVotes/schema';
 import { getCollaborativeEditorAccess } from './collabEditingPermissions';
 import { getVotingSystems } from '../../voting/votingSystems';
-import { fmCrosspostBaseUrlSetting, fmCrosspostSiteNameSetting, forumTypeSetting } from '../../instanceSettings';
+import { fmCrosspostBaseUrlSetting, fmCrosspostSiteNameSetting, forumTypeSetting, isLW } from '../../instanceSettings';
 import { forumSelect } from '../../forumTypeUtils';
 import * as _ from 'underscore';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
-import { documentIsNotDeleted, userOwns } from '../../vulcan-users/permissions';
+import { documentIsNotDeleted, userOwns, userOwnsAndOnLW } from '../../vulcan-users/permissions';
 import { userCanCommentLock, userCanModeratePost } from '../users/helpers';
 import { sequenceGetNextPostID, sequenceGetPrevPostID, sequenceContainsPost, getPrevPostIdFromPrevSequence, getNextPostIdFromNextSequence } from '../sequences/helpers';
 import { userOverNKarmaFunc } from "../../vulcan-users";
@@ -28,6 +28,8 @@ import { getDefaultViewSelector } from '../../utils/viewUtils';
 import GraphQLJSON from 'graphql-type-json';
 
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
+
+
 
 const urlHintText = isEAForum
     ? 'UrlHintText'
@@ -1047,14 +1049,15 @@ const schema: SchemaType<DbPost> = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    canCreate: ['admins', 'sunshineRegiment'],
-    canUpdate: ['admins', 'sunshineRegiment'],
-    group: formGroups.adminOptions,
+    canCreate: ['members', 'admins', 'sunshineRegiment'],
+    canUpdate: [userOwnsAndOnLW, 'admins', 'sunshineRegiment'],
+    group: isLW ? formGroups.options : formGroups.adminOptions,
     control: "select",
     form: {
-      options: () => {
-        return getVotingSystems()
-          .map(votingSystem => ({label: votingSystem.description, value: votingSystem.name}));
+      options: ({currentUser}:{currentUser: UsersCurrent}) => {
+        const votingSystems = getVotingSystems()
+        const filteredVotingSystems = currentUser.isAdmin ? votingSystems : votingSystems.filter(votingSystem => votingSystem.userCanActivate)
+        return filteredVotingSystems.map(votingSystem => ({label: votingSystem.description, value: votingSystem.name}));
       }
     },
     ...schemaDefaultValue(forumDefaultVotingSystem),

--- a/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
+++ b/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
@@ -12,6 +12,7 @@ import some from 'lodash/some';
 import mapValues from 'lodash/mapValues';
 import sumBy from 'lodash/sumBy'
 import sortBy from 'lodash/sortBy';
+import { isLW } from '../instanceSettings';
 
 export const addNewReactKarmaThreshold = new DatabasePublicSetting("reacts.addNewReactKarmaThreshold", 100);
 export const addNameToExistingReactKarmaThreshold = new DatabasePublicSetting("reacts.addNameToExistingReactKarmaThreshold", 20);
@@ -19,6 +20,7 @@ export const downvoteExistingReactKarmaThreshold = new DatabasePublicSetting("re
 
 registerVotingSystem<NamesAttachedReactionsVote, NamesAttachedReactionsScore>({
   name: "namesAttachedReactions",
+  userCanActivate: isLW,
   description: "Names-attached reactions",
   getCommentVotingComponent: () => Components.NamesAttachedReactionsVoteOnComment,
   getCommentBottomComponent: () => Components.NamesAttachedReactionsCommentBottom,

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -21,6 +21,7 @@ export type CommentVotingComponent = React.ComponentType<CommentVotingComponentP
 export interface VotingSystem<ExtendedVoteType=any, ExtendedScoreType=any> {
   name: string,
   description: string,
+  userCanActivate?: boolean, // toggles whether non-admins use this voting system
   getCommentVotingComponent: ()=>CommentVotingComponent,
   getCommentBottomComponent?: ()=>CommentVotingComponent,
   addVoteClient: (props: {
@@ -69,6 +70,7 @@ registerVotingSystem({
 registerVotingSystem({
   name: "twoAxis",
   description: "Two-Axis Approve and Agree",
+  userCanActivate: true,
   getCommentVotingComponent: () => Components.TwoAxisVoteOnComment,
   addVoteClient: ({voteType, document, oldExtendedScore, extendedVote, currentUser}: {voteType: string|null, document: VoteableTypeClient, oldExtendedScore: AnyBecauseTodo, extendedVote: AnyBecauseTodo, currentUser: UsersCurrent}): AnyBecauseTodo => {
     const newAgreementPower = calculateVotePower(currentUser.karma, extendedVote?.agreement||"neutral");

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -1,6 +1,7 @@
 import intersection from 'lodash/intersection';
 import moment from 'moment';
 import * as _ from 'underscore';
+import { isLW } from '../instanceSettings';
 import { getSchema } from'../utils/getSchema';
 
 class Group {
@@ -115,6 +116,10 @@ export const userOwns = function (user: UsersMinimumInfo|DbUser|null, document: 
     return documentUser.slug ? user.slug === documentUser.slug : user._id === documentUser._id;
   }
 };
+
+export const userOwnsAndOnLW = function (user:UsersMinimumInfo|DbUser|null, document: OwnableDocument): boolean {
+  return isLW && userOwns(user, document)
+}
 
 export const documentIsNotDeleted = (
   user: PermissionableUser|DbUser|null,


### PR DESCRIPTION
This PR allows LessWrong users to set their posts to use the react voting system. 

It adds an optional "userCanActivate" flag for votingSystems. Admins can set a post to any voting system, users can only use ones with that flag. I have the LW reacts system set to "isLW" so that it appears for LW users.

I've set it so that the field appears for all users on LW but not EA Forum, and on LW it appears in the advancedOptions group rather than the adminOptions group.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204688782308565) by [Unito](https://www.unito.io)
