### PR TITLE
Fix react voting optimisticResponse

### DIFF
--- a/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
@@ -229,7 +229,6 @@ const useNamesAttachedReactionsVoting = (voteProps: VotingProps<VoteableTypeClie
   }
   
   function addCurrentUserReaction(reactionName: string, vote: VoteOnReactionType) {
-    console.log
     if (!currentUser) {
       openLoginDialog();
       return;

--- a/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
@@ -229,6 +229,7 @@ const useNamesAttachedReactionsVoting = (voteProps: VotingProps<VoteableTypeClie
   }
   
   function addCurrentUserReaction(reactionName: string, vote: VoteOnReactionType) {
+    console.log
     if (!currentUser) {
       openLoginDialog();
       return;
@@ -330,7 +331,7 @@ const NamesAttachedReactionsCommentBottom = ({
   const anchorEl = useRef<HTMLElement|null>(null);
   const currentUser = useCurrentUser();
 
-  const extendedScore = document?.extendedScore as NamesAttachedReactionsScore|undefined;
+  const extendedScore = voteProps.document?.extendedScore as NamesAttachedReactionsScore|undefined;
   const reactionsShown = reactionsListToDisplayedNumbers(extendedScore?.reacts ?? null, currentUser?._id);
   const { getAlreadyUsedReactTypesByKarma } = useNamesAttachedReactionsVoting(voteProps)
   const alreadyUsedReactTypesByKarma = getAlreadyUsedReactTypesByKarma();


### PR DESCRIPTION
Reacting was weirdly slow. Oli found it was because we weren't using the optimistic document from voteProps

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204749616300407) by [Unito](https://www.unito.io)
