### PR TITLE
Fix display of EA emojis on question answers

### DIFF
--- a/packages/lesswrong/components/comments/PopularComment.tsx
+++ b/packages/lesswrong/components/comments/PopularComment.tsx
@@ -58,6 +58,10 @@ const styles = (theme: ThemeType) => ({
   date: {
     color: theme.palette.grey[600],
   },
+  vote: {
+    display: "flex",
+    alignItems: "center",
+  },
   body: {
     lineHeight: "160%",
     letterSpacing: "-0.14px",
@@ -146,7 +150,7 @@ const PopularComment = ({comment, classes}: {
           </LWTooltip>
         </div>
         {!comment.debateResponse && !comment.rejected &&
-          <InteractionWrapper>
+          <InteractionWrapper className={classes.vote}>
             <SmallSideVote
               document={comment}
               collection={Comments}

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -48,14 +48,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     flexShrink: 0,
   },
   vote: {
-    display: 'inline-block',
+    display: "flex",
     marginLeft: 10,
     fontFamily: theme.typography.commentStyle.fontFamily,
     color: theme.palette.grey[500],
     flexShrink: 0,
     flexGrow: 1,
     position: "relative",
-    top: -4
+    top: isEAForum ? 0 : -4,
   },
   footer: {
     marginTop: 5,


### PR DESCRIPTION
This PR fixes the wrapping of EA emojis on question answers and in the popular comments section.

Before:
<img width="707" alt="Screenshot 2023-07-25 at 17 52 04" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/82b5a9b1-2ccb-47af-8442-56ffc8b18a78">

After:
<img width="695" alt="Screenshot 2023-07-25 at 17 53 53" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/9b82712e-07a2-484b-9be8-9832a28c674f">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205137455448510) by [Unito](https://www.unito.io)
