### PR TITLE
Fix link-hover-preview deleting contents of links when linkIsExcludedFromPreview() is true

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -292,11 +292,11 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
   markHoverableLinks = (element: HTMLElement) => {
     const linkTags = this.htmlCollectionToArray(element.getElementsByTagName("a"));
     for (let linkTag of linkTags) {
-      const TagLinkContents = rawExtractElementChildrenToReactComponent(linkTag);
-      
       const href = linkTag.getAttribute("href");
       if (!href || linkIsExcludedFromPreview(href))
         continue;
+
+      const TagLinkContents = rawExtractElementChildrenToReactComponent(linkTag);
       const id = linkTag.getAttribute("id") ?? undefined;
       const rel = linkTag.getAttribute("rel") ?? undefined;
       const replacementElement = <Components.HoverPreviewLink


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/commit/66aceddf873794d8ab7920fd5df83b4b52dca82b#diff-a101a2569ccb9f908354aff6d2587b8fa31dd7f3198f13509a94b545f2353cdaR420

When changing `contentItemBody` to not be using `dangerouslySetInnerHTML`, the line in `markHoverableLinks` which gets the children of the link changed to have side effects (removing the children, to be added back in later). If we then aborted the substitution because `linkIsExcludedFromPreview` returned true (which happens for links directly to images), we would fail to add it back.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205742676418659) by [Unito](https://www.unito.io)
