### PR TITLE
Stop writing to Algolia now that we've switched to ElasticSearch

### DIFF
--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -8,7 +8,7 @@ import Portal from '@material-ui/core/Portal';
 import IconButton from '@material-ui/core/IconButton';
 import { useNavigation } from '../../lib/routeUtil';
 import withErrorBoundary from '../common/withErrorBoundary';
-import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
+import { getAlgoliaIndexName, getSearchClient, isSearchEnabled } from '../../lib/search/algoliaUtil';
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
@@ -164,8 +164,8 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
   const alignmentForum = forumTypeSetting.get() === 'AlignmentForum';
   const { SearchBarResults, ForumIcon } = Components
 
-  if (!isAlgoliaEnabled()) {
-    return <div>Search is disabled (Algolia App ID not configured on server)</div>
+  if (!isSearchEnabled()) {
+    return <div>Search is disabled (ElasticSearch not configured on server)</div>
   }
 
   return <div className={classes.root} onKeyDown={handleKeyDown}>

--- a/packages/lesswrong/components/search/SearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib'
 import { InstantSearch, Configure } from 'react-instantsearch-dom';
-import { isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
+import { getSearchClient, isSearchEnabled } from '../../lib/search/algoliaUtil';
 import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest, { OnSuggestionSelected } from 'react-autosuggest';
 
@@ -35,7 +35,7 @@ const SearchAutoComplete = ({ clickAction, placeholder, noSearchPlaceholder, ren
   renderInputComponent?: any,
   filters?: string,
 }) => {
-  if (!isAlgoliaEnabled()) {
+  if (!isSearchEnabled()) {
     // Fallback for when Algolia is unavailable (ie, local development installs).
     // This isn't a particularly nice UI, but it's functional enough to be able
     // to test other things.

--- a/packages/lesswrong/components/search/SearchPage.tsx
+++ b/packages/lesswrong/components/search/SearchPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Hits, Configure, Index, InstantSearch, SearchBox, CurrentRefinements } from 'react-instantsearch-dom';
-import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
+import { getAlgoliaIndexName, getSearchClient, isSearchEnabled } from '../../lib/search/algoliaUtil';
 import SearchIcon from '@material-ui/icons/Search';
 import { useLocation } from '../../lib/routeUtil';
 import { taggingNameIsSet, taggingNamePluralCapitalSetting } from '../../lib/instanceSettings';
@@ -113,9 +113,9 @@ const SearchPage = ({classes}:{
 
   const {query} = useLocation()
 
-  if(!isAlgoliaEnabled()) {
+  if(!isSearchEnabled()) {
     return <div className={classes.root}>
-      Search is disabled (Algolia App ID not configured on server)
+      Search is disabled (ElasticSearch not configured on server)
     </div>
   }
 

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -3,12 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import qs from 'qs';
 import { RefinementListExposed, RefinementListProvided, SearchState } from 'react-instantsearch/connectors';
 import { Hits, Configure, InstantSearch, SearchBox, Pagination, connectRefinementList, ToggleRefinement, NumericMenu, connectStats, ClearRefinements, connectScrollTo } from 'react-instantsearch-dom';
-import {
-  isAlgoliaEnabled,
-  getSearchClient,
-  AlgoliaIndexCollectionName,
-  collectionIsAlgoliaIndexed,
-} from '../../lib/search/algoliaUtil';
+import { getSearchClient, AlgoliaIndexCollectionName, collectionIsAlgoliaIndexed, isSearchEnabled } from '../../lib/search/algoliaUtil';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { forumTypeSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -366,9 +361,9 @@ const SearchPageTabbed = ({classes}:{
     }
   }, [query.query, searchState?.query]);
 
-  if (!isAlgoliaEnabled()) {
+  if (!isSearchEnabled()) {
     return <div className={classes.root}>
-      Search is disabled (Algolia App ID not configured on server)
+      Search is disabled (ElasticSearch not configured on server)
     </div>
   }
   

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { InstantSearch, SearchBox, Hits, Configure } from 'react-instantsearch-dom';
-import { getAlgoliaIndexName, isAlgoliaEnabled, getSearchClient } from '../../lib/search/algoliaUtil';
+import { getAlgoliaIndexName, getSearchClient, isSearchEnabled } from '../../lib/search/algoliaUtil';
 import { useCurrentUser } from '../common/withUser';
 import { userCanCreateTags } from '../../lib/betas';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -71,7 +71,7 @@ const AddTag = ({onTagSelected, isVotingContext, classes}: {
     }
   }, []);
 
-  if (!isAlgoliaEnabled()) {
+  if (!isSearchEnabled()) {
     return <div className={classes.root} ref={containerRef}>
       <input placeholder="Tag ID" type="text" onKeyPress={ev => {
         if (ev.charCode===13) {

--- a/packages/lesswrong/lib/search/algoliaUtil.ts
+++ b/packages/lesswrong/lib/search/algoliaUtil.ts
@@ -1,10 +1,8 @@
 import type { Client } from "algoliasearch/lite";
 import NativeSearchClient from "./NativeSearchClient";
-import {
-  algoliaAppIdSetting,
-  algoliaSearchKeySetting,
-  algoliaPrefixSetting,
-} from '../publicSettings';
+import { algoliaAppIdSetting, algoliaSearchKeySetting, algoliaPrefixSetting } from '../publicSettings';
+import { isEAForum } from "../instanceSettings";
+import { isAnyTest } from "../executionEnvironment";
 
 export const algoliaIndexedCollectionNames = ["Comments", "Posts", "Users", "Sequences", "Tags"] as const
 export type AlgoliaIndexCollectionName = typeof algoliaIndexedCollectionNames[number]
@@ -27,7 +25,10 @@ export const collectionIsAlgoliaIndexed = (collectionName: CollectionNameString)
   return (algoliaIndexedCollectionNames as unknown as string[]).includes(collectionName)
 }
 
-export const isAlgoliaEnabled = () => !!algoliaAppIdSetting.get() && !!algoliaSearchKeySetting.get();
+export const isAlgoliaEnabled = () => !!algoliaAppIdSetting.get() && !!algoliaSearchKeySetting.get() && !isAnyTest && !isEAForum
+
+// TODO: Hide search-UI if neither Elastic nor Algolia is configured
+export const isSearchEnabled = () => true;
 
 let searchClient: Client | null = null;
 

--- a/packages/lesswrong/server/search/elastic/elasticSettings.ts
+++ b/packages/lesswrong/server/search/elastic/elasticSettings.ts
@@ -1,5 +1,5 @@
 import { isAnyTest } from "../../../lib/executionEnvironment";
-import { PublicInstanceSetting, isEAForum } from "../../../lib/instanceSettings";
+import { PublicInstanceSetting } from "../../../lib/instanceSettings";
 
 export const elasticCloudIdSetting = new PublicInstanceSetting<string|null>(
   "elasticsearch.cloudId",
@@ -32,4 +32,3 @@ const disableElastic = new PublicInstanceSetting<boolean>(
 );
 
 export const isElasticEnabled = !isAnyTest && !disableElastic.get();
-export const isAlgoliaEnabled = !isAnyTest && !isEAForum;

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -21,8 +21,8 @@ import uniq from 'lodash/uniq';
 import keyBy from 'lodash/keyBy';
 import { userCanVote } from '../lib/collections/users/helpers';
 import { elasticSyncDocument } from './search/elastic/elasticCallbacks';
-import { collectionIsAlgoliaIndexed } from '../lib/search/algoliaUtil';
-import { isElasticEnabled, isAlgoliaEnabled } from './search/elastic/elasticSettings';
+import { collectionIsAlgoliaIndexed, isAlgoliaEnabled } from '../lib/search/algoliaUtil';
+import { isElasticEnabled } from './search/elastic/elasticSettings';
 import { isEAForum } from '../lib/instanceSettings';
 
 
@@ -80,7 +80,7 @@ const addVoteServer = async ({ document, collection, voteType, extendedVote, use
       void elasticSyncDocument(collection.collectionName, newDocument._id);
     }
   }
-  if (isAlgoliaEnabled) {
+  if (isAlgoliaEnabled()) {
     void algoliaExportById(collection as any, newDocument._id);
   }
   return {newDocument, vote};
@@ -206,7 +206,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
       void elasticSyncDocument(collection.collectionName, newDocument._id);
     }
   }
-  if (isAlgoliaEnabled) {
+  if (isAlgoliaEnabled()) {
     void algoliaExportById(collection as any, newDocument._id);
   }
   return newDocument;


### PR DESCRIPTION
This redirects everything that was previously checking `isAlgoliaEnabled()` to instead check `isSearchEnabled()`. Once this is merged, we can then take Algolia API keys out of our server config, which will stop the server from trying to write to Algolia, so that we can shut down the Algolia account and stop paying for it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205245163602186) by [Unito](https://www.unito.io)
