### PR TITLE
Fix broken redirects to Agent Foundations imported content

### DIFF
--- a/packages/lesswrong/server/legacy-redirects/routes.ts
+++ b/packages/lesswrong/server/legacy-redirects/routes.ts
@@ -44,11 +44,11 @@ function makeRedirect(res: ServerResponse, destination: string) {
 }
 
 async function findPostByLegacyAFId(legacyId: number) {
-  return await Posts.findOne({"agentFoundationsId": legacyId})
+  return await Posts.findOne({"agentFoundationsId": legacyId.toString()})
 }
 
 async function findCommentByLegacyAFId(legacyId: number) {
-  return await Comments.findOne({"agentFoundationsId": legacyId})
+  return await Comments.findOne({"agentFoundationsId": legacyId.toString()})
 }
 
 


### PR DESCRIPTION
This was broken by string-vs-number type confusion combined with the mongo->postgres switchover. Example of a broken redirect URI: https://www.lesswrong.com/item?id=32 .