### PR TITLE
Speed up html-to-text by using its compile() function to bake its config options

### DIFF
--- a/packages/lesswrong/server/karmaChanges.ts
+++ b/packages/lesswrong/server/karmaChanges.ts
@@ -2,10 +2,12 @@ import Votes from '../lib/collections/votes/collection';
 import { Tags } from '../lib/collections/tags/collection';
 import type { KarmaChangeSettingsType } from '../lib/collections/users/schema';
 import moment from '../lib/moment-timezone';
-import { htmlToText } from 'html-to-text';
+import { compile as compileHtmlToText } from 'html-to-text'
 import sumBy from 'lodash/sumBy';
 import VotesRepo, { CommentKarmaChange, KarmaChangesArgs, PostKarmaChange, TagRevisionKarmaChange } from './repos/VotesRepo';
 
+// Use html-to-text's compile() wrapper (baking in the default options) to make it faster when called repeatedly
+const htmlToTextDefault = compileHtmlToText();
 
 type ExtendedCommentKarmaChange = CommentKarmaChange & {
   tagSlug?: string,
@@ -183,7 +185,7 @@ export const getKarmaChanges = async ({user, startDate, endDate, nextBatchDate=n
   // Replace comment bodies with abbreviated plain-text versions (rather than
   // HTML).
   for (let comment of changedComments) {
-    comment.description = htmlToText(comment.description ?? "")
+    comment.description = htmlToTextDefault(comment.description ?? "")
       .substring(0, COMMENT_DESCRIPTION_LENGTH);
   }
 


### PR DESCRIPTION
Saves on the order of 20ms of CPU time per front-page render.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204763572886022) by [Unito](https://www.unito.io)
