### PR TITLE
Disable slower frontpage for logged out users (and reenable cache)

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -352,10 +352,10 @@ function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsView
     t => (t.filterMode!=="Hidden" && t.filterMode!=="Required" && t.filterMode!=="Default" && t.filterMode!==0)
   );
 
-  const useSlowerFrontpage = (context.currentUser || context.clientId) && isEAForum ?
+  const useSlowerFrontpage = context.currentUser && isEAForum ?
     getUserABTestGroup(context.currentUser, context.clientId || '', getABTestsMetadata()['slowerFrontpage']) === 'treatment'
     : false
-  
+
   const syntheticFields = {
     score: {$divide:[
       {$multiply: [

--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -35,7 +35,6 @@ const decayFactorFastestSetting = new DatabasePublicSetting<number>('frontpageAl
 const activityWeightSetting = new DatabasePublicSetting<number>('frontpageAlgorithm.activityWeight', 1.4)
 export const activityHalfLifeSetting = new DatabasePublicSetting<number>('frontpageAlgorithm.activityHalfLife', 60)
 export const frontpageDaysAgoCutoffSetting = new DatabasePublicSetting<number>('frontpageAlgorithm.daysAgoCutoff', 90)
-export const frontpageAlgoCacheDisabled = new DatabasePublicSetting<boolean>('frontpageAlgorithm.cacheDisabled', true)
 
 export const TIME_DECAY_FACTOR = timeDecayFactorSetting;
 // Basescore bonuses for various categories

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -136,9 +136,6 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
 };
 
 function isExcludedFromPageCache(path: string, abTestGroups: CompleteTestGroupAllocation): boolean {
-  if (isEAForum && abTestGroups["slowerFrontpage"] !== "control" && path === "/" && frontpageAlgoCacheDisabled.get()) {
-    return true;
-  }
   if (path.startsWith("/collaborateOnPost") || path.startsWith("/editPost")) return true;
   return false
 }

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -28,8 +28,6 @@ import { DatabaseServerSetting } from '../../databaseSettings';
 import type { Request, Response } from 'express';
 import type { TimeOverride } from '../../../lib/utils/timeUtil';
 import { getIpFromRequest } from '../../datadog/datadogMiddleware';
-import { isEAForum } from '../../../lib/instanceSettings';
-import { frontpageAlgoCacheDisabled } from '../../../lib/scoring';
 
 const slowSSRWarnThresholdSetting = new DatabaseServerSetting<number>("slowSSRWarnThreshold", 3000);
 


### PR DESCRIPTION
We can't see a clear effect of this in the A/B test and disabling the cache slows things down a lot for logged out users. We may also remove this for logged in users soon, but I want to deploy this before deciding on that because of the performance cost

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204805154446524) by [Unito](https://www.unito.io)
