### PR TITLE
add indexes for some poorly performing queries

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1542,3 +1542,13 @@ Posts.addView("myBookmarkedPosts", (terms: PostsViewTerms, _, context?: Resolver
     },
   };
 });
+
+
+/**
+ * For preventing `PostsRepo.getRecentlyActiveDialogues` from being a seq scan.
+ */
+void ensureCustomPgIndex(`
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Posts_max_postedAt_mostRecentPublishedDialogueResponseDate"
+  ON "Posts" (GREATEST("postedAt", "mostRecentPublishedDialogueResponseDate") DESC)
+  WHERE "collabEditorDialogue" IS TRUE AND draft IS NOT TRUE;
+`);

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1547,6 +1547,8 @@ Posts.addView("myBookmarkedPosts", (terms: PostsViewTerms, _, context?: Resolver
 /**
  * For preventing both `PostsRepo.getRecentlyActiveDialogues` and `PostsRepo.getMyActiveDialogues` from being seq scans on Posts.
  * Given the relatively small number of dialogues, `getMyActiveDialogues` still ends up being fast even though it needs to check each dialogue for userId/coauthorStatuses.
+ * 
+ * This also speeds up `UsersRepo.getUsersWhoHaveMadeDialogues` a bunch.
  */
 void ensureCustomPgIndex(`
   CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Posts_max_postedAt_mostRecentPublishedDialogueResponseDate"

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1545,10 +1545,11 @@ Posts.addView("myBookmarkedPosts", (terms: PostsViewTerms, _, context?: Resolver
 
 
 /**
- * For preventing `PostsRepo.getRecentlyActiveDialogues` from being a seq scan.
+ * For preventing both `PostsRepo.getRecentlyActiveDialogues` and `PostsRepo.getMyActiveDialogues` from being seq scans on Posts.
+ * Given the relatively small number of dialogues, `getMyActiveDialogues` still ends up being fast even though it needs to check each dialogue for userId/coauthorStatuses.
  */
 void ensureCustomPgIndex(`
   CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Posts_max_postedAt_mostRecentPublishedDialogueResponseDate"
   ON "Posts" (GREATEST("postedAt", "mostRecentPublishedDialogueResponseDate") DESC)
-  WHERE "collabEditorDialogue" IS TRUE AND draft IS NOT TRUE;
+  WHERE "collabEditorDialogue" IS TRUE;
 `);

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -28,6 +28,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           SELECT "postId", MAX("promotedAt") AS max_promotedAt
           FROM "Comments"
           WHERE "postId" IN ($1:csv)
+          AND "promotedAt" IS NOT NULL
           GROUP BY "postId"
       ) sq
       ON c."postId" = sq."postId" AND c."promotedAt" = sq.max_promotedAt;


### PR DESCRIPTION
The new perf metrics for db_repo_methods indicated that both `getRecentlyActiveDialogues` and `getMyActiveDialogues` were abominably slow, given what they were doing.  As well they must have been, since neither `collabEditorDialogue` nor `mostRecentPublishedDialogueResponseDate` were indexed anywhere, and correspondingly the query plans indicated the dreaded `Seq scan on "Posts" p` was chewing up DB cycles.

<img width="1063" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/d0afea3c-1bda-4f53-a680-fb29ca23852b">
<img width="1064" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/d18a3ed9-82db-4226-ad5c-3a0b459dd905">

This PR creates a partial index (only for dialogues) which orders by the same condition used by `getRecentlyActiveDialogues`, hopefully taking it from ~300ms (warm start) - 1s (cold start), to well under 1ms (at least if the reduction is similar to what it is on dev).  Initially I was also filtering on non-draft dialogues, but removing that part of the index condition also got `getMyActiveDialogues` down to ~1 ms (on dev), even though it's not really fine-tuned for the purpose.  (It makes it fast simply by dint of there not being that many dialogues, so even though it's doing an index scan, the index is tiny since it's a partial index.  If dialogues turn out to scale and there end up being a lot of them, it might at some point be worth making a dedicated index for that query too.)

Happily, this should bring also `UsersRepo.getUsersWhoHaveMadeDialogues` down to almost nothing (from >200ms p50).

I can't for the life of me figure out how to speed up `PostsRepo.getUsersReadPostsOfTargetUser`, or `CommentsRepo.getUsersRecommendedCommentsOfTargetUser` (which is similar to `getUsersReadPostsOfTargetUser`, but a bit more complicated... and the query plan ends up being somewhat different).

`CommentsRepo.getPromotedCommentsOnPosts` also had surprisingly poor performance:
<img width="1068" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/7e9a7ca5-347f-4444-bde9-4d0e183982b6">

What was happening here was that the query was running an index scan using `idx_Comments_postId`, and then (shockingly expensively) pulling those comments from storage, because the index didn't contain `promotedAt`.  Adding a full-table index seems like overkill, but adding partial index on `WHERE "promotedAt" IS NOT NULL` also requires adding a corresponding WHERE clause to the query to ensure that index gets used.

A similar thing was happening with `TagsRepo.getUserTopTags`:
<img width="1065" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/b7a87dc4-51ef-4ff5-8270-12591e20b277">

Except in this case the index didn't contain `postId`.  This one won't see as much improvement, from some testing, but it should still help significantly.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206226862159444) by [Unito](https://www.unito.io)
