### PR TITLE
Ship elasticsearch on the EA forum

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -45,8 +45,7 @@ export const userHasEagProfileImport = disabled;
 
 export const userHasEAEmojiReacts = isEAForum ? testServerOnly : disabled;
 
-export const userHasElasticsearch = (_user: UsersCurrent|DbUser|null): boolean =>
-  isEAForum && (testServerSetting.get() || (forumTitleSetting.get()?.toLowerCase()?.indexOf("staging") ?? -1) >= 0);
+export const userHasElasticsearch = isEAForum ? shippedFeature : disabled;
 
 // Shipped Features
 export const userCanManageTags = shippedFeature;


### PR DESCRIPTION
Elasticsearch is currently fully deployed to the beta site, but only the backend is enabled on prod - the frontend is still calling Algolia. This change switches us fully over to ES.

FYI @SharangP

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204828186095851) by [Unito](https://www.unito.io)
