### PR TITLE
Add warning to "remove from queue" if user has comments

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -10,17 +10,12 @@ import VisibilityOutlinedIcon from '@material-ui/icons/VisibilityOutlined';
 import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
 import classNames from 'classnames';
 import { useUpdate } from '../../lib/crud/withUpdate';
-import { useCreate } from '../../lib/crud/withCreate';
 import moment from 'moment';
-import { MODERATOR_ACTION_TYPES, AllRateLimitTypes, allRateLimits, rateLimitSet } from '../../lib/collections/moderatorActions/schema';
 import FlagIcon from '@material-ui/icons/Flag';
 import Input from '@material-ui/core/Input';
 import { getCurrentContentCount, UserContentCountPartial } from '../../lib/collections/moderatorActions/helpers';
 import { hideScrollBars } from '../../themes/styleUtils';
-import { getNewModActionNotes, getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
-import Menu from '@material-ui/core/Menu'
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import { getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   row: {
@@ -36,6 +31,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     '&:hover': {
       opacity: .5
     }
+  },
+  warningButton: {
+    color: theme.palette.error.light,
   },
   snooze10: {
     color: theme.palette.primary.main,
@@ -303,8 +301,12 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     <LWTooltip title="Snooze and Approve 1 (Appear in sidebar on next post or comment. User's future posts are autoapproved)" placement="top">
       <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
     </LWTooltip>
-    {user.needsReview && <LWTooltip title="Remove from queue (i.e. snooze without approving posts)">
-      <AlarmOffIcon className={classes.modButton} onClick={handleRemoveNeedsReview}/>
+    {user.needsReview && <LWTooltip
+      title={`${user.commentCount ? "Warning: user has made a comment! " : ""}Remove from queue (i.e. snooze without approving posts)`}
+    >
+      <AlarmOffIcon className={classNames(classes.modButton, {
+        [classes.warningButton]: user.commentCount,
+      })} onClick={handleRemoveNeedsReview}/>
     </LWTooltip>}
     <LWTooltip title="Approve" placement="top">
       <DoneIcon onClick={handleReview} className={classes.modButton}/>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -16,6 +16,7 @@ import Input from '@material-ui/core/Input';
 import { getCurrentContentCount, UserContentCountPartial } from '../../lib/collections/moderatorActions/helpers';
 import { hideScrollBars } from '../../themes/styleUtils';
 import { getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
+import { hideUnreviewedAuthorCommentsSettings } from '../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   row: {
@@ -294,18 +295,20 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     setNotes( newNotes )
   }
 
+  const userCommentsWarning = user.commentCount && hideUnreviewedAuthorCommentsSettings.get();
+
   const actionRow = <div className={classes.row}>
-    <LWTooltip title="Snooze and Approve 10 (Appear in sidebar after 10 posts and/or comments. User's future posts are autoapproverd)" placement="top">
+    <LWTooltip title="Snooze and Approve 10 (Appear in sidebar after 10 posts and/or comments. User's future posts are autoapproved)" placement="top">
       <AddAlarmIcon className={classNames(classes.snooze10, classes.modButton)} onClick={() => handleSnooze(10)}/>
     </LWTooltip>
     <LWTooltip title="Snooze and Approve 1 (Appear in sidebar on next post or comment. User's future posts are autoapproved)" placement="top">
       <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
     </LWTooltip>
     {user.needsReview && <LWTooltip
-      title={`${user.commentCount ? "Warning: user has made a comment! " : ""}Remove from queue (i.e. snooze without approving posts)`}
+      title={`${userCommentsWarning ? "Warning: user has made a comment! " : ""}Remove from queue (i.e. snooze without approving posts)`}
     >
       <AlarmOffIcon className={classNames(classes.modButton, {
-        [classes.warningButton]: user.commentCount,
+        [classes.warningButton]: userCommentsWarning,
       })} onClick={handleRemoveNeedsReview}/>
     </LWTooltip>}
     <LWTooltip title="Approve" placement="top">


### PR DESCRIPTION
Moderators will sometimes accidentally dismiss someone from the moderation queue and leave them with a pending comment that is now stuck in purgatory until they post again. This PR adds a warning.

We've not forum gated this @b0b3rt but let me know if you want us to.

<img width="475" alt="Screenshot 2023-06-06 at 17 17 32" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/eb88339c-a531-4c21-b183-004b11aaeeea">
<img width="516" alt="Screenshot 2023-06-06 at 17 17 27" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/d200c838-b527-4d44-8c13-b6554daf9427">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204770878883980) by [Unito](https://www.unito.io)
