### PR TITLE
Moderators can insert comments out-of-order in dialogues, with special styling

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -75,6 +75,17 @@ const styles = (theme: ThemeType): JssStyles => ({
     border: theme.palette.border.faint,
     background: theme.palette.panelBackground.darken05,
   },
+  moderatorCommentForm: {
+    border: theme.palette.border.faint,
+    background: theme.palette.panelBackground.darken05,
+  },
+  newCommentLabel: {
+    paddingLeft: theme.spacing.unit*1.5,
+    ...theme.typography.commentStyle,
+    ...theme.typography.body2,
+    fontWeight: 600,
+    marginTop: 12
+  },
 });
 
 export const InsertModeratorCommentContext = createContext<(()=>void)|null>(null);
@@ -212,18 +223,18 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
           },
         )}
       >
-        {showInsertModeratorCommentForm && <>
+        {showInsertModeratorCommentForm && <div className={classes.moderatorCommentForm}>
+          <div className={classes.newCommentLabel}>Moderator Comment</div>
           <CommentsNewForm
             post={post}
             type="comment"
-            replyFormStyle="minimalist"
             prefilledProps={{
               debateResponse: true,
               moderatorHat: true,
               postedAt: new Date(new Date(comment.postedAt).getTime()-1),
             }}
           />
-        </>}
+        </div>}
         {header}
         {menu}
         <div className={classes.commentWithReplyButton}>

--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -3,12 +3,13 @@ import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { userGetDisplayName, userCanModeratePost } from '../../../lib/collections/users/helpers';
 import { useSingle } from '../../../lib/crud/withSingle';
 
-const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
+const CommentActions = ({currentUser, comment, post, tag, showEdit, insertModeratorCommentInDialogue}: {
   currentUser: UsersCurrent, // Must be logged in
   comment: CommentsList,
   post?: PostsMinimumInfo,
   tag?: TagBasicInfo,
   showEdit: ()=>void,
+  insertModeratorCommentInDialogue?: ()=>void,
 }) => {
   const {
     EditCommentDropdownItem, ReportCommentDropdownItem, DeleteCommentDropdownItem,
@@ -90,7 +91,7 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       <BanUserFromPostDropdownItem comment={comment} post={postDetails} />
       <BanUserFromAllPostsDropdownItem comment={comment} post={postDetails} />
       <BanUserFromAllPersonalPostsDropdownItem comment={comment} post={postDetails} />
-      <ToggleIsModeratorCommentDropdownItem comment={comment} />
+      <ToggleIsModeratorCommentDropdownItem comment={comment} insertModeratorCommentInDialogue={insertModeratorCommentInDialogue}/>
     </DropdownMenu>
   );
 }

--- a/packages/lesswrong/components/dropdowns/comments/CommentsMenu.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentsMenu.tsx
@@ -20,13 +20,14 @@ const styles = (_theme: ThemeType): JssStyles => ({
   },
 })
 
