### PR TITLE
Allow MathML in the HTML sanitizer (for RSS crossposters)

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -286,7 +286,16 @@ export const sanitizeAllowedTags = [
   'ol', 'nl', 'li', 'b', 'i', 'u', 'strong', 'em', 'strike', 's',
   'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
   'tbody', 'tr', 'th', 'td', 'pre', 'img', 'figure', 'figcaption',
-  'section', 'span', 'sub', 'sup', 'ins', 'del', 'iframe'
+  'section', 'span', 'sub', 'sup', 'ins', 'del', 'iframe',
+  
+  //MathML elements (https://developer.mozilla.org/en-US/docs/Web/MathML/Element)
+  "math", "mi", "mn", "mo", "ms", "mspace", "mtext", "merror",
+  "mfrac", "mpadded", "mphantom", "mroot", "mrow", "msqrt", "mstyle",
+  "mmultiscripts", "mover", "mprescripts", "msub", "msubsup", "msup", "munder",
+  "munderover", "mtable", "mtd", "mtr",
+  
+  // MathML elements that are not included (because they're nonvisual or deprecated)
+  "maction", "semantics", "annotation", "annotation-xml", "menclose", "mfenced",
 ]
 
 const cssSizeRegex = /^(?:\d|\.)+(?:px|em|%)$/;
@@ -307,6 +316,8 @@ const allowedTableStyles = {
   'padding': [/^.*$/],
 };
 
+const allowedMathMLGlobalAttributes = ['mathvariant', 'dir', 'displaystyle', 'scriptlevel'];
+
 export const sanitize = function(s: string): string {
   return sanitizeHtml(s, {
     allowedTags: sanitizeAllowedTags,
@@ -325,6 +336,34 @@ export const sanitize = function(s: string): string {
       a: ['href', 'name', 'target', 'rel'],
       iframe: ['src', 'allowfullscreen', 'allow'],
       li: ['id', 'role'],
+      
+      // Attributes for MathML elements
+      math: [...allowedMathMLGlobalAttributes, 'display'],
+      mi: allowedMathMLGlobalAttributes,
+      mn: allowedMathMLGlobalAttributes,
+      mtext: allowedMathMLGlobalAttributes,
+      merror: allowedMathMLGlobalAttributes,
+      mfrac: [...allowedMathMLGlobalAttributes, 'linethickness'],
+      mmultiscripts: allowedMathMLGlobalAttributes,
+      mo: [...allowedMathMLGlobalAttributes, 'fence', 'largeop', 'lspace', 'maxsize', 'minsize', 'movablelimits', 'rspace', 'separator', 'stretchy', 'symmetric'],
+      mover: [...allowedMathMLGlobalAttributes, 'accent'],
+      mpadded: [...allowedMathMLGlobalAttributes, 'depth','height','lspace','voffset','width'],
+      mphantom: allowedMathMLGlobalAttributes,
+      mprescripts: allowedMathMLGlobalAttributes,
+      mroot: allowedMathMLGlobalAttributes,
+      mrow: allowedMathMLGlobalAttributes,
+      ms: [...allowedMathMLGlobalAttributes, 'lquote','rquote'],
+      mspace: [...allowedMathMLGlobalAttributes, 'depth','height','width'],
+      msqrt: allowedMathMLGlobalAttributes,
+      mstyle: allowedMathMLGlobalAttributes,
+      msub: allowedMathMLGlobalAttributes,
+      msubsup: allowedMathMLGlobalAttributes,
+      msup: allowedMathMLGlobalAttributes,
+      mtable: allowedMathMLGlobalAttributes,
+      mtd: [...allowedMathMLGlobalAttributes, 'columnspan','rowspan'],
+      mtr: allowedMathMLGlobalAttributes,
+      munder: [...allowedMathMLGlobalAttributes, 'accentunder'],
+      munderover: [...allowedMathMLGlobalAttributes, 'accent','accentunder'],
     },
     allowedIframeHostnames: [
       'www.youtube.com', 'youtube.com',

--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -293,9 +293,6 @@ export const sanitizeAllowedTags = [
   "mfrac", "mpadded", "mphantom", "mroot", "mrow", "msqrt", "mstyle",
   "mmultiscripts", "mover", "mprescripts", "msub", "msubsup", "msup", "munder",
   "munderover", "mtable", "mtd", "mtr",
-  
-  // MathML elements that are not included (because they're nonvisual or deprecated)
-  "maction", "semantics", "annotation", "annotation-xml", "menclose", "mfenced",
 ]
 
 const cssSizeRegex = /^(?:\d|\.)+(?:px|em|%)$/;


### PR DESCRIPTION
See: https://www.lesswrong.com/posts/6rnWQW8HtHoavPDiu/weekly-incidence-vs-cumulative-infections?commentId=2hfbGb2w5md7MSrRL

This adds MathML tags to the tag-whitelist in the sanitizer, along with (non-deprecated) attributes for those tags. I generated this by going through https://developer.mozilla.org/en-US/docs/Web/MathML/Element and copy-pasting element and attribute names. I don't believe any of the tags/attributes allowed here can have scripts in them (but there is nonzero risk of error on that).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205446460391328) by [Unito](https://www.unito.io)
