### PR TITLE
Reorder search results to put posts higher up

### DIFF
--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -1,11 +1,11 @@
 import { Components, registerComponent} from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { Snippet } from 'react-instantsearch-dom';
-import type { Hit } from 'react-instantsearch-core';
 import React from 'react';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
 import { tagGetCommentLink } from '../../lib/collections/tags/helpers';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
+import type { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -33,12 +33,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
-  hit: Hit<any>,
-  clickAction?: any,
-  classes: ClassesType,
-  showIcon?: boolean
-}) => {
+const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
   const comment = (hit as AlgoliaComment);
   const { LWTooltip } = Components
 

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -5,6 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { Snippet } from 'react-instantsearch-dom';
 import type { Hit } from 'react-instantsearch-core';
 import DescriptionIcon from '@material-ui/icons/Description';
+import { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,12 +36,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const PostsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
-  hit: Hit<any>,
-  clickAction?: any,
-  classes: ClassesType,
-  showIcon?: boolean
-}) => {
+const PostsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
   const post = (hit as AlgoliaPost);
   const { Typography, LWTooltip } = Components;
 

--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Hits, Configure, Index } from 'react-instantsearch-dom';
 import { AlgoliaIndexCollectionName, getAlgoliaIndexName } from '../../lib/search/algoliaUtil';
-import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 import { Link } from '../../lib/reactRouterWrapper';
 import { EA_FORUM_HEADER_HEIGHT } from '../common/Header';
-import { Hit } from 'react-instantsearch-core';
 import { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Hits, Configure, Index } from 'react-instantsearch-dom';
-import { getAlgoliaIndexName } from '../../lib/search/algoliaUtil';
-import { forumTypeSetting } from '../../lib/instanceSettings';
+import { AlgoliaIndexCollectionName, getAlgoliaIndexName } from '../../lib/search/algoliaUtil';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import { Link } from '../../lib/reactRouterWrapper';
 import { EA_FORUM_HEADER_HEIGHT } from '../common/Header';
