### PR TITLE
Only get new dialogue interest ping once a week

### DIFF
--- a/packages/lesswrong/server/dialogues/cron.ts
+++ b/packages/lesswrong/server/dialogues/cron.ts
@@ -9,7 +9,7 @@ addCronJob({
   interval: 'every 1 hour',
   async job() {
     const context = createAdminContext();
-    const usersWithNewChecks = await context.repos.users.getUsersWithNewDialogueChecks(60)
+    const usersWithNewChecks = await context.repos.users.getUsersWithNewDialogueChecks()
     usersWithNewChecks.forEach(user => {
       const notificationAbGroup = getUserABTestGroup({user}, newDialogueChecksNotificationABTest)
       if (notificationAbGroup === "control") return

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -284,7 +284,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
     `)
   }  
 
-  async getUsersWithNewDialogueChecks(minutes: number): Promise<DbUser[]> {
+  async getUsersWithNewDialogueChecks(): Promise<DbUser[]> {
     return this.manyOrNone(`
       SELECT DISTINCT ON ("Users"._id) "Users".*
       FROM "Users"
@@ -307,7 +307,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
               ), '1970-01-01')
           )
           AND (
-              "DialogueChecks"."checkedAt" > NOW() - INTERVAL '$1 minutes'
+              "DialogueChecks"."checkedAt" > NOW() - INTERVAL '1 week'
               OR
               NOT EXISTS (
                   SELECT 1
@@ -318,7 +318,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
               )
           )
           AND (
-            NOW() - INTERVAL '12 hours' > COALESCE((
+            NOW() - INTERVAL '1 week' > COALESCE((
               SELECT MAX("createdAt")
               FROM "Notifications"
               WHERE
@@ -326,7 +326,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
                 AND type = 'newDialogueChecks'
             ), '1970-01-01')
         )
-    `, [minutes])
+    `)
   }
 
   async getUsersTopUpvotedUsers(user:DbUser, limit = 20, recencyLimitDays = 10): Promise<UpvotedUser[]> {


### PR DESCRIPTION
This is kind of duplication over the top of our notification batching system, but it's quick and gets the job done and respects changed preferences

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206074729047544) by [Unito](https://www.unito.io)
