### PR TITLE
All LW rate limits don't affect your own posts

### DIFF
--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -98,14 +98,14 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 1 hours'),
       last20KarmaThreshold: -1,
       downvoterCountThreshold: 3,
-      appliesToOwnPosts: true,
+      appliesToOwnPosts: false,
       rateLimitMessage: `Users with -1 or less karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
     }, 
   // 3 comments per day rate limits
     {
       ...timeframe('3 Comments per 1 days'),
       karmaThreshold: 4,
-      appliesToOwnPosts: true,
+      appliesToOwnPosts: false,
       rateLimitType: "newUserDefault",
       rateLimitMessage: `Users with less than 5 karma can write up to 3 comments a day.<br/>${lwDefaultMessage}`,
     }, 


### PR DESCRIPTION
My current take is that it's "technically reasonable" for users with <5 karma to be rate limited on their own posts, but, a) I think other LW team members disagreed and I don't feel very strongly about it, b) I think the costs of having to model that some-but-not-all rate limits affect your own posts was more confusing and costly than it was worth.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205513917126221) by [Unito](https://www.unito.io)
