### PR TITLE
add lint to esbuild and reduce console log spam

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const process = require('process');
 const { zlib } = require("mz");
 const { getDatabaseConfig, startSshTunnel, getOutputDir, setOutputDir } = require("./scripts/startup/buildUtil");
-const { setClientRebuildInProgress, setServerRebuildInProgress, generateBuildId, startAutoRefreshServer, initiateRefresh } = require("./scripts/startup/autoRefreshServer");
+const { setClientRebuildInProgress, setServerRebuildInProgress, generateBuildId, startAutoRefreshServer, initiateRefresh, startLint } = require("./scripts/startup/autoRefreshServer");
 /**
  * This is used for clean exiting in Github workflows by the dev
  * only route /api/quit
@@ -106,6 +106,7 @@ build({
     setClientRebuildInProgress(true);
     inProgressBuildId = generateBuildId();
     config.define.buildId = `"${inProgressBuildId}"`;
+    startLint();
   },
   onEnd: (config, buildResult, ctx) => {
     setClientRebuildInProgress(false);
@@ -156,6 +157,7 @@ build({
   run: cliopts.run && serverCli,
   onStart: (config, changedFiles, ctx) => {
     setServerRebuildInProgress(true);
+    startLint();
   },
   onEnd: () => {
     setServerRebuildInProgress(false);

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -77,7 +77,6 @@ const analyticsColumnSet = new pgPromiseLib.helpers.ColumnSet(['environment', 'e
 // Writes an event to the analytics database.
 async function writeEventsToAnalyticsDB(events: {type: string, timestamp: Date, props: AnyBecauseTodo}[]) {
   const connection = getAnalyticsConnection()
-  const mirrorConnection = getMirrorAnalyticsConnection()
   
   if (connection) {
     try {
@@ -99,10 +98,7 @@ async function writeEventsToAnalyticsDB(events: {type: string, timestamp: Date, 
       
       inFlightRequestCounter.inFlightRequests++;
       try {
-        await Promise.all([
-          connection?.none(query),
-          mirrorConnection?.none(query)
-        ])
+        await connection?.none(query);
       } finally {
         inFlightRequestCounter.inFlightRequests--;
       }

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -107,9 +107,6 @@ export function startWebserver() {
   app.use(pickerMiddleware);
   app.use(botRedirectMiddleware);
   app.use(hstsMiddleware);
-
-  //eslint-disable-next-line no-console
-  console.log("Starting ForumMagnum server. Versions: "+JSON.stringify(process.versions));
   
   // create server
   // given options contains the schema
@@ -184,11 +181,7 @@ export function startWebserver() {
   app.use("/ckeditor-token", ckEditorTokenHandler)
   
   // Static files folder
-  // eslint-disable-next-line no-console
-  console.log(`Serving static files from ${path.join(__dirname, '../../client')}`);
   app.use(express.static(path.join(__dirname, '../../client')))
-  // eslint-disable-next-line no-console
-  console.log(`Serving static files from ${path.join(__dirname, '../../../public')}`);
   app.use(express.static(path.join(__dirname, '../../../public')))
   
   // Voyager is a GraphQL schema visual explorer

--- a/packages/lesswrong/server/branchDb.ts
+++ b/packages/lesswrong/server/branchDb.ts
@@ -25,7 +25,8 @@ export const getBranchDbName = async (): Promise<string | undefined> => {
       return dbName;
     }
   } catch (e) {
+    // Commenting out this console log because this feature is unfinished
     // eslint-disable-next-line no-console
-    console.warn("Warning loading branch dbs:", e.message, process.cwd());
+    // console.warn("Warning loading branch dbs:", e.message, process.cwd());
   }
 }

--- a/packages/lesswrong/server/cronUtil.ts
+++ b/packages/lesswrong/server/cronUtil.ts
@@ -1,9 +1,9 @@
-import { isAnyTest, onStartup } from '../lib/executionEnvironment';
+import { isAnyTest, isDevelopment, onStartup } from '../lib/executionEnvironment';
 import { SyncedCron } from './vendor/synced-cron/synced-cron-server';
 import { getCommandLineArguments } from './commandLine';
 
 SyncedCron.options = {
-  log: true,
+  log: !isDevelopment,
   collectionName: 'cronHistory',
   utc: false,
   collectionTTL: 172800

--- a/packages/lesswrong/server/search/elastic/ElasticClient.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticClient.ts
@@ -33,8 +33,6 @@ class ElasticClient {
     }
 
     if (!globalClient) {
-      // eslint-disable-next-line no-console
-      console.log("Connecting to Elasticsearch...");
       globalClient = new Client({
         requestTimeout: 600000,
         cloud: {id: cloudId},

--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -84,8 +84,6 @@ const initDatabases = ({postgresUrl, postgresReadUrl}: CommandLineArguments) =>
   ]);
 
 const initSettings = () => {
-  // eslint-disable-next-line no-console
-  console.log("Loading settings");
   return refreshSettingsCaches();
 }
 
@@ -93,8 +91,6 @@ const initPostgres = async () => {
   if (Collections.some(collection => collection instanceof PgCollection || collection instanceof SwitchingCollection)) {
     await ensureMongo2PgLockTableExists(getSqlClientOrThrow());
 
-    // eslint-disable-next-line no-console
-    console.log("Building postgres tables");
     for (const collection of Collections) {
       if (collection instanceof PgCollection || collection instanceof SwitchingCollection) {
         collection.buildPostgresTable();
@@ -102,8 +98,6 @@ const initPostgres = async () => {
     }
   }
 
-  // eslint-disable-next-line no-console
-  console.log("Initializing switching collections from lock table");
   const polls: Promise<void>[] = [];
   for (const collection of Collections) {
     if (collection instanceof SwitchingCollection) {
@@ -127,8 +121,6 @@ const initPostgres = async () => {
 }
 
 const executeServerWithArgs = async ({shellMode, command}: CommandLineArguments) => {
-  // eslint-disable-next-line no-console
-  console.log("Running onStartup functions");
   await runStartupFunctions();
 
   // define executableSchema
@@ -145,8 +137,6 @@ const executeServerWithArgs = async ({shellMode, command}: CommandLineArguments)
     process.kill(estrellaPid, 'SIGQUIT');
   } else if (!isAnyTest && !isMigrations) {
     watchForShellCommands();
-    // eslint-disable-next-line no-console
-    console.log("Starting webserver");
     startWebserver();
   }
 }
@@ -167,7 +157,6 @@ export const initServer = async (commandLineArguments?: CommandLineArguments) =>
 export const serverStartup = async () => {
   // Run server directly if not in cluster mode
   if (!clusterSetting.get()) {
-    console.log(`Running in non-cluster mode`);
     await serverStartupWorker();
     return;
   }
@@ -201,7 +190,6 @@ export const serverStartup = async () => {
 }
 
 export const serverStartupWorker = async () => {
-  console.log("Starting server");
   const commandLineArguments = await initServer();
   await executeServerWithArgs(commandLineArguments);
 }

--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -267,11 +267,6 @@ export const createSqlConnection = async (
     idleTimeoutMillis: pgConnIdleTimeoutMsSetting.get(),
   });
 
-  if (!isAnyTest) {
-    // eslint-disable-next-line no-console
-    console.log(`Connecting to postgres with a connection-pool max size of ${MAX_CONNECTIONS}`);
-  }
-
   const client: SqlClient = {
     ...db,
     $pool: db.$pool, // $pool is accessed with magic and isn't copied by spreading


### PR DESCRIPTION
Adds `yarn eslint` to esbuild's `onStart`, so we get linting as well as type checking on saves that trigger hot reload.  Also cuts down on some historical console logs that seem like they're more noisy than they're worth.

Co-authored-by: jimrandomh <jim@jimrandomh.org>