### PR TITLE
[EA Forum only] fix adding posts to sequences

### DIFF
--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -110,7 +110,8 @@ const postIcon = (post: PostsBase|PostsListBase) => {
   }
   const tagSettingIconKeys = Array.from(tagSettingIcons.keys())
   //Sometimes this function will be called with fragments that don't have the tag array, in that case assume that the tag array is empty
-  const postTags = post.hasOwnProperty('tags') ? (post as PostsListBase).tags : [] 
+  const postTags = post.hasOwnProperty('tags') ? (post as PostsListBase).tags : []
+  if (!postTags) return null
   const matchingTagSetting = tagSettingIconKeys.find(tagSetting => (postTags).find(tag => tag._id === tagSetting.get()));
   if (matchingTagSetting) {
     return tagSettingIcons.get(matchingTagSetting);


### PR DESCRIPTION
Bug reported via intercom, [see in slack here](https://cea-core.slack.com/archives/C038J512SD8/p1688743800612029):

"when I try to add a new post to my sequence, halfway through typing its name the screen disappears and is replaced with a mostly-blank screen"

@oetherington Looks like this was due to the post search results having `null` tags - this seems to fix it but let me know if you'd prefer to fix it some other way

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205005014372329) by [Unito](https://www.unito.io)
