### PR TITLE
add more analytics for recent discussion and popular comments

### DIFF
--- a/packages/lesswrong/components/comments/PopularComment.tsx
+++ b/packages/lesswrong/components/comments/PopularComment.tsx
@@ -102,12 +102,13 @@ const PopularCommentTitle: FC<{
         <Link
           to={postGetPageUrl(post)}
           className={classNames(classes.post, {[classes.postRead]: isRead})}
+          eventProps={{intent: 'expandPost'}}
         >
           {post.title}
         </Link>
       </InteractionWrapper>
       <InteractionWrapper>
-        <Link to={commentGetPageUrl(comment)} className={classes.link}>
+        <Link to={commentGetPageUrl(comment)} className={classes.link} eventProps={{intent: 'viewInThread'}}>
           View in thread
         </Link>
       </InteractionWrapper>

--- a/packages/lesswrong/components/common/excerpts/ContentExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/ContentExcerpt.tsx
@@ -152,7 +152,7 @@ const ContentExcerpt = ({
             )
         )
         : (
-          <Link to={moreLink} className={classes.continueReading}>
+          <Link to={moreLink} className={classes.continueReading} eventProps={{intent: 'expandPost'}}>
             {isTruncated
               ? "Continue reading"
               : `View ${contentTypeMap[contentType]}`

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -255,11 +255,11 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
         {hit.htmlBio && <ContentStyles contentType="comment" className={classes.description}>
           <div dangerouslySetInnerHTML={{__html: truncate(hit.htmlBio, 220)}} />
         </ContentStyles>}
-        {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
+        {/* {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
           <NewConversationButton user={hit} currentUser={currentUser} from="community_members_tab">
             <Button variant="contained" color="primary" className={classes.messageBtn}>Message</Button>
           </NewConversationButton>
-        </div>}
+        </div>} */}
       </div>
     </div>
   }

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -131,10 +131,11 @@ const PostsTitle = ({
   showDraftTag=true, 
   wrap=false, 
   showIcons=true,
-  isLink=true, 
-  curatedIconLeft=true, 
+  isLink=true,
+  curatedIconLeft=true,
   strikethroughTitle=false,
   Wrapper=DefaultWrapper,
+  linkEventProps,
   className,
 }:{
   post: PostsBase|PostsListBase,
@@ -150,6 +151,7 @@ const PostsTitle = ({
   curatedIconLeft?: boolean
   strikethroughTitle?: boolean
   Wrapper?: FC,
+  linkEventProps?: Record<string, string>,
   className?: string
 }) => {
   const currentUser = useCurrentUser();
@@ -194,7 +196,7 @@ const PostsTitle = ({
         </InteractionWrapper>
       </span>}
       <span className={!wrap ? classes.eaTitleDesktopEllipsis : undefined}>
-        {isLink ? <Link to={url}>{title}</Link> : title }
+        {isLink ? <Link to={url} eventProps={linkEventProps}>{title}</Link> : title }
       </span>
       {showIcons && <span className={classes.hideXsDown}>
         <InteractionWrapper className={classes.interactionWrapper}>

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionItem.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionItem.tsx
@@ -134,6 +134,7 @@ const EARecentDiscussionItem = ({
                 <Link
                   to={postUrlOverride ?? postGetPageUrl(post)}
                   className={classes.primaryText}
+                  eventProps={postUrlOverride ? undefined : {intent: 'expandPost'}}
                 >
                   {postTitleOverride ?? post.title}
                 </Link>

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -134,6 +134,7 @@ const EARecentDiscussionThread = ({
               post={post}
               read={post.isRead}
               className={classes.postTitle}
+              linkEventProps={{intent: 'expandPost'}}
             />
           </PostsItemTooltipWrapper>
           <EAPostMeta post={post} useEventStyles />


### PR DESCRIPTION
Some of this was in the old "Recent discussion" components that got lost in the update, some is just labeling links more clearly

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205743349199139) by [Unito](https://www.unito.io)
