### PR TITLE
Change minimum number of headings to show the ToC from 3 to 1

### DIFF
--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -20,7 +20,7 @@ import { commentsTableOfContentsEnabled } from '../lib/betas';
 // If comments-ToC is enabled, this is 0 because we need a post-ToC (even if
 // it's empty) to keep the horizontal position of things on the page from
 // being imbalanced.
-const MIN_HEADINGS_FOR_TOC = commentsTableOfContentsEnabled ? 0 : 3;
+const MIN_HEADINGS_FOR_TOC = commentsTableOfContentsEnabled ? 0 : 1;
 
 // Tags which define headings. Currently <h1>-<h4>, <strong>, and <b>. Excludes
 // <h5> and <h6> because their usage in historical (HTML) wasn't as a ToC-


### PR DESCRIPTION
Request from Lizka: change the minimum number of headings in a post to show the table of contents from 3 to 1. There's no need to forum gate this as `commentsTableOfContentsEnabled` is true for LW and AF.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206035227055159) by [Unito](https://www.unito.io)
