### PR TITLE
[EA Forum only] add 1 post/day rate limit for low karma users

### DIFF
--- a/packages/lesswrong/components/editor/RateLimitWarning.tsx
+++ b/packages/lesswrong/components/editor/RateLimitWarning.tsx
@@ -55,7 +55,7 @@ const RateLimitWarning = ({lastRateLimitExpiry, rateLimitMessage, classes}: {
 
   let message = `<p>You can post again in ${getTimeUntilNextPost()}.</p> ${rateLimitMessage ?? ''}`
   if (isEAForum) {
-    message = `You've written more than 3 comments in the last 30 minutes. Please wait ${getTimeUntilNextPost()} before commenting again. ${rateLimitMessage ?? ''}`
+    message = `${rateLimitMessage ?? ''} Please wait ${getTimeUntilNextPost()} before posting again.`
   }
 
   if (isEAForum) {

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -23,19 +23,25 @@ const timeframe = <A extends AutoRateLimit['actionType']>(timeframeString: Timef
 
 const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   POSTS: [
+    {
+      ...timeframe('1 Posts per 1 days'),
+      karmaThreshold: 49,
+      rateLimitType: "newUserDefault",
+      rateLimitMessage: `Users with less than 50 karma can publish up to 1 post a day.`
+    },
   ],
   COMMENTS: [
     {
       ...timeframe('4 Comments per 30 minutes'),
       karmaThreshold: 30,
       rateLimitType: "lowKarma",
-      rateLimitMessage: "You'll be able to post more comments as your karma increases.",
+      rateLimitMessage: "You've written more than 3 comments in the last 30 minutes. You'll be able to post more comments as your karma increases.",
       appliesToOwnPosts: true
     }, {
       ...timeframe('4 Comments per 30 minutes'),
       downvoteRatioThreshold: .3,
       rateLimitType: "downvoteRatio",
-      rateLimitMessage: "",
+      rateLimitMessage: "You've written more than 3 comments in the last 30 minutes.",
       appliesToOwnPosts: true
     },
   ]
@@ -181,7 +187,8 @@ const ALL = {
 
 export const autoPostRateLimits: ForumOptions<PostAutoRateLimit[]> = {
   EAForum: [
-    ALL.POSTS.FIVE_PER_DAY
+    ALL.POSTS.FIVE_PER_DAY,
+    ...EA.POSTS,
   ],
   LessWrong: [ 
     ...LW.POSTS,


### PR DESCRIPTION
This PR adds a 1 post/day rate limit for users with <50 karma on the EA Forum. Also slightly updates the messaging for rate limits.New:
![](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/aadd9b70-8cb7-46fd-a2bf-6163a63231ce)<hr />Existing commenting rate limit, updated copy:
![](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/1b948169-414d-4bfe-9286-575430c96125)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205642777548404) by [Unito](https://www.unito.io)
