### PR TITLE
[EA] Add an id to the EAUsersProfile karma info to make it easier to block

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersMetaInfo.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersMetaInfo.tsx
@@ -74,7 +74,7 @@ const EAUsersMetaInfo = ({user, classes}: {
   return (
     <ContentStyles contentType="comment" className={classes.iconsRow}>
       <LWTooltip title={`${userKarma} karma`}>
-        <span className={classes.userMetaInfo}>
+        <span className={classes.userMetaInfo} id='karma-info'>
           <ForumIcon icon="Karma" className={classes.userMetaInfoIcon} />
           {userKarma} karma
         </span>


### PR DESCRIPTION
Makes this uBlock Origin rule work:

```
###karma-info
```

(Note the three #s)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205234927034524) by [Unito](https://www.unito.io)
