### PR TITLE
Add user user_id and render startedAt to perf_metrics logging

### DIFF
--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -272,6 +272,7 @@ interface PerfMetric {
   gql_string?: string;
   ip?: string;
   user_agent?: string;
+  user_id?: string;
 }
 
 type IncompletePerfMetric = Omit<PerfMetric, 'ended_at'>;

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -273,6 +273,7 @@ interface PerfMetric {
   ip?: string;
   user_agent?: string;
   user_id?: string;
+  render_started_at?: Date;
 }
 
 type IncompletePerfMetric = Omit<PerfMetric, 'ended_at'>;

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -121,7 +121,7 @@ async function writeEventsToAnalyticsDB(events: {type: string, timestamp: Date, 
   }
 }
 
-const perfMetricsColumnSet = new pgPromiseLib.helpers.ColumnSet(['trace_id', 'op_type', 'op_name', 'started_at', 'ended_at', 'parent_trace_id', 'client_path', 'extra_data', 'gql_string_id', 'ip', 'user_agent', 'environment'], {table: 'perf_metrics'});
+const perfMetricsColumnSet = new pgPromiseLib.helpers.ColumnSet(['trace_id', 'op_type', 'op_name', 'started_at', 'ended_at', 'parent_trace_id', 'client_path', 'extra_data', 'gql_string_id', 'ip', 'user_agent', 'user_id', 'render_started_at', 'environment'], {table: 'perf_metrics'});
 
 interface PerfMetricGqlString {
   id: number;
@@ -212,6 +212,7 @@ async function flushPerfMetrics() {
           ip: perfMetric.ip ?? null,
           user_agent: perfMetric.user_agent ?? null,
           user_id: perfMetric.user_id ?? null,
+          render_started_at: perfMetric.render_started_at ?? null,
           ...gqlStringId
         }
       });

