### PR TITLE
Don't spawn mongo service contains in CI

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -23,10 +23,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      mongodb:
-        image: mongo:4.4.17
-        ports:
-          - 27017:27017
 
     steps:
     - name: Checkout code
@@ -38,14 +34,12 @@ jobs:
 
     - name: Setup database template
       env:
-        TESTING_DB_URL: mongodb://127.0.0.1:27017/test?retryWrites=true
         PG_URL: postgres://postgres:postgres@localhost:5432/postgres
       run: yarn init-cypress-db-ci
 
     - name: Cypress run
       uses: cypress-io/github-action@v4
       env:
-        TESTING_DB_URL: mongodb://127.0.0.1:27017/test?retryWrites=true
         PG_URL: postgres://postgres:postgres@localhost:5432/postgres
         CYPRESS_CACHE_FOLDER: ${{ steps.setup-environment.outputs.cypress-cache-folder }}
         NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -56,12 +56,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      mongodb:
-        image: mongo:4.4.17
-        ports:
-          - 27017:27017
     env:
-      TESTING_DB_URL: mongodb://127.0.0.1:27017/test?retryWrites=true
       PG_URL: postgres://postgres:postgres@localhost:5432/postgres
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:


### PR DESCRIPTION
We no longer need to spawn mongo service containers in CI pipelines

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205400940389219) by [Unito](https://www.unito.io)
