### PR TITLE
LW nonhuman audio podcast styling

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -7,7 +7,7 @@ import { getUrlClass } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import { isServer } from '../../../lib/executionEnvironment';
 import moment from 'moment';
-import { isEAForum } from '../../../lib/instanceSettings';
+import { isEAForum, isLWorAF } from '../../../lib/instanceSettings';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { PODCAST_TOOLTIP_SEEN_COOKIE } from '../../../lib/cookies/cookies';
 
@@ -148,6 +148,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     "&:hover": {
       opacity: 0.5,
     },
+  },
+  nonhumanAudio: {
+    color: theme.palette.grey[500],
   }
 });
 
@@ -305,13 +308,15 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
       </CommentsLink>
     );
 
-  const audioIcon = <LWTooltip title={'Listen to this post'} className={classes.togglePodcastContainer}>
+  const nonhumanAudio = post.podcastEpisodeId === null
+
+  const audioIcon = <LWTooltip title={'Listen to this post'} className={classNames(classes.togglePodcastContainer, {[classes.nonhumanAudio]: nonhumanAudio})}>
     <a href="#" onClick={toggleEmbeddedPlayer}>
       <ForumIcon icon="VolumeUp" className={classNames(classes.audioIcon, {[classes.audioIconOn]: showEmbeddedPlayer})} />
     </a>
   </LWTooltip>
   const audioNode = toggleEmbeddedPlayer && (
-    cachedTooltipSeen
+    (cachedTooltipSeen || isLWorAF)
       ? audioIcon
       : (
         <NewFeaturePulse className={classes.audioNewFeaturePulse}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -308,7 +308,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
       </CommentsLink>
     );
 
-  const nonhumanAudio = post.podcastEpisodeId === null
+  const nonhumanAudio = post.podcastEpisodeId === null && isLWorAF
 
   const audioIcon = <LWTooltip title={'Listen to this post'} className={classNames(classes.togglePodcastContainer, {[classes.nonhumanAudio]: nonhumanAudio})}>
     <a href="#" onClick={toggleEmbeddedPlayer}>


### PR DESCRIPTION
This
– makes it so on LessWrong, there is no pulse for audio (this is partly because we didn't especially want it on LW in the firstplace, and in particular didn't want it for AI-audio which isn't as good, and, partly because of a display bug where it was causing the UI to display out of alignment with the rest of the header info)

– makes it so if audio hasn't been created yet, the button is grey instead of green. We plan to also make it so that when the audio is created by AI, it continues to appear grey, but I don't yet know the url associated with the AI audio so haven't configured that part yet)

<img width="860" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/9078996f-64fc-4fbb-8bfc-438e8afa95c9">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205046656055649) by [Unito](https://www.unito.io)
