### PR TITLE
[EA Forum only] update VP event cards (Precipice is every 3 months now)

### DIFF
--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -24,7 +24,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     padding: '50px 24px',
     '& .VirtualProgramCard-eventCardDescription': {
       opacity: 1,
-      lineHeight: '1.8em',
+      lineHeight: '1.6em',
       marginTop: 30
     },
     '& .VirtualProgramCard-eventCardDeadline': {
@@ -67,8 +67,10 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   eventCardTitle: {
     ...theme.typography.headline,
+    fontFamily: theme.palette.fonts.sansSerifStack,
     color: 'white',
-    fontSize: 22,
+    fontSize: 20,
+    fontWeight: 600,
     marginTop: 8,
     marginBottom: 0
   },
@@ -90,7 +92,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   eventCardDeadline: {
     ...theme.typography.commentStyle,
     display: 'inline-block',
-    fontWeight: 'bold',
+    fontWeight: 600,
     color: 'white',
     fontSize: 16,
     paddingBottom: 5,
@@ -112,12 +114,12 @@ const VirtualProgramCard = ({program, classes}: {
   const now = moment()
   let deadline = now.date(28).day(0)
   // If that Sunday is in the past, use next month's 4th Sunday.
-  if (deadline.isBefore(moment())) {
-    deadline = now.add(1, 'months').date(28).day(0)
+  if (deadline.isBefore(now)) {
+    deadline = moment(now).add(1, 'months').date(28).day(0)
   }
   
-  // VP starts 15 days after the deadline, on a Monday
-  const startOfVp = moment(deadline).add(15, 'days')
+  // VP starts 22 days after the deadline, on a Monday
+  const startOfVp = moment(deadline).add(22, 'days')
   // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
   const endOfVp = moment(startOfVp).add(8, 'weeks').subtract(1, 'day')
 
@@ -144,6 +146,21 @@ const VirtualProgramCard = ({program, classes}: {
   }
   
   if (program === 'advanced') {
+    // Find the next deadline for applying to the Precipice VP, which is some Sunday every 3 months
+    // (as with the Intro/Advanced VP deadline, it will prob sometimes be off by a week or two).
+    // The first confirmed deadline is Nov 19, 2023, so we assume the deadlines will be
+    // ~the 3rd Sunday in Feb, May, Aug, and Nov each year. Start by checking Feb of this year.
+    let precipiceDeadline = moment(now).month(1).date(21).day(0)
+    // While that day is in the past, keep adding 3 months.
+    while (precipiceDeadline.isBefore(now)) {
+      precipiceDeadline = moment(precipiceDeadline).add(3, 'months').date(21).day(0)
+    }
+    
+    // VP starts 22 days after the deadline, on a Monday
+    const startOfPrecipice = moment(precipiceDeadline).add(22, 'days')
+    // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
+    const endOfPrecipice = moment(startOfPrecipice).add(8, 'weeks').subtract(1, 'day')
+    
     return <Card className={classes.eventCard}>
       <a
         href="https://www.effectivealtruism.org/virtual-programs/in-depth-program?utm_source=ea_forum&utm_medium=vp_card&utm_campaign=events_page"
@@ -170,7 +187,7 @@ const VirtualProgramCard = ({program, classes}: {
       >
         <div>
           <div className={classes.eventCardTime}>
-            {startOfVp.format('MMMM D')} - {endOfVp.format('MMMM D')}
+            {startOfPrecipice.format('MMMM D')} - {endOfPrecipice.format('MMMM D')}
           </div>
           <div className={classes.eventCardTitle}>
             <em>The Precipice</em> Reading Group
@@ -178,7 +195,7 @@ const VirtualProgramCard = ({program, classes}: {
           <div className={classes.eventCardDescription}>
             Join weekly discussions about existential risks and safeguarding the future of humanity
           </div>
-          <div className={classes.eventCardDeadline}>Apply by Sunday, {deadline.format('MMMM D')}</div>
+          <div className={classes.eventCardDeadline}>Apply by Sunday, {precipiceDeadline.format('MMMM D')}</div>
         </div>
       </a>
     </Card>


### PR DESCRIPTION
This PR is mostly to update the Precipice VP card dates, since it's switched to being every 3 months now. Intro and In-Depth are still monthly.

I also updated some of the styling to match the other event cards.

<img width="391" alt="Screen Shot 2023-09-23 at 3 04 19 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/7687061f-6874-4927-b1ef-17cd0fc84ea0">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205562824323497) by [Unito](https://www.unito.io)
