### PR TITLE
use live field metadata for generating queries with default values for not-null columns during migration

### DIFF
--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -122,3 +122,6 @@ export const hasProminentLogoSetting = new DatabasePublicSetting<boolean>("hasPr
 export const hasCookieConsentSetting = new DatabasePublicSetting<boolean>('hasCookieConsent', false)
 
 export const dialogueMatchmakingEnabled = new DatabasePublicSetting<boolean>('dialogueMatchmakingEnabled', false)
+
+/** For the purposes of generating queries based on field nullability, should we use live info from the database (and if so, how long do we keep it cached)? */
+export const cacheLiveDatabaseFieldsMs = new DatabasePublicSetting<number | null>('cacheLiveDatabaseFieldsMs', null);

--- a/packages/lesswrong/lib/sql/InsertQuery.ts
+++ b/packages/lesswrong/lib/sql/InsertQuery.ts
@@ -59,6 +59,7 @@ class InsertQuery<T extends DbObject> extends Query<T> {
     data: InsertQueryData<T> | InsertQueryData<T>[],
     _options: MongoInsertOptions<T> = {}, // TODO: What can options be?
     sqlOptions?: InsertSqlOptions<T>,
+    private liveFields?: Record<string, Type>
   ) {
     super(table, [`INSERT INTO "${table.getName()}"`]);
     data = Array.isArray(data) ? data : [data];
@@ -94,7 +95,7 @@ class InsertQuery<T extends DbObject> extends Query<T> {
       throw new Error("Empty insert data");
     }
 
-    const fields = this.table.getFields();
+    const fields = this.liveFields ?? this.table.getFields();
     this.atoms.push("(");
     let prefix = "";
     for (const key in fields) {

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -1,5 +1,5 @@
 import Table from "./Table";
-import { Type, JsonType, ArrayType, NotNullType } from "./Type";
+import { Type, JsonType, ArrayType, NotNullType, DefaultValueType } from "./Type";
 
 /**
  * Arg is a wrapper to mark a particular value as being an argument for the
@@ -10,10 +10,17 @@ class Arg {
   public typehint = "";
 
   constructor(public value: any, type?: Type) {
+    if (this.value === null && type instanceof DefaultValueType && type.isNotNull() && type.getDefaultValueString()) {
+      if (type.isArray() || type.toConcrete() instanceof JsonType) {
+        this.value = type.getDefaultValue();
+      } else {
+        this.value = type.getDefaultValueString();
+      }
+    }
     // JSON arrays make node-postgres fall over, but we can work around it
     // with a special-case typehint
-    if (Array.isArray(value) && value[0] && typeof value[0] === "object") {
-      if (type instanceof JsonType) {
+    if (Array.isArray(this.value) && this.value[0] && typeof this.value[0] === "object") {
+      if (type?.toConcrete() instanceof JsonType) {
         this.value = JSON.stringify(this.value);
         this.typehint = "::JSONB";
       } else {

--- a/packages/lesswrong/lib/sql/Table.ts
+++ b/packages/lesswrong/lib/sql/Table.ts
@@ -51,11 +51,12 @@ class Table<T extends DbObject> {
   }
 
   async getLiveFields(): Promise<Record<string, Type> | undefined> {
-    if (!cacheLiveDatabaseFieldsMs.get()) {
+    const ttl = cacheLiveDatabaseFieldsMs.get();
+    if (!ttl) {
       return undefined;
     }
 
-    if (this.cachedLiveFields && this.cachedLiveFields.cachedAt > (Date.now() - 10_000)) {
+    if (this.cachedLiveFields && this.cachedLiveFields.cachedAt > (Date.now() - ttl)) {
       return this.cachedLiveFields.liveFields;
     }
 

--- a/packages/lesswrong/lib/sql/Table.ts
+++ b/packages/lesswrong/lib/sql/Table.ts
@@ -120,7 +120,7 @@ class Table<T extends DbObject> {
     return this.indexes;
   }
 
-  setCollection(collection: CollectionBase<T>) {
+  private setCollection(collection: CollectionBase<T>) {
     this.collection = collection;
   }
 

--- a/packages/lesswrong/lib/sql/Type.ts
+++ b/packages/lesswrong/lib/sql/Type.ts
@@ -271,6 +271,10 @@ export class DefaultValueType extends Type {
     return `${this.type.toString()} DEFAULT ${this.getDefaultValueString()}`;
   }
 
+  getDefaultValue(): AnyBecauseHard {
+    return this.value
+  }
+
   getDefaultValueString(): string | null {
     return valueToString(this.value, this.type.isArray() ? this.type.subtype : undefined);
   }
@@ -281,6 +285,10 @@ export class DefaultValueType extends Type {
 
   isArray(): this is ArrayType {
     return this.type.isArray();
+  }
+
+  isNotNull(): boolean {
+    return this.type instanceof NotNullType;
   }
 }
 


### PR DESCRIPTION
EDIT: better accomplished by https://github.com/ForumMagnum/ForumMagnum/pull/8334; closing this PR.

https://github.com/ForumMagnum/ForumMagnum/pull/8051 presents us with a little bit of a problem: after the migration has run, but before the new code has been deployed, the old code will be trying to insert `NULL` values into columns which have been updated to be `NOT NULL`.

The new code fixed this issue by checking whether a field was `NOT NULL`, based on the field specification in the schema, and inserting the appropriate default value if one existed.  To cover the ~20 minute gap after the migration but before the new code has fully rolled out, we need to be doing something similar _before_ the migration runs.  Of course, since prior to the new code being deployed we don't have the updated schema (in code), we need to actually fetch the nullability metadata from the database in realtime.  This does that, and caches the results for a short period of time (I think ~10 seconds is fine), which I think strikes a reasonable balance between not sending a bunch of unnecessary queries for tables which see a lot of writes, while still keeping that info relatively up-to-date.

Functionally, if you set `cacheLiveDatabaseFieldsMs` to some value (i.e. `10000`), there should be no difference in behavior _until_ you run the migration in https://github.com/ForumMagnum/ForumMagnum/pull/8045, because there won't be any fields which are specified to be `NOT NULL` in the database but not in the live server code.  After running the migration, but before merging in https://github.com/ForumMagnum/ForumMagnum/pull/8045 (which will also have https://github.com/ForumMagnum/ForumMagnum/pull/8051 merged into it), this change should cause the same behavior w.r.t. insertion of default values for `NOT NULL` columns as would happen after merging those PRs in (but without checking live column metadata from the db).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206042903329471) by [Unito](https://www.unito.io)
