### PR TITLE
No commenting on other users' shortform containers, and add a notice

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -4,7 +4,8 @@ import Info from '@material-ui/icons/Info';
 import { forumTitleSetting, siteNameWithArticleSetting } from '../../../lib/instanceSettings';
 import { useCurrentUser } from '../../common/withUser';
 import { canNominate, postEligibleForReview, postIsVoteable, reviewIsActive, REVIEW_YEAR } from '../../../lib/reviewUtils';
-import {forumSelect} from "../../../lib/forumTypeUtils";
+import { forumSelect } from "../../../lib/forumTypeUtils";
+import { Link } from '../../../lib/reactRouterWrapper';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -83,6 +84,9 @@ const PostBodyPrefix = ({post, query, classes}: {
       This is a special post that holds your short-form writing. Because it's
       marked as a draft, your short-form posts will not be displayed. To un-draft
       it, pick Edit from the menu above, then click Publish.
+    </div>}
+    {post.shortform && !post.draft && <div className={classes.contentNotice}>
+      This is a special post for short-form writing by <Components.UsersNameDisplay user={post.user}/>. Only they can create top-level comments. Comments here also appear on the <Link to="/shortform">Shortform Page</Link> and <Link to="/allPosts">All Posts page</Link>.
     </div>}
 
     {post.rejected && <div className={classes.rejectionNotice}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -476,7 +476,11 @@ const PostsPage = ({post, refetch, classes}: {
         {/* Comments Section */}
         <div className={classes.commentsSection}>
           <AnalyticsContext pageSectionContext="commentsSection">
-            <PostsCommentsThread terms={{...commentTerms, postId: post._id}} post={post} newForm={!post.question} />
+            <PostsCommentsThread
+              terms={{...commentTerms, postId: post._id}}
+              post={post}
+              newForm={!post.question && (!post.shortform || post.userId===currentUser?._id)}
+            />
             {isAF && <AFUnreviewedCommentCount post={post}/>}
           </AnalyticsContext>
         </div>

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -200,8 +200,8 @@ export const userIsAllowedToComment = (user: UsersCurrent|DbUser|null, post: Pos
   if (user.allCommentingDisabled) return false
   if (user.commentingOnOtherUsersDisabled && post?.userId && (post.userId != user._id)) return false // this has to check for post.userId because that isn't consisently provided to CommentsNewForm components, which resulted in users failing to be able to comment on their own shortform post
 
-  if (post) { {
-    if (post.shortform && post.userId !== user._id)
+  if (post) {
+    if (post.shortform && post.userId !== user._id) {
       return false;
     }
 

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -200,21 +200,32 @@ export const userIsAllowedToComment = (user: UsersCurrent|DbUser|null, post: Pos
   if (user.allCommentingDisabled) return false
   if (user.commentingOnOtherUsersDisabled && post?.userId && (post.userId != user._id)) return false // this has to check for post.userId because that isn't consisently provided to CommentsNewForm components, which resulted in users failing to be able to comment on their own shortform post
 
-  if (!post) return true
-  if (post.commentsLocked) return false
-  if (post.rejected) return false 
-  if ((post.commentsLockedToAccountsCreatedAfter ?? new Date()) < user.createdAt) return false
+  if (post) { {
+    if (post.shortform && post.userId !== user._id)
+      return false;
+    }
 
-  if (userIsBannedFromPost(user, post, postAuthor)) {
-    return false
-  }
-
-  if (userIsBannedFromAllPosts(user, post, postAuthor)) {
-    return false
-  }
-
-  if (userIsBannedFromAllPersonalPosts(user, post, postAuthor) && !post.frontpageDate) {
-    return false
+    if (post.commentsLocked) {
+      return false
+    }
+    if (post.rejected) {
+      return false
+    }
+    if ((post.commentsLockedToAccountsCreatedAfter ?? new Date()) < user.createdAt) {
+      return false
+    }
+  
+    if (userIsBannedFromPost(user, post, postAuthor)) {
+      return false
+    }
+  
+    if (userIsBannedFromAllPosts(user, post, postAuthor)) {
+      return false
+    }
+  
+    if (userIsBannedFromAllPersonalPosts(user, post, postAuthor) && !post.frontpageDate) {
+      return false
+    }
   }
 
   return true


### PR DESCRIPTION
Prevents users from commenting on other users' shortform containers (both client-side by removing the comment box, and server-side with permissions). Also adds a message to the top of shortform container posts which reads: "This is a special post for short-form writing by Username. Only they can create top-level comments. Comments here also appear on the Shortform Page and All Posts page."

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204811769104437) by [Unito](https://www.unito.io)
