### PR TITLE
Remove momentjs fromNow styling

### DIFF
--- a/packages/lesswrong/components/editor/RateLimitWarning.tsx
+++ b/packages/lesswrong/components/editor/RateLimitWarning.tsx
@@ -13,15 +13,15 @@ const RateLimitWarning = ({lastRateLimitExpiry, rateLimitMessage}: {
   // moment.relativeTimeThreshold ensures that it doesn't appreviate unhelpfully to "now"
   moment.relativeTimeThreshold('ss', 0);
   // format momentJS fromNow to say "3 seconds" or "3 minutes" rather than 3s or 3m
-  moment.updateLocale('en', {
-    relativeTime: {
-      s: 'a few seconds', ss: '%d seconds',
-      m: 'a minute',      mm: '%d minutes',
-      h: 'an hour',       hh: '%d hours',
-      d: 'a day',         dd: '%d days',
-      w: 'a week',        ww: '%d weeks'
-    }
-  });
+  // moment.updateLocale('en', {
+  //   relativeTime: {
+  //     s: 'a few seconds', ss: '%d seconds',
+  //     m: 'a minute',      mm: '%d minutes',
+  //     h: 'an hour',       hh: '%d hours',
+  //     d: 'a day',         dd: '%d days',
+  //     w: 'a week',        ww: '%d weeks'
+  //   }
+  // });
   const fromNow = moment(lastRateLimitExpiry).fromNow(true)
 
   let message = `Please wait ${fromNow} before posting again. ${rateLimitMessage ?? ''}`


### PR DESCRIPTION
For the RateLimitWarning, I had used a function for updating momentJs fromNow styling. It had appeared to (correctly) only apply to a particular component. It turns out it... very briefly appears on all other fromNow components on pages with long load times. I'm removing it for now. Hopefully will find another way to style it nicely later.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204690748945064) by [Unito](https://www.unito.io)
