### PR TITLE
Make URL in 'New comment' email absolute

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -84,7 +84,7 @@ const EmailCommentsOnPostHeader = ({postId, classes}: {postId: string, classes: 
   if (!post)
     return null;
   
-  return <HeadingLink text={`New comments on ${post.title}`} href={postGetPageUrl(post)} classes={classes}/>
+  return <HeadingLink text={`New comments on ${post.title}`} href={postGetPageUrl(post, true)} classes={classes}/>
 }
 
 const EmailCommentsOnTagHeader = ({tagId, isSubforum, classes}: {tagId: string, isSubforum: boolean, classes: ClassesType}) => {


### PR DESCRIPTION
Reported for smalls. Currently you get a href like `https:///posts/<postId>/<postSlug>`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204954637221070) by [Unito](https://www.unito.io)
