### PR TITLE
Fix needing to double click items in giving season header

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -352,7 +352,7 @@ const Header = ({
         unFixed={unFixed}
         setUnFixed={setUnFixed}
         NavigationMenuButton={NavigationMenuButton}
-        RightHeaderItems={() => rightHeaderItemsNode}
+        rightHeaderItems={rightHeaderItemsNode}
         HeaderNavigationDrawer={HeaderNavigationDrawer}
         HeaderNotificationsMenu={HeaderNotificationsMenu}
       />

--- a/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/giving-portal/GivingSeasonHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, ReactNode } from "react";
 import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { useIsAboveBreakpoint } from "../../hooks/useScreenWidth";
 import { Link } from "../../../lib/reactRouterWrapper";
@@ -223,7 +223,7 @@ const GivingSeasonHeader = ({
   unFixed,
   setUnFixed,
   NavigationMenuButton,
-  RightHeaderItems,
+  rightHeaderItems,
   HeaderNavigationDrawer,
   HeaderNotificationsMenu,
   classes,
@@ -233,7 +233,7 @@ const GivingSeasonHeader = ({
   unFixed: boolean
   setUnFixed: (value: boolean) => void,
   NavigationMenuButton: FC,
-  RightHeaderItems: FC,
+  rightHeaderItems: ReactNode,
   HeaderNavigationDrawer: FC,
   HeaderNotificationsMenu: FC,
   classes: ClassesType,
@@ -369,7 +369,7 @@ const GivingSeasonHeader = ({
                   )}
                 </div>
               )}
-              <RightHeaderItems />
+              {rightHeaderItems}
             </Toolbar>
           </header>
           <HeaderNavigationDrawer />


### PR DESCRIPTION
You need to double click items on the right of the header (such as the search bar) to activate them. #8402 fixed this for the normal header, but not for the giving season header. This PR just ports the change over to there too.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206162804290385) by [Unito](https://www.unito.io)
