### PR TITLE
Improvements to the reaction hover

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -82,13 +82,13 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
     if (selectionInCommentRef && !selectionInPopupRef) {
       const anchorEl = commentItemRef.current;
       
-      if (anchorEl instanceof HTMLElement && selectedText.length > 1 ) {  
+      if (anchorEl instanceof HTMLElement && selectedText.length > 1 ) {
         setAnchorEl(anchorEl);
         setQuote(selectedText);
         setYOffset(getYOffsetFromDocument(selection, commentTextRef));
         const commentText = commentItemRef.current?.textContent ?? ""
         // Count the number of occurrences of the quote in the raw text
-        const count = (commentText.match(new RegExp(selectedText, "g")) || []).length;
+        const count = countStringsInString(commentText, selectedText);
         setDisabledButton(count > 1)
       } else {
         clearAll()
@@ -122,6 +122,17 @@ export const InlineReactSelectionWrapper = ({classes, comment, children, comment
       {children}
     </div>
   );
+}
+
+/** Count instances of a smaller string 'needle' in a larger string 'haystack'. */
+function countStringsInString(haystack: string, needle: string): number {
+  let count = 0;
+  let index = 0;
+  while ((index = haystack.indexOf(needle, index)) !== -1) {
+    count++;
+    index += needle.length;
+  }
+  return count;
 }
 
 const InlineReactSelectionWrapperComponent = registerComponent('InlineReactSelectionWrapper', InlineReactSelectionWrapper, {styles});

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -58,6 +58,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "inline-block",
     width: 2,
   },
+  mouseHoverTrap: {
+    position: "absolute",
+    right: 0,
+    height: 50,
+  },
   footerReactionHover: {
     width: 300,
   },
@@ -448,7 +453,7 @@ const NamesAttachedReactionsCommentBottom = ({
       {visibleReactionsDisplay.map(({react, numberShown}) =>
         <span key={react} onMouseLeave={() => markHighlights(quotes, faintHighlightClassName, commentItemRef)}>
           <HoverableReactionIcon
-            anchorEl={anchorEl}
+            reactionRowRef={anchorEl}
             react={react}
             numberShown={numberShown}
             voteProps={voteProps}
@@ -464,8 +469,11 @@ const NamesAttachedReactionsCommentBottom = ({
   </span>
 }
 
-const HoverableReactionIcon = ({anchorEl, react, numberShown, voteProps, classes, quote, commentItemRef}: {
-  anchorEl: RefObject<AnyBecauseTodo>,
+const HoverableReactionIcon = ({reactionRowRef, react, numberShown, voteProps, classes, quote, commentItemRef}: {
+  // reactionRowRef: Reference to the row of reactions, used as an anchor for the
+  // hover instead of the individual icon, so that the hover's position stays
+  // consistent as you move the mouse across the row.
+  reactionRowRef: RefObject<AnyBecauseTodo>,
   react: string,
   numberShown: number,
   voteProps: VotingProps<VoteableTypeClient>,
@@ -474,7 +482,7 @@ const HoverableReactionIcon = ({anchorEl, react, numberShown, voteProps, classes
   commentItemRef?: React.RefObject<HTMLDivElement>|null
 }) => {
   const { hover, eventHandlers: {onMouseOver, onMouseLeave} } = useHover();
-  const { ReactionIcon, PopperCard } = Components;
+  const { ReactionIcon, LWPopper } = Components;
   const { getCurrentUserReaction, getCurrentUserReactionVote, toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
   const currentUserReactionVote = getCurrentUserReactionVote(react);
   const currentUserReaction = getCurrentUserReaction(react)
@@ -519,14 +527,24 @@ const HoverableReactionIcon = ({anchorEl, react, numberShown, voteProps, classes
         {numberShown}
       </span>
   
-      {hover && anchorEl?.current && <PopperCard
-        open={!!hover} anchorEl={anchorEl.current}
+      {hover && reactionRowRef?.current && <LWPopper
+        open={!!hover} anchorEl={reactionRowRef.current}
         placement="bottom-end"
         allowOverflow={true}
-        
       >
-        <NamesAttachedReactionsHoverSingleReaction react={react} voteProps={voteProps} classes={classes} commentItemRef={commentItemRef}/>
-      </PopperCard>}
+        {/*
+          Add a 50px hoverable spacer left of the popup, below the reactions list,
+          so that the mouse has somewhere hoverable to cross when going from the
+          leftmost reactions to the hover form.
+        */}
+        <div className={classes.mouseHoverTrap} style={{width: reactionRowRef.current.clientWidth}}/>
+        <Card>
+          <NamesAttachedReactionsHoverSingleReaction
+            react={react} voteProps={voteProps} classes={classes}
+            commentItemRef={commentItemRef}
+          />
+        </Card>
+      </LWPopper>}
     </span>
     
     {/* Put a spacer element between footer reactions, rather than a margin, so

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -50,10 +50,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 2,
     paddingLeft: 7,
     paddingRight: 7,
-    marginRight: 2,
     "&:hover": {
       background: theme.palette.panelBackground.darken04,
     },
+  },
+  footerReactionSpacer: {
+    display: "inline-block",
+    width: 2,
   },
   footerReactionHover: {
     width: 300,
@@ -498,33 +501,40 @@ const HoverableReactionIcon = ({anchorEl, react, numberShown, voteProps, classes
     clearHighlights(commentItemRef)
   } 
 
-  return <span
-    className={classNames(
-      classes.footerReaction,
-      {
-        [classes.footerSelected]: currentUserReactionVote==="created"||currentUserReactionVote==="seconded",
-        [classes.footerSelectedAnti]: currentUserReactionVote==="disagreed",
-        [classes.hasQuotes]: quotesWithUndefinedRemoved.length > 0,
-      }
-    )}
-    onMouseEnter={handleMouseEnter}
-    onMouseLeave={handleMouseLeave}
-  >
-    <span onMouseDown={()=>{reactionClicked(react)}}>
-      <ReactionIcon react={react} />
-    </span>
-    <span className={classes.reactionCount}>
-      {numberShown}
-    </span>
-
-    {hover && anchorEl?.current && <PopperCard
-      open={!!hover} anchorEl={anchorEl.current}
-      placement="bottom-end"
-      allowOverflow={true}
-      
+  return <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <span
+      className={classNames(
+        classes.footerReaction,
+        {
+          [classes.footerSelected]: currentUserReactionVote==="created"||currentUserReactionVote==="seconded",
+          [classes.footerSelectedAnti]: currentUserReactionVote==="disagreed",
+          [classes.hasQuotes]: quotesWithUndefinedRemoved.length > 0,
+        }
+      )}
     >
-      <NamesAttachedReactionsHoverSingleReaction react={react} voteProps={voteProps} classes={classes} commentItemRef={commentItemRef}/>
-    </PopperCard>}
+      <span onMouseDown={()=>{reactionClicked(react)}}>
+        <ReactionIcon react={react} />
+      </span>
+      <span className={classes.reactionCount}>
+        {numberShown}
+      </span>
+  
+      {hover && anchorEl?.current && <PopperCard
+        open={!!hover} anchorEl={anchorEl.current}
+        placement="bottom-end"
+        allowOverflow={true}
+        
+      >
+        <NamesAttachedReactionsHoverSingleReaction react={react} voteProps={voteProps} classes={classes} commentItemRef={commentItemRef}/>
+      </PopperCard>}
+    </span>
+    
+    {/* Put a spacer element between footer reactions, rather than a margin, so
+      * that we can make the spacer element hoverable, getting rid of the
+      * close-and-open flash as you move the mouse horizontally across the
+      * reactions row.
+      */}
+    <span className={classes.footerReactionSpacer}/>
   </span>
 }
 

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -56,7 +56,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   footerReactionHover: {
-    maxWidth: 300,
+    width: 300,
   },
   reactionCount: {
     fontSize: 13,
@@ -106,6 +106,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     "&:hover": {
       background: theme.palette.panelBackground.darken04,
     },
+    
+    display: "flex",
+    alignItems: "flex-start",
+  },
+  hoverInfo: {
+    paddingLeft: 10,
+    maxWidth: 195,
+    flexGrow: 1,
   },
   hoverBallotLabel: {
     verticalAlign: "middle",
@@ -166,10 +174,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   footerSelectedAnti: {
     background: "rgb(255, 189, 189, .23)",
-  },
-  hoverInfo: {
-    paddingLeft: 10,
-    maxWidth: 195,
   },
   overviewButton: {
     opacity: .35,
@@ -646,32 +650,30 @@ const HoverBallotReactionRow = ({reactionName, usersWhoReacted, classes, comment
   classes: ClassesType,
   commentItemRef?: React.RefObject<HTMLDivElement>|null
 }) => {
-  const { ReactionIcon, Row, ReactionQuotesHoverInfo } = Components;
+  const { ReactionIcon, ReactionQuotesHoverInfo } = Components;
   const netReactionCount = sumBy(usersWhoReacted, r=>r.reactType==="disagreed"?-1:1);
   const { getCurrentUserReactionVote, setCurrentUserReaction } = useNamesAttachedReactionsVoting(voteProps);
 
   return <div key={reactionName}>
     <div className={classes.hoverBallotEntry}>
-      <Row justifyContent='space-between' alignItems='flex-start'>
-        <ReactionIcon react={reactionName} size={30}/>
-        <div className={classes.hoverInfo}>
-          <span className={classes.hoverBallotLabel}>
-            {getNamesAttachedReactionsByName(reactionName).label}
-          </span>
-          {getNamesAttachedReactionsByName(reactionName).description && <div className={classes.hoverBallotReactDescription}>
-            {getNamesAttachedReactionsByName(reactionName).description}
-          </div>}
-          <UsersWhoReacted usersWhoReacted={usersWhoReacted} classes={classes} wrap showTooltip={false}/>
+      <ReactionIcon react={reactionName} size={30}/>
+      <div className={classes.hoverInfo}>
+        <span className={classes.hoverBallotLabel}>
+          {getNamesAttachedReactionsByName(reactionName).label}
+        </span>
+        {getNamesAttachedReactionsByName(reactionName).description && <div className={classes.hoverBallotReactDescription}>
+          {getNamesAttachedReactionsByName(reactionName).description}
+        </div>}
+        <UsersWhoReacted usersWhoReacted={usersWhoReacted} classes={classes} wrap showTooltip={false}/>
 
-        </div>    
-        <ReactOrAntireactVote
-          reactionName={reactionName}
-          netReactionCount={netReactionCount}
-          currentUserReaction={getCurrentUserReactionVote(reactionName)}
-          setCurrentUserReaction={setCurrentUserReaction}
-          classes={classes}
-        />
-      </Row>
+      </div>
+      <ReactOrAntireactVote
+        reactionName={reactionName}
+        netReactionCount={netReactionCount}
+        currentUserReaction={getCurrentUserReactionVote(reactionName)}
+        setCurrentUserReaction={setCurrentUserReaction}
+        classes={classes}
+      />
     </div>
     <ReactionQuotesHoverInfo react={reactionName} voteProps={voteProps} commentItemRef={commentItemRef}/>
   </div>


### PR DESCRIPTION
* Don't use a regex (which has special-character problems) for counting strings
* Make reaction hover fixed-width again
* Make the 2px space between reaction icons hoverable
* Add a hoverable spacer below the reactions list, so that the mouse can cross to the popup

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204811136120000) by [Unito](https://www.unito.io)
