### PR TITLE
Fix formatting of karma >1000 in EA user tooltip

### DIFF
--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -79,7 +79,7 @@ const formatBio = (bio?: string): string => htmlToTextDefault(bio ?? "");
 const formatStat = (value?: number): string => {
   value ??= 0;
   return value > 10000
-    ? `${Math.floor(value / 1000)} ${value % 1000}`
+    ? `${Math.floor(value / 1000)} ${String(value % 1000).padStart(3, "0")}`
     : String(value);
 }
 


### PR DESCRIPTION
Because of the way that numbers work, we currently display the amount of user karma incorrectly in the EA user tooltip if the user has more than 1000 karma and the hundreds digit is 0.

Before:
<img width="286" alt="Screenshot 2023-09-01 at 14 30 53" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4ab11ab3-38f6-464e-9e65-d57bb56973fa">

After:
<img width="283" alt="Screenshot 2023-09-01 at 14 29 23" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/51a2d838-9b4f-4f3b-b616-3ceec28bcaad">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205404109751164) by [Unito](https://www.unito.io)
