### PR TITLE
Giving season post count tooltip

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -74,6 +74,7 @@ const styles = (theme: ThemeType) => ({
     maxWidth: 200,
     textAlign: "center",
     background: `${theme.palette.panelBackground.tooltipBackground2} !important}`,
+    transform: "translateY(8px)",
   },
 });
 

--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -57,13 +57,16 @@ const styles = (theme: ThemeType) => ({
     fontSize: 16,
     letterSpacing: "-0.16px",
   },
-  preVotes: {
-    opacity: 0.8,
+  metaInfo: {
     fontWeight: 500,
     fontSize: 14,
     letterSpacing: "-0.14px",
   },
+  preVotes: {
+    opacity: 0.8,
+  },
   postCount: {
+    opacity: 0.8,
     textDecoration: "none",
     "&:hover": {
       opacity: 1,
@@ -114,9 +117,11 @@ const ElectionCandidate = ({candidate, classes}: {
             {name}
           </Link>
         </div>
-        <div className={classes.preVotes}>
-          <ForumIcon icon="HeartOutline" className={classes.heartIcon} />
-          {preVoteCountString}
+        <div className={classes.metaInfo}>
+          <span className={classes.preVotes}>
+            <ForumIcon icon="HeartOutline" className={classes.heartIcon} />
+            {preVoteCountString}
+          </span>
           {tag &&
             <>
               {", "}

--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { Link } from "../../../lib/reactRouterWrapper";
 import { useVote } from "../../votes/withVote";
 import { getVotingSystemByName } from "../../../lib/voting/votingSystems";
+import { donationElectionTagId } from "../../../lib/eaGivingSeason";
 import classNames from "classnames";
 
 const imageSize = 52;
@@ -99,6 +100,7 @@ const ElectionCandidate = ({candidate, classes}: {
 
   const preVoteCountString = `${preVoteCount} pre-vote${preVoteCount === 1 ? "" : "s"}`;
   const postCountString = `${postCount} post${postCount === 1 ? "" : "s"}`;
+  const postsLink = `/search?query=&tags[0]=${donationElectionTagId}&tags[1]=${tag?._id}`;
 
   const {PreVoteButton, ForumIcon, LWTooltip} = Components;
   return (
@@ -130,7 +132,7 @@ const ElectionCandidate = ({candidate, classes}: {
                 placement="bottom"
                 popperClassName={classes.tooltip}
               >
-                <a href="#" className={classes.postCount}>
+                <a href={postsLink} className={classes.postCount}>
                   {postCountString}
                 </a>
               </LWTooltip>

--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -70,6 +70,11 @@ const styles = (theme: ThemeType) => ({
       textDecoration: "underline",
     },
   },
+  tooltip: {
+    maxWidth: 200,
+    textAlign: "center",
+    background: `${theme.palette.panelBackground.tooltipBackground2} !important}`,
+  },
 });
 
 const ElectionCandidate = ({candidate, classes}: {
@@ -83,12 +88,15 @@ const ElectionCandidate = ({candidate, classes}: {
   );
 
   const {
-    name, logoSrc, href, postCount, extendedScore, currentUserExtendedVote,
+    name, logoSrc, href, postCount, tag, extendedScore, currentUserExtendedVote,
   } = votingProps.document;
   const preVoteCount = extendedScore?.preVoteCount ?? 0;
   const hasVoted = !!currentUserExtendedVote?.preVote;
 
-  const {PreVoteButton, ForumIcon} = Components;
+  const preVoteCountString = `${preVoteCount} pre-vote${preVoteCount === 1 ? "" : "s"}`;
+  const postCountString = `${postCount} post${postCount === 1 ? "" : "s"}`;
+
+  const {PreVoteButton, ForumIcon, LWTooltip} = Components;
   return (
     <div className={classNames(classes.root, {
       [classes.rootVoted]: hasVoted,
@@ -107,11 +115,21 @@ const ElectionCandidate = ({candidate, classes}: {
         </div>
         <div className={classes.preVotes}>
           <ForumIcon icon="HeartOutline" className={classes.heartIcon} />
-          {preVoteCount} pre-vote{preVoteCount === 1 ? "" : "s"}
-          ,{" "}
-          <a href="#" className={classes.postCount}>
-            {postCount} post{postCount === 1 ? "" : "s"}
-          </a>
+          {preVoteCountString}
+          {tag &&
+            <>
+              {", "}
+              <LWTooltip
+                title={`View ${postCountString} tagged “${tag.name}” and “Donation Election”`}
+                placement="bottom"
+                popperClassName={classes.tooltip}
+              >
+                <a href="#" className={classes.postCount}>
+                  {postCountString}
+                </a>
+              </LWTooltip>
+            </>
+          }
         </div>
       </div>
     </div>

--- a/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
@@ -15,6 +15,9 @@ const styles = (theme: ThemeType) => ({
       opacity: 0.5,
     },
   },
+  tooltip: {
+    background: `${theme.palette.panelBackground.tooltipBackground2} !important}`,
+  },
 });
 
 type PreVoteProps = VotingProps<ElectionCandidateBasicInfo>;
@@ -55,6 +58,7 @@ const PreVoteButton = ({vote, document, className, classes}: PreVoteProps & {
           placement="bottom"
           open={hover}
           anchorEl={anchorEl}
+          className={classes.tooltip}
           hideOnTouchScreens
           tooltip
         >

--- a/packages/lesswrong/lib/collections/electionCandidates/fragments.ts
+++ b/packages/lesswrong/lib/collections/electionCandidates/fragments.ts
@@ -8,6 +8,9 @@ registerFragment(`
     logoSrc
     href
     description
+    tag {
+      ...TagBasicInfo
+    }
     postCount
     baseScore
     score

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -494,6 +494,17 @@ interface ConversationsDefaultFragment { // fragment on Conversations
   readonly archivedByIds: Array<string>,
 }
 
+interface ElectionCandidatesDefaultFragment { // fragment on ElectionCandidates
+  readonly electionName: string,
+  readonly name: string,
+  readonly logoSrc: string,
+  readonly href: string,
+  readonly description: string,
+  readonly userId: string,
+  readonly postCount: number,
+  readonly tagId: string | null,
+}
+
 interface PostEmbeddingsDefaultFragment { // fragment on PostEmbeddings
   readonly postId: string,
   readonly postHash: string,
@@ -3249,17 +3260,6 @@ interface UserRateLimitDisplay { // fragment on UserRateLimits
   readonly endedAt: Date | null,
 }
 
-interface ElectionCandidatesDefaultFragment { // fragment on ElectionCandidates
-  readonly electionName: string,
-  readonly name: string,
-  readonly logoSrc: string,
-  readonly href: string,
-  readonly description: string,
-  readonly userId: string,
-  readonly postCount: number,
-  readonly tagId: string | null,
-}
-
 interface ElectionCandidateBasicInfo { // fragment on ElectionCandidates
   readonly _id: string,
   readonly electionName: string,
@@ -3267,6 +3267,7 @@ interface ElectionCandidateBasicInfo { // fragment on ElectionCandidates
   readonly logoSrc: string,
   readonly href: string,
   readonly description: string,
+  readonly tag: TagBasicInfo|null,
   readonly postCount: number,
   readonly baseScore: number,
   readonly score: number,
@@ -3314,6 +3315,7 @@ interface FragmentTypes {
   UserTagRelsDefaultFragment: UserTagRelsDefaultFragment
   TagsDefaultFragment: TagsDefaultFragment
   ConversationsDefaultFragment: ConversationsDefaultFragment
+  ElectionCandidatesDefaultFragment: ElectionCandidatesDefaultFragment
   PostEmbeddingsDefaultFragment: PostEmbeddingsDefaultFragment
   PostRecommendationsDefaultFragment: PostRecommendationsDefaultFragment
   PostRelationsDefaultFragment: PostRelationsDefaultFragment
@@ -3510,7 +3512,6 @@ interface FragmentTypes {
   ModerationTemplateFragment: ModerationTemplateFragment
   UserRateLimitsDefaultFragment: UserRateLimitsDefaultFragment
   UserRateLimitDisplay: UserRateLimitDisplay
-  ElectionCandidatesDefaultFragment: ElectionCandidatesDefaultFragment
   ElectionCandidateBasicInfo: ElectionCandidateBasicInfo
   WithVoteElectionCandidate: WithVoteElectionCandidate
   TypingIndicatorInfo: TypingIndicatorInfo
@@ -3525,6 +3526,7 @@ interface CollectionNamesByFragmentName {
   UserTagRelsDefaultFragment: "UserTagRels"
   TagsDefaultFragment: "Tags"
   ConversationsDefaultFragment: "Conversations"
+  ElectionCandidatesDefaultFragment: "ElectionCandidates"
   PostEmbeddingsDefaultFragment: "PostEmbeddings"
   PostRecommendationsDefaultFragment: "PostRecommendations"
   PostRelationsDefaultFragment: "PostRelations"
@@ -3721,7 +3723,6 @@ interface CollectionNamesByFragmentName {
   ModerationTemplateFragment: "ModerationTemplates"
   UserRateLimitsDefaultFragment: "UserRateLimits"
   UserRateLimitDisplay: "UserRateLimits"
-  ElectionCandidatesDefaultFragment: "ElectionCandidates"
   ElectionCandidateBasicInfo: "ElectionCandidates"
   WithVoteElectionCandidate: "ElectionCandidates"
   TypingIndicatorInfo: "TypingIndicators"

--- a/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
+++ b/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
@@ -6,6 +6,9 @@
         "name": "Voteable",
         "possibleTypes": [
           {
+            "name": "ElectionCandidate"
+          },
+          {
             "name": "TagRel"
           },
           {
@@ -16,9 +19,6 @@
           },
           {
             "name": "Revision"
-          },
-          {
-            "name": "ElectionCandidate"
           }
         ]
       }


### PR DESCRIPTION
Adds a tooltip to the post count for election candidates:
<img width="386" alt="Screenshot 2023-10-30 at 14 20 16" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/36bd78ce-d4e9-45a7-a6b5-74933ae45379">

Also updates the styling of the vote button tooltip to match the new tooltip:
<img width="157" alt="Screenshot 2023-10-30 at 14 20 18" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/1575d0c9-5734-4a3b-b431-ec195612db13">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205834716696859) by [Unito](https://www.unito.io)
