### PR TITLE
Bug fixes for `EALargePostsItem`

### DIFF
--- a/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
@@ -6,6 +6,9 @@ import { useForeignApolloClient } from "../../hooks/useForeignApolloClient";
 import { useSingle } from "../../../lib/crud/withSingle";
 import type { CommonExcerptProps } from "./ContentExcerpt";
 
+const isSunshine = (post: PostsList | SunshinePostsList): post is SunshinePostsList =>
+  "user" in post;
+
 const PostExcerpt = ({
   post,
   hash,
@@ -16,6 +19,17 @@ const PostExcerpt = ({
 }) => {
   // Get the post body, accounting for whether or not this is a crosspost
   const {postContents, loading, error} = usePostContents({
+    /*
+     * TODO: This should use the `fragmentName` logic below, however, this
+     * requires a backend change that needs to be deployed to both LessWrong
+     * and the EA Forum before it will work. For now, we can just use `PostsList`
+     * with a cast, then at some point in the near future once it's deployed we
+     * can change it.
+     */
+    /*
+    post,
+    fragmentName: isSunshine(post) ? "SunshinePostsList" : "PostsList",
+     */
     post: post as PostsList,
     fragmentName: "PostsList",
     skip: !!hash,

--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -50,14 +50,31 @@ const getCrosspostQuery = gql`
  */
 const crosspostBatchKey = "crosspost";
 
-type PostFetchProps<FragmentTypeName extends PostFragments> =
+type PostFetchProps<FragmentTypeName extends CrosspostFragments> =
   Omit<UseSingleProps<FragmentTypeName>, "documentId" | "apolloClient">;
 
-type PostFragments = 'PostsWithNavigation' | 'PostsWithNavigationAndRevision' | 'PostsList';
+/**
+ * This lists the valid fragment names that can be passed to the foreign site
+ * when fetching a post with a cross-site request. Note that the fragment name
+ * passed to the foreign site _is_ validated against this list and will throw
+ * an error if the fragment name isn't here, so additions to this list need to
+ * be deployed to _both_ sites before deploying any logic that relies on them
+ * otherwise your cross-site requests with be rejected.
+ */
+export const crosspostFragments = [
+  "PostsWithNavigation",
+  "PostsWithNavigationAndRevision",
+  "PostsList",
+  "SunshinePostsList",
+  "PostsPage",
+] as const;
+
+type CrosspostFragments = typeof crosspostFragments[number];
+
 /**
  * Load foreign crosspost data from the foreign site
  */
-export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentTypeName extends PostFragments>(
+export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentTypeName extends CrosspostFragments>(
   localPost: Post,
   fetchProps: PostFetchProps<FragmentTypeName>,
 ): {
@@ -120,7 +137,7 @@ export const useForeignCrosspost = <Post extends PostWithForeignId, FragmentType
  * to fetch the body from the foreign site, and it it's not a crosspost then
  * the body will be returned directly from the input post.
  */
-export const usePostContents = <FragmentTypeName extends PostFragments>({
+export const usePostContents = <FragmentTypeName extends CrosspostFragments>({
   post,
   fragmentName,
   fetchProps,

--- a/packages/lesswrong/components/hooks/useForeignCrosspost.ts
+++ b/packages/lesswrong/components/hooks/useForeignCrosspost.ts
@@ -152,6 +152,11 @@ export const usePostContents = <FragmentTypeName extends PostFragments>({
   });
 
   if (isForeign) {
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error("Error fetching crosspost body:", error);
+    }
+
     const foreignPost: FragmentTypes[FragmentTypeName] | undefined = data?.getCrosspost;
     return {
       postContents: foreignPost?.contents,

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -122,7 +122,7 @@ const EALargePostsItem = ({
     documentSlug: post.slug,
   });
 
-  const {postContents, loading} = usePostContents({
+  const {postContents, loading, error} = usePostContents({
     post: post as PostsWithNavigation,
     fragmentName: "PostsWithNavigation",
   });
@@ -136,6 +136,9 @@ const EALargePostsItem = ({
   if (!imageUrl && !noImagePlaceholder) {
     imageUrl = siteImageSetting.get();
   }
+
+  const description = postContents?.plaintextDescription ??
+    post?.contents?.plaintextDescription;
 
   const {TruncatedAuthorsList, ForumIcon, PostsItemTooltipWrapper, Loading} = Components;
   return (
@@ -188,8 +191,8 @@ const EALargePostsItem = ({
             </div>
           </div>
           <div className={classes.postListItemPreview}>
-            {postContents?.plaintextDescription ?? post?.contents?.plaintextDescription}
-            {loading && <Loading />}
+            {description}
+            {loading && !error && !description && <Loading />}
           </div>
         </div>
         {imageUrl && <img className={classes.postListItemImage} src={imageUrl} />}

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -123,6 +123,13 @@ const EALargePostsItem = ({
   });
 
   const {postContents, loading, error} = usePostContents({
+    /*
+     * TODO: This should be `PostsList` instead of `PostsWithNavigation`, however,
+     * this requires a backend change that needs to be deployed to both LessWrong
+     * and the EA Forum before it will work. For now, we can just use
+     * `PostsWithNavigation` with a cast, then at some point in the near future
+     * once it's deployed we can change it.
+     */
     post: post as PostsWithNavigation,
     fragmentName: "PostsWithNavigation",
   });

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -81,8 +81,8 @@ const styles = (theme: ThemeType) => ({
     marginBottom: "auto",
   },
   postListItemImage: {
-    height: "auto",
-    maxWidth: 170,
+    width: 170,
+    height: 121,
     objectFit: "cover",
     marginLeft: 16,
     borderRadius: theme.borderRadius.small,

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -6,6 +6,7 @@ import { siteImageSetting } from "../vulcan-core/App";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Link } from "../../lib/reactRouterWrapper";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
+import { usePostContents } from "../hooks/useForeignCrosspost";
 import moment from "moment";
 import classNames from "classnames";
 
@@ -121,6 +122,11 @@ const EALargePostsItem = ({
     documentSlug: post.slug,
   });
 
+  const {postContents, loading} = usePostContents({
+    post: post as PostsWithNavigation,
+    fragmentName: "PostsWithNavigation",
+  });
+
   const timeFromNow = moment(new Date(post.postedAt)).fromNow();
   const ago = timeFromNow !== "now"
     ? <span className={classes.xsHide}>&nbsp;ago</span>
@@ -131,7 +137,7 @@ const EALargePostsItem = ({
     imageUrl = siteImageSetting.get();
   }
 
-  const {TruncatedAuthorsList, ForumIcon, PostsItemTooltipWrapper} = Components;
+  const {TruncatedAuthorsList, ForumIcon, PostsItemTooltipWrapper, Loading} = Components;
   return (
     <AnalyticsContext documentSlug={post.slug}>
       <div
@@ -182,7 +188,8 @@ const EALargePostsItem = ({
             </div>
           </div>
           <div className={classes.postListItemPreview}>
-            {post.contents?.plaintextDescription}
+            {postContents?.plaintextDescription ?? post?.contents?.plaintextDescription}
+            {loading && <Loading />}
           </div>
         </div>
         {imageUrl && <img className={classes.postListItemImage} src={imageUrl} />}

--- a/packages/lesswrong/server/fmCrosspost/types.ts
+++ b/packages/lesswrong/server/fmCrosspost/types.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import { crosspostFragments } from '../../components/hooks/useForeignCrosspost';
 
 /**
  */
@@ -158,6 +159,14 @@ export type CrosspostPayload = t.TypeOf<typeof CrosspostPayloadValidator>;
 
 export type Crosspost = Pick<DbPost, "_id" | "userId" | "fmCrosspost"> & DenormalizedCrosspostData;
 
+const getCrosspostFragmentsType = () => {
+  const result: Partial<Record<FragmentName, null>> = {};
+  for (const fragmentName of crosspostFragments) {
+    result[fragmentName] = null;
+  }
+  return t.keyof(result);
+}
+
 /**
  * Intersesction creates an intersection of types (i.e. type A & type B)
  */
@@ -165,8 +174,7 @@ export const GetCrosspostRequestValidator = t.intersection([
   t.strict({
     documentId: t.string,
     collectionName: t.literal('Posts'),
-    // This is a more performant way of representing a union of string literals
-    fragmentName: t.keyof({ 'PostsWithNavigation': null, 'PostsWithNavigationAndRevision': null, 'PostsList': null }),
+    fragmentName: getCrosspostFragmentsType(),
   }),
   t.partial({
     extraVariables: t.strict({


### PR DESCRIPTION
Fixes two bugs in `EALargePostsItem` reported by Agnes:

### Give the image a fixed height

Before:
<img width="747" alt="Screenshot 2024-01-11 at 00 43 52" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c068dbfd-0aee-47c3-9589-6e65f4ca7914">

After:
<img width="746" alt="Screenshot 2024-01-11 at 00 42 31" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c05bb052-dd0f-4797-a487-49edf8e3a858">

### Load crosspost bodies

Before:
<img width="739" alt="Screenshot 2024-01-11 at 00 54 52" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/7e71cfad-8c38-42ec-bba8-d110d938515e">

After:
<img width="740" alt="Screenshot 2024-01-11 at 00 52 29" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/5b8042d1-82a3-4ee4-8fb8-e48d2c702a69">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206323640704667) by [Unito](https://www.unito.io)
