### PR TITLE
Fixes "fixing agreement query so that it correctly filters out cancelled votes"

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -306,7 +306,8 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
-    
+            AND v."cancelled" IS NOT TRUE
+
         UNION ALL
     
         -- Joining Users with Comments and Votes
@@ -330,6 +331,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
+            AND v."cancelled" IS NOT TRUE
     )
   
     SELECT

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -306,7 +306,6 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
-            AND v."cancelled" IS FALSE
     
         UNION ALL
     
@@ -331,7 +330,6 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
             v."userId" = $1
             AND u._id != $1
             AND v."votedAt" > NOW() - INTERVAL '1.5 years'
-            AND v."cancelled" IS FALSE
     )
   
     SELECT


### PR DESCRIPTION
Follow up from ForumMagnum/ForumMagnum#8182, to address Robert's point that instead of IS FALSE we should have IS NOT TRUE

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205892299923209) by [Unito](https://www.unito.io)
