### PR TITLE
Add recommended content to dialogue match form and restyle

### DIFF
--- a/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
+++ b/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
@@ -287,7 +287,7 @@ export const CommentView: React.FC<CommentViewProps> = ({ comment, classes }) =>
 };
 
 const DialogueRecommendationRow = ({ targetUser, checkId, userIsChecked, userIsMatched, classes, showSuggestedTopics, onHide }: DialogueRecommendationRowProps) => {
-  const { DialogueCheckBox, UsersName, PostsItem2MetaInfo, Loading, PostsTooltip } = Components
+  const { DialogueCheckBox, UsersName, PostsItem2MetaInfo, Loading, PostsTooltip, CommentView } = Components
   const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
   const currentUser = useCurrentUser();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -380,7 +380,7 @@ const DialogueRecommendationRow = ({ targetUser, checkId, userIsChecked, userIsM
       <PostsTooltip postId={post._id}>
         <Link to={postGetPageUrl(post)}> {post.title} </Link>
       </PostsTooltip>})),
-    ...recommendedComments.map(comment => ({reactIconName: "elaborate", prefix: "comment: ", Content: <CommentView comment={comment} classes={classes} />}))
+    ...recommendedComments.map(comment => ({reactIconName: "elaborate", prefix: "comment: ", Content: <CommentView comment={comment} />}))
   ]
 
   return (

--- a/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
+++ b/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
@@ -3,7 +3,6 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useTracking } from "../../lib/analyticsEvents";
 import { useCurrentUser } from '../common/withUser';
 import { gql, useQuery } from '@apollo/client';
