### PR TITLE
Fix typing in date picker

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import DateTimePicker from 'react-datetime';
@@ -259,6 +259,7 @@ const DatePicker = ({label, name, value, below, onChange, onClose, classes}: {
   // we try to use the selected date to determine the tz (and default to now)
   const tzDate = value ? moment(value) : moment();
   const [error, setError] = useState(false)
+  const valueIsNullRef = useRef(!value)
 
   const handleDateChange = useCallback((newDate: Moment | string) => {
     let parsedDate: Date | null = null;
@@ -279,6 +280,9 @@ const DatePicker = ({label, name, value, below, onChange, onClose, classes}: {
     }
   }, [onChange]);
 
+  const valueJustCleared = !value && valueIsNullRef.current
+  valueIsNullRef.current = !value
+
   return <FormControl>
     <InputLabel className={classes.label}>
       { label } <span className={classes.timezone}>({tzDate.tz(moment.tz.guess()).zoneAbbr()})</span>
@@ -293,6 +297,7 @@ const DatePicker = ({label, name, value, below, onChange, onClose, classes}: {
           name:name,
           autoComplete:"off",
           className: classNames(classes.input, {[classes.error]: error}),
+          ...(valueJustCleared && {value: undefined}),
         }}
         onChange={handleDateChange}
         onBlur={handleDateChange}


### PR DESCRIPTION
Previously it would throw an error if you tried to type, now it lets you type and shows a red line if you type an invalid date
![Screenshot 2023-09-18 at 19 44 11](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/c454e602-d3bb-4b17-8a2c-858ceef8c24f)

Known issues with this:
1. The error doesn't actually block you from submitting the form (it just submits with the last valid value)
2. If you clear the input, then type an invalid date, then click clear again, it will not clear the second time

Both of these are relatively hard to fix, so I think it's worth merging like this. We could also make it so you can't type at all which would avoid these bugs

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205524926291485) by [Unito](https://www.unito.io)
