### PR TITLE
Fix sunshine message button

### DIFF
--- a/packages/lesswrong/components/hooks/useInitiateConversation.ts
+++ b/packages/lesswrong/components/hooks/useInitiateConversation.ts
@@ -52,23 +52,7 @@ export const useInitiateConversation = (props?: { includeModerators?: boolean })
 
   const conversation = results?.[0];
 
-  const initiateConversation = useCallback((userId: string) => {
-    console.log("Initiating conversation with", userId);
-    setUserId(userId)
-  }, []);
-
-
-  // log everything
-  console.log("useInitiateConversation", {
-    currentUser,
-    userId,
-    skip,
-    participantIds,
-    alignmentFields,
-    moderatorField,
-    conversation,
-    results,
-  })
+  const initiateConversation = useCallback((userId: string) => setUserId(userId), []);
 
   return {
     conversation,

--- a/packages/lesswrong/components/hooks/useInitiateConversation.ts
+++ b/packages/lesswrong/components/hooks/useInitiateConversation.ts
@@ -52,7 +52,23 @@ export const useInitiateConversation = (props?: { includeModerators?: boolean })
 
   const conversation = results?.[0];
 
-  const initiateConversation = useCallback((userId: string) => setUserId(userId), []);
+  const initiateConversation = useCallback((userId: string) => {
+    console.log("Initiating conversation with", userId);
+    setUserId(userId)
+  }, []);
+
+
+  // log everything
+  console.log("useInitiateConversation", {
+    currentUser,
+    userId,
+    skip,
+    participantIds,
+    alignmentFields,
+    moderatorField,
+    conversation,
+    results,
+  })
 
   return {
     conversation,

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect } from 'react';
+import React, { MouseEvent, ReactNode, useCallback, useEffect } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import qs from 'qs';
 import { useDialog } from '../common/withDialog';
@@ -51,7 +51,7 @@ const NewConversationButton = ({ user, currentUser, children, from, includeModer
   }, [conversation, embedConversation, getTemplateParams, navigate, templateQueries])
 
   const handleClick = currentUser
-    ? (e) => {
+    ? (e: MouseEvent) => {
       initiateConversation(user._id)
       e.stopPropagation()
     }

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -51,7 +51,10 @@ const NewConversationButton = ({ user, currentUser, children, from, includeModer
   }, [conversation, embedConversation, getTemplateParams, navigate, templateQueries])
 
   const handleClick = currentUser
-    ? () => initiateConversation(user._id)
+    ? (e) => {
+      initiateConversation(user._id)
+      e.stopPropagation()
+    }
     : () => openDialog({componentName: "LoginPopup"})
 
   if (currentUser && !userCanStartConversations(currentUser)) return null


### PR DESCRIPTION
Fixes this button:
![Screenshot 2023-11-16 at 17 51 31](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/1b3782f4-090d-445f-b7cc-440c0e187970)

The issue was that NewMessageButton requires an extra render cycle to navigate to the conversation, and it was being unmounted before that happened. Now it will stay rendered until the `navigate` event occurs. Note that if you click away after clicking it still won't work, but you'd have to do that very quickly for this to happen (I think this is near impossible on prod)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205970933616399) by [Unito](https://www.unito.io)
