### PR TITLE
fix case for stricter rate limit checks when there are no applicable votes on content

### DIFF
--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -287,8 +287,6 @@ function triggerReviewForStricterRateLimits(
   }
 }
 
-// function isNonEmptyArray()
-
 export async function checkForStricterRateLimits(userId: string, context: ResolverContext) {
   // We can't use a loader here because we need the user's karma which was just updated by this vote
   const votedOnUser = await Users.findOne({ _id: userId });

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -13,8 +13,8 @@ import { calculateRecentKarmaInfo, documentOnlyHasSelfVote, getAutoRateLimitInfo
 import Users from "../lib/collections/users/collection"
 import { triggerReview } from "./callbacks/sunshineCallbackUtils"
 import { appendToSunshineNotes } from "../lib/collections/users/helpers"
-
-
+import { isNonEmpty } from "fp-ts/Array"
+import type { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
 
 async function getModRateLimitHours(userId: string): Promise<number> {
   const moderatorRateLimit = await getModeratorRateLimit(userId)
@@ -233,7 +233,7 @@ export async function getRecentKarmaInfo (userId: string): Promise<RecentKarmaIn
   return calculateRecentKarmaInfo(userId, allVotes)
 }
 
-async function getVotesForComparison(userId: string, currentVotes: RecentVoteInfo[]) {
+async function getVotesForComparison(userId: string, currentVotes: NonEmptyArray<RecentVoteInfo>) {
   currentVotes = currentVotes.sort((a, b) => moment(b.votedAt).diff(a.votedAt));
   const [mostRecentVoteInfo] = currentVotes;
 
@@ -287,6 +287,8 @@ function triggerReviewForStricterRateLimits(
   }
 }
 
+// function isNonEmptyArray()
+
 export async function checkForStricterRateLimits(userId: string, context: ResolverContext) {
   // We can't use a loader here because we need the user's karma which was just updated by this vote
   const votedOnUser = await Users.findOne({ _id: userId });
@@ -299,6 +301,14 @@ export async function checkForStricterRateLimits(userId: string, context: Resolv
   const votesRepo = new VotesRepo();
 
   const allVotes = await votesRepo.getVotesOnRecentContent(votedOnUser._id);
+
+  // This might happen if a new user creates a draft post as their first thing
+  // That triggers a self-vote, but one that gets filtered out of getVotesOnRecentContent
+  // We check not-isNonEmpty rather than isEmpty because the type guard only works properly in that direction
+  if (!isNonEmpty(allVotes)) {
+    return;
+  }
+
   const comparisonVotes = await getVotesForComparison(votedOnUser._id, allVotes);
 
   const userKarmaInfoWindow = getCurrentAndPreviousUserKarmaInfo(votedOnUser, allVotes, comparisonVotes);


### PR DESCRIPTION
Oops.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205253932954282) by [Unito](https://www.unito.io)
