### PR TITLE
Exclude un-reactors from reactor lists on posts

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -122,7 +122,7 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
             v."isUnvote" IS NOT TRUE AND
             v."extendedVoteType" IS NOT NULL
         ) q
-        WHERE "key" IN ($2:csv)
+        WHERE "key" IN ($2:csv) AND "value" = TO_JSONB(TRUE)
         GROUP BY "key"
       ) q
     `, [postId, eaPublicEmojiNames]);


### PR DESCRIPTION
There's currently a bug where we show everyone who _ever_ added a reaction to a post even if they then removed that reaction. Note that this only affects reactions on posts, not on comments.

Can be seen very clearly on [https://forum.effectivealtruism.org/s/vw6tX5SyvTwMeSxJk/p/JYEAL8g7ArqGoTaX6](https://forum.effectivealtruism.org/s/vw6tX5SyvTwMeSxJk/p/JYEAL8g7ArqGoTaX6) and [https://forum.effectivealtruism.org/posts/w59DkYCJYqaYDpEqG/mistakes-flukes-and-good-calls-i-made-in-my-multiple-careers](https://forum.effectivealtruism.org/posts/w59DkYCJYqaYDpEqG/mistakes-flukes-and-good-calls-i-made-in-my-multiple-careers), for instance.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205556044262353) by [Unito](https://www.unito.io)
