### PR TITLE
[EA Forum only] noindex tag history and discussion pages

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -389,7 +389,8 @@ if (taggingNameIsSet.get()) {
       titleComponentName: 'TagPageTitle',
       subtitleComponentName: 'TagPageTitle',
       previewComponentName: 'TagHoverPreview',
-      background: "white"
+      background: "white",
+      noIndex: true,
     },
     {
       name: 'tagDiscussionCustomNameRedirect',
@@ -402,6 +403,7 @@ if (taggingNameIsSet.get()) {
       componentName: 'TagHistoryPage',
       titleComponentName: 'TagHistoryPageTitle',
       subtitleComponentName: 'TagHistoryPageTitle',
+      noIndex: true,
     },
     {
       name: 'tagHistoryCustomNameRedirect',


### PR DESCRIPTION
We don't want these pages showing up in search results, there's not much point in looking at them. Reported via [slack](https://cea-core.slack.com/archives/C038J512SD8/p1687020239458399).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204885242770700) by [Unito](https://www.unito.io)
