### PR TITLE
Make dialogues always collaborative

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -27,6 +27,7 @@ export function isCollaborative(post: DbPost, fieldName: string): boolean {
   if (post.shareWithUsers?.length > 0) return true;
   if (post.sharingSettings?.anyoneWithLinkCan && post.sharingSettings.anyoneWithLinkCan !== "none")
     return true;
+  if (post.collabEditorDialogue) return true;
   return false;
 }
 


### PR DESCRIPTION
Currently you can make a dialogue without participants, and then that creates a broken document that tries to run the post-fixers but breaks. This makes dialogues always collaborative, which IMO makes sense.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205686016326658) by [Unito](https://www.unito.io)
