### PR TITLE
Fix ckeditor narrow window comment box

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -198,14 +198,7 @@ const refreshDisplayMode = ( editor: any, sidebarElement: HTMLDivElement | null 
   if (!sidebarElement) return null
   const annotationsUIs = editor.plugins.get( 'AnnotationsUIs' );
   
-  if ( window.innerWidth < 1000 ) {
-    sidebarElement.classList.remove( 'narrow' );
-    sidebarElement.classList.add( 'hidden' );
-    
-    annotationsUIs.deactivateAll();
-    annotationsUIs.activate('inline');
-  }
-  else if ( window.innerWidth < 1400 ) {
+  if ( window.innerWidth < 1400 ) {
     sidebarElement.classList.remove( 'hidden' );
     sidebarElement.classList.add( 'narrow' );
     


### PR DESCRIPTION
The previous settings were causing a broken display of the comment input on mobile & other narrower-width browsers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205744587078150) by [Unito](https://www.unito.io)
