### PR TITLE
[EA Forum only] fine-tune new model for criticism tips card

### DIFF
--- a/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
+++ b/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
@@ -86,6 +86,7 @@ import type { PostIsCriticismRequest } from '../resolvers/postResolvers';
       Substituting in ${TAG}, and repeat for each tag.
       You can check each job with:
           openai api fine_tunes.follow -i ${id}
+      Update on 2023-11-27: You can now just do this all via their web UI, see https://platform.openai.com/docs/guides/fine-tuning
  *
  * 9. Retrieve the fine-tuned model IDs. Run
  *        openai api fine_tunes.list
@@ -277,11 +278,11 @@ export async function postIsCriticism(post: PostIsCriticismRequest): Promise<boo
   
   const template = await wikiSlugToTemplate("lm-config-autotag")
   const promptSuffix = 'Is this post critically examining the work, projects, or methodologies of specific individuals, organizations, or initiatives affiliated with the effective altruism (EA) movement or community?'
-  // This model was trained on ~2400 posts, generated using generateCandidateSetsForTagClassification
-  // (posts published from May 1 2022 - May 1 2023 combined with *all* posts tagged with "criticism of work in effective altruism").
-  // Since it's not super accurate, we may want to fine-tune it more in the future.
+  // This model was trained on ~2500 posts, generated using generateCandidateSetsForTagClassification
+  // (posts published from Nov 1 2022 - Nov 1 2023 combined with *all* posts tagged with "criticism of work in effective altruism").
+  // Since it's not super accurate, we may want to fine-tune a new version in the future.
   const languageModelResult = await api.completions.create({
-    model: 'curie:ft-centre-for-effective-altruism-2023-05-11-23-15-52',
+    model: 'ft:davinci-002:centre-for-effective-altruism::8PxrFevH',
     prompt: await postToPrompt({
       template,
       post,

--- a/packages/lesswrong/server/scripts/generativeModels/generateTaggingPostSets.ts
+++ b/packages/lesswrong/server/scripts/generativeModels/generateTaggingPostSets.ts
@@ -5,14 +5,12 @@ import { truncate } from '../../../lib/editor/ellipsize';
 import { postStatuses } from '../../../lib/collections/posts/constants';
 import { dataToMarkdown, htmlToMarkdown } from '../../editor/conversionUtils';
 import { getOpenAI, wikiSlugToTemplate } from '../../languageModels/languageModelIntegration';
-import { cheerioParse } from '../../utils/htmlUtil';
 import { postToPrompt, checkTags, getAutoAppliedTags, generatePostBodyCache, PostBodyCache } from '../../languageModels/autoTagCallbacks';
 import shuffle from 'lodash/shuffle';
 import take from 'lodash/take';
 import drop from 'lodash/drop';
 import sum from 'lodash/sum';
 import keyBy from 'lodash/keyBy';
-import mapValues from 'lodash/mapValues';
 import filter from 'lodash/filter';
 import fs from 'fs';
 import { getSiteUrl } from '../../vulcan-lib';
@@ -51,14 +49,15 @@ function weightedPartition<T>(list: T[], weights: number[]): T[][]
 }
 
 async function generateCandidateSetsForTagClassification(): Promise<void> {
-  const startDate = new Date("2021-01-01");
-  const endDate = new Date("2022-11-01");
+  const startDate = new Date("2022-11-01");
+  const endDate = new Date("2023-11-01");
   
   console.log(`Finding posts from ${startDate} to ${endDate}`); //eslint-disable-line no-console
   const posts = await Posts.find({
     draft: false, status: postStatuses.STATUS_APPROVED,
     isFuture: false, unlisted: false, shortform: false, authorIsUnreviewed: false,
     question: false, isEvent: false,
+    contents: {$ne: null},
     baseScore: {$gte: 10},
     tagRelevance: {$exists: true},
     postedAt: {$gte: startDate, $lte: endDate},


### PR DESCRIPTION
Given [this](https://openai.com/blog/gpt-4-api-general-availability), we fine-tuned a new model for the criticism tips card. We used `davinci-002` as the base and it performs about as well (maybe slightly better) than the old one, which was on `curie`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206051916184997) by [Unito](https://www.unito.io)
