### PR TITLE
Left align answer "Add comment" button

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -29,7 +29,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   answer: {
     display: "flex",
     alignItems: "baseline",
-    justifyContent: "flex-end",
   },
 })
 


### PR DESCRIPTION
I think as part of Jim's ToC rework we moved the "Add Comment" button to the right side next to the react, which is IMO inconsistent and ugly: 

<img width="592" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/a946be6c-3307-4e62-8cf5-c0c6808e32ba">

This moves it back to the left, like it used to be, IIRC

<img width="595" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/39e22249-4d00-49c9-bece-5ff7059fabb2">
