### PR TITLE
[EA Forum only] fix post item author link, and icons to the right of the post title

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -286,10 +286,12 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
               />
               <div className={classes.meta}>
                 <div className={classes.metaLeft} ref={authorExpandContainer}>
-                  <TruncatedAuthorsList
-                    post={post}
-                    expandContainer={authorExpandContainer}
-                  />
+                  <InteractionWrapper className={classes.interactionWrapper}>
+                    <TruncatedAuthorsList
+                      post={post}
+                      expandContainer={authorExpandContainer}
+                    />
+                  </InteractionWrapper>
                   <div>
                     {' · '}
                     <PostsItemDate post={post} noStyles includeAgo />

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -196,7 +196,9 @@ const PostsTitle = ({
         {isLink ? <Link to={url}>{title}</Link> : title }
       </span>
       {showIcons && <span className={classes.hideXsDown}>
-        <PostsItemIcons post={post} hideCuratedIcon={curatedIconLeft} hidePersonalIcon={!showPersonalIcon}/>
+        <InteractionWrapper className={classes.interactionWrapper}>
+          <PostsItemIcons post={post} hideCuratedIcon={curatedIconLeft} hidePersonalIcon={!showPersonalIcon}/>
+        </InteractionWrapper>
       </span>}
     </span>
   )


### PR DESCRIPTION
Small fix to make sure that clicking on an author's name in the post item doesn't also redirect you to the post page

EDIT: Also noticed that the icons to the right of the post title have the same issue, fixed that as well

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205004550099564) by [Unito](https://www.unito.io)
