### PR TITLE
Animate the chevron on frontpage collapsible sections

### DIFF
--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -3,6 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { SectionTitleProps } from "./SectionTitle";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Link } from "../../lib/reactRouterWrapper";
+import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
   title: {
@@ -29,9 +30,13 @@ const styles = (theme: ThemeType) => ({
     transform: "translateY(-1px)",
     fontSize: 16,
     cursor: "pointer",
+    transition: "transform 0.2s ease-in-out",
     "&:hover": {
       color: theme.palette.grey[800],
     }
+  },
+  chevronExpanded: {
+    transform: "rotate(90deg)",
   },
 });
 
@@ -71,9 +76,11 @@ const ExpandableSection = ({
                 hideOnTouchScreens
               >
                 <ForumIcon
-                  icon={expanded ? "ThickChevronDown" : "ThickChevronRight"}
+                  icon="ThickChevronRight"
                   onClick={toggleExpanded}
-                  className={classes.expandIcon}
+                  className={classNames(classes.expandIcon, {
+                    [classes.chevronExpanded]: expanded,
+                  })}
                 />
               </LWTooltip>
             </div>


### PR DESCRIPTION
This adds a little rotation animation to the chevrons for collapsible frontpage sections. Apart from looking nice, I often have a split-second after toggling one of these where my brain's trying to work out whether I collapsed it or un-collapsed it, and I genuinely think this makes it a bit clearer.