### PR TITLE
Fix position of audio icon when new feature pulse is shown

### DIFF
--- a/packages/lesswrong/components/common/NewFeaturePulse.tsx
+++ b/packages/lesswrong/components/common/NewFeaturePulse.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
+import classNames from 'classnames';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (_theme: ThemeType): JssStyles => ({
   root: {
     position: 'relative',
   },
@@ -14,7 +15,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const NewFeaturePulse = ({classes, children, dx=0, dy=0, width=50, height=50}: {
+const NewFeaturePulse = ({
+  className,
+  classes,
+  children,
+  dx=0,
+  dy=0,
+  width=50,
+  height=50,
+}: {
+  className?: string,
   classes: ClassesType,
   children: React.ReactNode,
   dx?: number;
@@ -22,7 +32,7 @@ const NewFeaturePulse = ({classes, children, dx=0, dy=0, width=50, height=50}: {
   width?: number;
   height?: number;
 }) => { 
-  return <span className={classes.root}>
+  return <span className={classNames(classes.root, className)}>
     <span className={classes.pulse}>
       <svg style={{ position: 'relative', left: dx, top: dy }} width={width} height={height} viewBox={`-50 -50 100 100`}pointerEvents="none" xmlns="http://www.w3.org/2000/svg">
         <circle id="circle" cx="0" cy="0" fill="none" opacity="0" r="10" stroke="#0c869b" strokeWidth="4">

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -99,6 +99,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     transform: isEAForum ? `translateY(${5-PODCAST_ICON_PADDING}px)` : `translateY(-${PODCAST_ICON_PADDING}px)`,
     padding: PODCAST_ICON_PADDING
   },
+  audioNewFeaturePulse: {
+    top: PODCAST_ICON_PADDING * 1.5,
+  },
   audioIconOn: {
     background: theme.palette.grey[200],
     borderRadius: theme.borderRadius.small
@@ -308,7 +311,13 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
     </a>
   </LWTooltip>
   const audioNode = toggleEmbeddedPlayer && (
-    cachedTooltipSeen ? audioIcon : <NewFeaturePulse dx={-10} dy={4}>{audioIcon}</NewFeaturePulse>
+    cachedTooltipSeen
+      ? audioIcon
+      : (
+        <NewFeaturePulse className={classes.audioNewFeaturePulse}>
+          {audioIcon}
+        </NewFeaturePulse>
+      )
   )
 
   const addToCalendarNode = post.startTime && <div className={classes.secondaryInfoLink}>


### PR DESCRIPTION
The audio icon in the posts page header is current misplaced when the new feature pulse is shown.

Before:
![image](https://github.com/ForumMagnum/ForumMagnum/assets/5075628/236ef19b-5a4e-4745-8db8-231d7c0e7ab4)

After:
<img width="892" alt="Screenshot 2023-07-03 at 18 16 27" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/befeeb84-1c50-401e-867c-a3f9ecd3ef20">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204957574856668) by [Unito](https://www.unito.io)
