### PR TITLE
[EA Forum only] updates for logged out user site header

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -328,11 +328,11 @@ const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNav
                 </NoSSR>
                 {!isEAForum && usersMenuNode}
                 {!currentUser && <UsersAccountMenu />}
-                {currentUser && <KarmaChangeNotifier
+                {currentUser && !currentUser.usernameUnset && <KarmaChangeNotifier
                   currentUser={currentUser}
                   className={(isEAForum && searchOpen) ? classes.hideXsDown : undefined}
                 />}
-                {currentUser && <NotificationsMenuButton
+                {currentUser && !currentUser.usernameUnset && <NotificationsMenuButton
                   unreadNotifications={unreadNotifications}
                   toggle={handleNotificationToggle}
                   open={notificationOpen}

--- a/packages/lesswrong/components/ea-forum/EAButton.tsx
+++ b/packages/lesswrong/components/ea-forum/EAButton.tsx
@@ -8,9 +8,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     backgroundColor: theme.palette.buttons.alwaysPrimary,
     color: theme.palette.text.alwaysWhite,
     fontSize: 14,
-    lineHeight: '23px',
+    lineHeight: '20px',
     textTransform: 'none',
-    padding: '6px 12px',
+    padding: '8px 12px',
     borderRadius: theme.borderRadius.default,
     boxShadow: 'none',
     '&:hover': {

--- a/packages/lesswrong/components/ea-forum/EAButton.tsx
+++ b/packages/lesswrong/components/ea-forum/EAButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib/components';
+import Button, { ButtonProps } from '@material-ui/core/Button';
+import classNames from 'classnames';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    backgroundColor: theme.palette.buttons.alwaysPrimary,
+    color: theme.palette.text.alwaysWhite,
+    fontSize: 14,
+    lineHeight: '23px',
+    textTransform: 'none',
+    padding: '6px 12px',
+    borderRadius: theme.borderRadius.default,
+    boxShadow: 'none',
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+      opacity: 1
+    }
+  },
+  grey: {
+    backgroundColor: theme.palette.grey[250],
+    color: theme.palette.grey[1000],
+    '&:hover': {
+      backgroundColor: theme.palette.grey[300],
+    }
+  }
+})
+
+/**
+ * Button component with the standard EA Forum styling
+ * (see login and sign up site header buttons for example)
+ */
+const EAButton = ({style, className, children, classes, ...buttonProps}: {
+  style?: 'primary'|'grey',
+  className?: string,
+  children: React.ReactNode,
+  classes: ClassesType
+} & ButtonProps) => {
+
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      className={classNames(classes.root, className, {[classes.grey]: style === 'grey'})}
+      {...buttonProps}
+    >
+      {children}
+    </Button>
+  )
+}
+
+const EAButtonComponent = registerComponent(
+  'EAButton', EAButton, {styles, stylePriority: -1}
+)
+
+declare global {
+  interface ComponentTypes {
+    EAButton: typeof EAButtonComponent
+  }
+}

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -9,7 +9,7 @@ import { withLocation } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    marginTop: 5,
+    marginTop: isEAForum ? undefined : 5,
   },
   userButton: {
     fontSize: '14px',
@@ -17,12 +17,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     opacity: .8,
     color: theme.palette.header.text,
   },
-  signUpButton: {
+  login: {
+    marginLeft: 12,
+    marginRight: 8
+  },
+  signUp: {
     display: 'inline-block',
-    [theme.breakpoints.down('xs')]: {
+    marginRight: 8,
+    '@media (max-width: 540px)': {
       display: 'none'
     }
-  }
+  },
 })
 
 interface UsersAccountMenuProps extends WithStylesProps {
@@ -61,6 +66,8 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
 
   render() {
     const { classes, location } = this.props
+    const { EAButton, WrappedLoginForm } = Components
+    
     // Location is always passed in by hoc. We can't make it a required prop due
     // to a limitation in our typings
     const { pathname } = location!
@@ -68,18 +75,12 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
     return (
       <div className={classes.root}>
         {forumTypeSetting.get() === 'EAForum' ? <>
-          <Button href={`/auth/auth0?returnTo=${pathname}`}>
-            <span className={classes.userButton}>
-              Login
-            </span>
-          </Button>
-          <div className={classes.signUpButton}>
-            <Button href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`}>
-              <span className={classes.userButton}>
-                Sign Up
-              </span>
-            </Button>
-          </div>
+          <EAButton style="grey" href={`/auth/auth0?returnTo=${pathname}`} className={classes.login}>
+            Login
+          </EAButton>
+          <EAButton href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`} className={classes.signUp}>
+            Sign up
+          </EAButton>
         </> : <>
           <Button onClick={this.handleClick}>
             <span className={classes.userButton}>
@@ -92,7 +93,7 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
             anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
             onClose={this.handleRequestClose}
           >
-            {this.state.open && <Components.WrappedLoginForm />}
+            {this.state.open && <WrappedLoginForm />}
           </Popover>
         </>}
       </div>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -51,6 +51,7 @@ importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedP
 importComponent("TargetedJobAdSection", () => require('../components/ea-forum/TargetedJobAdSection'))
 importComponent("TargetedJobAd", () => require('../components/ea-forum/TargetedJobAd'))
 importComponent("UrlHintText", () => require('../components/ea-forum/UrlHintText'))
+importComponent("EAButton", () => require('../components/ea-forum/EAButton'))
 importComponent("EAGApplicationImportForm", () => require('../components/ea-forum/users/EAGApplicationImportForm'))
 importComponent("EAUsersProfile", () => require('../components/ea-forum/users/EAUsersProfile'))
 importComponent("EAUsersProfileImage", () => require('../components/ea-forum/users/EAUsersProfileImage'))


### PR DESCRIPTION
This PR just contains the updates to the logged out user view of the site header from [this figma](https://www.figma.com/file/d09iVzNSpZp9GyWGcfkWmX/Q2.2-2023?node-id=130%3A7156&mode=dev). Basically it's just changing the login and sign up links to button styles, and I also used this opportunity to create an `EAButton` component to help standardize our buttons. I haven't replaced any other buttons yet - if @agnesstenlund is good with this PR then we can start replacing existing buttons in future PRs.

Old:
<img width="1439" alt="Screen Shot 2023-07-06 at 12 43 41 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/31075297-cda2-4c4b-99a0-9ca19abbc2b6">

New:
<img width="1439" alt="Screen Shot 2023-07-06 at 12 44 25 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/ac565700-0610-49ca-956f-181eec30f2f1">

-----
Old:
<img width="459" alt="Screen Shot 2023-07-06 at 12 46 05 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/4694d553-d90c-4e86-bdb6-16d241a7d89f">

New:
<img width="459" alt="Screen Shot 2023-07-06 at 12 45 24 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/3a86d501-edf9-4852-aaa5-c0676e7a7ff4">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204981481008522) by [Unito](https://www.unito.io)
