### PR TITLE
Various search fixes

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -87,7 +87,7 @@ export type IndexConfig = {
  * Fields that use full-text search (ie; generally all of the fields that are
  * listed in the `field` array) should use this mapping. This allows us to use
  * our normal full text analyzer with stemming and synonyms for normal searches,
- * but to fall back to the "standard" analyzer which has no stemming for advanced
+ * but to fall back to the exact analyzer which has no stemming for advanced
  * searches using quotes.
  */
 const fullTextMapping: MappingProperty = {
@@ -96,7 +96,7 @@ const fullTextMapping: MappingProperty = {
   fields: {
     exact: {
       type: "text",
-      analyzer: "standard",
+      analyzer: "fm_exact_analyzer",
     },
   },
 };
@@ -112,7 +112,7 @@ const shingleTextMapping: MappingProperty = {
   fields: {
     exact: {
       type: "text",
-      analyzer: "standard",
+      analyzer: "fm_exact_analyzer",
     },
   },
 };

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -12,6 +12,7 @@ export type Ranking = {
   scoring: {
     type: "numeric",
     pivot: number,
+    min?: number,
   } | {
     type: "date",
   } | {
@@ -221,7 +222,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
   },
   Users: {
     fields: [
-      "displayName^1000",
+      "displayName^10000",
       "bio",
       "mapLocationAddress",
       "jobTitle",
@@ -234,24 +235,25 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       {
         field: "karma",
         order: "desc",
-        weight: 25,
-        scoring: {type: "numeric", pivot: 4000},
+        weight: 2,
+        scoring: {type: "numeric", pivot: 5000, min: 1000},
       },
       {
         field: "karma",
         order: "desc",
-        weight: 12,
-        scoring: {type: "numeric", pivot: 1000},
+        weight: 1.5,
+        scoring: {type: "numeric", pivot: 1000, min: 1000},
       },
       {
         field: "karma",
         order: "desc",
-        weight: 4,
-        scoring: {type: "numeric", pivot: 100},
+        weight: 1,
+        scoring: {type: "numeric", pivot: 100, min: 10},
       },
       {
         field: "createdAt",
         order: "desc",
+        weight: 0.5,
         scoring: {type: "date"},
       },
     ],

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -221,7 +221,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
   },
   Users: {
     fields: [
-      "displayName^10",
+      "displayName^1000",
       "bio",
       "mapLocationAddress",
       "jobTitle",

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -279,6 +279,17 @@ class ElasticExporter {
                     "fm_punctuation_filter",
                   ],
                 },
+                fm_exact_analyzer: {
+                  type: "custom",
+                  tokenizer: "standard",
+                  filter: [
+                    "lowercase",
+                    "decimal_digit",
+                  ],
+                  char_filter: [
+                    "fm_punctuation_filter",
+                  ],
+                },
                 fm_synonym_analyzer: {
                   type: "custom",
                   tokenizer: "standard",

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -295,8 +295,9 @@ class ElasticExporter {
                   tokenizer: "standard",
                   filter: [
                     "lowercase",
-                    "fm_synonym_filter",
+                    "apostrophe",
                     "decimal_digit",
+                    "fm_synonym_filter",
                     "fm_english_stopwords",
                     "fm_english_stemmer",
                   ],

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -351,6 +351,12 @@ class ElasticExporter {
       AlgoliaIndexedCollection<AlgoliaIndexedDbObject>;
     const repo = this.getRepoByCollectionName(collectionName);
 
+    const indexName = this.getIndexName(collection);
+    const alias = await this.getExistingAliasTarget(indexName);
+    if (!alias) {
+      throw new Error("Alias is not configured - run `elasticConfigureIndexes`");
+    }
+
     const total = await repo.countSearchDocuments();
 
     // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -165,16 +165,18 @@ class ElasticExporter {
   }
 
   async deleteIndex(collectionName: AlgoliaIndexCollectionName) {
-    const client = this.client.getClient();
     const collection = getCollection(collectionName) as
       AlgoliaIndexedCollection<AlgoliaIndexedDbObject>;
-
     const aliasName = this.getIndexName(collection);
     const indexName = await this.getExistingAliasTarget(aliasName);
     if (!indexName) {
       throw new Error("Can't find backing index for collection " + collectionName);
     }
+    await this.deleteIndexByName(indexName);
+  }
 
+  async deleteIndexByName(indexName: string) {
+    const client = this.client.getClient();
     await client.indices.delete({
       index: indexName,
     });
@@ -477,6 +479,9 @@ Globals.elasticExportAll = () =>
 
 Globals.elasticDeleteIndex = (collectionName: AlgoliaIndexCollectionName) =>
   new ElasticExporter().deleteIndex(collectionName);
+
+Globals.elasticDeleteIndexByName = (indexName: string) =>
+  new ElasticExporter().deleteIndexByName(indexName);
 
 Globals.elasticDeleteOrphanedIndexes = () =>
   new ElasticExporter().deleteOrphanedIndexes();

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -66,7 +66,8 @@ class ElasticQuery {
     let expr: string;
     switch (scoring.type) {
     case "numeric":
-      expr = `saturation(Math.max(1, doc['${field}'].value), ${scoring.pivot}L)`;
+      const min = scoring.min ?? 1;
+      expr = `saturation(Math.max(${min}, doc['${field}'].value), ${scoring.pivot}L)`;
       break;
     case "date":
       const start = SEARCH_ORIGIN_DATE;
@@ -157,14 +158,14 @@ class ElasticQuery {
                 fields,
                 type: "phrase",
                 slop: 2,
-                boost: 2,
+                boost: 100,
               },
             },
             {
               match_phrase_prefix: {
                 [mainField]: {
                   query: search,
-                  boost: 20,
+                  boost: 1000,
                 },
               },
             },

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -129,7 +129,7 @@ class ElasticQuery {
         fuzziness: this.fuzziness,
         max_expansions: 10,
         prefix_length: 3,
-        minimum_should_match: "50%",
+        minimum_should_match: "75%",
         operator: "or",
       },
     };

--- a/packages/lesswrong/server/search/elastic/parseQuery.ts
+++ b/packages/lesswrong/server/search/elastic/parseQuery.ts
@@ -38,7 +38,11 @@ export const parseQuery = (query: string): QueryParserResult => {
       isAdvanced = true;
     }
 
-    tokens.push({type, token: token.replace(/[^\w\s]/g, "")});
+    // Replace dashes and underscores with spaces, and remove anything else that
+    // isn't whitespace or a word
+    token = token.replace(/[-_]/g, " ").replace(/[^\w\s]/g, "");
+
+    tokens.push({type, token});
   }
 
   return {tokens, isAdvanced};


### PR DESCRIPTION
This PR fixes several search bugs. In particular:

- Search for users now has a much better balance between searching for exact name matches and boosting relevancy by karma
- Fixed a bug with hyphenated words in the query parser
- Added an apostrophe filter which greatly improves searching for quick takes posts

In particular, the following searches for users which have been reported as problematic now produce much more sane results:
```
will howard
will macaskill
william macaskill
michael thurston
social hermit
claire zabel
```
and the following searches for posts:
```
centre for long-term resilience
lizka quick takes
```

This requires re-indexing (which I've so far only done on dev):
 1) Run `Globals.elasticConfigureIndexes()` which runs an _async_ reindex
 2) Wait for the reindex to complete (check the document count on the indexes to be sure) - this generally takes a couple of minutes
 3) When complete, run `./scripts/serverShellCommand.sh "Globals.elasticDeleteOrphanedIndexes()"`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205449857312252) by [Unito](https://www.unito.io)
