### PR TITLE
Add current user as a participant to conversations when messaging

### DIFF
--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -688,8 +688,17 @@ getCollectionHooks("Messages").newAsync.add(async function messageNewNotificatio
   await createNotifications({userIds: recipientIds, notificationType: 'newMessage', documentType: 'message', documentId: message._id, noEmail: message.noEmail});
 });
 
-getCollectionHooks("Conversations").editAsync.add(async function conversationEditNotification(conversation: DbConversation, oldConversation: DbConversation) {
-  const newParticipantIds = difference(conversation.participantIds || [], oldConversation.participantIds || []);
+getCollectionHooks("Conversations").editAsync.add(async function conversationEditNotification(
+  conversation: DbConversation,
+  oldConversation: DbConversation,
+  currentUser: DbUser | null,
+) {
+  // Filter out the new participant if the user added themselves (which can
+  // happen with mods)
+  const newParticipantIds = difference(
+    conversation.participantIds || [],
+    oldConversation.participantIds || [],
+  ).filter((id) => id !== currentUser?._id);
 
   if (newParticipantIds.length) {
     // Notify newly added users of the most recent message


### PR DESCRIPTION
If a moderator sends a message in a conversation they're not part of we need to add them as a particpant in that conversation otherwise they won't be notified of future messages.

We also have a notification for users when they are added to a conversation. We need to change this to not send a notification to the user if they added themselves.

I've not forum-gated this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206024017784729) by [Unito](https://www.unito.io)
