### PR TITLE
No deletion in dialogue postfixer + handle better out of sync editors (different coauthors)

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -110,15 +110,23 @@ function getMaxUserOrder(dialogueElements: (RootElement | CKElement)[]) {
 function assignUserOrders(dialogueMessages: (RootElement | CKElement)[], sortedCoauthors: UsersMinimumInfo[], writer: Writer) {
   return dialogueMessages.map(message => {
     const messageUserId = message.getAttribute('user-id');
+    const messageUserOrderAttribute = message.getAttribute('user-order');
+    const messageUserOrder = Number.parseInt((messageUserOrderAttribute ?? '0') as string);
     let userOrder = sortedCoauthors.findIndex((author) => author._id === messageUserId) + 1;
-    console.log("userOrder", {userOrder, messageUserId, sortedCoauthors, message})
-    if (!userOrder || userOrder < 1) {
-      userOrder = getMaxUserOrder(dialogueMessages) + 1;
+
+    console.log("userOrder", {messageUserOrderAttribute, messageUserOrder, userOrder, messageUserId, sortedCoauthors, messageAttributes: Array.from(message.getAttributes())});
+    if (userOrder < 1) {
+      if (messageUserOrder) {
+        console.log('setting userOrder from messageUserOrder', { userOrder, messageUserOrder, messageUserOrderAttribute, messageUserId });
+        userOrder = messageUserOrder;
+      } else {
+        console.log('setting userOrder from max user order', { userOrder, messageUserOrder, messageUserOrderAttribute, messageUserId });
+        userOrder = getMaxUserOrder(dialogueMessages) + 1;
+      }
     }
 
-    const messageUserOrder = message.getAttribute('user-order');
-    console.log({messageUserOrder})
-    if (userOrder !== Number.parseInt(messageUserOrder as string)) {
+    if (userOrder !== messageUserOrder) {
+      console.log('writing userOrder back to element', { userOrder, messageUserOrder, messageUserOrderAttribute, messageUserId });
       writer.setAttribute('user-order', userOrder, message);
       return true;
     }

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -103,13 +103,23 @@ function removeDuplicateInputs(dialogueMessageInputs: Node[], writer: Writer) {
   });
 }
 
+function getMaxUserOrder(dialogueElements: (RootElement | CKElement)[]) {
+  return dialogueElements.reduce((maxUserOrder, element) => {
+    const userOrder = Number.parseInt(element.getAttribute('user-order') as string);
+    if (userOrder && userOrder > maxUserOrder) {
+      return userOrder;
+    }
+    return maxUserOrder;
+  }, 0);
+}
+
 function assignUserOrders(dialogueMessages: (RootElement | CKElement)[], sortedCoauthors: UsersMinimumInfo[], writer: Writer) {
   return dialogueMessages.map(message => {
     const messageUserId = message.getAttribute('user-id');
     let userOrder = sortedCoauthors.findIndex((author) => author._id === messageUserId) + 1;
     console.log("userOrder", {userOrder, messageUserId, sortedCoauthors, message})
     if (!userOrder || userOrder < 1) {
-      userOrder = 1;
+      userOrder = getMaxUserOrder(dialogueMessages) + 1;
     }
 
     const messageUserOrder = message.getAttribute('user-order');
@@ -174,7 +184,7 @@ function createDialoguePostFixer(editor: Editor, sortedCoauthors: UsersMinimumIn
     const lastElementsAreAllInputs = areLastElementsAllInputs(lastChildren);
 
     if (incorrectOrder || !lastElementsAreAllInputs) {
-      const sortedInputs = sortBy(dialogueMessageInputs, (i) => sortedCoauthors.findIndex(author => author._id === i.getAttribute('user-id')))
+      const sortedInputs = sortBy(dialogueMessageInputs, (i) => Number.parseInt(i.getAttribute('user-order') as string))
       console.log({sortedInputs, dialogueMessageInputs, sortedCoauthors})
       sortedInputs.forEach(sortedInput => {
         writer.append(sortedInput, root);

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -104,13 +104,7 @@ function removeDuplicateInputs(dialogueMessageInputs: Node[], writer: Writer) {
 }
 
 function getMaxUserOrder(dialogueElements: (RootElement | CKElement)[]) {
-  return dialogueElements.reduce((maxUserOrder, element) => {
-    const userOrder = Number.parseInt(element.getAttribute('user-order') as string);
-    if (userOrder && userOrder > maxUserOrder) {
-      return userOrder;
-    }
-    return maxUserOrder;
-  }, 0);
+  return Math.max(...dialogueElements.map(element => Number.parseInt(element.getAttribute('user-order') as string)))
 }
 
 function assignUserOrders(dialogueMessages: (RootElement | CKElement)[], sortedCoauthors: UsersMinimumInfo[], writer: Writer) {


### PR DESCRIPTION
When someone is added as a coauthor of dialogue after start, we hit issues when other live users didn't have the latest coauthors list. Specifially the users without up-to-date list would have their post-fixers try to remove content from the new users, and end up in a post-fixer war.

We have removed all post-fix deletion to route around this issue, and compensated by making block ownership only respect users who are coauthors on a given client. This means if someone is removed as coauthor, their messages can be edited/deleted.

We also handled color assignment for a user not in the coauthors list, setting them to have an order greater than existing users/messages.