### PR TITLE
Fix continue reading bug

### DIFF
--- a/packages/lesswrong/server/partiallyReadSequences.ts
+++ b/packages/lesswrong/server/partiallyReadSequences.ts
@@ -77,7 +77,7 @@ const updateSequenceReadStatusForPostRead = async (userId: string, postId: strin
       };
       
       // Generate a new partiallyReadSequences, filtering out the sequence that
-      // was just finished and any other entry for this same collection.  
+      // was just finished and any other entry for this same collection.
       //
       // Minor oddity: It's possible to end up with the partially-read
       // list containing both a sequence and the collection that contains it,


### PR DESCRIPTION
This fixes a bug in continue reading, which broken during during the switch over to Postgres, in this commit:

https://github.com/ForumMagnum/ForumMagnum/commit/7f94ee0bf8ffb7b55d86d9c76f0194d6749e3cb9

(Looks like @oetherington accidentally changed the return type in the postgres half of the if-tree)

Since now we're not even using Mongo, I removed the mongo half completely. (@b0b3rt said this was fine, although on the off chance anyone is like 'wait no please keep mongo functionality', let me know)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205407128751306) by [Unito](https://www.unito.io)
