### PR TITLE
Fix an issue where getUnusedSlug can be very slow if there are many posts with the same slug-prefix

### DIFF
--- a/packages/lesswrong/lib/random.ts
+++ b/packages/lesswrong/lib/random.ts
@@ -13,9 +13,9 @@ export const ID_LENGTH = 17;
 // A random 17-digit string, using characters that are hard to confuse with each
 // other. If run on the server, cryptographically secure; if run on the client,
 // not.
-export const randomId = () => {
+export const randomId = (length=ID_LENGTH) => {
   if (bundleIsServer) {
-    const bytes = crypto.randomBytes(ID_LENGTH);
+    const bytes = crypto.randomBytes(length);
     const result: Array<string> = [];
     for (let byte of bytes) {
       // Discards part of each byte and has modulo bias. Doesn't matter in
@@ -25,7 +25,7 @@ export const randomId = () => {
     return result.join('');
   } else {
     const result: Array<string> = [];
-    for (let i=0; i<ID_LENGTH; i++)
+    for (let i=0; i<length; i++)
       result.push(unmistakableChars[randInt(unmistakableChars.length)]);
     return result.join('');
   }


### PR DESCRIPTION
Fun fact: If you create a post named "Test" in the dev DB (on a development laptop with slowish round trip time to the database), it takes over a minute, because it's checking whether slugs `test-1`, `test-2`, `test-3`, ... `test-300` are taken.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205645380841975) by [Unito](https://www.unito.io)
