### PR TITLE
Make z index for intercom important

### DIFF
--- a/packages/lesswrong/components/common/IntercomWrapper.tsx
+++ b/packages/lesswrong/components/common/IntercomWrapper.tsx
@@ -18,7 +18,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       }
     } : null),
     ".intercom-lightweight-app": {
-      zIndex: theme.zIndexes.intercomButton,
+      zIndex: `${theme.zIndexes.intercomButton} !important`,
     },
   },
 });


### PR DESCRIPTION
A higher z-index was overriding the one we set, causing it to show above the modal background. Intercom is loaded via a script so this could be a recent change. Before/after:
![Screenshot 2023-11-21 at 12 23 02](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/65fc313f-34a9-4d3d-88bc-38397009269b)
![Screenshot 2023-11-21 at 12 23 18](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/dd524adb-7830-4a87-a79d-3070e97a324b)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206001859433092) by [Unito](https://www.unito.io)
