### PR TITLE
changed name from debate to dialogue

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -685,6 +685,7 @@ const schema: SchemaType<DbComment> = {
   debateResponse: {
     type: Boolean,
     optional: true,
+    label: "Dialogue Response",
     nullable: true,
     canRead: ['guests'],
     canCreate: ['members', 'sunshineRegiment', 'admins'],


### PR DESCRIPTION
We changed the name from debate to dialog to be less combative-oriented

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205429000725955) by [Unito](https://www.unito.io)
