### PR TITLE
Make the scrollability of the reactions palette detectable

### DIFF
--- a/packages/lesswrong/components/votes/ReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/ReactionsPalette.tsx
@@ -67,7 +67,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   reactionPaletteScrollRegion: {
     width: 350,
-    maxHeight: 314,
+    maxHeight: 305,
     overflowY: "scroll",
     marginTop: 12
   },


### PR DESCRIPTION
The current design of the reactions palette hides half of the reactions behind a scrollbar, but the scrollbar is invisible and it's extremely easy to not realize it's there. This fixes that using the standard trick of setting the size such that there's a half-row at the bottom.

Before:
![Screenshot 2023-07-04 at 18 42 25](https://github.com/ForumMagnum/ForumMagnum/assets/101191/2d16fe40-6d63-4958-8b88-d3a86cb77547)

After:
![Screenshot 2023-07-04 at 18 42 01](https://github.com/ForumMagnum/ForumMagnum/assets/101191/6ecd0562-2059-4b93-aa51-acc4da749b43)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204966787974460) by [Unito](https://www.unito.io)
