### PR TITLE
Cap the size of postgres slow-query logs at 500b

### DIFF
--- a/packages/lesswrong/lib/sql/sqlClient.ts
+++ b/packages/lesswrong/lib/sql/sqlClient.ts
@@ -55,8 +55,9 @@ export async function logIfSlow<T>(execute: ()=>Promise<T>, describe: string|(()
     // eslint-disable-next-line no-console
     console.log(`Finished query #${queryID} (${milliseconds} ms)`);
   } else if (milliseconds > SLOW_QUERY_REPORT_CUTOFF_MS && !quiet && !isAnyTest) {
+    const description = getDescription();
     // eslint-disable-next-line no-console
-    console.trace(`Slow Postgres query detected (${milliseconds} ms): ${getDescription()}`);
+    console.trace(`Slow Postgres query detected (${milliseconds} ms): ${description.substring(0,500)}`);
   }
 
   return result;


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204812452434790) by [Unito](https://www.unito.io)
