### PR TITLE
Fix console errors due to JSS bug

### DIFF
--- a/packages/lesswrong/components/books/Book2020Animation.tsx
+++ b/packages/lesswrong/components/books/Book2020Animation.tsx
@@ -75,11 +75,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('xs')]: {
       height: (HEIGHT*.55) + (PADDING * 3.5),
     },
-    [theme.breakpoints.down('lg')]: {
-      '& $revealedContent': {
-        opacity: 1,
-      }
-    },
     [theme.breakpoints.down('md')]: {
       width: "100%",
     },
@@ -133,11 +128,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
     '&:hover': {
       ...revealedContent(theme),
-      [theme.breakpoints.up('lg')]: {
-        '& $revealedContent': {
-          left: 0
-        }
-      }
     },
   },
   book: {


### PR DESCRIPTION
Our version of JSS has a bug, [later patched](https://github.com/cssinjs/jss/commit/5ba7a653aad162fa5b00ab80d9c2f29e0a741baa), which caused referenced rules inside media queries not to be found. As a result, the only effect of the rules I've removed were to cause console errors.

Things I've done to test that there's no regression:

- Tried adding the rules correctly, and noticing that it caused a visual bug
- Inspected the resultant css and noticed that the current code does not accurately select the elements it's trying to select

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205360018082647) by [Unito](https://www.unito.io)
