### PR TITLE
Unified EA hover over component

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHoverOver.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHoverOver.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import type { PopperPlacementType } from "@material-ui/core/Popper";
+import type { AnalyticsProps } from "../../lib/analyticsEvents";
 import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
@@ -9,34 +10,52 @@ const styles = (theme: ThemeType) => ({
     borderRadius: theme.borderRadius.default,
     border: `1px solid ${theme.palette.grey[120]}`,
     boxShadow: theme.palette.boxShadow.eaCard,
-    padding: 12,
-    top: 2,
   },
 });
 
 const EAHoverOver = ({
-  hoverOver,
+  title,
   children,
   placement,
   inlineBlock,
+  As,
+  clickable,
+  flip,
+  analyticsProps,
   className,
+  popperClassName,
   classes,
 }: {
-  hoverOver: ReactNode,
+  /**
+   * This is the contents of the hover over, named `title` for compatability
+   * with LWTooltip
+   */
+  title: ReactNode,
   children: ReactNode,
   placement?: PopperPlacementType,
   inlineBlock?: boolean,
+  As?: keyof JSX.IntrinsicElements,
+  clickable?: boolean,
+  flip?: boolean,
+  analyticsProps?: AnalyticsProps,
   className?: string,
+  popperClassName?: string,
   classes: ClassesType,
 }) => {
   const {LWTooltip} = Components;
   return (
     <LWTooltip
-      title={hoverOver}
+      title={title}
       placement={placement}
       inlineBlock={inlineBlock}
-      popperClassName={classNames(classes.root, className)}
+      popperClassName={classNames(classes.root, popperClassName)}
       tooltip={false}
+      hideOnTouchScreens
+      As={As}
+      clickable={clickable}
+      flip={flip}
+      analyticsProps={analyticsProps}
+      className={className}
     >
       {children}
     </LWTooltip>

--- a/packages/lesswrong/components/ea-forum/EAHoverOver.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHoverOver.tsx
@@ -1,0 +1,56 @@
+import React, { ReactNode } from "react";
+import { Components, registerComponent } from "../../lib/vulcan-lib";
+import type { PopperPlacementType } from "@material-ui/core/Popper";
+import classNames from "classnames";
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    background: theme.palette.grey[0],
+    borderRadius: theme.borderRadius.default,
+    border: `1px solid ${theme.palette.grey[120]}`,
+    boxShadow: theme.palette.boxShadow.eaCard,
+    padding: 12,
+    top: 2,
+  },
+});
+
+const EAHoverOver = ({
+  hoverOver,
+  children,
+  placement,
+  inlineBlock,
+  className,
+  classes,
+}: {
+  hoverOver: ReactNode,
+  children: ReactNode,
+  placement?: PopperPlacementType,
+  inlineBlock?: boolean,
+  className?: string,
+  classes: ClassesType,
+}) => {
+  const {LWTooltip} = Components;
+  return (
+    <LWTooltip
+      title={hoverOver}
+      placement={placement}
+      inlineBlock={inlineBlock}
+      popperClassName={classNames(classes.root, className)}
+      tooltip={false}
+    >
+      {children}
+    </LWTooltip>
+  );
+}
+
+const EAHoverOverComponent = registerComponent(
+  "EAHoverOver",
+  EAHoverOver,
+  {styles, stylePriority: -1},
+);
+
+declare global {
+  interface ComponentTypes {
+    EAHoverOver: typeof EAHoverOverComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
@@ -6,10 +6,6 @@ import type { PostsPreviewTooltipProps } from "./PostsPreviewTooltip";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    background: theme.palette.grey[0],
-    borderRadius: theme.borderRadius.default,
-    border: `1px solid ${theme.palette.grey[120]}`,
-    boxShadow: theme.palette.boxShadow.eaCard,
     width: POST_PREVIEW_WIDTH,
     fontFamily: theme.palette.fonts.sansSerifStack,
     overflow: "hidden",
@@ -50,6 +46,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 130,
     objectFit: "cover",
     marginBottom: -4,
+    borderRadius: `0 0 ${theme.borderRadius.default}px ${theme.borderRadius.default}px`,
   },
 });
 

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
@@ -7,6 +7,7 @@ import {
   PostsPreviewTooltipSingleWithComment,
   TaggedPostTooltipSingle,
 } from "./PostsPreviewTooltipSingle";
