### PR TITLE
[EA Forum only] display reading progress bar at the top of the post page

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -23,7 +23,6 @@ import { PostsPageContext } from './PostsPageContext';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import Helmet from 'react-helmet';
 import { SHOW_PODCAST_PLAYER_COOKIE } from '../../../lib/cookies/cookies';
-import { useOnPageScroll } from '../../common/withOnPageScroll';
 import { isServer } from '../../../lib/executionEnvironment';
 
 export const MAX_COLUMN_WIDTH = 720

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -218,15 +218,17 @@ const PostsPage = ({post, refetch, classes}: {
     return () => {
       window.removeEventListener('scroll', updateReadingProgressBar)
     };
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
   const updateReadingProgressBar = () => {
     if (!postBodyRef.current || !readingProgressBarRef.current) return
 
-    const commentsPos = postBodyRef.current.getBoundingClientRect().bottom - window.innerHeight
-    const totalHeight = window.scrollY + commentsPos
-    const scrollPercent = (1 - commentsPos / totalHeight) * 100 + '%'
-		
-    readingProgressBarRef.current.style.setProperty("--scrollAmount", scrollPercent)
+    // position of post body bottom relative to the top of the viewport
+    const postBodyBottomPos = postBodyRef.current.getBoundingClientRect().bottom - window.innerHeight
+    // total distance from top of page to post body bottom
+    const totalHeight = window.scrollY + postBodyBottomPos
+    const scrollPercent = (1 - (postBodyBottomPos / totalHeight)) * 100
+
+    readingProgressBarRef.current.style.setProperty("--scrollAmount", `${scrollPercent}%`)
   }
   
   const getSequenceId = () => {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useNavigation, useSubscribedLocation } from '../../../lib/routeUtil';
 import { isPostAllowedType3Audio, postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
@@ -23,6 +23,8 @@ import { PostsPageContext } from './PostsPageContext';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import Helmet from 'react-helmet';
 import { SHOW_PODCAST_PLAYER_COOKIE } from '../../../lib/cookies/cookies';
+import { useOnPageScroll } from '../../common/withOnPageScroll';
+import { isServer } from '../../../lib/executionEnvironment';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -82,6 +84,19 @@ export const getPostDescription = (post: {contents?: {plaintextDescription: stri
 
 // Also used in PostsCompareRevisions
 export const styles = (theme: ThemeType): JssStyles => ({
+  readingProgressBar: {
+    position: 'fixed',
+    top: 0,
+    height: 4,
+    width: 'var(--scrollAmount)',
+    background: theme.palette.primary.main,
+    '--scrollAmount': '0%',
+    zIndex: theme.zIndexes.commentBoxPopup,
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: -8,
+      marginRight: -8
+    }
+  },
   title: {
     marginBottom: 32,
     [theme.breakpoints.down('sm')]: {
@@ -189,6 +204,30 @@ const PostsPage = ({post, refetch, classes}: {
   } : undefined;
 
   const welcomeBoxABTestGroup = useABTest(welcomeBoxABTest);
+  
+  // On the EA Forum, show a reading progress bar to indicate how far in the post you are.
+  // Your progress is hard to tell via the scroll bar because it includes the comments section.
+  const postBodyRef = useRef<HTMLDivElement|null>(null)
+  const readingProgressBarRef = useRef<HTMLDivElement|null>(null)
+  useEffect(() => {
+    if (!isEAForum || isServer || post.isEvent || post.question || post.debate || post.shortform || post.readTimeMinutes < 3) return
+
+    updateReadingProgressBar()
+    window.addEventListener('scroll', updateReadingProgressBar)
+    
+    return () => {
+      window.removeEventListener('scroll', updateReadingProgressBar)
+    };
+  }, [])
+  const updateReadingProgressBar = () => {
+    if (!postBodyRef.current || !readingProgressBarRef.current) return
+
+    const commentsPos = postBodyRef.current.getBoundingClientRect().bottom - window.innerHeight
+    const totalHeight = window.scrollY + commentsPos
+    const scrollPercent = (1 - commentsPos / totalHeight) * 100 + '%'
+		
+    readingProgressBarRef.current.style.setProperty("--scrollAmount", scrollPercent)
+  }
   
   const getSequenceId = () => {
     const { params } = location;
@@ -379,12 +418,13 @@ const PostsPage = ({post, refetch, classes}: {
     </Helmet>
     <PostsPageContext.Provider value={post}>
     <SideCommentVisibilityContext.Provider value={sideCommentModeContext}>
+    <div ref={readingProgressBarRef} className={classes.readingProgressBar}></div>
     <ToCColumn
       tableOfContents={tableOfContents}
       header={header}
       welcomeBox={welcomeBox}
     >
-      <div className={classes.centralColumn}>
+      <div ref={postBodyRef} className={classes.centralColumn}>
         {/* Body */}
         {/* The embedded player for posts with a manually uploaded podcast episode */}
         {post.podcastEpisode && <div className={classNames(classes.embeddedPlayer, { [classes.hideEmbeddedPlayer]: !showEmbeddedPlayer })}>


### PR DESCRIPTION
This PR adds a reading progress bar to the top of post pages. Your reading progress is hard to tell just via the normal browser scroll bar, because it includes the height of the comments section.

https://github.com/ForumMagnum/ForumMagnum/assets/9057804/f00a11fd-483d-4e8d-bc34-4426ad0278c6



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204770096587016) by [Unito](https://www.unito.io)
