### PR TITLE
Hide React button for non-participants in dialogues

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -36,7 +36,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     "@media print": {
       display: "none",
     },
-    minWidth: 'fit-content'
+    minWidth: 'fit-content',
+    marginLeft: 10
   },
   hideReplyLink: {
     visibility: 'hidden'
@@ -72,9 +73,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "flex",
     alignItems: "center"
   },
-  reacts: {
-    marginRight: 10
-  }
 });
 
 const getParticipantBorderStyle = (participantIndex: number) => {
@@ -201,7 +199,7 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
         </div>
         {replyState}
         <div className={classes.bottomUI}>
-          {VoteBottomComponent && <span className={classes.reacts}><VoteBottomComponent
+          {VoteBottomComponent && <VoteBottomComponent
             document={comment}
             hideKarma={post.hideCommentKarma}
             collection={Comments}
@@ -209,7 +207,7 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
             commentItemRef={commentItemRef}
             voteProps={voteProps}
             post={post}
-          /></span>}
+          />}
           {replyLink}
         </div>
       </div>

--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -1,6 +1,5 @@
 import React, {useRef, useState} from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useTracking } from "../../lib/analyticsEvents";
 import {useCurrentUser} from '../common/withUser';
 import {DebateResponseWithReplies} from './DebateResponseBlock';
 import classNames from 'classnames';
@@ -98,7 +97,6 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
   responses: DebateResponseWithReplies[],
   post: PostsWithNavigation | PostsWithNavigationAndRevision,
 }) => {
-    const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
     const { CommentUserName, CommentsItemDate, CommentBody, CommentsEditForm, CommentsMenu, DebateCommentsListSection } = Components;
 
     const responseStates = responses.map(_ => false);
@@ -201,11 +199,12 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
         {VoteBottomComponent && <div className={classes.reacts}>
           <VoteBottomComponent
             document={comment}
-            hideKarma={post?.hideCommentKarma}
+            hideKarma={post.hideCommentKarma}
             collection={Comments}
             votingSystem={votingSystem}
             commentItemRef={commentItemRef}
             voteProps={voteProps}
+            post={post}
           />
         </div>}
       </div>

--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -65,11 +65,16 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderColor: theme.palette.border.debateComment5
   },
   lwReactStyling: reactStyles(theme),
-  reacts: {
+  bottomUI: {
     position: 'absolute',
     right: 10,
-    bottom: -14,
+    bottom: -12,
+    display: "flex",
+    alignItems: "center"
   },
+  reacts: {
+    marginRight: 10
+  }
 });
 
 const getParticipantBorderStyle = (participantIndex: number) => {
@@ -193,11 +198,10 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
         {menu}
         <div className={classes.commentWithReplyButton}>
           {commentBodyOrEditor}
-          {replyLink}
         </div>
         {replyState}
-        {VoteBottomComponent && <div className={classes.reacts}>
-          <VoteBottomComponent
+        <div className={classes.bottomUI}>
+          {VoteBottomComponent && <span className={classes.reacts}><VoteBottomComponent
             document={comment}
             hideKarma={post.hideCommentKarma}
             collection={Comments}
@@ -205,8 +209,9 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
             commentItemRef={commentItemRef}
             voteProps={voteProps}
             post={post}
-          />
-        </div>}
+          /></span>}
+          {replyLink}
+        </div>
       </div>
     );
   }

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -23,6 +23,7 @@ import { AddReactionIcon } from '../../icons/AddReactionIcon';
 import difference from 'lodash/difference';
 import uniq from 'lodash/uniq';
 import { useTracking } from "../../../lib/analyticsEvents";
