### PR TITLE
Make reasonsForInitialReview configurable

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -2,6 +2,7 @@ import moment from "moment";
 import { isEAForum } from "../../instanceSettings";
 import ModeratorActions from "./collection";
 import { MAX_ALLOWED_CONTACTS_BEFORE_FLAG, postAndCommentRateLimits, PostAndCommentRateLimitTypes, RATE_LIMIT_ONE_PER_DAY, RATE_LIMIT_ONE_PER_FORTNIGHT, RATE_LIMIT_ONE_PER_MONTH, RATE_LIMIT_ONE_PER_THREE_DAYS, RATE_LIMIT_ONE_PER_WEEK, MODERATOR_ACTION_TYPES, AllRateLimitTypes, RATE_LIMIT_THREE_COMMENTS_PER_POST_PER_WEEK } from "./schema";
+import {DatabasePublicSetting} from '../../publicSettings.ts'
 
 /**
  * For a given RateLimitType, returns the number of hours a user has to wait before posting again.
@@ -102,35 +103,48 @@ type ReasonReviewIsNeeded = "mapLocation"|"firstPost"|"firstComment"|"contactedT
 type GetReasonForReviewResult =
     { needsReview: false, reason: ReasonNoReviewNeeded }
   | { needsReview: true, reason: ReasonReviewIsNeeded }
+type ReasonForInitialReview = Exclude<ReasonReviewIsNeeded, 'newContent'> 
+const reviewReasonsSetting = 
+  new DatabasePublicSetting<Array<ReasonForInitialReview>>(
+    'moderation.reasonsForInitialReview', 
+    ['firstPost', 'firstComment', 'contactedTooManyUsers', 'bio', 'profileImage'])
 
 export function getReasonForReview(user: DbUser|SunshineUsersList): GetReasonForReviewResult
 {
-  const fullyReviewed = user.reviewedByUserId && !user.snoozedUntilContentCount;
   /**
    * This covers several cases
    * 1) never reviewed users
    * 2) users who were removed from the review queue and weren't previously reviewed
    * 3) users who were removed from the review queue and *were* previously reviewed
    * 1 & 2 look indistinguishable, 3 will have a non-null reviewedAt date
-   */ 
-  const unreviewed = !user.reviewedByUserId;
-  const snoozed = user.reviewedByUserId && user.snoozedUntilContentCount;
+   */
 
+  const fullyReviewed = user.reviewedByUserId && !user.snoozedUntilContentCount;
   if (fullyReviewed) {
     return {needsReview: false, reason: 'alreadyApproved'};
   }
+  
+  const unreviewed = !user.reviewedByUserId;
+  const snoozed = user.reviewedByUserId && user.snoozedUntilContentCount;
+  
+  const reviewReasonMap: Record<ReasonForInitialReview, Function> = {
+    mapLocation: () => user.mapLocation,
+    firstPost: () => user.postCount,
+    firstComment: () => user.commentCount,
+    contactedTooManyUsers: () => (user.usersContactedBeforeReview?.length ?? 0) > MAX_ALLOWED_CONTACTS_BEFORE_FLAG,
+    // Depends on whether this is DbUser or SunshineUsersList
+    bio: () => 'htmlBio' in user ? user.htmlBio : user.biography?.html,
+    profileImage: () => user.profileImageId,
+  }
 
   if (unreviewed) {
-    if (user.mapLocation && isEAForum) return {needsReview: true, reason: 'mapLocation'};
-    if (user.postCount) return {needsReview: true, reason: 'firstPost'};
-    if (user.commentCount) return {needsReview: true, reason: 'firstComment'};
-    if ((user.usersContactedBeforeReview?.length ?? 0) > MAX_ALLOWED_CONTACTS_BEFORE_FLAG) {
-      return {needsReview: true, reason: 'contactedTooManyUsers'};
+    const reasonsForInitialReview = reviewReasonsSetting.get()
+    for (const reason of reasonsForInitialReview) {
+      if (!reviewReasonMap[reason]) throw new Error(`Invalid reason for initial review: ${reason}`)
+      if (reviewReasonMap[reason]()) {
+        return {needsReview: true, reason}
+      }
     }
-    // Depends on whether this is DbUser or SunshineUsersList
-    const htmlBio = 'htmlBio' in user ? user.htmlBio : user.biography?.html;
-    if (htmlBio) return {needsReview: true, reason: 'bio'};
-    if (user.profileImageId) return {needsReview: true, reason: 'profileImage'};
   } else if (snoozed) {
     const contentCount = getCurrentContentCount(user);
     if (contentCount >= user.snoozedUntilContentCount) {


### PR DESCRIPTION
This allows you to specify what would trigger initial user review as a DB setting

As this previously had an EA conditional: we need to add a setting override on EA side before merging this (adding `mapLocation` to the list of reasons that trigger review)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206155438046277) by [Unito](https://www.unito.io)
