### PR TITLE
Allow audio elements as part of RSS crosspost

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -287,7 +287,7 @@ export const sanitizeAllowedTags = [
   'ol', 'nl', 'li', 'b', 'i', 'u', 'strong', 'em', 'strike', 's',
   'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
   'tbody', 'tr', 'th', 'td', 'pre', 'img', 'figure', 'figcaption',
-  'section', 'span', 'sub', 'sup', 'ins', 'del', 'iframe',
+  'section', 'span', 'sub', 'sup', 'ins', 'del', 'iframe', 'audio',
   
   //MathML elements (https://developer.mozilla.org/en-US/docs/Web/MathML/Element)
   "math", "mi", "mn", "mo", "ms", "mspace", "mtext", "merror",
@@ -321,6 +321,7 @@ export const sanitize = function(s: string): string {
     allowedTags: sanitizeAllowedTags,
     allowedAttributes:  {
       ...sanitizeHtml.defaults.allowedAttributes,
+      audio: [ 'controls', 'src', 'style' ],
       img: [ 'src' , 'srcset', 'alt', 'style'],
       figure: ['style', 'class'],
       table: ['style'],


### PR DESCRIPTION
From Intercom: 

**Jefftk:** 
I wonder whether allowing the <audio> element to pass through from RSS would be safe? For example, https://www.lesswrong.com/posts/NTdfTaumDFFz4oMC4/boston-solstice-2023-retrospective would be better with the inline mp3 player you can see on the https://www.jefftk.com/p/boston-solstice-2023-retrospective version

**Me:** 
Oh, yeah, don't see any particular reason why not

=====

Tested on this post: lesswrong.com/posts/NTdfTaumDFFz4oMC4/boston-solstice-2023-retrospective

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206261773462004) by [Unito](https://www.unito.io)
