### PR TITLE
Add a `PostsTooltip` to the post title of popular comments

### DIFF
--- a/packages/lesswrong/components/comments/PopularComment.tsx
+++ b/packages/lesswrong/components/comments/PopularComment.tsx
@@ -96,16 +96,19 @@ const PopularCommentTitle: FC<{
   classes: ClassesType,
 }> = ({comment, post, classes}) => {
   const {isRead} = useRecordPostView(post);
+  const {PostsTooltip} = Components;
   return (
     <div className={classes.row}>
       <InteractionWrapper className={classes.postWrapper}>
-        <Link
-          to={postGetPageUrl(post)}
-          className={classNames(classes.post, {[classes.postRead]: isRead})}
-          eventProps={{intent: 'expandPost'}}
-        >
-          {post.title}
-        </Link>
+        <PostsTooltip postId={post._id}>
+          <Link
+            to={postGetPageUrl(post)}
+            className={classNames(classes.post, {[classes.postRead]: isRead})}
+            eventProps={{intent: 'expandPost'}}
+          >
+            {post.title}
+          </Link>
+        </PostsTooltip>
       </InteractionWrapper>
       <InteractionWrapper>
         <Link to={commentGetPageUrl(comment)} className={classes.link} eventProps={{intent: 'viewInThread'}}>


### PR DESCRIPTION
Long-standing feature request to add a posts tooltip to the post link in the title of popular comments on the frontpage.

<img width="449" alt="Screenshot 2023-12-19 at 10 55 52" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/af932378-1442-4dbc-b8b4-203255cc7f5d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206202949520172) by [Unito](https://www.unito.io)
