### PR TITLE
Fetch crosspost user connect token on click to avoid timeout

### DIFF
--- a/packages/lesswrong/components/form-components/FMCrosspostControl.tsx
+++ b/packages/lesswrong/components/form-components/FMCrosspostControl.tsx
@@ -145,31 +145,9 @@ const FMCrosspostControl = ({updateCurrentValues, classes, value, path, currentU
     fragmentName: "UsersCrosspostInfo",
     notifyOnNetworkStatusChange: true,
   });
-  const [token, setToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const loading = loadingUnlink || loadingDocument;
-
-  useEffect(() => {
-    const getToken = async () => {
-      if (!document?.fmCrosspostUserId) {
-        try {
-          const result = await fetch("/api/crosspostToken");
-          const {token, error} = await result.json();
-          if (token) {
-            setToken(token);
-          } else if (typeof error === 'string') {
-            setError(error);
-          } else {
-            setError("Couldn't create login token");
-          }
-        } catch {
-          setError("Couldn't create login token");
-        }
-      }
-    }
-    void getToken();
-  }, [document?.fmCrosspostUserId]);
 
   useOnFocusTab(() => {
     if (!loading && !document?.fmCrosspostUserId) {
@@ -177,12 +155,20 @@ const FMCrosspostControl = ({updateCurrentValues, classes, value, path, currentU
     }
   });
 
-  const onClickLogin = () => {
-    if (token?.length) {
-      const url = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", `crosspostLogin?token=${token}`);
-      window.open(url, "_blank")?.focus();
-    } else {
-      setError("Invalid login token - please try again");
+  const onClickLogin = async () => {
+    try {
+      const result = await fetch("/api/crosspostToken");
+      const {token, error} = await result.json();
+      if (token) {
+        const url = combineUrls(fmCrosspostBaseUrlSetting.get() ?? "", `crosspostLogin?token=${token}`);
+        window.open(url, "_blank")?.focus();
+      } else if (typeof error === 'string') {
+        setError(error);
+      } else {
+        setError("Couldn't create login token");
+      }
+    } catch {
+      setError("Couldn't create login token");
     }
   }
 


### PR DESCRIPTION
Connecting an EA forum account to LessWrong or vice-versa requires generating a JWT token. This token is currently generated when the edit post page loads, but it expires after 30 minutes. This PR changes this behaviour to instead only generate the token once the user clicks the button to connect accounts which makes a timeout much less likely.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205770537716918) by [Unito](https://www.unito.io)
