### PR TITLE
Add voting limits: 3 strong-votes on comments on the same post, 10 strong-votes in an hour

### DIFF
--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -506,15 +506,16 @@ class VotesRepo extends AbstractRepo<"Votes"> {
       SELECT
         v.*
       FROM
-        "Votes" v,
-        "Comments" c
+        "Votes" v
+      INNER JOIN "Comments" c ON (
+        c._id = v."documentId"
+        AND c."postId" = $2
+      )
       WHERE
         v."cancelled" IS FALSE
         AND v."userId" = $1
         AND v."documentId" != $3
         AND v."collectionName" = 'Comments'
-        AND c._id = v."documentId"
-        AND c."postId" = $2
     `, [userId, postId, excludedDocumentId]);
   }
 }

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -496,7 +496,27 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     );
     return results.map(({ vote_id }) => vote_id);
   }
-
+  
+  async getVotesOnSamePost({userId, postId, excludedDocumentId}: {
+    userId: string,
+    postId: string,
+    excludedDocumentId: string,
+  }): Promise<DbVote[]> {
+    return await this.manyOrNone(`
+      SELECT
+        v.*
+      FROM
+        "Votes" v
+        "Comments" c
+      WHERE
+        v."cancelled" IS FALSE
+        AND v."userId" = $1
+        AND v."documentId" != $3
+        AND v."collectionName" = "Comments"
+        AND c._id = v."documentId"
+        AND c."postId" = $2
+    `, [userId, postId, excludedDocumentId]);
+  }
 }
 
 recordPerfMetrics(VotesRepo);

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -506,13 +506,13 @@ class VotesRepo extends AbstractRepo<"Votes"> {
       SELECT
         v.*
       FROM
-        "Votes" v
+        "Votes" v,
         "Comments" c
       WHERE
         v."cancelled" IS FALSE
         AND v."userId" = $1
         AND v."documentId" != $3
-        AND v."collectionName" = "Comments"
+        AND v."collectionName" = 'Comments'
         AND c._id = v."documentId"
         AND c."postId" = $2
     `, [userId, postId, excludedDocumentId]);

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -401,13 +401,13 @@ const getVotingRateLimits = (user: DbUser): VotingRateLimit[] => {
         message: null,
       },
       {
-        voteCount: 3,
+        voteCount: 5,
         periodInMinutes: null,
         allOnSamePost: true,
         types: "onlyStrong",
         users: "allUsers",
         consequences: ["denyThisVote"],
-        message: "You can only strong-vote on up to three comments per post",
+        message: "You can only strong-vote on up to five comments per post",
       },
     ];
   }

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -23,6 +23,7 @@ import { elasticSyncDocument } from './search/elastic/elasticCallbacks';
 import { collectionIsSearchIndexed } from '../lib/search/searchUtil';
 import { isElasticEnabled } from './search/elastic/elasticSettings';
 import {Posts} from '../lib/collections/posts';
+import { VotesRepo } from './repos';
 
 
 // Test if a user has voted on the server
@@ -337,8 +338,9 @@ type Consequence = "warningPopup" | "denyThisVote" | "flagForModeration"
 
 interface VotingRateLimit {
   voteCount: number
-  /** Must be ≤ than 24 hours */
-  periodInMinutes: number
+  /** If provided, periodInMinutes must be ≤ than 24 hours. At least one of periodInMinutes or allOnSamePost must be provided. */
+  periodInMinutes: number|null,
+  allOnSamePost?: true,
   types: "all"|"onlyStrong"|"onlyDown"
   users: "allUsers"|"singleUser"
   consequences: Consequence[]
@@ -367,6 +369,14 @@ const getVotingRateLimits = (user: DbUser): VotingRateLimit[] => {
         message: "too many votes in one hour",
       },
       {
+        voteCount: 10,
+        periodInMinutes: 60,
+        types: "onlyStrong",
+        users: "allUsers",
+        consequences: ["denyThisVote"],
+        message: "too many strong-votes in one hour",
+      },
+      {
         voteCount: 100,
         periodInMinutes: 24*60,
         types: "all",
@@ -390,6 +400,15 @@ const getVotingRateLimits = (user: DbUser): VotingRateLimit[] => {
         consequences: ["warningPopup"],
         message: null,
       },
+      {
+        voteCount: 3,
+        periodInMinutes: null,
+        allOnSamePost: true,
+        types: "onlyStrong",
+        users: "allUsers",
+        consequences: ["denyThisVote"],
+        message: "You can only strong-vote on up to three comments per post",
+      },
     ];
   }
 }
