### PR TITLE
Add space to DM convo

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -201,7 +201,7 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
         {VoteBottomComponent && <div className={classes.reacts}>
           <VoteBottomComponent
             document={comment}
-            hideKarma={post?.hideCommentKarma}
+            hideKarma={post.hideCommentKarma}
             collection={Comments}
             votingSystem={votingSystem}
             commentItemRef={commentItemRef}

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -58,6 +58,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     gridArea: 'image',
     alignSelf: 'flex-end'
   },
+  username: {
+    marginRight: 6,
+    fontWeight: 600
+  }
 })
 
 /**
@@ -87,9 +91,9 @@ const MessageItem = ({message, classes}: {
       {profilePhoto}
       <Components.Typography variant="body2" className={classNames(classes.message, {[classes.backgroundIsCurrent]: isCurrentUser})}>
         <div className={classes.meta}>
-          {message.user && <Components.MetaInfo>
+          {message.user && <span className={classes.username}>
             <span className={colorClassName}><Components.UsersName user={message.user}/></span>
-          </Components.MetaInfo>}
+          </span>}
           <span>{" " /* Explicit space (rather than just padding/margin) for copy-paste purposes */}</span>
           {message.createdAt && <Components.MetaInfo>
             <span className={colorClassName}><Components.FormatDate date={message.createdAt}/></span>

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -41,7 +41,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft:theme.spacing.unit*1.5,
   },
   meta: {
-    marginBottom:theme.spacing.unit*1.5
+    marginBottom:theme.spacing.unit*1.5,
   },
   whiteMeta: {
     color: theme.palette.text.invertedBackgroundText2,
@@ -90,6 +90,7 @@ const MessageItem = ({message, classes}: {
           {message.user && <Components.MetaInfo>
             <span className={colorClassName}><Components.UsersName user={message.user}/></span>
           </Components.MetaInfo>}
+          <span>{" " /* Explicit space (rather than just padding/margin) for copy-paste purposes */}</span>
           {message.createdAt && <Components.MetaInfo>
             <span className={colorClassName}><Components.FormatDate date={message.createdAt}/></span>
           </Components.MetaInfo>}


### PR DESCRIPTION
Inspired by Jim's "copy pasting update" in https://github.com/ForumMagnum/ForumMagnum/pull/7817

I wanted to be able to copy-paste DMs and have it look reasonable. This involved slightly changing the formatting in a way that seems fine to me:

<img width="568" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/6012a8e9-6fa4-40ec-8f15-12e32218cd4f">

<img width="476" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/16969bdc-331f-4841-9b73-fea743465792">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205437442141902) by [Unito](https://www.unito.io)
