### PR TITLE
Viewpoints Iframe pr

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -290,7 +290,8 @@ export const sanitize = function(s: string): string {
       'metaforecast.org',
       'app.thoughtsaver.com',
       'ourworldindata.org',
-      'strawpoll.com'
+      'strawpoll.com',
+      'viewpoints.xyz'
     ],
     allowedClasses: {
       span: [ 'footnote-reference', 'footnote-label', 'footnote-back-link' ],

--- a/public/lesswrong-editor/src/editorConfigs.js
+++ b/public/lesswrong-editor/src/editorConfigs.js
@@ -87,6 +87,17 @@ const embedConfig = {
 				`
 			}
 		},
+		{
+			name: 'Viewpoints',
+			url: /^viewpoints\.xyz\/polls\/([\w-]+).*/,
+			html: ([match, slug]) => {
+				return `
+					<div data-viewpoints-slug="${slug}" class="owid-preview">
+						<iframe style="height: 400px; width: 100%; border: none;" src="https://${match}"/>
+					</div>
+				`
+			}
+		},
 	]
 }
 


### PR DESCRIPTION
Making viewpoints.xyz show as an iframe.

I couldn't test on my computer because I got this error. Please verify this PR or help me solve this error.

```
yarn start-local-db

yarn run v1.22.19
warning ../../../package.json: No license field
$ ./build.js --no-clear -run --watch --db ../LessWrong-Credentials/connectionConfigs/local.json --settings settings.json
Error reading ../LessWrong-Credentials/connectionConfigs/local.json: Error: ENOENT: no such file or directory, open '../LessWrong-Credentials/connectionConfigs/local.json'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. 
```

If you want to test the iframe try putting this url in

https://viewpoints.xyz/polls/ai-policies



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204911168877013) by [Unito](https://www.unito.io)
