### PR TITLE
publishing requires confirmation for lw dialogues

### DIFF
--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { useCurrentUser } from "../common/withUser";
 import { useTracking } from "../../lib/analyticsEvents";
-import {forumTitleSetting, forumTypeSetting} from "../../lib/instanceSettings";
+import {forumTitleSetting, forumTypeSetting, isLW} from "../../lib/instanceSettings";
 import { forumSelect } from '../../lib/forumTypeUtils';
 
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -72,12 +72,26 @@ const PostSubmit = ({
   saveDraftLabel = "Save as draft",
   feedbackLabel = "Request Feedback",
   cancelCallback, document, collectionName, classes
-}: PostSubmitProps, { updateCurrentValues, addToSuccessForm }: any) => {
+}: PostSubmitProps, { updateCurrentValues, addToSuccessForm, submitForm }: any) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking();
   if (!currentUser) throw Error("must be logged in to post")
 
   const { LWTooltip } = Components;
+
+  const submitWithConfirmation = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (confirm('Warning!  This will publish your dialogue and make it visible to other users.')) {
+      collectionName === "Posts" && await updateCurrentValues({draft: false});
+      await submitForm();
+    }
+  };
+
+  const submitWithoutConfirmation = () => collectionName === "Posts" && updateCurrentValues({draft: false});
+
+  const requireConfirmation = isLW && collectionName === 'Posts' && !!document.debate;
+
+  const onSubmitClick = requireConfirmation ? submitWithConfirmation : submitWithoutConfirmation;
 
   return (
     <React.Fragment>
@@ -127,7 +141,7 @@ const PostSubmit = ({
         </Button>
         <Button
           type="submit"
-          onClick={() => collectionName === "Posts" && updateCurrentValues({draft: false})}
+          onClick={onSubmitClick}
           className={classNames("primary-form-submit-button", classes.formButton, classes.submitButton)}
           {...(isEAForum ? {
             variant: "contained",
@@ -154,6 +168,7 @@ PostSubmit.contextTypes = {
   updateCurrentValues: PropTypes.func,
   addToSuccessForm: PropTypes.func,
   addToSubmitForm: PropTypes.func,
+  submitForm: PropTypes.func
 }
 
 


### PR DESCRIPTION
We've had a couple experiences where people have accidentally published dialogues without meaning to.  Interpose a confirmation modal for dialogues (forum-gated to LessWrong) to make this less likely to happen.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205635740868647) by [Unito](https://www.unito.io)
