### PR TITLE
Use short title on pages with a title component

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -38,7 +38,7 @@ const HeadTags = ({ogUrl: ogUrlProp, canonicalUrl: canonicalUrlProp, description
     return (
       <React.Fragment>
         { TitleComponent
-            ? <TitleComponent siteName={tabLongTitle} isSubtitle={false} />
+            ? <TitleComponent siteName={tabShortTitle} isSubtitle={false} />
             : <Helmet><title>
                 {titleString
                   ? `${titleString} — ${tabShortTitle}`


### PR DESCRIPTION
I intended for only pages with no other title to have the long title "Effective Altruism Forum", and for other pages to have "EA Forum as a suffix". Currently this is broken for post and tag pages because they have custom title components

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204915793574405) by [Unito](https://www.unito.io)
