### PR TITLE
Remove canCreate options from votingSystem.

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1058,7 +1058,6 @@ const schema: SchemaType<DbPost> = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    canCreate: ['admins', 'sunshineRegiment'],
     canUpdate: [userOwnsAndOnLW, 'admins', 'sunshineRegiment'],
     group: isLW ? formGroups.reactExperiment : formGroups.adminOptions,
     control: "select",

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1058,7 +1058,7 @@ const schema: SchemaType<DbPost> = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    canCreate: isLW ? ['members'] : ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
     canUpdate: [userOwnsAndOnLW, 'admins', 'sunshineRegiment'],
     group: isLW ? formGroups.reactExperiment : formGroups.adminOptions,
     control: "select",


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/7468 created a confusing UI experience for people creating posts, since people would see a "voting system" field that says "Two axis voting", but which gets automagically changed to "Reacts" after submitting the form, i.e:

![image](https://github.com/ForumMagnum/ForumMagnum/assets/3246710/603bd34d-1c66-448a-a320-058ff52b669d)

This PR removes the canCreate field, since AFAICT in the current regime it's basically incorrect to think of it as something you can control while creating. But I'm not 100% sure this is the right solution and interested in takes from @jimrandomh 