### PR TITLE
Fix sorting by location on the community map

### DIFF
--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useRef } from 'react';
 import { createStyles } from '@material-ui/core/styles';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { getSearchClient } from '../../../lib/search/algoliaUtil';
-import { Configure, connectSearchBox, connectStateResults, Hits, InstantSearch, Pagination } from 'react-instantsearch-dom';
+import { Configure, connectSearchBox, connectStateResults, Hits, InstantSearch, Pagination, Snippet } from 'react-instantsearch-dom';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';
@@ -23,7 +23,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     '@media (max-width: 1200px)': {
       padding: '0 20px',
     },
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('xs')]: {
       padding: 0
     },
   },
@@ -65,7 +65,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
     marginTop: 20,
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('xs')]: {
       gridTemplateColumns: '1fr',
       marginLeft: -8,
       marginRight: -8,
@@ -74,7 +74,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   peopleList: {
     height: 440,
     overflowY: 'scroll',
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('xs')]: {
       height: 'auto',
     },
   },
@@ -92,7 +92,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   photoRow: {
     display: 'flex',
-    columnGap: 10,
+    columnGap: 14,
     alignItems: 'center',
   },
   profileImage: {
@@ -133,7 +133,14 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   description: {
     color: theme.palette.grey[800],
+    display: '-webkit-box',
+    "-webkit-line-clamp": 2,
+    "-webkit-box-orient": 'vertical',
+    overflow: 'hidden',
     marginTop: 12,
+    [theme.breakpoints.down('xs')]: {
+      "-webkit-line-clamp": 4,
+    }
   },
   buttonRow: {
     display: 'flex',
@@ -144,7 +151,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     boxShadow: 'none'
   },
   mapContainer: {
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('xs')]: {
       display: 'none'
     },
   },
@@ -256,8 +263,8 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
             <div className={classes.location}>{hit.mapLocationAddress}</div>
           </div>
         </div>
-        {hit.htmlBio && <ContentStyles contentType="comment" className={classes.description}>
-          <div dangerouslySetInnerHTML={{__html: truncate(hit.htmlBio, 220)}} />
+        {hit.bio && <ContentStyles contentType="comment" className={classes.description}>
+          {hit.bio}
         </ContentStyles>}
         {/* {hit._id !== currentUser?._id && <div className={classes.buttonRow}>
           <NewConversationButton user={hit} currentUser={currentUser} from="community_members_tab">
@@ -270,8 +277,8 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
   
   // if the user hasn't selected a location, we show the whole map
   const mapOptions = userLocation.known ? {center: userLocation, zoom: 9} : {zoom: 1}
-  // if the user hasn't selected a location, we just show all users who have a map location (ordered by karma desc)
-  const searchOptions = userLocation.known ? {aroundLatLng: `${userLocation?.lat}, ${userLocation.lng}`} : {filters: "_geoloc.lat>-100"}
+  // if the user hasn't selected a location, we just show all users who have a map location (ordered by a mix of "relevance" and karma desc)
+  const searchOptions = userLocation.known ? {aroundLatLng: `${userLocation?.lat}, ${userLocation.lng}`} : {}
   
   return <InstantSearch
     indexName={'test_users'}
@@ -293,7 +300,7 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
         <SearchResultsMap {...mapOptions} className={classes.map} />
       </div>
     </div>
-    <Configure hitsPerPage={200} aroundRadius="all" {...searchOptions} />
+    <Configure hitsPerPage={200} aroundRadius="all" existsFilters={['_geoloc']} {...searchOptions} />
   </InstantSearch>
 }
 

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -227,7 +227,11 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
     // the distance from the user's location to the person's location
     let distanceToPerson;
     if (userLocation.known && hit._geoloc) {
-      distanceToPerson = `${distance(userLocation, hit._geoloc, distanceUnit)} ${distanceUnit}`
+      const location = {
+        lng: hit._geoloc.coordinates[0],
+        lat: hit._geoloc.coordinates[1],
+      };
+      distanceToPerson = `${distance(userLocation, location, distanceUnit)} ${distanceUnit}`
     }
     
     return <div className={classes.person}>

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useRef } from 'react';
 import { createStyles } from '@material-ui/core/styles';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { getSearchClient } from '../../../lib/search/algoliaUtil';
-import { Configure, connectSearchBox, connectStateResults, Hits, InstantSearch, Pagination, Snippet } from 'react-instantsearch-dom';
+import { Configure, connectSearchBox, connectStateResults, Hits, InstantSearch, Pagination } from 'react-instantsearch-dom';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Button from '@material-ui/core/Button';
 import { distance } from './LocalGroups';

--- a/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembersFullMap.tsx
@@ -25,7 +25,7 @@ const CommunityMembersFullMap = ({classes}: {
     searchClient={getSearchClient()}
   >
     <SearchResultsMap zoom={1} className={classes.map} />
-    <Configure hitsPerPage={1000} filters="_geoloc.lat>-100" />
+    <Configure hitsPerPage={1500} existsFilters={['_geoloc']} />
   </InstantSearch>
 }
 

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -130,18 +130,22 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
 }))
 
 /**
-   * Calculates the distance between the starting location and the ending location, as the crow flies
-   *
-   * @param {Object} start - the starting location
-   * @param {number} start.lat - the starting location's latitude
-   * @param {number} start.lng - the starting location's longitude
-   * @param {Object} end - the ending location
-   * @param {number} end.lat - the ending location's latitude
-   * @param {number} end.lng - the ending location's longitude
-   * @param {'km'|'mi'} distanceUnit - whether the result should be in km or miles
-   * @returns {number}
-   */
- export const distance = (start: {lat: number, lng: number}, end: {lat: number, lng: number}, distanceUnit: 'km'|'mi') => {
+ * Calculates the distance between the starting location and the ending location, as the crow flies
+ *
+ * @param {Object} start - the starting location
+ * @param {number} start.lat - the starting location's latitude
+ * @param {number} start.lng - the starting location's longitude
+ * @param {Object} end - the ending location
+ * @param {number} end.lat - the ending location's latitude
+ * @param {number} end.lng - the ending location's longitude
+ * @param {'km'|'mi'} distanceUnit - whether the result should be in km or miles
+ * @returns {number}
+ */
+export const distance = (
+  start: {lat: number, lng: number},
+  end: {lat: number, lng: number},
+  distanceUnit: 'km'|'mi',
+) => {
   const toRad = (num: number) => num * Math.PI / 180
   
   const dLat = toRad(end.lat - start.lat)

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -92,8 +92,8 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, className, cl
       if (!hit._geoloc || locations[hit._id]) return
       
       // within about a quarter mile radius
-      const lat = ((Math.random() - 0.5) * 0.01) + hit._geoloc.lat
-      const lng = ((Math.random() - 0.5) * 0.01) + hit._geoloc.lng
+      const lng = ((Math.random() - 0.5) * 0.01) + hit._geoloc.coordinates[0];
+      const lat = ((Math.random() - 0.5) * 0.01) + hit._geoloc.coordinates[1];
 
       locations[hit._id] = {lat, lng}
     })

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -44,7 +44,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     ...theme.typography.commentStyle,
     color: theme.palette.grey[800],
     fontSize: 14,
-    lineHeight: '1.8em',
+    lineHeight: '20px',
     display: '-webkit-box',
     "-webkit-line-clamp": 3,
     "-webkit-box-orient": 'vertical',
@@ -150,7 +150,7 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, className, cl
             onClose={() => setActiveResultId('')}
             hideBottomLinks
           >
-            {hit.htmlBio && <div className={classes.popupBio} dangerouslySetInnerHTML={{__html: hit.htmlBio}} />}
+            {hit.bio && <div className={classes.popupBio}>{hit.bio}</div>}
           </StyledMapPopup>}
         </React.Fragment>
       })}

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -182,7 +182,13 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
         u."groups",
         u."groups" @> ARRAY['alignmentForum'] AS "af",
         u."profileTagIds" AS "tags",
