### PR TITLE
handle case when services field is null for password resets

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -108,7 +108,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
       SET services = jsonb_set(
         CASE WHEN services -> 'password' IS NULL THEN
           jsonb_set(
-            services,
+            COALESCE(services, '{}'::JSONB),
             '{password}'::TEXT[],
             jsonb_build_object('bcrypt', $2),
             true


### PR DESCRIPTION
Some weird situations (maybe account merges) can result in a `null` value for a user's `services`.  Coalesce in those cases.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205980469766080) by [Unito](https://www.unito.io)
