### PR TITLE
Use server bundle hash in cacheStore

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -9,7 +9,7 @@ import sumBy from 'lodash/sumBy';
 import { dogstatsd } from '../../datadog/tracer';
 import { healthCheckUserAgentSetting } from './renderUtil';
 import PageCache from '../../../lib/collections/pagecache/collection';
-import { getClientBundle } from '../../utils/bundleUtils';
+import { getServerBundleHash } from '../../utils/bundleUtils';
 import PageCacheRepo from '../../repos/PageCacheRepo';
 import { DatabaseServerSetting } from '../../databaseSettings';
 
@@ -218,7 +218,7 @@ const cacheStoreLocal = (cacheKey: string, abTestGroups: RelevantTestGroupAlloca
 }
 
 const cacheStoreDB = (cacheKey: string, abTestGroups: RelevantTestGroupAllocation, rendered: RenderResult): void => {
-  const { bundleHash } = getClientBundle();
+  const bundleHash = getServerBundleHash();
 
   void PageCache.rawUpdateOne(
     {


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/7449 changed it to use the hash of the server bundle rather than the client bundle, but only on lookup so the cache has been broken since then

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204881408094445) by [Unito](https://www.unito.io)
