### PR TITLE
Make donation election link in home page RHS go to the #election element

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -600,7 +600,7 @@ export const EAHomeRightHandSide = ({classes}: {
       {isGivingSeason &&
         <div className={classes.givingSeason}>
           <div>
-            <Link to="/giving-portal">
+            <Link to="/giving-portal#election">
               Donate to the Election Fund
             </Link>
           </div>


### PR DESCRIPTION
Currently if you click "Donate to the Election Fund" here the actual link to donate is below the fold, I've made it go to the "Donation election 2023" section
![Screenshot 2023-12-05 at 17 26 35](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/694f7045-7011-4354-8f71-3277b3f7eb10)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206105675771341) by [Unito](https://www.unito.io)
