### PR TITLE
add utm tracking to post share urls

### DIFF
--- a/packages/lesswrong/client/logging.ts
+++ b/packages/lesswrong/client/logging.ts
@@ -59,9 +59,14 @@ userChangedCallback.add(function addUserIdToGoogleAnalytics(user: UsersCurrent |
 userChangedCallback.add(configureDatadogRum);
 
 window.addEventListener('load', ev => {
+  const urlParams = new URLSearchParams(document.location?.search)
+
   captureEvent("pageLoadFinished", {
     url: document.location?.href,
     referrer: document.referrer,
+    utmSource: urlParams.get('utm_source'),
+    utmMedium: urlParams.get('utm_medium'),
+    utmCampaign: urlParams.get('utm_campaign'),
     browserProps: browserProperties(),
     prefersDarkMode: devicePrefersDarkMode(),
     performance: {

--- a/packages/lesswrong/components/dropdowns/posts/SharePostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/SharePostActions.tsx
@@ -21,13 +21,14 @@ const SharePostActions = ({post, onClick, classes}: {
   classes: ClassesType,
 }) => {
   const { DropdownMenu, DropdownItem, DropdownDivider, SocialMediaIcon } = Components;
-  const postUrl = postGetPageUrl(post, true);
   const { captureEvent } = useTracking()
   const { flash } = useMessages();
   
+  const postUrl = (source: string) => `${postGetPageUrl(post, true)}?utm_campaign=post_share&utm_source=${source}`
+  
   const copyLink = () => {
     captureEvent('sharePost', {option: 'copyLink'})
-    void navigator.clipboard.writeText(postUrl);
+    void navigator.clipboard.writeText(postUrl('link'));
     flash("Link copied to clipboard");
   }
 
@@ -40,18 +41,18 @@ const SharePostActions = ({post, onClick, classes}: {
   
   const shareToTwitter = () => {
     captureEvent('sharePost', {option: 'twitter'})
-    const tweetText = `${linkTitle} ${postUrl}`;
+    const tweetText = `${linkTitle} ${postUrl('twitter')}`;
     const destinationUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
     openLinkInNewTab(destinationUrl);
   }
   const shareToFacebook = () => {
     captureEvent('sharePost', {option: 'facebook'})
-    const destinationUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(postUrl)}&t=${encodeURIComponent(linkTitle)}`;
+    const destinationUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(postUrl('facebook'))}&t=${encodeURIComponent(linkTitle)}`;
     openLinkInNewTab(destinationUrl);
   }
   const shareToLinkedIn = () => {
     captureEvent('sharePost', {option: 'linkedIn'})
-    const destinationUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl)}`;
+    const destinationUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl('linkedin'))}`;
     openLinkInNewTab(destinationUrl);
   }
 

--- a/packages/lesswrong/components/posts/SharePostPopup.tsx
+++ b/packages/lesswrong/components/posts/SharePostPopup.tsx
@@ -4,7 +4,7 @@ import Popper from "@material-ui/core/Popper";
 import Paper from "@material-ui/core/Paper";
 import Button from "@material-ui/core/Button";
 import { useForceRerender } from "../hooks/useFirstRender";
-import { postGetUrlWithSourceParam } from "../../lib/collections/posts/helpers";
+import { postGetPageUrl } from "../../lib/collections/posts/helpers";
 import { useTracking } from "../../lib/analyticsEvents";
 import { useMessages } from "../common/withMessages";
 import { forumTitleSetting } from "../../lib/instanceSettings";
@@ -208,7 +208,6 @@ const SharePostPopup = ({
   classes: ClassesType;
 }) => {
   const anchorEl = useRef<HTMLDivElement | null>(null);
-  const postUrl = postGetUrlWithSourceParam(post, "publish_share");
   const { captureEvent } = useTracking();
   const { flash } = useMessages();
   const [isClosing, setIsClosing] = useState(false);
@@ -236,9 +235,11 @@ const SharePostPopup = ({
     };
   }, []);
 
+  const postUrl = (source: string) => `${postGetPageUrl(post, true)}?utm_campaign=publish_share&utm_source=${source}`
+
   const copyLink = () => {
     captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "copyLink" });
-    void navigator.clipboard.writeText(postUrl);
+    void navigator.clipboard.writeText(postUrl('link'));
     flash("Link copied to clipboard");
   };
 
@@ -251,20 +252,20 @@ const SharePostPopup = ({
 
   const shareToTwitter = () => {
     captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "twitter" });
-    const tweetText = `${linkTitle} ${postUrl}`;
+    const tweetText = `${linkTitle} ${postUrl('twitter')}`;
     const destinationUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
     openLinkInNewTab(destinationUrl);
   };
   const shareToFacebook = () => {
     captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "facebook" });
     const destinationUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
-      postUrl
+      postUrl('facebook')
     )}&t=${encodeURIComponent(linkTitle)}`;
     openLinkInNewTab(destinationUrl);
   };
   const shareToLinkedIn = () => {
     captureEvent("sharePost", { pageElementContext: 'sharePostPopup', postId: post._id, option: "linkedIn" });
-    const destinationUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl)}`;
+    const destinationUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(postUrl('linkedin'))}`;
     openLinkInNewTab(destinationUrl);
   };
 

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -123,11 +123,6 @@ export const postGetPageUrl = function(post: PostsMinimumForGetPageUrl, isAbsolu
   return `${prefix}/posts/${post._id}/${post.slug}`;
 };
 
-export const postGetUrlWithSourceParam = (
-  post: PostsMinimumForGetPageUrl,
-  source: string,
-) => `${postGetPageUrl(post, true)}&source=${source}`;
-
 export const postGetCommentsUrl = (
   post: PostsMinimumForGetPageUrl,
   isAbsolute = false,


### PR DESCRIPTION
This PR adds some utm params to the post page URL that's generated when a user shares a post. This is based on briefly googling utm so I'm not sure if this is the right way to use it, feel free to suggest changes.