### PR TITLE
Hide 'react palette style' option on EA forum

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -648,6 +648,7 @@ const schema: SchemaType<DbUser> = {
     allowedValues: ['listView', 'gridView'],
     ...schemaDefaultValue('listView'),
     defaultValue: "listView",
+    hidden: isEAForum,
     control: "select",
     form: {
       options: function () { // options for the select form control


### PR DESCRIPTION
Probably should have been forum gated