### PR TITLE
EA Forum typography tweaks

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
+++ b/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { isEAForum } from '../../lib/instanceSettings';
 import Select from '@material-ui/core/Select';
 import withErrorBoundary from '../common/withErrorBoundary';
 import PropTypes from 'prop-types';
@@ -11,7 +12,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: 8,
   },
-  label: {},
+  label: {
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+  },
   settings: {
     paddingLeft: 20,
   },

--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -26,6 +26,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: 16,
     textAlign: "center",
     width: "100%",
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
 });
 

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -25,6 +25,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle,
     maxWidth: 600,
+    ...(isEAForum && {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+    }),
   },
   rejectionNotice: {
     ...theme.typography.contentNotice,

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Components, registerComponent} from '../../lib/vulcan-lib';
+import { isEAForum } from '../../lib/instanceSettings';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useHover } from '../common/withHover';
@@ -17,6 +18,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   postLink: {
     float:"right",
     marginRight: theme.spacing.unit,
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
   titleRow: {
     textOverflow: "ellipsis",

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -31,7 +31,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontFamily: theme.typography.uiSecondary.fontFamily,
     marginTop: 0,
     ...(isEAForum
-      ? {textTransform: "uppercase"}
+      ? {textTransform: "capitalize"}
       : theme.typography.smallCaps),
   },
   description: {

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -9,7 +9,6 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import { sectionFooterLeftStyles } from '../users/UsersProfile'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { nofollowKarmaThreshold } from '../../lib/publicSettings';
-import { isEAForum } from '../../lib/instanceSettings';
 
 export const sequencesImageScrim = (theme: ThemeType) => ({
   position: 'absolute',
@@ -30,9 +29,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   title: {
     fontFamily: theme.typography.uiSecondary.fontFamily,
     marginTop: 0,
-    ...(isEAForum
-      ? {textTransform: "capitalize"}
-      : theme.typography.smallCaps),
+    ...theme.typography.smallCaps,
   },
   description: {
     marginTop: theme.spacing.unit * 2,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -15,6 +15,7 @@ import VisibilityOutlinedIcon from '@material-ui/icons/VisibilityOutlined';
 import { Posts } from '../../lib/collections/posts';
 import { useCreate } from '../../lib/crud/withCreate';
 import { MANUAL_FLAG_ALERT } from '../../lib/collections/moderatorActions/schema';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   icon: {
@@ -35,7 +36,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   metaInfoRow: {
     marginBottom: 8,
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
   vote: {
     marginRight: 8

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -7,6 +7,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Select from '@material-ui/core/Select';
 import Checkbox from '@material-ui/core/Checkbox';
 import { withTimezone } from '../common/withTimezone';
+import { isEAForum } from '../../lib/instanceSettings';
 import withErrorBoundary from '../common/withErrorBoundary';
 import moment from '../../lib/moment-timezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
@@ -17,6 +18,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: 8,
     paddingRight: 8,
+  },
+  heading: {
+    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
   },
   radioGroup: {
     marginTop: 4,
@@ -154,7 +158,7 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
     </span>
     
     return <div className={classes.root}>
-      <Typography variant="body1">
+      <Typography variant="body1" className={classes.heading}>
         Vote Notifications
       </Typography>
       <Typography variant="body2">


### PR DESCRIPTION
FYI @agnesstenlund 

- Capitalize titles on the sequence page (instead of all uppercase)
<img width="612" alt="Screenshot 2023-07-03 at 13 18 21" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/65be59a3-55bd-4c79-845a-892062d40691">

- Fix serif on quick takes content warning
<img width="715" alt="Screenshot 2023-07-03 at 13 20 29" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/939b965f-48e7-4610-b4ec-5f41e476db08">

- Fix serif on vote count for unreviewed posts in sunshine sidebar
<img width="526" alt="Screenshot 2023-07-03 at 13 38 47" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/10e73e00-c9c9-45c1-a21c-8b6ba2a19242">

- Fix serif on "Link" button when adding posts to a sequence
<img width="720" alt="Screenshot 2023-07-03 at 13 42 28" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/bbc22844-4195-4cd0-bdf5-47764a0a68bb">

- Fix serif for notification settings
<img width="442" alt="Screenshot 2023-07-03 at 13 44 08" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/5e84ce1a-1292-404e-ad6b-337dc65f8f8f">

- Fix serif for notifications "Load more" button
<img width="259" alt="Screenshot 2023-07-03 at 13 47 14" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/00543ace-061d-42f3-8940-4e647ae58d84">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204955177920355) by [Unito](https://www.unito.io)
