### PR TITLE
remove dialogue toolbar button to insert non-message blocks

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -605,7 +605,6 @@ const CKPostEditor = ({
           'mathDisplay',
           'mediaEmbed',
           'footnote',
-          'rootParagraphBox',
         ]} : {}),
         autosave: {
           save (editor: any) {

--- a/public/lesswrong-editor/src/ckeditor5-dialogue-comments/dialogue-comment-box.js
+++ b/public/lesswrong-editor/src/ckeditor5-dialogue-comments/dialogue-comment-box.js
@@ -10,6 +10,9 @@ export default class DialogueCommentBox extends Plugin {
     }
 }
 
+/**
+ * @deprecated Deprecated in favor of the insert-paragraph arrows on message blocks
+ */
 class SimpleBoxUI extends Plugin {
     init() {
         /**
@@ -55,6 +58,7 @@ class SimpleBoxEditing extends Plugin {
         this._defineSchema();
         this._defineConverters();
 
+        // `insertRootParagraphBox` is deprecated in favor of the insert-paragraph arrows on message blocks
         this.editor.commands.add( 'insertRootParagraphBox', new InsertRootParagraphBoxCommand( this.editor ) );
         this.editor.commands.add( 'submitDialogueMessage', new SubmitDialogueMessageCommand( this.editor ) );
 
@@ -277,6 +281,9 @@ class SimpleBoxEditing extends Plugin {
     }
 }
 
+/**
+ * @deprecated Deprecated in favor of the insert-paragraph arrows on message blocks
+ */
 class InsertRootParagraphBoxCommand extends Command {
     execute() {
         const model = this.editor.model;


### PR DESCRIPTION
It's broken and in any case using the arrow buttons on message block border is better.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206085036037849) by [Unito](https://www.unito.io)
