### PR TITLE
fix password reset for oauth users who didn't have a password before

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -96,12 +96,21 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
     return this.none(`
       UPDATE "Users"
       SET services = jsonb_set(
-        jsonb_set(
-          services,
-          '{password, bcrypt}'::TEXT[],
-          to_jsonb($2::TEXT),
-          true
-        ),
+        CASE WHEN services -> 'password' IS NULL THEN
+          jsonb_set(
+            services,
+            '{password}'::TEXT[],
+            jsonb_build_object('bcrypt', $2),
+            true
+          )
+        ELSE
+          jsonb_set(
+            services,
+            '{password, bcrypt}'::TEXT[],
+            to_jsonb($2::TEXT),
+            true
+          )
+        END,
         '{resume, loginTokens}'::TEXT[],
         '[]'::JSONB,
         true


### PR DESCRIPTION
A user who'd only logged in with Github before reported an issue resetting his password.  Turns out that if you try to `jsonb_set` a path that doesn't exist in the object (i.e. `'{password, bcrypt}'`, where `password` doesn't exist for a user if they didn't register with native auth), it simply returns the record unchanged(!).

Possibly there's a more elegant way of doing this, but meh.  Tested both cases (users with pre-existing passwords, and users without).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205130508550715) by [Unito](https://www.unito.io)
