### PR TITLE
Fix build script SSH tunnel host-key saving failing if ~/.ssh doesn't exist

### DIFF
--- a/scripts/startup/buildUtil.js
+++ b/scripts/startup/buildUtil.js
@@ -161,6 +161,7 @@ async function startSshTunnel(sshTunnelCommand) {
     const sshHost = sshTunnelCommand.at(-1).split('@')[1];
     await execAsync(`
       if [ -z "$(ssh-keygen -F ${sshHost})" ]; then
+        mkdir -p ~/.ssh
         ssh-keyscan -H ${sshHost} >> ~/.ssh/known_hosts
       fi`
     );


### PR DESCRIPTION
Fixing another issue in the migration script involving SSH tunnels, with the unfortunate property that it's hard to test outside of the Github action runners environment.


