### PR TITLE
Event social previews use the event img if it exists

### DIFF
--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -87,14 +87,18 @@ ${postGetLink(post, true, false)}
   return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 
-// Select the social preview image for the post, using the manually-set
-// cloudinary image if available, or the auto-set from the post contents. If
-// neither of those are available, it will return null.
+// Select the social preview image for the post.
+// For events, we use their event image if that is set.
+// For other posts, we use the manually-set cloudinary image if available,
+// or the auto-set from the post contents. If neither of those are available,
+// it will return null.
 export const getSocialPreviewImage = (post: DbPost): string => {
   // Note: in case of bugs due to failed migration of socialPreviewImageId -> socialPreview.imageId,
   // edit this to support the old field "socialPreviewImageId", which still has the old data
-  const manualId = post.socialPreview?.imageId
-  if (manualId) return `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/c_fill,ar_1.91,g_auto/${manualId}`
+  const manualId = (post.isEvent && post.eventImageId) ? post.eventImageId : post.socialPreview?.imageId
+  if (manualId) {
+    return `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/c_fill,ar_1.91,g_auto/${manualId}`
+  }
   const autoUrl = post.socialPreviewImageAutoUrl
   return autoUrl || ''
 }


### PR DESCRIPTION
Currently this only affects the EA Forum. Our event page had an "event image" field before we added the ability to edit the social preview image, and we never married the two, so we were using the two fields inconsistently. This should make it more consistent.

The primary purpose of this change is to fix an issue where publishing an event with an event image doesn't show the event image in the little popup.