### PR TITLE
try restricting python version to fix broken deploys

### DIFF
--- a/.github/workflows/deployLWAFProd.yaml
+++ b/.github/workflows/deployLWAFProd.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '>=3.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '>=3.5 <3.12' # Version range or exact version of a Python version to use, using SemVer's version range syntax
     - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
     - name: Run Deploy
       run: scripts/deploy.sh LessWrongExpress ${{ matrix.environment }}


### PR DESCRIPTION
Our deploy workflow uses the latest version >= 3.5.  3.12 apparently included a change which removed some parts of stdlib, and caused a bunch of issues (e.g. https://stackoverflow.com/questions/77274572/multiqc-modulenotfounderror-no-module-named-imp).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205818096937468) by [Unito](https://www.unito.io)
