### PR TITLE
Allow admins to read all fields in account settings form

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -576,7 +576,7 @@ const schema: SchemaType<DbUser> = {
     optional: true,
     hidden: true,
     canCreate: ['members'],
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns],
   },
 
@@ -736,7 +736,7 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true,
     ...schemaDefaultValue(false),
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     control: 'checkbox',
     group: formGroups.siteCustomizations,
@@ -748,7 +748,7 @@ const schema: SchemaType<DbUser> = {
     type: Boolean,
     optional: true,
     ...schemaDefaultValue(false),
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     control: 'checkbox',
     group: formGroups.siteCustomizations,
@@ -1777,7 +1777,7 @@ const schema: SchemaType<DbUser> = {
 
   nearbyEventsNotificationsMongoLocation: {
     type: Object,
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     blackbox: true,
     optional: true,
     ...denormalizedField({
@@ -2116,7 +2116,7 @@ const schema: SchemaType<DbUser> = {
 
   partiallyReadSequences: {
     type: Array,
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns],
     optional: true,
     hidden: true,
@@ -2324,7 +2324,7 @@ const schema: SchemaType<DbUser> = {
   abTestOverrides: {
     type: GraphQLJSON, //Record<string,number>
     optional: true, hidden: true,
-    canRead: [userOwns],
+    canRead: [userOwns, 'sunshineRegiment', 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     blackbox: true,
   },


### PR DESCRIPTION
We were getting errors like this when an admin tried to update someone's account settings:
![Screenshot 2023-12-05 at 13 50 29](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/efbef9c1-4eb4-494e-9d77-4c032514a622)

I'm not sure why we were only just seeing this. We are editing a lot of account settings at the moment due to people claiming the [flair](https://forum.effectivealtruism.org/posts/eZkApbMzBn8teQwju/donation-election-rewards#Individual_rewards) reward here, but I've definitely edited people's account settings in the past and had it succeed

@b0b3rt @jimrandomh I'd be interested in whether you think this is a new bug, or if this should be handled a different way (e.g. admins can automatically read all fields)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206103236560130) by [Unito](https://www.unito.io)
