### PR TITLE
Tiny style fix to online users icon

### DIFF
--- a/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
+++ b/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
@@ -75,6 +75,10 @@ const styles = (theme: ThemeType) => ({
   visibilityIcon: {
     color: theme.palette.grey[400],
     fontSize: "1.7em",
+    cursor: "pointer",
+    '&:hover': {
+      opacity: 0.6
+    }
   }
 });
 


### PR DESCRIPTION
Upon Oli's request, make it clearer the "eye" icon can be interacted with. 
