### PR TITLE
[EA Forum only] digest tool: hide xpost read times, display publish date, update sort

### DIFF
--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -152,17 +152,6 @@ type TagUsage = {
   count: number
 }
 
-/**
- * Helper for sorting the posts list (doesn't correspond to actual vote strength)
- */
-const voteValues: Record<string, number> = {
-  'bigUpvote': 2,
-  'smallUpvote': 1,
-  'neutral': 0,
-  'smallDownvote': -1,
-  'bigDownvote': -2
-}
-
 
 const EditDigest = ({classes}:{classes: ClassesType}) => {
   const {params} = useLocation()
@@ -229,7 +218,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
         onsiteDigestStatus: postData.digestPost.onsiteDigestStatus ?? 'pending'
       }
     })
-    // sort the list by curated, then suggested for curation, then rating, then the current user's vote, then karma
+    // sort the list by curated, then suggested for curation, then rating, then karma
     newPosts.sort((a,b) => {
       if (a.curatedDate && !b.curatedDate) return -1
       if (!a.curatedDate && b.curatedDate) return 1
@@ -237,10 +226,6 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
       if (!a.suggestForCuratedUserIds && b.suggestForCuratedUserIds) return 1
       // TODO: add this back in once we've implemented the rating
       // if (a.rating !== b.rating) return b.rating - a.rating
-      const aVote = voteValues[a.currentUserVote] ?? 0
-      const bVote = voteValues[b.currentUserVote] ?? 0
-      if (aVote > bVote) return -1
-      if (aVote < bVote) return 1
       return b.baseScore - a.baseScore
     })
     setPosts(newPosts)

--- a/packages/lesswrong/lib/collections/digests/helpers.ts
+++ b/packages/lesswrong/lib/collections/digests/helpers.ts
@@ -4,6 +4,7 @@ import { SettingsOption } from "../posts/dropdownOptions"
 import { TupleSet, UnionOf } from "../../utils/typeGuardUtils"
 import { DIGEST_STATUSES } from "../digestPosts/schema"
 import type { DigestPost } from "../../../components/ea-forum/digest/EditDigest"
+import { isPostWithForeignId } from "../../../components/hooks/useForeignCrosspost"
 
 export const DIGEST_STATUS_OPTIONS = new TupleSet([...DIGEST_STATUSES, 'pending'] as const)
 export type InDigestStatusOption = UnionOf<typeof DIGEST_STATUS_OPTIONS>
@@ -42,10 +43,11 @@ export const getPostAuthors = (post: PostsListBase) => {
  *
  * <post title as link> (<post authors>, <read time> min)
  */
-export const getEmailDigestPostData = (post: PostsListBase) => {
+export const getEmailDigestPostData = (post: PostsListWithVotes) => {
   const url = combineUrls(getSiteUrl(), `/posts/${post._id}/${post.slug}`)
+  const readTimeText = isPostWithForeignId(post) ? '' : `, ${post.readTimeMinutes} min`
   const linkpostText = post.url ? ', link-post' : ''
-  return `<a href="${url}">${post.title}</a> (${getPostAuthors(post)}, ${post.readTimeMinutes} min${linkpostText})`
+  return `<a href="${url}">${post.title}</a> (${getPostAuthors(post)}${readTimeText}${linkpostText})`
 }
 
 /**
@@ -54,7 +56,7 @@ export const getEmailDigestPostData = (post: PostsListBase) => {
  * 1. <post title as link> (<post authors>, <read time> min)
  * 2. ...
  */
-export const getEmailDigestPostListData = (posts: PostsListBase[]) => {
+export const getEmailDigestPostListData = (posts: PostsListWithVotes[]) => {
   const digestData = posts.reduce((prev, next) => {
     return `${prev}<li>${getEmailDigestPostData(next)}</li>`
   }, '')


### PR DESCRIPTION
Some updates to the digest tool based on feedback from Lizka:

1. Hide read times for crossposts (I initially tried to show the right read time, but it's going to take a bit more work so for now I will hide them)
2. Display the publish date for each post, to take into account when looking at the post karma
3. Updated the sort order to remove the "your vote" criteria


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204947641498419) by [Unito](https://www.unito.io)
