### PR TITLE
Change /topics/all to /topics on EA Forum (for SEO)

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -14,7 +14,7 @@ import Sort from '@material-ui/icons/Sort'
 import Info from '@material-ui/icons/Info';
 import LocalLibrary from '@material-ui/icons/LocalLibrary';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
-import { communityPath } from '../../../lib/routes';
+import { communityPath, getAllTagsPath } from '../../../lib/routes';
 import { REVIEW_YEAR } from '../../../lib/reviewUtils';
 import { ForumOptions, preferredHeadingCase } from '../../../lib/forumTypeUtils';
 import { taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../../lib/instanceSettings';
@@ -114,7 +114,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'concepts',
       title: 'Concepts',
       mobileTitle: 'Concepts',
-      link: '/tags/all',
+      link: getAllTagsPath(),
       icon: conceptsIcon,
       tooltip: <div>
         Get an overview over all the concepts used on LessWrong
@@ -272,7 +272,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: taggingNamePluralSetting.get(),
       title: taggingNamePluralCapitalSetting.get(),
       mobileTitle: taggingNamePluralCapitalSetting.get(),
-      link: `/${taggingNamePluralSetting.get()}/all`,
+      link: getAllTagsPath(),
       iconComponent: TopicsIcon,
       selectedIconComponent: TopicsSelectedIcon,
       tooltip: `A sorted list of pages — “${taggingNamePluralCapitalSetting.get()}” — in the EA Forum Wiki, which explains 
@@ -377,7 +377,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       id: 'wiki',
       title: 'Wiki',
       mobileTitle: 'Wiki',
-      link: '/tags/all',
+      link: getAllTagsPath(),
       iconComponent: LocalOffer,
       tooltip: 'Collaboratively edited Tags and Wiki Articles',
       showOnMobileStandalone: true,

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -10,6 +10,7 @@ import { forumTitleSetting, isEAForum, siteNameWithArticleSetting, taggingNameCa
 import { curatedUrl } from '../../recommendations/RecommendationsAndCurated';
 import { ForumOptions, forumSelect } from '../../../lib/forumTypeUtils';
 import classNames from 'classnames';
+import { getAllTagsPath } from '../../../lib/routes';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -111,7 +112,7 @@ export const contentTypes: ForumOptions<ContentTypeRecord> = {
         durable format.
       </div>,
       Icon: TagIcon,
-      linkTarget: '/tags/all',
+      linkTarget: getAllTagsPath(),
     },
   },
   AlignmentForum: {
@@ -169,7 +170,7 @@ export const contentTypes: ForumOptions<ContentTypeRecord> = {
         a more durable format.
       </div>,
       Icon: TagIcon,
-      linkTarget: '/tags/all',
+      linkTarget: getAllTagsPath(),
     },
   },
   EAForum: {
@@ -222,7 +223,7 @@ export const contentTypes: ForumOptions<ContentTypeRecord> = {
         durable format.
       </div>,
       Icon: TagIcon,
-      linkTarget: '/tags/all',
+      linkTarget: getAllTagsPath(),
     },
     subforumDiscussion: {
       Icon: QuestionAnswerIcon,
@@ -286,7 +287,7 @@ export const contentTypes: ForumOptions<ContentTypeRecord> = {
         durable format.
       </div>,
       Icon: TagIcon,
-      linkTarget: '/tags/all',
+      linkTarget: getAllTagsPath(),
     },
   }
 }

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -7,6 +7,7 @@ import { userCanCreateTags } from '../../lib/betas';
 import { Link } from '../../lib/reactRouterWrapper';
 import { taggingNameCapitalSetting, taggingNamePluralCapitalSetting } from '../../lib/instanceSettings';
 import { tagCreateUrl, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
+import { getAllTagsPath } from '../../lib/routes';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -108,7 +109,7 @@ const AddTag = ({onTagSelected, isVotingContext, classes}: {
       }/>
     </InstantSearch>
     <DropdownDivider />
-    <Link target="_blank" to="/tags/all" className={classes.newTag}>
+    <Link target="_blank" to={getAllTagsPath()} className={classes.newTag}>
       All {taggingNamePluralCapitalSetting.get()}
     </Link>
     {userCanCreateTags(currentUser) && tagUserHasSufficientKarma(currentUser, "new") && <Link

--- a/packages/lesswrong/components/tagging/TagHistoryPageTitle.tsx
+++ b/packages/lesswrong/components/tagging/TagHistoryPageTitle.tsx
@@ -6,6 +6,7 @@ import { useTagBySlug } from './useTag';
 import { Link } from '../../lib/reactRouterWrapper';
 import { styles } from '../common/HeaderSubtitle';
 import { taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { getAllTagsPath } from '../../lib/routes';
 
 const TagHistoryPageTitle = ({isSubtitle, classes, siteName}: {
   isSubtitle: boolean,
@@ -19,7 +20,7 @@ const TagHistoryPageTitle = ({isSubtitle, classes, siteName}: {
   
   if (isSubtitle) {
     return (<span className={classes.subtitle}>
-      <Link to={`/${taggingNamePluralSetting.get()}/all`}>{taggingNamePluralCapitalSetting.get()}</Link>
+      <Link to={getAllTagsPath()}>{taggingNamePluralCapitalSetting.get()}</Link>
     </span>);
   } else if (!tag) {
     return null;

--- a/packages/lesswrong/components/tagging/TagPageTitle.tsx
+++ b/packages/lesswrong/components/tagging/TagPageTitle.tsx
@@ -6,6 +6,7 @@ import { useTagBySlug } from './useTag';
 import { Link } from '../../lib/reactRouterWrapper';
 import { styles } from '../common/HeaderSubtitle';
 import { taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { getAllTagsPath } from '../../lib/routes';
 
 const TagPageTitle = ({isSubtitle, classes, siteName}: {
   isSubtitle: boolean,
@@ -19,7 +20,7 @@ const TagPageTitle = ({isSubtitle, classes, siteName}: {
   
   if (isSubtitle) {
     return (<span className={classes.subtitle}>
-      <Link to={`/${taggingNamePluralSetting.get()}/all`}>{taggingNamePluralCapitalSetting.get()}</Link>
+      <Link to={getAllTagsPath()}>{taggingNamePluralCapitalSetting.get()}</Link>
     </span>);
   } else if (!tag) {
     return null;

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -7,9 +7,31 @@ import { forumSelect } from './forumTypeUtils';
 import pickBy from 'lodash/pickBy';
 import qs from 'qs';
 import {getPostPingbackById, getPostPingbackByLegacyId, getPostPingbackBySlug, getUserPingbackBySlug} from './pingback'
+import { pluralize } from './vulcan-lib';
 
 
 export const communityPath = '/community';
+
+const knownTagNames = ['tag', 'topic', 'concept']
+const useShortAllTagsPath = isEAForum;
+
+/**
+ * Get the path for the all tags page
+ */
+export const getAllTagsPath = () => {
+  return useShortAllTagsPath ? `/${taggingNamePluralSetting.get()}` : `/${taggingNamePluralSetting.get()}/all`;
+}
+
+/**
+ * Get all the paths that should redirect to the all tags page. This is all combinations of
+ * known tag names (e.g. 'topics', 'concepts') with and without `/all` at the end.
+ */
+export const getAllTagsRedirectPaths: () => string[] = () => {
+  const pathRoots = knownTagNames.map(tagName => `/${pluralize(tagName)}`)
+  const allPossiblePaths = pathRoots.map(root => [root, `${root}/all`])
+  const redirectPaths = ['/wiki', ...allPossiblePaths.flat().filter(path => path !== getAllTagsPath())]
+  return redirectPaths
+}
 
 const communitySubtitle = { subtitleLink: communityPath, subtitle: isEAForum ? 'Connect' : 'Community' };
 const rationalitySubtitle = { subtitleLink: "/rationality", subtitle: "Rationality: A-Z" };
@@ -325,16 +347,6 @@ addRoute(
 
   // Tags redirects
   {
-    name: "TagsAll",
-    path:'/tags',
-    redirect: () => `/tags/all`,
-  },
-  {
-    name: "Concepts",
-    path:'/concepts',
-    redirect: () => `/tags/all`,
-  },
-  {
     name: 'tagVoting',
     path: '/tagVoting',
     redirect: () => `/tagActivity`,
@@ -369,17 +381,6 @@ if (taggingNameIsSet.get()) {
       name: 'tagsSingleRedirectCustomName',
       path: '/tag/:slug',
       redirect: ({ params }) => `/${taggingNamePluralSetting.get()}/${params.slug}`,
-    },
-    {
-      name: 'tagsAllCustomName',
-      path: `/${taggingNamePluralSetting.get()}/all`,
-      componentName: isEAForum ? 'EAAllTagsPage' : 'AllTagsPage',
-      title: `${taggingNamePluralCapitalSetting.get()} — Main Page`,
-    },
-    {
-      name: "tagsRedirectCustomName",
-      path:'/tags/all',
-      redirect: () => `/${taggingNamePluralSetting.get()}/all`,
     },
     {
       name: 'tagDiscussionCustomName',
@@ -475,21 +476,10 @@ if (taggingNameIsSet.get()) {
       name: 'taggingDashboardCustomNameRedirect',
       path: '/tags/dashboard',
       redirect: () => `/${taggingNamePluralSetting.get()}/dashboard`
-    },
-    {
-      name: 'taggingAllCustomNameRedirect',
-      path: `/${taggingNamePluralSetting.get()}/`,
-      redirect: () => `/${taggingNamePluralSetting.get()}/all`
-    },
+    }
   )
 } else {
   addRoute(
-    {
-      name: 'allTags',
-      path: '/tags/all',
-      componentName: isEAForum ? 'EAAllTagsPage' : 'AllTagsPage',
-      title: forumTypeSetting.get() === 'EAForum' ? "The EA Forum Wiki" : "Concepts Portal",
-    },
     {
       name: 'tags.single',
       path: '/tag/:slug',
@@ -555,6 +545,24 @@ if (taggingNameIsSet.get()) {
     },
   )
 }
+
+// All tags page
+addRoute(
+  // The page itself
+  {
+    name: 'tagsAll',
+    path: getAllTagsPath(),
+    componentName: isEAForum ? 'EAAllTagsPage' : 'AllTagsPage',
+    title: isEAForum ? `${taggingNamePluralCapitalSetting.get()} — Main Page` : "Concepts Portal",
+  },
+  // And all the redirects to it
+  ...getAllTagsRedirectPaths().map((path, idx) => ({
+    name: `tagsAllRedirect${idx}`,
+    path,
+    redirect: () => getAllTagsPath(),
+  }))
+);
+
 
 onStartup(() => {
   const legacyRouteAcronym = legacyRouteAcronymSetting.get()
@@ -689,11 +697,6 @@ const forumSpecificRoutes = forumSelect<Route[]>({
     {
       name: 'EAGApplicationData',
       path: '/api/eag-application-data'
-    },
-    {
-      name: 'wikiTopisRedirect',
-      path: '/wiki',
-      redirect: () => `/${taggingNamePluralSetting.get()}/all`
     },
     {
       name: 'subforum',


### PR DESCRIPTION
This is to make it easier for search engines to work out that this is the top level page for topics. There was also a big mess of redirects in the `routes` file so I've cleaned that up to make this easier to change in future.

For reviewers: It's definitely worth testing all the redirects and different site settings work. I have done this but it would be very annoying if this broke some links so it's worth retesting

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204871160153557) by [Unito](https://www.unito.io)
