### PR TITLE
Replace the fragment for the dialogue list

### DIFF
--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -139,21 +139,18 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   const optInStartState = !!currentUser && !currentUser?.hideDialogueFacilitation 
   const [showOptIn, setShowOptIn] = useState(optInStartState);
 
-  const { results: dialoguePosts, error, count, loading, loadingInitial } = usePaginatedResolver({
+  const { results: dialoguePosts } = usePaginatedResolver({
     fragmentName: "PostsList",
     resolverName: "RecentlyActiveDialogues",
     limit: 3,
-    ssr: true
   }); 
-
-  console.log({ dialoguePosts, error, count, loading, loadingInitial })
 
   const {
     document: party,
   } = useSingle({
     documentId: "BJcNeJss4jxc68GQR",
     collectionName: "Posts",
-    fragmentName: "PostsList",
+    fragmentName: "PostsListWithVotes",
   });
 
   const dialoguesTooltip = <div>

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -140,7 +140,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   const [showOptIn, setShowOptIn] = useState(optInStartState);
 
   const { results: dialoguePosts } = usePaginatedResolver({
-    fragmentName: "PostsList",
+    fragmentName: "PostsListWithVotes",
     resolverName: "RecentlyActiveDialogues",
     limit: 3,
   }); 
@@ -168,7 +168,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
 
       {party && <PostsItem post={party}/>}
       
-      {dialoguePosts?.map((post: PostsListWithVotes, i: number) =>
+      {dialoguePosts?.map((post, i: number) =>
         <PostsItem
           key={post._id} post={post}
           showBottomBorder={i < dialoguePosts.length-1}

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -139,18 +139,21 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   const optInStartState = !!currentUser && !currentUser?.hideDialogueFacilitation 
   const [showOptIn, setShowOptIn] = useState(optInStartState);
 
-  const { results: dialoguePosts } = usePaginatedResolver({
-    fragmentName: "PostsPage",
+  const { results: dialoguePosts, error, count, loading, loadingInitial } = usePaginatedResolver({
+    fragmentName: "PostsList",
     resolverName: "RecentlyActiveDialogues",
     limit: 3,
+    ssr: true
   }); 
+
+  console.log({ dialoguePosts, error, count, loading, loadingInitial })
 
   const {
     document: party,
   } = useSingle({
     documentId: "BJcNeJss4jxc68GQR",
     collectionName: "Posts",
-    fragmentName: "PostsPage",
+    fragmentName: "PostsList",
   });
 
   const dialoguesTooltip = <div>


### PR DESCRIPTION
Because of some weird peculiarities of Apollo having a PostsPage fragment here broke the frontpage dialogue list, but only on the first load (😱)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205826551401385) by [Unito](https://www.unito.io)
