### PR TITLE
You cannot antireact to reactions on your own comments

### DIFF
--- a/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
+++ b/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
@@ -91,9 +91,17 @@ registerVotingSystem<NamesAttachedReactionsVote, NamesAttachedReactionsScore>({
     };
   },
 
-  isAllowedExtendedVote: (user: UsersCurrent|DbUser, oldExtendedScore: NamesAttachedReactionsScore, extendedVote: NamesAttachedReactionsVote) => {
+  isAllowedExtendedVote: (user: UsersCurrent|DbUser, document: DbVoteableType, oldExtendedScore: NamesAttachedReactionsScore, extendedVote: NamesAttachedReactionsVote) => {
     // Are there any reacts in this vote?
     if (extendedVote?.reacts && extendedVote.reacts.length>0) {
+      // Users cannot antireact to reactions on their own comments
+      if (some(extendedVote.reacts, r=>r.vote==="disagreed")) {
+        if (user._id===document.userId) {
+          return {allowed: false, reason: `You cannot antireact to reactions on your own comments`};
+        }
+      }
+      
+
       // If the user is disagreeing with a react, they need at least
       // downvoteExistingReactKarmaThreshold karma
       if (user.karma < downvoteExistingReactKarmaThreshold.get()

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -42,7 +42,7 @@ export interface VotingSystem<ExtendedVoteType=any, ExtendedScoreType=any> {
     currentUser: UsersCurrent
   })=>ExtendedScoreType
   computeExtendedScore: (votes: DbVote[], context: ResolverContext)=>Promise<ExtendedScoreType>
-  isAllowedExtendedVote?: (user: UsersCurrent|DbUser, oldExtendedScore: ExtendedScoreType, extendedVote: ExtendedVoteType) => {allowed: true}|{allowed: false, reason: string},
+  isAllowedExtendedVote?: (user: UsersCurrent|DbUser, document: DbVoteableType, oldExtendedScore: ExtendedScoreType, extendedVote: ExtendedVoteType) => {allowed: true}|{allowed: false, reason: string},
   isNonblankExtendedVote: (vote: DbVote) => boolean,
 }
 

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -285,7 +285,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
     const votingSystem = await getVotingSystemForDocument(document, context);
     if (extendedVote && votingSystem.isAllowedExtendedVote) {
       const oldExtendedScore = document.extendedScore;
-      const extendedVoteCheckResult = votingSystem.isAllowedExtendedVote(user, oldExtendedScore, extendedVote)
+      const extendedVoteCheckResult = votingSystem.isAllowedExtendedVote(user, document, oldExtendedScore, extendedVote)
       if (!extendedVoteCheckResult.allowed) {
         throw new Error(extendedVoteCheckResult.reason);
       }


### PR DESCRIPTION
Discussed in Slack thread: https://app.slack.com/client/T3ERD8FQT/CJUN2UAFN/thread/CJUN2UAFN-1686461489.244579?cdn_fallback=2

Antireactions make sense as a way for bystanders to remove unfair critical reacts, but when someone uses them to remove reacts from their own comments, it feels lame. Don't let users do that.