### PR TITLE
Expand the size of the notes field in ModeratorActions

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -64,7 +64,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 4,
     marginTop: 8,
     marginBottom: 8,
-    minHeight: 250,
     ...hideScrollBars,
     '& *': {
       ...hideScrollBars
@@ -366,7 +365,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         disableUnderline
         placeholder="Notes for other moderators"
         multiline
-        rows={5}
+        rows={10}
       />
     </div>
       <div>


### PR DESCRIPTION
Just increases the line-height from 5 to 10, since I frequently wanted to see a bit more.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204747945742024) by [Unito](https://www.unito.io)
