### PR TITLE
Show 'now' instead of 'now ago' for brand new posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -92,7 +92,11 @@ const PostsItemDate = ({post, noStyles, includeAgo, classes}: {
     </LWTooltip>
   }
 
-  const ago = includeAgo ? <span className={classes.xsHide}>&nbsp;ago</span> : null;
+  const dateToDisplay = post.curatedDate || post.postedAt;
+  const timeFromNow = moment(new Date(dateToDisplay)).fromNow();
+  const ago = includeAgo && timeFromNow !== "now"
+    ? <span className={classes.xsHide}>&nbsp;ago</span>
+    : null;
 
   if (post.curatedDate) {
     return <LWTooltip
@@ -103,7 +107,7 @@ const PostsItemDate = ({post, noStyles, includeAgo, classes}: {
       </div>}
     >
       <PostsItem2MetaInfo className={classes.postedAt}>
-        {moment(new Date(post.curatedDate)).fromNow()}
+        {timeFromNow}
         {ago}
       </PostsItem2MetaInfo>
     </LWTooltip>
@@ -114,7 +118,7 @@ const PostsItemDate = ({post, noStyles, includeAgo, classes}: {
     title={<ExpandedDate date={post.postedAt}/>}
   >
     <PostsItem2MetaInfo className={classes.postedAt}>
-      {moment(new Date(post.postedAt)).fromNow()}
+      {timeFromNow}
       {ago}
     </PostsItem2MetaInfo>
   </LWTooltip>


### PR DESCRIPTION
Currently, the date on brand new posts is displayed as "now ago". This PR changes it to just say "now".

Before:
<img width="364" alt="Screenshot 2023-07-19 at 23 40 46" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/d38eb7ac-a5b5-4ffb-ba9b-a2f8a83e842c">

After:
<img width="300" alt="Screenshot 2023-07-19 at 23 39 39" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/acaddf33-a355-4252-81f1-bfa7b84ab017">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205097157254502) by [Unito](https://www.unito.io)
