### PR TITLE
Add left border radius to giving season banner timeline

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonBanner.tsx
@@ -119,7 +119,9 @@ const styles = (theme: ThemeType) => ({
     padding: "6px 12px",
     borderLeft: `1px solid ${theme.palette.givingPortal.homepageHeader.main}`,
     "&:first-of-type": {
-      borderLeft: "none"
+      borderLeft: "none",
+      borderTopLeftRadius: theme.borderRadius.small,
+      borderBottomLeftRadius: theme.borderRadius.small,
     },
     "&:hover": {
       backgroundColor: theme.palette.givingPortal.homepageHeader.secondaryOpaqueDark,


### PR DESCRIPTION
<img width="205" alt="Screenshot 2023-11-14 at 02 06 10" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c938380d-8288-4b85-ac17-863eb6fc9367">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205945958561162) by [Unito](https://www.unito.io)
