### PR TITLE
Add collaboration mode that overrides Dialogue Block Ownership

### DIFF
--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -38,7 +38,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-export type CollaborationMode = "Viewing"|"Commenting"|"Editing";
+export type CollaborationMode = "Viewing"|"Commenting"|"Editing"|"Editing (override)";
 
 const EditorTopBar = ({accessLevel, collaborationMode, setCollaborationMode, post, connectedUsers, classes}: {
   accessLevel: CollaborativeEditingAccessLevel,
@@ -92,6 +92,12 @@ const EditorTopBar = ({accessLevel, collaborationMode, setCollaborationMode, pos
           Editing
           {canEditOnlyBecauseAdmin && " (admin override)"}
         </MenuItem>
+        {post.collabEditorDialogue && <MenuItem value="Editing (override)" key="Editing (override)"
+          disabled={!canEdit}
+        >
+          Editing (override)
+          {canEditOnlyBecauseAdmin && " (admin override)"}
+        </MenuItem>}
       </Select>
       <LWTooltip title="Collaborative docs automatically save all changes">
         <Button className={classes.saveStatus}>


### PR DESCRIPTION
Currently dialogue participants have block ownership which makes editing pretty annoying.  This PR introduces a new collaboration mode (alongside commenting, editing) called "Editing (override)"

When in editing override, you stay in override until you select another mode. You can edit any block (including delete) and you can accept any proposed changes, including your own.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205799444411331) by [Unito](https://www.unito.io)
