### PR TITLE
Hide some LW/AF specific user settings on the EA forum

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1886,6 +1886,7 @@ const schema: SchemaType<"Users"> = {
     canCreate: ['members'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     optional: true,
+    hidden: !isLWorAF,
     order: 47,
     group: formGroups.siteCustomizations,
     label: "Hide the frontpage book ad"
@@ -2375,6 +2376,7 @@ const schema: SchemaType<"Users"> = {
     canRead: ['guests'],
     canUpdate: ['admins'],
     group: formGroups.adminOptions,
+    hidden: !isLWorAF,
   },
   hideWalledGardenUI: {
     type: Boolean,
@@ -2414,6 +2416,7 @@ const schema: SchemaType<"Users"> = {
     label: "Payment Contact Email",
     tooltip: "An email you'll definitely check where you can receive information about receiving payments",
     group: formGroups.paymentInfo,
+    hidden: !isLWorAF,
   },
   paymentInfo: {
     type: String,
@@ -2423,6 +2426,7 @@ const schema: SchemaType<"Users"> = {
     label: "PayPal Info",
     tooltip: "Your PayPal account info, for sending small payments",
     group: formGroups.paymentInfo,
+    hidden: !isLWorAF,
   },
   
   // Cloudinary image id for the profile image (high resolution)
@@ -2877,7 +2881,8 @@ const schema: SchemaType<"Users"> = {
     canUpdate: ['alignmentForumAdmins', 'admins'],
     canCreate: ['alignmentForumAdmins', 'admins'],
     group: formGroups.adminOptions,
-    label: "AF Review UserId"
+    label: "AF Review UserId",
+    hidden: !isLWorAF,
   },
 
   afApplicationText: {


### PR DESCRIPTION
Hides the following from the account settings page:

 - `hideFrontpageBook2020Ad`
 - `walledGardenInvite`
 - `paymentEmail`
 - `paymentInfo`
 - `reviewForAlignmentForumUserId`

`paymentEmail` and `paymentInfo` are the only fields in the `Prize/payment info` group, so that entire group is no longer shown.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206287690771055) by [Unito](https://www.unito.io)
