### PR TITLE
Remove HoC versions of CRUD operations

### DIFF
--- a/packages/lesswrong/components/common/hocTypes.ts
+++ b/packages/lesswrong/components/common/hocTypes.ts
@@ -54,15 +54,6 @@ interface WithGlobalKeydownProps {
   addKeydownListener: any,
 }
 
-interface WithHoverProps {
-  hover: boolean,
-  anchorEl: HTMLElement|null,
-}
-
-interface WithApolloProps {
-  client: any;
-}
-
 // This is a bit arcane. I think of this basically as a type "function" that
 // says, for a given collection base, I am the DbObject extension it is using.
 // https://stackoverflow.com/questions/63631364/infer-nested-generic-types-in-typescript/63631544#63631544

--- a/packages/lesswrong/components/common/withHover.tsx
+++ b/packages/lesswrong/components/common/withHover.tsx
@@ -6,18 +6,6 @@ function datesDifference(a:Date, b:Date): number {
   return (a as any)-(b as any);
 }
 
-export const withHover = (trackingData?: any, propsToTrackingData?: any) => {
-  return <P extends {}>(WrappedComponent: React.FunctionComponent<P>) => (props: P) => {
-    const eventProps = {...trackingData, ...(propsToTrackingData || ((props: P)=>{}))(props)};
-    const { eventHandlers, hover, anchorEl } = useHover(eventProps);
-    return (
-      <span {...eventHandlers}>
-        <WrappedComponent {...props} hover={hover} anchorEl={anchorEl}/>
-      </span>
-    );
-  }
-}
-
 export const useHover = (eventProps?: Record<string,any>) => {
   const [hover, setHover] = useState(false)
   const [everHovered, setEverHovered] = useState(false)
@@ -80,5 +68,3 @@ export const useHover = (eventProps?: Record<string,any>) => {
     forceUnHover,
   }
 }
-
-export default withHover

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.tsx
@@ -11,10 +11,6 @@ import DoneIcon from '@material-ui/icons/Done';
 import ClearIcon from '@material-ui/icons/Clear';
 import { isLWorAF } from '../../lib/instanceSettings';
 
