### PR TITLE
Analytics logging of GraphQL questions (resolve and mutate)

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -1,5 +1,5 @@
 import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
-import React, { ComponentProps, useState, useEffect } from 'react';
+import React, {ComponentProps, useState, useEffect, useRef} from 'react';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser'
@@ -18,6 +18,8 @@ import { commentDefaultToAlignment } from '../../lib/collections/comments/helper
 import { isInFuture } from '../../lib/utils/timeUtil';
 import moment from 'moment';
 import { isEAForum } from '../../lib/instanceSettings';
+import { useTracking } from "../../lib/analyticsEvents";
+import { randomId } from "../../lib/random";
 
 export type CommentFormDisplayMode = "default" | "minimalist"
 
@@ -144,6 +146,8 @@ export type CommentsNewFormProps = {
 
 const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISCUSSION", parentComment, successCallback, type, cancelCallback, classes, removeFields, fragment = "CommentsList", formProps, enableGuidelines=true, padding=true, replyFormStyle = "default"}: CommentsNewFormProps) => {
   const currentUser = useCurrentUser();
+  const { captureEvent } = useTracking({eventProps: { postId: post?._id, tagId: tag?._id, tagCommentType}});
+  const commentSubmitIdRef = useRef(randomId());
   
   const userWithRateLimit = useSingle({
     documentId: currentUser?._id,
@@ -214,6 +218,7 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
       successCallback(comment, { form })
     }
     setLoading(false)
+    captureEvent("wrappedSuccessCallbackFinished", {commentSubmitId: commentSubmitIdRef.current})
     userWithRateLimit.refetch();
   };
 
@@ -323,6 +328,8 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
               cancelCallback={wrappedCancelCallback}
               submitCallback={(data: unknown) => {
                 setLoading(true);
+                commentSubmitIdRef.current = randomId()
+                captureEvent("wrappedSubmitCallbackStarted", {commentSubmitId: commentSubmitIdRef.current})
                 return data
               }}
               errorCallback={() => setLoading(false)}

--- a/packages/lesswrong/lib/vulcan-core/default_mutations.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_mutations.ts
@@ -2,6 +2,7 @@ import { Utils, getTypeName } from '../vulcan-lib';
 import { userCanDo, userOwns } from '../vulcan-users/permissions';
 import isEmpty from 'lodash/isEmpty';
 import { loggerConstructor } from '../utils/logging';
+import { captureEvent } from "../analyticsEvents";
 
 export interface MutationOptions<T extends DbObject> {
   newCheck?: (user: DbUser|null, document: T|null) => Promise<boolean>|boolean,
@@ -53,6 +54,7 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
       },
 
       async mutation(root: void, { data }: AnyBecauseTodo, context: ResolverContext) {
+        const startMutate = Date.now()
         logger('create mutation()')
         // TS doesn't understand that context indexed by collectionName properly
         const collection = context[collectionName] as CollectionBase<T>;
@@ -69,13 +71,16 @@ export function getDefaultMutations<N extends CollectionNameString>(collectionNa
         );
 
         // pass document to boilerplate createMutator function
-        return await Utils.createMutator({
+        const returnValue = await Utils.createMutator({
           collection,
           document: data,
           currentUser: context.currentUser,
           validate: true,
           context,
         });
+        const timeElapsed = Date.now() - startMutate
+        captureEvent("mutationCompleted", {mutationName, timeElapsed, documentId: returnValue.data._id})
+        return returnValue;
       },
     };
     mutations.create = createMutation;

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -3,6 +3,7 @@ import { restrictViewableFields } from '../vulcan-users/permissions';
 import { asyncFilter } from '../utils/asyncUtils';
 import { loggerConstructor, logGroupConstructor } from '../utils/logging';
 import { describeTerms, viewTermsToQuery } from '../utils/viewUtils';
+import { captureEvent } from "../analyticsEvents";
 
 const maxAllowedSkip = 2000;
 
@@ -28,6 +29,7 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
       description: `A list of ${typeName} documents matching a set of query terms`,
 
       async resolver(root: void, args: { input: {terms: ViewTermsBase, enableCache?: boolean, enableTotal?: boolean, createIfMissing?: Partial<T>} }, context: ResolverContext, { cacheControl }: AnyBecauseTodo) {
+        const startResolve = Date.now()
         const input = args?.input || {};
         const { terms={}, enableCache = false, enableTotal = false } = input;
         const logger = loggerConstructor(`views-${collectionName.toLowerCase()}-${terms.view?.toLowerCase() ?? 'default'}`)
@@ -83,7 +85,9 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
             data.totalCount = viewableDocs.length;
           }
         }
-
+  
+        const timeElapsed = Date.now() - startResolve;
+        captureEvent("resolveMultiCompleted", {documentIds: restrictedDocs.map((d: DbObject) => d._id), collectionName, timeElapsed, terms});
         // return results
         return data;
       },
@@ -95,6 +99,7 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
       description: `A single ${typeName} document fetched by ID or slug`,
 
       async resolver(root: void, { input = {} }: {input:any}, context: ResolverContext, { cacheControl }: AnyBecauseTodo) {
+        const startResolve = Date.now();
         const { enableCache = false, allowNull = false } = input;
         // In this context (for reasons I don't fully understand) selector is an object with a null prototype, i.e.
         // it has none of the methods you would usually associate with objects like `toString`. This causes various problems
@@ -160,7 +165,10 @@ export function getDefaultResolvers<N extends CollectionNameString>(collectionNa
         logGroupEnd();
         logger(`--------------- end \x1b[35m${typeName} Single Resolver\x1b[0m ---------------`);
         logger('');
-
+        
+        const timeElapsed = Date.now() - startResolve;
+        captureEvent("resolveSingleCompleted", {documentId: restrictedDoc._id, collectionName, timeElapsed});
+        
         // filter out disallowed properties and return resulting document
         return { result: restrictedDoc };
       },


### PR DESCRIPTION
Following performance issues, this PR adds logging on graphql queries both on client and server. On the client, it currently just logs comment submits.