### PR TITLE
Click to expand long tag diffs

### DIFF
--- a/packages/lesswrong/components/revisions/CompareRevisions.tsx
+++ b/packages/lesswrong/components/revisions/CompareRevisions.tsx
@@ -77,7 +77,7 @@ const CompareRevisions = ({
         rawWordCount={wordCount}
         graceWords={20}
         expanded={expanded}
-        getTruncatedSuffix={({wordsLeft}: {wordsLeft:number}) => <div className={classes.expand} onClick={() => setExpanded(true)}> Read More ({wordCount} words)</div>}
+        getTruncatedSuffix={({wordsLeft}: {wordsLeft:number}) => <div className={classes.expand} onClick={() => setExpanded(true)}> Read More ({wordsLeft} more words)</div>}
         dangerouslySetInnerHTML={{__html: diffResultHtml}}
         description={`tag ${documentId}`}
       />

--- a/packages/lesswrong/components/revisions/CompareRevisions.tsx
+++ b/packages/lesswrong/components/revisions/CompareRevisions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useQuery, gql } from '@apollo/client';
 
@@ -13,6 +13,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       textDecoration: "none",
     },
   },
+  expand: {
+    cursor: "pointer",
+    color: theme.palette.primary.main,
+    marginTop: 12
+  }
 });
 
 const CompareRevisions = ({
@@ -32,7 +37,9 @@ const CompareRevisions = ({
   classes: ClassesType,
   trim?: boolean
 }) => {
-  const { ContentItemBody, ErrorMessage, Loading } = Components;
+  const [expanded, setExpanded] = useState(false);
+
+  const { ErrorMessage, Loading, ContentItemTruncated } = Components;
   
   // Use the RevisionsDiff resolver to get a comparison between revisions (see
   // packages/lesswrong/server/resolvers/diffResolvers.ts).
@@ -51,7 +58,9 @@ const CompareRevisions = ({
     },
     ssr: true,
   });
-  
+
+  const diffResultHtml = diffResult?.RevisionsDiff;
+
   if (error) {
     return <ErrorMessage message={error.message}/>
   }
@@ -59,10 +68,19 @@ const CompareRevisions = ({
   if (loadingDiff)
     return <Loading/>
   
-  const diffResultHtml = diffResult?.RevisionsDiff;
+  const wordCount = diffResultHtml.split(" ").length
+
   return (
     <div className={classes.differences}>
-      <ContentItemBody dangerouslySetInnerHTML={{__html: diffResultHtml}}/>
+      <ContentItemTruncated
+        maxLengthWords={600}
+        rawWordCount={wordCount}
+        graceWords={20}
+        expanded={expanded}
+        getTruncatedSuffix={({wordsLeft}: {wordsLeft:number}) => <div className={classes.expand} onClick={() => setExpanded(true)}> Read More ({wordCount} words)</div>}
+        dangerouslySetInnerHTML={{__html: diffResultHtml}}
+        description={`tag ${documentId}`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Previously extremely long tag-diffs just took up and extremely-lot-of-space in Recent Discussion. This truncates them.

![image](https://github.com/ForumMagnum/ForumMagnum/assets/3246710/7d4b8894-1e68-437f-bf8d-befa33382557)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205272756576574) by [Unito](https://www.unito.io)
