### PR TITLE
Server-sent events auto reconnect on error

### DIFF
--- a/.github/workflows/deployEADev.yaml
+++ b/.github/workflows/deployEADev.yaml
@@ -2,7 +2,7 @@ name: Deploy EA Staging
 concurrency: deploy-ea-dev
 on:
   push:
-    branches: [ ea-deploy, master, server-sent-events-auto-reconnect ]
+    branches: [ ea-deploy, master ]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployEADev.yaml
+++ b/.github/workflows/deployEADev.yaml
@@ -2,7 +2,7 @@ name: Deploy EA Staging
 concurrency: deploy-ea-dev
 on:
   push:
-    branches: [ ea-deploy, master, widerMobileMargins ]
+    branches: [ ea-deploy, master, server-sent-events-auto-reconnect ]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/packages/lesswrong/client/serverSentEventsClient.ts
+++ b/packages/lesswrong/client/serverSentEventsClient.ts
@@ -22,8 +22,8 @@ function recreateEventSource() {
   console.log("Connecting to server-sent events");
   serverSentEventSource = new EventSource("/api/notificationEvents");
   serverSentEventSource.onerror = (errorEvent) => {
-    // eslint-disable-next-line no-console
     setTimeout(() => {
+      // eslint-disable-next-line no-console
       console.log(`Server-sent events error`, errorEvent);
       recreateEventSource();
     }, 3000);

--- a/packages/lesswrong/client/serverSentEventsClient.ts
+++ b/packages/lesswrong/client/serverSentEventsClient.ts
@@ -1,9 +1,34 @@
 import { onServerSentNotificationEvent } from "../components/hooks/useUnreadNotifications";
 
+let serverSentEventSource: EventSource|null = null;
+
 export function subscribeToNotifications() {
-  const evtSource = new EventSource("/api/notificationEvents");
-  evtSource.onmessage = (event) => {
+  recreateEventSource();
+}
+
+function recreateEventSource() {
+  if (serverSentEventSource) {
+    if (serverSentEventSource.readyState === EventSource.CLOSED) {
+      serverSentEventSource = null;
+    } else if (serverSentEventSource.readyState === EventSource.OPEN) {
+      serverSentEventSource.close();
+      serverSentEventSource = null;
+    } else if (serverSentEventSource.readyState === EventSource.CONNECTING) {
+      // If it's already connected, don't try to reconnect again.
+      return;
+    }
+  }
+  // eslint-disable-next-line no-console
+  console.log("Connecting to server-sent events");
+  serverSentEventSource = new EventSource("/api/notificationEvents");
+  serverSentEventSource.onerror = (errorEvent) => {
+    // eslint-disable-next-line no-console
+    setTimeout(() => {
+      console.log(`Server-sent events error`, errorEvent);
+      recreateEventSource();
+    }, 3000);
+  }
+  serverSentEventSource.onmessage = (event) => {
     onServerSentNotificationEvent(event.data);
   }
 }
-


### PR DESCRIPTION
Ollie and I tested this on the staging server, which has the same load balancer and Cloudfront settings as prod, with a live-updating DM conversation and it seemed to all work.

Co-Authored-By: Oetherington <ollie@etherington.xyz>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204845108679608) by [Unito](https://www.unito.io)
