### PR TITLE
resolve webhook bug

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -47,6 +47,7 @@ export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabl
 
 // Non-user-specific features
 export const dialoguesEnabled = true;
+export const ckEditorUserSessionsEnabled = isLWorAF;
 export const inlineReactsHoverEnabled = isLWorAF;
 /** On the post page, do we show users other content they might want to read */
 export const hasPostRecommendations = isEAForum;

--- a/packages/lesswrong/lib/collections/ckEditorUserSessions/collection.ts
+++ b/packages/lesswrong/lib/collections/ckEditorUserSessions/collection.ts
@@ -1,3 +1,4 @@
+import { ensureIndex } from "../../collectionIndexUtils";
 import { addUniversalFields, getDefaultResolvers } from "../../collectionUtils";
 import { createCollection } from "../../vulcan-lib";
 import schema from "./schema";
@@ -13,5 +14,7 @@ export const CkEditorUserSessions: CkEditorUserSessionsCollection = createCollec
 })
 
 addUniversalFields({ collection: CkEditorUserSessions })
+
+ensureIndex(CkEditorUserSessions, {documentId: 1, userId: 1})
 
 export default CkEditorUserSessions;

--- a/packages/lesswrong/lib/collections/ckEditorUserSessions/schema.ts
+++ b/packages/lesswrong/lib/collections/ckEditorUserSessions/schema.ts
@@ -6,16 +6,19 @@ const schema: SchemaType<DbCkEditorUserSession> = {
     type: String,
     nullable: false,
     canRead: ['admins'],
+    canCreate: ['admins'],
   },
   userId: {
     type: String,
     nullable: false,
     canRead: ['admins'], 
+    canCreate: ['admins'],
   },
   endedAt: {
     type: Date,
     optional: true,
     canRead: ['admins'],
+    canCreate: ['admins'],
   },
 }
 

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -551,15 +551,15 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
         p."coauthorStatuses",
         ARRAY_AGG(DISTINCT s."userId") AS "activeUserIds"
     FROM "Posts" AS p
-    LEFT JOIN public."CkEditorUserSessions" AS s ON p._id = s."documentId",
+    INNER JOIN public."CkEditorUserSessions" AS s ON p._id = s."documentId",
         unnest(p."coauthorStatuses") AS coauthors
     WHERE
         (
             coauthors ->> 'userId' = any($1)
             OR p."userId" = any($1)
         )
-        AND s._id IS NOT NULL
         AND s."endedAt" IS NULL
+        AND s."createdAt" > CURRENT_TIMESTAMP - INTERVAL '8 hours'
     GROUP BY p._id
     `, [userIds]);
   


### PR DESCRIPTION
Fixing the bug whereby the server would error on receiving new ckeditor webhooks, due to the createMutator not being properly configured

Also, add indexes for the CkEditorUserSessions table

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206176719035771) by [Unito](https://www.unito.io)
