### PR TITLE
Allow sunshineRegiment users to create user rate limits

### DIFF
--- a/packages/lesswrong/lib/collections/userRateLimits/index.ts
+++ b/packages/lesswrong/lib/collections/userRateLimits/index.ts
@@ -2,3 +2,4 @@ export * from  './collection';
 import './fragments';
 import './views';
 import './helpers';
+import './permissions';

--- a/packages/lesswrong/lib/collections/userRateLimits/permissions.ts
+++ b/packages/lesswrong/lib/collections/userRateLimits/permissions.ts
@@ -1,0 +1,10 @@
+import { adminsGroup } from "../../vulcan-users";
+import { sunshineRegimentGroup } from "../../permissions";
+
+const actions = [
+  "userratelimits.new",
+  "userratelimits.edit.all",
+];
+
+adminsGroup.can(actions);
+sunshineRegimentGroup.can(actions);


### PR DESCRIPTION
Currently, only admins can create user rate limits - this PR also gives this power to sunshine regiment members.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205650700567755) by [Unito](https://www.unito.io)
