### PR TITLE
Let users change editor back to ckeditor from html/markdown

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -279,6 +279,10 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     && (collectionName!=="Tags" || formType==="edit");
   
   const actualPlaceholder = (editorHintText || hintText || placeholder);
+
+  // document isn't necessarily defined. TODO: clean up rest of file
+  // to not rely on document
+  if (!document) return null;
     
   return <div className={classes.root}>
     {showEditorWarning &&

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -65,7 +65,11 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   
   const defaultEditorType = getUserDefaultEditor(currentUser);
   const currentEditorType = contents.type || defaultEditorType;
-  const showEditorWarning = (formType !== "new") && (initialEditorType !== currentEditorType) && (currentEditorType !== 'ckEditorMarkup')
+
+  const showEditorWarning = (formType !== "new") 
+    && (defaultEditorType !== currentEditorType) // if the user has a default editor, and it's not the same as the current editor
+    && (currentEditorType !== 'ckEditorMarkup') // the editor warning button only lets you convert things back to ckEditorMarkup,
+    // so we don't bother showing it if you're already in ckEditorMarkup
   
   // On the EA Forum, our bot checks if posts are potential criticism,
   // and if so we show a little card with tips on how to make it more likely to go well.
@@ -275,17 +279,15 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     && (collectionName!=="Tags" || formType==="edit");
   
   const actualPlaceholder = (editorHintText || hintText || placeholder);
-  
-  if (!document) return null;
-  
+    
   return <div className={classes.root}>
     {showEditorWarning &&
-    <Components.LastEditedInWarning
-      initialType={initialEditorType}
-      currentType={contents.type}
-      defaultType={defaultEditorType}
-      value={contents} setValue={wrappedSetContents}
-    />
+      <Components.LastEditedInWarning
+        initialType={initialEditorType}
+        currentType={contents.type}
+        defaultType={defaultEditorType}
+        value={contents} setValue={wrappedSetContents}
+      />
     }
     {!isCollabEditor &&<Components.LocalStorageCheck
       getLocalStorageHandlers={getLocalStorageHandlers}

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -66,10 +66,11 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   const defaultEditorType = getUserDefaultEditor(currentUser);
   const currentEditorType = contents.type || defaultEditorType;
 
-  const showEditorWarning = (formType !== "new") 
-    && (defaultEditorType !== currentEditorType) // if the user has a default editor, and it's not the same as the current editor
-    && (currentEditorType !== 'ckEditorMarkup') // the editor warning button only lets you convert things back to ckEditorMarkup,
-    // so we don't bother showing it if you're already in ckEditorMarkup
+  // We used to show this warning to a variety of editor types, but now we only want
+  // to show it to people using the html editor. Converting from markdown to ckEditor
+  // is error prone and we don't want to encourage it. We no longer support draftJS
+  // but some old posts still are using it so we show the warning for them too.
+  const showEditorWarning = (formType !== "new") && (currentEditorType === 'html' || currentEditorType === 'draftJS')
   
   // On the EA Forum, our bot checks if posts are potential criticism,
   // and if so we show a little card with tips on how to make it more likely to go well.

--- a/packages/lesswrong/components/editor/LastEditedInWarning.tsx
+++ b/packages/lesswrong/components/editor/LastEditedInWarning.tsx
@@ -33,7 +33,7 @@ const LastEditedInWarning = ({initialType, currentType, defaultType, value, setV
   return <div>
     {loading && <Loading/>}
     <Typography variant="body2" className={classes.lastEditedWarning}>
-      This document was last edited in {editorTypeToDisplay[initialType].name} format. Showing the{' '}
+      This document was last saved in {editorTypeToDisplay[initialType].name} format. Showing the{' '}
       {editorTypeToDisplay[currentType].name} editor.{' '}
       <a
         className={classes.clickHereColor}


### PR DESCRIPTION
I think at some point this UI got broken. I think it's supposed to appear if your default-editor is ckEditor, and your post is currently not using ckEditor markup. Instead of comparing to your default editor, it was comparing to the initial editor-type, which meant that most users in most circumstances wouldn't end up seeing the UI to switch back to ckEditor.

I'm _not_ very confident in my understanding of what this code is supposed to be doing, but I know that for users who crosspost via RSS (and therefore the post is html), they have no way to convert to ckEditor.

<img width="758" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/9b3d46c4-2a6e-485d-a32e-5f6775f1f0d8">

For reference: 

This code (and surrounding component) when through a major refactor during https://github.com/ForumMagnum/ForumMagnum/pull/5644/files. The previous code said:

```
const editorWarning =
      !editorOverride
      && formType !== "new"
      && collectionName !== 'Tags'
      && this.getInitialEditorType() !== this.getUserDefaultEditor(currentUser)
      && this.renderEditorWarning()    
      
  getCurrentEditorType = () => {
    // Tags can only be edited via CKEditor
    if (this.props.collectionName === 'Tags') return "ckEditorMarkup"

    const { editorOverride } = this.state || {} // Provide default since we can call this function before we initialize state

    // If there is an override, return that
    if (editorOverride)
      return editorOverride;

    return this.getInitialEditorType();
  }

  getInitialEditorType = () => {
    const { document, currentUser, fieldName, value } = this.props

    // Check whether we are directly passed a value in the form context, with a type (as a default value for example)
    if (value?.originalContents?.type) {
      return value.originalContents.type
    }
    // Next check whether the document came with a field value with a type specified
    const originalType = document?.[fieldName]?.originalContents?.type
    if (originalType) return originalType;

    // Finally pick the editor type from the user's config
    return this.getUserDefaultEditor(currentUser)
  }

  getUserDefaultEditor = (user) => {
    if (userUseMarkdownPostEditor(user)) return "markdown"
    if (user?.reenableDraftJs) return "draftJS"
    return "ckEditorMarkup"
  }
```

The old one notably compared the initialEditorType with the defaultEditorType. Somehow in the shuffle it switched to comparing the initialEditorType with the currentEditorType. I... feel confused about why we're comparing the default to the initialEditorType, rather than to the currentEditorType (it seems like what we want here is to check if you're not using the defaultEditor, and then provide an easy way to convert over to it if you want)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204921559266907) by [Unito](https://www.unito.io)
