### PR TITLE
Better post title wrapping

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -45,7 +45,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   lastWord: {
-    whiteSpace: "nowrap",
+    display: "inline-block",
   },
   linkIcon: {
     color: theme.palette.grey[500],
@@ -91,7 +91,6 @@ const PostsPageTitle = ({classes, post}: {
     </div>
   )
 }
-
 
 const PostsPageTitleComponent = registerComponent('PostsPageTitle', PostsPageTitle, {styles});
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -61,10 +61,11 @@ const PostsPageTitle = ({classes, post}: {
   const parentPost = _.filter(post.sourcePostRelations, rel => !!rel.sourcePost)?.[0]?.sourcePost
   const { Typography, ForumIcon } = Components;
   const showLinkIcon = post.url && isEAForum;
-  
-  const mostOfTitle = post.title.split(" ").slice(0, -1).join(" ");
-  const lastWordOfTitle = post.title.split(" ").slice(-1)[0];
-  
+
+  const words = post.title.trim().split(/\s+/);
+  const mostOfTitle = words.slice(0, -1).join(" ");
+  const lastWordOfTitle = words[words.length - 1];
+
   return (
     <div>
       {post.question && !parentPost && <Typography variant="title">


### PR DESCRIPTION
The EA forum displays a linkpost icon after the post title on the posts page for link posts. When the title wraps, we want to keep the link icon with the last word of the title to avoid having the link icon orphaned on its own on a new line. This works but there's a couple of issues with the current implementation:

- It breaks if the post title ends in whitespace or if there's irregular whitespace inside the post title (see /posts/iuZgbCHYDTiizsiDR/this-is-a-test-link-post in the dev DB).
- Because we disable word-wrapping for the final word we can get some really horrible overflow if that word is longer than a line. This is obviously rare in English, but is very common in other scripts that don't use whitespace in the same way such as Japanese (see /posts/ya9uenieRgbKkxPKL/anataga-ni-ke-reteiru-tsuno-e-tsumarianataha-to-ji-ni in either the dev or prod DB).

This PR normalises the whitespace to fix the first problem, and instead of disabling wrapping we just use an `inline-block` element to solve the second problem.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205771764504782) by [Unito](https://www.unito.io)
