### PR TITLE
Add -30 recent karma post rate limit

### DIFF
--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -62,9 +62,15 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Posts per 1 weeks'),
       last20PostKarmaThreshold: -15,
       downvoterCountThreshold: 4,
-      rateLimitMessage: `Users with -15 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with -15 or less karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
     }, 
-  // 1 post per 2+ weeks rate limits
+    {
+      ...timeframe('1 Posts per 1 weeks'),
+      last20KarmaThreshold: -30,
+      downvoterCountThreshold: 10,
+      rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
+    }, 
+    // 1 post per 2+ weeks rate limits
     {
       ...timeframe('1 Posts per 2 weeks'),
       karmaThreshold: -1,


### PR DESCRIPTION
- Add a new rule that limits posts based on recent post karma. We'd previously removed this because it was punishingly unfair (imagine you have one dogpiled comment), but Ray & I think this is a little fairer and Ray thinks we need it
- Edit some text to be more accurate

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205390507243991) by [Unito](https://www.unito.io)
