### PR TITLE
Add `noEmit: true` to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictBindCallApply": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "include": [
     "packages/lesswrong",


### PR DESCRIPTION
This gets rid of an eternal error in my VS Code `Problems` pane, and I think it's in fact the correct thing for use with ESBuild (e.g. `noEmit` referenced on the [ESBuild Typescript page](https://esbuild.github.io/content-types/#typescript)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206072790471269) by [Unito](https://www.unito.io)
