### PR TITLE
/history page (EA forum gated) has a Load More

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -63,15 +63,15 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
     return result?.meanKarma ?? 0;
   }
 
-  async getReadHistoryForUser(userId: string): Promise<Array<DbPost & {lastUpdated: Date}>> {
+  async getReadHistoryForUser(userId: string, limit: number): Promise<Array<DbPost & {lastUpdated: Date}>> {
     return await logIfSlow(async () => await this.getRawDb().many(`
       SELECT p.*, rs."lastUpdated"
       FROM "Posts" p
       JOIN "ReadStatuses" rs ON rs."postId" = p."_id"
       WHERE rs."userId" = '${userId}'
       ORDER BY rs."lastUpdated" desc
-      LIMIT 10
-    `), "getReadHistoryForUser");
+      LIMIT $1
+    `, [limit]), "getReadHistoryForUser");
   }
 
   async getEmojiReactors(


### PR DESCRIPTION
This involved a surprising amount of `apollo-client` magic involving fetch-policies, and a deleted sidetrack into what happens with `__typename` if you had the fetch-policy wrong.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204748935673484) by [Unito](https://www.unito.io)
