### PR TITLE
Don't throw an error when removing a crosspost if the foreign post doesn't exist

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -76,7 +76,9 @@ const updateCrosspost = async (postId: string, denormalizedData: DenormalizedCro
  */
 const removeCrosspost = async <T extends Crosspost>(post: T) => {
   if (!post.fmCrosspost || !post.fmCrosspost.foreignPostId) {
-    throw new Error("Cannot remove crosspost that doesn't exist");
+    // eslint-disable-next-line no-console
+    console.warn("Cannot remove crosspost that doesn't exist");
+    return;
   }
   await updateCrosspost(post.fmCrosspost.foreignPostId, {
     ...extractDenormalizedData(post),


### PR DESCRIPTION
If a user tries to create a crosspost but it fails because they don't have enough karma on the foreign forum then they often try to unset the option to crosspost on the original post. This fails because it tries to delete the foreign post, which doesn't exist because creation failed. This PR changes this behaviour to instead just log a warning in the console without throwing an exception.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204790610813348) by [Unito](https://www.unito.io)
