### PR TITLE
Improve Admin UI for tag permissions setting & add core tags filtering

### DIFF
--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { tagStyle } from './FooterTag';
-import { taggingNameSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -29,10 +28,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 }); 
 
-const CoreTagsChecklist = ({onTagSelected, classes, existingTagIds=[] }: {
+const CoreTagsChecklist = ({onTagSelected, classes, existingTagIds=[], shouldDisplayTag = () => true }: {
   onTagSelected?: (tag: {tagId: string, tagName: string}, existingTagIds: Array<string>)=>void,
   classes: ClassesType,
-  existingTagIds?: Array<string|undefined>
+  existingTagIds?: Array<string|undefined>,
+  shouldDisplayTag?: (tag: TagFragment) => boolean,
 }) => {
   const { TagsChecklist } = Components
 
@@ -49,7 +49,7 @@ const CoreTagsChecklist = ({onTagSelected, classes, existingTagIds=[] }: {
   if (loading) return <Loading/>
   if (!results) return null
   
-  return <TagsChecklist tags={results} onTagSelected={onTagSelected} selectedTagIds={existingTagIds}/>
+  return <TagsChecklist tags={results.filter(shouldDisplayTag)} onTagSelected={onTagSelected} selectedTagIds={existingTagIds}/>
 }
 
 

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -309,6 +309,7 @@ registerFragment(`
     moderationGuidelines {
       ...RevisionEdit
     }
+    canVoteOnRels
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -34,6 +34,8 @@ export const TAG_POSTS_SORT_ORDER_OPTIONS: Record<string, SettingsOption>  = {
   ...SORT_ORDER_OPTIONS,
 }
 
+const canVoteOnRelsOptions = ["userOwns", "userOwnsOnlyUpvote", ...permissionGroups]
+
 const schema: SchemaType<"Tags"> = {
   name: {
     type: String,
@@ -501,10 +503,15 @@ const schema: SchemaType<"Tags"> = {
     canCreate: ['admins', 'sunshineRegiment'],
     optional: true,
     group: formGroups.advancedOptions,
+    control: 'checkboxgroup',
+    label: "Who can add this tag to things or vote on its relevance?",
+    form: {
+      options: canVoteOnRelsOptions.map((key) => ({value: key, label: key})),
+    }
   },
   'canVoteOnRels.$': {
     type: String,
-    allowedValues: ["userOwns", "userOwnsOnlyUpvote", ...permissionGroups],
+    allowedValues: canVoteOnRelsOptions,
   },
   isSubforum: {
     type: Boolean,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -541,7 +541,7 @@ type ModeratorActionsCollection = CollectionBase<"ModeratorActions">;
 interface DbModeratorAction extends DbObject {
   __collectionName?: "ModeratorActions"
   userId: string
-  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting"
+  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits"
   endedAt: Date | null
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -943,7 +943,7 @@ interface NotificationsDefaultFragment { // fragment on Notifications
 
 interface ModeratorActionsDefaultFragment { // fragment on ModeratorActions
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits",
   readonly endedAt: Date | null,
 }
 
@@ -1094,15 +1094,11 @@ interface PostsAuthors { // fragment on Posts
 }
 
 interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
-  readonly biography: PostsAuthors_user_biography|null,
+  readonly biography: RevisionDisplay|null,
   readonly profileImageId: string,
   readonly moderationStyle: string,
   readonly bannedUserIds: Array<string>,
   readonly moderatorAssistance: boolean,
-}
-
-interface PostsAuthors_user_biography { // fragment on Revisions
-  readonly html: string,
 }
 
 interface PostsListBase extends PostsBase, PostsAuthors { // fragment on Posts
@@ -2489,6 +2485,7 @@ interface TagEditFragment extends TagDetailsFragment { // fragment on Tags
   readonly description: RevisionEdit|null,
   readonly subforumWelcomeText: RevisionEdit|null,
   readonly moderationGuidelines: RevisionEdit|null,
+  readonly canVoteOnRels: Array<"userOwns" | "userOwnsOnlyUpvote" | "guests" | "members" | "admins" | "sunshineRegiment" | "alignmentForumAdmins" | "alignmentForum" | "alignmentVoters" | "podcasters" | "canBypassPostRateLimit" | "trustLevel1" | "canModeratePersonal" | "canSuggestCuration" | "debaters" | "realAdmins">,
 }
 
 interface TagRecentDiscussion extends TagFragment { // fragment on Tags
@@ -3348,7 +3345,7 @@ interface ModeratorActionDisplay { // fragment on ModeratorActions
   readonly _id: string,
   readonly user: UsersMinimumInfo|null,
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits",
   readonly active: boolean,
   readonly createdAt: Date,
   readonly endedAt: Date | null,


### PR DESCRIPTION
- Shows allowed options for `canVoteOnRels` as a list of checkboxes
- Also adds ability to CoreTags display (to e.g. only show tags user can apply)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206296158058830) by [Unito](https://www.unito.io)
