### PR TITLE
Improve highlighting of results for advanced search queries

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticService.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticService.ts
@@ -15,6 +15,12 @@ type SanitizedIndexName = {
   sorting?: string,
 }
 
+const extractNamedHighlight = (
+  highlight: ElasticSearchHit["highlight"],
+  name: string,
+): string | undefined =>
+  highlight?.[name]?.[0] ?? highlight?.[name + ".exact"]?.[0];
+
 class ElasticService {
   constructor(
     private client = new ElasticClient(),
@@ -194,15 +200,19 @@ class ElasticService {
       _id,
       _snippetResult: {
         [config.snippet]: {
-          value: highlight?.[config.snippet]?.[0],
-          matchLevel: highlight?.[config.snippet]?.[0] ? "full" : "none",
+          value: extractNamedHighlight(highlight, config.snippet),
+          matchLevel: extractNamedHighlight(highlight, config.snippet)
+            ? "full"
+            : "none",
         },
       },
       ...(config.highlight && {
         _highlightResult: {
           [config.highlight]: {
-            value: highlight?.[config.highlight]?.[0],
-            matchLevel: highlight?.[config.highlight]?.[0] ? "full" : "none",
+            value: extractNamedHighlight(highlight, config.highlight),
+            matchLevel: extractNamedHighlight(highlight, config.highlight)
+              ? "full"
+              : "none",
           },
         },
       }),


### PR DESCRIPTION
This PR builds on #7613 to improve highlighting of results for advanced search queries (ie; queries with quotes). Currently, we use a "default" query for highlighting which means that the highlight for quoted queries containing multiple words often only shows one of the necessary words. This can be confusing, and even though the query is correct we've had users reporting that they think it's wrong because the highlight is misleading.

This PR improves the quality of the query used for highlighting advanced queries to ensure that quoted spans are highlighted correctly. The primary mechanism for this is by using the `*.exact` mappings for the relevant fields, switching to the "simple" analyzer, and using a `match_phrase` query. I also switched the highlighter from the default "unifed" highlighter to "plain" - to my eyes, this seems to give nicer results for us.

<img width="1506" alt="Screenshot 2023-08-30 at 12 32 35" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/175335ba-a35c-4342-b583-304a867111e2">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205384274708290) by [Unito](https://www.unito.io)
