### PR TITLE
Unfuck schema-generation

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -42,12 +42,14 @@ const STICKY_PRIORITIES = {
   4: "Max",
 }
 
-const forumDefaultVotingSystem = forumSelect({
-  EAForum: "twoAxis",
-  LessWrong: "namesAttachedReactions",
-  AlignmentForum: "namesAttachedReactions",
-  default: "default",
-})
+function getDefaultVotingSystem() {
+  return forumSelect({
+    EAForum: "twoAxis",
+    LessWrong: "namesAttachedReactions",
+    AlignmentForum: "namesAttachedReactions",
+    default: "default",
+  })
+}
 
 export interface RSVPType {
   name: string
@@ -1067,8 +1069,14 @@ const schema: SchemaType<DbPost> = {
         return filteredVotingSystems.map(votingSystem => ({label: votingSystem.description, value: votingSystem.name}));
       }
     },
-    ...schemaDefaultValue(forumDefaultVotingSystem),
-  },  
+
+    // This can't use schemaDefaultValue because it varies by forum-type.
+    // Trying to use schemaDefaultValue here with a branch by forum type broke
+    // schema generation/migrations.
+    defaultValue: "twoAxis",
+    onCreate: () => getDefaultVotingSystem(),
+    canAutofillDefault: true,
+  },
   myEditorAccess: resolverOnlyField({
     type: String,
     canRead: ['guests'],


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/7310 made it so that, if the forum-type is LW, posts are assigned a random voting system at creation time. Unfortunately this was done with `schemaDefaultValue`, making schema-generation nondeterministic if the forum type was LW. At the time I thought that this had narrowly avoided breaking schema generation by the luck of schemas being generated with a forum-type of `default`. My current understanding is that that was not true; instead, what was happening was that unit tests in CI would run with a forum-type of `EAForum`, which is consistent so it works, but if your local development environment was set to LW rather than EA Forum, then generating migrations locally would flip a coin. If you got the bad flip your schema would have a spurious change in it, which would then fail if you tried to take that schema and commit it somewhere where unit tests would run on it in CI.

Then https://github.com/ForumMagnum/ForumMagnum/pull/7333 changed it to not be randomized. Which you might think would be an improvement, but what it actually meant was that the coin would now always come up tails (bad). The next PR from the LW side to need a migration was https://github.com/ForumMagnum/ForumMagnum/pull/7328, which failed unit testing and was reverted in https://github.com/ForumMagnum/ForumMagnum/pull/7463. Initially I thought this was because I had messed up resolving merge conflicts in `schema_changelog.json` and tried to fix it by making a fresh branch and re-doing the schema generation: https://github.com/ForumMagnum/ForumMagnum/pull/7467. Which also didn't work, because in fact the problem wasn't with the branch, but with `master`.

This fixes the issue by replacing the call to `schemaDefaultValue`, which is not safe to use with a parameter that can vary, with an `onCreate` callback.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204879877735150) by [Unito](https://www.unito.io)
