### PR TITLE
fixing agreement query so that it correctly filters out cancelled votes

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -306,6 +306,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
+            AND v."cancelled" IS FALSE
     
         UNION ALL
     
@@ -330,6 +331,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
+            AND v."cancelled" IS FALSE
     )
   
     SELECT


### PR DESCRIPTION
Previously, we were counting every vote with "extendedVoteType" = "agreement" regardless of whether that vote had been cancelled or not. This PR fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205892280406519) by [Unito](https://www.unito.io)
