### PR TITLE
Nokibitz polish

### DIFF
--- a/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
+++ b/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
@@ -122,7 +122,7 @@ const ToCCommentBlock = ({commentTree, indentLevel, highlightedCommentId, highli
   highlightDate: Date|undefined,
   classes: ClassesType,
 }) => {
-  const { TableOfContentsRow } = Components;
+  const { UsersNameDisplay, TableOfContentsRow } = Components;
   const navigate = useNavigate();
   const location = useLocation();
   const { query } = location;
@@ -159,7 +159,7 @@ const ToCCommentBlock = ({commentTree, indentLevel, highlightedCommentId, highli
       })}>
         <span className={classes.commentKarma}>{comment.baseScore}</span>
         <span className={classes.commentAuthor}>
-          {comment.user ? userGetDisplayName(comment.user) : "[anonymous]"}
+          <UsersNameDisplay user={comment.user} simple/>
         </span>
       </span>
     </TableOfContentsRow>

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -32,19 +32,27 @@ const UsersNameDisplay = ({
   color=false,
   nofollow=false,
   simple=false,
-  classes,
   tooltipPlacement="left",
   pageSectionContext,
   className,
+  classes,
 }: {
+  /** The user whose name to show. If nullish, will show as "[anonymous]". */
   user: UsersMinimumInfo|null|undefined,
+  /** If the name is in the site primary color */
   color?: boolean,
+  /** If the name is a link, it's marked nofollow */
   nofollow?: boolean,
+  /** The name is only text, not a link, and doesn't have a hover */
   simple?: boolean,
-  classes: ClassesType,
+  /** Positioning of the tooltip, if there is one */
   tooltipPlacement?: PopperPlacementType,
+  /** If provided, a tracking string added to the link */
   pageSectionContext?: string,
+  /** An additional class to apply to the text */
   className?: string,
+
+  classes: ClassesType,
 }) => {
   const {eventHandlers, hover} = useHover({pageElementContext: "linkPreview",  pageSubElementContext: "userNameDisplay", userId: user?._id})
   const currentUser = useCurrentUser();
@@ -66,7 +74,12 @@ const UsersNameDisplay = ({
   const colorClass = color?classes.color:classes.noColor;
 
   if (simple) {
-    return <span {...eventHandlers} className={classNames(colorClass, className)}>
+    return <span
+      {...eventHandlers}
+      className={classNames(colorClass, className, {
+        [classes.noKibitz]: noKibitz
+      })}
+    >
       {displayName}
     </span>
   }
@@ -84,9 +97,9 @@ const UsersNameDisplay = ({
           placement={tooltipPlacement}
           inlineBlock={false}
         >
-          <Link to={profileUrl} className={classNames(colorClass, {
-            [classes.noKibitz]: noKibitz,
-          })}
+          <Link
+            to={profileUrl}
+            className={classNames(colorClass, { [classes.noKibitz]: noKibitz, })}
             {...(nofollow ? {rel:"nofollow"} : {})}
           >
             {displayName}

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -15,6 +15,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   noColor: {
     color: "inherit !important"
   },
+  noKibitz: {
+    minWidth: 55,
+  },
 });
 
 type DisableNoKibitzContextType = {disableNoKibitz: boolean, setDisableNoKibitz: (disableNoKibitz: boolean)=>void};
@@ -51,15 +54,15 @@ const UsersNameDisplay = ({
     && user
     && currentUser._id !== user._id  //don't nokibitz your own name
     && !disableNoKibitz
-    && !hover
   );
+  const nameHidden = noKibitz && !hover;
 
   if (!user || user.deleted) {
     return <Components.UserNameDeleted userShownToAdmins={user}/>
   }
   const { UserTooltip } = Components
 
-  const displayName = noKibitz ? "(hidden)" : userGetDisplayName(user);
+  const displayName = nameHidden ? "(hidden)" : userGetDisplayName(user);
   const colorClass = color?classes.color:classes.noColor;
 
   if (simple) {
@@ -81,7 +84,9 @@ const UsersNameDisplay = ({
           placement={tooltipPlacement}
           inlineBlock={false}
         >
-          <Link to={profileUrl} className={colorClass}
+          <Link to={profileUrl} className={classNames(colorClass, {
+            [classes.noKibitz]: noKibitz,
+          })}
             {...(nofollow ? {rel:"nofollow"} : {})}
           >
             {displayName}

--- a/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
@@ -337,7 +337,7 @@ class FormComponent<T extends DbObject> extends Component<FormComponentWrapperPr
 
     if (this.props.tooltip) {
       return <div>
-        <Components.LWTooltip title={this.props.tooltip} placement="left-start">
+        <Components.LWTooltip inlineBlock={false} title={this.props.tooltip} placement="left-start">
           <div>{ formComponent }</div>
         </Components.LWTooltip>
       </div>


### PR DESCRIPTION
Fix excess padding on form checkboxes with tooltips. Prevent hover-flicker on short usernames when nokibitz is on. Apply nokibitz to comments-ToC.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206282700086884) by [Unito](https://www.unito.io)
