### PR TITLE
[EA] Convert all posts to use EA emoji reactions

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -56,6 +56,7 @@ import './server/scripts/sendWrappedNotifications';
 import './server/scripts/removeRsvp';
 import './server/scripts/regenerateUnicodeSlugs';
 import './server/scripts/checkPostForSockpuppetVoting';
+import './server/scripts/convertAllPostsToEAEmojis';
 
 import './server/scripts/oneOffBanSpammers'
 import './server/scripts/ensureEmailInEmails';

--- a/packages/lesswrong/server/scripts/convertAllPostsToEAEmojis.ts
+++ b/packages/lesswrong/server/scripts/convertAllPostsToEAEmojis.ts
@@ -1,0 +1,123 @@
+/* eslint-disable no-console */
+
+import { getSqlClientOrThrow } from "../../lib/sql/sqlClient";
+import { pgPromiseLib } from "../sqlConnection";
+import { Globals } from "../vulcan-lib";
+
+type PostVotingSystem = Pick<DbPost, "_id" | "votingSystem">;
+type VoteType = Pick<DbVote, "documentId" | "extendedVoteType">;
+type VoteCounts = {agree: number, disagree: number};
+
+const convertDefaultVotingSystemToEAEmojis = async (postId: string) => {
+  await getSqlClientOrThrow().none(`
+    UPDATE "Posts"
+    SET "votingSystem" = 'eaEmojis'
+    WHERE "_id" = $1
+  `, [postId]);
+}
+
+const convertTwoAxisVotingSystemToEAEmojis = async (postId: string) => {
+  await getSqlClientOrThrow().tx(async (db) => {
+    const votes: VoteType[] = await db.any(`
+      UPDATE "Votes" AS v
+      SET "extendedVoteType" = CASE v."extendedVoteType"->>'agreement'
+        WHEN 'smallUpvote' THEN '{"agree":true}'::JSONB
+        WHEN 'bigUpvote' THEN '{"agree":true}'::JSONB
+        WHEN 'smallDownvote' THEN '{"disagree":true}'::JSONB
+        WHEN 'bigDownvote' THEN '{"disagree":true}'::JSONB
+        ELSE NULL
+        END
+      FROM "Comments" AS c
+      WHERE
+        c."_id" = v."documentId" AND
+        v."collectionName" = 'Comments' AND
+        c."postId" = $1 AND
+        v."cancelled" IS NOT TRUE AND
+        v."isUnvote" IS NOT TRUE AND
+        v."extendedVoteType"->>'agreement' IS NOT NULL
+      RETURNING "documentId", "extendedVoteType"
+    `, [postId]);
+
+    const voteCounts: Record<string, VoteCounts> = {};
+    for (const {documentId, extendedVoteType} of votes) {
+      if (!extendedVoteType) {
+        continue;
+      }
+      if (!voteCounts[documentId]) {
+        voteCounts[documentId] = {agree: 0, disagree: 0};
+      }
+      if (extendedVoteType.agree) {
+        voteCounts[documentId].agree++;
+      } else if (extendedVoteType.disagree) {
+        voteCounts[documentId].disagree++;
+      }
+    }
+
+    const commentIdsToUpdate = Object.keys(voteCounts);
+    const queries: {query: string, values: unknown[]}[] = [];
+    for (const commentId of commentIdsToUpdate) {
+      queries.push({
+        query: `
+          UPDATE "Comments"
+          SET "extendedScore" = "extendedScore" || $2::JSONB
+          WHERE "_id" = $1
+        `,
+        values: [commentId, voteCounts[commentId]],
+      });
+    }
+
+    queries.push({
+      query: `
+        UPDATE "Posts"
+        SET "votingSystem" = 'eaEmojis'
+        WHERE "_id" = $1
+      `,
+      values: [postId],
+    });
+
+    const concatenatedQuery = pgPromiseLib.helpers.concat(queries);
+    await db.multi(concatenatedQuery);
+  });
+}
+
+const convertAllPostsToEAEmojis = async () => {
+  console.log("Converting voting systems to EA emojis...");
+  const posts: PostVotingSystem[] = await getSqlClientOrThrow().any(`
+    SELECT "_id", "votingSystem"
+    FROM "Posts"
+    WHERE "votingSystem" <> 'eaEmojis'
+  `);
+
+  for (let i = 0; i < posts.length; i++) {
+    const post = posts[i];
+    try {
+      switch (post.votingSystem) {
+      case "default":
+        console.log(
+          "  ...converting default voting system for post",
+          post._id,
+          `(${i}/${posts.length})`,
+        );
+        await convertDefaultVotingSystemToEAEmojis(post._id);
+        break;
+      case "twoAxis":
+        console.log(
+          "  ...converting two-axis voting system for post",
+          post._id,
+          `(${i}/${posts.length})`,
+        );
+        await convertTwoAxisVotingSystemToEAEmojis(post._id);
+        break;
+      default:
+        // Do nothing for other voting systems
+        break;
+      }
+    } catch (e) {
+      console.error(`Failed to convert post ${post._id}:`, e);
+    }
+  }
+}
+
+Globals.convertDefaultVotingSystemToEAEmojis = convertDefaultVotingSystemToEAEmojis;
+Globals.convertTwoAxisVotingSystemToEAEmojis = convertTwoAxisVotingSystemToEAEmojis;
+Globals.convertAllPostsToEAEmojis = convertAllPostsToEAEmojis;

--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -9,7 +9,7 @@ import CreateExtensionQuery from "../lib/sql/CreateExtensionQuery";
 
 const pgConnIdleTimeoutMsSetting = new PublicInstanceSetting<number>('pg.idleTimeoutMs', 10000, 'optional')
 
-const pgPromiseLib = pgp({
+export const pgPromiseLib = pgp({
   noWarnings: isAnyTest,
   connect: async ({client}) => {
     const result: IResult<{oid: number}> = await client.query(


### PR DESCRIPTION
This PR adds a manual script to convert all historical posts to the new EA emojis voting system. Note that we only actually convert posts with the "default" voting system or the "twoAxis" voting system. The prod database currently has 3 posts with different experimental voting systems (LNbzDCgCH2py3cnJv, whEmrvK9pzioeircr and yMptv5msFnnfESCqm) which we leave as they are.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205585559880934) by [Unito](https://www.unito.io)
