### PR TITLE
Fix typo in the "combative" reaction description text

### DIFF
--- a/packages/lesswrong/lib/voting/reactions.tsx
+++ b/packages/lesswrong/lib/voting/reactions.tsx
@@ -222,7 +222,7 @@ export const namesAttachedReactions: NamesAttachedReactionType[] = [
     label: "Too Combative?",
     searchTerms: ["swords", "combative", "fighting", "battle", "war", "tribalism"],
     svg: "/reactionImages/nounproject/swords.svg",
-    description: "This seems more combative than it needs to be to communicate it's point.",
+    description: "This seems more combative than it needs to be to communicate its point.",
     filter: {padding: 2, scale:1},
   },
   


### PR DESCRIPTION
This is a single-character change that removes a mistaken apostrophe in the description for the "combative" reaction.

Formerly: "This seems more combative than it needs to be to communicate it's point."

The fix: "This seems more combative than it needs to be to communicate its point."

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205331965720846) by [Unito](https://www.unito.io)
