### PR TITLE
fix meetups month link

### DIFF
--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
@@ -107,7 +107,7 @@ const HomepageMapFilter = ({classes}:{classes:ClassesType}) => {
   return <Paper>
     <LWTooltip title="September is Meetups Month, celebrating Astral Codex Everywhere. Find a meetup near you." placement="left">
       <div className={classNames(classes.section, classes.title)}>
-        <Link to="/posts/fLdADsBLAMuGvky2M/meetups-everywhere-2022-times-and">
+        <Link to="/posts/ynpC7oXhXxGPNuCgH/acx-meetups-everywhere-2023-times-and-places">
           Meetups Month
         </Link>
       </div>


### PR DESCRIPTION
Meetups month link on the homepage community map was pointed to a post from 2022, instead of the most recent post.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205360319850296) by [Unito](https://www.unito.io)
