### PR TITLE
Improve pre-voting on mobile

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
@@ -7,12 +7,16 @@ import { useHover } from "../../common/withHover";
 import type { VotingProps } from "../../votes/votingProps";
 import classNames from "classnames";
 import { useTracking } from "../../../lib/analyticsEvents";
+import { isMobile } from "../../../lib/utils/isMobile";
 
 const styles = (theme: ThemeType) => ({
   root: {
     cursor: "pointer",
     color: theme.palette.givingPortal[1000],
-    fontSize: 20,
+    fontSize: 28,
+    padding: 4,
+    // Translate to offset the padding
+    transform: "translate(4px, -4px)",
     "&:hover": {
       opacity: 0.5,
     },
@@ -35,7 +39,7 @@ const PreVoteButton = ({vote, document, className, classes}: PreVoteProps & {
   const { captureEvent } = useTracking();
 
   const hasVoted = !!document.currentUserExtendedVote?.preVote;
-  const icon = hasVoted || hover ? "Heart" : "HeartOutline";
+  const icon = hasVoted || (hover && !isMobile()) ? "Heart" : "HeartOutline";
   const tooltip = hasVoted ? "Remove pre-vote" : "Pre-vote";
 
   const onVote = useCallback(async () => {

--- a/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
@@ -13,10 +13,10 @@ const styles = (theme: ThemeType) => ({
   root: {
     cursor: "pointer",
     color: theme.palette.givingPortal[1000],
-    fontSize: 28,
-    padding: 4,
+    fontSize: 32,
+    padding: 6,
     // Translate to offset the padding
-    transform: "translate(4px, -4px)",
+    transform: "translate(6px, -6px)",
     "&:hover": {
       opacity: 0.5,
     },

--- a/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/PreVoteButton.tsx
@@ -66,7 +66,7 @@ const PreVoteButton = ({vote, document, className, classes}: PreVoteProps & {
   const {LWPopper, ForumIcon} = Components;
   return (
     <>
-      {/* {everHovered &&
+      {everHovered &&
         <LWPopper
           placement="bottom"
           open={hover}
@@ -77,7 +77,7 @@ const PreVoteButton = ({vote, document, className, classes}: PreVoteProps & {
         >
           {tooltip}
         </LWPopper>
-      } */}
+      }
       <ForumIcon
         {...eventHandlers}
         onClick={onVote}


### PR DESCRIPTION
People reported pre-voting on mobile being broken/janky. It's not clear what problem they were experiencing but some issues were:
 - The hitbox for the heart button is quite small
 - Hover doesn't work well on mobile (hover persists after you click, which means when you cancel a pre-vote the heart is still filled, which is confusing)
 - On ios, you may have to click twice sometime to get it to work. I was able to reproduce this on browserstack (clicking once would sometimes only trigger a hover), although the free trial only allows a 1 minute test so I wasn't able to check that thoroughly

I've fixed the first two things. For the "ios issue", I think the problem may actually have been that the hitbox was so small that you could move out of the hitbox for the mouseup event, so only a hover would be triggered and not a click event (I'm able to reproduce this locally), so maybe that will be fixed by this too

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205869252295411) by [Unito](https://www.unito.io)
