### PR TITLE
Only shows archive button if handler is passed in

### DIFF
--- a/packages/lesswrong/components/posts/usePostsItem.ts
+++ b/packages/lesswrong/components/posts/usePostsItem.ts
@@ -149,7 +149,8 @@ export const usePostsItem = ({
     : postGetPageUrl(post, false, sequenceId || chapter?.sequenceId);
 
   const showDismissButton = Boolean(currentUser && resumeReading);
-  const showArchiveButton = Boolean(currentUser && post.draft && postCanDelete(currentUser, post));
+  const onArchive = toggleDeleteDraft?.bind(null, post);
+  const showArchiveButton = Boolean(currentUser && post.draft && postCanDelete(currentUser, post) && onArchive);
 
   const commentTerms: CommentsViewTerms = {
     view: "postsItemComments",
@@ -196,7 +197,7 @@ export const usePostsItem = ({
     showDismissButton,
     showArchiveButton,
     onDismiss: dismissRecommendation,
-    onArchive: toggleDeleteDraft?.bind(null, post),
+    onArchive,
     hasUnreadComments,
     hasNewPromotedComments,
     commentTerms,


### PR DESCRIPTION
The dialogues lists were showing an archive button but not passing the handler and so it did nothing. Robert and I made it so that the value of showArchiveButton is dependent on the handler existing.