### PR TITLE
Don't count debateResponses for rate limits

### DIFF
--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -71,7 +71,8 @@ function getPostRateLimitInfos(
 async function getCommentsInTimeframe(userId: string, maxTimeframe: number) {
   const commentsInTimeframe = await Comments.find(
     { userId: userId, 
-      postedAt: {$gte: moment().subtract(maxTimeframe, 'hours').toDate()}
+      postedAt: {$gte: moment().subtract(maxTimeframe, 'hours').toDate()},
+      debateResponse: {$ne: true}
     }, {
       sort: {postedAt: -1}, 
       projection: {postId: 1, postedAt: 1}

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -232,6 +232,8 @@ export default class VotesRepo extends AbstractRepo<DbVote> {
             SELECT _id FROM "Comments" 
             WHERE
               "Comments"."userId" = $1
+              AND
+              "Comments"."debateResponse" IS NOT true
             ORDER by "Comments"."postedAt" DESC
             LIMIT ${RECENT_CONTENT_COUNT}
           )


### PR DESCRIPTION
Debate responses aren't voted on. I believe (though only spent 5 minutes checking) is the place to exclude debate responses from comments when checking autoratelimit rules.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205469594964997) by [Unito](https://www.unito.io)
