### PR TITLE
Fix google account selection with auth0

### DIFF
--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -441,7 +441,9 @@ export const addAuthMiddlewares = (addConnectHandler: AnyBecauseTodo) => {
       scope: [
         'https://www.googleapis.com/auth/plus.login',
         'https://www.googleapis.com/auth/userinfo.email'
-      ], accessType: "offline", prompt: "consent"
+      ],
+      accessType: "offline",
+      prompt: "select_account consent",
     })(req, res, next)
   })
 


### PR DESCRIPTION
I was able to replicate _a_ bug where it tried to log me in to the wrong account and this fixed it, but I don't know if it's the same bug. I think this is correct but there's also a lot of decade-old conflicting documentation about how this is supposed to work so it's hard to be certain. My current feeling is that this is safe to merge, but that we should keep an eye on it and be ready to revert in case of bug reports.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204818946771360) by [Unito](https://www.unito.io)
