### PR TITLE
add handling for default subscription state for missing subscription types

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -4,6 +4,7 @@ import { userGetDisplayName } from '../../../lib/collections/users/helpers';
 import { useCurrentUser } from '../../common/withUser';
 import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema';
 import { isEAForum } from '../../../lib/instanceSettings';
+import { isDialogueParticipant } from '../../posts/PostsPage/PostsPage';
 
 // We use a context here vs. passing in a boolean prop because we'd need to pass
 // through ~4 layers of hierarchy
@@ -38,6 +39,9 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
 
   if (!post) return null;
   const postAuthor = post.user;
+
+  const userIsDialogueParticipant = currentUser && isDialogueParticipant(currentUser._id, post);
+  const showSubscribeToDialogueButton = post.collabEditorDialogue && !userIsDialogueParticipant;
 
   // WARNING: Clickable items in this menu must be full-width, and
   // ideally should use the <DropdownItem> component. In particular,
@@ -75,14 +79,14 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
         subscribeMessage={`Subscribe to posts by ${userGetDisplayName(postAuthor)}`}
         unsubscribeMessage={`Unsubscribe from posts by ${userGetDisplayName(postAuthor)}`}
       />
-      <NotifyMeDropdownItem
+      {showSubscribeToDialogueButton && <NotifyMeDropdownItem
         document={post}
         enabled={!!post.collabEditorDialogue}
         subscribeMessage="Subscribe to dialogue"
         unsubscribeMessage="Unsubscribe from dialogue"
         subscriptionType={subscriptionTypes.newPublishedDialogueMessages}
         tooltip="Notifies you when there is new activity in the dialogue"
-      />
+      />}
       <NotifyMeDropdownItem
         document={post}
         subscribeMessage="Subscribe to comments"

--- a/packages/lesswrong/components/hooks/useNotifyMe.ts
+++ b/packages/lesswrong/components/hooks/useNotifyMe.ts
@@ -17,7 +17,7 @@ import { userIsDefaultSubscribed } from "../../lib/subscriptionUtil";
 const currentUserIsSubscribed = (
   currentUser: UsersCurrent|null,
   results: SubscriptionState[]|undefined,
-  subscriptionType: AnyBecauseTodo,
+  subscriptionType: SubscriptionType,
   collectionName: CollectionNameString,
   document: AnyBecauseTodo,
 ) => {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -580,6 +580,9 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     return <PermanentRedirect url={lwURL}/>
   }
 
+  const userIsDialogueParticipant = currentUser && isDialogueParticipant(currentUser._id, post);
+  const showSubscribeToDialogueButton = post.collabEditorDialogue && !userIsDialogueParticipant;
+
   return (<AnalyticsContext pageContext="postsPage" postId={post._id}>
     <PostsPageContext.Provider value={post}>
     <SideCommentVisibilityContext.Provider value={sideCommentModeContext}>
@@ -612,7 +615,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
           </AnalyticsContext>
         </ContentStyles>}
 
-        {post.collabEditorDialogue && <Row justifyContent="center">
+        {showSubscribeToDialogueButton && <Row justifyContent="center">
           <div className={classes.subscribeToDialogue}>
             <NotifyMeDropdownItem
               document={post}

--- a/packages/lesswrong/lib/subscriptionUtil.ts
+++ b/packages/lesswrong/lib/subscriptionUtil.ts
@@ -1,12 +1,12 @@
-import { subscriptionTypes } from './collections/subscriptions/schema';
+import { SubscriptionType, subscriptionTypes } from './collections/subscriptions/schema';
 import * as _ from 'underscore';
 
 export function userIsDefaultSubscribed({user, subscriptionType, collectionName, document}: {
   user: DbUser|UsersCurrent|null,
-  subscriptionType: any,
+  subscriptionType: SubscriptionType,
   collectionName: CollectionNameString,
   document: any,
-})
+}): boolean
 {
   if (!user) return false;
   
@@ -26,6 +26,22 @@ export function userIsDefaultSubscribed({user, subscriptionType, collectionName,
       return user.auto_subscribe_to_my_comments && document.userId===user._id;
     case subscriptionTypes.newTagPosts:
       return false
+    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
+    // Figure out if it should be something else
+    case subscriptionTypes.newShortform:
+      return false;
+    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
+    // Figure out if it should be something else
+    case subscriptionTypes.newDebateComments:
+      return false;
+    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
+    // Figure out if it should be something else
+    case subscriptionTypes.newPublishedDialogueMessages:
+      return false;
+    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
+    // Figure out if it should be something else
+    case subscriptionTypes.newDialogueMessages:
+      return true;
     default:
       //eslint-disable-next-line no-console
       console.error("Unrecognized subscription type: "+subscriptionType);

--- a/packages/lesswrong/lib/subscriptionUtil.ts
+++ b/packages/lesswrong/lib/subscriptionUtil.ts
@@ -1,5 +1,6 @@
 import { SubscriptionType, subscriptionTypes } from './collections/subscriptions/schema';
 import * as _ from 'underscore';
+import { getConfirmedCoauthorIds } from './collections/posts/helpers';
 
 export function userIsDefaultSubscribed({user, subscriptionType, collectionName, document}: {
   user: DbUser|UsersCurrent|null,
@@ -26,22 +27,15 @@ export function userIsDefaultSubscribed({user, subscriptionType, collectionName,
       return user.auto_subscribe_to_my_comments && document.userId===user._id;
     case subscriptionTypes.newTagPosts:
       return false
-    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
-    // Figure out if it should be something else
     case subscriptionTypes.newShortform:
       return false;
-    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
-    // Figure out if it should be something else
     case subscriptionTypes.newDebateComments:
       return false;
-    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
-    // Figure out if it should be something else
     case subscriptionTypes.newPublishedDialogueMessages:
       return false;
-    // TODO: this was previously missing due to `subscriptionType` being typed `any`, so was going to default branch
-    // Figure out if it should be something else
     case subscriptionTypes.newDialogueMessages:
-      return true;
+      const authorIds = [document.userId, ...getConfirmedCoauthorIds(document)];
+      return authorIds.includes(user._id);
     default:
       //eslint-disable-next-line no-console
       console.error("Unrecognized subscription type: "+subscriptionType);


### PR DESCRIPTION
Stuff was missing types, things fell through the cracks.  I think `newDialogueMessages` is the only one of those which should be default-subscribed-to by the post author.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205744857404666) by [Unito](https://www.unito.io)
