### PR TITLE
Use instance setting rather than db setting for idle timeout

### DIFF
--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -1,10 +1,10 @@
 import pgp, { IDatabase, IEventContext } from "pg-promise";
 import Query from "../lib/sql/Query";
 import { queryWithLock } from "./queryWithLock";
-import { DatabaseServerSetting } from "./databaseSettings";
 import { isAnyTest } from "../lib/executionEnvironment";
+import { PublicInstanceSetting } from "../lib/instanceSettings";
 
-const pgConnIdleTimeoutMsSetting = new DatabaseServerSetting<number>('pg.idleTimeoutMs', 10000)
+const pgConnIdleTimeoutMsSetting = new PublicInstanceSetting<number>('pg.idleTimeoutMs', 10000, 'optional')
 
 const pgPromiseLib = pgp({
   noWarnings: isAnyTest,


### PR DESCRIPTION
We were getting the error `Failed to connect to postgres:  Requested database setting before settings loaded` on staging, for obvious reasons. I'm surprised this was working locally though

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204793531163796) by [Unito](https://www.unito.io)
