### PR TITLE
LW no longer needs to connect to mongodb

### DIFF
--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -108,7 +108,7 @@ const connectToPostgres = async (connectionString: string, target: DbTarget = "w
 
 const initDatabases = ({mongoUrl, postgresUrl, postgresReadUrl}: CommandLineArguments) =>
   Promise.all([
-    connectToMongo(mongoUrl),
+    //connectToMongo(mongoUrl), // No longer needed as both EA Forum and LW have switched all collections
     connectToPostgres(postgresUrl),
     connectToPostgres(postgresReadUrl, "read"),
   ]);


### PR DESCRIPTION
All our collections are switched. I tested locally running `yarn start-dev-db` and `start-prod-db` with this change (preventing connection to mongodb), and they worked. Once this is deployed, we should be able to turn off the mongodb servers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204921126170796) by [Unito](https://www.unito.io)
