### PR TITLE
Tag-flag tooltip is clickable (because in at least one case it contains a link)

### DIFF
--- a/packages/lesswrong/components/tagging/TagFlagItem.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagItem.tsx
@@ -92,7 +92,6 @@ const TagFlagItem = ({documentId, itemType = "tagFlagId", showNumber = true, sty
     <LWPopper
       open={hover}
       anchorEl={anchorEl}
-      clickable={false}
       placement="bottom-start"
     >
         {(["allPages", "userPages"].includes(itemType) || tagFlag) && <AnalyticsContext pageElementContext="hoverPreview">


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204868401646548) by [Unito](https://www.unito.io)
