### PR TITLE
Fix links in LW legacy format being broken on AF

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -862,7 +862,8 @@ Posts.addView("legacyIdPost", (terms: PostsViewTerms) => {
   if (isNaN(legacyId)) throw new Error("Invalid view argument: legacyId must be base36, was "+terms.legacyId);
   return {
     selector: {
-      legacyId: ""+legacyId
+      legacyId: ""+legacyId,
+      af: viewFieldAllowAny,
     },
     options: {
       limit: 1


### PR DESCRIPTION
This issue was reported as: Tag page https://www.alignmentforum.org/tag/holden-karnofsky contains a link to https://www.alignmentforum.org/lw/cbs/thoughts_on_the_singularity_institute_si/ which is broken. Actually, the link was to http://www.lesswrong.com/lw/cbs/thoughts_on_the_singularity_institute_si/ . The `PostLinkPreviewLegacy` component changed the http->https and the lesswrong.com->alignmentforum.org, then failed to have a working hover preview and making a broken link when clicked.

This changes the `legacyIdPost` resolver so it still works even if the default view contains `af:true` (ie, if it's being used by AF). This makes the link preview on that tag page work, and makes the alignmentforum version of the legacy post link function as a redirect to LW like it should.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204809757473352) by [Unito](https://www.unito.io)
