### PR TITLE
Fix submit button position for EA dialogues

### DIFF
--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -267,6 +267,7 @@ const dialogueStyle = (theme: ThemeType): JssStyles => ({
     ...(isFriendlyUI
       ? {
         right: 12,
+        bottom: 5,
         color: theme.palette.grey[1000],
         backgroundColor: theme.palette.grey[250],
         "&:hover": {


### PR DESCRIPTION
We had a couple of reports that the vertical positioning of the submit button is wrong for dialogues on the EA forum. I've never been able to repro the bug, but I'm guessing that this probably fixes it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206045938959309) by [Unito](https://www.unito.io)
