### PR TITLE
Alt-accounts notice in moderation UI uses all client IDs instead of only the first one

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserReviewStatus.tsx
@@ -47,7 +47,7 @@ export const UserReviewStatus = ({classes, user}: {
 
     {firstClientId?.firstSeenReferrer && <div className={classes.qualitySignalRow}>Initial referrer: <a href={firstClientId?.firstSeenReferrer}>{firstClientId?.firstSeenReferrer}</a></div>}
     {firstClientId?.firstSeenLandingPage && <div className={classes.qualitySignalRow}>Initial landing page: <Link to={firstClientId?.firstSeenLandingPage}>{firstClientId?.firstSeenLandingPage}</Link></div>}
-    {(firstClientId?.userIds?.length??0) > 1 && <AltAccountInfo user={user}/>}
+    {user.altAccountsDetected && <AltAccountInfo user={user}/>}
     <div className={classes.qualitySignalRow}>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
   </div>;
 }


### PR DESCRIPTION
This fixes an issue that caused false-negatives in alt-accounts detection in the moderation UI. Looking at the current moderation queue, there was in fact a user in there right now with a banned alt account that wasn't being picked up before, which is picked up with this patch applied.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204811244185683) by [Unito](https://www.unito.io)
