### PR TITLE
handle cmd+enter submit for dialogue messages without leaving a newline in the input

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -303,6 +303,7 @@ function handleSubmitWithoutNewline(editor: Editor, currentUser: UsersCurrent | 
   if (parentInputElement) {
     const owner = getBlockUserId(parentInputElement);
     if (owner === currentUser?._id) {
+      // This looks a bit deprecated but it's the same way we handle it in `Form.tsx` for form submission
       if ((event.ctrlKey || event.metaKey) && event.keyCode === 13 && parentInputElement) {
         event.stopPropagation();
         event.preventDefault();

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -639,4 +639,3 @@ declare global {
     CKPostEditor: typeof CKPostEditorComponent
   }
 }
-

--- a/public/lesswrong-editor/src/ckeditor5-dialogue-comments/dialogue-comment-box.js
+++ b/public/lesswrong-editor/src/ckeditor5-dialogue-comments/dialogue-comment-box.js
@@ -58,6 +58,8 @@ class SimpleBoxEditing extends Plugin {
         this.editor.commands.add( 'insertRootParagraphBox', new InsertRootParagraphBoxCommand( this.editor ) );
         this.editor.commands.add( 'submitDialogueMessage', new SubmitDialogueMessageCommand( this.editor ) );
 
+        // TODO: this is deprecated, see usage of `handleSubmitWithoutNewline` in `CKPostEditor.tsx`
+        // Remove this next time there's an actual reason to update the bundle
         this.editor.keystrokes.set( 'Ctrl+Enter', (evt, cancel) => {
 			const selection = editor.model.document.selection;
 			const selectedBlocks = Array.from(selection.getSelectedBlocks())


### PR DESCRIPTION
There's still a bug where pressing ctrl/cmd+enter in someone else's input will submit a message for you (and leave an additional newline in your input), because of the keystroke handling code in the plugin itself, but this at least should fix the behavior for what users are actually doing.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205892411017762) by [Unito](https://www.unito.io)
