### PR TITLE
Make the TOS checkbox label clickable

### DIFF
--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -5,6 +5,7 @@ import { useUpdateCurrentUser } from "../hooks/useUpdateCurrentUser";
 import { useMessages } from "../common/withMessages";
 import { Link } from "../../lib/reactRouterWrapper";
 import Checkbox from '@material-ui/core/Checkbox';
+import InputLabel from '@material-ui/core/InputLabel';
 
 export const TosLink: FC = ({children}) =>
   <Link to="/termsOfUse" target="_blank" rel="noreferrer">{children ?? "terms of use"}</Link>
@@ -15,11 +16,12 @@ export const LicenseLink: FC = ({children}) =>
   </a>
 
 const styles = (theme: ThemeType) => ({
-  root: {
+  checkboxLabel: {
     display: "flex",
     flexDirection: "row",
     rowGap: "15px",
     padding: "30px 5px 20px 5px",
+    cursor: 'pointer',
     "& a": {
       color: theme.palette.primary.main,
     },
@@ -65,7 +67,7 @@ const PostsAcceptTos = ({currentUser, classes}: {
   }
 
   return (
-    <div className={classes.root}>
+    <InputLabel className={classes.checkboxLabel}>
       <Checkbox
         onChange={onAccept}
         checked={loading}
@@ -79,7 +81,7 @@ const PostsAcceptTos = ({currentUser, classes}: {
           your content being available under a <LicenseLink /> license
         </Components.Typography>
       }
-    </div>
+    </InputLabel>
   );
 }
 


### PR DESCRIPTION
New users must accept terms of service before they can post their first post:

<img width="538" alt="Screenshot 2023-10-23 at 1 18 27 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/675520/8a9ec822-e5d8-4c3c-9ad0-a5e332149090">

But the checkbox label isn't clickable; they must click the actual checkbox. This PR fixes that (similarly to the changes of the [Make checkbox labels clickable](https://github.com/ForumMagnum/ForumMagnum/pull/6933) pull request).

(To test this, here's a query to make that checkbox appear again for your account: `update "Users" set "acceptedTos" = false where username = 'yourusername';`)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205782243238854) by [Unito](https://www.unito.io)
