### PR TITLE
[EA Forum only] Digest tool: copy all icon includes ? posts, and fix publish date for curated posts

### DIFF
--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -338,7 +338,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   const copyDigestToClipboard = async () => {
     if (!posts) return
     
-    const digestPosts = posts.filter(p => postStatuses[p._id].emailDigestStatus === 'yes')
+    const digestPosts = posts.filter(p => ['yes','maybe'].includes(postStatuses[p._id].emailDigestStatus))
     await navigator.clipboard.write(
       [new ClipboardItem({
         'text/html': new Blob([getEmailDigestPostListData(digestPosts)], {type: 'text/html'})

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
@@ -253,7 +253,8 @@ const EditDigestTableRow = ({post, postStatus, statusIconsDisabled, handleClickS
         </div>
         <div className={classes.postIcons}>
           <div className={classes.karma}>{post.baseScore} karma</div>
-          <PostsItemDate post={post} noStyles includeAgo />
+          {/* @ts-ignore I just want to clear out the curatedDate :( */}
+          <PostsItemDate post={{...post, curatedDate: null}} noStyles includeAgo />
           <ForumIcon icon="Link" className={classNames(classes.linkIcon, {[classes.hiddenIcon]: !post.url})} />
           <div className={classNames(classes.questionIcon, {[classes.hiddenIcon]: !post.question})}>Q</div>
           <ForumIcon icon="Star" className={classNames(classes.curatedIcon, {[classes.hiddenIcon]: !post.curatedDate})} />


### PR DESCRIPTION
This includes two small updates for the digest planning tool:
1. The "copy all" icon next to the Publish button now also copies posts marked as ? - this is to make it easier to include them in the google doc and get feedback
2. The date listed for curated posts is now the posts' `postedAt` date instead of curated date - the date here is mostly just used to calibrate how much karma we should expect the post should have, so we don't care about the curated date