### PR TITLE
Tiny UI fixes to frontpage matches

### DIFF
--- a/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
+++ b/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
@@ -184,21 +184,22 @@ const DialogueRecommendationRow = ({ rowProps, classes, showSuggestedTopics }: D
 
   if (!currentUser) return <></>;
   const preTopicRecommendations: TopicRecommendationWithContents[] | undefined = topicData?.GetTwoUserTopicRecommendations; 
-  const topicRecommendations = preTopicRecommendations?.filter(topic => topic.theirVote !== null);
+  const topicRecommendations = preTopicRecommendations?.filter(topic => ['agree', 'disagree'].includes(topic.theirVote) ); // todo: might want better type checking here in future for values of theirVote
   const numRecommendations = topicRecommendations?.length ?? 0;
   const numShown = isExpanded ? numRecommendations : 1
   const numHidden = Math.max(0, numRecommendations - numShown);
 
   const renderExpandCollapseText = () => {
+    if (!topicRecommendations || topicRecommendations.length === 0) return '';
     if (isExpanded) {
       return '▲ hide';
     }
   
-    if (numHidden > 0) {
+    if (numHidden > 0 || topicRecommendations[0].comment.contents.plaintextMainText.length > 84) { // hack... make better in future!
       return [
         '▼',
         <span key={targetUser._id} className={classes.bigScreenExpandNote}>
-          ... {numHidden} more
+          ...{numHidden > 0 ? ` ${numHidden} ` : ``}more
         </span>,
       ];
     }
@@ -213,7 +214,7 @@ const DialogueRecommendationRow = ({ rowProps, classes, showSuggestedTopics }: D
         })}>
           <div className={classNames(classes.dialogueLeftContainer, {
             [classes.dialogueLeftContainerExpandedMobile]: isExpanded,
-            [classes.dialogueLeftContainerNoTopics]: isExpanded || numRecommendations === 0
+            [classes.dialogueLeftContainerNoTopics]: numRecommendations === 0
           })}>
           <div className={ classes.dialogueMatchCheckbox }>
             <DialogueCheckBox
@@ -257,14 +258,14 @@ const DialogueRecommendationRow = ({ rowProps, classes, showSuggestedTopics }: D
           ))}
           
       </div>}
-      <div className={classes.dialogueRightContainer}>
+      {showSuggestedTopics && <div className={classes.dialogueRightContainer}>
         {<span className={classNames({
           [classes.hideIcon]: isExpanded,
           [classes.expandIcon]: !isExpanded
         })} onClick={toggleExpansion}>
           {renderExpandCollapseText()}
         </span>}
-      </div>
+      </div>}
       {!showSuggestedTopics && 
         <PostsItem2MetaInfo className={classes.dialogueMatchNote}>
           <div className={classes.dialogueMatchNote}>Check to maybe dialogue, if you find a topic</div>


### PR DESCRIPTION
Fixes various edge cases that caused ugly behavior, including: 
* topics moved too far right when expanded
* some users didn't have any expand button for overly long topics
* some users had an expand button, but with no content below it
* some users had an expand button yet were in the "no topics shown" A/B test group


BEFORE
<img width="544" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/df42f997-ab95-47d1-8e62-8e22e3827948">

<img width="554" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/96b754d2-e45d-431d-830a-7d6553a4f765">

<img width="597" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/fb042f8b-3691-49ea-8b0a-d42397bc94fb">

<img width="592" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/8f22cf1f-69dd-4815-a083-090669706653">

<img width="596" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/244ab312-23f9-4eaf-a27d-3a06c8ff8fc8">

AFTER

(all of the above fixed)