### PR TITLE
fix both anonymous link sharing and link sharing for dialogues

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -517,7 +517,7 @@ const CKPostEditor = ({
         }
 
         const userIds = formType === 'new' ? [userId] : [post.userId, ...getConfirmedCoauthorIds(post)];
-        if (post.collabEditorDialogue) {
+        if (post.collabEditorDialogue && accessLevel && accessLevelCan(accessLevel, 'edit')) {
           const rawAuthors = formType === 'new' ? [currentUser!] : filterNonnull([post.user, ...(post.coauthors ?? [])])
           const coauthors = uniqBy(
             rawAuthors.filter(coauthor => userIds.includes(coauthor._id)),

--- a/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorCallbacks.ts
@@ -96,16 +96,10 @@ defineQuery({
     //  * The logged-in user is the post author
     //  * The logged in user is an admin or moderator (or otherwise has edit permissions)
 
-    // User must exist
-    if (!currentUser?._id) {
-      throw new Error("No current user with _id");
-    }
-
     if (
       (post.shareWithUsers && _.contains(post.shareWithUsers, currentUser?._id))
-      || (linkSharingEnabled(post)
-          && (!canonicalLinkSharingKey || keysMatch))
-      || (linkSharingEnabled(post) && post.linkSharingKeyUsedBy?.includes(currentUser?._id))
+      || (linkSharingEnabled(post) && (!canonicalLinkSharingKey || keysMatch))
+      || (linkSharingEnabled(post) && (currentUser && post.linkSharingKeyUsedBy?.includes(currentUser._id)))
       || currentUser?._id === post.userId
       || userCanDo(currentUser, 'posts.edit.all')
     ) {


### PR DESCRIPTION
This PR fixes two issues:
1. the nullability PR accidentally broke anonymous link sharing by requiring that users be logged in for the `getLinkSharedPost` query
2. link sharing with users who aren't explicit collaborators didn't work for dialogues, because we were registering post fixers on the client side, and then manually writing a change to the document to trigger the post fixers.  When this was happening on the clients of link-shared users, CKEditor complained unless the link sharing setting was set to "edit", since it saw that the client of a user who didn't have "edit" authorization was trying to edit the collaborative document.  This blew up in the CKPostEditor `onInit`.  We fix this by only doing the post-fixer and manual change if the user has a sufficient access level.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206255255072551) by [Unito](https://www.unito.io)
