### PR TITLE
[EA] Career week header banner

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -345,14 +345,6 @@ const Layout = ({currentUser, children, classes}: {
                 sidebarHidden={hideNavigationSidebar}
                 toggleStandaloneNavigation={toggleStandaloneNavigation}
                 stayAtTop={Boolean(currentRoute?.fullscreen || currentRoute?.staticHeader)}
-                currentEvent={
-                  isEAForum
-                    ? {
-                      name: "Career week",
-                      link: "#",
-                    }
-                    : undefined
-                }
               />}
               {/* enable during ACX Everywhere */}
               {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap dontAskUserLocation={true}/></span>}

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -345,6 +345,14 @@ const Layout = ({currentUser, children, classes}: {
                 sidebarHidden={hideNavigationSidebar}
                 toggleStandaloneNavigation={toggleStandaloneNavigation}
                 stayAtTop={Boolean(currentRoute?.fullscreen || currentRoute?.staticHeader)}
+                currentEvent={
+                  isEAForum
+                    ? {
+                      name: "Career week",
+                      link: "#",
+                    }
+                    : undefined
+                }
               />}
               {/* enable during ACX Everywhere */}
               {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap dontAskUserLocation={true}/></span>}

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -14,6 +14,7 @@ import classNames from 'classnames';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { isEAForum, PublicInstanceSetting } from '../../lib/instanceSettings';
 import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
+import { currentEventHeader } from '../../lib/publicSettings';
 
 export const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 export const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
@@ -170,18 +171,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-type CurrentEvent = {
-  name: string,
-  link: string,
-}
-
 const Header = ({
   standaloneNavigationPresent,
   sidebarHidden,
   toggleStandaloneNavigation,
   stayAtTop=false,
   searchResultsArea,
-  currentEvent,
   classes,
 }: {
   standaloneNavigationPresent: boolean,
@@ -189,7 +184,6 @@ const Header = ({
   toggleStandaloneNavigation: ()=>void,
   stayAtTop?: boolean,
   searchResultsArea: React.RefObject<HTMLDivElement>,
-  currentEvent?: CurrentEvent,
   classes: ClassesType,
 }) => {
   const [navigationOpen, setNavigationOpenState] = useState(false);
@@ -202,6 +196,7 @@ const Header = ({
   const { captureEvent } = useTracking()
   const updateCurrentUser = useUpdateCurrentUser();
   const { unreadNotifications, unreadPrivateMessages, refetch: refetchNotificationCounts } = useUnreadNotifications();
+  const currentEvent = currentEventHeader.get();
 
   const setNavigationOpen = (open: boolean) => {
     setNavigationOpenState(open);

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -14,7 +14,6 @@ import classNames from 'classnames';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { isEAForum, PublicInstanceSetting } from '../../lib/instanceSettings';
 import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
-import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 
 export const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 export const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
@@ -74,6 +73,19 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     alignItems: 'center',
     fontWeight: isEAForum ? 400 : undefined,
+  },
+  currentEventLink: {
+    marginLeft: "1ch",
+    background: `linear-gradient(91deg,
+      ${theme.palette.text.currentEventHeader.start} 5.84%,
+      ${theme.palette.text.currentEventHeader.stop} 99.75%)
+    `,
+    backgroundClip: "text",
+    "-webkit-background-clip": "text",
+    "-webkit-text-fill-color": "transparent",
+    "&:hover": {
+      opacity: 0.8,
+    },
   },
   menuButton: {
     marginLeft: -theme.spacing.unit,
@@ -158,12 +170,26 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNavigation, stayAtTop=false, searchResultsArea, classes}: {
+type CurrentEvent = {
+  name: string,
+  link: string,
+}
+
+const Header = ({
+  standaloneNavigationPresent,
+  sidebarHidden,
+  toggleStandaloneNavigation,
+  stayAtTop=false,
+  searchResultsArea,
+  currentEvent,
+  classes,
+}: {
   standaloneNavigationPresent: boolean,
   sidebarHidden: boolean,
   toggleStandaloneNavigation: ()=>void,
   stayAtTop?: boolean,
   searchResultsArea: React.RefObject<HTMLDivElement>,
+  currentEvent?: CurrentEvent,
   classes: ClassesType,
 }) => {
   const [navigationOpen, setNavigationOpenState] = useState(false);
@@ -311,6 +337,14 @@ const Header = ({standaloneNavigationPresent, sidebarHidden, toggleStandaloneNav
                       {hasLogo && <div className={classes.siteLogo}><Components.SiteLogo/></div>}
                       {forumHeaderTitleSetting.get()}
                     </Link>
+                    {currentEvent &&
+                      <Link
+                        to={currentEvent.link}
+                        className={classes.currentEventLink}
+                      >
+                        {currentEvent.name}
+                      </Link>
+                    }
                     <HeaderSubtitle />
                   </div>
                 </div>

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -110,3 +110,10 @@ export const crosspostKarmaThreshold = new DatabasePublicSetting<number | null>(
 export const ddTracingSampleRate = new DatabasePublicSetting<number>('datadog.tracingSampleRate', 100) // Sample rate for backend traces, between 0 and 100
 export const ddRumSampleRate = new DatabasePublicSetting<number>('datadog.rumSampleRate', 100) // Sample rate for backend traces, between 0 and 100
 export const ddSessionReplaySampleRate = new DatabasePublicSetting<number>('datadog.sessionReplaySampleRate', 100) // Sample rate for backend traces, between 0 and 100
+
+export type CurrentEventHeader = {
+  name: string,
+  link: string,
+}
+
+export const currentEventHeader = new DatabasePublicSetting<CurrentEventHeader | null>("currentEventHeader", null);

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -215,6 +215,10 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
       yellow: "#f57f17",
       green: "#1b5e20",
     },
+    currentEventHeader: {
+      start: "#F6A958",
+      stop: "#D87D3C",
+    },
   },
   link: {
     unmarked: shades.greyAlpha(.87),

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -162,6 +162,10 @@ declare global {
         yellow: ColorString,
         green: ColorString,
       },
+      currentEventHeader: {
+        start: ColorString,
+        stop: ColorString,
+      },
     },
     linkHover: {
       dim: ColorString,


### PR DESCRIPTION
Add text to the site header advertising career week.

<img width="473" alt="Screenshot 2023-09-08 at 16 34 38" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/063c6674-1487-4ec6-b6bb-5d2840412d3f">
<img width="504" alt="Screenshot 2023-09-08 at 16 34 25" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/e6c057ec-ca8d-4f24-92ab-158f5f91e4d3">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205451056108330) by [Unito](https://www.unito.io)
