### PR TITLE
Make `classes` optionally strongly-typed

### DIFF
--- a/packages/lesswrong/components/books/Book2018Landing.tsx
+++ b/packages/lesswrong/components/books/Book2018Landing.tsx
@@ -302,7 +302,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const Hidden = ({classes}: ClassesType) => {
+const Hidden = ({classes}: {classes: ClassesType}) => {
   return (
     <div className={classes.mainQuoteContainer}>
       <div className={classes.mainQuote}>

--- a/packages/lesswrong/components/books/Book2019Landing.tsx
+++ b/packages/lesswrong/components/books/Book2019Landing.tsx
@@ -245,7 +245,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const HiddenQuote = ({classes}: ClassesType) => {
+const HiddenQuote = ({classes}: {classes: ClassesType}) => {
   return (
     <div className={classes.mainQuoteContainer}>
       <div className={classes.mainQuote}>

--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -40,7 +40,7 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
       return <CommentsListMeta>
         <span>
           Some comments are truncated due to high volume. <LWTooltip title={expandTooltip}>
-            <a className={!expandAllThreads && classes.button} onClick={()=>setExpandAllThreads(true)}>(⌘F to expand all)</a>
+            <a className={!expandAllThreads ? classes.button : undefined} onClick={()=>setExpandAllThreads(true)}>(⌘F to expand all)</a>
           </LWTooltip>
         </span>
         {currentUser 

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -217,7 +217,7 @@ const CommentsNode = ({
   const passedThroughItemProps = { comment, collapsed, showPinnedOnProfile, enableGuidelines, showParentDefault }
 
   
-  return <div className={comment.gapIndicator && classes.gapIndicator}>
+  return <div className={comment.gapIndicator ? classes.gapIndicator : undefined}>
     <CommentFrame
       comment={comment}
       treeOptions={treeOptions}

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -405,7 +405,7 @@ const ForumIcon = ({
   const customClass = customClassKey ? classes[customClassKey] : undefined;
   const fullClassName = classNames(className, {
     [classes.root]: !noDefaultStyles,
-    [customClass]: !noDefaultStyles && customClass,
+    [customClass as AnyBecauseHard]: !noDefaultStyles && customClass,
   });
 
   return <Icon className={fullClassName} {...props} />;

--- a/packages/lesswrong/components/common/TemplateComponent.tsx
+++ b/packages/lesswrong/components/common/TemplateComponent.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { useTracking } from "../../lib/analyticsEvents";
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   root: {
 
   }
 });
 
 export const TemplateComponent = ({classes}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
   return <div className={classes.root}>

--- a/packages/lesswrong/components/common/hocTypes.ts
+++ b/packages/lesswrong/components/common/hocTypes.ts
@@ -3,8 +3,19 @@ import { RouterLocation } from '../../lib/vulcan-lib';
 
 declare global {
 
-type ClassesType = Record<string,any>
-type JssStyles = any
+// This `any` should actually be `CSSProperties` from either MUI or JSS but this
+// currently causes an avalanche of type errors, I think due to the fact that
+// we're stuck on a precambrian version of MUI. Upgrading would probably fix this.
+type JssStyles<ClassKey extends string = string> = Record<ClassKey, AnyBecauseHard>;
+
+type JssStylesCallback<ClassKey extends string = string> = (
+  theme: ThemeType,
+) => JssStyles<ClassKey>;
+
+type ClassesType<
+  Styles extends JssStylesCallback<ClassKey> = JssStylesCallback<string>,
+  ClassKey extends string = string
+> = Readonly<Record<keyof ReturnType<Styles>, string>>;
 
 interface WithStylesProps {
   classes: ClassesType,

--- a/packages/lesswrong/components/messaging/ConversationItem.tsx
+++ b/packages/lesswrong/components/messaging/ConversationItem.tsx
@@ -59,7 +59,7 @@ const ConversationItem = ({conversation, updateConversation, currentUser, classe
   }
 
   return (
-    <div className={expanded ? classes.boxShadow : null}>
+    <div className={expanded ? classes.boxShadow : undefined}>
       <div className={classNames(classes.root, classes.wrap, {[classes.archivedItem]: isArchived})}>
         <Link to={`/inbox/${conversation._id}`} className={classNames(classes.title, classes.titleLineHeight, classes.commentFont)}>{conversationGetTitle(conversation, currentUser)}</Link>
         { conversation.participants

--- a/packages/lesswrong/components/messaging/FriendlyInbox.tsx
+++ b/packages/lesswrong/components/messaging/FriendlyInbox.tsx
@@ -224,7 +224,7 @@ const FriendlyInbox = ({
           })}
         >
           <div className={classNames(classes.columnHeader, classes.columnHeaderLeft)}>
-            <div className={classes.classes.headerText}>All messages</div>
+            <div className={classes.headerText}>All messages</div>
             <ForumIcon onClick={openNewConversationDialog} icon="PencilSquare" className={classes.actionIcon} />
           </div>
           <div className={classes.navigation}>

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -8,7 +8,7 @@ import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
 
-export const styles = (theme: ThemeType): JssStyles => ({
+export const styles = (theme: ThemeType) => ({
   root: {
     display: "flex",
     alignItems: "center",
@@ -166,10 +166,9 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
 });
 
-
 export type EAPostsItemProps = PostsItemConfig & {
   hideSecondaryInfo?: boolean,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 };
 
 const EAPostsItem = ({

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -55,7 +55,7 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
       {loading && showLoading && (topLoading || dimWhenLoading) && <Loading />}
       {orderedResults && !orderedResults.length && <PostsNoResults />}
 
-      <div className={boxShadow ? classes.posts : null}>
+      <div className={boxShadow ? classes.posts : undefined}>
         {itemProps?.map((props) => <PostsItem key={props.post._id} {...props} />)}
       </div>
       {showLoadMore && <SectionFooter>

--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
@@ -1,38 +1,10 @@
-import React, { Component } from 'react';
+import React, { Component, FC } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 import Checkbox from '@material-ui/core/Checkbox';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { ForumOptions, forumSelect } from '../../lib/forumTypeUtils';
 import InputLabel from '@material-ui/core/InputLabel';
-
-const defaultTooltipLWAF = ({classes}: {classes: ClassesType}) => <div className={classes.tooltip}>
-  <p>LW moderators will consider this post for frontpage</p>
-  <p className={classes.guidelines}>Things to aim for:</p>
-  <ul>
-    <li className={classes.guidelines}>
-      Usefulness, novelty and fun
-    </li>
-    <li className={classes.guidelines}>
-      Timeless content (minimize reference to current events)
-    </li>
-    <li className={classes.guidelines}>
-      Explain rather than persuade
-    </li>
-  </ul>
-</div>
-
-const defaultTooltipEAF = () =>
-  "Uncheck this box if you don't want your post to show in the Frontpage list. It will still appear in Recent discussion, Topics pages, and All posts.";
-
-const forumDefaultTooltip: ForumOptions<(classes?: ClassesType) => JSX.Element | string> = {
-  LessWrong: defaultTooltipLWAF,
-  AlignmentForum: defaultTooltipLWAF,
-  EAForum: defaultTooltipEAF,
-  default: defaultTooltipEAF,
-}
-
-const defaultTooltip = forumSelect(forumDefaultTooltip)
 
 const styles = (theme: ThemeType): JssStyles => ({
   submitToFrontpageWrapper: {
@@ -79,6 +51,36 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontStyle: "italic"
   },
 });
+
+const defaultTooltipLWAF = ({classes}: {classes: ClassesType<typeof styles>}) => <div className={classes.tooltip}>
+  <p>LW moderators will consider this post for frontpage</p>
+  <p className={classes.guidelines}>Things to aim for:</p>
+  <ul>
+    <li className={classes.guidelines}>
+      Usefulness, novelty and fun
+    </li>
+    <li className={classes.guidelines}>
+      Timeless content (minimize reference to current events)
+    </li>
+    <li className={classes.guidelines}>
+      Explain rather than persuade
+    </li>
+  </ul>
+</div>
+
+const defaultTooltipEAF = () =>
+  <>
+    Uncheck this box if you don't want your post to show in the Frontpage list. It will still appear in Recent discussion, Topics pages, and All posts.
+  </>
+
+const forumDefaultTooltip: ForumOptions<FC<{classes?: ClassesType<typeof styles>}>> = {
+  LessWrong: defaultTooltipLWAF,
+  AlignmentForum: defaultTooltipLWAF,
+  EAForum: defaultTooltipEAF,
+  default: defaultTooltipEAF,
+}
+
+const defaultTooltip = forumSelect(forumDefaultTooltip)
 
 export interface SubmitToFrontpageCheckboxProps extends WithStylesProps {
   fieldName?: string,

--- a/packages/lesswrong/components/recommendations/LWRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/LWRecommendations.tsx
@@ -7,7 +7,6 @@ import { useContinueReading } from './withContinueReading';
 import {AnalyticsContext, useTracking} from "../../lib/analyticsEvents";
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
 import classNames from 'classnames';
-import { PublicInstanceSetting } from '../../lib/instanceSettings';
 import { DatabasePublicSetting } from '../../lib/publicSettings';
 
 export const curatedUrl = "/recommendations"
@@ -204,7 +203,7 @@ const LWRecommendations = ({
         </div>
 
         {renderContinueReading && (
-          <div className={currentUser ? classes.subsection : null}>
+          <div className={currentUser ? classes.subsection : undefined}>
             <AnalyticsContext pageSubSectionContext="continueReading">
               <LWTooltip placement="top-start" title={continueReadingTooltip}>
                 <Link to={"/library"}>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -260,7 +260,7 @@ const RecommendationsAndCurated = ({
         </div>
 
         {renderContinueReading && (
-          <div className={currentUser ? classes.subsection : null}>
+          <div className={currentUser ? classes.subsection : undefined}>
             <AnalyticsContext pageSubSectionContext="continueReading">
               <LWTooltip placement="top-start" title={continueReadingTooltip}>
                 <Link to={"/library"}>

--- a/packages/lesswrong/components/review/ReviewQuickPage.tsx
+++ b/packages/lesswrong/components/review/ReviewQuickPage.tsx
@@ -147,7 +147,7 @@ export const ReviewQuickPage = ({classes}: {
       <div className={classes.menu}>
         Top Unreviewed Posts
       </div>
-      <div className={loading ? classes.loading : null}>
+      <div className={loading ? classes.loading : undefined}>
         {truncatedPostsResults.map(post => {
           return <div key={post._id} onClick={() => setExpandedPost(post)} className={classes.postRoot}>
             <PostsItem 

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -15,7 +15,7 @@ import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { getSpotlightUrl } from '../../lib/collections/spotlights/helpers';
 
 
-export const descriptionStyles = (theme: JssStyles) => ({
+export const descriptionStyles = (theme: ThemeType) => ({
   ...postBodyStyles(theme),
   ...(!isEAForum ? theme.typography.body2 : {}),
   lineHeight: '1.65rem',

--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -56,7 +56,7 @@ const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }:
       {displayTitle && <span className={classes.scoreTitleFormat}>
         <FormatDate date={comment.postedAt} />
       </span>}
-      <span className={displayTitle ? classes.scoreTitleFormat : null}>
+      <span className={displayTitle ? classes.scoreTitleFormat : undefined}>
         {comment.baseScore} 
       </span>
       {displayTitle && comment.post?.title }

--- a/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
@@ -60,7 +60,7 @@ const PostKarmaWithPreview = ({ post, classes, displayTitle, reviewedAt }: {
           {displayTitle && <span className={classes.scoreTitleFormat}>
             <FormatDate date={post.postedAt} />
           </span>}
-          <span className={displayTitle ? classes.scoreTitleFormat : null}>
+          <span className={displayTitle ? classes.scoreTitleFormat : undefined}>
             {post.baseScore}
           </span>
           {displayTitle && post.title}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListCount.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListCount.tsx
@@ -13,7 +13,7 @@ const SunshineListCount = ({ count, classes }: {
 }) => {
   const { MetaInfo } = Components
   if (count && count > 10) {
-    return <MetaInfo className={(count > 20) && classes.overflow}>({count})</MetaInfo>
+    return <MetaInfo className={count > 20 ? classes.overflow : undefined}>({count})</MetaInfo>
   } else {
     return null
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -37,7 +37,7 @@ const SunshineNewUsersItem = ({ user, classes, refetch, currentUser }: {
   const { SunshineListItem, SidebarHoverOver, SunshineNewUsersInfo, MetaInfo, FormatDate, FirstContentIcons } = Components
   
   return (
-    <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
+    <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : undefined}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
           <SunshineNewUsersInfo user={user} refetch={refetch} currentUser={currentUser}/>

--- a/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
@@ -62,7 +62,7 @@ const TagDiscussionButton = ({tag, text = "Discussion", hideLabelOnMobile = fals
     {...eventHandlers}
   >
     <CommentOutlinedIcon className={classes.discussionButtonIcon} />
-    <span className={hideLabelOnMobile ? classes.hideOnMobile : null}>{text}</span>
+    <span className={hideLabelOnMobile ? classes.hideOnMobile : undefined}>{text}</span>
     {!loading && <span className={classes.discussionCount}>&nbsp;{`(${totalCount || 0})`}</span>}
     <PopperCard open={hover} anchorEl={anchorEl} placement="bottom-start" >
       <TagDiscussion tag={tag}/>

--- a/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
@@ -50,7 +50,7 @@ const AddInlineReactionButton = ({voteProps, classes, quote, disabled}: {
     <span
       ref={buttonRef}
     >
-      {!open && <InsertEmoticonOutlined onClick={handleOpen} className={disabled ? classes.disabled : null}/>}
+      {!open && <InsertEmoticonOutlined onClick={handleOpen} className={disabled ? classes.disabled : undefined}/>}
       {open && <div className={classes.palette}>
         <ReactionsPalette
           getCurrentUserReactionVote={getCurrentUserReactionVote}


### PR DESCRIPTION
Currently we declare a component with styles like this:
```
const styles = () => ({
  root: {
    background: "red",
  },
})
const Component = ({classes}: {classes: ClassesType}) => {
  return (
     <div className={classes.root} />
  );
}
```

This works fine, but it's error prone as `classes` is typed as a `Record<string, any>`. For instance, it's easy to accidentally type `classes.rooy` instead of `classes.root`, and these errors can be really annoying to debug.

This PR is totally backwards compatible so you can still write components like this, but you can now optionally add a type parameter to `classes` in the component definition:
```
const Component = ({classes}: {classes: ClassesType<typeof styles>}) => {
```
and now your `classes` object knows the names of the classes that is contains and `classes.rooy` will give a type error. Your auto-complete can now also suggest to you what classnames are available.

The implementation is just a few lines of code in `hocTypes.ts`. As a proof of concept and for testing, I've added `<typeof styles>` to the `EAPostItem` component and to the `TemplateComponent` component. The rest of this PR is just fixing errors that were surfaced by adding this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205920247285531) by [Unito](https://www.unito.io)
