### PR TITLE
React Palette simplification

### DIFF
--- a/packages/lesswrong/components/votes/ReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/ReactionsPalette.tsx
@@ -99,10 +99,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[600],
   },
   reactPaletteFooter: {
-    display: "flex",
-    flexDirection: "row-reverse",
-    justifyContent: "space-between",
-    paddingBottom: 6,
+    textAlign: "center",
+    padding: 6,
+    paddingTop: 10
   },
   reactPaletteFooterFeedbackButton: {
     display: "inline",
@@ -190,11 +189,11 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote, cl
   const getReactionFromName = (name: string) => namesAttachedReactions.find(r => r.name === name && reactionsToShow.includes(r));
 
   const primary = [
-    'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'confused', 'thumbs-up', 
+    'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'seen', 'thumbs-up', 
   ].map(r => getReactionFromName(r)).filter(r => r);
 
   const emotions = [
-    'smile', 'laugh', 'disappointed', 'empathy', 'excitement', 'thumbs-up', 'thumbs-down', 'seen', 'thanks',
+    'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'paperclip', 
   ].map(r => getReactionFromName(r)).filter(r => r);
   
   const gridSectionB = [
@@ -303,7 +302,8 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote, cl
         <div>
           {listViewSectionD.map((react, i) => react && listReactButton(react, i%2 === 0 ? "left" : "right"))}
         </div>
-        <p className={classes.iconSection}>
+        <p>
+          {likelihoods.map(react => react && gridReactButton(react, 24))}
           {emotions.map(react => react && gridReactButton(react, 24))}
         </p>
       </div>}
@@ -321,21 +321,7 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote, cl
         {likelihoods.map(react => react && gridReactButton(react, 24))}
       </div>}
     </div>
-    {displayStyle === "listView" && <div className={classes.paddedRow}>
-      {likelihoods.map(react => react && gridReactButton(react, 24))}
-    </div>}
     <div className={classes.reactPaletteFooter}>
-      <LWTooltip title={currentUser?.hideIntercom ? "You must enable Intercom in your user settings" : ""}>
-        <a className={classes.reactPaletteFooterFeedbackButton} onClick={() => {
-            captureEvent("reactPaletteFeedbackButtonClicked")
-          // eslint-disable-next-line babel/new-cap
-            window.Intercom('trackEvent', 'suggest-react-palette-feedback')
-          }}>
-          <span className={classes.reactPaletteFeedbackButton}>
-            Request React / Give Feedback
-          </span>
-        </a>
-      </LWTooltip>
       {displayStyle == "listView" && <a className={classes.showAllButton} onClick={() => {
         setShowAll(!showAll)
         captureEvent("reactPaletteShowMoreClicked", {showAll: !showAll})

--- a/packages/lesswrong/lib/voting/reactions.tsx
+++ b/packages/lesswrong/lib/voting/reactions.tsx
@@ -287,7 +287,7 @@ export const namesAttachedReactions: NamesAttachedReactionType[] = [
     label: "Empathy",
     searchTerms: ["heart"],
     svg: "/reactionImages/nounproject/noun-heart-1212629.svg",
-    description: "I feel empathy towards this",
+    description: "",
     filter: {opacity: 0.6, translateY: 1, scale: 1.05},
     deprecated:false
   },
@@ -466,6 +466,7 @@ export const namesAttachedReactions: NamesAttachedReactionType[] = [
     description: "I'm guessing it's probably not worth the time to resolve this?",
     searchTerms: ["time cost"],
     svg: "/reactionImages/nounproject/timequestion.svg",
+    filter: {scale: .8},
     deprecated:false
   },
   {
@@ -535,7 +536,7 @@ export const namesAttachedReactions: NamesAttachedReactionType[] = [
     searchTerms: ["confused", "question", "questionmark", "bewildered"],
     svg: "/reactionImages/confused2.svg",
     description: "I don't have a clear explanation of what's going on here",
-    filter: {opacity: .9, translateY: -2.5, translateX: 0, scale: 1.15},
+    filter: {opacity: .9, translateY: -2.5, translateX: 0, scale: 1},
   },
   {
     name: "smile",


### PR DESCRIPTION
This moves the percentage-likelihood reacts below the fold, so they're still there but less overwhelming looking.

Also removes the "reacts feedback" button, since not many people were using it and it was also adding to overwhelm.

<img width="548" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/5d51d4e0-0374-42a2-9188-7b7fcdedcf54">

compared to what it previously looked like:

<img width="445" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/cc57537d-5c31-46f2-a2a8-1a22140d4b7d">

When expanded, it looks like this:

<img width="452" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/1791e954-17ac-4ff5-8346-d7339c66fc48">

compared to the original which looked like this:

<img width="418" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/f03a8338-1b42-4076-83ed-a23f58424328">

I also moved the "confused" reaction to the bottom row since it had rarely been used, moved "seen" up to the top row since it had been used occasionally and is a fairly standard react. I removed "thanks" and "empathy" from the bottom row since they already appeared earlier in the list (the only reason I included them originally was to fill up the bottom row. 


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205014507486859) by [Unito](https://www.unito.io)
