### PR TITLE
fix once per week rate limit and only count unique downvotes on net negative content

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
@@ -123,7 +123,7 @@ const RecentlyActiveUsers = ({ classes }: {
   const [expandId, setExpandId] = useState<string|null>(null);
 
   const [sorting, setSorting] = useState<SortingType>("lastNotificationsCheck");
-  const [ignoreLowKarma, setIgnoreLowKarma] = useState<boolean>(false); // TODO: implement this optio
+  const [ignoreLowKarma, setIgnoreLowKarma] = useState<boolean>(false);
 
   const {query} = useLocation();
   const limit = parseInt(query.limit) || 200 // this is using || instead of ?? because it correclty handles NaN 
@@ -187,7 +187,7 @@ const RecentlyActiveUsers = ({ classes }: {
     })
   };
 
-  let sortedUsers = results;
+  let sortedUsers = ignoreLowKarma ? results.filter(user => user.karma >= 5) : results;;
   switch (sorting) {
     case "karma":
       sortedUsers = usersSortByKarma(results);
@@ -208,8 +208,6 @@ const RecentlyActiveUsers = ({ classes }: {
       sortedUsers = userSortByLastNotificationsCheck(results);
       break
   } 
-
-  sortedUsers = ignoreLowKarma ? sortedUsers.filter(user => user.karma >= 5) : sortedUsers;
 
   return (
     <div className={classes.root}>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { userIsAdminOrMod } from '../../../lib/vulcan-users';
 import { useMulti } from '../../../lib/crud/withMulti';
@@ -136,9 +136,6 @@ const RecentlyActiveUsers = ({ classes }: {
     enableTotal: true
   });
 
-  if (!currentUser || !userIsAdminOrMod(currentUser)) {
-    return null;
-  }
 
   const handleExpand = (id: string) => {
     if (expandId === id) {
@@ -187,7 +184,8 @@ const RecentlyActiveUsers = ({ classes }: {
     })
   };
 
-  let sortedUsers = ignoreLowKarma ? results.filter(user => user.karma >= 5) : results;;
+  let sortedUsers = results
+
   switch (sorting) {
     case "karma":
       sortedUsers = usersSortByKarma(results);
@@ -208,6 +206,12 @@ const RecentlyActiveUsers = ({ classes }: {
       sortedUsers = userSortByLastNotificationsCheck(results);
       break
   } 
+
+  sortedUsers = ignoreLowKarma ? sortedUsers.filter(user => user.karma >= 5) : sortedUsers;
+
+  if (!currentUser || !userIsAdminOrMod(currentUser)) {
+    return null;
+  }
 
   return (
     <div className={classes.root}>

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/RecentlyActiveUsers.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { userIsAdminOrMod } from '../../../lib/vulcan-users';
 import { useMulti } from '../../../lib/crud/withMulti';

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -60,27 +60,30 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
-      last20KarmaThreshold: -15,
+      last20PostKarmaThreshold: -15,
       downvoterCountThreshold: 4,
       rateLimitMessage: `Users with -15 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
     }, 
   // 1 post per 2+ weeks rate limits
     {
       ...timeframe('1 Posts per 2 weeks'),
-      last20KarmaThreshold: -30,
+      karmaThreshold: -1,
+      last20PostKarmaThreshold: -30,
       downvoterCountThreshold: 5,
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 3 weeks'),
-      last20KarmaThreshold: -45,
+      karmaThreshold: -1,
+      last20PostKarmaThreshold: -45,
       downvoterCountThreshold: 5,
       rateLimitMessage: `Users with -45 or less karma on recent posts/comments can post once every 3 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
-      last20KarmaThreshold: -60, // uses last20Karma so it's not too hard to dig your way out 
-      downvoterCountThreshold: 5,
       ...timeframe('1 Posts per 4 weeks'),
+      last20PostKarmaThreshold: -60, // uses last20Karma so it's not too hard to dig your way out 
+      downvoterCountThreshold: 5,
+      karmaThreshold: -1,
       rateLimitMessage: `Users with -60 or less karma can post once every 4 weeks.<br/>${lwDefaultMessage}`
     }
   ],
@@ -126,6 +129,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 3 days'),
       last20KarmaThreshold: -15,
       downvoterCountThreshold: 5,
+      karmaThreshold: 499,
       appliesToOwnPosts: false,
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -133,7 +133,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Comments per 1 weeks'),
       lastMonthKarmaThreshold: -30,
-      downvoterCountThreshold: 5,
+      // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
+      last20KarmaThreshold: -1,
+      karmaThreshold: -1,
+      lastMonthDownvoterCountThreshold: 5,
       appliesToOwnPosts: false,
       rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${lwDefaultMessage}`
     },

--- a/packages/lesswrong/lib/rateLimits/types.ts
+++ b/packages/lesswrong/lib/rateLimits/types.ts
@@ -35,8 +35,8 @@ export interface AutoRateLimit {
   karmaThreshold?: number, // if set, limit will only apply to users with karma less than the threshold
   downvoteRatioThreshold?: number, // if set, limit will only apply to users who's ratio of received downvotes / total votes is higher than the listed threshold
   last20KarmaThreshold?: number //  if set, limit only applies to users whose past 20 posts and comments karma total is less than N
-  recentPostKarmaThreshold?: number // if set, limit only applies to users whose past 20 post karma total is less than N
-  recentCommentKarmaThreshold?: number // if set, limit only applies to users whose past 20 comment karma total is less than N
+  last20PostKarmaThreshold?: number // if set, limit only applies to users whose past 20 post karma total is less than N
+  last20CommentKarmaThreshold?: number // if set, limit only applies to users whose past 20 comment karma total is less than N
   downvoterCountThreshold?: number // if set, limit only applies to users whose past 20 posts and comments were downvoted by N or more people.
   postDownvoterCountThreshold?: number // if set, limit only applies to users whose past 20 posts were downvoted by N or more people.
   commentDownvoterCountThreshold?: number // if set, limit only applies to users whose past 20 comments were downvoted by N or more people.
@@ -45,15 +45,15 @@ export interface AutoRateLimit {
 }
 
 //convert rateLimitThresholds to union type
-export type RateLimitThreshold = "karmaThreshold"|"downvoteRatioThreshold"|"last20KarmaThreshold"|"recentPostKarmaThreshold"|"recentCommentKarmaThreshold"|"lastMonthKarmaThreshold"|"downvoterCountThreshold"|"postDownvoterCountThreshold"|"commentDownvoterCountThreshold"|"lastMonthDownvoterCountThreshold"
+export type RateLimitThreshold = "karmaThreshold"|"downvoteRatioThreshold"|"last20KarmaThreshold"|"last20PostKarmaThreshold"|"last20CommentKarmaThreshold"|"lastMonthKarmaThreshold"|"downvoterCountThreshold"|"postDownvoterCountThreshold"|"commentDownvoterCountThreshold"|"lastMonthDownvoterCountThreshold"
 
 export const rateLimitThresholds: RateLimitThreshold[] = [
   "karmaThreshold",
   "downvoteRatioThreshold", 
   
   "last20KarmaThreshold", 
-  "recentPostKarmaThreshold",
-  "recentCommentKarmaThreshold",
+  "last20PostKarmaThreshold",
+  "last20CommentKarmaThreshold",
   "lastMonthKarmaThreshold",
 
   "downvoterCountThreshold",

--- a/packages/lesswrong/lib/rateLimits/types.ts
+++ b/packages/lesswrong/lib/rateLimits/types.ts
@@ -87,4 +87,5 @@ export type RecentKarmaInfo = {
 
 export type RecentVoteInfo = Pick<DbVote, "_id"|"userId"|"power"|"documentId"|"collectionName"> & {
   postedAt: Date,
+  totalDocumentKarma: number
 }

--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -130,13 +130,13 @@ export function calculateRecentKarmaInfo(userId: string, allVotes: RecentVoteInf
   const last20PostKarma = postVotes.reduce((sum: number, vote: RecentVoteInfo) => sum + vote.power, 0)
   const last20CommentKarma = commentVotes.reduce((sum: number, vote: RecentVoteInfo) => sum + vote.power, 0)
   
-  const downvoters = nonUserIdTop20DocVotes.filter((vote: RecentVoteInfo) => vote.power < 0).map((vote: RecentVoteInfo) => vote.userId)
+  const downvoters = nonUserIdTop20DocVotes.filter((vote: RecentVoteInfo) => vote.power < 0 && vote.totalDocumentKarma < 0).map((vote: RecentVoteInfo) => vote.userId)
   const downvoterCount = uniq(downvoters).length
-  const commentDownvoters = commentVotes.filter((vote: RecentVoteInfo) => vote.power < 0).map((vote: RecentVoteInfo) => vote.userId)
+  const commentDownvoters = commentVotes.filter((vote: RecentVoteInfo) => vote.power < 0 && vote.totalDocumentKarma < 0).map((vote: RecentVoteInfo) => vote.userId)
   const commentDownvoterCount = uniq(commentDownvoters).length
-  const postDownvotes = postVotes.filter((vote: RecentVoteInfo) => vote.power < 0).map((vote: RecentVoteInfo) => vote.userId)
+  const postDownvotes = postVotes.filter((vote: RecentVoteInfo) => vote.power < 0 && vote.totalDocumentKarma < 0).map((vote: RecentVoteInfo) => vote.userId)
   const postDownvoterCount = uniq(postDownvotes).length
-  const lastMonthDownvotes = lastMonthVotes.filter((vote: RecentVoteInfo) => vote.power < 0).map((vote: RecentVoteInfo) => vote.userId)
+  const lastMonthDownvotes = lastMonthVotes.filter((vote: RecentVoteInfo) => vote.power < 0 && vote.totalDocumentKarma < 0).map((vote: RecentVoteInfo) => vote.userId)
   const lastMonthDownvoterCount = uniq(lastMonthDownvotes).length
   return { 
     last20Karma: last20Karma ?? 0, 

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -194,7 +194,7 @@ export default class VotesRepo extends AbstractRepo<DbVote> {
     const voteFields = `"Votes"._id, "Votes"."userId", "Votes"."power", "Votes"."documentId", "Votes"."collectionName"`
     const votes = await this.getRawDb().any(`
       (
-        SELECT ${voteFields}, "Posts"."postedAt"
+        SELECT ${voteFields}, "Posts"."postedAt", "Posts"."baseScore" AS "totalDocumentKarma"
         FROM "Votes"
         JOIN "Posts" on "Posts"._id = "Votes"."documentId"
         WHERE
@@ -213,7 +213,7 @@ export default class VotesRepo extends AbstractRepo<DbVote> {
       )
       UNION
       (
-        SELECT ${voteFields}, "Comments"."postedAt"
+        SELECT ${voteFields}, "Comments"."postedAt", "Comments"."baseScore" AS "totalDocumentKarma"
         FROM "Votes"
         JOIN "Comments" on "Comments"._id = "Votes"."documentId"
         WHERE

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -130,15 +130,15 @@ describe("calculateRecentKarmaInfo", function () {
   })
   it("downvoterCount includes all unique downvoters for recent 20 contents", () => {
     const {downvoterCount} = calculateRecentKarmaInfo("authorId", votes)
-    expect(downvoterCount).toEqual(4)
+    expect(downvoterCount).toEqual(8)
   })
   it("postDownvoterCount includes all unique downvoters from most recent 20 posts", () => {
     const {postDownvoterCount} = calculateRecentKarmaInfo("authorId", votes)
-    expect(postDownvoterCount).toEqual(4)
+    expect(postDownvoterCount).toEqual(10)
   })
   it("commentDownvoterCount includes all unique downvoters from most recent 20 comments", () => {
     const {commentDownvoterCount} = calculateRecentKarmaInfo("authorId", votes)
-    expect(commentDownvoterCount).toEqual(3)
+    expect(commentDownvoterCount).toEqual(7)
   })
   it("lastMonthKarma only includes votes from past month", () => {
     const {lastMonthKarma} = calculateRecentKarmaInfo("authorId", votes)
@@ -146,7 +146,7 @@ describe("calculateRecentKarmaInfo", function () {
   })
   it("lastMonthDownvoterCount includes all unique downvoters from past month content", () => {
     const {lastMonthDownvoterCount} = calculateRecentKarmaInfo("authorId", votes)
-    expect(lastMonthDownvoterCount).toEqual(4)
+    expect(lastMonthDownvoterCount).toEqual(8)
   })
 });
 

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -177,7 +177,7 @@ describe("shouldRateLimitApply", function () {
   it("returns true IFF recent user post karma is less than recentPostKarmaThreshold", () => {
     const recentKarmaInfoPostVotes = calculateRecentKarmaInfo("authorId", postDownVotes)
     const recentKarmaInfoCommentVotes = calculateRecentKarmaInfo("authorId", commentDownVotes)
-    const rateLimit = createCommentRateLimit({recentPostKarmaThreshold: -1})
+    const rateLimit = createCommentRateLimit({last20PostKarmaThreshold: -1})
     const user1 = createUserKarmaInfo()
     
     expect(shouldRateLimitApply(user1, rateLimit, recentKarmaInfoPostVotes)).toEqual(true)
@@ -186,7 +186,7 @@ describe("shouldRateLimitApply", function () {
   it("returns true IFF recent user comment karma is less than recentCommentKarmaThreshold", () => {
     const recentKarmaInfoPostVotes = calculateRecentKarmaInfo("authorId", postDownVotes)
     const recentKarmaInfoCommentVotes = calculateRecentKarmaInfo("authorId", commentDownVotes)
-    const rateLimit = createCommentRateLimit({recentCommentKarmaThreshold: -1})
+    const rateLimit = createCommentRateLimit({last20CommentKarmaThreshold: -1})
     const user1 = createUserKarmaInfo()
     
     expect(shouldRateLimitApply(user1, rateLimit, recentKarmaInfoPostVotes)).toEqual(false)


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205187056495265) by [Unito](https://www.unito.io)
