### PR TITLE
[EA] Add a spotlight for the intro sequence for the frontpage selected topic

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -43,14 +43,19 @@ const getStructuredData = () => ({
   }),
 })
 
+const styles = (theme: ThemeType): JssStyles => ({
+  spotlightMargin: {
+    marginBottom: 24,
+  },
+});
 
-const EAHome = () => {
+const EAHome = ({classes}: {classes: ClassesType}) => {
   const currentUser = useCurrentUser();
   const {
     RecentDiscussionFeed, EAHomeMainContent, QuickTakesSection,
     SmallpoxBanner, EventBanner, MaintenanceBanner, FrontpageReviewWidget,
     SingleColumnSection, HomeLatestPosts, EAHomeCommunityPosts, HeadTags,
-    EAPopularCommentsSection, BotSiteBanner, CurrentSpotlightItem
+    EAPopularCommentsSection, BotSiteBanner, DismissibleSpotlightItem
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
@@ -77,7 +82,7 @@ const EAHome = () => {
 
       <EAHomeMainContent FrontpageNode={
         () => <>
-          <CurrentSpotlightItem />
+          <DismissibleSpotlightItem current className={classes.spotlightMargin} />
           <HomeLatestPosts />
           {!currentUser?.hideCommunitySection && <EAHomeCommunityPosts />}
           {isEAForum && <QuickTakesSection />}
@@ -94,7 +99,7 @@ const EAHome = () => {
   )
 }
 
-const EAHomeComponent = registerComponent('EAHome', EAHome)
+const EAHomeComponent = registerComponent('EAHome', EAHome, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -117,11 +117,14 @@ const styles = (theme: ThemeType): JssStyles => ({
       backgroundColor: theme.palette.grey[1000],
     },
   },
+  spotlightMargin: {
+    marginBottom: 24,
+  },
   learnMoreLink: {
     fontSize: 14,
     color: theme.palette.grey[600],
     fontWeight: 600
-  }
+  },
 })
 
 type TopicsBarTab = {
@@ -185,7 +188,7 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
   const { results: coreTopics } = useMulti({
     terms: {view: "coreTags"},
     collectionName: "Tags",
-    fragmentName: 'TagBasicInfo',
+    fragmentName: 'TagDetailsFragment',
     limit: 40
   })
   let allTabs: TopicsBarTab[] = useMemo(() => {
@@ -208,6 +211,22 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
   const { history } = useNavigation()
   const { location, query } = useLocation()
   const { captureEvent } = useTracking()
+  const activeCoreTopic = useMemo(
+    () => coreTopics?.find(t => t._id === activeTab._id),
+    [coreTopics, activeTab]
+  );
+  
+  const { results: spotLightResults } = useMulti({
+    collectionName: 'Spotlights',
+    fragmentName: 'SpotlightDisplay',
+    terms: {
+      view: 'spotlightForSequence',
+      sequenceId: activeCoreTopic?.sequence?._id,
+      limit: 1
+    },
+    skip: !activeCoreTopic?.sequence?._id,
+  });
+  const spotlight = spotLightResults?.[0]
   
   useEffect(() => {
     if (coreTopics) {
@@ -280,7 +299,7 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
     captureEvent("topicsBarTabClicked", {topicsBarTabId: tab._id, topicsBarTabName: tab.shortName || tab.name})
   }
   
-  const { SingleColumnSection, ForumIcon, SectionTitle, PostsList2 } = Components
+  const { SingleColumnSection, ForumIcon, SectionTitle, PostsList2, DismissibleSpotlightItem } = Components
   
   const topicPostTerms = {
     ...tagPostTerms(activeTab, {}),
@@ -321,6 +340,10 @@ const EAHomeMainContent = ({FrontpageNode, classes}:{
 
       {activeTab.name === 'Frontpage' ? <FrontpageNode /> : <AnalyticsContext pageSectionContext="topicSpecificPosts">
         <SingleColumnSection>
+          {spotlight && <DismissibleSpotlightItem
+            spotlight={spotlight}
+            className={classes.spotlightMargin}
+          />}
           <SectionTitle title="New & upvoted" noTopMargin>
             <Link to={`/topics/${activeTab.slug}`} className={classes.learnMoreLink}>View more</Link>
           </SectionTitle>

--- a/packages/lesswrong/components/recommendations/LWRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/LWRecommendations.tsx
@@ -115,7 +115,7 @@ const LWRecommendations = ({
   }, [showSettings, captureEvent, setShowSettings]);
 
   const render = () => {
-    const { CurrentSpotlightItem, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton,
+    const { DismissibleSpotlightItem, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton,
       RecommendationsList, SectionTitle, LWTooltip, CuratedPostsList, Book2020FrontpageWidget, SectionSubtitle, ContinueReadingList, BookmarksList } = Components;
 
     const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
@@ -181,7 +181,7 @@ const LWRecommendations = ({
             onChange={(newSettings) => setSettings(newSettings)}
           /> }
         {!bookDisplaySetting.get() && <AnalyticsContext pageSubSectionContext="frontpageCuratedCollections">
-          <CurrentSpotlightItem />
+          <DismissibleSpotlightItem current />
         </AnalyticsContext>}
 
         <div className={classes.subsection}>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -142,7 +142,7 @@ const RecommendationsAndCurated = ({
   }, [showSettings, captureEvent, setShowSettings]);
 
   const render = () => {
-    const { CurrentSpotlightItem, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList,
+    const { DismissibleSpotlightItem, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList,
       RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip, CuratedPostsList, ForumIcon } = Components;
 
     const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
@@ -222,7 +222,7 @@ const RecommendationsAndCurated = ({
       <>
         {isLW && (
           <AnalyticsContext pageSubSectionContext="frontpageCuratedCollections">
-            <CurrentSpotlightItem />
+            <DismissibleSpotlightItem current />
           </AnalyticsContext>
         )}
 

--- a/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
@@ -6,20 +6,32 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_SPOTLIGHT_ITEM_PREFIX } from '../../lib/cookies/cookies';
 
-export const CurrentSpotlightItem = ({classes}: {
+export const DismissibleSpotlightItem = ({
+  current,
+  spotlight,
+  className,
+  classes,
+}: {
+  current?: boolean,
+  spotlight?: SpotlightDisplay,
+  className?: string,
   classes: ClassesType,
 }) => {
   const { SpotlightItem } = Components
   const { captureEvent } = useTracking()
 
-  const { results: [spotlight] = [] } = useMulti({
+  const { results: currentSpotlightResults } = useMulti({
     collectionName: 'Spotlights',
     fragmentName: 'SpotlightDisplay',
     terms: {
       view: 'mostRecentlyPromotedSpotlights',
       limit: 1
-    }
+    },
+    skip: !current,
   });
+  if (currentSpotlightResults && currentSpotlightResults.length > 0) {
+    spotlight = currentSpotlightResults[0];
+  }
 
   const cookieName = useMemo(() => `${HIDE_SPOTLIGHT_ITEM_PREFIX}${spotlight?.document._id}`, [spotlight]); //hiding in one place, hides everywhere
   const [cookies, setCookie] = useCookiesWithConsent([cookieName]);
@@ -33,20 +45,24 @@ export const CurrentSpotlightItem = ({classes}: {
         expires: moment().add(30, 'days').toDate(), //TODO: Figure out actual correct hiding behavior
         path: "/"
       });
-    captureEvent("spotlightItemHideItemClicked", { document: spotlight.document })
+    captureEvent("spotlightItemHideItemClicked", { document: spotlight?.document })
   }, [setCookie, cookieName, spotlight, captureEvent]);
 
   if (spotlight && !isHidden) {
-    return <SpotlightItem key={spotlight._id} spotlight={spotlight} hideBanner={hideBanner}/>
+    return <SpotlightItem
+      key={spotlight._id}
+      spotlight={spotlight}
+      hideBanner={hideBanner}
+      className={className}
+    />
   }
   return null
 }
 
-const CurrentSpotlightItemComponent = registerComponent('CurrentSpotlightItem', CurrentSpotlightItem);
+const DismissibleSpotlightItemComponent = registerComponent('DismissibleSpotlightItem', DismissibleSpotlightItem);
 
 declare global {
   interface ComponentTypes {
-    CurrentSpotlightItem: typeof CurrentSpotlightItemComponent
+    DismissibleSpotlightItem: typeof DismissibleSpotlightItemComponent
   }
 }
-

--- a/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
@@ -29,11 +29,9 @@ export const DismissibleSpotlightItem = ({
     },
     skip: !current,
   });
-  if (currentSpotlightResults && currentSpotlightResults.length > 0) {
-    spotlight = currentSpotlightResults[0];
-  }
+  const displaySpotlight = currentSpotlightResults?.[0] ?? spotlight;
 
-  const cookieName = useMemo(() => `${HIDE_SPOTLIGHT_ITEM_PREFIX}${spotlight?.document._id}`, [spotlight]); //hiding in one place, hides everywhere
+  const cookieName = useMemo(() => `${HIDE_SPOTLIGHT_ITEM_PREFIX}${displaySpotlight?.document._id}`, [displaySpotlight]); //hiding in one place, hides everywhere
   const [cookies, setCookie] = useCookiesWithConsent([cookieName]);
 
   const isHidden = useMemo(() => !!cookies[cookieName], [cookies, cookieName]);
@@ -45,13 +43,13 @@ export const DismissibleSpotlightItem = ({
         expires: moment().add(30, 'days').toDate(), //TODO: Figure out actual correct hiding behavior
         path: "/"
       });
-    captureEvent("spotlightItemHideItemClicked", { document: spotlight?.document })
-  }, [setCookie, cookieName, spotlight, captureEvent]);
+    captureEvent("spotlightItemHideItemClicked", { document: displaySpotlight?.document })
+  }, [setCookie, cookieName, displaySpotlight, captureEvent]);
 
-  if (spotlight && !isHidden) {
+  if (displaySpotlight && !isHidden) {
     return <SpotlightItem
-      key={spotlight._id}
-      spotlight={spotlight}
+      key={displaySpotlight._id}
+      spotlight={displaySpotlight}
       hideBanner={hideBanner}
       className={className}
     />

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -249,13 +249,21 @@ const getUrlFromDocument = (document: SpotlightDisplay_document, documentType: S
 }
 
 
-export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, refetchAllSpotlights}: {
+export const SpotlightItem = ({
+  spotlight,
+  showAdminInfo,
+  hideBanner,
+  refetchAllSpotlights,
+  className,
+  classes,
+}: {
   spotlight: SpotlightDisplay,
   showAdminInfo?: boolean,
   hideBanner?: () => void,
-  classes: ClassesType,
   // This is so that if a spotlight's position is updated (in SpotlightsPage), we refetch all of them to display them with their updated positions and in the correct order
   refetchAllSpotlights?: () => void,
+  className?: string,
+  classes: ClassesType,
 }) => {
   const {
     MetaInfo, FormatDate, AnalyticsTracker, ContentItemBody, CloudinaryImage2, LWTooltip,
@@ -277,7 +285,7 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
   };
   
   return <AnalyticsTracker eventType="spotlightItem" captureOnMount captureOnClick={false}>
-    <div className={classes.root} id={spotlight._id}>
+    <div className={classNames(classes.root, className)} id={spotlight._id}>
       <div className={classes.spotlightItem}>
         <div className={classNames(classes.content, {[classes.postPadding]: spotlight.documentType === "Post"})}>
           <div className={classes.title}>
@@ -365,7 +373,10 @@ export const SpotlightItem = ({classes, spotlight, showAdminInfo, hideBanner, re
   </AnalyticsTracker>
 }
 
-const SpotlightItemComponent = registerComponent('SpotlightItem', SpotlightItem, {styles});
+const SpotlightItemComponent = registerComponent('SpotlightItem', SpotlightItem, {
+  styles,
+  stylePriority: -1,
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -80,7 +80,7 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight, className}:
 const SpotlightStartOrContinueReadingComponent = registerComponent(
   'SpotlightStartOrContinueReading',
   SpotlightStartOrContinueReading,
-  {styles, stylePriority: -1}
+  {styles, stylePriority: -2}
 );
 
 declare global {

--- a/packages/lesswrong/lib/collections/spotlights/views.ts
+++ b/packages/lesswrong/lib/collections/spotlights/views.ts
@@ -3,7 +3,7 @@ import Spotlights from "./collection";
 
 declare global {
   interface SpotlightsViewTerms extends ViewTermsBase {
-
+    sequenceId?: string;
   }
 }
 
@@ -11,7 +11,8 @@ Spotlights.addView("mostRecentlyPromotedSpotlights", function (terms: Spotlights
   const limit = terms.limit ? { limit: terms.limit } : {};
   return {
     selector: {
-      draft: false
+      draft: false,
+      lastPromotedAt: { $lt: new Date() },
     },
     options: {
       sort: { lastPromotedAt: -1, position: 1 },
@@ -33,3 +34,14 @@ Spotlights.addView("spotlightsPage", function (terms: SpotlightsViewTerms) {
   }
 });
 
+Spotlights.addView("spotlightForSequence", (terms: SpotlightsViewTerms) => {
+  return {
+    selector: {
+      documentId: terms.sequenceId,
+      draft: false
+    },
+    options: {
+      sort: { position: 1 }
+    }
+  }
+});

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -294,6 +294,7 @@ registerFragment(`
     subforumIntroPostId
     tagFlagsIds
     postsDefaultSortOrder
+    introSequenceId
     
     autoTagModel
     autoTagPrompt

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -890,7 +890,7 @@ importComponent("SpotlightItem", () => require('../components/spotlights/Spotlig
 importComponent("SpotlightEditorStyles", () => require('../components/spotlights/SpotlightEditorStyles'));
 importComponent("SpotlightStartOrContinueReading", () => require('../components/spotlights/SpotlightStartOrContinueReading'));
 importComponent("SpotlightsPage", () => require('../components/spotlights/SpotlightsPage'));
-importComponent("CurrentSpotlightItem", () => require('../components/spotlights/CurrentSpotlightItem'));
+importComponent("DismissibleSpotlightItem", () => require('../components/spotlights/DismissibleSpotlightItem'));
 
 // Review Components
 // importComponent("FrontpageNominationPhase", () => require('../components/review/FrontpageNominationPhase'));


### PR DESCRIPTION
Lizka and I discussed adding this along with the regular spotlight during the hackathon.

<img width="884" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/e943bf2a-f63c-40bd-8a13-a319756679b6">

We need to create spotlights for the intro sequences on prod, which shouldn't be hard. And probably get 100% coverage?

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205390132689074) by [Unito](https://www.unito.io)
