### PR TITLE
Fix `EAPostsItem` right clicking again

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -257,9 +257,17 @@ const EAPostsItem = ({classes, ...props}: EAPostsItemProps) => {
     </>
   );
 
+  // The nesting here gets a little messy: we need to add the extra `Link`
+  // around the title to make it right-clickable/cmd+clickable. However,
+  // clicking this adds a second history item when navigating to the post
+  // normally requiring the user to press back twice to get to where they
+  // started so we need to wrap that whole thing in an `InteractionWrapper`
+  // too.
   const TitleWrapper: FC = ({children}) => (
     <PostsItemTooltipWrapper post={post} placement={tooltipPlacement} As="span">
-      {children}
+      <InteractionWrapper>
+        <Link to={postLink}>{children}</Link>
+      </InteractionWrapper>
     </PostsItemTooltipWrapper>
   );
 


### PR DESCRIPTION
We recently fixed a bug where clicking the title of an `EAPostsItem` would create 2 history items so the user would need to press back twice to get back to where they started (#7603) by removing an extra link wrapper.

It turns out that the reason for that extra wrapper was to fix a different bug where post titles couldn't be right clicked.

We should be able to fix both bugs at once by adding the extra link back in, and then wrapping the whole thing in `InteractionWrapper`.