### PR TITLE
Use schemaDefaultValue (or onCreate) to ensure fields are nonnull on insertion

### DIFF
--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -452,7 +452,7 @@ const schema: SchemaType<DbComment> = {
     type: Boolean,
     optional: true,
     hidden: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -44,7 +44,7 @@ const schema: SchemaType<DbGardenCode> = {
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     label: "Event Name",
-    defaultValue: "Guest Day Pass",
+    ...schemaDefaultValue("Guest Day Pass"),
     order: 10
   },
   userId: {

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -88,7 +88,7 @@ const schema: SchemaType<DbLocalgroup> = {
     canUpdate: ['members'],
     control: 'MultiSelectButtons',
     label: "Group Type:",
-    defaultValue: ["LW"],
+    ...schemaDefaultValue(["LW"]),
     minCount: 1, // Ensure that at least one type is selected
     form: {
       options: localGroupTypeFormOptions

--- a/packages/lesswrong/lib/collections/migrations/collection.ts
+++ b/packages/lesswrong/lib/collections/migrations/collection.ts
@@ -1,5 +1,5 @@
 import { createCollection } from '../../vulcan-lib';
-import { addUniversalFields } from '../../collectionUtils'
+import { addUniversalFields, schemaDefaultValue } from '../../collectionUtils'
 
 /*
  * NOTE: This collection only tracks the use of migrations located in
@@ -22,11 +22,11 @@ const schema: SchemaType<DbMigration> = {
   },
   finished: {
     type: Boolean,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
   },
   succeeded: {
     type: Boolean,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
   },
 };
 

--- a/packages/lesswrong/lib/collections/notifications/schema.ts
+++ b/packages/lesswrong/lib/collections/notifications/schema.ts
@@ -54,7 +54,7 @@ const schema: SchemaType<DbNotification> = {
   viewed: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['members'],
     canCreate: ['members'],
     canUpdate: ['members'],

--- a/packages/lesswrong/lib/collections/postRecommendations/schema.ts
+++ b/packages/lesswrong/lib/collections/postRecommendations/schema.ts
@@ -1,5 +1,6 @@
 import { foreignKeyField } from "../../utils/schemaUtils";
 import SimpleSchema from "simpl-schema";
+import { schemaDefaultValue } from "../../collectionUtils";
 
 export const schema: SchemaType<DbPostRecommendation> = {
   /** The user who the recommendation was generated for. */
@@ -78,7 +79,7 @@ export const schema: SchemaType<DbPostRecommendation> = {
    */
   recommendationCount: {
     type: SimpleSchema.Integer,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     optional: false,
     nullable: false,
     canRead: ["admins"],

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -256,7 +256,7 @@ const schema: SchemaType<DbPost> = {
     type: Number,
     optional: true,
     canRead: ['admins'],
-    defaultValue: 0
+    ...schemaDefaultValue(0),
   },
   // Timestamp of the last comment
   lastCommentedAt: {
@@ -272,7 +272,7 @@ const schema: SchemaType<DbPost> = {
     type: Number,
     optional: true,
     canRead: ['admins'],
-    defaultValue: 0
+    ...schemaDefaultValue(0),
   },
 
   deletedDraft: {
@@ -745,7 +745,6 @@ const schema: SchemaType<DbPost> = {
   reviewVoteCount: {
     type: Number,
     optional: true,
-    defaultValue: 0,
     ...denormalizedCountOfReferences({
       fieldName: "reviewVoteCount",
       collectionName: "Posts",
@@ -759,7 +758,6 @@ const schema: SchemaType<DbPost> = {
   positiveReviewVoteCount: {
     type: Number,
     optional: true,
-    defaultValue: 0,
     ...denormalizedCountOfReferences({
       fieldName: "positiveReviewVoteCount",
       collectionName: "Posts",
@@ -775,13 +773,13 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreAF: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   reviewVotesAF: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'reviewVotesAF.$': {
@@ -792,14 +790,14 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreHighKarma: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   // A list of each individual user's calculated quadratic vote, for users with >1000 karma
   reviewVotesHighKarma: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'reviewVotesHighKarma.$': {
@@ -810,14 +808,14 @@ const schema: SchemaType<DbPost> = {
   reviewVoteScoreAllKarma: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   // A list of each individual user's calculated quadratic vote, for all users
   reviewVotesAllKarma: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'reviewVotesAllKarma.$': {
@@ -829,13 +827,13 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreHighKarma: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   finalReviewVotesHighKarma: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'finalReviewVotesHighKarma.$': {
@@ -846,13 +844,13 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreAllKarma: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   finalReviewVotesAllKarma: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'finalReviewVotesAllKarma.$': {
@@ -863,13 +861,13 @@ const schema: SchemaType<DbPost> = {
   finalReviewVoteScoreAF: {
     type: Number, 
     optional: true,
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests']
   },
   finalReviewVotesAF: {
     type: Array,
     optional: true,
-    defaultValue: [],
+    ...schemaDefaultValue([]),
     canRead: ['guests']
   },
   'finalReviewVotesAF.$': {
@@ -1141,7 +1139,7 @@ const schema: SchemaType<DbPost> = {
     type: Boolean,
     optional: true,
     hidden: false,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['admins'],
     canCreate: ['admins'],
@@ -1154,7 +1152,7 @@ const schema: SchemaType<DbPost> = {
     type: Boolean,
     optional: true,
     hidden: false,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['admins'],
     canCreate: ['admins'],
@@ -1178,7 +1176,7 @@ const schema: SchemaType<DbPost> = {
   legacySpam: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     hidden: true,
     canRead: ['guests'],
     canUpdate: ['admins'],
@@ -2492,8 +2490,6 @@ const schema: SchemaType<DbPost> = {
   commentCount: {
     type: Number,
     optional: true,
-    defaultValue: 0,
-    
     ...denormalizedCountOfReferences({
       fieldName: "commentCount",
       collectionName: "Posts",
@@ -2508,8 +2504,6 @@ const schema: SchemaType<DbPost> = {
   topLevelCommentCount: {
     type: Number,
     optional: true,
-    defaultValue: 0,
-    
     ...denormalizedCountOfReferences({
       fieldName: "topLevelCommentCount",
       collectionName: "Posts",

--- a/packages/lesswrong/lib/collections/rssfeeds/schema.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/schema.ts
@@ -24,7 +24,7 @@ const schema: SchemaType<DbRSSFeed> = {
     control: "checkbox",
     optional: true,
     order: 30,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
   },
   displayFullContent: {
     type: Boolean,
@@ -34,7 +34,7 @@ const schema: SchemaType<DbRSSFeed> = {
     control: "checkbox",
     optional: true,
     order: 40,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
   },
   nickname: {
     type: String,

--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -220,7 +220,7 @@ const schema: SchemaType<DbSequence> = {
     type: Boolean,
     optional: true,
     label: "Alignment Forum",
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['alignmentVoters'],
     canCreate: ['alignmentVoters'],

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -654,7 +654,7 @@ const schema: SchemaType<DbTag> = {
   noindex: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.advancedOptions,

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -475,7 +475,7 @@ const schema: SchemaType<DbUser> = {
   noindex: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['admins', 'sunshineRegiment'],
     order: 48,
@@ -599,7 +599,7 @@ const schema: SchemaType<DbUser> = {
   legacy: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     hidden: true,
     canRead: [userOwns, 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
@@ -651,7 +651,6 @@ const schema: SchemaType<DbUser> = {
     group: formGroups.siteCustomizations,
     allowedValues: ['listView', 'gridView'],
     ...schemaDefaultValue('listView'),
-    defaultValue: "listView",
     hidden: isEAForum,
     control: "select",
     form: {
@@ -709,7 +708,7 @@ const schema: SchemaType<DbUser> = {
     order: 71,
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     group: formGroups.siteCustomizations,
@@ -724,7 +723,7 @@ const schema: SchemaType<DbUser> = {
     order: 72,
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     control: 'checkbox',
@@ -736,7 +735,7 @@ const schema: SchemaType<DbUser> = {
     order: 80,
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: [userOwns],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     control: 'checkbox',
@@ -748,7 +747,7 @@ const schema: SchemaType<DbUser> = {
     order: 90,
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: [userOwns],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     control: 'checkbox',
@@ -762,7 +761,7 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -775,7 +774,7 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -788,7 +787,7 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -802,7 +801,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     hidden: !isEAForum,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ["guests"],
     canUpdate: [userOwns, "sunshineRegiment", "admins"],
     canCreate: ["members"],
@@ -827,7 +826,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     hidden: !isEAForum,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -841,7 +840,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     hidden: !hasPostRecommendations,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ["guests"],
     canUpdate: [userOwns, "sunshineRegiment", "admins"],
     canCreate: ["members"],
@@ -855,7 +854,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     nullable: true,
     group: formGroups.siteCustomizations,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -872,7 +871,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     nullable: true,
     hidden: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
@@ -1105,11 +1104,6 @@ const schema: SchemaType<DbUser> = {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     hidden: true,
-    onUpdate: ({data, currentUser, oldDocument}) => {
-      if (data?.bookmarkedPostsMetadata) {
-        return _.uniq(data?.bookmarkedPostsMetadata, 'postId')
-      }
-    },
     ...arrayOfForeignKeysField({
       idFieldName: "bookmarkedPostsMetadata",
       resolverName: "bookmarkedPosts",
@@ -1117,6 +1111,11 @@ const schema: SchemaType<DbUser> = {
       type: "Post",
       getKey: (obj) => obj.postId
     }),
+    onUpdate: ({data, currentUser, oldDocument}) => {
+      if (data?.bookmarkedPostsMetadata) {
+        return _.uniq(data?.bookmarkedPostsMetadata, 'postId')
+      }
+    },
   },
 
   "bookmarkedPostsMetadata.$": {
@@ -1141,11 +1140,6 @@ const schema: SchemaType<DbUser> = {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
     hidden: true,
-    onUpdate: ({data, currentUser, oldDocument}) => {
-      if (data?.hiddenPostsMetadata) {
-        return uniqBy(data?.hiddenPostsMetadata, 'postId')
-      }
-    },
     ...arrayOfForeignKeysField({
       idFieldName: "hiddenPostsMetadata",
       resolverName: "hiddenPosts",
@@ -1153,6 +1147,11 @@ const schema: SchemaType<DbUser> = {
       type: "Post",
       getKey: (obj) => obj.postId
     }),
+    onUpdate: ({data, currentUser, oldDocument}) => {
+      if (data?.hiddenPostsMetadata) {
+        return uniqBy(data?.hiddenPostsMetadata, 'postId')
+      }
+    },
   },
 
   "hiddenPostsMetadata.$": {
@@ -1179,7 +1178,7 @@ const schema: SchemaType<DbUser> = {
   deleted: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     canRead: ['guests'],
     canUpdate: ['members', 'admins'],
     label: 'Deactivate',
@@ -1946,7 +1945,7 @@ const schema: SchemaType<DbUser> = {
     type: Number,
     optional: true,
     label: "Alignment Base Score",
-    defaultValue: 0,
+    ...schemaDefaultValue(0),
     canRead: ['guests'],
   },
 
@@ -2180,7 +2179,7 @@ const schema: SchemaType<DbUser> = {
   noExpandUnreadCommentsReview: {
     type: Boolean,
     optional: true,
-    defaultValue: false,
+    ...schemaDefaultValue(false),
     hidden: true,
     canRead: ['guests'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],

--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -2,6 +2,7 @@ import { addFieldsDict, denormalizedCountOfReferences, accessFilterMultiple } fr
 import { getWithLoader } from './loaders'
 import { userIsAdminOrMod } from './vulcan-users/permissions';
 import GraphQLJSON from 'graphql-type-json';
+import { schemaDefaultValue } from './collectionUtils';
 
 export type PermissionResult = {
   fail: false,
@@ -133,12 +134,8 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
     baseScore: {
       type: Number,
       optional: true,
-      defaultValue: 0,
+      ...schemaDefaultValue(0),
       canRead: customBaseScoreReadAccess || ['guests'],
-      onInsert: (document: DbInsertion<T>): number => {
-        // default to 0 if empty
-        return document.baseScore || 0;
-      }
     },
     extendedScore: {
       type: GraphQLJSON,
@@ -149,12 +146,8 @@ export const makeVoteable = <T extends DbVoteableType>(collection: CollectionBas
     score: {
       type: Number,
       optional: true,
-      defaultValue: 0,
+      ...schemaDefaultValue(0),
       canRead: ['guests'],
-      onInsert: (document: DbInsertion<T>): number => {
-        // default to 0 if empty
-        return document.score || 0;
-      }
     },
     // Whether the document is inactive. Inactive documents see their score
     // recalculated less often

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -133,7 +133,18 @@ export function arrayOfForeignKeysField<CollectionName extends keyof Collections
   
   return {
     type: Array,
+
     defaultValue: [],
+    onCreate: ({newDocument, fieldName}: {
+      newDocument: DbObject,
+      fieldName: string,
+    }) => {
+      if (newDocument[fieldName as keyof DbObject] === undefined) {
+        return [];
+      }
+    },
+    canAutofillDefault: true,
+
     resolveAs: {
       fieldName: resolverName,
       type: `[${type}!]!`,
@@ -361,7 +372,10 @@ export function denormalizedCountOfReferences<SourceType extends DbObject, Targe
   return {
     type: Number,
     optional: true,
+
     defaultValue: 0,
+    onCreate: ()=>0,
+    canAutofillDefault: true,
     
     denormalized: true,
     canAutoDenormalize: true,


### PR DESCRIPTION
This is a simpler solution to the same problem as https://github.com/ForumMagnum/ForumMagnum/pull/8318 .

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206052955339410) by [Unito](https://www.unito.io)