-interface SunshineNewCommentsItemProps extends WithHoverProps {
-  updateComment: any,
-}
-
 const SunshineNewCommentsItem = ({comment}: {
   comment: CommentsListWithParentMetadata
 }) => {

--- a/packages/lesswrong/lib/crud/withCreate.tsx
+++ b/packages/lesswrong/lib/crud/withCreate.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { ApolloError, gql } from '@apollo/client';
-import { Mutation } from '@apollo/client/react/components';
 import { useApolloClient, useMutation } from '@apollo/client/react/hooks';
-import type { MutationResult } from '@apollo/client/react';
-import { withApollo } from '@apollo/client/react/hoc';
-import { extractCollectionInfo, extractFragmentInfo, getCollection } from '../vulcan-lib';
-import { compose, withHandlers } from 'recompose';
+import { extractFragmentInfo, getCollection } from '../vulcan-lib';
 import { updateCacheAfterCreate } from './cacheUpdates';
-import { getExtraVariables } from './utils'
 import { loggerConstructor } from '../utils/logging';
 
 /**
@@ -37,49 +32,6 @@ const createClientTemplate = ({ typeName, fragmentName, extraVariablesString }: 
   }
 }`
 );
-
-/**
- * Higher-order-component wrapper that adds a prop createFoo to the wrapped
- * component, which can be called to create a new entry in the chosen
- * collection. DEPRECATED; use the hook version, useCreate, if possible.
- */
-export const withCreate = (options: any) => {
-  const { collectionName, collection } = extractCollectionInfo(options);
-  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
-
-  const typeName = collection.options.typeName;
-  const query = gql`
-    ${createClientTemplate({ typeName, fragmentName })}
-    ${fragment}
-  `;
-
-  const mutationWrapper = (Component: any) => (props: any) => (
-    <Mutation mutation={query}>
-      {(mutate: any, result: MutationResult<any>) => (
-        <Component
-          {...props}
-          mutate={mutate}
-          ownProps={props}
-        />
-      )}
-    </Mutation>
-  )
-
-  // wrap component with graphql HoC
-  return compose(
-    mutationWrapper,
-    withApollo,
-    withHandlers({
-      [`create${typeName}`]: ({ mutate, ownProps }) => ({data}: {data: any}) => {
-        const extraVariables = getExtraVariables(ownProps, options.extraVariables)
-        return mutate({
-          variables: { data, ...extraVariables },
-          update: updateCacheAfterCreate(typeName, ownProps.client)
-        });
-      },
-    })
-  )
-};
 
 /**
  * Hook that returns a function for creating a new object in a collection, along

--- a/packages/lesswrong/lib/crud/withDelete.tsx
+++ b/packages/lesswrong/lib/crud/withDelete.tsx
@@ -1,12 +1,8 @@
 import React, { useCallback } from 'react';
-import { getCollection, getFragment, extractCollectionInfo, extractFragmentInfo } from '../vulcan-lib';
-import { compose, withHandlers } from 'recompose';
+import { getCollection, extractFragmentInfo } from '../vulcan-lib';
 import { updateCacheAfterDelete } from './cacheUpdates';
-import { getExtraVariables } from './utils'
 import { useMutation, gql } from '@apollo/client';
 import type { ApolloError } from '@apollo/client';
-import { Mutation } from '@apollo/client/react/components';
-import type { MutationResult } from '@apollo/client/react';
 
 // Delete mutation query used on the client. Eg:
 //
@@ -34,52 +30,10 @@ const deleteClientTemplate = ({ typeName, fragmentName, extraVariablesString }: 
 }`;
 
 /**
- * Higher-order-component wrapper that adds a prop deleteFoo to the wrapped
- * component, which can be called to delete an entry in the chosen collection.
- * This should mostly never be used; firstly, because we strongly prefer to do
- * soft deletes (ie, setting a 'deleted' flag on the object to true), and also
- * because this is an HoC and we now strongly prefer hooks.
- *
- * (Unlike the other CRUD operations, this one doesn't have a hookified version
- * written yet, because it shouldn't be used).
+ * Hook that returns a function for a delete operation. This should mostly never
+ * be used, because we strongly prefer to do soft deletes (ie, setting a
+ * 'deleted' flag on the object to true).
  */
-export const withDelete = (options: any) => {
-  const { collectionName, collection } = extractCollectionInfo(options);
-  const { fragmentName, fragment } = extractFragmentInfo(options, collectionName);
-
-  const typeName = collection.options.typeName;
-  const query = gql`
-    ${deleteClientTemplate({ typeName, fragmentName })}
-    ${fragment}
-  `;
-
-  const mutationWrapper = (Component: any) => (props: any) => (
-    <Mutation mutation={query}>
-      {(mutate: any, mutationResult: MutationResult<any>) => (
-        <Component
-          {...props}
-          mutate={mutate}
-          ownProps={props}
-        />
-      )}
-    </Mutation>
-  )
-
-  // wrap component with graphql HoC
-  return compose(
-    mutationWrapper,
-    withHandlers({
-      [`delete${typeName}`]: ({ mutate, ownProps }) => ({selector}: {selector: any}) => {
-        const extraVariables = getExtraVariables(ownProps, options.extraVariables)
-        return mutate({
-          variables: { selector, ...extraVariables },
-          update: updateCacheAfterDelete(typeName)
-        });
-      },
-    })
-  )
-};
-
 export const useDelete = <CollectionName extends CollectionNameString>(options: {
   collectionName: CollectionName,
   fragmentName?: FragmentName,

--- a/packages/lesswrong/lib/crud/withUpdate.tsx
+++ b/packages/lesswrong/lib/crud/withUpdate.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback } from 'react';
 import { useMutation, gql } from '@apollo/client';
-import { Mutation } from '@apollo/client/react/components';
-import type { MutationResult } from '@apollo/client/react';
 import type { ApolloError } from '@apollo/client';
-import { compose, withHandlers } from 'recompose';
 import { getCollection, extractFragmentInfo } from '../vulcan-lib';
-import { getExtraVariables } from './utils';
 import { updateCacheAfterUpdate } from './cacheUpdates';
 
 // Update mutation query used on the client
@@ -32,51 +28,6 @@ const updateClientTemplate = ({ typeName, fragmentName, extraVariablesString }: 
     }
   }
 }`;
-
-/**
- * HoC that adds a function for mutating objects. DEPRECATED: You want to use
- * the hook version of this, useUpdate, instead.
- */
-export const withUpdate = (options: {
-  collectionName: CollectionNameString,
-  fragmentName?: FragmentName,
-  fragment?: any,
-  extraVariables?: any, //TODO: Unused?
-}) => {
-  const collection = getCollection(options.collectionName);
-  const {fragmentName, fragment} = extractFragmentInfo({fragmentName: options.fragmentName, fragment: options.fragment}, options.collectionName);
-
-  const typeName = collection.options.typeName;
-  const query = gql`
-    ${updateClientTemplate({ typeName, fragmentName })}
-    ${fragment}
-  `;
-
-  const mutationWrapper = (Component: any) => (props: any) => (
-    <Mutation mutation={query}>
-      {(mutate: any, mutationResult: MutationResult<any>) => (
-        <Component
-          {...props}
-          mutate={mutate}
-          ownProps={props}
-        />
-      )}
-    </Mutation>
-  )
-
-  return compose(
-    mutationWrapper,
-    withHandlers({
-      [`update${typeName}`]: ({ mutate, ownProps }: any) => ({ selector, data }: any) => {
-        const extraVariables = getExtraVariables(ownProps, options.extraVariables)
-        return mutate({
-          variables: { selector, data, ...extraVariables },
-          update: updateCacheAfterUpdate(typeName)
-        });
-      },
-    })
-  )
-};
 
 type FragmentOrFragmentName =
    {fragment: any, fragmentName?: never}


### PR DESCRIPTION
Hookifies the last users and removes the HoC versions of `withCreate`, `withUpdate`, `withDelete`, and `withHover`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206061178693838) by [Unito](https://www.unito.io)
