### PR TITLE
Hotfix for topic attribution bug

### DIFF
--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -11,6 +11,10 @@ type ExtendedCommentWithReactions = DbComment & {
   theirVote?: string,
 }
 
+type ExtendedCommentWithUserReaction = DbComment & {
+  userVote?: string,
+}
+
 export default class CommentsRepo extends AbstractRepo<DbComment> {
   constructor() {
     super(Comments);
@@ -90,9 +94,9 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
     `, [limit, pollCommentId]);
   }
 
-  async getPopularPollCommentsWithUserVotes (userId:string, limit: number, pollCommentId:string): Promise<(ExtendedCommentWithReactions)[]> {
+  async getPopularPollCommentsWithUserVotes (userId:string, limit: number, pollCommentId:string): Promise<(ExtendedCommentWithUserReaction)[]> {
     return await this.getRawDb().manyOrNone(`
-    SELECT c.*, v."extendedVoteType"->'reacts'->0->>'react' AS "yourVote"
+    SELECT c.*, v."extendedVoteType"->'reacts'->0->>'react' AS "userVote"
     FROM public."Comments" AS c
     INNER JOIN public."Votes" AS v ON c._id = v."documentId"
     WHERE

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -9,9 +9,6 @@ import { EA_FORUM_COMMUNITY_TOPIC_ID } from "../../lib/collections/tags/collecti
 type ExtendedCommentWithReactions = DbComment & {
   yourVote?: string,
   theirVote?: string,
-}
-
-type ExtendedCommentWithUserReaction = DbComment & {
   userVote?: string,
 }
 
@@ -94,7 +91,7 @@ export default class CommentsRepo extends AbstractRepo<DbComment> {
     `, [limit, pollCommentId]);
   }
 
-  async getPopularPollCommentsWithUserVotes (userId:string, limit: number, pollCommentId:string): Promise<(ExtendedCommentWithUserReaction)[]> {
+  async getPopularPollCommentsWithUserVotes (userId:string, limit: number, pollCommentId:string): Promise<(ExtendedCommentWithReactions)[]> {
     return await this.getRawDb().manyOrNone(`
     SELECT c.*, v."extendedVoteType"->'reacts'->0->>'react' AS "userVote"
     FROM public."Comments" AS c

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -112,10 +112,14 @@ defineQuery({
       return result
     }
 
-    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string) => {
+    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string, whoseVote:"you"|"they") => {
       const comments = await context.repos.comments.getPopularPollCommentsWithUserVotes(userId, limit * 3, pollCommentId)
       const sampled = sampleSize(comments, Math.round(limit / 2))
-      const result = sampled.map(comment => ({comment, recommendationReason: recommendationReason, yourVote: comment.yourVote, theirVote: comment.theirVote}));
+      const result = sampled.map(comment => {
+        return whoseVote === "you" 
+          ? {comment, recommendationReason: recommendationReason, yourVote: comment.userVote }
+          : {comment, recommendationReason: recommendationReason, theirVote: comment.userVote};
+      });
       return result
     }
 
@@ -130,9 +134,9 @@ defineQuery({
     async function* commentSources() {
       yield await getIntersectingUsersVotesOnPoll(userId, targetUserId, bensInterestingDisagreementsCommentId);
       yield await getIntersectingUsersVotesOnPoll(userId, targetUserId, worthwhileOpenAIDisagreementsCommentId);
-      yield await getUserVotesOnPoll(targetUserId, bensInterestingDisagreementsCommentId, "They reacted on this comment"); 
-      yield await getUserVotesOnPoll(targetUserId, worthwhileOpenAIDisagreementsCommentId, "They reacted on this comment");
-      yield await getUserVotesOnPoll(userId, bensInterestingDisagreementsCommentId, "You reacted on this comment");
+      yield await getUserVotesOnPoll(targetUserId, bensInterestingDisagreementsCommentId, "They reacted on this comment", "they"); 
+      yield await getUserVotesOnPoll(targetUserId, worthwhileOpenAIDisagreementsCommentId, "They reacted on this comment", "they");
+      yield await getUserVotesOnPoll(userId, bensInterestingDisagreementsCommentId, "You reacted on this comment", "you");
       yield await getPopularVotesOnPoll(bensInterestingDisagreementsCommentId, "This comment is popular");
     }
     

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -112,7 +112,7 @@ defineQuery({
       return result
     }
 
-    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string, whoseVote:string) => {
+    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string, whoseVote:"you"|"they") => {
       const comments = await context.repos.comments.getPopularPollCommentsWithUserVotes(userId, limit * 3, pollCommentId)
       const sampled = sampleSize(comments, Math.round(limit / 2))
       const result = sampled.map(comment => {

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -112,7 +112,7 @@ defineQuery({
       return result
     }
 
-    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string, whoseVote:"you"|"they") => {
+    const getUserVotesOnPoll = async (userId: string, pollCommentId: string, recommendationReason:string, whoseVote:string) => {
       const comments = await context.repos.comments.getPopularPollCommentsWithUserVotes(userId, limit * 3, pollCommentId)
       const sampled = sampleSize(comments, Math.round(limit / 2))
       const result = sampled.map(comment => {


### PR DESCRIPTION
Solving the bug as reported via intercom, where a user was a told a different person's topics belonged to them. 

Replicated the bug in dev, solvedf it, and then verified that it now correctly attributes topics both on frontpage recommendations, and in the topic modal. (Which are the two places this function is used)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206099881600098) by [Unito](https://www.unito.io)
