### PR TITLE
[EA] Date cutoff for frontpage quick takes

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -508,6 +508,7 @@ Comments.addView('shortformFrontpage', (terms: CommentsViewTerms) => {
       shortformFrontpage: true,
       deleted: false,
       parentCommentId: viewFieldNullOrMissing,
+      createdAt: {$gt: moment().subtract(5, 'days').toDate()},
     },
     options: {sort: {score: -1, lastSubthreadActivity: -1, postedAt: -1}}
   };


### PR DESCRIPTION
Introduces a 5-day cutoff for quick takes on the frontpage

The current frontpage has a quick take from ten days ago, and my subjective opinion is that this algorithm gave a better result by not including it. @SharangP

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205253669390494) by [Unito](https://www.unito.io)
