### PR TITLE
Removing `hasShareButtonsSetting`

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -4,7 +4,7 @@ import { userHasPingbacks } from '../../../lib/betas';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { useCurrentUser } from '../../common/withUser';
 import { MAX_COLUMN_WIDTH } from './PostsPage';
-import { isLWorAF, hasShareButtonsSetting } from '../../../lib/instanceSettings';
+import { isLWorAF } from '../../../lib/instanceSettings';
 import { getVotingSystemByName } from '../../../lib/voting/votingSystems';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 
@@ -99,7 +99,7 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
           </div>
           {isFriendlyUI && <div className={classes.secondaryInfoRight}>
             <BookmarkButton post={post} className={classes.bookmarkButton} placement='bottom-start' />
-            {hasShareButtonsSetting.get() && <SharePostButton post={post} />}
+            <SharePostButton post={post} />
             <span className={classes.actions}>
               <AnalyticsContext pageElementContext="tripleDotMenu">
                 <PostActionsButton post={post} includeBookmark={!isFriendlyUI} />

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -7,7 +7,7 @@ import { getUrlClass } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import { isServer } from '../../../lib/executionEnvironment';
 import moment from 'moment';
-import { hasShareButtonsSetting, isLWorAF } from '../../../lib/instanceSettings';
+import { isLWorAF } from '../../../lib/instanceSettings';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { PODCAST_TOOLTIP_SEEN_COOKIE } from '../../../lib/cookies/cookies';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
@@ -376,7 +376,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
       </div>
       <div className={classes.secondaryInfoRight}>
         <BookmarkButton post={post} className={classes.bookmarkButton} placement='bottom-start' />
-        {hasShareButtonsSetting.get() && <SharePostButton post={post} />}
+        <SharePostButton post={post} />
         {tripleDotMenuNode}
       </div>
     </div>

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -181,9 +181,6 @@ export const lowKarmaUserVotingCutoffDateSetting = new PublicInstanceSetting<str
 /** Currently LW-only; forum-gated in `userCanVote` */
 export const lowKarmaUserVotingCutoffKarmaSetting = new PublicInstanceSetting<number>("lowKarmaUserVotingCutoffKarma", 1, "optional");
 
-/** Whether to include a Share button. (Forums with no public access, or a more conservative style wouldn't want one.) */
-export const hasShareButtonsSetting = new PublicInstanceSetting<boolean>("hasShareButtons", true, "optional");
-
 /** Whether posts and other content is visible to non-logged-in users (TODO: actually implement this) */
 export const publicAccess = new PublicInstanceSetting<boolean>("publicAccess", true, "optional");
 


### PR DESCRIPTION
This was added in WakingUp codebase originally and migrated upstream as a part of #7908 
But it's true for all the forums (and there is additional confusion about it in the WakingUp codebase) so I figured I'll remove it to simplify things. People with waking up access can see more context in https://app.clickup.com/t/8686p22dk

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206147485321757) by [Unito](https://www.unito.io)
