### PR TITLE
[EA Forum only] cleanup the digests list

### DIFF
--- a/packages/lesswrong/components/ea-forum/digest/Digests.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/Digests.tsx
@@ -1,21 +1,28 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useMulti } from '../../../lib/crud/withMulti';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../../common/withUser';
 import { userIsAdmin } from '../../../lib/vulcan-users/permissions';
-import { getDigestName } from '../../../lib/collections/digests/helpers';
+import { getDigestInfo } from '../../../lib/collections/digests/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     maxWidth: 1200,
     margin: '10px auto'
   },
+  digests: {
+    display: 'grid',
+    gridTemplateColumns: '200px 50px 14px 50px',
+    alignItems: 'center',
+    gap: '10px 1px',
+    fontFamily: theme.typography.fontFamily,
+  },
   link: {
     color: theme.palette.primary.main,
-    fontFamily: theme.typography.fontFamily,
     fontSize: 16,
-    lineHeight: '22px'
+    lineHeight: '22px',
+    fontWeight: 600,
   }
 })
 
@@ -27,6 +34,7 @@ const Digests = ({classes}:{classes: ClassesType}) => {
     },
     collectionName: "Digests",
     fragmentName: 'DigestsMinimumInfo',
+    limit: 100,
     skip: !userIsAdmin(currentUser)
   })
   
@@ -44,14 +52,22 @@ const Digests = ({classes}:{classes: ClassesType}) => {
         title="Digests"
         noTopMargin
       />
-        
-      {results.map(digest => {
-        return <div key={digest._id}>
-          <Link to={`/admin/digests/${digest.num}`} className={classes.link}>
-            {getDigestName({digest})}
-          </Link>
-        </div>
-      })}
+      
+      <div className={classes.digests}>
+        {results.map(digest => {
+          const data = getDigestInfo(digest)
+          return <Fragment key={digest._id}>
+            <div>
+              <Link to={`/admin/digests/${digest.num}`} className={classes.link}>
+                {data.name}
+              </Link>
+            </div>
+            <div>{data.start}</div>
+            <div>-</div>
+            <div>{data.end}</div>
+          </Fragment>
+        })}
+      </div>
     </div>
   )
 }

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestHeader.tsx
@@ -95,7 +95,7 @@ export const EditDigestHeader = ({digest, classes}: {
 
   return <SectionTitle
     title={<span className={classes.root}>
-      {getDigestName({digest, includeDates: false})} ({startNode} - {endNode})
+      {getDigestName(digest)} ({startNode} - {endNode})
     </span>}
     noTopMargin
   />

--- a/packages/lesswrong/lib/collections/digests/helpers.ts
+++ b/packages/lesswrong/lib/collections/digests/helpers.ts
@@ -13,13 +13,23 @@ export type StatusField = 'emailDigestStatus'|'onsiteDigestStatus'
 /**
  * Returns the digest name in our standard format
  */
-export const getDigestName = ({digest, includeDates=true}: {digest: DigestsMinimumInfo, includeDates?: boolean}) => {
-  const name = `EA Forum Digest #${digest.num}`
-  if (!includeDates) return name
-  
-  const digestStartDateFormatted = moment(digest.startDate).format('MMM D')
-  const digestEndDateFormatted = digest.endDate ? moment(digest.endDate).format('MMM D') : 'now'
-  return `${name} (${digestStartDateFormatted} - ${digestEndDateFormatted})`
+export const getDigestName = (digest: DigestsMinimumInfo) => {
+  return `EA Forum Digest #${digest.num}`
+}
+
+/**
+ * Returns the digest name and dates
+ */
+export const getDigestInfo = (digest: DigestsMinimumInfo) => {
+  const name = getDigestName(digest)
+  const start = moment(digest.startDate).format('MMM D')
+  const end = digest.endDate ? moment(digest.endDate).format('MMM D') : 'now'
+
+  return {
+    name,
+    start,
+    end
+  }
 }
 
 /**


### PR DESCRIPTION
I just wanted to increase the limit to display more digests here, and I also ended up cleaning up the UI a bit to make it more readable.

Old:
<img width="342" alt="Screen Shot 2023-12-20 at 2 10 08 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/ae13ca09-2717-4834-8f15-e70531ed71f8">

New:
<img width="342" alt="Screen Shot 2023-12-20 at 2 09 44 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/1b4587ce-b6ba-4070-954e-6c1cbbf3cda1">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206215174297608) by [Unito](https://www.unito.io)
