### PR TITLE
Fix size of pinned comment icon on EA user profile

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -127,9 +127,15 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 10,
     marginBottom: '-3px',
   },
-  pinnedIcon: {
-    fontSize: 12
-  },
+  pinnedIcon: isEAForum
+    ? {
+      width: 16,
+      height: 16,
+      padding: 1.5,
+    }
+    : {
+      fontSize: 12
+    },
   title: {
     ...theme.typography.display2,
     ...theme.typography.postStyle,

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -396,7 +396,7 @@ const ForumIcon = ({
 
 const ForumIconComponent = registerComponent("ForumIcon", memo(ForumIcon), {
   styles,
-  stylePriority: -1,
+  stylePriority: -2,
 });
 
 declare global {


### PR DESCRIPTION
Fixes the size of the pinned comment icon on the EA users profile - I've just made it the same size as the pinned post icon.

Before:
<img width="272" alt="Screenshot 2023-10-10 at 16 08 44" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4e2dd09a-3655-4587-9a92-954649fd5f1a">


After:
<img width="234" alt="Screenshot 2023-10-10 at 16 08 17" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/aed90f39-0e52-40ff-ae8e-a44f9794f1d5">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205689835498665) by [Unito](https://www.unito.io)
