### PR TITLE
Prevent horizontal overflow in EA recent discussions items

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionItem.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionItem.tsx
@@ -59,6 +59,7 @@ const styles = (theme: ThemeType) => ({
   },
   content: {
     flexGrow: 1,
+    minWidth: 0,
     background: theme.palette.grey[0],
     border: `1px solid ${theme.palette.grey[200]}`,
     borderRadius: theme.borderRadius.default,


### PR DESCRIPTION
Fixes an overflow bug I missed in #7974 which only showed up when testing with prod data.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205679758420845) by [Unito](https://www.unito.io)
