### PR TITLE
Exact matches prioritized above karma in user search

### DIFF
--- a/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
+++ b/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
@@ -99,14 +99,12 @@ export const algoliaConfigureIndexes = async () => {
   ]
   await algoliaSetIndexSettingsAndWait(usersIndex, {
     searchableAttributes: isEAForum ? eaForumUsersSearchableAttrs : [
-      'displayName',
-      'slug',
+      'unordered(displayName)',
       'unordered(_id)',
     ],
     ranking: isEAForum ? eaForumUsersRanking : [
-      'exact',
+      'typo','geo','words','filters','proximity','attribute','exact',
       'desc(karma)',
-      'typo','geo','words','filters','proximity','attribute',
       'desc(createdAt)'
     ],
     attributesForFaceting: [

--- a/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
+++ b/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
@@ -99,12 +99,14 @@ export const algoliaConfigureIndexes = async () => {
   ]
   await algoliaSetIndexSettingsAndWait(usersIndex, {
     searchableAttributes: isEAForum ? eaForumUsersSearchableAttrs : [
-      'unordered(displayName)',
+      'displayName',
+      'slug',
       'unordered(_id)',
     ],
     ranking: isEAForum ? eaForumUsersRanking : [
+      'exact',
       'desc(karma)',
-      'typo','geo','words','filters','proximity','attribute','exact',
+      'typo','geo','words','filters','proximity','attribute',
       'desc(createdAt)'
     ],
     attributesForFaceting: [


### PR DESCRIPTION
It was previously impossible to search for some zero-karma users, which made it impossible to add them as coauthors or share them on things.

This puts "desc(karma)" lower in the list of priorities.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205129699534134) by [Unito](https://www.unito.io)
