### PR TITLE
Fix AF recent discussion

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
@@ -51,6 +51,7 @@ const AlignmentForumHome = ({classes}: {
         <RecentDiscussionThreadsList
           terms={{view: 'afRecentDiscussionThreadsList', limit:6}}
           maxAgeHours={24*7}
+          commentsLimit={4}
           af={true}
         />
       </SingleColumnSection>

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2388,8 +2388,10 @@ const schema: SchemaType<DbPost> = {
     graphQLtype: "[Comment]",
     canRead: ['guests'],
     graphqlArguments: 'commentsLimit: Int, maxAgeHours: Int, af: Boolean',
-    resolver: async (post: DbPost, args: {commentsLimit?: number, maxAgeHours?: number, af?: boolean}, context: ResolverContext) => {
-      const { commentsLimit=5, maxAgeHours=18, af=false } = args;
+    // commentsLimit for some reason can receive a null (which was happening in one case)
+    // we haven't figured out why yet
+    resolver: async (post: DbPost, args: {commentsLimit?: number|null, maxAgeHours?: number, af?: boolean}, context: ResolverContext) => {
+      const { commentsLimit, maxAgeHours=18, af=false } = args;
       const { currentUser, Comments } = context;
       const timeCutoff = moment(post.lastCommentedAt).subtract(maxAgeHours, 'hours').toDate();
       const loaderName = af?"recentCommentsAf" : "recentComments";
@@ -2401,7 +2403,7 @@ const schema: SchemaType<DbPost> = {
         ...(af ? {af:true} : {}),
       };
       const comments = await getWithCustomLoader<DbComment[],string>(context, loaderName, post._id, (postIds): Promise<DbComment[][]> => {
-        return context.repos.comments.getRecentCommentsOnPosts(postIds, commentsLimit, filter);
+        return context.repos.comments.getRecentCommentsOnPosts(postIds, commentsLimit ?? 5, filter);
       });
       return await accessFilterMultiple(currentUser, Comments, comments, context);
     }


### PR DESCRIPTION
AlignmentForum recent discussion was displaying no comments, until you hit "load more".

Robert and I looked into it and found the break was introduced in this commit:
https://github.com/ForumMagnum/ForumMagnum/commit/1486309fa6a0ab958640429521c4f01b28d7972b

and that reverting `manyOrNone` to `many` caused it to start displaying normally again.

This was really fucking weird, and we still don't know why exactly. But, the result of switching to "manyOrNone" is that somehow the commentsLimit would sometimes be `null` (instead of undefined, which would have gotten properly assigned a default value by the destructuring). 

It's separately the case that AlignmentForum should probably migrate to use RecentDiscussionFeed, but RecentDiscussionFeed was broken on AF for different reasons (which seem to be something along the lines of "it tries to feed a Tag resolver the "af" field, which doesn't exist for tags).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204848119660880) by [Unito](https://www.unito.io)
