### PR TITLE
Better validation of tag-renames

### DIFF
--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -10,6 +10,8 @@ import { taggingNameSetting } from '../../lib/instanceSettings';
 import { updateMutator } from '../vulcan-lib';
 
 function isValidTagName(name: string) {
+  if (!name || !name.length)
+    return false;
   return true;
 }
 
@@ -63,11 +65,11 @@ getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any
 });
 
 getCollectionHooks("Tags").updateValidate.add(async (validationErrors: Array<any>, {oldDocument, newDocument}: {oldDocument: DbTag, newDocument: DbTag}) => {
+  if (!isValidTagName(newDocument.name))
+    throw new Error(`Invalid ${taggingNameSetting.get()} name`);
+
   const newName = normalizeTagName(newDocument.name);
   if (oldDocument.name !== newName) { // Tag renamed?
-    if (!isValidTagName(newDocument.name))
-      throw new Error(`Invalid ${taggingNameSetting.get()} name`);
-    
     const existing = await Tags.find({name: newName, deleted:false}).fetch();
     if (existing.length > 0)
       throw new Error(`A ${taggingNameSetting.get()} by that name already exists`);


### PR DESCRIPTION
A very small thing, in response to an error spotted in Sentry, where a user on a phone tried to submit a tag-edit where the name field was edited to blank, producing an internal exception rather than a sensible error message.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204877434177086) by [Unito](https://www.unito.io)
