### PR TITLE
replace index on votes used by getKarmaChanges query

### DIFF
--- a/packages/lesswrong/lib/collections/votes/views.ts
+++ b/packages/lesswrong/lib/collections/votes/views.ts
@@ -18,8 +18,7 @@ ensureIndex(Votes, {cancelled:1, documentId:1});
 ensureIndex(Votes, {cancelled:1, userId:1, votedAt:-1});
 
 // Used by getKarmaChanges
-ensureIndex(Votes, {authorIds:1, votedAt:1, userId:1, afPower:1});
-
+ensureIndex(Votes, {authorIds: 1});
 
 Votes.addView("tagVotes", function () {
   return {

--- a/packages/lesswrong/server/migrations/20231211T000000.dropOldVoteIndex.ts
+++ b/packages/lesswrong/server/migrations/20231211T000000.dropOldVoteIndex.ts
@@ -1,0 +1,8 @@
+const dropOldVoteIndex = 'DROP INDEX IF EXISTS "idx_Votes_authorIds_votedAt_userId_afPower";';
+
+export const up = async ({db}: MigrationContext) => {
+  await db.none(dropOldVoteIndex);
+}
+
+export const down = async ({db}: MigrationContext) => {
+}


### PR DESCRIPTION
While investigating slow render times for `404`s (as part of a broader investigation around performance issues arising from a user accidentally DoSing us), we found that the `getKarmaChanges` query was attempting to use the `idx_Votes_authorIds_votedAt_userId_afPower` index, but was performing a bitmap index scan on it, and taking ~600 ms (for both of the individual queries that get called in that repo method).  My current best guess as to why is that it was a GIN index and trying to perform range comparisons (as with `votedAt`) just doesn't work.

So we're just replacing it with single-column GIN index on `authorIds`, and then the query takes on the order of 5-50 ms (tested with users who have ~2k and ~20k karma, respectively).

We need to drop the old index or postgres will continue to use it.  Thankfully (and hilariously), we can drop it before creating the new one, because we have other indexes which _still_ perform better than the one we're dropping.

NOTE: a few days after merging & deploying this, you will want to double-check your databases across all environments to ensure that nobody connected with an old branch and accidentally recreated the index from the `ensureIndex` call running again (which will again cause the queries to be slow).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206155833483804) by [Unito](https://www.unito.io)
