### PR TITLE
show ballot description for inline-only reacts, just not vote buttons

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/HoverBallotReactionRow.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/HoverBallotReactionRow.tsx
@@ -57,7 +57,7 @@ const HoverBallotReactionRow = ({reactionName, usersWhoReacted, classes, comment
   const allReactsAreInline = usersWhoReacted.every(userWhoReacted => userWhoReacted.quotes?.length);
 
   return <div key={reactionName}>
-    {!allReactsAreInline && <div className={classes.hoverBallotEntry}>
+    <div className={classes.hoverBallotEntry}>
       <ReactionIcon react={reactionName} size={30}/>
       <div className={classes.hoverInfo}>
         <span className={classes.hoverBallotLabel}>
@@ -71,13 +71,13 @@ const HoverBallotReactionRow = ({reactionName, usersWhoReacted, classes, comment
         <Components.UsersWhoReacted usersWhoReacted={usersWhoReacted} wrap showTooltip={false}/>
 
       </div>
-      <Components.ReactOrAntireactVote
+      {!allReactsAreInline && <Components.ReactOrAntireactVote
         reactionName={reactionName}
         netReactionCount={netReactionCount}
         currentUserReaction={getCurrentUserReactionVote(reactionName)}
         setCurrentUserReaction={setCurrentUserReaction}
-      />
-    </div>}
+      />}
+    </div>
     <ReactionQuotesHoverInfo react={reactionName} voteProps={voteProps} commentBodyRef={commentBodyRef}/>
   </div>
 }


### PR DESCRIPTION
Fixing an issue with https://github.com/ForumMagnum/ForumMagnum/pull/8055 where inline-only reacts no longer showed the react ballot with the react icon & name.  Now we show that, and we only hide the voting buttons on the ballot (since those are for the top-level document, rather than for the inline section).

<img width="777" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/6d16ef08-9a4c-470b-9986-d88be707385c">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205809274810448) by [Unito](https://www.unito.io)
