### PR TITLE
Fix bug where new posts dont appear in recent discussion due to commentCount being non-null

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -42,11 +42,20 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
 
   const lastVisitedAt = markedAsVisitedAt || post.lastVisitedAt
 
+  // For posts that have never been commented on, we do want to show them in the
+  // recent discussion feed. For posts which have been commented on, but the comments
+  // have been deleted, we don't want to show them (these are usually spam).
+  //
+  // There is no completely reliable way to tell the difference, but this is a fairly conservative
+  // (in favour of showing a post) heuristic.
+  const probablyNeverCommentedOn =
+    new Date(post.lastCommentedAt).getTime() - new Date(post.postedAt).getTime() < 30_000;
+
   // TODO verify whether/how this should be interacting with afCommentCount
   // New posts should render (to display their highlight).
-  // Posts with at least one comment should only render if that those comments
+  // Posts with at least one comment should only render if those comments
   // meet the frontpage filter requirements
-  const isSkippable = comments && !comments.length && post.commentCount !== null;
+  const isSkippable = comments && !comments.length && !probablyNeverCommentedOn;
 
   const treeOptions: CommentTreeOptions = {
     scrollOnExpand: true,


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/8045 Made it so commentCount starts as 0 rather than null, which broke the logic we used to decide whether a post had never been commented on vs having comments that were now deleted.

I've updated it to check if `lastCommentedAt` is close to (or before) `postedAt`, and use that as the criterion for deciding whether to show a post or not. The case where we don't want to show a post is when it gets a spam comment long after posting which we then delete

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206143262749473) by [Unito](https://www.unito.io)
