### PR TITLE
Forum gate notification settings

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1407,22 +1407,22 @@ const schema: SchemaType<DbUser> = {
   notificationDebateCommentsOnSubscribedPost: {
     label: "[Old Style] New dialogue content in a dialogue I'm subscribed to",
     ...notificationTypeSettingsField({ batchingFrequency: 'daily' }),
-    hidden: !dialoguesEnabled,
+    hidden: !isLW,
   },
   notificationDebateReplies: {
     label: "[Old Style] New dialogue content in a dialogue I'm participating in",
     ...notificationTypeSettingsField(),
-    hidden: !dialoguesEnabled,
+    hidden: !isLW,
   },
   notificationDialogueMatch: {
     label: "Another user and I have matched for a dialogue",
     ...notificationTypeSettingsField({ channel: "both" }),
-    hidden: !dialoguesEnabled,
+    hidden: !isLW,
   },
   notificationNewDialogueChecks: {
     label: "You have new people interested in dialogue-ing with you",
     ...notificationTypeSettingsField(),
-    hidden: !dialoguesEnabled,
+    hidden: !isLW,
   },
 
   hideDialogueFacilitation: {


### PR DESCRIPTION
Previously we were gating on whether dialogues were enabled, but EA Forum now has dialogues enabled but not all of these features.

Move to a straightforward `isLW` forum gate

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206154738843853) by [Unito](https://www.unito.io)
