### PR TITLE
Giving portal: add section ids, fix opportunity btn, link to Lizkas post

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/DonationOpportunity.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/DonationOpportunity.tsx
@@ -56,6 +56,7 @@ const styles = (theme: ThemeType) => ({
     alignItems: "center",
   },
   button: {
+    textAlign: 'center',
     padding: 12,
     borderRadius: theme.borderRadius.small,
     border: "none",
@@ -87,12 +88,14 @@ const DonationOpportunity = ({candidate, classes}: {
   const {name, logoSrc, description} = candidate;
   return (
     <div className={classes.root}>
-      <div className={classes.header}>
-        <div className={classes.imageContainer}>
-          <img src={logoSrc} className={classes.image} />
+      <Link to={candidate.href}>
+        <div className={classes.header}>
+          <div className={classes.imageContainer}>
+            <img src={logoSrc} className={classes.image} />
+          </div>
+          <div className={classes.name}>{name}</div>
         </div>
-        <Link to={candidate.href} className={classes.name}>{name}</Link>
-      </div>
+      </Link>
       <div className={classes.description}>{description}</div>
       <div className={classes.buttons}>
         {candidate.fundraiserLink && <Link to={candidate.fundraiserLink} className={classNames(classes.button, classes.buttonPrimary)}>

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -334,7 +334,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
     <AnalyticsContext pageContext="eaGivingPortal">
       <div className={classes.root}>
         <HeadTags title="Giving portal" />
-        <div className={classNames(classes.content, classes.mb20)}>
+        <div className={classNames(classes.content, classes.mb20)} id="top">
           <div className={classNames(classes.h1, classes.center, classes.mt30)}>
             Giving portal
           </div>
@@ -351,7 +351,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
           <Timeline {...timelineSpec} className={classes.hideOnMobile} />
         </div>
         <div className={classes.sectionSplit}>
-          <div className={classes.content}>
+          <div className={classes.content} id="election">
             <div className={classNames(classes.column, classes.mt60)}>
               <div className={classNames(classes.h1, classes.primaryText)}>
                 Donation election 2023
@@ -419,7 +419,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
           </div>
         </div>
         <div className={classes.sectionDark}>
-          <div className={classes.content}>
+          <div className={classes.content} id="candidates">
             <div className={classes.column}>
               <div className={classNames(classes.h2, classes.primaryText)}>
                 Candidates in the Election
@@ -462,7 +462,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
               classes.column,
               classes.mt60,
               classes.mb80,
-            )}>
+            )} id="posts">
               <div className={classNames(classes.h2, classes.primaryText)}>
                 Recent posts tagged &quot;Effective giving&quot;
               </div>
@@ -487,11 +487,11 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
           classes.content,
           classes.mt60,
           classes.mb80,
-        )}>
+        )} id="opportunities">
           <div className={classes.h1}>Other donation opportunities</div>
           <div className={classNames(classes.text, classes.textWide)}>
           Supporting high-impact work via donations is a core part of effective altruism. You can donate to featured projects below,{" "}
-            <a href={setupFundraiserLink}>run custom fundraisers</a>, or more.
+            <a href={setupFundraiserLink}>run custom fundraisers</a>, or <a href="https://www.givingwhatwecan.org">more</a>.
           </div>
           {showAmountRaised &&
             <div className={classes.text}>

--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -2,7 +2,7 @@ import moment from "moment";
 
 export const eaGivingSeason23ElectionName = "givingSeason23";
 
-export const donationElectionLink = "#"; // TODO link to Lizka's post once it's drafted
+export const donationElectionLink = "https://forum.effectivealtruism.org/posts/hAzhyikPnLnMXweXG/participate-in-the-donation-election-and-the-first-weekly";
 export const setupFundraiserLink = "https://www.givingwhatwecan.org/fundraisers";
 export const postsAboutElectionLink = "/topics/donation-election-2023";
 


### PR DESCRIPTION
A few quick updates to the Giving Portal:
1. Add a link to Lizka's announcement post
2. Add section ids so that we can link to sections
3. Center align the text in the "other opportunities" card buttons
4. Make the whole top section of the "other opportunities" cards clickable to include the org logo
5. In the "other opportunities" section, link the word "more" to GWWC home page

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205857273827638) by [Unito](https://www.unito.io)
