### PR TITLE
Update header "unFixed" value on page navigation

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useCallback } from 'react';
+import React, { useContext, useState, useCallback, useEffect } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import NoSSR from 'react-no-ssr';
@@ -186,7 +186,16 @@ const Header = ({
   const {toc} = useContext(SidebarsContext)!;
   const { captureEvent } = useTracking()
   const { unreadNotifications, unreadPrivateMessages, notificationsOpened } = useUnreadNotifications();
-  const { pathname } = useLocation()
+  const { pathname, hash } = useLocation()
+
+  useEffect(() => {
+    // When we move to a different page we will be positioned at the top of
+    // the page (unless the hash is set) but Headroom doesn't run this callback
+    // on navigation so we have to do it manually
+    if (!hash) {
+      setUnFixed(true);
+    }
+  }, [pathname, hash]);
 
   const setNavigationOpen = (open: boolean) => {
     setNavigationOpenState(open);


### PR DESCRIPTION
When we move to a different page we will be positioned at the top of the page (unless the hash is set). Unfortunately Headroom doesn't run the callback to update the value of "unfixed" on navigation so the header thinks it is still scrolled. This can cause bugs like this:

<img width="1512" alt="Screenshot 2023-11-22 at 14 02 03" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/ff2cc755-3136-48e4-8a2d-4d817efae1da">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206010469156983) by [Unito](https://www.unito.io)
