### PR TITLE
Show coauthored posts in 'more from the author' recommendations

### DIFF
--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -4,7 +4,7 @@ import { Link } from "../../lib/reactRouterWrapper";
 import { userGetProfileUrl } from "../../lib/collections/users/helpers";
 import { useRecentOpportunities } from "../hooks/useRecentOpportunities";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
-import { useMulti } from "../../lib/crud/withMulti";
+import { useRecommendations } from "./withRecommendations";
 import { usePaginatedResolver } from "../hooks/usePaginatedResolver";
 import { MAX_CONTENT_WIDTH } from "../posts/TableOfContents/ToCColumn";
 
@@ -42,17 +42,16 @@ const PostBottomRecommendations = ({post, classes}: {
   classes: ClassesType,
 }) => {
   const {
-    results: moreFromAuthorPosts,
-    loading: moreFromAuthorLoading,
-  } = useMulti({
-    collectionName: "Posts",
-    fragmentName: "PostsListWithVotes",
-    terms: {
-      userId: post.userId,
-      notPostIds: [post._id],
-      sortedBy: "topAdjusted",
-      limit: 3,
+    recommendationsLoading: moreFromAuthorLoading,
+    recommendations: moreFromAuthorPosts,
+  } = useRecommendations({
+    strategy: {
+      name: "moreFromAuthor",
+      postId: post._id,
+      context: "post-footer",
     },
+    count: 3,
+    disableFallbacks: true,
   });
 
   const {

--- a/packages/lesswrong/server/recommendations/MoreFromAuthorStrategy.ts
+++ b/packages/lesswrong/server/recommendations/MoreFromAuthorStrategy.ts
@@ -24,7 +24,10 @@ class MoreFromAuthorStrategy extends RecommendationStrategy {
       WHERE
         ${postFilter.filter}
         p."_id" <> $(postId) AND
-        (p."userId" = src."userId" OR coauthor."status"->>'userId' = src."userId")
+        (p."userId" = src."userId" OR (
+          coauthor."status"->>'userId' = src."userId" AND
+          (coauthor."status"->'confirmed' = TO_JSONB(TRUE) OR p."hasCoauthorPermission")
+        ))
       ORDER BY coauthor."status"->>'userId' = src."userId" DESC, p."score" DESC
       LIMIT $(count)
     `, {

--- a/packages/lesswrong/server/recommendations/MoreFromAuthorStrategy.ts
+++ b/packages/lesswrong/server/recommendations/MoreFromAuthorStrategy.ts
@@ -1,21 +1,37 @@
 import RecommendationStrategy, { RecommendationResult } from "./RecommendationStrategy";
 import type { StrategySpecification } from "../../lib/collections/users/recommendationSettings";
+import { getSqlClientOrThrow } from "../../lib/sql/sqlClient";
 
 /**
  * A recommendation strategy that returns more posts by the same author.
  */
 class MoreFromAuthorStrategy extends RecommendationStrategy {
   async recommend(
-    currentUser: DbUser|null,
+    _currentUser: DbUser|null,
     count: number,
     {postId}: StrategySpecification,
   ): Promise<RecommendationResult> {
-    const posts = await this.recommendDefaultWithPostFilter(
-      currentUser,
-      count,
+    const db = getSqlClientOrThrow();
+    const postFilter = this.getDefaultPostFilter();
+    const posts = await db.any(`
+      SELECT p.*
+      FROM "Posts" p
+      JOIN "Posts" src ON src."_id" = $(postId)
+      LEFT JOIN LATERAL (
+        SELECT UNNEST(p."coauthorStatuses") "status"
+      ) coauthor ON TRUE
+      ${postFilter.join}
+      WHERE
+        ${postFilter.filter}
+        p."_id" <> $(postId) AND
+        (p."userId" = src."userId" OR coauthor."status"->>'userId' = src."userId")
+      ORDER BY coauthor."status"->>'userId' = src."userId" DESC, p."score" DESC
+      LIMIT $(count)
+    `, {
       postId,
-      `p."userId" = (SELECT "userId" FROM "Posts" WHERE "_id" = $(postId))`,
-    );
+      count,
+      ...postFilter.args,
+    });
     return {posts, settings: {postId}};
   };
 }


### PR DESCRIPTION
Adds coauthored posts to the "more from the author" recommendations section under posts. Coauthored posts are shown below posts where the user is the main author.

<img width="777" alt="Screenshot 2023-10-05 at 13 17 44" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/969077fc-3e0e-4cf1-8f99-038f926989d8">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205657959292808) by [Unito](https://www.unito.io)
