### PR TITLE
don't replace empty arrays with null when calling updateCurrentValues

### DIFF
--- a/packages/lesswrong/lib/vulcan-forms/utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/utils.ts
@@ -24,7 +24,7 @@ export const flatten = function(data: AnyBecauseTodo) {
 };
 
 export const isEmptyValue = (value: AnyBecauseTodo) =>
-  typeof value === 'undefined' || value === null || value === '' || (Array.isArray(value) && value.length === 0);
+  typeof value === 'undefined' || value === null || value === '';
 
 
 /**


### PR DESCRIPTION
The recent nullability migration uncovered some strange Vulcan form behavior with respect to passing empty arrays into `updateCurrentValue` - they're treated as "empty" values by `isEmptyValue`, which means they then get set to `null` in the form's `currentDocument`.  This then fails in the database update operation, because most array columns aren't nullable anymore.

In particular, this was discovered by way of attempting to update a post's link sharing settings to "everyone with link can comment", the code path for which also sets `shareWithUsers` to whatever it's previous value was (an empty array, by default).