### PR TITLE
Prevent non-admins un-deleting posts

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -287,6 +287,12 @@ const schema: SchemaType<DbPost> = {
     canRead: ['guests'],
     canUpdate: ['members'],
     hidden: true,
+    onUpdate: ({data, document, oldDocument, currentUser}) => {
+      if (!currentUser?.isAdmin && oldDocument.deletedDraft && !document.deletedDraft) {
+        throw new Error("You cannot un-delete posts");
+      }
+      return data.deletedDraft;
+    },
   },
 
   // The post's status. One of pending (`1`), approved (`2`), rejected (`3`), spam (`4`) or deleted (`5`)


### PR DESCRIPTION
Members can change the deletedDraft flag on their posts, which makes sense because sometimes they'll want to delete their posts. But nothing stops them from changing a deleted post back to un-deleted, if they craft the right request. That's bad, right? Because sometimes admins delete bad posts, and intend that they stay deleted.

So this pull request adds an onUpdate check to DbPost.deletedDraft that prevents members changing deletedDraft=true to deletedDraft=false.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205356093820558) by [Unito](https://www.unito.io)
