### PR TITLE
add a multiselect option for ForumDropdown

### DIFF
--- a/packages/lesswrong/components/common/ForumDropdown.tsx
+++ b/packages/lesswrong/components/common/ForumDropdown.tsx
@@ -1,154 +1,26 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import Menu from '@material-ui/core/Menu';
-import { QueryLink } from '../../lib/reactRouterWrapper';
-import { isEAForum } from '../../lib/instanceSettings';
-import Button from '@material-ui/core/Button';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
-import classNames from 'classnames';
-import { defaultPostsLayout, SettingsOption } from '../../lib/collections/posts/dropdownOptions';
-import { useTracking } from '../../lib/analyticsEvents';
+import { SettingsOption } from '../../lib/collections/posts/dropdownOptions';
 
-const styles = (theme: ThemeType): JssStyles => ({
-  root: {
-    ...theme.typography.body2,
-    ...theme.typography.commentStyle,
-    color: theme.palette.grey[600],
-    textAlign: "center",
-    ...(!isEAForum && {
-      "& button:hover": {
-        backgroundColor: "transparent",
-      },
-    }),
-  },
-  button: {
-    textTransform: "none",
-    boxShadow: "none",
-    padding: 0,
-    fontSize: "14px",
-    minHeight: 32,
-    minWidth: 'unset',
-    cursor: "pointer",
-    color: theme.palette.primary.main,
-    paddingLeft: 12,
-    paddingRight: 6,
-    backgroundColor: "transparent",
-    ...(isEAForum && {
-      color: "inherit",
-      "&:hover": {
-        backgroundColor: theme.palette.grey[250],
-        color: theme.palette.grey[1000],
-      },
-    }),
-  },
-  openButton: {
-    ...(isEAForum && {
-      backgroundColor: theme.palette.grey[250],
-      color: theme.palette.grey[1000],
-    }),
-  },
-  dropdownIcon: {
-    verticalAlign: "middle",
-    position: "relative",
-    ...(isEAForum && { width: 16, height: 16, marginLeft: 4, padding: 1}),
-  },
-  padding: {
-    width: 10,
-  },
-  selectedIcon: {
-    verticalAlign: "middle",
-    position: "relative",
-    color: theme.palette.primary.main,
-    marginLeft: "auto",
-    marginRight: 2,
-    width: 19,
-    height: 19,
-  },
-  menu: {
-    marginTop: 28,
-    ...(isEAForum && {
-      "& a:hover": {
-        opacity: "inherit",
-      },
-    }),
-    '& .MuiList-padding': {
-      padding: '4px 0px',
-    }
-  },
-  menuItem: {
-    ...(isEAForum && {
-      color: theme.palette.grey[1000],
-      borderRadius: theme.borderRadius.small,
-      padding: "6px 8px",
-      margin: "0px 4px",
-      fontSize: "14px",
-      lineHeight: "14px",
-      "&:hover": {
-        backgroundColor: theme.palette.grey[250],
-        color: theme.palette.grey[1000],
-      },
-    }),
-    "&:focus": {
-      outline: "none",
-    },
-  },
-});
-
-const ForumDropdown = ({value=defaultPostsLayout, options, queryParam="layout", onSelect, eventProps, classes, className}:{
+const ForumDropdown = ({value, options, queryParam, onSelect, eventProps, className}:{
   value: string,
   options: Record<string, SettingsOption>,
   queryParam?: string,
   onSelect?: (value: string) => void,
   eventProps?: Record<string, string>
-  classes: ClassesType,
   className?: string,
 }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const { captureEvent } = useTracking()
-  const label = options[value].shortLabel || options[value].label
-  const { MenuItem, ForumIcon } = Components;
-
-  const dropdownIcon = isEAForum ? <ForumIcon icon="ThickChevronDown" className={classes.dropdownIcon} /> : <ArrowDropDownIcon className={classes.dropdownIcon}/>
-  return (
-    <div className={classNames(classes.root, className)}>
-      <Button
-        variant="contained"
-        onClick={(e) => {
-          captureEvent("forumDropdownOpened", {value, ...eventProps})
-          setAnchorEl(e.currentTarget)
-        }}
-        className={classNames(classes.button, { [classes.openButton]: Boolean(anchorEl) })}
-      >
-        {label} {dropdownIcon}
-      </Button>
-      <Menu open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} className={classes.menu}>
-        {Object.keys(options).map((option) => (
-          <QueryLink key={option} query={{ [queryParam]: option }} merge>
-            <MenuItem
-              value={option}
-              onClick={() => {
-                captureEvent("forumDropdownItemSelected", {oldValue: value, newValue: option, ...eventProps})
-                setAnchorEl(null);
-                onSelect?.(option);
-              }}
-              className={classes.menuItem}
-            >
-              {options[option].label}
-              {option === value && isEAForum && (
-                <>
-                  <div className={classes.padding}></div>
-                  <ForumIcon icon="Check" className={classes.selectedIcon} />
-                </>
-              )}
-            </MenuItem>
-          </QueryLink>
-        ))}
-      </Menu>
-    </div>
-  );
+  return <Components.ForumDropdownMultiselect
+    values={[value]}
+    options={options}
+    queryParam={queryParam}
+    onSelect={onSelect}
+    eventProps={eventProps}
+    className={className}
+  />
 }
 
-const ForumDropdownComponent = registerComponent('ForumDropdown', ForumDropdown, {styles});
+const ForumDropdownComponent = registerComponent('ForumDropdown', ForumDropdown);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/common/ForumDropdown.tsx
+++ b/packages/lesswrong/components/common/ForumDropdown.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { SettingsOption } from '../../lib/collections/posts/dropdownOptions';
 
-const ForumDropdown = ({value, options, queryParam, onSelect, eventProps, className}:{
+const ForumDropdown = ({value, options, queryParam, onSelect, className}:{
   value: string,
   options: Record<string, SettingsOption>,
   queryParam?: string,
   onSelect?: (value: string) => void,
-  eventProps?: Record<string, string>
   className?: string,
 }) => {
   return <Components.ForumDropdownMultiselect
@@ -15,7 +14,6 @@ const ForumDropdown = ({value, options, queryParam, onSelect, eventProps, classN
     options={options}
     queryParam={queryParam}
     onSelect={onSelect}
-    eventProps={eventProps}
     className={className}
   />
 }

--- a/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
+++ b/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
@@ -7,7 +7,6 @@ import Button from '@material-ui/core/Button';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import classNames from 'classnames';
 import { SettingsOption } from '../../lib/collections/posts/dropdownOptions';
-import { useTracking } from '../../lib/analyticsEvents';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -94,17 +93,15 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const ForumDropdownMultiselect = ({values, options, queryParam, onSelect, eventProps, classes, className}:{
+const ForumDropdownMultiselect = ({values, options, queryParam, onSelect, classes, className}:{
   values: string[],
   options: Record<string, SettingsOption>,
   queryParam?: string,
   onSelect?: (value: string) => void,
-  eventProps?: Record<string, string>
   classes: ClassesType,
   className?: string,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const { captureEvent } = useTracking()
   const label = values.reduce((prev, next) => {
     const nextLabel = options[next].shortLabel || options[next].label
     if (!prev) return nextLabel
@@ -118,7 +115,6 @@ const ForumDropdownMultiselect = ({values, options, queryParam, onSelect, eventP
       <Button
         variant="contained"
         onClick={(e) => {
-          captureEvent("ForumDropdownMultiselectOpened", {value: values, ...eventProps})
           setAnchorEl(e.currentTarget)
         }}
         className={classNames(classes.button, { [classes.openButton]: Boolean(anchorEl) })}
@@ -131,7 +127,6 @@ const ForumDropdownMultiselect = ({values, options, queryParam, onSelect, eventP
             key={option}
             value={option}
             onClick={() => {
-              captureEvent("ForumDropdownMultiselectItemSelected", {oldValue: values, newValue: option, ...eventProps})
               setAnchorEl(null);
               onSelect?.(option);
             }}

--- a/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
+++ b/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import Menu from '@material-ui/core/Menu';
+import { QueryLink } from '../../lib/reactRouterWrapper';
+import { isEAForum } from '../../lib/instanceSettings';
+import Button from '@material-ui/core/Button';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import classNames from 'classnames';
+import { SettingsOption } from '../../lib/collections/posts/dropdownOptions';
+import { useTracking } from '../../lib/analyticsEvents';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    ...theme.typography.body2,
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[600],
+    textAlign: "center",
+    ...(!isEAForum && {
+      "& button:hover": {
+        backgroundColor: "transparent",
+      },
+    }),
+  },
+  button: {
+    textTransform: "none",
+    boxShadow: "none",
+    padding: 0,
+    fontSize: "14px",
+    minHeight: 32,
+    minWidth: 'unset',
+    cursor: "pointer",
+    color: theme.palette.primary.main,
+    paddingLeft: 12,
+    paddingRight: 6,
+    backgroundColor: "transparent",
+    ...(isEAForum && {
+      color: "inherit",
+      "&:hover": {
+        backgroundColor: theme.palette.grey[250],
+        color: theme.palette.grey[1000],
+      },
+    }),
+  },
+  openButton: {
+    ...(isEAForum && {
+      backgroundColor: theme.palette.grey[250],
+      color: theme.palette.grey[1000],
+    }),
+  },
+  dropdownIcon: {
+    verticalAlign: "middle",
+    position: "relative",
+    ...(isEAForum && { width: 16, height: 16, marginLeft: 4, padding: 1}),
+  },
+  padding: {
+    width: 10,
+  },
+  selectedIcon: {
+    verticalAlign: "middle",
+    position: "relative",
+    color: theme.palette.primary.main,
+    marginLeft: "auto",
+    marginRight: 2,
+    width: 19,
+    height: 19,
+  },
+  menu: {
+    marginTop: 28,
+    ...(isEAForum && {
+      "& a:hover": {
+        opacity: "inherit",
+      },
+    }),
+    '& .MuiList-padding': {
+      padding: '4px 0px',
+    }
+  },
+  menuItem: {
+    ...(isEAForum && {
+      color: theme.palette.grey[1000],
+      borderRadius: theme.borderRadius.small,
+      padding: "6px 8px",
+      margin: "0px 4px",
+      fontSize: "14px",
+      lineHeight: "14px",
+      "&:hover": {
+        backgroundColor: theme.palette.grey[250],
+        color: theme.palette.grey[1000],
+      },
+    }),
+    "&:focus": {
+      outline: "none",
+    },
+  },
+});
+
+const ForumDropdownMultiselect = ({values, options, queryParam, onSelect, eventProps, classes, className}:{
+  values: string[],
+  options: Record<string, SettingsOption>,
+  queryParam?: string,
+  onSelect?: (value: string) => void,
+  eventProps?: Record<string, string>
+  classes: ClassesType,
+  className?: string,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const { captureEvent } = useTracking()
+  const label = values.reduce((prev, next) => {
+    const nextLabel = options[next].shortLabel || options[next].label
+    if (!prev) return nextLabel
+    return `${prev}, ${nextLabel}`
+  }, '')
+  const { MenuItem, ForumIcon } = Components;
+
+  const dropdownIcon = isEAForum ? <ForumIcon icon="ThickChevronDown" className={classes.dropdownIcon} /> : <ArrowDropDownIcon className={classes.dropdownIcon}/>
+  return (
+    <div className={classNames(classes.root, className)}>
+      <Button
+        variant="contained"
+        onClick={(e) => {
+          captureEvent("ForumDropdownMultiselectOpened", {value: values, ...eventProps})
+          setAnchorEl(e.currentTarget)
+        }}
+        className={classNames(classes.button, { [classes.openButton]: Boolean(anchorEl) })}
+      >
+        {label} {dropdownIcon}
+      </Button>
+      <Menu open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} className={classes.menu}>
+        {Object.keys(options).map((option) => {
+          const menuItem = <MenuItem
+            key={option}
+            value={option}
+            onClick={() => {
+              captureEvent("ForumDropdownMultiselectItemSelected", {oldValue: values, newValue: option, ...eventProps})
+              setAnchorEl(null);
+              onSelect?.(option);
+            }}
+            className={classes.menuItem}
+          >
+            {options[option].label}
+            {values.includes(option) && isEAForum && (
+              <>
+                <div className={classes.padding}></div>
+                <ForumIcon icon="Check" className={classes.selectedIcon} />
+              </>
+            )}
+          </MenuItem>
+          
+          if (queryParam) {
+            return <QueryLink key={option} query={{ [queryParam]: option }} merge>
+              {menuItem}
+            </QueryLink>
+          }
+          return menuItem
+        })}
+      </Menu>
+    </div>
+  );
+}
+
+const ForumDropdownMultiselectComponent = registerComponent('ForumDropdownMultiselect', ForumDropdownMultiselect, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ForumDropdownMultiselect: typeof ForumDropdownMultiselectComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsLayoutDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsLayoutDropdown.tsx
@@ -60,7 +60,7 @@ const PostsLayoutDropdown = ({classes, value=defaultPostsLayout, queryParam="lay
     });
   }, [currentUser, updateCurrentUser]);
 
-  return <ForumDropdown value={value} options={POSTS_LAYOUT_OPTIONS} queryParam={queryParam} onSelect={onSelect} eventProps={{parent: "LayoutDropdown"}} />;
+  return <ForumDropdown value={value} options={POSTS_LAYOUT_OPTIONS} queryParam={queryParam} onSelect={onSelect} />;
 }
 
 const PostsLayoutDropdownComponent = registerComponent('PostsLayoutDropdown', PostsLayoutDropdown, {styles});

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -25,7 +25,7 @@ const PostsListSortDropdown = ({value, options=defaultOptions, sortingParam="sor
         }, {})
     : TAG_POSTS_SORT_ORDER_OPTIONS;
 
-  return <ForumDropdown value={value} options={filteredOptions} queryParam={sortingParam} eventProps={{parent: "PostsListSortDropdown"}} />;
+  return <ForumDropdown value={value} options={filteredOptions} queryParam={sortingParam} />;
 }
 
 const PostsListSortDropdownComponent = registerComponent('PostsListSortDropdown', PostsListSortDropdown, {styles});

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -188,6 +188,7 @@ importComponent("ContentItemBody", () => require('../components/common/ContentIt
 importComponent("ContentItemTruncated", () => require('../components/common/ContentItemTruncated'));
 importComponent("SingleLineFeedEvent", () => require('../components/common/SingleLineFeedEvent'));
 importComponent("ForumDropdown", () => require('../components/common/ForumDropdown'));
+importComponent("ForumDropdownMultiselect", () => require('../components/common/ForumDropdownMultiselect'));
 importComponent("StrawPollLoggedOut", () => require('../components/common/StrawPollLoggedOut'));
 importComponent("FrontpageBestOfLWWidget", () => require('../components/review/FrontpageBestOfLWWidget'));
 


### PR DESCRIPTION
I wanted to use `ForumDropdown` for https://github.com/ForumMagnum/ForumMagnum/pull/7403, but it didn't support multiselect. So in this PR I've created a multiselect version (`ForumDropdownMultiselect`) that is largely the same as `ForumDropdown` was, and now `ForumDropdown` is just a wrapper on top of that. This is so that I didn't have to change the places where `ForumDropdown` was used, plus I think the single select version will be used more overall so it would be good to keep that interface clean.

Apologies, the diff is pretty annoying to read, but I promise most of the code is the same. This is also to reduce the size of https://github.com/ForumMagnum/ForumMagnum/pull/7403 before I publish that for review.

Example from my other branch:
<img width="315" alt="Screen Shot 2023-06-13 at 8 41 16 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/b4edf770-e826-4af4-a393-8f2e40f3d398">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204820964529770) by [Unito](https://www.unito.io)
