### PR TITLE
Add missing semicolons around nginx timeouts

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -60,8 +60,8 @@ http {
         }
         
         location /api/notificationEvents {
-            proxy_read_timeout 24h
-            proxy_send_timeout 24h
+            proxy_read_timeout 24h;
+            proxy_send_timeout 24h;
         }
 
         # Include the Elastic Beanstalk generated locations


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204836328831969) by [Unito](https://www.unito.io)
