### PR TITLE
Fix comments on answers being posted as top-level instead

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -270,13 +270,10 @@ const CommentsNewForm = ({
   }
 
   if (parentComment) {
-    console.log(`parentCommentId = ${parentComment._id}`);
     prefilledProps = {
       ...prefilledProps,
       parentCommentId: parentComment._id,
     };
-  } else {
-    console.log("No parent comment");
   }
 
   const SubmitComponent = ({submitLabel = "Submit"}) => {

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -137,7 +137,7 @@ export type CommentsNewFormProps = {
   post?: PostsMinimumInfo,
   tag?: TagBasicInfo,
   tagCommentType?: TagCommentType,
-  parentComment?: any,
+  parentComment?: CommentsList,
   successCallback?: CommentSuccessCallback,
   cancelCallback?: CommentCancelCallback,
   type: string,
@@ -270,10 +270,13 @@ const CommentsNewForm = ({
   }
 
   if (parentComment) {
+    console.log(`parentCommentId = ${parentComment._id}`);
     prefilledProps = {
       ...prefilledProps,
       parentCommentId: parentComment._id,
     };
+  } else {
+    console.log("No parent comment");
   }
 
   const SubmitComponent = ({submitLabel = "Submit"}) => {

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -256,7 +256,7 @@ const Answer = ({ comment, post, childComments, classes }: {
               <div className={classes.editor}>
                 <CommentsNewForm
                   post={post}
-                  parentComment={comment._id}
+                  parentComment={comment}
                   prefilledProps={{
                     parentAnswerId: comment._id,
                   }}


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206059677274477) by [Unito](https://www.unito.io)
