### PR TITLE
[EA Forum only] updates to the site header, mostly to reduce the size

### DIFF
--- a/cypress/e2e/set_username.cy.js
+++ b/cypress/e2e/set_username.cy.js
@@ -8,12 +8,13 @@ describe('Basic Login and Signup', function() {
 
   it('Prompts users to set their display name after signup.', function() {
     const newDisplayname = 'New User 123123';
-    const newUsername = 'new-user-123123';
     cy.loginAs(this.testUserUnsetUsername);
     cy.visit('/');
     cy.contains('Please choose a username').should('exist');
     cy.get('input[type="text"]').type(newDisplayname);
     cy.get('.NewUserCompleteProfile-submitButtonSection > button').click();
-    cy.contains(`a[href="/users/${newUsername}"]`, newDisplayname).should('exist');
+    // This is not a great test, but it should work -
+    // the notifications icon should only appear after the user has set their username.
+    cy.get(`button.NotificationsMenuButton-buttonClosed`).should('exist');
   });
 })

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -23,6 +23,7 @@ import { LayoutOptions, LayoutOptionsContext } from './hooks/useLayoutOptions';
 // enable during ACX Everywhere
 import { HIDE_MAP_COOKIE } from '../lib/cookies/cookies';
 import { useCookiePreferences } from './hooks/useCookiesWithConsent';
+import { EA_FORUM_HEADER_HEIGHT } from './common/Header';
 
 export const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 0)
 const petrovAfterTime = new DatabasePublicSetting<number>('petrov.afterTime', 0)
@@ -57,7 +58,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     background: theme.palette.background.default,
     // Make sure the background extends to the bottom of the page, I'm sure there is a better way to do this
     // but almost all pages are bigger than this anyway so it's not that important
