### PR TITLE
Add exact elasticsearch mapping

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -83,6 +83,24 @@ export type IndexConfig = {
   karmaField?: string,
 }
 
+/**
+ * Fields that use full-text search (ie; generally of of the fields that are
+ * listed in the `field` array) should use this mapping. This allows us to use
+ * our normal full text analyzer with stemming and synonyms for normal searches,
+ * but to fall back to the "standard" analyzer which has no stemming for advanced
+ * searches using quotes.
+ */
+const fullTextMapping = {
+  type: "text",
+  analyzer: "fm_synonym_analyzer",
+  fields: {
+    exact: {
+      type: "text",
+      analyzer: "standard",
+    },
+  },
+} as const;
+
 const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
   Comments: {
     fields: [
@@ -108,6 +126,9 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {term: {spam: false}},
     ],
     mappings: {
+      body: fullTextMapping,
+      postTitle: fullTextMapping,
+      authorDisplayName: fullTextMapping,
       authorSlug: {type: "keyword"},
       postGroupId: {type: "keyword"},
       postSlug: {type: "keyword"},
@@ -152,6 +173,10 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {range: {baseScore: {gte: 0}}},
     ],
     mappings: {
+      title: fullTextMapping,
+      authorDisplayName: fullTextMapping,
+      authorFullName: fullTextMapping,
+      body: fullTextMapping,
       authorSlug: {type: "keyword"},
       feedLink: {type: "keyword"},
       slug: {type: "keyword"},
@@ -212,6 +237,13 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {term: {deleteContent: false}},
     ],
     mappings: {
+      displayName: fullTextMapping,
+      bio: fullTextMapping,
+      mapLocationAddress: fullTextMapping,
+      jobTitle: fullTextMapping,
+      organization: fullTextMapping,
+      howICanHelpOthers: fullTextMapping,
+      howOthersCanHelpMe: fullTextMapping,
       careerStage: {type: "keyword"},
       groups: {type: "keyword"},
       slug: {type: "keyword"},
@@ -240,6 +272,9 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {term: {hidden: false}},
     ],
     mappings: {
+      body: fullTextMapping,
+      plaintextDescription: fullTextMapping,
+      authorDisplayName: fullTextMapping,
       userId: {type: "keyword"},
       authorSlug: {type: "keyword"},
       bannerImageId: {type: "keyword"},
@@ -276,6 +311,8 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {term: {adminOnly: false}},
     ],
     mappings: {
+      name: fullTextMapping,
+      description: fullTextMapping,
       bannerImageId: {type: "keyword"},
       parentTagId: {type: "keyword"},
       slug: {type: "keyword"},

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -84,7 +84,7 @@ export type IndexConfig = {
 }
 
 /**
- * Fields that use full-text search (ie; generally of of the fields that are
+ * Fields that use full-text search (ie; generally all of the fields that are
  * listed in the `field` array) should use this mapping. This allows us to use
  * our normal full text analyzer with stemming and synonyms for normal searches,
  * but to fall back to the "standard" analyzer which has no stemming for advanced

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -168,6 +168,12 @@ class ElasticQuery {
     };
   }
 
+  private textFieldToExactField(textField: string): string {
+    const [fieldName, relevance] = textField.split("^");
+    const exactField = `${fieldName}.exact`;
+    return relevance ? `${exactField}^${relevance}` : exactField;
+  }
+
   private compileAdvancedQuery(tokens: QueryToken[]): QueryDslQueryContainer {
     const {fields} = this.config;
 
@@ -181,7 +187,7 @@ class ElasticQuery {
         must.push({
           multi_match: {
             query: token,
-            fields,
+            fields: fields.map(this.textFieldToExactField.bind(this)),
             type: "phrase",
           },
         });


### PR DESCRIPTION
We recently had a bug report where a search for "communism" (with and without quotes) was returning results for "community". This happens because elasticsearch stems both words into "commun", which is fine without quotes but totally incorrect with quotes.

This PR adds explicit mappings for all full-text fields to index them with two separate analyzers; one with stemming and synonyms and one without. Normal queries do not need to change, and we can now fix the bug when searching with quotes by simple appending `.exact` to the field names. That is, the field `body` now contains the stemmed and synonynmed value, and `body.exact` has the unstemmed version.

This PR requires running `Globals.elasticConfigureIndexes()`. I've already done this on dev, but not staging or prod. It _is_ safe to run before deploying.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204854389666223) by [Unito](https://www.unito.io)
