### PR TITLE
Replace elasticsearch `exclude` parameter with `excludes`

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -434,7 +434,7 @@ class ElasticQuery {
         },
         sort: this.compileSort(sorting, coordinates),
         _source: {
-          exclude: ["exportedAt", ...privateFields],
+          excludes: ["exportedAt", ...privateFields],
         },
       },
     };


### PR DESCRIPTION
Elasticsearch is issuing warnings because we're using the `exclude` parameter which is now deprecated in favour of `excludes`. For our purposes they're functional identical, but this should make us more future proof in case the old version ever gets removed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206202766402337) by [Unito](https://www.unito.io)
