### PR TITLE
make audio icon look like a toggle button

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -402,8 +402,13 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
               className={classes.headerImage}
             />
           </div>}
-        <PostCoauthorRequest post={post} currentUser={currentUser} />
-        <PostsPagePostHeader post={post} answers={answers ?? []} toggleEmbeddedPlayer={toggleEmbeddedPlayer} dialogueResponses={debateResponses}/>
+          <PostCoauthorRequest post={post} currentUser={currentUser} />
+          <PostsPagePostHeader
+            post={post}
+            answers={answers ?? []}
+            showEmbeddedPlayer={showEmbeddedPlayer}
+            toggleEmbeddedPlayer={toggleEmbeddedPlayer}
+            dialogueResponses={debateResponses} />
         </div>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -91,10 +91,15 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: isEAForum ? undefined : theme.palette.primary.main,
     height: isEAForum ? undefined : PODCAST_ICON_SIZE,
   },
-  togglePodcastIcon: {
-    width: PODCAST_ICON_SIZE,
-    height: PODCAST_ICON_SIZE,
-    transform: isEAForum ? "translateY(5px)" : undefined
+  audioIcon: {
+    width: PODCAST_ICON_SIZE + 4,
+    height: PODCAST_ICON_SIZE + 4,
+    transform: isEAForum ? "translateY(3px)" : "translateY(-2px)",
+    padding: 2
+  },
+  audioIconOn: {
+    background: theme.palette.grey[200],
+    borderRadius: theme.borderRadius.small
   },
   actions: {
     color: isEAForum ? undefined : theme.palette.grey[500],
@@ -212,10 +217,11 @@ const CommentsLink: FC<{
 
 /// PostsPagePostHeader: The metadata block at the top of a post page, with
 /// title, author, voting, an actions menu, etc.
-const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggleEmbeddedPlayer, hideMenu, hideTags, classes}: {
+const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEmbeddedPlayer, toggleEmbeddedPlayer, hideMenu, hideTags, classes}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
   answers?: CommentsList[],
   dialogueResponses?: CommentsList[],
+  showEmbeddedPlayer?: boolean,
   toggleEmbeddedPlayer?: () => void,
   hideMenu?: boolean,
   hideTags?: boolean,
@@ -284,21 +290,14 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], toggle
       {postGetAnswerCountStr(answerCount)}
     </CommentsLink>
   
-  const audioNode = toggleEmbeddedPlayer &&
-    (cachedTooltipSeen ?
-      <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
-        <a href="#" onClick={toggleEmbeddedPlayer}>
-          <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
-        </a>
-      </LWTooltip> :
-      <NewFeaturePulse dx={-10} dy={4}>
-        <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
-        <a href="#" onClick={toggleEmbeddedPlayer}>
-          <ForumIcon icon="VolumeUp" className={classes.togglePodcastIcon} />
-        </a>
-        </LWTooltip>
-      </NewFeaturePulse>
-    )
+  const audioIcon = <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
+    <a href="#" onClick={toggleEmbeddedPlayer}>
+      <ForumIcon icon="VolumeUp" className={classNames(classes.audioIcon, {[classes.audioIconOn]: showEmbeddedPlayer})} />
+    </a>
+  </LWTooltip>
+  const audioNode = toggleEmbeddedPlayer && (
+    cachedTooltipSeen ? audioIcon : <NewFeaturePulse dx={-10} dy={4}>{audioIcon}</NewFeaturePulse>
+  )
     
   const addToCalendarNode = post.startTime && <div className={classes.secondaryInfoLink}>
     <AddToCalendarButton post={post} label="Add to calendar" hideTooltip />

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -94,8 +94,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: isEAForum ? undefined : PODCAST_ICON_SIZE,
   },
   audioIcon: {
-    width: PODCAST_ICON_SIZE + PODCAST_ICON_PADDING*2,
-    height: PODCAST_ICON_SIZE + PODCAST_ICON_PADDING*2,
+    width: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2),
+    height: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2),
     transform: isEAForum ? `translateY(${5-PODCAST_ICON_PADDING}px)` : `translateY(-${PODCAST_ICON_PADDING}px)`,
     padding: PODCAST_ICON_PADDING
   },

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -13,6 +13,8 @@ import { PODCAST_TOOLTIP_SEEN_COOKIE } from '../../../lib/cookies/cookies';
 
 const SECONDARY_SPACING = 20;
 const PODCAST_ICON_SIZE = isEAForum ? 22 : 24;
+// some padding around the icon to make it look like a stateful toggle button
+const PODCAST_ICON_PADDING = isEAForum ? 4 : 2
 
 const styles = (theme: ThemeType): JssStyles => ({
   header: {
@@ -38,7 +40,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   eventHeader: {
-    marginBottom:0,
+    marginBottom: 0,
   },
   authorAndSecondaryInfo: {
     display: 'flex',
@@ -92,10 +94,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: isEAForum ? undefined : PODCAST_ICON_SIZE,
   },
   audioIcon: {
-    width: PODCAST_ICON_SIZE + 4,
-    height: PODCAST_ICON_SIZE + 4,
-    transform: isEAForum ? "translateY(3px)" : "translateY(-2px)",
-    padding: 2
+    width: PODCAST_ICON_SIZE + PODCAST_ICON_PADDING*2,
+    height: PODCAST_ICON_SIZE + PODCAST_ICON_PADDING*2,
+    transform: isEAForum ? `translateY(${5-PODCAST_ICON_PADDING}px)` : `translateY(-${PODCAST_ICON_PADDING}px)`,
+    padding: PODCAST_ICON_PADDING
   },
   audioIconOn: {
     background: theme.palette.grey[200],


### PR DESCRIPTION
This PR adds a background to the post page audio icon when the player is open, to make it look like a stateful toggle button. This helps users understand that they can click to close the player.

<img width="709" alt="Screen Shot 2023-06-22 at 5 40 15 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/2ca32102-b58f-4d3f-9de3-aecb480e2224">

-----
<img width="709" alt="Screen Shot 2023-06-22 at 5 40 09 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/2aa75feb-3468-4f25-ad17-00e5752b5a99">

-----
On LW:
<img width="648" alt="Screen Shot 2023-06-22 at 5 38 53 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/8fb5094e-3cec-429b-bcac-9f33766b23e3">

-----
<img width="648" alt="Screen Shot 2023-06-22 at 5 38 47 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/ba913d95-16ed-4c46-8767-17856275c306">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204885944481758) by [Unito](https://www.unito.io)
