### PR TITLE
Fix a missing between username and date when copy-pasting out of dialogues

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponseBlock.tsx
+++ b/packages/lesswrong/components/comments/DebateResponseBlock.tsx
@@ -22,7 +22,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: 'end',
   },
   username: {
-    marginRight: 10,
+    marginRight: 6,
     fontSize: '1.35rem'
   },
   replyLink: {
@@ -144,6 +144,7 @@ export const DebateResponseBlock = ({ responses, post, orderedParticipantList, d
 
       const header = showHeader && <>
         <CommentUserName comment={comment} className={classes.username} />
+        <span>{" " /* Explicit space (rather than just padding/margin) for copy-paste purposes */}</span>
         <CommentsItemDate comment={comment} post={post} />
       </>;
 


### PR DESCRIPTION
On the theory that what some users want is to have a dialogue, then have someone take it and edit it, and that what the editor will probably do is copy-paste the dialogue into the New Post page or Google Docs, I tried that copy paste. It mostly worked, but usernames and comment-timestamps appeared next to each other with no space. So, add a space (and reduce the margin by the corresponding amount.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205429046726704) by [Unito](https://www.unito.io)
