### PR TITLE
UI nitpicks post October release

### DIFF
--- a/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
@@ -88,7 +88,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   viewMore: {
     marginTop: 14,
     fontFamily: theme.palette.fonts.sansSerifStack,
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 600,
     color: theme.palette.grey[600],
   },

--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.headerStyle,
     ...(isEAForum && {
       fontWeight: 700,
-      fontSize: isEAForum ? "3rem" : 32,
+      fontSize: "3rem",
       marginBottom: 12,
     }),
     width: "100%",

--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.headerStyle,
     ...(isEAForum && {
       fontWeight: 700,
-      fontSize: 32,
+      fontSize: isEAForum ? "3rem" : 32,
       marginBottom: 12,
     }),
     width: "100%",

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -632,6 +632,8 @@ const forumSpecificRoutes = forumSelect<Route[]>({
       path: '/best-of',
       componentName: 'EABestOfPage',
       title: 'Best of the Forum',
+      subtitle: 'Best of the Forum',
+      subtitleLink: '/best-of',
     },
     {
       name: 'BestOfCamelCase',


### PR DESCRIPTION
* "View more" on best of page is now 14px instead of 16px
* Best of page now have a subtitle in the top bar (like events and groups)
* Draft post titles are now the same size as published titles

![Screenshot 2023-10-02 at 16 00 14](https://github.com/ForumMagnum/ForumMagnum/assets/13235378/47c43b04-f57f-4535-ab92-e5aca80eaf58)
![Screenshot 2023-10-02 at 16 00 23](https://github.com/ForumMagnum/ForumMagnum/assets/13235378/88c3bc4f-2714-495f-80de-b4581b427e09)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205632392729320) by [Unito](https://www.unito.io)
