### PR TITLE
replace unapprove with expand for sunshine info on user profiles

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -1,11 +1,9 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import React from 'react';
+import React, { useState } from 'react';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
 import NoSSR from 'react-no-ssr';
-import { useUpdate } from '../../lib/crud/withUpdate';
-import { getNewSnoozeUntilContentCount } from './ModeratorActions';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -17,7 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: ClassesType}) => {
-
+  const [expanded, setExpanded] = useState(false);
   const currentUser = useCurrentUser()
 
   const { SunshineNewUsersInfo, SectionButton } = Components
@@ -28,27 +26,15 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
     fragmentName: 'SunshineUsersList',
   });
 
-  const { mutate: updateUser } = useUpdate({
-    collectionName: "Users",
-    fragmentName: 'SunshineUsersList',
-  });
-
   if (!user) return null
-
-  const unapproveUser = async () => {
-    await updateUser({
-      selector: { _id: userId },
-      data: {
-        snoozedUntilContentCount: getNewSnoozeUntilContentCount(user, 1)
-      },
-    })
-  }
 
   if (!currentUser || !userCanDo(currentUser, 'posts.moderate.all')) return null
   
-  if (user.reviewedByUserId && !user.snoozedUntilContentCount) return <div className={classes.root} onClick={unapproveUser}>
-    <SectionButton>Unapprove</SectionButton>
-  </div>
+  if (user.reviewedByUserId && !user.snoozedUntilContentCount && !expanded) {
+    return <div className={classes.root} onClick={() => setExpanded(true)}>
+      <SectionButton>Expand</SectionButton>
+    </div>
+  }
   
   return <div className={classes.root}>
     <NoSSR>


### PR DESCRIPTION
When viewing a user's profile, we often want to look at the sunshine info without actually unapproving them.  Now that we have a separate button inside that very component for putting users back into the review queue, it's time to just change it to "Expand" (with no effects on the user).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205279922724179) by [Unito](https://www.unito.io)
