### PR TITLE
Only send dialogue notifications if you haven't checked your previous dialogue notifications

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -231,10 +231,10 @@ export async function notifyDialogueParticipantsNewMessage(newMessageAuthorId: s
 
   const notifications = await Notifications.find({userId: {$in: debateParticipantIds}, documentId: post._id, documentType: 'post', type: 'newDialogueMessages', createdAt: {$gt: earliestLastNotificationsCheck }}).fetch();
 
-  // Only notify users who haven't checked their notifications since the last message was posted. For each user, compare their lastNotificationsCheck to the notifications with their userId.
+  // Only notify users who haven't checked their notifications since the last message was posted.
   const userIdsToNotify = debateParticipants.filter(user => {
     const userNotifications = notifications.filter(notification => notification.userId === user._id);
-    const userLastNotificationCreatedAt = _.max(userNotifications.map(notification => notification.createdAt));
+    const userLastNotificationCreatedAt = _.max([...userNotifications.map(notification => notification.createdAt), post.createdAt]);
     return moment(userLastNotificationCreatedAt).isBefore(moment(user.lastNotificationsCheck));
   }).map(user => user._id);
 


### PR DESCRIPTION
Previously, if someone made a ton of dialogue responses, they would all show up as notifications for the collaborators in the dialogue (i.e you might get like 50 notifications). This makes it so you only get at most one notification until you check your notifications again.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205671835070464) by [Unito](https://www.unito.io)
