### PR TITLE
Postgres index improvements and fix for two N+1-selects

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -147,7 +147,7 @@ export type CommentsNewFormProps = {
 const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISCUSSION", parentComment, successCallback, type, cancelCallback, classes, removeFields, fragment = "CommentsList", formProps, enableGuidelines=true, padding=true, replyFormStyle = "default"}: CommentsNewFormProps) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking({eventProps: { postId: post?._id, tagId: tag?._id, tagCommentType}});
-  const commentSubmitIdRef = useRef(randomId());
+  const commentSubmitStartTimeRef = useRef(Date.now());
   
   const userWithRateLimit = useSingle({
     documentId: currentUser?._id,
@@ -218,10 +218,11 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
       successCallback(comment, { form })
     }
     setLoading(false)
-    captureEvent("wrappedSuccessCallbackFinished", {commentSubmitId: commentSubmitIdRef.current})
+    const timeElapsed = Date.now() - commentSubmitStartTimeRef.current;
+    captureEvent("wrappedSuccessCallbackFinished", {timeElapsed, commentId: comment._id})
     userWithRateLimit.refetch();
   };
-
+  
   const wrappedCancelCallback = (...args: unknown[]) => {
     if (cancelCallback) {
       cancelCallback(...args)
@@ -328,8 +329,8 @@ const CommentsNewForm = ({prefilledProps = {}, post, tag, tagCommentType = "DISC
               cancelCallback={wrappedCancelCallback}
               submitCallback={(data: unknown) => {
                 setLoading(true);
-                commentSubmitIdRef.current = randomId()
-                captureEvent("wrappedSubmitCallbackStarted", {commentSubmitId: commentSubmitIdRef.current})
+                commentSubmitStartTimeRef.current = Date.now()
+                captureEvent("wrappedSubmitCallbackStarted")
                 return data
               }}
               errorCallback={() => setLoading(false)}

--- a/packages/lesswrong/lib/collections/notifications/views.ts
+++ b/packages/lesswrong/lib/collections/notifications/views.ts
@@ -57,6 +57,9 @@ ensureIndex(Notifications, {userId:1, type:1, createdAt:-1});
 // that is being deleted
 ensureIndex(Notifications, {documentId:1});
 
+// Used by server-sent events
+ensureIndex(Notifications, {createdAt:1});
+
 Notifications.addView("adminAlertNotifications", (terms: NotificationsViewTerms) => {
   return {
     selector: {

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2396,7 +2396,7 @@ const schema: SchemaType<DbPost> = {
         ...(af ? {af:true} : {}),
       };
       const comments = await getWithCustomLoader<DbComment[],string>(context, loaderName, post._id, (postIds): Promise<DbComment[][]> => {
-        return context.repos.comments.getRecentCommentCommentsOnPosts(postIds, commentsLimit, filter);
+        return context.repos.comments.getRecentCommentsOnPosts(postIds, commentsLimit, filter);
       });
       return await accessFilterMultiple(currentUser, Comments, comments, context);
     }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -7,7 +7,7 @@ import { postCanEditHideCommentKarma, postGetPageUrl, postGetEmailShareUrl, post
 import { postStatuses, postStatusLabels } from './constants';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { TagRels } from "../tagRels/collection";
-import { loadByIds, getWithLoader } from '../../loaders';
+import { loadByIds, getWithLoader, getWithCustomLoader } from '../../loaders';
 import { formGroups } from './formGroups';
 import SimpleSchema from 'simpl-schema'
 import { DEFAULT_QUALITATIVE_VOTE } from '../reviewVotes/schema';
@@ -915,7 +915,9 @@ const schema: SchemaType<DbPost> = {
     resolver: async (post, args, context: ResolverContext) => {
       const { currentUser, Comments } = context;
       if (post.lastCommentPromotedAt) {
-        const comment = await Comments.findOne({postId: post._id, promoted: true}, {sort:{promotedAt: -1}})
+        const comment: DbComment|null = await getWithCustomLoader<DbComment|null,string>(context, "lastPromotedComments", post._id, async (postIds: string[]): Promise<Array<DbComment|null>> => {
+          return await context.repos.comments.getPromotedCommentsOnPosts(postIds);
+        });
         return await accessFilterSingle(currentUser, Comments, comment, context)
       }
     }
@@ -2385,17 +2387,17 @@ const schema: SchemaType<DbPost> = {
       const { commentsLimit=5, maxAgeHours=18, af=false } = args;
       const { currentUser, Comments } = context;
       const timeCutoff = moment(post.lastCommentedAt).subtract(maxAgeHours, 'hours').toDate();
-      const comments = await Comments.find({
+      const loaderName = af?"recentCommentsAf" : "recentComments";
+      const filter: MongoSelector<DbComment> = {
         ...getDefaultViewSelector("Comments"),
-        postId: post._id,
         score: {$gt:0},
         deletedPublic: false,
         postedAt: {$gt: timeCutoff},
         ...(af ? {af:true} : {}),
-      }, {
-        limit: commentsLimit,
-        sort: {postedAt:-1}
-      }).fetch();
+      };
+      const comments = await getWithCustomLoader<DbComment[],string>(context, loaderName, post._id, (postIds): Promise<DbComment[][]> => {
+        return context.repos.comments.getRecentCommentCommentsOnPosts(postIds, commentsLimit, filter);
+      });
       return await accessFilterMultiple(currentUser, Comments, comments, context);
     }
   }),

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { getKarmaInflationSeries, timeSeriesIndexExpr } from '../../../server/karmaInflation/cache';
-import { combineIndexWithDefaultViewIndex, ensureIndex } from '../../collectionIndexUtils';
+import { combineIndexWithDefaultViewIndex, ensureIndex, ensureCustomPgIndex } from '../../collectionIndexUtils';
 import type { FilterMode, FilterSettings, FilterTag } from '../../filterSettings';
 import { forumTypeSetting, isEAForum } from '../../instanceSettings';
 import { defaultVisibilityTags } from '../../publicSettings';
@@ -1310,6 +1310,7 @@ ensureIndex(Posts,
   augmentForDefaultView({ "pingbacks.Posts": 1, baseScore: 1 }),
   { name: "posts.pingbackPosts" }
 );
+ensureCustomPgIndex(`CREATE INDEX IF NOT EXISTS idx_posts_pingbacks ON "Posts" USING gin(pingbacks);`);
 
 // TODO: refactor nominations2018 to use nominationCount + postedAt
 Posts.addView("nominations2018", (terms: PostsViewTerms) => {

--- a/packages/lesswrong/lib/collections/sessions/collection.ts
+++ b/packages/lesswrong/lib/collections/sessions/collection.ts
@@ -11,6 +11,7 @@ export const Sessions: SessionsCollection = createCollection({
   logChanges: false,
 });
 
+ensureIndex(Sessions, {_id:1, expires:1});
 ensureIndex(Sessions, {expires: 1});
 
 Sessions.checkAccess = async (

--- a/packages/lesswrong/lib/loaders.ts
+++ b/packages/lesswrong/lib/loaders.ts
@@ -2,6 +2,7 @@ import { Utils } from './vulcan-lib'; // import from vulcan:lib because vulcan:c
 import DataLoader from 'dataloader';
 import * as _ from 'underscore';
 
+
 //
 // Do a query, with a custom loader for query batching. This effectively does a
 // find query, where all of the fields of the query are kept constant within a
@@ -17,8 +18,7 @@ import * as _ from 'underscore';
 //     the batch.
 //   id: The value of the field whose values vary between queries in the batch.
 //
-export async function getWithLoader<T extends DbObject>(context: ResolverContext, collection: CollectionBase<T>, loaderName: string, baseQuery:any={}, groupByField: keyof T, id: string, projection:any=undefined): Promise<Array<T>>
-{
+export async function getWithLoader<T extends DbObject>(context: ResolverContext, collection: CollectionBase<T>, loaderName: string, baseQuery:any={}, groupByField: keyof T, id: string, projection:any=undefined): Promise<Array<T>> {
   if (!context.extraLoaders) {
     context.extraLoaders = {};
   }
@@ -39,8 +39,7 @@ export async function getWithLoader<T extends DbObject>(context: ResolverContext
   return await context.extraLoaders[loaderName].load(id);
 }
 
-export async function getWithCustomLoader<T extends DbObject, ID>(context: ResolverContext, collection: CollectionBase<T>, loaderName: string, id: ID, idsToResults: (ids: Array<ID>)=>Promise<Array<T>>): Promise<Array<T>>
-{
+export async function getWithCustomLoader<T, ID>(context: ResolverContext, loaderName: string, id: ID, idsToResults: (ids: Array<ID>)=>Promise<T[]>): Promise<T> {
   if (!context.extraLoaders[loaderName]) {
     context.extraLoaders[loaderName] = new DataLoader(idsToResults, { cache: true });
   }

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -123,9 +123,13 @@ abstract class Query<T extends DbObject> {
    * public API for flexability.
    */
   compile(argOffset = 0, subqueryOffset = 'A'.charCodeAt(0)): {sql: string, args: any[]} {
+    return this.compileAtoms(this.atoms, argOffset, subqueryOffset);
+  }
+  
+  compileAtoms(atoms: Atom<T>[], argOffset = 0, subqueryOffset = 'A'.charCodeAt(0)): {sql: string, args: any[]} {
     const strings: string[] = [];
     let args: any[] = [];
-    for (const atom of this.atoms) {
+    for (const atom of atoms) {
       if (atom instanceof Arg) {
         strings.push(`$${++argOffset}${atom.typehint}`);
         args.push(atom.value);
@@ -507,7 +511,7 @@ abstract class Query<T extends DbObject> {
    * Compile an arbitrary Mongo selector into an array of atoms.
    * `this.atoms` is not modified.
    */
-  protected compileSelector(selector: MongoSelector<T>): Atom<T>[] {
+  public compileSelector(selector: MongoSelector<T>): Atom<T>[] {
     const keys = Object.keys(selector);
     if (keys.length === 0) {
       return [];

--- a/packages/lesswrong/lib/utils/asyncUtils.ts
+++ b/packages/lesswrong/lib/utils/asyncUtils.ts
@@ -42,3 +42,6 @@ export const promisify = (fn: Function) =>
       })
     })
 
+export async function sleep(duration: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, duration); });
+}

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -218,11 +218,9 @@ const performQueryFromViewParameters = async <T extends DbObject>(collection: Co
     return await collection.aggregate(pipeline).toArray();
   } else {
     logger('performQueryFromViewParameters connector find', selector, terms, options);
-    return await Utils.Connectors.find(collection,
-      {
-        ...selector,
-        $comment: describeTerms(terms),
-      },
-      options);
+    return await collection.find({
+      ...selector,
+      $comment: describeTerms(terms),
+    }, options).fetch();
   }
 }

--- a/packages/lesswrong/server/deleteUserContent.ts
+++ b/packages/lesswrong/server/deleteUserContent.ts
@@ -4,10 +4,7 @@ import Users from "../lib/collections/users/collection";
 import { getAdminTeamAccount, noDeletionPmReason } from "./callbacks/commentCallbacks";
 import { exportUserData } from "./exportUserData";
 import { createAdminContext, Globals, updateMutator } from './vulcan-lib';
-
-const sleep = (ms: number) => {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
-};
+import { sleep } from "../lib/utils/asyncUtils";
 
 /** Please ensure that we know that the user is who they say they are! */
 export const deleteUserContent = async (

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -29,7 +29,7 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
     return postIds.map(postId => commentsByPost[postId] ?? null);
   }
 
-  async getRecentCommentCommentsOnPosts(postIds: string[], limit: number, filter: MongoSelector<DbComment>): Promise<DbComment[][]> {
+  async getRecentCommentsOnPosts(postIds: string[], limit: number, filter: MongoSelector<DbComment>): Promise<DbComment[][]> {
     const selectQuery = new SelectQuery(this.getCollection().table, filter)
     const selectQueryAtoms = selectQuery.compileSelector(filter);
     const {sql: filterWhereClause, args: filterArgs} = selectQuery.compileAtoms(selectQueryAtoms, 2);

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -1,0 +1,61 @@
+import Comments from "../../lib/collections/comments/collection";
+import AbstractRepo from "./AbstractRepo";
+import SelectQuery from "../../lib/sql/SelectQuery";
+import PgCollection from "../../lib/sql/PgCollection";
+import keyBy from 'lodash/keyBy';
+import groupBy from 'lodash/groupBy';
+import orderBy from 'lodash/orderBy';
+
+
+export default class CommentsRepo extends AbstractRepo<DbComment> {
+  constructor() {
+    super(Comments);
+  }
+
+  async getPromotedCommentsOnPosts(postIds: string[]): Promise<(DbComment|null)[]> {
+    const comments = await this.many(`
+      SELECT c.*
+      FROM "Comments" c
+      JOIN (
+          SELECT "postId", MAX("promotedAt") AS max_promotedAt
+          FROM "Comments"
+          WHERE "postId" IN $1
+          GROUP BY "postId"
+      ) sq
+      ON c."postId" = sq."postId" AND c."promotedAt" = sq.max_promotedAt;
+    `, [postIds]);
+    
+    const commentsByPost = keyBy(comments, c=>c.postId);
+    return postIds.map(postId => commentsByPost[postId] ?? null);
+  }
+
+  async getRecentCommentCommentsOnPosts(postIds: string[], limit: number, filter: MongoSelector<DbComment>): Promise<DbComment[][]> {
+    const selectQuery = new SelectQuery(this.getCollection().table, filter)
+    const selectQueryAtoms = selectQuery.compileSelector(filter);
+    const {sql: filterWhereClause, args: filterArgs} = selectQuery.compileAtoms(selectQueryAtoms, 2);
+
+    const comments = await this.many(`
+      WITH cte AS (
+        SELECT
+          comment_with_rownumber.*,
+          ROW_NUMBER() OVER (PARTITION BY comment_with_rownumber."postId" ORDER BY comment_with_rownumber."postedAt" DESC) as rn
+        FROM "Comments" comment_with_rownumber
+        WHERE comment_with_rownumber."postId" IN ($1:csv)
+        AND (
+          ${filterWhereClause}
+        )
+      )
+      SELECT *
+      FROM cte
+      WHERE rn <= $2
+    `, [postIds, limit, ...filterArgs]);
+    
+    const commentsByPost = groupBy(comments, c=>c.postId);
+    return postIds.map(postId =>
+      orderBy(
+        commentsByPost[postId] ?? [],
+        c => -c.postedAt.getTime()
+      )
+    );
+  }
+}

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -1,3 +1,4 @@
+import CommentsRepo from "./CommentsRepo";
 import ConversationsRepo from "./ConversationsRepo";
 import DatabaseMetadataRepo from "./DatabaseMetadataRepo";
 import DebouncerEventsRepo from "./DebouncerEventsRepo";
@@ -13,6 +14,7 @@ declare global {
 }
 
 const getAllRepos = () => ({
+  comments: new CommentsRepo(),
   conversations: new ConversationsRepo(),
   databaseMetadata: new DatabaseMetadataRepo(),
   debouncerEvents: new DebouncerEventsRepo(),
@@ -25,6 +27,7 @@ const getAllRepos = () => ({
 } as const);
 
 export {
+  CommentsRepo,
   ConversationsRepo,
   DatabaseMetadataRepo,
   DebouncerEventsRepo,


### PR DESCRIPTION
Extends index utility function interface to allow raw-er SQL, so that index type options are accessible (in particular, `idx_posts_pingbacks` is a GIN index). Uses `getWithCustomLoader` to address two N+1 selects in resolvers on Posts, with directly written queries going through `CommentsRepo`. One of these (`getRecentCommentsOnPost`) uses mongo-to-postgres handling to generate part of the query; this part was written while pairing with Ollie.