### PR TITLE
Fix spurious warnings about missing revs in convertImagesToCloudinary

### DIFF
--- a/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
+++ b/packages/lesswrong/server/scripts/convertImagesToCloudinary.ts
@@ -210,10 +210,8 @@ export async function convertImagesInObject<N extends CollectionNameString>(
     
     const latestRev = await getLatestRev(_id, fieldName);
     if (!latestRev) {
-      if (!isAnyTest) {
-        // eslint-disable-next-line no-console
-        console.error(`Could not find a latest-revision for ${collectionName} ID: ${_id}`);
-      }
+      // If this field doesn't have a latest rev, it's empty (common eg for
+      // moderation guidelines).
       return 0;
     }
     


### PR DESCRIPTION
`convertImagesToCloudinary` sometimes gets run on fields other than contents (eg, moderation guidelines), and those fields are often blank. This leads to scary but meaningless warnings that show up in logs and Sentry. DDon't warn in that case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206262521077459) by [Unito](https://www.unito.io)
