### PR TITLE
Forum-gate adding A/B test groups to analytics events, un-forum-gate filtering out junk SSR events

### DIFF
--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -6,7 +6,7 @@ import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '../../lib/abTestImpl';
 import { CLIENT_ID_COOKIE } from '../../lib/cookies/cookies';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
-import { isLW } from '../../lib/instanceSettings';
+import { isLWorAF } from '../../lib/instanceSettings';
 
 export const AnalyticsClient = () => {
   const currentUser = useCurrentUser();
@@ -35,7 +35,7 @@ export const AnalyticsClient = () => {
     AnalyticsUtil.clientWriteEvents = flushEvents;
     AnalyticsUtil.clientContextVars.userId = currentUserId;
     AnalyticsUtil.clientContextVars.clientId = clientId;
-    if (!isLW) {
+    if (!isLWorAF) {
       AnalyticsUtil.clientContextVars.abTestGroupsUsed = abTestGroupsUsed;
     }
 

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -6,6 +6,7 @@ import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '../../lib/abTestImpl';
 import { CLIENT_ID_COOKIE } from '../../lib/cookies/cookies';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
+import { isLW } from '../../lib/instanceSettings';
 
 export const AnalyticsClient = () => {
   const currentUser = useCurrentUser();
@@ -34,8 +35,10 @@ export const AnalyticsClient = () => {
     AnalyticsUtil.clientWriteEvents = flushEvents;
     AnalyticsUtil.clientContextVars.userId = currentUserId;
     AnalyticsUtil.clientContextVars.clientId = clientId;
-    AnalyticsUtil.clientContextVars.abTestGroupsUsed = abTestGroupsUsed;
-    
+    if (!isLW) {
+      AnalyticsUtil.clientContextVars.abTestGroupsUsed = abTestGroupsUsed;
+    }
+
     return function cleanup() {
       AnalyticsUtil.clientWriteEvents = null;
     }

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -88,7 +88,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     const rendered = await renderRequest({
       req, user, startTime, res, clientId, userAgent,
     });
-    if (!isLWorAF || shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
+    if (shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
       Vulcan.captureEvent("ssr", {
         ...ssrEventParams,
         userId: user?._id,
@@ -119,7 +119,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
       console.log(`Rendered ${url} for logged out ${ip}: ${printTimings(rendered.timings)} (${userAgent})`);
     }
 
-    if (!isLWorAF || shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
+    if (shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
       Vulcan.captureEvent("ssr", {
         ...ssrEventParams,
         userId: null,


### PR DESCRIPTION
 - LW don't want A/B test groups in their events because it bloats the raw analytics table
 - Un-forum-gate the change introduces in https://github.com/ForumMagnum/ForumMagnum/pull/7800 to filter out SSr events due to health checks or bots

I have made a followup ticket to unify this checking for bot user agents with the check in `botRedirect.ts`: https://app.asana.com/0/1124817936128791/1205442383981364/f

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205442417171610) by [Unito](https://www.unito.io)
