### PR TITLE
replace old unique index declarations with custom ones

### DIFF
--- a/packages/lesswrong/lib/collections/databaseMetadata/collection.ts
+++ b/packages/lesswrong/lib/collections/databaseMetadata/collection.ts
@@ -1,7 +1,7 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils';
-import { ensureIndex } from '../../collectionIndexUtils'
+import { ensureCustomPgIndex, ensureIndex } from '../../collectionIndexUtils'
 
 export const DatabaseMetadata: DatabaseMetadataCollection = createCollection({
   collectionName: "DatabaseMetadata",
@@ -11,4 +11,8 @@ export const DatabaseMetadata: DatabaseMetadataCollection = createCollection({
 });
 addUniversalFields({collection: DatabaseMetadata});
 
-ensureIndex(DatabaseMetadata, { name: 1 }, { unique: true });
+void ensureCustomPgIndex(`
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_DatabaseMetadata_name"
+  ON public."DatabaseMetadata" USING btree
+  (name)
+`);

--- a/packages/lesswrong/lib/collections/debouncerEvents/collection.ts
+++ b/packages/lesswrong/lib/collections/debouncerEvents/collection.ts
@@ -1,7 +1,7 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils';
-import { ensureIndex } from '../../collectionIndexUtils'
+import { ensureCustomPgIndex, ensureIndex } from '../../collectionIndexUtils'
 
 export const DebouncerEvents: DebouncerEventsCollection = createCollection({
   collectionName: 'DebouncerEvents',
@@ -15,15 +15,11 @@ addUniversalFields({collection: DebouncerEvents})
 ensureIndex(DebouncerEvents, { dispatched:1, af:1, delayTime:1 });
 ensureIndex(DebouncerEvents, { dispatched:1, af:1, upperBoundTime:1 });
 
-ensureIndex(
-  DebouncerEvents,
-  { dispatched: 1, af: 1, key: 1, name: 1 },
-  {
-    unique: true,
-    partialFilterExpression: {
-      dispatched: false,
-    },
-  },
-);
+void ensureCustomPgIndex(`
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_DebouncerEvents_dispatched_af_key_name_filtered"
+  ON public."DebouncerEvents" USING btree
+  (dispatched, af, key, name)
+  WHERE (dispatched IS FALSE)
+`);
 
 export default DebouncerEvents;

--- a/packages/lesswrong/lib/collections/pagecache/collection.ts
+++ b/packages/lesswrong/lib/collections/pagecache/collection.ts
@@ -1,7 +1,7 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils'
-import { ensureIndex } from '../../collectionIndexUtils';
+import { ensureCustomPgIndex, ensureIndex } from '../../collectionIndexUtils';
 
 export const PageCache: PageCacheCollection = createCollection({
   collectionName: 'PageCache',
@@ -14,6 +14,11 @@ export const PageCache: PageCacheCollection = createCollection({
 addUniversalFields({collection: PageCache})
 
 ensureIndex(PageCache, {path: 1, bundleHash: 1, expiresAt: 1})
-ensureIndex(PageCache, {path: 1, abTestGroups: 1, bundleHash: 1}, {unique: true})
+
+void ensureCustomPgIndex(`
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_PageCache_path_abTestGroups_bundleHash"
+  ON public."PageCache" USING btree
+  (path, "abTestGroups", "bundleHash")
+`);
 
 export default PageCache;

--- a/packages/lesswrong/lib/collections/readStatus/collection.ts
+++ b/packages/lesswrong/lib/collections/readStatus/collection.ts
@@ -1,6 +1,6 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils';
-import { ensureIndex } from '../../collectionIndexUtils'
+import { ensureCustomPgIndex, ensureIndex } from '../../collectionIndexUtils'
 import { foreignKeyField } from '../../utils/schemaUtils'
 
 const schema: SchemaType<DbReadStatus> = {
@@ -52,7 +52,11 @@ export const ReadStatuses: ReadStatusesCollection = createCollection({
 
 addUniversalFields({collection: ReadStatuses});
 
-ensureIndex(ReadStatuses, {userId:1, postId:1, tagId:1}, {unique: true})
+void ensureCustomPgIndex(`
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_ReadStatuses_userId_postId_tagId"
+  ON public."ReadStatuses" USING btree
+  (COALESCE("userId", ''::character varying), COALESCE("postId", ''::character varying), COALESCE("tagId", ''::character varying))
+`);
 ensureIndex(ReadStatuses, {userId:1, postId:1, isRead:1, lastUpdated:1})
 ensureIndex(ReadStatuses, {userId:1, tagId:1, isRead:1, lastUpdated:1})
 

--- a/packages/lesswrong/server/migrations/20231211T000000.dropOldIndexes.ts
+++ b/packages/lesswrong/server/migrations/20231211T000000.dropOldIndexes.ts
@@ -1,0 +1,37 @@
+const dropOldDatabaseMetadataIndex = 'DROP INDEX IF EXISTS "idx_DatabaseMetadata_name_old";';
+  
+const dropOldDebouncerEventsIndex = 'DROP INDEX IF EXISTS "idx_DebouncerEvents_dispatched_af_key_name_filtered_old";';
+  
+const dropOldPageCacheIndex = 'DROP INDEX IF EXISTS "idx_PageCache_path_abTestGroups_bundleHash_old";'
+
+// Only drop the read statuses index if the old one still exists to be renamed afterwards
+const dropReadStatusesIndex = `
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'i' AND c.relname = 'idx_ReadStatuses_userId_postId_tagId_old'
+    ) THEN
+      EXECUTE 'DROP INDEX IF EXISTS "idx_ReadStatuses_userId_postId_tagId"';
+    END IF;
+  END
+  $$;
+`;
+
+const renameReadStatusesIndex = `
+  ALTER INDEX IF EXISTS "idx_ReadStatuses_userId_postId_tagId_old"
+  RENAME TO "idx_ReadStatuses_userId_postId_tagId";
+`;
+
+
+export const up = async ({db}: MigrationContext) => {
+  await db.none(dropOldDatabaseMetadataIndex);
+  await db.none(dropOldDebouncerEventsIndex);
+  await db.none(dropOldPageCacheIndex);
+  await db.none(dropReadStatusesIndex);
+  await db.none(renameReadStatusesIndex);
+}
+
+export const down = async ({db}: MigrationContext) => {
+}

--- a/packages/lesswrong/server/testingSqlClient.ts
+++ b/packages/lesswrong/server/testingSqlClient.ts
@@ -53,23 +53,23 @@ const ensureMigratedIndexes = async (client: SqlClient) => {
   // eslint-disable-next-line no-console
   console.log('Creating custom indexes');
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_DatabaseMetadata_name_old"
+    CREATE UNIQUE INDEX "idx_DatabaseMetadata_name"
     ON public."DatabaseMetadata" USING btree
-    (COALESCE(name, ''));
+    (name);
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered_old"
+    CREATE UNIQUE INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered"
     ON public."DebouncerEvents" USING btree
-    (dispatched, af, COALESCE(key, ''), COALESCE(name, ''))
+    (dispatched, af, key, name)
     WHERE (dispatched IS FALSE);
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_PageCache_path_abTestGroups_bundleHash_old"
+    CREATE UNIQUE INDEX "idx_PageCache_path_abTestGroups_bundleHash"
     ON public."PageCache" USING btree
-    (COALESCE(path, ''), "abTestGroups", COALESCE("bundleHash", ''));
+    (path, "abTestGroups", "bundleHash");
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_ReadStatuses_userId_postId_tagId_old"
+    CREATE UNIQUE INDEX "idx_ReadStatuses_userId_postId_tagId"
     ON public."ReadStatuses" USING btree
     (COALESCE("userId", ''), COALESCE("postId", ''::character varying), COALESCE("tagId", ''::character varying));
   `, options);

--- a/packages/lesswrong/server/testingSqlClient.ts
+++ b/packages/lesswrong/server/testingSqlClient.ts
@@ -111,7 +111,7 @@ const buildTables = async (client: SqlClient) => {
     }
   }
 
-  await ensureMigratedIndexes(client);
+  // await ensureMigratedIndexes(client);
   await updateFunctions(client);
   await ensurePostgresViewsExist(client);
 }

--- a/packages/lesswrong/server/testingSqlClient.ts
+++ b/packages/lesswrong/server/testingSqlClient.ts
@@ -111,7 +111,7 @@ const buildTables = async (client: SqlClient) => {
     }
   }
 
-  // await ensureMigratedIndexes(client);
+  await ensureMigratedIndexes(client);
   await updateFunctions(client);
   await ensurePostgresViewsExist(client);
 }

--- a/packages/lesswrong/server/testingSqlClient.ts
+++ b/packages/lesswrong/server/testingSqlClient.ts
@@ -53,23 +53,23 @@ const ensureMigratedIndexes = async (client: SqlClient) => {
   // eslint-disable-next-line no-console
   console.log('Creating custom indexes');
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_DatabaseMetadata_name"
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_DatabaseMetadata_name"
     ON public."DatabaseMetadata" USING btree
     (name);
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered"
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_DebouncerEvents_dispatched_af_key_name_filtered"
     ON public."DebouncerEvents" USING btree
     (dispatched, af, key, name)
     WHERE (dispatched IS FALSE);
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_PageCache_path_abTestGroups_bundleHash"
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_PageCache_path_abTestGroups_bundleHash"
     ON public."PageCache" USING btree
     (path, "abTestGroups", "bundleHash");
   `, options);
   await ensureCustomPgIndex(`
-    CREATE UNIQUE INDEX "idx_ReadStatuses_userId_postId_tagId"
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_ReadStatuses_userId_postId_tagId"
     ON public."ReadStatuses" USING btree
     (COALESCE("userId", ''), COALESCE("postId", ''::character varying), COALESCE("tagId", ''::character varying));
   `, options);

--- a/packages/lesswrong/server/testingSqlClient.ts
+++ b/packages/lesswrong/server/testingSqlClient.ts
@@ -44,9 +44,9 @@ export const preparePgTables = () => {
 }
 
 /**
- * This is part of the nullability PR.
- * We need to keep around the old indexes for use in the ON CONFLICT constraints in the rewritten upsert queries.
- * So we need to ensure those indexes also exist in the test db for cypress tests, until we fix the whole index situation in a follow-up PR.
+ * These are custom indexes we created during the nullability PR for various ON CONFLICT queries.
+ * We need to run them here but with options to ensure they actually get run, because the calls to create them in the codebase don't get run during test setup.
+ * We need a better way to handle `ensureCustomPgIndex` properly for indexes required by tests.
  */
 const ensureMigratedIndexes = async (client: SqlClient) => {
   const options = { overrideCanEnsureIndexes: true, runImmediately: true, client };


### PR DESCRIPTION
As a follow-up to https://github.com/ForumMagnum/ForumMagnum/pull/8045, we should:
1. replace the `ensureIndex` calls responsible for making the unique indexes used by various `ON CONFLICT` queries with `ensureCustomPgIndex`, since anyone starting a ForumMagnum instance from scratch might end up with the wrong indexes (the query builder may generate them with `COALESCE` calls that don't correctly correspond to the `ON CONFLICT` queries).
2. run the following SQL manually (since I can't figure out how to get `yarn migrate create --name=[...]` to work):
```
DROP INDEX "idx_DatabaseMetadata_name_old";
  
DROP INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered_old";
  
DROP INDEX "idx_PageCache_path_abTestGroups_bundleHash_old";
  
DROP INDEX "idx_ReadStatuses_userId_postId_tagId";

ALTER INDEX "idx_ReadStatuses_userId_postId_tagId_old"
RENAME TO "idx_ReadStatuses_userId_postId_tagId";
```

Technically we can leave everything in place, but there's a race condition with the two ReadStatuses indexes in particular that will pollute our error logs (though it doesn't have any functional consequences otherwise, as far as I can tell).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206125326200184) by [Unito](https://www.unito.io)
