### PR TITLE
Pre launch tweaks to voting portal

### DIFF
--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -92,6 +92,22 @@ const styles = (theme: ThemeType) => ({
       textDecoration: "underline",
     },
   },
+  descriptionTooltip: {
+    maxWidth: 320,
+    marginTop: 8,
+    textAlign: "left",
+    borderRadius: `${theme.borderRadius.default}px !important`,
+    backgroundColor: `${theme.palette.grey[900]} !important}`,
+    display: "-webkit-box",
+    "-webkit-box-orient": "vertical",
+    "-webkit-line-clamp": 12, // Just stop it from really overflowing
+  },
+  hoverUnderline: {
+    '&:hover': {
+      textUnderlineOffset: '3px',
+      textDecoration: 'underline',
+    }
+  },
   tooltip: {
     maxWidth: 200,
     textAlign: "center",
@@ -116,7 +132,7 @@ const ElectionCandidate = ({candidate, type="preVote", selected, onSelect, class
   );
 
   const {
-    name, logoSrc, fundraiserLink, postCount, tag, extendedScore, currentUserExtendedVote,
+    name, logoSrc, fundraiserLink, href, postCount, tag, extendedScore, currentUserExtendedVote, description,
   } = votingProps.document;
   const preVoteCount = extendedScore?.preVoteCount ?? 0;
   const hasVoted = !!currentUserExtendedVote?.preVote;
@@ -128,6 +144,8 @@ const ElectionCandidate = ({candidate, type="preVote", selected, onSelect, class
   // We don't want to accidentally navigate away from the page if the user is selecting candidates
   const newTabProps = { target: "_blank", rel: "noopener noreferrer" };
   const linkProps = isSelect ? newTabProps : {};
+
+  const linkUrl = isSelect ? href : fundraiserLink;
 
   const {PreVoteButton, ForumIcon, LWTooltip} = Components;
   return (
@@ -147,14 +165,28 @@ const ElectionCandidate = ({candidate, type="preVote", selected, onSelect, class
           />
         )}
         <div className={classes.imageContainer}>
-          <Link to={fundraiserLink || ""} {...linkProps}>
+          <Link to={linkUrl || ""} {...linkProps}>
             <img src={logoSrc} className={classes.image} />
           </Link>
         </div>
         <div className={classes.details}>
-          <div className={classes.name}>
-            <Link to={fundraiserLink || ""} {...linkProps}>{name}</Link>
-          </div>
+          <LWTooltip
+            disabled={!isSelect}
+            className={classes.name}
+            title={description}
+            placement="bottom"
+            popperClassName={classes.descriptionTooltip}
+          >
+            <Link
+              to={linkUrl || ""}
+              className={classNames({
+                [classes.hoverUnderline]: isSelect,
+              })}
+              {...linkProps}
+            >
+              {name}
+            </Link>
+          </LWTooltip>
           <div className={classes.metaInfo}>
             {!isSelect && (
               <span className={classes.preVotes}>

--- a/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/ElectionCandidate.tsx
@@ -97,7 +97,8 @@ const styles = (theme: ThemeType) => ({
     marginTop: 8,
     textAlign: "left",
     borderRadius: `${theme.borderRadius.default}px !important`,
-    backgroundColor: `${theme.palette.grey[900]} !important}`,
+    // FIXME setting this background color breaks unrelated styles for some reason
+    // backgroundColor: `${theme.palette.grey[900]} !important}`,
     display: "-webkit-box",
     "-webkit-box-orient": "vertical",
     "-webkit-line-clamp": 12, // Just stop it from really overflowing

--- a/packages/lesswrong/components/ea-forum/voting-portal/EAVotingPortalAllocateVotesPage.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/EAVotingPortalAllocateVotesPage.tsx
@@ -8,9 +8,13 @@ import { useMessages } from "../../common/withMessages";
 import { processLink } from "./VotingPortalIntro";
 import { useCurrentUser } from "../../common/withUser";
 import { userCanVoteInDonationElection } from "../../../lib/eaGivingSeason";
+import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
   ...votingPortalStyles(theme),
+  mb2: {
+    marginBottom: 12,
+  },
   tipsBox: {
     position: "absolute",
     top: 48,
@@ -121,7 +125,7 @@ const EAVotingPortalAllocateVotesPage = ({
       <div className={classes.root}>
         <div className={classes.content} id="top">
           <div className={classes.h2}>3. Allocate your votes</div>
-          <div className={classes.subtitle}>
+          <div className={classNames(classes.subtitle, classes.mb2)}>
             <div className={classes.subtitleParagraph}>
               {subtitleStart}{" "}
               <b>
@@ -136,22 +140,6 @@ const EAVotingPortalAllocateVotesPage = ({
               </Link>{" "}
               describes how we’ll use the scores to determine the winners in the Donation Election.
             </div>
-          </div>
-          <div className={classes.tipsBox}>
-            <div className={classes.h3}>Tips</div>
-            <ul>
-              <li>
-                Make sure the relative point assignments are reasonable to you; if you give Project A twice the points
-                as Project B, you should think that Project A should get twice the funding as Project B.
-              </li>
-              <li>
-                Any points you assign to candidates you don’t think will win are not wasted — if a candidate you
-                assigned points to is eliminated, your other points will count for more.
-              </li>
-              <li>
-                Don’t worry about your total point score, the points will be normalised before being counted.
-              </li>
-            </ul>
           </div>
           <ElectionAllocateVote voteState={voteState} setVoteState={setVoteState} />
         </div>

--- a/packages/lesswrong/components/ea-forum/voting-portal/EAVotingPortalSelectCandidatesPage.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/EAVotingPortalSelectCandidatesPage.tsx
@@ -116,8 +116,8 @@ const EAVotingPortalSelectCandidatesPage = ({
           />
         </div>
         <VotingPortalFooter
-          leftText="Go back"
-          leftHref="/voting-portal"
+          leftText={electionVote.submittedAt ? "Go back to intro" : "Go back"}
+          leftHref={electionVote.submittedAt ? "/voting-portal?thankyou=false" : "/voting-portal"}
           middleNode={
             <div>
               Selected {selectedIds.length}/{totalCount} candidates

--- a/packages/lesswrong/components/ea-forum/voting-portal/ElectionAllocateVote.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/ElectionAllocateVote.tsx
@@ -23,11 +23,6 @@ const styles = (theme: ThemeType) => ({
     flexWrap: "wrap",
     width: "100%",
   },
-  controls: {
-    display: "flex",
-    justifyContent: "space-between",
-    width: "100%",
-  },
   dropdown: {
     "& .ForumDropdownMultiselect-button": {
       color: theme.palette.givingPortal[1000],
@@ -101,10 +96,29 @@ const styles = (theme: ThemeType) => ({
       width: "100%",
     },
   },
-  sortButton: {
-    padding: "6px 12px",
-    marginLeft: 6,
-  }
+  controls: {
+    display: "flex",
+    justifyContent: "flex-end",
+    width: "100%",
+    height: 22, // Fixed height because the sort button may or may not be there
+  },
+  sort: {
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontWeight: 600,
+    color: theme.palette.givingPortal[1000],
+    fontSize: 16,
+    marginRight: 12,
+    backgroundColor: "inherit",
+    display: "flex",
+    alignItems: "center",
+  },
+  sortIcon: {
+    width: 18,
+    height: 18,
+  },
+  hidden: {
+    display: "none",
+  },
 });
 
 const AllocateVoteRow = ({
@@ -193,7 +207,9 @@ const ElectionAllocateVote = ({
     [selectedResults, voteState]
   );
   const canUpdateSort = useMemo(
-    () => stringify(sortedResults?.map((r) => r._id)) !== stringify(displayedResults?.map((r) => r._id)),
+    () =>
+      displayedResults?.length &&
+      stringify(sortedResults?.map((r) => r._id)) !== stringify(displayedResults?.map((r) => r._id)),
     [sortedResults, displayedResults]
   );
 
@@ -209,18 +225,18 @@ const ElectionAllocateVote = ({
     }
   }, [displayedResults, sortedResults, updateSort]);
 
-  const { Loading } = Components;
+  const { Loading, ForumIcon } = Components;
   return (
     <div className={classNames(classes.root, className)}>
       <div className={classes.controls}>
         <button
-          className={classNames(classes.button, classes.sortButton, {
-            [classes.buttonDisabled]: !canUpdateSort,
+          className={classNames(classes.sort, {
+            [classes.hidden]: !canUpdateSort,
           })}
           disabled={!canUpdateSort}
           onClick={updateSort}
         >
-          Sort high to low
+          <ForumIcon icon="NarrowArrowDown" className={classes.sortIcon} /> Sort descending
         </button>
       </div>
       <div className={classes.table}>
@@ -237,6 +253,17 @@ const ElectionAllocateVote = ({
           </React.Fragment>
         ))}
       </div>
+      {displayedResults.length > 10 && <div className={classes.controls}>
+        <button
+          className={classNames(classes.sort, {
+            [classes.hidden]: !canUpdateSort,
+          })}
+          disabled={!canUpdateSort}
+          onClick={updateSort}
+        >
+          <ForumIcon icon="NarrowArrowDown" className={classes.sortIcon} /> Sort descending
+        </button>
+      </div>}
     </div>
   );
 };

--- a/packages/lesswrong/components/ea-forum/voting-portal/ElectionAllocateVote.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/ElectionAllocateVote.tsx
@@ -70,10 +70,25 @@ const styles = (theme: ThemeType) => ({
     width: imageSize,
     height: imageSize,
   },
+  descriptionTooltip: {
+    maxWidth: 320,
+    marginTop: 8,
+    textAlign: "left",
+    borderRadius: `${theme.borderRadius.default}px !important`,
+    // FIXME setting this background color breaks unrelated styles for some reason
+    // backgroundColor: `${theme.palette.grey[900]} !important}`,
+    display: "-webkit-box",
+    "-webkit-box-orient": "vertical",
+    "-webkit-line-clamp": 12, // Just stop it from really overflowing
+  },
   candidateName: {
     fontWeight: 600,
     fontSize: 18,
     color: theme.palette.givingPortal[1000],
+    '&:hover': {
+      textUnderlineOffset: '3px',
+      textDecoration: 'underline',
+    }
   },
   allocateInput: {
     width: 150,
@@ -132,7 +147,9 @@ const AllocateVoteRow = ({
   setVoteState: Dispatch<SetStateAction<Record<string, number | string | null>>>;
   classes: ClassesType<typeof styles>;
 }) => {
-  const { _id: candidateId, name, logoSrc, fundraiserLink } = candidate;
+  const { LWTooltip } = Components;
+
+  const { _id: candidateId, name, logoSrc, href, description } = candidate;
   const naiveValue = voteState[candidateId];
   const formattedValue =
     typeof naiveValue === "number"
@@ -144,13 +161,15 @@ const AllocateVoteRow = ({
       <div className={classes.allocateVoteRow}>
         <div className={classes.details}>
           <div className={classes.imageContainer}>
-            <Link to={fundraiserLink || ""} target="_blank" rel="noopener noreferrer">
+            <Link to={href || ""} target="_blank" rel="noopener noreferrer">
               <img src={logoSrc} className={classes.image} />
             </Link>
           </div>
-          <Link to={fundraiserLink || ""} className={classes.candidateName} target="_blank" rel="noopener noreferrer">
-            {name}
-          </Link>
+          <LWTooltip title={description} placement="bottom" popperClassName={classes.descriptionTooltip}>
+            <Link to={href || ""} className={classes.candidateName} target="_blank" rel="noopener noreferrer">
+              {name}
+            </Link>
+          </LWTooltip>
         </div>
         <OutlinedInput
           className={classes.allocateInput}
@@ -160,7 +179,8 @@ const AllocateVoteRow = ({
             const value = e.target.value;
             if (value === "" || value === null) {
               setVoteState((prev) => ({ ...prev, [candidateId]: null } as Record<string, number | string | null>));
-            } else if (/^\d*\.?\d*$/.test(value) && value.length < 15) { // Only allow positive (decimal) numbers up to 15 characters
+            } else if (/^\d*\.?\d*$/.test(value) && value.length < 15) {
+              // Only allow positive (decimal) numbers up to 15 characters
               setVoteState((prev) => ({ ...prev, [candidateId]: value } as Record<string, number | string | null>));
             }
           }}

--- a/packages/lesswrong/components/ea-forum/voting-portal/ElectionComparePair.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/ElectionComparePair.tsx
@@ -51,10 +51,25 @@ const styles = (theme: ThemeType) => ({
     width: imageSize,
     height: imageSize,
   },
+  descriptionTooltip: {
+    maxWidth: 320,
+    marginTop: 8,
+    textAlign: "left",
+    borderRadius: `${theme.borderRadius.default}px !important`,
+    // FIXME setting this background color breaks unrelated styles for some reason
+    // backgroundColor: `${theme.palette.grey[900]} !important}`,
+    display: "-webkit-box",
+    "-webkit-box-orient": "vertical",
+    "-webkit-line-clamp": 12, // Just stop it from really overflowing
+  },
   candidateName: {
     color: theme.palette.givingPortal[1000],
     fontSize: 16,
     fontWeight: 600,
+    '&:hover': {
+      textUnderlineOffset: '3px',
+      textDecoration: 'underline',
+    }
   },
   switchOrderButton: {
     gap: "6px",
@@ -80,19 +95,25 @@ const CandidateDetails = ({
   candidate: ElectionCandidateBasicInfo;
   classes: ClassesType<typeof styles>;
 }) => {
-  const { name, logoSrc, fundraiserLink } = candidate;
+  const { name, logoSrc, href, description } = candidate;
+  const { LWTooltip } = Components;
 
   return (
     <div className={classes.candidateDetails}>
       <div className={classes.imageContainer}>
-        <Link to={fundraiserLink || ""} target="_blank" rel="noopener noreferrer">
+        <Link to={href || ""} target="_blank" rel="noopener noreferrer">
           <img src={logoSrc} className={classes.image} />
         </Link>
       </div>
-      {/* TODO tooltip */}
-      <Link to={fundraiserLink || ""} target="_blank" rel="noopener noreferrer" className={classes.candidateName}>
-        {name}
-      </Link>
+      <LWTooltip
+        title={description}
+        placement="bottom"
+        popperClassName={classes.descriptionTooltip}
+      >
+        <Link to={href || ""} target="_blank" rel="noopener noreferrer" className={classes.candidateName}>
+          {name}
+        </Link>
+      </LWTooltip>
     </div>
   );
 }

--- a/packages/lesswrong/components/ea-forum/voting-portal/VotingPortalIntro.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/VotingPortalIntro.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { registerComponent } from "../../../lib/vulcan-lib";
+import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { HEADER_HEIGHT } from "../../common/Header";
 import { Link } from "../../../lib/reactRouterWrapper";
 import classNames from "classnames";
@@ -121,7 +121,18 @@ const styles = (theme: ThemeType) => ({
       background: theme.palette.grey[200],
     },
   },
+  imageWrapper: {
+    maxWidth: 700,
+    width: "100%",
+    margin: "0 auto",
+  },
+  image: {
+    width: "100%",
+    borderRadius: theme.borderRadius.default,
+  },
 });
+
+const imageId = 'voting-portal-intro-image';
 
 const fundLink = "https://www.givingwhatwecan.org/fundraisers/ea-forum-donation-election-fund-2023";
 const exploreLink = "/giving-portal";
@@ -136,6 +147,8 @@ const VotingPortalIntro = ({classes}: {
   const currentUser = useCurrentUser();
   const { openDialog } = useDialog();
   const { flash } = useMessages();
+
+  const { CloudinaryImage2 } = Components;
 
   const isLoggedIn = !!currentUser;
   const userCanVote = userCanVoteInDonationElection(currentUser);
@@ -168,20 +181,8 @@ const VotingPortalIntro = ({classes}: {
           </span>{" "}
         </div>
       </div>
-      <div className={classes.inset}>
-        <div className={classes.h2}>How voting works</div>
-        <div className={classes.h3}>1. Select candidates you want to vote for</div>
-        <div>
-          These are the candidates you’ll allocate points to. The ones you don’t select will automatically get 0 points.
-        </div>
-        <div className={classes.h3}>2. Compare candidates</div>
-        <div>You'll compare pairs of candidates to create a draft point allocation. (You can skip this step).</div>
-        <div className={classes.h3}>3. Allocate your points</div>
-        <div>
-          Finalize your point allocation, which should represent how you’d distribute funding between the candidates if
-          it were up to you.
-        </div>
-        <div className={classes.h3}>4. Submit your votes</div>
+      <div className={classes.imageWrapper}>
+        <CloudinaryImage2 publicId={imageId} className={classes.image}/>
       </div>
       <div>
         Your vote is anonymous to other users. If we have reason to believe you've committed{" "}

--- a/packages/lesswrong/components/ea-forum/voting-portal/VotingPortalThankYou.tsx
+++ b/packages/lesswrong/components/ea-forum/voting-portal/VotingPortalThankYou.tsx
@@ -6,6 +6,7 @@ import { useWindowSize } from "../../hooks/useScreenWidth";
 import ReactConfetti from "react-confetti";
 import { useUpdateCurrentUser } from "../../hooks/useUpdateCurrentUser";
 import { useTracking } from "../../../lib/analyticsEvents";
+import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -16,7 +17,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.givingPortal[1000],
     background: theme.palette.givingPortal.thankYouBackground,
     borderRadius: 12,
-    padding: "48px 32px",
+    padding: "48px 32px 24px 32px",
     width: 550,
     maxWidth: "100%",
     [theme.breakpoints.down("xs")]: {
@@ -135,6 +136,7 @@ const styles = (theme: ThemeType) => ({
     fontWeight: 600,
     lineHeight: "24px",
     paddingLeft: 20,
+    marginBottom: 0,
     "& li:not(:first-child)": {
       marginTop: 8,
     },
@@ -145,6 +147,15 @@ const styles = (theme: ThemeType) => ({
         opacity: 1,
       },
     },
+  },
+  whiteButton: {
+    background: theme.palette.grey[0],
+    color: theme.palette.givingPortal[1000],
+    border: theme.palette.border.grey200,
+    borderRadius: theme.borderRadius.default,
+    margin: "0 auto",
+    width: "fit-content",
+    padding: "12px 20px",
   },
 });
 
@@ -230,12 +241,10 @@ const VotingPortalThankYou = ({currentUser, classes}: {
             Explore other giving opportunities
           </Link>
         </li>
-        <li>
-          <Link to="/voting-portal/select-candidates">
-            Edit your vote <em>(until 15th December)</em>
-          </Link>
-        </li>
       </ul>
+      <Link to="/voting-portal/select-candidates" className={classNames(classes.button, classes.whiteButton)}>
+        Edit your vote (until Dec 15)
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
See [designs here](https://www.figma.com/file/OWruitRTyWpmLJjaT4RedA/Voting-portal?node-id=455%3A5082&mode=dev)

This is all the things we decided to prioritise before launch in [this doc](https://docs.google.com/document/d/1KhW9qdd9ZK5U5wGtltBAR7f0HcMQCzf-YPWTqbTPhnA/edit). Here is the list:
- Change normalisation (normalise to a total of 100 and round to 2 sig. fig.
- Restyle "sort high to low" to have the styling of a link and disappear when it is disabled
- Button rather than link for "Edit your vote"
- Show candidate info on hover
- Use href instead of fundraiser for candidate links
- "Go back" should go to intro page even after submitting
- (didn't do) Remove disabled "Next pair"
  - I tried this and I couldn't find a way to do it that didn't look much worse than the original (or was more confusing). It's quite disorienting to have the button disappear, and having the tooltip appear over the disabled button is quite useful for knowing what to do next
- Add illustration to intro page

## Screenshots (in roughly the order above):
![Screenshot 2023-11-30 at 20 58 59](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/ff73a6fe-a56a-46be-b853-3010058d924a)
![Screenshot 2023-11-30 at 20 59 09](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/3ee3762b-6ec2-48f5-bce4-62c66f8f0c1b)
![Screenshot 2023-11-30 at 20 59 19](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/86da590f-5a1a-485c-9f08-457d07b2031f)
![Screenshot 2023-11-30 at 21 01 18](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/becfd43c-761c-4310-9919-d1218dc90438)
![Screenshot 2023-11-30 at 21 01 36](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/225dd6e1-534c-4619-b29b-f81caaac2a00)
