### PR TITLE
enable  flip in post header's actions popper

### DIFF
--- a/packages/lesswrong/components/common/LWPopper.tsx
+++ b/packages/lesswrong/components/common/LWPopper.tsx
@@ -43,6 +43,7 @@ const LWPopper = ({
   className,
   tooltip=false,
   allowOverflow,
+  flip,
   open,
   anchorEl,
   placement,
@@ -53,6 +54,7 @@ const LWPopper = ({
   children: ReactNode,
   tooltip?: boolean,
   allowOverflow?: boolean,
+  flip?: boolean,
   open: boolean,
   placement?: PopperPlacementType,
   anchorEl: any,
@@ -63,16 +65,19 @@ const LWPopper = ({
   const [everOpened, setEverOpened] = useState(open);
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
+  const flipModifier = !flip && allowOverflow ? [
+    {
+      name: 'flip',
+      enabled: false,
+    }
+  ] : [];
+
   const preventOverflowModifier = allowOverflow ? [
     {
       name: 'preventOverflow',
       enabled: false,
-    },
-    {
-      name: 'flip',
-      enabled: false,
-    },
-  ] : []
+    }
+  ] : [];
 
   const { styles, attributes } = usePopper(anchorEl, popperElement, {
     placement,
@@ -83,6 +88,7 @@ const LWPopper = ({
           gpuAcceleration: false, // true by default
         },
       },
+      ...flipModifier,
       ...preventOverflowModifier
     ],
   });

--- a/packages/lesswrong/components/common/PopperCard.tsx
+++ b/packages/lesswrong/components/common/PopperCard.tsx
@@ -3,15 +3,16 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import Card from '@material-ui/core/Card';
 import { PopperPlacementType } from '@material-ui/core/Popper'
 
-const PopperCard = ({children, placement="bottom-start", open, anchorEl, allowOverflow, style}: {
+const PopperCard = ({children, placement="bottom-start", open, anchorEl, allowOverflow, flip, style}: {
   children?: React.ReactNode,
   placement?: PopperPlacementType,
   open: boolean,
   anchorEl: HTMLElement|null,
   allowOverflow?: boolean,
+  flip?: boolean,
   style?: CSSProperties,
 }) => {
-  return <Components.LWPopper open={open} anchorEl={anchorEl} placement={placement} allowOverflow={allowOverflow}>
+  return <Components.LWPopper open={open} anchorEl={anchorEl} placement={placement} allowOverflow={allowOverflow} flip={flip}>
     <Card style={style}>
       {children}
     </Card>

--- a/packages/lesswrong/components/dropdowns/DropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownItem.tsx
@@ -35,6 +35,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     flexGrow: 1,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
   },
   afterIcon: {
     fontSize: 20,

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -12,6 +12,7 @@ export const AllowHidingFrontPagePostsContext = React.createContext<boolean>(fal
 const styles = (_theme: ThemeType): JssStyles => ({
   root: {
     minWidth: isEAForum ? undefined : 300,
+    maxWidth: "calc(100vw - 100px)",
   },
 })
 

--- a/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
@@ -23,11 +23,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const PostActionsButton = ({post, vertical, popperGap, autoPlace, includeBookmark=true, classes}: {
+const PostActionsButton = ({post, vertical, popperGap, autoPlace, flip, includeBookmark=true, classes}: {
   post: PostsList|SunshinePostsList,
   vertical?: boolean,
   popperGap?: number,
   autoPlace?: boolean,
+  flip?: boolean,
   includeBookmark?: boolean,
   classes: ClassesType,
 }) => {
@@ -72,6 +73,7 @@ const PostActionsButton = ({post, vertical, popperGap, autoPlace, includeBookmar
       anchorEl={anchorEl.current}
       placement={popperPlacement}
       allowOverflow
+      flip={flip}
       style={gapStyle}
     >
       {/*FIXME: ClickAwayListener doesn't handle portals correctly, which winds up making submenus inoperable. But we do still need clickaway to close.*/}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -327,7 +327,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const tripleDotMenuNode = !hideMenu &&
     <span className={classes.actions}>
       <AnalyticsContext pageElementContext="tripleDotMenu">
-        <PostActionsButton post={post} includeBookmark={!isEAForum} />
+        <PostActionsButton post={post} includeBookmark={!isEAForum} flip={true}/>
       </AnalyticsContext>
     </span>
 


### PR DESCRIPTION
An alternative to #7554 (which was reverted in #7627).

This PR enables the Popper.js' flip modifier to automatically flip the popper of PostHeader's ActionsButton.
It uses flip rather than preventOverflow, because the latter affects vertical overflow as well (which causes unwanted behavior when scrolling).

# Screenshots
## Desktop
![image](https://github.com/ForumMagnum/ForumMagnum/assets/37066741/4dfd9660-04a6-45c0-bb43-4a85cf66d265)

## Mobile with actions button on the right
![image](https://github.com/ForumMagnum/ForumMagnum/assets/37066741/16751dd9-5b3f-45b5-9c06-fdeaed90a580)

## Mobile with actions button on the left
![image](https://github.com/ForumMagnum/ForumMagnum/assets/37066741/5602dda1-fdb3-4ad5-b4e0-d7f6da9ee33a)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205158502782984) by [Unito](https://www.unito.io)
