### PR TITLE
Space out postgres ensure-index calls

### DIFF
--- a/packages/lesswrong/lib/utils/asyncUtils.ts
+++ b/packages/lesswrong/lib/utils/asyncUtils.ts
@@ -42,3 +42,6 @@ export const promisify = (fn: Function) =>
       })
     })
 
+export async function sleep(duration: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, duration); });
+}

--- a/packages/lesswrong/server/deleteUserContent.ts
+++ b/packages/lesswrong/server/deleteUserContent.ts
@@ -4,10 +4,7 @@ import Users from "../lib/collections/users/collection";
 import { getAdminTeamAccount, noDeletionPmReason } from "./callbacks/commentCallbacks";
 import { exportUserData } from "./exportUserData";
 import { createAdminContext, Globals, updateMutator } from './vulcan-lib';
-
-const sleep = (ms: number) => {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
-};
+import { sleep } from "../lib/utils/asyncUtils";
 
 /** Please ensure that we know that the user is who they say they are! */
 export const deleteUserContent = async (


### PR DESCRIPTION
When a new server starts up, it sends a bunch of `CREATE INDEX IF NOT EXIST` queries. In theory, these are usually no-ops. However, it sends _all of them at once_. In a local-development-server context, this can lead to an extremely-long pageload, if that pageload happens to land while the index-create queries are running, since even if the queries aren't doing anything, they are nevertheless depleting the client's connection pool.

This makes it so that the on-startup index creation (a) is delayed slightly longer from startup, (b) is limited to one at a time, and (c) has a 500ms sleep between index-create operations.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204694919949439) by [Unito](https://www.unito.io)
