### PR TITLE
Fix issue where latest-posts list was sometimes double-fetched

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -7,6 +7,7 @@ import { useTimezone } from './withTimezone';
 import { AnalyticsContext, useOnMountTracking } from '../../lib/analyticsEvents';
 import { useFilterSettings } from '../../lib/filterSettings';
 import moment from '../../lib/moment-timezone';
+import { useCurrentTime } from '../../lib/utils/timeUtil';
 import {forumTypeSetting, taggingNamePluralSetting, taggingNameSetting} from '../../lib/instanceSettings';
 import { sectionTitleStyle } from '../common/SectionTitle';
 import { AllowHidingFrontPagePostsContext } from '../dropdowns/posts/PostActions';
@@ -101,8 +102,8 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
   } = Components
   const limit = parseInt(query.limit) || defaultLimit;
 
-  const now = moment().tz(timezone);
-  const dateCutoff = now.subtract(frontpageDaysAgoCutoffSetting.get(), 'days').format("YYYY-MM-DD");
+  const now = useCurrentTime();
+  const dateCutoff = moment(now).tz(timezone).subtract(frontpageDaysAgoCutoffSetting.get(), 'days').format("YYYY-MM-DD");
 
   const recentPostsTerms = {
     ...query,


### PR DESCRIPTION
Using the current time (from the clock) inside React components is unsafe, because it changes every time the render function runs. Taking that time, adjusting it by an offset, and putting it into a query parameter means that query is then different each time, potentially leading to a double (or even triple) query. (In practice, in instrumentation, I usually saw it run only once, occasionally twice. But the times it ran twice, it slows down the front-page SSR enough to notice.)