### PR TITLE
Add option to disable fallback strategies for recommendations

### DIFF
--- a/packages/lesswrong/components/recommendations/PostSideRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostSideRecommendations.tsx
@@ -95,6 +95,10 @@ const PostSideRecommendations = ({post, className, classes}: {
     return null;
   }
 
+  if (!loading && items.length < 1) {
+    return null;
+  }
+
   const {Loading, IntercomFeedbackButton} = Components;
   const List = numbered ? "ol" : "ul";
   return (

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -62,8 +62,14 @@ export interface StrategySpecification extends StrategySettings {
 }
 
 export interface RecommendationsAlgorithmWithStrategy {
+  /** The strategy to use */
   strategy: StrategySpecification,
+  /** The maximum number of results to return */
   count?: number,
+  /** If the selected strategy fails to generate `count` results then, by
+   * default, we automatically switch to using a different strategy as a
+   * fallback. Set `disableFallbacks` to true to prevent this. */
+  disableFallbacks?: boolean,
 }
 
 export interface DefaultRecommendationsAlgorithm {

--- a/packages/lesswrong/lib/postSideRecommendations.tsx
+++ b/packages/lesswrong/lib/postSideRecommendations.tsx
@@ -100,6 +100,7 @@ const useGeneratorWithStrategy = (
       ...strategy,
     },
     count: 3,
+    disableFallbacks: true,
   };
   const {
     recommendations: posts = [],

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -385,7 +385,13 @@ addGraphQLResolvers({
 
       if (recommendationsAlgorithmHasStrategy(algorithm)) {
         const service = new RecommendationService();
-        return service.recommend(currentUser, clientId, count, algorithm.strategy);
+        return service.recommend(
+          currentUser,
+          clientId,
+          count,
+          algorithm.strategy,
+          algorithm.disableFallbacks,
+        );
       }
 
       const recommendedPosts = await getRecommendedPosts({count, algorithm, currentUser})

--- a/packages/lesswrong/server/recommendations/RecommendationService.ts
+++ b/packages/lesswrong/server/recommendations/RecommendationService.ts
@@ -44,12 +44,13 @@ class RecommendationService {
     clientId: string|null,
     count: number,
     strategy: StrategySpecification,
+    disableFallbacks = false,
   ): Promise<DbPost[]> {
     if (strategy.forceLoggedOutView) {
       currentUser = null;
     }
 
-    const strategies = this.getStrategyStack(strategy.name);
+    const strategies = this.getStrategyStack(strategy.name, disableFallbacks);
     let posts: DbPost[] = [];
 
     while (count > 0 && strategies.length) {
@@ -86,7 +87,11 @@ class RecommendationService {
 
   private getStrategyStack(
     primaryStrategy: RecommendationStrategyName,
+    disableFallbacks = false,
   ): RecommendationStrategyName[] {
+    if (disableFallbacks) {
+      return [primaryStrategy];
+    }
     const strategies = Object.keys(this.strategies) as RecommendationStrategyName[];
     return [
       primaryStrategy,


### PR DESCRIPTION
By default, if a recommendation strategy returns too few results we automatically switch to using a different strategy until we have enough. This works well for recommendations under the post where we just want something like "more posts you might be interested in", but it works less well for right-hand side recommendations where we use more specific requirements like "more from <some specific tag>". This can result in us displaying posts as having a particular tag that they don't actually have.

This PR adds a `disableFallbacks` parameter to prevent this happending, and also hides the right-hand side recommendations section if no relevant results are found.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205137834917437) by [Unito](https://www.unito.io)