-const CommentsMenu = ({classes, className, comment, post, tag, showEdit, icon}: {
+const CommentsMenu = ({classes, className, comment, post, tag, showEdit, insertModeratorCommentInDialogue, icon}: {
   classes: ClassesType,
   className?: string,
   comment: CommentsList,
   post?: PostsMinimumInfo,
   tag?: TagBasicInfo,
   showEdit: ()=>void,
+  insertModeratorCommentInDialogue?: ()=>void,
   icon?: any,
 }) => {
   const [anchorEl, setAnchorEl] = useState<any>(null);
@@ -67,6 +68,7 @@ const CommentsMenu = ({classes, className, comment, post, tag, showEdit, icon}: 
           post={post}
           tag={tag}
           showEdit={showEdit}
+          insertModeratorCommentInDialogue={insertModeratorCommentInDialogue}
         />}
       </Menu>
     </>

--- a/packages/lesswrong/components/dropdowns/comments/ToggleIsModeratorCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/ToggleIsModeratorCommentDropdownItem.tsx
@@ -5,7 +5,10 @@ import { useCurrentUser } from '../../common/withUser';
 import { userCanDo } from '../../../lib/vulcan-users/permissions';
 import { preferredHeadingCase } from '../../../lib/forumTypeUtils';
 
-const ToggleIsModeratorCommentDropdownItem = ({comment}: {comment: CommentsList}) => {
+const ToggleIsModeratorCommentDropdownItem = ({comment, insertModeratorCommentInDialogue}: {
+  comment: CommentsList,
+  insertModeratorCommentInDialogue?: ()=>void,
+}) => {
   const currentUser = useCurrentUser();
   const {mutate: updateComment} = useUpdate({
     collectionName: "Comments",
@@ -30,29 +33,34 @@ const ToggleIsModeratorCommentDropdownItem = ({comment}: {comment: CommentsList}
       data: {moderatorHat: false},
     });
   }
-
+  
   const {DropdownItem} = Components;
-  if (comment.moderatorHat) {
-    return (
-      <DropdownItem
-        title={preferredHeadingCase("Un-mark as Moderator Comment")}
-        onClick={handleUnmarkAsModeratorComment}
-      />
-    );
-  }
+  const buttons: React.ReactNode[] = [];
 
-  return (
-    <>
-      <DropdownItem
-        title={preferredHeadingCase("Mark as Moderator Comment (visible)")}
-        onClick={handleMarkAsModeratorComment()}
-      />
-      <DropdownItem
-        title={preferredHeadingCase("Mark as Moderator Comment (invisible)")}
-        onClick={handleMarkAsModeratorComment({ hideModeratorHat: true })}
-      />
-    </>
-  );
+  if (insertModeratorCommentInDialogue) {
+    buttons.push(<DropdownItem
+      title={preferredHeadingCase("Insert Moderator Comment Above")}
+      onClick={insertModeratorCommentInDialogue}
+    />);
+  }
+  
+  if (comment.moderatorHat) {
+    buttons.push(<DropdownItem
+      title={preferredHeadingCase("Un-mark as Moderator Comment")}
+      onClick={handleUnmarkAsModeratorComment}
+    />);
+  } else {
+    buttons.push(<DropdownItem
+      title={preferredHeadingCase("Mark as Moderator Comment (visible)")}
+      onClick={handleMarkAsModeratorComment()}
+    />);
+    buttons.push(<DropdownItem
+      title={preferredHeadingCase("Mark as Moderator Comment (invisible)")}
+      onClick={handleMarkAsModeratorComment({ hideModeratorHat: true })}
+    />);
+  }
+  
+  return <>{buttons}</>;
 }
 
 const ToggleIsModeratorCommentDropdownItemComponent = registerComponent(

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -64,7 +64,19 @@ const schema: SchemaType<DbComment> = {
     type: Date,
     optional: true,
     canRead: ['guests'],
-    onInsert: (document, currentUser) => new Date(),
+    // HACK: Dialogue-moderators can create comments with retroactive postedAt dates, to
+    // make them appear out of order in the log of a dialogue. (The real creation date
+    // will be in the `createdAt` field.)
+    canCreate: ['sunshineRegiment','admins'],
+    canUpdate: ['sunshineRegiment','admins'],
+    hidden: true,
+    onInsert: (document, currentUser) => {
+      if (document.postedAt && document.debateResponse) {
+        return undefined;
+      } else {
+        return new Date();
+      }
+    }
   },
   // The comment author's name
   author: {


### PR DESCRIPTION
Moderators (currently: site moderators) can put moderator comments into dialogues. It looks like this:

![Screenshot 2023-09-08 at 14 26 32](https://github.com/ForumMagnum/ForumMagnum/assets/101191/286bdc14-7ce4-4df8-b868-a104cd194397)

To create these, you can either promote an existing comment, or pick "Insert Moderator Comment Above" in the triple-dot menu, which will retroactively place a comment in the history by giving it a fake `postedAt`. Moderator comments are always in their own debate-response block, and can be replied to the same as other debate-response blocks.

![Screenshot 2023-09-08 at 14 26 48](https://github.com/ForumMagnum/ForumMagnum/assets/101191/d4a9291b-9781-4449-8c03-b5a87a546ace)

Moderator comments are identified by the `moderatorHat` flag (which is already a thing that can be used in regular comment threads, and which had preexisting UI for setting and clearing it).

This is currently only available to site moderators. It would be nice to extend this to the first author of a debate-post, but that involves some slightly complicated wiring, since it requires field-level permissions that depend on the post and that shouldn't be granted in other contexts, in particular the permission to create a comment with a fake `postedAt` date and to set the `moderatorHat` flag.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205454180835703) by [Unito](https://www.unito.io)
