### PR TITLE
Add check notification opt-out on matching page

### DIFF
--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -165,7 +165,7 @@ const xsGridBaseStyles = (theme: ThemeType) => ({
 const styles = (theme: ThemeType) => ({
   root: {
     padding: 20,
-    ...commentBodyStyles(theme),
+    ...commentBodyStyles(theme, true),
     background: theme.palette.background.default,
     [theme.breakpoints.up('md')]: {
       marginTop: -50
@@ -381,10 +381,10 @@ const styles = (theme: ThemeType) => ({
     display: 'flex',
     alignItems: 'flex-start',
   },
-  optInLabel: {
+  optionControlLabel: {
     paddingLeft: 8,
   },
-  optInCheckbox: {
+  optionControlCheckbox: {
     height: 10,
     width: 30,
     color: theme.palette.dialogueMatching.optIn,
@@ -503,6 +503,9 @@ const styles = (theme: ThemeType) => ({
   },
   syncText: {
     color: theme.palette.text.dim3,
+  },
+  checkNotificationControl: {
+    marginBottom: 4
   }
 });
 
@@ -603,6 +606,42 @@ const headerTexts = {
   bio: "Bio",
   tags: "Frequent commented topics",
   postsRead: "Posts you've read"
+}
+
+const CheckNotificationControl = ({ classes }: { classes: ClassesType<typeof styles> }) => {
+  const updateCurrentUser = useUpdateCurrentUser();
+  const currentUser = useCurrentUser();
+  const [currentChannel, setCurrentChannel] = useState(currentUser?.notificationNewDialogueChecks.channel);
+  if (currentUser === null || currentChannel == null) return null;
+
+
+  const handleToggle = async () => {
+    const newChannel = currentChannel === "none" ? "onsite" : "none";
+    setCurrentChannel(newChannel)
+    await updateCurrentUser({
+      notificationNewDialogueChecks: {
+        ...currentUser.notificationNewDialogueChecks,
+        channel: newChannel,
+      }
+    })
+  }
+
+  return (
+    <div className={classes.checkNotificationControl}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={currentChannel !== "none"}
+            onChange={handleToggle}
+            className={classes.optionControlCheckbox}
+          />
+        }
+        label={null}
+        className={classes.optionControlLabel}
+      />{"Receive notifications when someone you've not yet checked checks you"}
+    </div>
+  )
+
 }
 
 const UserBio = ({ classes, userId }: { classes: ClassesType<typeof styles>, userId: string }) => {
@@ -1456,15 +1495,16 @@ export const DialogueMatchingPage = ({classes}: {
           <li>You can then see each other's answers, and choose whether start a dialogue</li>
         </ul>
         
+        <CheckNotificationControl classes={classes} />
         <div className={classes.optInContainer}>
-          <FormControlLabel className={classes.optInLabel}
+          <FormControlLabel className={classes.optionControlLabel}
             control={
               <Checkbox
                 checked={optIn}
                 onChange={event => handleOptInToRevealDialogueChecks(event)}
                 name="optIn"
                 color="primary"
-                className={classes.optInCheckbox}
+                className={classes.optionControlCheckbox}
               />
             }
             label={null}

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -216,6 +216,7 @@ registerFragment(`
     hideDialogueFacilitation
     optedInToDialogueFacilitation
     revealChecksToAdmins
+    notificationNewDialogueChecks
 
     showDialoguesList
     showMyDialogues

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2843,6 +2843,12 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   readonly hideDialogueFacilitation: boolean,
   readonly optedInToDialogueFacilitation: boolean,
   readonly revealChecksToAdmins: boolean,
+  readonly notificationNewDialogueChecks: {
+    channel: "none" | "onsite" | "email" | "both",
+    batchingFrequency: "realtime" | "daily" | "weekly",
+    timeOfDayGMT: number,
+    dayOfWeekGMT: string,
+  },
   readonly showDialoguesList: boolean,
   readonly showMyDialogues: boolean,
   readonly showMatches: boolean,


### PR DESCRIPTION
Adds an easier & more visible way to opt out of the "You have new checks" notification.

Adds that notification field to the CurrentUser fragment so that we can easily get the right initial state of the checkbox

<img width="1336" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/12041390/b5b8a3fa-142b-4be7-9064-15c1ce175b9d">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206146600623617) by [Unito](https://www.unito.io)
