### PR TITLE
Add tooltips to post title icons

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -64,7 +64,7 @@ const PostsPageTitle = ({classes, post}: {
   classes: ClassesType<typeof styles>,
 }) => {
   const parentPost = post.sourcePostRelations?.filter(rel => !!rel.sourcePost)?.[0]?.sourcePost;
-  const { Typography, ForumIcon } = Components;
+  const { Typography, ForumIcon, LWTooltip } = Components;
   const showLinkIcon = post.url && isFriendlyUI;
   const showDialogueIcon = post.collabEditorDialogue && isFriendlyUI;
 
@@ -91,10 +91,14 @@ const PostsPageTitle = ({classes, post}: {
           <span className={classes.lastWord}>
             {lastWordOfTitle}
             {showLinkIcon &&
-              <ForumIcon className={classes.linkIcon} icon="BoldLink" />
+              <LWTooltip title="Link post">
+                <ForumIcon className={classes.linkIcon} icon="BoldLink" />
+              </LWTooltip>
             }
             {showDialogueIcon &&
-              <ForumIcon className={classes.dialogueIcon} icon="ChatBubbleLeftRight" />
+              <LWTooltip title="Dialogue">
+                <ForumIcon className={classes.dialogueIcon} icon="ChatBubbleLeftRight" />
+              </LWTooltip>
             }
           </span>
         </Link>


### PR DESCRIPTION
Add tooltips to the icons shown after post titles. No forum-gating is needed as the icons themselves are already forum-gated.

<img width="635" alt="Screenshot 2023-11-23 at 14 25 48" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/179c9e1a-c1a3-4292-9c13-1934f5da6fe4">
<img width="576" alt="Screenshot 2023-11-23 at 14 25 41" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/fd852f37-29d3-4672-8930-6fc4eee99945">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206018127847549) by [Unito](https://www.unito.io)
