### PR TITLE
[EA Forum only] add icon for closing the left menu

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -315,6 +315,7 @@ const Layout = ({currentUser, children, classes}: {
               {!currentRoute?.standalone && <Header
                 searchResultsArea={searchResultsAreaRef}
                 standaloneNavigationPresent={standaloneNavigation}
+                sidebarHidden={hideNavigationSidebar}
                 toggleStandaloneNavigation={toggleStandaloneNavigation}
                 stayAtTop={Boolean(currentRoute?.fullscreen || currentRoute?.staticHeader)}
               />}

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -61,6 +61,7 @@ import MuiPuzzleIcon from "@material-ui/icons/Extension";
 import MuiCheckIcon from "@material-ui/icons/Check";
 import MuiEllipsisVerticalIcon from "@material-ui/icons/MoreVert";
 import MuiShareIcon from "@material-ui/icons/Share";
+import MuiMenuIcon from "@material-ui/icons/Menu";
 
 /**
  * ForumIcon can be used with custom SVG elements but you MUST pass through
@@ -78,6 +79,7 @@ import { CardIcon } from "../icons/cardIcon";
 import { ListIcon } from "../icons/listIcon";
 import { AddEmojiIcon } from "../icons/addEmoji";
 import { SoftUpArrowIcon } from "../icons/softUpArrowIcon";
+import { MenuIcon } from "../icons/menuIcon";
 import { CloseMenuIcon } from "../icons/closeMenuIcon";
 
 /**
@@ -135,6 +137,7 @@ export type ForumIconName =
   "Share" |
   "ClipboardDocumentList" |
   "ClipboardDocument" |
+  "Menu" |
   "CloseMenu";
 
 const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
@@ -187,6 +190,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Share: MuiShareIcon,
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
+    Menu: MuiMenuIcon,
     CloseMenu: CloseMenuIcon,
   },
   EAForum: {
@@ -238,6 +242,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Share: ShareIcon,
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
+    Menu: MenuIcon,
     CloseMenu: CloseMenuIcon,
   },
 };

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -78,6 +78,7 @@ import { CardIcon } from "../icons/cardIcon";
 import { ListIcon } from "../icons/listIcon";
 import { AddEmojiIcon } from "../icons/addEmoji";
 import { SoftUpArrowIcon } from "../icons/softUpArrowIcon";
+import { CloseMenuIcon } from "../icons/closeMenuIcon";
 
 /**
  * This exists to allow us to easily use different icon sets on different
@@ -133,7 +134,8 @@ export type ForumIconName =
   "EllipsisVertical" |
   "Share" |
   "ClipboardDocumentList" |
-  "ClipboardDocument";
+  "ClipboardDocument" |
+  "CloseMenu";
 
 const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
   default: {
@@ -185,6 +187,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Share: MuiShareIcon,
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
+    CloseMenu: CloseMenuIcon,
   },
   EAForum: {
     VolumeUp: SpeakerWaveIcon,
@@ -235,6 +238,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Share: ShareIcon,
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
+    CloseMenu: CloseMenuIcon,
   },
 };
 

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -6,7 +6,6 @@ import NoSSR from 'react-no-ssr';
 import Headroom from '../../lib/react-headroom'
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
 import TocIcon from '@material-ui/icons/Toc';
 import { useCurrentUser } from '../common/withUser';
 import { SidebarsContext } from './SidebarsWrapper';
@@ -208,7 +207,7 @@ const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNav
                 aria-label="Menu"
                 onClick={()=>setNavigationOpen(true)}
               >
-                <MenuIcon />
+                <ForumIcon icon="Menu" />
               </IconButton>
             </div>
             <div className={classes.hideMdUp}>
@@ -234,7 +233,7 @@ const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNav
             aria-label="Menu"
             onClick={()=>setNavigationOpen(true)}
           >
-            <MenuIcon/>
+            <ForumIcon icon="Menu" />
           </IconButton>
       }
       {standaloneNavigationPresent && unFixed && <IconButton
@@ -246,7 +245,7 @@ const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNav
         aria-label="Menu"
         onClick={toggleStandaloneNavigation}
       >
-        {(isEAForum && !sidebarHidden) ? <ForumIcon icon="CloseMenu" /> : <MenuIcon/>}
+        {(isEAForum && !sidebarHidden) ? <ForumIcon icon="CloseMenu" /> : <ForumIcon icon="Menu" />}
       </IconButton>}
     </React.Fragment>
   }

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -135,8 +135,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAtTop=false, searchResultsArea, classes}: {
+const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNavigation, stayAtTop=false, searchResultsArea, classes}: {
   standaloneNavigationPresent: boolean,
+  sidebarHidden: boolean,
   toggleStandaloneNavigation: ()=>void,
   stayAtTop?: boolean,
   searchResultsArea: React.RefObject<HTMLDivElement>,
@@ -245,7 +246,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
         aria-label="Menu"
         onClick={toggleStandaloneNavigation}
       >
-        <MenuIcon />
+        {(isEAForum && !sidebarHidden) ? <ForumIcon icon="CloseMenu" /> : <MenuIcon/>}
       </IconButton>}
     </React.Fragment>
   }
@@ -254,7 +255,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
 
   const {
     SearchBar, UsersMenu, UsersAccountMenu, NotificationsMenuButton, NavigationDrawer,
-    NotificationsMenu, KarmaChangeNotifier, HeaderSubtitle, Typography
+    NotificationsMenu, KarmaChangeNotifier, HeaderSubtitle, Typography, ForumIcon
   } = Components;
 
   return (

--- a/packages/lesswrong/components/icons/closeMenuIcon.tsx
+++ b/packages/lesswrong/components/icons/closeMenuIcon.tsx
@@ -5,10 +5,10 @@ export const CloseMenuIcon = (props: React.HTMLAttributes<SVGElement>) => {
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g id="heroicons-mini/bars-3">
       <g id="Rectangle 4920 (Stroke)">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4.75C2 4.33579 2.33579 4 2.75 4H17.25C17.6642 4 18 4.33579 18 4.75C18 5.16421 17.6642 5.5 17.25 5.5H2.75C2.33579 5.5 2 5.16421 2 4.75ZM7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10ZM2 15.25C2 14.8358 2.33579 14.5 2.75 14.5H17.25C17.6642 14.5 18 14.8358 18 15.25C18 15.6642 17.6642 16 17.25 16H2.75C2.33579 16 2 15.6642 2 15.25Z" fill="currentColor"/>
+        <path fillRule="evenodd" clipRule="evenodd" d="M2 4.75C2 4.33579 2.33579 4 2.75 4H17.25C17.6642 4 18 4.33579 18 4.75C18 5.16421 17.6642 5.5 17.25 5.5H2.75C2.33579 5.5 2 5.16421 2 4.75ZM7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10ZM2 15.25C2 14.8358 2.33579 14.5 2.75 14.5H17.25C17.6642 14.5 18 14.8358 18 15.25C18 15.6642 17.6642 16 17.25 16H2.75C2.33579 16 2 15.6642 2 15.25Z" fill="currentColor"/>
         <path d="M7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10Z" fill="currentColor"/>
       </g>
-        <path id="Vector" d="M5 8L3 10L5 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <path id="Vector" d="M5 8L3 10L5 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
       </g>
     </svg>
   );

--- a/packages/lesswrong/components/icons/closeMenuIcon.tsx
+++ b/packages/lesswrong/components/icons/closeMenuIcon.tsx
@@ -3,13 +3,8 @@ import React from "react";
 export const CloseMenuIcon = (props: React.HTMLAttributes<SVGElement>) => {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <g id="heroicons-mini/bars-3">
-      <g id="Rectangle 4920 (Stroke)">
-        <path fillRule="evenodd" clipRule="evenodd" d="M2 4.75C2 4.33579 2.33579 4 2.75 4H17.25C17.6642 4 18 4.33579 18 4.75C18 5.16421 17.6642 5.5 17.25 5.5H2.75C2.33579 5.5 2 5.16421 2 4.75ZM7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10ZM2 15.25C2 14.8358 2.33579 14.5 2.75 14.5H17.25C17.6642 14.5 18 14.8358 18 15.25C18 15.6642 17.6642 16 17.25 16H2.75C2.33579 16 2 15.6642 2 15.25Z" fill="currentColor"/>
-        <path d="M7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10Z" fill="currentColor"/>
-      </g>
-        <path id="Vector" d="M5 8L3 10L5 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-      </g>
+      <path d="M2 5H18M8 10.25H18M2 15.5H18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M5 8.29999L3 10.3L5 12.3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   );
 }

--- a/packages/lesswrong/components/icons/closeMenuIcon.tsx
+++ b/packages/lesswrong/components/icons/closeMenuIcon.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export const CloseMenuIcon = (props: React.HTMLAttributes<SVGElement>) => {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <g id="heroicons-mini/bars-3">
+      <g id="Rectangle 4920 (Stroke)">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4.75C2 4.33579 2.33579 4 2.75 4H17.25C17.6642 4 18 4.33579 18 4.75C18 5.16421 17.6642 5.5 17.25 5.5H2.75C2.33579 5.5 2 5.16421 2 4.75ZM7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10ZM2 15.25C2 14.8358 2.33579 14.5 2.75 14.5H17.25C17.6642 14.5 18 14.8358 18 15.25C18 15.6642 17.6642 16 17.25 16H2.75C2.33579 16 2 15.6642 2 15.25Z" fill="currentColor"/>
+        <path d="M7 10C7 9.58579 7.33579 9.25 7.75 9.25H17.25C17.6642 9.25 18 9.58579 18 10C18 10.4142 17.6642 10.75 17.25 10.75H7.75C7.33579 10.75 7 10.4142 7 10Z" fill="currentColor"/>
+      </g>
+        <path id="Vector" d="M5 8L3 10L5 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </g>
+    </svg>
+  );
+}

--- a/packages/lesswrong/components/icons/menuIcon.tsx
+++ b/packages/lesswrong/components/icons/menuIcon.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const MenuIcon = (props: React.HTMLAttributes<SVGElement>) => {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M2 5H18M2 10.25H18M2 15.5H18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
This PR adds a new icon that displays in the left side of the site header when the left menu is open. This is to help communicate to users that clicking it will close the menu rather than open another menu.

<img width="277" alt="Screen Shot 2023-06-27 at 11 20 51 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/cb02eeca-2178-456c-ab5c-5209c6a83e7d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204922029100571) by [Unito](https://www.unito.io)
