### PR TITLE
Create cron job to clear stale recommendations

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -100,6 +100,7 @@ import './server/notificationCallbacksHelpers';
 import './server/voteServer';
 import './server/recommendations';
 import './server/recommendations/mutations';
+import './server/recommendations/recommedationsCron';
 import './server/recommendations/UniquePostUpvoters';
 import './server/emails/emailTokens';
 import './server/partiallyReadSequences';

--- a/packages/lesswrong/server/recommendations/recommedationsCron.ts
+++ b/packages/lesswrong/server/recommendations/recommedationsCron.ts
@@ -1,0 +1,11 @@
+import { addCronJob } from "../cronUtil";
+import { PostRecommendationsRepo } from "../repos";
+
+addCronJob({
+  name: "clearStaleRecommendations",
+  interval: "every 24 hours",
+  job: async () => {
+    const repo = new PostRecommendationsRepo();
+    await repo.clearStaleRecommendations();
+  },
+});

--- a/packages/lesswrong/server/repos/PostRecommendationsRepo.ts
+++ b/packages/lesswrong/server/repos/PostRecommendationsRepo.ts
@@ -100,6 +100,11 @@ export default class PostRecommendationsRepo extends AbstractRepo<DbPostRecommen
     `);
     // Delete all recommendations that were never clicked that were last
     // recommended at least 3 months ago
+    // This is currently disabled as it will ruin the analytics - if we
+    // want to enable this is the future then we should probably move
+    // the data into a separate "archive" table instead of completely
+    // deleting it.
+    /*
     await this.none(`
       DELETE
       FROM "PostRecommendations"
@@ -107,5 +112,6 @@ export default class PostRecommendationsRepo extends AbstractRepo<DbPostRecommen
         "clickedAt" IS NULL AND
         (CURRENT_TIMESTAMP - "createdAt") > '3 months'
     `);
+    */
   }
 }

--- a/packages/lesswrong/server/repos/PostRecommendationsRepo.ts
+++ b/packages/lesswrong/server/repos/PostRecommendationsRepo.ts
@@ -87,4 +87,25 @@ export default class PostRecommendationsRepo extends AbstractRepo<DbPostRecommen
       `, [clientId, postId]);
     }
   }
+
+  async clearStaleRecommendations(): Promise<void> {
+    // Delete all recommedations that are at least 1 day old and that
+    // never appeared above the fold
+    await this.none(`
+      DELETE
+      FROM "PostRecommendations"
+      WHERE
+        "recommendationCount" < 1 AND
+        (CURRENT_TIMESTAMP - "createdAt") > '1 day'
+    `);
+    // Delete all recommendations that were never clicked that were last
+    // recommended at least 3 months ago
+    await this.none(`
+      DELETE
+      FROM "PostRecommendations"
+      WHERE
+        "clickedAt" IS NULL AND
+        (CURRENT_TIMESTAMP - "createdAt") > '3 months'
+    `);
+  }
 }


### PR DESCRIPTION
The performance of post recommendations is a lot worse than it could be because we generate a _lot_ of data in the database (the table is currently about 1.3GB and growing fast). Some of this data is useful, but a lot of it is not. This PR adds a cron job to remove old records:

- We remove all generated recommendations that are at least 1 day old and that were never observed by the user (ie; they never came above the fold). This is about 85% of all the data. I think this should be fine to do since we mostly care about the ratio of observed recommendations to clicks, rather than unobserved recommendations to clicks.
- We remove recommendations that were never clicked that were last recommended >3 months ago. This won't currently delete any recommendations as posts page recommendations are less than 3 months old. This will also solve the problem that, over a long period of time, we'll eventually run out of posts to recommend because we'll be able to recycle old posts. This is definitely more contentious.

I'd appreciate any feedback from @SharangP on whether or not you think these are good rules, and whether or not this will have a negative impact on the metrics you're tracking. We could also change the rules if you can come up with something better, or if you'd rather keep the data then we can make a separate `PostRecommendationsArchive` table to store all the stuff we just want for analytics purposes.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204827884978296) by [Unito](https://www.unito.io)
