### PR TITLE
Add admin script to remove an RSVP

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -50,6 +50,7 @@ import './server/scripts/dropAndSeedJestPg';
 import './server/scripts/makeMigrations';
 import './server/scripts/reviewGetResultsPost';
 import './server/scripts/sendWrappedNotifications';
+import './server/scripts/removeRsvp';
 
 import './server/scripts/oneOffBanSpammers'
 import './server/scripts/ensureEmailInEmails';

--- a/packages/lesswrong/server/scripts/removeRsvp.ts
+++ b/packages/lesswrong/server/scripts/removeRsvp.ts
@@ -1,0 +1,28 @@
+import { Posts } from "../../lib/collections/posts";
+import { Globals } from "../vulcan-lib";
+
+const removeRsvp = async (eventId: string, userNameOrId: string) => {
+  const event = await Posts.findOne({_id: eventId});
+  if (!event) {
+    throw new Error("Event does not exist");
+  }
+
+  const {rsvps} = event;
+  if (!Array.isArray(rsvps)) {
+    throw new Error("Event has no RSVPs");
+  }
+
+  const newRsvps = rsvps.filter(
+    (rsvp) => rsvp.userId !== userNameOrId && rsvp.name !== userNameOrId,
+  );
+  if (newRsvps.length !== rsvps.length - 1) {
+    throw new Error("Error filtering out user id from rsvp list");
+  }
+
+  await Posts.rawUpdateOne(
+    {_id: eventId},
+    {$set: {rsvps: newRsvps}},
+  );
+}
+
+Globals.removeRsvp = removeRsvp;


### PR DESCRIPTION
We had a smalls request to remove an RSVP from an event, but there's currently not an easy way to do this (or at least, I couldn't find one).

This PR adds a quick and dirty admin script that can be used as `./scripts/serverShellCommand.sh "Globals.removeRsvp('<postId>', 'userNameOrId')"`.

I already ran this on the event in question so no more action is needed there.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204955417496507) by [Unito](https://www.unito.io)
