### PR TITLE
Even more elastic improvements

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -109,6 +109,12 @@ const fullTextMapping: MappingProperty = {
 const shingleTextMapping: MappingProperty = {
   type: "text",
   analyzer: "fm_shingle_analyzer",
+  fields: {
+    exact: {
+      type: "text",
+      analyzer: "standard",
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
This PR adds a couple more small Elastic improvements:

- Adds an 'exact' sub-field on shingle fields. This mainly affects searching for users by name and fixes a regression from when we switched to using a shingle mapping here.
- Improves the queries generated for prefix matching, most notably by using the `exact` subfields. This means that, for instance, "moderat" will match "moderators".

The dev indexes are already reconfigured, but not prod or staging yet.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205064375376985) by [Unito](https://www.unito.io)
