### PR TITLE
Fix post-resync refresh after using the Resync RSS button

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/ResyncRssDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/ResyncRssDropdownItem.tsx
@@ -94,6 +94,7 @@ const ResyncRssDialog = ({onClose, post, classes}: {
   const { mutate: updatePost } = useUpdate({
     collectionName: "Posts",
     fragmentName: "PostsEdit",
+    skipCacheUpdate: true,
   });
   const [isSaving, setIsSaving] = useState(false);
   

--- a/packages/lesswrong/lib/crud/withUpdate.tsx
+++ b/packages/lesswrong/lib/crud/withUpdate.tsx
@@ -134,6 +134,6 @@ export const useUpdate = <CollectionName extends CollectionNameString>(options: 
       variables: { selector, data, ...extraVariables },
       update: options.skipCacheUpdate ? undefined : updateCacheAfterUpdate(typeName)
     })
-  }, [mutate, typeName]);
+  }, [mutate, typeName, options.skipCacheUpdate]);
   return {mutate: wrappedMutate, loading, error, called, data};
 }

--- a/packages/lesswrong/lib/crud/withUpdate.tsx
+++ b/packages/lesswrong/lib/crud/withUpdate.tsx
@@ -106,6 +106,7 @@ type FragmentOrFragmentName =
  */
 export const useUpdate = <CollectionName extends CollectionNameString>(options: FragmentOrFragmentName & {
   collectionName: CollectionName,
+  skipCacheUpdate?: boolean,
 }): {
   /** Set a field to `null` to delete it */
   mutate: WithUpdateFunction<CollectionBase<ObjectsByCollectionName[CollectionName]>>,
@@ -131,7 +132,7 @@ export const useUpdate = <CollectionName extends CollectionNameString>(options: 
   }) => {
     return mutate({
       variables: { selector, data, ...extraVariables },
-      update: updateCacheAfterUpdate(typeName)
+      update: options.skipCacheUpdate ? undefined : updateCacheAfterUpdate(typeName)
     })
   }, [mutate, typeName]);
   return {mutate: wrappedMutate, loading, error, called, data};


### PR DESCRIPTION
For reasons I'm not entirely clear on, after submitting the Resync RSS form (which does a `useUpdate`) and doing the client-side cache updates, an exception would get thrown from Apollo internals. Turn off the client-side cache update in this case, since we're going to refetch everything anyways.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205663790729794) by [Unito](https://www.unito.io)
