### PR TITLE
Users who are admins+moderators can disable their powers for testing and reclaim them

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -249,6 +249,7 @@ const Layout = ({currentUser, children, classes}: {
       IntercomWrapper,
       HomepageCommunityMap,
       CookieBanner,
+      AdminToggle,
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -329,6 +330,7 @@ const Layout = ({currentUser, children, classes}: {
                 [classes.unspacedGridActivated]: shouldUseGridLayout && unspacedGridLayout,
                 [classes.fullscreenBodyWrapper]: currentRoute?.fullscreen}
               )}>
+                {isEAForum && <AdminToggle />}
                 {standaloneNavigation && <NavigationStandalone
                   sidebarHidden={hideNavigationSidebar}
                   unspacedGridLayout={unspacedGridLayout}

--- a/packages/lesswrong/components/admin/AdminToggle.tsx
+++ b/packages/lesswrong/components/admin/AdminToggle.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { useCurrentUser } from '../common/withUser';
 import { userIsMemberOf } from '../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
+import { useAdminToggle } from './useAdminToggle';
 
 const styles = (theme: ThemeType): JssStyles => ({
   toggle: {
@@ -63,7 +63,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 26,
     backgroundColor: theme.palette.text.alwaysWhite,
     borderRadius: '50%',
-    transition: 'left .2s ease',
+    // transition: 'left .2s ease',
     [theme.breakpoints.down('md')]: {
       left: 70,
       height: 18,
@@ -82,49 +82,22 @@ export const AdminToggle = ({classes}: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser()
-  const updateCurrentUser = useUpdateCurrentUser()
-  const [disabled, setDisabled] = useState(false)
+  const {loading, toggleOn, toggleOff} = useAdminToggle()
   
   if (!currentUser) return null
-  
-  const handleToggleOn = async () => {
-    setDisabled(true)
-    await updateCurrentUser({
-      isAdmin: true,
-      groups: [...currentUser.groups, "sunshineRegiment"],
-    })
-    window.location.reload()
-  }
- 
-  const handleToggleOff = async () => {
-    setDisabled(true)
-    // If not a member of the realAdmins group, add that group
-    // before giving up admin powers so that we'll be able to take
-    // the admin powers back
-    let groups = currentUser.groups;
-    if (!groups.some(g => g === "realAdmins")) {
-      groups = [...currentUser.groups, "realAdmins"]
-      await updateCurrentUser({ groups })
-    }
-    await updateCurrentUser({
-      isAdmin: false,
-      groups: groups.filter(g => g !== "sunshineRegiment"),
-    })
-    window.location.reload()
-  }
 
   if (currentUser.isAdmin) {
     return <div
-      className={classNames(classes.toggle, {[classes.toggleDisabled]: disabled})}
-      onClick={disabled ? undefined : handleToggleOff}
+      className={classNames(classes.toggle, {[classes.toggleDisabled]: loading})}
+      onClick={loading ? undefined : toggleOff}
     >
       <div className={classes.onText}>Admin on</div>
       <div className={classes.toggleDot}></div>
     </div>
   } else if (!currentUser.isAdmin && userIsMemberOf(currentUser, "realAdmins")) {
     return <div
-      className={classNames(classes.toggle, classes.toggleOff, {[classes.toggleDisabled]: disabled})}
-      onClick={disabled ? undefined : handleToggleOn}
+      className={classNames(classes.toggle, classes.toggleOff, {[classes.toggleDisabled]: loading})}
+      onClick={loading ? undefined : toggleOn}
     >
       <div className={classes.offText}>Admin off</div>
       <div className={classNames(classes.toggleDot, classes.toggleDotOff)}></div>

--- a/packages/lesswrong/components/admin/AdminToggle.tsx
+++ b/packages/lesswrong/components/admin/AdminToggle.tsx
@@ -12,20 +12,29 @@ const styles = (theme: ThemeType): JssStyles => ({
     bottom: 20,
     display: 'flex',
     alignItems: 'center',
-    height: 40,
-    width: 128,
+    height: 36,
+    width: 118,
     backgroundColor: theme.palette.buttons.alwaysPrimary,
     color: theme.palette.text.alwaysWhite,
-    fontSize: 14,
+    fontSize: 13,
     fontFamily: theme.typography.fontFamily,
     fontWeight: 600,
-    padding: '6px 18px',
-    borderRadius: 20,
+    padding: '0 18px',
+    borderRadius: 18,
     boxShadow: theme.palette.boxShadow.eaCard,
     cursor: 'pointer',
     zIndex: theme.zIndexes.intercomButton,
     '&:hover': {
       backgroundColor: theme.palette.primary.dark,
+    },
+    [theme.breakpoints.down('md')]: {
+      left: 10,
+      bottom: 58,
+      height: 26,
+      width: 92,
+      fontSize: 11,
+      padding: '0 12px',
+      borderRadius: 13,
     },
     [theme.breakpoints.down('xs')]: {
       display: 'none'
@@ -49,15 +58,23 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   toggleDot: {
     position: 'absolute',
-    left: 92,
-    height: 30,
-    width: 30,
+    left: 87,
+    height: 26,
+    width: 26,
     backgroundColor: theme.palette.text.alwaysWhite,
     borderRadius: '50%',
     transition: 'left .2s ease',
+    [theme.breakpoints.down('md')]: {
+      left: 70,
+      height: 18,
+      width: 18,
+    }
   },
   toggleDotOff: {
-    left: 6
+    left: 5,
+    [theme.breakpoints.down('md')]: {
+      left: 4
+    }
   }
 });
 

--- a/packages/lesswrong/components/admin/AdminToggle.tsx
+++ b/packages/lesswrong/components/admin/AdminToggle.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { registerComponent } from '../../lib/vulcan-lib';
+import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
+import { useCurrentUser } from '../common/withUser';
+import { userIsMemberOf } from '../../lib/vulcan-users/permissions';
+import classNames from 'classnames';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  toggle: {
+    position: 'fixed',
+    left: 20,
+    bottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+    height: 40,
+    width: 128,
+    backgroundColor: theme.palette.buttons.alwaysPrimary,
+    color: theme.palette.text.alwaysWhite,
+    fontSize: 14,
+    fontFamily: theme.typography.fontFamily,
+    fontWeight: 600,
+    padding: '6px 18px',
+    borderRadius: 20,
+    boxShadow: theme.palette.boxShadow.eaCard,
+    cursor: 'pointer',
+    zIndex: theme.zIndexes.intercomButton,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+    },
+    [theme.breakpoints.down('xs')]: {
+      display: 'none'
+    }
+  },
+  toggleOff: {
+    backgroundColor: theme.palette.grey[400],
+    '&:hover': {
+      backgroundColor: theme.palette.grey[500],
+    }
+  },
+  toggleDisabled: {
+    cursor: 'default',
+  },
+  onText: {
+    textAlign: 'left',
+  },
+  offText: {
+    flexGrow: 1,
+    textAlign: 'right',
+  },
+  toggleDot: {
+    position: 'absolute',
+    left: 92,
+    height: 30,
+    width: 30,
+    backgroundColor: theme.palette.text.alwaysWhite,
+    borderRadius: '50%',
+    transition: 'left .2s ease',
+  },
+  toggleDotOff: {
+    left: 6
+  }
+});
+
+export const AdminToggle = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const currentUser = useCurrentUser()
+  const updateCurrentUser = useUpdateCurrentUser()
+  const [disabled, setDisabled] = useState(false)
+  
+  if (!currentUser) return null
+  
+  const handleToggleOn = async () => {
+    setDisabled(true)
+    await updateCurrentUser({
+      isAdmin: true,
+      groups: [...currentUser.groups, "sunshineRegiment"],
+    })
+    window.location.reload()
+  }
+ 
+  const handleToggleOff = async () => {
+    setDisabled(true)
+    // If not a member of the realAdmins group, add that group
+    // before giving up admin powers so that we'll be able to take
+    // the admin powers back
+    let groups = currentUser.groups;
+    if (!groups.some(g => g === "realAdmins")) {
+      groups = [...currentUser.groups, "realAdmins"]
+      await updateCurrentUser({ groups })
+    }
+    await updateCurrentUser({
+      isAdmin: false,
+      groups: groups.filter(g => g !== "sunshineRegiment"),
+    })
+    window.location.reload()
+  }
+
+  if (currentUser.isAdmin) {
+    return <div
+      className={classNames(classes.toggle, {[classes.toggleDisabled]: disabled})}
+      onClick={disabled ? undefined : handleToggleOff}
+    >
+      <div className={classes.onText}>Admin on</div>
+      <div className={classes.toggleDot}></div>
+    </div>
+  } else if (!currentUser.isAdmin && userIsMemberOf(currentUser, "realAdmins")) {
+    return <div
+      className={classNames(classes.toggle, classes.toggleOff, {[classes.toggleDisabled]: disabled})}
+      onClick={disabled ? undefined : handleToggleOn}
+    >
+      <div className={classes.offText}>Admin off</div>
+      <div className={classNames(classes.toggleDot, classes.toggleDotOff)}></div>
+    </div>
+  }
+  
+  return null
+}
+
+const AdminToggleComponent = registerComponent('AdminToggle', AdminToggle, {styles});
+
+declare global {
+  interface ComponentTypes {
+    AdminToggle: typeof AdminToggleComponent
+  }
+}
+

--- a/packages/lesswrong/components/admin/useAdminToggle.ts
+++ b/packages/lesswrong/components/admin/useAdminToggle.ts
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { useCurrentUser } from "../common/withUser";
+import { useUpdateCurrentUser } from "../hooks/useUpdateCurrentUser";
+import { userIsMemberOf } from "../../lib/vulcan-users/permissions";
+
+/**
+ * Functionality for the toggle that lets admins disable their admin + mod powers
+ * and re-enable them. This is useful for admins to be able to see the site
+ * as most users would see it.
+ *
+ * Note that we assign both the admin and sunshineRegiment roles when this is
+ * toggled back on, even if the admin didn't have the sunshineRegiment role previously.
+ * This is probably fine since admins can already do everything.
+ */
+export const useAdminToggle = (): {
+  loading: boolean,
+  toggleOn?: () => void,
+  toggleOff?: () => void,
+} => {
+  const currentUser = useCurrentUser()
+  const updateCurrentUser = useUpdateCurrentUser()
+  const [loading, setLoading] = useState(false)
+  
+  if (!currentUser) {
+    return {
+      loading: false
+    }
+  }
+  
+  /**
+   * If the current user has disabled their admin powers, then re-assign them
+   * to the admin and sunshineRegiment groups.
+   */
+  const toggleOn = async () => {
+    if (currentUser.isAdmin || !userIsMemberOf(currentUser, "realAdmins")) return
+    
+    setLoading(true)
+    await updateCurrentUser({
+      isAdmin: true,
+      groups: [...currentUser.groups, "sunshineRegiment"],
+    })
+    window.location.reload()
+  }
+
+  /**
+   * If the current user is an admin, then disable their admin + mod powers,
+   * and assign them to the realAdmins group so that they can re-enable them.
+   */
+  const toggleOff = async () => {
+    if (!currentUser.isAdmin) return
+    
+    setLoading(true)
+    // If not a member of the realAdmins group, add that group
+    // before giving up admin powers so that we'll be able to take
+    // the admin powers back
+    let groups = currentUser.groups;
+    if (!groups.some(g => g === "realAdmins")) {
+      groups = [...currentUser.groups, "realAdmins"]
+      await updateCurrentUser({ groups })
+    }
+    await updateCurrentUser({
+      isAdmin: false,
+      groups: groups.filter(g => g !== "sunshineRegiment"),
+    })
+    window.location.reload()
+  }
+
+  return {
+    loading,
+    toggleOn,
+    toggleOff
+  }
+}

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -14,7 +14,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog'
 import { useHover } from '../common/withHover'
-import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum, isLWorAF } from '../../lib/instanceSettings';
 import {afNonMemberDisplayInitialPopup} from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import { userCanPost } from '../../lib/collections/posts';
 import postSchema from '../../lib/collections/posts/schema';
@@ -66,7 +66,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   deactivated: {
     color: theme.palette.grey[600],
     marginLeft: 20
-  }
+  },
+  adminToggleItem: isEAForum ? {
+    display: 'none',
+    [theme.breakpoints.down('xs')]: {
+      display: 'block'
+    }
+  } : {}
 })
 
 const UsersMenu = ({classes}: {
@@ -269,40 +275,41 @@ const UsersMenu = ({classes}: {
             {isEAForum && accountSettingsNode}
 
             {/*
-              If you're both an admin and a moderator, you can disable your
-              powers and take them back. (If you're only an admin or only a
-              moderator, you can't use this feature, because in the disabled-
-              state we don't keep track of the difference between admins who are
-              vs aren't also moderators.
+              If you're an admin, you can disable your admin + moderator
+              powers and take them back.
             */}
-            {currentUser.isAdmin && userIsMemberOf(currentUser, "sunshineRegiment") && <DropdownItem
-              title={"Disable Admin Powers"}
-              onClick={async () => {
-                // If not a member of the realAdmins group, add that group
-                // before giving up admin powers so that we'll be able to take
-                // the admin powers back
-                let groups = currentUser.groups;
-                if (!groups.find(g=>g==="realAdmins")) {
-                  groups = [...currentUser.groups, "realAdmins"];
-                  await updateCurrentUser({ groups });
-                }
-                await updateCurrentUser({
-                  isAdmin: false,
-                  groups: filter(groups, g=>g!=="sunshineRegiment"),
-                });
-                window.location.reload();
-              }}
-            />}
-            {!currentUser.isAdmin && userIsMemberOf(currentUser, "realAdmins") && <DropdownItem
-              title={"Reenable Admin Powers"}
-              onClick={async () => {
-                await updateCurrentUser({
-                  isAdmin: true,
-                  groups: [...currentUser.groups, "sunshineRegiment"],
-                });
-                window.location.reload();
-              }}
-            />}
+            {currentUser.isAdmin && <div className={classes.adminToggleItem}>
+              <DropdownItem
+                title={preferredHeadingCase("Disable Admin Powers")}
+                onClick={async () => {
+                  // If not a member of the realAdmins group, add that group
+                  // before giving up admin powers so that we'll be able to take
+                  // the admin powers back
+                  let groups = currentUser.groups;
+                  if (!groups.find(g=>g==="realAdmins")) {
+                    groups = [...currentUser.groups, "realAdmins"];
+                    await updateCurrentUser({ groups });
+                  }
+                  await updateCurrentUser({
+                    isAdmin: false,
+                    groups: filter(groups, g=>g!=="sunshineRegiment"),
+                  });
+                  window.location.reload();
+                }}
+              />
+            </div>}
+            {!currentUser.isAdmin && userIsMemberOf(currentUser, "realAdmins") && <div className={classes.adminToggleItem}>
+              <DropdownItem
+                title={preferredHeadingCase("Re-enable Admin Powers")}
+                onClick={async () => {
+                  await updateCurrentUser({
+                    isAdmin: true,
+                    groups: [...currentUser.groups, "sunshineRegiment"],
+                  });
+                  window.location.reload();
+                }}
+              />
+            </div>}
 
             <DropdownDivider />
             

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -14,14 +14,13 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog'
 import { useHover } from '../common/withHover'
-import { forumTypeSetting, isEAForum, isLWorAF } from '../../lib/instanceSettings';
+import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import {afNonMemberDisplayInitialPopup} from "../../lib/alignment-forum/displayAFNonMemberPopups";
 import { userCanPost } from '../../lib/collections/posts';
 import postSchema from '../../lib/collections/posts/schema';
 import { DisableNoKibitzContext } from './UsersNameDisplay';
 import { preferredHeadingCase } from '../../lib/forumTypeUtils';
-import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
-import filter from 'lodash/filter';
+import { useAdminToggle } from '../admin/useAdminToggle';
 
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -82,7 +81,7 @@ const UsersMenu = ({classes}: {
   const {eventHandlers, hover, anchorEl} = useHover();
   const {openDialog} = useDialog();
   const {disableNoKibitz, setDisableNoKibitz} = useContext(DisableNoKibitzContext );
-  const updateCurrentUser = useUpdateCurrentUser();
+  const {toggleOn, toggleOff} = useAdminToggle();
 
   if (!currentUser) return null;
   if (currentUser.usernameUnset) {
@@ -281,33 +280,13 @@ const UsersMenu = ({classes}: {
             {currentUser.isAdmin && <div className={classes.adminToggleItem}>
               <DropdownItem
                 title={preferredHeadingCase("Disable Admin Powers")}
-                onClick={async () => {
-                  // If not a member of the realAdmins group, add that group
-                  // before giving up admin powers so that we'll be able to take
-                  // the admin powers back
-                  let groups = currentUser.groups;
-                  if (!groups.find(g=>g==="realAdmins")) {
-                    groups = [...currentUser.groups, "realAdmins"];
-                    await updateCurrentUser({ groups });
-                  }
-                  await updateCurrentUser({
-                    isAdmin: false,
-                    groups: filter(groups, g=>g!=="sunshineRegiment"),
-                  });
-                  window.location.reload();
-                }}
+                onClick={toggleOff}
               />
             </div>}
             {!currentUser.isAdmin && userIsMemberOf(currentUser, "realAdmins") && <div className={classes.adminToggleItem}>
               <DropdownItem
                 title={preferredHeadingCase("Re-enable Admin Powers")}
-                onClick={async () => {
-                  await updateCurrentUser({
-                    isAdmin: true,
-                    groups: [...currentUser.groups, "sunshineRegiment"],
-                  });
-                  window.location.reload();
-                }}
+                onClick={toggleOn}
               />
             </div>}
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -332,7 +332,7 @@ const schema: SchemaType<DbUser> = {
     input: 'checkbox',
     optional: true,
     canCreate: ['admins'],
-    canUpdate: ['admins'],
+    canUpdate: ['admins','realAdmins'],
     canRead: ['guests'],
     group: adminGroup,
   },
@@ -488,7 +488,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     control: 'checkboxgroup',
     canCreate: ['admins'],
-    canUpdate: ['alignmentForumAdmins', 'admins'],
+    canUpdate: ['alignmentForumAdmins', 'admins', 'realAdmins'],
     canRead: ['guests'],
     group: adminGroup,
     form: {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -576,6 +576,7 @@ importComponent("MigrationsDashboardRow", () => require('../components/admin/mig
 importComponent("AdminHome", () => require('../components/admin/AdminHome'));
 importComponent("AdminMetadata", () => require('../components/admin/AdminMetadata'));
 importComponent("AdminSynonymsPage", () => require('../components/admin/AdminSynonymsPage'));
+importComponent("AdminToggle", () => require('../components/admin/AdminToggle'));
 importComponent("RandomUserPage", () => require('../components/admin/RandomUserPage'));
 importComponent("ModerationDashboard", () => require('../components/sunshineDashboard/ModerationDashboard'));
 importComponent("RecentlyActiveUsers", () => require('../components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers'));

--- a/packages/lesswrong/lib/permissions.ts
+++ b/packages/lesswrong/lib/permissions.ts
@@ -10,6 +10,14 @@ export const tagManagerGroup = createGroup("tagManager");
 export const canSuggestCurationGroup = createGroup("canSuggestCuration");
 export const debaterGroup = createGroup("debaters");
 
+/**
+ * Admin users can turn off their admin power, to test aspects of the site in
+ * a way that accurately reflects what non-admins see (in particular, so that
+ * they see any permissions-related bugs), while retaining the ability to take
+ * their admin power back.
+ */
+export const realAdminsGroup = createGroup("realAdmins");
+
 // This is referenced by the schema so you must run `yarn generate` after
 // updating it
 export const permissionGroups = [
@@ -26,4 +34,5 @@ export const permissionGroups = [
   'canModeratePersonal',
   'canSuggestCuration',
   'debaters',
+  'realAdmins',
 ] as const;


### PR DESCRIPTION
Add an option to disable being an admin/moderator, and claim it back. To keep track of when a user is an admin but has their powers disabled, we add a `realAdmins` group. This edits the actual user object to be a not-moderator not-admin to ensure that admins testing this way can see any permissions-related bugs accurately.

(Future work: EA Forum had a design for this feature using a floating button in the bottom left, rather than it being in the user menu, for quick toggle.)

![Screenshot 2023-07-14 at 14 19 24](https://github.com/ForumMagnum/ForumMagnum/assets/101191/103bb2ee-5876-4cfa-a3eb-91f3f3ea1592)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205068060513013) by [Unito](https://www.unito.io)
