### PR TITLE
Fix ea recent discussions truncation

### DIFF
--- a/packages/lesswrong/components/common/excerpts/ContentExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/ContentExcerpt.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { Link } from "../../../lib/reactRouterWrapper";
 import type { ContentStyleType } from "../ContentStyles";
 import classNames from "classnames";
+import { truncate } from "../../../lib/editor/ellipsize";
 
 const HTML_CHARS_PER_LINE_HEURISTIC = 120;
 const EXPAND_IN_PLACE_LINES = 10;
@@ -18,16 +19,11 @@ const contentTypeMap: Record<ContentStyleType, string> = {
 };
 
 const styles = (theme: ThemeType) => ({
-  root: {
-  },
+  root: {},
   excerpt: {
     position: "relative",
     fontSize: "1.1rem",
     lineHeight: "1.5em",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    display: "-webkit-box",
-    "-webkit-box-orient": "vertical",
   },
   content: {
     "& h1": {fontSize: "16px !important"},
@@ -77,6 +73,16 @@ const ContentExcerpt = ({
   const expandInPlace = alwaysExpandInPlace ||
     contentHtml.length < HTML_CHARS_PER_LINE_HEURISTIC * EXPAND_IN_PLACE_LINES;
 
+  // We use `truncate` here rather than webkit-box overflow shenanigans
+  // because of bugs in certain versions of ios safari
+  const truncatedHtml = truncate(
+    contentHtml,
+    lines * HTML_CHARS_PER_LINE_HEURISTIC,
+    "characters",
+    "...",
+    false,
+  );
+
   const {ContentStyles, ContentItemBody} = Components;
   return (
     <div className={classNames(classes.root, className)}>
@@ -86,7 +92,7 @@ const ContentExcerpt = ({
         style={expanded ? undefined : {WebkitLineClamp: lines}}
       >
         <ContentItemBody
-          dangerouslySetInnerHTML={{__html: contentHtml}}
+          dangerouslySetInnerHTML={{__html: truncatedHtml}}
           className={classes.content}
         />
       </ContentStyles>

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -23,6 +23,7 @@ export const truncate = (
   truncateLength: number,
   truncateBy?: "words" | "characters" | "paragraphs",
   suffix?: string,
+  allowTruncationMidWord?: boolean,
 ) => {
   const newTruncateBy = truncateBy || "characters"
   const newSuffix = (suffix !== undefined) ? suffix : "..."
@@ -35,6 +36,7 @@ export const truncate = (
     TruncateLength: Math.floor(truncateLength - (truncateLength/4)) || truncateLength,
     TruncateBy: newTruncateBy,
     Suffix: `${newSuffix}`,
+    Strict: allowTruncationMidWord ?? true,
   });
   return styles + truncatedHtml;
 }

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -23,7 +23,7 @@ export const truncate = (
   truncateLength: number,
   truncateBy?: "words" | "characters" | "paragraphs",
   suffix?: string,
-  allowTruncationMidWord?: boolean,
+  allowTruncationMidWord = true,
 ) => {
   const newTruncateBy = truncateBy || "characters"
   const newSuffix = (suffix !== undefined) ? suffix : "..."
@@ -36,7 +36,7 @@ export const truncate = (
     TruncateLength: Math.floor(truncateLength - (truncateLength/4)) || truncateLength,
     TruncateBy: newTruncateBy,
     Suffix: `${newSuffix}`,
-    Strict: allowTruncationMidWord ?? true,
+    Strict: allowTruncationMidWord,
   });
   return styles + truncatedHtml;
 }

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -18,7 +18,12 @@ export const highlightFromHTML = (html: string): string => {
   });
 };
 
-export const truncate = (html: string|null|undefined, truncateLength: number, truncateBy?: string, suffix?: string) => {
+export const truncate = (
+  html: string|null|undefined,
+  truncateLength: number,
+  truncateBy?: "words" | "characters" | "paragraphs",
+  suffix?: string,
+) => {
   const newTruncateBy = truncateBy || "characters"
   const newSuffix = (suffix !== undefined) ? suffix : "..."
 


### PR DESCRIPTION
The new EA recent discussions section is broken on some versions of ios because safari is terrible:

![image](https://github.com/ForumMagnum/ForumMagnum/assets/5075628/e82c0b97-3355-40a5-a508-499d95ee8cde)

I don't actually have an affected device to test on, but this _should_ fix it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205650438705574) by [Unito](https://www.unito.io)
