### PR TITLE
Reconfigure existing elastic indexes asynchronously

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -105,6 +105,10 @@ class ElasticExporter {
    * You should wait a couple of minutes for the reindexing to complete, check
    * that the document count on the new index is >= the document count on the old
    * index, then run `Globals.elasticDeleteOrphanedIndexes()`.
+   *
+   * Whilst exporting, there'll be a short period during copying where search
+   * will continue to work but not all the documents are available - this is
+   * currently ~45 seconds for EA forum prod as of 2023-06-22.
    */
   async configureIndex(collectionName: AlgoliaIndexCollectionName) {
     const client = this.client.getClient();


### PR DESCRIPTION
Currently, it's difficult/impossible to reconfigure indexes on staging/prod because there's so much data that we hit the kibana timeout before the process can complete (we don't hit the timout on dev because there's not enough data).

This PR changes the reconfigure script to build the new indexes asynchronously, and then adds a separate command to delete the orphaned indexes once all the data has been copied and the aliases have been switched.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204866535171725) by [Unito](https://www.unito.io)
