### PR TITLE
Dialogue Notifications for Subscribed to Dialogue Folks

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2566,7 +2566,7 @@ const schema: SchemaType<DbPost> = {
     canRead: ['guests'],
     resolver: async (post, _, context) => {
       if (!post.debate) return 0;
-      return context.repos.posts.getDialogueResponseCount(post)
+      return context.repos.posts.getDialogueResponseIds(post).length
     } 
   }),
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -223,7 +223,7 @@ getCollectionHooks("Posts").updateAsync.add(async function eventUpdatedNotificat
   }
 });
 
-getCollectionHooks("Posts").editAsync.add(async function newDialogueSubscribersNotification ({document: newPost, oldDocument: oldPost}: {document: DbPost, oldDocument: DbPost}) {
+getCollectionHooks("Posts").editAsync.add(async function newPublisedDialogueMessageNotification (newPost: DbPost, oldPost: DbPost) {
   if (newPost.debate) {
   
     const postsRepo = new PostsRepo()
@@ -244,13 +244,11 @@ getCollectionHooks("Posts").editAsync.add(async function newDialogueSubscribersN
 
     const debateSubscriberIds = debateSubscribers.map(sub => sub._id);
     const debateSubscriberIdsToNotify = _.difference(debateSubscriberIds, debateParticipantIds);
-    await createNotifications({ userIds: debateSubscriberIdsToNotify, notificationType: 'newPublishedDebateMessage', documentType: 'post', documentId: newPost._id });
+    await createNotifications({ userIds: debateSubscriberIdsToNotify, notificationType: 'newPublishedDialogueMessage', documentType: 'post', documentId: newPost._id });
 
     // Handle debate participants
     // const subscribedParticipantIds = _.intersection(debateSubscriberIds, debateParticipantIds);
     // await createNotifications({ userIds: subscribedParticipantIds, notificationType: 'newDebateReply', documentType: 'post', documentId: newPost._id });
-    
-
   }
 };
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -249,9 +249,6 @@ getCollectionHooks("Posts").editAsync.add(async function newDialogueSubscribersN
     // Handle debate participants
     // const subscribedParticipantIds = _.intersection(debateSubscriberIds, debateParticipantIds);
     // await createNotifications({ userIds: subscribedParticipantIds, notificationType: 'newDebateReply', documentType: 'post', documentId: newPost._id });
-
-    // Avoid notifying users who are subscribed to both the debate comments and regular comments on a debate twice 
-    notifiedUsers = [...notifiedUsers, ...debateSubscriberIdsToNotify, ...subscribedParticipantIds];
     
 
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -349,14 +349,14 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
     return count;
   }
 
-  getDialogueResponseCount = (post:DbPost) => {
+  getDialogueResponseIds = (post:DbPost) => {
     const html = post.contents.originalContents.data;
     const parsedHtml= cheerioParse(html);
     
     const blocksWithId = parsedHtml('block[message-id]');
     const ids : string[] = blocksWithId.map( (i, block) => parsedHtml(block).attr('message-id')).get();
     
-    return ids.length;
+    return ids;
   }
 
   getDialogueMessageTimestamps = (post: DbPost): Date[] => {


### PR DESCRIPTION
This switches over dialogue notifications to use new ckEditor-based implementation instead of comments.

Limits this set of notifications to subscribed readers (not coauthors) as readers only get upon publication.

Determines that new responses have been made by comparing `message-id`'s between old and new revision.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205662344912875) by [Unito](https://www.unito.io)
