### PR TITLE
EA Post types fixes

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -204,6 +204,7 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
                 onTagSelected={onTagSelected}
                 onTagRemoved={onTagRemoved}
                 displaySelected="highlight"
+                shortNames
               />
             </>
           }

--- a/packages/lesswrong/components/tagging/TagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/TagsChecklist.tsx
@@ -96,6 +96,7 @@ const TagsChecklist = ({
   tooltips = true,
   truncate = false,
   smallText = false,
+  shortNames = false,
 }: {
   onTagSelected?: (
     tag: { tagId: string; tagName: string; parentTagId?: string },
@@ -109,6 +110,7 @@ const TagsChecklist = ({
   tooltips?: boolean;
   truncate?: boolean;
   smallText?: boolean,
+  shortNames?: boolean,
 }) => {
   const { LWTooltip, LoadMore, ForumIcon } = Components;
   const [loadMoreClicked, setLoadMoreClicked] = useState(false);
@@ -144,7 +146,7 @@ const TagsChecklist = ({
   const handleOnTagSelected = (tag: AnyBecauseTodo, existingTagIds: AnyBecauseTodo) => onTagSelected({ tagId: tag._id, tagName: tag.name, parentTagId: tag.parentTag?._id }, existingTagIds)
   const handleOnTagRemoved = (tag: AnyBecauseTodo, existingTagIds: AnyBecauseTodo) => onTagRemoved({ tagId: tag._id, tagName: tag.name, parentTagId: tag.parentTag?._id }, existingTagIds)
 
-  const getTagName = ({tag}: TagsChecklistItem) => smallText
+  const getTagName = ({tag}: TagsChecklistItem) => smallText || shortNames
     ? tag.shortName ?? tag.name
     : tag.name;
 

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -270,6 +270,7 @@ registerFragment(`
 registerFragment(`
   fragment TagEditFragment on Tag {
     ...TagDetailsFragment
+    isPostType
     parentTag {
       ...TagBasicInfo
     }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2287,6 +2287,7 @@ interface TagFullContributorsList { // fragment on Tags
 }
 
 interface TagEditFragment extends TagDetailsFragment { // fragment on Tags
+  readonly isPostType: boolean,
   readonly parentTag: TagBasicInfo|null,
   readonly subforumIntroPostId: string,
   readonly tagFlagsIds: Array<string>,


### PR DESCRIPTION
- Use the short name for post types on the edit post page
- Include `isPostType` in `TagEditFragment`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205173543354966) by [Unito](https://www.unito.io)
