### PR TITLE
Add baseFontSize as a theme variable

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -72,6 +72,7 @@ export const baseTheme: BaseThemeSpecification = {
     const spacingUnit = 8
   
     return {
+      baseFontSize: 13,
       breakpoints: {
         values: {
           xs: 0,

--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -7,7 +7,7 @@ export const commentsNodeRootMarginBottom = 17
 
 const clearStyle = (theme: ThemeType): JssStyles => ({
   html: {
-    fontSize: 13,
+    fontSize: theme.baseFontSize,
     boxSizing: "border-box",
     "-webkit-font-smoothing": "antialiased",
     "-moz-osx-font-smoothing": "grayscale",

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -508,6 +508,8 @@ declare global {
   
   type ThemeType = {
     forumType: ForumTypeString,
+
+    baseFontSize: number,
     
     breakpoints: {
       /** Down is *inclusive* - down(sm) will go up to the md breakpoint */


### PR DESCRIPTION
This PR makes the base font size configurable in theme files. We're using it at WakingUp.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206165895289748) by [Unito](https://www.unito.io)
