### PR TITLE
Election candidate tagged posts

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -4,8 +4,18 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { Link } from "../../../lib/reactRouterWrapper";
 import { SECTION_WIDTH } from "../../common/SingleColumnSection";
 import { formatStat } from "../../users/EAUserTooltipContent";
-import { useDonationOpportunities, useElectionCandidates } from "./hooks";
-import type { TimelineSpec } from "./Timeline";
+import {
+  useAmountRaised,
+  useDonationOpportunities,
+  useElectionCandidates,
+} from "./hooks";
+import {
+  donationElectionLink,
+  donationElectionTagId,
+  effectiveGivingTagId,
+  timelineSpec,
+  votingOpensDate,
+} from "../../../lib/eaGivingSeason";
 import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
@@ -168,50 +178,6 @@ const styles = (theme: ThemeType) => ({
   mb80: { marginBottom: 80 },
   mb100: { marginBottom: 100 },
 });
-
-const useAmountRaised = () => {
-  // TODO: Query for the actual amount
-  return {
-    raisedForElectionFund: 3720,
-    donationTarget: 15000,
-    totalRaised: 10250,
-  };
-}
-
-const donationElectionLink = "#"; // TODO
-
-const votingOpensDate = new Date("2023-12-01");
-
-const donationElectionTagId = "L6NqHZkLc4xZ7YtDr"; // TODO: This tag doesn't exist yet
-const effectiveGivingTagId = "L6NqHZkLc4xZ7YtDr";
-
-const timelineSpec: TimelineSpec = {
-  start: new Date("2023-11-15"),
-  end: new Date("2023-12-31"),
-  points: [
-    {date: new Date("2023-11-28"), description: "Giving Tuesday"},
-    {date: votingOpensDate, description: "Voting starts"},
-    {date: new Date("2023-12-15"), description: "Voting ends"},
-    {date: new Date("2023-12-20"), description: "Election winner announced"},
-  ],
-  spans: [
-    {
-      start: new Date("2023-11-21"),
-      end: new Date("2023-11-28"),
-      description: "Effective giving spotlight Week",
-    },
-    {
-      start: new Date("2023-11-30"),
-      end: new Date("2023-12-07"),
-      description: "Marginal Funding Week",
-    },
-    {
-      start: new Date("2023-12-08"),
-      end: new Date("2023-12-16"),
-      description: "Forum BOTEC-a-thon Week",
-    },
-  ],
-};
 
 const getListTerms = (
   tagId: string,

--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -51,13 +51,20 @@ const styles = (theme: ThemeType) => ({
     fontSize: 14,
     letterSpacing: "-0.14px",
   },
+  postCount: {
+    textDecoration: "none",
+    "&:hover": {
+      opacity: 1,
+      textDecoration: "underline",
+    },
+  },
 });
 
 const ElectionCandidate = ({candidate, classes}: {
   candidate: ElectionCandidateBasicInfo,
   classes: ClassesType,
 }) => {
-  const {name, logoSrc, href, baseScore} = candidate;
+  const {name, logoSrc, href, postCount, baseScore} = candidate;
   return (
     <Link to={href} className={classes.root}>
       <div className={classes.imageContainer}>
@@ -69,6 +76,10 @@ const ElectionCandidate = ({candidate, classes}: {
         </div>
         <div className={classes.preVotes}>
           {baseScore} pre-vote{baseScore === 1 ? "" : "s"}
+          ,{" "}
+          <a href="#" className={classes.postCount}>
+            {postCount} post{postCount === 1 ? "" : "s"}
+          </a>
         </div>
       </div>
     </Link>

--- a/packages/lesswrong/components/ea-forum/giving-portal/Timeline.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/Timeline.tsx
@@ -2,25 +2,8 @@ import React from "react";
 import { registerComponent } from "../../../lib/vulcan-lib";
 import { useCurrentTime } from "../../../lib/utils/timeUtil";
 import { SquigglyArrowIcon } from "../../icons/squigglyArrow";
+import type { TimelineSpec } from "../../../lib/eaGivingSeason";
 import moment from "moment";
-
-type TimelinePoint = {
-  date: Date,
-  description: string,
-}
-
-type TimelineSpan = {
-  start: Date,
-  end: Date,
-  description: string,
-}
-
-export type TimelineSpec = {
-  start: Date,
-  end: Date,
-  points: TimelinePoint[],
-  spans: TimelineSpan[],
-}
 
 const formatDate = (date: Date) => moment(date).format("MMM D");
 

--- a/packages/lesswrong/components/ea-forum/giving-portal/hooks.ts
+++ b/packages/lesswrong/components/ea-forum/giving-portal/hooks.ts
@@ -1,16 +1,24 @@
 import { useMulti } from "../../../lib/crud/withMulti";
-
-const givingSeason23ElectionName = "givingSeason23";
+import { eaGivingSeason23ElectionName } from "../../../lib/eaGivingSeason";
 
 export const useElectionCandidates = () => {
   return useMulti({
     collectionName: "ElectionCandidates",
     fragmentName: "ElectionCandidateBasicInfo",
     terms: {
-      electionName: givingSeason23ElectionName,
+      electionName: eaGivingSeason23ElectionName,
     },
   });
 }
 
 // TODO: Should this have separate logic to useElectionCandidates?
 export const useDonationOpportunities = useElectionCandidates;
+
+export const useAmountRaised = () => {
+  // TODO: Query for the actual amount
+  return {
+    raisedForElectionFund: 3720,
+    donationTarget: 15000,
+    totalRaised: 10250,
+  };
+}

--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -1,0 +1,55 @@
+export const eaGivingSeason23ElectionName = "givingSeason23";
+
+export const donationElectionLink = "#"; // TODO
+
+export const votingOpensDate = new Date("2023-12-01");
+
+// TODO: This tag doesn't exist yet
+export const donationElectionTagId = "L6NqHZkLc4xZ7YtDr";
+export const effectiveGivingTagId = "L6NqHZkLc4xZ7YtDr";
+
+type TimelinePoint = {
+  date: Date,
+  description: string,
+}
+
+type TimelineSpan = {
+  start: Date,
+  end: Date,
+  description: string,
+}
+
+export type TimelineSpec = {
+  start: Date,
+  end: Date,
+  points: TimelinePoint[],
+  spans: TimelineSpan[],
+}
+
+export const timelineSpec: TimelineSpec = {
+  start: new Date("2023-11-15"),
+  end: new Date("2023-12-31"),
+  points: [
+    {date: new Date("2023-11-28"), description: "Giving Tuesday"},
+    {date: votingOpensDate, description: "Voting starts"},
+    {date: new Date("2023-12-15"), description: "Voting ends"},
+    {date: new Date("2023-12-20"), description: "Election winner announced"},
+  ],
+  spans: [
+    {
+      start: new Date("2023-11-21"),
+      end: new Date("2023-11-28"),
+      description: "Effective giving spotlight Week",
+    },
+    {
+      start: new Date("2023-11-30"),
+      end: new Date("2023-12-07"),
+      description: "Marginal Funding Week",
+    },
+    {
+      start: new Date("2023-12-08"),
+      end: new Date("2023-12-16"),
+      description: "Forum BOTEC-a-thon Week",
+    },
+  ],
+};

--- a/packages/lesswrong/server/posts/index.ts
+++ b/packages/lesswrong/server/posts/index.ts
@@ -3,4 +3,3 @@ import './out';
 import './graphql';
 
 import './callbacks/other';
-

--- a/packages/lesswrong/server/repos/ElectionCandidatesRepo.ts
+++ b/packages/lesswrong/server/repos/ElectionCandidatesRepo.ts
@@ -1,0 +1,29 @@
+import AbstractRepo from "./AbstractRepo";
+import ElectionCandidates from "../../lib/collections/electionCandidates/collection";
+import { getViewablePostsSelector } from "./helpers";
+
+export default class ElectionCandidatesRepo extends AbstractRepo<DbElectionCandidate> {
+  constructor() {
+    super(ElectionCandidates);
+  }
+
+  async updatePostCounts(
+    electionName: string,
+    electionTagId: string,
+  ): Promise<void> {
+    await this.none(`
+      UPDATE "ElectionCandidates"
+      SET "postCount" = (
+        SELECT COUNT(*)
+        FROM "Posts"
+        WHERE
+          ("tagRelevance"->$2)::INTEGER >= 1 AND
+          ("tagRelevance"->"tagId")::INTEGER >= 1 AND
+          ${getViewablePostsSelector()}
+      )
+      WHERE
+        "electionName" = $1 AND
+        "tagId" IS NOT NULL
+    `, [electionName, electionTagId]);
+  }
+}

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -3,6 +3,7 @@ import CommentsRepo from "./CommentsRepo";
 import ConversationsRepo from "./ConversationsRepo";
 import DatabaseMetadataRepo from "./DatabaseMetadataRepo";
 import DebouncerEventsRepo from "./DebouncerEventsRepo";
+import ElectionCandidatesRepo from "./ElectionCandidatesRepo";
 import LocalgroupsRepo from "./LocalgroupsRepo";
 import PostEmbeddingsRepo from "./PostEmbeddingsRepo";
 import PostRecommendationsRepo from "./PostRecommendationsRepo";
@@ -23,6 +24,7 @@ const getAllRepos = () => ({
   conversations: new ConversationsRepo(),
   databaseMetadata: new DatabaseMetadataRepo(),
   debouncerEvents: new DebouncerEventsRepo(),
+  electionCandidates: new ElectionCandidatesRepo(),
   localgroups: new LocalgroupsRepo(),
   PostEmbeddingsRepo: new PostEmbeddingsRepo(),
   postRecommendations: new PostRecommendationsRepo(),
@@ -39,6 +41,7 @@ export {
   ConversationsRepo,
   DatabaseMetadataRepo,
   DebouncerEventsRepo,
+  ElectionCandidatesRepo,
   LocalgroupsRepo,
   PostEmbeddingsRepo,
   PostRecommendationsRepo,

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -6,8 +6,13 @@ import { voteCallbacks } from '../../lib/voting/vote';
 import { performVoteServer } from '../voteServer';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { updateDenormalizedContributorsList } from '../resolvers/tagResolvers';
-import { taggingNameSetting } from '../../lib/instanceSettings';
+import { isEAForum, taggingNameSetting } from '../../lib/instanceSettings';
 import { updateMutator } from '../vulcan-lib';
+import { ElectionCandidatesRepo } from '../repos';
+import {
+  donationElectionTagId,
+  eaGivingSeason23ElectionName,
+} from '../../lib/eaGivingSeason';
 
 function isValidTagName(name: string) {
   if (!name || !name.length)
@@ -23,6 +28,17 @@ function normalizeTagName(name: string) {
     return name;
 }
 
+const updateDonationElectionPostCounts = async (
+  tagRelDict: Record<string, number>,
+) => {
+  if (isEAForum && (tagRelDict[donationElectionTagId] ?? 0) >= 1) {
+    await new ElectionCandidatesRepo().updatePostCounts(
+      eaGivingSeason23ElectionName,
+      donationElectionTagId,
+    );
+  }
+}
+
 export async function updatePostDenormalizedTags(postId: string) {
   if (!postId) {
     // eslint-disable-next-line no-console
@@ -31,14 +47,16 @@ export async function updatePostDenormalizedTags(postId: string) {
   }
 
   const tagRels: Array<DbTagRel> = await TagRels.find({postId, deleted: false}).fetch();
-  const tagRelDict: Partial<Record<string,number>> = {};
-  
+  const tagRelDict: Record<string, number> = {};
+
   for (let tagRel of tagRels) {
     if (tagRel.baseScore > 0)
       tagRelDict[tagRel.tagId] = tagRel.baseScore;
   }
-  
+
   await Posts.rawUpdateOne({_id:postId}, {$set: {tagRelevance: tagRelDict}});
+
+  void updateDonationElectionPostCounts(tagRelDict);
 }
 
 getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any>, {document: tag}: {document: DbTag}) => {


### PR DESCRIPTION
This implements the post count for posts tagged as relevant to the donation election. A post is considered relevant to a particular candidate if it is tagged with both that candidate's tag _and_ the overall donation election tag. The overall donation election tag doesn't exist yet, so for now it's just using the effective giving tag (ie; a post will be included in the post count for GiveDirectly if it is tagged both "GiveDirectly" and "effective giving"). This will be trivial to change once the tag is created.The post count is displayed as a link on the candidate on the giving portal page, but the link doesn't yet go anywhere for two reasons:

* I don't know where it's supposed to go.
* I don't want to make many changes to the `ElectionCandidate` component in this PR because there's some bigger changes in the pre-voting PR that are going to conflict. We can implement this in a separate PR later.

This PR is currently pointing at the `election-candidate-collection` branch, but once that's merged this should go straight into the `ea-giving-season-23` feature branch.![](https://github.com/ForumMagnum/ForumMagnum/assets/5075628/cc5731f9-434f-4766-bc9a-79bbaace2b49)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205817633233447) by [Unito](https://www.unito.io)
