### PR TITLE
Sunshine user contents show postedAt

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -23,8 +23,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[900],
   },
   scoreTitleFormat: {
-    width: 20,
-    display: "inline-block"
+    width: 30,
+    marginRight: 8,
+    display: "inline-block",
+    textAlign: "center"
   },
   titleDisplay: {
     display: "block"
@@ -43,7 +45,7 @@ const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }:
   reviewedAt: Date
 }) => {
   const { hover, anchorEl, eventHandlers } = useHover();
-  const { LWPopper, CommentsNode } = Components
+  const { LWPopper, CommentsNode, FormatDate } = Components
 
   if (!comment) return null 
 
@@ -51,7 +53,12 @@ const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }:
     <Link className={classNames({[classes.highlight]: comment.postedAt > reviewedAt, [classes.deleted]: comment.deleted, [classes.default]: !comment.deleted})}
       to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}
     >
-      <span className={displayTitle ? classes.scoreTitleFormat : null}>{comment.baseScore} </span>
+      {displayTitle && <span className={classes.scoreTitleFormat}>
+        <FormatDate date={comment.postedAt} />
+      </span>}
+      <span className={displayTitle ? classes.scoreTitleFormat : null}>
+        {comment.baseScore} 
+      </span>
       {displayTitle && comment.post?.title }
     </Link>
     <LWPopper

--- a/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
@@ -23,8 +23,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "block"
   },
   scoreTitleFormat: {
-    width: 20,
-    display: "inline-block"
+    width: 30,
+    marginRight: 8,
+    display: "inline-block",
+    textAlign: "center"
   },
   highlight: {
     color: theme.palette.primary.main,
@@ -40,11 +42,14 @@ const PostKarmaWithPreview = ({ post, classes, displayTitle, reviewedAt }: {
   reviewedAt: Date
 }) => {
   const { hover, anchorEl, eventHandlers } = useHover();
-  const { LWPopper, PostsPreviewTooltip, MetaInfo } = Components
+  const { LWPopper, PostsPreviewTooltip, FormatDate } = Components
 
   return <span className={classNames(classes.root, {[classes.titleDisplay]: displayTitle})} {...eventHandlers}>
     <Link className={classNames({[classes.highlight]: post.postedAt > reviewedAt, [classes.draft]: post.draft, [classes.default]: !post.draft})}
       to={postGetPageUrl(post)}>
+      {displayTitle && <span className={classes.scoreTitleFormat}>
+        <FormatDate date={post.postedAt} />
+      </span>}
       <span className={displayTitle ? classes.scoreTitleFormat : null}>
         {post.baseScore} 
       </span>


### PR DESCRIPTION
Adds postedAt dates to the posts/comments in the Moderation Dashboard, when you view the user's recent posts/comments as a list showing the titles (instead of the default view which just shows karma)

<img width="452" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/8e051fca-885f-42cf-b54d-6a2074dd77d6">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204931598496473) by [Unito](https://www.unito.io)
