### PR TITLE
Fix text overflow for usernames on messages with many participants

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationItem.tsx
+++ b/packages/lesswrong/components/messaging/ConversationItem.tsx
@@ -11,6 +11,12 @@ import * as _ from 'underscore';
 
 const styles = (theme: ThemeType): JssStyles => ({
   ...postsItemLikeStyles(theme),
+  wrap: {
+    flexWrap: "wrap",
+  },
+  titleLineHeight: {
+    lineHeight: "1.5em",
+  },
   leftMargin: {
     marginLeft: theme.spacing.unit * 2
   },
@@ -54,8 +60,8 @@ const ConversationItem = ({conversation, updateConversation, currentUser, classe
 
   return (
     <div className={expanded ? classes.boxShadow : null}>
-      <div className={classNames(classes.root, {[classes.archivedItem]: isArchived})}>
-        <Link to={`/inbox/${conversation._id}`} className={classNames(classes.title, classes.commentFont)}>{conversationGetTitle(conversation, currentUser)}</Link>
+      <div className={classNames(classes.root, classes.wrap, {[classes.archivedItem]: isArchived})}>
+        <Link to={`/inbox/${conversation._id}`} className={classNames(classes.title, classes.titleLineHeight, classes.commentFont)}>{conversationGetTitle(conversation, currentUser)}</Link>
         { conversation.participants
           .filter(user => user._id !== currentUser._id)
           .map(user => <span key={user._id} className={classes.leftMargin}>


### PR DESCRIPTION
This PR fixes particpant names overflowing for messages with many participants, as well as fixing font descendors being cutoff by the line height.

The change is _not_ currently forum gated.

Before:
<img width="879" alt="Screenshot 2023-07-31 at 21 43 36" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/34f0615c-83c8-471a-86fd-bb39c5d008e8">
<img width="404" alt="Screenshot 2023-07-31 at 21 43 29" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/9f4a14aa-0371-4e48-aa05-0b187b273858">

After:
<img width="791" alt="Screenshot 2023-07-31 at 21 42 45" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4f1ee569-49bb-436c-8565-9d57f7fd0eac">
<img width="402" alt="Screenshot 2023-07-31 at 21 43 00" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/e45a7736-4d66-4c2f-b4fe-d5147dda185e">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205176790333015) by [Unito](https://www.unito.io)
