### PR TITLE
Fix `wikiOnly` tags being shown in search when faceted out

### DIFF
--- a/packages/lesswrong/components/form-components/TagMultiselect.tsx
+++ b/packages/lesswrong/components/form-components/TagMultiselect.tsx
@@ -80,7 +80,7 @@ const TagMultiselect = ({ value, path, classes, label, placeholder, hidePostCoun
             clickAction={(id: string, tag: AlgoliaTag | null) => addTag(id, tag)}
             placeholder={placeholder}
             hidePostCount={hidePostCount}
-            filters="wikiOnly:false"
+            facetFilters={{wikiOnly: false}}
             isVotingContext={isVotingContext}
           />
         </div>

--- a/packages/lesswrong/components/search/SearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.tsx
@@ -24,7 +24,24 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const SearchAutoComplete = ({ clickAction, placeholder, noSearchPlaceholder, renderSuggestion, hitsPerPage=7, indexName, classes, renderInputComponent, filters }: {
+const formatFacetFilters = (
+  facetFilters?: Record<string, boolean>,
+): string[][] | undefined =>
+  facetFilters
+    ? [Object.keys(facetFilters).map((key) => `${key}:${facetFilters[key]}`)]
+    : undefined;
+
+const SearchAutoComplete = ({
+  clickAction,
+  placeholder,
+  noSearchPlaceholder,
+  renderSuggestion,
+  hitsPerPage=7,
+  indexName,
+  classes,
+  renderInputComponent,
+  facetFilters,
+}: {
   clickAction: (_id: string, object: any) => void,
   placeholder: string,
   noSearchPlaceholder: string,
@@ -33,7 +50,7 @@ const SearchAutoComplete = ({ clickAction, placeholder, noSearchPlaceholder, ren
   indexName: string,
   classes: ClassesType,
   renderInputComponent?: any,
-  filters?: string,
+  facetFilters?: Record<string, boolean>,
 }) => {
   if (!isSearchEnabled()) {
     // Fallback for when Algolia is unavailable (ie, local development installs).
@@ -60,7 +77,10 @@ const SearchAutoComplete = ({ clickAction, placeholder, noSearchPlaceholder, ren
     <div className={classes.autoComplete}>
       { /* @ts-ignore */ }
       <AutocompleteTextbox onSuggestionSelected={onSuggestionSelected} placeholder={placeholder} renderSuggestion={renderSuggestion} renderInputComponent={renderInputComponent}/>
-      <Configure hitsPerPage={hitsPerPage} filters={filters}/>
+      <Configure
+        hitsPerPage={hitsPerPage}
+        facetFilters={formatFacetFilters(facetFilters)}
+      />
     </div>
   </InstantSearch>
 }

--- a/packages/lesswrong/components/search/TagsSearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/TagsSearchAutoComplete.tsx
@@ -2,11 +2,17 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib'
 import { getAlgoliaIndexName } from '../../lib/search/algoliaUtil';
 
-const TagsSearchAutoComplete = ({clickAction, placeholder='Search for posts', hidePostCount=false, filters, isVotingContext}:{
+const TagsSearchAutoComplete = ({
+  clickAction,
+  placeholder='Search for posts',
+  hidePostCount=false,
+  facetFilters,
+  isVotingContext,
+}:{
   clickAction: (id: string, tag: AlgoliaTag | null) => void,
   placeholder?: string,
   hidePostCount?: boolean,
-  filters?: string
+  facetFilters?: Record<string, boolean>,
   isVotingContext?: boolean
 }) => {
   return <Components.SearchAutoComplete
@@ -15,7 +21,7 @@ const TagsSearchAutoComplete = ({clickAction, placeholder='Search for posts', hi
     renderSuggestion={(hit: any) => <Components.TagSearchHit hit={hit} hidePostCount={hidePostCount} isVotingContext={isVotingContext} />}
     placeholder={placeholder}
     noSearchPlaceholder='Tag ID'
-    filters={filters}
+    facetFilters={facetFilters}
   />
 }
 


### PR DESCRIPTION
We have a search facet that filters out `wikiOnly` tags when tagging a post. This is defined using the `filters` parameter on the search endpoint which was never implemented when we switched to elasticsearch. For the sake of keeping the API simple, I switched the frontend to instead use the `facetFilters` parameter which is already supported by the backend.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205510920760427) by [Unito](https://www.unito.io)
