### PR TITLE
Giving season timeline scale

### DIFF
--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -53,12 +53,12 @@ export type TimelineSpec = {
 
 export const timelineSpec: TimelineSpec = {
   start: new Date("2023-11-01"),
-  end: new Date("2023-12-31"),
+  end: new Date("2023-12-20"),
   points: [
     {date: new Date("2023-11-01"), description: ""},
     {date: votingOpensDate, description: ""},
     {date: new Date("2023-12-15"), description: ""},
-    {date: new Date("2023-12-31"), description: ""},
+    {date: new Date("2023-12-20"), description: ""},
   ],
   spans: [
     {

--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -91,24 +91,4 @@ export const timelineSpec: TimelineSpec = {
       hatched: true,
     },
   ],
-  // We have a lot of events in November and few in December. This function
-  // allows us to space out Novemeber to use most of the timeline and only give
-  // what's left to December. A point `inputSplit` along the timeline will be
-  // linearly mapped to `outputSplit`, with points after `inputSplit` being
-  // squeezed linearly into the remaining space.
-  // This could almost certainly be simplified, but it's too late in the day
-  // for algebra.
-  divisionToPercent: (division: number, divisions: number) => {
-    const inputSplit = 0.5;
-    const outputSplit = 0.65;
-    const multiplier = (100 / inputSplit) * outputSplit;
-    const halfWay = divisions * inputSplit;
-    if (division < halfWay) {
-      return (division / divisions) * multiplier;
-    } else {
-      const multiplier2 = (100 / inputSplit) * (1 - outputSplit);
-      return ((halfWay / divisions) * multiplier) +
-        (((division - halfWay) / divisions) * multiplier2);
-    }
-  },
 };


### PR DESCRIPTION
This PR changes to scaling of the giving season timeline to be linear throughout November and December as requested by Lizka. To fit everything in a bit better I've also changed the end date from 31st December to 20th December (obviously we can change this again if more events get added).

<img width="1212" alt="Screenshot 2023-11-06 at 13 44 20" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/3c8c4aee-9a49-4b9e-bac7-5e7182793970">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205885580168360) by [Unito](https://www.unito.io)