-        u."mapLocation"->'geometry'->'location' AS "_geoloc",
+        CASE WHEN u."mapLocation"->'geometry'->'location' IS NULL THEN NULL ELSE
+          JSONB_BUILD_OBJECT(
+            'type', 'point',
+            'coordinates', JSONB_BUILD_ARRAY(
+              u."mapLocation"->'geometry'->'location'->'lng',
+              u."mapLocation"->'geometry'->'location'->'lat'
+          )) END AS "_geoloc",
         u."mapLocation"->'formatted_address' AS "mapLocationAddress",
         NOW() AS "exportedAt"
       FROM "Users" u

--- a/packages/lesswrong/server/search/algoliaDocuments.d.ts
+++ b/packages/lesswrong/server/search/algoliaDocuments.d.ts
@@ -64,8 +64,8 @@ interface AlgoliaUser {
   groups: Array<string>,
   af: boolean,
   _geoloc?: {
-    lat: number,
-    lng: number
+    type: "Point",
+    coordinates: number[],
   },
   mapLocationAddress?: string,
   tags: Array<string>,

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -82,6 +82,10 @@ export type IndexConfig = {
    * `baseScore` if not defined.
    */
   karmaField?: string,
+  /**
+   * Field used for location based geo-sorting
+   */
+  locationField?: string,
 }
 
 /**
@@ -116,6 +120,10 @@ const shingleTextMapping: MappingProperty = {
       analyzer: "fm_exact_analyzer",
     },
   },
+};
+
+const geopointMapping: MappingProperty = {
+  type: "geo_point",
 };
 
 /**
@@ -257,7 +265,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
         scoring: {type: "date"},
       },
     ],
-    tiebreaker: "publicDateMs",
+    tiebreaker: "karma",
     filters: [
       {range: {karma: {gte: 0}}},
       {term: {deleted: false}},
@@ -277,6 +285,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       website: keywordMapping,
       profileImageId: keywordMapping,
       tags: keywordMapping,
+      _geoloc: geopointMapping,
     },
     privateFields: [
       "deleteContent",
@@ -284,6 +293,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
       "isAdmin",
     ],
     karmaField: "karma",
+    locationField: "_geoloc",
   },
   Sequences: {
     fields: [

--- a/packages/lesswrong/server/search/elastic/ElasticService.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticService.ts
@@ -51,6 +51,7 @@ class ElasticService {
       preTag: params.highlightPreTag,
       postTag: params.highlightPostTag,
       filters: this.parseFilters(params.facetFilters, params.numericFilters),
+      coordinates: this.parseLatLng(params.aroundLatLng),
     });
 
     const nbHits = typeof result.hits.total === "number"
@@ -188,6 +189,26 @@ class ElasticService {
       throw new Error("Invalid numeric value: " + value);
     }
     return parsed;
+  }
+
+  /**
+   * We want coordinates in the format [lng, lat], not [lat, lng]
+   * They're passed in as a string like "75, -0.5"
+   */
+  private parseLatLng(value?: string): number[] | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const coordinates = value.split(", ").map((n) => parseFloat(n));
+    if (coordinates.length !== 2) {
+      return undefined;
+    }
+    for (const coordinate of coordinates) {
+      if (typeof coordinate !== "number" || !Number.isFinite(coordinate)) {
+        return undefined;
+      }
+    }
+    return [coordinates[1], coordinates[0]];
   }
 
   private urlEncode(params: Record<string, unknown>): string {

--- a/packages/lesswrong/server/search/elastic/ElasticService.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticService.ts
@@ -50,7 +50,7 @@ class ElasticService {
       limit: hitsPerPage,
       preTag: params.highlightPreTag,
       postTag: params.highlightPostTag,
-      filters: this.parseFilters(params.facetFilters, params.numericFilters),
+      filters: this.parseFilters(params.facetFilters, params.numericFilters, params.existsFilters),
       coordinates: this.parseLatLng(params.aroundLatLng),
     });
 
