### PR TITLE
Remove self matches on dialogue matching page

### DIFF
--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -1270,14 +1270,15 @@ export const DialogueMatchingPage = ({classes}: {
 
   const userDialogueUsefulData: UserDialogueUsefulData = data?.GetUserDialogueUsefulData;
 
-  const matchedUsers: UsersOptedInToDialogueFacilitation[] | undefined = matchedUsersResult?.GetDialogueMatchedUsers;
+  const matchedUsersWithSelf: UsersOptedInToDialogueFacilitation[] | undefined = matchedUsersResult?.GetDialogueMatchedUsers
+  const matchedUsers = matchedUsersWithSelf?.filter(user => user._id !== currentUser._id)
   const matchedUserIds = matchedUsers?.map(user => user._id) ?? [];
   const topUsers = userDialogueUsefulData?.topUsers.filter(user => !matchedUserIds.includes(user._id));
   const recentlyActiveTopUsers = topUsers.filter(user => user.recently_active_matchmaking)
   const nonRecentlyActiveTopUsers = topUsers.filter(user => !user.recently_active_matchmaking)
-  const dialogueUsers = userDialogueUsefulData?.dialogueUsers.filter(user => !matchedUserIds.includes(user._id));
-  const optedInUsers = usersOptedInToDialogueFacilitation.filter(user => !matchedUserIds.includes(user._id));
-  const activeDialogueMatchSeekers = userDialogueUsefulData?.activeDialogueMatchSeekers.filter(user => !matchedUserIds.includes(user._id));
+  const dialogueUsers = userDialogueUsefulData?.dialogueUsers.filter(user => !matchedUserIds.includes(user._id) && !(user._id === currentUser._id));
+  const optedInUsers = usersOptedInToDialogueFacilitation.filter(user => !matchedUserIds.includes(user._id) && !(user._id === currentUser._id));
+  const activeDialogueMatchSeekers = userDialogueUsefulData?.activeDialogueMatchSeekers.filter(user => !matchedUserIds.includes(user._id) && !(user._id === currentUser._id));
   
   if (loading) return <Loading />
   if (error ?? !userDialogueChecks ?? userDialogueChecks.length > 1000) return <p>Error </p>; // if the user has clicked that much stuff things might break...... 

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -1304,9 +1304,6 @@ export const DialogueMatchingPage = ({classes}: {
   return (
   <div className={classes.root}>
     <div className={classes.container}>
-      <div className={classes.mobileWarning}>
-        Dialogues matching doesn't render well on narrow screens right now. <br/> <br /> Please view on laptop or tablet!
-      </div>
 
       <h1>Dialogue Matching</h1>
       <ul>


### PR DESCRIPTION
A simple PR that filters out the current user from the various lists displayed

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205982145384480) by [Unito](https://www.unito.io)
