### PR TITLE
EA New feature tweaks

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -391,7 +391,7 @@ const Layout = ({currentUser, children, classes}: {
                     <NavigationStandalone
                       sidebarHidden={hideNavigationSidebar}
                       unspacedGridLayout={unspacedGridLayout}
-                      className={classes.standaloneNav}
+                      noTopMargin={eaHomeLayout}
                     />
                   </StickyWrapper>
                 }

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -36,10 +36,19 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const NavigationStandalone = (
-  {sidebarHidden, unspacedGridLayout, className, classes}:
-  {sidebarHidden: boolean, unspacedGridLayout?: boolean, className: string, classes: ClassesType}
-) => {
+const NavigationStandalone = ({
+  sidebarHidden,
+  unspacedGridLayout,
+  noTopMargin,
+  className,
+  classes,
+}: {
+  sidebarHidden: boolean,
+  unspacedGridLayout?: boolean,
+  noTopMargin?: boolean,
+  className?: string,
+  classes: ClassesType,
+}) => {
   const { TabNavigationMenu, TabNavigationMenuFooter } = Components
   const { location } = useLocation();
 
@@ -55,7 +64,10 @@ const NavigationStandalone = (
         unmountOnExit
       >
         {/* In the unspaced grid layout the sidebar can appear on top of other componenents, so make the background transparent */}
-        <TabNavigationMenu transparentBackground={unspacedGridLayout}/>
+        <TabNavigationMenu
+          transparentBackground={unspacedGridLayout}
+          noTopMargin={noTopMargin}
+        />
       </Slide>
     </div>
     {!isEAForum && <div className={classNames(classes.footerBar, className)}>

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -25,7 +25,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   menuItem: {
-    width: "fit-content",
+    width: 190,
   },
   navButton: {
     '&:hover': {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -19,8 +19,11 @@ const styles = (theme: ThemeType): JssStyles => {
       flexDirection: "column",
       justifyContent: "space-around",
       maxWidth: TAB_NAVIGATION_MENU_WIDTH,
-      paddingTop: isEAForum ? undefined : 15,
+      paddingTop: 15,
       paddingLeft: isEAForum ? 6 : undefined,
+    },
+    noTopMargin: {
+      paddingTop: "0px !important",
     },
     navSidebarTransparent: {
       zIndex: 10,
@@ -44,14 +47,20 @@ const styles = (theme: ThemeType): JssStyles => {
   }
 }
 
-const TabNavigationMenu = ({onClickSection, transparentBackground, classes}: {
+const TabNavigationMenu = ({
+  onClickSection,
+  transparentBackground,
+  noTopMargin,
+  classes,
+}: {
   onClickSection?: (e?: React.BaseSyntheticEvent) => void,
   transparentBackground?: boolean,
+  noTopMargin?: boolean,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking()
-  const { TabNavigationItem, FeaturedResourceBanner } = Components
+  const { TabNavigationItem } = Components
   const customComponentProps = {currentUser}
   
   const handleClick = (e: React.BaseSyntheticEvent, tabId: string) => {
@@ -61,10 +70,13 @@ const TabNavigationMenu = ({onClickSection, transparentBackground, classes}: {
 
   return (
       <AnalyticsContext pageSectionContext="navigationMenu">
-        <div className={classNames(classes.root, {[classes.navSidebarTransparent]: transparentBackground})}>
+        <div className={classNames(classes.root, {
+          [classes.navSidebarTransparent]: transparentBackground,
+          [classes.noTopMargin]: noTopMargin,
+        })}>
           {forumSelect(menuTabs).map(tab => {
             if ('loggedOutOnly' in tab && tab.loggedOutOnly && currentUser) return null
-            
+
             if ('divider' in tab) {
               return <div key={tab.id} className={classes.divider} />
             }

--- a/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
@@ -1,18 +1,35 @@
 import React from "react";
 import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { postGetPageUrl } from "../../../lib/collections/posts/helpers";
+import { usePostContents } from "../../hooks/useForeignCrosspost";
 
 const PostExcerpt = ({post, lines = 3, className}: {
   post: PostsList,
   lines?: number,
   className?: string,
 }) => {
-  const contentHtml = post.contents?.htmlHighlight;
+  const {postContents, loading, error} = usePostContents({
+    post,
+    fragmentName: "PostsList",
+  });
+
+  const {Loading, ContentExcerpt} = Components;
+  if (loading) {
+    return (
+      <Loading />
+    );
+  }
+
+  if (error) {
+    // eslint-disable-next-line
+    console.error("Error loading excerpt body:", error);
+  }
+
+  const contentHtml = postContents?.htmlHighlight;
   if (!contentHtml) {
     return null;
   }
 
-  const {ContentExcerpt} = Components;
   return (
     <ContentExcerpt
       contentHtml={contentHtml}

--- a/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useCurrentTime } from "../../lib/utils/timeUtil";
+import { useCurrentCuratedPostCount } from "../hooks/useCurrentCuratedPostCount";
 import { Link } from "../../lib/reactRouterWrapper";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { useMulti } from "../../lib/crud/withMulti";
@@ -138,6 +139,8 @@ const allCollectionIds = [...featuredCollectionsCollectionIds];
 const digestLink = "https://effectivealtruism.us8.list-manage.com/subscribe?u=52b028e7f799cca137ef74763&id=7457c7ff3e";
 
 const EABestOfPage = ({ classes }: { classes: ClassesType }) => {
+  const currentCuratedPostCount = useCurrentCuratedPostCount();
+
   const { results: posts, loading } = useMulti({
     terms: {postIds: allPostIds, limit: allPostIds.length},
     collectionName: "Posts",
@@ -253,12 +256,12 @@ const EABestOfPage = ({ classes }: { classes: ClassesType }) => {
               <div>
                 <h2 className={classes.heading}>Highlights this month</h2>
                 <div className={classes.listSection}>
-                  {monthlyHighlights?.map((post) => (
+                  {monthlyHighlights?.map((post, i) => (
                     <EAPostsItem
                       key={post._id}
                       post={post}
                       className={classes.postsItem}
-                      showIcons={false}
+                      curatedIconLeft={i < currentCuratedPostCount}
                       hideSecondaryInfo
                     />
                   ))}

--- a/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
@@ -272,7 +272,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType }) => {
             </AnalyticsContext>
             <AnalyticsContext pageSectionContext="featuredVideo">
               <div>
-                <h2 className={classes.heading}>Featured video</h2>
+                <h2 className={classes.heading}>Featured videos</h2>
                 <div className={classNames(classes.listSection, classes.listGap)}>
                   {featuredVideoPosts.map((post) => (
                     <PostsVideoCard key={post._id} post={post} />

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -74,6 +74,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     rowGap: '6px',
   },
   digestAd: {
+    maxWidth: 280,
     backgroundColor: theme.palette.grey[200],
     padding: '12px 16px',
     borderRadius: theme.borderRadius.default

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -37,7 +37,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   sidebarToggle: {
     position: 'absolute',
-    top: 30,
     right: 0,
     height: 36,
     width: 30,

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -647,9 +647,9 @@ export const EAHomeRightHandSide = ({classes}: {
         </div>
       </AnalyticsContext>
 
-      <Link to="/#" className={classes.feedbackLink}>
+      <a href="mailto:forum@effectivealtruism.org" className={classes.feedbackLink}>
         Send feedback
-      </Link>
+      </a>
     </div>
   </AnalyticsContext>
 }

--- a/packages/lesswrong/components/hooks/useCurrentCuratedPostCount.ts
+++ b/packages/lesswrong/components/hooks/useCurrentCuratedPostCount.ts
@@ -1,0 +1,6 @@
+import { useCurrentUser } from "../common/withUser";
+
+export const useCurrentCuratedPostCount = () => {
+  const currentUser = useCurrentUser();
+  return currentUser ? 3 : 2;
+}

--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -37,13 +37,29 @@ const overrideFields = [
   "readTimeMinutes",
 ] as const;
 
+const getCrosspostQuery = gql`
+  query GetCrosspostQuery($args: JSON) {
+    getCrosspost(args: $args)
+  }
+`;
+
+/**
+ * These queries can be slow (and the timing is unpredictable), so use
+ * `batchKey: "crosspost"` to make sure it doesn't get batched together with
+ * other queries and block them
+ */
+const crosspostBatchKey = "crosspost";
+
+type PostFetchProps<FragmentTypeName extends PostFragments> =
+  Omit<UseSingleProps<FragmentTypeName>, "documentId" | "apolloClient">;
+
 type PostFragments = 'PostsWithNavigation' | 'PostsWithNavigationAndRevision' | 'PostsList';
 /**
  * Load foreign crosspost data from the foreign site
  */
 export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentTypeName extends PostFragments>(
   localPost: Post,
-  fetchProps: Omit<UseSingleProps<FragmentTypeName>, "documentId" | "apolloClient">,
+  fetchProps: PostFetchProps<FragmentTypeName>,
 ): {
   loading: boolean,
   error?: ApolloError,
@@ -58,20 +74,15 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
     throw new Error("Crosspost has not been created yet");
   }
 
-  const getCrosspostQuery = gql`
-    query GetCrosspostQuery($args: JSON) {
-      getCrosspost(args: $args)
-    }
-  `;
-
-  const args = {
-    ...fetchProps,
-    documentId: localPost.fmCrosspost.foreignPostId
-  };
-
-  // This query can be slow (and the timing is unpredictable), so use `batchKey: "crosspost"` to make sure it
-  // doesn't get batched together with other queries and block them
-  const { data, loading, error } = useQuery(getCrosspostQuery, { variables: { args, batchKey: "crosspost" } });
+  const {data, loading, error} = useQuery(getCrosspostQuery, {
+    variables: {
+      args: {
+        ...fetchProps,
+        documentId: localPost.fmCrosspost.foreignPostId,
+      },
+      batchKey: crosspostBatchKey,
+    },
+  });
 
   const foreignPost: FragmentTypes[FragmentTypeName] = data?.getCrosspost;
 
@@ -100,5 +111,56 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
     localPost,
     foreignPost,
     combinedPost,
+  };
+}
+
+/**
+ * Returns the post contents for any post, abstracting over whether or not the
+ * post is a crosspost. If the post is a crosspost then a request will be made
+ * to fetch the body from the foreign site, and it it's not a crosspost then
+ * the body will be returned directly from the input post.
+ */
+export const usePostContents = <FragmentTypeName extends PostFragments>({
+  post,
+  fragmentName,
+  fetchProps,
+}: {
+  post: FragmentTypes[FragmentTypeName],
+  fragmentName: FragmentTypeName,
+  fetchProps?: PostFetchProps<FragmentTypeName>,
+}): {
+  postContents?: FragmentTypes[FragmentTypeName]["contents"],
+  loading: boolean,
+  error?: ApolloError,
+} => {
+  const isCrosspost = isPostWithForeignId(post);
+  const isForeign = isCrosspost && !post.fmCrosspost.hostedHere;
+
+  const {data, loading, error} = useQuery(getCrosspostQuery, {
+    variables: {
+      args: {
+        ...fetchProps,
+        collectionName: "Posts",
+        fragmentName,
+        documentId: post.fmCrosspost?.foreignPostId,
+      },
+      batchKey: crosspostBatchKey,
+    },
+    skip: !isForeign,
+  });
+
+  if (isForeign) {
+    const foreignPost: FragmentTypes[FragmentTypeName] | undefined = data?.getCrosspost;
+    return {
+      postContents: foreignPost?.contents,
+      loading,
+      error,
+    };
+  }
+
+  return {
+    postContents: post.contents,
+    loading: false,
+    error: undefined,
   };
 }

--- a/packages/lesswrong/components/hooks/useRecentOpportunities.ts
+++ b/packages/lesswrong/components/hooks/useRecentOpportunities.ts
@@ -2,6 +2,19 @@ import moment from "moment";
 import { useTimezone } from "../common/withTimezone";
 import { UseMultiResult, useMulti } from "../../lib/crud/withMulti";
 
+const requiredTags: string[] = [
+  "z8qFsGt5iXyZiLbjN", // Opportunities to take action
+];
+
+const subscribedTags: string[] = [
+  "fCcrMpyRbozMfwYPF", // Application announcements
+  "be4pBryMKxLhkmgvE", // Funding opportunities
+  "2BvgFyR85zX25osTT", // Fellowships and internships
+  "54Ls7K7N53kYws9ja", // Job listing (open)
+  "vgT4Fiybt4qjHLoBv", // Bounty (open)
+  "ihpwNfh2ZxR4ZHaAK", // Prizes and contests
+];
+
 export const useRecentOpportunities =<
   FragmentTypeName extends keyof FragmentTypes
 > ({
@@ -20,10 +33,10 @@ export const useRecentOpportunities =<
     collectionName: "Posts",
     terms: {
       view: "magic",
-      filterSettings: {tags: [{
-        tagId: "z8qFsGt5iXyZiLbjN", // topics/opportunities-to-take-action
-        filterMode: "Required",
-      }]},
+      filterSettings: {tags: [
+        ...requiredTags.map((tagId) => ({tagId, filterMode: "Required"})),
+        ...subscribedTags.map((tagId) => ({tagId, filterMode: "Subscribed"})),
+      ]},
       after: dateCutoff,
       limit,
     },

--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -21,6 +21,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle,
   },
+  link: {
+    color: theme.palette.primary.main,
+  },
   negativeTopMargin: {
     marginTop: -14,
   }
@@ -36,7 +39,11 @@ const LinkPostMessage = ({post, classes, negativeTopMargin}: {
 
   return (
     <div className={classNames(classes.root, {[classes.negativeTopMargin]: negativeTopMargin})}>
-      This is a linkpost for <a href={postGetLink(post)} target={postGetLinkTarget(post)}>{post.url}</a>
+      This is a linkpost for <a
+        href={postGetLink(post)}
+        target={postGetLinkTarget(post)}
+        className={classes.link}
+      >{post.url}</a>
     </div>
   );
 }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -214,7 +214,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: isEAForum ? 16 : undefined
   },
   noCommentsPlaceholder: {
-    margin: "100px 0 20px 0",
+    marginTop: 60,
     color: theme.palette.grey[600],
     textAlign: "center",
     fontFamily: theme.palette.fonts.sansSerifStack,

--- a/packages/lesswrong/components/recommendations/CuratedPostsList.tsx
+++ b/packages/lesswrong/components/recommendations/CuratedPostsList.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useCurrentUser } from '../common/withUser';
+import { useCurrentCuratedPostCount } from "../hooks/useCurrentCuratedPostCount";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const CuratedPostsList = () => {
-  const currentUser = useCurrentUser();
+  const currentCuratedPostCount = useCurrentCuratedPostCount();
   return (
     <AnalyticsContext listContext="curatedPosts" pageSubSectionContext="curatedPosts">
       <Components.PostsList2
-        terms={{view:"curated", limit: currentUser ? 3 : 2}}
+        terms={{view:"curated", limit: currentCuratedPostCount}}
         showNoResults={false}
         showLoadMore={false}
         hideLastUnread={true}

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -49,6 +49,7 @@ const PostBottomRecommendations = ({post, classes}: {
     fragmentName: "PostsListWithVotes",
     terms: {
       userId: post.userId,
+      notPostIds: [post._id],
       sortedBy: "topAdjusted",
       limit: 3,
     },
@@ -74,7 +75,6 @@ const PostBottomRecommendations = ({post, classes}: {
 
   const hasUserPosts = post.user &&
     (moreFromAuthorLoading || !!moreFromAuthorPosts?.length);
-
 
   const {
     PostsLoading, ToCColumn, EAPostsItem, EALargePostsItem, UserTooltip,

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -11,8 +11,8 @@ import { MAX_CONTENT_WIDTH } from "../posts/TableOfContents/ToCColumn";
 const styles = (theme: ThemeType) => ({
   root: {
     background: theme.palette.grey[55],
-    padding: "80px 0",
-    marginTop: 80,
+    padding: "60px 0 80px 0",
+    marginTop: 60,
   },
   section: {
     maxWidth: MAX_CONTENT_WIDTH,

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -46,7 +46,7 @@ export const userHasEagProfileImport = disabled;
 
 export const userHasEAHomeRHS = isEAForum ? shippedFeature : disabled;
 
-export const userHasPopularCommentsSection = isEAForum ? adminOrBeta : disabled;
+export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabled;
 
 // Shipped Features
 export const userCanManageTags = shippedFeature;

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -55,6 +55,7 @@ declare global {
     after?: Date|string|null,
     timeField?: keyof DbPost,
     postIds?: Array<string>,
+    notPostIds?: Array<string>,
     reviewYear?: number,
     reviewPhase?: ReviewPhase,
     excludeContents?: boolean,
@@ -189,6 +190,7 @@ Posts.addDefaultView((terms: PostsViewTerms, _, context: ResolverContext) => {
       hiddenRelatedQuestion: false,
       groupId: viewFieldNullOrMissing,
       ...(terms.postIds && {_id: {$in: terms.postIds}}),
+      ...(terms.notPostIds && {_id: {$nin: terms.notPostIds}}),
       ...(terms.hideCommunity ? postCommentedExcludeCommunity : {}),
       ...validFields,
       ...alignmentForum

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -274,8 +274,11 @@ createPaginatedResolver({
   name: "CuratedAndPopularThisWeek",
   graphQLType: "Post",
   callback: async (
-    context: ResolverContext,
+    {repos, currentUser}: ResolverContext,
     limit: number,
-  ): Promise<DbPost[]> => context.repos.posts.getCuratedAndPopularPosts({limit}),
+  ): Promise<DbPost[]> => repos.posts.getCuratedAndPopularPosts({
+    currentUser,
+    limit,
+  }),
   cacheMaxAgeMs: 1000 * 60 * 60, // 1 hour
 });


### PR DESCRIPTION
This PR addresses the issuses and changes requested for the current batch of new features:
- Popular comments
  - Un beta-gate the popular comments section
- Best of page
  - Rename "featured video" to "featured videos"
  - Show curated stars on "highlights this month" posts
  - Boost relevant tags in lists of recommendad opportunities on best of page and frontpage RHS
- Bottom of post recommendations
  - Exclude the current post from "more from the author"
  - Exclude read posts from "curated and popular this week"
  - Reduce vertical padding
- Recent discussions
  - Fix color of link post link
  - Fix display of crosspost bodies in recent discussions
- Main navigation menu
  - Fix main menu item link hit boxes
  - Fix main menu top margin on pages other than the frontpage
- Frontpage RHS
  - Align the toggle with the top of the sidebar
  - Limit the width of the digest ad
  - Add a `mailto` link for the "Give feedback" button (eventually, we probably want to add an Intercom integration here but this is a good first step and will probably remain as a backup for people who haven't enabled Intercom)

It was also requested to change the default sorting of posts for the "opportunities to take action" tag from "most relevant" to "magic". This is possible without code changes by just changing the `postsDefaultSortOrder` value in the database (which I've done).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205611297057064) by [Unito](https://www.unito.io)
