### PR TITLE
Don't show duplicate image uploaders on create-event form

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1438,7 +1438,7 @@ const schema: SchemaType<DbPost> = {
     control: "SocialPreviewUpload",
     group: formGroups.socialPreview,
     order: 4,
-    hidden: ({document}) => isLWorAF && !!document.collabEditorDialogue,
+    hidden: ({document}) => (isLWorAF && !!document.collabEditorDialogue) || (isEAForum && document.isEvent),
   },
 
   fmCrosspost: {


### PR DESCRIPTION
On the create-event form, don't show a social-preview image uploader on EA Forum because there's already an event-image uploader that users should use instead

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206082275749446) by [Unito](https://www.unito.io)
