### PR TITLE
Add my dialogues to frontpage & dialogues page

### DIFF
--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -167,7 +167,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
     <p>Dialogues between a small group of users. Click to see more.</p>
   </div>
 
-  const renderMyDialogues = myDialogues?.length 
+  const renderMyDialogues = !!currentUser && myDialogues?.length 
 
   const myDialoguesTooltip = <div>
       <div>These are the dialoges you are involved in (both drafts and published)</div>

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -57,6 +57,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   prompt: {
     color: theme.palette.lwTertiary.main,
     fontWeight: 645,
+  },
+
+  subheading: {
+    marginTop: '10px',
   }
 });
 
@@ -134,7 +138,7 @@ const DialogueFacilitationBox = ({ classes, currentUser, setShowOptIn }: { class
 };
 
 const DialoguesList = ({ classes }: { classes: ClassesType }) => {
-  const { PostsItem, LWTooltip, SingleColumnSection, SectionTitle } = Components
+  const { PostsItem, LWTooltip, SingleColumnSection, SectionTitle, SectionSubtitle } = Components
   const currentUser = useCurrentUser()
   const optInStartState = !!currentUser && !currentUser?.hideDialogueFacilitation 
   const [showOptIn, setShowOptIn] = useState(optInStartState);
@@ -142,6 +146,12 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   const { results: dialoguePosts } = usePaginatedResolver({
     fragmentName: "PostsListWithVotes",
     resolverName: "RecentlyActiveDialogues",
+    limit: 3,
+  }); 
+
+  const { results: myDialogues } = usePaginatedResolver({
+    fragmentName: "PostsListWithVotes",
+    resolverName: "MyDialogues",
     limit: 3,
   }); 
 
@@ -156,6 +166,12 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   const dialoguesTooltip = <div>
     <p>Beta feature: Dialogues between a small group of users. Click to see more.</p>
   </div>
+
+  const renderMyDialogues = myDialogues?.length 
+
+  const myDialoguesTooltip = <div>
+      <div>These are dialogues that you are a coauthor on (including drafts and published dialogues).</div>
+    </div>
 
   return <AnalyticsContext pageSubSectionContext="dialoguesList">
     <SingleColumnSection>
@@ -174,6 +190,28 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
           showBottomBorder={i < dialoguePosts.length-1}
         />
       )}
+
+      {renderMyDialogues && (
+          <div className={classes.subsection}>
+            <AnalyticsContext pageSubSectionContext="myDialogues">
+              <LWTooltip placement="top-start" title={myDialoguesTooltip}>
+                <Link to={"/dialogues"}>
+                  <SectionSubtitle className={classes.subheading}>
+                    My Draft Dialogues (Only Visible to Me)
+                  </SectionSubtitle>
+                </Link>
+              </LWTooltip>
+              {myDialogues?.map((post, i: number) =>
+                <PostsItem
+                  key={post._id} post={post}
+                  showBottomBorder={i < myDialogues.length-1}
+                />
+              )}
+            </AnalyticsContext>
+          </div>
+        )}
+      
+
    </SingleColumnSection>
   </AnalyticsContext>
 }

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -164,13 +164,13 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
   });
 
   const dialoguesTooltip = <div>
-    <p>Beta feature: Dialogues between a small group of users. Click to see more.</p>
+    <p>Dialogues between a small group of users. Click to see more.</p>
   </div>
 
   const renderMyDialogues = myDialogues?.length 
 
   const myDialoguesTooltip = <div>
