### PR TITLE
Don't fetch tagRels during ssr in FooterTagList (performance improvement)

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -13,6 +13,7 @@ import { sortBy } from 'underscore';
 import { forumSelect } from '../../lib/forumTypeUtils';
 import { useMessages } from '../common/withMessages';
 import { isEAForum } from '../../lib/instanceSettings';
+import { isServer } from '../../lib/executionEnvironment';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -93,6 +94,7 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false, s
     fragmentName: "TagRelMinimumFragment", // Must match the fragment in the mutation
     limit: 100,
     fetchPolicy: 'cache-and-network',
+    ssr: true,
   });
 
   const tagIds = (results||[]).map((tag) => tag._id)

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -78,13 +78,14 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false, s
   const { flash } = useMessages();
   const { LWTooltip, AddTagButton, CoreTagsChecklist } = Components
 
-  // [Epistemic status - two years later guessing] This loads the tagrels via a
-  // database query instead of using the denormalized field on posts. This
-  // causes a shift of the tag in non-SSR contexts. I believe without
-  // empirically testing this, that it's to allow the mutation to seamlessly
-  // reorder the tags, by updating the result of this query. But you could
-  // imagine that this could start with the ordering of the tags on the post
-  // object, and then use the result from the database once we have it.
+  // We already have the tags as a resolver on the post, this additional query
+  // serves two purposes:
+  // - It fetches more info that is only required on hover (the tagRel score,
+  // the truncated description). Fetching this in a second round trip allows the
+  // initial render to be faster.
+  // - (somewhat speculative) It allows the mutation to be handled more seamlessly
+  // (incrementing the score and reordering the tags) by updating the result of
+  // this query
   const { results, loading, loadingInitial, refetch } = useMulti({
     terms: {
       view: "tagsOnPost",
@@ -94,7 +95,8 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false, s
     fragmentName: "TagRelMinimumFragment", // Must match the fragment in the mutation
     limit: 100,
     fetchPolicy: 'cache-and-network',
-    ssr: true,
+    // Only fetch this as a follow-up query on the client
+    ssr: false,
   });
 
   const tagIds = (results||[]).map((tag) => tag._id)

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -1,13 +1,14 @@
 import { WatchQueryFetchPolicy, ApolloError, useQuery, NetworkStatus, gql, useApolloClient } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
 import qs from 'qs';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import compose from 'recompose/compose';
 import withState from 'recompose/withState';
 import * as _ from 'underscore';
 import { extractCollectionInfo, extractFragmentInfo, getFragment, getCollection, pluralize, camelCaseify } from '../vulcan-lib';
 import { useLocation, useNavigation } from '../routeUtil';
 import { invalidateQuery } from './cacheUpdates';
+import { isServer } from '../executionEnvironment';
 
 // Template of a GraphQL query for withMulti/useMulti. A sample query might look
 // like:
@@ -234,6 +235,7 @@ export interface UseMultiOptions<
   queryLimitName?: string,
   alwaysShowLoadMore?: boolean,
   createIfMissing?: Partial<ObjectsByCollectionName[CollectionName]>,
+  ssr?: boolean,
 }
 
 export type LoadMoreCallback = (limitOverride?: number) => void
@@ -278,6 +280,7 @@ export function useMulti<
   queryLimitName,
   alwaysShowLoadMore = false,
   createIfMissing,
+  ssr = true,
 }: UseMultiOptions<FragmentTypeName,CollectionName>): {
   loading: boolean,
   loadingInitial: boolean,
@@ -332,7 +335,8 @@ export function useMulti<
     pollInterval, 
     fetchPolicy,
     nextFetchPolicy: newNextFetchPolicy as WatchQueryFetchPolicy,
-    ssr: true,
+    // TODO note that this is a workaround (see https://github.com/apollographql/apollo-client/issues/5918)
+    ssr: ssr || !isServer,
     skip,
     notifyOnNetworkStatusChange: true
   }

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -335,7 +335,8 @@ export function useMulti<
     pollInterval, 
     fetchPolicy,
     nextFetchPolicy: newNextFetchPolicy as WatchQueryFetchPolicy,
-    // TODO note that this is a workaround (see https://github.com/apollographql/apollo-client/issues/5918)
+    // This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
+    // the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
     ssr: ssr || !isServer,
     skip,
     notifyOnNetworkStatusChange: true

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -184,17 +184,19 @@ const cacheLookupDB = async (cacheKey: string, abTestGroups: CompleteTestGroupAl
 }
 
 const cacheLookup = async (cacheKey: string, abTestGroups: CompleteTestGroupAllocation): Promise<RenderResult|null|undefined> => {
-  const localResult = cacheLookupLocal(cacheKey, abTestGroups);
-  if (localResult) {
-    return localResult;
-  }
-
-  if (dbPageCacheEnabledSetting.get()) {
-    const dbResult = await cacheLookupDB(cacheKey, abTestGroups);
-    return dbResult;
-  }
-
   return null;
+  // TODO uncomment
+  // const localResult = cacheLookupLocal(cacheKey, abTestGroups);
+  // if (localResult) {
+  //   return localResult;
+  // }
+
+  // if (dbPageCacheEnabledSetting.get()) {
+  //   const dbResult = await cacheLookupDB(cacheKey, abTestGroups);
+  //   return dbResult;
+  // }
+
+  // return null;
 }
 
 const objIsSubset = <A extends Record<string, any>, B extends Record<string, any>>(subset: A, superset: B): boolean => {

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -184,19 +184,17 @@ const cacheLookupDB = async (cacheKey: string, abTestGroups: CompleteTestGroupAl
 }
 
 const cacheLookup = async (cacheKey: string, abTestGroups: CompleteTestGroupAllocation): Promise<RenderResult|null|undefined> => {
+  const localResult = cacheLookupLocal(cacheKey, abTestGroups);
+  if (localResult) {
+    return localResult;
+  }
+
+  if (dbPageCacheEnabledSetting.get()) {
+    const dbResult = await cacheLookupDB(cacheKey, abTestGroups);
+    return dbResult;
+  }
+
   return null;
-  // TODO uncomment
-  // const localResult = cacheLookupLocal(cacheKey, abTestGroups);
-  // if (localResult) {
-  //   return localResult;
-  // }
-
-  // if (dbPageCacheEnabledSetting.get()) {
-  //   const dbResult = await cacheLookupDB(cacheKey, abTestGroups);
-  //   return dbResult;
-  // }
-
-  // return null;
 }
 
 const objIsSubset = <A extends Record<string, any>, B extends Record<string, any>>(subset: A, superset: B): boolean => {


### PR DESCRIPTION
This defers the fetching of tagRels in FooterTagList to the client side. This has no effect on the initial render as the post has enough info about the tags to render the actual chip, it's just the tooltip contents that requires these tagRels

On the frontpage this fetch happens currently after everything else has already loaded, so removing this should save ~200ms on the page load.

Here are the traces of a frontpage SSR request before and after. The important thing to note is that there were some TagRel queries right at the end which are now gone

Before:
![Screenshot 2023-06-12 at 12 14 45](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/fd46b2f0-cf4a-43f7-8550-6991105aed98)
After:
![Screenshot 2023-06-12 at 12 14 54](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/629cda12-1fdd-4131-8749-d9e396a12bcf)
