### PR TITLE
Try MatchingPage without SSR

### DIFF
--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -29,6 +29,7 @@ import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import partition from 'lodash/partition';
 import {dialogueMatchmakingEnabled} from '../../lib/publicSettings';
+import NoSSR from 'react-no-ssr';
 
 export type UpvotedUser = {
   _id: string;
@@ -1465,11 +1466,13 @@ export const DialogueMatchingPage = ({classes}: {
   </div>)
 }
 
+const NoSSRMatchingPage = (props: {classes: ClassesType<typeof styles>}) => <NoSSR><DialogueMatchingPage {...props} /></NoSSR>
+
 const DialogueNextStepsButtonComponent = registerComponent('DialogueNextStepsButton', DialogueNextStepsButton, {styles});
 const MessageButtonComponent = registerComponent('MessageButton', MessageButton, {styles});
 const DialogueCheckBoxComponent = registerComponent('DialogueCheckBox', DialogueCheckBox, {styles});
 const DialogueUserRowComponent = registerComponent('DialogueUserRow', DialogueUserRow, {styles});
-const DialogueMatchingPageComponent = registerComponent('DialogueMatchingPage', DialogueMatchingPage, {styles});
+const DialogueMatchingPageComponent = registerComponent('DialogueMatchingPage', NoSSRMatchingPage, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -1469,7 +1469,7 @@ export const DialogueMatchingPage = ({classes}: {
 }
 
 const NoSSRMatchingPage = (props: {classes: ClassesType<typeof styles>}) =>
-  useABTest(dialogueMatchingPageNoSSRABTest) == 'noSSR'
+  useABTest(dialogueMatchingPageNoSSRABTest) === 'noSSR'
   ? <NoSSR><DialogueMatchingPage {...props} /></NoSSR>
   : <DialogueMatchingPage {...props} />
 

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -30,6 +30,8 @@ import mergeWith from 'lodash/mergeWith';
 import partition from 'lodash/partition';
 import {dialogueMatchmakingEnabled} from '../../lib/publicSettings';
 import NoSSR from 'react-no-ssr';
+import { useABTest } from '../../lib/abTestImpl';
+import { dialogueMatchingPageNoSSRABTest } from '../../lib/abTests';
 
 export type UpvotedUser = {
   _id: string;
@@ -1466,7 +1468,10 @@ export const DialogueMatchingPage = ({classes}: {
   </div>)
 }
 
-const NoSSRMatchingPage = (props: {classes: ClassesType<typeof styles>}) => <NoSSR><DialogueMatchingPage {...props} /></NoSSR>
+const NoSSRMatchingPage = (props: {classes: ClassesType<typeof styles>}) =>
+  useABTest(dialogueMatchingPageNoSSRABTest) == 'noSSR'
+  ? <NoSSR><DialogueMatchingPage {...props} /></NoSSR>
+  : <DialogueMatchingPage {...props} />
 
 const DialogueNextStepsButtonComponent = registerComponent('DialogueNextStepsButton', DialogueNextStepsButton, {styles});
 const MessageButtonComponent = registerComponent('MessageButton', MessageButton, {styles});

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -95,3 +95,19 @@ export const dialogueFacilitationMessagesABTest = new ABTest({
     },
   },
 });
+
+// Does non-SSR rendering of the DialogueMatchingPage help with anything?
+export const dialogueMatchingPageNoSSRABTest = new ABTest({
+  name: "dialogueMatchingPageNoSSR",
+  description: "Different rendering of the DialogueMatchingPage",
+  groups: {
+    control: {
+      description: "Control version",
+      weight: 1,
+    },
+    noSSR: {
+      description: "Non-SSR version",
+      weight: 1,
+    },
+  },
+});


### PR DESCRIPTION
The SSR for MatchingPage takes a looooong time. You can wait for ~10s to see anything if you navigate directly to `/dialogueMatching`. But without SSR, you see interesting things appear quickly and the rest gets populated over time.

Let's see if it makes a difference to use the non-SSR'd version.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206043358571072) by [Unito](https://www.unito.io)
