### PR TITLE
use null-safe access for coauthors field

### DIFF
--- a/packages/lesswrong/components/posts/usePostsUserAndCoauthors.ts
+++ b/packages/lesswrong/components/posts/usePostsUserAndCoauthors.ts
@@ -10,7 +10,7 @@ export const usePostsUserAndCoauthors = (post: PostsList|SunshinePostsList) => {
     topCommentAuthor = null;
   }
 
-  const coauthors = post.coauthors?.filter(({_id}) => !postCoauthorIsPending(post, _id));
+  const coauthors = post.coauthors?.filter(({_id}) => !postCoauthorIsPending(post, _id)) ?? [];
   const authors = [post.user, ...coauthors].filter(
     (user): user is UsersMinimumInfo => !!user,
   );

--- a/packages/lesswrong/components/posts/usePostsUserAndCoauthors.ts
+++ b/packages/lesswrong/components/posts/usePostsUserAndCoauthors.ts
@@ -10,7 +10,7 @@ export const usePostsUserAndCoauthors = (post: PostsList|SunshinePostsList) => {
     topCommentAuthor = null;
   }
 
-  const coauthors = post.coauthors.filter(({_id}) => !postCoauthorIsPending(post, _id));
+  const coauthors = post.coauthors?.filter(({_id}) => !postCoauthorIsPending(post, _id));
   const authors = [post.user, ...coauthors].filter(
     (user): user is UsersMinimumInfo => !!user,
   );

--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
@@ -169,7 +169,7 @@ const PostsPageRecommendationItem = ({
         <div className={classes.author}>
           <InteractionWrapper className={classes.interactionWrapper}>
             <UsersName user={post.user} />
-            {post.coauthors.length > 0 &&
+            {post.coauthors?.length > 0 &&
               <LWTooltip
                 title={
                   <div>

--- a/packages/lesswrong/lib/collections/posts/permissions.ts
+++ b/packages/lesswrong/lib/collections/posts/permissions.ts
@@ -51,7 +51,7 @@ Posts.checkAccess = async (currentUser: DbUser|null, post: DbPost, context: Reso
     return true;
   } else if (!currentUser && !!canonicalLinkSharingKey && constantTimeCompare({ correctValue: canonicalLinkSharingKey, unknownValue: unvalidatedLinkSharingKey })) {
     return true;
-  } else if (post.isFuture || post.draft) {
+  } else if (post.isFuture || post.draft || post.deletedDraft) {
     return false;
     // TODO: consider getting rid of this clause entirely and instead just relying on default view filter, 
     // since LW is now allowing people to see rejected content and preventing them from seeing 'not-yet-rejected

--- a/packages/lesswrong/server/emailComponents/EmailPostAuthors.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailPostAuthors.tsx
@@ -14,7 +14,7 @@ const EmailPostAuthors = ({post}: {
   return <>
     {groupName}
     <span>by <EmailUsername user={post.user}/>
-      {post.coauthors.map((coauthor,i) => [
+      {post.coauthors?.map((coauthor,i) => [
         ", ", <EmailUsername key={i} user={coauthor}/>
       ])}
     </span>


### PR DESCRIPTION
We sometimes get reports that users see errors like `e.coauthors is null` in various posts lists (front page, `/allPosts`, etc).  This happens if a post has `deletedDraft: true` but also `draft: false`; in this case, the post is not filtered out of result sets(?) but blows up because the `coauthors` resolver generates a non-nullable type despite the field being nullable (because `canRead` is set to only `documentIsNotDeleted`).

There are several issues:
1. We sometimes have posts with `deletedDraft: true` but also `draft: false` (this is not a valid invariant)
2. We seem to be returning those posts to users who aren't the author??? (this PR fixes that in `Posts.checkAccess`)
3. For fields which don't have `guest` permissions for `canRead`, we don't correctly generate types with `|null`.   This is pretty tricky.  I have a WIP PR up here but I'm not sure it's taking the right approach: https://github.com/ForumMagnum/ForumMagnum/pull/7311

In the meantime I just manually made all access of `coauthors` null-safe in addition to patching the permissions hole.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204858358001820) by [Unito](https://www.unito.io)
