### PR TITLE
Show latest dialogue messages when clicking unread

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -5,7 +5,7 @@ import { sequenceGetPageUrl } from "../../lib/collections/sequences/helpers";
 import { collectionGetPageUrl } from "../../lib/collections/collections/helpers";
 import withErrorBoundary from '../common/withErrorBoundary';
 import classNames from 'classnames';
-import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
+import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { getReviewPhase, postEligibleForReview, postIsVoteable, REVIEW_YEAR } from '../../lib/reviewUtils';
@@ -346,8 +346,10 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
     resumeReading,
     sticky,
     renderComments,
+    renderDialogueMessages,
     condensedAndHiddenComments,
     toggleComments,
+    toggleDialogueMessages,
     showAuthor,
     showDate,
     showTrailingButtons,
@@ -386,9 +388,9 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
   const {
     PostsItemComments, KarmaDisplay, PostsTitle, PostsUserAndCoauthors, LWTooltip,
     PostActionsButton, PostsItemIcons, PostsItem2MetaInfo, PostsItemTooltipWrapper,
-    BookmarkButton, PostsItemDate, PostsItemNewCommentsWrapper, AnalyticsTracker,
-    AddToCalendarButton, PostsItemReviewVote, ReviewPostButton, PostReadCheckbox,
-    PostMostValuableCheckbox, PostsItemTrailingButtons,
+    BookmarkButton, PostsItemDate, PostsItemNewCommentsWrapper, PostsItemNewDialogueResponses,
+    AnalyticsTracker, AddToCalendarButton, PostsItemReviewVote, ReviewPostButton,
+    PostReadCheckbox, PostMostValuableCheckbox, PostsItemTrailingButtons,
   } = Components;
 
   const reviewCountsTooltip = `${post.nominationCount2019 || 0} nomination${(post.nominationCount2019 === 1) ? "" :"s"} / ${post.reviewCount2019 || 0} review${(post.nominationCount2019 === 1) ? "" :"s"}`
@@ -475,7 +477,7 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
             </PostsItem2MetaInfo>}
 
             {!!post.unreadDebateResponseCount && <PostsItem2MetaInfo className={classes.unreadDebateResponseContainer}>
-              <div className={classes.unreadDebateResponseCount} onClick={toggleComments}>
+              <div className={classes.unreadDebateResponseCount} onClick={toggleDialogueMessages}>
                 <DebateIcon className={classes.unreadDebateResponsesIcon}/>
                 {post.unreadDebateResponseCount}
               </div>
@@ -561,6 +563,10 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
                 condensed: condensedAndHiddenComments,
               }}
             />
