### PR TITLE
[EA] Small fixes for and from JP

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -8,7 +8,6 @@ import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
-import { useCurrentUser } from "../common/withUser";
 
 export const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -15,7 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   highlightContinue: {
     marginTop:theme.spacing.unit*2,
     fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
-    '&& a': {
+    '&& a, && a:hover': {
       color: theme.palette.primary.main,
     },
   },

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -15,6 +15,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   highlightContinue: {
     marginTop:theme.spacing.unit*2,
     fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+    '&& a': {
+      color: theme.palette.primary.main,
+    },
   },
   smallerFonts: {
     fontSize: '1.1rem',

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -8,6 +8,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { idSettingIcons, tagSettingIcons } from "../../lib/collections/posts/constants";
 import { communityPath } from '../../lib/routes';
 import { isEAForum } from '../../lib/instanceSettings';
+import { InteractionWrapper } from '../common/useClickableCell';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -93,6 +94,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     top: -1,
     marginRight: 4,
+  },
+  interactionWrapper: {
+    display: "inline-block",
   },
   strikethroughTitle: {
     textDecoration: "line-through"
@@ -184,7 +188,9 @@ const PostsTitle = ({
       [classes.strikethroughTitle]: strikethroughTitle
     }, className)}>
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
-        <CuratedIcon hasColor />
+        <InteractionWrapper className={classes.interactionWrapper}>
+          <CuratedIcon hasColor />
+        </InteractionWrapper>
       </span>}
       <span className={!wrap ? classes.eaTitleDesktopEllipsis : undefined}>
         {isLink ? <Link to={url}>{title}</Link> : title }


### PR DESCRIPTION
- Visited posts should no longer show a purple "Continue reading" link in recent discussion (image of the bug attached).
- Clicking on the curated star should now take you to the curation page instead of to the post

Old:
<img width="453" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/64d1855a-70a3-4859-b5a2-a4288a872dd3">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204940886855703) by [Unito](https://www.unito.io)
