### PR TITLE
Solve LW menu item height being too short for the letter 'g'

### DIFF
--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -108,7 +108,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
           fontFamily: sansSerifStack,
           color: palette.grey[800],
           fontSize: "1.1rem",
-          lineHeight: "1em"
+          lineHeight: "1.1em"
         }
       },
       MuiListItem: {


### PR DESCRIPTION
On the LessWrong top right users menu, the lower part of the letter g is slightly cut off (tested in Chrome and Firefox on MacOS, and in Chrome on Android):

<img width="158" alt="lw-menu-g-descenders" src="https://github.com/ForumMagnum/ForumMagnum/assets/675520/286f6485-83e7-4045-9493-94d761ba78c2">

Increasing the MuiMenuItem lineheight of the lesswrongTheme from 1em to 1.1em solves this, so this is a single-line change that does that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205349474051802) by [Unito](https://www.unito.io)
