### PR TITLE
Posts suggested for curation should be sorted by post date, not creation date

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1261,7 +1261,7 @@ Posts.addView("sunshineCuratedSuggestions", function (terms) {
     },
     options: {
       sort: {
-        createdAt: -1,
+        postedAt: -1,
       },
       hint: "posts.sunshineCuratedSuggestions",
     }

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1268,7 +1268,7 @@ Posts.addView("sunshineCuratedSuggestions", function (terms) {
   }
 })
 ensureIndex(Posts,
-  augmentForDefaultView({ createdAt:1, reviewForCuratedUserId:1, suggestForCuratedUserIds:1, }),
+  augmentForDefaultView({ postedAt:1, reviewForCuratedUserId:1, suggestForCuratedUserIds:1, }),
   {
     name: "posts.sunshineCuratedSuggestions",
     partialFilterExpression: {suggestForCuratedUserIds: {$exists:true}},


### PR DESCRIPTION
Posts in the "Suggestions for Curated" list were sorted by `createdAt`, rather than `postedAt`. So when a moderator tried to curate a post today that had spent a year in its author's drafts folder, he couldn't find it, because you had to click Load More twice. Change it to be sorted by `postedAt`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204694424361946) by [Unito](https://www.unito.io)
