### PR TITLE
Fix giving portal image height

### DIFF
--- a/packages/lesswrong/components/common/CloudinaryImage2.tsx
+++ b/packages/lesswrong/components/common/CloudinaryImage2.tsx
@@ -111,7 +111,7 @@ const CloudinaryImage2 = ({
   if (fullWidthHeader) {
     // We always double the height, to account for high dpi screens. We can't
     // combine srcset width-checking with DPI-checking unfortunately.
-    const srcSetHeight = ((height || DEFAULT_HEADER_HEIGHT)*2).toString()
+    const srcSetHeight = (cloudinaryProps.h || (DEFAULT_HEADER_HEIGHT*2).toString())
     // NB: we lie about the final width here, we don't know it
     srcSetFunc = (imgId) => `
       ${makeCloudinaryImageUrl(imgId, {...cloudinaryProps, ...{w: '450', h: srcSetHeight}})} 450w,

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -445,7 +445,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
             </div>
           </div>
         </div>
-        <CloudinaryImage2 publicId="giving_portal_23_hero" fullWidthHeader />
+        <CloudinaryImage2 publicId="giving_portal_23_hero" fullWidthHeader imgProps={{ h: "1200" }} />
         <div className={classes.sectionLight}>
           <div className={classes.content}>
             <div className={classNames(


### PR DESCRIPTION
Without this:
<img width="1228" alt="Screenshot 2023-11-01 at 12 46 44" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/8706aca9-b8bc-4ef0-88ba-4b9cd4dc6fee">
With this:
<img width="1228" alt="Screenshot 2023-11-01 at 12 46 20" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/a4a3bbea-0192-4e6e-a85c-1bc0d0dd14c7">

I've checked every other cloudinary image that sets `imageProps` and none seem to be affected

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205852590400821) by [Unito](https://www.unito.io)
