### PR TITLE
Add recommended comments to dialogues view on frontpage

### DIFF
--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -261,6 +261,22 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
     `, [postIds, startDate, endDate]);
   }
 
+  async getUsersRecommendedCommentsOfTargetUser(userId: string, targetUserId: string, limit = 20): Promise<DbComment[]> {
+    return this.any(`
+      SELECT c.*
+      FROM "ReadStatuses" AS rs
+      INNER JOIN "Posts" AS p ON rs."postId" = p._id
+      INNER JOIN "Comments" AS c ON c."postId" = p._id
+      WHERE
+          rs."userId" = $1
+          AND c."userId" = $2
+          AND rs."isRead" IS TRUE
+          AND c."baseScore" > 7
+      ORDER BY rs."lastUpdated" DESC
+      LIMIT $3
+    `, [userId, targetUserId, limit]);
+  }
+
   async getCommentsWithElicitData(): Promise<DbComment[]> {
     return await this.any(`
       SELECT *

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -164,8 +164,7 @@ defineQuery({
       throw new Error('Must be logged in to view recommended comments of target user')
     }
 
-    let comments = await repos.comments.getUsersRecommendedCommentsOfTargetUser(userId, targetUserId, limit)
-    comments = await accessFilterMultiple(currentUser, Comments, comments, context)
-    return comments
+    const comments = await repos.comments.getUsersRecommendedCommentsOfTargetUser(userId, targetUserId, limit)
+    return await accessFilterMultiple(currentUser, Comments, comments, context)
   },
 });

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -153,3 +153,19 @@ defineQuery({
     return recommendedComments
   },
 });
+
+defineQuery({
+  name: "UsersRecommendedCommentsOfTargetUser",
+  resultType: "[Comment]",
+  argTypes: "(userId: String!, targetUserId: String!, limit: Int!)",
+  fn: async (root: void, {userId, targetUserId, limit}: {userId: string, targetUserId: string, limit: number}, context: ResolverContext) => {
+    const { currentUser, repos } = context
+    if (!currentUser) {
+      throw new Error('Must be logged in to view recommended comments of target user')
+    }
+
+    let comments = await repos.comments.getUsersRecommendedCommentsOfTargetUser(userId, targetUserId, limit)
+    comments = await accessFilterMultiple(currentUser, Comments, comments, context)
+    return comments
+  },
+});


### PR DESCRIPTION
We make a database query for "comments from the target user, with at least 8 karma, on posts you've read, sorted by how recently you read those posts". If we find any, we recommend them in the dialogues matching row 

<img width="590" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/5dbca792-846e-44cf-a6a3-5da60efb8516">

<img width="601" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/8bc1cb6a-e2d3-4e4f-b347-960bef0953c7">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206062637376128) by [Unito](https://www.unito.io)
