### PR TITLE
[EA Forum only] add some missing analytics for share post popup

### DIFF
--- a/packages/lesswrong/components/posts/SharePostPopup.tsx
+++ b/packages/lesswrong/components/posts/SharePostPopup.tsx
@@ -237,7 +237,7 @@ const SharePostPopup = ({
   }, []);
 
   const copyLink = () => {
-    captureEvent("sharePost", { option: "copyLink" });
+    captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "copyLink" });
     void navigator.clipboard.writeText(postUrl);
     flash("Link copied to clipboard");
   };
@@ -250,20 +250,20 @@ const SharePostPopup = ({
   const linkTitle = `${post.title} - ${siteName}`;
 
   const shareToTwitter = () => {
-    captureEvent("sharePost", { option: "twitter" });
+    captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "twitter" });
     const tweetText = `${linkTitle} ${postUrl}`;
     const destinationUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
     openLinkInNewTab(destinationUrl);
   };
   const shareToFacebook = () => {
-    captureEvent("sharePost", { option: "facebook" });
+    captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "facebook" });
     const destinationUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
       postUrl
     )}&t=${encodeURIComponent(linkTitle)}`;
     openLinkInNewTab(destinationUrl);
   };
   const shareToLinkedIn = () => {
-    captureEvent("sharePost", { option: "linkedIn" });
+    captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "linkedIn" });
     const destinationUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl)}`;
     openLinkInNewTab(destinationUrl);
   };


### PR DESCRIPTION
I noticed a lot of `sharePost` events were missing a `postId`. Also thought it would be good to add the context for the share post popup events.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1205996764929706) by [Unito](https://www.unito.io)
