### PR TITLE
Label comments on events in recent discussions as comments rather than scheduled events

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -49,19 +49,19 @@ const getItemProps = (
   post: PostsRecentDiscussion,
   comments: CommentsList[] = [],
 ): EARecentDiscussionItemProps => {
-  if (post.isEvent) {
-    // It's a new event
-    return {
-      icon: "Calendar",
-      iconVariant: "grey",
-      user: post.user,
-      action: "scheduled",
-      post,
-      timestamp: post.postedAt,
-    };
-  }
-
   if (!comments?.length) {
+    // It's a new event
+    if (post.isEvent) {
+      return {
+        icon: "Calendar",
+        iconVariant: "grey",
+        user: post.user,
+        action: "scheduled",
+        post,
+        timestamp: post.postedAt,
+      };
+    }
+
     // We're displaying the post as a new post
     return {
       icon: post.question ? "Q" : "DocumentFilled",


### PR DESCRIPTION
This PR fixes a current bug where comments on an event show in recent discussions as the commenter scheduling the event.

Before:
![image](https://github.com/ForumMagnum/ForumMagnum/assets/5075628/4bbfbca9-54e7-401f-bae2-e41df917c8fe)

After:
<img width="496" alt="Screenshot 2023-10-10 at 16 14 53" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/d5a4d74d-61a6-4a2c-9ecb-53a20c820dfc">

