### PR TITLE
Make word-counter resilient to LaTeX errors (including those introduced by conversions)

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -257,13 +257,17 @@ export async function dataToCkEditor(data: AnyBecauseTodo, type: string) {
  * When we calculate the word count we want to ignore footnotes. There's two syntaxes
  * for footnotes in markdown:
  *
+ * ```
  * 1.  ^**[^](#fnreflexzxp4wr9h)**^
  *
  *     The contents of my footnote
+ * ```
  *
  * and
  *
+ * ```
  * [^1]: The contents of my footnote.
+ * ```
  *
  * In both cases, the footnote must start at character 0 on the line. The strategy here
  * is just to find the first place where this occurs and then to ignore to the end of
@@ -271,21 +275,51 @@ export async function dataToCkEditor(data: AnyBecauseTodo, type: string) {
  *
  * We adopt a similar strategy for ignoring appendices. We find the first header tag that
  * contains the word 'appendix' (case-insensitive), and ignore to the end of the document.
+ *
+ * This function runs when content is saved, not when it's loaded, so it's not too
+ * performance sensitive. On the flip side, updates to this function won't affect
+ * existing content (without a migration) until the content is edited and resaved.
+ *
+ * This involves converting from whatever format the content is in to markdown to do
+ * the footnote removal, then to HTML to do the appendix removal, then back to markdown
+ * to count the words. Any of these steps can potentially fail (throw an exception).
+ * In particular, if the post contains LaTeX which contains syntax errors, that can
+ * cause a failure; and there is (currently, 2023-08-21) at least one escaping bug which
+ * can cause format conversions to _introduce_ LaTeX syntax errors for later conversion
+ * steps to run into. Our strategy for this is to keep a running best estimate, to be
+ * returned if any step fails.
  */
 export async function dataToWordCount(data: AnyBecauseTodo, type: string) {
+  let bestWordCount = 0;
+
   try {
+    // Convert to markdown and count words by splitting spaces
     const markdown = dataToMarkdown(data, type) ?? "";
+    bestWordCount = markdown.trim().split(/[\s]+/g).length;
+    
+    // Try to remove footnotes and update the count accordingly
     const withoutFootnotes = markdown
       .split(/^1\. {2}\^\*\*\[\^\]\(#(.|\n)*/m)[0]
       .split(/^\[\^1\]:.*/m)[0];
+    
+    // Sanity check: if removing footnotes lowered the word count by over 60%, we might
+    // have removed too much.
+    const wordCountWithoutFootnotes = withoutFootnotes.trim().split(/[\s]+/g).length;
+    if (wordCountWithoutFootnotes < bestWordCount*.4) {
+      return bestWordCount;
+    }
+    bestWordCount = wordCountWithoutFootnotes;
+
+    // Convert to HTML and try removing appendixes
     const htmlWithoutFootnotes = await dataToHTML(withoutFootnotes, "markdown") ?? "";
-    const withoutFootnotesAndAppendices = htmlWithoutFootnotes
+    const htmlWithoutFootnotesAndAppendices = htmlWithoutFootnotes
       .split(/<h[1-6]>.*(appendix).*<\/h[1-6]>/i)[0];
-    const words = withoutFootnotesAndAppendices.match(/[^\s]+/g) ?? [];
-    return words.length;
+    const markdownWithoutFootnotesAndAppendices = dataToMarkdown(htmlWithoutFootnotesAndAppendices, "html");
+    bestWordCount = markdownWithoutFootnotesAndAppendices.trim().split(/[\s]+/g).length;
   } catch(err) {
     // eslint-disable-next-line no-console
-    console.error("Error in dataToWordCount", data, type, err)
-    return 0
+    console.error("Error in dataToWordCount", err)
   }
+
+  return bestWordCount
 }

--- a/packages/lesswrong/unitTests/editorUtils.tests.ts
+++ b/packages/lesswrong/unitTests/editorUtils.tests.ts
@@ -159,16 +159,25 @@ A sample piece of content[^footnote1] that has complex footnotes[^footnote2]
     `, "markdown")).toBe(9);
   });
   it("excludes appendices", async () => {
-    expect(await dataToWordCount(`
-A sample piece of content that has one appendix.
-
-Section 1
-=========
-
-Appendix 1
-==========
-
-Lorem ipsum dolor sit amet.
-    `, "markdown")).toBe(11);
+    // Construct the same document with and without an appendix added, and enforce
+    // that their word counts are the same.
+    //
+    // (Note that word counting has a bunch of dumb subtleties, and in particular,
+    // the "=========" hr winds up getting counted. This is why we test this with a
+    // comparison, rather than an exact count.)
+    const nonAppendixMarkdown =
+      "A sample piece of content that has one appendix.\n"
+      +"\n"
+      +"Section 1\n"
+      +"=========\n"
+      +"\n";
+    const appendixMarkdown =
+      "Appendix 1\n"
+      +"==========\n"
+      +"\n"
+      +"Lorem ipsum dolor sit amet."
+    const wordCountWithoutAppendix = await dataToWordCount(nonAppendixMarkdown, "markdown");
+    const wordCountWithAppendix = await dataToWordCount(nonAppendixMarkdown+appendixMarkdown, "markdown");
+    expect(wordCountWithoutAppendix).toBe(wordCountWithAppendix);
   });
 });


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/issues/7392 modified `dataToWordCount` to have a stage where it looks for a section-heading containing the string "Appendix", and exclude everything after that from the word-count. In order to do this, it goes through an extra format-conversion step; where before it would go from the original format (usually CkEditor HTLM) to Markdown, and after it would go from original to Markdown then to HTML. Unfortunately, there's an unrelated bug in our HTML-to-Markdown conversion (or perhaps in our Markdown-to-HTML conversion) which causes LaTeX statements to wind up double- escaped, making them syntactically invalid, so on posts containing affected LaTeX (such as https://www.lesswrong.com/posts/zkfmhWQXsZweijmzi/causality-and-a-cost-semantics-for-neural-networks), this would throw an exception and return a word-count of 0.

To fix this, I modified `dataToWordCount` to be more error-tolerant. Rather than requiring every format conversion to succeed, it keeps a running best guess at the word count, and if any format conversion fails, it stops there and uses that. I also made it do its final count in Markdown, rather than in HTML, since I believe that's more accurate; counting in HTML would count `<p>lorem</p><p>ipsum</p>` as one word (since there's no whitespace between the tags), and count `<span class="someclass">lorem</span>` as two (since there's a space in the tag).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205320913160629) by [Unito](https://www.unito.io)
