### PR TITLE
LW Deploy: fix implicit null/undef coercion that parent comment arrows were relying on

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -214,6 +214,8 @@ export const CommentsItemMeta = ({
     relevantTagsTruncated = relevantTagsTruncated.slice(0, 1);
   }
 
+
+
   const {
     CommentShortformIcon, CommentDiscussionIcon, ShowParentComment, CommentUserName,
     CommentsItemDate, SmallSideVote, CommentOutdatedWarning, FooterTag, LoadMore,
@@ -233,8 +235,11 @@ export const CommentsItemMeta = ({
           !(hideParentCommentToggleForTopLevel &&
             comment.parentCommentId === comment.topLevelCommentId
           ) &&
-          parentCommentId !== comment.parentCommentId &&
-          parentAnswerId !== comment.parentCommentId &&
+          /* We're often comparing null to undefined, so we need to explicitly use a double-eq-negation */
+          /* eslint-disable-next-line eqeqeq */
+          parentCommentId != comment.parentCommentId &&
+          /* eslint-disable-next-line eqeqeq */
+          parentAnswerId != comment.parentCommentId &&
         <ShowParentComment
           comment={comment}
           active={showParentState}

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -186,7 +186,9 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           <CoreTagIcon tag={comment.tag} />
         </div>}
 
-        {!hideParentCommentToggle && parentCommentId!==comment.parentCommentId && <span className={classes.parentComment}>
+        {/* We're often comparing null to undefined, so we need to explicitly use a double-eq-negation */}
+        {/* eslint-disable-next-line eqeqeq */}
+        {!hideParentCommentToggle && parentCommentId!=comment.parentCommentId && <span className={classes.parentComment}>
           <ShowParentComment comment={comment} />
         </span>}
         {!hideKarma && <span className={classes.karma}>


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/ForumMagnum/ForumMagnum/pull/8347

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206117279201886) by [Unito](https://www.unito.io)
