### PR TITLE
Add script to generate report on inflation adjusted karma

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -294,7 +294,7 @@ const getFrontpageFilter = (filterSettings: FilterSettings): {filter: any, softF
   }
 }
 
-function buildInflationAdjustedField(): any {
+export function buildInflationAdjustedField(): any {
   const karmaInflationSeries = getKarmaInflationSeries();
   return {
     karmaInflationAdjustedScore: {

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -36,6 +36,7 @@ import './server/scripts/fixKarmaField';
 import './server/scripts/fixEmailField';
 import './server/scripts/fixFrontpageCount';
 import './server/scripts/generateUserActivityReport';
+import './server/scripts/generateInflationAdjustedKarmaReport';
 import './server/scripts/voteMigration';
 import './server/scripts/slugDeduplication';
 import './server/scripts/debuggingScripts';

--- a/packages/lesswrong/server/scripts/generateInflationAdjustedKarmaReport.ts
+++ b/packages/lesswrong/server/scripts/generateInflationAdjustedKarmaReport.ts
@@ -1,0 +1,53 @@
+import { Globals } from "../vulcan-lib";
+import { Posts } from "../../lib/collections/posts";
+import { getKarmaInflationSeries } from "../karmaInflation/cache";
+import { buildInflationAdjustedField } from "../../lib/collections/posts/views";
+import { postGetPageUrl } from "../../lib/collections/posts/helpers";
+import fs from 'fs';
+
+const RELATIVE_TO = '2023-07-01T00:00:00.000Z';
+
+const generateInflationAdjustedKarmaReport = async ({threshold = 100, relativeTo = RELATIVE_TO}: {threshold?: number, relativeTo?: string}) => {
+  const karmaInflationSeries = getKarmaInflationSeries();
+
+  // Get threshold in inflation adjusted karma
+  const relativeToIdx = Math.floor((new Date(relativeTo).getTime() - karmaInflationSeries.start) / karmaInflationSeries.interval);
+  const adjustment = (karmaInflationSeries.values[relativeToIdx] || karmaInflationSeries.values[karmaInflationSeries.values.length - 1])
+  const adjustedThreshold = threshold * adjustment;
+
+  // Get all posts with required fields
+  const pipeline = [
+    {
+      $addFields: buildInflationAdjustedField()
+    },
+    {
+      $project: {
+        _id: 1,
+        slug: 1,
+        baseScore: 1,
+        postedAt: 1,
+        wordCount: "$contents.wordCount",
+      }
+    }
+  ];
+
+  const posts = await Posts.aggregate(pipeline).toArray();
+
+  // filter posts where the adjusted karma is above the threshold
+  const results = posts.filter((post: AnyBecauseHard) => post.karmaInflationAdjustedScore > adjustedThreshold);
+
+  // sort the results by descending adjusted karma
+  results.sort((a: AnyBecauseHard, b: AnyBecauseHard) => b.karmaInflationAdjustedScore - a.karmaInflationAdjustedScore);
+
+  // write the results to a CSV file
+  const csvFileName = 'inflation_adjusted_karma_report.csv';
+  const header = 'post_id,posted_at,slug,url,karma,adjusted_karma,word_count\n';
+  const fileRows = results.map((post: AnyBecauseHard) => `${post._id},${post.postedAt.toISOString()},${post.slug},https://forum.effectivealtruism.org${postGetPageUrl(post)},${post.baseScore},${post.karmaInflationAdjustedScore / adjustment},${post.wordCount}`).join('\n');
+  fs.writeFileSync(csvFileName, header + fileRows);
+
+  // log the name of the CSV file
+  // eslint-disable-next-line no-console
+  console.log(`Inflation adjusted karma report saved to ${csvFileName}`);
+}
+
+Globals.generateInflationAdjustedKarmaReport = generateInflationAdjustedKarmaReport;


### PR DESCRIPTION
Because of the way this is set up it's surprisingly hard to get the numbers on inflation adjusted karma. I'm adding this script in case we need to do so again

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204963535610901) by [Unito](https://www.unito.io)