-      <div>These are dialogues that you are a coauthor on (including drafts and published dialogues).</div>
+      <div>These are the dialoges you are involved in (both drafts and published)</div>
     </div>
 
   return <AnalyticsContext pageSubSectionContext="dialoguesList">

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -197,7 +197,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType }) => {
               <LWTooltip placement="top-start" title={myDialoguesTooltip}>
                 <Link to={"/dialogues"}>
                   <SectionSubtitle className={classes.subheading}>
-                    My Draft Dialogues (Only Visible to Me)
+                    My Dialogues (only visible to you)
                   </SectionSubtitle>
                 </Link>
               </LWTooltip>

--- a/packages/lesswrong/components/dialogues/DialoguesPage.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesPage.tsx
@@ -5,6 +5,7 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { usePaginatedResolver } from '../hooks/usePaginatedResolver';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useSingle } from '../../lib/crud/withSingle';
+import { useCurrentUser } from '../common/withUser';
 
 const DialoguesPage = () => {
   const { PostsItem, LWTooltip, SingleColumnSection, SectionTitle, SectionFooter, LoadMore } = Components
@@ -20,6 +21,10 @@ const DialoguesPage = () => {
     resolverName: "MyDialogues",
     limit: 10,
   }); 
+
+  const currentUser = useCurrentUser();
+
+  const renderMyDialogues = currentUser && myDialogues?.length
 
   const { document: announcementPost } = useSingle({
     documentId: "kQuSZG8ibfW6fJYmo",
@@ -37,22 +42,22 @@ const DialoguesPage = () => {
 
   return <AnalyticsContext pageContext="DialoguesPage">
     <SingleColumnSection>
-      <AnalyticsContext pageSectionContext="MyDialoguesList">
-        <SectionTitle
-            title={<LWTooltip placement="top-start" title={myDialoguesTooltip}>
-              My Dialogues (Drafts & Published)
-            </LWTooltip>}
-          />
-        {myDialogues?.map((post: PostsListWithVotes, i: number) =>
-          <PostsItem
-            key={post._id} post={post}
-            showBottomBorder={i < myDialogues.length-1}
-          />
-        )}
-        <SectionFooter>
-          <LoadMore {...myDialoguesLoadMoreProps}/>
-        </SectionFooter>
-      </AnalyticsContext>
+      {renderMyDialogues && <AnalyticsContext pageSectionContext="MyDialoguesList">
+          <SectionTitle
+              title={<LWTooltip placement="top-start" title={myDialoguesTooltip}>
+                My Dialogues (Drafts & Published)
+              </LWTooltip>}
+            />
+          {myDialogues?.map((post: PostsListWithVotes, i: number) =>
+            <PostsItem
+              key={post._id} post={post}
+              showBottomBorder={i < myDialogues.length-1}
+            />
+          )}
+          <SectionFooter>
+            <LoadMore {...myDialoguesLoadMoreProps}/>
+          </SectionFooter>
+        </AnalyticsContext>}
 
       <AnalyticsContext pageSectionContext="DialoguesList">
         <SectionTitle

--- a/packages/lesswrong/components/dialogues/DialoguesPage.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesPage.tsx
@@ -14,6 +14,12 @@ const DialoguesPage = () => {
     resolverName: "RecentlyActiveDialogues",
     limit: 20,
   }); 
+  
+  const { results: myDialogues, loadMoreProps: myDialoguesLoadMoreProps } = usePaginatedResolver({
+    fragmentName: "PostsPage",
+    resolverName: "MyDialogues",
+    limit: 10,
+  }); 
 
   const { document: announcementPost } = useSingle({
     documentId: "kQuSZG8ibfW6fJYmo",
@@ -22,28 +28,51 @@ const DialoguesPage = () => {
   });
 
   const dialoguesTooltip = <div>
-    <p>Beta feature: Dialogues between a small group of users.</p>
+    <p>Dialogues between a small group of users.</p>
+  </div>
+
+  const myDialoguesTooltip = <div>
+    <p>These are the dialoges you are involved in (both drafts and published)</p>
   </div>
 
   return <AnalyticsContext pageContext="DialoguesPage">
     <SingleColumnSection>
-      <SectionTitle
-        title={<LWTooltip placement="top-start" title={dialoguesTooltip}>
-          Dialogues
-        </LWTooltip>}
-      />
-      {announcementPost && <PostsItem
-        key={"kQuSZG8ibfW6fJYmo"} post={announcementPost} forceSticky
-      />}
-      {dialoguePosts?.map((post: PostsListWithVotes, i: number) =>
-        <PostsItem
-          key={post._id} post={post}
-          showBottomBorder={i < dialoguePosts.length-1}
+      <AnalyticsContext pageSectionContext="MyDialoguesList">
+        <SectionTitle
+            title={<LWTooltip placement="top-start" title={myDialoguesTooltip}>
+              My Dialogues (Drafts & Published)
+            </LWTooltip>}
+          />
+        {myDialogues?.map((post: PostsListWithVotes, i: number) =>
+          <PostsItem
+            key={post._id} post={post}
+            showBottomBorder={i < myDialogues.length-1}
+          />
+        )}
+        <SectionFooter>
+          <LoadMore {...myDialoguesLoadMoreProps}/>
+        </SectionFooter>
+      </AnalyticsContext>
+
+      <AnalyticsContext pageSectionContext="DialoguesList">
+        <SectionTitle
+          title={<LWTooltip placement="top-start" title={dialoguesTooltip}>
+            Dialogues
+          </LWTooltip>}
         />
-      )}
-      <SectionFooter>
-        <LoadMore {...loadMoreProps}/>
-      </SectionFooter>
+        {announcementPost && <PostsItem
+          key={"kQuSZG8ibfW6fJYmo"} post={announcementPost} forceSticky
+        />}
+        {dialoguePosts?.map((post: PostsListWithVotes, i: number) =>
+          <PostsItem
+            key={post._id} post={post}
+            showBottomBorder={i < dialoguePosts.length-1}
+          />
+        )}
+        <SectionFooter>
+          <LoadMore {...loadMoreProps}/>
+        </SectionFooter>
+      </AnalyticsContext>
    </SingleColumnSection>
   </AnalyticsContext>
 }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -219,7 +219,8 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
       FROM (
           SELECT DISTINCT ON (p._id) p.* 
           FROM "Posts" p, UNNEST("coauthorStatuses") unnested
-          WHERE p."collabEditorDialogue" IS TRUE AND ((UNNESTED->>'userId' = $1) OR (p."userId" = $1))
+          WHERE p."collabEditorDialogue" IS TRUE 
+          AND ((UNNESTED->>'userId' = $1) OR (p."userId" = $1))
       ) dialogues
       ORDER BY "modifiedAt" DESC
       LIMIT $2

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -213,6 +213,19 @@ export default class PostsRepo extends AbstractRepo<DbPost> {
     `, [limit]);
   }
 
+  getMyActiveDialogues(userId: string, limit = 3): Promise<DbPost[]> {
+    return this.any(`
+      SELECT * 
+      FROM (
+          SELECT DISTINCT ON (p._id) p.* 
+          FROM "Posts" p, UNNEST("coauthorStatuses") unnested
+          WHERE p."collabEditorDialogue" IS TRUE AND ((UNNESTED->>'userId' = $1) OR (p."userId" = $1))
+      ) dialogues
+      ORDER BY "modifiedAt" DESC
+      LIMIT $2
+    `, [userId, limit]);
+  }
+
   async getPostIdsWithoutEmbeddings(): Promise<string[]> {
     const results = await this.getRawDb().any(`
       SELECT p."_id"

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -328,3 +328,16 @@ createPaginatedResolver({
   ): Promise<DbPost[]> => repos.posts.getRecentlyActiveDialogues(limit),
   cacheMaxAgeMs: 1000 * 60 * 10, // 10 min
 });
+
+createPaginatedResolver({
+  name: "MyDialogues",
+  graphQLType: "Post",
+  callback: async (
+    {repos, currentUser}: ResolverContext,
+    limit: number,
+  ): Promise<DbPost[]> => {
+      if (!currentUser) throw new Error("Cannot retrieves dialogues because no user logged in.")
+      return repos.posts.getMyActiveDialogues(currentUser._id, limit)
+    },
+  cacheMaxAgeMs: 1000 * 60 * 10, // 10 min
+});

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -336,8 +336,9 @@ createPaginatedResolver({
     {repos, currentUser}: ResolverContext,
     limit: number,
   ): Promise<DbPost[]> => {
-      if (!currentUser) throw new Error("Cannot retrieves dialogues because no user logged in.")
+      if (!currentUser) return []
       return repos.posts.getMyActiveDialogues(currentUser._id, limit)
     },
-  cacheMaxAgeMs: 1000 * 60 * 10, // 10 min
+  // Caching is not user specific, do not use caching here else you will share users' drafts
+  cacheMaxAgeMs: 0, 
 });

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -334,9 +334,10 @@ createPaginatedResolver({
   name: "MyDialogues",
   graphQLType: "Post",
   callback: async (
-    {repos, currentUser, context}: ResolverContext,
+    context: ResolverContext,
     limit: number,
   ): Promise<DbPost[]> => {
+      const {repos, currentUser} = context
       if (!currentUser) return []
       const posts = await repos.posts.getMyActiveDialogues(currentUser._id, limit);
       return await accessFilterMultiple(currentUser, Posts, posts, context);

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -2,7 +2,7 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { sideCommentFilterMinKarma, sideCommentAlwaysExcludeKarma } from '../../lib/collections/posts/constants';
 import { Comments } from '../../lib/collections/comments/collection';
 import { SideCommentsCache, SideCommentsResolverResult, getLastReadStatus, sideCommentCacheVersion } from '../../lib/collections/posts/schema';
-import { augmentFieldsDict, denormalizedField } from '../../lib/utils/schemaUtils'
+import { augmentFieldsDict, denormalizedField, accessFilterMultiple } from '../../lib/utils/schemaUtils'
 import { getLocalTime } from '../mapsUtils'
 import { isNotHostedHere } from '../../lib/collections/posts/helpers';
 import { matchSideComments } from '../sideComments';
@@ -15,6 +15,7 @@ import { addGraphQLQuery, addGraphQLResolvers, addGraphQLSchema } from '../vulca
 import { postIsCriticism } from '../languageModels/autoTagCallbacks';
 import { createPaginatedResolver } from './paginatedResolver';
 import { getDefaultPostLocationFields, getDialogueResponseIds, getDialogueMessageTimestamps } from "../posts/utils";
+
 
 augmentFieldsDict(Posts, {
   // Compute a denormalized start/end time for events, accounting for the
@@ -333,11 +334,12 @@ createPaginatedResolver({
   name: "MyDialogues",
   graphQLType: "Post",
   callback: async (
-    {repos, currentUser}: ResolverContext,
+    {repos, currentUser, context}: ResolverContext,
     limit: number,
   ): Promise<DbPost[]> => {
       if (!currentUser) return []
-      return repos.posts.getMyActiveDialogues(currentUser._id, limit)
+      const posts = await repos.posts.getMyActiveDialogues(currentUser._id, limit);
+      return await accessFilterMultiple(currentUser, Posts, posts, context);
     },
   // Caching is not user specific, do not use caching here else you will share users' drafts
   cacheMaxAgeMs: 0, 


### PR DESCRIPTION
This adds a section called "My Dialogues (only visible to you)" to the frontpage, and a big section called "My Dialogues (Drafts & Published)" to the /dialogues page.

[Coauthored with Ruby.]

Screenshots below.

<img width="748" alt="Screen Shot 2023-10-30 at 6 44 11 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/24915924/dc3eedb9-5fe6-4122-b278-2cd5de49747a">

<img width="792" alt="Screen Shot 2023-10-30 at 6 39 20 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/24915924/8e7ce397-dddd-4d06-877b-74a970112733">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205840999650931) by [Unito](https://www.unito.io)
