### PR TITLE
Add ability to explicitly set a batchKey for a graphql query, and separate out crosspost queries into their own batch

### DIFF
--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -69,7 +69,9 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
     documentId: localPost.fmCrosspost.foreignPostId
   };
 
-  const { data, loading, error } = useQuery(getCrosspostQuery, { variables: { args } });
+  // This query can be slow (and the timing is unpredictable), so use `batchKey: "crosspost"` to make sure it
+  // doesn't get batched together with other queries and block them
+  const { data, loading, error } = useQuery(getCrosspostQuery, { variables: { args, batchKey: "crosspost" } });
 
   const foreignPost: FragmentTypes[FragmentTypeName] = data?.getCrosspost;
 


### PR DESCRIPTION
Graphql queries are batched together by BatchHttpLink, which means fast queries can get stuck waiting for slow queries to complete. Crosspost queries can often become very slow if there is some problem on the LW servers, which tends to slow down the whole frontpage load when a user reaches the frontpage by navigating (because a crosspost query from recent discussion gets batched together with all the others)

This PR adds the ability to explicitly set a batchKey for an individual query, to make sure it is sent in a separate batch. It also does this for crossposting specifically.

I think this is an anti-pattern to do generally, we don't want to be manually tuning individual queries, so I haven't added it as a proper parameter you can pass in to useSingle or useMulti. You would just have to pass it in to `extraVariables`. Crossposting is enough of a special case that I think it is worth doing in that case though