### PR TITLE
Set sshKey to no-access automatically

### DIFF
--- a/scripts/startup/buildUtil.js
+++ b/scripts/startup/buildUtil.js
@@ -85,6 +85,14 @@ function getDatabaseConfig(opts) {
       host: "localhost",
       port: (dbConfig.sshTunnel.localPort || 5433),
     });
+    const sshKeyPath = path.join(path.dirname(opts.db), dbConfig.sshTunnel.key);
+    if(fs.statSync(sshKeyPath).mode & fs.constants.S_IROTH) {
+      // If the key is world-readable ssh will refuse to use it, so change the permissions
+      // File permissions aren't reproduced by git checkouts, so we have to do this here
+      // rather than in the credentials repo.
+      fs.chmodSync(sshKeyPath, 0600);
+    }
+
     sshTunnelCommand = [
       "-C",
       "-N",
@@ -128,7 +136,7 @@ function readFileOrDie(path) {
   try {
     return fs.readFileSync(path, 'utf8').trim();
   } catch(e) {
-    die(`Error reading ${opts.postgresUrlFile}: ${e}`);
+    die(`Error reading ${path}: ${e}`);
   }
 }
 


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/7218 relied on a private ssh key in credentials repo not being publicly readable, but git doesn't have the ability to transmit file-read-access, so by default the file was publicly readable on each device that downloaded the latest LessWrongCredentials repo.

This PR adds a fix which updates the file to have the correct permissions.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204718155313484) by [Unito](https://www.unito.io)
