### PR TITLE
Fix an SSR mismatch in tag-order in FooterTagList by adding a full set of tiebreaks to sortTags

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -9,7 +9,7 @@ import { tagStyle, smallTagTextStyle } from './FooterTag';
 import classNames from 'classnames';
 import Card from '@material-ui/core/Card';
 import { Link } from '../../lib/reactRouterWrapper';
-import { sortBy } from 'underscore';
+import sortBy from 'lodash/sortBy';
 import { forumSelect } from '../../lib/forumTypeUtils';
 import { useMessages } from '../common/withMessages';
 import { isEAForum } from '../../lib/instanceSettings';
@@ -57,7 +57,11 @@ const styles = (theme: ThemeType): JssStyles => ({
 export function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo|null|undefined): Array<T> {
   return sortBy(
     list,
-    isEAForum ? (item) => !toTag(item)?.core : (item) => toTag(item)?.core,
+    [
+      isEAForum ? (item) => !toTag(item)?.core : (item) => toTag(item)?.core,
+      (item) => toTag(item)?.name,
+      (item) => toTag(item)?._id,
+    ]
   );
 }
 


### PR DESCRIPTION
In this area of the code, there are two ways of getting the tag list: from the post's `tags` field, and from the `tagsOnPost` resolver, both of which are fine. The intended design here is that we use the `tagsOnPost` resolver post-SSR because that's able to be client-side updated if you add more tags, but use the `tags` field in SSR because that's faster. The issue is that the two fields have subtly different sort orders: `tagsOnPost` is sorted by the `_id` of the `TagRel`, while tags is sorted by the order they appear in the `tagRelevance` field on the post, which I think is insertion order. After we retrieve one of these tag lists, we then sort it inside the component by core, using a stable sort with no tiebreaks. This leads to an SSR mismatch, where the tags can change order after load.

Fix this by adding tiebreaks to `sortTags` in `FooterTagList` so that the sort-order is fully unambiguous.