### PR TITLE
Add ip and userAgent to graphql request logging

### DIFF
--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -235,6 +235,8 @@ interface PerfMetric {
   client_path?: string;
   extra_data?: Json;
   gql_string?: string;
+  ip?: string;
+  user_agent?: string;
 }
 
 type IncompletePerfMetric = Omit<PerfMetric, 'ended_at'>;

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -4,7 +4,7 @@ import { AnalyticsUtil } from '../lib/analyticsEvents';
 import { PublicInstanceSetting } from '../lib/instanceSettings';
 import { addStaticRoute } from './vulcan-lib/staticRoutes';
 import { addGraphQLMutation, addGraphQLResolvers } from '../lib/vulcan-lib/graphql';
-import {pgPromiseLib, getAnalyticsConnection, getMirrorAnalyticsConnection, AnalyticsConnectionPool} from './analytics/postgresConnection'
+import { pgPromiseLib, getAnalyticsConnection, AnalyticsConnectionPool } from './analytics/postgresConnection'
 import chunk from 'lodash/chunk';
 import Table from '../lib/sql/Table';
 import { NotNullType, StringType, IntType } from '../lib/sql/Type';
@@ -121,7 +121,7 @@ async function writeEventsToAnalyticsDB(events: {type: string, timestamp: Date, 
   }
 }
 
-const perfMetricsColumnSet = new pgPromiseLib.helpers.ColumnSet(['trace_id', 'op_type', 'op_name', 'started_at', 'ended_at', 'parent_trace_id', 'client_path', 'extra_data', 'gql_string_id', 'environment'], {table: 'perf_metrics'});
+const perfMetricsColumnSet = new pgPromiseLib.helpers.ColumnSet(['trace_id', 'op_type', 'op_name', 'started_at', 'ended_at', 'parent_trace_id', 'client_path', 'extra_data', 'gql_string_id', 'ip', 'user_agent', 'environment'], {table: 'perf_metrics'});
 
 interface PerfMetricGqlString {
   id: number;
@@ -203,6 +203,8 @@ async function flushPerfMetrics() {
           parent_trace_id: perfMetric.parent_trace_id ?? null,
           client_path: perfMetric.client_path ?? null,
           extra_data: perfMetric.extra_data ?? null,
+          ip: perfMetric.ip ?? null,
+          user_agent: perfMetric.user_agent ?? null,
           ...gqlStringId
         }
       });

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -2,8 +2,9 @@ import { v4 } from 'uuid';
 import { queuePerfMetric } from './analyticsWriter';
 import type { Request, Response, NextFunction } from 'express';
 import { performanceMetricLoggingEnabled } from '../lib/publicSettings';
+import { getForwardedWhitelist } from './forwarded_whitelist';
 
-type IncompletePerfMetricProps = Pick<PerfMetric, 'op_type' | 'op_name' | 'parent_trace_id' | 'extra_data' | 'client_path' | 'gql_string'>;
+type IncompletePerfMetricProps = Pick<PerfMetric, 'op_type' | 'op_name' | 'parent_trace_id' | 'extra_data' | 'client_path' | 'gql_string' | 'ip' | 'user_agent'>;
 
 export function generateTraceId() {
   return v4();
@@ -31,7 +32,9 @@ export function perfMetricMiddleware(req: Request, res: Response, next: NextFunc
     const perfMetric = openPerfMetric({
       op_type: 'request',
       op_name: req.originalUrl,
-      client_path: req.headers['request-origin-path'] as string
+      client_path: req.headers['request-origin-path'] as string,
+      ip: getForwardedWhitelist().getClientIP(req),
+      user_agent: req.headers["user-agent"]
     });
 
     Object.assign(req, { perfMetric });


### PR DESCRIPTION
What is says on the tin. Useful for investigating requests that are bringing down the servers.