### PR TITLE
ensure revert to revision doesn't delete comments and suggestions

### DIFF
--- a/packages/lesswrong/server/ckEditor/ckEditorApi.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorApi.ts
@@ -414,6 +414,7 @@ Globals.cke.log = Object.fromEntries(Object.entries(Globals.cke).map(([key, val]
 
   const withLoggedOutput = async (...args: any[]) => {
     const result = await val(...args);
+    // eslint-disable-next-line no-console
     console.log({ result });
     return result;
   };


### PR DESCRIPTION
Upgrading to ckEditor's v5 api made the `DELETE /document/{document_id}` API delete the entire document, including live collaborative session, comments, suggestions, etc.  Instead of doing that, let's only delete the document contents in storage, so that if someone reverts to a revision that has comment/suggestion markers in the html, those still have things to point to.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205848773438786) by [Unito](https://www.unito.io)
