### PR TITLE
Remove leftmost week on mobile version of giving season banner

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonBanner.tsx
@@ -107,9 +107,6 @@ const styles = (theme: ThemeType) => ({
     ["@media (max-width: 600px)"]: {
       marginBottom: 12,
     },
-    ["@media (max-width: 520px)"]: {
-      alignSelf: "flex-start",
-    },
     ["@media (max-width: 380px)"]: {
       display: "none",
     },


### PR DESCRIPTION
Currently Donation Debate Week is cut off, this is a hacky fix for that:
![Screenshot 2023-11-21 at 11 37 04](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/8283ab68-2fb8-4198-ab16-ae88c8892dcb)

The ideal fix would be making the timeline scrollable and starting scrolled to the right, but that wasn't that straightforward to do. I may have time to come back to it later in the week but I would rather get this out as it's only relevant when Donation Debate Week is active

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206001756365686) by [Unito](https://www.unito.io)
