### PR TITLE
[EA Forum only] small updates to site header user menu

### DIFF
--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -117,6 +117,13 @@ const UsersMenu = ({classes}: {
   const buttonNode = <Button classes={{root: classes.userButtonRoot}}>
     {userButtonNode}
   </Button>
+  
+  const accountSettingsNode = <DropdownItem
+    title={preferredHeadingCase("Account Settings")}
+    to="/account"
+    icon="Settings"
+    iconClassName={classes.icon}
+  />
 
   return (
     <div className={classes.root} {...eventHandlers}>
@@ -137,13 +144,13 @@ const UsersMenu = ({classes}: {
             }}>
               {userCanPost(currentUser) &&
                 <DropdownItem
-                  title="New Question"
+                  title={preferredHeadingCase("New Question")}
                   to="/newPost?question=true"
                 />
               }
               {userCanPost(currentUser) &&
                 <DropdownItem
-                  title="New Post"
+                  title={preferredHeadingCase("New Post")}
                   to="/newPost"
                 />
               }
@@ -151,7 +158,7 @@ const UsersMenu = ({classes}: {
                   !isEAForum &&
                   userCanCreateField(currentUser, postSchema['debate']) &&
                 <DropdownItem
-                  title="New Dialogue"
+                  title={preferredHeadingCase("New Dialogue")}
                   to="/newpost?debate=true"
                 />
               }
@@ -163,20 +170,20 @@ const UsersMenu = ({classes}: {
               */}
             {showNewButtons && (!isEAForum || userCanComment(currentUser)) &&
               <DropdownItem
-                title={isEAForum ? "New Quick take" : "New Shortform"}
+                title={isEAForum ? "New quick take" : "New Shortform"}
                 onClick={() => openDialog({componentName:"NewShortformDialog"})}
               />
             }
             {showNewButtons && <DropdownDivider />}
             {showNewButtons && userCanPost(currentUser) &&
               <DropdownItem
-                title="New Event"
+                title={preferredHeadingCase("New Event")}
                 to="/newPost?eventForm=true"
               />
             }
             {showNewButtons && currentUser.karma >= 1000 &&
               <DropdownItem
-                title="New Sequence"
+                title={preferredHeadingCase("New Sequence")}
                 to="/sequencesnew"
               />
             }
@@ -229,12 +236,7 @@ const UsersMenu = ({classes}: {
                 />
               </ThemePickerMenu>
             }
-            <DropdownItem
-              title={preferredHeadingCase("Account Settings")}
-              to="/account"
-              icon="Settings"
-              iconClassName={classes.icon}
-            />
+            {!isEAForum && accountSettingsNode}
             <DropdownItem
               title={preferredHeadingCase("Private Messages")}
               to="/inbox"
@@ -251,7 +253,7 @@ const UsersMenu = ({classes}: {
             }
             {currentUser.shortformFeedId &&
               <DropdownItem
-                title={isEAForum ? "Your Quick takes" : "Shortform Page"}
+                title={isEAForum ? "Your quick takes" : "Shortform Page"}
                 to={postGetPageUrl({
                   _id: currentUser.shortformFeedId,
                   slug: "shortform",
@@ -260,6 +262,7 @@ const UsersMenu = ({classes}: {
                 iconClassName={classes.icon}
               />
             }
+            {isEAForum && accountSettingsNode}
 
             <DropdownDivider />
 


### PR DESCRIPTION
This PR makes all the options in our user menu sentence case (which @agnesstenlund was [good with doing](https://cea-core.slack.com/archives/C038J512SD8/p1687880841336809)), plus moves the "Account settings" option to the bottom of its section (since I think it makes more sense for it to be there). ([Related discussion in slack](https://cea-core.slack.com/archives/C03R2G12W2K/p1688766037735089))

<img width="259" alt="Screen Shot 2023-07-10 at 6 35 55 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/66a88b2a-df1f-40ad-80be-785ecf1d06bd">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205005367105654) by [Unito](https://www.unito.io)
