### PR TITLE
Fix a null-reference crash in inline-reacts highlighting on /moderation

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -82,7 +82,7 @@ const CommentBody = ({
   
   const votingSystem = getVotingSystemByName(comment.votingSystem);
   let highlights: Record<string,ContentReplacedSubstringComponent>|undefined = undefined;
-  if (votingSystem.getCommentHighlights) {
+  if (voteProps && votingSystem.getCommentHighlights) {
     highlights = votingSystem.getCommentHighlights({comment, voteProps});
   }
 

--- a/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
+++ b/packages/lesswrong/lib/voting/namesAttachedReactions.tsx
@@ -155,14 +155,14 @@ registerVotingSystem<NamesAttachedReactionsVote, NamesAttachedReactionsScore>({
     comment: CommentsList
     voteProps: VotingProps<VoteableTypeClient>
   }) => {
-    return getDocumentHighlights(voteProps.document.extendedScore, voteProps);
+    return getDocumentHighlights(voteProps.document?.extendedScore, voteProps);
   },
   
   getPostHighlights: ({post, voteProps}: {
     post: PostsBase
     voteProps: VotingProps<VoteableTypeClient>
   }) => {
-    return getDocumentHighlights(voteProps.document.extendedScore, voteProps);
+    return getDocumentHighlights(voteProps.document?.extendedScore, voteProps);
   }
 });
 

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -64,11 +64,11 @@ export interface VotingSystem<ExtendedVoteType=any, ExtendedScoreType=any> {
   isNonblankExtendedVote: (vote: DbVote) => boolean,
   getCommentHighlights?: (props: {
     comment: CommentsList
-    voteProps?: VotingProps<VoteableTypeClient>
+    voteProps: VotingProps<VoteableTypeClient>
   }) => Record<string, ContentReplacedSubstringComponent>
   getPostHighlights?: (props: {
     post: PostsBase
-    voteProps?: VotingProps<VoteableTypeClient>
+    voteProps: VotingProps<VoteableTypeClient>
   }) => Record<string, ContentReplacedSubstringComponent>
 }
 


### PR DESCRIPTION
Fixes a crash of the `/moderation` page, introduced by my recent changes to inline-react highlighting.

(I'm confused how this one made it past the type-checker; `getCommentHighlights` is defined in `votingSystems.tsx` to take an optional `voteProps`, but then instantiated in `namesAttachedReactions.tsx` with that prop being required, which should be a mismatch.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205722316103083) by [Unito](https://www.unito.io)
