### PR TITLE
Reexport posts to elastic after tag updates

### DIFF
--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -13,6 +13,7 @@ import {
   donationElectionTagId,
   eaGivingSeason23ElectionName,
 } from '../../lib/eaGivingSeason';
+import { elasticSyncDocument } from '../search/elastic/elasticCallbacks';
 
 function isValidTagName(name: string) {
   if (!name || !name.length)
@@ -55,7 +56,7 @@ export async function updatePostDenormalizedTags(postId: string) {
   }
 
   await Posts.rawUpdateOne({_id:postId}, {$set: {tagRelevance: tagRelDict}});
-
+  void elasticSyncDocument("Posts", postId);
   void updateDonationElectionPostCounts(tagRelDict);
 }
 


### PR DESCRIPTION
We don't currently update posts in Elasticsearch after editing tags which renders the tag filter on the search page relatively useless.

It's recommended (but not necessarily required) to run `Globals.elasticExportCollection('Posts')` after deploying this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205886078182320) by [Unito](https://www.unito.io)
