### PR TITLE
allow antireacting to inline reacts

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/HoverBallotReactionRow.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/HoverBallotReactionRow.tsx
@@ -53,8 +53,11 @@ const HoverBallotReactionRow = ({reactionName, usersWhoReacted, classes, comment
   const netReactionCount = sumBy(usersWhoReacted, r=>r.reactType==="disagreed"?-1:1);
   const { getCurrentUserReactionVote, setCurrentUserReaction } = useNamesAttachedReactionsVoting(voteProps);
 
+  // Don't show the "general" (non-quote-specific) ballot for this react if all the instances of this react are inline (quote-specific)
+  const allReactsAreInline = usersWhoReacted.every(userWhoReacted => userWhoReacted.quotes?.length);
+
   return <div key={reactionName}>
-    <div className={classes.hoverBallotEntry}>
+    {!allReactsAreInline && <div className={classes.hoverBallotEntry}>
       <ReactionIcon react={reactionName} size={30}/>
       <div className={classes.hoverInfo}>
         <span className={classes.hoverBallotLabel}>
@@ -74,7 +77,7 @@ const HoverBallotReactionRow = ({reactionName, usersWhoReacted, classes, comment
         currentUserReaction={getCurrentUserReactionVote(reactionName)}
         setCurrentUserReaction={setCurrentUserReaction}
       />
-    </div>
+    </div>}
     <ReactionQuotesHoverInfo react={reactionName} voteProps={voteProps} commentBodyRef={commentBodyRef}/>
   </div>
 }

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -505,7 +505,7 @@ const NamesAttachedReactionsHoverSingleReaction = ({react, voteProps, classes, c
   const extendedScore = voteProps.document?.extendedScore as NamesAttachedReactionsScore|undefined;
 
   const alreadyUsedReactions: NamesAttachedReactionsList = extendedScore?.reacts ?? {};
-
+  
   return <div className={classes.footerReactionHover}>
     <Components.HoverBallotReactionRow
       key={react}

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -505,7 +505,7 @@ const NamesAttachedReactionsHoverSingleReaction = ({react, voteProps, classes, c
   const extendedScore = voteProps.document?.extendedScore as NamesAttachedReactionsScore|undefined;
 
   const alreadyUsedReactions: NamesAttachedReactionsList = extendedScore?.reacts ?? {};
-  
+
   return <div className={classes.footerReactionHover}>
     <Components.HoverBallotReactionRow
       key={react}

--- a/packages/lesswrong/components/votes/lwReactions/ReactOrAntireactVote.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactOrAntireactVote.tsx
@@ -21,6 +21,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 24,
     height: 24,
     verticalAlign: "middle",
+    cursor: 'pointer'
   },
   voteArrowLeft: {
     transform: 'rotate(-90deg)',

--- a/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 import { NamesAttachedReactionsList, NamesAttachedReactionsScore } from '../../../lib/voting/namesAttachedReactions';
 import { useCurrentUser } from '../../common/withUser';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { useNamesAttachedReactionsVoting } from './NamesAttachedReactionsVoteOnComment';
 import filter from 'lodash/filter';
 import uniq from 'lodash/uniq';
-import { dimHighlightClassName, highlightSelectorClassName } from '../../comments/CommentsItem/CommentsItem';
+import sumBy from 'lodash/sumBy';
 import type { VotingProps } from '../votingProps';
 import { ContentItemBody } from '../../common/ContentItemBody';
 
@@ -68,10 +68,8 @@ const ReactionQuotesHoverInfo = ({react, voteProps, commentBodyRef, classes}:{
   commentBodyRef?: React.RefObject<ContentItemBody>|null,
   classes: ClassesType
 }) => {
-  const { LWTooltip } = Components;
+  const { ReactOrAntireactVote } = Components;
   const extendedScore = voteProps.document?.extendedScore as NamesAttachedReactionsScore|undefined;
-
-  const currentUser = useCurrentUser();
 
   const alreadyUsedReactions: NamesAttachedReactionsList = extendedScore?.reacts ?? {};
   const usersWhoReacted = alreadyUsedReactions[react]
@@ -84,7 +82,7 @@ const ReactionQuotesHoverInfo = ({react, voteProps, commentBodyRef, classes}:{
     return { quote, users: usersWhoReactedToQuote  }
   })
 
-  const { toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
+  const { getCurrentUserReactionVote, setCurrentUserReaction, toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
 
   function handleHoverQuote (quote: string) {
     // TODO
@@ -98,7 +96,12 @@ const ReactionQuotesHoverInfo = ({react, voteProps, commentBodyRef, classes}:{
 
   return <div className={classes.root}>
     {quotesWithUsers.map(({quote, users}) => {
-      const currentUserReactedToQuote = users?.find(r => r.userId === currentUser?._id)
+      const netQuoteReactionCount = sumBy(users, (user) => user.reactType==="disagreed"?-1:1)
+      
+      // Pass in `setCurrentUserReaction` as a closure over the current `quote`, since `ReactOrAntireactVote` doesn't know anything about quotes
+      type SetCurrentUserReactionPropType = ComponentPropsWithoutRef<typeof ReactOrAntireactVote>['setCurrentUserReaction'];
+      const setCurrentUserQuoteReaction: SetCurrentUserReactionPropType = (reactionName, reaction) => setCurrentUserReaction(reactionName, reaction, quote);
+
       return <div key={quote} className={classes.quote}>
           <div className={classes.tinyQuoteRow} onMouseEnter={() => handleHoverQuote(quote)} onMouseLeave={() => handleLeaveQuote()}>
             <div className={classes.tinyQuoteWrapper}>
@@ -109,11 +112,12 @@ const ReactionQuotesHoverInfo = ({react, voteProps, commentBodyRef, classes}:{
                 {users?.map(user => user.displayName)?.join(", ")}
               </div>
             </div>
-            <LWTooltip title={currentUserReactedToQuote ? "Remove your react to this snippet" : "Endorse this react for this snippet"} placement="right">
-              <div className={classes.tinyQuoteReactToggle} onClick={() => toggleReaction(react, quote)}>
-                {currentUserReactedToQuote ? "x" : "+1"}
-              </div>
-            </LWTooltip>
+            <ReactOrAntireactVote
+              reactionName={react}
+              currentUserReaction={getCurrentUserReactionVote(react)}
+              netReactionCount={netQuoteReactionCount}
+              setCurrentUserReaction={setCurrentUserQuoteReaction}
+            />
           </div>
         </div>
       })}

--- a/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
@@ -82,7 +82,7 @@ const ReactionQuotesHoverInfo = ({react, voteProps, commentBodyRef, classes}:{
     return { quote, users: usersWhoReactedToQuote  }
   })
 
-  const { getCurrentUserReactionVote, setCurrentUserReaction, toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
+  const { getCurrentUserReactionVote, setCurrentUserReaction } = useNamesAttachedReactionsVoting(voteProps);
 
   function handleHoverQuote (quote: string) {
     // TODO


### PR DESCRIPTION
There's currently no way to antireact to inline reacts.  If you do the obvious thing and try to antireact to one, you'll actually be antireacting to the top-level react on the entire document, rather than to the inline quote.  This will often produce confusing results, such as the top-level react having only antireacters (you), and the inline react hover not correctly displaying the net reaction count for that inline react.

To fix this, we do two things:
1. For existing reacts on documents which only have inline reacts (and no top-level reacts), we hide the top-level react ballot so as to prevent users from accidentally antireacting to the top-level react (which is probably not what they're intending to do in that situation.  We continue to show it as normal if a given react is used in both a top-level and inline fashion on the same document.
2. We switch from only allowing users to "+1" endorse inline reacts, to allowing them to both upvote/downvote inline reacts, as we do with top-level reacts.

Old:
<img width="786" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/d3ba608f-9af6-4600-8a86-de6d63e5d4f8">
<img width="792" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/fe3ad756-9866-4d9e-bdc9-20f46b659072">
<img width="777" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/7d5837c8-42f8-4a76-ba7a-f12ba89d73e5">


New:
<img width="780" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/f44718c3-d3fa-47b7-a2cb-7135e6bba727">
<img width="783" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/2f82be6d-29cd-4f09-bd6d-bd5058bc9626">
<img width="782" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/ebe21778-d692-457d-a64a-26c1fb48cc81">

(Still allows top-level reacting using the same react as an existing inline react, users will just need to manually go into the react pallete for it.)
<img width="791" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/c802aa22-064d-4904-9984-d145ff7df326">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205764765761014) by [Unito](https://www.unito.io)
