### PR TITLE
Elastic export should use upsert instead of create

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -400,9 +400,14 @@ class ElasticExporter {
       datasource: documents,
       onDocument: (document: AlgoliaDocument) => {
         const {id: _id} = this.formatDocument(document);
-        return {
-          create: {_index, _id},
-        };
+        return [
+          {
+            update: {_index, _id},
+          },
+          {
+            doc_as_upsert: true,
+          },
+        ];
       },
       onDrop: (doc) => erroredDocuments.push(doc),
     });


### PR DESCRIPTION
Currently, the elastic exporter uses a create operation which throws an error if the document already exists in the index. It should use an upsert instead.

You can test this with, for instance, `./scripts/serverShellCommand.sh "Globals.elasticExportCollection('Tags')"`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204918310821560) by [Unito](https://www.unito.io)
