### PR TITLE
Fix cmd+click in `useClickableCell`

### DIFF
--- a/packages/lesswrong/components/common/useClickableCell.tsx
+++ b/packages/lesswrong/components/common/useClickableCell.tsx
@@ -15,8 +15,12 @@ export const useClickableCell = ({href, onClick}: ClickableCellProps) => {
   // We make the entire "cell" a link. In sub-items need to be separately
   // clickable then wrap them in an `InteractionWrapper`.
   const wrappedOnClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
     if (onClick) {
       onClick(e);
+    } else if (e.metaKey || e.ctrlKey) {
+      window.open(href, "_blank");
     } else {
       history.push(href);
     }


### PR DESCRIPTION
Cmd+click (or ctrl+click) is currently broken for the `EAPostsList`, and other components that use `useClickableCell`. This PR fixes the bug.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204955561433113) by [Unito](https://www.unito.io)
