### PR TITLE
Make the EA Forum banner cookie necessary

### DIFF
--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -106,7 +106,7 @@ export const HIDE_MORE_FROM_THE_FORUM_RECOMMENDATIONS_COOKIE = registerCookie({
 
 export const HIDE_EA_FORUM_SURVEY_BANNER_COOKIE = registerCookie({
   name: "hide_ea_forum_survey_banner",
-  type: "functional",
+  type: "necessary",
   description: "Don't show the EA Forum survey banner",
 });
 


### PR DESCRIPTION
We're getting a lot of bug reports of the EA forum banner not being closeable, which happens when people reject "functional" cookies. This PR changes the cookie to "necessary" to fix the issue.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205222823763548) by [Unito](https://www.unito.io)
