### PR TITLE
[EA] Fix DB settings upsert script for new form of the unique index

### DIFF
--- a/scripts/loadDbSettings.ts
+++ b/scripts/loadDbSettings.ts
@@ -50,7 +50,7 @@ const insert = async (db: Database, id: string, name: string, data: Record<strin
   await db.none(`
     INSERT INTO "DatabaseMetadata" ("_id", "name", "value")
     VALUES ($1, $2, $3)
-    ON CONFLICT (COALESCE("name", ''::TEXT)) DO UPDATE SET "value" = $3
+    ON CONFLICT (name) DO UPDATE SET "value" = $3
   `, [ id, name, data ]);
 }
 
@@ -58,7 +58,7 @@ const setDatabaseId = async (db: Database, id: string, databaseId: string) => {
   await db.none(`
     INSERT INTO "DatabaseMetadata" ("_id", "name", "value")
     VALUES ($1, $2, TO_JSONB($3::TEXT))
-    ON CONFLICT (COALESCE("name", ''::TEXT)) DO UPDATE
+    ON CONFLICT (name) DO UPDATE
     SET "value" = TO_JSONB($3::TEXT)
   `, [ id, "databaseId", databaseId ]);
 }


### PR DESCRIPTION
#8454 changed the way the unique index on DatabaseMetadata was created, from a unique `COALESCE("name", ''::TEXT)` to a unique `"name"`. As a consequence, our script for upserting our altered database settings was trying to match an out out of date index.

(cc @b0b3rt, FYI)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206208545657672) by [Unito](https://www.unito.io)
