### PR TITLE
Fix timeline timezones again

### DIFF
--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -52,39 +52,39 @@ export type TimelineSpec = {
 }
 
 export const timelineSpec: TimelineSpec = {
-  start: new Date("2023/11/01"),
-  end: new Date("2023/12/20"),
+  start: new Date("2023-11-01"),
+  end: new Date("2023-12-20"),
   points: [
-    {date: new Date("2023/11/01"), description: ""},
+    {date: new Date("2023-11-01"), description: ""},
     {date: votingOpensDate, description: ""},
-    {date: new Date("2023/12/15"), description: ""},
-    {date: new Date("2023/12/20"), description: ""},
+    {date: new Date("2023-12-15"), description: ""},
+    {date: new Date("2023-12-20"), description: ""},
   ],
   spans: [
     {
-      start: new Date("2023/11/07"),
-      end: new Date("2023/11/14"),
+      start: new Date("2023-11-07"),
+      end: new Date("2023-11-14"),
       description: "Effective Giving Spotlight",
       href: `/s/YvGiiYnekY7anj5FB`,
       consecutive: true,
     },
     {
-      start: new Date("2023/11/14"),
-      end: new Date("2023/11/21"),
+      start: new Date("2023-11-14"),
+      end: new Date("2023-11-21"),
       description: "Marginal Funding Week",
       href: `${donationElectionLink}#Marginal_Funding_Week`,
       consecutive: true,
     },
     {
-      start: new Date("2023/11/21"),
-      end: new Date("2023/11/28"),
+      start: new Date("2023-11-21"),
+      end: new Date("2023-11-28"),
       description: "Donation Debate Week",
       href: `${donationElectionLink}#Donation_Debate_Week`,
       consecutive: true,
     },
     {
-      start: new Date("2023/12/01"),
-      end: new Date("2023/12/15"),
+      start: new Date("2023-12-01"),
+      end: new Date("2023-12-15"),
       description: "Vote in the Election",
       href: `${donationElectionLink}#Voting_opens_December_1___more_information`,
       hideDates: true,


### PR DESCRIPTION
This PR fixes the timeline timezones again.

I've tested with the timezone set to Seoul, London and San Francisco and it was correct in all three cases.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205898493702866) by [Unito](https://www.unito.io)
