### PR TITLE
Create a middleware to allow making some routes admin-only

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
-import { parseRoute, parsePath } from '../../lib/vulcan-core/appContext';
+import {parseRoute, parsePath, checkUserRouteAccess} from '../../lib/vulcan-core/appContext'
 import { classifyHost, useLocation, getUrlClass } from '../../lib/routeUtil';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { isServer } from '../../lib/executionEnvironment';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { isMobile } from '../../lib/utils/isMobile'
 import { locationHashIsFootnote } from '../posts/PostsPage/CollapsedFootnotes';
+import {useCurrentUser} from '../common/withUser'
 
 export const parseRouteWithErrors = (onsiteUrl: string, contentSourceDescription?: string) => {
   return parseRoute({
@@ -56,6 +57,7 @@ const HoverPreviewLink = ({ href, contentSourceDescription, id, rel, noPrefetch,
 }) => {
   const URLClass = getUrlClass()
   const location = useLocation();
+  const currentUser = useCurrentUser()
 
   // Invalid link with no href? Don't transform it.
   if (!href) {
@@ -83,7 +85,7 @@ const HoverPreviewLink = ({ href, contentSourceDescription, id, rel, noPrefetch,
     const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
     const hostType = classifyHost(linkTargetAbsolute.host)
     if (!linkIsExcludedFromPreview(onsiteUrl) && (hostType==="onsite" || hostType==="mirrorOfUs" || isServer)) {
-      const parsedUrl = parseRouteWithErrors(onsiteUrl, contentSourceDescription)
+      const parsedUrl = checkUserRouteAccess(currentUser, parseRouteWithErrors(onsiteUrl, contentSourceDescription))
       const destinationUrl = hostType==="onsite" ? parsedUrl.url : href;
 
       if (parsedUrl.currentRoute) {

--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -9,6 +9,7 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import { parseRouteWithErrors } from '../linkPreview/HoverPreviewLink';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useNavigate } from '../../lib/reactRouterWrapper';
+import {checkUserRouteAccess} from '../../lib/vulcan-core/appContext'
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -145,7 +146,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
       )
     }
 
-    const parsedPath = parseRouteWithErrors(notificationLink);
+    const parsedPath = checkUserRouteAccess(currentUser, parseRouteWithErrors(notificationLink));
     switch (notification.documentType) {
       case "tagRel":
         return (

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -6,7 +6,15 @@ import { TimeOverride, TimeContext } from '../../lib/utils/timeUtil';
 // eslint-disable-next-line no-restricted-imports
 import { useLocation, withRouter } from 'react-router';
 import { useQueryCurrentUser } from '../../lib/crud/withCurrentUser';
-import { LocationContext, parseRoute, ServerRequestStatusContext, SubscribeLocationContext, ServerRequestStatusContextType, NavigationContext } from '../../lib/vulcan-core/appContext';
+import {
+  LocationContext,
+  parseRoute,
+  ServerRequestStatusContext,
+  SubscribeLocationContext,
+  ServerRequestStatusContextType,
+  NavigationContext,
+  checkUserRouteAccess,
+} from '../../lib/vulcan-core/appContext'
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
 import { MessageContextProvider } from '../common/FlashMessages';
 import type { History } from 'history'
@@ -47,7 +55,8 @@ const App = ({serverRequestStatus, timeOverride, history}: ExternalProps & {
   }, [currentUser?._id]);
 
   // Parse the location into a route/params/query/etc.
-  const location = parseRoute({location: reactDomLocation});
+  const location = checkUserRouteAccess(currentUser, parseRoute({location: reactDomLocation}));
+  
   if (location.redirected) {
     return (
       <Components.PermanentRedirect url={location.url} />

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -801,24 +801,28 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path: '/admin/digests',
       componentName: 'Digests',
       title: 'Digests',
+      isAdmin: true,
     },
     {
       name: 'ElectionCandidates',
       path: '/admin/election-candidates',
       componentName: 'AdminElectionCandidates',
       title: 'Election Candidates',
+      isAdmin: true,
     },
     {
       name: 'EditElectionCandidate',
       path: '/admin/election-candidates/:id',
       componentName: 'EditElectionCandidate',
       title: 'Edit Election Candidate',
+      isAdmin: true,
     },
     {
       name: 'ElectionVotes',
       path: '/admin/election-votes',
       componentName: 'AdminElectionVotes',
       title: 'Election Votes',
+      isAdmin: true,
     },
     {
       name: 'EditDigest',
@@ -827,13 +831,15 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       title: 'Edit Digest',
       subtitle: 'Digests',
       subtitleLink: '/admin/digests',
-      staticHeader: true
+      staticHeader: true,
+      isAdmin: true,
     },
     {
       name: 'recommendationsSample',
       path: '/admin/recommendationsSample',
       componentName: 'RecommendationsSamplePage',
-      title: "Recommendations Sample"
+      title: "Recommendations Sample",
+      isAdmin: true,
     },
     {
       name: 'CookiePolicy',
@@ -1646,6 +1652,7 @@ addRoute(
     path: '/reviewAdmin/:year',
     componentName: 'ReviewAdminDashboard',
     title: "Review Admin Dashboard",
+    isAdmin: true,
   }
 );
 

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Components, Routes } from '../vulcan-lib';
+import {Components, getRouteMatchingPathname} from '../vulcan-lib'
 // eslint-disable-next-line no-restricted-imports
 import { matchPath } from 'react-router';
 import qs from 'qs'
@@ -73,17 +73,7 @@ export function parseRoute({location, followRedirects=true, onError=null}: {
   followRedirects?: boolean,
   onError?: null|((err: string)=>void),
 }): RouterLocation {
-  const routeNames = Object.keys(Routes);
-  let currentRoute: Route|null = null;
-  let params={};
-  for (let routeName of routeNames) {
-    const route = Routes[routeName];
-    const match = matchPath(location.pathname, { path: route.path, exact: true, strict: false });
-    if (match) {
-      currentRoute = route;
-      params = match.params;
-    }
-  }
+  const currentRoute = getRouteMatchingPathname(location.pathname)
   
   if (!currentRoute) {
     if (onError) {
@@ -104,7 +94,8 @@ export function parseRoute({location, followRedirects=true, onError=null}: {
       }
     }
   }
-  
+
+  const params= currentRoute ? matchPath(location.pathname, { path: currentRoute.path, exact: true, strict: false })!.params : {}
   const RouteComponent = currentRoute?.componentName ? Components[currentRoute.componentName] : Components.Error404;
   const result: RouterLocation = {
     currentRoute: currentRoute!, //TODO: Better null handling than this

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -122,6 +122,10 @@ export function parseRoute({location, followRedirects=true, onError=null}: {
   return result;
 }
 
+/**
+ * Check if user can access given route, and if not - override the component we'll render to 404 page
+ * Also removes the "currentRoute" and "params" fields so downstream code treats this as a 404 (not rendering previews, etc)
+ */
 export const checkUserRouteAccess = (user: UsersCurrent | null, location: RouterLocation): RouterLocation => {
   if (userCanAccessRoute(user, location.currentRoute)) return location
 

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Components, getRouteMatchingPathname} from '../vulcan-lib'
+import {Components, getRouteMatchingPathname, userCanAccessRoute} from '../vulcan-lib'
 // eslint-disable-next-line no-restricted-imports
 import { matchPath } from 'react-router';
 import qs from 'qs'
@@ -121,3 +121,15 @@ export function parseRoute({location, followRedirects=true, onError=null}: {
   
   return result;
 }
+
+export const checkUserRouteAccess = (user: UsersCurrent | null, location: RouterLocation): RouterLocation => {
+  if (userCanAccessRoute(user, location.currentRoute)) return location
+
+  return {
+    ...location,
+    RouteComponent: Components.Error404,
+    currentRoute: null,
+    params: {},
+  }
+}
+

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -125,3 +125,10 @@ export const getRouteMatchingPathname = (pathname: string): Route | undefined  =
     exact: true,
     strict: false,
   }))
+
+export const userCanAccessRoute = (user?: UsersCurrent | DbUser | null, route?: Route | null): boolean => {
+  if (!route) return true // Anyone can access a non-existent route (which would 404)
+  if (user?.isAdmin) return true
+
+  return !route.isAdmin
+}

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -1,4 +1,6 @@
 import * as _ from 'underscore';
+// eslint-disable-next-line no-restricted-imports
+import {matchPath} from 'react-router'
 
 export type PingbackDocument = {
   collectionName: CollectionNameString,
@@ -62,6 +64,7 @@ export type Route = {
   // Not used for post-pages because we don't know whether a post page is going
   // to be a 404 until we render it.
   enableResourcePrefetch?: boolean
+  isAdmin?: boolean
 };
 
 /** Populated by calls to addRoute */
@@ -115,3 +118,10 @@ export const overrideRoute = (...routes: Route[]): void => {
   }
   addRoute(...routes);
 }
+
+export const getRouteMatchingPathname = (pathname: string): Route | undefined  =>
+  Object.values(Routes).findLast((route) => matchPath(pathname, {
+    path: route.path,
+    exact: true,
+    strict: false,
+  }))

--- a/packages/lesswrong/server/adminRoutesMiddleware.ts
+++ b/packages/lesswrong/server/adminRoutesMiddleware.ts
@@ -1,23 +1,16 @@
 import type {AddMiddlewareType} from './apolloServer.ts'
 import express from 'express'
-import {getRouteMatchingPathname} from '../lib/vulcan-lib'
+import {getRouteMatchingPathname, userCanAccessRoute} from '../lib/vulcan-lib'
 
 export const addAdminRoutesMiddleware = (addConnectHandler: AddMiddlewareType) => {
   addConnectHandler(checkAdminRouteAccess)
 }
 
 const checkAdminRouteAccess = (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  if (nonAdminTryingAccessAdminRoute(req)) {
+  if (!userCanAccessRoute(req.user, getRouteMatchingPathname(req.path))) {
     res.redirect('/404')
   } else {
     next()
   }
-}
-
-const nonAdminTryingAccessAdminRoute = (req: express.Request) => {
-  const route = getRouteMatchingPathname(req.path)
-  if (!route) return false
-
-  return route.isAdmin && !req.user?.isAdmin
 }
 

--- a/packages/lesswrong/server/adminRoutesMiddleware.ts
+++ b/packages/lesswrong/server/adminRoutesMiddleware.ts
@@ -1,0 +1,23 @@
+import type {AddMiddlewareType} from './apolloServer.ts'
+import express from 'express'
+import {getRouteMatchingPathname} from '../lib/vulcan-lib'
+
+export const addAdminRoutesMiddleware = (addConnectHandler: AddMiddlewareType) => {
+  addConnectHandler(checkAdminRouteAccess)
+}
+
+const checkAdminRouteAccess = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (nonAdminTryingAccessAdminRoute(req)) {
+    res.redirect('/404')
+  } else {
+    next()
+  }
+}
+
+const nonAdminTryingAccessAdminRoute = (req: express.Request) => {
+  const route = getRouteMatchingPathname(req.path)
+  if (!route) return false
+
+  return route.isAdmin && !req.user?.isAdmin
+}
+

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -52,6 +52,7 @@ import ElasticController from './search/elastic/ElasticController';
 import type { ApolloServerPlugin, GraphQLRequestContext, GraphQLRequestListener } from 'apollo-server-plugin-base';
 import { asyncLocalStorage, closePerfMetric, openPerfMetric, perfMetricMiddleware, setAsyncStoreValue } from './perfMetrics';
 import { performanceMetricLoggingEnabled } from '../lib/publicSettings';
+import {addAdminRoutesMiddleware} from './adminRoutesMiddleware'
 
 class ApolloServerLogging implements ApolloServerPlugin<ResolverContext> {
   requestDidStart({ request, context }: GraphQLRequestContext<ResolverContext>): GraphQLRequestListener<ResolverContext> {
@@ -135,6 +136,7 @@ export function startWebserver() {
   addStripeMiddleware(addMiddleware);
   // Most middleware need to run after those added by addAuthMiddlewares, so that they can access the user that passport puts on the request.  Be careful if moving it!
   addAuthMiddlewares(addMiddleware);
+  addAdminRoutesMiddleware(addMiddleware);
   addForumSpecificMiddleware(addMiddleware);
   addSentryMiddlewares(addMiddleware);
   addClientIdMiddleware(addMiddleware);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es2019", "dom"],
+    "lib": ["es2023", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
This also designates some example routes admin-only (without removing their in-component checks for now)

The original motivation for this is making some routes admin only on Waking-UP forum which are public on other forums, but I think this is generally probably a better approach vs having a check on each component.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206252214463774) by [Unito](https://www.unito.io)
