### PR TITLE
Fix spotlight item width

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -14,7 +14,9 @@ const LWHome = () => {
       <AnalyticsContext pageContext="homePage">
         <React.Fragment>
 
-          <DismissibleSpotlightItem current />
+          <SingleColumnSection>
+            <DismissibleSpotlightItem current />
+          </SingleColumnSection>
 
           {!reviewIsActive() && <LWRecommendations configName="frontpage" />}
 


### PR DESCRIPTION
Spotlight item width was wonky at certain page widths, due to having 100% width and not being in a container. Introduced in [49ddbd0180039928e759e9c9f89699ad08b89708](https://github.com/ForumMagnum/ForumMagnum/commit/49ddbd0180039928e759e9c9f89699ad08b89708) which added the `DismissibleSpotlightItem` without wrapping it in a `SingleColumnSection` (it was previously removed together with the rest of `RecommendationsAndCurated`, which wraps it that way, and which is temporarily removed to make room for the review)