### PR TITLE
Refactor autoRateLimits

### DIFF
--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -27,7 +27,7 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   COMMENTS: [
     {
       ...timeframe('4 Comments per 30 minutes'),
-      isActive: (user) => (user.karma <= 30),
+      isActive: (user) => (user.karma < 30),
       rateLimitType: "lowKarma",
       rateLimitMessage: "You'll be able to post more comments as your karma increases.",
       appliesToOwnPosts: true

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -50,13 +50,13 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('2 Posts per 1 weeks'),
       rateLimitType: "newUserDefault",
-      isActive: user => user.karma < 5,
+      isActive: user => (user.karma < 5),
       rateLimitMessage: `Users with less than 5 karma can write up to 2 posts a week.<br/>${lwDefaultMessage}`,
     }, 
   // 1 post per week rate limits
     {
       ...timeframe('1 Posts per 1 weeks'),
-      isActive: user => user.karma <= -3,
+      isActive: user => (user.karma <= -3),
       rateLimitMessage: `Users with -3 or less karma can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
@@ -135,7 +135,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Comments per 1 days'),
       appliesToOwnPosts: false,
-      isActive: user => user.karma <= -3,
+      isActive: user => (user.karma <= -3),
       rateLimitMessage: `Users with -3 or less karma can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
     {
@@ -201,7 +201,6 @@ export const autoPostRateLimits: ForumOptions<PostAutoRateLimit[]> = {
   ],
   LessWrong: [ 
     ...LW.POSTS,
-    ALL.POSTS.FIVE_PER_DAY
   ],
   default: [
     ALL.POSTS.FIVE_PER_DAY

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -155,7 +155,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       isActive: (user, features) => (
         user.karma < 500 &&
         features?.last20Karma <= -15 && 
-        features?.downvoterCount >= 5 && 
+        features?.downvoterCount >= 5
       ),
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -28,7 +28,7 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   COMMENTS: [
     {
       ...timeframe('4 Comments per 30 minutes'),
-      isActive: (user) => user.karma <= 30,
+      isActive: (user) => (user.karma <= 30),
       rateLimitType: "lowKarma",
       rateLimitMessage: "You'll be able to post more comments as your karma increases.",
       appliesToOwnPosts: true
@@ -119,7 +119,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('3 Comments per 1 days'),
       appliesToOwnPosts: false,
       rateLimitType: "newUserDefault",
-      isActive: user => user.karma < 5,
+      isActive: user => (user.karma < 5),
       rateLimitMessage: `Users with less than 5 karma can write up to 3 comments a day.<br/>${lwDefaultMessage}`,
     }, 
     {
@@ -153,9 +153,9 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 3 days'),
       appliesToOwnPosts: false,
       isActive: (user, features) => (
+        user.karma < 500 &&
         features?.last20Karma <= -15 && 
         features?.downvoterCount >= 5 && 
-        user.karma < 500
       ),
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 
@@ -164,10 +164,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 1 weeks'),
       appliesToOwnPosts: false,
       isActive: (user, features) => (
-        features?.lastMonthKarma <= -30 && 
-        features?.last20Karma < -1 && 
         user.karma < 0 && 
-        features?.lastMonthDownvoterCount >= 5
+        features?.last20Karma < -1 && 
+        features?.lastMonthDownvoterCount >= 5 &&
+        features?.lastMonthKarma <= -30
       ),
       // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
       rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${lwDefaultMessage}`
@@ -180,7 +180,7 @@ const ALL = {
     FIVE_PER_DAY: {
       ...timeframe('5 Posts per 1 days'),
       rateLimitType: "universal",
-      isActive: (user:RateLimitUser) => true,
+      isActive: () => true,
       rateLimitMessage: "Users cannot post more than 5 posts a day.",
     }
   },
@@ -188,7 +188,7 @@ const ALL = {
     ONE_PER_EIGHT_SECONDS: {
       ...timeframe('1 Comments per 8 seconds'),
       rateLimitType: "universal",
-      isActive: (user:RateLimitUser)  => true,
+      isActive: ()  => true,
       rateLimitMessage: "Users cannot submit more than 1 comment per 8 seconds to prevent double-posting.",
       appliesToOwnPosts: true
     }
@@ -213,6 +213,7 @@ export const autoCommentRateLimits: ForumOptions<CommentAutoRateLimit[]> = {
     ...EA.COMMENTS
   ],
   LessWrong: [
+    ALL.COMMENTS.ONE_PER_EIGHT_SECONDS, 
     ...LW.COMMENTS
   ],
   default: [

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -55,52 +55,52 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   // 1 post per week rate limits
     {
       ...timeframe('1 Posts per 1 weeks'),
-      isActive: user => (user.karma <= -3),
-      rateLimitMessage: `Users with -3 or less karma can post once per week.<br/>${lwDefaultMessage}`
+      isActive: user => (user.karma < -2),
+      rateLimitMessage: `Users with less than -2 karma can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
       isActive: (user, features) => (
-        features.last20PostKarma <= -15 && 
+        features.last20PostKarma < -15 && 
         features.postDownvoterCount >= 4
       ),
-      rateLimitMessage: `Users with -15 or less karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -15 karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
       isActive: (user, features) => (
-        features.last20PostKarma <= -30 && 
+        features.last20PostKarma < -30 && 
         features.postDownvoterCount >= 10
       ),
-      rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -30 karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
     }, 
     // 1 post per 2+ weeks rate limits
     {
       ...timeframe('1 Posts per 2 weeks'),
       isActive: (user, features) => ( 
         user.karma < 0 && 
-        features.last20Karma <= -30 && 
+        features.last20Karma < -30 && 
         features.postDownvoterCount >= 5
       ),
-      rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -30 karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 3 weeks'),
       isActive: (user, features) => (
         user.karma < 0 && 
-        features.last20PostKarma <= -45 && 
+        features.last20PostKarma < -45 && 
         features.postDownvoterCount >= 5
       ),
-      rateLimitMessage: `Users with -45 or less karma on recent posts can post once every 3 weeks.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -45 karma on recent posts can post once every 3 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 4 weeks'),
       isActive: (user, features) => (
         user.karma < 0 && 
-        features.last20Karma <= -60 && 
+        features.last20Karma < -60 && 
         features.postDownvoterCount >= 5
       ), // uses last20Karma so it's not too hard to dig your way out 
-      rateLimitMessage: `Users with -60 or less karma on recent comments/posts can post once every 4 weeks.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -60 karma on recent comments/posts can post once every 4 weeks.<br/>${lwDefaultMessage}`
     }
   ],
   COMMENTS: [ 
@@ -108,10 +108,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 1 hours'),
       appliesToOwnPosts: false,
       isActive: (user, features) => (
-        features.last20Karma <= -1 && 
+        features.last20Karma < 0 && 
         features.downvoterCount >= 3
       ),
-      rateLimitMessage: `Users with -1 or less karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than 0 karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
     }, 
   // 3 comments per day rate limits
     {
@@ -126,7 +126,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: false,
       isActive: (user, features) => (
         user.karma < 2000 && 
-        features.last20Karma <= 0
+        features.last20Karma < 1
       ),  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 2000+ karma I trust you more to go on long conversations
       rateLimitMessage: `You've recently posted a lot without getting upvoted. Users are limited to 3 comments/day unless their last ${RECENT_CONTENT_COUNT} posts/comments have at least 2+ net-karma.<br/>${lwDefaultMessage}`,
     }, 
@@ -134,18 +134,18 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Comments per 1 days'),
       appliesToOwnPosts: false,
-      isActive: user => (user.karma <= -3),
-      rateLimitMessage: `Users with -3 or less karma can write up to 1 comment per day.<br/>${lwDefaultMessage}`
+      isActive: user => (user.karma < -2),
+      rateLimitMessage: `Users with less than -2 karma can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Comments per 1 days'),
 
       appliesToOwnPosts: false,
       isActive: (user, features) => (
-        features.last20Karma <= -5 && 
+        features.last20Karma < -5 && 
         features.downvoterCount >= (user.karma < 2000 ? 4 : 7)
       ), // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
-      rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -5 karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
   // 1 comment per 3 days rate limits
     {
@@ -153,10 +153,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: false,
       isActive: (user, features) => (
         user.karma < 500 &&
-        features.last20Karma <= -15 && 
+        features.last20Karma < -15 && 
         features.downvoterCount >= 5
       ),
-      rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
+      rateLimitMessage: `Users with less than -15 karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 
   // 1 comment per week rate limits
     {

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -28,7 +28,7 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   COMMENTS: [
     {
       ...timeframe('4 Comments per 30 minutes'),
-      isActive: user => user.karma <= 30,
+      isActive: (user) => user.karma <= 30,
       rateLimitType: "lowKarma",
       rateLimitMessage: "You'll be able to post more comments as your karma increases.",
       appliesToOwnPosts: true
@@ -61,30 +61,46 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
-      isActive: (user, features) => features?.last20PostKarma <= -15 && features?.postDownvoterCount >= 4,
+      isActive: (user, features) => (
+        features?.last20PostKarma <= -15 && 
+        features?.postDownvoterCount >= 4
+      ),
       rateLimitMessage: `Users with -15 or less karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
-      isActive: (user, features) => features?.last20PostKarma <= -30 && features?.postDownvoterCount >= 10,
+      isActive: (user, features) => (
+        features?.last20PostKarma <= -30 && 
+        features?.postDownvoterCount >= 10
+      ),
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
     }, 
     // 1 post per 2+ weeks rate limits
     {
       ...timeframe('1 Posts per 2 weeks'),
-      isActive: (user, features) => {
-        return user.karma < 0 && features?.last20Karma <= -30 && features?.postDownvoterCount >= 5
-      },
+      isActive: (user, features) => ( 
+        user.karma < 0 && 
+        features?.last20Karma <= -30 && 
+        features?.postDownvoterCount >= 5
+      ),
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 3 weeks'),
-      isActive: (user, features) => user.karma < 0 && features?.last20PostKarma <= -45 && features?.postDownvoterCount >= 5,
+      isActive: (user, features) => (
+        user.karma < 0 && 
+        features?.last20PostKarma <= -45 && 
+        features?.postDownvoterCount >= 5
+      ),
       rateLimitMessage: `Users with -45 or less karma on recent posts can post once every 3 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 4 weeks'),
-      isActive: (user, features) => user.karma < 0 && features?.last20Karma <= -60 && features?.postDownvoterCount >= 5, // uses last20Karma so it's not too hard to dig your way out 
+      isActive: (user, features) => (
+        user.karma < 0 && 
+        features?.last20Karma <= -60 && 
+        features?.postDownvoterCount >= 5
+      ), // uses last20Karma so it's not too hard to dig your way out 
       rateLimitMessage: `Users with -60 or less karma on recent comments/posts can post once every 4 weeks.<br/>${lwDefaultMessage}`
     }
   ],
@@ -92,7 +108,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Comments per 1 hours'),
       appliesToOwnPosts: false,
-      isActive: (user, features) => features?.last20Karma <= -1 && features?.downvoterCount >= 3,
+      isActive: (user, features) => (
+        features?.last20Karma <= -1 && 
+        features?.downvoterCount >= 3
+      ),
       rateLimitMessage: `Users with -1 or less karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
     }, 
   // 3 comments per day rate limits
@@ -106,7 +125,10 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('3 Comments per 1 days'), // semi-established users can make up to 20 posts/comments without getting upvoted, before hitting a 3/day comment rate limit
       appliesToOwnPosts: false,
-      isActive: (user, features) => user.karma < 2000 && features?.last20Karma <= 0,  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 2000+ karma I trust you more to go on long conversations
+      isActive: (user, features) => (
+        user.karma < 2000 && 
+        features?.last20Karma <= 0
+      ),  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 2000+ karma I trust you more to go on long conversations
       rateLimitMessage: `You've recently posted a lot without getting upvoted. Users are limited to 3 comments/day unless their last ${RECENT_CONTENT_COUNT} posts/comments have at least 2+ net-karma.<br/>${lwDefaultMessage}`,
     }, 
   // 1 comment per day rate limits
@@ -120,21 +142,33 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 1 days'),
 
       appliesToOwnPosts: false,
-      isActive: (user, features) => features?.last20Karma <= -5 && features?.downvoterCount >= (user.karma < 2000 ? 4 : 7), // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
+      isActive: (user, features) => (
+        features?.last20Karma <= -5 && 
+        features?.downvoterCount >= (user.karma < 2000 ? 4 : 7)
+      ), // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
       rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
   // 1 comment per 3 days rate limits
     {
       ...timeframe('1 Comments per 3 days'),
       appliesToOwnPosts: false,
-      isActive: (user, features) => features?.last20Karma <= -15 && features?.downvoterCount >= 5 && user.karma < 500,
+      isActive: (user, features) => (
+        features?.last20Karma <= -15 && 
+        features?.downvoterCount >= 5 && 
+        user.karma < 500
+      ),
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 
   // 1 comment per week rate limits
     {
       ...timeframe('1 Comments per 1 weeks'),
       appliesToOwnPosts: false,
-      isActive: (user, features) => features?.lastMonthKarma <= -30 && features?.last20Karma < -1 && user.karma < 0 && features?.lastMonthDownvoterCount >= 5,
+      isActive: (user, features) => (
+        features?.lastMonthKarma <= -30 && 
+        features?.last20Karma < -1 && 
+        user.karma < 0 && 
+        features?.lastMonthDownvoterCount >= 5
+      ),
       // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
       rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${lwDefaultMessage}`
     },

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -1,5 +1,6 @@
 import type { ForumOptions } from "../forumTypeUtils";
 import type { AutoRateLimit, CommentAutoRateLimit, PostAutoRateLimit, TimeframeUnitType } from "./types";
+import type { RateLimitUser } from "./utils";
 
 /**
  * Post rate limits
@@ -27,13 +28,13 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   COMMENTS: [
     {
       ...timeframe('4 Comments per 30 minutes'),
-      karmaThreshold: 30,
+      isActive: user => user.karma <= 30,
       rateLimitType: "lowKarma",
       rateLimitMessage: "You'll be able to post more comments as your karma increases.",
       appliesToOwnPosts: true
     }, {
       ...timeframe('4 Comments per 30 minutes'),
-      downvoteRatioThreshold: .3,
+      isActive: (user, features) => features?.downvoteRatio >= 0.3,
       rateLimitType: "downvoteRatio",
       rateLimitMessage: "",
       appliesToOwnPosts: true
@@ -48,114 +49,93 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   // 2 posts per week rate limits
     {
       ...timeframe('2 Posts per 1 weeks'),
-      karmaThreshold: 4,
       rateLimitType: "newUserDefault",
+      isActive: user => user.karma < 5,
       rateLimitMessage: `Users with less than 5 karma can write up to 2 posts a week.<br/>${lwDefaultMessage}`,
     }, 
   // 1 post per week rate limits
     {
       ...timeframe('1 Posts per 1 weeks'),
-      karmaThreshold: -1,
+      isActive: user => user.karma <= -3,
       rateLimitMessage: `Users with -3 or less karma can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
-      last20PostKarmaThreshold: -15,
-      downvoterCountThreshold: 4,
+      isActive: (user, features) => features?.last20PostKarma <= -15 && features?.postDownvoterCount >= 4,
       rateLimitMessage: `Users with -15 or less karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
-      last20KarmaThreshold: -30,
-      downvoterCountThreshold: 10,
+      isActive: (user, features) => features?.last20PostKarma <= -30 && features?.postDownvoterCount >= 10,
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
     }, 
     // 1 post per 2+ weeks rate limits
     {
       ...timeframe('1 Posts per 2 weeks'),
-      karmaThreshold: -1,
-      last20PostKarmaThreshold: -30,
-      downvoterCountThreshold: 5,
+      isActive: (user, features) => {
+        return user.karma < 0 && features?.last20Karma <= -30 && features?.postDownvoterCount >= 5
+      },
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 3 weeks'),
-      karmaThreshold: -1,
-      last20PostKarmaThreshold: -45,
-      downvoterCountThreshold: 5,
-      rateLimitMessage: `Users with -45 or less karma on recent posts/comments can post once every 3 weeks.<br/>${lwDefaultMessage}`
+      isActive: (user, features) => user.karma < 0 && features?.last20PostKarma <= -45 && features?.postDownvoterCount >= 5,
+      rateLimitMessage: `Users with -45 or less karma on recent posts can post once every 3 weeks.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 4 weeks'),
-      last20PostKarmaThreshold: -60, // uses last20Karma so it's not too hard to dig your way out 
-      downvoterCountThreshold: 5,
-      karmaThreshold: -1,
-      rateLimitMessage: `Users with -60 or less karma can post once every 4 weeks.<br/>${lwDefaultMessage}`
+      isActive: (user, features) => user.karma < 0 && features?.last20Karma <= -60 && features?.postDownvoterCount >= 5, // uses last20Karma so it's not too hard to dig your way out 
+      rateLimitMessage: `Users with -60 or less karma on recent comments/posts can post once every 4 weeks.<br/>${lwDefaultMessage}`
     }
   ],
   COMMENTS: [ 
     {
       ...timeframe('1 Comments per 1 hours'),
-      last20KarmaThreshold: -1,
-      downvoterCountThreshold: 3,
       appliesToOwnPosts: false,
+      isActive: (user, features) => features?.last20Karma <= -1 && features?.downvoterCount >= 3,
       rateLimitMessage: `Users with -1 or less karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
     }, 
   // 3 comments per day rate limits
     {
       ...timeframe('3 Comments per 1 days'),
-      karmaThreshold: 4,
       appliesToOwnPosts: false,
       rateLimitType: "newUserDefault",
+      isActive: user => user.karma < 5,
       rateLimitMessage: `Users with less than 5 karma can write up to 3 comments a day.<br/>${lwDefaultMessage}`,
     }, 
     {
       ...timeframe('3 Comments per 1 days'), // semi-established users can make up to 20 posts/comments without getting upvoted, before hitting a 3/day comment rate limit
-      last20KarmaThreshold: 1, // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes
-      karmaThreshold: 1999, // at 2000+ karma I trust you more to go on long conversations
       appliesToOwnPosts: false,
+      isActive: (user, features) => user.karma < 2000 && features?.last20Karma <= 0,  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 2000+ karma I trust you more to go on long conversations
       rateLimitMessage: `You've recently posted a lot without getting upvoted. Users are limited to 3 comments/day unless their last ${RECENT_CONTENT_COUNT} posts/comments have at least 2+ net-karma.<br/>${lwDefaultMessage}`,
     }, 
   // 1 comment per day rate limits
     {
       ...timeframe('1 Comments per 1 days'),
-      karmaThreshold: -1,
       appliesToOwnPosts: false,
+      isActive: user => user.karma <= -3,
       rateLimitMessage: `Users with -3 or less karma can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Comments per 1 days'),
-      last20KarmaThreshold: -5,
-      karmaThreshold: 1999, // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
-      downvoterCountThreshold: 4,
+
       appliesToOwnPosts: false,
-      rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
-    }, 
-    {
-      ...timeframe('1 Comments per 1 days'),
-      last20KarmaThreshold: -5,
-      downvoterCountThreshold: 7,
-      appliesToOwnPosts: false,
+      isActive: (user, features) => features?.last20Karma <= -5 && features?.downvoterCount >= (user.karma < 2000 ? 4 : 7), // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
       rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
   // 1 comment per 3 days rate limits
     {
       ...timeframe('1 Comments per 3 days'),
-      last20KarmaThreshold: -15,
-      downvoterCountThreshold: 5,
-      karmaThreshold: 499,
       appliesToOwnPosts: false,
+      isActive: (user, features) => features?.last20Karma <= -15 && features?.downvoterCount >= 5 && user.karma < 500,
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 
   // 1 comment per week rate limits
     {
       ...timeframe('1 Comments per 1 weeks'),
-      lastMonthKarmaThreshold: -30,
-      // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
-      last20KarmaThreshold: -1,
-      karmaThreshold: -1,
-      lastMonthDownvoterCountThreshold: 5,
       appliesToOwnPosts: false,
+      isActive: (user, features) => features?.lastMonthKarma <= -30 && features?.last20Karma < -1 && user.karma < 0 && features?.lastMonthDownvoterCount >= 5,
+      // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
       rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${lwDefaultMessage}`
     },
   ]
@@ -166,6 +146,7 @@ const ALL = {
     FIVE_PER_DAY: {
       ...timeframe('5 Posts per 1 days'),
       rateLimitType: "universal",
+      isActive: (user:RateLimitUser) => true,
       rateLimitMessage: "Users cannot post more than 5 posts a day.",
     }
   },
@@ -173,6 +154,7 @@ const ALL = {
     ONE_PER_EIGHT_SECONDS: {
       ...timeframe('1 Comments per 8 seconds'),
       rateLimitType: "universal",
+      isActive: (user:RateLimitUser)  => true,
       rateLimitMessage: "Users cannot submit more than 1 comment per 8 seconds to prevent double-posting.",
       appliesToOwnPosts: true
     }
@@ -185,6 +167,7 @@ export const autoPostRateLimits: ForumOptions<PostAutoRateLimit[]> = {
   ],
   LessWrong: [ 
     ...LW.POSTS,
+    ALL.POSTS.FIVE_PER_DAY
   ],
   default: [
     ALL.POSTS.FIVE_PER_DAY
@@ -197,8 +180,7 @@ export const autoCommentRateLimits: ForumOptions<CommentAutoRateLimit[]> = {
     ...EA.COMMENTS
   ],
   LessWrong: [
-    ALL.COMMENTS.ONE_PER_EIGHT_SECONDS, 
-    ...LW.COMMENTS,
+    ...LW.COMMENTS
   ],
   default: [
     ALL.COMMENTS.ONE_PER_EIGHT_SECONDS

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -1,6 +1,5 @@
 import type { ForumOptions } from "../forumTypeUtils";
 import type { AutoRateLimit, CommentAutoRateLimit, PostAutoRateLimit, TimeframeUnitType } from "./types";
-import type { RateLimitUser } from "./utils";
 
 /**
  * Post rate limits
@@ -34,7 +33,7 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: true
     }, {
       ...timeframe('4 Comments per 30 minutes'),
-      isActive: (user, features) => features?.downvoteRatio >= 0.3,
+      isActive: (user, features) => features.downvoteRatio >= 0.3,
       rateLimitType: "downvoteRatio",
       rateLimitMessage: "",
       appliesToOwnPosts: true
@@ -62,16 +61,16 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
     {
       ...timeframe('1 Posts per 1 weeks'),
       isActive: (user, features) => (
-        features?.last20PostKarma <= -15 && 
-        features?.postDownvoterCount >= 4
+        features.last20PostKarma <= -15 && 
+        features.postDownvoterCount >= 4
       ),
       rateLimitMessage: `Users with -15 or less karma on their recent posts can post once per week.<br/>${lwDefaultMessage}`
     }, 
     {
       ...timeframe('1 Posts per 1 weeks'),
       isActive: (user, features) => (
-        features?.last20PostKarma <= -30 && 
-        features?.postDownvoterCount >= 10
+        features.last20PostKarma <= -30 && 
+        features.postDownvoterCount >= 10
       ),
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once per week.<br/>${lwDefaultMessage}`
     }, 
@@ -80,8 +79,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Posts per 2 weeks'),
       isActive: (user, features) => ( 
         user.karma < 0 && 
-        features?.last20Karma <= -30 && 
-        features?.postDownvoterCount >= 5
+        features.last20Karma <= -30 && 
+        features.postDownvoterCount >= 5
       ),
       rateLimitMessage: `Users with -30 or less karma on their recent posts/comments can post once every 2 weeks.<br/>${lwDefaultMessage}`
     }, 
@@ -89,8 +88,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Posts per 3 weeks'),
       isActive: (user, features) => (
         user.karma < 0 && 
-        features?.last20PostKarma <= -45 && 
-        features?.postDownvoterCount >= 5
+        features.last20PostKarma <= -45 && 
+        features.postDownvoterCount >= 5
       ),
       rateLimitMessage: `Users with -45 or less karma on recent posts can post once every 3 weeks.<br/>${lwDefaultMessage}`
     }, 
@@ -98,8 +97,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Posts per 4 weeks'),
       isActive: (user, features) => (
         user.karma < 0 && 
-        features?.last20Karma <= -60 && 
-        features?.postDownvoterCount >= 5
+        features.last20Karma <= -60 && 
+        features.postDownvoterCount >= 5
       ), // uses last20Karma so it's not too hard to dig your way out 
       rateLimitMessage: `Users with -60 or less karma on recent comments/posts can post once every 4 weeks.<br/>${lwDefaultMessage}`
     }
@@ -109,8 +108,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('1 Comments per 1 hours'),
       appliesToOwnPosts: false,
       isActive: (user, features) => (
-        features?.last20Karma <= -1 && 
-        features?.downvoterCount >= 3
+        features.last20Karma <= -1 && 
+        features.downvoterCount >= 3
       ),
       rateLimitMessage: `Users with -1 or less karma on recent posts/comments can comment once per hour.<br/>${lwDefaultMessage}`
     }, 
@@ -127,7 +126,7 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: false,
       isActive: (user, features) => (
         user.karma < 2000 && 
-        features?.last20Karma <= 0
+        features.last20Karma <= 0
       ),  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 2000+ karma I trust you more to go on long conversations
       rateLimitMessage: `You've recently posted a lot without getting upvoted. Users are limited to 3 comments/day unless their last ${RECENT_CONTENT_COUNT} posts/comments have at least 2+ net-karma.<br/>${lwDefaultMessage}`,
     }, 
@@ -143,8 +142,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
 
       appliesToOwnPosts: false,
       isActive: (user, features) => (
-        features?.last20Karma <= -5 && 
-        features?.downvoterCount >= (user.karma < 2000 ? 4 : 7)
+        features.last20Karma <= -5 && 
+        features.downvoterCount >= (user.karma < 2000 ? 4 : 7)
       ), // at 2000+ karma, I think your downvotes are more likely to be from people who disagree with you, rather than from people who think you're a troll
       rateLimitMessage: `Users with -5 or less karma on recent posts/comments can write up to 1 comment per day.<br/>${lwDefaultMessage}`
     }, 
@@ -154,8 +153,8 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: false,
       isActive: (user, features) => (
         user.karma < 500 &&
-        features?.last20Karma <= -15 && 
-        features?.downvoterCount >= 5
+        features.last20Karma <= -15 && 
+        features.downvoterCount >= 5
       ),
       rateLimitMessage: `Users with -15 or less karma on recent posts/comments can write up to 1 comment every 3 days. ${lwDefaultMessage}`
     }, 
@@ -165,9 +164,9 @@ const LW: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       appliesToOwnPosts: false,
       isActive: (user, features) => (
         user.karma < 0 && 
-        features?.last20Karma < -1 && 
-        features?.lastMonthDownvoterCount >= 5 &&
-        features?.lastMonthKarma <= -30
+        features.last20Karma < -1 && 
+        features.lastMonthDownvoterCount >= 5 &&
+        features.lastMonthKarma <= -30
       ),
       // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
       rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${lwDefaultMessage}`

--- a/packages/lesswrong/lib/rateLimits/types.ts
+++ b/packages/lesswrong/lib/rateLimits/types.ts
@@ -24,6 +24,7 @@ AutoRateLimits can take in an optional karmaThreshold or downvoteRatio parameter
 applies to users who meet that karmaThreshold and/or downvoteRatio criteria. If both params are set, the 
 rate limit only applies if both conditions are met. If neither param is set, the rate limit applies to all users.
 */
+export type IsActiveFunction = (user: RateLimitUser, features: RateLimitFeatures) => boolean;
 export interface AutoRateLimit {
   actionType: "Posts"|"Comments", // which collection the rate limit applies to
   timeframeLength: number, // how long the time timeframe is (measured in the timeframeUnit, below)
@@ -31,7 +32,7 @@ export interface AutoRateLimit {
   itemsPerTimeframe: number, // number of items a user can post/comment/etc before triggering rate limit
   rateLimitType?: RateLimitType // short name used in analytics db
   rateLimitMessage: string // A message displayed to users when they are rate limited.
-  isActive: (user: RateLimitUser, features: RateLimitFeatures) => boolean, 
+  isActive: IsActiveFunction, 
 }
 
 export interface PostAutoRateLimit extends AutoRateLimit {

--- a/packages/lesswrong/lib/rateLimits/types.ts
+++ b/packages/lesswrong/lib/rateLimits/types.ts
@@ -1,4 +1,4 @@
-import {RateLimitUser} from "./utils"
+export type RateLimitUser = UserKarmaInfo|DbUser
 
 export type TimeframeUnitType = 'seconds'|'minutes'|'hours'|'days'|'weeks'|'months'
 export type RateLimitType = "moderator"|"lowKarma"|"universal"|"downvoteRatio"|"newUserDefault"
@@ -31,7 +31,7 @@ export interface AutoRateLimit {
   itemsPerTimeframe: number, // number of items a user can post/comment/etc before triggering rate limit
   rateLimitType?: RateLimitType // short name used in analytics db
   rateLimitMessage: string // A message displayed to users when they are rate limited.
-  isActive: (user: RateLimitUser, features?: AnyBecauseTodo) => boolean, 
+  isActive: (user: RateLimitUser, features: RateLimitFeatures) => boolean, 
 }
 
 export interface PostAutoRateLimit extends AutoRateLimit {
@@ -75,3 +75,7 @@ export type RateLimitComparison<T extends AutoRateLimit> = {
   isStricter: false;
   strictestNewRateLimit?: undefined;
 };
+
+export type RateLimitFeatures = RecentKarmaInfo & {
+  downvoteRatio: number,
+}

--- a/packages/lesswrong/lib/rateLimits/types.ts
+++ b/packages/lesswrong/lib/rateLimits/types.ts
@@ -1,3 +1,5 @@
+import {RateLimitUser} from "./utils"
+
 export type TimeframeUnitType = 'seconds'|'minutes'|'hours'|'days'|'weeks'|'months'
 export type RateLimitType = "moderator"|"lowKarma"|"universal"|"downvoteRatio"|"newUserDefault"
  
@@ -29,38 +31,8 @@ export interface AutoRateLimit {
   itemsPerTimeframe: number, // number of items a user can post/comment/etc before triggering rate limit
   rateLimitType?: RateLimitType // short name used in analytics db
   rateLimitMessage: string // A message displayed to users when they are rate limited.
-
-  // The following parameters are optional, and if set, the rate limit will only apply to users who meet all thresholds:
-
-  karmaThreshold?: number, // if set, limit will only apply to users with karma less than the threshold
-  downvoteRatioThreshold?: number, // if set, limit will only apply to users who's ratio of received downvotes / total votes is higher than the listed threshold
-  last20KarmaThreshold?: number //  if set, limit only applies to users whose past 20 posts and comments karma total is less than N
-  last20PostKarmaThreshold?: number // if set, limit only applies to users whose past 20 post karma total is less than N
-  last20CommentKarmaThreshold?: number // if set, limit only applies to users whose past 20 comment karma total is less than N
-  downvoterCountThreshold?: number // if set, limit only applies to users whose past 20 posts and comments were downvoted by N or more people.
-  postDownvoterCountThreshold?: number // if set, limit only applies to users whose past 20 posts were downvoted by N or more people.
-  commentDownvoterCountThreshold?: number // if set, limit only applies to users whose past 20 comments were downvoted by N or more people.
-  lastMonthKarmaThreshold?: number // if set, limit only applies to votes on content from the last month
-  lastMonthDownvoterCountThreshold?: number // if set, limit only applies to users whose content in the last month was downvoted by N or more people.
+  isActive: (user: RateLimitUser, features?: AnyBecauseTodo) => boolean, 
 }
-
-//convert rateLimitThresholds to union type
-export type RateLimitThreshold = "karmaThreshold"|"downvoteRatioThreshold"|"last20KarmaThreshold"|"last20PostKarmaThreshold"|"last20CommentKarmaThreshold"|"lastMonthKarmaThreshold"|"downvoterCountThreshold"|"postDownvoterCountThreshold"|"commentDownvoterCountThreshold"|"lastMonthDownvoterCountThreshold"
-
-export const rateLimitThresholds: RateLimitThreshold[] = [
-  "karmaThreshold",
-  "downvoteRatioThreshold", 
-  
-  "last20KarmaThreshold", 
-  "last20PostKarmaThreshold",
-  "last20CommentKarmaThreshold",
-  "lastMonthKarmaThreshold",
-
-  "downvoterCountThreshold",
-  "postDownvoterCountThreshold",
-  "commentDownvoterCountThreshold",
-  "lastMonthDownvoterCountThreshold"
-]
 
 export interface PostAutoRateLimit extends AutoRateLimit {
   actionType: "Posts",  
@@ -103,5 +75,3 @@ export type RateLimitComparison<T extends AutoRateLimit> = {
   isStricter: false;
   strictestNewRateLimit?: undefined;
 };
-
-

--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -5,7 +5,9 @@ import { getDownvoteRatio } from "../../components/sunshineDashboard/UsersReview
 import { forumSelect } from "../forumTypeUtils"
 import { userIsAdmin, userIsMemberOf } from "../vulcan-users"
 import { autoCommentRateLimits, autoPostRateLimits } from "./constants"
-import { AutoRateLimit, RateLimitComparison, RateLimitInfo, rateLimitThresholds, RecentKarmaInfo, RecentVoteInfo, TimeframeUnitType, UserKarmaInfo, UserKarmaInfoWindow } from "./types"
+import { AutoRateLimit, RateLimitComparison, RateLimitInfo, RecentKarmaInfo, RecentVoteInfo, TimeframeUnitType, UserKarmaInfo, UserKarmaInfoWindow } from "./types"
+
+export type RateLimitUser = UserKarmaInfo|DbUser
 
 export function getModRateLimitInfo(documents: Array<DbPost|DbComment>, modRateLimitHours: number, itemsPerTimeframe: number): RateLimitInfo|null {
   if (modRateLimitHours <= 0) return null
@@ -18,7 +20,7 @@ export function getModRateLimitInfo(documents: Array<DbPost|DbComment>, modRateL
   }
 }
 
-export function getUserRateLimitIntervalHours(userRateLimit: DbUserRateLimit | null): number {
+export function getManualRateLimitIntervalHours(userRateLimit: DbUserRateLimit | null): number {
   if (!userRateLimit) return 0;
   return moment.duration(userRateLimit.intervalLength, userRateLimit.intervalUnit).asHours();
 }
@@ -40,7 +42,7 @@ export function getStrictestRateLimitInfo(rateLimits: Array<RateLimitInfo|null>)
   return sortedRateLimits[0] ?? null;
 }
 
-export function getUserRateLimitInfo(userRateLimit: DbUserRateLimit|null, documents: Array<DbPost|DbComment>): RateLimitInfo|null {
+export function getManualRateLimitInfo(userRateLimit: DbUserRateLimit|null, documents: Array<DbPost|DbComment>): RateLimitInfo|null {
   if (!userRateLimit) return null
   const nextEligible = getNextAbleToSubmitDate(documents, userRateLimit.intervalUnit, userRateLimit.intervalLength, userRateLimit.actionsPerInterval)
   if (!nextEligible) return null
@@ -49,35 +51,6 @@ export function getUserRateLimitInfo(userRateLimit: DbUserRateLimit|null, docume
     rateLimitType: "moderator",
     rateLimitMessage: "A moderator has rate limited you."
   }
-}
-
-export function shouldRateLimitApply(user: UserKarmaInfo, rateLimit: AutoRateLimit, recentKarmaInfo: RecentKarmaInfo): boolean {
-  // rate limit conditions
-  const { karmaThreshold, downvoteRatioThreshold, 
-          last20KarmaThreshold, last20PostKarmaThreshold: recentPostKarmaThreshold, last20CommentKarmaThreshold: recentCommentKarmaThreshold,
-          downvoterCountThreshold, postDownvoterCountThreshold, commentDownvoterCountThreshold, 
-          lastMonthKarmaThreshold, lastMonthDownvoterCountThreshold } = rateLimit
-
-  // user's recent karma info
-  const { last20Karma, lastMonthKarma, last20PostKarma, last20CommentKarma, 
-          downvoterCount, postDownvoterCount, commentDownvoterCount, lastMonthDownvoterCount } = recentKarmaInfo
-  
-  // Karma is actually sometimes null, and numeric comparisons with null always return false (sometimes incorrectly)
-  if ((karmaThreshold !== undefined) && (user.karma) > karmaThreshold) return false 
-  if ((downvoteRatioThreshold !== undefined) && getDownvoteRatio(user) < downvoteRatioThreshold) return false
-
-  if ((last20KarmaThreshold !== undefined) && (last20Karma > last20KarmaThreshold)) return false
-  if ((recentPostKarmaThreshold !== undefined) && (last20PostKarma > recentPostKarmaThreshold)) return false
-  if ((recentCommentKarmaThreshold !== undefined) && (last20CommentKarma > recentCommentKarmaThreshold)) return false
-
-  if ((lastMonthKarmaThreshold !== undefined && (lastMonthKarma > lastMonthKarmaThreshold))) return false
-  if ((lastMonthDownvoterCountThreshold !== undefined && (lastMonthDownvoterCount > lastMonthDownvoterCountThreshold))) return false
-
-  if ((downvoterCountThreshold !== undefined) && (downvoterCount < downvoterCountThreshold)) return false
-  if ((postDownvoterCountThreshold !== undefined) && (postDownvoterCount < postDownvoterCountThreshold)) return false
-  if ((commentDownvoterCountThreshold !== undefined) && (commentDownvoterCount < commentDownvoterCountThreshold)) return false
-
-  return true
 }
 
 export function getNextAbleToSubmitDate(documents: Array<DbPost|DbComment>, timeframeUnit: TimeframeUnitType, timeframeLength: number, itemsPerTimeframe: number): Date|null {
@@ -89,11 +62,11 @@ export function getNextAbleToSubmitDate(documents: Array<DbPost|DbComment>, time
   return moment(doc.postedAt).add(timeframeLength, timeframeUnit).toDate()
 }
 
-export function getAutoRateLimitInfo(user: DbUser, rateLimit: AutoRateLimit,  documents: Array<DbPost|DbComment>, recentKarmaInfo: RecentKarmaInfo): RateLimitInfo|null {
+export function getAutoRateLimitInfo(user: RateLimitUser, features: AnyBecauseTodo, rateLimit: AutoRateLimit,  documents: Array<DbPost|DbComment>, recentKarmaInfo: RecentKarmaInfo): RateLimitInfo|null {
   // rate limit effects
   const { timeframeUnit, timeframeLength, itemsPerTimeframe, rateLimitMessage, rateLimitType } = rateLimit 
 
-  if (!shouldRateLimitApply(user, rateLimit, recentKarmaInfo)) return null
+  if (!rateLimit.isActive(user, features)) return null 
 
   const nextEligible = getNextAbleToSubmitDate(documents, timeframeUnit, timeframeLength, itemsPerTimeframe)
   if (!nextEligible) return null 
@@ -156,13 +129,12 @@ export function calculateRecentKarmaInfo(userId: string, allVotes: RecentVoteInf
 
 function getRateLimitName (rateLimit: AutoRateLimit) {
   let rateLimitName = `${rateLimit.itemsPerTimeframe} ${rateLimit.actionType} per ${rateLimit.timeframeLength} ${rateLimit.timeframeUnit}`
-  const thresholdInfo = rateLimitThresholds.map(threshold => rateLimit[threshold] ? `${rateLimit[threshold]} ${threshold.replace("Threshold", "")}` : undefined).filter(threshold => threshold)
-  return rateLimitName += ` (${thresholdInfo.join(", ")})`
+  return rateLimitName += ` (via function: ${rateLimit.isActive.toString()})`
 }
 
 function getActiveRateLimits<T extends AutoRateLimit>(user: UserKarmaInfo & { recentKarmaInfo: RecentKarmaInfo }, autoRateLimits: T[]) {
   const nonUniversalLimits = autoRateLimits.filter(rateLimit => rateLimit.rateLimitType !== "universal")
-  return nonUniversalLimits.filter(rateLimit => shouldRateLimitApply(user, rateLimit, user.recentKarmaInfo))
+  return nonUniversalLimits.filter(rateLimit => (!rateLimit.isActive(user, user.recentKarmaInfo)))
 }
 
 export function getActiveRateLimitNames(user: SunshineUsersList, autoRateLimits: AutoRateLimit[]) {

--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -1,13 +1,10 @@
 import groupBy from "lodash/groupBy"
 import uniq from "lodash/uniq"
 import moment from "moment"
-import { getDownvoteRatio } from "../../components/sunshineDashboard/UsersReviewInfoCard"
 import { forumSelect } from "../forumTypeUtils"
 import { userIsAdmin, userIsMemberOf } from "../vulcan-users"
 import { autoCommentRateLimits, autoPostRateLimits } from "./constants"
-import { AutoRateLimit, RateLimitComparison, RateLimitInfo, RecentKarmaInfo, RecentVoteInfo, TimeframeUnitType, UserKarmaInfo, UserKarmaInfoWindow } from "./types"
-
-export type RateLimitUser = UserKarmaInfo|DbUser
+import { AutoRateLimit, RateLimitComparison, RateLimitFeatures, RateLimitInfo, RateLimitUser, RecentKarmaInfo, RecentVoteInfo, TimeframeUnitType, UserKarmaInfo, UserKarmaInfoWindow } from "./types"
 
 export function getModRateLimitInfo(documents: Array<DbPost|DbComment>, modRateLimitHours: number, itemsPerTimeframe: number): RateLimitInfo|null {
   if (modRateLimitHours <= 0) return null
@@ -62,7 +59,7 @@ export function getNextAbleToSubmitDate(documents: Array<DbPost|DbComment>, time
   return moment(doc.postedAt).add(timeframeLength, timeframeUnit).toDate()
 }
 
-export function getAutoRateLimitInfo(user: RateLimitUser, features: AnyBecauseTodo, rateLimit: AutoRateLimit,  documents: Array<DbPost|DbComment>, recentKarmaInfo: RecentKarmaInfo): RateLimitInfo|null {
+export function getAutoRateLimitInfo(user: RateLimitUser, features: RateLimitFeatures, rateLimit: AutoRateLimit,  documents: Array<DbPost|DbComment>): RateLimitInfo|null {
   // rate limit effects
   const { timeframeUnit, timeframeLength, itemsPerTimeframe, rateLimitMessage, rateLimitType } = rateLimit 
 

--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -136,15 +136,6 @@ export function calculateRecentKarmaInfo(userId: string, allVotes: RecentVoteInf
   }
 }
 
-export function calculateFeaturesForTest(userId: string, userKarmaInfo: UserKarmaInfo, allVotes: RecentVoteInfo[]): AnyBecauseTodo {
-  const recentKarmaInfo = calculateRecentKarmaInfo(userId, allVotes)
-  const features = {
-    ...recentKarmaInfo, 
-    downvoteRatio: getDownvoteRatio(userKarmaInfo)
-  }
-  return features
-}
-
 function getRateLimitName (rateLimit: AutoRateLimit) {
   let rateLimitName = `${rateLimit.itemsPerTimeframe} ${rateLimit.actionType} per ${rateLimit.timeframeLength} ${rateLimit.timeframeUnit}`
   return rateLimitName += ` (via function: ${rateLimit.isActive.toString()})`

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -171,9 +171,9 @@ async function getCommentRateLimitInfos({commentsInTimeframe, user, modRateLimit
 
   const modSpecificPostRateLimitInfo = getModPostSpecificRateLimitInfo(commentsOnOthersPostsInTimeframe, modPostSpecificRateLimitHours, postId, userIsAuthor)
 
-  const manualRateLimitInfo = userIsAuthor ? null : getManualRateLimitInfo(manualCommentRateLimit, commentsOnOthersPostsInTimeframe) // ROBERT STUFF
+  const manualRateLimitInfo = userIsAuthor ? null : getManualRateLimitInfo(manualCommentRateLimit, commentsOnOthersPostsInTimeframe) 
 
-  const autoRateLimits = forumSelect(autoCommentRateLimits) // RAY STUFF
+  const autoRateLimits = forumSelect(autoCommentRateLimits)
   const filteredAutoRateLimits = autoRateLimits?.filter(rateLimit => {
     if (userIsAuthor) return rateLimit.appliesToOwnPosts
     return true 

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -9,12 +9,13 @@ import { userIsAdmin, userIsMemberOf } from "../lib/vulcan-users/permissions"
 import VotesRepo from "./repos/VotesRepo"
 import { autoCommentRateLimits, autoPostRateLimits } from "../lib/rateLimits/constants"
 import type { CommentAutoRateLimit, PostAutoRateLimit, RateLimitComparison, RateLimitInfo, RecentKarmaInfo, RecentVoteInfo, UserRateLimit } from "../lib/rateLimits/types"
-import { calculateRecentKarmaInfo, documentOnlyHasSelfVote, getAutoRateLimitInfo, getCurrentAndPreviousUserKarmaInfo, getMaxAutoLimitHours, getModRateLimitInfo, getRateLimitStrictnessComparisons, getStrictestRateLimitInfo, getUserRateLimitInfo, getUserRateLimitIntervalHours, shouldIgnorePostRateLimit } from "../lib/rateLimits/utils"
+import { calculateRecentKarmaInfo, documentOnlyHasSelfVote, getAutoRateLimitInfo, getCurrentAndPreviousUserKarmaInfo, getMaxAutoLimitHours, getModRateLimitInfo, getRateLimitStrictnessComparisons, getStrictestRateLimitInfo, getManualRateLimitInfo, getManualRateLimitIntervalHours, shouldIgnorePostRateLimit } from "../lib/rateLimits/utils"
 import Users from "../lib/collections/users/collection"
 import { triggerReview } from "./callbacks/sunshineCallbackUtils"
 import { appendToSunshineNotes } from "../lib/collections/users/helpers"
 import { isNonEmpty } from "fp-ts/Array"
 import type { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
+import { getDownvoteRatio } from "../components/sunshineDashboard/UsersReviewInfoCard"
 
 async function getModRateLimitHours(userId: string): Promise<number> {
   const moderatorRateLimit = await getModeratorRateLimit(userId)
@@ -35,7 +36,7 @@ async function getPostsInTimeframe(user: DbUser, maxHours: number) {
   }, {sort: {postedAt: -1}, projection: {postedAt: 1}}).fetch()
 }
 
-function getUserRateLimit<T extends DbUserRateLimit['type']>(userId: string, type: T) {
+function getManualRateLimit<T extends DbUserRateLimit['type']>(userId: string, type: T) {
   return UserRateLimits.findOne({
     userId,
     type,
@@ -55,11 +56,16 @@ function getPostRateLimitInfos(
   recentKarmaInfo: RecentKarmaInfo
 ): Array<RateLimitInfo> {
   // for each rate limit, get the next date that user could post  
-  const userPostRateLimitInfo = getUserRateLimitInfo(userPostRateLimit, postsInTimeframe)
+  const userPostRateLimitInfo = getManualRateLimitInfo(userPostRateLimit, postsInTimeframe)
+
+  const features = {
+    ...recentKarmaInfo, 
+    downvoteRatio: getDownvoteRatio(user)
+  } 
 
   const autoRatelimits = forumSelect(autoPostRateLimits)
   const autoRateLimitInfos = autoRatelimits?.map(
-    rateLimit => getAutoRateLimitInfo(user, rateLimit, postsInTimeframe, recentKarmaInfo)
+    rateLimit => getAutoRateLimitInfo(user, features, rateLimit, postsInTimeframe, recentKarmaInfo)
   ) ?? []
 
   // modRateLimitInfo is sort of deprecated, but we're still using it for at least a couple months
@@ -136,12 +142,12 @@ async function getCommentsOnOthersPosts(comments: Array<DbComment>, userId: stri
   return commentsOnNonauthorPosts
 }
 
-async function getCommentRateLimitInfos({commentsInTimeframe, user, modRateLimitHours, modPostSpecificRateLimitHours, postId, userCommentRateLimit, recentKarmaInfo, context}: {
+async function getCommentRateLimitInfos({commentsInTimeframe, user, modRateLimitHours, modPostSpecificRateLimitHours, postId, manualCommentRateLimit, recentKarmaInfo, context}: {
   commentsInTimeframe: Array<DbComment>,
   user: DbUser,
   modRateLimitHours: number,
   modPostSpecificRateLimitHours: number,
-  userCommentRateLimit: UserRateLimit<'allComments'> | null,
+  manualCommentRateLimit: UserRateLimit<'allComments'> | null,
   postId: string | null,
   recentKarmaInfo: RecentKarmaInfo,
   context: ResolverContext
@@ -151,22 +157,28 @@ async function getCommentRateLimitInfos({commentsInTimeframe, user, modRateLimit
     getCommentsOnOthersPosts(commentsInTimeframe, user._id)
   ])
 
+  // Deprecated! TODO: remove!
   const modGeneralRateLimitInfo = getModRateLimitInfo(commentsOnOthersPostsInTimeframe, modRateLimitHours, 1)
 
   const modSpecificPostRateLimitInfo = getModPostSpecificRateLimitInfo(commentsOnOthersPostsInTimeframe, modPostSpecificRateLimitHours, postId, userIsAuthor)
 
-  const userRateLimitInfo = userIsAuthor ? null : getUserRateLimitInfo(userCommentRateLimit, commentsOnOthersPostsInTimeframe)
+  const manualRateLimitInfo = userIsAuthor ? null : getManualRateLimitInfo(manualCommentRateLimit, commentsOnOthersPostsInTimeframe) // ROBERT STUFF
 
-  const autoRateLimits = forumSelect(autoCommentRateLimits)
+  const autoRateLimits = forumSelect(autoCommentRateLimits) // RAY STUFF
   const filteredAutoRateLimits = autoRateLimits?.filter(rateLimit => {
     if (userIsAuthor) return rateLimit.appliesToOwnPosts
     return true 
   })
 
+  const features = {
+    ...recentKarmaInfo, 
+    downvoteRatio: getDownvoteRatio(user)
+  }
+
   const autoRateLimitInfos = filteredAutoRateLimits?.map(
-    rateLimit => getAutoRateLimitInfo(user, rateLimit, commentsInTimeframe, recentKarmaInfo)
+    rateLimit => getAutoRateLimitInfo(user, features, rateLimit, commentsInTimeframe, recentKarmaInfo)
   ) ?? []
-  return [modGeneralRateLimitInfo, modSpecificPostRateLimitInfo, userRateLimitInfo, ...autoRateLimitInfos].filter((rateLimit): rateLimit is RateLimitInfo => rateLimit !== null)
+  return [modGeneralRateLimitInfo, modSpecificPostRateLimitInfo, manualRateLimitInfo, ...autoRateLimitInfos].filter((rateLimit): rateLimit is RateLimitInfo => rateLimit !== null)
 }
 
 export async function rateLimitDateWhenUserNextAbleToPost(user: DbUser): Promise<RateLimitInfo|null> {
@@ -175,21 +187,21 @@ export async function rateLimitDateWhenUserNextAbleToPost(user: DbUser): Promise
   
   // does the user have a moderator-assigned rate limit?
   // also get the recent karma info, we'll need it later
-  const [modRateLimitHours, userPostRateLimit, recentKarmaInfo] = await Promise.all([
+  const [modRateLimitHours, manualPostRateLimit, recentKarmaInfo] = await Promise.all([
     getModRateLimitHours(user._id),
-    getUserRateLimit(user._id, 'allPosts'),
+    getManualRateLimit(user._id, 'allPosts'),
     getRecentKarmaInfo(user._id)
   ]);
 
   // what's the longest rate limit timeframe being evaluated?
-  const userPostRateLimitHours = getUserRateLimitIntervalHours(userPostRateLimit);
+  const manualPostRateLimitHours = getManualRateLimitIntervalHours(manualPostRateLimit);
   const maxPostAutolimitHours = getMaxAutoLimitHours(forumSelect(autoPostRateLimits));
-  const maxHours = Math.max(modRateLimitHours, userPostRateLimitHours, maxPostAutolimitHours);
+  const maxHours = Math.max(modRateLimitHours, manualPostRateLimitHours, maxPostAutolimitHours);
 
   // fetch the posts from within the maxTimeframe
   const postsInTimeframe = await getPostsInTimeframe(user, maxHours);
 
-  const rateLimitInfos = getPostRateLimitInfos(user, postsInTimeframe, modRateLimitHours, userPostRateLimit, recentKarmaInfo);
+  const rateLimitInfos = getPostRateLimitInfos(user, postsInTimeframe, modRateLimitHours, manualPostRateLimit, recentKarmaInfo);
 
   return getStrictestRateLimitInfo(rateLimitInfos)
 }
@@ -200,18 +212,18 @@ export async function rateLimitDateWhenUserNextAbleToComment(user: DbUser, postI
 
   // does the user have a moderator-assigned rate limit?
   // also get the recent karma info, we'll need it later
-  const [modRateLimitHours, modPostSpecificRateLimitHours, userCommentRateLimit, recentKarmaInfo] = await Promise.all([
+  const [modRateLimitHours, modPostSpecificRateLimitHours, manualCommentRateLimit, recentKarmaInfo] = await Promise.all([
     getModRateLimitHours(user._id),
     getModPostSpecificRateLimitHours(user._id),
-    getUserRateLimit(user._id, 'allComments'),
+    getManualRateLimit(user._id, 'allComments'),
     getRecentKarmaInfo(user._id)
   ]);
 
-  const userCommentRateLimitHours = getUserRateLimitIntervalHours(userCommentRateLimit);
+  const manualCommentRateLimitHours = getManualRateLimitIntervalHours(manualCommentRateLimit);
 
   // what's the longest rate limit timeframe being evaluated?
   const maxCommentAutolimitHours = getMaxAutoLimitHours(forumSelect(autoCommentRateLimits))
-  const maxHours = Math.max(modRateLimitHours, modPostSpecificRateLimitHours, maxCommentAutolimitHours, userCommentRateLimitHours);
+  const maxHours = Math.max(modRateLimitHours, modPostSpecificRateLimitHours, maxCommentAutolimitHours, manualCommentRateLimitHours);
 
   // fetch the comments from within the maxTimeframe
   const commentsInTimeframe = await getCommentsInTimeframe(user._id, maxHours);
@@ -222,7 +234,7 @@ export async function rateLimitDateWhenUserNextAbleToComment(user: DbUser, postI
     modRateLimitHours,
     modPostSpecificRateLimitHours,
     postId,
-    userCommentRateLimit,
+    manualCommentRateLimit,
     recentKarmaInfo,
     context,
   });

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -2,8 +2,8 @@ import sum from "lodash/sum";
 import groupBy from "lodash/groupBy";
 import range from "lodash/range";
 import moment from "moment";
-import { CommentAutoRateLimit, RecentVoteInfo, UserKarmaInfo } from "../lib/rateLimits/types";
-import { RateLimitUser, calculateRecentKarmaInfo } from "../lib/rateLimits/utils";
+import { CommentAutoRateLimit, RecentVoteInfo, UserKarmaInfo, RateLimitUser } from "../lib/rateLimits/types";
+import { calculateRecentKarmaInfo } from "../lib/rateLimits/utils";
 
 function createVote(overrideVoteFields?: Partial<RecentVoteInfo>): RecentVoteInfo {
   const defaultVoteInfo = {

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -177,7 +177,7 @@ describe("shouldRateLimitApply", function () {
     expect(rateLimit.isActive(user1, features2)).toEqual(true)
   })
   it("returns true IFF recent user post karma is less than recentPostKarmaThreshold", () => {
-    const rateLimit = createCommentRateLimit((user, features) => features.last20PostKarma <= 0)
+    const rateLimit = createCommentRateLimit((user, features) => features.last20PostKarma < 0)
     const user1 = createUserKarmaInfo()
     const featuresPostVotes = calculateFeaturesForTest("authorId", user1, postDownVotes)
     const featuresCommentVotes = calculateFeaturesForTest("authorId", user1, commentDownVotes)

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -158,7 +158,7 @@ describe("shouldRateLimitApply", function () {
   const oldCommentDownvotes = range(20).map(k => createCommentVote({power: -1, postedAt: moment().subtract(5, 'weeks').toDate()}))
 
   it("returns true IFF user karma is less than karma threshold", () => {
-    const rateLimit = createCommentRateLimit(user => user.karma < 0)
+    const rateLimit = createCommentRateLimit(user => user.karma <= 0)
     const user1 = createUserKarmaInfo({karma: 0})
     const features1 = calculateFeaturesForTest("authorId", user1, commentUpvotes) 
     const user2 = createUserKarmaInfo({karma: 1})

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -33,7 +33,7 @@ function createPostVote(overrideVoteFields?: Omit<Partial<RecentVoteInfo>, "coll
   return createVote({...defaultVoteInfo, ...overrideVoteFields})
 } 
 
-function createCommentRateLimit(isActive: (user:RateLimitUser, features?:any) => boolean): CommentAutoRateLimit {
+function createCommentRateLimit(isActive: (user:RateLimitUser) => boolean): CommentAutoRateLimit {
   return  {
     actionType: "Comments",
     timeframeUnit: 'days',

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -186,7 +186,7 @@ describe("shouldRateLimitApply", function () {
     expect(rateLimit.isActive(user1, featuresCommentVotes)).toEqual(false)
   })
   it("returns true IFF recent user comment karma is less than recentCommentKarmaThreshold", () => {
-    const rateLimit = createCommentRateLimit((user, features) => features.last20CommentKarma <= 0)
+    const rateLimit = createCommentRateLimit((user, features) => features.last20CommentKarma < 0)
     const user1 = createUserKarmaInfo()
     const featuresPostVotes = calculateFeaturesForTest("authorId", user1, postDownVotes)
     const featuresCommentVotes = calculateFeaturesForTest("authorId", user1, commentDownVotes)

--- a/packages/lesswrong/unitTests/autoRateLimit.tests.ts
+++ b/packages/lesswrong/unitTests/autoRateLimit.tests.ts
@@ -196,7 +196,7 @@ describe("shouldRateLimitApply", function () {
   })
   it("returns true IFF lastMonthKarma is less than lastMonthKarmaKarmaThreshold", () => {
     const user1 = createUserKarmaInfo()
-    const rateLimit = createCommentRateLimit((user, features) => features.lastMonthKarma <= 0)
+    const rateLimit = createCommentRateLimit((user, features) => features.lastMonthKarma < 0)
     const featuresOldCommentVotes = calculateFeaturesForTest("authorId", user1, oldCommentDownvotes)
     const featuresNewCommentVotes = calculateFeaturesForTest("authorId", user1, commentDownVotes)
     


### PR DESCRIPTION
Changing the previously overparameterised type signature, to one where each rateLimit instead just takes as input a boolean function, that determines whether it's active or not. 

Also renames the ambiguously named userRateLimits to some version of manualRateLimit in various places. 

This is the first step to then more easily add some new, somewhat more complicated rate limits. (In addition, TODO remains to remove the deprecated ModeratorAction rate limits, which should be replaced with the manual ones)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206292005425856) by [Unito](https://www.unito.io)