--- a/packages/lesswrong/server/analyticsWriter.ts
+++ b/packages/lesswrong/server/analyticsWriter.ts
@@ -211,6 +211,7 @@ async function flushPerfMetrics() {
           extra_data: perfMetric.extra_data ?? null,
           ip: perfMetric.ip ?? null,
           user_agent: perfMetric.user_agent ?? null,
+          user_id: perfMetric.user_id ?? null,
           ...gqlStringId
         }
       });

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -133,6 +133,7 @@ export function startWebserver() {
   app.use('/ckeditor-webhook', express.json({ limit: '50mb' }));
 
   addStripeMiddleware(addMiddleware);
+  // Most middleware need to run after those added by addAuthMiddlewares, so that they can access the user that passport puts on the request.  Be careful if moving it!
   addAuthMiddlewares(addMiddleware);
   addForumSpecificMiddleware(addMiddleware);
   addSentryMiddlewares(addMiddleware);
@@ -174,7 +175,6 @@ export function startWebserver() {
 
   app.use('/graphql', express.json({ limit: '50mb' }));
   app.use('/graphql', express.text({ type: 'application/graphql' }));
-  //perfMetricMiddleware needs to run after addAuthMiddlewares, so that it can access the user that passport puts on the request
   app.use('/graphql', perfMetricMiddleware);
   apolloServer.applyMiddleware({ app })
 

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -174,6 +174,7 @@ export function startWebserver() {
 
   app.use('/graphql', express.json({ limit: '50mb' }));
   app.use('/graphql', express.text({ type: 'application/graphql' }));
+  //perfMetricMiddleware needs to run after addAuthMiddlewares, so that it can access the user that passport puts on the request
   app.use('/graphql', perfMetricMiddleware);
   apolloServer.applyMiddleware({ app })
 

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -47,6 +47,28 @@ export function closePerfMetric(openPerfMetric: IncompletePerfMetric) {
   queuePerfMetric(perfMetric);
 }
 
+export function addStartRenderTimeToPerfMetric() {
+  const store = asyncLocalStorage.getStore();
+  if (!store) {
+    // eslint-disable-next-line no-console
+    console.log('Missing asyncLocalStorage context when trying to add start render time to the perf metric for the current request!');
+    return;
+  }
+
+  if (!store.requestPerfMetric) {
+    // eslint-disable-next-line no-console
+    console.log('Missing perf metric for the current request in the asyncLocalStorage context when trying to add start render time to it!');
+    return;
+  }
+
+  setAsyncStoreValue('requestPerfMetric', {
+    ...store.requestPerfMetric,
+    render_started_at: new Date(),
+  });
+
+
+}
+
 /**
  * We have a dedicated function to send off the perf metric for the top-level request
  * This is because we track it in the async local storage context,

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -80,7 +80,8 @@ export function perfMetricMiddleware(req: Request, res: Response, next: NextFunc
     op_name: req.originalUrl,
     client_path: req.headers['request-origin-path'] as string,
     ip: getForwardedWhitelist().getClientIP(req),
-    user_agent: req.headers["user-agent"]
+    user_agent: req.headers["user-agent"],
+    user_id: req.user?._id,
   });
 
   res.on('finish', () => {

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -48,21 +48,17 @@ export function closePerfMetric(openPerfMetric: IncompletePerfMetric) {
 }
 
 export function addStartRenderTimeToPerfMetric() {
-  const store = asyncLocalStorage.getStore();
-  if (!store) {
-    // eslint-disable-next-line no-console
-    console.log('Missing asyncLocalStorage context when trying to add start render time to the perf metric for the current request!');
-    return;
-  }
-  if (!store.requestPerfMetric) {
-    // eslint-disable-next-line no-console
-    console.log('Missing perf metric for the current request in the asyncLocalStorage context when trying to add start render time to it!');
-    return;
-  }
-
-  setAsyncStoreValue('requestPerfMetric', {
-    ...store.requestPerfMetric,
-    render_started_at: new Date(),
+  setAsyncStoreValue('requestPerfMetric', (incompletePerfMetric) => {
+    if (!incompletePerfMetric) {
+      // eslint-disable-next-line no-console
+      console.log('Missing perf metric for the current request in the asyncLocalStorage context when trying to add start render time to it!');
+      return;
+    }
+    
+    return {
+      ...incompletePerfMetric,
+      render_started_at: new Date()
+    };
   });
 }
 

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -6,7 +6,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { performanceMetricLoggingEnabled } from '../lib/publicSettings';
 import { getForwardedWhitelist } from './forwarded_whitelist';
 
-type IncompletePerfMetricProps = Pick<PerfMetric, 'op_type' | 'op_name' | 'parent_trace_id' | 'extra_data' | 'client_path' | 'gql_string' | 'ip' | 'user_agent'>;
+type IncompletePerfMetricProps = Pick<PerfMetric, 'op_type' | 'op_name' | 'parent_trace_id' | 'extra_data' | 'client_path' | 'gql_string' | 'ip' | 'user_agent' | 'user_id'>;
 
 interface AsyncLocalStorageContext {
   resolverContext?: ResolverContext;

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -109,9 +109,6 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     recordCacheBypass({path: getPathFromReq(req), userAgent: userAgent ?? ''});
     
     if (performanceMetricLoggingEnabled.get()) {
-
-      console.log("do we have user??", user?._id)
-
       const perfMetric = openPerfMetric({
         op_type: "ssr",
         op_name: "skipCache",

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -28,7 +28,7 @@ import { DatabaseServerSetting } from '../../databaseSettings';
 import type { Request, Response } from 'express';
 import type { TimeOverride } from '../../../lib/utils/timeUtil';
 import { getIpFromRequest } from '../../datadog/datadogMiddleware';
-import { asyncLocalStorage, closePerfMetric, closeRequestPerfMetric, openPerfMetric, setAsyncStoreValue } from '../../perfMetrics';
+import { addStartRenderTimeToPerfMetric, asyncLocalStorage, closePerfMetric, closeRequestPerfMetric, openPerfMetric, setAsyncStoreValue } from '../../perfMetrics';
 import { maxRenderQueueSize, performanceMetricLoggingEnabled } from '../../../lib/publicSettings';
 import { getForwardedWhitelist } from '../../forwarded_whitelist';
 import { onStartup, isAnyTest } from '../../../lib/executionEnvironment';
@@ -109,6 +109,9 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     recordCacheBypass({path: getPathFromReq(req), userAgent: userAgent ?? ''});
     
     if (performanceMetricLoggingEnabled.get()) {
+
+      console.log("do we have user??", user?._id)
+
       const perfMetric = openPerfMetric({
         op_type: "ssr",
         op_name: "skipCache",
@@ -219,6 +222,7 @@ function queueRenderRequest(params: RenderRequestParams): Promise<RenderResult> 
     requestQueue.push({
       callback: async () => {
         let result: RenderResult;
+        addStartRenderTimeToPerfMetric();
         try {
           result = await renderRequest(params);
         } finally {

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -31,8 +31,7 @@ import { getIpFromRequest } from '../../datadog/datadogMiddleware';
 import { asyncLocalStorage, closePerfMetric, closeRequestPerfMetric, openPerfMetric, setAsyncStoreValue } from '../../perfMetrics';
 import { maxRenderQueueSize, performanceMetricLoggingEnabled } from '../../../lib/publicSettings';
 import { getForwardedWhitelist } from '../../forwarded_whitelist';
-import { onStartup } from '../../../lib/executionEnvironment';
-import { isAnyTest } from '../../../lib/executionEnvironment';
+import { onStartup, isAnyTest } from '../../../lib/executionEnvironment';
 
 const slowSSRWarnThresholdSetting = new DatabaseServerSetting<number>("slowSSRWarnThreshold", 3000);
 


### PR DESCRIPTION
(@b0b3rt edit) We also start logging a new analytics event that records the SSR queue state every five seconds (if it's not empty when the `setInterval` goes off).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206208473886837) by [Unito](https://www.unito.io)
