### PR TITLE
Hotfix to fix Quick review page

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -129,6 +129,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 12
   },
   nominationTimeRemaining: {
+    [theme.breakpoints.down('sm')]: {
+      display: "none"
+    },
     marginRight: "auto",
     marginLeft: 4,
     textAlign: "left"

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1474,13 +1474,13 @@ ensureIndex(Posts,
 Posts.addView("reviewQuickPage", (terms: PostsViewTerms) => {
   return {
     selector: {
-      $or: [{ reviewCount: null }, { reviewCount: 0 }],
+      $or: [{ reviewCount: 0 }],
       positiveReviewVoteCount: { $gte: REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD },
-      reviewVoteScoreAllKarma: { $gte: QUICK_REVIEW_SCORE_THRESHOLD }
+      // reviewVoteScoreAllKarma: { $gte: QUICK_REVIEW_SCORE_THRESHOLD }
     },
     options: {
       sort: {
-        reviewVoteScoreHighKarma: -1
+        baseScore: -1
       }
     }
   }


### PR DESCRIPTION
This fixes the quick review page, which relies on the reviewVoteScore fields to be populated, but those are not yet populated (they require running a manual migration).

The migration seems a bit jank, so it seemed better to do this hotfix and fix the scores tomorrow.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206190048249065) by [Unito](https://www.unito.io)
