### PR TITLE
Update auto rate limits so 2000+ users have more leeway

### DIFF
--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -120,7 +120,15 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Comments per 1 days'),
       last20KarmaThreshold: -5,
+      karmaThreshold: 1999, // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
       downvoterCountThreshold: 4,
+      appliesToOwnPosts: false,
+      rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
+    }, 
+    {
+      ...timeframe('1 Comments per 1 days'),
+      last20KarmaThreshold: -5,
+      downvoterCountThreshold: 7,
       appliesToOwnPosts: false,
       rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 


### PR DESCRIPTION
This makes it so 2000+ karma users require more unique downvoters to get the 1 comment/day rate limit

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205289569941450) by [Unito](https://www.unito.io)
