### PR TITLE
Fix Crossposting, 2023-10-11

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -3,10 +3,11 @@ import Users from "../../lib/collections/users/collection";
 import { randomId } from "../../lib/random";
 import { loggerConstructor } from "../../lib/utils/logging";
 import { UpdateCallbackProperties } from "../mutationCallbacks";
-import { DenormalizedCrosspostData, denormalizedFieldKeys, extractDenormalizedData } from "./denormalizedFields";
+import { denormalizedFieldKeys, extractDenormalizedData } from "./denormalizedFields";
 import { makeCrossSiteRequest } from "./resolvers";
 import { signToken } from "./tokens";
 import type { Crosspost, CrosspostPayload, UpdateCrosspostPayload } from "./types";
+import { DenormalizedCrosspostData } from "./types";
 
 export async function performCrosspost<T extends Crosspost>(post: T): Promise<T> {
   const logger = loggerConstructor('callbacks-posts')
@@ -147,11 +148,15 @@ export async function handleCrosspostUpdate(
     return data;
   }
 
+  /**
+   * TODO: Null is made legal value for fields but database types are incorrectly generated without null. 
+   * Hacky fix for now. Search 84b2 to find all instances of this casting.
+   */
   return performCrosspost({
     _id,
     userId,
     fmCrosspost,
     ...extractDenormalizedData(newDocument),
     ...data,
-  });
+  }) as Partial<DbPost>; 
 }

--- a/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
+++ b/packages/lesswrong/server/fmCrosspost/denormalizedFields.ts
@@ -1,26 +1,5 @@
-import * as t from 'io-ts';
 import pick from "lodash/pick";
-
-/**
- * In general, we try to keep a single source of truth for all post data that's
- * crossposted on the original server and let the foreign server make graphql
- * requests when it needs access to this.
- *
- * Some fields have to be denormalized across sites and these are defined here. In
- * general, a field needs to be denormalized if it's used by PostsList2 or
- * in database selectors (but these rules aren't strict).
- */
-const requiredDenormalizedFields = {
-  draft: t.boolean,
-  deletedDraft: t.boolean,
-  title: t.string,
-  isEvent: t.boolean,
-  question: t.boolean,
-} as const;
-
-const optionalDenormalizedFields = {
-  url: t.string,
-} as const;
+import { DenormalizedCrosspostData, optionalDenormalizedFields, requiredDenormalizedFields } from './types';
 
 type RequiredKey = keyof typeof requiredDenormalizedFields;
 type OptionalKey = keyof typeof optionalDenormalizedFields;
@@ -30,19 +9,6 @@ export const denormalizedFieldKeys: FieldKey[] = [
   ...Object.keys(requiredDenormalizedFields) as RequiredKey[],
   ...Object.keys(optionalDenormalizedFields) as OptionalKey[],
 ];
-
-export const DenormalizedCrosspostValidator = t.intersection([
-  t.strict(requiredDenormalizedFields),
-  t.partial(optionalDenormalizedFields),
-]);
-
-export type ReadonlyDenormalizedCrosspostData = t.TypeOf<typeof DenormalizedCrosspostValidator>;
-
-type Writeable<T> = {
-  -readonly [P in keyof T]: Writeable<T[P]>;
-};
-
-export type DenormalizedCrosspostData = Writeable<ReadonlyDenormalizedCrosspostData>;
 
 export const extractDenormalizedData = <T extends DenormalizedCrosspostData>(data: T): DenormalizedCrosspostData =>
   pick(data, ...denormalizedFieldKeys);

--- a/packages/lesswrong/server/fmCrosspost/requestHandlers.ts
+++ b/packages/lesswrong/server/fmCrosspost/requestHandlers.ts
@@ -62,6 +62,10 @@ export const onCrosspostRequest: PostRouteOf<'crosspost'> = async (req) => {
     throw new InvalidUserError();
   }
 
