### PR TITLE
Dotted line appears on hover

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -161,9 +161,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       backgroundColor: theme.palette.grey[200]
     },
     [`& .${faintHighlightClassName}`]: {
-      borderBottom: theme.palette.border.dashed500,
       backgroundColor: "unset",
-    }
+    },
+    [`&:hover .${faintHighlightClassName}`]: {
+      borderBottom: theme.palette.border.dashed500,
+    },
   }
 });
 


### PR DESCRIPTION
Makes the dotted line for inline reacts only appear on hoverover

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204763724026475) by [Unito](https://www.unito.io)
