### PR TITLE
[EA] Fix overflow of `EAPostsItem`s with checkboxes on mobile sequences

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -18,6 +18,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   readCheckbox: {
     minWidth: 24,
+    [theme.breakpoints.down("xs")]: {
+      marginLeft: -12,
+    },
   },
   expandedCommentsWrapper: {
     display: "flex",

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -220,12 +220,10 @@ export const eaForumTheme: SiteThemeSpecification = {
           sansSerifStack
         },
         chapterTitle: {
-          fontSize: "1.25em",
           fontStyle: "unset",
           textTransform: "unset",
           color: palette.grey[800],
-          lineHeight: "1.75em",
-          fontFamily: serifStack
+          fontFamily: sansSerifStack
         },
         largeChapterTitle: {
           fontSize: "2.2rem"

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -223,7 +223,8 @@ export const eaForumTheme: SiteThemeSpecification = {
           fontStyle: "unset",
           textTransform: "unset",
           color: palette.grey[800],
-          fontFamily: sansSerifStack
+          fontFamily: sansSerifStack,
+          fontWeight: 500,
         },
         largeChapterTitle: {
           fontSize: "2.2rem"


### PR DESCRIPTION
Plus, bonus: sans serif titles for chapters

Before

<img width="410" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/7a4c0ba2-7f2b-4a20-8003-807ee41e835a">

After

<img width="419" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/43d7cd4a-7680-4f5a-9035-1bd5eba82954">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205253687555060) by [Unito](https://www.unito.io)
