### PR TITLE
[EA Forum only] use EAButton in digest tool

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAButton.tsx
+++ b/packages/lesswrong/components/ea-forum/EAButton.tsx
@@ -5,8 +5,6 @@ import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    backgroundColor: theme.palette.buttons.alwaysPrimary,
-    color: theme.palette.text.alwaysWhite,
     fontSize: 14,
     lineHeight: '20px',
     textTransform: 'none',
@@ -14,11 +12,22 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderRadius: theme.borderRadius.default,
     boxShadow: 'none',
     '&:hover': {
-      backgroundColor: theme.palette.primary.dark,
       opacity: 1
+    },
+  },
+  variantContained: {
+    backgroundColor: theme.palette.buttons.alwaysPrimary,
+    color: theme.palette.text.alwaysWhite,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+    },
+    '&:disabled': {
+      backgroundColor: theme.palette.buttons.alwaysPrimary,
+      color: theme.palette.text.alwaysWhite,
+      opacity: .5,
     }
   },
-  grey: {
+  greyContained: {
     backgroundColor: theme.palette.grey[250],
     color: theme.palette.grey[1000],
     '&:hover': {
@@ -31,7 +40,7 @@ const styles = (theme: ThemeType): JssStyles => ({
  * Button component with the standard EA Forum styling
  * (see login and sign up site header buttons for example)
  */
-const EAButton = ({style, className, children, classes, ...buttonProps}: {
+const EAButton = ({style, variant="contained", className, children, classes, ...buttonProps}: {
   style?: 'primary'|'grey',
   className?: string,
   children: React.ReactNode,
@@ -40,9 +49,12 @@ const EAButton = ({style, className, children, classes, ...buttonProps}: {
 
   return (
     <Button
-      variant="contained"
+      variant={variant}
       color="primary"
-      className={classNames(classes.root, className, {[classes.grey]: style === 'grey'})}
+      className={classNames(classes.root, className, {
+        [classes.variantContained]: variant === 'contained',
+        [classes.greyContained]: variant === 'contained' && style === 'grey'
+      })}
       {...buttonProps}
     >
       {children}

--- a/packages/lesswrong/components/ea-forum/digest/ConfirmPublishDialog.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/ConfirmPublishDialog.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import DialogContent from '@material-ui/core/DialogContent';
-import Button from '@material-ui/core/Button';
 import DialogActions from '@material-ui/core/DialogActions';
 import { useUpdate } from '../../../lib/crud/withUpdate';
-import classNames from 'classnames';
-
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -21,15 +18,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     marginBottom: 14
   },
-  btn: {
-    fontSize: 14,
-    textTransform: 'none',
-    boxShadow: 'none'
-  },
-  btnPrimary: {
-    backgroundColor: theme.palette.buttons.alwaysPrimary,
-    color: theme.palette.text.alwaysWhite,
-  }
 })
 
 const ConfirmPublishDialog = ({ digest, onClose, classes }: {
@@ -55,9 +43,11 @@ const ConfirmPublishDialog = ({ digest, onClose, classes }: {
     })
     onClose?.()
   }
+  
+  const { LWDialog, EAButton } = Components
 
   return (
-    <Components.LWDialog open onClose={onClose} dialogClasses={{paper: classes.root}}>
+    <LWDialog open onClose={onClose} dialogClasses={{paper: classes.root}}>
       <DialogContent className={classes.text}>
         <div className={classes.heading}>
           Are you sure you want to publish this digest?
@@ -68,14 +58,14 @@ const ConfirmPublishDialog = ({ digest, onClose, classes }: {
         </div>
       </DialogContent>
       <DialogActions>
-        <Button variant="outlined" color="primary" onClick={onClose} className={classes.btn}>
+        <EAButton variant="outlined" onClick={onClose}>
           Cancel
-        </Button>
-        <Button variant="contained" color="primary" onClick={handlePublish} className={classNames(classes.btn, classes.btnPrimary)}>
+        </EAButton>
+        <EAButton onClick={handlePublish}>
           Publish
-        </Button>
+        </EAButton>
       </DialogActions>
-    </Components.LWDialog>
+    </LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestPublishBtn.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestPublishBtn.tsx
@@ -1,20 +1,9 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useUpdate } from '../../../lib/crud/withUpdate';
-import Button from '@material-ui/core/Button';
 import { useDialog } from '../../common/withDialog';
-import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
-  btn: {
-    fontSize: 14,
-    textTransform: 'none',
-    boxShadow: 'none'
-  },
-  publishBtn: {
-    backgroundColor: theme.palette.buttons.alwaysPrimary,
-    color: theme.palette.text.alwaysWhite,
-  },
   questionMark: {
     alignSelf: 'center',
     color: theme.palette.grey[600]
@@ -61,17 +50,12 @@ const EditDigestPublishBtn = ({digest, classes} : {
     }
   }
   
-  const { LWTooltip, ForumIcon } = Components
+  const { EAButton, LWTooltip, ForumIcon } = Components
 
   return <>
-    <Button
-      variant={isPublished ? 'outlined' : 'contained'}
-      color="primary"
-      onClick={handleBtnClick}
-      className={classNames(classes.btn, {[classes.publishBtn]: !isPublished})}
-    >
+    <EAButton variant={isPublished ? 'outlined' : 'contained'} onClick={handleBtnClick}>
       {isPublished ? 'Unpublish' : 'Publish'}
-    </Button>
+    </EAButton>
 
     <LWTooltip
       title={<>


### PR DESCRIPTION
This is just a small PR to use the `EAButton` component in the digest tool. I also used this opportunity to update the `EAButton` a bit, to handle more options.

Old:
<img width="173" alt="Screen Shot 2023-08-01 at 4 34 41 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/1cb12b83-380c-4cd9-842c-6c2465671ed1">

New:
<img width="173" alt="Screen Shot 2023-08-01 at 4 26 52 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/6e15c0a1-bbf4-4610-a005-db521a3ab6a0">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205187578427442) by [Unito](https://www.unito.io)
