### PR TITLE
Fix comment-post association on VoteHistoryTab

### DIFF
--- a/packages/lesswrong/components/bookmarks/VoteHistoryTab.tsx
+++ b/packages/lesswrong/components/bookmarks/VoteHistoryTab.tsx
@@ -54,7 +54,7 @@ const VoteHistoryTab = ({classes}: {classes: ClassesType}) => {
       return <CommentsNode
         key={item._id}
         comment={item}
-        treeOptions={{showPostTitle: true, forceNotSingleLine: true}}
+        treeOptions={{showPostTitle: true, forceNotSingleLine: true, post: item.post || undefined}}
         truncated
       />
     }

--- a/packages/lesswrong/lib/collections/votes/fragments.ts
+++ b/packages/lesswrong/lib/collections/votes/fragments.ts
@@ -43,7 +43,7 @@ registerFragment(`
   fragment UserVotesWithDocument on Vote {
     ...UserVotes
     comment {
-      ...CommentsList
+      ...CommentsListWithParentMetadata
     }
     post {
       ...PostsListWithVotes

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3013,7 +3013,7 @@ interface UserVotes { // fragment on Votes
 }
 
 interface UserVotesWithDocument extends UserVotes { // fragment on Votes
-  readonly comment: CommentsList|null,
+  readonly comment: CommentsListWithParentMetadata|null,
   readonly post: PostsListWithVotes|null,
 }
 


### PR DESCRIPTION
Comments on the vote history page (/saved#votehistory) weren't properly associated with their posts, so their permalinks were just to the root domain (issue #7698), and their menus were missing options (issue #7699). Changing the comment fragment from CommentsList to CommentsListWithParentMetadata solves this.

(I didn't really intend to solve these issues, but stumbled into it when looking at forumType conditionals.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205348359134582) by [Unito](https://www.unito.io)
