### PR TITLE
Remove subtitle-ability of PostsPageHeaderTitle component

### DIFF
--- a/packages/lesswrong/components/titles/PostsPageHeaderTitle.tsx
+++ b/packages/lesswrong/components/titles/PostsPageHeaderTitle.tsx
@@ -4,12 +4,9 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { useLocation } from '../../lib/routeUtil';
 import { Helmet } from 'react-helmet';
 import { styles } from '../common/HeaderSubtitle';
-import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const PostsPageHeaderTitle = ({isSubtitle, siteName, classes}: {
-  isSubtitle: boolean,
+const PostsPageHeaderTitle = ({siteName}: {
   siteName: string,
-  classes: ClassesType,
 }) => {
   const { params: {_id, postId} } = useLocation();
   const { document: post, loading } = useSingle({
@@ -18,33 +15,14 @@ const PostsPageHeaderTitle = ({isSubtitle, siteName, classes}: {
     fragmentName: "PostsBase",
     fetchPolicy: 'cache-only',
   });
-  
+
   if (!post || loading) return null;
   const titleString = `${post.title} — ${siteName}`
-  
-  if (!isSubtitle)
-    return <Helmet>
-      <title>{titleString}</title>
-      <meta property='og:title' content={titleString}/>
-    </Helmet>
-  
-  if (forumTypeSetting.get() !== 'AlignmentForum' && post.af) {
-    // TODO: A (broken) bit of an earlier iteration of the header subtitle
-    // tried to made AF posts have a subtitle which said "AGI Alignment" and
-    // linked to /alignment. But that bit of code was broken, and also that URL
-    // is invalid. Maybe make a sensible place for it to link to, then put it
-    // back? (alignment-forum.org isn't necessarily good to link to, because
-    // it's invite-only.)
-    return null;
-  } else if (post.frontpageDate) {
-    return null;
-  } else if (post.userId) {
-    // TODO: For personal blogposts, put the user in the sutitle. There was an
-    // attempt to do this in a previous implementation, which didn't work.
-    return null;
-  }
-  
-  return null;
+
+  return <Helmet>
+    <title>{titleString}</title>
+    <meta property='og:title' content={titleString}/>
+  </Helmet>
 }
 
 const PostsPageHeaderTitleComponent = registerComponent("PostsPageHeaderTitle", PostsPageHeaderTitle, {styles});

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -310,7 +310,6 @@ addRoute(
     path: '/s/:sequenceId/p/:postId',
     componentName: 'SequencesPost',
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreviewSequencePost',
     getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params.postId),
     background: "white"
@@ -1315,7 +1314,6 @@ addRoute(
     path:'/posts/:_id/:slug?',
     componentName: 'PostsSingle',
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: isEAForum ? undefined : 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreview',
     getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
     background: postBackground
@@ -1325,7 +1323,6 @@ addRoute(
     path:'/posts/slug/:slug?',
     componentName: 'PostsSingleSlugRedirect',
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: isEAForum ? undefined : 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreviewSlug',
     getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     background: postBackground
@@ -1444,7 +1441,6 @@ addRoute(
     name: 'comment.greaterwrong',
     componentName: "PostsSingle",
     titleComponentName: 'PostsPageHeaderTitle',
-    subtitleComponentName: 'PostsPageHeaderTitle',
     previewComponentName: "PostCommentLinkPreviewGreaterWrong",
     noIndex: true,
     // TODO: Handle pingbacks leading to comments.


### PR DESCRIPTION
This component only ever returned `null` in the case where it was used as a subtitle. Presumably in the past it has returned something different but now those cases are gone.

See also [this discussion](https://github.com/ForumMagnum/ForumMagnum/pull/7843#discussion_r1320354295), where @oetherington and @jpaddison3 noticed the same thing, this was causing some problems with our new `currentEvent` subtitle because it wouldn't show if PostsPageHeaderTitle was used as a subtitle component.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205514826364770) by [Unito](https://www.unito.io)
