### PR TITLE
Remove early return for users without recommended partners

### DIFF
--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -252,8 +252,6 @@ const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => 
 
   const recommendedDialoguePartnersRowPropsList = currentUser && manyRecommendedUsers?.map(targetUser => ({targetUser, ...getUserCheckInfo(targetUser, userDialogueChecks)}) )
 
-  if (!recommendedDialoguePartnersRowPropsList) return <></>;
-
   const dialoguesTooltip = (<div>
     <p>Dialogues between a small group of users. Click to see more.</p>
   </div>);
@@ -305,7 +303,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => 
 
       {dialogueMatchmakingEnabled.get() && <AnalyticsContext pageSubSectionContext="frontpageDialogueMatchmaking">
         {<div>
-          { currentUser?.showRecommendedPartners && showReciprocityRecommendations && recommendedDialoguePartnersRowPropsList.length > 0 &&
+          { currentUser?.showRecommendedPartners && showReciprocityRecommendations && !!recommendedDialoguePartnersRowPropsList && recommendedDialoguePartnersRowPropsList.length > 0 &&
             <div className={classes.explanatoryNoteBox}>
               <Typography
                 component='span'


### PR DESCRIPTION
This code had an error where it would early return from rendering the dialogues list if the user had no potential matches (for example, if one is logged out).

This removes that early return.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206098987658641) by [Unito](https://www.unito.io)
