### PR TITLE
[EA] Show authors in post hovers from sequences

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import classNames from 'classnames';
 import type { PopperPlacementType } from '@material-ui/core/Popper/Popper';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -43,7 +44,7 @@ const SequencesSmallPostLink = ({classes, post, sequenceId, large, placement="le
     </span>
     <PostsTooltip
       post={post}
-      postsList
+      postsList={!isEAForum}
       placement={placement}
       inlineBlock={false}
       clickable


### PR DESCRIPTION
Slack request from Lizka to show author names in post hovers from sequences:
<img width="775" alt="Screenshot 2023-10-18 at 13 26 09" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/cc15d82d-0770-4558-8996-b7e51979b727">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205747320687693) by [Unito](https://www.unito.io)
