### PR TITLE
Switch Twitter link-card style

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -57,8 +57,15 @@ const HeadTags = ({
           <meta name='description' content={description}/>
           <meta name='viewport' content='width=device-width, initial-scale=1'/>
 
-          {/* twitter */}
-          <meta name='twitter:card' content={useSmallImage ? 'summary' : 'summary_large_image'}/>
+          {/* Twitter link-card
+           * Note 2023-10-05: Twitter's "summary_large_image" card currently shows only
+           * an image with no title/description/etc, so we only ever use "summary". Before
+           * Twitter made this change, we switched between "summary" and "summary_large_image"
+           * based on the `useSmallImage` prop. Twitter is getting backlash about this, so
+           * they might revert (in which case we might also revert).
+           * See: https://news.ycombinator.com/item?id=37782945
+           */}
+          <meta name='twitter:card' content={'summary'}/>
           {image && <meta name='twitter:image:src' content={image}/>}
           { /* <meta name='twitter:title' content={title}/> */ }
           <meta name='twitter:description' content={description}/>


### PR DESCRIPTION
Twitter's "summary_large_image" card currently shows only an image with no title/description/etc, so we only ever use "summary". Before Twitter made this change, we switched between "summary" and "summary_large_image" based on the `useSmallImage` prop. Twitter is getting backlash about this, so they might revert (in which case we might also revert).

See: https://news.ycombinator.com/item?id=37782945

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205664146372173) by [Unito](https://www.unito.io)