+          </div>}
+
+          {renderDialogueMessages && <div className={classes.newCommentsSection} onClick={toggleDialogueMessages}>
+            <PostsItemNewDialogueResponses postId={post._id} unreadCount={post.unreadDebateResponseCount} />
           </div>}
         </div>
         {showMostValuableCheckbox && <div className={classes.mostValuableCheckbox}>

--- a/packages/lesswrong/components/posts/PostsItemNewDialogueResponses.tsx
+++ b/packages/lesswrong/components/posts/PostsItemNewDialogueResponses.tsx
@@ -1,0 +1,26 @@
+import { gql, useQuery } from "@apollo/client";
+import { Components, registerComponent } from "../../lib/vulcan-lib";
+import React from "react";
+
+const PostsItemNewDialogueResponses = ({postId, unreadCount} : {postId: string, unreadCount: number}) => {
+  
+  const { ContentItemBody, Loading, NoContent }= Components
+
+  const { data, loading } = useQuery(gql`
+    query LatestDialogueMessages($dialogueId: String!, $unreadCount: Int!) {
+      latestDialogueMessages(dialogueId: $dialogueId, numMessages: $unreadCount)
+    }
+  `, {variables: {dialogueId: postId, unreadCount  }});
+
+  return loading ? <Loading /> : data ? data.length ? <ContentItemBody
+    dangerouslySetInnerHTML={{__html: data.latestDialogueMessages.join('')}} />
+    : <NoContent>No new responses found</NoContent> : <div></div>
+}
+
+const PostsItemNewDialogueResponsesComponent = registerComponent('PostsItemNewDialogueResponses', PostsItemNewDialogueResponses);
+
+declare global {
+  interface ComponentTypes {
+    PostsItemNewDialogueResponses: typeof PostsItemNewDialogueResponsesComponent
+  }
+}

--- a/packages/lesswrong/components/posts/usePostsItem.ts
+++ b/packages/lesswrong/components/posts/usePostsItem.ts
@@ -116,6 +116,7 @@ export const usePostsItem = ({
 }: PostsItemConfig) => {
   const [showComments, setShowComments] = useState(defaultToShowComments);
   const [readComments, setReadComments] = useState(false);
+  const [showDialogueMessages, setShowDialogueMessages] = useState(false);
   const {isRead, recordPostView} = useRecordPostView(post);
   const {isPostRepeated, addPost} = useHideRepeatedPosts();
 
@@ -128,6 +129,14 @@ export const usePostsItem = ({
       setReadComments(true);
     },
     [post, recordPostView, setShowComments, showComments, setReadComments],
+  );
+
+  const toggleDialogueMessages = useCallback(
+    () => {
+      recordPostView({post, extraEventProperties: {type: "toggleDialogueMessages"}})
+      setShowDialogueMessages(!showDialogueMessages);
+    },
+    [post, recordPostView, setShowDialogueMessages, showDialogueMessages],
   );
 
   const compareVisitedAndCommentedAt = (
@@ -180,8 +189,10 @@ export const usePostsItem = ({
     resumeReading,
     sticky: forceSticky || isSticky(post, terms),
     renderComments: showComments || (defaultToShowUnreadComments && hadUnreadComments),
+    renderDialogueMessages: showDialogueMessages,
     condensedAndHiddenComments: defaultToShowUnreadComments && !showComments,
     toggleComments,
+    toggleDialogueMessages,
     showAuthor: !post.isEvent && !hideAuthor,
     showDate: showPostedAt && !resumeReading,
     showTrailingButtons: !hideTrailingButtons,

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -403,6 +403,7 @@ importComponent("EAKarmaDisplay", () => require('../components/common/EAKarmaDis
 importComponent("PostsItemMetaInfo", () => require('../components/posts/PostsItemMetaInfo'));
 importComponent("PostsItemNewCommentsWrapper", () => require('../components/posts/PostsItemNewCommentsWrapper'));
 importComponent("PostsItemNewCommentsList", () => require('../components/posts/PostsItemNewCommentsList'));
+importComponent("PostsItemNewDialogueResponses", () => require('../components/posts/PostsItemNewDialogueResponses'));
 importComponent("PostsDialogItemNewCommentsList", () => require('../components/posts/PostsDialogItemNewCommentsList'));
 importComponent("PostsItemNewCommentsListNode", () => require('../components/posts/PostsItemNewCommentsListNode'));
 importComponent("PostsItemIcons", () => require('../components/posts/PostsItemIcons'));

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -126,6 +126,7 @@ import './server/callbacks/localgroupCallbacks';
 import './server/callbacks/gardenCodeCallbacks';
 import './server/resolvers/commentResolvers';
 import './server/resolvers/notificationResolvers';
+import './server/resolvers/dialogueMessageResolvers';
 import './server/callbacks/postCallbacks';
 import './server/posts/validatePost';
 import './server/callbacks/chapterCallbacks';

--- a/packages/lesswrong/server/resolvers/dialogueMessageResolvers.ts
+++ b/packages/lesswrong/server/resolvers/dialogueMessageResolvers.ts
@@ -1,0 +1,22 @@
+import { handleDialogueHtml } from "../editor/conversionUtils";
+import { cheerioParse } from "../utils/htmlUtil";
+import { defineQuery } from "../utils/serverGraphqlUtil";
+
+const extractLatestDialogueMessages = async (dialogueHtml: string, numMessages: number): Promise<String[]> => {
+  if (numMessages <= 0) return Promise.resolve([])
+  const html = await handleDialogueHtml(dialogueHtml)
+  const $ = cheerioParse(html);
+  const messages = $('.dialogue-message');
+  return messages.toArray().slice(-numMessages).map(message => $(message).toString());
+};
+
+defineQuery({
+  name: "latestDialogueMessages",
+  resultType: "[String!]",
+  argTypes: "(dialogueId: String!, numMessages: Int!)",
+  fn: async (_, { dialogueId, numMessages }: { dialogueId: string, numMessages: number }, context: ResolverContext): Promise<String[]> => {
+    const dialogue = await context.Posts.findOne({_id: dialogueId})
+    if (!dialogue || !dialogue.collabEditorDialogue) return []
+    return await extractLatestDialogueMessages(dialogue?.contents.html, numMessages);
+  }
+})


### PR DESCRIPTION
New dialogue messages to read! 😮 
<img width="779" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/12041390/5137caf0-9877-4717-9ee2-80ad8e512357">

Previously when you would click on the new messages icon, just comments 😞 
<img width="797" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/12041390/5eca21db-fe1d-4215-b1a5-38a0823ba9c4">

Now, dialogue responses! 🎊 
<img width="802" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/12041390/1c71ac70-b04e-4a2f-a426-de223ea5969a">

---

I think we have to keep around `PostsDialogItemNewCommentsList` in case old comment-based dialogues get new responses.
