### PR TITLE
[EA Forum only] adjust topic and sequence pages for shorter top bar

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -9,6 +9,8 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import { sectionFooterLeftStyles } from '../users/UsersProfile'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { nofollowKarmaThreshold } from '../../lib/publicSettings';
+import { isEAForum } from '../../lib/instanceSettings';
+import { EA_FORUM_HEADER_HEIGHT } from '../common/Header';
 
 export const sequencesImageScrim = (theme: ThemeType) => ({
   position: 'absolute',
@@ -21,7 +23,7 @@ export const sequencesImageScrim = (theme: ThemeType) => ({
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    paddingTop: 380,
+    paddingTop: isEAForum ? 320 : 380,
   },
   titleWrapper: {
     paddingLeft: theme.spacing.unit/2
@@ -39,7 +41,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   banner: {
     position: "absolute",
     right: 0,
-    top: 60,
+    top: isEAForum ? EA_FORUM_HEADER_HEIGHT : 60,
     width: "100vw",
     height: 380,
     zIndex: theme.zIndexes.sequenceBanner,
@@ -73,8 +75,8 @@ const styles = (theme: ThemeType): JssStyles => ({
       marginTop: -100,
     },
     [theme.breakpoints.down('xs')]: {
-      marginTop: theme.spacing.unit,
-      padding: theme.spacing.unit
+      marginTop: isEAForum ? undefined : theme.spacing.unit,
+      padding: isEAForum ? 16 : theme.spacing.unit
     },
   },
   leftAction: {

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -23,7 +23,7 @@ export const sequencesImageScrim = (theme: ThemeType) => ({
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    paddingTop: isEAForum ? 320 : 380,
+    paddingTop: isEAForum ? (270 + EA_FORUM_HEADER_HEIGHT) : 380,
   },
   titleWrapper: {
     paddingLeft: theme.spacing.unit/2

--- a/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
@@ -12,6 +12,11 @@ import { taggingNameCapitalSetting, taggingNamePluralCapitalSetting, taggingName
 import { tagCreateUrl, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  coreTagsTitle: {
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 20
+    }
+  },
   portalSection: {
     marginBottom: theme.spacing.unit*8,
   },
@@ -63,7 +68,7 @@ const EAAllTagsPage = ({classes}: {
   return (
     <AnalyticsContext pageContext="allTagsPage">
       <SingleColumnSection>
-        <SectionTitle title={`Core ${taggingNamePluralSetting.get()}`} noTopMargin />
+        <SectionTitle title={`Core ${taggingNamePluralSetting.get()}`} noTopMargin className={classes.coreTagsTitle} />
         <CoreTagsSection />
         <div className={classes.portalSection}>
           <SectionTitle title={portalTitle}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -18,6 +18,7 @@ import { useTagBySlug } from './useTag';
 import { isEAForum, taggingNameCapitalSetting, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 import { getTagStructuredData } from "./TagPageRouter";
+import { EA_FORUM_HEADER_HEIGHT } from "../common/Header";
 
 export const tagPageHeaderStyles = (theme: ThemeType) => ({
   postListMeta: {
@@ -50,14 +51,13 @@ export const styles = (theme: ThemeType): JssStyles => ({
       width: '100%',
     },
     position: 'absolute',
-    top: 90,
+    top: EA_FORUM_HEADER_HEIGHT,
     [theme.breakpoints.down('sm')]: {
       width: 'unset',
       '& > picture > img': {
         height: 200,
         width: '100%',
       },
-      top: 77,
       left: -4,
       right: -4,
     },

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -312,14 +312,6 @@ export const eaForumTheme: SiteThemeSpecification = {
             display: 'none'
           }
         },
-        SequencesPage: {
-          root: {
-            paddingTop: 345,
-          },
-          banner: {
-            top: 77,
-          },
-        },
         EAAllTagsPage: {
           portal: {
             background: palette.grey[0],


### PR DESCRIPTION
This PR adjusts three pages to account for the new shorter site header. Below are screenshots of the current (broken) versions.

-----
Sequence page
![Screen Shot 2023-07-06 at 7 06 43 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/388ea6e2-bf03-42cb-9e23-b6630eec348f)

-----
All Topics page (I think this issue predates the header change but I also fixed this)
![Screen Shot 2023-07-06 at 7 06 59 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/414ce990-39c0-428f-a99d-94b1fd4737e0)

-----
Topic page (non-core) with banner
![Screen Shot 2023-07-06 at 7 07 47 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/d1aa13bc-28d5-4d36-a5d5-30fb910fc3d9)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204983808434504) by [Unito](https://www.unito.io)
