### PR TITLE
Fix typingIndicator getting sent repeatedly

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -382,9 +382,11 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     limit: 1000
   });
   
-  useOnNotificationsChanged(currentUser, () => {
-    if (currentUser && isDialogueParticipant(currentUser._id, post)) {
-      refetchDebateResponses();
+  useOnNotificationsChanged(currentUser, (message) => {
+    if (message.eventType === 'notificationCheck') {
+      if (currentUser && isDialogueParticipant(currentUser._id, post)) {
+        refetchDebateResponses();
+      }
     }
   });
 

--- a/packages/lesswrong/server/serverSentEvents.ts
+++ b/packages/lesswrong/server/serverSentEvents.ts
@@ -164,7 +164,7 @@ async function checkForTypingIndicators() {
   const typingIndicatorInfos = await new TypingIndicatorsRepo().getRecentTypingIndicators(lastTypingIndicatorsCheck)
 
   if (typingIndicatorInfos.length > 0) {
-    // Take the newest createdAt of a typingIndicator we saw, or one second ago,
+    // Take the newest lastUpdated of a typingIndicator we saw, or one second ago,
     // whichever is earlier, as the cutoff date for the next query. 
     // See checkForNotifications for more details.
     const newestTypingIndicatorDate: Date = maxBy(typingIndicatorInfos, n=>new Date(n.lastUpdated))!.lastUpdated;

--- a/packages/lesswrong/server/serverSentEvents.ts
+++ b/packages/lesswrong/server/serverSentEvents.ts
@@ -167,7 +167,7 @@ async function checkForTypingIndicators() {
     // Take the newest createdAt of a typingIndicator we saw, or one second ago,
     // whichever is earlier, as the cutoff date for the next query. 
     // See checkForNotifications for more details.
-    const newestTypingIndicatorDate: Date = maxBy(typingIndicatorInfos, n=>new Date(n.createdAt))!.createdAt;
+    const newestTypingIndicatorDate: Date = maxBy(typingIndicatorInfos, n=>new Date(n.lastUpdated))!.lastUpdated;
     const oneSecondAgo = moment().subtract(1, 'seconds').toDate();
     if (newestTypingIndicatorDate > oneSecondAgo) {
       lastTypingIndicatorsCheck = oneSecondAgo;


### PR DESCRIPTION
There were two additional bugs with TypingIndicators

1. TypingIndicators were accidentally triggering the "reload all debateResponse comments" refetch, because that didn't check for the new eventType field

2. The "time to check for new TypingIndicators" wasn't properly updating because it was using the createdAt date for TypingIndicators (which never changes) rather than the lastUpdated field (which does)

This had previously resulted in, every time the typingIndicator throttle triggered, it'd _both_ receive a typingIndicators message (even if there weren't new ones) and would refetch all the comments.