@@ -114,6 +114,7 @@ class ElasticService {
   parseFilters(
     facetFilters?: string[][],
     numericFilters?: string[],
+    existsFilters?: string[],
   ): QueryFilter[] {
     const result: QueryFilter[] = [];
 
@@ -166,6 +167,13 @@ class ElasticService {
         field,
         value: this.parseNumericValue(value),
         op,
+      });
+    }
+    
+    for (const filter of existsFilters ?? []) {
+      result.push({
+        type: "exists",
+        field: filter,
       });
     }
 

--- a/packages/lesswrong/server/search/elastic/SearchQuery.ts
+++ b/packages/lesswrong/server/search/elastic/SearchQuery.ts
@@ -14,6 +14,7 @@ const querySchema = z.object({
     page: z.optional(z.number().int().nonnegative()),
     facetFilters: z.optional(z.array(z.array(z.string()))),
     numericFilters: z.optional(z.array(z.string())),
+    aroundLatLng: z.optional(z.string()),
   }),
 });
 

--- a/packages/lesswrong/server/search/elastic/SearchQuery.ts
+++ b/packages/lesswrong/server/search/elastic/SearchQuery.ts
@@ -14,6 +14,7 @@ const querySchema = z.object({
     page: z.optional(z.number().int().nonnegative()),
     facetFilters: z.optional(z.array(z.array(z.string()))),
     numericFilters: z.optional(z.array(z.string())),
+    existsFilters: z.optional(z.array(z.string())),
     aroundLatLng: z.optional(z.string()),
   }),
 });

--- a/packages/lesswrong/unitTests/elastic/elasticService.tests.ts
+++ b/packages/lesswrong/unitTests/elastic/elasticService.tests.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 describe("ElasticService", () => {
-  it("Can parse facet and numeric filters", () => {
+  it("Can parse facet, numeric, and exists filters", () => {
     const service = new ElasticService();
     const result = service.parseFilters(
       [
@@ -24,6 +24,7 @@ describe("ElasticService", () => {
         "g>=6",
         "h=7",
       ],
+      ['j', 'k']
     );
     expect(result).toStrictEqual([
       {type: "facet", field: "a", value: true, negated: false},
@@ -35,6 +36,8 @@ describe("ElasticService", () => {
       {type: "numeric", field: "f", value: 5, op: "gt"},
       {type: "numeric", field: "g", value: 6, op: "gte"},
       {type: "numeric", field: "h", value: 7, op: "eq"},
+      {type: "exists", field: "j"},
+      {type: "exists", field: "k"},
     ]);
   });
 });


### PR DESCRIPTION
This PR fixes the broken list of users on the community map page.

Deploying this is a bit annoying because we're changing the internal format of a pre-existing JSON field which isn't supported by our current tooling. If we're happy to have 1-2 minutes where users aren't searchable then the simplest thing to do is:
```
./scripts/serverShellCommand.sh --wait "Globals.elasticDeleteIndex('Users')"
./scripts/serverShellCommand.sh --wait "Globals.elasticConfigureIndex('Users')"
./scripts/serverShellCommand.sh --wait "Globals.elasticExportCollection('Users')"
```
Note that this has to be done _after_ deploying the new code.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205970566813638) by [Unito](https://www.unito.io)
