### PR TITLE
Fix a crash on older iOS Safari versions

### DIFF
--- a/packages/lesswrong/components/themes/usePrefersDarkMode.tsx
+++ b/packages/lesswrong/components/themes/usePrefersDarkMode.tsx
@@ -26,8 +26,10 @@ export const PrefersDarkModeProvider = ({children}: {
         prefersDarkMode: matches,
       });
     }
-    query.addEventListener("change", handler);
-    return () => query.removeEventListener("change", handler);
+    if (query.addEventListener) {
+      query.addEventListener("change", handler);
+      return () => query.removeEventListener("change", handler);
+    }
   }, [query]);
 
   return (


### PR DESCRIPTION
Reproduced the crash (and the fix) on Browserstack with iPad Mini 2013/v13.


