### PR TITLE
Fix alignment of bottom-of-post recommendations when there is no ToC

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -514,7 +514,8 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   // as we read ToC data from the foreign site and it includes answers
   // which don't exists locally. TODO: Remove this gating when we finally
   // rewrite crossposting.
-  const tableOfContents = sectionData && !isCrosspostedQuestion
+  const hasTableOfContents = !!sectionData && !isCrosspostedQuestion;
+  const tableOfContents = hasTableOfContents
     ? <TableOfContents sectionData={sectionData} title={post.title} />
     : null;
 
@@ -676,7 +677,10 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
       </AnalyticsInViewTracker>
     </ToCColumn>
     {isEAForum && <AnalyticsInViewTracker eventProps={{inViewType: "postPageFooterRecommendations"}}>
-      <PostBottomRecommendations post={post} />
+      <PostBottomRecommendations
+        post={post}
+        hasTableOfContents={hasTableOfContents}
+      />
     </AnalyticsInViewTracker>}
     </SideCommentVisibilityContext.Provider>
     </PostsPageContext.Provider>

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -37,8 +37,9 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const PostBottomRecommendations = ({post, classes}: {
+const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision,
+  hasTableOfContents?: boolean,
   classes: ClassesType,
 }) => {
   const {
@@ -81,7 +82,10 @@ const PostBottomRecommendations = ({post, classes}: {
   return (
     <AnalyticsContext pageSectionContext="postPageFooterRecommendations">
       <div className={classes.root}>
-        <ToCColumn tableOfContents={<div />} notHideable>
+        <ToCColumn
+          tableOfContents={hasTableOfContents ? <div /> : null}
+          notHideable
+        >
           <div>
             {hasUserPosts &&
               <div className={classes.section}>


### PR DESCRIPTION
PR #8147 fixed a bug where the post body is misaligned for posts with no table of contents. Bottom-of-post recommendations use this same logic and we therefore need to make a similar change in order for this to be aligned with the post body and comments above.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205911579203327) by [Unito](https://www.unito.io)
