### PR TITLE
Add banner to bot site

### DIFF
--- a/packages/lesswrong/components/common/BotSiteBanner.tsx
+++ b/packages/lesswrong/components/common/BotSiteBanner.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { registerComponent, Components } from "../../lib/vulcan-lib";
+import { Link } from "../../lib/reactRouterWrapper";
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    padding: 20,
+    width: "100%",
+    fontFamily: theme.palette.fonts.serifStack,
+    fontSize: 18,
+    marginTop: 12,
+    border: theme.palette.border.commentBorder,
+    borderWidth: 2,
+    borderRadius: theme.borderRadius.default,
+    borderColor: theme.palette.primary.main,
+    background: theme.palette.background.pageActiveAreaBackground,
+    [theme.breakpoints.down("xs")]: {
+      padding: 12,
+      fontSize: 16,
+    },
+  },
+});
+
+const BotSiteBanner = ({ classes }: { classes: ClassesType }) => {
+  const { SingleColumnSection } = Components;
+
+  return (
+    <SingleColumnSection className={classes.root}>
+      <div>
+        Welcome to the EA Forum bot site. If you are trying to access the Forum programmatically (either by scraping or
+        via the api) please use this site rather than <Link to={"https://forum.effectivealtruism.org"}>forum.effectivealtruism.org</Link>.
+        <br />
+        <br />
+        This site has the same content as the main site, but is run in a separate environment to avoid bots overloading the main site
+        and affecting performance for human users.
+      </div>
+    </SingleColumnSection>
+  );
+};
+
+const BotSiteBannerComponent = registerComponent("BotSiteBanner", BotSiteBanner, { styles });
+
+declare global {
+  interface ComponentTypes {
+    BotSiteBanner: typeof BotSiteBannerComponent;
+  }
+}

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -13,6 +13,7 @@ const showSmallpoxSetting = new DatabasePublicSetting<boolean>('showSmallpox', f
 const showHandbookBannerSetting = new DatabasePublicSetting<boolean>('showHandbookBanner', false)
 const showEventBannerSetting = new DatabasePublicSetting<boolean>('showEventBanner', false)
 const showMaintenanceBannerSetting = new DatabasePublicSetting<boolean>('showMaintenanceBanner', false)
+const isBotSiteSetting = new PublicInstanceSetting<boolean>('botSite.isBotSite', false, 'optional');
 
 /**
  * Build structured data to help with SEO.
@@ -49,7 +50,7 @@ const EAHome = () => {
     RecentDiscussionFeed, EAHomeMainContent, QuickTakesSection,
     SmallpoxBanner, EventBanner, MaintenanceBanner, FrontpageReviewWidget,
     SingleColumnSection, HomeLatestPosts, EAHomeCommunityPosts, HeadTags,
-    EAPopularCommentsSection,
+    EAPopularCommentsSection, BotSiteBanner
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
@@ -60,6 +61,7 @@ const EAHome = () => {
   const maintenanceTimeValue = maintenanceTime.get()
   const isBeforeMaintenanceTime = maintenanceTimeValue && Date.now() < new Date(maintenanceTimeValue).getTime() + (5*60*1000)
   const shouldRenderMaintenanceBanner = showMaintenanceBannerSetting.get() && isBeforeMaintenanceTime
+  const shouldRenderBotSiteBanner = isBotSiteSetting.get() && isEAForum
 
   return (
     <AnalyticsContext pageContext="homePage">
@@ -67,6 +69,7 @@ const EAHome = () => {
       {shouldRenderMaintenanceBanner && <MaintenanceBanner />}
       {shouldRenderSmallpox && <SmallpoxBanner/>}
       {shouldRenderEventBanner && <EventBanner />}
+      {shouldRenderBotSiteBanner && <BotSiteBanner />}
 
       {/* <SingleColumnSection>
         <CurrentSpotlightItem />

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -55,6 +55,7 @@ importComponent("EditDigestTableRow", () => require('../components/ea-forum/dige
 importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
 importComponent("EventBanner", () => require('../components/ea-forum/EventBanner'));
 importComponent("MaintenanceBanner", () => require('../components/common/MaintenanceBanner'));
+importComponent("BotSiteBanner", () => require('../components/common/BotSiteBanner'));
 
 importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
 importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))


### PR DESCRIPTION
Adding a banner to https://forum-bots.effectivealtruism.org/ , mainly so people who realise their bots are being redirected there will understand why if they go to the url. Also, even though the site has `noindex` tags set now it doesn't seem to have come through to google yet so people might still end up there accidentally

<img width="1087" alt="Screenshot 2023-08-21 at 16 03 31" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/06457bf9-143a-4918-92f2-a4a51e07efe4">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205319779514740) by [Unito](https://www.unito.io)
