### PR TITLE
Make cookie to hide survey banner necessary

### DIFF
--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -106,7 +106,7 @@ export const HIDE_MORE_FROM_THE_FORUM_RECOMMENDATIONS_COOKIE = registerCookie({
 
 export const HIDE_EA_FORUM_SURVEY_BANNER_COOKIE = registerCookie({
   name: "hide_ea_forum_survey_banner",
-  type: "functional",
+  type: "necessary",
   description: "Don't show the EA Forum survey banner",
 });
 


### PR DESCRIPTION
We got a bug report that someone couldn't close the banner because they had rejected cookies. It's fine to make this specific cookie "necessary" as it's not used by a third party and isn't tracking any sensitive data.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205222866224988) by [Unito](https://www.unito.io)
