### PR TITLE
revert tag revision functionality and button

### DIFF
--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -8,8 +8,10 @@ export type CloseableComponents = {
   [T in keyof ComponentTypes]: FromPartial<ComponentTypes[T]['propTypes']> extends { onClose: any } | undefined ? T : never
 }[keyof ComponentTypes];
 
-export interface OpenDialogContextType<T extends CloseableComponents = CloseableComponents> {
-  openDialog: ({componentName, componentProps, noClickawayCancel}: {
+// const foo: CloseableComponents = 'TagVersionHistory'
+
+export interface OpenDialogContextType {
+  openDialog: <T extends CloseableComponents>({componentName, componentProps, noClickawayCancel}: {
     componentName: T,
     componentProps?: Omit<React.ComponentProps<typeof Components[T]>,"onClose"|"classes">,
     noClickawayCancel?: boolean,

--- a/packages/lesswrong/components/dropdowns/posts/EditTagsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/EditTagsDropdownItem.tsx
@@ -5,7 +5,7 @@ import { preferredHeadingCase } from "../../../lib/forumTypeUtils";
 import { taggingNamePluralCapitalSetting } from "../../../lib/instanceSettings";
 
 const EditTagsDropdownItem = ({post, closeMenu}: {
-  post: PostsBase,
+  post: PostsList | SunshinePostsList,
   closeMenu?: () => void,
 }) => {
   const {openDialog} = useDialog();

--- a/packages/lesswrong/components/editor/TagVersionHistory.tsx
+++ b/packages/lesswrong/components/editor/TagVersionHistory.tsx
@@ -1,0 +1,190 @@
+import React, {useEffect, useState} from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
+import { useDialog } from '../common/withDialog';
+import { useMulti } from '../../lib/crud/withMulti';
+import { useSingle } from '../../lib/crud/withSingle';
+import Button from '@material-ui/core/Button';
+import classNames from 'classnames';
+import {CENTRAL_COLUMN_WIDTH} from "../posts/PostsPage/PostsPage";
+import {commentBodyStyles, postBodyStyles} from "../../themes/stylePiping";
+import {useMessages} from "../common/withMessages";
+import { useMutation, gql } from '@apollo/client';
+import { useTracking } from '../../lib/analyticsEvents';
+import { useCurrentUser } from '../common/withUser';
+import { canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
+import { tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
+import { preferredHeadingCase } from '../../lib/forumTypeUtils';
+
+const LEFT_COLUMN_WIDTH = 160
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    width: CENTRAL_COLUMN_WIDTH + LEFT_COLUMN_WIDTH + 64, //should import post
+    display: "flex",
+    padding: 24,
+    justifyContent: 'space-between'
+  },
+  leftColumn: {
+    ...commentBodyStyles(theme),
+  },
+  revisionRow: {
+    padding: 12,
+    cursor: "pointer",
+  },
+  selectedRevision: {
+    background: theme.palette.grey[200],
+  },
+  versionNumber: {
+    color: theme.palette.grey[900],
+    marginRight: 8
+  },
+  editedAt: {
+    color: theme.palette.grey[600],
+    marginLeft: 8
+  },
+  selectedRevisionDisplay: {
+    width: CENTRAL_COLUMN_WIDTH,
+    ...postBodyStyles(theme)
+  },
+  restoreButton: {
+    textAlign: "center",
+    marginBottom: 32,
+    marginTop: 16,
+    paddingRight: 100
+  },
+  loadMore: {
+    paddingLeft: 12
+  }
+});
+
+const TagVersionHistoryButton = ({tagId, classes}: {
+  tagId: string,
+  classes: ClassesType
+}) => {
+  const { openDialog } = useDialog();
+  const { captureEvent } = useTracking()
+
+  return <Button
+    onClick={() => {
+      captureEvent("tagVersionHistoryButtonClicked", {tagId})
+      openDialog({
+        componentName: "TagVersionHistory",
+        componentProps: {
+          tagId
+        },
+      })
+    }}
+  >
+    {preferredHeadingCase('Revert To Previous Version')}
+  </Button>
+}
+
+const TagVersionHistory = ({tagId, onClose, classes}: {
+  tagId: string,
+  onClose: ()=>void,
+  classes: ClassesType
+}) => {
+  const { LWDialog, Loading, ContentItemBody, FormatDate, LoadMore, ChangeMetricsDisplay } = Components;
+  const currentUser = useCurrentUser();
+  const [selectedRevisionId,setSelectedRevisionId] = useState<string|null>(null);
+  const [revertInProgress,setRevertInProgress] = useState(false);
+  // We need the $contributorsLimit arg to satisfy the fragment, other graphql complains, even though we don't use any results that come back.
+  const [revertMutation] = useMutation(gql`
+    mutation revertToRevision($tagId: String!, $revertToRevisionId: String!, $contributorsLimit: Int) {
+      revertTagToRevision(tagId: $tagId, revertToRevisionId: $revertToRevisionId) {
+        ...TagPageFragment
+      }
+    }
+    ${fragmentTextForQuery("TagPageFragment")}
+  `, {
+    ignoreResults: true
+  });
+  const [revertLoading, setRevertLoading] = useState(false);
+  const canRevert = tagUserHasSufficientKarma(currentUser, 'edit');
+  
+  const { results: revisions, loading: loadingRevisions, loadMoreProps } = useMulti({
+    terms: {
+      view: "revisionsOnDocument",
+      documentId: tagId,
+      fieldName: "description",
+    },
+    fetchPolicy: "cache-and-network",
+    collectionName: "Revisions",
+    fragmentName: "RevisionMetadataWithChangeMetrics",
+  });
+  
+  useEffect(() => {
+    revisions && revisions.length > 0 && setSelectedRevisionId(revisions[0]._id)
+  }, [revisions])
+  
+  const { document: revision } = useSingle({
+    skip: !selectedRevisionId,
+    documentId: selectedRevisionId||"",
+    collectionName: "Revisions",
+    fetchPolicy: "cache-first",
+    fragmentName: "RevisionDisplay",
+  });
+
+  const { captureEvent } = useTracking()
+  
+  return <LWDialog open={true} maxWidth={false} onClose={onClose}>
+    <div className={classes.root}>
+      <div className={classes.leftColumn}>
+        {loadingRevisions && <Loading/>}
+        {revisions && revisions.map(rev =>
+          <div key={rev._id}
+            className={classNames(classes.revisionRow, {
+              [classes.selectedRevision]: rev._id===selectedRevisionId,
+            })}
+            onClick={() => setSelectedRevisionId(rev._id)}
+          >
+            <span className={classes.versionNumber}>{rev.version}</span>
+            <ChangeMetricsDisplay changeMetrics={rev.changeMetrics}/>
+            <span className={classes.editedAt}><FormatDate date={rev.editedAt}/></span>
+          </div>
+        )}
+        <div className={classes.loadMore}>
+          <LoadMore {...loadMoreProps}/>
+        </div>
+      </div>
+      <div className={classes.selectedRevisionDisplay}>
+        {revision && canRevert && <div className={classes.restoreButton}>
+          {revertLoading
+            ? <Loading/>
+            : <Button variant="contained" color="primary" onClick={async () => {
+                captureEvent("restoreTagVersionClicked", {tagId, revisionId: selectedRevisionId})
+                setRevertInProgress(true);
+                await revertMutation({
+                  variables: {
+                    tagId: tagId,
+                    revertToRevisionId: selectedRevisionId,
+                  },
+                });
+                // Hard-refresh the page to get things back in sync
+                location.reload();
+              }}
+            >
+              RESTORE THIS VERSION{" "}
+              {revertInProgress && <Loading/>}
+            </Button>
+          }
+        </div>}
+        {revision && <ContentItemBody
+          dangerouslySetInnerHTML={{__html: revision.html}}
+          description="TagVersionHistory revision"
+        />}
+      </div>
+    </div>
+  </LWDialog>
+}
+
+const TagVersionHistoryButtonComponent = registerComponent("TagVersionHistoryButton", TagVersionHistoryButton, {styles});
+const TagVersionHistoryComponent = registerComponent("TagVersionHistory", TagVersionHistory, {styles});
+
+declare global {
+  interface ComponentTypes {
+    TagVersionHistoryButton: typeof TagVersionHistoryButtonComponent
+    TagVersionHistory: typeof TagVersionHistoryComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -208,7 +208,7 @@ const TagPage = ({classes}: {
     PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, Typography,
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection,
     TagPageButtonRow, ToCColumn, SubscribeButton, CloudinaryImage2, TagIntroSequence,
-    TagTableOfContents, ContentStyles,
+    TagTableOfContents, TagVersionHistoryButton, ContentStyles,
   } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -416,14 +416,17 @@ const TagPage = ({classes}: {
             { revision && tag.description && (tag.description as TagRevisionFragment_description).user && <div className={classes.pastRevisionNotice}>
               You are viewing revision {tag.description.version}, last edited by <UsersNameDisplay user={(tag.description as TagRevisionFragment_description).user}/>
             </div>}
-            {editing ? <EditTagForm
-              tag={tag}
-              successCallback={ async () => {
-                setEditing(false)
-                await client.resetStore()
-              }}
-              cancelCallback={() => setEditing(false)}
-            /> :
+            {editing ? <div>
+              <EditTagForm
+                tag={tag}
+                successCallback={ async () => {
+                  setEditing(false)
+                  await client.resetStore()
+                }}
+                cancelCallback={() => setEditing(false)}
+              />
+              <TagVersionHistoryButton tagId={tag._id} />
+            </div> :
             <div onClick={clickReadMore}>
               <ContentStyles contentType="tag">
                 <ContentItemBody

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -11,6 +11,10 @@ export const tagMinimumKarmaPermissions = forumSelect({
     new: 10,
     edit: 10,
   },
+  LessWrong: {
+    new: 1,
+    edit: 1,
+  },
   // Default is to allow all users to create/edit tags
   default: {
     new: -1000,

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -388,6 +388,7 @@ importComponent("PostsAnalyticsPage", () => require('../components/posts/PostsAn
 importComponent("PostCollaborationEditor", () => require('../components/editor/PostCollaborationEditor'));
 importComponent("CollabEditorPermissionsNotices", () => require('../components/editor/CollabEditorPermissionsNotices'));
 importComponent(["PostVersionHistory","PostVersionHistoryButton"], () => require('../components/editor/PostVersionHistory'));
+importComponent(["TagVersionHistory","TagVersionHistoryButton"], () => require('../components/editor/TagVersionHistory'));
 importComponent("EditorTopBar", () => require('../components/editor/EditorTopBar'));
 
 importComponent("PostsGroupDetails", () => require('../components/posts/PostsGroupDetails'));

--- a/packages/lesswrong/server/resolvers/revisionResolvers.ts
+++ b/packages/lesswrong/server/resolvers/revisionResolvers.ts
@@ -3,7 +3,7 @@ import { dataToMarkdown, dataToHTML, dataToCkEditor } from '../editor/conversion
 import { highlightFromHTML, truncate } from '../../lib/editor/ellipsize';
 import { htmlStartingAtHash } from '../extractHighlights';
 import { augmentFieldsDict } from '../../lib/utils/schemaUtils'
-import { defineQuery } from '../utils/serverGraphqlUtil';
+import { defineMutation, defineQuery } from '../utils/serverGraphqlUtil';
 import { compile as compileHtmlToText } from 'html-to-text'
 import sanitizeHtml, {IFrame} from 'sanitize-html';
 import { extractTableOfContents } from '../tableOfContents';
@@ -11,6 +11,10 @@ import * as _ from 'underscore';
 import { dataToDraftJS } from './toDraft';
 import { sanitize, sanitizeAllowedTags } from '../../lib/vulcan-lib/utils';
 import { htmlToTextDefault } from '../../lib/htmlToText';
+import { tagMinimumKarmaPermissions, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
+import { getLatestRev } from '../editor/make_editable_callbacks';
+import isEqual from 'lodash/isEqual';
+import { updateMutator } from '../vulcan-lib/mutators';
 
 // Use html-to-text's compile() wrapper (baking in options) to make it faster when called repeatedly
 const htmlToTextPlaintextDescription = compileHtmlToText({
@@ -146,4 +150,42 @@ defineQuery({
         };
     }
   },
+});
+
+defineMutation({
+  name: "revertTagToRevision",
+  resultType: "Tag",
+  argTypes: "(tagId: String!, revertToRevisionId: String!)",
+  fn: async (root: void, { tagId, revertToRevisionId }: { tagId: string, revertToRevisionId: string }, context: ResolverContext) => {
+    const { currentUser, loaders, Tags } = context;
+    if (!tagUserHasSufficientKarma(currentUser, 'edit')) {
+      throw new Error(`Must be logged in and have ${tagMinimumKarmaPermissions['edit']} karma to revert tags to older revisions`);
+    }
+
+    const [tag, revertToRevision, latestRevision] = await Promise.all([
+      loaders.Tags.load(tagId),
+      loaders.Revisions.load(revertToRevisionId),
+      getLatestRev(tagId, 'description')
+    ]);
+
+    const anyDiff = !isEqual(tag.description.originalContents, revertToRevision.originalContents);
+
+    if (!tag)               throw new Error('Invalid tagId');
+    if (!revertToRevision)  throw new Error('Invalid revisionId');
+    // I don't think this should be possible if we find a revision to revert to, but...
+    if (!latestRevision)    throw new Error('Tag is missing latest revision');
+    if (!anyDiff)           throw new Error(`Can't find difference between revisions`);
+
+    await updateMutator({
+      collection: Tags,
+      context,
+      documentId: tag._id,
+      data: {
+        description: {
+          originalContents: revertToRevision.originalContents,
+        },
+      },
+      currentUser,
+    });
+  }
 });


### PR DESCRIPTION
Turns out we didn't have a button to revert tags to previous revisions, like we do for posts.  Motivated by discovering that most of the links in the `rationality` tag have been broken since a manual attempt at fixing a bad edit caused them to point to the wrong place.  Not super sure what to do about the location/styling of the button.

<img width="695" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/56c34c5e-ff8d-4394-a39e-d11aac259343">
