### PR TITLE
Auto archive dialogues that have gone stale. Show archive notice

### DIFF
--- a/packages/lesswrong/components/editor/ArchiveNotice.tsx
+++ b/packages/lesswrong/components/editor/ArchiveNotice.tsx
@@ -1,0 +1,127 @@
+import React, {useState} from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import ArchiveIcon from "@material-ui/icons/Archive";
+import { Link, useNavigate } from '../../lib/reactRouterWrapper';
+import classNames from 'classnames';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import {useUpdate} from '../../lib/crud/withUpdate';
+import {useLocation} from '../../lib/routeUtil';
+import {useCurrentUser} from '../common/withUser';
+import {userGetProfileUrl} from '../../lib/collections/users/helpers';
+import {useMessages} from '../common/withMessages';
+
+
+const styles = (theme: ThemeType): JssStyles => ({
+  lwBanner: {
+    padding: 16,
+    backgroundColor: theme.palette.background.warningTranslucent,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    marginBottom: "60px",
+  },
+  hidden: {
+    display: "none"
+  },
+  title: {
+    fontWeight: 670,
+  },
+  icon: {
+    marginLeft: 8,
+    marginRight: 16,
+    height: 24,
+    color: theme.palette.grey[500]
+  },
+  buttonRow: {
+    display: 'flex',
+    displayDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonShared: {
+    ...theme.typography.commentStyle,
+     height: '36px',
+     paddingLeft: 16,
+     paddingRight: 16,
+     marginRight: 10,
+     color: 'white',
+     fontSize: '14px',
+     border: 0,
+     fontWeight: '500',
+     cursor: 'pointer',
+     letterSpacing: '0.6',
+     borderRadius: '6px',
+     transition: 'all 0.2s ease',
+     boxShadow: '0px 4px 5.5px 0px rgba(0, 0, 0, 0.07)',
+     '&:hover': {
+       opacity: 0.8
+     },
+  },
+  restoreButton: {
+    background: theme.palette.buttons.alwaysPrimary,
+  },
+  closeIcon: { 
+    color: theme.palette.grey[500],
+    opacity: 0.5,
+    padding: 2,
+  },
+  subtleText: {
+    color: theme.palette.text.dim3,
+  }
+});
+
+// Tells the user when they can next comment or post if they're rate limited, and a brief explanation
+const ArchiveNotice = ({post, classes}: {
+  post: PostsPage, 
+  classes: ClassesType
+}) => {
+  const { ContentStyles, Loading } = Components
+  const [hidden, setHidden] = useState(false)
+  const {flash} = useMessages();
+
+  const {mutate: updatePost, loading, error} = useUpdate({
+    collectionName: "Posts",
+    fragmentName: 'PostsEdit',
+  });
+
+  const handleRestore = async () => {
+    await updatePost({
+      selector: {_id: post._id},
+      data: {deletedDraft: false}
+    })
+    flash({
+      messageString: "Restored", 
+      type: "success", 
+    })
+  }
+
+  if (loading) return <Loading />
+  if (error) return <p>Error: {error.message}</p>
+
+  return (
+  <ContentStyles contentType="comment" className={classNames(classes.lwBanner, {[classes.hidden]: hidden})}>
+    
+      <div>
+        <p className={classes.title}>This draft is archived</p>
+          <p>It may either have been archived by a coauthor, or auto-archived due to inactivity.</p>
+          <p className={classes.subtleText}>See all your archived drafts: <Link to={"/drafts?includeArchived=true"}>{"lesswrong.com/drafts"}</Link> 
+        </p>
+        <div className={classes.buttonRow}>
+          <button className={classNames(classes.buttonShared, classes.restoreButton)} type="button" onClick={handleRestore}>
+            Restore
+          </button>
+        </div>
+      </div> 
+    <IconButton className={classes.closeIcon} onClick={() => setHidden(true)}>
+      <CloseIcon />
+    </IconButton>
+  </ContentStyles>)
+}
+
+const ArchiveNoticeComponent = registerComponent('ArchiveNotice', ArchiveNotice, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ArchiveNotice: typeof ArchiveNoticeComponent
+  }
+}

