### PR TITLE
Import cron job to clear PageCache table

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -14,6 +14,7 @@ import './server/rss-integration/cron';
 import './server/rss-integration/callbacks';
 import './server/karmaInflation/cron';
 import './server/useractivities/cron';
+import './server/pageCache/cron';
 import './server/users/cron'
 import './server/database-import/force_batch_update_scores';
 import './server/database-import/cleanup_scripts';


### PR DESCRIPTION
I forgot to import this in https://github.com/ForumMagnum/ForumMagnum/pull/7327 , so old entries are not getting cleared (which is fine, but the table will get pretty bloated eventually)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204793787758065) by [Unito](https://www.unito.io)