+import { getConfirmedCoauthorIds } from '../../../lib/collections/posts/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -428,7 +429,7 @@ const NamesAttachedReactionsVoteOnComment = ({document, hideKarma=false, collect
 }
 
 const NamesAttachedReactionsCommentBottom = ({
-  document, hideKarma=false, commentItemRef, classes, voteProps
+  document, hideKarma=false, commentItemRef, classes, voteProps, post
 }: NamesAttachedReactionsCommentBottomProps & WithStylesProps) => {
   const anchorEl = useRef<HTMLElement|null>(null);
   const currentUser = useCurrentUser();
@@ -449,7 +450,9 @@ const NamesAttachedReactionsCommentBottom = ({
   useEffect(() => {
     commentItemRef &&  markHighlights(quotes, faintHighlightClassName, commentItemRef)
   }, [quotes, commentItemRef])
-  
+
+  const showReactButton = !(post && post.debate && currentUser && [...getConfirmedCoauthorIds(post), post.userId].includes(currentUser._id))
+
   return <span className={classes.footerReactionsRow} ref={anchorEl}>
     {visibleReactionsDisplay.length > 0 && <span className={classes.footerReactions}>
       {visibleReactionsDisplay.map(({react, numberShown}) =>
@@ -464,7 +467,7 @@ const NamesAttachedReactionsCommentBottom = ({
           />
         </span>
       )}
-      {hideKarma && <AddReactionIcon />}
+      {hideKarma && showReactButton && <AddReactionIcon />}
     </span>}
     {hiddenReacts.length > 0 && <ReactionOverviewButton voteProps={voteProps} classes={classes}/>}
     <AddReactionButton voteProps={voteProps} classes={classes}/>

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -451,7 +451,11 @@ const NamesAttachedReactionsCommentBottom = ({
     commentItemRef &&  markHighlights(quotes, faintHighlightClassName, commentItemRef)
   }, [quotes, commentItemRef])
 
-  const showReactButton = !(post && post.debate && currentUser && [...getConfirmedCoauthorIds(post), post.userId].includes(currentUser._id))
+
+  const isDebateComment = post?.debate && document.debateResponse
+  const canReactUserIds = post ? [...getConfirmedCoauthorIds(post), post.userId] : []
+  const userIsDebateParticipant = currentUser && canReactUserIds.includes(currentUser._id)
+  const showReactButton = !isDebateComment || userIsDebateParticipant
 
   return <span className={classes.footerReactionsRow} ref={anchorEl}>
     {visibleReactionsDisplay.length > 0 && <span className={classes.footerReactions}>
@@ -467,10 +471,10 @@ const NamesAttachedReactionsCommentBottom = ({
           />
         </span>
       )}
-      {hideKarma && showReactButton && <AddReactionIcon />}
+      {hideKarma && <AddReactionIcon />}
     </span>}
     {hiddenReacts.length > 0 && <ReactionOverviewButton voteProps={voteProps} classes={classes}/>}
-    <AddReactionButton voteProps={voteProps} classes={classes}/>
+    {showReactButton && <AddReactionButton voteProps={voteProps} classes={classes}/>}
   </span>
 }
 

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -20,6 +20,7 @@ registerFragment(`
     coauthorStatuses
     hasCoauthorPermission
     rejected
+    debate
   }
 `);
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -892,6 +892,7 @@ interface PostsMinimumInfo { // fragment on Posts
   }> | null,
   readonly hasCoauthorPermission: boolean,
   readonly rejected: boolean,
+  readonly debate: boolean | null,
 }
 
 interface PostsMinimumInfo_currentUserReviewVote { // fragment on ReviewVotes

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -11,15 +11,18 @@ import pickBy from 'lodash/pickBy';
 import fromPairs from 'lodash/fromPairs';
 import { VotingProps } from '../../components/votes/votingProps';
 
-export type CommentVotingComponentProps = {
-  document: CommentsList|PostsWithVotes|RevisionMetadataWithChangeMetrics,
+type VotingPropsDocument = CommentsList|PostsWithVotes|RevisionMetadataWithChangeMetrics
+
+export type CommentVotingComponentProps<T extends VotingPropsDocument = VotingPropsDocument> = {
+  document: T,
   hideKarma?: boolean,
   collection: any,
   votingSystem: VotingSystem,
   commentItemRef?: React.RefObject<HTMLDivElement>|null,
   voteProps?: VotingProps<VoteableTypeClient>,
+  post?: PostsWithNavigation | PostsWithNavigationAndRevision,
 }
-export interface NamesAttachedReactionsCommentBottomProps extends CommentVotingComponentProps {
+export interface NamesAttachedReactionsCommentBottomProps extends CommentVotingComponentProps<CommentsList> {
   voteProps: VotingProps<VoteableTypeClient>,
 }
 

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -255,7 +255,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
 
   if (!selfVote && collectionName === "Comments" && (document as DbComment).debateResponse) {
     const post = await Posts.findOne({_id: (document as DbComment).postId});
-    const acceptedCoauthorIds = post ? getConfirmedCoauthorIds(post) : [];
+    const acceptedCoauthorIds = post ? [...getConfirmedCoauthorIds(post), post.userId] : [];
     if (!acceptedCoauthorIds.includes(user._id)) {
       throw new Error("Cannot vote on debate responses unless you're an accepted coauthor");
     }


### PR DESCRIPTION
We previously made it so only dialogue participants could react to dialogResponse comments, but the "add react" button was still visible for everyone. This hides it for non-participants.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205447188819595) by [Unito](https://www.unito.io)
