### PR TITLE
Mark fields as not-nullable in schema files

### DIFF
--- a/packages/lesswrong/lib/collectionUtils.ts
+++ b/packages/lesswrong/lib/collectionUtils.ts
@@ -79,6 +79,7 @@ export function schemaDefaultValue<T extends DbObject>(defaultValue: any): Parti
     onCreate: fillIfMissing,
     onUpdate: throwIfSetToNull,
     canAutofillDefault: true,
+    nullable: false
   }
 }
 

--- a/packages/lesswrong/lib/collections/advisorRequests/schema.ts
+++ b/packages/lesswrong/lib/collections/advisorRequests/schema.ts
@@ -34,6 +34,7 @@ const schema: SchemaType<DbAdvisorRequest> = {
       // TODO not-null: is this collection being used at all?
       nullable: true,
     }),
+    nullable: false,
     hidden: true,
     canCreate: ['members', 'admins'],
     canRead: [userOwns, 'admins'],
@@ -52,6 +53,7 @@ const schema: SchemaType<DbAdvisorRequest> = {
   jobAds: {
     type: Object,
     optional: true,
+    nullable: false,
     // TODO not-null: is this collection being used at all?
     hidden: true,
     blackbox: true,

--- a/packages/lesswrong/lib/collections/advisorRequests/schema.ts
+++ b/packages/lesswrong/lib/collections/advisorRequests/schema.ts
@@ -31,6 +31,7 @@ const schema: SchemaType<DbAdvisorRequest> = {
       resolverName: "user",
       collectionName: "Users",
       type: "User",
+      // TODO not-null: is this collection being used at all?
       nullable: true,
     }),
     hidden: true,
@@ -41,6 +42,7 @@ const schema: SchemaType<DbAdvisorRequest> = {
   interestedInMetaculus: {
     type: Boolean,
     optional: true,
+    // TODO not-null: is this collection being used at all?
     hidden: true,
     canCreate: ['members', 'admins'],
     canRead: [userOwns, 'admins'],
@@ -50,6 +52,7 @@ const schema: SchemaType<DbAdvisorRequest> = {
   jobAds: {
     type: Object,
     optional: true,
+    // TODO not-null: is this collection being used at all?
     hidden: true,
     blackbox: true,
     canCreate: ['members', 'admins'],

--- a/packages/lesswrong/lib/collections/bans/schema.ts
+++ b/packages/lesswrong/lib/collections/bans/schema.ts
@@ -4,7 +4,8 @@ import { foreignKeyField } from '../../utils/schemaUtils'
 const schema: SchemaType<DbBan> = {
   expirationDate: {
     type: Date,
-    optional: true,
+    optional: false,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
@@ -22,6 +23,7 @@ const schema: SchemaType<DbBan> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     hidden: true,
   },
   ip: {
@@ -43,6 +45,7 @@ const schema: SchemaType<DbBan> = {
   comment: {
     type: String,
     optional:true,
+    nullable: false, //TODO not-null: should this really not be nullable?
     canRead: ['guests'],
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -65,6 +65,7 @@ const schema: SchemaType<DbBook> = {
       type: "Post"
     }),
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['members'],
     canCreate: ['members'],
@@ -84,6 +85,7 @@ const schema: SchemaType<DbBook> = {
       type: "Sequence"
     }),
     optional: true,
+    nullable: false,
     canRead: ["guests"],
     canUpdate: ['members'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/collections/schema.ts
+++ b/packages/lesswrong/lib/collections/collections/schema.ts
@@ -14,6 +14,7 @@ const schema: SchemaType<DbCollection> = {
       nullable: true
     }),
     optional: true,
+    nullable: false,
     canRead: ['guests'],
   },
 
@@ -112,6 +113,8 @@ const schema: SchemaType<DbCollection> = {
   firstPageLink: {
     type: String,
     optional: true,
+    // TODO not-null: not clear whether this one should be set to nullable: false or not.  LW doesn't have any empty values, but it doesn't have a default value.
+    nullable: false,
     canRead: ["guests"],
     canUpdate: ["admins"],
     canCreate: ["admins"],

--- a/packages/lesswrong/lib/collections/commentModeratorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/commentModeratorActions/schema.ts
@@ -27,9 +27,11 @@ const schema: SchemaType<DbCommentModeratorAction> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
   },
   type: {
     type: String,
+    nullable: false,
     control: 'select',
     allowedValues: Object.keys(COMMENT_MODERATOR_ACTION_TYPES),
     options: () => Object.entries(COMMENT_MODERATOR_ACTION_TYPES).map(([value, label]) => ({ value, label })),

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -65,6 +65,7 @@ const schema: SchemaType<DbComment> = {
     optional: true,
     canRead: ['guests'],
     onInsert: (document, currentUser) => new Date(),
+    nullable: false
   },
   // The comment author's name
   author: {
@@ -141,6 +142,7 @@ const schema: SchemaType<DbComment> = {
       nullable: true,
     }),
     optional: true,
+    nullable: false,
     canRead: [isEAForum ? documentIsNotDeleted : 'guests'],
     canCreate: ['members'],
     hidden: true,
@@ -454,7 +456,7 @@ const schema: SchemaType<DbComment> = {
     type: Boolean,
     optional: true,
     hidden: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -799,6 +799,7 @@ const schema: SchemaType<DbComment> = {
   },
 
   suggestForAlignmentUserIds: {
+    nullable: false,
     ...arrayOfForeignKeysField({
       idFieldName: "suggestForAlignmentUserIds",
       resolverName: "suggestForAlignmentUsers",

--- a/packages/lesswrong/lib/collections/conversations/schema.ts
+++ b/packages/lesswrong/lib/collections/conversations/schema.ts
@@ -12,6 +12,7 @@ const schema: SchemaType<DbConversation> = {
     label: "Conversation Title"
   },
   participantIds: {
+    nullable: false,
     ...arrayOfForeignKeysField({
       idFieldName: "participantIds",
       resolverName: "participants",
@@ -73,6 +74,7 @@ const schema: SchemaType<DbConversation> = {
       type: "User"
     }),
     optional: true,
+    nullable: false,
     hidden: true,
     canRead: ['guests'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
+++ b/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
@@ -7,10 +7,12 @@
 const schema: SchemaType<DbDatabaseMetadata> = {
   name: {
     type: String,
+    nullable: false
   },
   value: {
     type: Object,
-    blackbox: true
+    blackbox: true,
+    nullable: false
   },
 };
 

--- a/packages/lesswrong/lib/collections/debouncerEvents/schema.ts
+++ b/packages/lesswrong/lib/collections/debouncerEvents/schema.ts
@@ -2,12 +2,14 @@
 const schema = {
   name: {
     type: String,
+    nullable: false
   },
   af: {
     type: Boolean,
   },
   dispatched: {
     type: Boolean,
+    nullable: false
   },
   failed: {
     type: Boolean,
@@ -15,13 +17,16 @@ const schema = {
   
   delayTime: {
     type: Date,
+    nullable: false
   },
   upperBoundTime: {
     type: Date,
+    nullable: false
   },
   
   key: {
     type: String,
+    nullable: false
   },
   pendingEvents: {
     type: Array,

--- a/packages/lesswrong/lib/collections/digestPosts/schema.ts
+++ b/packages/lesswrong/lib/collections/digestPosts/schema.ts
@@ -17,6 +17,7 @@ const schema: SchemaType<DbDigestPost> = {
     canCreate: ['admins'],
     canUpdate: ['admins'],
     hidden: true,
+    nullable: false
   },
   postId: {
     ...foreignKeyField({
@@ -30,12 +31,13 @@ const schema: SchemaType<DbDigestPost> = {
     canCreate: ['admins'],
     canUpdate: ['admins'],
     hidden: true,
+    nullable: false,
   },
   // is this post in the email digest?
   emailDigestStatus: {
     type: String,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null – intentionally nullable?
     canRead: ['guests'],
     canUpdate: ['admins'],
     canCreate: ['admins'],
@@ -44,7 +46,7 @@ const schema: SchemaType<DbDigestPost> = {
   onsiteDigestStatus: {
     type: String,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null – intentionally nullable?
     canRead: ['guests'],
     canUpdate: ['admins'],
     canCreate: ['admins'],

--- a/packages/lesswrong/lib/collections/emailTokens/schema.ts
+++ b/packages/lesswrong/lib/collections/emailTokens/schema.ts
@@ -3,9 +3,11 @@ import { foreignKeyField } from '../../../lib/utils/schemaUtils';
 const schema: SchemaType<DbEmailTokens> = {
   token: {
     type: String,
+    nullable: false,
   },
   tokenType: {
     type: String,
+    nullable: false,
   },
   userId: {
     ...foreignKeyField({
@@ -14,7 +16,8 @@ const schema: SchemaType<DbEmailTokens> = {
       collectionName: "Users",
       type: "User",
       nullable: false,
-    })
+    }),
+    nullable: false,
   },
   usedAt: {
     type: Date,

--- a/packages/lesswrong/lib/collections/featuredResources/schema.ts
+++ b/packages/lesswrong/lib/collections/featuredResources/schema.ts
@@ -1,6 +1,7 @@
 const schema: SchemaType<DbFeaturedResource> = {
   title: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
@@ -8,6 +9,7 @@ const schema: SchemaType<DbFeaturedResource> = {
   },
   body: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
@@ -15,6 +17,7 @@ const schema: SchemaType<DbFeaturedResource> = {
   },
   ctaText: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
@@ -22,6 +25,7 @@ const schema: SchemaType<DbFeaturedResource> = {
   },
   ctaUrl: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['admins'],
     canCreate: ['admins'],
@@ -33,6 +37,7 @@ const schema: SchemaType<DbFeaturedResource> = {
     canCreate: ['admins'],
     canUpdate: ['admins'],
     optional: true,
+    nullable: false,
     control: 'datetime',
   },
 }

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -35,6 +35,7 @@ const schema: SchemaType<DbGardenCode> = {
     type: String,
     optional: true,
     canRead: ['guests'],
+    nullable: false,
     onInsert: (gardenCode) => {
       return generateCode(4)
     },
@@ -46,6 +47,7 @@ const schema: SchemaType<DbGardenCode> = {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     label: "Event Name",
     defaultValue: "Guest Day Pass",
+    nullable: false,
     order: 10
   },
   userId: {
@@ -58,7 +60,8 @@ const schema: SchemaType<DbGardenCode> = {
     }),
     onCreate: ({currentUser}) => currentUser!._id,
     canRead: ['guests'],
-    optional: true
+    optional: true,
+    nullable: false,
   },
   // gatherTownUsername: {
   //   optional: true,
@@ -72,6 +75,7 @@ const schema: SchemaType<DbGardenCode> = {
     type: String,
     optional: true,
     canRead: ['guests'],
+    nullable: false,
     onInsert: async (gardenCode) => {
       return await Utils.getUnusedSlugByCollectionName("GardenCodes", slugify(gardenCode.title))
     },
@@ -95,6 +99,7 @@ const schema: SchemaType<DbGardenCode> = {
     control: 'datetime',
     label: "End Time",
     optional: true,
+    nullable: false,
     order: 25,
     onInsert: (gardenCode) => {
       return moment(gardenCode.startTime).add(12, 'hours').toDate()

--- a/packages/lesswrong/lib/collections/images/collection.ts
+++ b/packages/lesswrong/lib/collections/images/collection.ts
@@ -1,14 +1,15 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils'
 import { ensureIndex } from '../../collectionIndexUtils';
-import { forumTypeSetting } from '../../instanceSettings';
 
 const schema: SchemaType<DbImages> = {
   originalUrl: {
     type: String,
+    nullable: false,
   },
   cdnHostedUrl: {
     type: String,
+    nullable: false,
   },
 };
 

--- a/packages/lesswrong/lib/collections/legacyData/collection.ts
+++ b/packages/lesswrong/lib/collections/legacyData/collection.ts
@@ -6,9 +6,11 @@ import { forumTypeSetting } from '../../instanceSettings';
 const schema: SchemaType<DbLegacyData> = {
   objectId: {
     type: String,
+    nullable: false,
   },
   collectionName: {
     type: String,
+    nullable: false,
   },
 };
 

--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -13,6 +13,7 @@ const schema: SchemaType<DbMessage> = {
     canRead: ['members'],
     canCreate: ['admins'],
     optional: true,
+    nullable: false,
     hidden: true,
   },
   conversationId: {
@@ -25,6 +26,7 @@ const schema: SchemaType<DbMessage> = {
     }),
     canRead: ['members'],
     canCreate: ['members'],
+    nullable: false,
     hidden: true,
   },
   noEmail: {

--- a/packages/lesswrong/lib/collections/migrations/collection.ts
+++ b/packages/lesswrong/lib/collections/migrations/collection.ts
@@ -16,17 +16,21 @@ import { addUniversalFields } from '../../collectionUtils'
 const schema: SchemaType<DbMigration> = {
   name: {
     type: String,
+    nullable: false,
   },
   started: {
     type: Date,
+    nullable: false,
   },
   finished: {
     type: Boolean,
     defaultValue: false,
+    nullable: false,
   },
   succeeded: {
     type: Boolean,
     defaultValue: false,
+    nullable: false,
   },
 };
 

--- a/packages/lesswrong/lib/collections/moderationTemplates/schema.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/schema.ts
@@ -11,10 +11,12 @@ const schema: SchemaType<DbModerationTemplate> = {
     canCreate: ['members'],
     canUpdate: ['members'],
     order: 1,
+    nullable: false,
   },
   // This field is misnamed - it doesn't have anything to do with objects on foreign collections.  It's just a "type".
   collectionName: {
     type: String,
+    nullable: false,
     canCreate: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -90,11 +90,13 @@ const schema: SchemaType<DbModeratorAction> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     control: 'SearchSingleUser'
     // hidden: true,
   },
   type: {
     type: String,
+    nullable: false,
     control: 'select',
     allowedValues: Object.keys(MODERATOR_ACTION_TYPES),
     options: () => Object.entries(MODERATOR_ACTION_TYPES).map(([value, label]) => ({ value, label })),

--- a/packages/lesswrong/lib/collections/notifications/schema.ts
+++ b/packages/lesswrong/lib/collections/notifications/schema.ts
@@ -6,6 +6,7 @@ const schema: SchemaType<DbNotification> = {
     type: String,
     foreignKey: "Users",
     optional: true,
+    nullable: false,
     canRead: userOwns,
   },
   documentId: {
@@ -38,11 +39,13 @@ const schema: SchemaType<DbNotification> = {
   message: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: userOwns,
   },
   type: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: userOwns,
   },
   deleted: {

--- a/packages/lesswrong/lib/collections/pagecache/schema.ts
+++ b/packages/lesswrong/lib/collections/pagecache/schema.ts
@@ -65,27 +65,34 @@ const RenderResultSchemaType = new SimpleSchema({
 const schema: SchemaType<DbPageCacheEntry> = {
   path: {
     type: String,
+    nullable: false,
   },
   abTestGroups: {
     // This is always a Record<string, string>
     type: Object,
     blackbox: true,
+    nullable: false,
   },
   bundleHash: {
     type: String,
+    nullable: false,
   },
   renderedAt: {
     type: Date,
+    nullable: false,
   },
   expiresAt: {
     type: Date,
+    nullable: false,
   },
   ttlMs: {
     // This can be inferred from renderedAt and expiresAt, but it's useful to have for debugging
     type: Number,
+    nullable: false,
   },
   renderResult: {
     type: RenderResultSchemaType,
+    nullable: false,
   },
 };
 

--- a/packages/lesswrong/lib/collections/petrovDayLaunchs/schema.ts
+++ b/packages/lesswrong/lib/collections/petrovDayLaunchs/schema.ts
@@ -3,6 +3,7 @@ const schema: SchemaType<DbPetrovDayLaunch> = {
   launchCode: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],

--- a/packages/lesswrong/lib/collections/podcastEpisodes/schema.ts
+++ b/packages/lesswrong/lib/collections/podcastEpisodes/schema.ts
@@ -10,6 +10,7 @@ const schema: SchemaType<DbPodcastEpisode> = {
       nullable: false
     }),
     optional: true, // ???
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['podcasters', 'admins']
   },

--- a/packages/lesswrong/lib/collections/postRecommendations/schema.ts
+++ b/packages/lesswrong/lib/collections/postRecommendations/schema.ts
@@ -12,7 +12,7 @@ export const schema: SchemaType<DbPostRecommendation> = {
       nullable: false,
     }),
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, confirm that this nullability is intended
     canRead: ["admins"],
     canUpdate: ["admins"],
     canCreate: ["admins"],
@@ -27,7 +27,7 @@ export const schema: SchemaType<DbPostRecommendation> = {
   clientId: {
     type: String,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, confirm that this nullability is intended
     canRead: ["admins"],
     canUpdate: ["admins"],
     canCreate: ["admins"],
@@ -65,7 +65,7 @@ export const schema: SchemaType<DbPostRecommendation> = {
   strategySettings: {
     type: Object,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, confirm that this nullability is intended
     blackbox: true,
     canRead: ["admins"],
     canUpdate: ["admins"],
@@ -98,7 +98,7 @@ export const schema: SchemaType<DbPostRecommendation> = {
   clickedAt: {
     type: Date,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, confirm that this nullability is intended
     canRead: ["admins"],
     canUpdate: ["admins"],
     canCreate: ["admins"],

--- a/packages/lesswrong/lib/collections/postRelations/schema.ts
+++ b/packages/lesswrong/lib/collections/postRelations/schema.ts
@@ -5,6 +5,7 @@ const schema: SchemaType<DbPostRelation> = {
     // "subQuestion"
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],
@@ -17,6 +18,7 @@ const schema: SchemaType<DbPostRelation> = {
       type: "Post",
       nullable: true
     }),
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
   },
@@ -28,6 +30,7 @@ const schema: SchemaType<DbPostRelation> = {
       type: "Post",
       nullable: true
     }),
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
   },

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -166,6 +166,7 @@ const schema: SchemaType<DbPost> = {
   postedAt: {
     type: Date,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
@@ -246,6 +247,7 @@ const schema: SchemaType<DbPost> = {
   slug: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     onInsert: async (post) => {
       return await Utils.getUnusedSlugByCollectionName("Posts", slugify(post.title))
@@ -260,6 +262,7 @@ const schema: SchemaType<DbPost> = {
   viewCount: {
     type: Number,
     optional: true,
+    nullable: false,
     canRead: ['admins'],
     defaultValue: 0
   },
@@ -276,6 +279,7 @@ const schema: SchemaType<DbPost> = {
   clickCount: {
     type: Number,
     optional: true,
+    nullable: false,
     canRead: ['admins'],
     defaultValue: 0
   },
@@ -299,6 +303,7 @@ const schema: SchemaType<DbPost> = {
   status: {
     type: Number,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins', 'sunshineRegiment'],
@@ -321,6 +326,7 @@ const schema: SchemaType<DbPost> = {
   isFuture: {
     type: Boolean,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     onInsert: (post) => {
       // Set the post's isFuture to true if necessary
@@ -425,6 +431,7 @@ const schema: SchemaType<DbPost> = {
       nullable: true
     }),
     optional: true,
+    nullable: false,
     control: 'text',
     canRead: [documentIsNotDeleted],
     canUpdate: ['admins'],
@@ -780,12 +787,14 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreAF: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
   reviewVotesAF: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -797,6 +806,7 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreHighKarma: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
@@ -804,6 +814,7 @@ const schema: SchemaType<DbPost> = {
   reviewVotesHighKarma: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -815,6 +826,7 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreAllKarma: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
@@ -822,6 +834,7 @@ const schema: SchemaType<DbPost> = {
   reviewVotesAllKarma: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -834,12 +847,14 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreHighKarma: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
   finalReviewVotesHighKarma: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -851,12 +866,14 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreAllKarma: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
   finalReviewVotesAllKarma: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -868,12 +885,14 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreAF: {
     type: Number, 
     optional: true,
+    nullable: false,
     defaultValue: 0,
     canRead: ['guests']
   },
   finalReviewVotesAF: {
     type: Array,
     optional: true,
+    nullable: false,
     defaultValue: [],
     canRead: ['guests']
   },
@@ -1144,6 +1163,7 @@ const schema: SchemaType<DbPost> = {
   forceAllowType3Audio: {
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: false,
     defaultValue: false,
     canRead: ['guests'],
@@ -1157,6 +1177,7 @@ const schema: SchemaType<DbPost> = {
   legacy: {
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: false,
     defaultValue: false,
     canRead: ['guests'],
@@ -1182,6 +1203,7 @@ const schema: SchemaType<DbPost> = {
   legacySpam: {
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     hidden: true,
     canRead: ['guests'],
@@ -1453,7 +1475,7 @@ const schema: SchemaType<DbPost> = {
       foreignPostId: { type: String, optional: true, nullable: true },
     }),
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, why explicitly set?
     canRead: [documentIsNotDeleted],
     canUpdate: [allOf(userOwns, userPassesCrosspostingKarmaThreshold), 'admins'],
     canCreate: [userPassesCrosspostingKarmaThreshold, 'admins'],
@@ -1830,6 +1852,7 @@ const schema: SchemaType<DbPost> = {
   maxBaseScore: {
     type: Number,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     hidden: true,
     onInsert: (document) => document.baseScore || 0,
@@ -1931,6 +1954,7 @@ const schema: SchemaType<DbPost> = {
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     hidden: true,
     control: "UsersListEditor",
     group: formGroups.event,
@@ -2287,6 +2311,7 @@ const schema: SchemaType<DbPost> = {
     canCreate: ['members'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     hidden: true, 
     
     ...arrayOfForeignKeysField({
@@ -2812,6 +2837,7 @@ const schema: SchemaType<DbPost> = {
     canCreate: ['members', 'sunshineRegiment', 'admins'],
     canUpdate: ['members', 'alignmentForum', 'alignmentForumAdmins'],
     optional: true,
+    nullable: false,
     hidden: true,
     label: "Suggested for Alignment by",
     control: "UsersListEditor",

--- a/packages/lesswrong/lib/collections/readStatus/collection.ts
+++ b/packages/lesswrong/lib/collections/readStatus/collection.ts
@@ -30,12 +30,15 @@ const schema: SchemaType<DbReadStatus> = {
       type: "User",
       nullable: false,
     }),
+    nullable: false,
   },
   isRead: {
     type: Boolean,
+    nullable: false,
   },
   lastUpdated: {
     type: Date,
+    nullable: false,
   },
 };
 

--- a/packages/lesswrong/lib/collections/reports/schema.ts
+++ b/packages/lesswrong/lib/collections/reports/schema.ts
@@ -13,6 +13,7 @@ const schema: SchemaType<DbReport> = {
     canCreate: ['members'],
     hidden: true,
     optional: true,
+    nullable: false
   },
   reportedUserId: {
     ...foreignKeyField({
@@ -85,6 +86,7 @@ const schema: SchemaType<DbReport> = {
   },
   closedAt: {
     optional: true,
+    nullable: false,
     type: Date,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],

--- a/packages/lesswrong/lib/collections/reviewVotes/schema.ts
+++ b/packages/lesswrong/lib/collections/reviewVotes/schema.ts
@@ -16,7 +16,8 @@ const schema: SchemaType<DbReviewVote> = {
     }),
     onCreate: ({currentUser}) => currentUser!._id,
     canRead: ['guests'],
-    optional: true
+    optional: true,
+    nullable: false,
   },
   postId: {
     ...foreignKeyField({
@@ -27,6 +28,7 @@ const schema: SchemaType<DbReviewVote> = {
       nullable: true,
     }),
     canRead: ['guests'],
+    nullable: false,
   },
   qualitativeScore: {
     type: SimpleSchema.Integer, 

--- a/packages/lesswrong/lib/collections/revisions/schema.ts
+++ b/packages/lesswrong/lib/collections/revisions/schema.ts
@@ -102,6 +102,7 @@ const schema: SchemaType<DbRevision> = {
   version: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests']
   },
   commitMessage: {
@@ -185,6 +186,7 @@ const schema: SchemaType<DbRevision> = {
     type: Number,
     canRead: ['guests'],
     optional: true,
+    nullable: false,
     // resolveAs defined in resolvers.js
   },
   htmlHighlight: {
@@ -209,6 +211,7 @@ const schema: SchemaType<DbRevision> = {
   },
   changeMetrics: {
     type: Object,
+    nullable: false,
     blackbox: true,
     canRead: ['guests']
   },

--- a/packages/lesswrong/lib/collections/rssfeeds/schema.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/schema.ts
@@ -15,6 +15,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canCreate: ['members'],
     canUpdate: ['admins'],
     optional: true,
+    nullable: false,
   },
   ownedByUser: {
     type: Boolean,
@@ -23,6 +24,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canUpdate: ['admins'],
     control: "checkbox",
     optional: true,
+    nullable: false,
     order: 30,
     defaultValue: false,
   },
@@ -33,6 +35,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canUpdate: ['admins'],
     control: "checkbox",
     optional: true,
+    nullable: false,
     order: 40,
     defaultValue: false,
   },
@@ -42,6 +45,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canCreate: ['members'],
     canUpdate: ['admins'],
     optional: true,
+    nullable: false,
     order: 10,
   },
   url: {
@@ -50,6 +54,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canCreate: ['members'],
     canUpdate: ['admins'],
     optional: true,
+    nullable: false,
     order: 20,
   },
   // Set to 'inactive' to prevent posting
@@ -66,6 +71,7 @@ const schema: SchemaType<DbRSSFeed> = {
     canCreate: ['members'],
     canUpdate: ['admins'],
     optional: true,
+    nullable: false,
     logChanges: false,
   },
   setCanonicalUrl: {

--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -12,6 +12,7 @@ const schema: SchemaType<DbSequence> = {
       nullable: true,
     }),
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
@@ -219,6 +220,7 @@ const schema: SchemaType<DbSequence> = {
   af: {
     type: Boolean,
     optional: true,
+    nullable: false,
     label: "Alignment Forum",
     defaultValue: false,
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/sessions/schema.ts
+++ b/packages/lesswrong/lib/collections/sessions/schema.ts
@@ -16,11 +16,11 @@ const schema: SchemaType<DbSession> = {
   session: {
     type: Object,
     blackbox: true,
-    ...commonFields(true),
+    ...commonFields(true), //TODO not-null: confirm this should be nullable?
   },
   expires: {
     type: Date,
-    ...commonFields(true),
+    ...commonFields(true), //TODO not-null: confirm this should be nullable?
   },
   lastModified: {
     type: Date,

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -10,6 +10,7 @@ const DOCUMENT_TYPES = ['Sequence', 'Post'];
 const SpotlightDocumentType = new SimpleSchema({
   documentType: {
     type: String,
+    nullable: false,
     allowedValues: DOCUMENT_TYPES,
   }
 });
@@ -42,6 +43,7 @@ const shiftSpotlightItems = async ({ startBound, endBound, offset, context }: Sh
 const schema: SchemaType<DbSpotlight> = {
   documentId: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'],
@@ -85,6 +87,7 @@ const schema: SchemaType<DbSpotlight> = {
     canCreate: ['admins', 'sunshineRegiment'],
     order: 30,
     optional: true,
+    nullable: false,
     onCreate: async ({ newDocument, context }) => {
       const [currentSpotlight, lastSpotlightByPosition] = await Promise.all([
         context.Spotlights.findOne({}, { sort: { lastPromotedAt: -1 } }),

--- a/packages/lesswrong/lib/collections/subscriptions/schema.ts
+++ b/packages/lesswrong/lib/collections/subscriptions/schema.ts
@@ -29,9 +29,11 @@ const schema: SchemaType<DbSubscription> = {
     onCreate: ({currentUser}) => currentUser!._id,
     canRead: [userOwns],
     optional: true,
+    nullable: false,
   },
   state: {
     type: String,
+    nullable: false,
     allowedValues: ['subscribed', 'suppressed'],
     canCreate: ['members'],
     canRead: [userOwns],
@@ -43,6 +45,7 @@ const schema: SchemaType<DbSubscription> = {
   },
   collectionName: {
     type: String, 
+    nullable: false,
     typescriptType: "CollectionNameString",
     canRead: [userOwns],
     canCreate: ['members']
@@ -55,6 +58,7 @@ const schema: SchemaType<DbSubscription> = {
   },
   type: {
     type: String,
+    nullable: false,
     allowedValues: Object.values(subscriptionTypes),
     canCreate: ['members'],
     canRead: [userOwns]

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -9,6 +9,7 @@ import { adminsGroup, userCanDo } from '../../vulcan-users/permissions';
 const schema: SchemaType<DbTagFlag> = {
   name: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['members', 'admins', 'sunshineRegiment'],
     canCreate: ['members', 'admins', 'sunshineRegiment'],
@@ -16,6 +17,7 @@ const schema: SchemaType<DbTagFlag> = {
   },
   deleted: {
     optional: true,
+    nullable: false,
     type: Boolean,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
@@ -26,6 +28,7 @@ const schema: SchemaType<DbTagFlag> = {
   slug: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     onInsert: async (tagFlag) => {
       return await Utils.getUnusedSlugByCollectionName("TagFlags", slugify(tagFlag.name))
@@ -39,6 +42,7 @@ const schema: SchemaType<DbTagFlag> = {
   order: {
     type: Number,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     canCreate: ['admins', 'sunshineRegiment'], 

--- a/packages/lesswrong/lib/collections/tagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/tagRels/collection.ts
@@ -9,6 +9,7 @@ import { userOwns } from '../../vulcan-users/permissions';
 
 const schema: SchemaType<DbTagRel> = {
   tagId: {
+    nullable: false,
     ...foreignKeyField({
       idFieldName: "tagId",
       resolverName: "tag",
@@ -20,6 +21,7 @@ const schema: SchemaType<DbTagRel> = {
     canCreate: ['members'],
   },
   postId: {
+    nullable: false,
     ...foreignKeyField({
       idFieldName: "postId",
       resolverName: "post",

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -38,6 +38,7 @@ export const TAG_POSTS_SORT_ORDER_OPTIONS: Record<string, SettingsOption>  = {
 const schema: SchemaType<DbTag> = {
   name: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],
@@ -64,6 +65,7 @@ const schema: SchemaType<DbTag> = {
   slug: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
@@ -548,6 +550,7 @@ const schema: SchemaType<DbTag> = {
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.advancedOptions,
     optional: true,
+    nullable: false,
     control: "UsersListEditor",
     label: "Subforum Moderators",
   },
@@ -618,6 +621,7 @@ const schema: SchemaType<DbTag> = {
       type: "Tag"
     }),
     optional: true,
+    nullable: false,
     // To edit this, you have to edit the parent tag of the tag you are adding, and this will be automatically updated. It's like this for
     // largely historical reasons, we didn't used to materialise the sub tag ids at all, but this had performance issues
     hidden: true,
@@ -654,6 +658,7 @@ const schema: SchemaType<DbTag> = {
   noindex: {
     type: Boolean,
     optional: true,
+    nullable:false,
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],

--- a/packages/lesswrong/lib/collections/userMostValuablePosts/schema.ts
+++ b/packages/lesswrong/lib/collections/userMostValuablePosts/schema.ts
@@ -4,6 +4,7 @@ import { userOwns } from '../../vulcan-users/permissions';
 
 const schema: SchemaType<DbUserMostValuablePost> = {
   userId: {
+    nullable: false,
     ...foreignKeyField({
       idFieldName: "userId",
       resolverName: "user",
@@ -16,6 +17,7 @@ const schema: SchemaType<DbUserMostValuablePost> = {
     canUpdate: [userOwns, 'admins'],
   },
   postId: {
+    nullable: false,
     ...foreignKeyField({
       idFieldName: "postId",
       resolverName: "post",

--- a/packages/lesswrong/lib/collections/userTagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/userTagRels/collection.ts
@@ -16,6 +16,7 @@ const schema: SchemaType<DbUserTagRel> = {
     canCreate: ['members'],
   },
   userId: {
+    nullable: false,
     ...foreignKeyField({
       idFieldName: "userId",
       resolverName: "user",
@@ -57,6 +58,7 @@ const schema: SchemaType<DbUserTagRel> = {
   subforumHideIntroPost: {
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: true,
     label: "Don't show the intro post at the top of topic feeds",
     canRead: [userOwns, 'admins'],

--- a/packages/lesswrong/lib/collections/useractivities/schema.ts
+++ b/packages/lesswrong/lib/collections/useractivities/schema.ts
@@ -1,19 +1,24 @@
 const schema: SchemaType<DbUserActivity> = {
   visitorId: {
-    type: String
+    type: String,
+    nullable: true
   },
   type: {
     type: String,
     allowedValues: ["userId", "clientId"],
+    nullable: true
   },
   startDate: {
-    type: Date
+    type: Date,
+    nullable: true
   },
   endDate: {
-    type: Date
+    type: Date,
+    nullable: true //TODO not-null, confirm that this should be nullable
   },
   activityArray: {
-    type: Array
+    type: Array,
+    nullable: true
   },
   'activityArray.$': {
     // In practice this is currently a boolean, but we could support weighting by how long exactly they were active for

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -333,6 +333,7 @@ const schema: SchemaType<DbUser> = {
     label: 'Admin',
     input: 'checkbox',
     optional: true,
+    nullable: false,
     canCreate: ['admins'],
     canUpdate: ['admins','realAdmins'],
     canRead: ['guests'],
@@ -473,6 +474,7 @@ const schema: SchemaType<DbUser> = {
   noindex: {
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
@@ -597,6 +599,7 @@ const schema: SchemaType<DbUser> = {
   legacy: {
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     hidden: true,
     canRead: [userOwns, 'admins'],
@@ -643,6 +646,7 @@ const schema: SchemaType<DbUser> = {
   reactPaletteStyle: {
     type: String,
     optional: true,
+    nullable: false,
     canRead: [userOwns, 'admins'],
     canUpdate: [userOwns, 'admins'],
     label: "React Palette Style",
@@ -707,6 +711,7 @@ const schema: SchemaType<DbUser> = {
     order: 71,
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
@@ -722,6 +727,7 @@ const schema: SchemaType<DbUser> = {
     order: 72,
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
@@ -734,6 +740,7 @@ const schema: SchemaType<DbUser> = {
     order: 80,
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: [userOwns],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
@@ -746,6 +753,7 @@ const schema: SchemaType<DbUser> = {
     order: 90,
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: [userOwns],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
@@ -759,6 +767,7 @@ const schema: SchemaType<DbUser> = {
     order: 91,
     type: Boolean,
     optional: true,
+    nullable: false,
     group: formGroups.siteCustomizations,
     defaultValue: false,
     canRead: ['guests'],
@@ -772,6 +781,7 @@ const schema: SchemaType<DbUser> = {
     order: 92,
     type: Boolean,
     optional: true,
+    nullable: false,
     group: formGroups.siteCustomizations,
     defaultValue: false,
     canRead: ['guests'],
@@ -785,6 +795,7 @@ const schema: SchemaType<DbUser> = {
     order: 93,
     type: Boolean,
     optional: true,
+    nullable: false,
     group: formGroups.siteCustomizations,
     defaultValue: false,
     canRead: ['guests'],
@@ -798,6 +809,7 @@ const schema: SchemaType<DbUser> = {
     order: 93,
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: !isEAForum,
     group: formGroups.siteCustomizations,
     defaultValue: false,
@@ -823,6 +835,7 @@ const schema: SchemaType<DbUser> = {
     order: 94,
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: forumTypeSetting.get() !== 'EAForum',
     group: formGroups.siteCustomizations,
     defaultValue: false,
@@ -837,6 +850,7 @@ const schema: SchemaType<DbUser> = {
     order: 95,
     type: Boolean,
     optional: true,
+    nullable: false,
     hidden: !isEAForum,
     group: formGroups.siteCustomizations,
     defaultValue: false,
@@ -851,7 +865,7 @@ const schema: SchemaType<DbUser> = {
     order: 96,
     type: Boolean,
     optional: true,
-    nullable: true,
+    nullable: true,//TODO not-null – examine this
     group: formGroups.siteCustomizations,
     defaultValue: false,
     canRead: ['guests'],
@@ -868,7 +882,7 @@ const schema: SchemaType<DbUser> = {
   acceptedTos: {
     type: Boolean,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null, I assume intentional?
     hidden: true,
     defaultValue: false,
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
@@ -1101,6 +1115,7 @@ const schema: SchemaType<DbUser> = {
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     hidden: true,
     onUpdate: ({data, currentUser, oldDocument}) => {
       if (data?.bookmarkedPostsMetadata) {
@@ -1137,6 +1152,7 @@ const schema: SchemaType<DbUser> = {
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
+    nullable: false,
     hidden: true,
     onUpdate: ({data, currentUser, oldDocument}) => {
       if (data?.hiddenPostsMetadata) {
@@ -1176,6 +1192,7 @@ const schema: SchemaType<DbUser> = {
   deleted: {
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: ['members', 'admins'],
@@ -2109,6 +2126,7 @@ const schema: SchemaType<DbUser> = {
   noExpandUnreadCommentsReview: {
     type: Boolean,
     optional: true,
+    nullable: false,
     defaultValue: false,
     hidden: true,
     canRead: ['guests'],
@@ -2428,6 +2446,7 @@ const schema: SchemaType<DbUser> = {
     }),
     hidden: true,
     optional: true,
+    nullable: false, //TODO not-null: check this one
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],
@@ -2455,6 +2474,7 @@ const schema: SchemaType<DbUser> = {
     }),
     hidden: true,
     optional: true,
+    nullable: false,
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],
@@ -2654,7 +2674,7 @@ const schema: SchemaType<DbUser> = {
   allowDatadogSessionReplay: {
     type: Boolean,
     optional: true,
-    nullable: true,
+    nullable: true, //TODO not-null: I assume intentional
     hidden: forumTypeSetting.get() !== 'EAForum',
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],

--- a/packages/lesswrong/lib/collections/votes/schema.ts
+++ b/packages/lesswrong/lib/collections/votes/schema.ts
@@ -25,6 +25,7 @@ const schema: SchemaType<DbVote> = {
   // The id of the document that was voted on
   documentId: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
     // No explicit foreign-key relation because which collection this is depends on collectionName
   },
@@ -32,6 +33,7 @@ const schema: SchemaType<DbVote> = {
   // The name of the collection the document belongs to
   collectionName: {
     type: String,
+    nullable: false,
     typescriptType: "CollectionNameString",
     canRead: ['guests'],
   },
@@ -39,6 +41,7 @@ const schema: SchemaType<DbVote> = {
   // The id of the user that voted
   userId: {
     type: String,
+    nullable: false,
     canRead: [userOwns, docIsTagRel, 'admins'],
     foreignKey: 'Users',
   },
@@ -70,6 +73,7 @@ const schema: SchemaType<DbVote> = {
   // neutral if it doesn't.
   voteType: {
     type: String,
+    nullable: false,
     canRead: ['guests'],
   },
   
@@ -93,6 +97,7 @@ const schema: SchemaType<DbVote> = {
   power: {
     type: Number,
     optional: true,
+    nullable: false,    
     canRead: [userOwns, docIsTagRel, 'admins'],
     
     // Can be inferred from userId+voteType+votedAt (votedAt necessary because
@@ -131,6 +136,7 @@ const schema: SchemaType<DbVote> = {
   votedAt: {
     type: Date,
     optional: true,
+    nullable: false,
     canRead: [userOwns, docIsTagRel, 'admins'],
   },
 

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -646,7 +646,7 @@ interface DbPost extends DbObject {
   nextDayReminderSent: boolean
   onlyVisibleToLoggedIn: boolean
   onlyVisibleToEstablishedAccounts: boolean
-  hideFromRecentDiscussions: boolean | null
+  hideFromRecentDiscussions: boolean
   votingSystem: string
   podcastEpisodeId: string | null
   forceAllowType3Audio: boolean
@@ -676,7 +676,7 @@ interface DbPost extends DbObject {
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null
+  }
   canonicalSequenceId: string
   canonicalCollectionSlug: string
   canonicalBookId: string
@@ -738,8 +738,8 @@ interface DbPost extends DbObject {
   commentCount: number
   topLevelCommentCount: number
   criticismTipsDismissed: boolean
-  debate: boolean | null
-  collabEditorDialogue: boolean | null
+  debate: boolean
+  collabEditorDialogue: boolean
   rejected: boolean
   rejectedReason: string | null
   rejectedByUserId: string
@@ -1059,11 +1059,11 @@ interface UserActivitiesCollection extends CollectionBase<DbUserActivity, "UserA
 
 interface DbUserActivity extends DbObject {
   __collectionName?: "UserActivities"
-  visitorId: string
-  type: "userId" | "clientId"
-  startDate: Date
-  endDate: Date
-  activityArray: Array<number>
+  visitorId: string | null
+  type: "userId" | "clientId" | null
+  startDate: Date | null
+  endDate: Date | null
+  activityArray: Array<number> | null
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
 }
@@ -1130,7 +1130,7 @@ interface DbUser extends DbObject {
   theme: {
     name: "default" | "dark" | "auto" | null,
     siteThemeOverride: any /*{"definitions":[{"blackbox":true}]}*/,
-  } | null
+  }
   lastUsedTimezone: string
   whenConfirmationEmailSent: Date
   legacy: boolean
@@ -1428,7 +1428,7 @@ interface DbUser extends DbObject {
   subforumPreferredLayout: "card" | "list"
   experiencedIn: Array<string> | null
   interestedIn: Array<string> | null
-  allowDatadogSessionReplay: boolean | null
+  allowDatadogSessionReplay: boolean
   afPostCount: number
   afCommentCount: number
   afSequenceCount: number

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -54,7 +54,7 @@ interface UsersDefaultFragment { // fragment on Users
   readonly theme: {
     name: "default" | "dark" | "auto" | null,
     siteThemeOverride: any /*{"definitions":[{"blackbox":true}]}*/,
-  } | null,
+  },
   readonly lastUsedTimezone: string,
   readonly whenConfirmationEmailSent: Date,
   readonly legacy: boolean,
@@ -353,7 +353,7 @@ interface UsersDefaultFragment { // fragment on Users
   readonly subforumPreferredLayout: "card" | "list",
   readonly experiencedIn: Array<string> | null,
   readonly interestedIn: Array<string> | null,
-  readonly allowDatadogSessionReplay: boolean | null,
+  readonly allowDatadogSessionReplay: boolean,
   readonly afPostCount: number,
   readonly afCommentCount: number,
   readonly afSequenceCount: number,
@@ -619,7 +619,7 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly nextDayReminderSent: boolean,
   readonly onlyVisibleToLoggedIn: boolean,
   readonly onlyVisibleToEstablishedAccounts: boolean,
-  readonly hideFromRecentDiscussions: boolean | null,
+  readonly hideFromRecentDiscussions: boolean,
   readonly votingSystem: string,
   readonly podcastEpisodeId: string | null,
   readonly forceAllowType3Audio: boolean,
@@ -649,7 +649,7 @@ interface PostsDefaultFragment { // fragment on Posts
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null,
+  },
   readonly canonicalSequenceId: string,
   readonly canonicalCollectionSlug: string,
   readonly canonicalBookId: string,
@@ -715,8 +715,8 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly topLevelCommentCount: number,
   readonly criticismTipsDismissed: boolean,
   readonly languageModelSummary: string,
-  readonly debate: boolean | null,
-  readonly collabEditorDialogue: boolean | null,
+  readonly debate: boolean,
+  readonly collabEditorDialogue: boolean,
   readonly totalDialogueResponseCount: number,
   readonly unreadDebateResponseCount: number,
   readonly rejected: boolean,
@@ -915,8 +915,8 @@ interface PostsMinimumInfo { // fragment on Posts
   }> | null,
   readonly hasCoauthorPermission: boolean,
   readonly rejected: boolean,
-  readonly debate: boolean | null,
-  readonly collabEditorDialogue: boolean | null,
+  readonly debate: boolean,
+  readonly collabEditorDialogue: boolean,
 }
 
 interface PostsMinimumInfo_currentUserReviewVote { // fragment on ReviewVotes
@@ -955,7 +955,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly curatedDate: Date,
   readonly commentsLocked: boolean,
   readonly commentsLockedToAccountsCreatedAfter: Date,
-  readonly debate: boolean | null,
+  readonly debate: boolean,
   readonly question: boolean,
   readonly hiddenRelatedQuestion: boolean,
   readonly originalPostRelationSourceId: string,
@@ -1090,7 +1090,7 @@ interface PostsList extends PostsListBase { // fragment on Posts
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null,
+  },
 }
 
 interface PostsList_contents { // fragment on Revisions
@@ -1147,7 +1147,7 @@ interface PostsDetails extends PostsListBase { // fragment on Posts
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null,
+  },
 }
 
 interface PostsDetails_canonicalSequence { // fragment on Sequences
@@ -1290,8 +1290,8 @@ interface PostsEdit extends PostsDetails { // fragment on Posts
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null,
-  readonly hideFromRecentDiscussions: boolean | null,
+  },
+  readonly hideFromRecentDiscussions: boolean,
   readonly hideFromPopularComments: boolean,
   readonly moderationGuidelines: RevisionEdit|null,
   readonly customHighlight: RevisionEdit|null,
@@ -1346,7 +1346,7 @@ interface SunshinePostsList extends PostsListBase { // fragment on Posts
     isCrosspost: boolean,
     hostedHere: boolean | null,
     foreignPostId: string | null,
-  } | null,
+  },
   readonly rejectedReason: string | null,
   readonly contents: SunshinePostsList_contents|null,
   readonly user: SunshinePostsList_user|null,
@@ -2703,7 +2703,7 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly theme: {
     name: "default" | "dark" | "auto" | null,
     siteThemeOverride: any /*{"definitions":[{"blackbox":true}]}*/,
-  } | null,
+  },
   readonly bookmarkedPostsMetadata: Array<any /*{"definitions":[{}]}*/>,
   readonly hiddenPostsMetadata: Array<any /*{"definitions":[{}]}*/>,
   readonly auto_subscribe_to_my_posts: boolean,
@@ -2734,7 +2734,7 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly subforumPreferredLayout: "card" | "list",
   readonly experiencedIn: Array<string> | null,
   readonly interestedIn: Array<string> | null,
-  readonly allowDatadogSessionReplay: boolean | null,
+  readonly allowDatadogSessionReplay: boolean,
   readonly hideFrontpageBook2020Ad: boolean,
 }
 
@@ -2862,7 +2862,7 @@ interface UsersEdit extends UsersProfile { // fragment on Users
   readonly theme: {
     name: "default" | "dark" | "auto" | null,
     siteThemeOverride: any /*{"definitions":[{"blackbox":true}]}*/,
-  } | null,
+  },
   readonly email: string,
   readonly whenConfirmationEmailSent: Date,
   readonly emailSubscribedToCurated: boolean,
@@ -2886,7 +2886,7 @@ interface UsersEdit extends UsersProfile { // fragment on Users
   readonly googleLocation: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly location: string,
   readonly mapLocation: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly allowDatadogSessionReplay: boolean | null,
+  readonly allowDatadogSessionReplay: boolean,
   readonly reviewedByUserId: string,
   readonly reviewForAlignmentForumUserId: string,
   readonly groups: Array<string>,

--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -2,6 +2,7 @@ import { addFieldsDict, denormalizedCountOfReferences, accessFilterMultiple } fr
 import { getWithLoader } from './loaders'
 import { userIsAdminOrMod } from './vulcan-users/permissions';
 import GraphQLJSON from 'graphql-type-json';
+import { schemaDefaultValue } from './collectionUtils';
 
 export type PermissionResult = {
   fail: false,
@@ -133,12 +134,9 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
     baseScore: {
       type: Number,
       optional: true,
-      defaultValue: 0,
+      nullable: false,
       canRead: customBaseScoreReadAccess || ['guests'],
-      onInsert: (document: DbInsertion<T>): number => {
-        // default to 0 if empty
-        return document.baseScore || 0;
-      }
+      ...schemaDefaultValue(0),
     },
     extendedScore: {
       type: GraphQLJSON,
@@ -149,19 +147,16 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
     score: {
       type: Number,
       optional: true,
-      defaultValue: 0,
+      nullable: false,
       canRead: ['guests'],
-      onInsert: (document: DbInsertion<T>): number => {
-        // default to 0 if empty
-        return document.score || 0;
-      }
+      ...schemaDefaultValue(0),
     },
     // Whether the document is inactive. Inactive documents see their score
     // recalculated less often
     inactive: {
       type: Boolean,
       optional: true,
-      onInsert: () => false
+      ...schemaDefaultValue(false),
     },
     afBaseScore: {
       type: Number,

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -8,6 +8,7 @@ import type { GraphQLScalarType } from 'graphql';
 import DataLoader from 'dataloader';
 import * as _ from 'underscore';
 import { loggerConstructor } from './logging';
+import { schemaDefaultValue } from '../collectionUtils';
 
 export const generateIdResolverSingle = <CollectionName extends CollectionNameString>({
   collectionName, fieldName, nullable
@@ -94,6 +95,10 @@ export const accessFilterMultiple = async <T extends DbObject>(currentUser: DbUs
 /**
  * This field is stored in the database as a string, but resolved as the
  * referenced document
+ * 
+ * @param {Object=} params
+ * @param {boolean} params.nullable
+ * whether the resolver field is nullable, not the original database field
  */
 export const foreignKeyField = <CollectionName extends CollectionNameString>({idFieldName, resolverName, collectionName, type, nullable=true}: {
   idFieldName: string,
@@ -133,7 +138,7 @@ export function arrayOfForeignKeysField<CollectionName extends keyof Collections
   
   return {
     type: Array,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     resolveAs: {
       fieldName: resolverName,
       type: `[${type}!]!`,

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -361,6 +361,7 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
   return {
     type: Number,
     optional: true,
+    nullable: false,
     defaultValue: 0,
     
     denormalized: true,


### PR DESCRIPTION
RobertM and I determined which database fields either have a default value or empirically contain no null values. We generated SQL commands to populate missing values with defaults, and then command SQL commands to update the database columns to disallow null values.

This PR introduces corresponding changes in the schema files for the SQL database commands.

SQL database command generation here: https://app.hex.tech/dac32525-33e6-44f9-bbcf-65a0ba40152a/hex/0ebd1ba6-40e5-47d2-a499-ae7db3f3c632/draft/logic