### PR TITLE
Hide progress bar overflow on EA giving portal page

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -176,14 +176,13 @@ const styles = (theme: ThemeType) => ({
     backgroundColor: theme.palette.givingPortal[800],
     borderRadius: theme.borderRadius.small,
     marginBottom: 16,
+    overflow: "hidden",
   },
   progress: {
     position: "absolute",
     left: 0,
     top: 0,
     backgroundColor: theme.palette.givingPortal[1000],
-    borderBottomLeftRadius: theme.borderRadius.small,
-    borderTopLeftRadius: theme.borderRadius.small,
     height: "100%",
   },
   raisedSoFar: {


### PR DESCRIPTION
The donation goal is almost complete and the bar is in danger of overflowing before we update the goal amount. This change makes sure the bar never becomes more than 100% full.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205911861540021) by [Unito](https://www.unito.io)
