### PR TITLE
Order EA emoji users by date

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -154,13 +154,13 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
             "commentId",
             "key",
             (ARRAY_AGG(
-              "displayName" ORDER BY COALESCE("karma", 0) DESC)
+              "displayName" ORDER BY "createdAt" ASC)
             ) AS "displayNames"
           FROM (
             SELECT
               c."_id" AS "commentId",
               u."displayName",
-              u."karma",
+              v."createdAt",
               (JSONB_EACH(v."extendedVoteType")).*
             FROM "Comments" c
             JOIN "Votes" v ON

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -107,12 +107,12 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
         SELECT
           "key",
           (ARRAY_AGG(
-            "displayName" ORDER BY COALESCE("karma", 0) DESC)
+            "displayName" ORDER BY "createdAt" ASC)
           ) AS "displayNames"
         FROM (
           SELECT
             u."displayName",
-            u."karma",
+            v."createdAt",
             (JSONB_EACH(v."extendedVoteType")).*
           FROM "Votes" v
           JOIN "Users" u ON u."_id" = v."userId"


### PR DESCRIPTION
Hovering over EA emojis currently shows the users who selected that emoji ordered by the amount of karma they have from most to least. This PR changes this to instead order them by the date they added the emoji from oldest to newest.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205651707912184) by [Unito](https://www.unito.io)
