### PR TITLE
Non digest recommendation algorithms

### DIFF
--- a/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
-import classNames from "classnames";
+import { useCurrentTime } from "../../lib/utils/timeUtil";
 import { Link } from "../../lib/reactRouterWrapper";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { useMulti } from "../../lib/crud/withMulti";
-import { usePaginatedResolver } from "../hooks/usePaginatedResolver";
 import keyBy from "lodash/keyBy";
+import moment from "moment";
+import classNames from "classnames";
 
 const MAX_WIDTH = 1500;
 const MD_WIDTH = 1000;
@@ -155,12 +156,17 @@ const EABestOfPage = ({ classes }: { classes: ClassesType }) => {
     fragmentName: 'CollectionsBestOfFragment',
   });
 
+  const currentTime = useCurrentTime();
   const {
     results: monthlyHighlights,
     loading: monthlyHighlightsLoading,
-  } = usePaginatedResolver({
+  } = useMulti({
+    collectionName: "Posts",
     fragmentName: "PostsListWithVotes",
-    resolverName: "DigestHighlights",
+    terms: {
+      view: "curated",
+      after: moment(currentTime).subtract(1, "month").startOf("day").toDate(),
+    },
   });
 
   const postsById = useMemo(() => keyBy(posts, '_id'), [posts]);
@@ -252,6 +258,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType }) => {
                       key={post._id}
                       post={post}
                       className={classes.postsItem}
+                      showIcons={false}
                       hideSecondaryInfo
                     />
                   ))}

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -194,6 +194,7 @@ const EAPostsItem = ({
     resumeReading,
     strikethroughTitle,
     curatedIconLeft,
+    showIcons,
     isRead,
     showReadCheckbox,
     tooltipPlacement,
@@ -290,6 +291,7 @@ const EAPostsItem = ({
                   showPersonalIcon,
                   strikethroughTitle,
                   curatedIconLeft,
+                  showIcons,
                 }}
                 Wrapper={TitleWrapper}
                 read={isRead && !showReadCheckbox}

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -55,11 +55,11 @@ const PostBottomRecommendations = ({post, classes}: {
   });
 
   const {
-    results: digestPosts,
-    loading: digestLoading,
+    results: curatedAndPopularPosts,
+    loading: curatedAndPopularLoading,
   } = usePaginatedResolver({
     fragmentName: "PostsPage",
-    resolverName: "DigestPostsThisWeek",
+    resolverName: "CuratedAndPopularThisWeek",
     limit: 3,
   });
 
@@ -109,13 +109,13 @@ const PostBottomRecommendations = ({post, classes}: {
             }
             <div className={classes.section}>
               <div className={classes.sectionHeading}>
-                Recommended by the Forum team this week
+                Curated and popular this week
               </div>
-              {digestLoading && !digestPosts?.length &&
+              {curatedAndPopularLoading && !curatedAndPopularPosts?.length &&
                 <PostsLoading />
               }
-              <AnalyticsContext pageSubSectionContext="digestThisWeek">
-                {digestPosts?.map((post) => (
+              <AnalyticsContext pageSubSectionContext="curatedAndPopular">
+                {curatedAndPopularPosts?.map((post) => (
                   <EALargePostsItem
                     key={post._id}
                     post={post}

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -5,6 +5,7 @@ export const getViewablePostsSelector = (postsTableAlias?: string) => {
   return `
     ${aliasPrefix}"status" = ${postStatuses.STATUS_APPROVED} AND
     ${aliasPrefix}"draft" = FALSE AND
+    ${aliasPrefix}"deletedDraft" = FALSE AND
     ${aliasPrefix}"isFuture" = FALSE AND
     ${aliasPrefix}"unlisted" = FALSE AND
     ${aliasPrefix}"shortform" = FALSE AND

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -269,3 +269,13 @@ createPaginatedResolver({
   ): Promise<DbPost[]> => context.repos.posts.getTopWeeklyDigestPosts(limit),
   cacheMaxAgeMs: 1000 * 60 * 60, // 1 hour
 });
+
+createPaginatedResolver({
+  name: "CuratedAndPopularThisWeek",
+  graphQLType: "Post",
+  callback: async (
+    context: ResolverContext,
+    limit: number,
+  ): Promise<DbPost[]> => context.repos.posts.getCuratedAndPopularPosts({limit}),
+  cacheMaxAgeMs: 1000 * 60 * 60, // 1 hour
+});


### PR DESCRIPTION
Adds new recommendation algorithm to avoid using the digest:

- Highlights this month on the best-of page now uses posts that were created this month that have been curated (this could be posts that were curated this month but are any age, if we want more results)
- "Recommended by the Forum team this week" under posts is now "Curated and popular this week", which selects any posts curated this week, and if there are less than 3 (which there usually are) we just pick the highest karma non-community posts to make up the difference