### PR TITLE
Skip mirroring images with invalid URLs

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -88,11 +88,15 @@ function getImageUrlWhitelist() {
 }
 
 function urlNeedsMirroring(url: string, filterFn: (url: string) => boolean) {
-  const parsedUrl = new URL(url);
-  if (getImageUrlWhitelist().indexOf(parsedUrl.hostname) !== -1) {
+  try {
+    const parsedUrl = new URL(url);
+    if (getImageUrlWhitelist().indexOf(parsedUrl.hostname) !== -1) {
+      return false;
+    }
+    return filterFn(url);
+  } catch (e) {
     return false;
   }
-  return filterFn(url);
 }
 
 async function convertImagesInHTML(html: string, originDocumentId: string, urlFilterFn: (url: string) => boolean = () => true): Promise<{count: number, html: string}> {


### PR DESCRIPTION
We've had a lot of reports over the last couple of days of users having errors when creating posts, and this leading to posts being created multiple times due to re-clicking "Submit". I've still not been able to replicate the error, but the stack traces say it's a "TypeError: Invalid URL" error happening at `new URL` in `urlNeedsMirroring`. This can happen for anything that isn's a valid URL like `null` or `undefined` or `www.google.com` (without "https://"). The safest thing to do seems to just be to catch the error and continue in this situation - the worst thing that can happen is that a valid URL doesn't get mirrored, but if this happens then the URL probably isn't valid anyway.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205648580044189) by [Unito](https://www.unito.io)
