### PR TITLE
update migrate so we can check pending/executed for any env

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -8,7 +8,6 @@
  */
 require("ts-node/register");
 const { getDatabaseConfig, startSshTunnel } = require("./scripts/startup/buildUtil");
-const { readFile } = require("fs").promises;
 
 const initGlobals = (args, isProd) => {
   global.bundleIsServer = true;
@@ -61,7 +60,7 @@ const settingsFileName = (mode, forum) => {
     }
     return 'settings-local-dev-devdb.json'
   }
-  return `settings-${mode}.json`;  
+  return `settings-${mode}.json`;
 };
 
 (async () => {
@@ -77,7 +76,7 @@ const settingsFileName = (mode, forum) => {
     mode = "dev";
   } else if (mode === "production") {
     mode = "prod";
-  } else if (!isRunCommand) {
+  } else if (!["up", "down", "pending", "executed"].includes(command)) {
     mode = "dev";
   }
 


### PR DESCRIPTION
I tried to check `yarn migrate executed staging` and it secretly checked `dev` instead. Seems like we should be able to run `pending` and `executed` on any env.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205136795028357) by [Unito](https://www.unito.io)
