### PR TITLE
Community map fixes

### DIFF
--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -24,7 +24,8 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   popupTitle: {
     display: 'flex',
     columnGap: 10,
-    alignItems: 'center'
+    alignItems: 'center',
+    color: theme.palette.text.alwaysBlack,
   },
   profileImage: {
     'box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),

--- a/packages/lesswrong/server/search/elastic/ElasticService.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticService.ts
@@ -29,7 +29,7 @@ class ElasticService {
     const result = await this.client.search({
       index,
       sorting,
-      search: params.query,
+      search: params.query ?? "",
       offset: page * hitsPerPage,
       limit: hitsPerPage,
       preTag: params.highlightPreTag,
@@ -61,7 +61,7 @@ class ElasticService {
         nbHits: true,
         typo: true,
       },
-      query: params.query,
+      query: params.query ?? "",
       params: this.urlEncode(params),
       index: indexName,
       processingTimeMS: timeMS,

--- a/packages/lesswrong/server/search/elastic/SearchQuery.ts
+++ b/packages/lesswrong/server/search/elastic/SearchQuery.ts
@@ -2,12 +2,12 @@ import { z } from "zod";
 
 /**
  * The is the schema of the request sent from the InstantSearch frontend to
- * Algolia, and we implmenet this same interface in Elasticsearch.
+ * Algolia, and we implement this same interface in Elasticsearch.
  */
 const querySchema = z.object({
   indexName: z.string(),
   params: z.object({
-    query: z.string(),
+    query: z.optional(z.string()),
     highlightPreTag: z.optional(z.string()),
     highlightPostTag: z.optional(z.string()),
     hitsPerPage: z.optional(z.number().int().nonnegative()),

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -200,6 +200,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     warning: "#832013",
     red: "#ff0000",
     alwaysWhite: "#fff",
+    alwaysBlack: "#000",
     sequenceIsDraft: "rgba(100, 169, 105, 0.9)",
     sequenceTitlePlaceholder: shades.inverseGreyAlpha(0.5),
     primaryDarkOnDim: '#085d6c', // text that is meant to be shown on the primaryDim background color

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -148,6 +148,7 @@ declare global {
       warning: ColorString,
       red: ColorString,
       alwaysWhite: ColorString,
+      alwaysBlack: ColorString,
       sequenceIsDraft: ColorString,
       sequenceTitlePlaceholder: ColorString,
       primaryDarkOnDim: ColorString,


### PR DESCRIPTION
Thsis PR fixes 2 issues on the /community/map page:

- No results are currently shown because the search query sends no query string. The elastic backend expects _some_ query to be sent, even if it's the empty string. The change here is to just allow requests with no query and to interpret this as being an empty string.
- We force the username in results to always be black whatever color scheme is in use, as the background is always white. It's currently white text on a white background in dark mode.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205123522713969) by [Unito](https://www.unito.io)
