### PR TITLE
Mitigate performance cost of post recommendations

### DIFF
--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
@@ -7,8 +7,10 @@ import type {
   WeightedFeature,
 } from "../../lib/collections/users/recommendationSettings";
 import { CENTRAL_COLUMN_WIDTH, MAX_COLUMN_WIDTH } from "../posts/PostsPage/PostsPage";
+import NoSSR from "react-no-ssr";
 
 const PADDING = (MAX_COLUMN_WIDTH - CENTRAL_COLUMN_WIDTH) / 4;
+const COUNT = 3;
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -25,6 +27,15 @@ const styles = (theme: ThemeType) => ({
     // We don't pad right here in order to not over-pad the triple-dot menu
     paddingLeft: PADDING,
   },
+  listWrapper: {
+    // Approx height of 3 posts, to avoid layout shift
+    minHeight: 42 * COUNT,
+    [theme.breakpoints.down("sm")]: {
+      // We can't know the actual height on small screens due to wrapping, so hedge and
+      // make it a bit taller
+      minHeight: 60 * COUNT,
+    },
+  }
 });
 
 const PostsPageRecommendationsList = ({
@@ -55,29 +66,39 @@ const PostsPageRecommendationsList = ({
       features,
       forceLoggedOutView,
     },
-    count: 3,
+    count: COUNT,
   };
 
-  const {SectionTitle, RecommendationsList, PostsPageRecommendationItem} = Components;
+  const {SectionTitle, RecommendationsList, PostsPageRecommendationItem, PostsLoading} = Components;
+
+  const loadingFallback = (
+    <div className={classes.listWrapper}>
+      <PostsLoading />
+    </div>
+  );
+
   return (
     <div className={classes.root}>
       {title && <SectionTitle title={title} className={classes.title} />}
-      <RecommendationsList
-        algorithm={recommendationsAlgorithm}
-        ListItem={
-          (props: {
-            post: PostsListWithVotesAndSequence,
-            translucentBackground?: boolean,
-          }) => (
-            <PostsPageRecommendationItem
-              {...props}
-              translucentBackground
-              className={classes.item}
-              disableAnalytics={forceLoggedOutView}
-            />
-          )
-        }
-      />
+      <NoSSR onSSR={loadingFallback}>
+        <RecommendationsList
+          algorithm={recommendationsAlgorithm}
+          loadingFallback={loadingFallback}
+          ListItem={
+            (props: {
+              post: PostsListWithVotesAndSequence,
+              translucentBackground?: boolean,
+            }) => (
+              <PostsPageRecommendationItem
+                {...props}
+                translucentBackground
+                className={classes.item}
+                disableAnalytics={forceLoggedOutView}
+              />
+            )
+          }
+        />
+      </NoSSR>
     </div>
   );
 }

--- a/packages/lesswrong/components/recommendations/RecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.tsx
@@ -19,18 +19,20 @@ const RecommendationsList = ({
   algorithm,
   translucentBackground,
   ListItem = Components.PostsItem,
+  loadingFallback,
   classes,
 }: {
   algorithm: RecommendationsAlgorithm,
   translucentBackground?: boolean,
   ListItem?: RecommendationsListItem,
+  loadingFallback?: JSX.Element,
   classes: ClassesType,
 }) => {
   const {PostsLoading, Typography} = Components;
   const {recommendationsLoading, recommendations} = useRecommendations(algorithm);
 
   if (recommendationsLoading || !recommendations)
-    return <PostsLoading/>
+    return loadingFallback ?? <PostsLoading/>;
 
   return <div>
     {recommendations.map(post =>

--- a/packages/lesswrong/components/recommendations/withRecommendations.ts
+++ b/packages/lesswrong/components/recommendations/withRecommendations.ts
@@ -18,6 +18,7 @@ export const useRecommendations = (algorithm: RecommendationsAlgorithm): {
     variables: {
       count: algorithm?.count || 10,
       algorithm: algorithm || defaultAlgorithmSettings,
+      batchKey: "recommendations"
     },
     ssr: true,
   });


### PR DESCRIPTION
 - NoSSR the recommendations list
 - Add a batchKey to recommendations queries so other queries don't get stuck behind them

This (the NoSSR part) will unfortunately make recommendations much slower to load in absolute terms (time from refreshing the page to recommendations appearing). But seeing as they are by far the slowest thing to load at the moment (usually at least as slow as everything else combined) I think it is worth it. Also this frees us up to experiment with recommendations without having to immediately worry about the performance impact.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204807805772387) by [Unito](https://www.unito.io)
