### PR TITLE
Don't autosave values identical to the saved value

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -174,7 +174,9 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
   
   const saveBackup = useCallback((newContents: EditorContents) => {
-    if (isBlank(newContents)) {
+    const sameAsSaved = newContents.value === document?.[fieldName]?.ckEditorMarkup
+
+    if (isBlank(newContents) || sameAsSaved) {
       getLocalStorageHandlers(currentEditorType).reset();
       hasUnsavedDataRef.current.hasUnsavedData = false;
     } else {
@@ -185,7 +187,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
         hasUnsavedDataRef.current.hasUnsavedData = false;
       }
     }
-  }, [getLocalStorageHandlers, currentEditorType]);
+  }, [getLocalStorageHandlers, currentEditorType, document, fieldName]);
 
   /**
    * Update the edited field (e.g. "contents") so that other form components can access the updated value. The direct motivation for this


### PR DESCRIPTION
This PR alters the autosaving function to check whether the value it's about to save is identical to the value of the saved document that you're editing. If so, it skips autosaving and wipes the autosave value for that document.

One way you can get to this case is if you open a post for editing, alter some text, change your mind, then alter it back. Currently, the autosave saves that, so if you then abandon your changes then come back later, you'll get a confusing autosave message, prompting you to restore text that's already there.

(This probably doesn't come up much, but Waking Up testers noticed it.)