### PR TITLE
Don't redirect GreaterWrong links to onsite equivalents in link hover-preview

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import { parseRoute, parsePath } from '../../lib/vulcan-core/appContext';
-import { hostIsOnsite, useLocation, getUrlClass } from '../../lib/routeUtil';
+import { classifyHost, useLocation, getUrlClass } from '../../lib/routeUtil';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { isServer } from '../../lib/executionEnvironment';
 import withErrorBoundary from '../common/withErrorBoundary';
@@ -76,9 +76,10 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel, 
     const linkTargetAbsolute = new URLClass(href, currentURL);
 
     const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
-    if (!linkIsExcludedFromPreview(onsiteUrl) && (hostIsOnsite(linkTargetAbsolute.host) || isServer)) {
+    const hostType = classifyHost(linkTargetAbsolute.host)
+    if (!linkIsExcludedFromPreview(onsiteUrl) && (hostType==="onsite" || hostType==="mirrorOfUs" || isServer)) {
       const parsedUrl = parseRouteWithErrors(onsiteUrl, contentSourceDescription)
-      const destinationUrl = parsedUrl.url;
+      const destinationUrl = hostType==="onsite" ? parsedUrl.url : href;
 
       if (parsedUrl.currentRoute) {
         const PreviewComponent: any = parsedUrl.currentRoute.previewComponentName ? Components[parsedUrl.currentRoute.previewComponentName] : null;

--- a/packages/lesswrong/lib/executionEnvironment.ts
+++ b/packages/lesswrong/lib/executionEnvironment.ts
@@ -63,7 +63,7 @@ export const setInstanceSettings = (settings: any) => {
   instanceSettings = settings;
 }
 
-export const getAbsoluteUrl = (maybeRelativeUrl?: string): string => {
+export const getAbsoluteUrl = (): string => {
   if (defaultSiteAbsoluteUrl?.length>0) {
     return defaultSiteAbsoluteUrl;
   } else {

--- a/packages/lesswrong/server/pingbacks.ts
+++ b/packages/lesswrong/server/pingbacks.ts
@@ -1,7 +1,7 @@
 import { cheerioParse } from './utils/htmlUtil';
 import { parseRoute, parsePath } from '../lib/vulcan-core/appContext';
 import { getSiteUrl } from '../lib/vulcan-lib/utils';
-import { hostIsOnsite, getUrlClass } from '../lib/routeUtil';
+import { classifyHost, getUrlClass } from '../lib/routeUtil';
 import * as _ from 'underscore';
 
 // Given an HTML document, extract the links from it and convert them to a set
@@ -28,7 +28,8 @@ export const htmlToPingbacks = async (html: string, exclusions?: Array<{collecti
       // by an absolute link).
       const linkTargetAbsolute = new URLClass(link, getSiteUrl());
       
-      if (hostIsOnsite(linkTargetAbsolute.host)) {
+      const hostType = classifyHost(linkTargetAbsolute.host)
+      if (hostType==="onsite" || hostType==="mirrorOfUs") {
         const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
         const parsedUrl = parseRoute({
           location: parsePath(onsiteUrl),


### PR DESCRIPTION
Co-Authored-By: Robert Mushkablat <bobert.mushky@gmail.com>

We noticed we were accidentally redirecting links to greaterwrong back to lesswrong, because greaterwrong was in the list of whitelisted domains (for hover-preview purposes).  This fixes that, and also fixes the existing issue with our `Link` implementation, which would only work for links pointing to the same host (and silently drop the rest on the floor).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204820722843350) by [Unito](https://www.unito.io)
