### PR TITLE
Don't try to update vote-counts for votes on the wrong collection

### DIFF
--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -125,7 +125,7 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
         foreignCollectionName: "Votes",
         foreignTypeName: "vote",
         foreignFieldName: "documentId",
-        filterFn: (vote: DbVote) => !vote.cancelled
+        filterFn: (vote: DbVote) => !vote.cancelled && vote.collectionName===collection.collectionName
       }),
       canRead: ['guests'],
     },


### PR DESCRIPTION
Found while investigating why comment-submission is slow. Impact unclear.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204731542786925) by [Unito](https://www.unito.io)
