### PR TITLE
Update comment sort names

### DIFF
--- a/packages/lesswrong/components/comments/CommentsViews.tsx
+++ b/packages/lesswrong/components/comments/CommentsViews.tsx
@@ -8,17 +8,18 @@ import qs from 'qs'
 import * as _ from 'underscore';
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import type { Option } from '../common/InlineSelect';
+import { preferredHeadingCase } from '../../lib/forumTypeUtils';
 
 export const viewNames: Partial<Record<CommentsViewName,string>> = {
-  'postCommentsMagic': isEAForum ? 'new & upvoted' : 'magic (new & upvoted)',
-  'postCommentsTop': 'top scoring',
-  'postCommentsRecentReplies': 'latest reply',
-  'afPostCommentsTop': 'top scoring',
-  'postCommentsNew': 'newest',
-  'postCommentsOld': 'oldest',
-  'postCommentsBest': 'highest karma',
-  'postCommentsDeleted': 'deleted',
-  'postLWComments': 'top scoring (include LW)',
+  'postCommentsMagic': isEAForum ? 'New & upvoted' : 'magic (new & upvoted)',
+  'postCommentsTop': isEAForum ? 'Top' : 'top scoring',
+  'postCommentsRecentReplies': preferredHeadingCase('latest reply'),
+  'afPostCommentsTop': preferredHeadingCase('top scoring'),
+  'postCommentsNew': isEAForum ? 'New' : 'newest',
+  'postCommentsOld': isEAForum ? 'Old' : 'oldest',
+  'postCommentsBest': preferredHeadingCase('highest karma'),
+  'postCommentsDeleted': preferredHeadingCase('deleted'),
+  'postLWComments': preferredHeadingCase('top scoring (include LW)'),
 }
 
 const CommentsViews = ({post, classes}: {

--- a/packages/lesswrong/components/comments/CommentsViews.tsx
+++ b/packages/lesswrong/components/comments/CommentsViews.tsx
@@ -5,27 +5,11 @@ import { userCanDo } from '../../lib/vulcan-users/permissions';
 import { commentGetDefaultView } from '../../lib/collections/comments/helpers'
 import { useCurrentUser } from '../common/withUser';
 import qs from 'qs'
-import * as _ from 'underscore';
-import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
+import { isEmpty } from 'underscore';
 import type { Option } from '../common/InlineSelect';
-import { preferredHeadingCase } from '../../lib/forumTypeUtils';
+import { getCommentViewOptions } from '../../lib/commentViewOptions';
 
-export const viewNames: Partial<Record<CommentsViewName,string>> = {
-  'postCommentsMagic': isEAForum ? 'New & upvoted' : 'magic (new & upvoted)',
-  'postCommentsTop': isEAForum ? 'Top' : 'top scoring',
-  'postCommentsRecentReplies': preferredHeadingCase('latest reply'),
-  'afPostCommentsTop': preferredHeadingCase('top scoring'),
-  'postCommentsNew': isEAForum ? 'New' : 'newest',
-  'postCommentsOld': isEAForum ? 'Old' : 'oldest',
-  'postCommentsBest': preferredHeadingCase('highest karma'),
-  'postCommentsDeleted': preferredHeadingCase('deleted'),
-  'postLWComments': preferredHeadingCase('top scoring (include LW)'),
-}
-
-const CommentsViews = ({post, classes}: {
-  post?: PostsDetails,
-  classes: ClassesType,
-}) => {
+const CommentsViews = ({post}: {post?: PostsDetails}) => {
   const currentUser = useCurrentUser();
   const { history } = useNavigation();
   const location = useLocation();
@@ -36,29 +20,14 @@ const CommentsViews = ({post, classes}: {
   const handleViewClick = (opt: Option & {value: CommentsViewName}) => {
     const view = opt.value
     const { query } = location;
-    const currentQuery = _.isEmpty(query) ? {view: 'postCommentsTop'} : query
+    const currentQuery = isEmpty(query) ? {view: 'postCommentsTop'} : query
     const newQuery = {...currentQuery, view: view, postId: post ? post._id : undefined}
     history.push({...location.location, search: `?${qs.stringify(newQuery)}`})
   };
 
-  const commentsTopView: CommentsViewName = forumTypeSetting.get() === 'AlignmentForum' ? "afPostCommentsTop" : "postCommentsTop"
-  let views: Array<CommentsViewName> = ["postCommentsMagic", commentsTopView, "postCommentsNew", "postCommentsOld", "postCommentsRecentReplies"]
-  const adminViews: Array<CommentsViewName> = ["postCommentsDeleted"]
-  const afViews: Array<CommentsViewName> = ["postLWComments"]
   const currentView: string = query?.view || commentGetDefaultView(post||null, currentUser)
-
-  if (userCanDo(currentUser, "comments.softRemove.all")) {
-    views = views.concat(adminViews);
-  }
-
-  const af = forumTypeSetting.get() === 'AlignmentForum'
-  if (af) {
-    views = views.concat(afViews);
-  }
-
-  const viewOptions: Array<Option> = views.map((view) => {
-    return {value: view, label: viewNames[view] || view}
-  })
+  const includeAdminViews = userCanDo(currentUser, "comments.softRemove.all");
+  const viewOptions = getCommentViewOptions({includeAdminViews});
   const selectedOption = viewOptions.find((option) => option.value === currentView) || viewOptions[0]
 
   return <InlineSelect options={viewOptions} selected={selectedOption} handleSelect={handleViewClick}/>
@@ -72,4 +41,3 @@ declare global {
     CommentsViews: typeof CommentsViewsComponent,
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -9,7 +9,6 @@ import { useRecordPostView } from '../../hooks/useRecordPostView';
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import {forumTitleSetting, forumTypeSetting, isEAForum} from '../../../lib/instanceSettings';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
-import { viewNames } from '../../comments/CommentsViews';
 import classNames from 'classnames';
 import { userHasSideComments } from '../../../lib/betas';
 import { forumSelect } from '../../../lib/forumTypeUtils';
@@ -24,6 +23,7 @@ import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import Helmet from 'react-helmet';
 import { SHOW_PODCAST_PLAYER_COOKIE } from '../../../lib/cookies/cookies';
 import { isServer } from '../../../lib/executionEnvironment';
+import { isValidCommentView } from '../../../lib/commentViewOptions';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -271,7 +271,8 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
 
   const defaultView = commentGetDefaultView(post, currentUser)
   // If the provided view is among the valid ones, spread whole query into terms, otherwise just do the default query
-  const commentTerms: CommentsViewTerms = Object.keys(viewNames).includes(query.view)
+  const commentOpts = {includeAdminViews: currentUser?.isAdmin};
+  const commentTerms: CommentsViewTerms = isValidCommentView(query.view, commentOpts)
     ? {...(query as CommentsViewTerms), limit:1000}
     : {view: defaultView, limit: 1000}
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -6,9 +6,9 @@ import { isPostWithForeignId } from "./PostsPageCrosspostWrapper";
 import { commentGetDefaultView } from '../../../lib/collections/comments/helpers';
 import { useCurrentUser } from '../../common/withUser';
 import { useMulti } from '../../../lib/crud/withMulti';
-import { viewNames } from '../../comments/CommentsViews';
 import { useSubscribedLocation } from '../../../lib/routeUtil';
 import { postsCommentsThreadMultiOptions } from '../PostsCommentsThread';
+import { isValidCommentView } from '../../../lib/commentViewOptions';
 
 const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   sequenceId: string|null,
@@ -44,7 +44,8 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   // for the first to finish.
   const defaultView = commentGetDefaultView(null, currentUser)
   // If the provided view is among the valid ones, spread whole query into terms, otherwise just do the default query
-  const terms: CommentsViewTerms = Object.keys(viewNames).includes(query.view)
+  const commentOpts = {includeAdminViews: currentUser?.isAdmin};
+  const terms: CommentsViewTerms = isValidCommentView(query.view, commentOpts)
     ? {...(query as CommentsViewTerms), limit:1000}
     : {view: defaultView, limit: 1000, postId: documentId}
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -6,7 +6,7 @@ import { userGroups, userOwns, userIsAdmin, userHasntChangedName } from '../../v
 import { formGroups } from './formGroups';
 import * as _ from 'underscore';
 import { schemaDefaultValue } from '../../collectionUtils';
-import { forumTypeSetting, hasEventsSetting, isEAForum, isLW, taggingNamePluralCapitalSetting, taggingNamePluralSetting, taggingNameSetting } from "../../instanceSettings";
+import { forumTypeSetting, hasEventsSetting, isEAForum, taggingNamePluralCapitalSetting, taggingNamePluralSetting, taggingNameSetting } from "../../instanceSettings";
 import { accessFilterMultiple, arrayOfForeignKeysField, denormalizedCountOfReferences, denormalizedField, foreignKeyField, googleLocationToMongoLocation, resolverOnlyField } from '../../utils/schemaUtils';
 import { postStatuses } from '../posts/constants';
 import GraphQLJSON from 'graphql-type-json';
@@ -15,6 +15,7 @@ import uniqBy from 'lodash/uniqBy'
 import { userThemeSettings, defaultThemeOptions } from "../../../themes/themeNames";
 import { postsLayouts } from '../posts/dropdownOptions';
 import type { ForumIconName } from '../../../components/common/ForumIcon';
+import { getCommentViewOptions } from '../../commentViewOptions';
 
 ///////////////////////////////////////
 // Order for the Schema is as follows. Change as you see fit:
@@ -610,22 +611,10 @@ const schema: SchemaType<DbUser> = {
     group: formGroups.siteCustomizations,
     control: "select",
     form: {
-      // TODO - maybe factor out??
-      options: function () { // options for the select form control
-        let commentViews = [
-          {value:'postCommentsMagic', label: isEAForum ? 'new & upvoted' : 'magic (new & upvoted)'},
-          {value:'postCommentsTop', label: 'top scoring'},
-          {value:'postCommentsNew', label: 'newest'},
-          {value:'postCommentsOld', label: 'oldest'},
-          {value:'postCommentsRecentReplies', label: 'latest reply'},
-        ];
-        if (forumTypeSetting.get() === 'AlignmentForum') {
-          return commentViews.concat([
-            {value:'postLWComments', label: 'magical algorithm (include LW)'}
-          ])
-        }
-        return commentViews
-      }
+      // getCommentViewOptions has optional parameters so it's safer to wrap it
+      // in a lambda. We don't currently enable admin-only sorting options for
+      // admins - we could but it seems not worth the effort.
+      options: () => getCommentViewOptions(),
     },
   },
 

--- a/packages/lesswrong/lib/commentViewOptions.ts
+++ b/packages/lesswrong/lib/commentViewOptions.ts
@@ -1,0 +1,54 @@
+import { preferredHeadingCase } from "./forumTypeUtils";
+import { forumTypeSetting, isAF, isEAForum } from "./instanceSettings";
+
+const customViewNames: Partial<Record<CommentsViewName,string>> = {
+  'postCommentsMagic': isEAForum ? 'New & upvoted' : 'magic (new & upvoted)',
+  'postCommentsTop': isEAForum ? 'Top' : 'top scoring',
+  'postCommentsRecentReplies': preferredHeadingCase('latest reply'),
+  'afPostCommentsTop': preferredHeadingCase('top scoring'),
+  'postCommentsNew': isEAForum ? 'New' : 'newest',
+  'postCommentsOld': isEAForum ? 'Old' : 'oldest',
+  'postCommentsBest': preferredHeadingCase('highest karma'),
+  'postCommentsDeleted': preferredHeadingCase('deleted'),
+  'postLWComments': preferredHeadingCase('top scoring (include LW)'),
+}
+
+const commentsTopView: CommentsViewName =
+  forumTypeSetting.get() === 'AlignmentForum'
+    ? "afPostCommentsTop"
+    : "postCommentsTop";
+const defaultViews: CommentsViewName[] = [
+  "postCommentsMagic",
+  commentsTopView,
+  "postCommentsNew",
+  "postCommentsOld",
+  "postCommentsRecentReplies",
+];
+const adminViews: CommentsViewName[] = ["postCommentsDeleted"];
+const afViews: CommentsViewName[] = ["postLWComments"];
+
+type CommentViewsConfig = {
+  includeAdminViews?: boolean,
+}
+
+const getCommentViewNames = (
+  options?: CommentViewsConfig,
+): CommentsViewName[] => [
+  ...defaultViews,
+  ...(options?.includeAdminViews ? adminViews : []),
+  ...(isAF ? afViews : []),
+];
+
+export const getCommentViewOptions = (
+  options?: CommentViewsConfig,
+): {value: CommentsViewName, label: string}[] =>
+  getCommentViewNames(options).map((view) => ({
+    value: view,
+    label: customViewNames[view] ?? view,
+  }));
+
+export const isValidCommentView = (
+  name: string,
+  options?: CommentViewsConfig,
+): name is CommentsViewName =>
+  getCommentViewNames(options).includes(name as CommentsViewName);


### PR DESCRIPTION
This PR updates the names in the comment sort options for the EA forum to use sentence-case and to match the wording used for post sort options ([relevant slack thread](https://cea-core.slack.com/archives/C038J512SD8/p1686660670228429)).

It also does some internal plumbing just to tidy this code up, and to prevent having duplicated options between the posts page and the user settings page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204854735977136) by [Unito](https://www.unito.io)
