### PR TITLE
Hide draft default recommendations

### DIFF
--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -166,7 +166,15 @@ const recommendablePostFilter = (algorithm: DefaultRecommendationsAlgorithm) => 
   if (algorithm.excludeDefaultRecommendations) {
     return recommendationFilter
   } else {
-    return {$or: [recommendationFilter, { defaultRecommendation: true}]}
+    return {
+      $or: [
+        recommendationFilter,
+        {
+          ...getDefaultViewSelector("Posts"), // Ensure drafts are still excluded
+          defaultRecommendation: true,
+        },
+      ],
+    };
   }
 }
 


### PR DESCRIPTION
Fixes a bug where "Test crosspost" (a draft) was appearing in recommendations because it had `defaultRecommendation` set to true. I have also set that specific one to false in the meantime

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205731054101862) by [Unito](https://www.unito.io)
