### PR TITLE
Sort recent users on dialogue matching in the other direction and move that section up

### DIFF
--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -1582,6 +1582,25 @@ export const DialogueMatchingPage = ({classes}: {
       </> }
       <div className={classes.rootFlex}>
         <div className={classes.matchContainer}>
+          <h3>Recently active on dialogue matching</h3>
+          <UserTable
+            users={activeDialogueMatchSeekers}
+            tableContext={'other'}
+            classes={classes}
+            gridClassName={classes.matchContainerGridV2}
+            currentUser={currentUser}
+            userDialogueChecks={userDialogueChecks}
+            showBio={true}
+            showKarma={false}
+            showAgreement={false}
+            showPostsYouveRead={true}
+            showFrequentCommentedTopics={true}
+            showHeaders={true}
+          />
+        </div>
+      </div>
+      <div className={classes.rootFlex}>
+        <div className={classes.matchContainer}>
           <h3>Published dialogues</h3>
           <UserTable
             users={dialogueUsers}
@@ -1621,25 +1640,6 @@ export const DialogueMatchingPage = ({classes}: {
         </div>
       </div>
       <br />
-      <div className={classes.rootFlex}>
-        <div className={classes.matchContainer}>
-          <h3>Recently active on dialogue matching</h3>
-          <UserTable
-            users={activeDialogueMatchSeekers}
-            tableContext={'other'}
-            classes={classes}
-            gridClassName={classes.matchContainerGridV2}
-            currentUser={currentUser}
-            userDialogueChecks={userDialogueChecks}
-            showBio={true}
-            showKarma={false}
-            showAgreement={false}
-            showPostsYouveRead={true}
-            showFrequentCommentedTopics={true}
-            showHeaders={true}
-          />
-        </div>
-      </div>
       <IntercomWrapper />
     </div>
   </AnalyticsContext>)

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -534,9 +534,9 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
         MAX(dc."checkedAt") AS "mostRecentCheckedAt"
       FROM public."Users" AS u
       LEFT JOIN public."DialogueChecks" AS dc ON u._id = dc."userId"
-      WHERE u."optedInToDialogueFacilitation" IS TRUE OR dc."userId" IS NOT NULL
+      WHERE dc."userId" IS NOT NULL
       GROUP BY u._id
-      ORDER BY "mostRecentCheckedAt" ASC
+      ORDER BY "mostRecentCheckedAt" DESC
       LIMIT $1;
     `, [limit])
   }


### PR DESCRIPTION
Also no longer unions in users who just opted in to facilitation in that section. That was needed in the beginning when no one had been active, but now isn't necessary, and also breaks the sort.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206146945776876) by [Unito](https://www.unito.io)
