### PR TITLE
Force expanded quick takes to be un-truncated and un-collapsed

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -33,6 +33,8 @@ const QuickTakesListItem = ({quickTake, classes}: {
           }}
           comment={quickTake}
           loadChildrenSeparately
+          forceUnTruncated
+          forceUnCollapsed
         />
       </div>
     )


### PR DESCRIPTION
Quick takes with negative karma can be displayed on the frontpage. When a quick takes with negative karma is expanded its body will be collapsed which is annoying, and it can't be expanded as clicking the button just un-expands the quick take:
<img width="491" alt="Screenshot 2023-10-23 at 19 33 06" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/78e8d449-9152-4cf4-ab50-c171fb6c4603">

This PR forces the comment body to be expanded inline:
<img width="464" alt="Screenshot 2023-10-23 at 19 34 36" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c10b85e3-13f1-44a0-b6be-f3fbfca643f8">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205787108216512) by [Unito](https://www.unito.io)
