### PR TITLE
Reduce typing indicator rate-limit risk, and streamline duplicate isDialogueParticipant

### DIFF
--- a/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
+++ b/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
@@ -13,10 +13,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-// The throttle period and the indicator period don't necessarily
-// need to be the same, but I think it makes sense for them to be the same
-// for now and seemed nicer to not have random magic numbers in the code.
-const INDICATOR_PERIOD = 20000;
+const INCIDATOR_UPDATE_PERIOD = 15000
+const INDICATOR_DISPLAY_PERIOD = 20000;
 
 export const DebateTypingIndicator = ({classes, post}: {
   classes: ClassesType,
@@ -42,7 +40,7 @@ export const DebateTypingIndicator = ({classes, post}: {
     if (currentUser && isDialogueParticipant(currentUser._id, post)) {
       void upsertTypingIndicator({variables: {documentId: post._id}})
     }
-  }, INDICATOR_PERIOD));
+  }, INCIDATOR_UPDATE_PERIOD));
 
   useOnNotificationsChanged(currentUser, (message) => {
     if (message.eventType === 'typingIndicator') {
@@ -57,7 +55,7 @@ export const DebateTypingIndicator = ({classes, post}: {
   if (!currentUser) return null;
 
   const otherUsers = typingIndicators.filter((typingIndicator) => {
-    const twentySecondsAgo = Date.now() - INDICATOR_PERIOD;
+    const twentySecondsAgo = Date.now() - INDICATOR_DISPLAY_PERIOD;
     const typingIndicatorIsRecent = (new Date(typingIndicator.lastUpdated).getTime()) > twentySecondsAgo;
     const typingIndicatorIsNotCurrentUser = typingIndicator.userId !== currentUser._id
     return typingIndicatorIsRecent && typingIndicatorIsNotCurrentUser

--- a/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
+++ b/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
@@ -37,6 +37,9 @@ export const DebateTypingIndicator = ({classes, post}: {
     // Note, ideally we'd have a more specific trigger for the typing indicator
     // rather than "literally any keypress", but that was a bit more complicated
     // and this is a good enough approximation for now.
+
+    // If we continue to use this in more places or update it, we may want to 
+    // make it more specific 
     if (currentUser && isDialogueParticipant(currentUser._id, post)) {
       void upsertTypingIndicator({variables: {documentId: post._id}})
     }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useNavigation, useSubscribedLocation } from '../../../lib/routeUtil';
-import { isPostAllowedType3Audio, postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
+import { getConfirmedCoauthorIds, isPostAllowedType3Audio, postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
 import { commentGetDefaultView } from '../../../lib/collections/comments/helpers'
 import { useCurrentUser } from '../../common/withUser';
 import withErrorBoundary from '../../common/withErrorBoundary'
@@ -383,7 +383,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   });
   
   useOnNotificationsChanged(currentUser, () => {
-    if (currentUser && isDialogueParticipant(currentUser, post)) {
+    if (currentUser && isDialogueParticipant(currentUser._id, post)) {
       refetchDebateResponses();
     }
   });
@@ -634,13 +634,13 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   </AnalyticsContext>);
 }
 
-export function isDialogueParticipant(user: UsersCurrent, post: PostsDetails) {
-  return post.debate && (
-    post.userId === user._id
-    || post.coauthors.find(coauthor => coauthor._id === user._id)
-  );
-}
+export type PostParticipantInfo = Partial<Pick<PostsDetails, "userId"|"debate"|"hasCoauthorPermission" | "coauthorStatuses">>
 
+export function isDialogueParticipant(userId: string, post: PostParticipantInfo) {
+  if (post.userId === userId) return true 
+  if (getConfirmedCoauthorIds(post).includes(userId)) return true
+  return false
+}
 const PostsPageComponent = registerComponent('PostsPage', PostsPage, {
   styles, hocs: [withErrorBoundary],
   areEqual: "auto",

--- a/packages/lesswrong/server/resolvers/typingIndicatorsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/typingIndicatorsResolvers.ts
@@ -1,23 +1,17 @@
-import {getConfirmedCoauthorIds} from "../../lib/collections/posts/helpers";
+import { isDialogueParticipant } from "../../components/posts/PostsPage/PostsPage";
 import TypingIndicatorsRepo from "../repos/TypingIndicatorsRepo";
 import {defineMutation} from "../utils/serverGraphqlUtil";
-
-function isUserDialogueParticipant(userId: string, post: DbPost) {
-  if (post.userId === userId) return true 
-  if (getConfirmedCoauthorIds(post).includes(userId)) return true
-  return false
-}
 
 defineMutation({
   name: "upsertUserTypingIndicator",
   resultType: "TypingIndicator",
   argTypes: "(documentId: String!)",
   fn: async (_, {documentId}:{documentId:string}, {currentUser, loaders}) => {
-    if (!currentUser) throw new Error("No user was provided")
+    if (!currentUser) throw new Error("wNo user was provided")
     const post = await loaders.Posts.load(documentId)
     if (!post) throw new Error("No post was provided")
     if (!post.debate) throw new Error("Post is not a dialogue")
-    if (!isUserDialogueParticipant(currentUser._id, post)) throw new Error("User is not a dialog participant")
+    if (!isDialogueParticipant(currentUser._id, post)) throw new Error("User is not a dialog participant")
 
     await new TypingIndicatorsRepo().upsertTypingIndicator(currentUser._id, post._id)
   } 

--- a/packages/lesswrong/server/resolvers/typingIndicatorsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/typingIndicatorsResolvers.ts
@@ -7,7 +7,7 @@ defineMutation({
   resultType: "TypingIndicator",
   argTypes: "(documentId: String!)",
   fn: async (_, {documentId}:{documentId:string}, {currentUser, loaders}) => {
-    if (!currentUser) throw new Error("wNo user was provided")
+    if (!currentUser) throw new Error("No user was provided")
     const post = await loaders.Posts.load(documentId)
     if (!post) throw new Error("No post was provided")
     if (!post.debate) throw new Error("Post is not a dialogue")


### PR DESCRIPTION
This cleans up a few things about TypingIndicators

– we were previously sending off TypingIndicator updates every 300 ms, which added up to enough requests to get IP addresses rate limited. This reduces the update throttle-interval to every 15000 ms. (It's plausible to me it should literally be the same as the period that we display the indicator, which is 20000 ms, but I wasn't sure, seemed probably good to design it so we can easily tweak them independently but they live next to each other so it's easy to think about how they relate)

– there were two versions of the "isDialogueParticipant" function, and this trims out one of them.

– adds a comment flagging that we're currently using a somewhat simplified trigger for the typing indicator.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205513827069601) by [Unito](https://www.unito.io)
