### PR TITLE
convert react-headroom to typescript to unblock migrations using ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,8 @@
     "@shelf/jest-mongodb": "^2.0.0",
     "@types/csso": "^5.0.0",
     "@types/mark.js": "^8.11.8",
+    "@types/raf": "^3.4.0",
+    "@types/shallowequal": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/lesswrong/lib/react-headroom/index.d.ts
+++ b/packages/lesswrong/lib/react-headroom/index.d.ts
@@ -1,3 +1,0 @@
-
-const Headroom: AnyBecauseTodo
-export default Headroom

--- a/packages/lesswrong/lib/react-headroom/index.tsx
+++ b/packages/lesswrong/lib/react-headroom/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react' // eslint-disable-line import/no-unresolved
+import React, { Component, CSSProperties } from 'react' // eslint-disable-line import/no-unresolved
 import PropTypes from 'prop-types'
 import shallowequal from 'shallowequal'
 import raf from 'raf'
@@ -6,7 +6,25 @@ import shouldUpdate from './shouldUpdate'
 
 const noop = () => {}
 
-export default class Headroom extends Component {
+interface HeadroomProps {
+  className: string,
+  parent: () => HTMLElement | Window,
+  children?: React.ReactNode,
+  disableInlineStyles: boolean,
+  disable: boolean,
+  height: number,
+  upTolerance: number,
+  downTolerance: number,
+  onPin: () => void,
+  onUnpin: () => void,
+  onUnfix: () => void,
+  wrapperStyle: Record<string, any>,
+  pinStart: number,
+  style?: Record<string, any>,
+  calcHeightOnResize: boolean,
+}
+
+export default class Headroom extends Component<HeadroomProps, AnyBecauseTodo> {
   static propTypes = {
     className: PropTypes.string,
     parent: PropTypes.func,
@@ -39,7 +57,13 @@ export default class Headroom extends Component {
     calcHeightOnResize: true,
   };
 
-  static getDerivedStateFromProps (props, state) {
+  currentScrollY: number
+  lastKnownScrollY: number
+  scrollTicking: boolean
+  resizeTicking: boolean
+  inner: any
+
+  static getDerivedStateFromProps (props: { disable: any }, state: { state: string }) {
     if (props.disable && state.state !== 'unfixed') {
       return {
         translateY: 0,
@@ -52,7 +76,7 @@ export default class Headroom extends Component {
     return null
   }
 
-  constructor (props) {
+  constructor (props: AnyBecauseTodo) {
     super(props)
     // Class variables.
     this.currentScrollY = 0
@@ -78,14 +102,14 @@ export default class Headroom extends Component {
     }
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
+  shouldComponentUpdate (nextProps: any, nextState: any) {
     return (
       !shallowequal(this.props, nextProps) ||
       !shallowequal(this.state, nextState)
     )
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate (prevProps: { children?: React.ReactNode; disable: boolean }, prevState: { state: string }) {
     // If children have changed, remeasure height.
     if (prevProps.children !== this.props.children) {
       this.setHeightOffset()
@@ -114,7 +138,7 @@ export default class Headroom extends Component {
     this.props.parent().removeEventListener('resize', this.handleResize)
   }
 
-  setRef = ref => (this.inner = ref)
+  setRef = (ref: any) => (this.inner = ref)
 
   setHeightOffset = () => {
     /*this.setState({
@@ -124,10 +148,11 @@ export default class Headroom extends Component {
   }
 
   getScrollY = () => {
-    if (this.props.parent().pageYOffset !== undefined) {
-      return this.props.parent().pageYOffset
-    } else if (this.props.parent().scrollTop !== undefined) {
-      return this.props.parent().scrollTop
+    const parent = this.props.parent()
+    if ('pageYOffset' in parent && parent.pageYOffset !== undefined) {
+      return parent.pageYOffset
+    } else if ('scrollTop' in parent && parent.scrollTop !== undefined) {
+      return parent.scrollTop
     } else {
       return (document.documentElement || document.body.parentNode || document.body).scrollTop
     }
@@ -150,12 +175,12 @@ export default class Headroom extends Component {
     )
   }
 
-  getElementPhysicalHeight = elm => Math.max(
+  getElementPhysicalHeight = (elm: { offsetHeight: number; clientHeight: number }) => Math.max(
     elm.offsetHeight,
     elm.clientHeight
   )
 
-  getElementHeight = elm => Math.max(
+  getElementHeight = (elm: { scrollHeight: number; offsetHeight: number; clientHeight: number }) => Math.max(
     elm.scrollHeight,
     elm.offsetHeight,
     elm.clientHeight,
@@ -166,7 +191,7 @@ export default class Headroom extends Component {
 
     return (parent === window || parent === document.body)
       ? this.getViewportHeight()
-      : this.getElementPhysicalHeight(parent)
+      : this.getElementPhysicalHeight(parent as HTMLElement)
   }
 
   getScrollerHeight = () => {
@@ -174,10 +199,10 @@ export default class Headroom extends Component {
 
     return (parent === window || parent === document.body)
       ? this.getDocumentHeight()
-      : this.getElementHeight(parent)
+      : this.getElementHeight(parent as HTMLElement)
   }
 
-  isOutOfBound = (currentScrollY) => {
+  isOutOfBound = (currentScrollY: number) => {
     const pastTop = currentScrollY < 0
 
     const scrollerPhysicalHeight = this.getScrollerPhysicalHeight()
@@ -273,7 +298,9 @@ export default class Headroom extends Component {
   }
 
   render () {
-    const { className: userClassName, ...divProps } = this.props
+    // Type cast is necessary to prevent typescript from complaining about trying to delete readonly properties
+    // This is vendored code and presumably has been working more or less fine the whole time
+    const { className: userClassName, ...divProps } = this.props as AnyBecauseTodo
     delete divProps.onUnpin
     delete divProps.onPin
     delete divProps.onUnfix
@@ -289,14 +316,14 @@ export default class Headroom extends Component {
 
     const { style, wrapperStyle, ...rest } = divProps
 
-    let innerStyle = {
+    let innerStyle: CSSProperties = {
       position: this.props.disable || this.state.state === 'unfixed' ? 'relative' : 'fixed',
       top: 0,
       left: 0,
       right: 0,
       zIndex: 1,
       WebkitTransform: `translate3D(0, ${this.state.translateY}, 0)`,
-      MsTransform: `translate3D(0, ${this.state.translateY}, 0)`,
+      msTransform: `translate3D(0, ${this.state.translateY}, 0)`,
       transform: `translate3D(0, ${this.state.translateY}, 0)`,
     }
 

--- a/packages/lesswrong/lib/react-headroom/index.tsx
+++ b/packages/lesswrong/lib/react-headroom/index.tsx
@@ -18,9 +18,9 @@ interface HeadroomProps {
   onPin: () => void,
   onUnpin: () => void,
   onUnfix: () => void,
-  wrapperStyle: Record<string, any>,
+  wrapperStyle: Record<string, AnyBecauseTodo>,
   pinStart: number,
-  style?: Record<string, any>,
+  style?: Record<string, AnyBecauseTodo>,
   calcHeightOnResize: boolean,
 }
 
@@ -61,9 +61,9 @@ export default class Headroom extends Component<HeadroomProps, AnyBecauseTodo> {
   lastKnownScrollY: number
   scrollTicking: boolean
   resizeTicking: boolean
-  inner: any
+  inner: AnyBecauseTodo
 
-  static getDerivedStateFromProps (props: { disable: any }, state: { state: string }) {
+  static getDerivedStateFromProps (props: { disable: AnyBecauseTodo }, state: { state: string }) {
     if (props.disable && state.state !== 'unfixed') {
       return {
         translateY: 0,
@@ -102,7 +102,7 @@ export default class Headroom extends Component<HeadroomProps, AnyBecauseTodo> {
     }
   }
 
-  shouldComponentUpdate (nextProps: any, nextState: any) {
+  shouldComponentUpdate (nextProps: AnyBecauseTodo, nextState: AnyBecauseTodo) {
     return (
       !shallowequal(this.props, nextProps) ||
       !shallowequal(this.state, nextState)
@@ -138,7 +138,7 @@ export default class Headroom extends Component<HeadroomProps, AnyBecauseTodo> {
     this.props.parent().removeEventListener('resize', this.handleResize)
   }
 
-  setRef = (ref: any) => (this.inner = ref)
+  setRef = (ref: AnyBecauseTodo) => (this.inner = ref)
 
   setHeightOffset = () => {
     /*this.setState({

--- a/packages/lesswrong/lib/react-headroom/shouldUpdate.ts
+++ b/packages/lesswrong/lib/react-headroom/shouldUpdate.ts
@@ -1,8 +1,8 @@
 export default function (
   lastKnownScrollY = 0,
   currentScrollY = 0,
-  props = {},
-  state = {}
+  props: AnyBecauseTodo = {},
+  state: AnyBecauseTodo = {}
 ) {
   const scrollDirection = currentScrollY >= lastKnownScrollY ? 'down' : 'up'
   const distanceScrolled = Math.abs(currentScrollY - lastKnownScrollY)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,6 +3709,11 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz"
   integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
 
+"@types/raf@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/raf/-/raf-3.4.0.tgz#2b72cbd55405e071f1c4d29992638e022b20acc2"
+  integrity sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz"
@@ -3946,6 +3951,11 @@
   dependencies:
     "@types/mime" "*"
     "@types/node" "*"
+
+"@types/shallowequal@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/shallowequal/-/shallowequal-1.1.1.tgz#aad262bb3f2b1257d94c71d545268d592575c9b1"
+  integrity sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==
 
 "@types/simpl-schema@^1.10.4":
   version "1.10.4"


### PR DESCRIPTION
tl;dr: adding `import { EA_FORUM_HEADER_HEIGHT } from './common/Header';` to `Layout.tsx` borked migrations because `migrate.js` uses `ts-node` to import the server code, which has some differences in behavior from `esbuild`, and a bunch of transitive dependencies caused that new import to bring in `react-headroom`, which was a vendored JSX (rather than TSX) file.

This PR only converts `react-headroom` to Typescript, with no functional changes (i.e. untangling those imports, which can be done in a follow-up PR).

For more detail, see this slack thread: https://app.slack.com/client/T3ERD8FQT/CJUN2UAFN

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204974955468522) by [Unito](https://www.unito.io)
