### PR TITLE
Fix search failing when query returns a very-long post

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -340,6 +340,13 @@ class ElasticQuery {
       type: "plain",
       pre_tags: [preTag ?? "<em>"],
       post_tags: [postTag ?? "</em>"],
+
+      // This is the default value for index.highlight.max_analyzed_offset
+      // which we haven't customized. If this wasn't set here or was set
+      // larger than the corresponding setting on the index, then search
+      // would fail entirely when results contain a poss where the
+      // plain-text version of the body is larger than this.
+      max_analyzed_offset: 1000000,
     };
     return {
       index,
@@ -353,12 +360,6 @@ class ElasticQuery {
             [snippetName]: {
               ...highlightConfig,
               highlight_query: snippetQuery,
-              // This is the default value for index.highlight.max_analyzed_offset
-              // which we haven't customized. If this wasn't set here or was set
-              // larger than the corresponding setting on the index, then search
-              // would fail entirely when results contain a poss where the
-              // plain-text version of the body is larger than this.
-              max_analyzed_offset: 1000000,
             },
             ...(highlightName && {
               [highlightName]: {

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -353,6 +353,12 @@ class ElasticQuery {
             [snippetName]: {
               ...highlightConfig,
               highlight_query: snippetQuery,
+              // This is the default value for index.highlight.max_analyzed_offset
+              // which we haven't customized. If this wasn't set here or was set
+              // larger than the corresponding setting on the index, then search
+              // would fail entirely when results contain a poss where the
+              // plain-text version of the body is larger than this.
+              max_analyzed_offset: 1000000,
             },
             ...(highlightName && {
               [highlightName]: {


### PR DESCRIPTION
Searching for some posts would fail with:

```The length [1172188] of field [org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext$Field@6df18257] in doc[sHGxvJrBag7nhTQvb]/index[posts_1690498279910] exceeds the [index.highlight.max_analyzed_offset] limit [1000000]. To avoid this error, set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.```

Eg the query "invu" which should return https://www.lesswrong.com/posts/sHGxvJrBag7nhTQvb/invulnerable-incomplete-preferences-a-formal-statement-1 as a result.

This applies the suggested change, and it does indeed cause the search to no longer fail. (The value of `1000000` is a default value in the index config, which we don't customize.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205446351094086) by [Unito](https://www.unito.io)
