### PR TITLE
Improve dimensions of answer/comment focus mode

### DIFF
--- a/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
@@ -54,11 +54,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   whitescreen: {
     display: "none",
-    position: "absolute",
-    left: -300,
-    width: 3000,
-    top: 0,
-    height: 5000,
+    position: "fixed",
+    inset: 0,
     backgroundColor: theme.palette.panelBackground.default,
     zIndex: theme.zIndexes.questionPageWhitescreen,
   },


### PR DESCRIPTION
When answering question posts, you can click a focus mode button to remove most of the content of the page. It's the full-screen icon button (middle-right):

<img width="768" alt="Screenshot 2023-09-09 at 6 26 21 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/675520/b3e105ad-5475-41aa-b2e4-dd58530bd106">

When you click it, it covers most of the content of the page with a large white rectangle:

```
whitescreen: {
    display: "none",
    position: "absolute",
    left: -300,
    width: 3000,
    top: 0,
    height: 5000,
    backgroundColor: theme.palette.panelBackground.default,
    zIndex: theme.zIndexes.questionPageWhitescreen,
}
```

This blocks out the content, but makes the scrollbars widen, as the page is now much bigger:

<img width="771" alt="Screenshot 2023-09-09 at 6 26 29 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/675520/7e597a95-f03b-4f5b-8b9d-8d93a3480dff">


Instead, we can make the box have position "fixed" and inset 0 (inset is CSS shorthand to set the top, right, bottom, and left values all at once), making the box fit exactly over wherever the user is on the page.

```
whitescreen: {
    display: "none",
    position: "fixed",
    inset: 0,
    backgroundColor: theme.palette.panelBackground.default,
    zIndex: theme.zIndexes.questionPageWhitescreen,
}
```


This blocks the content as intended by the focus mode feature, without expanding the size of the page. See how the horizontal scrollbar has not appeared, and the vertical scrollbar is the same as it was before clicking Focus Mode.

<img width="767" alt="Screenshot 2023-09-09 at 6 39 22 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/675520/5f5624bf-51dc-4ba2-b568-fa40b9ec628e">

This addresses most of issue #7697.