--- a/packages/lesswrong/components/editor/DialogueAutoArchiveNotice.tsx
+++ b/packages/lesswrong/components/editor/DialogueAutoArchiveNotice.tsx
@@ -1,0 +1,155 @@
+import React, {useState} from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import moment from 'moment';
+import { isEAForum } from '../../lib/instanceSettings';
+import AlarmIcon from '@material-ui/icons/Alarm';
+import { isFriendlyUI } from '../../themes/forumTheme';
+import { Link, useNavigate } from '../../lib/reactRouterWrapper';
+import classNames from 'classnames';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import {useUpdate} from '../../lib/crud/withUpdate';
+import {useLocation} from '../../lib/routeUtil';
+import {useCurrentUser} from '../common/withUser';
+import {userGetProfileUrl} from '../../lib/collections/users/helpers';
+import {useMessages} from '../common/withMessages';
+
+
+const styles = (theme: ThemeType): JssStyles => ({
+  lwBanner: {
+    padding: 12,
+    backgroundColor: theme.palette.background.warningTranslucent,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    marginBottom: "60px",
+  },
+  hidden: {
+    display: "none"
+  },
+  title: {
+    fontWeight: 670,
+  },
+  icon: {
+    marginLeft: 8,
+    marginRight: 16,
+    height: 24,
+    color: theme.palette.grey[500]
+  },
+  buttonRow: {
+    display: 'flex',
+    displayDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonShared: {
+    ...theme.typography.commentStyle,
+     height: '36px',
+     paddingLeft: 16,
+     paddingRight: 16,
+     marginRight: 10,
+     color: 'white',
+     fontSize: '14px',
+     border: 0,
+     fontWeight: '500',
+     cursor: 'pointer',
+     letterSpacing: '0.6',
+     borderRadius: '6px',
+     transition: 'all 0.2s ease',
+     boxShadow: '0px 4px 5.5px 0px rgba(0, 0, 0, 0.07)',
+     '&:hover': {
+       opacity: 0.8
+     },
+  },
+  okayButton: {
+    background: theme.palette.buttons.alwaysPrimary,
+  },
+  archiveButton: {
+    background: "none",
+    color: theme.palette.text.primary,
+    border: theme.palette.border.grey300,
+  },
+  closeIcon: { 
+    color: theme.palette.grey[500],
+    opacity: 0.5,
+    padding: 2,
+  },
+  subtleText: {
+    color: theme.palette.text.dim3,
+  }
+});
+
+// Tells the user when they can next comment or post if they're rate limited, and a brief explanation
+const DialogueAutoArchiveNotice = ({dialogue, daysLeft, classes}: {
+  dialogue: PostsPage, 
+  daysLeft: number,
+  classes: ClassesType
+}) => {
+  const { ContentStyles, Loading } = Components
+  const [hidden, setHidden] = useState(false)
+  const navigate = useNavigate();
+  const location = useLocation();
+  const {flash} = useMessages();
+  const currentUser = useCurrentUser();
+
+  const {mutate: updatePost, loading, error} = useUpdate({
+    collectionName: "Posts",
+    fragmentName: 'PostsEdit',
+  });
+
+  const handleArchive = async () => {
+    await updatePost({
+      selector: {_id: dialogue._id},
+      data: {deletedDraft: true}
+    })
+    const postUrl = location.location
+    const profileUrl = userGetProfileUrl(currentUser)
+    navigate(profileUrl)
+    flash({
+      messageString: "Dialogue archived", 
+      type: "success", 
+      action: () => { // Undo action
+          void updatePost({
+            selector: {_id: dialogue._id},
+            data: {deletedDraft: false}
+          })
+          navigate(postUrl)
+          flash({messageString: "Restoring... It's okay to change your mind :)", type: "success"})
+      }
+    })
+  }
+
+  if (loading) return <Loading />
+  if (error) return <p>Error: {error.message}</p>
+
+  return (
+  <ContentStyles contentType="comment" className={classNames(classes.lwBanner, {[classes.hidden]: hidden})}>
+    <AlarmIcon className={classes.icon} />
+
+    <div>
+      <p className={classes.title}>This dialogue will auto-archive in {daysLeft} days, unless there are new edits</p>
+        <p>To keep your drafts orderly, we archive dialogues without activity. To cancel archiving, just make any edit below.</p>
+        <p className={classes.subtleText}>See all your drafts, including archived: <Link to={"/drafts?includeArchived=true"}>{"lesswrong.com/drafts"}</Link> 
+      </p>
+      <div className={classes.buttonRow}>
+        <button className={classNames(classes.buttonShared, classes.okayButton)} type="button" onClick={() => setHidden(true)}>
+          Okay
+        </button>
+        <button className={classNames(classes.buttonShared, classes.archiveButton)} type="button" onClick={handleArchive}>
+          Archive now
+        </button>
+      </div>
+    </div>  
+    
+    <IconButton className={classes.closeIcon} onClick={() => setHidden(true)}>
+      <CloseIcon />
+    </IconButton>
+  </ContentStyles>)
+}
+
+const DialogueAutoArchiveNoticeComponent = registerComponent('DialogueAutoArchiveNotice', DialogueAutoArchiveNotice, {styles});
+
+declare global {
+  interface ComponentTypes {
+    DialogueAutoArchiveNotice: typeof DialogueAutoArchiveNoticeComponent
+  }
+}

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -476,6 +476,7 @@ registerFragment(`
     }
     myEditorAccess
     linkSharingKey
+    lastRevisionAt
   }
 `)
 

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -25,6 +25,7 @@ import { crosspostKarmaThreshold } from '../../publicSettings';
 import { getDefaultViewSelector } from '../../utils/viewUtils';
 import GraphQLJSON from 'graphql-type-json';
 import { addGraphQLSchema } from '../../vulcan-lib/graphql';
+import Revisions from '../revisions/collection';
 
 const urlHintText = isEAForum
     ? 'UrlHintText'
@@ -2831,6 +2832,16 @@ const schema: SchemaType<"Posts"> = {
     canCreate: ['admins'],
     canUpdate: [userOwns, 'admins'],
   },
+
+  lastRevisionAt: resolverOnlyField({
+    type: Date,
+    optional: true,
+    canRead: ['guests'],
+    resolver: async (post: DbPost, args: void, context: ResolverContext) => {
+      const lastRevision = await Revisions.findOne({documentId: post._id}, {sort: {editedAt: -1}});
+      return lastRevision?.editedAt
+    }
+  })
 };
 
 export default schema;

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -640,6 +640,8 @@ importComponent("TopicSuggestion", () => require('../components/dialogues/Dialog
 importComponent("CommentView", () => require('../components/dialogues/DialogueRecommendationRow'));
 importComponent("CalendlyIFrame", () => require('../components/dialogues/CalendlyIFrame'));
 importComponent("ActiveDialogues", () => require('../components/dialogues/ActiveDialogues'));
+importComponent("DialogueAutoArchiveNotice", () => require('../components/editor/DialogueAutoArchiveNotice'));
+importComponent("ArchiveNotice", () => require('../components/editor/ArchiveNotice'));
 
 
 importComponent("ParentCommentSingle", () => require('../components/comments/ParentCommentSingle'));

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -631,6 +631,29 @@ interface SequencesDefaultFragment { // fragment on Sequences
   readonly af: boolean,
 }
 
+interface RevisionsDefaultFragment { // fragment on Revisions
+  readonly documentId: string,
+  readonly collectionName: string,
+  readonly fieldName: string,
+  readonly editedAt: Date,
+  readonly updateType: "initial" | "patch" | "minor" | "major",
+  readonly version: string,
+  readonly commitMessage: string,
+  readonly userId: string,
+  readonly draft: boolean,
+  readonly originalContents: any /*ContentType*/,
+  readonly html: string,
+  readonly markdown: string,
+  readonly draftJS: any /*JSON*/,
+  readonly ckEditorMarkup: string,
+  readonly wordCount: number | null,
+  readonly htmlHighlight: string,
+  readonly htmlHighlightStartingAtHash: string,
+  readonly plaintextDescription: string,
+  readonly plaintextMainText: string,
+  readonly changeMetrics: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
 interface PostsDefaultFragment { // fragment on Posts
   readonly postedAt: Date,
   readonly modifiedAt: Date,
@@ -1316,6 +1339,7 @@ interface PostsPage extends PostsDetails { // fragment on Posts
   readonly customHighlight: RevisionDisplay|null,
   readonly myEditorAccess: string,
   readonly linkSharingKey: string | null,
+  readonly lastRevisionAt: Date,
 }
 
 interface PostsEdit extends PostsDetails { // fragment on Posts
@@ -2592,29 +2616,6 @@ interface PodcastEpisodeFull { // fragment on PodcastEpisodes
   readonly externalEpisodeId: string,
 }
 
-interface RevisionsDefaultFragment { // fragment on Revisions
-  readonly documentId: string,
-  readonly collectionName: string,
-  readonly fieldName: string,
-  readonly editedAt: Date,
-  readonly updateType: "initial" | "patch" | "minor" | "major",
-  readonly version: string,
-  readonly commitMessage: string,
-  readonly userId: string,
-  readonly draft: boolean,
-  readonly originalContents: any /*ContentType*/,
-  readonly html: string,
-  readonly markdown: string,
-  readonly draftJS: any /*JSON*/,
-  readonly ckEditorMarkup: string,
-  readonly wordCount: number | null,
-  readonly htmlHighlight: string,
-  readonly htmlHighlightStartingAtHash: string,
-  readonly plaintextDescription: string,
-  readonly plaintextMainText: string,
-  readonly changeMetrics: any /*{"definitions":[{"blackbox":true}]}*/,
-}
-
 interface UsersMinimumInfo { // fragment on Users
   readonly _id: string,
   readonly slug: string,
@@ -3565,6 +3566,7 @@ interface FragmentTypes {
   TagRelsDefaultFragment: TagRelsDefaultFragment
   BooksDefaultFragment: BooksDefaultFragment
   SequencesDefaultFragment: SequencesDefaultFragment
+  RevisionsDefaultFragment: RevisionsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
   TypingIndicatorsDefaultFragment: TypingIndicatorsDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
@@ -3721,7 +3723,6 @@ interface FragmentTypes {
   PodcastSelect: PodcastSelect
   PodcastEpisodesDefaultFragment: PodcastEpisodesDefaultFragment
   PodcastEpisodeFull: PodcastEpisodeFull
-  RevisionsDefaultFragment: RevisionsDefaultFragment
   UsersMinimumInfo: UsersMinimumInfo
   UsersProfile: UsersProfile
   UsersCurrent: UsersCurrent
@@ -3793,6 +3794,7 @@ interface FragmentTypesByCollection {
   TagRels: "TagRelsDefaultFragment"|"TagRelBasicInfo"|"TagRelFragment"|"TagRelHistoryFragment"|"TagRelCreationFragment"|"TagRelMinimumFragment"|"WithVoteTagRel"
   Books: "BooksDefaultFragment"|"BookPageFragment"|"BookEdit"
   Sequences: "SequencesDefaultFragment"|"SequencesPageTitleFragment"|"SequencesPageFragment"|"SequenceContinueReadingFragment"|"SequencesPageWithChaptersFragment"|"SequencesEdit"
+  Revisions: "RevisionsDefaultFragment"|"RevisionDisplay"|"RevisionEdit"|"RevisionMetadata"|"RevisionMetadataWithChangeMetrics"|"RevisionHistoryEntry"|"RevisionTagFragment"|"RecentDiscussionRevisionTagFragment"|"WithVoteRevision"
   Posts: "PostsDefaultFragment"|"PostsMinimumInfo"|"PostsBase"|"PostsWithVotes"|"PostsListWithVotes"|"PostsListWithVotesAndSequence"|"PostsReviewVotingList"|"PostsAuthors"|"PostsListBase"|"PostsList"|"PostsListTag"|"PostsListTagWithVotes"|"PostsDetails"|"PostsExpandedHighlight"|"PostsPlaintextDescription"|"PostsRevision"|"PostsRevisionEdit"|"PostsWithNavigationAndRevision"|"PostsWithNavigation"|"PostSequenceNavigation"|"PostsPage"|"PostsEdit"|"PostsEditQueryFragment"|"PostsEditMutationFragment"|"PostsRevisionsList"|"PostsRecentDiscussion"|"ShortformRecentDiscussion"|"UsersBannedFromPostsModerationLog"|"SunshinePostsList"|"WithVotePost"|"HighlightWithHash"|"PostWithDialogueMessage"|"PostSideComments"|"PostWithGeneratedSummary"|"PostsEditCriticismTips"|"PostsBestOfList"|"SuggestAlignmentPost"
   TypingIndicators: "TypingIndicatorsDefaultFragment"|"TypingIndicatorInfo"
   Votes: "VotesDefaultFragment"|"TagRelVotes"|"TagVotingActivity"|"UserVotes"|"UserVotesWithDocument"
@@ -3803,7 +3805,6 @@ interface FragmentTypesByCollection {
   Messages: "MessagesDefaultFragment"|"messageListFragment"
   Notifications: "NotificationsDefaultFragment"|"NotificationsList"
   ModeratorActions: "ModeratorActionsDefaultFragment"|"ModeratorActionDisplay"
-  Revisions: "RevisionDisplay"|"RevisionEdit"|"RevisionMetadata"|"RevisionMetadataWithChangeMetrics"|"RevisionHistoryEntry"|"RevisionTagFragment"|"RecentDiscussionRevisionTagFragment"|"WithVoteRevision"|"RevisionsDefaultFragment"
   RSSFeeds: "RSSFeedsDefaultFragment"|"RSSFeedMinimumInfo"|"newRSSFeedFragment"|"RSSFeedMutationFragment"
   Reports: "ReportsDefaultFragment"|"unclaimedReportsList"
   TagFlags: "TagFlagFragment"|"TagFlagEditFragment"|"TagFlagsDefaultFragment"
@@ -3847,6 +3848,7 @@ interface CollectionNamesByFragmentName {
   TagRelsDefaultFragment: "TagRels"
   BooksDefaultFragment: "Books"
   SequencesDefaultFragment: "Sequences"
+  RevisionsDefaultFragment: "Revisions"
   PostsDefaultFragment: "Posts"
   TypingIndicatorsDefaultFragment: "TypingIndicators"
   VotesDefaultFragment: "Votes"
@@ -4003,7 +4005,6 @@ interface CollectionNamesByFragmentName {
   PodcastSelect: "Podcasts"
   PodcastEpisodesDefaultFragment: "PodcastEpisodes"
   PodcastEpisodeFull: "PodcastEpisodes"
-  RevisionsDefaultFragment: "Revisions"
   UsersMinimumInfo: "Users"
   UsersProfile: "Users"
   UsersCurrent: "Users"

--- a/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
+++ b/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
@@ -12,10 +12,10 @@
             "name": "TagRel"
           },
           {
-            "name": "Post"
+            "name": "Revision"
           },
           {
-            "name": "Revision"
+            "name": "Post"
           },
           {
             "name": "Comment"


### PR DESCRIPTION
This PR: 
* Checks on the postspage whether a given dialogue is stale and, if so, shows a banner with a countdown until when it is to be archived. 
* Runs a cron-job doing the actual auto-archiving
[TODO] Notifies users when a draft of theirs is auto-archived

Also, 
* Add banner to any archived post saying it's archived (because no such indication existed!), giving the user the option to restore it