### PR TITLE
Darkmode inline reacts

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -157,16 +157,20 @@ const styles = (theme: ThemeType): JssStyles => ({
       filter: "opacity(0.8)",
     },
     [`& .${highlightSelectorClassName}`]: {
-      backgroundColor: theme.palette.background.primaryTranslucentHeavy
+      backgroundColor: theme.palette.background.primaryTranslucentHeavy,
+      color: "unset",
     },
     [`& .${dimHighlightClassName}`]: {
-      backgroundColor: theme.palette.grey[200]
+      backgroundColor: theme.palette.grey[200],
+      color: "unset",
     },
     [`& .${faintHighlightClassName}`]: {
       backgroundColor: "unset",
+      color: "unset",
     },
     [`&:hover .${faintHighlightClassName}`]: {
       borderBottom: theme.palette.border.dashed500,
+      color: "unset",
     },
   }
 });

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -156,16 +156,18 @@ const styles = (theme: ThemeType): JssStyles => ({
     '&:hover .react-hover-style': {
       filter: "opacity(0.8)",
     },
+    // mark.js applies a default highlight of yellow background and black text. 
+    // we need to override to apply our own themes, and avoid being unreadable in dark mode
+    [`& .${faintHighlightClassName}`]: {
+      backgroundColor: "unset",
+      color: "unset",
+    },
     [`& .${highlightSelectorClassName}`]: {
       backgroundColor: theme.palette.background.primaryTranslucentHeavy,
       color: "unset",
     },
     [`& .${dimHighlightClassName}`]: {
       backgroundColor: theme.palette.grey[200],
-      color: "unset",
-    },
-    [`& .${faintHighlightClassName}`]: {
-      backgroundColor: "unset",
       color: "unset",
     },
     [`&:hover .${faintHighlightClassName}`]: {

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -203,7 +203,7 @@ export const darkModeTheme: UserThemeSpecification = {
       diffDeleted: "#b92424",
       primaryDim: "#28383e",
       primaryTranslucent: "rgba(99,141,103,0.3)",
-      primaryTranslucentHeavy: "rgba(99,141,103,0.3)",
+      primaryTranslucentHeavy: "rgba(99,141,103,0.6)",
       warningTranslucent: "rgba(255,173,8,0.3)",
       transparent: 'transparent'
     },


### PR DESCRIPTION
The highlighting effect for inline reacts overrode the darkmode text-color style. This PR unsets the text color, and improves the highlighting color so it looks nicer on darkmode.

BEFORE:
<img width="874" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/fd301e37-f474-4f62-ab9a-fd32734e3488">

<img width="837" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/df72e21d-9f7d-464f-b1b2-d5d4baaeb09f">


AFTER:
<img width="755" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/cf08ae0d-5dfd-47f3-829e-b54036606e17">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204821802491204) by [Unito](https://www.unito.io)
