### PR TITLE
Rejection reasons refactor

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
@@ -34,7 +34,7 @@ export const RejectContentButton = ({contentWrapper, classes}: {
   const { eventHandlers, anchorEl } = useHover();
   const { rejectContent, unrejectContent } = useRejectContent(contentWrapper);
   const [showRejectionDialog, setShowRejectionDialog] = useState(false);
-  const { LWPopper, ContentRejectionDialog, LWTooltip, MetaInfo } = Components;
+  const { LWPopper, RejectContentDialog, LWTooltip, MetaInfo } = Components;
   const { content } = contentWrapper;
 
   const handleRejectContent = (reason: string) => {
@@ -58,9 +58,9 @@ export const RejectContentButton = ({contentWrapper, classes}: {
         className={classes.popper}
         clickable={true}
         allowOverflow={true}
-        placement={"bottom-start"}
+        placement={"right"}
       >
-        <ContentRejectionDialog rejectContent={handleRejectContent}/>
+        <RejectContentDialog rejectContent={handleRejectContent}/>
       </LWPopper>
     </ClickAwayListener>}
   </span>

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -49,6 +49,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 6,
     paddingLeft: 12,
     paddingBottom: 6
+  },
+  topReason: {
+    fontWeight: 600
+  },
+  nonTopReason: {
+    opacity: .6
   }
 });
 

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -9,7 +9,6 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card'
 import EditIcon from '@material-ui/icons/Edit'
 import { Link } from '../../lib/reactRouterWrapper';
-import { getRejectionMessage } from '../../server/callbacks/commentCallbacks';
 
 const styles = (theme: ThemeType): JssStyles => ({
   dialogContent: {
@@ -50,12 +49,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 6,
     paddingLeft: 12,
     paddingBottom: 6
-  },
-  topReason: {
-    fontWeight: 600
-  },
-  nonTopReason: {
-    opacity: .6
   }
 });
 
@@ -68,6 +61,7 @@ const RejectContentDialog = ({classes, rejectContent}: {
   const [selections, setSelections] = useState<Record<string,boolean>>({});
   const [hideTextField, setHideTextField] = useState(true);
   const [rejectedReason, setRejectedReason] = useState('');
+  const [showMore, setShowMore] = useState(false)
 
   const { results: rejectionTemplates, loadMoreProps } = useMulti({
     collectionName: 'ModerationTemplates',
@@ -122,23 +116,15 @@ const RejectContentDialog = ({classes, rejectContent}: {
     <div className={classes.loadMore}>
       <LoadMore {...loadMoreProps} />
     </div>
-    <div className={hideTextField ? classes.hideModalTextField : null}>
-      <ContentStyles contentType={"comment"} className={classes.root}>
-        <ContentItemBody
-          dangerouslySetInnerHTML={{__html: getRejectionMessage("[name]",null)}}
-        />
-      </ContentStyles>
-
-      <TextField
-        id="comment-moderation-rejection-reason"
-        label="Full message"
-        className={classes.modalTextField}
-        value={rejectedReason}
-        onChange={(event) => setRejectedReason(event.target.value)}
-        fullWidth
-        multiline
-      />
-    </div>
+    <TextField
+      id="comment-moderation-rejection-reason"
+      label="Full message"
+      className={classNames(classes.modalTextField, { [classes.hideModalTextField]: hideTextField })}
+      value={rejectedReason}
+      onChange={(event) => setRejectedReason(event.target.value)}
+      fullWidth
+      multiline
+    />
   </div>
   
   return (

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -31,7 +31,7 @@ const SunshineNewUsersList = ({ classes, terms, currentUser }: {
     return (
       <div>
         <SunshineListTitle>
-          <Link to="/admin/moderation">New Users</Link>
+          <Link to="/admin/moderation">Unreviewed Users</Link>
           <SunshineListCount count={totalCount}/>
         </SunshineListTitle>
         {results.map(user =>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -613,7 +613,7 @@ importComponent("CommentsReviewInfoCard", () => require('../components/sunshineD
 importComponent(["EmailHistory", "EmailHistoryPage"], () => require('../components/sunshineDashboard/EmailHistory'));
 importComponent("ModeratorActions", () => require('../components/sunshineDashboard/ModeratorActions'));
 importComponent("ModerationAltAccounts", () => require('../components/sunshineDashboard/ModerationAltAccounts'));
-importComponent("ContentRejectionDialog", () => require('../components/sunshineDashboard/ContentRejectionDialog'));
+importComponent("RejectContentDialog", () => require('../components/sunshineDashboard/RejectContentDialog'));
 importComponent("RejectContentButton", () => require('../components/sunshineDashboard/RejectContentButton'));
 importComponent("UserRateLimitItem", () => require('../components/sunshineDashboard/UserRateLimitItem'));
 

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -272,8 +272,8 @@ async function sendModerationPM({ messageContents, lwAccount, comment, noEmail, 
 
 export function getRejectionMessage (rejectedContentLink: string, rejectedReason: string|null) {
   let messageContents = `
-  <p>Unfortunately, I rejected your ${rejectedContentLink}. LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality.</p>
-  <p>We get a lot of content from new users and we can't give detailed feedback on every piece we reject. But I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>`
+  <p>Unfortunately, I rejected your ${rejectedContentLink}.</p>
+  <p>LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality. We get a lot of content from new users and sadly can't give detailed feedback on every piece we reject, but I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>`
   if (rejectedReason) {
     messageContents += `<p>Your content didn't meet the bar for at least the following reason(s):</p>
     <p>${rejectedReason}</p>`;

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -270,6 +270,17 @@ async function sendModerationPM({ messageContents, lwAccount, comment, noEmail, 
   }
 }
 
+export function getRejectionMessage (rejectedContentLink: string, rejectedReason: string|null) {
+  let messageContents = `
+  <p>Unfortunately, I rejected your ${rejectedContentLink}. LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality.</p>
+  <p>We get a lot of content from new users and we can't give detailed feedback on every piece we reject. But I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>`
+  if (rejectedReason) {
+    messageContents += `<p>Your content didn't meet the bar for at least the following reason(s):</p>
+    <p>${rejectedReason}</p>`;
+  }
+  return messageContents;
+}
+
 async function commentsRejectSendPMAsync (comment: DbComment, currentUser: DbUser) {
   let rejectedContentLink = "[Error: content not found]"
   let contentTitle: string|null = null
@@ -290,14 +301,7 @@ async function commentsRejectSendPMAsync (comment: DbComment, currentUser: DbUse
 
   const commentUser = await Users.findOne({_id: comment.userId})
 
-  let messageContents =
-      // TODO: make link conditional on forum, or something
-      `Unfortunately, I rejected your ${rejectedContentLink}.  (The LessWrong moderator team is raising its moderation standards, see <a href="https://www.lesswrong.com/posts/kyDsgQGHoLkXz6vKL/lw-team-is-adjusting-moderation-policy">this announcement</a> for details).`
-
-  if (comment.rejectedReason) {
-    messageContents += ` <p>Your comment didn't meet the bar for at least the following reason(s):</p><p>${comment.rejectedReason}</p>`;
-  }
-  
+  let messageContents = getRejectionMessage(rejectedContentLink, comment.rejectedReason)
   
   // EAForum always sends an email when deleting comments. Other ForumMagnum sites send emails if the user has been approved, but not otherwise (so that admins can reject comments by mediocre users without sending them an email notification that might draw their attention back to the site.)
   const noEmail = forumTypeSetting.get() === "EAForum" 

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -24,7 +24,7 @@ import { updatePostDenormalizedTags } from '../tagging/tagCallbacks';
 import Conversations from '../../lib/collections/conversations/collection';
 import Messages from '../../lib/collections/messages/collection';
 import { isAnyTest } from '../../lib/executionEnvironment';
-import { getAdminTeamAccount } from './commentCallbacks';
+import { getAdminTeamAccount, getRejectionMessage } from './commentCallbacks';
 import { DatabaseServerSetting } from '../databaseSettings';
 import { isPostAllowedType3Audio, postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { postStatuses } from '../../lib/collections/posts/constants';
@@ -310,14 +310,9 @@ getCollectionHooks("Posts").updateAsync.add(async function sendRejectionPM({ new
   if (postRejected) {
     const postUser = await Users.findOne({_id: post.userId});
 
-    let messageContents =
-        // TODO: make link conditional on forum, or something
-        `Unfortunately, I rejected your post <a href="https://lesswrong.com/posts/${post._id}/${post.slug}">${post.title}</a>. (The LessWrong moderator team is raising its moderation standards, see <a href="https://www.lesswrong.com/posts/kyDsgQGHoLkXz6vKL/lw-team-is-adjusting-moderation-policy">this announcement</a> for details).`
+    const rejectedContentLink = `<span>post, <a href="https://lesswrong.com/posts/${post._id}/${post.slug}">${post.title}</a></span>`
+    let messageContents = getRejectionMessage(rejectedContentLink, post.rejectedReason)
   
-    if (post.rejectedReason) {
-      messageContents += ` Your post didn't meet the bar for at least the following reason(s): ${post.rejectedReason}`;
-    }
-
     // FYI EA Forum: Decide if you want this to always send emails the way you do for deletion. We think it's better not to.
     const noEmail = isEAForum
     ? false 


### PR DESCRIPTION
PR updates rejections to:
– have the rejected reasons list now shows all reasons (rather than the top 6), but highlights the top 6 to help make it easier to parse.
– updates the rejection default message
– refactors the rejection default message into a function shared between posts and comments (I hope to also eventually make it visible from the rejection dialog, but didn't get to that as part of this PR)
– renames ContentRejectionDialog to RejectContentDialog so that it's easier to find near RejectContentButton

<img width="434" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/f0162477-11ee-4c5d-a11f-c62eacffa618">

<img width="587" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/0ec30cf9-8478-46ea-ba35-f2ed2e910dc5">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204791158184097) by [Unito](https://www.unito.io)
