### PR TITLE
Fix biosecurity tag icon

### DIFF
--- a/packages/lesswrong/components/tagging/CoreTagIcon.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagIcon.tsx
@@ -19,8 +19,7 @@ import { forumSelect } from '../../lib/forumTypeUtils';
 // Don't want to fight the type system about the type of the MUI icon
 export const coreTagIconMap = forumSelect<Record<string, any>>({
   EAForum: {
-    biosecurity: DnaIcon,
-    'biosecurity-and-pandemic-preparedness': DnaIcon, // Replacing biosecurity
+    'biosecurity-and-pandemics': DnaIcon,
     'existential-risk': MushroomCloudIcon,
     'global-catastrophic-risk': MushroomCloudIcon, // (Possibly) replacing existential-risk
     'cause-prioritization': CausePrioIcon,


### PR DESCRIPTION
The slug for the biosecurity tag has changed which means the icon is currently broken:
<img width="475" alt="Screenshot 2023-06-04 at 23 24 52" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/acb2bda5-704c-4dc7-8641-6f0dea7c1f31">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204753039628539) by [Unito](https://www.unito.io)
