### PR TITLE
Fix location input overflowing its bounds in meetup-poke widget

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionMeetupsPoke.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionMeetupsPoke.tsx
@@ -29,10 +29,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: 500,
   },
   
+  locationInputWrapper: {
+    display: "flex",
+  },
   locationInput: {
     display: "inline-block",
     borderBottom: `1px solid ${theme.palette.text.normal}`,
-    width: 350,
+    flexGrow: 1,
     marginTop: 40,
     marginBottom: 40,
     position: "relative",
@@ -165,7 +168,7 @@ const RecentDiscussionMeetupsPoke = ({classes}: {
     <div>Did you know that there are LessWrong meetups? To get email notification
     of meetups near you, enter your location:</div>
     
-    <div>
+    <div className={classes.locationInputWrapper}>
       {mapsLoaded ? <Geosuggest
         ref={geosuggestElement}
         placeholder="My Location"


### PR DESCRIPTION
Fix a layout issue that affects (the narrowest subset of) phone screens.

Before:
![screen_shot_2023-11-10_at_5 59 44_pm](https://github.com/ForumMagnum/ForumMagnum/assets/101191/3b48684b-b87a-45f8-ad52-334990715ad6)

After:
![Screenshot 2023-11-13 at 17 18 18](https://github.com/ForumMagnum/ForumMagnum/assets/101191/eba1e902-1a89-4e18-97c9-582babead0d5)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205946193878689) by [Unito](https://www.unito.io)
