### PR TITLE
rename wrapped function properly

### DIFF
--- a/packages/lesswrong/server/repos/perfMetricWrapper.ts
+++ b/packages/lesswrong/server/repos/perfMetricWrapper.ts
@@ -56,7 +56,7 @@ function wrapWithPerfMetrics(method: Function, repoName: string, methodName: str
     return results;
   };
 
-  wrappedFn.name = `perfMetricWrapped_${methodName}`;
+  Object.defineProperty(wrappedFn, 'name', { value: `perfMetricWrapped_${methodName}`, writable: false });
 
   return wrappedFn;
 }


### PR DESCRIPTION
When running a `migrate` command, ts-node blows up when trying to set a new value for a function's `name` by direct assignment (as I was doing when wrapping repo methods with perf metrics) with "Cannot assign to read only property 'name' of function".  `Object.defineProperty` gets around this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206200880317819) by [Unito](https://www.unito.io)
