### PR TITLE
Fix bug in EAUsersProfileTabbedSection due to conditional rendering on number rather than boolean

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
+++ b/packages/lesswrong/components/ea-forum/users/modules/EAUsersProfileTabbedSection.tsx
@@ -152,7 +152,7 @@ const EAUsersProfileTabbedSection = ({tabs, classes}: {
             })}
           >
             {tab.label}
-            {tab.count && <div className={classes.tabCount}>{tab.count}</div>}
+            {!!tab.count && <div className={classes.tabCount}>{tab.count}</div>}
           </Typography>
         })}
         <div className={classes.tabRowAction}>


### PR DESCRIPTION
Before/after:
![Screenshot 2023-12-05 at 13 55 35](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/90eb9211-1df2-4a1a-8800-415c43b76e13)

![Screenshot 2023-12-05 at 13 57 09](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/30231104-0c9d-4191-831b-7338ce7a49f7)



