### PR TITLE
cut over search to elastic and use new search page for LW

### DIFF
--- a/packages/lesswrong/components/search/ExpandedUsersSearchHit.tsx
+++ b/packages/lesswrong/components/search/ExpandedUsersSearchHit.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import type { Hit } from 'react-instantsearch-core';
 import { Snippet } from 'react-instantsearch-dom';
 import LocationIcon from '@material-ui/icons/LocationOn'
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -71,9 +72,9 @@ const ExpandedUsersSearchHit = ({hit, classes}: {
 
   return <div className={classes.root}>
     <Link to={`${userGetProfileUrl(user)}?from=search_page`} className={classes.link}>
-      <div className={classes.profilePhotoCol}>
+      {isEAForum && <div className={classes.profilePhotoCol}>
         <UsersProfileImage user={user} size={36} />
-      </div>
+      </div>}
       <div>
         <div className={classes.displayNameRow}>
           <span className={classes.displayName}>

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -28,7 +28,6 @@ import {
   getElasticSortingsForCollection,
   isValidElasticSorting,
 } from '../../lib/search/elasticUtil';
-import { userHasElasticsearch } from '../../lib/betas';
 import { communityPath } from '../../lib/routes';
 
 const hitsPerPage = 10
@@ -436,7 +435,7 @@ const SearchPageTabbed = ({classes}:{
           <Link to={`${communityPath}#individuals`}>View community map</Link>
         </div>}
 
-        {elasticCollectionIsCustomSortable(tab) && userHasElasticsearch(null) &&
+        {elasticCollectionIsCustomSortable(tab) &&
           <>
             <Typography variant="headline" className={classes.filtersHeadline}>
               Sort

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -43,8 +43,6 @@ export const userHasCommentProfileImages = disabled;
 
 export const userHasEagProfileImport = disabled;
 
-export const userHasElasticsearch = isEAForum ? shippedFeature : disabled;
-
 export const userHasPopularCommentsSection = isEAForum ? adminOnly : disabled;
 
 // Shipped Features
@@ -53,3 +51,4 @@ export const userCanCreateTags = shippedFeature;
 export const userCanUseTags = shippedFeature;
 export const userCanViewRevisionHistory = shippedFeature;
 export const userHasPingbacks = shippedFeature;
+export const userHasElasticsearch = shippedFeature;

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -356,7 +356,7 @@ addRoute(
   {
     name: 'search',
     path: '/search',
-    componentName: forumTypeSetting.get() === 'EAForum' ? 'SearchPageTabbed' : 'SearchPage',
+    componentName: 'SearchPageTabbed',
     title: 'Search',
     background: "white"
   },

--- a/packages/lesswrong/lib/search/algoliaUtil.ts
+++ b/packages/lesswrong/lib/search/algoliaUtil.ts
@@ -1,11 +1,10 @@
-import algoliasearch, { Client } from "algoliasearch/lite";
+import type { Client } from "algoliasearch/lite";
 import NativeSearchClient from "./NativeSearchClient";
 import {
   algoliaAppIdSetting,
   algoliaSearchKeySetting,
   algoliaPrefixSetting,
 } from '../publicSettings';
-import { userHasElasticsearch } from "../betas";
 
 export const algoliaIndexedCollectionNames = ["Comments", "Posts", "Users", "Sequences", "Tags"] as const
 export type AlgoliaIndexCollectionName = typeof algoliaIndexedCollectionNames[number]
@@ -32,16 +31,6 @@ export const isAlgoliaEnabled = () => !!algoliaAppIdSetting.get() && !!algoliaSe
 
 let searchClient: Client | null = null;
 
-const getAlgoliaSearchClient = (): Client | null => {
-  const algoliaAppId = algoliaAppIdSetting.get()
-  const algoliaSearchKey = algoliaSearchKeySetting.get()
-  if (!algoliaAppId || !algoliaSearchKey)
-    return null;
-  if (!searchClient)
-    searchClient = algoliasearch(algoliaAppId, algoliaSearchKey);
-  return searchClient;
-}
-
 const getNativeSearchClient = (): Client | null => {
   if (!searchClient) {
     searchClient = new NativeSearchClient();
@@ -50,9 +39,7 @@ const getNativeSearchClient = (): Client | null => {
 }
 
 export const getSearchClient = (): Client => {
-  const client = userHasElasticsearch(null)
-    ? getNativeSearchClient()
-    : getAlgoliaSearchClient();
+  const client = getNativeSearchClient();
   if (!client) {
     throw new Error("Couldn't initialize search client");
   }


### PR DESCRIPTION
Enabling ElasticSearch on LessWrong, as well as switching over to the new tabbed search page!
<img width="1728" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/7530889f-4f18-44d9-853e-4cfad918a7ed">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205163040460247) by [Unito](https://www.unito.io)
