### PR TITLE
Remove "slow postgres" spam when developing locally

### DIFF
--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -1,12 +1,13 @@
 import pgp, { IDatabase, IEventContext } from "pg-promise";
 import type { IClient, IResult } from "pg-promise/typescript/pg-subset";
 import Query from "../lib/sql/Query";
-import { isAnyTest } from "../lib/executionEnvironment";
+import { isAnyTest, isProduction } from "../lib/executionEnvironment";
 import { PublicInstanceSetting } from "../lib/instanceSettings";
 import omit from "lodash/omit";
 import { logAllQueries } from "../lib/sql/sqlClient";
 
-const SLOW_QUERY_REPORT_CUTOFF_MS = 2000;
+
+const SLOW_QUERY_REPORT_CUTOFF_MS = isProduction ? 2000 : 4000; // deal with latency issues causing console spam when running locally
 
 const pgConnIdleTimeoutMsSetting = new PublicInstanceSetting<number>('pg.idleTimeoutMs', 10000, 'optional')
 


### PR DESCRIPTION
The latency connection to the postgres server is much longer when running the prod server locally, as such a ton of normal queries are flagged as being slow. This makes the console a giant mess. 

This PR solves by just setting the slow query report cutoff time to be a bit larger when developing locally. 