### PR TITLE
Filter unique authors when creating dialogue post fixer

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -14,6 +14,7 @@ import { useCurrentUser } from '../common/withUser';
 import { useMessages } from '../common/withMessages';
 import { getConfirmedCoauthorIds } from '../../lib/collections/posts/helpers';
 import sortBy from 'lodash/sortBy'
+import uniqBy from 'lodash/uniqBy';
 import { filterNonnull } from '../../lib/utils/typeGuardUtils';
 import { gql, useMutation } from "@apollo/client";
 import type { Editor } from '@ckeditor/ckeditor5-core';
@@ -504,7 +505,10 @@ const CKPostEditor = ({
         const userIds = formType === 'new' ? [userId] : [post.userId, ...getConfirmedCoauthorIds(post)];
         if (post.collabEditorDialogue) {
           const rawAuthors = formType === 'new' ? [currentUser!] : filterNonnull([post.user, ...(post.coauthors ?? [])])
-          const coauthors = rawAuthors.filter(coauthor => userIds.includes(coauthor._id));
+          const coauthors = uniqBy(
+            rawAuthors.filter(coauthor => userIds.includes(coauthor._id)),
+            (user) => user._id,
+          );
           editor.model.document.registerPostFixer( createDialoguePostFixer(editor, coauthors) );
 
           // This is just to trigger the postFixer when the editor is initialized


### PR DESCRIPTION
We don't currently ensure that the list of authors only contains unique authors when creating the dialogue post fixer. Having duplicate authors is unlikely, but it is physically possible by adding the main post author as a coauthor as well (this happened in testing as it isn't clear from the "New Dialogue" dialog that you don't need to add yourself as an author to be involved). Unfortunately, this causes an infinite loop and crashes the browser tab which is... bad.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206002337382300) by [Unito](https://www.unito.io)
