### PR TITLE
Allow hiding individual matches from frontpage

### DIFF
--- a/packages/lesswrong/components/dialogues/DialoguesList.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesList.tsx
@@ -12,7 +12,8 @@ import MuiPeopleIcon from "@material-ui/icons/People";
 import { dialogueMatchmakingEnabled } from '../../lib/publicSettings';
 import { useUpsertDialogueCheck } from '../hooks/useUpsertDialogueCheck';
 import { DialogueUserResult } from './DialogueRecommendationRow';
-
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 
 const styles = (theme: ThemeType) => ({
   dialogueFacilitationItem: {
@@ -144,16 +145,22 @@ const styles = (theme: ThemeType) => ({
     '&:hover': {
       color: theme.palette.primary.light,
     }
-  }
+  },
+  closeIcon: { 
+    color: theme.palette.grey[500],
+    opacity: 0.5,
+    padding: 2,
+  },
 });
 
 interface DialogueMatchRowProps {
   rowProps: DialogueUserRowProps<boolean>; 
   classes: ClassesType<typeof styles>; 
   showMatchNote: boolean;
+  onHide: ({ dialogueCheckId, targetUserId }: { dialogueCheckId: string|undefined; targetUserId: string; }) => void;
 }
 
-const DialogueMatchRow = ({ rowProps, classes, showMatchNote }: DialogueMatchRowProps) => {
+const DialogueMatchRow = ({ rowProps, classes, showMatchNote, onHide }: DialogueMatchRowProps) => {
   const { DialogueCheckBox, UsersName, MessageButton, DialogueNextStepsButton, PostsItem2MetaInfo } = Components
 
   const { targetUser, checkId, userIsChecked, userIsMatched } = rowProps;
@@ -193,6 +200,9 @@ const DialogueMatchRow = ({ rowProps, classes, showMatchNote }: DialogueMatchRow
           />
         </div>
       </div>
+      <IconButton className={classes.closeIcon} onClick={() => onHide({dialogueCheckId: checkId, targetUserId: targetUser._id})}>
+        <CloseIcon />
+      </IconButton>
     </div>
   );
 };
@@ -229,7 +239,11 @@ const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => 
   const hideRecommendation = ({dialogueCheckId, targetUserId}: {dialogueCheckId:string|undefined, targetUserId:string}) => {
     captureEvent("hide_dialogue_recommendation")
     void upsertUserDialogueCheck({ targetUserId, hideInRecommendations: true, checkId: dialogueCheckId });
+  }
 
+  const hideMatch = ({dialogueCheckId, targetUserId}: {dialogueCheckId:string|undefined, targetUserId:string}) => {
+    captureEvent("hide_dialogue_frontpage_match")
+    void upsertUserDialogueCheck({ targetUserId, hideInRecommendations: true, checkId: dialogueCheckId });
   }
 
   const matchedUsers: DialogueUserResult[] | undefined = matchedUsersResult?.GetDialogueMatchedUsers;
@@ -313,7 +327,7 @@ const DialoguesList = ({ classes }: { classes: ClassesType<typeof styles> }) => 
               </ Typography>
             </div>}
           {currentUser?.showMatches && matchRowPropsList?.map((rowProps, index) => (
-            <DialogueMatchRow key={index} rowProps={rowProps} classes={classes} showMatchNote={true} />
+            !rowProps.hideInRecommendations && <DialogueMatchRow key={index} rowProps={rowProps} classes={classes} showMatchNote={true} onHide={hideMatch}/>
           ))}
           {showReciprocityRecommendations && currentUser?.showRecommendedPartners && recommendedDialoguePartnersRowPropsList?.map((rowProps, index) => (
             !rowProps.hideInRecommendations && <DialogueRecommendationRow key={index} targetUser={rowProps.targetUser} checkId={rowProps.checkId} userIsChecked={rowProps.userIsChecked} userIsMatched={rowProps.userIsMatched} showSuggestedTopics={true} onHide={hideRecommendation} />

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -576,7 +576,7 @@ getCollectionHooks("Posts").updateAfter.add(async (post: DbPost, props: UpdateCa
         updateMutator({ // reset check
           collection: DialogueChecks,
           documentId: dialogueCheck._id,
-          set: { checked: false },
+          set: { checked: false, hideInRecommendations: false },
           currentUser: adminContext.currentUser,
           context: adminContext,
           validate: false


### PR DESCRIPTION
Want to avoid users' frontpage getting clocked up. Add the hiding "x" to matches, moved over from recommendations. 

Also, if a dialogue is published, we reset the hide preference on the check between those two users. 

<img width="372" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/aadfc0b9-d99e-4c3a-b621-932257c5f940">

<img width="600" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/21347592/0f30930f-66c0-437b-9ec9-bfcda4c0887f">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206186979948630) by [Unito](https://www.unito.io)
