### PR TITLE
Fix post having a negative comment count after purging commenter

### DIFF
--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -38,12 +38,6 @@ getCollectionHooks("Messages").newAsync.add(async function updateConversationAct
   });
 });
 
-getCollectionHooks("Users").editAsync.add(async function userEditNullifyVotesCallbacksAsync(user: DbUser, oldUser: DbUser) {
-  if (user.nullifyVotes && !oldUser.nullifyVotes) {
-    await nullifyVotesForUser(user);
-  }
-});
-
 getCollectionHooks("Users").editAsync.add(async function userEditChangeDisplayNameCallbacksAsync(user: DbUser, oldUser: DbUser) {
   // if the user is setting up their profile and their username changes from that form,
   // we don't want this action to count toward their one username change
@@ -59,7 +53,10 @@ getCollectionHooks("Users").editAsync.add(async function userEditChangeDisplayNa
   }
 });
 
-getCollectionHooks("Users").updateAsync.add(function userEditDeleteContentCallbacksAsync({newDocument, oldDocument, currentUser}) {
+getCollectionHooks("Users").updateAsync.add(async function userEditDeleteContentCallbacksAsync({newDocument, oldDocument, currentUser}) {
+  if (newDocument.nullifyVotes && !oldDocument.nullifyVotes) {
+    await nullifyVotesForUser(newDocument);
+  }
   if (newDocument.deleteContent && !oldDocument.deleteContent && currentUser) {
     void userDeleteContent(newDocument, currentUser);
   }


### PR DESCRIPTION
Bug: Make an account. Post a spam comment on a post with 0 other comments. Purge the spammer account. The `commentCount` field on the post is now -1.

Looking at log traces of this, we determined that there is some sort of subtle race condition happening between a mutation that happens when a callback cancels the spammer's self-vote on the comment, and the mutation that happens to mark the comment as deleted, such that the `comments.update.after` callback sees two changes (correct) but thinks that both changes include a change from `deleted:false` to `deleted:true` (incorrect). We fix this by making the nullify-votes and the delete-content parts of the spammer-purge operation happen sequentially, rather than happening in parallel.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206082836134684) by [Unito](https://www.unito.io)
