### PR TITLE
Fix searching from the navbar on the search page

### DIFF
--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -357,6 +357,16 @@ const SearchPageTabbed = ({classes}:{
     }
   }, [searchState, captureSearch])
 
+  useEffect(() => {
+    if (query.query !== searchState?.query) {
+      setSearchState((current) => ({
+        ...current,
+        page: "1",
+        query: query.query,
+      }));
+    }
+  }, [query.query, searchState?.query]);
+
   if (!isAlgoliaEnabled()) {
     return <div className={classes.root}>
       Search is disabled (Algolia App ID not configured on server)


### PR DESCRIPTION
This PR fixes a bug where trying to search using the search box in the navigation bar doesn't work whilst on the search page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205138131933274) by [Unito](https://www.unito.io)
