### PR TITLE
fix "notify me" action for logged out users

### DIFF
--- a/packages/lesswrong/components/hooks/useNotifyMe.ts
+++ b/packages/lesswrong/components/hooks/useNotifyMe.ts
@@ -83,8 +83,6 @@ export const useNotifyMe = ({
     eventProps: {documentId: document._id, documentType: documentType},
   });
 
-  const skip = !currentUser;
-
   // Get existing subscription, if there is one
   const {results, loading, invalidateCache} = useMulti({
     terms: {
@@ -98,7 +96,7 @@ export const useNotifyMe = ({
     collectionName: "Subscriptions",
     fragmentName: "SubscriptionState",
     enableTotal: false,
-    skip
+    skip: !currentUser
   });
   
   const onSubscribe = async (e: MouseEvent) => {
@@ -136,9 +134,15 @@ export const useNotifyMe = ({
     }
   }
   
-  // By default, we want to allow logged out users to see the element and click on it,
+  // If we are hiding the notify element, don't return an onSubscribe.
+  if (!currentUser && hideForLoggedOutUsers) {
+    return {
+      loading: false
+    }
+  }
+  // By default, we allow logged out users to see the element and click on it,
   // so that we can prompt them with the login/sign up buttons.
-  if (!currentUser && !hideForLoggedOutUsers) {
+  if (!currentUser) {
     return {
       loading: false,
       disabled: false,
@@ -149,9 +153,7 @@ export const useNotifyMe = ({
 
   if (loading) {
     return {
-      // Apollo (sometimes?) returns `loading: true` when you skip the query.
-      // If we skipped fetching subscription state because there's no logged-in user, don't return loading: true.
-      loading: skip ? false : true,
+      loading: true,
     };
   };
 

--- a/packages/lesswrong/components/notifications/NotifyMeButton.tsx
+++ b/packages/lesswrong/components/notifications/NotifyMeButton.tsx
@@ -39,6 +39,7 @@ const NotifyMeButton = ({
   hideLabel = false,
   hideLabelOnMobile = false,
   hideIfNotificationsDisabled = false,
+  hideForLoggedOutUsers = false,
   asButton = false,
   componentIfSubscribed,
 }: {
@@ -54,6 +55,8 @@ const NotifyMeButton = ({
   hideLabel?: boolean,
   hideLabelOnMobile?: boolean
   hideIfNotificationsDisabled?: boolean,
+  // by default, we show the button to logged out users so that we can prompt them to login/sign up when they click it
+  hideForLoggedOutUsers?: boolean,
   // uses <a> by default, set this to use <button>
   asButton?: boolean,
   // display this component if the user is already subscribed, instead of the unsubscribeMessage
@@ -63,6 +66,7 @@ const NotifyMeButton = ({
     document,
     overrideSubscriptionType,
     hideIfNotificationsDisabled,
+    hideForLoggedOutUsers,
   });
 
   if (disabled) {


### PR DESCRIPTION
We got a report that the "Subscribe to be notified when an event is added" link on the [group details page](https://forum.effectivealtruism.org/groups/TGgHpPNHnM4sS6Gcc) doesn't do anything when clicking as a logged out user. This fixes the link, so that it works the same as the other "notify me" actions - logged out users should get prompted to login/sign up.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205902635195180) by [Unito](https://www.unito.io)
