### PR TITLE
skip akismet check for reviewed users

### DIFF
--- a/packages/lesswrong/server/akismet.ts
+++ b/packages/lesswrong/server/akismet.ts
@@ -87,8 +87,10 @@ async function checkForAkismetSpam({document, type}: AnyBecauseTodo) {
 
 getCollectionHooks("Comments").newAfter.add(async function checkCommentForSpamWithAkismet(comment: DbComment, currentUser: DbUser|null) {
     if (!currentUser) throw new Error("Submitted comment has no associated user");
+
+    const unreviewedUser = !currentUser.reviewedByUserId;
     
-    if (akismetKeySetting.get()) {
+    if (unreviewedUser && akismetKeySetting.get()) {
       const start = Date.now();
 
       const spam = await checkForAkismetSpam({document: comment, type: "comment"})


### PR DESCRIPTION
The `checkForAkismetSpamCompleted` analytics event has revealed that the akismet callback seems to be responsible for the overwhelming majority of tail-latency when creating comments.  Two possibilities here:
1. it's because of the `LWEvents.find` call in `constructAkismetReport` (it can't realistically be the `Users.findOne` or `Posts.findOne`, since if those were pathological we'd notice it elsewhere)
2. it's on akismet's side (the `checkSpam` call)

Rather than spend a bunch of time debugging this, let's just... stop checking with akismet for already-reviewed users (who are enormously unlikely to be spammers).
![image](https://github.com/ForumMagnum/ForumMagnum/assets/2136984/c8689c64-93a2-491a-b8db-52c030c29ceb)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204761985192252) by [Unito](https://www.unito.io)
