### PR TITLE
Fix line-wrapping of links within posts

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -406,7 +406,7 @@ export const CommentsItem = ({
             <Components.ForumIcon icon="Pin" className={classes.pinnedIcon} />
           </div>}
           {moderatedCommentId === comment._id && <FlagIcon className={classes.flagIcon} />}
-          {showPostTitle && !isChild && hasPostField(comment) && comment.post && <PostsTooltip postId={comment.postId}>
+          {showPostTitle && !isChild && hasPostField(comment) && comment.post && <PostsTooltip inlineBlock postId={comment.postId}>
               <Link className={classes.postTitle} to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>
                 {comment.post.draft && "[Draft] "}
                 {comment.post.title}

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
@@ -16,7 +16,7 @@ const PostsTooltip = ({
   tagRelId,
   hash,
   postsList,
-  inlineBlock,
+  inlineBlock=false,
   As,
   clickable,
   flip,

--- a/packages/lesswrong/components/sequences/CollectionsItem.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsItem.tsx
@@ -139,7 +139,7 @@ export const CollectionsItem = ({classes, showCloseIcon, collection}: {
           </div> : description}
         </ContentStyles>
         {firstPost && <div className={classes.firstPost}>
-          First Post: <PostsTooltip postId={firstPost.postId}>
+          First Post: <PostsTooltip inlineBlock postId={firstPost.postId}>
             <Link to={firstPost.postUrl}>{firstPost.postTitle}</Link>
           </PostsTooltip>
         </div>}

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -71,6 +71,7 @@ export const SpotlightStartOrContinueReading = ({classes, spotlight, className}:
         key={`${spotlight._id}-${post._id}`}
         post={post}
         flip={false}
+        inlineBlock
       >
         <Link to={postGetPageUrl(post, false, firstPostSequenceId)}>
           <div className={classNames(classes.postProgressBox, {[classes.read]: post.isRead || clientPostsRead[post._id]})} />


### PR DESCRIPTION
See: https://lworg.slack.com/archives/CJUN2UAFN/p1697691599333549

Changes in https://github.com/ForumMagnum/ForumMagnum/pull/7958 accidentally made it so that hover-preview links in posts were `display:inline-block`, causing them to wrap incorrectly. This makes them not be that, by making `PostsTooltip` default to normal wrapping rather than inline-block, and then adding inline-block to the few places where it actually makes sense.