### PR TITLE
Add shingle elasticsearch mapping for username fields

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -90,7 +90,7 @@ export type IndexConfig = {
  * but to fall back to the "standard" analyzer which has no stemming for advanced
  * searches using quotes.
  */
-const fullTextMapping = {
+const fullTextMapping: MappingProperty = {
   type: "text",
   analyzer: "fm_synonym_analyzer",
   fields: {
@@ -99,7 +99,25 @@ const fullTextMapping = {
       analyzer: "standard",
     },
   },
-} as const;
+};
+
+/**
+ * The shingle text mapping is particularly suited to short text fields that
+ * often contain punctuation but not a lot of semantic meaning, such as
+ * usernames.
+ */
+const shingleTextMapping: MappingProperty = {
+  type: "text",
+  analyzer: "fm_shingle_analyzer",
+};
+
+/**
+ * Fields that should not be analyzed at all (ie; ids, slugs or enums) should
+ * use a keyword mapping.
+ */
+const keywordMapping: MappingProperty = {
+  type: "keyword",
+};
 
 const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
   Comments: {
@@ -128,15 +146,16 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
     mappings: {
       body: fullTextMapping,
       postTitle: fullTextMapping,
-      authorDisplayName: fullTextMapping,
-      authorSlug: {type: "keyword"},
-      postGroupId: {type: "keyword"},
-      postSlug: {type: "keyword"},
-      userId: {type: "keyword"},
-      tags: {type: "keyword"},
-      tagId: {type: "keyword"},
-      tagSlug: {type: "keyword"},
-      tagCommentType: {type: "keyword"},
+      authorDisplayName: shingleTextMapping,
+      authorUserName: shingleTextMapping,
+      authorSlug: shingleTextMapping,
+      postGroupId: keywordMapping,
+      postSlug: keywordMapping,
+      userId: keywordMapping,
+      tags: keywordMapping,
+      tagId: keywordMapping,
+      tagSlug: keywordMapping,
+      tagCommentType: keywordMapping,
     },
     privateFields: [
       "authorIsUnreviewed",
@@ -174,15 +193,15 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
     ],
     mappings: {
       title: fullTextMapping,
-      authorDisplayName: fullTextMapping,
-      authorFullName: fullTextMapping,
+      authorDisplayName: shingleTextMapping,
+      authorFullName: shingleTextMapping,
+      authorSlug: shingleTextMapping,
       body: fullTextMapping,
-      authorSlug: {type: "keyword"},
-      feedLink: {type: "keyword"},
-      slug: {type: "keyword"},
-      tags: {type: "keyword"},
-      url: {type: "keyword"},
-      userId: {type: "keyword"},
+      feedLink: keywordMapping,
+      slug: keywordMapping,
+      tags: keywordMapping,
+      url: keywordMapping,
+      userId: keywordMapping,
     },
     privateFields: [
       "authorIsUnreviewed",
@@ -237,19 +256,19 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {term: {deleteContent: false}},
     ],
     mappings: {
-      displayName: fullTextMapping,
+      displayName: shingleTextMapping,
       bio: fullTextMapping,
       mapLocationAddress: fullTextMapping,
       jobTitle: fullTextMapping,
       organization: fullTextMapping,
       howICanHelpOthers: fullTextMapping,
       howOthersCanHelpMe: fullTextMapping,
-      careerStage: {type: "keyword"},
-      groups: {type: "keyword"},
-      slug: {type: "keyword"},
-      website: {type: "keyword"},
-      profileImageId: {type: "keyword"},
-      tags: {type: "keyword"},
+      careerStage: keywordMapping,
+      groups: keywordMapping,
+      slug: shingleTextMapping,
+      website: keywordMapping,
+      profileImageId: keywordMapping,
+      tags: keywordMapping,
     },
     privateFields: [
       "deleteContent",
@@ -274,10 +293,10 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
     mappings: {
       body: fullTextMapping,
       plaintextDescription: fullTextMapping,
-      authorDisplayName: fullTextMapping,
-      userId: {type: "keyword"},
-      authorSlug: {type: "keyword"},
-      bannerImageId: {type: "keyword"},
+      authorDisplayName: shingleTextMapping,
+      userId: keywordMapping,
+      authorSlug: shingleTextMapping,
+      bannerImageId: keywordMapping,
     },
     privateFields: [
       "draft",
@@ -313,9 +332,9 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
     mappings: {
       name: fullTextMapping,
       description: fullTextMapping,
-      bannerImageId: {type: "keyword"},
-      parentTagId: {type: "keyword"},
-      slug: {type: "keyword"},
+      bannerImageId: keywordMapping,
+      parentTagId: keywordMapping,
+      slug: keywordMapping,
     },
     privateFields: [
       "deleted",

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -193,16 +193,23 @@ class ElasticExporter {
                   type: "synonym",
                   synonyms: [],
                 },
+                fm_shingle_filter: {
+                  type: "shingle",
+                  min_shingle_size: 2,
+                  max_shingle_size: 3,
+                  output_unigrams: true,
+                },
+                fm_whitespace_filter: {
+                  type: "pattern_replace",
+                  pattern: " ",
+                  replacement: "",
+                },
               },
               char_filter: {
                 fm_punctuation_filter: {
-                  type: "mapping",
-                  mappings: [
-                    "_ => ",
-                    "- => ",
-                    "( => ",
-                    ") => ",
-                  ],
+                  type: "pattern_replace",
+                  pattern: "[()_-]+",
+                  replacement: " ",
                 },
               },
               analyzer: {
@@ -224,6 +231,19 @@ class ElasticExporter {
                     "lowercase",
                     "fm_synonym_filter",
                     "porter_stem",
+                  ],
+                  char_filter: [
+                    "fm_punctuation_filter",
+                  ],
+                },
+                fm_shingle_analyzer: {
+                  type: "custom",
+                  tokenizer: "standard",
+                  filter: [
+                    "lowercase",
+                    "fm_synonym_filter",
+                    "fm_shingle_filter",
+                    "fm_whitespace_filter",
                   ],
                   char_filter: [
                     "fm_punctuation_filter",


### PR DESCRIPTION
Agnes noticed that underscores in usernames make them tricky to search for. With this PR, all of "Ben West", "ben_west", "ben__west" and "benwest" will be able to match the account "ben__west". This may end up being too lenient, but I think it should be fine.

So far, I've only configured the indexes on dev.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204862698896921) by [Unito](https://www.unito.io)
