### PR TITLE
Remove `text-decoration` from default styles for <u> tags

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -327,6 +327,9 @@ const baseBodyStyles = (theme: ThemeType): JssStyles => ({
   '& ol > li > ol > li > ol': {
     listStyle: 'lower-roman',
   },
+  "& u": {
+    textDecoration: "none",
+  },
 })
 
 export const postBodyStyles = (theme: ThemeType): JssStyles => {


### PR DESCRIPTION
The `<u>` tag exists from the dark days of HTML which just applies `text-decoration: underline` to whatever it surrounds. There's no way to manually add these tags from the text editor, but it seems it's possible to accidentally add it in some cases when pasting for some(?) sources. For instance, see [https://forum.effectivealtruism.org/posts/PNJ52f9WMoZNhoumy/magnus-vinding-s-shortform?commentId=o6SXynNQhQ2P77ztu](https://forum.effectivealtruism.org/posts/PNJ52f9WMoZNhoumy/magnus-vinding-s-shortform?commentId=o6SXynNQhQ2P77ztu). This looks pretty ugly and goes against the other styling we have in place so this PR just manually overrides this default to remove the underline.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205784392970920) by [Unito](https://www.unito.io)
