### PR TITLE
Fix various bugs in moderation queue

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationDashboard.tsx
@@ -87,6 +87,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     top: 3
   },
+  main: {
+    width: "100%",
+  }
 });
 
 const tabs = new TupleSet(['sunshineNewUsers', 'allUsers', 'recentlyActive'] as const);

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -162,6 +162,7 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
   }
   
   const handleNeedsReview = () => {
+    if (user.needsReview) return null;
     const newNotes = getModSignatureWithNote("set to manual review") + notes;
     void updateUser({
       selector: {_id: user._id},

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -55,6 +55,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   permissionDisabled: {
     border: "none"
   },
+  disabledButton: {
+    opacity: .5,
+    cursor: "default"
+  },
   notes: {
     border: theme.palette.border.faint,
     borderRadius: 2,
@@ -305,13 +309,13 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     <LWTooltip title="Snooze and Approve 1 (Appear in sidebar on next post or comment. User's future posts are autoapproved)" placement="top">
       <SnoozeIcon className={classes.modButton} onClick={() => handleSnooze(1)}/>
     </LWTooltip>
-    {user.needsReview && <LWTooltip
+    <LWTooltip
       title={`${userCommentsWarning ? "Warning: user has made a comment! " : ""}Remove from queue (i.e. snooze without approving posts)`}
     >
       <AlarmOffIcon className={classNames(classes.modButton, {
         [classes.warningButton]: userCommentsWarning,
       })} onClick={handleRemoveNeedsReview}/>
-    </LWTooltip>}
+    </LWTooltip>
     <LWTooltip title="Approve" placement="top">
       <DoneIcon onClick={handleReview} className={classes.modButton}/>
     </LWTooltip>
@@ -329,9 +333,9 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
         {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
       </div>
     </LWTooltip>
-    {!user.needsReview && <LWTooltip title="Return this user to the review queue">
-      <VisibilityOutlinedIcon className={classes.modButton} onClick={handleNeedsReview}/>
-    </LWTooltip>}
+    <LWTooltip title="Return this user to the review queue">
+      <VisibilityOutlinedIcon className={classNames(classes.modButton, {[classes.disabledButton]: user.needsReview})} onClick={handleNeedsReview}/>
+    </LWTooltip>
   </div>
 
   const permissionsRow = <div className={classes.row}>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserAutoRateLimitsDisplay.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserAutoRateLimitsDisplay.tsx
@@ -52,9 +52,9 @@ export const downvoterTooltip = (user: SunshineUsersList) => {
   return <div>
     <div>Recent Downvoters</div>
     <div><em>{user.recentKarmaInfo.downvoterCount} downvoters from last 20 posts/comments</em></div>
+    <div><em>{user.recentKarmaInfo.lastMonthDownvoterCount} downvoters in the last month</em></div>
     <div><em>{user.recentKarmaInfo.postDownvoterCount} downvoters on last 20 posts</em></div>
     <div><em>{user.recentKarmaInfo.commentDownvoterCount} downvoters on last 20 comments</em></div>
-    <div><em>{user.recentKarmaInfo.lastMonthDownvoterCount} downvoters on last 20 comments</em></div>
   </div>
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -1,7 +1,7 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import _filter from 'lodash/filter';
-import { RejectContentButton } from './RejectContentButton';
+import { isLWorAF } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -39,10 +39,10 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
   return (
     <div className={classes.root}>
       {(newComments.length > 0) && newComments.map(comment=><div className={classes.comment} key={`sunshine-new-user-${comment._id}`}>
-        <div className={classes.rejection}>
+        {isLWorAF && <div className={classes.rejection}>
           {comment.rejected && <RejectedReasonDisplay reason={comment.rejectedReason}/>}
           <RejectContentButton contentWrapper={{collectionName:"Comments", content:comment}}/>
-        </div>
+        </div>}
         <CommentsNode 
           treeOptions={{
             condensed: false,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -1,10 +1,11 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import React from 'react';
+import React, { useState } from 'react';
 import withErrorBoundary from '../common/withErrorBoundary'
 import { useMulti } from '../../lib/crud/withMulti';
 import * as _ from 'underscore';
 import { userCanDo } from '../../lib/vulcan-users';
-import { CONTENT_LIMIT } from './UsersReviewInfoCard';
+import { CONTENT_LIMIT, DEFAULT_BIO_WORDCOUNT, MAX_BIO_WORDCOUNT } from './UsersReviewInfoCard';
+import { truncate } from '../../lib/editor/ellipsize';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -87,6 +88,8 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
   currentUser: UsersCurrent
 }) => {
 
+  const [bioWordcount, setBioWordcount] = useState<number>(DEFAULT_BIO_WORDCOUNT)
+
   const { results: posts = [], loading: postsLoading } = useMulti({
     terms:{view:"sunshineNewUsersPosts", userId: user._id},
     collectionName: "Posts",
@@ -109,6 +112,7 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
   } = Components
 
   if (!userCanDo(currentUser, "posts.moderate.all")) return null
+  const bioHtml = truncate(user.htmlBio, bioWordcount, "words")
   
   // All elements in this component should also appar in UsersReviewInfoCard
   return (
@@ -125,7 +129,7 @@ const SunshineNewUsersInfo = ({ user, classes, refetch, currentUser }: {
                   <SunshineSendMessageWithDefaults user={user}/>
                 </div>
               </div>              
-              <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
+              <div dangerouslySetInnerHTML={{__html: bioHtml}} className={classes.bio} onClick={() => setBioWordcount(MAX_BIO_WORDCOUNT)}/>
               {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
             </div>
             <ModeratorActions user={user} currentUser={currentUser} comments={comments} posts={posts} refetch={refetch}/>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -67,6 +67,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderBottom: theme.palette.border.sunshineNewUsersInfoHR,
   },
   bio: {
+    wordBreak: "break-word",
     '& a': {
       color: theme.palette.primary.main,
     },

--- a/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/UsersReviewInfoCard.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import { hideScrollBars } from '../../themes/styleUtils';
 import { getReasonForReview } from '../../lib/collections/moderatorActions/helpers';
 import { UserKarmaInfo } from '../../lib/rateLimits/types';
+import { truncate } from '../../lib/editor/ellipsize';
 
 export const CONTENT_LIMIT = 20
 
@@ -84,6 +85,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 12
   },
   bio: {
+    wordBreak: "break-word",
     '& a': {
       color: theme.palette.primary.main,
     },
@@ -153,6 +155,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
+export const DEFAULT_BIO_WORDCOUNT = 250
+export const MAX_BIO_WORDCOUNT = 10000
+
 export function getDownvoteRatio(user: UserKarmaInfo): number {
   // First check if the sum of the individual vote count fields
   // add up to something close (with 5%) to the voteReceivedCount field.
@@ -183,6 +188,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   } = Components
 
   const [contentExpanded, setContentExpanded] = useState<boolean>(false)
+  const [bioWordcount, setBioWordcount] = useState<number>(DEFAULT_BIO_WORDCOUNT)
   
   const { results: posts = [], loading: postsLoading } = useMulti({
     terms:{view:"sunshineNewUsersPosts", userId: user._id},
@@ -246,6 +252,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
   </div>
 
   const renderExpand = !!(posts?.length || comments?.length)
+  const truncatedHtml = truncate(user.htmlBio, bioWordcount, "words")
   
   return (
     <div className={classNames(classes.root, {[classes.flagged]:user.sunshineFlagged})}>
@@ -257,7 +264,7 @@ const UsersReviewInfoCard = ({ user, refetch, currentUser, classes }: {
           </div>
         </div>
         <div className={classes.contentColumn}>
-          <div dangerouslySetInnerHTML={{__html: user.htmlBio}} className={classes.bio}/>
+          <div dangerouslySetInnerHTML={{__html: truncatedHtml}} className={classes.bio} onClick={() => setBioWordcount(MAX_BIO_WORDCOUNT)}/>
           {user.website && <div>Website: <a href={`https://${user.website}`} target="_blank" rel="noopener noreferrer" className={classes.website}>{user.website}</a></div>}
           {votesRow}
           <ContentSummaryRows user={user} posts={posts} comments={comments} loading={commentsLoading || postsLoading} />

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -117,6 +117,7 @@ export const forumTypeSetting = new PublicInstanceSetting<ForumTypeString>('foru
 export const isLW = forumTypeSetting.get() === "LessWrong"
 export const isEAForum = forumTypeSetting.get() === "EAForum"
 export const isAF = forumTypeSetting.get() === "AlignmentForum"
+export const isLWorAF = isLW || isAF
 
 export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'LessWrong', 'warning') // Default title for URLs
 


### PR DESCRIPTION
This PR
– adds a word-break wrap to user bios so if they have a longass word in their bio it doesn't make the ModerationDashboard have a crazy wide width.
– makes it so the ModerationDashboard has a max width, so if any future size-breaking bugs happen there is a fallback
– switches from hiding the "return user to review queue" button if they're already in the review-queue, to greying it out (so it's less confusing about what's going on)
– fixes the labeling of the lastMonthDownvoterCount in the recent karma tooltip
– truncates bios in the moderation user info components so that longass bios don't take up multiple screen-heights by default (you can click to expand them)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204919980703974) by [Unito](https://www.unito.io)
