### PR TITLE
Exclude posts tagged with 'translation' from recent discussions

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { useTimezone } from './withTimezone';
 import { AnalyticsContext, useOnMountTracking } from '../../lib/analyticsEvents';
-import { useFilterSettings } from '../../lib/filterSettings';
+import { FilterSettings, useFilterSettings } from '../../lib/filterSettings';
 import moment from '../../lib/moment-timezone';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
 import {forumTypeSetting, taggingNamePluralSetting, taggingNameSetting} from '../../lib/instanceSettings';
@@ -16,8 +16,8 @@ import classNames from 'classnames';
 import {useUpdateCurrentUser} from "../hooks/useUpdateCurrentUser";
 import { reviewIsActive } from '../../lib/reviewUtils';
 import { forumSelect } from '../../lib/forumTypeUtils';
-import { useABTest } from '../../lib/abTestImpl';
 import { frontpageDaysAgoCutoffSetting } from '../../lib/scoring';
+import { EA_FORUM_TRANSLATION_TOPIC_ID } from '../../lib/collections/tags/collection';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum';
 
@@ -80,6 +80,24 @@ const advancedSortingText = isEAForum
 
 const defaultLimit = isEAForum ? 11 : 13;
 
+const applyConstantFilters = (filterSettings: FilterSettings): FilterSettings => {
+  if (!isEAForum) {
+    return filterSettings;
+  }
+  const tags = filterSettings.tags.filter(
+    ({tagId}) => tagId !== EA_FORUM_TRANSLATION_TOPIC_ID,
+  );
+  tags.push({
+    tagId: EA_FORUM_TRANSLATION_TOPIC_ID,
+    tagName: "Translation",
+    filterMode: "Hidden",
+  });
+  return {
+    ...filterSettings,
+    tags,
+  };
+}
+
 const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
   const location = useLocation();
   const updateCurrentUser = useUpdateCurrentUser();
@@ -104,7 +122,7 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
 
   const recentPostsTerms = {
     ...query,
-    filterSettings: filterSettings,
+    filterSettings: applyConstantFilters(filterSettings),
     after: dateCutoff,
     view: "magic",
     forum: true,

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -17,6 +17,7 @@ interface ExtendedTagsCollection extends TagsCollection {
 }
 
 export const EA_FORUM_COMMUNITY_TOPIC_ID = 'ZCihBFp5P64JCvQY6';
+export const EA_FORUM_TRANSLATION_TOPIC_ID = 'f4d3KbWLszzsKqxej';
 export const EA_FORUM_APRIL_FOOLS_DAY_TOPIC_ID = '4saLTjJHsbduczFti';
 
 export const Tags: ExtendedTagsCollection = createCollection({

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -1,9 +1,12 @@
 import { mergeFeedQueries, defineFeedResolver, viewBasedSubquery, fixedIndexSubquery } from '../utils/feedUtil';
 import { Posts } from '../../lib/collections/posts/collection';
-import { EA_FORUM_COMMUNITY_TOPIC_ID, Tags } from '../../lib/collections/tags/collection';
+import {
+  EA_FORUM_COMMUNITY_TOPIC_ID,
+  EA_FORUM_TRANSLATION_TOPIC_ID,
+  Tags,
+} from '../../lib/collections/tags/collection';
 import { Revisions } from '../../lib/collections/revisions/collection';
 import { forumTypeSetting, isEAForum } from '../../lib/instanceSettings';
-import { filterModeIsSubscribed } from '../../lib/filterSettings';
 import Comments from '../../lib/collections/comments/collection';
 import { viewFieldAllowAny } from '../vulcan-lib';
 
@@ -59,6 +62,11 @@ defineFeedResolver<Date>({
       postCommentedExcludeCommunity = communityFilters.none;
     }
 
+    const translationFilter = {$or: [
+      {[`tagRelevance.${EA_FORUM_TRANSLATION_TOPIC_ID}`]: {$lt: 1}},
+      {[`tagRelevance.${EA_FORUM_TRANSLATION_TOPIC_ID}`]: {$exists: false}},
+    ]};
+
     return await mergeFeedQueries<SortKeyType>({
       limit, cutoff, offset,
       subqueries: [
@@ -81,6 +89,7 @@ defineFeedResolver<Date>({
               ? {$and: [
                 postCommentedEventsCriteria,
                 postCommentedExcludeCommunity,
+                translationFilter,
               ]}
               : postCommentedEventsCriteria),
           },


### PR DESCRIPTION
Recently, we've been getting waves of translations jamming up recent discussions. This PR excludes the 'translation' tag from showing up there.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205296287378882) by [Unito](https://www.unito.io)
