### PR TITLE
Only show recommendations on even days, and fix the bug where same user shown twice

### DIFF
--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -202,7 +202,9 @@ const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => 
   const currentUser = useCurrentUser()
   const [showSettings, setShowSettings] = useState(false);
   const { captureEvent } = useTracking();
-  const showReciprocityRecommendations = (currentUser?.karma ?? 0) > 100 // hide reciprocity recommendations if user has less than 100 karma
+  const currentDate = new Date();
+  const isEvenDay = currentDate.getDate() % 2 === 0;
+  const showReciprocityRecommendations = ((currentUser?.karma ?? 0) > 100) && isEvenDay; // hide reciprocity recommendations if user has less than 100 karma, or if the current day is not an even number (just a hack to avoid spamming folks)
 
   const { results: dialoguePosts } = usePaginatedResolver({
     fragmentName: "PostsListWithVotes",

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -510,7 +510,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
       LIMIT $3
     )
     -- If the above query doesn't return enough users, then fill in the rest with users who you've upvoted
-      UNION ALL
+      UNION
       (
         SELECT u.*
         FROM unnest($2::text[]) AS uv(_id)


### PR DESCRIPTION

* In order to not spam users on frontpage, we only show recommended dialogue users every other day (on even days). Seemed like a fair enough hack for now
* Also solves the bug where the same user used to appear twice in recommendations occasionally

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206126421437729) by [Unito](https://www.unito.io)
