### PR TITLE
filter out analytics events not used by lw

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -162,10 +162,13 @@ const FooterTagList = ({
 
   const tagIds = (results||[]).map((tag) => tag._id)
 
-  // LW doesn't get a lot of use out of `tagListMounted` events and there are a lot of them
-  if (!isLWorAF) {
-    useOnMountTracking({eventType: "tagList", eventProps: {tagIds}, captureOnMount: eventProps => eventProps.tagIds.length > 0, skip: !tagIds.length||loading})
-  }
+  useOnMountTracking({
+    eventType: "tagList",
+    eventProps: {tagIds},
+    captureOnMount: eventProps => eventProps.tagIds.length > 0,
+    // LW doesn't get a lot of use out of `tagListMounted` events and there are a lot of them
+    skip: isLWorAF || !tagIds.length || loading
+  });
 
   const [mutate] = useMutation(gql`
     mutation addOrUpvoteTag($tagId: String, $postId: String) {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -12,7 +12,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { sortBy } from 'underscore';
 import { forumSelect } from '../../lib/forumTypeUtils';
 import { useMessages } from '../common/withMessages';
-import { isEAForum, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { isEAForum, isLWorAF, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import stringify from 'json-stringify-deterministic';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -161,7 +161,11 @@ const FooterTagList = ({
   }, [setShowAll, setDisplayShowAllButton]);
 
   const tagIds = (results||[]).map((tag) => tag._id)
-  useOnMountTracking({eventType: "tagList", eventProps: {tagIds}, captureOnMount: eventProps => eventProps.tagIds.length > 0, skip: !tagIds.length||loading})
+
+  // LW doesn't get a lot of use out of `tagListMounted` events and there are a lot of them
+  if (!isLWorAF) {
+    useOnMountTracking({eventType: "tagList", eventProps: {tagIds}, captureOnMount: eventProps => eventProps.tagIds.length > 0, skip: !tagIds.length||loading})
+  }
 
   const [mutate] = useMutation(gql`
     mutation addOrUpvoteTag($tagId: String, $postId: String) {

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -159,7 +159,7 @@ function shouldRecordSsrAnalytics(userAgent?: string) {
     return true;
   }
 
-  return !userAgentExclusions.some(excludedAgent => userAgent.includes(excludedAgent));
+  return !userAgentExclusions.some(excludedAgent => userAgent.toLowerCase().includes(excludedAgent));
 }
 
 export const getThemeOptionsFromReq = (req: Request, user: DbUser|null): AbstractThemeOptions => {


### PR DESCRIPTION
We're finding these pretty noisy and we don't get any use out of them.  Forum-gated in case the EA forum wants to keep them, but easy to change if not.  Merging in quickly because we want to delete all the corresponding historical records from the database and don't want new ones going in after that happens.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205400266975571) by [Unito](https://www.unito.io)
