### PR TITLE
Try removing host from StatsD to get it to send data from staging

### DIFF
--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -13,7 +13,6 @@ tracer.use('express', {
 })
 
 export const dogstatsd = new StatsD({
-  host: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
   prefix: 'forummagnum.'
 });
 


### PR DESCRIPTION
I can receive data from this locally but not in staging for some reason. I'm trying removing the IS_DOCKER check because it works without that locally

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204726913305647) by [Unito](https://www.unito.io)
