### PR TITLE
Use same date cutoff for Frontpage and community section

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -8,6 +8,7 @@ import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../../lib/collections/tags/collecti
 import { useExpandedFrontpageSection } from '../hooks/useExpandedFrontpageSection';
 import { SHOW_COMMUNITY_POSTS_SECTION_COOKIE } from '../../lib/cookies/cookies';
 import { useFilterSettings } from '../../lib/filterSettings';
+import { frontpageDaysAgoCutoffSetting } from '../../lib/scoring';
 
 const styles = (theme: ThemeType): JssStyles => ({
   readMoreLinkMobile: {
@@ -33,7 +34,7 @@ const EAHomeCommunityPosts = ({classes}:{classes: ClassesType}) => {
   const {filterSettings: userFilterSettings} = useFilterSettings()
 
   const now = moment().tz(timezone)
-  const dateCutoff = now.subtract(90, 'days').format("YYYY-MM-DD")
+  const dateCutoff = now.subtract(frontpageDaysAgoCutoffSetting.get(), 'days').format("YYYY-MM-DD")
 
   const recentPostsTerms = {
     view: "magic",


### PR DESCRIPTION
When you log in with a very inactive account, you current still see the [Nonlinear post](https://forum.effectivealtruism.org/posts/32LMQsjEMm6NK2GTH/sharing-information-about-nonlinear) because it has way higher karma than most other posts since then. This fixes that, here the section after the change:
![Screenshot 2023-11-21 at 11 26 47](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/110c8a0a-8056-4afd-b86e-fcda4d8c4e78)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206001535366448) by [Unito](https://www.unito.io)
