### PR TITLE
Careers week header improvements

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -14,7 +14,6 @@ import classNames from 'classnames';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { isEAForum, PublicInstanceSetting } from '../../lib/instanceSettings';
 import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
-import { currentEventHeader } from '../../lib/publicSettings';
 
 export const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 export const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
@@ -74,19 +73,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: 'flex',
     alignItems: 'center',
     fontWeight: isEAForum ? 400 : undefined,
-  },
-  currentEventLink: {
-    marginLeft: "1ch",
-    background: `linear-gradient(91deg,
-      ${theme.palette.text.currentEventHeader.start} 5.84%,
-      ${theme.palette.text.currentEventHeader.stop} 99.75%)
-    `,
-    backgroundClip: "text",
-    "-webkit-background-clip": "text",
-    "-webkit-text-fill-color": "transparent",
-    "&:hover": {
-      opacity: 0.8,
-    },
   },
   menuButton: {
     marginLeft: -theme.spacing.unit,
@@ -196,7 +182,6 @@ const Header = ({
   const { captureEvent } = useTracking()
   const updateCurrentUser = useUpdateCurrentUser();
   const { unreadNotifications, unreadPrivateMessages, refetch: refetchNotificationCounts } = useUnreadNotifications();
-  const currentEvent = currentEventHeader.get();
 
   const setNavigationOpen = (open: boolean) => {
     setNavigationOpenState(open);
@@ -332,14 +317,6 @@ const Header = ({
                       {hasLogo && <div className={classes.siteLogo}><Components.SiteLogo/></div>}
                       {forumHeaderTitleSetting.get()}
                     </Link>
-                    {currentEvent &&
-                      <Link
-                        to={currentEvent.link}
-                        className={classes.currentEventLink}
-                      >
-                        {currentEvent.name}
-                      </Link>
-                    }
                     <HeaderSubtitle />
                   </div>
                 </div>

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { Link } from '../../lib/reactRouterWrapper';
 import { isEAForum } from '../../lib/instanceSettings';
+import { currentEventHeader } from '../../lib/publicSettings';
 
 export const styles = (theme: ThemeType): JssStyles => ({
   subtitle: {
@@ -12,20 +13,34 @@ export const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.header.text,
     borderLeft: theme.palette.border.appBarSubtitleDivider,
   },
+  currentEventLink: {
+    marginLeft: "1em",
+    background: `linear-gradient(
+      91deg,
+      ${theme.palette.text.currentEventHeader.start} 5.84%,
+      ${theme.palette.text.currentEventHeader.stop} 99.75%
+    )`,
+    backgroundClip: "text",
+    "-webkit-background-clip": "text",
+    "-webkit-text-fill-color": "transparent",
+    "&:hover": {
+      opacity: 0.8,
+    },
+  },
 });
 
 const HeaderSubtitle = ({classes}: {
   classes: ClassesType,
 }) => {
   const { currentRoute } = useSubscribedLocation();
-  if (!currentRoute) return null
+  if (!currentRoute) {
+    return null;
+  }
+
   const SubtitleComponent: any = currentRoute.subtitleComponentName ? Components[currentRoute.subtitleComponentName] : null;
   const subtitleString = currentRoute.subtitle;
   const subtitleLink = currentRoute.subtitleLink;
-  
-  if (!SubtitleComponent && !subtitleString)
-    return null;
-  
+
   if (SubtitleComponent) {
     return <SubtitleComponent isSubtitle={true} />
   } else if (subtitleLink) {
@@ -37,7 +52,17 @@ const HeaderSubtitle = ({classes}: {
       {subtitleString}
     </span>
   } else {
-    return null;
+    const currentEvent = currentEventHeader.get();
+    return currentEvent
+      ? (
+        <Link
+          to={currentEvent.link}
+          className={classes.currentEventLink}
+        >
+          {currentEvent.name}
+        </Link>
+      )
+      : null;
   }
 }
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1315,7 +1315,7 @@ addRoute(
     path:'/posts/:_id/:slug?',
     componentName: 'PostsSingle',
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: 'PostsPageHeaderTitle',
+    subtitleComponentName: isEAForum ? undefined : 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreview',
     getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
     background: postBackground
@@ -1325,7 +1325,7 @@ addRoute(
     path:'/posts/slug/:slug?',
     componentName: 'PostsSingleSlugRedirect',
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: 'PostsPageHeaderTitle',
+    subtitleComponentName: isEAForum ? undefined : 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreviewSlug',
     getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     background: postBackground


### PR DESCRIPTION
Remove the careers week event link from the page header on pages with a subtitle.

Unfortunately, some pages (most notably the post page) lie about having a subtitle by providing a component that always returns null. I've disabled this for the EA forum on posts pages - there may be other pages with this problem that we can fix as we find them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205454290211877) by [Unito](https://www.unito.io)
