### PR TITLE
Fix alignment of posts without ToC

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -568,7 +568,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
       </div>
     : null;
 
-  const rightColumnChildren = <>
+  const rightColumnChildren = welcomeBox || (showRecommendations && recommendationsPosition === "right") && <>
     {welcomeBox}
     {showRecommendations && recommendationsPosition === "right" && <PostSideRecommendations post={post} />}
   </>;

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -568,7 +568,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
       </div>
     : null;
 
-  const rightColumnChildren = welcomeBox || (showRecommendations && recommendationsPosition === "right") && <>
+  const rightColumnChildren = (welcomeBox || (showRecommendations && recommendationsPosition === "right")) && <>
     {welcomeBox}
     {showRecommendations && recommendationsPosition === "right" && <PostSideRecommendations post={post} />}
   </>;


### PR DESCRIPTION
There was some logic in the ToC component that was clearly trying to account for the presence of the stuff in the right column, but it wasn't properly triggering. This fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205857164218687) by [Unito](https://www.unito.io)