+  /**
+   * TODO: Null is made legal value for fields but database types are incorrectly generated without null. 
+   * Hacky fix for now. Search 84b2 to find all instances of this casting.
+   */
   const document: Partial<DbPost> = {
     userId: user._id,
     fmCrosspost: {
@@ -70,7 +74,7 @@ export const onCrosspostRequest: PostRouteOf<'crosspost'> = async (req) => {
       foreignPostId: postId,
     },
     ...denormalizedData,
-  };
+  } as Partial<DbPost>;
 
   const {data: post} = await Utils.createMutator({
     document,
@@ -92,10 +96,11 @@ export const onCrosspostRequest: PostRouteOf<'crosspost'> = async (req) => {
   };
 };
 
+//TODO: clean up typecast `as Partial<DbPost>` below, Code: 84b2
 export const onUpdateCrosspostRequest: PostRouteOf<'updateCrosspost'> = async (req) => {
   const { token } = req;
   const {postId, ...rest} = await verifyToken(token, UpdateCrosspostPayloadValidator.is);
-  const denormalizedData: Partial<DbPost> = extractDenormalizedData(rest);
+  const denormalizedData: Partial<DbPost> = extractDenormalizedData(rest) as Partial<DbPost>;
   await Posts.rawUpdateOne({_id: postId}, {$set: denormalizedData});
   return { status: 'updated' };
 };

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -1,5 +1,64 @@
 import * as t from 'io-ts';
-import { DenormalizedCrosspostData, DenormalizedCrosspostValidator } from './denormalizedFields';
+
+/**
+ */
+interface PartialWithNullC<P extends t.Props>
+  extends t.PartialType<
+    P,
+    {
+      [K in keyof P]?: t.TypeOf<P[K]> | null
+    },
+    {
+      [K in keyof P]?: t.OutputOf<P[K]> | null
+    },
+    unknown
+  > {}
+
+export const partialWithNull = <P extends t.Props>(props: P): PartialWithNullC<P> => {
+  return t.partial(Object.fromEntries(
+    Object.entries(props).map(([key, validator]: [string, t.Type<any> | t.PartialType<any>]) => {
+      if ('props' in validator) {
+        return [key, t.union([t.null, partialWithNull(validator.props)])] as const;
+      } else {
+        return [key, t.union([t.null, validator])] as const;
+      }
+    })
+  )) as unknown as PartialWithNullC<P>;
+};
+
+type Writeable<T> = {
+  -readonly [P in keyof T]: Writeable<T[P]>;
+};
+
+export type ReadonlyDenormalizedCrosspostData = t.TypeOf<typeof DenormalizedCrosspostValidator>;
+
+export type DenormalizedCrosspostData = Writeable<ReadonlyDenormalizedCrosspostData>;
+
+/**
+ * In general, we try to keep a single source of truth for all post data that's
+ * crossposted on the original server and let the foreign server make graphql
+ * requests when it needs access to this.
+ *
+ * Some fields have to be denormalized across sites and these are defined here. In
+ * general, a field needs to be denormalized if it's used by PostsList2 or
+ * in database selectors (but these rules aren't strict).
+ */
+export const requiredDenormalizedFields = {
+  draft: t.boolean,
+  deletedDraft: t.boolean,
+  title: t.string,
+  isEvent: t.boolean,
+  question: t.boolean,
+} as const;
+
+export const optionalDenormalizedFields = {
+  url: t.string,
+} as const;
+
+export const DenormalizedCrosspostValidator = t.intersection([
+  t.strict(requiredDenormalizedFields),
+  partialWithNull(optionalDenormalizedFields),
+]);
 
 export const CrosspostTokenResponseValidator = t.strict({
   token: t.string
@@ -121,33 +180,6 @@ export const GetCrosspostRequestValidator = t.intersection([
 
 export type GetCrosspostRequest = t.TypeOf<typeof GetCrosspostRequestValidator>;
 
-/**
- * Nearly all fields returned from the other forum's internal GraphQL request can be `null`
- * That's different from them being missing in the response body
- */
-// interface PartialWithNullC<P extends t.Props>
-//   extends t.PartialType<
-//     P,
-//     {
-//       [K in keyof P]?: t.TypeOf<P[K]> | null
-//     },
-//     {
-//       [K in keyof P]?: t.OutputOf<P[K]> | null
-//     },
-//     unknown
-//   > {}
-
-// const partialWithNull = <P extends t.Props>(props: P): PartialWithNullC<P> => {
-//   return t.partial(Object.fromEntries(
-//     Object.entries(props).map(([key, validator]: [string, t.Type<any> | t.PartialType<any>]) => {
-//       if ('props' in validator) {
-//         return [key, t.union([t.null, partialWithNull(validator.props)])] as const;
-//       } else {
-//         return [key, t.union([t.null, validator])] as const;
-//       }
-//     })
-//   )) as unknown as PartialWithNullC<P>;
-// };
 
 /**
  * Partial, in addition to treating all of the specified fields as optional, is permissive with respect to fields not specified


### PR DESCRIPTION
Crossposting has been broken for a while, seems to be due to URL field returning null and that not being allowed according to the validator. The change to make to URL not required was insufficient.

Fix here works by making optional values in `DenormalizedCrosspostValidator` be `PartialWithNull`. Some errors in other places due to DatabaseTypes not being correctly generated with null, we fixed those via typecasting for now.

Paired on this with RobertM (he did the navigating).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205704659159395) by [Unito](https://www.unito.io)
