### PR TITLE
don't reupload images if a post's html hasn't changed

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -341,7 +341,12 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
    * See: https://app.asana.com/0/628521446211730/1203311932993130/f
    * It's fine to leave it here just in case though
    */
-  getCollectionHooks(collectionName).editAsync.add(async (doc: DbObject) => {
+  getCollectionHooks(collectionName).editAsync.add(async (doc: DbObject, oldDoc: DbObject) => {
+    const isPostContentsContext = collectionName === 'Posts' && fieldName === 'contents';
+    const hasChanged = (oldDoc as DbPost).contents?.html !== (doc as DbPost).contents?.html;
+    
+    if (isPostContentsContext && !hasChanged) return;
+    
     await Globals.convertImagesInObject(collectionName, doc._id, fieldName);
   })
   getCollectionHooks(collectionName).newAsync.add(async (doc: DbObject) => {

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -343,10 +343,10 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
    */
   getCollectionHooks(collectionName).editAsync.add(async (doc: DbObject, oldDoc: DbObject) => {
     const isPostContentsContext = collectionName === 'Posts' && fieldName === 'contents';
-    const hasChanged = (oldDoc as DbPost).contents?.html !== (doc as DbPost).contents?.html;
+    const hasChanged = (oldDoc as DbPost)?.contents?.html !== (doc as DbPost)?.contents?.html;
     
     if (isPostContentsContext && !hasChanged) return;
-    
+
     await Globals.convertImagesInObject(collectionName, doc._id, fieldName);
   })
   getCollectionHooks(collectionName).newAsync.add(async (doc: DbObject) => {


### PR DESCRIPTION
We're calling out to `convertImagesInObject` for pretty much all post mutations, including `lastCommentedAt` being updated (which happens whenever a user comments).  Local motivation is that this was interacting badly with a separate bug which caused images to break, but let's not do that for no reason anyways.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205672400037309) by [Unito](https://www.unito.io)
