### PR TITLE
Fix comment rate limit

### DIFF
--- a/packages/lesswrong/integrationTests/utils.ts
+++ b/packages/lesswrong/integrationTests/utils.ts
@@ -12,6 +12,7 @@ import { randomId } from '../lib/random';
 import type { PartialDeep } from 'type-fest'
 import { asyncForeachSequential } from '../lib/utils/asyncUtils';
 import Localgroups from '../lib/collections/localgroups/collection';
+import { UserRateLimits } from '../lib/collections/userRateLimits';
 
 // Hooks Vulcan's runGraphQL to handle errors differently. By default, Vulcan
 // would dump errors to stderr; instead, we want to (a) suppress that output,
@@ -347,6 +348,16 @@ export const createDummyRevision = async (user: DbUser, data?: Partial<DbRevisio
     validate: false,
   });
   return newRevisionResponse.data;
+}
+
+export const createDummyUserRateLimit = async (user: DbUser, data: Partial<DbUserRateLimit>) => {
+  const userRateLimit = await createMutator({
+    collection: UserRateLimits,
+    document: data,
+    currentUser: user,
+    validate: false,
+  });
+  return {...userRateLimit};
 }
 
 export const clearDatabase = async () => {

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -207,9 +207,11 @@ export async function rateLimitDateWhenUserNextAbleToComment(user: DbUser, postI
     getRecentKarmaInfo(user._id)
   ]);
 
+  const userCommentRateLimitHours = getUserRateLimitIntervalHours(userCommentRateLimit);
+
   // what's the longest rate limit timeframe being evaluated?
   const maxCommentAutolimitHours = getMaxAutoLimitHours(forumSelect(autoCommentRateLimits))
-  const maxHours = Math.max(modRateLimitHours, modPostSpecificRateLimitHours, maxCommentAutolimitHours);
+  const maxHours = Math.max(modRateLimitHours, modPostSpecificRateLimitHours, maxCommentAutolimitHours, userCommentRateLimitHours);
 
   // fetch the comments from within the maxTimeframe
   const commentsInTimeframe = await getCommentsInTimeframe(user._id, maxHours);


### PR DESCRIPTION
Unless I'm very confused, moderator-imposed rate limits for comments don't work. (It's plausible that I'm very confused? I'd have thought that this bug would be noticed sooner.)

The function `rateLimitDateWhenUserNextAbleToComment` is supposed to consider the lengths of the various kinds of rate limits (e.g. the one-per-eight-seconds rule that applies to everyone, and ones from ModeratorActions), but it omits the ones in UserRateLimits. My understanding of the history is that ModeratorActions existed first, and UserRateLimits replaced that system, or augmented it. In that transition, I suspect that the comment rate limits in UserRateLimits were missed.

This branch has two commits. The first commit, [Add integration test for mod-applied user comment rate limits](https://github.com/ForumMagnum/ForumMagnum/commit/5ff754f7d4a584c83c16422c842c5097f890f543), adds a test that demonstrates the problem (when GitHub ran the tests, [it failed as expected](https://github.com/ForumMagnum/ForumMagnum/actions/runs/6680749338)). The second commit, [Fix mod-applied user comment rate limits](https://github.com/ForumMagnum/ForumMagnum/commit/74ab74fd7ead99498f8529f7eccd01a238d3e06f), fixes it ([the GitHub tests succeeded](https://github.com/ForumMagnum/ForumMagnum/actions/runs/6680786955)).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205830130827727) by [Unito](https://www.unito.io)
