### PR TITLE
[EA Forum only] update Groups & People page url, and visited link color on dark mode

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersMetaInfo.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersMetaInfo.tsx
@@ -6,6 +6,7 @@ import {
   SOCIAL_MEDIA_PROFILE_FIELDS,
   CAREER_STAGES,
 } from "../../../lib/collections/users/schema";
+import { communityPath } from "../../../lib/routes";
 
 const styles = (theme: ThemeType): JssStyles => ({
   iconsRow: {
@@ -21,6 +22,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     "& a": {
       color: theme.palette.grey[600],
       "&:hover": {
+        color: theme.palette.grey[600],
+      },
+      "&:visited": {
         color: theme.palette.grey[600],
       }
     }
@@ -91,7 +95,7 @@ const EAUsersMetaInfo = ({user, classes}: {
           : null;
       })}
       {user.mapLocation &&
-        <Link to="/community#individuals" className={classes.userMetaInfo}>
+        <Link to={`${communityPath}#individuals`} className={classes.userMetaInfo}>
           <ForumIcon icon="MapPin" className={classes.userMetaInfoIcon} />
           {user.mapLocation.formatted_address}
         </Link>

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -11,6 +11,7 @@ import { forumTypeSetting, isEAForum } from '../../../lib/instanceSettings';
 import { getDefaultEventImg } from './HighlightedEventCard';
 import { useCurrentUser } from '../../common/withUser';
 import classNames from 'classnames';
+import { communityPath } from '../../../lib/routes';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   noResults: {
@@ -199,7 +200,7 @@ const EventCards = ({events, loading, numDefaultCards, hideSpecialCards, hideGro
     return <div className={classes.noResults}>
       <div className={classes.noResultsText}>No upcoming events matching your search</div>
       <div className={classes.noResultsCTA}>
-        <Link to={'/community'} className={classes.communityLink}>
+        <Link to={communityPath} className={classes.communityLink}>
           Explore the {communityName}
         </Link>
       </div>

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -30,6 +30,7 @@ import {
   isValidElasticSorting,
 } from '../../lib/search/elasticUtil';
 import { userHasElasticsearch } from '../../lib/betas';
+import { communityPath } from '../../lib/routes';
 
 const hitsPerPage = 10
 
@@ -423,7 +424,7 @@ const SearchPageTabbed = ({classes}:{
         <ClearRefinements />
 
         {tab === 'Users' && forumTypeSetting.get() === 'EAForum' && <div className={classes.mapLink}>
-          <Link to="/community#individuals">View community map</Link>
+          <Link to={`${communityPath}#individuals`}>View community map</Link>
         </div>}
 
         {elasticCollectionIsCustomSortable(tab) && userHasElasticsearch(null) &&

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -32,7 +32,7 @@ export const getAllTagsRedirectPaths: () => string[] = () => {
   return redirectPaths
 }
 
-export const communityPath = isEAForum ? '/groupsAndPeople' : '/community';
+export const communityPath = isEAForum ? '/groups' : '/community';
 const communitySubtitle = { subtitleLink: communityPath, subtitle: isEAForum ? 'Groups & people' : 'Community' };
 
 const rationalitySubtitle = { subtitleLink: "/rationality", subtitle: "Rationality: A-Z" };

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -134,6 +134,9 @@ const forumComponentPalette = (shadePalette: ThemeShadePalette) =>
       text: {
         primaryAlert: '#F3F9FA'
       },
+      link: {
+        visited: '#9b71be',
+      },
       panelBackground: {
         default: shadePalette.grey[20],
       },
@@ -186,7 +189,8 @@ export const darkModeTheme: UserThemeSpecification = {
       },
     },
     link: {
-      primaryDim: '#3a7883'
+      primaryDim: '#3a7883',
+      visited: "#bb7c43",
     },
     panelBackground: {
       translucent: "rgba(0,0,0,.87)",


### PR DESCRIPTION
Changed the URL to be just `/groups` to make it neater, and picked a lighter purple for the visited link color on dark mode. (Sorry I generally don't like to combine random things in a PR but these are both small so hopefully it's not too annoying!)

<img width="604" alt="Screen Shot 2023-06-26 at 11 58 34 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/48514bdf-3f4b-4bad-b359-ee93102b3416">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204909387436855) by [Unito](https://www.unito.io)
