### PR TITLE
Strongly type props for `AnalyticsContext`

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsList.tsx
+++ b/packages/lesswrong/components/posts/AllPostsList.tsx
@@ -72,7 +72,7 @@ const AllPostsList = ({
     return (
       <AnalyticsContext
         listContext={"allPostsPage"}
-        terms={{view: "allTime", ...baseTerms}}
+        terms={{view: "allTime" as PostsViewName, ...baseTerms}}
       >
         <PostsList2
           terms={{

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -1,12 +1,12 @@
 import { addGraphQLSchema } from './vulcan-lib/graphql';
 import { RateLimiter } from './rateLimiter';
-import React, { useContext, useEffect, useState, useRef, useCallback } from 'react'
+import React, { useContext, useEffect, useState, useRef, useCallback, ReactNode } from 'react'
 import { hookToHoc } from './hocUtils'
 import { isClient, isServer, isDevelopment, isAnyTest } from './executionEnvironment';
 import { ColorHash } from './vendor/colorHash';
 import { DatabasePublicSetting } from './publicSettings';
 import { getPublicSettingsLoaded } from './settingsCache';
-import * as _ from 'underscore';
+import { throttle } from 'underscore';
 import moment from 'moment';
 import { Globals } from './vulcan-lib/config';
 
@@ -102,11 +102,13 @@ export function captureEvent(eventType: string, eventProps?: Record<string,any>,
   }
 }
 
+type TrackingContext = Record<string, unknown>;
 
-const ReactTrackingContext = React.createContext({});
+const ReactTrackingContext = React.createContext<TrackingContext>({});
 
 
-/* HOW TO USE ANALYTICS CONTEXT WRAPPER COMPONENTS
+/**
+HOW TO USE ANALYTICS CONTEXT WRAPPER COMPONENTS
 When you create a new feature (page, widget,button, etc.) or change the structure of a page, 
 you should wrap the relevant components in an <AnalyticsContext> component. These 
 components allow passing contextual information to the analytics event capture 
@@ -154,19 +156,52 @@ will likely have to add tracking manually with a captureEvent call. (Search code
 The best way to ensure you are tracking correctly with is to look at the logs
 in the client or server (ensure getShowAnalyticsDebug is returning true).
 */
-
-export const AnalyticsContext = ({children, ...props}: any) => {
+export const AnalyticsContext = ({children, ...props}: {
+  children: ReactNode,
+  pageContext?: string,
+  pageSectionContext?: string,
+  pageSubSectionContext?: string,
+  pageElementContext?: string,
+  reviewYear?: string,
+  path?: string,
+  resourceName?: string,
+  resourceUrl?: string,
+  chapter?: string,
+  documentSlug?: string,
+  postId?: string,
+  sequenceId?: string,
+  commentId?: string,
+  tagId?: string,
+  tagName?: string,
+  tagSlug?: string,
+  userIdDisplayed?: string,
+  hoverPreviewType?: string,
+  sortedBy?: string,
+  branch?: string,
+  href?: string,
+  limit?: number,
+  capturePostItemOnMount?: boolean,
+  singleLineComment?: boolean,
+  onsite?: boolean,
+  terms?: PostsViewTerms,
+  /** @deprecated Use `pageSectionContext` instead */
+  listContext?: string,
+  /** @deprecated Use `pageSectionContext` instead */
+  pageSection?: "karmaChangeNotifer",
+  /** @deprecated Use `pageSubSectionContext` instead */
+  pageSubsectionContext?: "latestReview",
+}) => {
   const existingContextData = useContext(ReactTrackingContext)
-  
+
   // Create a child context, which is the parent context plus the provided props
   // merged on top of it. But create it in a referentially stable way: reuse
   // the same object, so that changes never cause child components to rerender.
   // (As long as they captured the context in the obvious way, they'll still get
   // the newest values of these props when they actually log an event.)
-  const newContextData = useRef({...existingContextData});
+  const newContextData = useRef<TrackingContext>({...existingContextData});
   for (let key of Object.keys(props))
-    (newContextData.current as AnyBecauseTodo)[key] = props[key];
-  
+    newContextData.current[key] = props[key as keyof typeof props];
+
   return <ReactTrackingContext.Provider value={newContextData.current}>
     {children}
   </ReactTrackingContext.Provider>
@@ -178,10 +213,9 @@ export const AnalyticsContext = ({children, ...props}: any) => {
 // useCallback return the same thing each tie.
 const emptyEventProps = {} as any;
 
-export function useTracking({eventType="unnamed", eventProps=emptyEventProps, skip=false}: {
+export function useTracking({eventType="unnamed", eventProps=emptyEventProps}: {
   eventType?: string,
   eventProps?: any,
-  skip?: boolean
 }={}) {
   const trackingContext = useContext(ReactTrackingContext)
 
@@ -284,7 +318,7 @@ const throttledStoreEvent = (event: AnyBecauseTodo) => {
         steadyStateLimit: rateLimitKBps*1024,
         timestamp: now
       }),
-      exceeded: _.throttle(() => {
+      exceeded: throttle(() => {
         pendingAnalyticsEvents.push({
           type: "rateLimitExceeded",
           timestamp: now,

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -134,6 +134,9 @@ USE THIS CONVENTION FOR TRACKING EVENT LOCATION
     -use when wanting to mark where within a section something occurs
 * listContext is historical. Now just use pageSection.
 
+When adding a new prop simply add it to the list in the type of the `props` argument here.
+Arguments can be of any type that can be handled by JSON.stringify. It's fine to have a low
+barrier for adding new props here.
 
 Also, context labels and their values should be camelCase, e.g. `pageSectionContext="fromTheArchives"`, 
 and *not* `page_section_context="From the Archives" or the like.


### PR DESCRIPTION
The props for `AnalyticsContext` are currently typed as `any`. This is kind-of correct since it can actually take any props (well, at least anything that's JSON.stringify-able), but it means it ends up being rather confusing to use for several reasons:

- If you want to know what props are set by other components your only option is to grep the codebase which is annoying and error prone
- Some props such as `listContext` are officially deprecated but you won't know this unless you read the comment on `AnalyticsContext` (which, prior to this PR, is a normal comment and not a doc comment so your editor is unlikely to help you here)
- In some cases, the props are spelt wrong (`pageSubsectionContext` instead of `pageSubSectionContext` or `pageSection` instead of `pageSectionContext`)

This PR adds strong types for these props which will make it easier to unify props across components, and you can now use doc comments to mark certain props as deprecated. I'd still propose that we keep a _very_ low barrier for adding extra props here though.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205679611635206) by [Unito](https://www.unito.io)
