### PR TITLE
Fix search bar not opening on the first click

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -306,7 +306,7 @@ const Header = ({
   </div>
 
   // the items on the right-hand side (search, notifications, user menu, login/sign up buttons)
-  const RightHeaderItems = () => <div className={classes.rightHeaderItems}>
+  const rightHeaderItemsNode = <div className={classes.rightHeaderItems}>
     <NoSSR onSSR={<div className={classes.searchSSRStandin} />} >
       <SearchBar onSetIsActive={setSearchOpen} searchResultsArea={searchResultsArea} />
     </NoSSR>
@@ -352,7 +352,7 @@ const Header = ({
         unFixed={unFixed}
         setUnFixed={setUnFixed}
         NavigationMenuButton={NavigationMenuButton}
-        RightHeaderItems={RightHeaderItems}
+        RightHeaderItems={() => rightHeaderItemsNode}
         HeaderNavigationDrawer={HeaderNavigationDrawer}
         HeaderNotificationsMenu={HeaderNotificationsMenu}
       />
@@ -393,7 +393,7 @@ const Header = ({
                   </Link>
                 </div>
               </Typography>
-              <RightHeaderItems />
+              {rightHeaderItemsNode}
             </Toolbar>
           </header>
           <HeaderNavigationDrawer />


### PR DESCRIPTION
Fix a bug introduced in https://github.com/ForumMagnum/ForumMagnum/commit/b62b2e724a1a9381255075d4a0e1b12533b1f2b9 which made the search bar not open the first time you click it.

That commit changed `rightHeaderItemsNode` in the Header component. Befire it was a React fragment that looked like this:

```
const rightHeaderItemsNode = <div ...>
  {/*...*/}
</div>
```

It changed into a locally-declared component like this:

```
const RightHeaderItems = () => <div>
  {/*...*/}
</div>
```

This is a different component each time Header rerenders, because it isn't referentially-stable. This means that anything inside of it doesn't get merged with the previous render, so it loses its state.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206088298177247) by [Unito](https://www.unito.io)
