### PR TITLE
track when messages are sent to a post author

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -21,9 +21,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   authorMarkers: AUTHOR_MARKER_STYLES,
 })
 
-const PostsAuthors = ({classes, post}: {
+const PostsAuthors = ({classes, post, pageSectionContext}: {
   classes: ClassesType,
   post: PostsDetails,
+  pageSectionContext?: string,
 }) => {
   const { UsersName, UserCommentMarkers, PostsCoauthor, Typography } = Components
   return <Typography variant="body1" component="span" className={classes.root}>
@@ -31,12 +32,12 @@ const PostsAuthors = ({classes, post}: {
       {!post.user || post.hideAuthor
         ? <Components.UserNameDeleted/>
         : <>
-          <UsersName user={post.user} />
+          <UsersName user={post.user} pageSectionContext={pageSectionContext} />
           <UserCommentMarkers user={post.user} className={classes.authorMarkers} />
         </>
       }
       {post.coauthors?.map(coauthor =>
-        <PostsCoauthor key={coauthor._id} post={post} coauthor={coauthor} />
+        <PostsCoauthor key={coauthor._id} post={post} coauthor={coauthor} pageSectionContext={pageSectionContext} />
       )}
     </span>
   </Typography>

--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -8,9 +8,10 @@ const styles = (_: ThemeType): JssStyles => ({
   markers: AUTHOR_MARKER_STYLES,
 });
 
-const PostsCoauthor = ({ post, coauthor, classes }: {
+const PostsCoauthor = ({ post, coauthor, pageSectionContext, classes }: {
   post: PostsDetails,
   coauthor: UsersMinimumInfo,
+  pageSectionContext?: string,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
@@ -29,7 +30,7 @@ const PostsCoauthor = ({ post, coauthor, classes }: {
     : UsersName;
   return (
     <>
-      , <Component user={coauthor} />
+      , <Component user={coauthor} pageSectionContext={pageSectionContext} />
       {!isPending && <UserCommentMarkers user={coauthor} className={classes.markers} />}
     </>
   );

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -285,7 +285,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
         <PostsPageTitle post={post} />
         <div className={classes.secondaryInfo}>
           <span className={classes.authors}>
-            <PostsAuthors post={post}/>
+            <PostsAuthors post={post} pageSectionContext="post_header" />
           </span>
           { post.feed && post.feed.user &&
             <LWTooltip title={`Crossposted from ${feedLinkDescription}`}>

--- a/packages/lesswrong/components/users/UsersName.tsx
+++ b/packages/lesswrong/components/users/UsersName.tsx
@@ -26,6 +26,7 @@ const UsersName = ({
   tooltipPlacement?: PopperPlacementType,
   noTooltip?: boolean,
   color?: boolean,
+  pageSectionContext?: string,
   /** Add an extra class/styling to the link */
   className?: string,
 }) => {

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -31,6 +31,7 @@ const UsersNameDisplay = ({
   simple=false,
   classes,
   tooltipPlacement="left",
+  pageSectionContext,
   className,
 }: {
   user: UsersMinimumInfo|null|undefined,
@@ -39,6 +40,7 @@ const UsersNameDisplay = ({
   simple?: boolean,
   classes: ClassesType,
   tooltipPlacement?: PopperPlacementType,
+  pageSectionContext?: string,
   className?: string,
 }) => {
   const {eventHandlers, hover} = useHover({pageElementContext: "linkPreview",  pageSubElementContext: "userNameDisplay", userId: user?._id})
@@ -65,6 +67,11 @@ const UsersNameDisplay = ({
       {displayName}
     </span>
   }
+  
+  let profileUrl = userGetProfileUrl(user)
+  if (pageSectionContext) {
+    profileUrl += `?from=${pageSectionContext}`
+  }
 
   return <span className={className}>
     <span {...eventHandlers}>
@@ -74,7 +81,7 @@ const UsersNameDisplay = ({
           placement={tooltipPlacement}
           inlineBlock={false}
         >
-          <Link to={userGetProfileUrl(user)} className={colorClass}
+          <Link to={profileUrl} className={colorClass}
             {...(nofollow ? {rel:"nofollow"} : {})}
           >
             {displayName}


### PR DESCRIPTION
`EAUsersProfile` already handles tracking the message source, so this PR just adds the `from` param to the links to authors' profiles in the post page header.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204790134610344) by [Unito](https://www.unito.io)
