### PR TITLE
Fix adding posts on tag page

### DIFF
--- a/packages/lesswrong/components/search/SearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.tsx
@@ -24,8 +24,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const formatFacetFilters = (
-  facetFilters?: Record<string, boolean>,
+export const formatFacetFilters = (
+  facetFilters?: Record<string, boolean | string>,
 ): string[][] | undefined =>
   facetFilters
     ? [Object.keys(facetFilters).map((key) => `${key}:${facetFilters[key]}`)]

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -61,6 +61,20 @@ const styles = (theme: ThemeType): JssStyles => ({
       bottom: 3
     }
   },
+  searchBox: {
+    "& form": {
+      display: "flex",
+      gap: "6px",
+    },
+    "& svg": {
+      fill: theme.palette.grey[1000],
+    },
+    "& input": {
+      background: theme.palette.grey[55],
+      borderRadius: theme.borderRadius.small,
+      padding: 6,
+    },
+  },
   closeIcon: {
     fontSize: '16px',
     color: theme.palette.icon.maxIntensity,
@@ -140,7 +154,7 @@ const AddPostsToTag = ({classes, tag}: {
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
               * null is the only option that actually suppresses the extra X button.
             // @ts-ignore */}
-            <SearchBox focusShortcuts={[]} autoFocus={true} reset={null} />
+            <SearchBox focusShortcuts={[]} autoFocus={true} reset={null} className={classes.searchBox} />
             <CloseIcon className={classes.closeIcon} onClick={() => setSearchOpen(false)}/>
           </div>
           <SearchPagination />

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -12,6 +12,7 @@ import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog';
 import CloseIcon from '@material-ui/icons/Close';
 import { preferredHeadingCase } from '../../lib/forumTypeUtils';
+import { formatFacetFilters } from '../search/SearchAutoComplete';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -145,7 +146,7 @@ const AddPostsToTag = ({classes, tag}: {
           <SearchPagination />
         </div>
         <Configure
-          facetFilters={`tags:-zxmLyuTr7nujF523s`}
+          facetFilters={formatFacetFilters({tags: `-${tag._id}`})}
           hitsPerPage={10}
         />
         <Hits hitComponent={({hit}: {hit: any}) => <span className={classes.postHit} onClick={() => onPostSelected(hit._id)}>

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -25,7 +25,7 @@ export type QueryFilter = {
 } & ({
   type: "facet",
   value: boolean | string,
-  negated?: boolean,
+  negated: boolean,
 } | {
   type: "numeric",
   value: number,

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -25,6 +25,7 @@ export type QueryFilter = {
 } & ({
   type: "facet",
   value: boolean | string,
+  negated?: boolean,
 } | {
   type: "numeric",
   value: number,
@@ -99,11 +100,21 @@ class ElasticQuery {
     for (const filter of this.queryData.filters) {
       switch (filter.type) {
       case "facet":
-        terms.push({
+        const term: QueryDslQueryContainer = {
           term: {
             [filter.field]: filter.value,
           },
-        });
+        };
+        terms.push(
+          filter.negated
+            ? {
+              bool: {
+                should: [],
+                must_not: [term],
+              },
+            }
+            : term,
+        );
         break;
       case "numeric":
         terms.push({

--- a/packages/lesswrong/server/search/elastic/ElasticService.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticService.ts
@@ -118,14 +118,20 @@ class ElasticService {
 
     for (const group of facetFilters ?? []) {
       for (const facet of group) {
-        const [field, value] = facet.split(":");
+        let [field, value] = facet.split(":");
         if (!field || !value) {
           throw new Error("Invalid facet: " + facet);
+        }
+        let negated = false;
+        if (value[0] === "-") {
+          negated = true;
+          value = value.slice(1);
         }
         result.push({
           type: "facet",
           field,
           value: this.parseFacetValue(value),
+          negated,
         });
       }
     }

--- a/packages/lesswrong/unitTests/elastic/elasticService.tests.ts
+++ b/packages/lesswrong/unitTests/elastic/elasticService.tests.ts
@@ -16,6 +16,7 @@ describe("ElasticService", () => {
         ["a:true"],
         ["b:false"],
         ["c:test"],
+        ["c:-test"],
       ], [
         "d<3",
         "e<=4",
@@ -25,9 +26,10 @@ describe("ElasticService", () => {
       ],
     );
     expect(result).toStrictEqual([
-      {type: "facet", field: "a", value: true},
-      {type: "facet", field: "b", value: false},
-      {type: "facet", field: "c", value: "test"},
+      {type: "facet", field: "a", value: true, negated: false},
+      {type: "facet", field: "b", value: false, negated: false},
+      {type: "facet", field: "c", value: "test", negated: false},
+      {type: "facet", field: "c", value: "test", negated: true},
       {type: "numeric", field: "d", value: 3, op: "lt"},
       {type: "numeric", field: "e", value: 4, op: "lte"},
       {type: "numeric", field: "f", value: 5, op: "gt"},


### PR DESCRIPTION
We had a bug report from Lizka that the search box for adding tags directly from the tags page wasn't working. It turns out this was due to the elasticsearch backend not supporting negated facets. Upon furth inspection, it also turns out that there's a bug that's been here for the last three years when a test tag ID from lesswrong was hard coded into the filter instead of using the actual current tag ID for filtering results, so I fixed that too.

I also added dark mode styling for the search box:
<img width="336" alt="Screenshot 2023-09-27 at 23 22 40" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/e3f736ab-c1a6-483a-972c-1eb6d719e5a0">
<img width="314" alt="Screenshot 2023-09-27 at 23 22 49" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/bd019af2-daee-4339-a912-f423485511bc">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205598261006312) by [Unito](https://www.unito.io)
