### PR TITLE
clean up new user registration page a bit

### DIFF
--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -14,12 +14,19 @@ import { LicenseLink, TosLink } from "../posts/PostsAcceptTos";
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: theme.palette.panelBackground.default,
-    padding: theme.spacing.unit * 6
+    padding: isEAForum ? 20 : theme.spacing.unit * 6,
+    [theme.breakpoints.down('md')]: {
+      padding: isEAForum ? '30px 20px' : undefined,
+    }
   },
   title: {
-    marginTop: 0
+    marginTop: 0,
+    [theme.breakpoints.down('md')]: {
+      fontSize: isEAForum ? 28 : undefined,
+    }
   },
   section: {
+    maxWidth: 600,
     marginTop: theme.spacing.unit * 6,
     "& .MuiTypography-body1": {
       color: theme.palette.text.normal,
@@ -28,6 +35,10 @@ const styles = (theme: ThemeType): JssStyles => ({
       color: theme.palette.grey[600],
     },
   },
+  sectionHeadingText: isEAForum ? {
+    fontWeight: 600,
+    fontSize: 24
+  } : {},
   sectionHelperText: {
     color: theme.palette.grey[600],
     fontSize: '1rem',
@@ -72,7 +83,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
     }
   `, {refetchQueries: ['getCurrentUser']})
   const {flash} = useMessages();
-  const {SingleColumnSection, Typography} = Components
+  const {SingleColumnSection, Typography, EAButton} = Components
 
   function validateUsername(username: string): void {
     if (username.length === 0) {
@@ -117,14 +128,16 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
   
   return <SingleColumnSection>
     <div className={classes.root}>
-      <Typography variant='display3' gutterBottom className={classes.title}>
+      <Typography variant={isEAForum ? 'display2' : 'display3'} gutterBottom className={classes.title}>
         Thanks for registering for {siteNameWithArticleSetting.get()}
       </Typography>
       <Typography variant='body2'>
         Please take a second to complete your profile
       </Typography>
       <div className={classes.section}>
-        <Typography variant='display1' gutterBottom>Please choose a username</Typography>
+        <Typography variant='display1' className={classes.sectionHeadingText} gutterBottom>
+          Please choose a username
+        </Typography>
         <Typography variant='body1' className={classes.sectionHelperText} gutterBottom>
           We encourage you to use your real name, as it will help other people
           in the community to identify you, but you can choose a pseudonym. If
@@ -146,7 +159,9 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
       
       {/* Facebook user with no email fix (very small % of users) */}
       {!currentUser?.email && <div className={classes.section}>
-        <Typography variant='display1' gutterBottom>Please enter your email</Typography>
+        <Typography variant='display1' className={classes.sectionHeadingText} gutterBottom>
+          Please enter your email
+        </Typography>
         <Typography variant='body1' className={classes.sectionHelperText} gutterBottom>
           {/* I'd rather be honest than concise here. */}
           To get here without an email you must have logged in with Facebook
@@ -161,7 +176,9 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
       </div>}
 
       {isEAForum && <div className={classes.section}>
-        <Typography variant='display1' gutterBottom>Would you like to get digest emails?</Typography>
+        <Typography variant='display1' className={classes.sectionHeadingText} gutterBottom>
+          Would you like to get digest emails?
+        </Typography>
         <Typography variant='body1' className={classes.sectionHelperText} gutterBottom>
           The EA Forum Digest is a weekly summary of the best content, curated by the EA Forum team.
         </Typography>
@@ -183,14 +200,16 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
             under a <LicenseLink /> license.
           </Typography>
         }
-        <Button
+        {isEAForum ? <EAButton onClick={handleSave} disabled={!!validationError}>
+          Submit
+        </EAButton> : <Button
           onClick={handleSave}
           color='primary'
           variant='outlined'
           disabled={!!validationError}
         >
           Save
-        </Button>
+        </Button>}
       </div>
     </div>
   </SingleColumnSection>

--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from "react";
 import classnames from "classnames";
 import { gql, useMutation } from "@apollo/client";
-import Button from "@material-ui/core/Button";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import TextField from "@material-ui/core/TextField";
@@ -14,15 +13,15 @@ import { LicenseLink, TosLink } from "../posts/PostsAcceptTos";
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: theme.palette.panelBackground.default,
-    padding: isEAForum ? 20 : theme.spacing.unit * 6,
-    [theme.breakpoints.down('md')]: {
-      padding: isEAForum ? '30px 20px' : undefined,
+    padding: '40px 50px',
+    [theme.breakpoints.down('xs')]: {
+      padding: '30px 20px',
     }
   },
   title: {
     marginTop: 0,
     [theme.breakpoints.down('md')]: {
-      fontSize: isEAForum ? 28 : undefined,
+      fontSize: 28,
     }
   },
   section: {
@@ -33,17 +32,20 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
     "& .MuiFormHelperText-root": {
       color: theme.palette.grey[600],
+      fontFamily: theme.palette.fonts.sansSerifStack,
     },
   },
-  sectionHeadingText: isEAForum ? {
+  sectionHeadingText: {
     fontWeight: 600,
-    fontSize: 24
-  } : {},
+    fontSize: 24,
+    [theme.breakpoints.down('md')]: {
+      fontSize: 20,
+    }
+  },
   sectionHelperText: {
     color: theme.palette.grey[600],
     fontSize: '1rem',
-    ...theme.typography.italic,
-    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.palette.fonts.sansSerifStack,
     "& a": {
       color: theme.palette.primary.main,
     },
@@ -91,7 +93,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
       return
     }
     if (username.length > 70) {
-      setValidationError('username too long')
+      setValidationError('Username must be less than 70 characters')
       return
     }
     // TODO: Really want them to be able to tell live if their username is
@@ -128,11 +130,11 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
   
   return <SingleColumnSection>
     <div className={classes.root}>
-      <Typography variant={isEAForum ? 'display2' : 'display3'} gutterBottom className={classes.title}>
+      <Typography variant="display2" gutterBottom className={classes.title}>
         Thanks for registering for {siteNameWithArticleSetting.get()}
       </Typography>
       <Typography variant='body2'>
-        Please take a second to complete your profile
+        Take a moment to complete your profile
       </Typography>
       <div className={classes.section}>
         <Typography variant='display1' className={classes.sectionHeadingText} gutterBottom>
@@ -200,16 +202,9 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ current
             under a <LicenseLink /> license.
           </Typography>
         }
-        {isEAForum ? <EAButton onClick={handleSave} disabled={!!validationError}>
+        <EAButton onClick={handleSave} disabled={!!validationError}>
           Submit
-        </EAButton> : <Button
-          onClick={handleSave}
-          color='primary'
-          variant='outlined'
-          disabled={!!validationError}
-        >
-          Save
-        </Button>}
+        </EAButton>
       </div>
     </div>
   </SingleColumnSection>


### PR DESCRIPTION
This PR is just cleaning up the styling a bit on the new user registration page (the one where you pick your username). This should basically not affect LW.

Old, desktop:
<img width="1440" alt="Screen Shot 2023-08-08 at 10 31 57 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/ddd9aa6f-55db-4e90-926e-1ddfcabedcdf">

New, desktop:
<img width="1440" alt="Screen Shot 2023-08-08 at 10 52 07 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/80789bfa-9c6a-49b5-8f62-51eabc9b4481">

-----
Old, mobile:
<img width="366" alt="Screen Shot 2023-08-08 at 10 54 46 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/7d21092c-8325-4a32-868c-0050e7556027">

New, mobile:
<img width="366" alt="Screen Shot 2023-08-08 at 10 59 48 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/8c6f957e-b802-4731-bb01-3ed70e6c3e2e">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205234270505745) by [Unito](https://www.unito.io)
