### PR TITLE
Don't produce lots of console-log spam when the Chrome debugger tries to fetch /node_modules/... paths

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -226,6 +226,16 @@ export function startWebserver() {
 
   addServerSentEventsEndpoint(app);
 
+  app.get('/node_modules/*', (req, res) => {
+    // Under some circumstances (I'm not sure exactly what the trigger is), the
+    // Chrome JS debugger tries to load a bunch of /node_modules/... paths
+    // (presumably for some sort of source mapping). If these were treated as
+    // normal pageloads, this would produce a ton of console-log spam, which is
+    // disruptive. So instead just serve a minimal 404.
+    res.status(404);
+    res.end("");
+  });
+
   app.get('*', async (request, response) => {
     response.setHeader("Content-Type", "text/html; charset=utf-8"); // allows compression
 


### PR DESCRIPTION
Under some circumstances (I'm not sure exactly what the trigger is), the Chrome JS debugger tries to load a bunch of /node_modules/... paths (presumably for some sort of source mapping). If these were treated as normal pageloads, this would produce a ton of console-log spam, which is disruptive. So instead just serve a minimal 404.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205752432710886) by [Unito](https://www.unito.io)
