### PR TITLE
Change default comment order to a setting (#168)

### DIFF
--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -6,8 +6,7 @@ import { userCanDo } from '../../vulcan-users/permissions';
 import { userGetDisplayName } from "../users/helpers";
 import { tagGetCommentLink } from '../tags/helpers';
 import { TagCommentType } from './types';
-import { hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
-import { forumSelect } from '../../forumTypeUtils';
+import { defaultCommentOrderSetting, hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
 
 // Get a comment author's name
 export async function commentGetAuthorName(comment: DbComment): Promise<string> {
@@ -82,12 +81,9 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
 }
 
 export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
-  const fallback = forumSelect({
-    AlignmentForum: "afPostCommentsTop",
-    EAForum: "postCommentsMagic",
-    default: "postCommentsTop",
-  });
-  return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
+  return (post?.commentSortOrder as CommentsViewName) ||
+    (currentUser?.commentSorting as CommentsViewName) ||
+    defaultCommentOrderSetting.get();
 }
 
 export const commentGetKarma = (comment: CommentsList|DbComment): number => {

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -122,3 +122,5 @@ export const hasProminentLogoSetting = new DatabasePublicSetting<boolean>("hasPr
 export const hasCookieConsentSetting = new DatabasePublicSetting<boolean>('hasCookieConsent', false)
 
 export const dialogueMatchmakingEnabled = new DatabasePublicSetting<boolean>('dialogueMatchmakingEnabled', false)
+
+export const defaultCommentOrderSetting = new DatabasePublicSetting<string>('post.defaultCommentOrder', 'postCommentsTop');


### PR DESCRIPTION
This commit changes the default comment order to use a new post.defaultCommentOrder setting, rather than the current hardcoded forumSelect.

EAForum will want their setting to be "postCommentsMagic", and AlignmentForum will want "afPostCommentsTop". LessWrong and WakingUp will use the default, "postCommentsTop".
