### PR TITLE
Make updateScoreInactiveDocuments correctly update very low scores

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -63,7 +63,6 @@ import './server/scripts/validateDatabase';
 import './server/scripts/validateMakeEditableDenormalization';
 import './server/scripts/mergeAccounts';
 import "./server/scripts/testPostDescription";
-import "./server/scripts/updateInactiveDocuments";
 import "./server/scripts/importEAGUserInterests";
 import "./server/scripts/importLocalgroups";
 import "./server/scripts/setUserTagFilters";

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -63,6 +63,7 @@ import './server/scripts/validateDatabase';
 import './server/scripts/validateMakeEditableDenormalization';
 import './server/scripts/mergeAccounts';
 import "./server/scripts/testPostDescription";
+import "./server/scripts/updateInactiveDocuments";
 import "./server/scripts/importEAGUserInterests";
 import "./server/scripts/importLocalgroups";
 import "./server/scripts/setUserTagFilters";

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -26,69 +26,6 @@ interface BatchUpdateParams {
   forceUpdate?: boolean;
 }
 
-/*
-
-Update a document's score if necessary.
-
-Returns how many documents have been updated (1 or 0).
-
-*/
-export const updateScore = async ({collection, item, forceUpdate}: {
-  collection: any;
-  item: DbPost;
-  forceUpdate?: boolean;
-}) => {
-
-  // Age Check
-  const postedAt = item?.frontpageDate?.valueOf() || item?.postedAt?.valueOf()
-  const now = new Date().getTime();
-  const age = now - postedAt;
-  const ageInHours = age / (60 * 60 * 1000);
-
-  // If for some reason item doesn't have a "postedAt" property, abort
-  // Or, if post has been scheduled in the future, don't update its score
-  if (!postedAt || postedAt > now)
-    return 0;
-
-
-
-  // For performance reasons, the database is only updated if the difference between the old score and the new score
-  // is meaningful enough. To find out, we calculate the "power" of a single vote after n days.
-  // We assume that after n days, a single vote will not be powerful enough to affect posts' ranking order.
-  // Note: sites whose posts regularly get a lot of votes can afford to use a lower n.
-
-  // n =  number of days after which a single vote will not have a big enough effect to trigger a score update
-  //      and posts can become inactive
-  const n = INACTIVITY_THRESHOLD_DAYS;
-  // x = score increase amount of a single vote after n days (for n=100, x=0.000040295)
-  const x = getSingleVotePower();
-
-  // HN algorithm
-  const newScore = recalculateScore(item);
-
-  // Note: before the first time updateScore runs on a new item, its score will be at 0
-  const scoreDiff = Math.abs(item.score || 0 - newScore);
-
-  // console.log('// now: ', now)
-  // console.log('// age: ', age)
-  // console.log('// ageInHours: ', ageInHours)
-  // console.log('// baseScore: ', baseScore)
-  // console.log('// item.score: ', item.score)
-  // console.log('// newScore: ', newScore)
-  // console.log('// scoreDiff: ', scoreDiff)
-  // console.log('// x: ', x)
-
-  // only update database if difference is larger than x to avoid unnecessary updates
-  if (forceUpdate || scoreDiff > x) {
-    await collection.updateOne(item._id, {$set: {score: newScore, inactive: false}});
-    return 1;
-  } else if(ageInHours > n*24) {
-    // only set a post as inactive if it's older than n days
-    await collection.updateOne(item._id, {$set: {inactive: true}});
-  }
-  return 0;
-};
-
 const getMongoCollectionProjections = (collectionName: CollectionNameString) => {
   const collectionProjections: Partial<Record<CollectionNameString, any>> = {
     Posts: {

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -10,7 +10,8 @@ import {
 import * as _ from 'underscore';
 import { Posts } from "../lib/collections/posts";
 import { runSqlQuery } from "../lib/sql/sqlClient";
-import { chunk, compact } from "lodash";
+import chunk from "lodash/chunk";
+import compact from "lodash/compact";
 
 // INACTIVITY_THRESHOLD_DAYS =  number of days after which a single vote will not have a big enough effect to trigger a score update
 //      and posts can become inactive

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -10,7 +10,7 @@ import {
 import * as _ from 'underscore';
 import { Posts } from "../lib/collections/posts";
 import { runSqlQuery } from "../lib/sql/sqlClient";
-import chunk from "lodash/chunk";
+import { chunk, compact } from "lodash";
 
 // INACTIVITY_THRESHOLD_DAYS =  number of days after which a single vote will not have a big enough effect to trigger a score update
 //      and posts can become inactive
@@ -198,7 +198,7 @@ export const batchUpdateScore = async ({collection, inactive = false, forceUpdat
   const batches = chunk(items, 1000); // divide items into chunks of 1000
 
   for (let batch of batches) {
-    let itemUpdates = _.compact(batch.map((i: AnyBecauseTodo) => {
+    let itemUpdates = compact(batch.map((i: AnyBecauseTodo) => {
       if (forceUpdate || i.scoreDiffSignificant) {
         updatedDocumentsCounter++;
         return {

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -1,6 +1,5 @@
 import { getCollection, Vulcan } from "./vulcan-lib";
 import {
-  recalculateScore,
   timeDecayExpr,
   postScoreModifiers,
   commentScoreModifiers,


### PR DESCRIPTION
We were seeing some instances of very old comments not being ordered correctly when sorted by magic. This was because (80% confident this was the only problem) they were being filtered out when updating because the difference between oldScore and newScore wasn't big enough in absolute terms, even though in relative terms it was significant.

I've changed the calculation to use a threshold that is relative to the power of one vote _at the time the comment was posted_, rather than a fixed value.

I've only updated the postgres version.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204834086579434) by [Unito](https://www.unito.io)
