### PR TITLE
implementing flagging suspected targeted downvoting for moderation

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -19,6 +19,7 @@ export const FLAGGED_FOR_N_DMS = 'flaggedForNDMs';
 export const AUTO_BLOCKED_FROM_SENDING_DMS = 'autoBlockedFromSendingDMs';
 export const REJECTED_POST = 'rejectedPost';
 export const REJECTED_COMMENT = 'rejectedComment';
+export const POTENTIAL_TARGETED_DOWNVOTING = 'potentialTargetedDownvoting';
 
 export const postRateLimits = [] as const
 
@@ -60,7 +61,8 @@ export const MODERATOR_ACTION_TYPES = {
   [FLAGGED_FOR_N_DMS]: 'Auto-flagged for sending suspiciously many DMs',
   [AUTO_BLOCKED_FROM_SENDING_DMS]: 'Auto-blocked from sending DMs for trying to send suspiciously many DMs',
   [REJECTED_POST]: 'Rejected Post',
-  [REJECTED_COMMENT]: 'Rejected Comment'
+  [REJECTED_COMMENT]: 'Rejected Comment',
+  [POTENTIAL_TARGETED_DOWNVOTING]: 'Suspected targeted downvoting of a specific user'
 };
 
 /** The max # of users an unapproved account is allowed to DM before being flagged */

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -442,7 +442,7 @@ interface ModeratorActionsCollection extends CollectionBase<DbModeratorAction, "
 interface DbModeratorAction extends DbObject {
   __collectionName?: "ModeratorActions"
   userId: string
-  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment"
+  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting"
   endedAt: Date | null
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -858,7 +858,7 @@ interface RevisionsDefaultFragment { // fragment on Revisions
 
 interface ModeratorActionsDefaultFragment { // fragment on ModeratorActions
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting",
   readonly endedAt: Date | null,
 }
 
@@ -2610,7 +2610,6 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly experiencedIn: Array<string> | null,
   readonly interestedIn: Array<string> | null,
   readonly allowDatadogSessionReplay: boolean | null,
-  readonly recentKarmaInfo: any,
 }
 
 interface UsersCurrentCommentRateLimit { // fragment on Users
@@ -3047,7 +3046,7 @@ interface ModeratorActionDisplay { // fragment on ModeratorActions
   readonly _id: string,
   readonly user: UsersMinimumInfo|null,
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting",
   readonly active: boolean,
   readonly createdAt: Date,
   readonly endedAt: Date | null,

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -266,7 +266,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   } else {
     if (!skipRateLimits) {
       const { moderatorActionType } = await checkVotingRateLimits({ document, collection, voteType, user });
-      if (moderatorActionType && !(await wasVotingPatternWarningDeliveredRecently(user))) {
+      if (moderatorActionType && !(await wasVotingPatternWarningDeliveredRecently(user, moderatorActionType))) {
         if (moderatorActionType === RECEIVED_VOTING_PATTERN_WARNING) showVotingPatternWarning = true;
         void createMutator({
           collection: ModeratorActions,
@@ -316,10 +316,10 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   };
 }
 
-async function wasVotingPatternWarningDeliveredRecently(user: DbUser): Promise<boolean> {
+async function wasVotingPatternWarningDeliveredRecently(user: DbUser, moderatorActionType: DbModeratorAction["type"]): Promise<boolean> {
   const mostRecentWarning = await ModeratorActions.findOne({
     userId: user._id,
-    type: RECEIVED_VOTING_PATTERN_WARNING,
+    type: moderatorActionType,
   }, {
     sort: {createdAt: -1}
   });

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -269,7 +269,6 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
       const { moderatorActionType } = await checkVotingRateLimits({ document, collection, voteType, user });
       if (moderatorActionType && !(await wasVotingPatternWarningDeliveredRecently(user, moderatorActionType))) {
         if (moderatorActionType === RECEIVED_VOTING_PATTERN_WARNING) showVotingPatternWarning = true;
-        const endTime = isEAForum ? new Date() : undefined;
         void createMutator({
           collection: ModeratorActions,
           context,
@@ -278,7 +277,6 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
           document: {
             userId: user._id,
             type: moderatorActionType,
-            endedAt: endTime
           }
         });
       }


### PR DESCRIPTION
Co-Authored-By: RickiHeicklen [ricki.heicklen@gmail.com](mailto:ricki.heicklen@gmail.com)
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204947905096322) by [Unito](https://www.unito.io)

Put a user in the moderator queue if they have downvoted 9 of a specific other user's comments/posts within 2 minutes. (The 10th vote is actually the vote that triggers the user to be added to the queue, since the rate limit evaluation is backwards-looking.)

This is intended to catch cases of suspected targeted downvoting, where a user downvotes another user quickly, likely to rate limit that user. 
