### PR TITLE
[LW] No more randomization. Just enable reacts on all posts.

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -25,7 +25,6 @@ import { allOf } from '../../utils/functionUtils';
 import { crosspostKarmaThreshold } from '../../publicSettings';
 import { userHasSideComments } from '../../betas';
 import { getDefaultViewSelector } from '../../utils/viewUtils';
-import sample from 'lodash/sample';
 import GraphQLJSON from 'graphql-type-json';
 
 const isEAForum = (forumTypeSetting.get() === 'EAForum')
@@ -45,8 +44,8 @@ const STICKY_PRIORITIES = {
 
 const forumDefaultVotingSystem = forumSelect({
   EAForum: "twoAxis",
-  LessWrong: sample(["twoAxis", "namesAttachedReactions"]),
-  AlignmentForum: sample(["twoAxis", "namesAttachedReactions"]),
+  LessWrong: "namesAttachedReactions",
+  AlignmentForum: "namesAttachedReactions",
   default: "default",
 })
 


### PR DESCRIPTION
I don't think we're getting data fast enough and I don't think even enough that we'll have the sample size to make interesting comparisons. So for LW, making reacts the default.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204762309301555) by [Unito](https://www.unito.io)
