### PR TITLE
Add ratelimit info to SunshineNewUsersInfo

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -104,7 +104,7 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
   });
 
   const {
-    MetaInfo, SunshineNewUserPostsList, SunshineNewUserCommentsList, ContentSummaryRows, LWTooltip,
+    MetaInfo, SunshineNewUserPostsList, SunshineNewUserCommentsList, ContentSummaryRows, LWTooltip, UserAutoRateLimitsDisplay,
     Typography, SunshineSendMessageWithDefaults, UserReviewStatus, ModeratorMessageCount, UserReviewMetadata, ModeratorActions, NewUserDMSummary
   } = Components
 
@@ -116,6 +116,7 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
         <Typography variant="body2">
           <MetaInfo>
             <UserReviewMetadata user={user}/>
+            <UserAutoRateLimitsDisplay user={user} showKarmaMeta/>
             <div className={classes.info}>
               <div className={classes.topRow}>
                 <UserReviewStatus user={user}/>


### PR DESCRIPTION
This got dropped by accident from SunshineNewUsersInfo when I pulled it out of UserReviewMetadata

<img width="842" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/1589e971-b439-44ee-bb5b-2f52a98229b6">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204885909437739) by [Unito](https://www.unito.io)
