### PR TITLE
Fix wrapping in post and comment links

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -276,6 +276,7 @@ const PostLinkPreviewWithPost = ({href, post, id, children, classes}: {
       hash={hash}
       placement="bottom-start"
       clickable={!isEAForum}
+      As="span"
     >
       <Link className={classes.link} to={href} id={id} smooth>
         {children}
@@ -306,7 +307,12 @@ const CommentLinkPreviewWithComment = ({classes, href, comment, post, id, childr
 
   const {PostsTooltip} = Components;
   return (
-    <PostsTooltip post={post} comment={comment} placement="bottom-start">
+    <PostsTooltip
+      post={post}
+      comment={comment}
+      placement="bottom-start"
+      As="span"
+    >
       <Link className={classes.link} to={href} id={id}>
         {children}
       </Link>


### PR DESCRIPTION
Fixes a small regression from #7958 that causes links in posts to often appear on a new line instead of inline.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205742618831864) by [Unito](https://www.unito.io)
