### PR TITLE
Events are not rate limited

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -59,6 +59,8 @@ const PostsEditForm = ({ documentId, classes }: {
     collectionName: "Users",
     fragmentName: "UsersCurrentPostRateLimit",
     skip: !currentUser,
+    extraVariables: { eventForm: 'Boolean' },
+    extraVariablesValues: { eventForm: document?.isEvent }
   });
   const rateLimitNextAbleToPost = userWithRateLimit?.rateLimitNextAbleToPost
     

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -207,6 +207,8 @@ const PostsNewForm = ({classes}: {
     fragmentName: "UsersCurrentPostRateLimit",
     fetchPolicy: "cache-and-network",
     skip: !currentUser,
+    extraVariables: { eventForm: 'Boolean' },
+    extraVariablesValues: { eventForm: !!eventForm }
   });
   const rateLimitNextAbleToPost = userWithRateLimit?.rateLimitNextAbleToPost
 

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -225,7 +225,7 @@ registerFragment(`
 registerFragment(`
   fragment UsersCurrentPostRateLimit on User {
     _id
-    rateLimitNextAbleToPost
+    rateLimitNextAbleToPost(eventForm: $eventForm)
   }
 `);
 

--- a/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
@@ -6,7 +6,7 @@ import { rateLimitDateWhenUserNextAbleToComment, rateLimitDateWhenUserNextAbleTo
 
 // Post rate limiting
 getCollectionHooks("Posts").createValidate.add(async function PostsNewRateLimit (validationErrors, { newDocument: post, currentUser }) {
-  if (!post.draft) {
+  if (!post.draft && !post.isEvent) {
     await enforcePostRateLimit(currentUser!);
   }
   return validationErrors;
@@ -14,7 +14,7 @@ getCollectionHooks("Posts").createValidate.add(async function PostsNewRateLimit 
 
 getCollectionHooks("Posts").updateValidate.add(async function PostsUndraftRateLimit (validationErrors, { oldDocument, newDocument, currentUser }) {
   // Only undrafting is rate limited, not other edits
-  if (oldDocument.draft && !newDocument.draft) {
+  if (oldDocument.draft && !newDocument.draft && !newDocument.isEvent) {
     await enforcePostRateLimit(currentUser!);
   }
   return validationErrors;

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -27,7 +27,7 @@ async function getPostsInTimeframe(user: DbUser, maxHours: number) {
   return await Posts.find({
     userId:user._id, 
     draft: false,
-    event: false, // I've never seen event-spam, and sometimes people need to make 100+ events for special occassions -- Ray
+    isEvent: false, // I've never seen event-spam, and sometimes people need to make 100+ events for special occassions -- Ray
     postedAt: {$gte: moment().subtract(maxHours, 'hours').toDate()}
   }, {sort: {postedAt: -1}, projection: {postedAt: 1}}).fetch()
 }

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -27,6 +27,7 @@ async function getPostsInTimeframe(user: DbUser, maxHours: number) {
   return await Posts.find({
     userId:user._id, 
     draft: false,
+    event: false, // I've never seen event-spam, and sometimes people need to make 100+ events for special occassions -- Ray
     postedAt: {$gte: moment().subtract(maxHours, 'hours').toDate()}
   }, {sort: {postedAt: -1}, projection: {postedAt: 1}}).fetch()
 }

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -67,7 +67,11 @@ augmentFieldsDict(Users, {
     nullable: true,
     resolveAs: {
       type: GraphQLJSON,
-      resolver: async (user: DbUser, args, context: ResolverContext): Promise<RateLimitInfo|null> => {
+      arguments: 'eventForm: Boolean',
+      resolver: async (user: DbUser, args: { eventForm?: boolean }, context: ResolverContext): Promise<RateLimitInfo|null> => {
+        const { eventForm } = args
+        if (eventForm) return null
+
         const rateLimit = await rateLimitDateWhenUserNextAbleToPost(user);
         if (rateLimit) {
           return rateLimit


### PR DESCRIPTION
Currently events are subject to rate limits, but it's common for users with 0 karma to make events for their meetups and it's kind of a pain for them to have to limit them to 2-postings-per-week. 

I've never actually seen Event Spam and if it came up I think we could just handle it via manual moderation, so for now am just filtering out events.

Edit by @b0b3rt: this now also doesn't check the rate limit in post callbacks or in the resolver field returned to the client for displaying the rate limit info, in the case the post is an event.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205129723463029) by [Unito](https://www.unito.io)
