### PR TITLE
Improve default ordering of chapters in sequences

### DIFF
--- a/packages/lesswrong/components/sequences/ChaptersList.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersList.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 
-const ChaptersList = ({sequenceId, canEdit}: {
+const ChaptersList = ({sequenceId, canEdit, nextSuggestedNumberRef}: {
   sequenceId: string,
   canEdit: boolean,
+  nextSuggestedNumberRef: React.MutableRefObject<number>,
 }) => {
   const { results, loading } = useMulti({
     terms: {
@@ -16,17 +17,23 @@ const ChaptersList = ({sequenceId, canEdit}: {
     fragmentName: 'ChaptersFragment',
     enableTotal: false,
   });
-  if (results && !loading) {
-    return <div className="chapters-list">
-      {results.map((chapter) => <Components.ChaptersItem
-        key={chapter._id}
-        chapter={chapter}
-        canEdit={canEdit}
-      />)}
-    </div>
-  } else {
+
+  if (!results || loading) {
     return <Components.Loading />
   }
+
+  // If any chapter has a number already, suggest the next number after the highest number.
+  // Otherwise, suggest the next number after the number of chapters.
+  const nextNumber = Math.max(...results.map((chapter) => chapter.number ?? 0), results.length) + 1;
+  nextSuggestedNumberRef.current = nextNumber;
+
+  return <div className="chapters-list">
+    {results.map((chapter) => <Components.ChaptersItem
+      key={chapter._id}
+      chapter={chapter}
+      canEdit={canEdit}
+    />)}
+  </div>
 }
 
 const ChaptersListComponent = registerComponent('ChaptersList', ChaptersList)

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
@@ -95,6 +95,8 @@ const SequencesPage = ({ documentId, classes }: {
 }) => {
   const [edit,setEdit] = useState(false);
   const [showNewChapterForm,setShowNewChapterForm] = useState(false);
+  const nextSuggestedNumberRef = useRef(1);
+
   const currentUser = useCurrentUser();
   const { document, loading } = useSingle({
     documentId,
@@ -175,14 +177,14 @@ const SequencesPage = ({ documentId, classes }: {
         </ContentStyles>
         <div>
           <AnalyticsContext listContext={"sequencePage"} sequenceId={document._id} capturePostItemOnMount>
-            <ChaptersList sequenceId={document._id} canEdit={canEditChapter} />
+            <ChaptersList sequenceId={document._id} canEdit={canEditChapter} nextSuggestedNumberRef={nextSuggestedNumberRef} />
           </AnalyticsContext>
           {canCreateChapter && <SectionFooter>
             <SectionButton>
               <a onClick={() => setShowNewChapterForm(true)}>Add Chapter</a>
             </SectionButton>
           </SectionFooter>}
-          {showNewChapterForm && <ChaptersNewForm prefilledProps={{sequenceId: document._id}}/>}
+          {showNewChapterForm && <ChaptersNewForm prefilledProps={{sequenceId: document._id, number: nextSuggestedNumberRef.current}}/>}
         </div>
       </div>
     </SingleColumnSection>

--- a/packages/lesswrong/lib/collections/chapters/views.ts
+++ b/packages/lesswrong/lib/collections/chapters/views.ts
@@ -11,7 +11,7 @@ declare global {
 Chapters.addView("SequenceChapters", function (terms: ChaptersViewTerms) {
   return {
     selector: {sequenceId: terms.sequenceId},
-    options: {sort: {number: 1}, limit: terms.limit || 20},
+    options: {sort: {number: 1, createdAt: 1}, limit: terms.limit || 20},
   };
 });
 ensureIndex(Chapters, { sequenceId: 1, number: 1 })


### PR DESCRIPTION
Currently we have a lot of sequences where all the chapters have `number` as `null`, so it's up to the whims of postgres as to the order they are returned in. Maybe this was fine in mongo because insert order was preserved but now it's become a problem with the migration.

In any case, in this PR I've added:
 - ordering by createdAt if there is no `number`
 - defaulting to the next number rather than `null` when creating a new chapter

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205211935665496) by [Unito](https://www.unito.io)
