### PR TITLE
Add better logs to page cache to investigate bug

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -153,7 +153,7 @@ export const cachedPageRender = async (req: Request, abTestGroups: CompleteTestG
 const cacheLookupLocal = (cacheKey: string, abTestGroups: CompleteTestGroupAllocation): RenderResult|null|undefined => {
   if (!(cacheKey in cachedABtestsIndex)) {
     // eslint-disable-next-line no-console
-    console.log("Local cache miss: no cached page with this cacheKey for any A/B test group combination");
+    console.log(`Local cache miss for cacheKey ${cacheKey}: no cached page for any A/B test group combination`);
     return null;
   }
   const abTestCombinations: Array<RelevantTestGroupAllocation> = cachedABtestsIndex[cacheKey];
@@ -163,13 +163,16 @@ const cacheLookupLocal = (cacheKey: string, abTestGroups: CompleteTestGroupAlloc
         cacheKey: cacheKey,
         abTestGroups: abTestCombinations[i]
       }));
-      if (lookupResult)
+      if (lookupResult) {
+        // eslint-disable-next-line no-console
+        console.log(`Local cache hit for cacheKey ${cacheKey}`);
         return lookupResult;
+      }
     }
   }
 
   // eslint-disable-next-line no-console
-  console.log(`Local cache miss: page is cached, but with the wrong A/B test groups: wanted ${JSON.stringify(abTestGroups)}, had available ${JSON.stringify(cachedABtestsIndex[cacheKey])}`);
+  console.log(`Local cache miss for cacheKey ${cacheKey}: wrong A/B test groups: wanted ${JSON.stringify(abTestGroups)}, had available ${JSON.stringify(cachedABtestsIndex[cacheKey])}`);
   return null;
 }
 
@@ -178,9 +181,13 @@ const cacheLookupDB = async (cacheKey: string, abTestGroups: CompleteTestGroupAl
 
   if (!cacheResult?.renderResult) {
     // eslint-disable-next-line no-console
-    console.log(`DB cache miss: no cached page with this cacheKey and a valid A/B test group combination`);
+    console.log(`DB cache miss for cacheKey ${cacheKey}: no cached page with this cacheKey and a valid A/B test group combination`);
+    return null;
   }
-  return cacheResult?.renderResult ?? null;
+
+  // eslint-disable-next-line no-console
+  console.log(`DB cache hit for cacheKey ${cacheKey}`);
+  return cacheResult?.renderResult;
 }
 
 const cacheLookup = async (cacheKey: string, abTestGroups: CompleteTestGroupAllocation): Promise<RenderResult|null|undefined> => {


### PR DESCRIPTION
I have a suspicion the db-level caching is broken again, but there isn't enough info in the logs to confirm this easily (especially: we only log misses but not hits)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204935831939330) by [Unito](https://www.unito.io)
