### PR TITLE
Remove negative margin on LinkPostMessage everywhere except the posts page

### DIFF
--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -10,7 +10,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     wordBreak: 'break-word',
     width: '100%',
     padding: 16,
-    margin: "0 0 18px 0",
+    marginBottom: 18,
     backgroundColor: theme.palette.grey[100],
     color: theme.palette.grey[1000],
     boxSizing: 'border-box',
@@ -21,21 +21,21 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle,
   },
-  noMargin: {
-    marginBottom: 0
+  negativeTopMargin: {
+    marginTop: -14,
   }
 })
 
-const LinkPostMessage = ({post, classes, noMargin}: {
+const LinkPostMessage = ({post, classes, negativeTopMargin}: {
   post: PostsBase,
   classes: ClassesType,
-  noMargin?: boolean
+  negativeTopMargin?: boolean
 }) => {
   if (!post.url)
     return null;
 
   return (
-    <div className={classNames(classes.root, {[classes.noMargin]:noMargin})}>
+    <div className={classNames(classes.root, {[classes.negativeTopMargin]: negativeTopMargin})}>
       This is a linkpost for <a href={postGetLink(post)} target={postGetLinkTarget(post)}>{post.url}</a>
     </div>
   );

--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -10,7 +10,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     wordBreak: 'break-word',
     width: '100%',
     padding: 16,
-    margin: "-14px 0 18px 0",
+    margin: "0 0 18px 0",
     backgroundColor: theme.palette.grey[100],
     color: theme.palette.grey[1000],
     boxSizing: 'border-box',

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -120,7 +120,7 @@ const PostBodyPrefix = ({post, query, classes}: {
         <Info className={classes.infoIcon}/>
       </LWTooltip>
     </div>}
-    <LinkPostMessage post={post} />
+    <LinkPostMessage post={post} negativeTopMargin />
     {query?.revision && post.contents && <PostsRevisionMessage post={post} />}
   </>;
 }


### PR DESCRIPTION
The negative margin was causing this issue in recent discussion:
![image](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/5db57ed8-488e-433b-8ff3-b06116a515ed)

This PR fixes that. I still think it looks much better with the negative margin in the posts page itself, and also that it isn't worth refactoring to remove it by reducing the margin above because that will affect a lot of other things, so I have left it in there. Here is a screenshot with and without in case anyone things we should remove it entirely:
![Screenshot 2023-07-28 at 10 15 20](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/26043d7c-6e5d-47ee-934a-0dfdcce31b76)
![Screenshot 2023-07-28 at 10 15 39](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/1a583db0-f883-48ec-ba25-33f56a73b415)


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205159241305306) by [Unito](https://www.unito.io)
