### PR TITLE
Fix spotlight imageFade default value

### DIFF
--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -193,9 +193,13 @@ const schema: SchemaType<DbSpotlight> = {
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
     order: 86,
-    ...schemaDefaultValue(isEAForum ? true : false),
     optional: true,
     nullable: false,
+    // we're not using schemaDefaultValue because we can't use forumType
+    // conditionals without breaking schema hash logic
+    defaultValue: true,
+    onCreate: ({document}) => document.imageFade ?? (isEAForum ? true : false),
+    canAutofillDefault: true,
   },
   spotlightImageId: {
     type: String,


### PR DESCRIPTION
A previous EA Forum PR can made spotlight imageFade into a schemaDefaultValue, which breaks our schema hash system. This changes it to use the same logic we used on the voting system.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205511997344779) by [Unito](https://www.unito.io)
