### PR TITLE
UsersProfile fragment no longer inherits SunshineUsersList fragment

### DIFF
--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -85,7 +85,9 @@ registerFragment(`
     petrovPressedButtonDate
     petrovOptOut
     sortDraftsBy
-    ...SunshineUsersList
+    email
+    emails
+    banned
     ...SharedUserBooleans
     noindex
     paymentEmail

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2631,7 +2631,7 @@ interface UsersMinimumInfo { // fragment on Users
   readonly givingSeason2023VotedFlair: boolean,
 }
 
-interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBooleans { // fragment on Users
+interface UsersProfile extends UsersMinimumInfo, SharedUserBooleans { // fragment on Users
   readonly oldSlugs: Array<string>,
   readonly groups: Array<string>,
   readonly jobTitle: string,
@@ -2672,6 +2672,9 @@ interface UsersProfile extends UsersMinimumInfo, SunshineUsersList, SharedUserBo
   readonly petrovPressedButtonDate: Date,
   readonly petrovOptOut: boolean | null,
   readonly sortDraftsBy: string,
+  readonly email: string,
+  readonly emails: Array<any /*{"definitions":[{}]}*/>,
+  readonly banned: Date,
   readonly noindex: boolean,
   readonly paymentEmail: string,
   readonly paymentInfo: string,


### PR DESCRIPTION
The UsersProfile fragment was inheriting the SunshineUsersList fragment, which includes some queries that are really only intended for the moderator sidebar, but which, by being in the UsersProfile fragment, would also be in the UsersCurrent fragment. This slows down SSR because everything in UsersCurrent has to finish resolving before page rendering can proceed. This replaces the `SunshineUsersList` with just the fields that the type system thinks are needed.

That fragment-inheritance was first added in [this commit](https://github.com/ForumMagnum/ForumMagnum/commit/279f0d6cdb9f96d02d9f36b31c22985ccf903011), which suggests that this PR might make it so that you have to refresh after unapproving a user in order for the client-side cache to update properly.