### PR TITLE
Notifications page

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -2,7 +2,6 @@ import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import classNames from 'classnames';
 import React, { useState } from 'react';
-import Card from '@material-ui/core/Card';
 import { getNotificationTypeByName } from '../../lib/notificationTypes';
 import { getUrlClass, useNavigation } from '../../lib/routeUtil';
 import { useHover } from '../common/withHover';
@@ -58,6 +57,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
+export const renderMessage = (notification: NotificationsList) => {
+  const { TagRelNotificationItem } = Components
+  switch (notification.documentType) {
+    // TODO: add case for tagRel
+    case 'tagRel': 
+      return <TagRelNotificationItem tagRelId={notification.documentId}/>
+    default:
+      return notification.message
+  }
+}
+
 const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, classes}: {
   notification: NotificationsList,
   lastNotificationsCheck: any,
@@ -71,7 +81,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
   });
   const { captureEvent } = useTracking();
   const { history } = useNavigation();
-  const { LWPopper } = Components
+  const { LWPopper, NotificationsPreview} = Components
   const notificationType = getNotificationTypeByName(notification.type);
 
   const notificationLink = (notificationType.getLink
@@ -82,47 +92,6 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
     })
     : notification.link
   );
-
-  const renderPreview = () => {
-    const { PostsPreviewTooltipSingle, TaggedPostTooltipSingle, PostsPreviewTooltipSingleWithComment, ConversationPreview, PostNominatedNotification } = Components
-    const parsedPath = parseRouteWithErrors(notificationLink)
-
-    if (notificationType.onsiteHoverView) {
-      return <Card>
-        {notificationType.onsiteHoverView({notification})}
-      </Card>
-    } else if (notification.type == "postNominated") {
-      return <Card><PostNominatedNotification postId={notification.documentId}/></Card>
-    } else {
-      switch (notification.documentType) {
-        case 'tagRel':
-          return  <Card><TaggedPostTooltipSingle tagRelId={notification.documentId} /></Card>
-        case 'post':
-          return <Card><PostsPreviewTooltipSingle postId={notification.documentId} /></Card>
-        case 'comment':
-          const postId = parsedPath?.params?._id
-          if (!postId) return null
-          return <Card><PostsPreviewTooltipSingleWithComment postId={parsedPath?.params?._id} commentId={notification.documentId} /></Card>
-        case 'message':
-          return <Card>
-            <ConversationPreview conversationId={parsedPath?.params?._id} currentUser={currentUser} />
-          </Card>
-        default:
-          return null
-      }
-    }
-  }
-
-  const renderMessage = () => {
-    const { TagRelNotificationItem } = Components
-    switch (notification.documentType) {
-      // TODO: add case for tagRel
-      case 'tagRel': 
-        return <TagRelNotificationItem tagRelId={notification.documentId}/>
-      default:
-        return notification.message
-    }
-  }
   
   return (
     <span {...eventHandlers}>
@@ -132,7 +101,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
         placement="left-start"
         allowOverflow
       >
-        <span className={classes.preview}>{renderPreview()}</span>
+        <span className={classes.preview}>{<NotificationsPreview notification={notification} currentUser={currentUser} lastNotificationsCheck={lastNotificationsCheck}/>}</span>
       </LWPopper>
       <a
         href={notificationLink}
@@ -175,7 +144,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
       >
       {notificationType.getIcon()}
       <div className={classes.notificationLabel}>
-        {renderMessage()}
+        {renderMessage(notification)}
       </div>
     </a>
     </span>

--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -5,6 +5,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { preferredHeadingCase } from '../../lib/forumTypeUtils';
 import { isEAForum } from '../../lib/instanceSettings';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,6 +36,7 @@ const NotificationsList = ({ terms, currentUser, classes }: {
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
+
   const { results, loading, loadMore } = useMulti({
     terms,
     collectionName: "Notifications",
@@ -61,11 +63,10 @@ const NotificationsList = ({ terms, currentUser, classes }: {
           <ListItem
             button={true}
             className={classes.loadMoreButton}
-            onClick={() => loadMore()}
           >
-            <div className={classes.loadMoreLabel}>
-              {preferredHeadingCase("Load More")}
-            </div>
+            <Link to={"/notifications"} className={classes.loadMoreLabel}>
+              {preferredHeadingCase("View All")}
+            </Link>
           </ListItem>}
       </List>
     )

--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -9,7 +9,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    width: 270,
     overflowY: "auto",
     padding: 0,
   },
@@ -22,12 +21,14 @@ const styles = (theme: ThemeType): JssStyles => ({
   loadMoreButton: {
     fontSize: "14px",
     padding: 0,
+    width: "100%",
+    display: "flex",
+    justifyContent: "center",
   },
-  loadMoreLabel: {
+  seeAllLabel: {
     padding: 16,
     textAlign: "center",
-    width: "100%",
-    fontFamily: isEAForum ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.palette.fonts.sansSerifStack
   },
 });
 
@@ -36,12 +37,14 @@ const NotificationsList = ({ terms, currentUser, classes }: {
   currentUser: UsersCurrent,
   classes: ClassesType,
 }) => {
+  const { NotificationsItem, Row, Loading, LoadMore } = Components;
 
-  const { results, loading, loadMore } = useMulti({
+  const { results, loading, loadMoreProps } = useMulti({
     terms,
     collectionName: "Notifications",
     fragmentName: 'NotificationsList',
     limit: 20,
+    itemsPerPage: 100,
     enableTotal: false
   });
   const [lastNotificationsCheck] = useState(
@@ -52,7 +55,7 @@ const NotificationsList = ({ terms, currentUser, classes }: {
     return (
       <List className={classes.root}>
         {results.map(notification =>
-          <Components.NotificationsItem
+          <NotificationsItem
             notification={notification}
             lastNotificationsCheck={lastNotificationsCheck}
             currentUser={currentUser}
@@ -61,17 +64,17 @@ const NotificationsList = ({ terms, currentUser, classes }: {
         )}
         {results.length >= 20 &&
           <ListItem
-            button={true}
             className={classes.loadMoreButton}
           >
-            <Link to={"/notifications"} className={classes.loadMoreLabel}>
+            <LoadMore {...loadMoreProps}/>
+            <Link to={"/notifications"} className={classes.seeAllLabel}>
               {preferredHeadingCase("View All")}
             </Link>
           </ListItem>}
       </List>
     )
   } else if (loading) {
-    return <Components.Loading/>
+    return <Loading/>
   } else {
     const modifier =
         (terms.type === undefined) ? (<></>)

--- a/packages/lesswrong/components/notifications/NotificationsPage.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { useTracking } from "../../lib/analyticsEvents";
+import { useCurrentUser } from '../common/withUser';
+import { useUnreadNotifications } from '../hooks/useUnreadNotifications';
+import Badge from '@material-ui/core/Badge';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import ClearIcon from '@material-ui/icons/Clear';
+import PostsIcon from '@material-ui/icons/Description';
+import CommentsIcon from '@material-ui/icons/ModeComment';
+import MailIcon from '@material-ui/icons/Mail';
+import { useMulti } from '../../lib/crud/withMulti';
+import { renderMessage } from './NotificationsItem';
+import { getNotificationTypeByName } from '../../lib/notificationTypes';
+
+
+const styles = (theme: ThemeType): JssStyles => ({
+  notification: {
+    marginBottom: 24,
+  },
+  message: {
+    marginTop: 8,
+    marginRight: 24,
+    ...theme.typography.commentStyle,
+    display: "flex",
+    alignItems: "center",
+    color: theme.palette.grey[600],
+    '& svg': {
+      fontSize: 16,
+      marginLeft: '4px !important',
+      opacity: .5
+    }
+  },
+  notificationPreview: {
+    width: 400
+  }
+});
+
+export const NotificationsPage = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
+  const { NotificationsList, NotificationsPreview, ErrorAccessDenied, SingleColumnSection, SectionTitle } = Components
+  const currentUser = useCurrentUser();
+  const { unreadNotifications, unreadPrivateMessages, notificationsOpened } = useUnreadNotifications();
+  const [tab,setTab] = useState(0);
+  const [lastNotificationsCheck] = useState(
+    ((currentUser?.lastNotificationsCheck) || ""),
+  );
+  const notificationCategoryTabs: Array<{ name: string, icon: ()=>React.ReactNode, terms: NotificationsViewTerms }> = [
+    {
+      name: "All Notifications",
+      icon: () => (<Components.ForumIcon icon="Bell" className={classes.icon}/>),
+      terms: {view: "userNotifications"},
+    },
+    {
+      name: "New Posts",
+      icon: () => (<PostsIcon classes={{root: classes.icon}}/>),
+      terms: {view: 'userNotifications', type: "newPost"},
+    },
+    {
+      name: "New Comments",
+      icon: () => (<CommentsIcon classes={{root: classes.icon}}/>),
+      terms: {view: 'userNotifications', type: "newComment"},
+    },
+    {
+      name: "New Messages",
+      icon: () => (
+        <Badge
+          classes={{ root: classes.badgeContainer, badge: classes.badge }}
+          badgeContent={unreadPrivateMessages>0 ? `${unreadPrivateMessages}` : ""}
+        >
+          <MailIcon classes={{root: classes.icon}} />
+        </Badge>
+      ),
+      terms: {view: 'userNotifications', type: "newMessage"},
+    }
+  ];
+  const category = notificationCategoryTabs[tab];
+  const notificationTerms = category.terms;
+
+  if (!currentUser) { return <ErrorAccessDenied /> }
+
+  const { results, loading, loadMore } = useMulti({
+    terms: {...notificationTerms, userId: currentUser._id},
+    collectionName: "Notifications",
+    fragmentName: 'NotificationsList',
+    limit: 20,
+    enableTotal: false
+  });
+
+  return <div className={classes.root}>
+    <SingleColumnSection>
+      <SectionTitle title="Notifications">
+
+      </SectionTitle>
+      {results?.map((notification) => <div className={classes.notification} key={notification._id} >
+        <div className={classes.message}>
+          {getNotificationTypeByName(notification.type).getIcon()}
+          {renderMessage(notification)}
+        </div>
+        <div className={classes.notificationPreview}>
+          <NotificationsPreview notification={notification} currentUser={currentUser} lastNotificationsCheck={lastNotificationsCheck}/>
+          </div>
+        </div>)}
+    </SingleColumnSection>
+  </div>;
+}
+
+const NotificationsPageComponent = registerComponent('NotificationsPage', NotificationsPage, {styles});
+
+declare global {
+  interface ComponentTypes {
+    NotificationsPage: typeof NotificationsPageComponent
+  }
+}

--- a/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
@@ -1,0 +1,60 @@
+// TODO: Import component in components.ts
+import React, { useState } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { getNotificationTypeByName } from '../../lib/notificationTypes';
+import { renderMessage } from './NotificationsItem';
+import { commentBodyStyles } from '../../themes/stylePiping';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    width: 440,
+    marginBottom: 24,
+  },
+  message: {
+    marginTop: 8,
+    marginRight: 24,
+    cursor: "pointer",
+    ...commentBodyStyles(theme),
+    display: "flex",
+    alignItems: "center",
+    color: theme.palette.grey[600],
+    '& svg': {
+      fontSize: 16,
+      marginLeft: '4px !important',
+      opacity: .5
+    }
+  },
+  notificationPreview: {
+    marginLeft: 40
+  }
+});
+
+export const NotificationsPageItem = ({classes, notification, currentUser}: {
+  notification: NotificationsList,
+  currentUser: UsersCurrent,
+  classes: ClassesType
+}) => {
+  const { NotificationsPreview } = Components
+  const [lastNotificationsCheck] = useState(
+    ((currentUser?.lastNotificationsCheck) || ""),
+  );
+
+  if (!currentUser) return null
+  return <div className={classes.root} key={notification._id} >
+    <div className={classes.message}>
+      {getNotificationTypeByName(notification.type).getIcon()}
+      {renderMessage(notification)}
+    </div>
+    <div className={classes.notificationPreview}>
+      <NotificationsPreview notification={notification} currentUser={currentUser} lastNotificationsCheck={lastNotificationsCheck}/>
+    </div>
+  </div>;
+}
+
+const NotificationsPageItemComponent = registerComponent('NotificationsPageItem', NotificationsPageItem, {styles});
+
+declare global {
+  interface ComponentTypes {
+    NotificationsPageItem: typeof NotificationsPageItemComponent
+  }
+}

--- a/packages/lesswrong/components/notifications/NotificationsPreview.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPreview.tsx
@@ -34,6 +34,8 @@ export const NotificationsPreview = ({classes, currentUser, notification, lastNo
 
   const parsedPath = parseRouteWithErrors(notificationLink)
 
+  if (!currentUser) return null
+
   if (notificationType.onsiteHoverView) {
     return <Card>
       {notificationType.onsiteHoverView({notification})}

--- a/packages/lesswrong/components/notifications/NotificationsPreview.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPreview.tsx
@@ -1,0 +1,69 @@
+// TODO: Import component in components.ts
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { useTracking } from "../../lib/analyticsEvents";
+import Card from '@material-ui/core/Card';
+import { parseRouteWithErrors } from '../linkPreview/HoverPreviewLink';
+import { getNotificationTypeByName } from '../../lib/notificationTypes';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+
+  }
+});
+
+export const NotificationsPreview = ({classes, currentUser, notification, lastNotificationsCheck}: {
+  classes: ClassesType,
+  currentUser: UsersCurrent,
+  notification: NotificationsList,
+  lastNotificationsCheck: any,
+}) => {
+  const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
+  const { PostsPreviewTooltipSingle, TaggedPostTooltipSingle, PostsPreviewTooltipSingleWithComment, ConversationPreview, PostNominatedNotification } = Components
+
+  const notificationType = getNotificationTypeByName(notification.type);
+
+  const notificationLink = (notificationType.getLink
+    ? notificationType.getLink({
+      documentType: notification.documentType,
+      documentId: notification.documentId,
+      extraData: notification.extraData,
+    })
+    : notification.link
+  );
+
+  const parsedPath = parseRouteWithErrors(notificationLink)
+
+  if (notificationType.onsiteHoverView) {
+    return <Card>
+      {notificationType.onsiteHoverView({notification})}
+    </Card>
+  } else if (notification.type == "postNominated") {
+    return <Card><PostNominatedNotification postId={notification.documentId}/></Card>
+  } else {
+    switch (notification.documentType) {
+      case 'tagRel':
+        return  <Card><TaggedPostTooltipSingle tagRelId={notification.documentId} /></Card>
+      case 'post':
+        return <Card><PostsPreviewTooltipSingle postId={notification.documentId} /></Card>
+      case 'comment':
+        const postId = parsedPath?.params?._id
+        if (!postId) return null
+        return <Card><PostsPreviewTooltipSingleWithComment postId={parsedPath?.params?._id} commentId={notification.documentId} /></Card>
+      case 'message':
+        return <Card>
+          <ConversationPreview conversationId={parsedPath?.params?._id} currentUser={currentUser} />
+        </Card>
+      default:
+        return null
+    }
+  }
+}
+
+const NotificationsPreviewComponent = registerComponent('NotificationsPreview', NotificationsPreview, {styles});
+
+declare global {
+  interface ComponentTypes {
+    NotificationsPreview: typeof NotificationsPreviewComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -164,7 +164,9 @@ importComponent("newFeedButton", () => require('../components/feeds/newFeedButto
 //importComponent("editFeedButton", () => require('../components/feeds/editFeedButton'));
 
 importComponent("NotificationsMenu", () => require('../components/notifications/NotificationsMenu'));
+importComponent("NotificationsPage", () => require('../components/notifications/NotificationsPage'));
 importComponent("NotificationsList", () => require('../components/notifications/NotificationsList'));
+importComponent("NotificationsPreview", () => require('../components/notifications/NotificationsPreview'));
 importComponent("TagRelNotificationItem", () => require('../components/notifications/TagRelNotificationItem'));
 importComponent("NotificationsItem", () => require('../components/notifications/NotificationsItem'));
 importComponent("NotificationsMenuButton", () => require('../components/notifications/NotificationsMenuButton'));

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -167,6 +167,7 @@ importComponent("NotificationsMenu", () => require('../components/notifications/
 importComponent("NotificationsPage", () => require('../components/notifications/NotificationsPage'));
 importComponent("NotificationsList", () => require('../components/notifications/NotificationsList'));
 importComponent("NotificationsPreview", () => require('../components/notifications/NotificationsPreview'));
+importComponent("NotificationsPageItem", () => require('../components/notifications/NotificationsPageItem'));
 importComponent("TagRelNotificationItem", () => require('../components/notifications/TagRelNotificationItem'));
 importComponent("NotificationsItem", () => require('../components/notifications/NotificationsItem'));
 importComponent("NotificationsMenuButton", () => require('../components/notifications/NotificationsMenuButton'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1494,6 +1494,12 @@ addRoute(
     redirect: () => `/reviewVoting/${REVIEW_YEAR}`,
   },
   {
+    name: 'notifications',
+    path: '/notifications',
+    componentName: 'NotificationsPage',
+    title: "Notifications"
+  },
+  {
     name: 'userReviewsByYear',
     path:'/users/:slug/reviews/:year',
     componentName: 'UserReviews',


### PR DESCRIPTION
For awhile I've wanted a view where I just read all my notifications. I have some ideas for other things to do with this view if it's better optimized (some version of it could maybe replace Recent Discussion, although there's some tricksiness of figuring out what things to display).

I plan to group them by Day.

![](https://github.com/ForumMagnum/ForumMagnum/assets/3246710/a2d0829b-3e5d-4c1a-8ac5-7d043c3d7ec6)

![](https://github.com/ForumMagnum/ForumMagnum/assets/3246710/a7860c0f-dfc4-44cc-8508-38309d2cf21d)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205634807975538) by [Unito](https://www.unito.io)
