### PR TITLE
HorizScrollBlock no longer leaves a scroll indicator if its own insertion made horiz-scroll no longer necessary

### DIFF
--- a/packages/lesswrong/components/common/HorizScrollBlock.tsx
+++ b/packages/lesswrong/components/common/HorizScrollBlock.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useRef, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import classNames from 'classnames';
 
@@ -78,7 +78,7 @@ const HorizScrollBlock = ({children, classes}: {
   const [isScrolledAllTheWayLeft, setIsScrolledAllTheWayLeft] = useState(true);
   const [isScrolledAllTheWayRight, setIsScrolledAllTheWayRight] = useState(false);
   
-  const onScroll = useCallback(() => {
+  const updateScrollBounds = useCallback(() => {
     if (scrollableContentsRef.current) {
       const scrollLeft = scrollableContentsRef.current.scrollLeft;
       setIsScrolledAllTheWayLeft((scrollLeft===0));
@@ -86,6 +86,10 @@ const HorizScrollBlock = ({children, classes}: {
         scrollLeft === scrollableContentsRef.current.scrollWidth - scrollableContentsRef.current.clientWidth
       ));
     }
+  }, []);
+  
+  useEffect(() => {
+    updateScrollBounds();
   }, []);
 
   return <div className={classes.scrollIndicatorWrapper}>
@@ -100,7 +104,7 @@ const HorizScrollBlock = ({children, classes}: {
       }}
     />
     <div
-      className={classes.scrollableContents} ref={scrollableContentsRef} onScroll={onScroll}>
+      className={classes.scrollableContents} ref={scrollableContentsRef} onScroll={updateScrollBounds}>
       {children}
     </div>
     <div

--- a/packages/lesswrong/components/common/HorizScrollBlock.tsx
+++ b/packages/lesswrong/components/common/HorizScrollBlock.tsx
@@ -90,7 +90,7 @@ const HorizScrollBlock = ({children, classes}: {
   
   useEffect(() => {
     updateScrollBounds();
-  }, []);
+  }, [updateScrollBounds]);
 
   return <div className={classes.scrollIndicatorWrapper}>
     <div


### PR DESCRIPTION
See: https://lworg.slack.com/archives/CJUN2UAFN/p1699661130370779

The original bug report was that on https://www.lesswrong.com/posts/7qGxm2mgafEbtYHBf/survey-on-the-acceleration-risks-of-our-new-rfps-to-study, a table shows a horiz-scroll indicator, but doesn't have any actual horizontal scrolling. This PR is a narrow fix, which hides the horizontal scroll indicator if it turns out to be unnecessary. This PR does _not_ address the rabbit hole that this uncovered; in particular that page still has a layout-shift on load, caused by inserting the `HorizScrollBlock` component.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205952629606437) by [Unito](https://www.unito.io)
