### PR TITLE
add a bit more analytics to Recent Discussion

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { useCurrentUser } from '../common/withUser';
-import { AnalyticsContext } from "../../lib/analyticsEvents"
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents"
 import { CommentTreeNode, commentTreesEqual } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import { HIGHLIGHT_DURATION } from './CommentFrame';
@@ -110,6 +110,7 @@ const CommentsNode = ({
   classes,
 }: CommentsNodeProps) => {
   const currentUser = useCurrentUser();
+  const { captureEvent } = useTracking()
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
   const [collapsed, setCollapsed] = useState(!forceUnCollapsed && (comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene'));
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
@@ -162,6 +163,7 @@ const CommentsNode = ({
   const handleExpand = async (event?: React.MouseEvent) => {
     event?.stopPropagation()
     if (isTruncated || isSingleLine) {
+      captureEvent('commentExpanded', {postId: comment.postId, commentId: comment._id})
       setTruncated(false);
       setSingleLine(false);
       setTruncatedStateSet(true);

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -79,10 +79,10 @@ const HighlightBody = ({
       expanded={expanded}
       getTruncatedSuffix={({wordsLeft}: {wordsLeft:number}) => <div className={classes.highlightContinue}>
         {(forceSeeMore || wordsLeft < 1000)
-          ? <Link to={postGetPageUrl(post)} onClick={clickExpand}>
+          ? <Link to={postGetPageUrl(post)} onClick={clickExpand} eventProps={{intent: 'expandPost'}}>
               ({preferredHeadingCase("See More")} – {wordsLeft} more words)
             </Link>
-          : <Link to={postGetPageUrl(post)}>
+          : <Link to={postGetPageUrl(post)} eventProps={{intent: 'expandPost'}}>
               ({preferredHeadingCase("Continue Reading")}  – {wordsLeft} more words)
             </Link>
         }

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -241,7 +241,7 @@ const RecentDiscussionThread = ({
           <div className={classes.postItem}>
             {post.group && <PostsGroupDetails post={post} documentId={post.group._id} inRecentDiscussion={true} />}
             <div className={classes.titleAndActions}>
-              <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})}>
+              <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})} eventProps={{intent: 'expandPost'}}>
                 {post.title}
               </Link>
               {isSubforumIntroPost && currentUser ? <Button


### PR DESCRIPTION
The EA Forum team is thinking about ways we can improve / overhaul the "Recent Discussion" section of the front page. In this PR, I'm just adding tracking for when users click to expand comments and posts that appear in that section. After looking at how people use it, we might lean more heavily into focusing on comments or posts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205087557572721) by [Unito](https://www.unito.io)
