### PR TITLE
Import useTracking/captureEvent into component template to encourage use

### DIFF
--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -10,6 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 export const TemplateComponent = ({classes}: {
   classes: ClassesType,
 }) => {
+  const { captureEvent } = useTracking();
   return <div className={classes.root}>
 
   </div>;

--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -11,7 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 export const TemplateComponent = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { captureEvent } = useTracking();
+  const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
   return <div className={classes.root}>
 
   </div>;


### PR DESCRIPTION
We've been finding ourselves wanting analytics on things that didn't have tracking added at the time of creation. As an easy way to encourage, adding the tracking imports to remind people.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204837386135904) by [Unito](https://www.unito.io)
