### PR TITLE
Fix hover behavior of comment previews

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -313,6 +313,7 @@ const CommentLinkPreviewWithComment = ({classes, href, comment, post, id, childr
       comment={comment}
       placement="bottom-start"
       As="span"
+      clickable={!isFriendlyUI}
     >
       <Link className={classes.link} to={href} id={id}>
         {children}


### PR DESCRIPTION
For some reason comment hover previews stopped being clickable. My guess is to do with the recent EA Forum refactors in the space.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206118719276873) by [Unito](https://www.unito.io)
