### PR TITLE
Fix commentSorting options for users

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -613,9 +613,11 @@ const schema: SchemaType<DbUser> = {
       // TODO - maybe factor out??
       options: function () { // options for the select form control
         let commentViews = [
-          {value:'postCommentsTop', label: 'magical algorithm'},
-          {value:'postCommentsNew', label: 'most recent'},
+          {value:'postCommentsMagic', label: isEAForum ? 'new & upvoted' : 'magic (new & upvoted)'},
+          {value:'postCommentsTop', label: 'top scoring'},
+          {value:'postCommentsNew', label: 'newest'},
           {value:'postCommentsOld', label: 'oldest'},
+          {value:'postCommentsRecentReplies', label: 'latest reply'},
         ];
         if (forumTypeSetting.get() === 'AlignmentForum') {
           return commentViews.concat([

--- a/packages/lesswrong/server/migrations/20230615T100000.migrate_commentSorting.ts
+++ b/packages/lesswrong/server/migrations/20230615T100000.migrate_commentSorting.ts
@@ -1,0 +1,15 @@
+import Users from "../../lib/collections/users/collection";
+
+export const acceptsSchemaHash = "8f9b37b6b8213a24c21dba39e77f7bbb";
+
+export const up = async ({db}: MigrationContext) => {
+  if (!Users.isPostgres()) return
+
+  await db.none(`UPDATE "Users" SET "commentSorting" = 'postCommentsMagic' WHERE "commentSorting" = 'postCommentsTop'`)
+}
+
+export const down = async ({db}: MigrationContext) => {
+  if (!Users.isPostgres()) return
+
+  await db.none(`UPDATE "Users" SET "commentSorting" = 'postCommentsTop' WHERE "commentSorting" = 'postCommentsMagic'`)
+}

--- a/packages/lesswrong/server/migrations/20230615T100000.migrate_commentSorting.ts
+++ b/packages/lesswrong/server/migrations/20230615T100000.migrate_commentSorting.ts
@@ -1,7 +1,5 @@
 import Users from "../../lib/collections/users/collection";
 
-export const acceptsSchemaHash = "8f9b37b6b8213a24c21dba39e77f7bbb";
-
 export const up = async ({db}: MigrationContext) => {
   if (!Users.isPostgres()) return
 


### PR DESCRIPTION
Previously the one called "magical algorithm" was actually sorting by "top", and there was no way to actually sort by magic. I've also added all of the other sortings in as options except "deleted"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204833142590457) by [Unito](https://www.unito.io)
