### PR TITLE
denormalize crosspost url field, so that link icon appears in post item

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -19,6 +19,7 @@ export const denormalizedFieldKeys = [
   "title",
   "isEvent",
   "question",
+  "url",
 ] as const;
 
 export const isValidDenormalizedData = (payload: unknown): payload is DenormalizedCrosspostData =>
@@ -26,7 +27,8 @@ export const isValidDenormalizedData = (payload: unknown): payload is Denormaliz
   hasBooleanParam(payload, "deletedDraft") &&
   hasStringParam(payload, "title") &&
   hasBooleanParam(payload, "isEvent") &&
-  hasBooleanParam(payload, "question");
+  hasBooleanParam(payload, "question") &&
+  hasStringParam(payload, "url");
 
 export type DenormalizedCrosspostData = Pick<DbPost, typeof denormalizedFieldKeys[number]>;
 

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -63,6 +63,7 @@ const DenormalizedCrosspostValidator = t.strict({
   title: t.string,
   isEvent: t.boolean,
   question: t.boolean,
+  url: t.string,
 });
 
 /**


### PR DESCRIPTION
In response to a bug reported on [intercom](https://app.intercom.com/a/inbox/xycbzvda/inbox/shared/all/conversation/69456500022260?view=List)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205013879648421) by [Unito](https://www.unito.io)
