### PR TITLE
Donation debate week 2023 banner

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -248,7 +248,7 @@ const styles = (theme: ThemeType) => ({
     maxWidth: 280,
     background: theme.palette.grey[0],
     borderRadius: theme.borderRadius.default,
-    padding: "16px 12px",
+    padding: 16,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: 16,
     fontWeight: 700,

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -25,8 +25,11 @@ import { applePodcastsLogoIcon } from '../icons/ApplePodcastsLogoIcon';
 import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import { useRecentOpportunities } from '../hooks/useRecentOpportunities';
 import { podcastAddictLogoIcon } from '../icons/PodcastAddictLogoIcon';
+import { useAmountRaised, useIsGivingSeason } from './giving-portal/hooks';
+import { eaGivingSeason23ElectionName } from '../../lib/eaGivingSeason';
+import { formatStat } from '../users/EAUserTooltipContent';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   root: {
     paddingRight: 50,
     marginTop: 10,
@@ -236,6 +239,44 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: 600,
     fontSize: 13,
   },
+  givingSeason: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "12px",
+    width: "100%",
+    background: theme.palette.grey[0],
+    borderRadius: theme.borderRadius.default,
+    padding: "16px 12px",
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontSize: 16,
+    fontWeight: 700,
+    color: theme.palette.givingPortal[1000],
+    marginBottom: 32,
+  },
+  givingSeasonAmount: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: "8px",
+    width: "100%",
+    color: theme.palette.grey[1000],
+  },
+  givingSeasonProgress: {
+    background: theme.palette.givingPortal[900],
+    borderRadius: theme.borderRadius.small,
+    overflow: "hidden",
+    width: "100%",
+    height: 8,
+    "& *": {
+      height: "100%",
+      background: theme.palette.givingPortal[1000],
+    },
+  },
+  givingSeasonLearnMore: {
+    fontSize: 14,
+    fontWeight: 600,
+  },
 });
 
 /**
@@ -247,7 +288,7 @@ const styles = (theme: ThemeType): JssStyles => ({
  * See RecentDiscussionSubscribeReminder.tsx for the other component.
  */
 const DigestAd = ({classes}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser()
   const updateCurrentUser = useUpdateCurrentUser()
@@ -384,7 +425,7 @@ const DigestAd = ({classes}: {
  * This is a list of upcoming (nearby) events. It uses logic similar to EventsList.tsx.
  */
 const UpcomingEventsSection = ({classes}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const { timezone } = useTimezone()
   const currentUser = useCurrentUser()
@@ -423,7 +464,7 @@ const UpcomingEventsSection = ({classes}: {
       </LWTooltip>
       {upcomingEvents?.map(event => {
         const shortDate = moment(event.startTime).tz(timezone).format("MMM D")
-        return <div key={event._id} className={classes.post}>
+        return <div key={event._id}>
           <div className={classes.postTitle}>
             <PostsItemTooltipWrapper post={event} As="span">
               <Link to={postGetPageUrl(event)} className={classes.postTitleLink}>
@@ -449,8 +490,13 @@ const UpcomingEventsSection = ({classes}: {
  * This is the primary EA Forum home page right-hand side component.
  */
 export const EAHomeRightHandSide = ({classes}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
+  const isGivingSeason = useIsGivingSeason();
+  const {
+    data: amountRaised,
+    loading: amountRaisedLoading,
+  } = useAmountRaised(eaGivingSeason23ElectionName);
   const currentUser = useCurrentUser()
   const updateCurrentUser = useUpdateCurrentUser()
   const { captureEvent } = useTracking()
@@ -496,7 +542,10 @@ export const EAHomeRightHandSide = ({classes}: {
 
   if (!userHasEAHomeRHS(currentUser)) return null
   
-  const { SectionTitle, PostsItemTooltipWrapper, PostsItemDate, LWTooltip, ForumIcon } = Components
+  const {
+    SectionTitle, PostsItemTooltipWrapper, PostsItemDate, LWTooltip, ForumIcon,
+    Loading,
+  } = Components
   
   const sidebarToggleNode = <div className={classes.sidebarToggle} onClick={handleToggleSidebar}>
     <LWTooltip title={isHidden ? 'Show sidebar' : 'Hide sidebar'}>
@@ -537,6 +586,29 @@ export const EAHomeRightHandSide = ({classes}: {
   return <AnalyticsContext pageSectionContext="homeRhs">
     {!!currentUser && sidebarToggleNode}
     <div className={classes.root}>
+      {/* TODO: Remove after giving season ends */}
+      {isGivingSeason &&
+        <div className={classes.givingSeason}>
+          <div>Donate to the Election Fund</div>
+          <div className={classes.givingSeasonAmount}>
+            {amountRaisedLoading && <Loading />}
+            {amountRaised?.totalRaised &&
+              <>
+                <div className={classes.givingSeasonProgress}>
+                  <div style={{
+                    width: `${100 * amountRaised.totalRaised / amountRaised.totalTarget}%`,
+                  }} />
+                </div>
+                ${formatStat(Math.round(amountRaised.totalRaised))} raised so far
+              </>
+            }
+          </div>
+          <Link to="giving-portal" className={classes.givingSeasonLearnMore}>
+            Learn more
+          </Link>
+        </div>
+      }
+
       {digestAdNode}
       
       <AnalyticsContext pageSubSectionContext="resources">
@@ -584,7 +656,7 @@ export const EAHomeRightHandSide = ({classes}: {
               noBottomPadding
             />
           </LWTooltip>
-          {opportunityPosts?.map(post => <div key={post._id} className={classes.post}>
+          {opportunityPosts?.map(post => <div key={post._id}>
             <div className={classes.postTitle}>
               <PostsItemTooltipWrapper post={post} As="span">
                 <Link to={postGetPageUrl(post)} className={classes.postTitleLink}>
@@ -616,7 +688,7 @@ export const EAHomeRightHandSide = ({classes}: {
               postAuthor = post.user.displayName
             }
             const readTime = isPostWithForeignId(post) ? '' : `, ${post.readTimeMinutes} min`
-            return <div key={post._id} className={classes.post}>
+            return <div key={post._id}>
               <div className={classes.postTitle}>
                 <PostsItemTooltipWrapper post={post} As="span">
                   <Link to={postGetPageUrl(post)} className={classes.postTitleLink}>

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -265,14 +265,14 @@ const styles = (theme: ThemeType) => ({
     fontSize: 14,
   },
   givingSeasonProgress: {
-    background: theme.palette.givingPortal[900],
+    background: theme.palette.givingPortal.homepageHeader.light1,
     borderRadius: theme.borderRadius.small,
     overflow: "hidden",
     width: "100%",
     height: 8,
     "& *": {
       height: "100%",
-      background: theme.palette.givingPortal[1000],
+      background: theme.palette.givingPortal.homepageHeader.main,
     },
   },
   givingSeasonLearnMore: {

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -242,9 +242,10 @@ const styles = (theme: ThemeType) => ({
   givingSeason: {
     display: "flex",
     flexDirection: "column",
-    alignItems: "center",
+    alignItems: "flex-start",
     gap: "12px",
     width: "100%",
+    maxWidth: 280,
     background: theme.palette.grey[0],
     borderRadius: theme.borderRadius.default,
     padding: "16px 12px",
@@ -261,6 +262,7 @@ const styles = (theme: ThemeType) => ({
     gap: "8px",
     width: "100%",
     color: theme.palette.grey[1000],
+    fontSize: 14,
   },
   givingSeasonProgress: {
     background: theme.palette.givingPortal[900],
@@ -275,7 +277,15 @@ const styles = (theme: ThemeType) => ({
   },
   givingSeasonLearnMore: {
     fontSize: 14,
-    fontWeight: 600,
+    fontWeight: 500,
+    color: theme.palette.grey[600],
+    "& a": {
+      textDecoration: "underline",
+      "&:hover": {
+        textDecoration: "none",
+        opacity: 1,
+      },
+    },
   },
 });
 
@@ -603,9 +613,10 @@ export const EAHomeRightHandSide = ({classes}: {
               </>
             }
           </div>
-          <Link to="giving-portal" className={classes.givingSeasonLearnMore}>
-            Learn more
-          </Link>
+          <div className={classes.givingSeasonLearnMore}>
+            The fund will be designated for the top 3 candidates, based on
+            Forum users' votes. <Link to="giving-portal">Learn more</Link>
+          </div>
         </div>
       }
 

--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
@@ -63,7 +63,7 @@ export const givingSeasonGradient = (
     height,
     margin: "0 auto",
     "@media (max-width: 1200px)": {
-      background: `linear-gradient(76deg, ${theme.palette.givingPortal.homepageHeader.dark} 10%, ${theme.palette.givingPortal.homepageHeader.main} 40%, ${theme.palette.background.transparent} 70%, ${theme.palette.givingPortal.homepageHeader.main})`,
+      background: `linear-gradient(to right, ${theme.palette.givingPortal.homepageHeader.dark} 10%, ${theme.palette.givingPortal.homepageHeader.main} 40%, ${theme.palette.background.transparent} 70%, ${theme.palette.givingPortal.homepageHeader.main})`,
     },
     [theme.breakpoints.down("sm")]: {
       display: "none",

--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { Components, registerComponent } from "../../../lib/vulcan-lib";
+import { useIsAboveBreakpoint } from "../../hooks/useScreenWidth";
 import { Link } from "../../../lib/reactRouterWrapper";
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import {
@@ -184,6 +185,7 @@ const GivingSeasonHeader = ({
   classes: ClassesType,
 }) => {
   const {Typography} = Components;
+  const isDesktop = useIsAboveBreakpoint("md");
   return (
     <AnalyticsContext pageSectionContext="header" siteEvent="givingSeason2023">
       <div className={classNames(classes.root, classes.rootGivingSeason, {
@@ -198,6 +200,7 @@ const GivingSeasonHeader = ({
           })}
           onUnfix={() => setUnFixed(true)}
           onUnpin={() => setUnFixed(false)}
+          disable={isDesktop}
         >
           <header className={classes.appBarGivingSeason}>
             <div className={classes.givingSeasonGradient} />

--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -16,7 +16,7 @@ export const effectiveGivingTagId = "L6NqHZkLc4xZ7YtDr";
 export const heroImageId = "giving_portal_23_hero";
 
 /** Cloudinary ID for the frontpage header background image */
-export const headerImageId = "giving_portal_23_hero2";
+export const headerImageId = "giving_portal_23_hero3";
 
 const votingAccountCreationCutoff = new Date("2023/10/23");
 

--- a/packages/lesswrong/lib/eaGivingSeason.ts
+++ b/packages/lesswrong/lib/eaGivingSeason.ts
@@ -85,7 +85,7 @@ export const timelineSpec: TimelineSpec = {
       start: new Date("2023-11-21"),
       end: new Date("2023-11-28"),
       description: "Donation Debate Week",
-      href: `${donationElectionLink}#Donation_Debate_Week`,
+      href: `/s/exEpwrsESEELJji3n`,
       consecutive: true,
     },
     {


### PR DESCRIPTION
- Add new banner image for donation debate week
- Add "amount raised" section to the frontpage RHS section (not that we're currently over the goal so the progress bar looks weird - we probably need to raise the goal?)
- Fix gradient discontinuity on tablet sized screens
- Disable hiding half the banner on scroll on desktop

Note that there's still some preexisting bugs (such as the bar being kept open on scroll if you open the search input) but these can be fixed separately.

<img width="1512" alt="Screenshot 2023-11-21 at 16 15 28" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/2513f07b-77bc-41e3-8b38-146dcae6eea8">



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206002597472994) by [Unito](https://www.unito.io)
