### PR TITLE
fix  three dots menu in post header gets cropped in mobile

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -327,7 +327,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const tripleDotMenuNode = !hideMenu &&
     <span className={classes.actions}>
       <AnalyticsContext pageElementContext="tripleDotMenu">
-        <PostActionsButton post={post} includeBookmark={!isEAForum} />
+        <PostActionsButton post={post} includeBookmark={!isEAForum} autoPlace/>
       </AnalyticsContext>
     </span>
 


### PR DESCRIPTION
On mobile, clicking the actions button (three dots) in a post's header, sometimes causes the menu to pop up partially out of the screen bounds.
![www lesswrong com_posts_bJ2haLkcGeLtTWaD5_welcome-to-lesswrong(Pixel 5)](https://github.com/ForumMagnum/ForumMagnum/assets/37066741/b8414bdc-8b4e-4f95-9a9b-daa685710c40)

This fixes it by autoplacing the menu so that it floats to the left of the button on small screens.

![localhost_3000_posts_kqi5GBEFqjLmdxqiX_hello-worls(Pixel 5)](https://github.com/ForumMagnum/ForumMagnum/assets/37066741/111caba1-388a-4641-8cfa-299b37351cfd)

Admittedly the current implementation of autoPlace would cause it to float to the left even in some medium screens where this isn't necessary. But calculating the exact threshold seems like an overkill, and probably doesn't matter for most screens anyway.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1204996732530760) by [Unito](https://www.unito.io)
