### PR TITLE
Fix voting bug on popular comments

### DIFF
--- a/packages/lesswrong/components/hooks/usePaginatedResolver.ts
+++ b/packages/lesswrong/components/hooks/usePaginatedResolver.ts
@@ -94,7 +94,7 @@ export const usePaginatedResolver = <
   }
 
   useEffect(() => {
-    if (results?.length && results.length > (list?.length ?? 0)) {
+    if (results?.length && results.length >= (list?.length ?? 0)) {
       setList(results);
     }
   }, [results, list?.length]);


### PR DESCRIPTION
For paginated resolvers, we actually render a cached version of the result rather than the return value from `getQuery`. This change makes the list refresh even if the length is the same which fixes the current bug where you can't vote on comments in the "Popular comments" section. Eventually, I'd like to work out how we can remove this caching layer and use the result directly, but I don't have time at the moment so this will do for now.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205568534950570) by [Unito](https://www.unito.io)
