### PR TITLE
Fix AF voting

### DIFF
--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -15,7 +15,7 @@ export const recalculateAFBaseScore = async (document: VoteableType): Promise<nu
     afPower: {$exists: true},
     cancelled: false,
   }).fetch()
-  return votes ? votes.reduce((sum, vote) => { return vote.afPower ?? 0 + sum}, 0) : 0
+  return votes ? votes.reduce((sum, vote) => { return (vote.afPower ?? 0) + sum }, 0) : 0
 }
 
 async function updateAlignmentKarmaServer (newDocument: DbVoteableType, vote: DbVote): Promise<VoteDocTuple> {


### PR DESCRIPTION
[https://github.com/ForumMagnum/ForumMagnum/commit/31c648667d6e835d053426cd97e2c53e71fbdd09#diff-f5ee8a7fae29435bf470a8[…]db6f279f31c0e1327756dc61R18](https://github.com/ForumMagnum/ForumMagnum/commit/31c648667d6e835d053426cd97e2c53e71fbdd09#diff-f5ee8a7fae29435bf470a8aabe2ff9a6cbf262c6db6f279f31c0e1327756dc61R18) had the wrong order of operations; it should be `(vote.afPower ?? 0) + sum` but instead it evaluates as `vote.afPower ?? (0 + sum)`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206145597082571) by [Unito](https://www.unito.io)
