### PR TITLE
[EA Forum only] allow users to edit the digest's start and end dates

### DIFF
--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -172,7 +172,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   const digest = results?.[0]
 
   // get the list of posts eligible for this digest
-  const { data, refetch } = useQuery(gql`
+  const { data } = useQuery(gql`
     query getDigestPlannerData($digestId: String, $startDate: Date, $endDate: Date) {
       DigestPlannerData(digestId: $digestId, startDate: $startDate, endDate: $endDate) {
         post {
@@ -446,7 +446,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   }
   
   // if we have no posts to display, just show the page heading
-  const pageHeadingNode = <EditDigestHeader digest={digest} refetchPosts={refetch} />
+  const pageHeadingNode = <EditDigestHeader digest={digest} />
   if (!posts.length) {
     return <div className={classes.root}>
       {pageHeadingNode}

--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -172,7 +172,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   const digest = results?.[0]
 
   // get the list of posts eligible for this digest
-  const { data } = useQuery(gql`
+  const { data, refetch } = useQuery(gql`
     query getDigestPlannerData($digestId: String, $startDate: Date, $endDate: Date) {
       DigestPlannerData(digestId: $digestId, startDate: $startDate, endDate: $endDate) {
         post {
@@ -201,12 +201,13 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   const [postStatuses, setPostStatuses] = useState<Record<string, DigestPost>>({})
   // disable all status icons while processing the previous click
   const [statusIconsDisabled, setStatusIconsDisabled] = useState<boolean>(false)
-  // disable all status icons while processing the previous click
+  // by default, the current user's votes are hidden, but they can click the column header to reveal them
   const [votesVisible, setVotesVisible] = useState<boolean>(false)
   
   useEffect(() => {
-    // this is just to initialize the list of posts and statuses
-    if (!eligiblePosts || posts) return
+    // This is just to initialize the list of posts and statuses.
+    // It should only happen again if the digest dates change and we refetch the posts.
+    if (!eligiblePosts) return
     
     const newPosts: Array<PostWithRating> = []
     const newPostStatuses: Record<string,DigestPost> = {}
@@ -230,7 +231,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
     })
     setPosts(newPosts)
     setPostStatuses(newPostStatuses)
-  }, [eligiblePosts]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [eligiblePosts])
   
   // the digest status of each post is saved on a DigestPost record
   const { create: createDigestPost } = useCreate({
@@ -445,7 +446,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   }
   
   // if we have no posts to display, just show the page heading
-  const pageHeadingNode = <EditDigestHeader digest={digest} />
+  const pageHeadingNode = <EditDigestHeader digest={digest} refetchPosts={refetch} />
   if (!posts.length) {
     return <div className={classes.root}>
       {pageHeadingNode}

--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -8,7 +8,7 @@ import { useMessages } from '../../common/withMessages';
 import { useCreate } from '../../../lib/crud/withCreate';
 import { useUpdate } from '../../../lib/crud/withUpdate';
 import { useLocation } from '../../../lib/routeUtil';
-import { DIGEST_STATUS_OPTIONS, InDigestStatusOption, StatusField, getDigestName, getEmailDigestPostListData, getStatusFilterOptions } from '../../../lib/collections/digests/helpers';
+import { DIGEST_STATUS_OPTIONS, InDigestStatusOption, StatusField, getEmailDigestPostListData, getStatusFilterOptions } from '../../../lib/collections/digests/helpers';
 import { useCurrentUser } from '../../common/withUser';
 import { userIsAdmin } from '../../../lib/vulcan-users/permissions';
 import classNames from 'classnames';
@@ -348,7 +348,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   }
 
 
-  const { Loading, SectionTitle, ForumDropdown, ForumDropdownMultiselect, ForumIcon, LWTooltip,
+  const { Loading, EditDigestHeader, ForumDropdown, ForumDropdownMultiselect, ForumIcon, LWTooltip,
     EditDigestPublishBtn, EditDigestTableRow, Error404 } = Components
   
   // list of the most common tags in the overall posts list
@@ -445,10 +445,7 @@ const EditDigest = ({classes}:{classes: ClassesType}) => {
   }
   
   // if we have no posts to display, just show the page heading
-  const pageHeadingNode = <SectionTitle
-    title={getDigestName({digest})}
-    noTopMargin
-  />
+  const pageHeadingNode = <EditDigestHeader digest={digest} />
   if (!posts.length) {
     return <div className={classes.root}>
       {pageHeadingNode}

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { Components, registerComponent } from '../../../lib/vulcan-lib';
+import { getDigestName } from '../../../lib/collections/digests/helpers';
+import moment from 'moment';
+import { useUpdate } from '../../../lib/crud/withUpdate';
+import classNames from 'classnames';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+  },
+  date: {
+    cursor: "pointer",
+    "&:hover": {
+      color: theme.palette.grey[800],
+    },
+  }
+});
+
+export const EditDigestHeader = ({digest, classes}: {
+  digest: DigestsMinimumInfo,
+  classes: ClassesType,
+}) => {
+  const [isEditingStartDate, setIsEditingStartDate] = useState(false);
+  const [isEditingEndDate, setIsEditingEndDate] = useState(false);
+  const {mutate: updateDigest} = useUpdate({
+    collectionName: "Digests",
+    fragmentName: "DigestsMinimumInfo",
+  });
+
+  const startFormatted = moment(digest.startDate).format('MMM D')
+  const endFormatted = digest.endDate ? moment(digest.endDate).format('MMM D') : 'now'
+
+  const onChangeDate = (field: string, date?: Date) => {
+    if (date) {
+      updateDigest({
+        selector: {_id: digest._id},
+        data: {
+          [field]: date,
+        },
+      });
+    }
+  }
+
+  const {SectionTitle, DatePicker} = Components;
+
+  const startNode = isEditingStartDate
+    ? (
+      <DatePicker
+        label="Start date"
+        value={new Date(digest.startDate)}
+        onChange={onChangeDate.bind(null, "startDate")}
+        below
+      />
+    )
+    : (
+      <span onClick={() => setIsEditingStartDate(true)} className={classes.date}>
+        {startFormatted}
+      </span>
+    );
+
+  const endNode = isEditingEndDate && digest.endDate
+    ? (
+      <DatePicker
+        label="End date"
+        value={new Date(digest.endDate)}
+        onChange={onChangeDate.bind(null, "endDate")}
+        below
+      />
+    )
+    : (
+      <span
+        onClick={() => setIsEditingEndDate(true)}
+        className={classNames({[classes.date]: digest.endDate})}
+      >
+        {endFormatted}
+      </span>
+    );
+
+  return <SectionTitle
+    title={<span className={classes.root}>
+      {getDigestName({digest, includeDates: false})} ({startNode} - {endNode})
+    </span>}
+    noTopMargin
+  />
+}
+
+const EditDigestHeaderComponent = registerComponent('EditDigestHeader', EditDigestHeader, {styles});
+
+declare global {
+  interface ComponentTypes {
+    EditDigestHeader: typeof EditDigestHeaderComponent
+  }
+}

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
@@ -38,7 +38,7 @@ export const EditDigestHeader = ({digest, refetchPosts, classes}: {
   const startFormatted = moment(digest.startDate).format('MMM D')
   const endFormatted = digest.endDate ? moment(digest.endDate).format('MMM D') : 'now'
 
-  const onChangeDate = (field: string, date?: Date) => {
+  const onChangeDate = (field: "startDate"|"endDate", date?: Date) => {
     if (date) {
       void updateDigest({
         selector: {_id: digest._id},

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
-    alignItems: "center",
     gap: "4px",
   },
   date: {
@@ -16,13 +15,19 @@ const styles = (theme: ThemeType): JssStyles => ({
     "&:hover": {
       color: theme.palette.grey[800],
     },
+  },
+  datePicker: {
+    transform: 'translateY(-12px)',
+    zIndex: 2
   }
 });
 
-export const EditDigestHeader = ({digest, classes}: {
+export const EditDigestHeader = ({digest, refetchPosts, classes}: {
   digest: DigestsMinimumInfo,
+  refetchPosts: () => void,
   classes: ClassesType,
 }) => {
+  // clicking on the start or end date lets you edit it
   const [isEditingStartDate, setIsEditingStartDate] = useState(false);
   const [isEditingEndDate, setIsEditingEndDate] = useState(false);
   const {mutate: updateDigest} = useUpdate({
@@ -35,7 +40,7 @@ export const EditDigestHeader = ({digest, classes}: {
 
   const onChangeDate = (field: string, date?: Date) => {
     if (date) {
-      updateDigest({
+      void updateDigest({
         selector: {_id: digest._id},
         data: {
           [field]: date,
@@ -48,12 +53,15 @@ export const EditDigestHeader = ({digest, classes}: {
 
   const startNode = isEditingStartDate
     ? (
-      <DatePicker
-        label="Start date"
-        value={new Date(digest.startDate)}
-        onChange={onChangeDate.bind(null, "startDate")}
-        below
-      />
+      <div className={classes.datePicker}>
+        <DatePicker
+          label="Start date"
+          value={new Date(digest.startDate)}
+          onChange={onChangeDate.bind(null, "startDate")}
+          onClose={refetchPosts}
+          below
+        />
+      </div>
     )
     : (
       <span onClick={() => setIsEditingStartDate(true)} className={classes.date}>
@@ -63,12 +71,15 @@ export const EditDigestHeader = ({digest, classes}: {
 
   const endNode = isEditingEndDate && digest.endDate
     ? (
-      <DatePicker
-        label="End date"
-        value={new Date(digest.endDate)}
-        onChange={onChangeDate.bind(null, "endDate")}
-        below
-      />
+      <div className={classes.datePicker}>
+        <DatePicker
+          label="End date"
+          value={new Date(digest.endDate)}
+          onChange={onChangeDate.bind(null, "endDate")}
+          onClose={refetchPosts}
+          below
+        />
+      </div>
     )
     : (
       <span

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
@@ -22,9 +22,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-export const EditDigestHeader = ({digest, refetchPosts, classes}: {
+export const EditDigestHeader = ({digest, classes}: {
   digest: DigestsMinimumInfo,
-  refetchPosts: () => void,
   classes: ClassesType,
 }) => {
   // clicking on the start or end date lets you edit it
@@ -58,7 +57,9 @@ export const EditDigestHeader = ({digest, refetchPosts, classes}: {
           label="Start date"
           value={new Date(digest.startDate)}
           onChange={onChangeDate.bind(null, "startDate")}
-          onClose={refetchPosts}
+          onClose={(newDate: Date) => {
+            setIsEditingStartDate(false)
+          }}
           below
         />
       </div>
@@ -76,7 +77,9 @@ export const EditDigestHeader = ({digest, refetchPosts, classes}: {
           label="End date"
           value={new Date(digest.endDate)}
           onChange={onChangeDate.bind(null, "endDate")}
-          onClose={refetchPosts}
+          onClose={(newDate: Date) => {
+            setIsEditingEndDate(false)
+          }}
           below
         />
       </div>

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
@@ -280,7 +280,7 @@ const EditDigestTableRow = ({post, postStatus, statusIconsDisabled, handleClickS
     </td>
     {/* <td className={classes.ratingCol}>{post.rating}</td> */}
     <td className={classes.commentsCol}>
-      {post.commentCount && <a href={`${postGetPageUrl(post)}#comments`} target="_blank" rel="noreferrer" className={classes.link}>
+      {post.commentCount > 0 && <a href={`${postGetPageUrl(post)}#comments`} target="_blank" rel="noreferrer" className={classes.link}>
         <ForumIcon icon="Comment" className={classes.commentIcon} />
         {post.commentCount}
       </a>}

--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -6,6 +6,7 @@ import moment from '../../lib/moment-timezone';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 import type { Moment } from 'moment';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   input: {
@@ -20,6 +21,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   timezone: {
     marginLeft: 4
+  },
+
+  wrapperAbove: {
+    "& .rdtPicker": {
+      bottom: 30,
+    },
+  },
+  wrapperBelow: {
+    "& .rdtOpen .DatePicker-input": {
+      borderBottom: `solid 1px ${theme.palette.grey[550]}`,
+    },
   },
 
   // Styles from react-datetime (https://github.com/arqex/react-datetime)
@@ -40,7 +52,6 @@ const styles = (theme: ThemeType): JssStyles => ({
       background: theme.palette.panelBackground.default,
       boxShadow: theme.palette.boxShadow.moreFocused,
       border: `1px solid ${theme.palette.grey[55]}`,
-      bottom: 30,
     },
     "& .rdtOpen .rdtPicker": {
       display: "block",
@@ -232,10 +243,11 @@ const styles = (theme: ThemeType): JssStyles => ({
  * a date/time. Needs the wrapping to get its styles. This is split from
  * FormComponentDateTime so that it can be used in non-vulcan-forms contexts.
  */
-const DatePicker = ({label, name, value, onChange, classes}: {
+const DatePicker = ({label, name, value, below, onChange, classes}: {
   label?: string,
   name?: string,
   value?: Date,
+  below?: boolean,
   onChange: (newValue: Date)=>void,
   classes: ClassesType
 }) => {
@@ -247,7 +259,10 @@ const DatePicker = ({label, name, value, onChange, classes}: {
     <InputLabel className={classes.label}>
       { label } <span className={classes.timezone}>({tzDate.tz(moment.tz.guess()).zoneAbbr()})</span>
     </InputLabel>
-    <div className={classes.wrapper}>
+    <div className={classNames(classes.wrapper, {
+      [classes.wrapperAbove]: !below,
+      [classes.wrapperBelow]: below,
+    })}>
       <DateTimePicker
         value={value}
         inputProps={{

--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -243,12 +243,13 @@ const styles = (theme: ThemeType): JssStyles => ({
  * a date/time. Needs the wrapping to get its styles. This is split from
  * FormComponentDateTime so that it can be used in non-vulcan-forms contexts.
  */
-const DatePicker = ({label, name, value, below, onChange, classes}: {
+const DatePicker = ({label, name, value, below, onChange, onClose, classes}: {
   label?: string,
   name?: string,
   value?: Date,
   below?: boolean,
   onChange: (newValue: Date)=>void,
+  onClose?: (newValue: Date)=>void,
   classes: ClassesType
 }) => {
   // since tz abbrev can depend on the date (i.e. EST vs EDT),
@@ -272,8 +273,11 @@ const DatePicker = ({label, name, value, below, onChange, classes}: {
         }}
         onChange={(newDate: Moment) => {
           // newDate argument is a Moment object given by react-datetime.
-          // HACK: Convert to `Date` in a more sensible way than this
-          onChange((newDate as any)._d)
+          onChange(newDate.toDate())
+        }}
+        onBlur={(newDate: Moment) => {
+          // newDate argument is a Moment object given by react-datetime.
+          onClose?.(newDate.toDate())
         }}
       />
     </div>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -39,6 +39,7 @@ importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHa
 importComponent("EAForumWrappedPage", () => require('../components/ea-forum/EAForumWrappedPage'));
 importComponent("Digests", () => require('../components/ea-forum/digest/Digests'));
 importComponent("EditDigest", () => require('../components/ea-forum/digest/EditDigest'));
+importComponent("EditDigestHeader", () => require('../components/ea-forum/digest/EditDigestHeader'));
 importComponent("EditDigestPublishBtn", () => require('../components/ea-forum/digest/EditDigestPublishBtn'));
 importComponent("ConfirmPublishDialog", () => require('../components/ea-forum/digest/ConfirmPublishDialog'));
 importComponent("EditDigestTableRow", () => require('../components/ea-forum/digest/EditDigestTableRow'));

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -2,36 +2,36 @@ import { getCollectionHooks } from '../mutationCallbacks';
 import Digests from '../../lib/collections/digests/collection';
 import { createMutator, updateMutator } from '../vulcan-lib/mutators';
 
-getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, context}: {document: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
+getCollectionHooks("Digests").updateAsync.add(async ({newDocument, oldDocument, context}: {newDocument: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
   // if we are not currently publishing this digest, skip
-  if (!document.publishedDate || oldDocument.publishedDate) return
+  if (!newDocument.publishedDate || oldDocument.publishedDate) return
   // if a newer digest already exists, skip
-  const newerDigest = await Digests.findOne({ num: {$gt: document.num} })
+  const newerDigest = await Digests.findOne({ num: {$gt: newDocument.num} })
   if (newerDigest) return
   
   // when we first publish a digest, create the next one
   void createMutator({
     collection: Digests,
     document: {
-      num: document.num + 1,
-      startDate: document.endDate ?? new Date()
+      num: newDocument.num + 1,
+      startDate: newDocument.endDate ?? new Date()
     },
     validate: false,
     context
   })
 })
 
-getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, context}: {document: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
+getCollectionHooks("Digests").updateAsync.add(async ({newDocument, oldDocument, context}: {newDocument: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
   // if we change a digest's start date, make sure to update the preceeding digest's end date to match,
   // so that we don't miss any eligible posts
-  if (document.startDate && document.startDate !== oldDocument.startDate) {
+  if (newDocument.startDate && newDocument.startDate !== oldDocument.startDate) {
     void updateMutator({
       collection: Digests,
       selector: {
-        num: document.num - 1,
+        num: newDocument.num - 1,
       },
       set: {
-        endDate: document.startDate,
+        endDate: newDocument.startDate,
       },
       validate: false,
     });
@@ -39,14 +39,14 @@ getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, con
 
   // if we change a digest's end date, make sure to update any subsequent digest's start date to match,
   // so that we don't miss any eligible posts
-  if (document.endDate && document.endDate !== oldDocument.endDate) {
+  if (newDocument.endDate && newDocument.endDate !== oldDocument.endDate) {
     void updateMutator({
       collection: Digests,
       selector: {
-        num: document.num + 1,
+        num: newDocument.num + 1,
       },
       set: {
-        startDate: document.endDate,
+        startDate: newDocument.endDate,
       },
       validate: false,
     });

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -22,6 +22,8 @@ getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, con
 })
 
 getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, context}: {document: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
+  // if we change a digest's start date, make sure to update the preceeding digest's end date to match,
+  // so that we don't miss any eligible posts
   if (document.startDate && document.startDate !== oldDocument.startDate) {
     void updateMutator({
       collection: Digests,
@@ -35,6 +37,8 @@ getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, con
     });
   }
 
+  // if we change a digest's end date, make sure to update any subsequent digest's start date to match,
+  // so that we don't miss any eligible posts
   if (document.endDate && document.endDate !== oldDocument.endDate) {
     void updateMutator({
       collection: Digests,

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -1,6 +1,6 @@
 import { getCollectionHooks } from '../mutationCallbacks';
 import Digests from '../../lib/collections/digests/collection';
-import { createMutator } from '../vulcan-lib/mutators';
+import { createMutator, updateMutator } from '../vulcan-lib/mutators';
 
 getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, context}: {document: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
   // if we are not currently publishing this digest, skip
@@ -20,3 +20,31 @@ getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, con
     context
   })
 })
+
+getCollectionHooks("Digests").updateAsync.add(async ({document, oldDocument, context}: {document: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
+  if (document.startDate && document.startDate !== oldDocument.startDate) {
+    void updateMutator({
+      collection: Digests,
+      selector: {
+        num: document.num - 1,
+      },
+      set: {
+        endDate: document.startDate,
+      },
+      validate: false,
+    });
+  }
+
+  if (document.endDate && document.endDate !== oldDocument.endDate) {
+    void updateMutator({
+      collection: Digests,
+      selector: {
+        num: document.num + 1,
+      },
+      set: {
+        startDate: document.endDate,
+      },
+      validate: false,
+    });
+  }
+});


### PR DESCRIPTION
This PR updates the "Edit digest" page, such that clicking on the start or end date turns it into an input that lets you edit it. It's not pretty but this is an internal admin page, and we should rarely need to change these dates. It's also nice that it's quick to do, and the post list updates when the date picker closes.

<img width="372" alt="Screen Shot 2023-07-27 at 1 27 41 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/451cf1d4-fd5a-472e-8307-a03cb491916a">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205154958486831) by [Unito](https://www.unito.io)