@@ -404,7 +423,7 @@ const getVotingRateLimits = (user: DbUser): VotingRateLimit[] => {
  * May also add apply voting-related consequences such as flagging the user for
  * moderation, as side effects.
  */
-const checkVotingRateLimits = async ({ document, user }: {
+const checkVotingRateLimits = async ({ document, collection, voteType, user }: {
   document: DbVoteableType,
   collection: CollectionBase<VoteableCollectionName>,
   voteType: string,
@@ -416,14 +435,23 @@ const checkVotingRateLimits = async ({ document, user }: {
   if(document.userId === user._id)
     return {};
   
-  // Retrieve all non-cancelled votes cast by this user in the past 24 hours
+  // Retrieve all non-cancelled votes cast by this user that were either cast
+  // in the past 24 hours, or are on comments on the same post as this one
   const oneDayAgo = moment().subtract(1, 'days').toDate();
-  const votesInLastDay = await Votes.find({
-    userId: user._id,
-    authorIds: {$ne: user._id}, // Self-votes don't count
-    votedAt: {$gt: oneDayAgo},
-    cancelled:false
-  }).fetch();
+  const postId = (document as any)?.postId ?? null;
+  const [votesInLastDay, votesOnCommentsOnThisPost] = await Promise.all([
+    Votes.find({
+      userId: user._id,
+      authorIds: {$ne: user._id}, // Self-votes don't count
+      votedAt: {$gt: oneDayAgo},
+      cancelled:false
+    }).fetch(),
+    postId ? new VotesRepo().getVotesOnSamePost({
+      userId: user._id,
+      postId,
+      excludedDocumentId: document._id
+    }) : [],
+  ]);
   
   // Go through rate limits checking if each applies. If more than one rate
   // limit applies, we take the union of the consequences of exceeding all of
@@ -432,10 +460,21 @@ const checkVotingRateLimits = async ({ document, user }: {
   let rateLimitConsequences = new Set<Consequence>();
   
   for (const rateLimit of getVotingRateLimits(user)) {
-    if (votesInLastDay.length < rateLimit.voteCount)
-      continue;
+    let votesToConsider = rateLimit.allOnSamePost
+      ? votesOnCommentsOnThisPost
+      : votesInLastDay;
 
-    const numMatchingVotes = getRelevantVotes(rateLimit, document, votesInLastDay).length;
+    if (votesToConsider.length < rateLimit.voteCount) {
+      continue;
+    }
+    if (rateLimit.types === "onlyDown" && !voteTypeIsDown(voteType)) {
+      continue;
+    }
+    if (rateLimit.types === "onlyStrong" && !voteTypeIsStrong(voteType)) {
+      continue;
+    }
+
+    const numMatchingVotes = getRelevantVotes(rateLimit, document, votesToConsider).length;
     
     if (numMatchingVotes >= rateLimit.voteCount) {
       if (!firstExceededRateLimit) {
@@ -470,26 +509,40 @@ const checkVotingRateLimits = async ({ document, user }: {
   return { moderatorActionType };
 }
 
-function getRelevantVotes(rateLimit: VotingRateLimit, document: DbVoteableType, votes: DbVote[]): DbVote[] {
+function getRelevantVotes(
+  rateLimit: VotingRateLimit,
+  document: DbVoteableType,
+  votes: DbVote[],
+): DbVote[] {
   const now = new Date().getTime();
 
   return votes.filter(vote => {
     const ageInMS = now - vote.votedAt.getTime();
     const ageInMinutes = ageInMS / (1000 * 60);
 
-    if (ageInMinutes > rateLimit.periodInMinutes)
+    if (rateLimit.periodInMinutes && ageInMinutes > rateLimit.periodInMinutes) {
       return false;
+    }
+    
     if (rateLimit.users === "singleUser" && !!document.userId &&!vote.authorIds?.includes(document.userId))
       return false;
 
-    const isStrong = (vote.voteType === "bigDownvote" || vote.voteType === "bigUpvote");
-    const isDown = (vote.voteType === "smallDownvote" || vote.voteType === "bigDownvote");
+    const isStrong = voteTypeIsStrong(vote.voteType);
+    const isDown = voteTypeIsDown(vote.voteType);
     if (rateLimit.types === "onlyStrong" && !isStrong)
       return false;
     if (rateLimit.types === "onlyDown" && !isDown)
       return false;
     return true;
   })
+}
+
+function voteTypeIsStrong(voteType: string): boolean {
+  return voteType==="bigDownvote" || voteType==="bigUpvote";
+}
+
+function voteTypeIsDown(voteType: string): boolean {
+  return voteType==="bigDownvote" || voteType==="smallDownvote";
 }
 
 function voteHasAnyEffect(votingSystem: VotingSystem, vote: DbVote, af: boolean) {


### PR DESCRIPTION
Adds a limit where you can only strong-vote 3 times on comments on a single post. The idea is that if someone is worked up about a controversy-thread, such that they would strong-vote on everything, they're limited to only 3 strong-votes, which reduces the degree to which they can control post-scores to something closer to the level of influence that more casual commenters have.

Also adds a limit of 10 strong-votes per hour, which is meant to discourage people from using strong-votes for all their voting.

(PR comments for the technical side; for the policy-discussion about these rate limits, use the Slack thread thread in forum-magnum-product.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206217785958930) by [Unito](https://www.unito.io)
