### PR TITLE
Update post vote tooltip text

### DIFF
--- a/packages/lesswrong/components/votes/PostsVoteDefault.tsx
+++ b/packages/lesswrong/components/votes/PostsVoteDefault.tsx
@@ -99,7 +99,7 @@ const PostsVoteDefault = ({
       [classes.voteBlockHorizontal]: useHorizontalLayout,
     })}>
       <Tooltip
-        title={whyYouCantVote ?? "Click-and-hold for strong vote"}
+        title={whyYouCantVote ?? "Click-and-hold for strong vote (click twice on mobile)"}
         placement={tooltipPlacement}
         classes={{tooltip: classes.tooltip}}
       >
@@ -156,7 +156,7 @@ const PostsVoteDefault = ({
         }
       </div>
       <Tooltip
-        title={whyYouCantVote ?? "Click-and-hold for strong vote"}
+        title={whyYouCantVote ?? "Click-and-hold for strong vote (click twice on mobile)"}
         placement={tooltipPlacement}
         classes={{tooltip: classes.tooltip}}
       >


### PR DESCRIPTION
Requested by @agnesstenlund via [slack](https://cea-core.slack.com/archives/C038J512SD8/p1698141627997159)

On mobile, you need to double tap to strong vote. The comment vote tooltip explains the desktop vs mobile difference, but the post vote tooltip doesn't. This PR just updates the tooltip text to explain both, to be consistent with the comment vote tooltip.

<img width="558" alt="Screen Shot 2023-10-31 at 2 40 43 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/b495eccf-9a86-4f5a-9ed7-9e0adc580df9">

-----
(For reference, this is the comment vote tooltip, unchanged):
<img width="244" alt="Screen Shot 2023-10-31 at 2 47 05 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/0a12dbab-a07a-4af8-8caf-ee83dcd350ee">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205847890610733) by [Unito](https://www.unito.io)
