### PR TITLE
Fix ckeditor mirrored img srcsets

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -159,7 +159,7 @@ function getImageUrlsFromImgTag(tag: any): string[] {
   }
   const srcset: string = tag.attr("srcset");
   if (srcset) {
-    const imageVariants = srcset.split(",").map(tok=>tok.trim());
+    const imageVariants = srcset.split(", ").map(tok=>tok.trim());
     for (let imageVariant of imageVariants) {
       const [url, _size] = imageVariant.split(" ").map(tok=>tok.trim());
       if (url) imageUrls.push(url);
@@ -170,7 +170,7 @@ function getImageUrlsFromImgTag(tag: any): string[] {
 }
 
 function rewriteSrcset(srcset: string, urlMap: Record<string,string>): string {
-  const imageVariants = srcset.split(",").map(tok=>tok.trim());
+  const imageVariants = srcset.split(", ").map(tok=>tok.trim());
   const rewrittenImageVariants = imageVariants.map(variant => {
     let tokens = variant.split(" ");
     if (tokens[0] in urlMap)

--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -159,7 +159,7 @@ function getImageUrlsFromImgTag(tag: any): string[] {
   }
   const srcset: string = tag.attr("srcset");
   if (srcset) {
-    const imageVariants = srcset.split(", ").map(tok=>tok.trim());
+    const imageVariants = srcset.split(/,\s/g).map(tok=>tok.trim());
     for (let imageVariant of imageVariants) {
       const [url, _size] = imageVariant.split(" ").map(tok=>tok.trim());
       if (url) imageUrls.push(url);
@@ -170,7 +170,7 @@ function getImageUrlsFromImgTag(tag: any): string[] {
 }
 
 function rewriteSrcset(srcset: string, urlMap: Record<string,string>): string {
-  const imageVariants = srcset.split(", ").map(tok=>tok.trim());
+  const imageVariants = srcset.split(/,\s/g).map(tok=>tok.trim());
   const rewrittenImageVariants = imageVariants.map(variant => {
     let tokens = variant.split(" ");
     if (tokens[0] in urlMap)


### PR DESCRIPTION
This was reported by Lorenzo via [slack](https://cea-core.slack.com/archives/C027Z3794F3/p1696758716846219):

> Images sometimes don't show up in comments after they're posted, but they come back if I click "edit" and then stay after I click "save"

Lorenzo also provided the img tag in slack. Seems like the issue is that, when we are mirroring images, we don't account for commas in the srcset URLs and accidentally insert extra spaces. I didn't actually find the right path to reproduce this issue but I think this should fix it.

<img src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/947bec59-f2ac-410e-85d4-82070f778b8b" width="500">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205848127005747) by [Unito](https://www.unito.io)
