### PR TITLE
Revert giving portal default random sorting

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidatesList.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidatesList.tsx
@@ -80,7 +80,7 @@ const ElectionCandidatesList = ({type="preVote", selectedCandidateIds, onSelect,
   classes: ClassesType,
 }) => {
   const isSelect = type === "select";
-  const [sortBy, setSortBy] = useState<ElectionCandidatesSort | "random">("random");
+  const [sortBy, setSortBy] = useState<ElectionCandidatesSort | "random">("mostPreVoted");
   const {results, loading} = useElectionCandidates(sortBy);
 
   const allSelected = useMemo(


### PR DESCRIPTION
As described in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/8341) , there is a bug in the random sorting of candidates that results in names and logos getting mixed up. That PR didn't end up fixing it and I can't pin down what the problem is, so I'm setting the default sorting back to `mostPreVoted` temporarily as it's quite a serious bug

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206060645128442) by [Unito](https://www.unito.io)
