### PR TITLE
[EA Forum only] a few small adjustments to the post page header

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -2,7 +2,7 @@ import React, { memo, ComponentType, MouseEventHandler, CSSProperties } from "re
 import { registerComponent } from "../../lib/vulcan-lib";
 import { forumSelect, ForumOptions } from "../../lib/forumTypeUtils";
 import classNames from "classnames";
-import SpeakerWaveIcon from "@heroicons/react/24/solid/SpeakerWaveIcon";
+import SpeakerWaveIcon from "@heroicons/react/24/outline/SpeakerWaveIcon";
 import BookmarkIcon from "@heroicons/react/24/solid/BookmarkIcon";
 import StarIcon from "@heroicons/react/24/solid/StarIcon";
 import StarOutlineIcon from "@heroicons/react/24/outline/StarIcon";

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -188,7 +188,6 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
     commentCount,
     hasUnreadComments,
     primaryTag,
-    hasAudio,
     sticky,
     showDraftTag,
     showPersonalIcon,
@@ -298,9 +297,6 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
                     {(!post.fmCrosspost?.isCrosspost || post.fmCrosspost.hostedHere) && <span className={classes.readTime}>
                       {' · '}{post.readTimeMinutes || 1}m read
                     </span>}
-                  </div>
-                  <div className={classes.audio}>
-                    {hasAudio && <ForumIcon icon="VolumeUp" />}
                   </div>
                 </div>
                 <div className={classNames(

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { isEAForum } from '../../../lib/instanceSettings';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { ExpandedDate } from '../../common/FormatDate';
+import moment from 'moment';
 
 const styles = (theme: ThemeType): JssStyles => ({
   date: {
@@ -39,10 +40,20 @@ const PostsPageDate = ({ post, hasMajorRevision, classes }: {
     )
   }
   
+  let format = "Do MMM YYYY"
+  if (isEAForum) {
+    format = "MMM D YYYY"
+    // hide the year if it's this year
+    const now = moment()
+    if (now.isSame(moment(post.postedAt), 'year')) {
+      format = "MMM D"
+    }
+  }
+  
   return (<React.Fragment>
     <LWTooltip title={tooltip} placement="bottom">
         <span className={classes.date}>
-          <FormatDate date={post.postedAt} format={isEAForum ? "D MMM YYYY" : "Do MMM YYYY"} tooltip={false} />
+          <FormatDate date={post.postedAt} format={format} tooltip={false} />
         </span>
     </LWTooltip>
   </React.Fragment>);

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -61,12 +61,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   togglePodcastContainer: {
     marginRight: SECONDARY_SPACING,
     verticalAlign: 'middle',
-    color: theme.palette.primary.main,
+    color: isEAForum ? undefined : theme.palette.primary.main,
     height: PODCAST_ICON_SIZE,
   },
   togglePodcastIcon: {
     width: PODCAST_ICON_SIZE,
     height: PODCAST_ICON_SIZE,
+    transform: isEAForum ? "translateY(-2px)" : undefined
   },
   actions: {
     display: 'inline-block',
@@ -243,6 +244,10 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
     commentCount,
   } = useMemo(() => getResponseCounts(post, answers), [post, answers]);
   
+  const readingTimeNode = !post.isEvent && <LWTooltip title={`${wordCount} words`}>
+    <span className={classes.wordCount}>{readTime} min read</span>
+  </LWTooltip>
+
   const commentCountNode = <CommentsLink anchor="#comments" className={classes.secondaryInfoLink}>
     {isEAForum ?
       <>
@@ -250,6 +255,22 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
       </> : postGetCommentCountStr(post, commentCount)
     }
   </CommentsLink>
+  
+  const audioNode = toggleEmbeddedPlayer &&
+    (cachedTooltipSeen ?
+      <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
+        <a href="#" onClick={toggleEmbeddedPlayer}>
+          <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
+        </a>
+      </LWTooltip> :
+      <NewFeaturePulse dx={-10} dy={4}>
+        <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
+        <a href="#" onClick={toggleEmbeddedPlayer}>
+          <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
+        </a>
+        </LWTooltip>
+      </NewFeaturePulse>
+    )
 
   // TODO: If we are not the primary author of this post, but it was shared with
   // us as a draft, display a notice and a link to the collaborative editor.
@@ -274,15 +295,15 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
             </LWTooltip>
           }
           {post.fmCrosspost?.isCrosspost && !post.fmCrosspost.hostedHere && <CrosspostHeaderIcon post={post} />}
-          {!post.isEvent && <LWTooltip title={`${wordCount} words`}>
-            <span className={classes.wordCount}>{readTime} min read</span>
-          </LWTooltip>}
+          {!isEAForum && readingTimeNode}
           {!post.isEvent && <span className={classes.date}>
             <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />
           </span>}
+          {isEAForum && readingTimeNode}
           {post.isEvent && <div className={classes.groupLinks}>
             <Components.GroupLinks document={post} noMargin={true} />
           </div>}
+          {isEAForum && audioNode}
           {post.question &&
             <CommentsLink anchor="#answers" className={classes.secondaryInfoLink}>
               {postGetAnswerCountStr(answerCount)}
@@ -292,22 +313,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
             {commentCountNode}
           </LWTooltip> : commentCountNode}
           {isEAForum && <BookmarkButton post={post} className={classes.bookmarkButton} placement='bottom-start' />}
-          {toggleEmbeddedPlayer &&
-            (cachedTooltipSeen ?
-              <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
-                <a href="#" onClick={toggleEmbeddedPlayer}>
-                  <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
-                </a>
-              </LWTooltip> :
-              <NewFeaturePulse dx={-10} dy={4}>
-                <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
-                <a href="#" onClick={toggleEmbeddedPlayer}>
-                  <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
-                </a>
-                </LWTooltip>
-              </NewFeaturePulse>
-            )
-          }
+          {!isEAForum && audioNode}
           {post.startTime && <div className={classes.secondaryInfoLink}>
             <AddToCalendarButton post={post} label="Add to calendar" hideTooltip={true} />
           </div>}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -12,7 +12,7 @@ import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { PODCAST_TOOLTIP_SEEN_COOKIE } from '../../../lib/cookies/cookies';
 
 const SECONDARY_SPACING = 20;
-const PODCAST_ICON_SIZE = isEAForum ? 20 : 24;
+const PODCAST_ICON_SIZE = isEAForum ? 22 : 24;
 
 const styles = (theme: ThemeType): JssStyles => ({
   header: {

--- a/packages/lesswrong/components/posts/usePostsItem.ts
+++ b/packages/lesswrong/components/posts/usePostsItem.ts
@@ -170,7 +170,6 @@ export const usePostsItem = ({
     commentsLink: postLink + "#comments",
     commentCount: postGetCommentCount(post),
     primaryTag: hideTag ? null : postGetPrimaryTag(post),
-    hasAudio: !!post.podcastEpisodeId,
     tagRel,
     resumeReading,
     sticky: forceSticky || isSticky(post, terms),


### PR DESCRIPTION
This is part of a [larger set of changes](https://www.figma.com/file/d09iVzNSpZp9GyWGcfkWmX/Q2.2-2023?type=design&node-id=13-10576) that we're planning for updating the design of the post page header. This PR includes a few small pieces of it, including reordering some of the info and changing the audio icon.

-----
Before:
<img width="704" alt="Screen Shot 2023-05-31 at 3 12 09 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/c41a2513-c9fd-449d-b11e-1a7b7f6572e0">

-----
After:
<img width="704" alt="Screen Shot 2023-05-31 at 3 16 32 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/b2441b99-5e44-40fe-a1c7-38ad5fd3cef3">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204729605648949) by [Unito](https://www.unito.io)
