### PR TITLE
stop automod from putting users into the review queue

### DIFF
--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -73,9 +73,6 @@ voteCallbacks.cancelAsync.add(async function cancelVoteCount ({newDocument, vote
 });
 
 voteCallbacks.castVoteAsync.add(async function checkAutomod ({newDocument, vote}: VoteDocTuple) {
-  if (forumTypeSetting.get() === 'LessWrong') {
-    void triggerAutomodIfNeeded(newDocument.userId)
-  }
   if (vote.collectionName === 'Comments') {
     void triggerCommentAutomodIfNeeded(newDocument, vote);
   }


### PR DESCRIPTION
With auto ratelimits now in place, there doesn't seem to be value in having users get added to the review queue for getting downvoted a bit or for hitting negative karma.  I'm open to keeping it around with much stricter thresholds but there isn't a very convenient way to directly translate a user becoming affected by an auto ratelimit into them getting put into the review queue.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205114535574626) by [Unito](https://www.unito.io)
