### PR TITLE
Fix -1 `commentCounts` due to unreviewed users

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2506,7 +2506,7 @@ const schema: SchemaType<DbPost> = {
       foreignCollectionName: "Comments",
       foreignTypeName: "comment",
       foreignFieldName: "postId",
-      filterFn: comment => !comment.deleted && !comment.rejected && !comment.debateResponse
+      filterFn: comment => !comment.deleted && !comment.rejected && !comment.debateResponse && !comment.authorIsUnreviewed,
     }),
     canRead: ['guests'],
   },


### PR DESCRIPTION
We have a long-standing bug where posts can sometimes end up with a negative comment count. It's possible that this is actually due to multiple bugs, but the most obvious and easily-reproducible case is when an unreviewed user creates a comment and then gets rejected. This case also has a sub-bug where the comment count will be 1 whilst displaying 0 comments as the unreviewed comment is hidden.

This fix here is just to add `authorIsUnreviewed` to the filter function for the denormalized count of references. Once this is merged you can run `./scripts/serverShellCommand.sh --wait "Globals.recomputeDenormalizedValues({collectionName: 'Posts', fieldName: 'commentCount'})"` to fix existing instances of this bug (note that this is pretty slow - you may want to increase the batch size in `runDenormalizedFieldMigration`).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206163102817347) by [Unito](https://www.unito.io)
