### PR TITLE
Post social previews should use mirrored version of auto-selected img

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -23,7 +23,7 @@ const cloudinaryApiSecret = new DatabaseServerSetting<string>("cloudinaryApiSecr
 // Given a URL which (probably) points to an image, download that image,
 // re-upload it to cloudinary, and return a cloudinary URL for that image. If
 // the URL is already Cloudinary or can't be downloaded, returns null instead.
-async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): Promise<string|null> {
+export async function moveImageToCloudinary(oldUrl: string, originDocumentId: string): Promise<string|null> {
   const logger = loggerConstructor("image-conversion")
   const alreadyRehosted = await findAlreadyMovedImage(oldUrl);
   if (alreadyRehosted) return alreadyRehosted;


### PR DESCRIPTION
We automatically mirror all images in each post to Cloudinary. This PR makes it so that, when we auto-select an image from the post to use as the social preview image, we use the mirrored version of the image.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206082747467575) by [Unito](https://www.unito.io)
