### PR TITLE
increase localgroup select limit

### DIFF
--- a/packages/lesswrong/components/form-components/SelectLocalgroup.tsx
+++ b/packages/lesswrong/components/form-components/SelectLocalgroup.tsx
@@ -21,7 +21,7 @@ const SelectLocalgroup = (props: any) => {
     terms: {
       view: user.isAdmin ? 'all' : 'userActiveGroups',
       userId: user._id,
-      limit: 300
+      limit: 500
     },
     skip: !user
   });


### PR DESCRIPTION
EAF now has >400 active groups, so increasing this now to prevent the list from getting cut off. The plan is to put localgroups in elasticsearch at some point to make them better searchable.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206044662665574) by [Unito](https://www.unito.io)