-import { TagWithCommentCount } from '../users/DialogueMatchingPage';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
@@ -11,7 +10,6 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { truncatise } from '../../lib/truncatise';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
-import {DialogueUserResult} from './DialoguesList';
 
 const styles = (theme: ThemeType) => ({
   dialogueUserRow: { 
@@ -83,12 +81,14 @@ const styles = (theme: ThemeType) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    paddingBottom: '5px',
   },
   reactIcon: {
     paddingRight: "4px",
   },
   suggestionRow: {
     display: 'flex',
+    lineHeight: '1.15em',
   },
   agreeText: {
     color: theme.palette.text.dim3,
@@ -138,7 +138,10 @@ const styles = (theme: ThemeType) => ({
   bigScreenExpandNote: {
     [theme.breakpoints.down('xs')]: {
       display: 'none'
-    }
+    },
+  },
+  caret: {
+    fontSize: '0.7em',
   },
   commentSourcePost: {
     color: theme.palette.text.dim3,
@@ -150,19 +153,29 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-type PostYouveRead = {
+export type PostYouveRead = {
   _id: string;
   title: string;
   slug: string;
 }
 
-type RecommendedComment = {
+export type RecommendedComment = {
   _id: string;
   postId: string;
   contents: {
     html: string;
     plaintextMainText: string;
   };
+}
+
+export type TagWithCommentCount = {
+  tag: DbTag,
+  commentCount: number
+}
+
+export interface DialogueUserResult {
+  _id: string;
+  displayName: string;
 }
 
 interface DialogueRecommendationRowProps {
@@ -197,7 +210,7 @@ interface TopicSuggestionProps {
   isExpanded: boolean;
 }
 
-const TopicSuggestion = ({reactIconName, prefix, Content, classes, isExpanded}: TopicSuggestionProps) => {
+export const TopicSuggestion = ({reactIconName, prefix, Content, classes, isExpanded}: TopicSuggestionProps) => {
   const { ReactionIcon } = Components
   return (
     <div className={classes.suggestionRow}>
@@ -226,10 +239,10 @@ interface ExpandCollapseTextProps {
 const ExpandCollapseText = ({classes, isExpanded, numHidden, toggleExpansion}: ExpandCollapseTextProps) => {
   let text 
   if (isExpanded) {
-    text = <>▲ hide</>;
+    text = <><span className={classes.caret}>▲</span> hide</>;
   } else {
     text = <>
-      ▼<span key="1" className={classes.bigScreenExpandNote}>
+      <span className={classes.caret} >▼</span><span key="1" className={classes.bigScreenExpandNote}>
         ...{numHidden > 0 ? ` ${numHidden} ` : ``}more
       </span>
     </>
@@ -249,8 +262,7 @@ interface CommentViewProps {
   classes: ClassesType<typeof styles>;
 }
 
-const CommentView: React.FC<CommentViewProps> = ({ comment, classes }) => {
-
+export const CommentView: React.FC<CommentViewProps> = ({ comment, classes }) => {
   const { PostsTooltip, Loading } = Components
 
   const { document: post, loading, error } = useSingle({
@@ -273,6 +285,7 @@ const CommentView: React.FC<CommentViewProps> = ({ comment, classes }) => {
     </PostsTooltip>
   );
 };
+
 const DialogueRecommendationRow = ({ targetUser, checkId, userIsChecked, userIsMatched, classes, showSuggestedTopics, onHide }: DialogueRecommendationRowProps) => {
   const { DialogueCheckBox, UsersName, PostsItem2MetaInfo, Loading, PostsTooltip } = Components
   const { captureEvent } = useTracking(); //it is virtuous to add analytics tracking to new components
@@ -419,6 +432,7 @@ const DialogueRecommendationRow = ({ targetUser, checkId, userIsChecked, userIsM
 
 const DialogueRecommendationRowComponent = registerComponent('DialogueRecommendationRow', DialogueRecommendationRow, {styles});
 const TopicSuggestionComponent = registerComponent('TopicSuggestion', TopicSuggestion, {styles});
+const CommentViewComponent = registerComponent('CommentView', CommentView, {styles});
 const ExpandCollapseComponent = registerComponent('ExpandCollapseText', ExpandCollapseText, {styles});
 
 
@@ -426,6 +440,7 @@ declare global {
   interface ComponentTypes {
     DialogueRecommendationRow: typeof DialogueRecommendationRowComponent,
     TopicSuggestion: typeof TopicSuggestionComponent,
+    CommentView: typeof CommentViewComponent,
     ExpandCollapseText: typeof ExpandCollapseComponent,
   }
 }

--- a/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
+++ b/packages/lesswrong/components/dialogues/DialogueRecommendationRow.tsx
@@ -141,7 +141,7 @@ const styles = (theme: ThemeType) => ({
     },
   },
   caret: {
-    fontSize: '0.7em',
+    fontSize: '0.83em',
   },
   commentSourcePost: {
     color: theme.palette.text.dim3,

--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -10,7 +10,8 @@ import { DialogueUserRowProps, getRowProps, getUserCheckInfo } from '../users/Di
 import { useDialogueMatchmaking } from '../hooks/useDialogueMatchmaking';
 import MuiPeopleIcon from "@material-ui/icons/People";
 import { dialogueMatchmakingEnabled } from '../../lib/publicSettings';
-import {useUpsertDialogueCheck} from '../hooks/useUpsertDialogueCheck';
+import { useUpsertDialogueCheck } from '../hooks/useUpsertDialogueCheck';
+import { DialogueUserResult } from './DialogueRecommendationRow';
 
 
 const styles = (theme: ThemeType) => ({
@@ -195,11 +196,6 @@ const DialogueMatchRow = ({ rowProps, classes, showMatchNote }: DialogueMatchRow
     </div>
   );
 };
-
-export interface DialogueUserResult {
-  _id: string;
-  displayName: string;
-}
  
 const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => {
   const { PostsItem, SectionButton, SettingsButton, LWTooltip, SingleColumnSection, SectionTitle, SectionSubtitle, DialoguesSectionFrontpageSettings, DialogueRecommendationRow, Typography } = Components

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -828,7 +828,7 @@ return (
           {allRecommendations.slice(0, numShown).map( (item, index) => <TopicSuggestion key={index} reactIconName={item.reactIconName} prefix={item.prefix} Content={item.Content} isExpanded={isExpanded} />) } 
         </div>
         <div className={classes.recommendedContentRightContainer}>
-          {(allRecommendations && allRecommendations.length > 0) && <ExpandCollapseText isExpanded={isExpanded} numHidden={numHidden} toggleExpansion={toggleExpansion} />}
+          <ExpandCollapseText isExpanded={isExpanded} numHidden={numHidden} toggleExpansion={toggleExpansion} />
         </div>
       </div>
     </div>

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -32,7 +32,7 @@ import partition from 'lodash/partition';
 import {dialogueMatchmakingEnabled} from '../../lib/publicSettings';
 import NoSSR from 'react-no-ssr';
 import { useABTest } from '../../lib/abTestImpl';
-import { dialogueMatchingPageNoSSRABTest } from '../../lib/abTests';
+import { dialogueMatchingPageNoSSRABTest, showRecommendedContentInMatchForm } from '../../lib/abTests';
 import { PostYouveRead, RecommendedComment, TagWithCommentCount } from '../dialogues/DialogueRecommendationRow';
 
 export type UpvotedUser = {
@@ -842,6 +842,7 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
   const [formatSync, setFormatSync] = useState<SyncPreference>(dialogueCheck.matchPreference?.syncPreference ?? "Meh");
   const [formatAsync, setFormatAsync] = useState<SyncPreference>(dialogueCheck.matchPreference?.asyncPreference ?? "Meh");
   const [formatNotes, setFormatNotes] = useState(dialogueCheck.matchPreference?.formatNotes ?? "");
+  const showRecommendedContent = useABTest(showRecommendedContentInMatchForm);
 
   const { create, called, loading: loadingCreatedMatchPreference, data: newMatchPreference } = useCreate({
     collectionName: "DialogueMatchPreferences",
@@ -961,7 +962,7 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
           </DialogActions>
       </LWDialog>
   )}
-
+ 
   const ScheduleLabels = ({extraClass}: {extraClass?: string}) => <>
     <label className={classNames(classes.dialogueFormatLabel, extraClass)}>Great</label>
     <label className={classNames(classes.dialogueFormatLabel, extraClass)}>Okay</label>
@@ -973,11 +974,10 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
       <div className={classes.dialogBox}>
         <DialogTitle className={classes.dialogueTitle}><span className={classes.matchHeader}>(Match)</span> {targetUserDisplayName}</DialogTitle>
         <DialogContent >
-          <UserRecommendedContent targetUserId={targetUserId} classes={classes} />
+          {showRecommendedContent === "show" &&  <UserRecommendedContent targetUserId={targetUserId} classes={classes} />}
           <h3 className={classes.sectionHeader}>Topics</h3>
-          {/* <div>Check any suggestion you're interested in, or add your own.</div> */}
           {userSuggestedTopics.length > 0 && <>
-            <div className={classes.topicsOrigin} >{targetUserDisplayName} was interested in</div>
+            <div className={classes.topicsOrigin} >{targetUserDisplayName} was interested in the below. Check ones you like.</div>
             <div className={classes.dialogueTopicList}>
               {userSuggestedTopics.map((topic) => <div className={classes.dialogueTopicRow} key={topic.text}>
                 <Checkbox 

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -33,6 +33,7 @@ import {dialogueMatchmakingEnabled} from '../../lib/publicSettings';
 import NoSSR from 'react-no-ssr';
 import { useABTest } from '../../lib/abTestImpl';
 import { dialogueMatchingPageNoSSRABTest } from '../../lib/abTests';
+import { PostYouveRead, RecommendedComment, TagWithCommentCount } from '../dialogues/DialogueRecommendationRow';
 
 export type UpvotedUser = {
   _id: string;
@@ -66,11 +67,6 @@ export type UserDialogueUsefulData = {
   dialogueUsers: UsersOptedInToDialogueFacilitation[],
   topUsers: UpvotedUser[],
   activeDialogueMatchSeekers: DbUser[]
-}
-
-export type TagWithCommentCount = {
-  tag: DbTag,
-  commentCount: number
 }
 
 export type TopicRecommendationData = DbComment[]
@@ -254,6 +250,11 @@ const styles = (theme: ThemeType) => ({
     alignItems: 'center',
   },
   schedulingQuestion: {
+    lineHeight: '1.15em',
+  },
+  schedulingRow: {
+    marginTop: 5,
+    marginBottom: 5,
   },
   messageButton: {
     maxHeight: minRowHeight,
@@ -389,8 +390,7 @@ const styles = (theme: ThemeType) => ({
     marginRight: '-10px', // to get the prompt to line up closer
   },
   dialogueTopicList: {
-    marginTop: 16,
-    marginBottom: 16
+    marginBottom: 10
   },
   dialogueTopicRow: {
     display: 'flex',
@@ -415,16 +415,23 @@ const styles = (theme: ThemeType) => ({
     }
   },
   dialogueTitle: {
+    color: theme.palette.lwTertiary.main,
     paddingBottom: 8
   },
   dialogueFormatGrid: {
     display: 'grid',
     grid: 'auto-flow / 1fr 40px 40px 40px',
     alignItems: 'center',
-    marginBottom: 8
+    marginBottom: 16,
+    rowGap: '6px',
   },
-  dialogueFormatHeader: {
-    marginBottom: 8,
+  sectionHeader: {
+    color: theme.palette.lwTertiary.main,
+    marginBottom: 3,
+    marginTop: 13
+  },
+  matchHeader: {
+    color: theme.palette.lwTertiary.main
   },
   dialogueFormatLabel: {
     textAlign: 'center',
@@ -447,6 +454,54 @@ const styles = (theme: ThemeType) => ({
     borderRadius: 5,
     backgroundColor: theme.palette.greyAlpha(0.05),
     whiteSpace: 'nowrap'
+  },
+  contentRecommendationsCard: {
+    paddingLeft: 8,
+    paddingRight: 8,
+    paddingBottom: 4,
+    paddingTop: 5,
+    borderRadius: 5,
+    backgroundColor: theme.palette.greyAlpha(0.05),
+    marginTop: 5,
+    marginBottom: 5,
+  },
+  cardTitle: {
+    color: theme.palette.text.dim3,
+    marginBottom: 3,
+    fontSize: "0.9em"
+  },
+  recommendedContentContainer: {
+    display: 'flex',
+  },
+  recommendedContentContainerExpandedMobile: {
+    [theme.breakpoints.down('xs')]: {
+      display: 'block',
+    },
+  },
+  contentRecommendationsList: {
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    color: theme.palette.text.primary,
+    fontSize: 'small',
+    overflow: 'hidden',
+    justifyContent: 'space-between'
+  },
+  recommendedContentRightContainer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginLeft: 'auto',
+  },
+  topicsOrigin: {
+    color: theme.palette.text.dim3,
+    marginBottom: 7,
+  },
+  mobileBreak: {
+    display: 'none',
+    [theme.breakpoints.down('xs')]: {
+      display: 'block',
+    },
+  },
+  syncText: {
+    color: theme.palette.text.dim3,
   }
 });
 
@@ -679,6 +734,107 @@ const Headers = ({ titles, classes, headerClasses }: { titles: string[], headerC
 
 export type ExtendedDialogueMatchPreferenceTopic = DbDialogueMatchPreference["topicPreferences"][number] & {matchedPersonPreference?: "Yes" | "Meh" | "No", recommendationReason: string, theirVote?: string, yourVote?: string}
 
+type UserRecommendedContentProps = {
+  classes: ClassesType<typeof styles>;
+  targetUserId: string;
+}
+
+const UserRecommendedContent = ({ classes, targetUserId }: UserRecommendedContentProps ) => {
+  const { PostsTooltip, Loading, CommentView, TopicSuggestion, ExpandCollapseText } = Components;
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const currentUser = useCurrentUser();
+  const { captureEvent } = useTracking()
+
+  const { loading: tagLoading, error: tagError, data: tagData } = useQuery(gql`
+  query UserTopTags($userId: String!) {
+    UserTopTags(userId: $userId) {
+      tag {
+        name
+        _id
+      }
+      commentCount
+    }
+  }
+`, {
+  variables: { userId: targetUserId },
+  skip: !currentUser
+});
+
+const { loading: postsLoading, error: postsError, data: postsData } = useQuery(gql`
+  query UsersReadPostsOfTargetUser($userId: String!, $targetUserId: String!, $limit: Int!) {
+    UsersReadPostsOfTargetUser(userId: $userId, targetUserId: $targetUserId, limit: $limit) {
+      _id
+      title
+      slug
+    }
+  }
+`, {
+  variables: { userId: currentUser?._id, targetUserId: targetUserId, limit : 4 },
+  skip: !currentUser
+});
+
+const { loading: commentsLoading, error: commentsError, data: commentsData } = useQuery(gql`
+  query UsersRecommendedCommentsOfTargetUser($userId: String!, $targetUserId: String!, $limit: Int!) {
+    UsersRecommendedCommentsOfTargetUser(userId: $userId, targetUserId: $targetUserId, limit: $limit) {
+      _id
+      postId
+      contents {
+        html
+        plaintextMainText
+      }
+    }
+  }
+`, {
+  variables: { userId: currentUser?._id, targetUserId: targetUserId, limit : 3 },
+  skip: !currentUser
+});
+
+const topTags:TagWithCommentCount[] | undefined = tagData?.UserTopTags;
+const readPosts:PostYouveRead[] | undefined = postsData?.UsersReadPostsOfTargetUser
+const recommendedComments:RecommendedComment[] | undefined = commentsData?.UsersRecommendedCommentsOfTargetUser
+
+if (!currentUser || !topTags || !readPosts || !recommendedComments) return <Loading />;
+const tagsSentence = topTags.slice(0, 4).map(tag => tag.tag.name).join(', ');
+const numRecommendations = (readPosts?.length ?? 0) + (recommendedComments?.length ?? 0) + (tagsSentence === "" ? 0 : 1);
+const numShown = isExpanded ? numRecommendations : 2
+const numHidden = Math.max(0, numRecommendations - numShown);
+
+const allRecommendations:{reactIconName:string, prefix:string, Content:JSX.Element}[] = [
+  ...(topTags.length > 0 ? [{reactIconName: "examples", prefix: "top tags: ", Content: <>{tagsSentence}</>}] : []),
+  ...readPosts.map(post => ({reactIconName: "elaborate", prefix: "post: ", Content: 
+    <PostsTooltip postId={post._id}>
+      <Link to={postGetPageUrl(post)}> {post.title} </Link>
+    </PostsTooltip>})),
+  ...recommendedComments.map(comment => ({reactIconName: "elaborate", prefix: "comment: ", Content: <CommentView comment={comment} />}))
+]
+
+const toggleExpansion = () => {
+  setIsExpanded(!isExpanded);
+  captureEvent("toggle_expansion_inside_match_form")
+};
+
+if (allRecommendations.length === 0) return null;
+
+return (
+  <AnalyticsContext pageElementContext={'userRecommendedContent'} >
+    <div className={classes.contentRecommendationsCard} >
+      <div className={classes.cardTitle}>
+        Recommended content
+      </div>
+      <div className={classNames(classes.recommendedContentContainer, {
+        [classes.recommendedContentContainerExpandedMobile]: isExpanded})}>
+        <div className={classes.contentRecommendationsList}>
+          {allRecommendations.slice(0, numShown).map( (item, index) => <TopicSuggestion key={index} reactIconName={item.reactIconName} prefix={item.prefix} Content={item.Content} isExpanded={isExpanded} />) } 
+        </div>
+        <div className={classes.recommendedContentRightContainer}>
+          {(allRecommendations && allRecommendations.length > 0) && <ExpandCollapseText isExpanded={isExpanded} numHidden={numHidden} toggleExpansion={toggleExpansion} />}
+        </div>
+      </div>
+    </div>
+  </AnalyticsContext>)
+}
+
 const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName, dialogueCheckId, classes, dialogueCheck }: NextStepsDialogProps) => {
   const { LWDialog, ReactionIcon, LWTooltip } = Components;
 
@@ -786,6 +942,7 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
   }), [topicRecommendations])
 
   const [recommendedTopics, userSuggestedTopics]  = partition(topicPreferences, topic => topic.matchedPersonPreference !== "Yes")
+
   if (called && !loadingCreatedMatchPreference && !(newMatchPreference as any)?.createDialogueMatchPreference?.data?.generatedDialogueId) {
     return (
       <LWDialog open onClose={onClose}>
@@ -814,10 +971,13 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
   return (
     <LWDialog open onClose={onClose} className={classes.mobileDialog}>
       <div className={classes.dialogBox}>
-        <DialogTitle className={classes.dialogueTitle}>Alright, you matched with {targetUserDisplayName}!</DialogTitle>
+        <DialogTitle className={classes.dialogueTitle}><span className={classes.matchHeader}>(Match)</span> {targetUserDisplayName}</DialogTitle>
         <DialogContent >
+          <UserRecommendedContent targetUserId={targetUserId} classes={classes} />
+          <h3 className={classes.sectionHeader}>Topics</h3>
+          {/* <div>Check any suggestion you're interested in, or add your own.</div> */}
           {userSuggestedTopics.length > 0 && <>
-            <div>Here are some topics {targetUserDisplayName} was interested in:</div>
+            <div className={classes.topicsOrigin} >{targetUserDisplayName} was interested in</div>
             <div className={classes.dialogueTopicList}>
               {userSuggestedTopics.map((topic) => <div className={classes.dialogueTopicRow} key={topic.text}>
                 <Checkbox 
@@ -836,8 +996,8 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
                     {topic.text}
                   </div>
               </div>)}
-          </div></>}
-            <div>Topic suggestions. Check any you're interested in discussing.</div>
+            </div></>}
+            <div className={classes.topicsOrigin}>Suggested</div>
             <div className={classes.dialogueTopicList}>
               {recommendedTopics.map((topic) => <div className={classes.dialogueTopicRow} key={topic.text}>
                 <Checkbox 
@@ -875,27 +1035,24 @@ const NextStepsDialog = ({ onClose, userId, targetUserId, targetUserDisplayName,
                 Add Topic
               </Button>
             </div>
-            <br />
+            <br className={classes.mobileBreak} />
             <div className={classes.dialogueFormatGrid}>
-              <h3 className={classes.dialogueFormatHeader}>What Format Do You Prefer?</h3>
+              <h3 className={classes.sectionHeader}>Format</h3>
               <ScheduleLabels />
-              
-              <div className={classes.schedulingQuestion}><strong>Sync:</strong> Find a synchronous 1-3hr block to sit down and dialogue</div>
-              {SYNC_PREFERENCE_VALUES.map((value, idx) => <Checkbox 
-                  key={value}
-                  checked={formatSync === value}
-                  className={classes.dialogSchedulingCheckbox}
-                  onChange={event => setFormatSync(value as SyncPreference)}
-                  />)}
-
-              <div className={classes.schedulingQuestion}><strong>Async:</strong> Have an asynchronous dialogue where you reply where convenient</div>
-              {SYNC_PREFERENCE_VALUES.map((value, idx) => <Checkbox 
-                  key={value}
-                  checked={formatAsync === value}
-                  className={classes.dialogSchedulingCheckbox}
-                  onChange={event => setFormatAsync(value as SyncPreference)}
-              />)}
-              
+                <div className={classes.schedulingQuestion}><span className={classes.syncText}>Sync:</span> Find a synchronous 1-3hr block to sit down and dialogue</div>
+                {SYNC_PREFERENCE_VALUES.map((value, idx) => <Checkbox 
+                    key={value}
+                    checked={formatSync === value}
+                    className={classes.dialogSchedulingCheckbox}
+                    onChange={event => setFormatSync(value as SyncPreference)}
+                    />)}
+                <div className={classes.schedulingQuestion}><span className={classes.syncText}>Async:</span> Have an asynchronous dialogue where you reply where convenient</div>
+                {SYNC_PREFERENCE_VALUES.map((value, idx) => <Checkbox 
+                    key={value}
+                    checked={formatAsync === value}
+                    className={classes.dialogSchedulingCheckbox}
+                    onChange={event => setFormatAsync(value as SyncPreference)}
+                />)}
             </div>      
             <TextField
               multiline

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -141,3 +141,19 @@ export const dialogueMatchingPageNoSSRABTest = new ABTest({
     },
   },
 });
+
+// Does showing people recommended content in the form increase conversion ratio?
+export const showRecommendedContentInMatchForm = new ABTest({
+  name: "showRecommendedContentInMatchForm",
+  description: "Include a little card in the dialogue matchmaking form that lists a matched user's recent comments and posts, and potentially other user content",
+  groups: {
+    show: {
+      description: "Show",
+      weight: 1,
+    },
+    noShow: {
+      description: "Don't show",
+      weight: 1,
+    },
+  },
+});

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -634,7 +634,8 @@ importComponent("DialoguesPage", () => require('../components/dialogues/Dialogue
 importComponent("DialogueMatchingPage", () => require('../components/users/DialogueMatchingPage'));
 importComponent("DialoguesSectionFrontpageSettings", () => require('../components/dialogues/DialoguesSectionFrontpageSettings'));
 importComponent("DialogueRecommendationRow", () => require('../components/dialogues/DialogueRecommendationRow'));
-
+importComponent("TopicSuggestion", () => require('../components/dialogues/DialogueRecommendationRow'));
+importComponent("CommentView", () => require('../components/dialogues/DialogueRecommendationRow'));
 
 importComponent("ParentCommentSingle", () => require('../components/comments/ParentCommentSingle'));
 importComponent("ModerationGuidelinesBox", () => require('../components/comments/ModerationGuidelines/ModerationGuidelinesBox'));

--- a/packages/lesswrong/server/repos/TagsRepo.ts
+++ b/packages/lesswrong/server/repos/TagsRepo.ts
@@ -1,6 +1,6 @@
 import AbstractRepo from "./AbstractRepo";
 import Tags from "../../lib/collections/tags/collection";
-import { TagWithCommentCount } from "../../components/users/DialogueMatchingPage";
+import { TagWithCommentCount } from "../../components/dialogues/DialogueRecommendationRow";
 export default class TagsRepo extends AbstractRepo<DbTag> {
   constructor() {
     super(Tags);

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -545,7 +545,7 @@ defineQuery({
       throw new Error('User must be logged in to get recommended users');
     }
 
-    const upvotedUsers = await context.repos.users.getUsersTopUpvotedUsers(currentUser, 100, 720)
+    const upvotedUsers = await context.repos.users.getUsersTopUpvotedUsers(currentUser, 35, 720)
     const recommendedUsers = await context.repos.users.getDialogueRecommendedUsers(currentUser._id, upvotedUsers);
 
     // Shuffle and limit the list to 2 users


### PR DESCRIPTION
* Add a card to the dialogues match form containing recommended content by the other user (top tags, posts, comments)
* Restyle the whole dialogue match form to look cleaner given this
* Fix some dependency cycles that resulted

Before: 
<img width="442" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/172717be-2611-4011-9783-50177d1ef8de">

After: 
<img width="448" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/8fd468f6-ad30-484f-8deb-ceb6e85502ed">

