### PR TITLE
Update giving portal posts lists

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -517,11 +517,6 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
                   loadMoreMessage="View more"
                 />
               </div>
-              <div className={classes.rowThin}>
-                <Link to={`/topics/${effectiveGivingTag?.slug}`} className={classes.button}>
-                  Contribute to the discussion
-                </Link>
-              </div>
             </div>
           </div>
         </div>

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { Components, getSiteUrl, registerComponent } from "../../../lib/vulcan-lib";
 import { useSingle } from "../../../lib/crud/withSingle";
-import { useMulti } from "../../../lib/crud/withMulti";
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import { Link } from "../../../lib/reactRouterWrapper";
 import { SECTION_WIDTH } from "../../common/SingleColumnSection";
@@ -27,10 +26,6 @@ import { useMessages } from "../../common/withMessages";
 import { useUpdateCurrentUser } from "../../hooks/useUpdateCurrentUser";
 import { useCurrentUser } from "../../common/withUser";
 import { useDialog } from "../../common/withDialog";
-import { useCurrentTime } from "../../../lib/utils/timeUtil";
-import moment from "moment";
-import { useTimezone } from "../../common/withTimezone";
-import { frontpageDaysAgoCutoffSetting } from "../../../lib/scoring";
 import { CloudinaryPropsType, makeCloudinaryImageUrl } from "../../common/CloudinaryImage2";
 
 const styles = (theme: ThemeType) => ({
@@ -298,7 +293,7 @@ const socialImageProps: CloudinaryPropsType = {
   f: "auto",
 };
 
-const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
+const EAGivingPortalPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const { data: amountRaised, loading: amountRaisedLoading } = useAmountRaised(eaGivingSeason23ElectionName);
 
   const {
@@ -311,11 +306,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
     collectionName: "Tags",
     fragmentName: "TagBasicInfo",
   });
-  const {document: effectiveGivingTag} = useSingle({
-    documentId: effectiveGivingTagId,
-    collectionName: "Tags",
-    fragmentName: "TagBasicInfo",
-  });
+  /*
   const {
     results: relevantSequences,
     loading: loadingRelevantSequences,
@@ -326,16 +317,13 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
       "wog9xb8cdqDySbBvM", // TODO: Add more sequences here
     ]},
   });
+   */
   const currentUser = useCurrentUser();
   const updateCurrentUser = useUpdateCurrentUser();
   const [notifyForVotingOn, setNotifyForVotingOn] = useState(currentUser?.givingSeasonNotifyForVoting ?? false);
   const {flash} = useMessages();
   const {openDialog} = useDialog();
   const { captureEvent } = useTracking({ eventProps: { pageContext: "eaGivingPortal" } });
-
-  const { timezone } = useTimezone();
-  const now = useCurrentTime();
-  const dateCutoff = moment(now).tz(timezone).subtract(frontpageDaysAgoCutoffSetting.get(), 'days').format("YYYY-MM-DD");
 
   const toggleNotifyWhenVotingOpens = useCallback(() => {
     captureEvent('toggleNotifyWhenVotingOpens', { notifyForVotingOn: !notifyForVotingOn })
@@ -364,7 +352,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
 
   const {
     Loading, LoadMore, HeadTags, Timeline, ElectionFundCTA, ForumIcon, PostsList2,
-    ElectionCandidatesList, DonationOpportunity, CloudinaryImage2, EASequenceCard,
+    ElectionCandidatesList, DonationOpportunity, CloudinaryImage2, QuickTakesList,
   } = Components;
   return (
     <AnalyticsContext pageContext="eaGivingPortal">
@@ -517,6 +505,18 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
                   loadMoreMessage="View more"
                 />
               </div>
+              <div className={classNames(
+                classes.h2,
+                classes.primaryText,
+                classes.mt30,
+              )}>
+                Quick takes tagged &quot;Effective Giving&quot;
+              </div>
+              <QuickTakesList
+                showCommunity
+                tagId={effectiveGivingTagId}
+                className={classNames(classes.postsList, classes.primaryLoadMore)}
+              />
             </div>
           </div>
         </div>

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -253,7 +253,12 @@ const styles = (theme: ThemeType) => ({
   w100: { width: "100%" },
 });
 
-const getListTerms = ({ tagId, sortedBy, limit, after }: { tagId: string; sortedBy: PostSortingModeWithRelevanceOption; limit: number, after: string }): PostsViewTerms => ({
+const getListTerms = ({ tagId, sortedBy, limit, after }: {
+  tagId: string,
+  sortedBy: PostSortingModeWithRelevanceOption,
+  limit: number,
+  after?: string,
+}): PostsViewTerms => ({
   filterSettings: {
     tags: [
       {
@@ -347,7 +352,11 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
     flash(`Notifications ${notifyForVotingOn ? "disabled" : "enabled"}`);
   }, [captureEvent, notifyForVotingOn, currentUser, updateCurrentUser, flash, openDialog]);
 
-  const effectiveGivingPostsTerms = getListTerms({ tagId: effectiveGivingTagId, sortedBy: "magic", limit: 8, after: dateCutoff });
+  const donationElectionPostsTerms = getListTerms({
+    tagId: donationElectionTagId,
+    sortedBy: "magic",
+    limit: 8,
+  });
 
   const totalRaisedFormatted = formatDollars(amountRaised.totalRaised);
   const raisedForElectionFundFormatted = formatDollars(amountRaised.raisedForElectionFund);
@@ -497,14 +506,14 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType}) => {
               classes.mb80,
             )} id="posts">
               <div className={classNames(classes.h2, classes.primaryText)}>
-                Recent posts tagged &quot;Effective giving&quot;
+                Posts tagged &quot;Donation Election 2023&quot;
               </div>
               <div className={classNames(
                 classes.postsList,
                 classes.primaryLoadMore,
               )}>
                 <PostsList2
-                  terms={effectiveGivingPostsTerms}
+                  terms={donationElectionPostsTerms}
                   loadMoreMessage="View more"
                 />
               </div>

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -515,6 +515,7 @@ const EAGivingPortalPage = ({classes}: {classes: ClassesType<typeof styles>}) =>
               <QuickTakesList
                 showCommunity
                 tagId={effectiveGivingTagId}
+                maxAgeDays={30}
                 className={classNames(classes.postsList, classes.primaryLoadMore)}
               />
             </div>

--- a/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useMulti } from "../../lib/crud/withMulti";
 
-const QuickTakesList = ({showCommunity, tagId, className}: {
+const QuickTakesList = ({showCommunity, tagId, maxAgeDays, className}: {
   showCommunity?: boolean,
   tagId?: string,
+  maxAgeDays?: number,
   className?: string,
 }) => {
   const {
@@ -17,6 +18,7 @@ const QuickTakesList = ({showCommunity, tagId, className}: {
       view: "shortformFrontpage",
       showCommunity,
       relevantTagId: tagId,
+      maxAgeDays,
     },
     limit: 5,
     collectionName: "Comments",

--- a/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useMulti } from "../../lib/crud/withMulti";
 
-const QuickTakesList = ({showCommunity, className}: {
+const QuickTakesList = ({showCommunity, tagId, className}: {
   showCommunity?: boolean,
+  tagId?: string,
   className?: string,
 }) => {
   const {
@@ -15,6 +16,7 @@ const QuickTakesList = ({showCommunity, className}: {
     terms: {
       view: "shortformFrontpage",
       showCommunity,
+      relevantTagId: tagId,
     },
     limit: 5,
     collectionName: "Comments",

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -14,6 +14,7 @@ declare global {
     postId?: string,
     userId?: string,
     tagId?: string,
+    relevantTagId?: string,
     parentCommentId?: string,
     parentAnswerId?: string,
     topLevelCommentId?: string,
@@ -525,9 +526,18 @@ Comments.addView('shortformFrontpage', (terms: CommentsViewTerms) => {
       deleted: false,
       parentCommentId: viewFieldNullOrMissing,
       createdAt: {$gt: moment().subtract(5, 'days').toDate()},
-      ...(!terms.showCommunity && {
-        relevantTagIds: {$ne: EA_FORUM_COMMUNITY_TOPIC_ID},
-      }),
+      $and: [
+        !terms.showCommunity
+          ? {
+            relevantTagIds: {$ne: EA_FORUM_COMMUNITY_TOPIC_ID},
+          }
+          : {},
+        !!terms.relevantTagId
+          ? {
+            relevantTagIds: terms.relevantTagId,
+          }
+          : {},
+      ],
       // Quick takes older than 2 hours must have at least 1 karma, quick takes
       // younger than 2 hours must have at least -5 karma
       $or: [

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -15,6 +15,7 @@ declare global {
     userId?: string,
     tagId?: string,
     relevantTagId?: string,
+    maxAgeDays?: number,
     parentCommentId?: string,
     parentAnswerId?: string,
     topLevelCommentId?: string,
@@ -519,13 +520,14 @@ Comments.addView('shortform', (terms: CommentsViewTerms) => {
 
 Comments.addView('shortformFrontpage', (terms: CommentsViewTerms) => {
   const twoHoursAgo = moment().subtract(2, 'hours').toDate();
+  const maxAgeDays = terms.maxAgeDays ?? 5;
   return {
     selector: {
       shortform: true,
       shortformFrontpage: true,
       deleted: false,
       parentCommentId: viewFieldNullOrMissing,
-      createdAt: {$gt: moment().subtract(5, 'days').toDate()},
+      createdAt: {$gt: moment().subtract(maxAgeDays, 'days').toDate()},
       $and: [
         !terms.showCommunity
           ? {


### PR DESCRIPTION
- Change giving portal posts list tag from "Effective giving" to "Donation election 2023"
- Remove the "Contribute to the discussion" button under the posts list
- Add a list of quick takes tagged "Effective giving" from the last 30 days (this cut-off is configurable if we want to change it)

<img width="644" alt="Screenshot 2023-11-21 at 19 05 20" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/ff710399-07d9-4cdc-a1f1-6751be4d4d11">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206004563317445) by [Unito](https://www.unito.io)
