### PR TITLE
Quick takes styling tweaks

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
@@ -78,6 +78,8 @@ const styles = (theme: ThemeType) => ({
     },
   },
   body: {
+    fontSize: "1.1rem",
+    lineHeight: "1.5em",
     overflow: "hidden",
     textOverflow: "ellipsis",
     display: "-webkit-box",

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -2,7 +2,15 @@ import React, { useCallback, useState } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useTracking } from "../../lib/analyticsEvents";
 
-const QuickTakesListItem = ({quickTake}: {
+const styles = (_theme: ThemeType) => ({
+  expandedRoot: {
+    "& .comments-node-root": {
+      marginBottom: 8,
+    },
+  },
+});
+
+const QuickTakesListItem = ({quickTake, classes}: {
   quickTake: ShortformComments,
   classes: ClassesType,
 }) => {
@@ -16,15 +24,17 @@ const QuickTakesListItem = ({quickTake}: {
   const {CommentsNode, QuickTakesCollapsedListItem} = Components;
   return expanded
     ? (
-      <CommentsNode
-        treeOptions={{
-          post: quickTake.post ?? undefined,
-          showCollapseButtons: true,
-          onToggleCollapsed: () => wrappedSetExpanded(!expanded),
-        }}
-        comment={quickTake}
-        loadChildrenSeparately
-      />
+      <div className={classes.expandedRoot}>
+        <CommentsNode
+          treeOptions={{
+            post: quickTake.post ?? undefined,
+            showCollapseButtons: true,
+            onToggleCollapsed: () => wrappedSetExpanded(!expanded),
+          }}
+          comment={quickTake}
+          loadChildrenSeparately
+        />
+      </div>
     )
     : (
       <QuickTakesCollapsedListItem
@@ -37,6 +47,7 @@ const QuickTakesListItem = ({quickTake}: {
 const QuickTakesListItemComponent = registerComponent(
   "QuickTakesListItem",
   QuickTakesListItem,
+  {styles},
 );
 
 declare global {

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -2,15 +2,7 @@ import React, { useCallback, useState } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useTracking } from "../../lib/analyticsEvents";
 
-const styles = (_theme: ThemeType) => ({
-  expandedRoot: {
-    "& .comments-node-root": {
-      marginBottom: 0,
-    },
-  },
-});
-
-const QuickTakesListItem = ({quickTake, classes}: {
+const QuickTakesListItem = ({quickTake}: {
   quickTake: ShortformComments,
   classes: ClassesType,
 }) => {
@@ -24,17 +16,15 @@ const QuickTakesListItem = ({quickTake, classes}: {
   const {CommentsNode, QuickTakesCollapsedListItem} = Components;
   return expanded
     ? (
-      <div className={classes.expandedRoot}>
-        <CommentsNode
-          treeOptions={{
-            post: quickTake.post ?? undefined,
-            showCollapseButtons: true,
-            onToggleCollapsed: () => wrappedSetExpanded(!expanded),
-          }}
-          comment={quickTake}
-          loadChildrenSeparately
-        />
-      </div>
+      <CommentsNode
+        treeOptions={{
+          post: quickTake.post ?? undefined,
+          showCollapseButtons: true,
+          onToggleCollapsed: () => wrappedSetExpanded(!expanded),
+        }}
+        comment={quickTake}
+        loadChildrenSeparately
+      />
     )
     : (
       <QuickTakesCollapsedListItem
@@ -47,7 +37,6 @@ const QuickTakesListItem = ({quickTake, classes}: {
 const QuickTakesListItemComponent = registerComponent(
   "QuickTakesListItem",
   QuickTakesListItem,
-  {styles},
 );
 
 declare global {


### PR DESCRIPTION
This PR changes the typography in collapsed quick takes to match expanded quick takes, and adds a bottom margin underneath expanded quick takes.

<img width="869" alt="Screenshot 2023-06-28 at 15 54 16" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/00070f98-f1c8-4a84-a979-dc5368142248">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204925953274488) by [Unito](https://www.unito.io)
