### PR TITLE
skip dialogue matchmaking queries for logged out users

### DIFF
--- a/packages/lesswrong/components/hooks/useDialogueMatchmaking.ts
+++ b/packages/lesswrong/components/hooks/useDialogueMatchmaking.ts
@@ -32,6 +32,7 @@ type UseDialogueMatchmakingResults<T extends MatchmakingProps> = {
 export const useDialogueMatchmaking = <T extends MatchmakingProps>(props: T): UseDialogueMatchmakingResults<T> => {
   const { getMatchedUsers, getOptedInUsers, getUserDialogueChecks } = props;
   const currentUser = useCurrentUser();
+  const skipByDefault = !currentUser || !dialogueMatchmakingEnabled.get();
 
   const matchedUsersQueryResult = useQuery(gql`
     query GetDialogueMatchedUsers {
@@ -40,7 +41,7 @@ export const useDialogueMatchmaking = <T extends MatchmakingProps>(props: T): Us
         displayName
       }
     }
-  `, { skip: !getMatchedUsers || !dialogueMatchmakingEnabled.get() });
+  `, { skip: skipByDefault || !getMatchedUsers });
 
   const userDialogueChecksResult = useMulti({
     terms: {
@@ -50,7 +51,7 @@ export const useDialogueMatchmaking = <T extends MatchmakingProps>(props: T): Us
     },
     fragmentName: "DialogueCheckInfo",
     collectionName: "DialogueChecks",
-    skip: !getUserDialogueChecks || !dialogueMatchmakingEnabled.get()
+    skip: skipByDefault || !getUserDialogueChecks
   });
 
   const usersOptedInResult = useMulti({
@@ -60,7 +61,7 @@ export const useDialogueMatchmaking = <T extends MatchmakingProps>(props: T): Us
     },
     fragmentName: 'UsersOptedInToDialogueFacilitation',
     collectionName: 'Users',
-    skip: !getOptedInUsers || !dialogueMatchmakingEnabled.get()
+    skip: skipByDefault || !getOptedInUsers
   });
 
   return {


### PR DESCRIPTION
We shouldn't be making these queries for logged out users, since they won't ever return anything anyways.