### PR TITLE
Fix auto-refresh in development environments

### DIFF
--- a/scripts/startup/buildUtil.js
+++ b/scripts/startup/buildUtil.js
@@ -177,4 +177,12 @@ async function startSshTunnel(sshTunnelCommand) {
   }
 }
 
-module.exports = { getDatabaseConfig, startSshTunnel };
+let outputDir = './build';
+function setOutputDir(dir) {
+  outputDir = dir;
+}
+function getOutputDir(dir) {
+  return outputDir;
+}
+
+module.exports = { getDatabaseConfig, startSshTunnel, getOutputDir, setOutputDir };


### PR DESCRIPTION
This got broken by some refactoring, after which the try-catch in `isServerReady` (which is only supposed to catch connection errors due to the server not having bound the port yet) was suppressing a missing-import error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204858408620152) by [Unito](https://www.unito.io)
