### PR TITLE
Randomize reacts/default-voting on LW

### DIFF
--- a/packages/lesswrong/lib/collections/posts/formGroups.ts
+++ b/packages/lesswrong/lib/collections/posts/formGroups.ts
@@ -71,6 +71,12 @@ export const formGroups: Partial<Record<string,FormGroupType>> = {
     label: preferredHeadingCase("Canonical Sequence"),
     startCollapsed: true,
   },
+  reactExperiment: {
+    order: 35,
+    name: "reactExperiment",
+    label: "Reacts Experiment",
+    startCollapsed: false,
+  },
   advancedOptions: {
     order:40,
     name: "advancedOptions",

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -25,6 +25,7 @@ import { allOf } from '../../utils/functionUtils';
 import { crosspostKarmaThreshold } from '../../publicSettings';
 import { userHasSideComments } from '../../betas';
 import { getDefaultViewSelector } from '../../utils/viewUtils';
+import sample from 'lodash/sample';
 import GraphQLJSON from 'graphql-type-json';
 
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
@@ -42,14 +43,10 @@ const STICKY_PRIORITIES = {
   4: "Max",
 }
 
-const randomizeString = (strings: string[]): string => {
-  return strings[Math.floor(Math.random() * strings.length)];
-}
-
 const forumDefaultVotingSystem = forumSelect({
   EAForum: "twoAxis",
-  LessWrong: randomizeString(["twoAxis", "namesAttachedReactions"]),
-  AlignmentForum: randomizeString(["twoAxis", "namesAttachedReactions"]),
+  LessWrong: sample(["twoAxis", "namesAttachedReactions"]),
+  AlignmentForum: sample(["twoAxis", "namesAttachedReactions"]),
   default: "default",
 })
 

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -42,10 +42,14 @@ const STICKY_PRIORITIES = {
   4: "Max",
 }
 
+const randomizeString = (strings: string[]): string => {
+  return strings[Math.floor(Math.random() * strings.length)];
+}
+
 const forumDefaultVotingSystem = forumSelect({
   EAForum: "twoAxis",
-  LessWrong: "twoAxis",
-  AlignmentForum: "twoAxis",
+  LessWrong: randomizeString(["twoAxis", "namesAttachedReactions"]),
+  AlignmentForum: randomizeString(["twoAxis", "namesAttachedReactions"]),
   default: "default",
 })
 
@@ -1051,7 +1055,7 @@ const schema: SchemaType<DbPost> = {
     canRead: ['guests'],
     canCreate: isLW ? ['members'] : ['admins', 'sunshineRegiment'],
     canUpdate: [userOwnsAndOnLW, 'admins', 'sunshineRegiment'],
-    group: isLW ? formGroups.advancedOptions : formGroups.adminOptions,
+    group: isLW ? formGroups.reactExperiment : formGroups.adminOptions,
     control: "select",
     form: {
       options: ({currentUser}:{currentUser: UsersCurrent}) => {

--- a/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
+++ b/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
@@ -21,7 +21,7 @@ export const downvoteExistingReactKarmaThreshold = new DatabasePublicSetting("re
 registerVotingSystem<NamesAttachedReactionsVote, NamesAttachedReactionsScore>({
   name: "namesAttachedReactions",
   userCanActivate: isLW,
-  description: "Names-attached reactions",
+  description: "Reacts (Two-axis plus Names-attached reactions)",
   getCommentVotingComponent: () => Components.NamesAttachedReactionsVoteOnComment,
   getCommentBottomComponent: () => Components.NamesAttachedReactionsCommentBottom,
   addVoteClient: ({voteType, document, oldExtendedScore, extendedVote, currentUser}: {

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -69,7 +69,7 @@ registerVotingSystem({
 
 registerVotingSystem({
   name: "twoAxis",
-  description: "Two-Axis Approve and Agree",
+  description: "Default (Two-Axis Approve and Agree)",
   userCanActivate: true,
   getCommentVotingComponent: () => Components.TwoAxisVoteOnComment,
   addVoteClient: ({voteType, document, oldExtendedScore, extendedVote, currentUser}: {voteType: string|null, document: VoteableTypeClient, oldExtendedScore: AnyBecauseTodo, extendedVote: AnyBecauseTodo, currentUser: UsersCurrent}): AnyBecauseTodo => {


### PR DESCRIPTION
This PR a) makes it so on LessWrong and Alignment forum, posts have a 50/50 chance of getting reacts vs regular voting, an b) it's more obvious that this is a thing you can configure.

<img width="786" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/fa8f0a33-4dc7-4ccf-ba83-ba177a2ada9c">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204748637404153) by [Unito](https://www.unito.io)
