### PR TITLE
Implement tags descriptionTruncationCount for the EA Forum

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -313,7 +313,9 @@ const TagPage = ({classes}: {
   let description = htmlWithAnchors;
   // EA Forum wants to truncate much less than LW
   if (isEAForum) {
-    description = truncated ? truncateTagDescription(htmlWithAnchors) : htmlWithAnchors;
+    description = truncated
+      ? truncateTagDescription(htmlWithAnchors, tag.descriptionTruncationCount)
+      : htmlWithAnchors;
   } else {
     description = (truncated && !tag.wikiOnly)
     ? truncate(htmlWithAnchors, tag.descriptionTruncationCount || 4, "paragraphs", "<span>...<p><a>(Read More)</a></p></span>")

--- a/packages/lesswrong/components/tagging/subforums/SubforumWikiTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumWikiTab.tsx
@@ -83,7 +83,9 @@ const SubforumWikiTab = ({tag, revision, truncated, setTruncated, classes}: {
   let description = htmlWithAnchors;
   // EA Forum wants to truncate much less than LW
   if(isEAForum) {
-    description = truncated ? truncateTagDescription(htmlWithAnchors) : htmlWithAnchors;
+    description = truncated
+      ? truncateTagDescription(htmlWithAnchors, tag.descriptionTruncationCount)
+      : htmlWithAnchors;
   } else {
     description = (truncated && !tag.wikiOnly)
       ? truncate(htmlWithAnchors, tag.descriptionTruncationCount || 4, "paragraphs", "<span>...<p><a>(Read More)</a></p></span>")

--- a/packages/lesswrong/lib/utils/truncateTagDescription.ts
+++ b/packages/lesswrong/lib/utils/truncateTagDescription.ts
@@ -1,4 +1,5 @@
 import { isServer } from "../executionEnvironment";
+import { truncate } from "../editor/ellipsize";
 import { preferredHeadingCase } from "../forumTypeUtils";
 
 const getInnerHTML = (html: string) => {
@@ -11,7 +12,18 @@ const getInnerHTML = (html: string) => {
   }
 }
 
-const truncateTagDescription = (htmlWithAnchors: string, withReadMore = true) => {
+const truncateTagDescription = (
+  htmlWithAnchors: string,
+  descriptionTruncationCount?: number,
+) => {
+  if (descriptionTruncationCount) {
+    return truncate(
+      htmlWithAnchors,
+      descriptionTruncationCount,
+      "paragraphs",
+      "<span>...<p><a>(Read More)</a></p></span>",
+    );
+  }
   for (let matchString of [
       'id="Further_reading"',
       'id="Bibliography"',
@@ -21,7 +33,7 @@ const truncateTagDescription = (htmlWithAnchors: string, withReadMore = true) =>
     if(htmlWithAnchors.includes(matchString)) {
       const truncationLength = htmlWithAnchors.indexOf(matchString);
       /**
-       * The `truncate` method used below uses a complicated criterion for what
+       * The `truncate` method used above uses a complicated criterion for what
        * counts as a character. Here, we want to truncate at a known index in
        * the string. So rather than using `truncate`, we can slice the string
        * at the desired index, use `parseFromString` to clean up the HTML,
@@ -29,7 +41,7 @@ const truncateTagDescription = (htmlWithAnchors: string, withReadMore = true) =>
        */
       const innerHTML = getInnerHTML(htmlWithAnchors.slice(0, truncationLength));
       const readMore = preferredHeadingCase("Read More");
-      return innerHTML + (withReadMore ? `<span>...<p><a>(${readMore})</a></p></span>` : "");
+      return innerHTML + `<span>...<p><a>(${readMore})</a></p></span>`;
     }
   }
   return htmlWithAnchors


### PR DESCRIPTION
Lizka recently requested the ability to truncate tag descriptions on the tag page. This already exists as the field `descriptionTruncationCount` which is the number of paragraphs to show, but this is only implemented for LessWrong and not for the EA Forum which uses a different truncation algorithm. This PR adds this field to the EA Forum's algorithm.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204828374041525) by [Unito](https://www.unito.io)
