### PR TITLE
Add recency factor to popular comments algorithm

### DIFF
--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -78,13 +78,20 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
     minScore = 15,
     offset = 0,
     limit = 3,
-    recencyFactor = 50000,
+    recencyWeight = 0.1,
+    recencyFactor = 1000000,
+    recencyBias = 60 * 60 * 2,
   }: {
     offset?: number,
     limit?: number,
     minScore?: number,
-    // The higher the recency factor, the higher we weight "newness"
+    // The weight of the recency component
+    recencyWeight?: number,
+    // The factor to divide age by for the recency bonus
     recencyFactor?: number,
+    // The minimum age that a post will be considered as having, to avoid
+    // over selecting brand new comments - defaults to 2 hours
+    recencyBias?: number,
   }): Promise<DbComment[]> {
     return this.any(`
       SELECT c.*
@@ -106,10 +113,10 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
       JOIN "Comments" c ON c."_id" = q."_id"
       JOIN "Posts" p ON c."postId" = p."_id"
       WHERE p."hideFromPopularComments" IS NOT TRUE
-      ORDER BY q."confidence" * EXP(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - c."postedAt") / -$4) DESC
+      ORDER BY q."confidence" + $4 * EXP((EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - c."postedAt") + $6) / -$5) DESC
       OFFSET $2
       LIMIT $3
-    `, [minScore, offset, limit, recencyFactor]);
+    `, [minScore, offset, limit, recencyWeight, recencyFactor, recencyBias]);
   }
 
   private getSearchDocumentQuery(): string {


### PR DESCRIPTION
This PR adds a simple recency bonus to comments in the popular comments algorithm with an exponential backoff. The `recencyFactor` may need some fine tuning, but this default seemed reasonable to me in testing. We limit popular comments to comments created in the last week, so `EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - c."postedAt")` will be a value between 0 (for a brand new comment) and 604800 (for a one week old comment).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205484191926291) by [Unito](https://www.unito.io)
