### PR TITLE
Don't SSR if request is cancelled while waiting in the request queue

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -328,6 +328,12 @@ export function startWebserver() {
       ? await asyncLocalStorage.run({}, () => renderWithCache(request, response, user))
       : await renderWithCache(request, response, user);
     
+    if (renderResult.aborted) {
+      response.status(499);
+      response.end();
+      return;
+    }
+    
     const {
       ssrBody,
       headers,

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -130,9 +130,11 @@ export const cachedPageRender = async (req: Request, abTestGroups: CompleteTestG
   }
   
   const rendered = await renderPromise;
-  // eslint-disable-next-line no-console
-  console.log(`Completed render with A/B test groups: ${JSON.stringify(rendered.relevantAbTestGroups)}`);
-  cacheStore(cacheKey, rendered.relevantAbTestGroups, rendered);
+  if (!rendered.aborted) {
+    // eslint-disable-next-line no-console
+    console.log(`Completed render with A/B test groups: ${JSON.stringify(rendered.relevantAbTestGroups)}`);
+    cacheStore(cacheKey, rendered.relevantAbTestGroups, rendered);
+  }
   
   inProgressRenders[cacheKey] = inProgressRenders[cacheKey].filter(r => r!==inProgressRender);
   if (!inProgressRenders[cacheKey].length)
@@ -184,7 +186,10 @@ const cacheLookupDB = async (cacheKey: string, abTestGroups: CompleteTestGroupAl
 
   // eslint-disable-next-line no-console
   console.log(`DB cache hit for cacheKey ${cacheKey}`);
-  return cacheResult?.renderResult;
+  return {
+    ...cacheResult?.renderResult,
+    aborted: false
+  };
 }
 
 const cacheLookup = async (cacheKey: string, abTestGroups: CompleteTestGroupAllocation): Promise<RenderResult|null|undefined> => {


### PR DESCRIPTION
This makes it so that if a request waits in the request queue, but by the time its turn comes up the request's connection is already closed, then we don't do an SSR for that request. In theory, this should significantly improve recovery time after a server is overloaded with excessive requests, if the clients behind those requests close their connections before waiting for them to complete.

Tested by filling up a local development server's request queue with
```
for i in {1..50}; do wget "http://localhost:3000/?noCache=${i}" & done 
```
then while that's working, doing
```
wget localhost:3000/?distinctive-url
```
in another console and quickly cancelling it with ^C. I then searched a log file of the server's console output to check that the `?distinctive-url` request (and no others) had skipped SSR.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206215828873328) by [Unito](https://www.unito.io)
