### PR TITLE
add a default sequence banner img for EA Forum

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -143,9 +143,10 @@ const SequencesPage = ({ documentId, classes }: {
         <NoSSR>
           <div>
             <CloudinaryImage
-              publicId={document.bannerImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"}
+              publicId={document.bannerImageId || (isEAForum ? "Banner/yeldubyolqpl3vqqy0m6.jpg" : "sequences/vnyzzznenju0hzdv6pqb.jpg")}
               width="auto"
               height="380"
+              imgProps={{quality: '100'}}
             />
             <div className={classes.imageScrim}/>
           </div>


### PR DESCRIPTION
Not sure how long this has been the case, but our sequence page default banner img was broken, presumably because it's a LW-specific URL.

<img width="721" alt="Screen Shot 2023-07-24 at 4 01 38 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/111e73e0-a6e3-4cd8-92e0-5d00f5d903ed">

-----
I just used our default event banner img here:

<img width="721" alt="Screen Shot 2023-07-24 at 3 59 30 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/d8a1451d-2245-4f9a-839a-8ab18f2da95b">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205130367194740) by [Unito](https://www.unito.io)
