### PR TITLE
Allow line wrapping in very long usernames on the profile page

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -110,6 +110,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 8,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontWeight: 500,
+    overflowWrap: "anywhere",
   },
   deletedUsername: {
     textDecoration: 'line-through'


### PR DESCRIPTION
Before:
<img width="894" alt="Screenshot 2023-09-25 at 17 12 05" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/fc759edd-0eae-4372-8124-bec6940ad09e">

After:
<img width="777" alt="Screenshot 2023-09-25 at 17 11 50" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/dd610d8c-d6a9-49d0-b269-c1b69736c3eb">
