### PR TITLE
Fix community map keyword search

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -375,6 +375,11 @@ class ElasticQuery {
       coordinates,
     } = this.queryData;
     const {privateFields} = this.config;
+
+    // We sorting by nearest-geographically we disable custom highlighting as
+    // this isn't supported by elastic and causes an exception
+    const hasCustomHighlight = !coordinates;
+
     const {
       searchQuery,
       snippetName,
@@ -401,23 +406,25 @@ class ElasticQuery {
       body: {
         track_scores: true,
         track_total_hits: true,
-        highlight: {
-          fields: {
-            [snippetName]: {
-              ...highlightConfig,
-              highlight_query: snippetQuery,
-            },
-            ...(highlightName && {
-              [highlightName]: {
+        ...(hasCustomHighlight && {
+          highlight: {
+            fields: {
+              [snippetName]: {
                 ...highlightConfig,
-                highlight_query: highlightQuery,
+                highlight_query: snippetQuery,
               },
-            }),
+              ...(highlightName && {
+                [highlightName]: {
+                  ...highlightConfig,
+                  highlight_query: highlightQuery,
+                },
+              }),
+            },
+            number_of_fragments: 1,
+            fragment_size: 140,
+            no_match_size: 140,
           },
-          number_of_fragments: 1,
-          fragment_size: 140,
-          no_match_size: 140,
-        },
+        }),
         query: {
           script_score: {
             query: {

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -376,7 +376,7 @@ class ElasticQuery {
     } = this.queryData;
     const {privateFields} = this.config;
 
-    // We sorting by nearest-geographically we disable custom highlighting as
+    // When sorting by nearest-geographically we disable custom highlighting as
     // this isn't supported by elastic and causes an exception
     const hasCustomHighlight = !coordinates;
 


### PR DESCRIPTION
Our custom highlighting doesn't play nicely with nearest-geographically sorting - in fact, it causes an exception inside elastic that aborts the search. We don't actually use or need and highlighting here though, so we can just disable it in this case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206202929176531) by [Unito](https://www.unito.io)
