### PR TITLE
Fix missing bottom padding on EA users profile image

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfileImage.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfileImage.tsx
@@ -56,7 +56,7 @@ const EAUsersProfileImage = ({user, classes}: {
 
   if (!userCanEditUser(currentUser, user)) {
     return (
-      <UsersProfileImage user={user} size={SIZE} />
+      <UsersProfileImage user={user} size={SIZE} className={classes.root} />
     );
   }
 


### PR DESCRIPTION
When viewing the user profile of a user who you do not have permission to edit (ie; it's not you and you're not an admin), there's currently too little padding between the image and the username due to a class not being applied in the right place (thanks Agnes for spotting this!)

Before:
<img width="353" alt="Screenshot 2023-09-08 at 16 52 07" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c44a7229-f5d4-4a77-8fb3-8f97ddd55b22">

After:
<img width="339" alt="Screenshot 2023-09-08 at 16 53 28" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/dd819403-155c-4e3d-8786-987918d0289e">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205451146100636) by [Unito](https://www.unito.io)
