### PR TITLE
Clean up Datatable class, eliminating the last of the CRUD-HoCs

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModGPTDashboard.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModGPTDashboard.tsx
@@ -8,6 +8,7 @@ import type { Column } from '../vulcan-core/Datatable';
 import { userIsAdminOrMod } from '../../lib/vulcan-users/permissions';
 import sanitizeHtml from 'sanitize-html';
 import { htmlToText } from 'html-to-text';
+import { useMulti } from '../../lib/crud/withMulti';
 
 const styles = (theme: JssStyles) => ({
   root: {
@@ -99,6 +100,7 @@ const ModGPTDashboard = ({classes}: {
   classes: ClassesType
 }) => {
   const currentUser = useCurrentUser()
+  
   if (!userIsAdminOrMod(currentUser)) {
     return <Components.Error404 />
   }
@@ -108,15 +110,11 @@ const ModGPTDashboard = ({classes}: {
       <Components.SectionTitle title="ModGPT Dashboard" noTopMargin />
 
       <Components.Datatable
-        collection={Comments}
+        collectionName="Comments"
         columns={columns}
-        options={{
-          fragmentName: 'CommentsListWithModGPTAnalysis',
-          terms: {view: "checkedByModGPT"},
-          limit: 10,
-          enableTotal: true
-        }}
-        showEdit={false}
+        fragmentName={'CommentsListWithModGPTAnalysis'}
+        terms={{view: "checkedByModGPT"}}
+        limit={10}
       />
     </div>
   )

--- a/packages/lesswrong/components/sunshineDashboard/moderationLog/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/moderationLog/ModerationLog.tsx
@@ -252,76 +252,52 @@ const ModerationLog = ({classes}: {
         <div className={classes.section}>
           <h3 id="deleted-comments">Deleted Comments</h3>
           <Components.Datatable
-            collection={Comments}
+            collectionName="Comments"
             columns={deletedCommentColumns}
-            options={{
-              fragmentName: 'DeletedCommentsModerationLog',
-              terms: {view: "allCommentsDeleted"},
-              limit: 10,
-              enableTotal: true
-            }}
-            showEdit={false}
+            fragmentName={'DeletedCommentsModerationLog'}
+            terms={{view: "allCommentsDeleted"}}
+            limit={10}
           />
         </div>
         {shouldShowEndUserModeration && <>
           <div className={classNames(classes.section, classes.floatLeft)}>
             <h3 id="users-banned-from-posts">Users Banned From Posts</h3>
             <Components.Datatable
-              collection={Posts}
+              collectionName="Posts"
               columns={usersBannedFromPostsColumns}
-              options={{
-                fragmentName: 'UsersBannedFromPostsModerationLog',
-                terms: {view: "postsWithBannedUsers"},
-                limit: 10,
-                enableTotal: true
-              }}
-              showEdit={false}
-              showNew={false}
+              fragmentName={'UsersBannedFromPostsModerationLog'}
+              terms={{view: "postsWithBannedUsers"}}
+              limit={10}
             />
           </div>
           <div className={classNames(classes.section, classes.floatLeft)}>
             <h3 id="users-banned-from-users">Users Banned From Users</h3>
             <Components.Datatable
-              collection={Users}
+              collectionName="Users"
               columns={usersBannedFromUsersColumns}
-              options={{
-                fragmentName: 'UsersBannedFromUsersModerationLog',
-                terms: {view: "usersWithBannedUsers"},
-                limit: 10,
-                enableTotal: true
-              }}
-              showEdit={false}
-              showNew={false}
+              fragmentName={'UsersBannedFromUsersModerationLog'}
+              terms={{view: "usersWithBannedUsers"}}
+              limit={10}
             />
           </div>
           <div className={classes.section}>
             <h3 id="moderated-users">Moderated Users</h3>
             <Components.Datatable
-              collection={ModeratorActions}
+              collectionName="ModeratorActions"
               columns={moderatorActionColumns}
-              options={{
-                terms: {view: "restrictionModerationActions"},
-                fragmentName: 'ModeratorActionDisplay',
-                limit: 10,
-                enableTotal: true
-              }}
-              showEdit={false}
-              showNew={false}
+              terms={{view: "restrictionModerationActions"}}
+              fragmentName={'ModeratorActionDisplay'}
+              limit={10}
             />
           </div>
           <div className={classes.section}>
             <h3 id="rate-limited-users">Rate Limited Users</h3>
             <Components.Datatable
-              collection={UserRateLimits}
+              collectionName="UserRateLimits"
               columns={userRateLimitColumns}
-              options={{
-                terms: {view: "activeUserRateLimits"},
-                fragmentName: 'UserRateLimitDisplay',
-                limit: 10,
-                enableTotal: true
-              }}
-              showEdit={false}
-              showNew={false}
+              terms={{view: "activeUserRateLimits"}}
+              fragmentName={'UserRateLimitDisplay'}
+              limit={10}
             />
           </div>
         </>}

--- a/packages/lesswrong/components/vulcan-core/Datatable.tsx
+++ b/packages/lesswrong/components/vulcan-core/Datatable.tsx
@@ -1,125 +1,59 @@
 import { Components, registerComponent, getCollection } from '../../lib/vulcan-lib';
-import { LoadMoreCallback, withMulti } from '../../lib/crud/withMulti';
-import withUser from '../common/withUser';
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
+import { LoadMoreCallback, useMulti } from '../../lib/crud/withMulti';
+import React from 'react';
 import { getSchema } from '../../lib/utils/getSchema';
 import { getFieldValue } from './Card';
 import _sortBy from 'lodash/sortBy';
-import classNames from 'classnames';
-import type { ColumnComponents } from './datatableTypes';
 import { formatLabel, formatMessage } from '../../lib/vulcan-i18n/provider';
+import { useCurrentUser } from '../common/withUser';
+
+type ColumnComponent = React.ComponentType<{column: any}>
 
 export interface Column {
   name: string;
-  sortable?: string;
+  sortable?: false;
   label?: string;
   order?: number;
-  component?: ComponentTypes[ColumnComponents];
-  componentName?: ColumnComponents
+  component?: ColumnComponent;
 }
-
-/*
-
-Datatable Component
-
-*/
-
-// see: http://stackoverflow.com/questions/1909441/jquery-keyup-delay
-const delay = (function(){
-  var timer: any = 0;
-  return function(callback: () => void, ms: number){
-    clearTimeout (timer);
-    timer = setTimeout(callback, ms);
-  };
-})();
 
 const getColumnName = (column: Column) => (
-  typeof column === 'string' 
-  ? column 
-  : column.label || column.name
+  typeof column === 'string'
+    ? column 
+    : column.label || column.name
 );
 
-class Datatable extends PureComponent<any,any> {
-
-  constructor(props: any) {
-    super(props);
-    this.updateQuery = this.updateQuery.bind(this);
-    this.state = {
-      value: '',
-      query: '',
-      currentSort: {}
-    };
-  }
-
-  toggleSort = (column: string) => {
-    let currentSort;
-    if (!this.state.currentSort[column]) {
-      currentSort = { [column] : 1 };
-    } else if (this.state.currentSort[column] === 1) {
-      currentSort = { [column] : -1 };
-    } else {
-      currentSort = {};
-    }
-    this.setState({ currentSort });
-  }
-
-  updateQuery(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    e.persist();
-    e.preventDefault();
-    this.setState({
-      value: e.target.value
-    });
-    delay(() => {
-      this.setState({
-        query: e.target.value
-      });
-    }, 700 );
-  }
-
-  render() {
-    if (this.props.data) { // static JSON datatable
-      // TODO: that's definitely not the right type for columns, does this case ever get hit?
-      // @ts-ignore
-      return <Components.DatatableContents columns={Object.keys(this.props.data[0])} {...this.props} results={this.props.data} />;
-            
-    } else { // dynamic datatable with data loading
-      
-      const collection = this.props.collection || getCollection(this.props.collectionName);
-      const options = {
-        collection,
-        ...this.props.options
-      };
-
-      const DatatableWithMulti: any = withMulti(options)(Components.DatatableContents);
-
-      // add _id to orderBy when we want to sort a column, to avoid breaking the graphql() hoc;
-      // see https://github.com/VulcanJS/Vulcan/issues/2090#issuecomment-433860782
-      // this.state.currentSort !== {} is always false, even when console.log(this.state.currentSort) displays {}. So we test on the length of keys for this object.
-      const orderBy = Object.keys(this.state.currentSort).length == 0 ? {} : { ...this.state.currentSort, _id: -1 };
-
-      return (
-        <Components.DatatableLayout collectionName={collection.options.collectionName}>
-          <DatatableWithMulti {...this.props} collection={collection} terms={{ query: this.state.query, orderBy: orderBy }} currentUser={this.props.currentUser} toggleSort={this.toggleSort} currentSort={this.state.currentSort}/>
-        </Components.DatatableLayout>
-      );
-    }
-  }
+export const Datatable = <
+  FragmentTypeName extends keyof FragmentTypes,
+  CollectionName extends CollectionNameString = CollectionNamesByFragmentName[FragmentTypeName]
+>({columns, collectionName, fragmentName, limit, terms}: {
+  columns: Column[],
+  collectionName: CollectionNameString,
+  fragmentName: FragmentTypeName
+  limit?: number,
+  terms: ViewTermsByCollectionName[CollectionName]
+}) => {
+  const collection = getCollection(collectionName);
+  const { results, loading, loadingMore, loadMore, count, totalCount } = useMulti({
+    collectionName,
+    fragmentName,
+    terms: terms,
+    limit,
+    enableTotal: true,
+  });
+  return <DatatableLayout collectionName={collection.options.collectionName}>
+    <DatatableContents
+      columns={columns}
+      collection={collection}
+      results={results}
+      loading={loading}
+      loadingMore={loadingMore}
+      loadMore={loadMore}
+      count={count}
+      totalCount={totalCount!}
+    />
+  </DatatableLayout>
 }
-
-(Datatable as any).propTypes = {
-  title: PropTypes.string,
-  collection: PropTypes.object,
-  columns: PropTypes.array,
-  data: PropTypes.array,
-  options: PropTypes.object,
-  emptyState: PropTypes.object,
-};
-const DatatableComponent = registerComponent('Datatable', Datatable, {
-  hocs: [withUser]
-});
-
-export default Datatable;
 
 const DatatableLayout = ({ collectionName, children }: {
   collectionName: CollectionNameString;
@@ -129,18 +63,10 @@ const DatatableLayout = ({ collectionName, children }: {
     {children}
   </div>
 );
-const DatatableLayoutComponent = registerComponent('DatatableLayout', DatatableLayout);
 
-/*
-
-DatatableHeader Component
-
-*/
-const DatatableHeader = ({ collection, column, toggleSort, currentSort }: {
+const DatatableHeader = ({ collection, column }: {
   collection: CollectionBase<any>
   column: Column;
-  toggleSort: (name: string) => void;
-  currentSort: Record<string, number>;
 }) => {
   const columnName = getColumnName(column);
   
@@ -158,81 +84,26 @@ const DatatableHeader = ({ collection, column, toggleSort, currentSort }: {
     */
     const formattedLabel = formatLabel({fieldName: columnName, collectionName: collection.collectionName, schema: schema});
 
-    // if sortable is a string, use it as the name of the property to sort by. If it's just `true`, use column.name
-    const sortPropertyName = typeof column.sortable === 'string' ? column.sortable : column.name;
-    return column.sortable 
-    ? <Components.DatatableSorter name={sortPropertyName} label={formattedLabel} toggleSort={toggleSort} currentSort={currentSort} /> 
-    : <Components.DatatableHeaderCellLayout>{formattedLabel}</Components.DatatableHeaderCellLayout>;
-
+    return <DatatableHeaderCellLayout>{formattedLabel}</DatatableHeaderCellLayout>;
   } else {
-
     const formattedLabel = formatMessage({ id: columnName, defaultMessage: columnName });
     return (
-      <Components.DatatableHeaderCellLayout
+      <DatatableHeaderCellLayout
         className={`datatable-th-${columnName.toLowerCase().replace(/\s/g, '-')}`}
       >
         {formattedLabel}
-      </Components.DatatableHeaderCellLayout>
+      </DatatableHeaderCellLayout>
     );
   }
 };
-const DatatableHeaderComponent = registerComponent('DatatableHeader', DatatableHeader);
 
 const DatatableHeaderCellLayout = ({ children, ...otherProps }: {
   children: React.ReactNode;
 } & React.DetailedHTMLProps<React.ThHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>) => (
   <th {...otherProps}>{children}</th>
 );
-const DatatableHeaderCellLayoutComponent = registerComponent('DatatableHeaderCellLayout', DatatableHeaderCellLayout);
 
-const SortNone = () =>
-  <svg width='16' height='16' viewBox='0 0 438 438' fill='none' xmlns='http://www.w3.org/2000/svg'>
-    <path d='M25.7368 247.243H280.263C303.149 247.243 314.592 274.958 298.444 291.116L171.18 418.456C161.128 428.515 144.872 428.515 134.926 418.456L7.55631 291.116C-8.59221 274.958 2.85078 247.243 25.7368 247.243ZM298.444 134.884L171.18 7.54408C161.128 -2.51469 144.872 -2.51469 134.926 7.54408L7.55631 134.884C-8.59221 151.042 2.85078 178.757 25.7368 178.757H280.263C303.149 178.757 314.592 151.042 298.444 134.884Z' transform='translate(66 6)' fill='currentColor' fillOpacity='0.2' />
-  </svg>;
-
-const SortDesc = () =>
-  <svg width="16" height="16" viewBox="0 0 438 438" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M25.7368 0H280.263C303.149 0 314.592 27.7151 298.444 43.8734L171.18 171.213C161.128 181.272 144.872 181.272 134.926 171.213L7.55631 43.8734C-8.59221 27.7151 2.85078 0 25.7368 0Z" transform="translate(66 253.243)" fill="currentColor" fillOpacity="0.7"/>
-    <path d="M171.18 7.54408L298.444 134.884C314.592 151.042 303.149 178.757 280.263 178.757H25.7368C2.85078 178.757 -8.59221 151.042 7.55631 134.884L134.926 7.54408C144.872 -2.51469 161.128 -2.51469 171.18 7.54408Z" transform="translate(66 6)" fill="currentColor" fillOpacity="0.2"/>
-  </svg>;
-
-const SortAsc = () =>
-  <svg width="16" height="16" viewBox="0 0 438 438" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M298.444 134.884L171.18 7.54408C161.128 -2.51469 144.872 -2.51469 134.926 7.54408L7.55631 134.884C-8.59221 151.042 2.85078 178.757 25.7368 178.757H280.263C303.149 178.757 314.592 151.042 298.444 134.884Z" transform="translate(66 6)" fill="currentColor" fillOpacity="0.7"/>
-    <path d="M280.263 0H25.7368C2.85078 0 -8.59221 27.7151 7.55631 43.8734L134.926 171.213C144.872 181.272 161.128 181.272 171.18 171.213L298.444 43.8734C314.592 27.7151 303.149 0 280.263 0Z" transform="translate(66 253.243)" fill="currentColor" fillOpacity="0.2"/>
-  </svg>;
-
-const DatatableSorter = ({ name, label, toggleSort, currentSort }: {
-  name: string;
-  label: string;
-  toggleSort: (name: string) => void;
-  currentSort: Record<string, number>;
-}) => 
-  <th>
-    <div className="datatable-sorter" onClick={() => {toggleSort(name);}}>
-      <span className="datatable-sorter-label">{label}</span>
-      <span className="sort-icon">
-        {!currentSort[name] ? (
-          <SortNone/> 
-        ) : currentSort[name] === 1 ? (
-          <SortAsc/>
-        ) : (
-          <SortDesc/> 
-        )
-      }
-      </span>
-    </div>
-  </th>;
-
-const DatatableSorterComponent = registerComponent('DatatableSorter', DatatableSorter);
-
-/*
-
-DatatableContents Component
-
-*/
-
-interface DatatableContentsProps {
+const DatatableContents = (props: {
   columns: Column[];
   title?: string;
   collection: CollectionBase<any>;
@@ -241,22 +112,11 @@ interface DatatableContentsProps {
   loadMore: LoadMoreCallback;
   count?: number;
   totalCount: number;
-  networkStatus?: number;
-  currentUser: UsersCurrent | null;
+  loadingMore: boolean;
   emptyState?: JSX.Element;
-  toggleSort: (name: string) => void;
-  currentSort: Record<string, number>;
-  rowClass: (document: any) => string;
-}
-
-const DatatableContents = (props: DatatableContentsProps) => {
-
-  // if no columns are provided, default to using keys of first array item
-  const { title, collection, results, columns, loading, loadMore, 
-    count, totalCount, networkStatus, currentUser, emptyState, 
-    toggleSort, currentSort } = props;
-
-  const { DatatableHeader, DatatableContentsHeadLayout, DatatableTitle, DatatableContentsLayout, DatatableContentsInnerLayout, DatatableContentsBodyLayout, LoadMore } = Components
+}) => {
+  const { title, collection, results, columns, loading, loadingMore, loadMore, count, totalCount, emptyState } = props;
+  const { LoadMore } = Components;
 
   if (loading) {
     return <div className="datatable-list datatable-list-loading"><Components.Loading /></div>;
@@ -264,7 +124,6 @@ const DatatableContents = (props: DatatableContentsProps) => {
     return emptyState || null;
   }
 
-  const isLoadingMore = networkStatus === 2;
   const hasMore = totalCount > results.length;
   const sortedColumns = _sortBy(columns, column => column.order);
   return (
@@ -272,35 +131,25 @@ const DatatableContents = (props: DatatableContentsProps) => {
       {title && <DatatableTitle title={title}/>}
       <DatatableContentsInnerLayout>
         <DatatableContentsHeadLayout>
-          {
-            sortedColumns
-              .map((column, index) => (
-                <DatatableHeader
-                  key={index} collection={collection} column={column}
-                  toggleSort={toggleSort} currentSort={currentSort} />)
-              )
+          {sortedColumns.map((column, index) =>
+            <DatatableHeader key={index} collection={collection} column={column} />)
           }
         </DatatableContentsHeadLayout>
         <DatatableContentsBodyLayout>
-          {results.map((document: any, index: number) => <Components.DatatableRow {...props} collection={collection} columns={columns} document={document} key={index} currentUser={currentUser} />)}
+          {results.map((document: any, index: number) => <DatatableRow {...props} collection={collection} columns={columns} document={document} key={index} />)}
         </DatatableContentsBodyLayout>
       </DatatableContentsInnerLayout>
       {hasMore &&
-        <Components.DatatableContentsMoreLayout>
-          {isLoadingMore
+        <DatatableContentsMoreLayout>
+          {loadingMore
             ? <Components.Loading />
-            : (
-            <LoadMore count={count} totalCount={totalCount} loadMore={loadMore} />
-            )
+            : <LoadMore count={count} totalCount={totalCount} loadMore={loadMore} />
           }
-        </Components.DatatableContentsMoreLayout>
+        </DatatableContentsMoreLayout>
       }
     </DatatableContentsLayout>
   );
 };
-DatatableContents.propTypes = {
-};
-const DatatableContentsComponent = registerComponent('DatatableContents', DatatableContents);
 
 const DatatableContentsLayout = ({ children }: {
   children: React.ReactNode;
@@ -309,7 +158,6 @@ const DatatableContentsLayout = ({ children }: {
     {children}
   </div>
 );
-const DatatableContentsLayoutComponent = registerComponent('DatatableContentsLayout', DatatableContentsLayout);
 const DatatableContentsInnerLayout = ({ children }: {
   children: React.ReactNode;
 }) => (
@@ -317,7 +165,6 @@ const DatatableContentsInnerLayout = ({ children }: {
     {children}
   </table>
 );
-const DatatableContentsInnerLayoutComponent = registerComponent('DatatableContentsInnerLayout', DatatableContentsInnerLayout);
 const DatatableContentsHeadLayout = ({ children }: {
   children: React.ReactNode;
 }) => (
@@ -327,13 +174,11 @@ const DatatableContentsHeadLayout = ({ children }: {
     </tr>
   </thead>
 );
-const DatatableContentsHeadLayoutComponent = registerComponent('DatatableContentsHeadLayout', DatatableContentsHeadLayout);
 const DatatableContentsBodyLayout = ({ children }: {
   children: React.ReactNode;
 }) => (
   <tbody>{children}</tbody>
 );
-const DatatableContentsBodyLayoutComponent = registerComponent('DatatableContentsBodyLayout', DatatableContentsBodyLayout);
 const DatatableContentsMoreLayout = ({ children }: {
   children: React.ReactNode;
 }) => (
@@ -341,57 +186,34 @@ const DatatableContentsMoreLayout = ({ children }: {
     {children}
   </div>
 );
-const DatatableContentsMoreLayoutComponent = registerComponent('DatatableContentsMoreLayout', DatatableContentsMoreLayout);
 
-/*
-
-DatatableTitle Component
-
-*/
 const DatatableTitle = ({ title }: {
   title: string;
-}) => 
-  <div className="datatable-title">{title}</div>;
+}) => {
+  return <div className="datatable-title">{title}</div>;
+}
 
-const DatatableTitleComponent = registerComponent('DatatableTitle', DatatableTitle);
-
-/*
-
-DatatableRow Component
-
-*/
 
 interface DatatableRowProps {
   columns: Column[];
   document: any;
-  currentUser: UsersCurrent | null;
-  rowClass: string | ((document: any) => string);
   collection: CollectionBase<any>;
 }
 
 const DatatableRow = (props: DatatableRowProps) => {
-
-  const { columns, document, currentUser, rowClass } = props;
-
-  const row = typeof rowClass === 'function' ? rowClass(document) : rowClass || '';
+  const { columns, document } = props;
   const sortedColumns = _sortBy(columns, column => column.order);
 
-  return (
-  <Components.DatatableRowLayout className={`datatable-item ${row}`}>
-      {
-        sortedColumns
-        .map((column, index) => (
-        <Components.DatatableCell 
-        key={index}
-        column={column} document={document} 
-        currentUser={currentUser} />
-      ))}
-  </Components.DatatableRowLayout>
-  );
+  return <DatatableRowLayout className={`datatable-item`}>
+    {
+      sortedColumns
+        .map((column, index) => (<DatatableCell
+          key={index}
+          column={column} document={document} 
+        />))
+    }
+  </DatatableRowLayout>
 };
-DatatableRow.propTypes = {
-};
-const DatatableRowComponent = registerComponent('DatatableRow', DatatableRow);
 
 const DatatableRowLayout = ({ children, ...otherProps }: {
   children: React.ReactNode;
@@ -400,29 +222,13 @@ const DatatableRowLayout = ({ children, ...otherProps }: {
     {children}
   </tr>
 );
-const DatatableRowLayoutComponent = registerComponent('DatatableRowLayout', DatatableRowLayout);
 
-/*
-
-DatatableCell Component
-
-*/
-
-const cellStyles = (theme: JssStyles) => ({
-  cell: {
-    padding: 4
-  }
-})
-const DatatableCell = ({ classes, column, document, currentUser }: {
-  classes: ClassesType;
+const DatatableCell = ({ column, document }: {
   column: Column;
   document: any;
-  currentUser: UsersCurrent | null
 }) => {
-  const Component: any = column.component 
-  || (column.componentName && Components[column.componentName])
-  || Components.DatatableDefaultCell;
-  const columnName = getColumnName(column);
+  const Component = column.component || DatatableDefaultCell;
+  const currentUser = useCurrentUser();
   const componentProps = {
     column,
     document,
@@ -430,54 +236,35 @@ const DatatableCell = ({ classes, column, document, currentUser }: {
   };
 
   return (
-    <Components.DatatableCellLayout className={classNames(`datatable-item-${columnName.toLowerCase().replace(/\s/g, '-')}`, classes.cell)}>
+    <DatatableCellLayout style={{padding: 4}} >
       <Component {...componentProps} />
-    </Components.DatatableCellLayout>
+    </DatatableCellLayout>
   );
 };
-DatatableCell.propTypes = {
-};
-const DatatableCellComponent = registerComponent('DatatableCell', DatatableCell, {styles: cellStyles});
 
 const DatatableCellLayout = ({ children, ...otherProps }: {
   children: React.ReactNode;
 } & React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>) => (
   <td {...otherProps}>{children}</td>
 );
-const DatatableCellLayoutComponent = registerComponent('DatatableCellLayout', DatatableCellLayout);
 
-/*
-
-DatatableDefaultCell Component
-
-*/
 const DatatableDefaultCell = ({ column, document }: {
   column: Column;
   document: any;
-}) =>
-  <div>{typeof column === 'string' ? getFieldValue(document[column]) : getFieldValue(document[column.name])}</div>;
+}) => {
+  return <div>
+    {typeof column === 'string'
+      ? getFieldValue(document[column])
+      : getFieldValue(document[column.name])
+     }
+  </div>;
+}
 
-const DatatableDefaultCellComponent = registerComponent('DatatableDefaultCell', DatatableDefaultCell);
 
+const DatatableComponent = registerComponent('Datatable', Datatable);
 
 declare global {
   interface ComponentTypes {
     Datatable: typeof DatatableComponent,
-    DatatableLayout: typeof DatatableLayoutComponent,
-    DatatableHeader: typeof DatatableHeaderComponent,
-    DatatableHeaderCellLayout: typeof DatatableHeaderCellLayoutComponent,
-    DatatableSorter: typeof DatatableSorterComponent,
-    DatatableContents: typeof DatatableContentsComponent,
-    DatatableContentsLayout: typeof DatatableContentsLayoutComponent,
-    DatatableContentsInnerLayout: typeof DatatableContentsInnerLayoutComponent,
-    DatatableContentsHeadLayout: typeof DatatableContentsHeadLayoutComponent,
-    DatatableContentsBodyLayout: typeof DatatableContentsBodyLayoutComponent,
-    DatatableContentsMoreLayout: typeof DatatableContentsMoreLayoutComponent,
-    DatatableTitle: typeof DatatableTitleComponent,
-    DatatableRow: typeof DatatableRowComponent,
-    DatatableRowLayout: typeof DatatableRowLayoutComponent,
-    DatatableCell: typeof DatatableCellComponent,
-    DatatableCellLayout: typeof DatatableCellLayoutComponent,
-    DatatableDefaultCell: typeof DatatableDefaultCellComponent,
   }
 }

--- a/packages/lesswrong/components/vulcan-core/datatableTypes.ts
+++ b/packages/lesswrong/components/vulcan-core/datatableTypes.ts
@@ -1,3 +1,0 @@
-export type ColumnComponents = {
-  [T in keyof ComponentTypes]: FromPartial<ComponentTypes[T]['propTypes']> extends { column: any; } | undefined ? T : never
-}[keyof ComponentTypes];

--- a/packages/lesswrong/integrationTests/emails.tests.tsx
+++ b/packages/lesswrong/integrationTests/emails.tests.tsx
@@ -1,6 +1,6 @@
 import "./integrationTestSetup";
 import React from 'react';
-import { withSingle, useSingle } from '../lib/crud/withSingle';
+import { useSingle } from '../lib/crud/withSingle';
 import { createDummyUser, createDummyPost } from './utils'
 import { emailDoctype, generateEmail } from '../server/emails/renderEmail';
 import { withStyles, createStyles } from '@material-ui/core/styles';
@@ -66,22 +66,27 @@ describe('renderEmail', () => {
     (email.html as any).should.equal(emailDoctype+'<body><div>Hello, <div class="StyledComponent-underlined" style="text-decoration: underline;">World</div></div></body>');
   });
   
-  it("Can use Apollo HoCs", async () => {
+  it("Can use Apollo useSingle", async () => {
     const user = await createDummyUser();
     const post = await createDummyPost(user, { title: "Email unit test post" });
     
-    const PostTitleComponent: any = withSingle({
-      collectionName: "Posts",
-      fragmentName: 'PostsRevision',
-      extraVariables: {
-        version: 'String'
-      }
-    })(
-      ({document}) => <div>{document?.title}</div>
-    );
+    const PostTitleComponent= ({documentId}: {documentId: string}) => {
+      const { document } = useSingle({
+        documentId,
+        collectionName: "Posts",
+        fragmentName: 'PostsRevision',
+        extraVariables: {
+          version: 'String'
+        },
+        extraVariablesValues: {
+          version: null,
+        },
+      });
+      return <div>{document?.title}</div>;
+    }
     
     const email = await renderTestEmail({
-      bodyComponent: <PostTitleComponent documentId={post._id} version={null} />,
+      bodyComponent: <PostTitleComponent documentId={post._id}/>,
     });
     (email.html as any).should.equal(emailDoctype+'<body><div>Email unit test post</div></body>');
   });

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -1,17 +1,14 @@
 import { WatchQueryFetchPolicy, ApolloError, useQuery, NetworkStatus, gql, useApolloClient } from '@apollo/client';
-import { graphql } from '@apollo/client/react/hoc';
 import qs from 'qs';
 import { useState } from 'react';
-import compose from 'recompose/compose';
-import withState from 'recompose/withState';
 import * as _ from 'underscore';
-import { extractCollectionInfo, extractFragmentInfo, getFragment, getCollection, pluralize, camelCaseify } from '../vulcan-lib';
+import { extractFragmentInfo, getFragment, getCollection, pluralize, camelCaseify } from '../vulcan-lib';
 import { useLocation } from '../routeUtil';
 import { invalidateQuery } from './cacheUpdates';
 import { isServer } from '../executionEnvironment';
 import { useNavigate } from '../reactRouterWrapper';
 
-// Template of a GraphQL query for withMulti/useMulti. A sample query might look
+// Template of a GraphQL query for useMulti. A sample query might look
 // like:
 //
 // mutation multiMovieQuery($input: MultiMovieInput) {
@@ -59,160 +56,6 @@ function getGraphQLQueryFromOptions({collectionName, collection, fragmentName, f
     ${multiClientTemplate({ typeName, fragmentName, extraVariablesString })}
     ${fragment}
   `;
-}
-
-/**
- * HoC for querying a collection for a list of results. DEPRECATED: you probably
- * want to be using the hook version, useMulti, instead.
- */
-export function withMulti({
-  limit = 10, // Only used as a fallback if terms.limit is not specified
-  pollInterval = 0, //LESSWRONG: Polling is disabled, and by now it would probably horribly break if turned on
-  enableTotal = false, //LESSWRONG: enableTotal defaults false
-  enableCache = false,
-  extraVariables,
-  fetchPolicy,
-  notifyOnNetworkStatusChange,
-  propertyName = "results",
-  collectionName, collection,
-  fragmentName, fragment,
-  terms: queryTerms,
-}: {
-  limit?: number,
-  pollInterval?: number,
-  enableTotal?: boolean,
-  enableCache?: boolean,
-  extraVariables?: any,
-  fetchPolicy?: WatchQueryFetchPolicy,
-  notifyOnNetworkStatusChange?: boolean,
-  propertyName?: string,
-  collectionName?: CollectionNameString,
-  collection?: CollectionBase<any>,
-  fragmentName?: FragmentName,
-  fragment?: any,
-  terms?: any,
-}) {
-  // if this is the SSR process, set pollInterval to null
-  // see https://github.com/apollographql/apollo-client/issues/1704#issuecomment-322995855
-  //pollInterval = typeof window === 'undefined' ? null : pollInterval;
-
-  ({ collectionName, collection } = extractCollectionInfo({ collectionName, collection }));
-  ({ fragmentName, fragment } = extractFragmentInfo({ fragmentName, fragment }, collectionName));
-
-  const typeName = collection!.options.typeName;
-  const resolverName = collection!.options.multiResolverName;
-  
-  const query = getGraphQLQueryFromOptions({ collectionName, collection, fragmentName, fragment, extraVariables });
-
-  return compose(
-    // wrap component with HoC that manages the terms object via its state
-    withState('paginationTerms', 'setPaginationTerms', (props: any) => {
-      // get initial limit from props, or else options
-      const paginationLimit = (props.terms && props.terms.limit) || limit;
-      const paginationTerms = {
-        limit: paginationLimit,
-        itemsPerPage: paginationLimit,
-      };
-
-      return paginationTerms;
-    }),
-
-    // wrap component with graphql HoC
-    graphql(
-      query,
-
-      {
-        alias: `with${pluralize(typeName)}`,
-
-        // graphql query options
-        options(props: any) {
-          const { terms, paginationTerms, ...rest } = props;
-          // get terms from options, then props, then pagination
-          const mergedTerms = { ...queryTerms, ...terms, ...paginationTerms };
-          const graphQLOptions: any = {
-            variables: {
-              input: {
-                terms: mergedTerms,
-                enableCache,
-                enableTotal,
-              },
-              ...(_.pick(rest, Object.keys(extraVariables || {})))
-            },
-            // note: pollInterval can be set to 0 to disable polling (20s by default)
-            pollInterval,
-            ssr: true,
-          };
-
-          if (fetchPolicy) {
-            graphQLOptions.fetchPolicy = fetchPolicy;
-          }
-
-          // set to true if running into https://github.com/apollographql/apollo-client/issues/1186
-          if (notifyOnNetworkStatusChange) {
-            graphQLOptions.notifyOnNetworkStatusChange = notifyOnNetworkStatusChange;
-          }
-
-          return graphQLOptions;
-        },
-
-        // define props returned by graphql HoC
-        props(props: any) {
-          // see https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
-          if (!(props?.data)) throw new Error("Missing props.data");
-          const refetch = props.data.refetch,
-            // results = Utils.convertDates(collection, props.data[listResolverName]),
-            results = props.data[resolverName] && props.data[resolverName].results,
-            totalCount = props.data[resolverName] && props.data[resolverName].totalCount,
-            networkStatus = props.data.networkStatus,
-            loadingInitial = props.data.networkStatus === 1,
-            loading = props.data.networkStatus === 1,
-            loadingMore = props.data.networkStatus === 2,
-            error = props.data.error;
-
-          if (error) {
-            // This error was already caught by the apollo middleware, but the
-            // middleware had no idea who  made the query. To aid in debugging, log a
-            // stack trace here.
-            // eslint-disable-next-line no-console
-            console.error(error.message)
-          }
-
-          return {
-            // see https://github.com/apollostack/apollo-client/blob/master/src/queries/store.ts#L28-L36
-            // note: loading will propably change soon https://github.com/apollostack/apollo-client/issues/831
-            loading,
-            loadingInitial,
-            loadingMore,
-            [propertyName]: results,
-            totalCount,
-            refetch,
-            networkStatus,
-            error,
-            count: results && results.length,
-
-            // regular load more (reload everything)
-            loadMore(providedTerms: any) {
-              // if new terms are provided by presentational component use them, else default to incrementing current limit once
-              const newTerms =
-                typeof providedTerms === 'undefined'
-                  ? {
-                      /*...props.ownProps.terms,*/ ...props.ownProps.paginationTerms,
-                      limit: results.length + props.ownProps.paginationTerms.itemsPerPage,
-                    }
-                  : providedTerms;
-
-              props.ownProps.setPaginationTerms(newTerms);
-            },
-
-            fragmentName,
-            fragment,
-            ...props.ownProps, // pass on the props down to the wrapped component
-            data: props.data,
-          };
-        },
-      }
-    )
-  );
 }
 
 export interface UseMultiOptions<

--- a/packages/lesswrong/lib/crud/withSingle.ts
+++ b/packages/lesswrong/lib/crud/withSingle.ts
@@ -1,10 +1,9 @@
 import { ApolloClient, NormalizedCacheObject, ApolloError, gql, useQuery, WatchQueryFetchPolicy } from '@apollo/client';
-import { graphql } from '@apollo/client/react/hoc';
 import * as _ from 'underscore';
-import { extractCollectionInfo, extractFragmentInfo, getCollection } from '../vulcan-lib';
+import { extractFragmentInfo, getCollection } from '../vulcan-lib';
 import { camelCaseify } from '../vulcan-lib/utils';
 
-// Template of a GraphQL query for withSingle/useSingle. A sample query might look
+// Template of a GraphQL query for useSingle. A sample query might look
 // like:
 //
 // query singleMovieQuery($input: SingleMovieInput) {
@@ -70,81 +69,6 @@ export function getGraphQLQueryFromOptions({ extraVariables, collection, fragmen
 export function getResolverNameFromOptions<T extends DbObject>(collection: CollectionBase<T>): string {
   const typeName = collection.options.typeName;
   return camelCaseify(typeName);
-}
-
-/**
- * HoC for querying a collection for a single document. DEPRECATEDS: you
- * probably want to be using the hook version, useSingle, instead.
- */
-export function withSingle({
-  collectionName, collection,
-  fragmentName, fragment,
-  extraVariables, fetchPolicy, propertyName = 'document',
-}: {
-  collectionName?: CollectionNameString,
-  collection?: any,
-  fragmentName?: FragmentName,
-  fragment?: any,
-  extraVariables?: any,
-  fetchPolicy?: WatchQueryFetchPolicy,
-  propertyName?: string,
-}) {
-  ({ collectionName, collection } = extractCollectionInfo({ collectionName, collection }));
-  ({ fragmentName, fragment } = extractFragmentInfo({ fragment, fragmentName }, collectionName));
-
-  const query = getGraphQLQueryFromOptions({ extraVariables, collection, fragment, fragmentName })
-  const resolverName = getResolverNameFromOptions(collection)
-  const typeName = collection.options.typeName
-  
-  return graphql(query, {
-    alias: `with${typeName}`,
-
-    options(props) {
-      const { documentId, slug, selector = { documentId, slug }, ...rest } = props as any;
-      // OpenCrud backwards compatibility
-      // From the provided arguments, pick the key-value pairs where the key is also in extraVariables option
-      const extraVariablesValues = _.pick(rest, Object.keys(extraVariables || {}))  
-      const graphQLOptions: any = {
-        variables: {
-          input: {
-            selector,
-          },
-          ...extraVariablesValues
-        }
-      };
-
-      if (fetchPolicy) {
-        graphQLOptions.fetchPolicy = fetchPolicy;
-      }
-
-      return graphQLOptions;
-    },
-    props: (returnedProps: any) => {
-      const { /* ownProps, */ data } = returnedProps;
-
-      const props = {
-        loading: data.loading,
-        refetch: data.refetch,
-        // document: Utils.convertDates(collection, data[singleResolverName]),
-        [propertyName]: data[resolverName] && data[resolverName].result,
-        fragmentName,
-        fragment,
-        data
-      };
-
-      if (data.error) {
-        // This error was already caught by the apollo middleware, but the
-        // middleware had no idea who  made the query. To aid in debugging, log a
-        // stack trace here.
-        // eslint-disable-next-line no-console
-        console.error(data.error.message)
-        // get graphQL error (see https://github.com/thebigredgeek/apollo-errors/issues/12)
-        props.error = data.error.graphQLErrors[0];
-      }
-
-      return props;
-    }
-  });
 }
 
 type TSuccessReturn<FragmentTypeName extends keyof FragmentTypes> = {loading: false, error: undefined, document: FragmentTypes[FragmentTypeName]};


### PR DESCRIPTION
Refactors `Datatable`, a (very lightly used) class from Vulcan, such that it no longer uses the HoC version of `withMulti`. Since this was the last usage of `withMulti` anywhere, we then make it hook-only (ie only `useMulti` exists).

(Some unused functionality from `Datatable` was dropped in the process, in particular clicking on columns and having it autogenerate view terms to sort by that column. This functionality was definitely unused and pretty unlikely to have been working.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205981278444645) by [Unito](https://www.unito.io)
