### PR TITLE
fix review views for null reviewCount

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1443,8 +1443,6 @@ Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
       positiveReviewVoteCount: { $gte: getPositiveVoteThreshold(terms.reviewPhase) },
-      // This $or is only valid while `INITIAL_REVIEW_THRESHOLD` is 0.  This probably used to "work" when we were on mongo, but doesn't work on postgres (prior to the nullability migration)
-      $or: [{ reviewCount: null }, { reviewCount: { $gte: INITIAL_REVIEW_THRESHOLD } }],
       _id: { $nin: reviewExcludedPostIds }
     },
     options: {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1443,7 +1443,8 @@ Posts.addView("reviewVoting", (terms: PostsViewTerms) => {
   return {
     selector: {
       positiveReviewVoteCount: { $gte: getPositiveVoteThreshold(terms.reviewPhase) },
-      reviewCount: { $gte: INITIAL_REVIEW_THRESHOLD },
+      // This $or is only valid while `INITIAL_REVIEW_THRESHOLD` is 0.  This probably used to "work" when we were on mongo, but doesn't work on postgres (prior to the nullability migration)
+      $or: [{ reviewCount: null }, { reviewCount: { $gte: INITIAL_REVIEW_THRESHOLD } }],
       _id: { $nin: reviewExcludedPostIds }
     },
     options: {
@@ -1466,7 +1467,7 @@ ensureIndex(Posts,
 Posts.addView("reviewQuickPage", (terms: PostsViewTerms) => {
   return {
     selector: {
-      reviewCount: 0,
+      $or: [{ reviewCount: null }, { reviewCount: 0 }],
       positiveReviewVoteCount: { $gte: REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD },
       reviewVoteScoreAllKarma: { $gte: QUICK_REVIEW_SCORE_THRESHOLD }
     },


### PR DESCRIPTION
Probably this worked with mongo.  Then we didn't catch it in dev because we'd run the nullability migration, which filled in all the `null` values with 0.  🤦

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206099132381867) by [Unito](https://www.unito.io)
