### PR TITLE
[EA] Allow changing a post to a question and vice versa

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -495,6 +495,7 @@ const schema: SchemaType<DbPost> = {
     ...schemaDefaultValue(false),
     canRead: ['guests'],
     canCreate: ['members'],
+    canUpdate: ['members'],
     hidden: true,
   },
 


### PR DESCRIPTION
Previously the behaviour was:
 - You couldn't change the value of `question` after a post was created

Now the behaviour is:
 - You can change a post to a question and vice versa
 - If there are comments on a post and then you change it to a question, they stay as comments and not answers
 - If there are answers on a question and then you change it to a post, they don't appear on the post

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205320150444945) by [Unito](https://www.unito.io)
