### PR TITLE
Hide ACX Frontpage map

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -206,8 +206,9 @@ const Layout = ({currentUser, children, classes}: {
   const showCookieBanner = cookieConsentRequired === true && !cookieConsentGiven;
 
   // enable during ACX Everywhere
-  const [cookies] = useCookiesWithConsent()
-  const renderCommunityMap = (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !cookies[HIDE_MAP_COOKIE]
+  // const [cookies] = useCookiesWithConsent()
+  const renderCommunityMap = false // replace with following line to enable during ACX Everywhere
+  // (forumTypeSetting.get() === "LessWrong") && (currentRoute?.name === 'home') && (!currentUser?.hideFrontpageMap) && !cookies[HIDE_MAP_COOKIE]
   
   const {mutate: updateUser} = useUpdate({
     collectionName: "Users",


### PR DESCRIPTION
This hides the frontpage map. It leaves in most of the relevant infrastructure so that it's easier to turn on next time. (I think we maybe actually want to switch this to work more like Petrov Day, where you enter a start-date and end-date into a database setting, and then it naturally turns off without intervention later on, but, will tackle that later)

Right now the map has been up ~2 weeks, which I think is roughly what we intended (although we hadn't made an explicit plan for teardown)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205459543658177) by [Unito](https://www.unito.io)
