### PR TITLE
ForumGate DeletedCommentUser

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/moderationLog/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/moderationLog/ModerationLog.tsx
@@ -105,7 +105,7 @@ const ModeratorTypeDisplay = ({column, document}: {
 
 const deletedCommentColumns: Column[] = [
   {
-    name: 'user',
+    name: 'Comment Author',
     component: UserDisplay,
   },
   {

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -4,7 +4,7 @@ import { mongoFindOne } from '../../mongoQueries';
 import { userGetDisplayNameById } from '../../vulcan-users/helpers';
 import { schemaDefaultValue } from '../../collectionUtils';
 import { Utils } from '../../vulcan-lib';
-import { forumTypeSetting, taggingNameSetting } from "../../instanceSettings";
+import { forumTypeSetting, isEAForum, taggingNameSetting } from "../../instanceSettings";
 import { commentAllowTitle, commentGetPageUrlFromDB } from './helpers';
 import { tagCommentTypes } from './types';
 import { getVotingSystemNameForDocument } from '../../voting/votingSystems';
@@ -141,7 +141,7 @@ const schema: SchemaType<DbComment> = {
       nullable: true,
     }),
     optional: true,
-    canRead: [documentIsNotDeleted],
+    canRead: [isEAForum ? documentIsNotDeleted : 'guests'],
     canCreate: ['members'],
     hidden: true,
   },


### PR DESCRIPTION
The permissions for userId were changed here:
https://github.com/ForumMagnum/ForumMagnum/commit/cfa7edd9f507d189d1446b548b2fd454d8ad7a20 

To make it so only admins and owners could see the name of deleted users. This made the /moderation page deleted comments section much more confusing on LessWrong.

This PR forum-gates that change. @oetherington I'm interested in more context on what the goal was for the other PR.

Also changes the name of the "user" column to "comment author" to be more clear.

<img width="784" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/cee275d5-6ba5-404e-8b6d-a64fd56e84af">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204800045533320) by [Unito](https://www.unito.io)
