### PR TITLE
Rework inline reaction button hover effect

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
@@ -19,48 +19,18 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const AddInlineReactionButton = ({voteProps, classes, quote, commentItemRef}: {
+const AddInlineReactionButton = ({voteProps, classes, quote, disabled}: {
   voteProps: VotingProps<VoteableTypeClient>,
   classes: ClassesType,
   quote?: string,
-  commentItemRef?: React.RefObject<HTMLDivElement>|null
+  disabled?: boolean
 }) => {
   const [open,setOpen] = useState(false);
   const buttonRef = useRef<HTMLElement|null>(null);
   const { LWTooltip, ReactionsPalette } = Components;
-  const [disabled, setDisabled] = useState(false);
 
   const { getCurrentUserReactionVote, toggleReaction, getCurrentUserReaction } = useNamesAttachedReactionsVoting(voteProps);
   
-  // while moused over the button, if the text appears multiple times it highlights both of 
-  // them so it's easier to figure out the minimal text to highlight
-  function handleHover() {
-    const ref = commentItemRef?.current
-    if (!ref) return
-    let markInstance = new Mark(ref);
-
-    // Extract the raw text content of the entire HTML document
-    let rawText = ref.textContent ?? ""
-
-    // Count the number of occurrences of the quote in the raw text
-    let count = (rawText.match(new RegExp(quote ?? "", "g")) || []).length;
-
-    markInstance.unmark({className: hideSelectorClassName});
-    markInstance.mark(quote ?? "", {
-        separateWordSearch: false,
-        acrossElements: true,
-        diacritics: true,
-        className: hideSelectorClassName
-    });
-    setDisabled(count > 1)
-  }
-
-  const handleHoverEnd = () => {
-    const ref = commentItemRef?.current
-    if (!ref) return
-    let markInstance = new Mark(ref);
-    markInstance.unmark({className: hideSelectorClassName});
-  }
 
   const handleOpen = () => {
     !disabled && setOpen(true)
@@ -81,7 +51,7 @@ const AddInlineReactionButton = ({voteProps, classes, quote, commentItemRef}: {
     <span
       ref={buttonRef}
     >
-      {!open && <InsertEmoticonOutlined onClick={handleOpen} onMouseOver={handleHover} onMouseLeave={handleHoverEnd}/>}
+      {!open && <InsertEmoticonOutlined onClick={handleOpen} className={disabled ? classes.disabled : null}/>}
       {open && <div className={classes.palette}>
         <ReactionsPalette
           getCurrentUserReaction={getCurrentUserReaction}

--- a/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
@@ -3,8 +3,6 @@ import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { VotingProps } from "../withVote";
 import InsertEmoticonOutlined from '@material-ui/icons/InsertEmoticon';
 import { useNamesAttachedReactionsVoting } from "./NamesAttachedReactionsVoteOnComment";
-import Mark from 'mark.js';
-import { hideSelectorClassName } from "./InlineReactSelectionWrapper";
 
 const styles = (theme: ThemeType): JssStyles => ({
   disabled: {

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -88,9 +88,7 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
         setYOffset(getYOffsetFromDocument(selection, commentTextRef));
         const commentText = commentItemRef.current?.textContent ?? ""
         // Count the number of occurrences of the quote in the raw text
-        console.log({commentText, selectedText})
-        let count = (commentText.match(new RegExp(selectedText, "g")) || []).length;
-        console.log(count)
+        const count = (commentText.match(new RegExp(selectedText, "g")) || []).length;
         setDisabledButton(count > 1)
       } else {
         clearAll()

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -32,6 +32,7 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
   const [quote, setQuote] = useState<string>("");
   const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);
   const [yOffset, setYOffset] = useState<number>(0);
+  const [disabledButton, setDisabledButton] = useState<boolean>(false);
 
   const { AddInlineReactionButton, LWPopper } = Components;
 
@@ -59,15 +60,19 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
       let markInstance = new Mark(ref);
       markInstance.unmark({className: hideSelectorClassName});
     }
+
+    function clearAll() {
+      setAnchorEl(null);
+      setQuote("")
+      unMark()
+      setDisabledButton(false)
+    }
   
-    
     const selection = window.getSelection()
     const selectedText = selection?.toString() ?? ""
     const selectionAnchorNode = selection?.anchorNode
     if (!selectionAnchorNode) {
-      setAnchorEl(null);
-      setQuote("")
-      unMark()
+      clearAll()
       return
     }
 
@@ -81,16 +86,18 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
         setAnchorEl(anchorEl);
         setQuote(selectedText);
         setYOffset(getYOffsetFromDocument(selection, commentTextRef));
+        const commentText = commentItemRef.current?.textContent ?? ""
+        // Count the number of occurrences of the quote in the raw text
+        console.log({commentText, selectedText})
+        let count = (commentText.match(new RegExp(selectedText, "g")) || []).length;
+        console.log(count)
+        setDisabledButton(count > 1)
       } else {
-        setAnchorEl(null);
-        setQuote("")
-        unMark()
+        clearAll()
       }
     }
     if (!selectionInCommentRef && !selectionInPopupRef) {
-      setAnchorEl(null);
-      setQuote("")
-      unMark()
+      clearAll()
     }
   }, [commentItemRef, commentTextRef]);
   
@@ -111,7 +118,7 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
         <span ref={popupRef} className={classes.button} 
           style={{position:"relative", top: yOffset, marginLeft: 12}}
         >
-          <AddInlineReactionButton quote={quote} voteProps={voteProps} commentItemRef={commentItemRef}/>
+          <AddInlineReactionButton quote={quote} voteProps={voteProps} commentItemRef={commentItemRef} disabled={disabledButton}/>
         </span> 
       </LWPopper>
       {children}

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -118,7 +118,7 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
         <span ref={popupRef} className={classes.button} 
           style={{position:"relative", top: yOffset, marginLeft: 12}}
         >
-          <AddInlineReactionButton quote={quote} voteProps={voteProps} commentItemRef={commentItemRef} disabled={disabledButton}/>
+          <AddInlineReactionButton quote={quote} voteProps={voteProps} disabled={disabledButton}/>
         </span> 
       </LWPopper>
       {children}


### PR DESCRIPTION
Previously, mousing over the add-inline-react button would highlight all duplicates of the text you selected, to make it easier to see how much you had to expand the selection in order to get a unique string. 

This caused a minor bug on Chrome and Firefox, and a major bug on Firefox. (It'd mess with the selection in random ways, and on Firefox this caused the selection listener to think it needed to disappear the button)

This wasn't that important an effect in the first place, so I'm just removing the effect. I'm also moving the regex that checks for duplicate strings up a level into the InlineReactSelectionWrapper, so that the button greys out if it doesn't have a valid selection.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204797381430122) by [Unito](https://www.unito.io)
