### PR TITLE
Add Table of contents to post editor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -69,7 +69,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     return getLSHandlers(getLocalStorageId, document, name,
       getLSKeyPrefix(editorType)
     );
-  }, [collectionName, document, name, fieldName]);
+  }, [document, name, editableFieldOptions.getLocalStorageId]);
   
   const [contents,setContents] = useState(() => getInitialEditorContents(
     value, document, fieldName, currentUser

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -15,6 +15,7 @@ import type { PostSubmitProps } from './PostSubmit';
 import { userIsPodcaster } from '../../lib/vulcan-users/permissions';
 import { SHARE_POPUP_QUERY_PARAM } from './PostsPage/PostsPage';
 import { isEAForum } from '../../lib/instanceSettings';
+import { DynamicTableOfContentsContext } from './TableOfContents/DynamicTableOfContents';
 
 const PostsEditForm = ({ documentId, classes }: {
   documentId: string,
@@ -41,7 +42,7 @@ const PostsEditForm = ({ documentId, classes }: {
   }, [isDraft]);
 
   const { WrappedSmartForm, PostSubmit, SubmitToFrontpageCheckbox, HeadTags, ForeignCrosspostEditForm,
-    RateLimitWarning } = Components
+    RateLimitWarning, DynamicTableOfContents } = Components
   
   const saveDraftLabel: string = ((post) => {
     if (!post) return "Save Draft"
@@ -111,66 +112,68 @@ const PostsEditForm = ({ documentId, classes }: {
   }
   
   return (
-    <div className={classes.postForm}>
-      <HeadTags title={document.title} />
-      {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
-      {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
-      <NoSSR>
-        <WrappedSmartForm
-          collectionName="Posts"
-          removeFields={document.debate ? ['debate'] : []}
-          documentId={documentId}
-          queryFragment={getFragment('PostsEditQueryFragment')}
-          mutationFragment={getFragment('PostsEditMutationFragment')}
-          successCallback={(post: any, options: any) => {
-            const alreadySubmittedToAF = post.suggestForAlignmentUserIds && post.suggestForAlignmentUserIds.includes(post.userId)
-            if (!post.draft && !alreadySubmittedToAF) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
-            if (options?.submitOptions?.redirectToEditor) {
-              history.push(postGetEditUrl(post._id, false, post.linkSharingKey));
-            } else {
-              // If they are publishing a draft, show the share popup
-              // Note: we can't use isDraft here because it gets updated to true when they click "Publish"
-              const showSharePopup = isEAForum && wasEverDraft.current && !post.draft
-              const sharePostQuery = `?${SHARE_POPUP_QUERY_PARAM}=true`
-              history.push({pathname: postGetPageUrl(post), search: showSharePopup ? sharePostQuery : ''})
+    <DynamicTableOfContents title={document.title}>
+      <div className={classes.postForm}>
+        <HeadTags title={document.title} />
+        {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
+        {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
+        <NoSSR>
+          <WrappedSmartForm
+            collectionName="Posts"
+            removeFields={document.debate ? ['debate'] : []}
+            documentId={documentId}
+            queryFragment={getFragment('PostsEditQueryFragment')}
+            mutationFragment={getFragment('PostsEditMutationFragment')}
+            successCallback={(post: any, options: any) => {
+              const alreadySubmittedToAF = post.suggestForAlignmentUserIds && post.suggestForAlignmentUserIds.includes(post.userId)
+              if (!post.draft && !alreadySubmittedToAF) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
+              if (options?.submitOptions?.redirectToEditor) {
+                history.push(postGetEditUrl(post._id, false, post.linkSharingKey));
+              } else {
+                // If they are publishing a draft, show the share popup
+                // Note: we can't use isDraft here because it gets updated to true when they click "Publish"
+                const showSharePopup = isEAForum && wasEverDraft.current && !post.draft
+                const sharePostQuery = `?${SHARE_POPUP_QUERY_PARAM}=true`
+                history.push({pathname: postGetPageUrl(post), search: showSharePopup ? sharePostQuery : ''})
 
-              if (!showSharePopup) {
-                flash({ messageString: `Post "${post.title}" edited`, type: 'success'});
+                if (!showSharePopup) {
+                  flash({ messageString: `Post "${post.title}" edited`, type: 'success'});
+                }
               }
-            }
-          }}
-          eventForm={document.isEvent}
-          removeSuccessCallback={({ documentId, documentTitle }: { documentId: string; documentTitle: string; }) => {
-            // post edit form is being included from a single post, redirect to index
-            // note: this.props.params is in the worst case an empty obj (from react-router)
-            if (params._id) {
-              history.push('/');
-            }
+            }}
+            eventForm={document.isEvent}
+            removeSuccessCallback={({ documentId, documentTitle }: { documentId: string; documentTitle: string; }) => {
+              // post edit form is being included from a single post, redirect to index
+              // note: this.props.params is in the worst case an empty obj (from react-router)
+              if (params._id) {
+                history.push('/');
+              }
 
-            flash({ messageString: `Post "${documentTitle}" deleted.`, type: 'success'});
-            // todo: handle events in collection callbacks
-            // this.context.events.track("post deleted", {_id: documentId});
-          }}
-          showRemove={true}
-          submitLabel={isDraft ? "Publish" : "Publish Changes"}
-          formComponents={{FormSubmit:EditPostsSubmit}}
-          extraVariables={{
-            version: 'String'
-          }}
-          version="draft"
-          noSubmitOnCmdEnter
-          repeatErrors
-          
-          /*
-           * addFields includes tagRelevance because the field permissions on
-           * the schema say the user can't edit this field, but the widget
-           * "edits" the tag list via indirect operations (upvoting/downvoting
-           * relevance scores).
-           */
-          addFields={document.isEvent ? [] : ['tagRelevance']}
-        />
-      </NoSSR>
-    </div>
+              flash({ messageString: `Post "${documentTitle}" deleted.`, type: 'success'});
+              // todo: handle events in collection callbacks
+              // this.context.events.track("post deleted", {_id: documentId});
+            }}
+            showRemove={true}
+            submitLabel={isDraft ? "Publish" : "Publish Changes"}
+            formComponents={{FormSubmit:EditPostsSubmit}}
+            extraVariables={{
+              version: 'String'
+            }}
+            version="draft"
+            noSubmitOnCmdEnter
+            repeatErrors
+            
+            /*
+            * addFields includes tagRelevance because the field permissions on
+            * the schema say the user can't edit this field, but the widget
+            * "edits" the tag list via indirect operations (upvoting/downvoting
+            * relevance scores).
+            */
+            addFields={document.isEvent ? [] : ['tagRelevance']}
+          />
+        </NoSSR>
+      </div>
+    </DynamicTableOfContents>
   );
 }
 

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -173,7 +173,7 @@ const PostsNewForm = ({classes}: {
   });
   
   const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox, RecaptchaWarning, SingleColumnSection,
-    Typography, Loading, NewPostModerationWarning, RateLimitWarning } = Components
+    Typography, Loading, NewPostModerationWarning, RateLimitWarning, DynamicTableOfContents } = Components
   const userHasModerationGuidelines = currentUser && currentUser.moderationGuidelines && currentUser.moderationGuidelines.originalContents
   const af = forumTypeSetting.get() === 'AlignmentForum'
   const debateForm = !!(query && query.debate);
@@ -248,44 +248,47 @@ const PostsNewForm = ({classes}: {
   const postWillBeHidden = isLW && !currentUser.reviewedByUserId
 
   return (
-    <div className={classes.postForm}>
-      <RecaptchaWarning currentUser={currentUser}>
-        <Components.PostsAcceptTos currentUser={currentUser} />
-        {postWillBeHidden && <NewPostModerationWarning />}
-        {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
-        <NoSSR>
-          <WrappedSmartForm
-            collectionName="Posts"
-            mutationFragment={getFragment('PostsPage')}
-            prefilledProps={prefilledProps}
-            successCallback={(post: any, options: any) => {
-              if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
-              if (options?.submitOptions?.redirectToEditor) {
-                history.push(postGetEditUrl(post._id));
-              } else {
-                // If they are publishing a non-draft post, show the share popup
-                const showSharePopup = isEAForum && !post.draft
-                const sharePostQuery = `?${SHARE_POPUP_QUERY_PARAM}=true`
-                const url  = postGetPageUrl(post);
-                history.push({pathname: url, search: showSharePopup ? sharePostQuery: ''})
+    <DynamicTableOfContents title={"New Post"}>
+      <div className={classes.postForm}>
+        <RecaptchaWarning currentUser={currentUser}>
+          <Components.PostsAcceptTos currentUser={currentUser} />
+          {postWillBeHidden && <NewPostModerationWarning />}
+          {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
+          <NoSSR>
+              <WrappedSmartForm
+                collectionName="Posts"
+                mutationFragment={getFragment('PostsPage')}
+                prefilledProps={prefilledProps}
+                successCallback={(post: any, options: any) => {
+                  if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
+                  if (options?.submitOptions?.redirectToEditor) {
+                    history.push(postGetEditUrl(post._id));
+                  } else {
+                    // If they are publishing a non-draft post, show the share popup
+                    const showSharePopup = isEAForum && !post.draft
+                    const sharePostQuery = `?${SHARE_POPUP_QUERY_PARAM}=true`
+                    const url  = postGetPageUrl(post);
+                    history.push({pathname: url, search: showSharePopup ? sharePostQuery: ''})
 
-                const postDescription = post.draft ? "Draft" : "Post";
-                if (!showSharePopup) {
-                  flash({ messageString: `${postDescription} created`, type: 'success'});
-                }
-              }
-            }}
-            eventForm={eventForm}
-            debateForm={debateForm}
-            repeatErrors
-            noSubmitOnCmdEnter
-            formComponents={{
-              FormSubmit: NewPostsSubmit
-            }}
-          />
-        </NoSSR>
-      </RecaptchaWarning>
-    </div>
+                    const postDescription = post.draft ? "Draft" : "Post";
+                    if (!showSharePopup) {
+                      flash({ messageString: `${postDescription} created`, type: 'success'});
+                    }
+                  }
+                }}
+                eventForm={eventForm}
+                debateForm={debateForm}
+                repeatErrors
+                noSubmitOnCmdEnter
+                formComponents={{
+                  FormSubmit: NewPostsSubmit
+                }}
+              />
+          </NoSSR>
+        </RecaptchaWarning>
+      </div>
+    </DynamicTableOfContents>
+
   );
 }
 

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -248,7 +248,7 @@ const PostsNewForm = ({classes}: {
   const postWillBeHidden = isLW && !currentUser.reviewedByUserId
 
   return (
-    <DynamicTableOfContents title={"New Post"}>
+    <DynamicTableOfContents>
       <div className={classes.postForm}>
         <RecaptchaWarning currentUser={currentUser}>
           <Components.PostsAcceptTos currentUser={currentUser} />

--- a/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
@@ -6,12 +6,13 @@ import { ToCData } from '../../../lib/tableOfContents';
 
 export interface DynamicTableOfContentsContextType {
   setToc: (document: EditorContents) => void;
+  htmlWithAnchors?: EditorContents;
 }
 
 export const DynamicTableOfContentsContext = React.createContext<DynamicTableOfContentsContextType | null>(null);
 
 export const DynamicTableOfContents = ({title, children}: {
-  title: string,
+  title?: string,
   children: React.ReactNode
 }) => {
   const [latestHtml, setLatestHtml] = useState<string | null>(null);
@@ -41,19 +42,18 @@ export const DynamicTableOfContents = ({title, children}: {
     }
   }, [data, latestToc])
 
-  const context = useMemo(() => ({setToc: setToc}), [setToc]);
+  const context = useMemo(() => ({setToc: setToc, htmlWithAnchors: latestToc?.html}), [setToc, latestToc]);
 
-  const tableOfContents = latestToc
-    ? <TableOfContents 
-        sectionData={latestToc}
-        title={title}
-      />
-    : null
+  const sectionData = latestToc ?? {html:null, sections:[], headingsCount:0};
+  const displayedTitle = title || (sectionData.headingsCount > 0 ? "Table of Contents" : "")
 
   return <div>
     <DynamicTableOfContentsContext.Provider value={context}>
       <ToCColumn 
-        tableOfContents={tableOfContents}
+        tableOfContents={<TableOfContents 
+          sectionData={sectionData}
+          title={displayedTitle}
+        />}
       >
         {children}
       </ToCColumn>

--- a/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Components, registerComponent } from '../../../lib/vulcan-lib';
+import { EditorContents } from '../../editor/Editor';
+import { useQuery, gql } from '@apollo/client';
+import { ToCData } from '../../../lib/tableOfContents';
+
+export interface DynamicTableOfContentsContextType {
+  setToc: (document: EditorContents) => void;
+}
+
+export const DynamicTableOfContentsContext = React.createContext<DynamicTableOfContentsContextType | null>(null);
+
+export const DynamicTableOfContents = ({title, children}: {
+  title: string,
+  children: React.ReactNode
+}) => {
+  const [latestHtml, setLatestHtml] = useState<string | null>(null);
+  const { TableOfContents, ToCColumn } = Components
+  const [latestToc, setLatestToc] = useState<ToCData | null>(null);
+
+  const { data, loading, error } = useQuery(gql`
+    query ExtractTableOfContentsQuery($html: String!) {
+      generateTableOfContents(html: $html)
+    }
+  `, {
+    variables: {
+      html: latestHtml ?? ''
+    }
+  })
+
+  const setToc = useCallback((document: EditorContents) => {
+    // TODO handle markdown and everything else
+    if (document.type === 'ckEditorMarkup') {
+      setLatestHtml(document.value)
+    }
+  }, []);
+
+  useEffect(() => {
+    if (data?.generateTableOfContents && data.generateTableOfContents !== latestToc) {
+      setLatestToc(data.generateTableOfContents)
+    }
+  }, [data, latestToc])
+
+  const context = useMemo(() => ({setToc: setToc}), [setToc]);
+
+  const tableOfContents = latestToc
+    ? <TableOfContents 
+        sectionData={latestToc}
+        title={title}
+      />
+    : null
+
+  return <div>
+    <DynamicTableOfContentsContext.Provider value={context}>
+      <ToCColumn 
+        tableOfContents={tableOfContents}
+      >
+        {children}
+      </ToCColumn>
+    </DynamicTableOfContentsContext.Provider>
+  </div>;
+}
+
+const DynamicTableOfContentsComponent = registerComponent('DynamicTableOfContents', DynamicTableOfContents);
+
+declare global {
+  interface ComponentTypes {
+    DynamicTableOfContents: typeof DynamicTableOfContentsComponent
+  }
+}
+

--- a/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/DynamicTableOfContents.tsx
@@ -6,7 +6,6 @@ import { ToCData } from '../../../lib/tableOfContents';
 
 export interface DynamicTableOfContentsContextType {
   setToc: (document: EditorContents) => void;
-  htmlWithAnchors?: EditorContents;
 }
 
 export const DynamicTableOfContentsContext = React.createContext<DynamicTableOfContentsContextType | null>(null);
@@ -42,7 +41,7 @@ export const DynamicTableOfContents = ({title, children}: {
     }
   }, [data, latestToc])
 
-  const context = useMemo(() => ({setToc: setToc, htmlWithAnchors: latestToc?.html}), [setToc, latestToc]);
+  const context = useMemo(() => ({setToc: setToc}), [setToc]);
 
   const sectionData = latestToc ?? {html:null, sections:[], headingsCount:0};
   const displayedTitle = title || (sectionData.headingsCount > 0 ? "Table of Contents" : "")

--- a/packages/lesswrong/components/posts/TableOfContents/index.ts
+++ b/packages/lesswrong/components/posts/TableOfContents/index.ts
@@ -5,3 +5,4 @@ importComponent("TableOfContentsList", () => require('./TableOfContentsList'));
 importComponent("TableOfContentsRow", () => require('./TableOfContentsRow'));
 importComponent("AnswerTocRow", () => require('./AnswerTocRow'));
 importComponent("ToCColumn", () => require('./ToCColumn'));
+importComponent("DynamicTableOfContents", () => require('./DynamicTableOfContents'));

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -74,6 +74,7 @@ makeEditable({
       canUpdate: ['members', 'sunshineRegiment', 'admins'],
       canCreate: ['members']
     },
+    hasToc: true,
   }
 })
 

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -40,6 +40,7 @@ export interface MakeEditableOptions {
   pingbacks?: boolean,
   revisionsHaveCommitMessages?: boolean,
   hidden?: boolean,
+  hasToc?: boolean,
 }
 
 export const defaultEditorPlaceholder = isEAForum ?

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -361,6 +361,10 @@ defineQuery({
   resultType: "JSON",
   argTypes: "(html: String!)",
   fn: (root: void, {html}:{html:string}, context: ResolverContext) => {
-    return extractTableOfContents(html)
+    if (html) {
+      return extractTableOfContents(html)
+    } else {
+      return {html: null, sections: [], headingsCount: 0}
+    }
   }
 })

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -13,6 +13,8 @@ import { updateDenormalizedHtmlAttributions } from './tagging/updateDenormalized
 import { annotateAuthors } from './attributeEdits';
 import { getDefaultViewSelector } from '../lib/utils/viewUtils';
 import type { ToCData, ToCSection } from '../lib/tableOfContents';
+import { defineQuery } from './utils/serverGraphqlUtil';
+import GraphQLJSON from 'graphql-type-json';
 
 // Number of headings below which a table of contents won't be generated.
 const MIN_HEADINGS_FOR_TOC = 3;
@@ -353,3 +355,12 @@ const getToCforTag = async ({document, version, context}: {
 
 Utils.getToCforPost = getToCforPost;
 Utils.getToCforTag = getToCforTag;
+
+defineQuery({
+  name: "generateTableOfContents",
+  resultType: "JSON",
+  argTypes: "(html: String!)",
+  fn: (root: void, {html}:{html:string}, context: ResolverContext) => {
+    return extractTableOfContents(html)
+  }
+})


### PR DESCRIPTION
This adds a Table of Contents to both the PostsNewForm and the PostsEditForm. It updates when autosave triggers (i.e. when you're idle for 3 seconds)

It does not currently make the headings click-to-scroll.