### PR TITLE
Make requestFeedbackKarmaLevel into a setting 

### DIFF
--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import { useCurrentUser } from "../common/withUser";
 import { useTracking } from "../../lib/analyticsEvents";
 import {forumTitleSetting, isEAForum, isLW } from "../../lib/instanceSettings";
-import { forumSelect } from '../../lib/forumTypeUtils';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import {requestFeedbackKarmaLevelSetting} from '../../lib/publicSettings.ts'
 
@@ -61,8 +60,6 @@ export type PostSubmitProps = FormButtonProps & {
   classes: ClassesType
 }
 
-const requestFeedbackKarmaLevel = requestFeedbackKarmaLevelSetting.get()
-
 const PostSubmit = ({
   submitLabel = "Submit",
   cancelLabel = "Cancel",
@@ -89,6 +86,7 @@ const PostSubmit = ({
   const requireConfirmation = isLW && collectionName === 'Posts' && !!document.debate;
 
   const onSubmitClick = requireConfirmation ? submitWithConfirmation : submitWithoutConfirmation;
+  const requestFeedbackKarmaLevel = requestFeedbackKarmaLevelSetting.get()
 
   return (
     <React.Fragment>
@@ -106,7 +104,7 @@ const PostSubmit = ({
         </div>
       }
       <div className={classes.submitButtons}>
-        {requestFeedbackKarmaLevel && currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
+        {requestFeedbackKarmaLevel !== null && currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
           // EA Forum title is Effective Altruism Forum, which is unecessarily long
           title={`Request feedback from the ${isEAForum ? "EA Forum" : forumTitleSetting.get()} team.`}
         >

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -8,6 +8,7 @@ import { useTracking } from "../../lib/analyticsEvents";
 import {forumTitleSetting, isEAForum, isLW } from "../../lib/instanceSettings";
 import { forumSelect } from '../../lib/forumTypeUtils';
 import { isFriendlyUI } from '../../themes/forumTheme';
+import {requestFeedbackKarmaLevelSetting} from '../../lib/publicSettings.ts'
 
 export const styles = (theme: ThemeType): JssStyles => ({
   formButton: {
@@ -60,10 +61,7 @@ export type PostSubmitProps = FormButtonProps & {
   classes: ClassesType
 }
 
-const requestFeedbackKarmaLevel = forumSelect({
-  EAForum: 200,
-  default: 100,
-})
+const requestFeedbackKarmaLevel = requestFeedbackKarmaLevelSetting.get()
 
 const PostSubmit = ({
   submitLabel = "Submit",
@@ -108,7 +106,7 @@ const PostSubmit = ({
         </div>
       }
       <div className={classes.submitButtons}>
-        {currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
+        {requestFeedbackKarmaLevel && currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
           // EA Forum title is Effective Altruism Forum, which is unecessarily long
           title={`Request feedback from the ${isEAForum ? "EA Forum" : forumTitleSetting.get()} team.`}
         >

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -124,3 +124,5 @@ export const dialogueMatchmakingEnabled = new DatabasePublicSetting<boolean>('di
 export const maxRenderQueueSize = new DatabasePublicSetting<number>('maxRenderQueueSize', 10);
 export const performanceMetricLoggingEnabled = new DatabasePublicSetting<boolean>('performanceMetricLoggingEnabled', false)
 export const performanceMetricLoggingBatchSize = new DatabasePublicSetting<number>('performanceMetricLoggingBatchSize', 100)
+// Null means requests are disabled
+export const requestFeedbackKarmaLevelSetting = new DatabasePublicSetting<number | null>('post.requestFeedbackKarmaLevel', 100);


### PR DESCRIPTION
Requires a setting update on EA forum side, as we're migrating from ForumSelect that had an EA override

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206216596475507) by [Unito](https://www.unito.io)
