### PR TITLE
Log postgres connection pool limit on startup, on the theory that the envvar might have gotten lost somewhere

### DIFF
--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -151,6 +151,9 @@ export const createSqlConnection = async (
     connectionString: url,
     max: MAX_CONNECTIONS,
   });
+  
+  // eslint-disable-next-line no-console
+  console.log(`Connecting to postgres with a connection-pool max size of ${MAX_CONNECTIONS}`);
 
   const client: SqlClient = {
     ...db,


### PR DESCRIPTION
Trivial PR that adds a console-log of something I want to check. Am going to force-merge this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204695311709555) by [Unito](https://www.unito.io)
