### PR TITLE
Truncate slow query log to avoid dumping entire html pages

### DIFF
--- a/packages/lesswrong/lib/sql/sqlClient.ts
+++ b/packages/lesswrong/lib/sql/sqlClient.ts
@@ -35,10 +35,9 @@ let queriesExecuted = 0;
 
 export async function logIfSlow<T>(execute: ()=>Promise<T>, describe: string|(()=>string), quiet?: boolean) {
   function getDescription(): string {
-    if (typeof describe==='string')
-      return describe;
-    else
-      return describe();
+    const describeString = typeof describe==='string' ? describe : describe();
+    // Truncate this at a pretty high limit, just to avoid logging things like entire rendered pages
+    return describeString.slice(0, 5000);
   }
   
   let queryID: number = ++queriesExecuted;


### PR DESCRIPTION
I noticed that since adding the shared page cache I occasionally get loads of html dumped into the terminal when there is a slow query, this slows down the server quite a lot. I've added a limit of 5000 characters to prevent this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204807318728469) by [Unito](https://www.unito.io)
