### PR TITLE
Increase nginx timeouts for /api/notificationEvents

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -58,6 +58,11 @@ http {
             proxy_set_header    X-Real-IP              $remote_addr;
             proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
         }
+        
+        location /api/notificationEvents {
+            proxy_read_timeout 24h
+            proxy_send_timeout 24h
+        }
 
         # Include the Elastic Beanstalk generated locations
         include conf.d/elasticbeanstalk/*.conf;


### PR DESCRIPTION
Increase nginx timeouts for `/api/notificationEvents`. This might be sufficient to make server-sent events work in prod, but more likely we will also need to make a similar change to our Elastic Beanstalk config to address timeouts there.

Co-Authored-By: Robert Mushkablat <bobert.mushky@gmail.com>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204820883492753) by [Unito](https://www.unito.io)
