### PR TITLE
[EA Forum only] fix VP dates for August

### DIFF
--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -107,12 +107,17 @@ const VirtualProgramCard = ({program, classes}: {
   const { captureEvent } = useTracking()
   
   // Find the next deadline for applying to the Intro VP, which is usually the 4th Sunday of every month
-  // (though it will sometimes move to the 5th Sunday - this is not accounted for in the code).
+  // (though it will sometimes move to the 3rd or 5th Sunday - this is not accounted for in the code).
   // This defaults to the Sunday in the week of the 28th day of this month.
-  let deadline = moment().date(28).day(0)
+  const now = moment()
+  let deadline = now.date(28).day(0)
+  // Aug 2023 has the deadline on the 3rd Sunday
+  if (now.month() === 7) {
+    deadline.subtract(1, 'week')
+  }
   // If that Sunday is in the past, use next month's 4th Sunday.
   if (deadline.isBefore(moment())) {
-    deadline = moment().add(1, 'months').date(28).day(0)
+    deadline = now.add(1, 'months').date(28).day(0)
   }
   
   // VP starts 15 days after the deadline, on a Monday


### PR DESCRIPTION
I happened to look at the EA.org [VP page](https://www.effectivealtruism.org/virtual-programs) and noticed that the dates are not the same as on our [Events page](https://forum.effectivealtruism.org/events), so I adjusted them to match:

<img width="356" alt="Screen Shot 2023-08-07 at 11 33 58 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/6c40db2e-8a7c-4c0d-b909-0272e27ab2d8">

I'll plan to remove this exception from the code in September.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205224877330073) by [Unito](https://www.unito.io)
