### PR TITLE
Fix bug due to unstable seedrandom

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/hooks.ts
+++ b/packages/lesswrong/components/ea-forum/giving-portal/hooks.ts
@@ -5,9 +5,9 @@ import { isEAForum } from "../../../lib/instanceSettings";
 import { useCurrentTime } from "../../../lib/utils/timeUtil";
 import moment from "moment";
 import { useCurrentUser } from "../../common/withUser";
-import seedrandom from "../../../lib/seedrandom";
 import { useCookiesWithConsent } from "../../hooks/useCookiesWithConsent";
 import { CLIENT_ID_COOKIE } from "../../../lib/cookies/cookies";
+import { stableSeedrandom } from "../../../lib/stableSeedrandom";
 
 export type ElectionAmountRaised = {
   raisedForElectionFund: number,
@@ -41,8 +41,9 @@ export const useElectionCandidates = (
 
   let resultsCopy = results ? [...results] : undefined;
   if (sortBy === "random") {
-    const rng = seedrandom(currentUser?.abTestKey ?? clientId);
-    resultsCopy?.sort(() => rng() - 0.5);
+    const randomSeed = currentUser?.abTestKey ?? clientId ?? "default";
+    const rng = stableSeedrandom(randomSeed);
+    resultsCopy?.sort(() => rng.next() - 0.5);
   }
 
   return {

--- a/packages/lesswrong/lib/seedrandom.ts
+++ b/packages/lesswrong/lib/seedrandom.ts
@@ -24,6 +24,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// IMPORTANT NOTE: We have come across a bug where this gives a different result on Safari, which
+// resulted in a server/client mismatch error. We should fix this across the board, but in the meantime
+// prefer using stableSeedrandom.ts if you don't need cryptographic security or any guarantee of
+// particularly good randomness (Note: I'm not sure if the version in this file is actually cryptographically
+// secure, but stableSeedrandom definitely isn't).
+
 function Alea(seed: string) {
   // @ts-ignore
   var me = this,

--- a/packages/lesswrong/lib/stableSeedrandom.ts
+++ b/packages/lesswrong/lib/stableSeedrandom.ts
@@ -1,0 +1,33 @@
+// This was written as a quick replacement for ./seedrandom.ts, which was giving different results
+// on Safari than on the server. This version is just the quickest old fashioned rng I could write,
+// if you need really good randomness or cryptographic security you should probably use something else.
+
+class StableSeedRandom {
+  private seed: number;
+  private readonly m: number = 2 ** 31;
+  private readonly a: number = 1103515245;
+  private readonly c: number = 12345;
+
+  constructor(seed: string) {
+    this.seed = this.stringToSeed(seed);
+  }
+
+  private stringToSeed(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  next(): number {
+    this.seed = ((this.a * this.seed) + this.c) % this.m;
+    return this.seed / (this.m - 1);
+  }
+}
+
+export function stableSeedrandom(seed: string): StableSeedRandom {
+  return new StableSeedRandom(seed);
+}

--- a/packages/lesswrong/lib/stableSeedrandom.ts
+++ b/packages/lesswrong/lib/stableSeedrandom.ts
@@ -28,6 +28,13 @@ class StableSeedRandom {
   }
 }
 
+/**
+ * Usage:
+ * ```
+ * const rng = stableSeedrandom("seed");
+ * rng.next(); // returns a random number between 0 and 1
+ * ```
+ */
 export function stableSeedrandom(seed: string): StableSeedRandom {
   return new StableSeedRandom(seed);
 }


### PR DESCRIPTION
`seedrandom` was giving different results on Safari than on the server, and this was causing the list of election candidates to get messed up (logos matching up to the wrong titles):
![image](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/e0a73a3f-3809-435f-84c1-0f172fc88295)

I've added a more stable rng to fix this acute problem, and made a [ticket](https://app.asana.com/0/628521446211730/1206057192173271/f) to follow up and come up with a long term solution

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206057164185243) by [Unito](https://www.unito.io)
