### PR TITLE
Make agree/disagree emojis mutually exclusive in `eaEmojis` voting system

### DIFF
--- a/packages/lesswrong/components/votes/EAReactsSection.tsx
+++ b/packages/lesswrong/components/votes/EAReactsSection.tsx
@@ -11,6 +11,7 @@ import {
   eaAnonymousEmojiPalette,
   eaEmojiPalette,
   EmojiOption,
+  getEmojiMutuallyExclusivePartner,
 } from "../../lib/voting/eaEmojiPalette";
 import type { VotingProps } from "./votingProps";
 import Menu from "@material-ui/core/Menu";
@@ -233,13 +234,19 @@ const EAReactsSection: FC<{
       return;
     }
 
+    const extendedVote = {
+      ...voteProps.document.currentUserExtendedVote,
+      [emojiOption.name]: !isEmojiSelected(voteProps, emojiOption),
+    };
+    const partner = getEmojiMutuallyExclusivePartner(emojiOption.name);
+    if (partner && extendedVote[emojiOption.name]) {
+      extendedVote[partner] = false;
+    }
+
     voteProps.vote({
       document: voteProps.document,
       voteType: voteProps.document.currentUserVote ?? "neutral",
-      extendedVote: {
-        ...voteProps.document.currentUserExtendedVote,
-        [emojiOption.name]: !isEmojiSelected(voteProps, emojiOption),
-      },
+      extendedVote,
       currentUser,
     });
   }, [currentUser, openDialog, voteProps]);

--- a/packages/lesswrong/lib/voting/eaEmojiPalette.ts
+++ b/packages/lesswrong/lib/voting/eaEmojiPalette.ts
@@ -54,3 +54,14 @@ export const eaEmojiNames = [
 ].map(({name}) => name);
 
 export const eaPublicEmojiNames = eaEmojiPalette.map(({name}) => name);
+
+export const getEmojiMutuallyExclusivePartner = (emojiName: string) => {
+  switch (emojiName) {
+  case "agree":
+    return "disagree";
+  case "disagree":
+    return "agree";
+  default:
+    return undefined;
+  }
+}


### PR DESCRIPTION
It's currently possible to both agree and disagree with a single comment or post which is incorrect.

I've not made any attempt to change existing places where this has happened because:

1. We don't know whether the user actually wanted to agree or disagree
2. There's only 13 such votes in the entire database which seems acceptable

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205591491093968) by [Unito](https://www.unito.io)
