### PR TITLE
fix bug with iterating over undefined openConnections[userId]

### DIFF
--- a/packages/lesswrong/server/serverSentEvents.ts
+++ b/packages/lesswrong/server/serverSentEvents.ts
@@ -250,10 +250,12 @@ async function checkForActiveDialoguePartners() {
 
       const messageString = `data: ${JSON.stringify(message)}\n\n`;
 
-      for (let connection of openConnections[userId]) {
-        connection.res.write(messageString);
-        connection.newestNotificationTimestamp = new Date();
-      } 
+      if (openConnections[userId]) {
+        for (let connection of openConnections[userId]) {
+          connection.res.write(messageString);
+          connection.newestNotificationTimestamp = new Date();
+        } 
+      }
     }
   }
 }


### PR DESCRIPTION
Two line fix. You can ascertain by looking at the similar behavior in checkForNotifications and checkForTypingIndicators. 

Not sure how this slipped and ended up different, but fixed now.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206187235960568) by [Unito](https://www.unito.io)
