### PR TITLE
change debate icon in notification

### DIFF
--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -25,6 +25,7 @@ import startCase from 'lodash/startCase';
 import { GiftIcon } from '../components/icons/giftIcon';
 import {userGetDisplayName} from './collections/users/helpers'
 import {TupleSet, UnionOf} from './utils/typeGuardUtils'
+import DebateIcon from '@material-ui/icons/Forum';
 
 export const notificationDocumentTypes = new TupleSet(['post', 'comment', 'user', 'message', 'tagRel', 'localgroup'] as const)
 export type NotificationDocument = UnionOf<typeof notificationDocumentTypes>
@@ -291,7 +292,7 @@ export const NewDebateReplyNotification = registerNotificationType({
     return await commentGetAuthorName(document) + ' left a new reply on the dialogue "' + await getCommentParentTitle(document) + '"';
   },
   getIcon() {
-    return <CommentsIcon style={iconStyles}/>
+    return <DebateIcon style={iconStyles}/>
   },
 });
 


### PR DESCRIPTION
Changing the icon of new debate notifications to match the frontpage debate icon. 

(Currently it's the same as the comment notification icon, which is annoying when scanning notifications)

<img width="246" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/1a0f799d-d656-4e1f-8e04-3eeeb39888a4">
