### PR TITLE
Fix infinite loop when changing digest date

### DIFF
--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -1,6 +1,6 @@
 import { getCollectionHooks } from '../mutationCallbacks';
 import Digests from '../../lib/collections/digests/collection';
-import { createMutator, updateMutator } from '../vulcan-lib/mutators';
+import { createMutator } from '../vulcan-lib/mutators';
 
 getCollectionHooks("Digests").updateAsync.add(async ({newDocument, oldDocument, context}: {newDocument: DbDigest, oldDocument: DbDigest, context: ResolverContext}) => {
   // if we are not currently publishing this digest, skip

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -25,30 +25,18 @@ getCollectionHooks("Digests").updateAsync.add(async ({newDocument, oldDocument, 
   // if we change a digest's start date, make sure to update the preceeding digest's end date to match,
   // so that we don't miss any eligible posts
   if (newDocument.startDate && newDocument.startDate !== oldDocument.startDate) {
-    void updateMutator({
-      collection: Digests,
-      selector: {
-        num: newDocument.num - 1,
-      },
-      set: {
-        endDate: newDocument.startDate,
-      },
-      validate: false,
-    });
+    await Digests.rawUpdateOne(
+      {num: newDocument.num - 1},
+      {$set: {endDate: newDocument.startDate}},
+    );
   }
 
   // if we change a digest's end date, make sure to update any subsequent digest's start date to match,
   // so that we don't miss any eligible posts
   if (newDocument.endDate && newDocument.endDate !== oldDocument.endDate) {
-    void updateMutator({
-      collection: Digests,
-      selector: {
-        num: newDocument.num + 1,
-      },
-      set: {
-        startDate: newDocument.endDate,
-      },
-      validate: false,
-    });
+    await Digests.rawUpdateOne(
+      {num: newDocument.num + 1},
+      {$set: {startDate: newDocument.endDate}},
+    );
   }
 });


### PR DESCRIPTION
Fantastic bug.

When we update the date on a digest we also update the date of the neighbouring digest to match. However, this is done in a callback and uses update mutator, which means we then run the call backs on the neighbouring digest... which then runs the callback on the original digest which then runs the callback on the neighbouring digest, etc. etc.

The only way to stop the loop is to restart the server.

This is what happens to the database CPU usage:
<img width="1348" alt="Screenshot 2023-08-03 at 01 36 38" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4da59b52-d5f1-49e7-83c7-6e91b49294f5">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205199488992193) by [Unito](https://www.unito.io)
