### PR TITLE
Fix analytics typecheck in PopularCommentsSection

### DIFF
--- a/packages/lesswrong/components/comments/PopularCommentsList.tsx
+++ b/packages/lesswrong/components/comments/PopularCommentsList.tsx
@@ -25,7 +25,7 @@ const PopularCommentsList = ({classes}: {classes: ClassesType}) => {
 
   const {LoadMore, PopularComment} = Components;
   return (
-    <AnalyticsContext pageSection="popularCommentsList">
+    <AnalyticsContext pageSectionContext="popularCommentsList">
       <div className={classes.root}>
         {results?.map((comment) =>
           <PopularComment


### PR DESCRIPTION
Fixes a type error that was caused by an incompatability between #7945 and #7994 which were merged at roughly the same time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205709950302972) by [Unito](https://www.unito.io)
