### PR TITLE
Forum gate elicit cutover

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -51,6 +51,7 @@ export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabl
 // Non-user-specific features
 export const dialoguesEnabled = isLWorAF;
 export const inlineReactsHoverEnabled = isLWorAF;
+export const useElicitApi = !isLWorAF;
 
 // Shipped Features
 export const userCanManageTags = shippedFeature;

--- a/packages/lesswrong/server/resolvers/elicitPredictions.ts
+++ b/packages/lesswrong/server/resolvers/elicitPredictions.ts
@@ -6,6 +6,7 @@ import { encode } from 'querystring'
 import { onStartup } from '../../lib/executionEnvironment';
 import ElicitQuestions from '../../lib/collections/elicitQuestions/collection';
 import ElicitQuestionPredictions from '../../lib/collections/elicitQuestionPredictions/collection';
+import { isLW, isLWorAF } from '../../lib/instanceSettings';
 
 const ElicitUserType = `type ElicitUser {
   isQuestionCreator: Boolean
@@ -135,7 +136,45 @@ interface ElicitQuestionWithPredictions {
   predictions: DbElicitQuestionPrediction[]
 }
 
-async function getElicitQuestionWithPredictions(questionId: string): Promise<ElicitQuestionWithPredictions | Record<any, never>> {
+async function getElicitQuestionWithPredictions(questionId: string) {
+  const elicitData: any = await getPredictionDataFromElicit(questionId)
+  const predictions = await getPredictionsFromElicit(questionId)
+  if (!elicitData || !predictions) return {}
+  const { title, notes, resolvesBy, resolution } = elicitData
+  const processedPredictions = predictions.map(({
+    id,
+    prediction,
+    createdAt,
+    notes,
+    creator,
+    sourceUrl,
+    sourceId,
+    binaryQuestionId
+  }) => ({
+    _id: id,
+    predictionId: id,
+    prediction,
+    createdAt: new Date(createdAt),
+    notes,
+    creator: {
+      ...creator,
+      _id: creator.id
+    },
+    sourceUrl,
+    sourceId,
+    binaryQuestionId
+  }))
+  return {
+    _id: questionId,
+    title,
+    notes,
+    resolution: resolution === "YES",
+    resolvesBy: new Date(resolvesBy),
+    predictions: processedPredictions
+  }
+}
+
+async function getLocalElicitQuestionWithPredictions(questionId: string): Promise<ElicitQuestionWithPredictions | Record<any, never>> {
   const [questionData, predictionData] = await Promise.all([
     ElicitQuestions.findOne(questionId),
     ElicitQuestionPredictions.find({ binaryQuestionId: questionId }).fetch()
@@ -162,23 +201,25 @@ onStartup(() => {
       },
       Query: {
         async ElicitBlockData(root: void, {questionId}: {questionId: string}, context: ResolverContext) {
-          return await getElicitQuestionWithPredictions(questionId)
+          if (!isLWorAF) return await getElicitQuestionWithPredictions(questionId);
+          
+          return await getLocalElicitQuestionWithPredictions(questionId);
         }
       },
       Mutation: {
-        async MakeElicitPrediction(root: void, {questionId, prediction}: {questionId: string, prediction: number}, { currentUser }: ResolverContext) {
-          
-          // Elicit API is (to be) shut down. We don't support predictions (yet?)
-          
-          // Ancient code, as preserved by Robert's wish
-          // if (!currentUser) throw Error("Can only make elicit prediction when logged in")
-          // if (prediction) {
-          //   const responseData: any = await sendElicitPrediction(questionId, prediction, currentUser)
-          //   if (!responseData?.binaryQuestionId) throw Error("Error in sending prediction to Elicit")
-          // } else { // If we provide a falsy prediction (including 0, since 0 isn't a valid prediction, we cancel our current prediction)
-          //   await cancelElicitPrediction(questionId, currentUser)
-          // }
-          const newData = await getElicitQuestionWithPredictions(questionId)
+        async MakeElicitPrediction(root: void, {questionId, prediction}: {questionId: string, prediction: number}, { currentUser }: ResolverContext) {                  
+          if (!currentUser) throw Error("Can only make elicit prediction when logged in")
+          if (isLWorAF) {
+            // Elicit API is (to be) shut down. We don't support predictions (yet?)
+            return await getLocalElicitQuestionWithPredictions(questionId);
+          }
+          if (prediction) {
+            const responseData: any = await sendElicitPrediction(questionId, prediction, currentUser)
+            if (!responseData?.binaryQuestionId) throw Error("Error in sending prediction to Elicit")
+          } else { // If we provide a falsy prediction (including 0, since 0 isn't a valid prediction, we cancel our current prediction)
+            await cancelElicitPrediction(questionId, currentUser)
+          }
+          const newData = await getLocalElicitQuestionWithPredictions(questionId)
           return newData
         }
       }


### PR DESCRIPTION
Elicit has been asking us to deprecate usage of their API for a while now.  Doing this forum-gated since the EA forum may want to test the manual migration for the import themselves.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205904106262119) by [Unito](https://www.unito.io)
