### PR TITLE
dialogue participants are confirmed by default

### DIFF
--- a/packages/lesswrong/components/posts/NewDialogueDialog.tsx
+++ b/packages/lesswrong/components/posts/NewDialogueDialog.tsx
@@ -63,7 +63,7 @@ const NewDialogueDialog = ({onClose, classes}: {
         title,
         draft: true,
         collabEditorDialogue: true,
-        coauthorStatuses: participants.map(userId => ({userId, confirmed: false, requested: false})),
+        coauthorStatuses: participants.map(userId => ({userId, confirmed: true, requested: false})),
         shareWithUsers: participants,
         sharingSettings: {
           anyoneWithLinkCan: "none",


### PR DESCRIPTION
Fixing an issue where users see the coauthor confirmation request for dialogues, despite that not being required/enabled in principle.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205772051405264) by [Unito](https://www.unito.io)