+import { isEAForum } from "../../../lib/instanceSettings";
 
 const PostsTooltip = ({
   post,
@@ -78,9 +79,10 @@ const PostsTooltip = ({
     return null;
   }, [tagRelId, post, postId, postsList, comment, commentId, hash]);
 
-  const {LWTooltip} = Components;
+  const {EAHoverOver, LWTooltip} = Components;
+  const Tooltip = isEAForum ? EAHoverOver : LWTooltip;
   return (
-    <LWTooltip
+    <Tooltip
       title={renderTitle()}
       placement={placement}
       tooltip={false}
@@ -97,7 +99,7 @@ const PostsTooltip = ({
       className={className}
     >
       {children}
-    </LWTooltip>
+    </Tooltip>
   );
 }
 

--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -11,6 +11,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: "100%",
     gap: "12px",
     fontSize: 14,
+    fontWeight: 450,
+    lineHeight: "19.5px",
     fontFamily: theme.palette.fonts.sansSerifStack,
   },
   header: {

--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -11,6 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: "100%",
     gap: "12px",
     fontSize: 14,
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
   header: {
     display: "flex",

--- a/packages/lesswrong/components/users/UserTooltip.tsx
+++ b/packages/lesswrong/components/users/UserTooltip.tsx
@@ -3,42 +3,41 @@ import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { isEAForum } from "../../lib/instanceSettings";
 import type { PopperPlacementType } from "@material-ui/core/Popper/Popper";
 
-const styles = (theme: ThemeType) => ({
-  tooltip: isEAForum
-    ? {
-      background: theme.palette.grey[0],
-      borderRadius: theme.borderRadius.default,
-      border: `1px solid ${theme.palette.grey[120]}`,
-      boxShadow: theme.palette.boxShadow.eaCard,
-      padding: 12,
-      top: 2,
-    }
-    : {},
-});
-
-const UserTooltip = ({user, placement, inlineBlock, children, classes}: {
+type UserTooltipProps = {
   user: UsersMinimumInfo,
   placement?: PopperPlacementType,
   inlineBlock?: boolean,
   children: ReactNode,
-  classes: ClassesType,
-}) => {
-  const {LWTooltip, EAUserTooltipContent, LWUserTooltipContent} = Components;
-  const Main = isEAForum ? EAUserTooltipContent : LWUserTooltipContent;
-
-  return (
-    <LWTooltip
-      title={<Main user={user} />}
-      placement={placement}
-      inlineBlock={inlineBlock}
-      popperClassName={classes.tooltip}
-    >
-      {children}
-    </LWTooltip>
-  );
 }
 
-const UserTooltipComponent = registerComponent("UserTooltip", UserTooltip, {styles});
+const UserTooltip =
+  isEAForum
+    ? ({user, placement, inlineBlock, children}: UserTooltipProps) => {
+      const {EAHoverOver, EAUserTooltipContent} = Components;
+      return (
+        <EAHoverOver
+          hoverOver={<EAUserTooltipContent user={user} />}
+          placement={placement}
+          inlineBlock={inlineBlock}
+        >
+          {children}
+        </EAHoverOver>
+      );
+    }
+    : ({user, placement, inlineBlock, children}: UserTooltipProps) => {
+      const {LWTooltip, LWUserTooltipContent} = Components;
+      return (
+        <LWTooltip
+          title={<LWUserTooltipContent user={user} />}
+          placement={placement}
+          inlineBlock={inlineBlock}
+        >
+          {children}
+        </LWTooltip>
+      );
+    }
+
+const UserTooltipComponent = registerComponent("UserTooltip", UserTooltip);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/users/UserTooltip.tsx
+++ b/packages/lesswrong/components/users/UserTooltip.tsx
@@ -3,41 +3,40 @@ import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { isEAForum } from "../../lib/instanceSettings";
 import type { PopperPlacementType } from "@material-ui/core/Popper/Popper";
 
-type UserTooltipProps = {
+const styles = () => ({
+  root: isEAForum
+    ? {
+      padding: 12,
+      top: 2,
+    }
+    : {},
+});
+
+const UserTooltip = ({user, placement, inlineBlock, children, classes}: {
   user: UsersMinimumInfo,
   placement?: PopperPlacementType,
   inlineBlock?: boolean,
   children: ReactNode,
+  classes: ClassesType,
+}) => {
+  const {
+    EAHoverOver, EAUserTooltipContent, LWTooltip, LWUserTooltipContent,
+  } = Components;
+  const Tooltip = isEAForum ? EAHoverOver : LWTooltip;
+  const Content = isEAForum ? EAUserTooltipContent : LWUserTooltipContent;
+  return (
+    <Tooltip
+      title={<Content user={user} />}
+      placement={placement}
+      inlineBlock={inlineBlock}
+      popperClassName={classes.root}
+    >
+      {children}
+    </Tooltip>
+  );
 }
 
-const UserTooltip =
-  isEAForum
-    ? ({user, placement, inlineBlock, children}: UserTooltipProps) => {
-      const {EAHoverOver, EAUserTooltipContent} = Components;
-      return (
-        <EAHoverOver
-          hoverOver={<EAUserTooltipContent user={user} />}
-          placement={placement}
-          inlineBlock={inlineBlock}
-        >
-          {children}
-        </EAHoverOver>
-      );
-    }
-    : ({user, placement, inlineBlock, children}: UserTooltipProps) => {
-      const {LWTooltip, LWUserTooltipContent} = Components;
-      return (
-        <LWTooltip
-          title={<LWUserTooltipContent user={user} />}
-          placement={placement}
-          inlineBlock={inlineBlock}
-        >
-          {children}
-        </LWTooltip>
-      );
-    }
-
-const UserTooltipComponent = registerComponent("UserTooltip", UserTooltip);
+const UserTooltipComponent = registerComponent("UserTooltip", UserTooltip, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -42,6 +42,7 @@ importComponent("EAHomeCommunityPosts", () => require('../components/ea-forum/EA
 importComponent("EATermsOfUsePage", () => require('../components/ea-forum/EATermsOfUsePage'));
 importComponent("EASequencesHome", () => require('../components/ea-forum/EASequencesHome'));
 importComponent("EABestOfPage", () => require('../components/ea-forum/EABestOfPage'));
+importComponent("EAHoverOver", () => require('../components/ea-forum/EAHoverOver'));
 importComponent("EASequenceOrCollectionCard", () => require('../components/ea-forum/EASequenceOrCollectionCard'));
 importComponent("EASequenceCard", () => require('../components/ea-forum/EASequenceCard'));
 importComponent("EACollectionCard", () => require('../components/ea-forum/EACollectionCard'));


### PR DESCRIPTION
This PR is just a refactor with no new functionality. It adds a unified `EAHoverOver` component to be used instead of `LWTooltip` for hover overs on the EA forum, allowing us to share the styles between the different components. It is currently only used by the user hover and the post hover, but will soon be used by the redesigns of the hovers for tags, sequences and collections as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205768219751172) by [Unito](https://www.unito.io)