-    minHeight: `calc(100vh - ${forumTypeSetting.get() === "EAForum" ? 90 : 64}px)`,
+    minHeight: `calc(100vh - ${forumTypeSetting.get() === "EAForum" ? EA_FORUM_HEADER_HEIGHT : 64}px)`,
     gridArea: 'main',
     [theme.breakpoints.down('sm')]: {
       paddingTop: 0,

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -37,6 +37,7 @@ import ShareIcon from "@heroicons/react/24/outline/ArrowUpTrayIcon";
 import ClipboardDocumentListIcon from "@heroicons/react/24/outline/ClipboardDocumentListIcon";
 import ClipboardDocumentIcon from "@heroicons/react/24/outline/ClipboardDocumentIcon";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
+import SearchIcon from "@heroicons/react/24/outline/MagnifyingGlassIcon";
 import MuiVolumeUpIcon from "@material-ui/icons/VolumeUp";
 import MuiBookmarkIcon from "@material-ui/icons/Bookmark";
 import MuiBookmarkBorderIcon from "@material-ui/icons/BookmarkBorder";
@@ -62,6 +63,7 @@ import MuiPuzzleIcon from "@material-ui/icons/Extension";
 import MuiCheckIcon from "@material-ui/icons/Check";
 import MuiEllipsisVerticalIcon from "@material-ui/icons/MoreVert";
 import MuiShareIcon from "@material-ui/icons/Share";
+import MuiSearchIcon from '@material-ui/icons/Search';
 
 /**
  * ForumIcon can be used with custom SVG elements but you MUST pass through
@@ -135,7 +137,8 @@ export type ForumIconName =
   "Share" |
   "ClipboardDocumentList" |
   "ClipboardDocument" |
-  "QuestionMarkCircle";
+  "QuestionMarkCircle" |
+  "Search";
 
 const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
   default: {
@@ -188,6 +191,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
     QuestionMarkCircle: QuestionMarkCircleIcon,
+    Search: MuiSearchIcon,
   },
   EAForum: {
     VolumeUp: SpeakerWaveIcon,
@@ -239,6 +243,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     ClipboardDocumentList: ClipboardDocumentListIcon,
     ClipboardDocument: ClipboardDocumentIcon,
     QuestionMarkCircle: QuestionMarkCircleIcon,
+    Search: SearchIcon,
   },
 };
 

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -18,6 +18,7 @@ import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
 
 export const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 export const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
+export const EA_FORUM_HEADER_HEIGHT = 66
 
 const styles = (theme: ThemeType): JssStyles => ({
   appBar: {
@@ -35,9 +36,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     // This height (including the breakpoint at xs/600px) is set by Headroom, and this wrapper (which surrounds
     // Headroom and top-pads the page) has to match.
-    height: 64,
+    height: isEAForum ? EA_FORUM_HEADER_HEIGHT : 64,
     [theme.breakpoints.down('xs')]: {
-      height: 56,
+      height: isEAForum ? EA_FORUM_HEADER_HEIGHT : 56,
     },
     "@media print": {
       display: "none"
@@ -69,7 +70,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: -theme.spacing.unit,
     marginRight: theme.spacing.unit,
   },
-  siteLogo: {
+  siteLogo: isEAForum ? {
+    marginLeft:  -7,
+    marginRight: 6,
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: -12,
+      marginRight: 3
+    },
+  } : {
     marginLeft: -theme.spacing.unit * 1.5,
   },
   hideLgUp: {
@@ -95,6 +103,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   rightHeaderItems: {
     marginRight: -theme.spacing.unit,
     display: "flex",
+    alignItems: isEAForum ? 'center' : undefined
   },
   // Prevent rearranging of mobile header when search loads after SSR
   searchSSRStandin: {
@@ -256,6 +265,12 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
     SearchBar, UsersMenu, UsersAccountMenu, NotificationsMenuButton, NavigationDrawer,
     NotificationsMenu, KarmaChangeNotifier, HeaderSubtitle, Typography
   } = Components;
+  
+  const usersMenuNode = <div className={searchOpen ? classes.hideMdDown : undefined}>
+    <AnalyticsContext pageSectionContext="usersMenu">
+      <UsersMenu />
+    </AnalyticsContext>
+  </div>
 
   return (
     <AnalyticsContext pageSectionContext="header">
@@ -296,11 +311,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
                 <NoSSR onSSR={<div className={classes.searchSSRStandin} />} >
                   <SearchBar onSetIsActive={setSearchOpen} searchResultsArea={searchResultsArea} />
                 </NoSSR>
-                {currentUser && <div className={searchOpen ? classes.hideMdDown : undefined}>
-                    <AnalyticsContext pageSectionContext="usersMenu">
-                      <UsersMenu />
-                    </AnalyticsContext>
-                  </div>}
+                {!isEAForum && currentUser && usersMenuNode}
                 {!currentUser && <UsersAccountMenu />}
                 {currentUser && <KarmaChangeNotifier currentUser={currentUser} />}
                 {currentUser && <NotificationsMenuButton
@@ -308,6 +319,7 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
                   toggle={handleNotificationToggle}
                   open={notificationOpen}
                 />}
+                {isEAForum && currentUser && usersMenuNode}
               </div>
             </Toolbar>
           </header>

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -31,6 +31,15 @@ const styles = (theme: ThemeType): JssStyles => ({
     boxSizing: "border-box",
     flexShrink: 0,
     flexDirection: "column",
+    ...(isEAForum ? {
+      padding: '1px 20px',
+      [theme.breakpoints.down('sm')]: {
+        padding: '1px 11px',
+      },
+      [theme.breakpoints.down('xs')]: {
+        padding: '9px 11px',
+      },
+    } : {})
   },
   root: {
     // This height (including the breakpoint at xs/600px) is set by Headroom, and this wrapper (which surrounds

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -103,7 +103,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   rightHeaderItems: {
     marginRight: -theme.spacing.unit,
     display: "flex",
-    alignItems: isEAForum ? 'center' : undefined
+    alignItems: isEAForum ? 'center' : undefined,
   },
   // Prevent rearranging of mobile header when search loads after SSR
   searchSSRStandin: {

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -95,6 +95,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       display: "none",
     },
   },
+  hideXsDown: {
+    [theme.breakpoints.down('xs')]: {
+      display: "none",
+    },
+  },
   hideMdUp: {
     [theme.breakpoints.up('md')]: {
       display: "none",
@@ -266,7 +271,8 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
     NotificationsMenu, KarmaChangeNotifier, HeaderSubtitle, Typography
   } = Components;
   
-  const usersMenuNode = <div className={searchOpen ? classes.hideMdDown : undefined}>
+  const usersMenuClass = isEAForum ? classes.hideXsDown : classes.hideMdDown
+  const usersMenuNode = currentUser && <div className={searchOpen ? usersMenuClass : undefined}>
     <AnalyticsContext pageSectionContext="usersMenu">
       <UsersMenu />
     </AnalyticsContext>
@@ -311,15 +317,19 @@ const Header = ({standaloneNavigationPresent, toggleStandaloneNavigation, stayAt
                 <NoSSR onSSR={<div className={classes.searchSSRStandin} />} >
                   <SearchBar onSetIsActive={setSearchOpen} searchResultsArea={searchResultsArea} />
                 </NoSSR>
-                {!isEAForum && currentUser && usersMenuNode}
+                {!isEAForum && usersMenuNode}
                 {!currentUser && <UsersAccountMenu />}
-                {currentUser && <KarmaChangeNotifier currentUser={currentUser} />}
+                {currentUser && <KarmaChangeNotifier
+                  currentUser={currentUser}
+                  className={(isEAForum && searchOpen) ? classes.hideXsDown : undefined}
+                />}
                 {currentUser && <NotificationsMenuButton
                   unreadNotifications={unreadNotifications}
                   toggle={handleNotificationToggle}
                   open={notificationOpen}
+                  className={(isEAForum && searchOpen) ? classes.hideXsDown : undefined}
                 />}
-                {isEAForum && currentUser && usersMenuNode}
+                {isEAForum && usersMenuNode}
               </div>
             </Toolbar>
           </header>

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { Link } from '../../lib/reactRouterWrapper';
+import { isEAForum } from '../../lib/instanceSettings';
 
 export const styles = (theme: ThemeType): JssStyles => ({
   subtitle: {
     marginLeft: '1em',
     paddingLeft: '1em',
-    textTransform: 'uppercase',
+    textTransform: isEAForum ? undefined : 'uppercase',
     color: theme.palette.header.text,
     borderLeft: theme.palette.border.appBarSubtitleDivider,
   },

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -78,6 +78,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: 'fixed',
     color: isEAForum ? theme.palette.grey[600] : undefined,
     margin: '12px',
+    '&:hover': {
+      color: isEAForum ? theme.palette.grey[800] : undefined,
+      cursor: 'pointer'
+    }
   },
   closeSearchIcon: {
     fontSize: 14,

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -3,13 +3,12 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useOnNavigate } from '../hooks/useOnNavigate';
 import { InstantSearch, SearchBox, connectMenu } from 'react-instantsearch-dom';
 import classNames from 'classnames';
-import SearchIcon from '@material-ui/icons/Search';
 import CloseIcon from '@material-ui/icons/Close';
 import Portal from '@material-ui/core/Portal';
 import { useNavigation } from '../../lib/routeUtil';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
 
@@ -77,6 +76,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   searchIcon: {
     position: 'fixed',
+    color: isEAForum ? theme.palette.grey[600] : undefined,
     margin: '12px',
   },
   closeSearchIcon: {
@@ -96,7 +96,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     "& .ais-SearchBox-input::placeholder": {
       color: theme.palette.text.invertedBackgroundText3,
     },
-  },  
+  },
 })
 
 const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
@@ -160,9 +160,9 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
   }, [currentQuery, captureSearch])
 
   const alignmentForum = forumTypeSetting.get() === 'AlignmentForum';
-  const { SearchBarResults } = Components
+  const { SearchBarResults, ForumIcon } = Components
 
-  if(!isAlgoliaEnabled()) {
+  if (!isAlgoliaEnabled()) {
     return <div>Search is disabled (Algolia App ID not configured on server)</div>
   }
 
@@ -180,7 +180,7 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
         )}>
           {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
           <div onClick={handleSearchTap}>
-            <SearchIcon className={classes.searchIcon}/>
+            <ForumIcon icon="Search" className={classes.searchIcon}/>
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
               * null is the only option that actually suppresses the extra X button.
              // @ts-ignore */}

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -464,7 +464,7 @@ const Community = ({classes}: {
             <div className={classes.keywordSearch}>
               <OutlinedInput
                 labelWidth={0}
-                startAdornment={<Search className={classes.searchIcon}/>}
+                startAdornment={<ForumIcon icon="Search" className={classes.searchIcon}/>}
                 placeholder="Search groups"
                 onChange={handleKeywordSearch}
                 className={classes.keywordSearchInput}

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -17,7 +17,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import Button from '@material-ui/core/Button';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
-import Search from '@material-ui/icons/Search';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Chip from '@material-ui/core/Chip';
@@ -387,7 +386,7 @@ const Community = ({classes}: {
             <div className={classes.keywordSearch}>
               <OutlinedInput
                 labelWidth={0}
-                startAdornment={<Search className={classes.searchIcon}/>}
+                startAdornment={<ForumIcon icon="Search" className={classes.searchIcon}/>}
                 placeholder="Search groups"
                 onChange={handleKeywordSearch}
                 className={classes.keywordSearchInput}

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -5,7 +5,6 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { getSearchClient } from '../../../lib/search/algoliaUtil';
 import { Configure, connectSearchBox, connectStateResults, Hits, InstantSearch, Pagination } from 'react-instantsearch-dom';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
-import Search from '@material-ui/icons/Search';
 import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';
 import { useTracking } from '../../../lib/analyticsEvents';
@@ -190,13 +189,13 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
   const { captureEvent } = useTracking()
   const keywordSearchTimer = useRef<any>(null)
 
-  const { NewConversationButton, SearchResultsMap, ContentStyles } = Components
+  const { NewConversationButton, SearchResultsMap, ContentStyles, ForumIcon } = Components
   
   const SearchBox: React.FunctionComponent<SearchBoxProvided> = ({currentRefinement, refine}) => {
     return <div className={classes.keywordSearch}>
       <OutlinedInput
         labelWidth={0}
-        startAdornment={<Search className={classes.searchIcon}/>}
+        startAdornment={<ForumIcon icon="Search" className={classes.searchIcon}/>}
         placeholder="Search people"
         value={currentRefinement}
         onChange={e => {

--- a/packages/lesswrong/components/ea-forum/SiteLogo.tsx
+++ b/packages/lesswrong/components/ea-forum/SiteLogo.tsx
@@ -6,11 +6,14 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { getLogoUrl } from '../../lib/vulcan-lib/utils';
-import { forumTitleSetting } from '../../lib/instanceSettings';
+import { forumTitleSetting, isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    height: 48
+    height: isEAForum ? 34 : 48,
+    [theme.breakpoints.down('sm')]: {
+      height: isEAForum ? 30 : 48,
+    },
   }
 })
 

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -3,6 +3,7 @@ import Badge from '@material-ui/core/Badge';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import IconButton from '@material-ui/core/IconButton';
 import { isEAForum } from '../../lib/instanceSettings';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   badgeContainer: {
@@ -36,10 +37,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const NotificationsMenuButton = ({ unreadNotifications, open, toggle, classes }: {
+const NotificationsMenuButton = ({ unreadNotifications, open, toggle, className, classes }: {
   unreadNotifications: number,
   open: boolean,
   toggle: ()=>void,
+  className?: string,
   classes: ClassesType,
 }) => {
   const { ForumIcon } = Components
@@ -47,7 +49,7 @@ const NotificationsMenuButton = ({ unreadNotifications, open, toggle, classes }:
 
   return (
     <Badge
-      classes={{ root: classes.badgeContainer, badge: classes.badge }}
+      classes={{ root: classNames(classes.badgeContainer, className), badge: classes.badge }}
       badgeContent={(unreadNotifications>0) ? `${unreadNotifications}` : ""}
     >
       <IconButton

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -12,7 +12,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   badge: {
     backgroundColor: 'inherit',
-    color: theme.palette.header.text,
+    color: isEAForum ? theme.palette.grey[600] : theme.palette.header.text,
     fontWeight: 500,
     right: "1px",
     top: "1px",
@@ -28,11 +28,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   buttonOpen: {
     backgroundColor: theme.palette.buttons.notificationsBellOpen.background,
-    color: theme.palette.buttons.notificationsBellOpen.icon,
+    color: isEAForum ? theme.palette.grey[600] : theme.palette.buttons.notificationsBellOpen.icon,
   },
   buttonClosed: {
     backgroundColor: "transparent",
-    color: theme.palette.header.text,
+    color: isEAForum ? theme.palette.grey[600] : theme.palette.header.text,
   },
 });
 

--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { Hits, Configure, Index, CurrentRefinements } from 'react-instantsearch-dom';
+import { Hits, Configure, Index } from 'react-instantsearch-dom';
 import { getAlgoliaIndexName } from '../../lib/search/algoliaUtil';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { Link } from '../../lib/reactRouterWrapper';
+import { EA_FORUM_HEADER_HEIGHT } from '../common/Header';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -13,14 +14,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     width:520,
     position: "fixed",
     right: 0,
-    top: forumTypeSetting.get() === 'EAForum' ? 90 : 64,
+    top: forumTypeSetting.get() === 'EAForum' ? EA_FORUM_HEADER_HEIGHT : 64,
     display: "flex",
     flexWrap: "wrap",
     [theme.breakpoints.down('sm')]: {
       width: "100%"
     },
     [theme.breakpoints.down('xs')]: {
-      top: forumTypeSetting.get() === 'EAForum' ? 78 : 48,
+      top: forumTypeSetting.get() === 'EAForum' ? EA_FORUM_HEADER_HEIGHT : 48,
     },
   },
   searchResults: {

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -14,7 +14,6 @@ import { forumTypeSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, ta
 import { Link } from '../../lib/reactRouterWrapper';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import SearchIcon from '@material-ui/icons/Search';
 import InfoIcon from '@material-ui/icons/Info';
 import Select from '@material-ui/core/Select';
 import moment from 'moment';
@@ -312,7 +311,7 @@ const SearchPageTabbed = ({classes}:{
 
   const {
     ErrorBoundary, ExpandedUsersSearchHit, ExpandedPostsSearchHit, ExpandedCommentsSearchHit,
-    ExpandedTagsSearchHit, ExpandedSequencesSearchHit, Typography, LWTooltip, MenuItem,
+    ExpandedTagsSearchHit, ExpandedSequencesSearchHit, Typography, LWTooltip, MenuItem, ForumIcon
   } = Components;
 
   // we try to keep the URL synced with the search state
@@ -450,7 +449,7 @@ const SearchPageTabbed = ({classes}:{
       <div className={classes.resultsColumn}>
         <div className={classes.searchBoxRow}>
           <div className={classes.searchInputArea}>
-            <SearchIcon className={classes.searchIcon}/>
+            <ForumIcon icon="Search" className={classes.searchIcon}/>
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
               * null is the only option that actually suppresses the extra X button.
             // @ts-ignore */}

--- a/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
@@ -15,6 +15,7 @@ import { TagCommentType } from '../../lib/collections/comments/types';
 import { tagGetHistoryUrl } from '../../lib/collections/tags/helpers';
 import { preferredHeadingCase } from '../../lib/forumTypeUtils';
 import { isEAForum } from '../../lib/instanceSettings';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -200,8 +201,9 @@ const KarmaChangesDisplay = ({karmaChanges, classes, handleClose }: {
   );
 }
 
-const KarmaChangeNotifier = ({currentUser, classes}: {
+const KarmaChangeNotifier = ({currentUser, className, classes}: {
   currentUser: UsersCurrent, //component can only be used if logged in
+  className?: string,
   classes: ClassesType,
 }) => {
   const updateCurrentUser = useUpdateCurrentUser();
@@ -265,7 +267,7 @@ const KarmaChangeNotifier = ({currentUser, classes}: {
     const { LWClickAwayListener, LWPopper, ForumIcon } = Components;
 
     return <AnalyticsContext pageSection="karmaChangeNotifer">
-      <div className={classes.root}>
+      <div className={classNames(classes.root, className)}>
         <div ref={anchorEl}>
           <IconButton onClick={handleToggle} className={classes.karmaNotifierButton}>
             {starIsHollow
@@ -296,7 +298,7 @@ const KarmaChangeNotifier = ({currentUser, classes}: {
 }
 
 const KarmaChangeNotifierComponent = registerComponent('KarmaChangeNotifier', KarmaChangeNotifier, {
-  styles, hocs: [withErrorBoundary]
+  styles, stylePriority: -1, hocs: [withErrorBoundary]
 });
 
 declare global {

--- a/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
@@ -14,6 +14,7 @@ import { useTracking, AnalyticsContext } from '../../lib/analyticsEvents';
 import { TagCommentType } from '../../lib/collections/comments/types';
 import { tagGetHistoryUrl } from '../../lib/collections/tags/helpers';
 import { preferredHeadingCase } from '../../lib/forumTypeUtils';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -28,7 +29,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     zIndex: theme.zIndexes.karmaChangeNotifier,
   },
   starIcon: {
-    color: theme.palette.header.text,
+    color: isEAForum ? theme.palette.grey[600] : theme.palette.header.text,
   },
   title: {
     display: 'block',

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -31,7 +31,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   userButtonRoot: {
     // Mui default is 16px, so we're halving it to bring it into line with the
     // rest of the header components
-    paddingLeft: isEAForum ? undefined : theme.spacing.unit,
+    paddingLeft: isEAForum ? 12 : theme.spacing.unit,
     paddingRight: theme.spacing.unit
   },
   userButtonContents: {

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -113,14 +113,16 @@ const UsersMenu = ({classes}: {
       <ForumIcon icon="ThickChevronDown" className={classes.arrowIcon} />
     </div>
   }
+  
+  const buttonNode = <Button classes={{root: classes.userButtonRoot}}>
+    {userButtonNode}
+  </Button>
 
   return (
     <div className={classes.root} {...eventHandlers}>
-      <Link to={`/users/${currentUser.slug}`}>
-        <Button classes={{root: classes.userButtonRoot}}>
-          {userButtonNode}
-        </Button>
-      </Link>
+      {isEAForum ? buttonNode : <Link to={`/users/${currentUser.slug}`}>
+        {buttonNode}
+      </Link>}
       <LWPopper
         open={hover}
         anchorEl={anchorEl}

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -47,6 +47,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     columnGap: 4
   },
   arrowIcon: {
+    color: theme.palette.grey[600],
     fontSize: 18
   },
   notAMember: {

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -24,14 +24,14 @@ import { preferredHeadingCase } from '../../lib/forumTypeUtils';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    marginTop: 5,
+    marginTop: isEAForum ? undefined : 5,
     wordBreak: 'break-all',
     position: "relative"
   },
   userButtonRoot: {
     // Mui default is 16px, so we're halving it to bring it into line with the
     // rest of the header components
-    paddingLeft: theme.spacing.unit,
+    paddingLeft: isEAForum ? undefined : theme.spacing.unit,
     paddingRight: theme.spacing.unit
   },
   userButtonContents: {
@@ -40,13 +40,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: isEAForum ? undefined : 400,
     color: theme.palette.header.text,
     wordBreak: 'break-word',
-    ...(isEAForum && {
-      lineHeight: '18px',
-      display: '-webkit-box',
-      "-webkit-box-orient": "vertical",
-      "-webkit-line-clamp": 2,
-      overflow: 'hidden'
-    })
+  },
+  userImageButton: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: 4
+  },
+  arrowIcon: {
+    fontSize: 18
   },
   notAMember: {
     marginLeft: 5,
@@ -85,27 +86,38 @@ const UsersMenu = ({classes}: {
 
   const showNewButtons = (forumTypeSetting.get() !== 'AlignmentForum' || userCanDo(currentUser, 'posts.alignment.new')) && !currentUser.deleted
   const isAfMember = currentUser.groups && currentUser.groups.includes('alignmentForum')
-
+  
   const {
-    LWPopper, LWTooltip, ThemePickerMenu, DropdownMenu, DropdownItem, DropdownDivider,
-  } = Components;
+    LWPopper, LWTooltip, ThemePickerMenu, DropdownMenu, DropdownItem, DropdownDivider, UsersProfileImage, ForumIcon
+  } = Components
+  
+  // By default, we show the user's display name as the menu button.
+  let userButtonNode = <span className={classes.userButtonContents}>
+    {userGetDisplayName(currentUser)}
+    {currentUser.deleted && <LWTooltip title={<div className={classes.deactivatedTooltip}>
+      <div>Your account has been deactivated:</div>
+      <ul>
+        <li>Your username appears as '[Anonymous]' on comments/posts</li>
+        <li>Your profile page is not accessible</li>
+      </ul>
+    </div>}>
+      <span className={classes.deactivated}>[Deactivated]</span>
+    </LWTooltip>}
+    {forumTypeSetting.get() === 'AlignmentForum' && !isAfMember && <span className={classes.notAMember}> (Not a Member) </span>}
+  </span>
+  // On the EA Forum, if the user isn't deactivated, we instead show their profile image and a little arrow.
+  if (isEAForum && !currentUser.deleted) {
+    userButtonNode = <div className={classes.userImageButton}>
+      <UsersProfileImage user={currentUser} size={32} />
+      <ForumIcon icon="ThickChevronDown" className={classes.arrowIcon} />
+    </div>
+  }
+
   return (
     <div className={classes.root} {...eventHandlers}>
       <Link to={`/users/${currentUser.slug}`}>
         <Button classes={{root: classes.userButtonRoot}}>
-          <span className={classes.userButtonContents}>
-            {userGetDisplayName(currentUser)}
-            {currentUser.deleted && <LWTooltip title={<div className={classes.deactivatedTooltip}>
-              <div>Your account has been deactivated:</div>
-              <ul>
-                <li>Your username appears as '[Anonymous]' on comments/posts</li>
-                <li>Your profile page is not accessible</li>
-              </ul>
-            </div>}>
-              <span className={classes.deactivated}>[Deactivated]</span>
-            </LWTooltip>}
-            {forumTypeSetting.get() === 'AlignmentForum' && !isAfMember && <span className={classes.notAMember}> (Not a Member) </span>}
-          </span>
+          {userButtonNode}
         </Button>
       </Link>
       <LWPopper
@@ -185,7 +197,7 @@ const UsersMenu = ({classes}: {
             }
             {!isEAForum &&
               <DropdownItem
-                title="My Drafts"
+                title={preferredHeadingCase("My Drafts")}
                 to="/drafts"
                 icon="Edit"
                 iconClassName={classes.icon}
@@ -193,7 +205,7 @@ const UsersMenu = ({classes}: {
             }
             {!currentUser.deleted &&
               <DropdownItem
-                title={("User Profile")}
+                title={preferredHeadingCase("User Profile")}
                 to={`/users/${currentUser.slug}`}
                 icon="User"
                 iconClassName={classes.icon}

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -244,23 +244,14 @@ export const eaForumTheme: SiteThemeSpecification = {
           }
         },
         Header: {
-          root: {
-            height: 90,
-            '@media (max-width: 959.95px) and (min-width: 600px)': {
-              height: 86, // I don't know why headroom shifts by 4 pixels, don't ask me
+          appBar: {
+            padding: '1px 20px',
+            [defaultTheme.breakpoints.down('sm')]: {
+              padding: '1px 11px',
             },
             [defaultTheme.breakpoints.down('xs')]: {
-              height: 77,
+              padding: '9px 11px',
             },
-          },
-          appBar: {
-            padding: 11,
-            '@media (min-width: 960px)': {
-              paddingLeft: 20,
-              paddingRight: 20,
-              paddingTop: 13,
-              paddingBottom: 13,
-            }
           },
         },
         MetaInfo: {

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -243,17 +243,6 @@ export const eaForumTheme: SiteThemeSpecification = {
             padding: ".7rem",
           }
         },
-        Header: {
-          appBar: {
-            padding: '1px 20px',
-            [defaultTheme.breakpoints.down('sm')]: {
-              padding: '1px 11px',
-            },
-            [defaultTheme.breakpoints.down('xs')]: {
-              padding: '9px 11px',
-            },
-          },
-        },
         MetaInfo: {
           root: {
             fontFamily: sansSerifStack


### PR DESCRIPTION
This PR includes most of the changes from this [Figma](https://www.figma.com/file/d09iVzNSpZp9GyWGcfkWmX/Q2.2-2023?node-id=130%3A7096&mode=dev). There are various UI improvements to the site header, many of which reduce its visual size/prominence. [This other small PR](https://github.com/ForumMagnum/ForumMagnum/pull/7499) is also related.

Specific changes:
1. Header height is smaller 🙌 , and is consistent between screen sizes
2. Logo is smaller, particularly on mobile
3. User menu button was moved to the far right, and changed from the user's display name to their profile image (or placeholder if they don't have one)
4. Replaced the magnifying glass icon with the HeroIcons version
5. All icons on the right side are now a lighter grey

Old:
<img width="1439" alt="Screen Shot 2023-06-30 at 1 33 56 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/74b09472-4e45-4ded-9f79-b2f480737a61">

New:
<img width="1439" alt="Screen Shot 2023-06-30 at 1 33 17 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/fe04ab23-0f70-4121-9a3e-40166495e0b3">

-----
This also gives us a bit more horizontal space on mobile.

Old:
<img width="404" alt="Screen Shot 2023-06-30 at 12 36 30 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/c9ad20eb-aeb2-4c51-ad97-8809275a343e">

New:
<img width="404" alt="Screen Shot 2023-06-30 at 12 37 08 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/9cfe0cd9-d5fc-4e34-be93-1fb4964e8d00">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204946504469699) by [Unito](https://www.unito.io)
