### PR TITLE
A/B test four different wordings for new dialogue check notifications

### DIFF
--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -157,3 +157,26 @@ export const showRecommendedContentInMatchForm = new ABTest({
     },
   },
 });
+
+export const checkNotificationMessageContent = new ABTest({
+  name: "checkNotificationMessageContent",
+  description: "Send different wording of the notification message upon a user receiving new checks",
+  groups: {
+    v1: {
+      description: "Wording version 1",
+      weight: 1,
+    },
+    v2: {
+      description: "Wording version 2",
+      weight: 1,
+    },
+    v3: {
+      description: "Wording version 3",
+      weight: 1,
+    },
+    v4: {
+      description: "Wording version 4",
+      weight: 1,
+    },
+  },
+});

--- a/packages/lesswrong/server/dialogues/cron.ts
+++ b/packages/lesswrong/server/dialogues/cron.ts
@@ -15,6 +15,7 @@ addCronJob({
         notificationType: "newDialogueChecks",
         documentType: null,
         documentId: null,
+        extraData: {userId: user._id}, // passed for the AB test
         context,
       })
     })


### PR DESCRIPTION
Tested that it works as expected in dev, by forcing notification, seeing I received them, switching to different A/B groups, and noting that I received different notifications.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206124941381435) by [Unito](https://www.unito.io)
