### PR TITLE
[EA Forum only] fix post item title link

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -259,7 +259,7 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
 
   const TitleWrapper: FC = ({children}) => (
     <PostsItemTooltipWrapper post={post} placement={tooltipPlacement} As="span">
-      <Link to={postLink}>{children}</Link>
+      {children}
     </PostsItemTooltipWrapper>
   );
 


### PR DESCRIPTION
We have a weird bug on live where, after clicking on a post item title to view the post page, you have to click back twice to get back to the previous page. I think this was because of the duplicate links (on the title and the post item).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205098240737666) by [Unito](https://www.unito.io)
