### PR TITLE
Don't try to fetch debate-responses for counting if not a debate-post

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2446,6 +2446,7 @@ const schema: SchemaType<DbPost> = {
     nullable: true,
     canRead: ['guests'],
     resolver: async (post, _, context) => {
+      if (!post.debate) return 0;
       const { Comments, currentUser } = context;
 
       const lastReadStatus = await getLastReadStatus(post, context);


### PR DESCRIPTION
The `unreadDebateResponseCount` resolver contains an N+1 select, in fetching comments in order to count how many unread debate comments there are. This works out to one spurious (predictably empty result set) DB query per marked-as-read query appearing on the front page.

Filter that to only run the query for posts that are at least debate posts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204879982299869) by [Unito](https://www.unito.io)
