### PR TITLE
Small changes to Comment Submit tracking

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -147,7 +147,7 @@ export type CommentsNewFormProps = {
 const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISCUSSION", parentComment, successCallback, type, cancelCallback, classes, removeFields, fragment = "CommentsList", formProps, enableGuidelines=true, padding=true, replyFormStyle = "default"}: CommentsNewFormProps) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking({eventProps: { postId: post?._id, tagId: tag?._id, tagCommentType}});
-  const commentSubmitStartTimeRef = useRef<number>();
+  const commentSubmitStartTimeRef = useRef<number>(Date.now());
   
   const userWithRateLimit = useSingle({
     documentId: currentUser?._id,

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -147,7 +147,7 @@ export type CommentsNewFormProps = {
 const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISCUSSION", parentComment, successCallback, type, cancelCallback, classes, removeFields, fragment = "CommentsList", formProps, enableGuidelines=true, padding=true, replyFormStyle = "default"}: CommentsNewFormProps) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking({eventProps: { postId: post?._id, tagId: tag?._id, tagCommentType}});
-  const commentSubmitStartTimeRef = useRef<number>(Date.now());
+  const commentSubmitStartTimeRef = useRef(Date.now());
   
   const userWithRateLimit = useSingle({
     documentId: currentUser?._id,


### PR DESCRIPTION
Makes success/completion event contain duration, no longer requiring matching with the start event. Also includes commentId for joining

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204718484302316) by [Unito](https://www.unito.io)