+import { Hit } from 'react-instantsearch-core';
+import { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -74,48 +76,29 @@ const SearchBarResults = ({closeSearch, currentQuery, classes}: {
 }) => {
   const { PostsSearchHit, SequencesSearchHit, UsersSearchHit, TagsSearchHit, CommentsSearchHit } = Components
 
+  const searchTypes: Array<{
+    type: AlgoliaIndexCollectionName;
+    Component: React.ComponentType<Omit<SearchHitComponentProps, "classes">>;
+  }> = [
+    { type: "Users", Component: UsersSearchHit },
+    { type: "Posts", Component: PostsSearchHit },
+    { type: "Tags", Component: TagsSearchHit },
+    { type: "Comments", Component: CommentsSearchHit },
+    { type: "Sequences", Component: SequencesSearchHit },
+  ];
+
   return <div className={classes.root}>
     <div className={classes.searchResults}>
-        <Components.ErrorBoundary>
-          <div className={classes.list}>
-            <Index indexName={getAlgoliaIndexName("Users")}>
-              <Configure hitsPerPage={3} />
-              <Hits hitComponent={(props) => <UsersSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-            </Index>
-          </div>
-        </Components.ErrorBoundary>
-        <Components.ErrorBoundary>
-          <div className={classes.list}>
-            <Index indexName={getAlgoliaIndexName("Tags")}>
-              <Configure hitsPerPage={3} />
-              <Hits hitComponent={(props) => <TagsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-            </Index>
-          </div>
-        </Components.ErrorBoundary>
-        <Components.ErrorBoundary>
-          <div className={classes.list}>
-            <Index indexName={getAlgoliaIndexName("Posts")}>
-              <Configure hitsPerPage={3} />
-              <Hits hitComponent={(props) => <PostsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-            </Index>
-          </div>
-        </Components.ErrorBoundary>
-        <Components.ErrorBoundary>
-          <div className={classes.list}>
-            <Index indexName={getAlgoliaIndexName("Comments")}>
-              <Configure hitsPerPage={3} />
-              <Hits hitComponent={(props) => <CommentsSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-            </Index>
-          </div>
-        </Components.ErrorBoundary>
-        <Components.ErrorBoundary>
-          <div className={classes.list}>
-            <Index indexName={getAlgoliaIndexName("Sequences")}>
-              <Configure hitsPerPage={3} />
-              <Hits hitComponent={(props) => <SequencesSearchHit clickAction={closeSearch} {...props} showIcon/>} />
-            </Index>
-          </div>
-        </Components.ErrorBoundary>
+        {searchTypes.map(({ type, Component }) => (
+          <Components.ErrorBoundary key={type}>
+            <div className={classes.list}>
+              <Index indexName={getAlgoliaIndexName(type)}>
+                <Configure hitsPerPage={3} />
+                <Hits hitComponent={(props) => <Component clickAction={closeSearch} {...props} showIcon/>} />
+              </Index>
+            </div>
+          </Components.ErrorBoundary>
+        ))}
         <Link to={`/search?query=${currentQuery}`} className={classes.seeAll}>
           See all results
         </Link>

--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -5,6 +5,7 @@ import type { Hit } from 'react-instantsearch-core';
 import LocalLibraryIcon from '@material-ui/icons/LocalLibrary';
 import { Snippet } from 'react-instantsearch-dom';
 import { isEAForum } from '../../lib/instanceSettings';
+import { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -50,12 +51,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const SequencesSearchHit = ({hit, clickAction, classes, showIcon=false}: {
-  hit: Hit<any>,
-  clickAction?: any,
-  classes: ClassesType,
-  showIcon?: boolean
-}) => {
+const SequencesSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
   const sequence: AlgoliaSequence = hit;
   const { LWTooltip, MetaInfo } = Components
   

--- a/packages/lesswrong/components/search/TagsSearchHit.tsx
+++ b/packages/lesswrong/components/search/TagsSearchHit.tsx
@@ -3,9 +3,9 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { Snippet } from 'react-instantsearch-dom';
-import type { Hit } from 'react-instantsearch-core';
 import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
+import type { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,12 +35,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const TagsSearchHit = ({hit, clickAction, classes, showIcon=false}: {
-  hit: Hit<any>,
-  clickAction?: any,
-  classes: ClassesType,
-  showIcon?: boolean
-}) => {
+const TagsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
   const { LWTooltip } = Components
   const tag = hit as AlgoliaTag;
 

--- a/packages/lesswrong/components/search/UsersSearchHit.tsx
+++ b/packages/lesswrong/components/search/UsersSearchHit.tsx
@@ -3,7 +3,7 @@ import { userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import PersonIcon from '@material-ui/icons/Person';
 import React from 'react';
-import type { Hit } from 'react-instantsearch-core';
+import type { SearchHitComponentProps } from './types';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -25,12 +25,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const UsersSearchHit = ({hit, clickAction, classes, showIcon=false}: {
-  hit: Hit<any>,
-  clickAction?: any,
-  classes: ClassesType,
-  showIcon?: boolean
-}) => {
+const UsersSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
   const { LWTooltip, MetaInfo, FormatDate } = Components
   const user = hit as AlgoliaUser
 

--- a/packages/lesswrong/components/search/types.ts
+++ b/packages/lesswrong/components/search/types.ts
@@ -1,0 +1,8 @@
+import { Hit } from "react-instantsearch-core"
+
+export type SearchHitComponentProps = {
+  hit: Hit<AnyBecauseTodo>,
+  clickAction?: any,
+  classes: ClassesType,
+  showIcon?: boolean
+}


### PR DESCRIPTION
I often find it annoying to have to scroll down to posts on mobile when I search for something, so I've moved them up one place. I have also done a bit of refactoring to make this easier to reorder in future

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205009196789184) by [Unito](https://www.unito.io)
