### PR TITLE
Speed up truncatise()

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -57,13 +57,12 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const truncateGuidelines = (guidelines: string) => {
-  const truncatiseOptions = {
+  return truncatise(guidelines, {
     TruncateLength: 300,
     TruncateBy: "characters",
     Suffix: `... <a>(${preferredHeadingCase("Read More")})</a>`,
     Strict: false
-  }
-  return truncatise(guidelines, truncatiseOptions)
+  });
 }
 
 const getPostModerationGuidelines = (post: PostsList, classes: ClassesType) => {

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -8,13 +8,14 @@ export const TRUNCATION_KARMA_THRESHOLD = 10
 
 export const highlightFromHTML = (html: string | null): string => {
   if (!html) return ""
-  const styles = html.match(/<style[\s\S]*?<\/style>/g) || ""
-  const htmlRemovedStyles = html.replace(/<style[\s\S]*?<\/style>/g, '');
+  const styles: string[]|null = html.match(/<style[\s\S]*?<\/style>/g);
+  const htmlWithoutStyles = styles ? html.replace(/<style[\s\S]*?<\/style>/g, '') : html;
+  const suffix = styles ? `... ${styles}` : '... ';
 
-  return truncatise(htmlRemovedStyles, {
+  return truncatise(htmlWithoutStyles, {
     TruncateLength: highlightMaxChars,
     TruncateBy: "characters",
-    Suffix: `... ${styles}`,
+    Suffix: suffix,
   });
 };
 
@@ -69,7 +70,7 @@ export const answerTocExcerptFromHTML = (html: string): string => {
 
   const firstParagraph = truncatise(htmlRemovedStyles, {
     TruncateLength: 1,
-    TruncateBy: "paragraph",
+    TruncateBy: "paragraphs",
     Suffix: '',
   });
 

--- a/packages/lesswrong/unitTests/truncatise.tests.ts
+++ b/packages/lesswrong/unitTests/truncatise.tests.ts
@@ -1,0 +1,33 @@
+import chai from 'chai';
+import { truncatise } from "../lib/truncatise";
+
+describe('truncatise', () => {
+  it('truncates by word count', () => {
+    chai.assert.equal(
+      truncatise("one two three four five six", {
+        TruncateLength: 3,
+        Suffix: "..."
+      }),
+      "one two three..."
+    );
+  });
+  it('truncates by paragraph count', () => {
+    chai.assert.equal(
+      truncatise("<p>one</p><p>two</p><p>three</p><p>four</p><p>five</p><p>six</p>", {
+        TruncateLength: 3,
+        TruncateBy: "paragraphs",
+        Suffix: "..."
+      }),
+      "<p>one</p><p>two</p><p>three...</p>"
+    );
+  });
+  it('closes open tags', () => {
+    chai.assert.equal(
+      truncatise("<p>one <b><a href=\"www.example.com\">two three four</a> five</b> six</p>", {
+        TruncateLength: 3,
+        Suffix: "..."
+      }),
+      "<p>one <b><a href=\"www.example.com\">two three</a></b>...</p>"
+    );
+  });
+});


### PR DESCRIPTION
Truncatise is a library which takes HTML, and shortens it to a target character, word, or paragraph count. We vendored/forked this library long ago. It's not very fast; it's written as-if a Shlemiel the Painter algorithm (though I think V8 sneakily optimizes that away), and does a bunch of unnecessary memory-allocating and regexing. Rewrite it, simplifying the code, dropping the unused StripHTML feature, and greatly speeding it up. Performance improvement for the logged-out front page was about 30ms (5%) overall (using the profiler to look only at the highlightFromHTML and truncatise functions). Also add a few unit tests for it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206277096841119) by [Unito](https://www.unito.io)
