### PR TITLE
Debate response styling is separated slightly

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -10,6 +10,7 @@ import {lwReactStyles} from './CommentsItem/CommentsItem';
 
 const styles = (theme: ThemeType): JssStyles => ({
   innerDebateComment: {
+    marginTop: 6,
     padding: '8px 8px 8px 16px',
     borderLeft: 'solid',
     borderLeftWidth: '2px',


### PR DESCRIPTION
I found that sometimes I really wanted to make a debate response that felt more separated from my previous response. I do _also_ sometimes want to be able to write out multiple chains of responses that add up to one big essay. Here I'm experimenting with a slight margin in between them, which I think probably works okay for both use cases.

Not 100% sure this is good, PR review can include deciding that.

<img width="794" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/40e10629-8eca-4849-ad62-46e2f2e08dd0">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205513876390415) by [Unito](https://www.unito.io)
