### PR TITLE
fix infinite loading spinner for sub status icon when no logged-in user

### DIFF
--- a/packages/lesswrong/components/hooks/useNotifyMe.ts
+++ b/packages/lesswrong/components/hooks/useNotifyMe.ts
@@ -81,6 +81,8 @@ export const useNotifyMe = ({
     eventProps: {documentId: document._id, documentType: documentType},
   });
 
+  const skip = !currentUser;
+
   // Get existing subscription, if there is one
   const {results, loading, invalidateCache} = useMulti({
     terms: {
@@ -94,12 +96,14 @@ export const useNotifyMe = ({
     collectionName: "Subscriptions",
     fragmentName: "SubscriptionState",
     enableTotal: false,
-    skip: !currentUser
+    skip
   });
 
   if (loading) {
     return {
-      loading: true,
+      // Apollo returns `loading: true` when you skip the query.
+      // If we skipped fetching subscription state because there's no logged-in user, don't return loading: true.
+      loading: skip ? false : true,
     };
   };
 


### PR DESCRIPTION
The bell icon next to the Subscribe button remains in an infinite loading state if you SSR a tag page directly, rather than navigate to one from elsewhere on LessWrong, while logged out.  I'm pretty sure this comes from useNotifyMe, which does the following:
```
  // Get existing subscription, if there is one
  const {results, loading, invalidateCache} = useMulti({
    terms: {
      view: "subscriptionState",
      documentId: document._id,
      userId: currentUser?._id,
      type: subscriptionType,
      collectionName,
      limit: 1,
    },
    collectionName: "Subscriptions",
    fragmentName: "SubscriptionState",
    enableTotal: false,
    skip: !currentUser
  });

  if (loading) {
    return {
      loading: true,
    };
  };
```

Unfortunately, Apollo returns loading: true when you set skip: true.

Bug:
![image](https://github.com/ForumMagnum/ForumMagnum/assets/2136984/f5615314-88e5-4b05-9393-45817bae4a46)

Fixed:
<img width="701" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/7eba1419-2e34-416b-95b6-1dda540e7487">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205289342026757) by [Unito](https://www.unito.io)
