### PR TITLE
Fix add-react hoverover bug

### DIFF
--- a/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/NamesAttachedReactionsVoteOnComment.tsx
@@ -72,8 +72,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   addReactionButton: {
     verticalAlign: "bottom",
-    filter: "opacity(0.15)",
     cursor: "pointer",
+    '& .react-hover-style': {
+      filter: "opacity(0.15)",
+    },
     "& svg": {
       width: 20,
       height: 20,
@@ -729,9 +731,9 @@ export const AddReactionButton = ({voteProps, classes}: {
     <span
       ref={buttonRef}
       onClick={ev => setOpen(true)}
-      className={classNames(classes.addReactionButton, "react-hover-style")}
+      className={classes.addReactionButton}
     >
-      <AddReactionIcon />
+      <span className="react-hover-style"><AddReactionIcon /></span>
       {open && <LWClickAwayListener onClickAway={() => setOpen(false)}>
         <PopperCard
           open={open} anchorEl={buttonRef.current}


### PR DESCRIPTION
Previously this was changing the opacity for a larger set of icons. This narrows the scope.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204762911715475) by [Unito](https://www.unito.io)
