### PR TITLE
Fix crash when inline-reacting to an AF comment that you haven't otherwise voted on

### DIFF
--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -26,9 +26,9 @@ const addVoteClient = ({ document, collection, voteType, extendedVote, user, vot
   user: UsersCurrent,
   votingSystem: VotingSystem,
 }) => {
-  const power = getVotePower({user, voteType, document});
+  const power = getVotePower({user, voteType: voteType ?? "neutral", document});
   const isAfVote = (document.af && userCanDo(user, "votes.alignment"))
-  const afPower = isAfVote ? calculateVotePower(user.afKarma, voteType) : 0;
+  const afPower = isAfVote ? calculateVotePower(user.afKarma, voteType ?? "neutral") : 0;
 
   const newDocument = {
     ...document,
@@ -76,9 +76,9 @@ const cancelVoteClient = ({document, collection, user, votingSystem}: {
   // points based on the user's new vote weight, which will then be corrected
   // when the server responds.
   const voteType = document.currentUserVote;
-  const power = getVotePower({user, voteType, document});
+  const power = getVotePower({user, voteType: voteType ?? "neutral", document});
   const isAfVote = (document.af && userCanDo(user, "votes.alignment"))
-  const afPower = isAfVote ? calculateVotePower(user.afKarma, voteType) : 0;
+  const afPower = isAfVote ? calculateVotePower(user.afKarma, voteType ?? "neutral") : 0;
   
   const newDocument = {
     ...document,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205732658622170) by [Unito](https://www.unito.io)
