### PR TITLE
fix color of dashed underlines for inline reacts

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -21,12 +21,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     ".CommentsItem-body:hover .InlineReactHoverableHighlight-highlight": {
       textDecorationLine: 'underline',
       textDecorationStyle: 'dashed',
-      textDecorationColor: theme.palette.border.dashed500,
+      textDecorationColor: theme.palette.text.dim4,
     },
     ".PostsPage-postContent:hover .InlineReactHoverableHighlight-highlight": {
       textDecorationLine: 'underline',
       textDecorationStyle: 'dashed',
-      textDecorationColor: theme.palette.border.dashed500,
+      textDecorationColor: theme.palette.text.dim4,
     }
   }
 })

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -22,11 +22,13 @@ const styles = (theme: ThemeType): JssStyles => ({
       textDecorationLine: 'underline',
       textDecorationStyle: 'dashed',
       textDecorationColor: theme.palette.text.dim4,
+      textUnderlineOffset: '3px'
     },
     ".PostsPage-postContent:hover .InlineReactHoverableHighlight-highlight": {
       textDecorationLine: 'underline',
       textDecorationStyle: 'dashed',
       textDecorationColor: theme.palette.text.dim4,
+      textUnderlineOffset: '3px'
     }
   }
 })


### PR DESCRIPTION
Was using the wrong css style for the color of the dashed underline.  I think this is using the intended color (it's the one that's inside of the `dashed500` style); it does look less overwhelming/cluttered.

Wrong:
<img width="563" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/729b31d9-5742-465e-9768-97a4021bb714">

Fixed:
<img width="553" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/fe20e8b1-2c3f-4d2d-945d-c5ef6212d168">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205724537725182) by [Unito](https://www.unito.io)
