### PR TITLE
style updates to site header search icon

### DIFF
--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -11,6 +11,7 @@ import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../li
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
+import { IconButton } from '@material-ui/core';
 
 const VirtualMenu = connectMenu(() => null);
 
@@ -51,6 +52,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
       height: "100%",
       width: "100%",
+      paddingTop: isEAForum ? 5 : undefined,
       paddingRight: 0,
       paddingLeft: 48,
       verticalAlign: "bottom",
@@ -60,15 +62,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       fontSize: 'inherit',
       "-webkit-appearance": "none",
       cursor: "text",
-      borderRadius:5,
-
-      [theme.breakpoints.down('tiny')]: {
-        backgroundColor: theme.palette.grey[200],
-        zIndex: theme.zIndexes.searchBar,
-        width:110,
-        height:36,
-        paddingLeft:10
-      },
+      borderRadius: 5,
     },
     "&.open .ais-SearchBox-input": {
       display:"inline-block",
@@ -76,12 +70,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   searchIcon: {
     position: 'fixed',
-    color: isEAForum ? theme.palette.grey[600] : undefined,
-    margin: '12px',
-    '&:hover': {
-      color: isEAForum ? theme.palette.grey[800] : undefined,
-      cursor: 'pointer'
-    }
+    color: isEAForum ? undefined : theme.palette.header.text,
   },
   closeSearchIcon: {
     fontSize: 14,
@@ -89,7 +78,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   searchBarClose: {
     display: "inline-block",
     position: "absolute",
-    top: 15,
+    top: isEAForum ? 18 : 15,
     right: 5,
     cursor: "pointer"
   },
@@ -184,7 +173,9 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
         )}>
           {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
           <div onClick={handleSearchTap}>
-            <ForumIcon icon="Search" className={classes.searchIcon}/>
+            <IconButton className={classes.searchIcon}>
+              <ForumIcon icon="Search" />
+            </IconButton>
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
               * null is the only option that actually suppresses the extra X button.
              // @ts-ignore */}

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -5,13 +5,13 @@ import { InstantSearch, SearchBox, connectMenu } from 'react-instantsearch-dom';
 import classNames from 'classnames';
 import CloseIcon from '@material-ui/icons/Close';
 import Portal from '@material-ui/core/Portal';
+import IconButton from '@material-ui/core/IconButton';
 import { useNavigation } from '../../lib/routeUtil';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
-import { IconButton } from '@material-ui/core';
 
 const VirtualMenu = connectMenu(() => null);
 

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -12,6 +12,7 @@ import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../li
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
+import { useCurrentUser } from './withUser';
 
 const VirtualMenu = connectMenu(() => null);
 
@@ -68,10 +69,17 @@ const styles = (theme: ThemeType): JssStyles => ({
       display:"inline-block",
     },
   },
+  searchInputAreaSmall: isEAForum ? {
+    minWidth: 34,
+  } : {},
   searchIcon: {
     position: 'fixed',
     color: isEAForum ? undefined : theme.palette.header.text,
   },
+  searchIconSmall: isEAForum ? {
+    padding: 6,
+    marginTop: 6,
+  } : {},
   closeSearchIcon: {
     fontSize: 14,
   },
@@ -97,6 +105,7 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
   searchResultsArea: any,
   classes: ClassesType
 }) => {
+  const currentUser = useCurrentUser()
   const [inputOpen,setInputOpen] = useState(false);
   const [searchOpen,setSearchOpen] = useState(false);
   const [currentQuery,setCurrentQuery] = useState("");
@@ -169,11 +178,11 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
         <div className={classNames(
           classes.searchInputArea,
           {"open": inputOpen},
-          {[classes.alignmentForum]: alignmentForum}
+          {[classes.alignmentForum]: alignmentForum, [classes.searchInputAreaSmall]: !currentUser}
         )}>
           {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
           <div onClick={handleSearchTap}>
-            <IconButton className={classes.searchIcon}>
+            <IconButton className={classNames(classes.searchIcon, {[classes.searchIconSmall]: !currentUser})}>
               <ForumIcon icon="Search" />
             </IconButton>
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -32,7 +32,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     // Mui default is 16px, so we're halving it to bring it into line with the
     // rest of the header components
     paddingLeft: isEAForum ? 12 : theme.spacing.unit,
-    paddingRight: theme.spacing.unit
+    paddingRight: theme.spacing.unit,
+    borderRadius: isEAForum ? theme.borderRadius.default : undefined
   },
   userButtonContents: {
     textTransform: 'none',

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -110,6 +110,7 @@ export const eaForumTheme: SiteThemeSpecification = {
     },
   }),
   make: (palette: ThemePalette) => {
+    const defaultBorderRadius = 6
     const basicText = {
       color: palette.grey[900],
       // use ems (not rems) to preserve relative height even if font-size is changed
@@ -122,7 +123,7 @@ export const eaForumTheme: SiteThemeSpecification = {
         mainLayoutPaddingTop: 20
       },
       borderRadius: {
-        default: 6,
+        default: defaultBorderRadius,
         small: 4,
       },
       typography: {
@@ -367,6 +368,11 @@ export const eaForumTheme: SiteThemeSpecification = {
             marginRight: 12,
           }
         },
+        MuiIconButton: {
+          root: {
+            borderRadius: defaultBorderRadius
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This is a small PR to update the styling of the search icon in the site header to match the other icons. [Relevant figma here](https://www.figma.com/file/d09iVzNSpZp9GyWGcfkWmX/Q2.2-2023?node-id=130%3A7137&mode=dev). It's based off of https://github.com/ForumMagnum/ForumMagnum/pull/7547 but that's just for convenience since they both touch header styling - you don't need to read that one.

Basically I made the search icon into an `IconButton` so that it gets the background on hover, and made all our icon buttons backgrounds squares rather than circles:
<img width="257" alt="Screen Shot 2023-07-06 at 4 48 46 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/37e47cf0-3ce7-4b44-945f-b0009b89bba9">

I figured this switch to `IconButton` was fine to keep for LW as well, since it just makes their site header icons more consistent with each other. I left it with the default circle background on hover:
![Screen Shot 2023-07-06 at 4 47 33 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/71d1db35-0486-438f-8af0-fc7913fef25f)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204983314773539) by [Unito](https://www.unito.io)
