### PR TITLE
[EA] Giving portal gets the red header treatment

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -344,7 +344,7 @@ const Header = ({
   // special case for the homepage header of EA Forum Giving Season 2023
   // TODO: delete after 2023
   const isGivingSeason = useIsGivingSeason();
-  if ((isGivingSeason && pathname === "/") || (pathname.startsWith("/voting-portal"))) {
+  if ((isGivingSeason && pathname === "/") || (pathname.startsWith("/voting-portal")) || (pathname.startsWith("/giving-portal"))) {
     return (
       <GivingSeasonHeader
         searchOpen={searchOpen}

--- a/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/EAGivingPortalPage.tsx
@@ -264,7 +264,7 @@ const styles = (theme: ThemeType) => ({
   w100: { width: "100%" },
   
   votingBanner: {
-    backgroundColor: theme.palette.givingPortal.homepageHeader.main,
+    backgroundColor: theme.palette.givingPortal.homepageHeader.dark,
     color: theme.palette.text.alwaysWhite,
   },
   votingBannerContent: {

--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
@@ -240,7 +240,7 @@ const GivingSeasonHeader = ({
 }) => {
   const { Typography, HeadTags, HeaderSubtitle } = Components;
   const isDesktop = useIsAboveBreakpoint("md");
-  const { pathname } = useLocation();
+  const { pathname, currentRoute } = useLocation();
   const { electionVote } = useElectionVote("givingSeason23");
   const currentUser = useCurrentUser();
 
@@ -276,6 +276,7 @@ const GivingSeasonHeader = ({
   const isVotingPortal = pathname.startsWith("/voting-portal");
   // Show voting steps if we are on a path like /voting-portal/compare (with anything after /voting-portal/)
   const showVotingSteps = isVotingPortal && /\/voting-portal\/\w/.test(pathname);
+  const solidHeader = currentRoute?.path !== "/";
 
   return (
     <AnalyticsContext pageSectionContext="header" siteEvent="givingSeason2023">
@@ -306,10 +307,10 @@ const GivingSeasonHeader = ({
           <header
             className={classNames(
               classes.appBarGivingSeason,
-              isVotingPortal ? classes.solidBackground : advertiseVoting ? classes.homePageVotingBackground : classes.homePageBackground
+              solidHeader ? classes.solidBackground : advertiseVoting ? classes.homePageVotingBackground : classes.homePageBackground
             )}
           >
-            {!isVotingPortal && <div className={classes.givingSeasonGradient} />}
+            {!solidHeader && <div className={classes.givingSeasonGradient} />}
             <Toolbar disableGutters={isEAForum} className={classes.toolbarGivingSeason}>
               <div className={classes.leftHeaderItems}>
                 <NavigationMenuButton />


### PR DESCRIPTION
I was surprised that the Giving Portal had a blue traditional header bar. I think it worked better before we put a red voting banner on there, but now looks kinda weird. It's a pretty quick change to make it red, so I did. I open the comments for discussion on whether we should actually merge this.

Before:

<img width="1504" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/25c4485d-16ce-4e49-84ed-7b964e798cef">


After:

<img width="753" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/81e6d3f3-591a-48ff-9123-7c52287ce429">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206098581403329) by [Unito](https://www.unito.io)
