### PR TITLE
[EA Forum only] digest ad in the post page footer

### DIFF
--- a/packages/lesswrong/components/ea-forum/DigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/DigestAd.tsx
@@ -235,7 +235,7 @@ const DigestAd = ({largeVersion, className, classes}: {
         <h2 className={classNames(classes.heading, {[classes.headingLarge]: largeVersion})}>Get the best posts in your email</h2>
         <ForumIcon icon="Close" className={classes.close} onClick={handleClose} />
       </div>
-      <div className={classes.body}>
+      <div className={classNames(classes.body, {[classes.bodyLarge]: largeVersion})}>
         Sign up for the EA Forum Digest to get curated recommendations every week
       </div>
       {formNode}

--- a/packages/lesswrong/components/ea-forum/DigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/DigestAd.tsx
@@ -1,0 +1,256 @@
+import React, { useRef, useState } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
+import { useMessages } from '../common/withMessages';
+import { useCurrentUser } from '../common/withUser';
+import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
+import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
+import { userHasEmailAddress } from '../../lib/collections/users/helpers';
+import TextField from '@material-ui/core/TextField';
+import { eaForumDigestSubscribeURL } from '../recentDiscussion/RecentDiscussionSubscribeReminder';
+import { Link } from '../../lib/reactRouterWrapper';
+import classNames from 'classnames';
+import { hasDigests } from '../../lib/betas';
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    backgroundColor: theme.palette.grey[200],
+    fontSize: 13,
+    fontWeight: 450,
+    fontFamily: theme.typography.fontFamily,
+    padding: '12px 16px',
+    borderRadius: theme.borderRadius.default,
+  },
+  headingRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    columnGap: 8,
+    marginBottom: 12
+  },
+  heading: {
+    fontWeight: 600,
+    fontSize: 16,
+    margin: 0
+  },
+  close: {
+    height: 16,
+    width: 16,
+    color: theme.palette.grey[600],
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.palette.grey[800],
+    }
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: '19px',
+    fontWeight: 500,
+    color: theme.palette.grey[600],
+    textWrap: 'pretty',
+    marginBottom: 15
+  },
+  form: {
+    display: 'flex',
+    alignItems: 'baseline',
+    columnGap: 8,
+    rowGap: '12px'
+  },
+  formInput: {
+    flexGrow: 1,
+    background: theme.palette.grey[0],
+    borderRadius: theme.borderRadius.default,
+    '& .MuiInputLabel-outlined': {
+      transform: 'translate(14px,12px) scale(1)',
+      '&.MuiInputLabel-shrink': {
+        transform: 'translate(14px,-6px) scale(0.75)',
+      }
+    },
+    '& .MuiNotchedOutline-root': {
+      borderRadius: theme.borderRadius.default,
+    },
+    '& .MuiOutlinedInput-input': {
+      padding: 11
+    }
+  },
+  formBtnWideScreen: {
+    '@media(max-width: 1450px)': {
+      display: 'none'
+    }
+  },
+  formBtnNarrowScreen: {
+    display: 'none',
+    '@media(max-width: 1450px)': {
+      display: 'inline'
+    }
+  },
+  formBtnArrow: {
+    transform: 'translateY(3px)',
+    fontSize: 16
+  },
+  success: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: 10,
+    fontSize: 13,
+    lineHeight: '19px',
+    color: theme.palette.grey[800],
+  },
+  successCheckIcon: {
+    color: theme.palette.icon.greenCheckmark
+  },
+  successLink: {
+    color: theme.palette.primary.main
+  },
+});
+
+/**
+ * This is the Forum Digest ad that appears at the top of the EA Forum home page right hand side.
+ * It has some overlap with the Forum Digest ad that appears in "Recent discussion".
+ * In particular, both components use currentUser.hideSubscribePoke,
+ * so for logged in users, hiding one ad hides the other.
+ *
+ * See RecentDiscussionSubscribeReminder.tsx for the other component.
+ */
+const DigestAd = ({className, classes}: {
+  className?: string,
+  classes: ClassesType<typeof styles>,
+}) => {
+  const currentUser = useCurrentUser()
+  const updateCurrentUser = useUpdateCurrentUser()
+  const emailRef = useRef<HTMLInputElement|null>(null)
+  const ls = getBrowserLocalStorage()
+  const [isHidden, setIsHidden] = useState(
+    // logged out user clicked the X in this ad, or previously submitted the form
+    (!currentUser && ls?.getItem('hideHomeDigestAd')) ||
+    // user is already subscribed
+    currentUser?.subscribedToDigest ||
+    // user is logged in and clicked the X in this ad, or "Don't ask again" in the ad in "Recent discussion"
+    currentUser?.hideSubscribePoke
+  )
+  const [loading, setLoading] = useState(false)
+  const [subscribeClicked, setSubscribeClicked] = useState(false)
+  const { flash } = useMessages()
+  const { captureEvent } = useTracking()
+  
+  // Only show this on sites that have a digest
+  if (!hasDigests) return null
+  
+  // This should never happen, but just exit if it does.
+  if (!currentUser && !ls) return null
+  
+  // If the user just submitted the form, make sure not to hide it, so that it properly finishes submitting.
+  // Alternatively, if the logged in user just clicked "Subscribe", show the success text rather than hiding this.
+  if (isHidden && !subscribeClicked) return null
+  
+  // If the user is logged in and has an email address, we show their email address and the "Subscribe" button.
+  // Otherwise, we show the form with the email address input.
+  const showForm = !currentUser || !userHasEmailAddress(currentUser)
+  
+  const handleClose = () => {
+    setIsHidden(true)
+    captureEvent("digestAdClosed")
+    if (currentUser) {
+      void updateCurrentUser({hideSubscribePoke: true})
+    } else {
+      ls.setItem('hideHomeDigestAd', true)
+    }
+  }
+  
+  const handleUserSubscribe = async () => {
+    setLoading(true)
+    setSubscribeClicked(true)
+    captureEvent("digestAdSubscribed")
+    
+    if (currentUser) {
+      try {
+        await updateCurrentUser({
+          subscribedToDigest: true,
+          unsubscribeFromAll: false
+        })
+      } catch(e) {
+        flash('There was a problem subscribing you to the digest. Please try again later.')
+      }
+    }
+    if (showForm && emailRef.current?.value) {
+      ls.setItem('hideHomeDigestAd', true)
+    }
+    
+    setLoading(false)
+  }
+  
+  const { ForumIcon, EAButton } = Components
+  
+  const buttonProps = loading ? {disabled: true} : {}
+  // button either says "Subscribe" or has a right arrow depending on the screen width
+  const buttonContents = <>
+    <span className={classes.formBtnWideScreen}>Subscribe</span>
+    <span className={classes.formBtnNarrowScreen}>
+      <ForumIcon icon="ArrowRight" className={classes.formBtnArrow} />
+    </span>
+  </>
+  
+  // Show the form to submit to Mailchimp directly,
+  // or display the logged in user's email address and the Subscribe button
+  let formNode = showForm ? (
+    <form action={eaForumDigestSubscribeURL} method="post" className={classes.form}>
+      <TextField
+        inputRef={emailRef}
+        variant="outlined"
+        label="Email address"
+        placeholder="example@email.com"
+        name="EMAIL"
+        required
+        className={classes.formInput}
+      />
+      <EAButton type="submit" onClick={handleUserSubscribe} {...buttonProps}>
+        {buttonContents}
+      </EAButton>
+    </form>
+  ) : (
+    <div className={classes.form}>
+      <TextField
+        variant="outlined"
+        value={currentUser.email}
+        className={classes.formInput}
+        disabled={true}
+      />
+      <EAButton onClick={handleUserSubscribe} {...buttonProps}>
+        {buttonContents}
+      </EAButton>
+    </div>
+  )
+  
+  // If a logged in user with an email address subscribes, show the success message.
+  if (!showForm && subscribeClicked) {
+    formNode = <div className={classes.success}>
+      <ForumIcon icon="CheckCircle" className={classes.successCheckIcon} />
+      <div>
+        Thanks for subscribing! You can edit your subscription via
+        your <Link to={'/account?highlightField=subscribedToDigest'} className={classes.successLink}>
+          account settings
+        </Link>.
+      </div>
+    </div>
+  }
+  
+  return <AnalyticsContext pageSubSectionContext="digestAd">
+    <div className={classNames(classes.root, className)}>
+      <div className={classes.headingRow}>
+        <h2 className={classes.heading}>Get the best posts in your email</h2>
+        <ForumIcon icon="Close" className={classes.close} onClick={handleClose} />
+      </div>
+      <div className={classes.body}>
+        Sign up for the EA Forum Digest to get curated recommendations every week
+      </div>
+      {formNode}
+    </div>
+  </AnalyticsContext>
+}
+
+const DigestAdComponent = registerComponent("DigestAd", DigestAd, {styles});
+
+declare global {
+  interface ComponentTypes {
+    DigestAd: typeof DigestAdComponent
+  }
+}

--- a/packages/lesswrong/components/ea-forum/DigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/DigestAd.tsx
@@ -6,7 +6,6 @@ import { useCurrentUser } from '../common/withUser';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import { userHasEmailAddress } from '../../lib/collections/users/helpers';
-import TextField from '@material-ui/core/TextField';
 import { eaForumDigestSubscribeURL } from '../recentDiscussion/RecentDiscussionSubscribeReminder';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
@@ -21,6 +20,9 @@ const styles = (theme: ThemeType) => ({
     padding: '12px 16px',
     borderRadius: theme.borderRadius.default,
   },
+  rootLarge: {
+    padding: '16px 20px',
+  },
   headingRow: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -31,6 +33,9 @@ const styles = (theme: ThemeType) => ({
     fontWeight: 600,
     fontSize: 16,
     margin: 0
+  },
+  headingLarge: {
+    fontSize: 20,
   },
   close: {
     height: 16,
@@ -49,43 +54,46 @@ const styles = (theme: ThemeType) => ({
     textWrap: 'pretty',
     marginBottom: 15
   },
+  bodyLarge: {
+    fontSize: 14,
+    lineHeight: '20px',
+  },
   form: {
     display: 'flex',
-    alignItems: 'baseline',
     columnGap: 8,
     rowGap: '12px'
   },
   formInput: {
-    flexGrow: 1,
+    minWidth: 0,
+    flex: '1 1 0',
     background: theme.palette.grey[0],
+    padding: 11,
     borderRadius: theme.borderRadius.default,
-    '& .MuiInputLabel-outlined': {
-      transform: 'translate(14px,12px) scale(1)',
-      '&.MuiInputLabel-shrink': {
-        transform: 'translate(14px,-6px) scale(0.75)',
-      }
+    border: theme.palette.border.normal,
+    '&:hover': {
+      border: theme.palette.border.slightlyIntense2,
     },
-    '& .MuiNotchedOutline-root': {
-      borderRadius: theme.borderRadius.default,
-    },
-    '& .MuiOutlinedInput-input': {
-      padding: 11
+    '&:focus': {
+      border: `1px solid ${theme.palette.primary.main}`,
     }
   },
+  formBtn: {
+    flex: 'none'
+  },
   formBtnWideScreen: {
-    '@media(max-width: 1450px)': {
+    [theme.breakpoints.down('xs')]: {
       display: 'none'
     }
   },
   formBtnNarrowScreen: {
     display: 'none',
-    '@media(max-width: 1450px)': {
-      display: 'inline'
+    [theme.breakpoints.down('xs')]: {
+      display: 'inline',
+      height: 15
     }
   },
   formBtnArrow: {
-    transform: 'translateY(3px)',
-    fontSize: 16
+    fontSize: 15
   },
   success: {
     display: 'flex',
@@ -111,7 +119,8 @@ const styles = (theme: ThemeType) => ({
  *
  * See RecentDiscussionSubscribeReminder.tsx for the other component.
  */
-const DigestAd = ({className, classes}: {
+const DigestAd = ({largeVersion, className, classes}: {
+  largeVersion?: boolean,
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
@@ -181,40 +190,27 @@ const DigestAd = ({className, classes}: {
   const { ForumIcon, EAButton } = Components
   
   const buttonProps = loading ? {disabled: true} : {}
-  // button either says "Subscribe" or has a right arrow depending on the screen width
-  const buttonContents = <>
+  const arrow = <ForumIcon icon="ArrowRight" className={classes.formBtnArrow} />
+  // By default the button is just a right arrow.
+  // For the large version of the ad, it either says "Subscribe" or has an arrow depending on the screen width.
+  const buttonContents = largeVersion ? <>
     <span className={classes.formBtnWideScreen}>Subscribe</span>
-    <span className={classes.formBtnNarrowScreen}>
-      <ForumIcon icon="ArrowRight" className={classes.formBtnArrow} />
-    </span>
-  </>
+    <span className={classes.formBtnNarrowScreen}>{arrow}</span>
+  </> : arrow
   
   // Show the form to submit to Mailchimp directly,
   // or display the logged in user's email address and the Subscribe button
   let formNode = showForm ? (
     <form action={eaForumDigestSubscribeURL} method="post" className={classes.form}>
-      <TextField
-        inputRef={emailRef}
-        variant="outlined"
-        label="Email address"
-        placeholder="example@email.com"
-        name="EMAIL"
-        required
-        className={classes.formInput}
-      />
-      <EAButton type="submit" onClick={handleUserSubscribe} {...buttonProps}>
+      <input ref={emailRef} name="EMAIL" placeholder="Email address" className={classes.formInput} required={true} />
+      <EAButton type="submit" onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
         {buttonContents}
       </EAButton>
     </form>
   ) : (
     <div className={classes.form}>
-      <TextField
-        variant="outlined"
-        value={currentUser.email}
-        className={classes.formInput}
-        disabled={true}
-      />
-      <EAButton onClick={handleUserSubscribe} {...buttonProps}>
+      <input value={currentUser.email} className={classes.formInput} disabled={true} required={true} />
+      <EAButton onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
         {buttonContents}
       </EAButton>
     </div>
@@ -234,9 +230,9 @@ const DigestAd = ({className, classes}: {
   }
   
   return <AnalyticsContext pageSubSectionContext="digestAd">
-    <div className={classNames(classes.root, className)}>
+    <div className={classNames(classes.root, {[classes.rootLarge]: largeVersion}, className)}>
       <div className={classes.headingRow}>
-        <h2 className={classes.heading}>Get the best posts in your email</h2>
+        <h2 className={classNames(classes.heading, {[classes.headingLarge]: largeVersion})}>Get the best posts in your email</h2>
         <ForumIcon icon="Close" className={classes.close} onClick={handleClose} />
       </div>
       <div className={classes.body}>
@@ -247,7 +243,7 @@ const DigestAd = ({className, classes}: {
   </AnalyticsContext>
 }
 
-const DigestAdComponent = registerComponent("DigestAd", DigestAd, {styles});
+const DigestAdComponent = registerComponent("DigestAd", DigestAd, {styles, stylePriority: -1});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -1,10 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import NoSSR from 'react-no-ssr';
 import moment from 'moment';
 import classNames from 'classnames';
 import sortBy from 'lodash/sortBy';
 import findIndex from 'lodash/findIndex';
-import TextField from '@material-ui/core/TextField';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { Link } from '../../lib/reactRouterWrapper';
@@ -12,17 +11,14 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useTimezone } from '../common/withTimezone';
 import { useCurrentUser } from '../common/withUser';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
-import { useMessages } from '../common/withMessages';
-import { useUserLocation, userHasEmailAddress } from '../../lib/collections/users/helpers';
+import { useUserLocation } from '../../lib/collections/users/helpers';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { getCityName } from '../localGroups/TabNavigationEventsList';
 import { isPostWithForeignId } from '../hooks/useForeignCrosspost';
-import { eaForumDigestSubscribeURL } from '../recentDiscussion/RecentDiscussionSubscribeReminder';
 import { userHasEAHomeRHS } from '../../lib/betas';
 import { spotifyLogoIcon } from '../icons/SpotifyLogoIcon';
 import { pocketCastsLogoIcon } from '../icons/PocketCastsLogoIcon';
 import { applePodcastsLogoIcon } from '../icons/ApplePodcastsLogoIcon';
-import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import { useRecentOpportunities } from '../hooks/useRecentOpportunities';
 import { podcastAddictLogoIcon } from '../icons/PodcastAddictLogoIcon';
 
@@ -67,9 +63,6 @@ const styles = (theme: ThemeType) => ({
     fontFamily: theme.typography.fontFamily,
     marginBottom: 32,
   },
-  digestAdSection: {
-    maxWidth: 334,
-  },
   podcastsSection: {
     rowGap: '6px',
   },
@@ -101,87 +94,7 @@ const styles = (theme: ThemeType) => ({
   },
   digestAd: {
     maxWidth: 280,
-    backgroundColor: theme.palette.grey[200],
-    padding: '12px 16px',
-    borderRadius: theme.borderRadius.default
-  },
-  digestAdHeadingRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    columnGap: 8,
-    marginBottom: 12
-  },
-  digestAdHeading: {
-    fontWeight: 600,
-    fontSize: 16,
-    margin: 0
-  },
-  digestAdClose: {
-    height: 16,
-    width: 16,
-    color: theme.palette.grey[600],
-    cursor: 'pointer',
-    '&:hover': {
-      color: theme.palette.grey[800],
-    }
-  },
-  digestAdBody: {
-    fontSize: 13,
-    lineHeight: '19px',
-    fontWeight: 500,
-    color: theme.palette.grey[600],
-    marginBottom: 15
-  },
-  digestForm: {
-    display: 'flex',
-    alignItems: 'baseline',
-    columnGap: 8,
-    rowGap: '12px'
-  },
-  digestFormInput: {
-    flexGrow: 1,
-    background: theme.palette.grey[0],
-    borderRadius: theme.borderRadius.default,
-    '& .MuiInputLabel-outlined': {
-      transform: 'translate(14px,12px) scale(1)',
-      '&.MuiInputLabel-shrink': {
-        transform: 'translate(14px,-6px) scale(0.75)',
-      }
-    },
-    '& .MuiNotchedOutline-root': {
-      borderRadius: theme.borderRadius.default,
-    },
-    '& .MuiOutlinedInput-input': {
-      padding: 11
-    }
-  },
-  digestFormBtnWideScreen: {
-    '@media(max-width: 1450px)': {
-      display: 'none'
-    }
-  },
-  digestFormBtnNarrowScreen: {
-    display: 'none',
-    '@media(max-width: 1450px)': {
-      display: 'inline'
-    }
-  },
-  digestFormBtnArrow: {
-    transform: 'translateY(3px)',
-    fontSize: 16
-  },
-  digestSuccess: {
-    display: 'flex',
-    columnGap: 10,
-    fontSize: 13,
-    lineHeight: '19px',
-    color: theme.palette.grey[800],
-  },
-  digestSuccessCheckIcon: {
-    color: theme.palette.icon.greenCheckmark
-  },
-  digestSuccessLink: {
-    color: theme.palette.primary.main
+    marginBottom: 32,
   },
   sectionTitle: {
     fontSize: 12,
@@ -284,147 +197,6 @@ const WrappedAd = ({classes}: {
   </AnalyticsContext>
 }
 
-/**
- * This is the Forum Digest ad that appears at the top of the EA Forum home page right hand side.
- * It has some overlap with the Forum Digest ad that appears in "Recent discussion".
- * In particular, both components use currentUser.hideSubscribePoke,
- * so for logged in users, hiding one ad hides the other.
- *
- * See RecentDiscussionSubscribeReminder.tsx for the other component.
- */
-const DigestAd = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
-  const currentUser = useCurrentUser()
-  const updateCurrentUser = useUpdateCurrentUser()
-  const emailRef = useRef<HTMLInputElement|null>(null)
-  const ls = getBrowserLocalStorage()
-  const [isHidden, setIsHidden] = useState(
-    // logged out user clicked the X in this ad, or previously submitted the form
-    (!currentUser && ls?.getItem('hideHomeDigestAd')) ||
-    // user is already subscribed
-    currentUser?.subscribedToDigest ||
-    // user is logged in and clicked the X in this ad, or "Don't ask again" in the ad in "Recent discussion"
-    currentUser?.hideSubscribePoke
-  )
-  const [loading, setLoading] = useState(false)
-  const [subscribeClicked, setSubscribeClicked] = useState(false)
-  const { flash } = useMessages()
-  const { captureEvent } = useTracking()
-  
-  // This should never happen, but just exit if it does.
-  if (!currentUser && !ls) return null
-  
-  // If the user just submitted the form, make sure not to hide it, so that it properly finishes submitting.
-  // Alternatively, if the logged in user just clicked "Subscribe", show the success text rather than hiding this.
-  if (isHidden && !subscribeClicked) return null
-  
-  // If the user is logged in and has an email address, we show their email address and the "Subscribe" button.
-  // Otherwise, we show the form with the email address input.
-  const showForm = !currentUser || !userHasEmailAddress(currentUser)
-  
-  const handleClose = () => {
-    setIsHidden(true)
-    captureEvent("digestAdClosed")
-    if (currentUser) {
-      void updateCurrentUser({hideSubscribePoke: true})
-    } else {
-      ls.setItem('hideHomeDigestAd', true)
-    }
-  }
-  
-  const handleUserSubscribe = async () => {
-    setLoading(true)
-    setSubscribeClicked(true)
-    captureEvent("digestAdSubscribed")
-    
-    if (currentUser) {
-      try {
-        await updateCurrentUser({
-          subscribedToDigest: true,
-          unsubscribeFromAll: false
-        })
-      } catch(e) {
-        flash('There was a problem subscribing you to the digest. Please try again later.')
-      }
-    }
-    if (showForm && emailRef.current?.value) {
-      ls.setItem('hideHomeDigestAd', true)
-    }
-    
-    setLoading(false)
-  }
-  
-  const { ForumIcon, EAButton } = Components
-  
-  const buttonProps = loading ? {disabled: true} : {}
-  // button either says "Subscribe" or has a right arrow depending on the screen width
-  const buttonContents = <>
-    <span className={classes.digestFormBtnWideScreen}>Subscribe</span>
-    <span className={classes.digestFormBtnNarrowScreen}>
-      <ForumIcon icon="ArrowRight" className={classes.digestFormBtnArrow} />
-    </span>
-  </>
-  
-  // Show the form to submit to Mailchimp directly,
-  // or display the logged in user's email address and the Subscribe button
-  let formNode = showForm ? (
-    <form action={eaForumDigestSubscribeURL} method="post" className={classes.digestForm}>
-      <TextField
-        inputRef={emailRef}
-        variant="outlined"
-        label="Email address"
-        placeholder="example@email.com"
-        name="EMAIL"
-        required
-        className={classes.digestFormInput}
-      />
-      <EAButton type="submit" onClick={handleUserSubscribe} {...buttonProps}>
-        {buttonContents}
-      </EAButton>
-    </form>
-  ) : (
-    <div className={classes.digestForm}>
-      <TextField
-        variant="outlined"
-        value={currentUser.email}
-        className={classes.digestFormInput}
-        disabled={true}
-      />
-      <EAButton onClick={handleUserSubscribe} {...buttonProps}>
-        {buttonContents}
-      </EAButton>
-    </div>
-  )
-  
-  // If a logged in user with an email address subscribes, show the success message.
-  if (!showForm && subscribeClicked) {
-    formNode = <div className={classes.digestSuccess}>
-      <ForumIcon icon="CheckCircle" className={classes.digestSuccessCheckIcon} />
-      <div>
-        Thanks for subscribing! You can edit your subscription via
-        your <Link to={'/account?highlightField=subscribedToDigest'} className={classes.digestSuccessLink}>
-          account settings
-        </Link>.
-      </div>
-    </div>
-  }
-  
-  return <AnalyticsContext pageSubSectionContext="digestAd">
-    <div className={classNames(classes.section, classes.digestAdSection)}>
-      <div className={classes.digestAd}>
-        <div className={classes.digestAdHeadingRow}>
-          <h2 className={classes.digestAdHeading}>Get the best posts in your email</h2>
-          <ForumIcon icon="Close" className={classes.digestAdClose} onClick={handleClose} />
-        </div>
-        <div className={classes.digestAdBody}>
-          Sign up for the EA Forum Digest to get curated recommendations every week
-        </div>
-        {formNode}
-      </div>
-    </div>
-  </AnalyticsContext>
-}
 
 /**
  * This is a list of upcoming (nearby) events. It uses logic similar to EventsList.tsx.
@@ -543,7 +315,7 @@ export const EAHomeRightHandSide = ({classes}: {
   if (!userHasEAHomeRHS(currentUser)) return null
   
   const {
-    SectionTitle, PostsItemTooltipWrapper, PostsItemDate, LWTooltip, ForumIcon,
+    SectionTitle, PostsItemTooltipWrapper, PostsItemDate, LWTooltip, ForumIcon, DigestAd
   } = Components
   
   const sidebarToggleNode = <div className={classes.sidebarToggle} onClick={handleToggleSidebar}>
@@ -555,7 +327,7 @@ export const EAHomeRightHandSide = ({classes}: {
   if (isHidden) return sidebarToggleNode
   
   // NoSSR sections that could affect the logged out user cache
-  let digestAdNode = <DigestAd classes={classes} />
+  let digestAdNode = <DigestAd className={classes.digestAd} />
   let upcomingEventsNode = <UpcomingEventsSection classes={classes} />
   if (!currentUser) {
     digestAdNode = <NoSSR>{digestAdNode}</NoSSR>

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -8,6 +8,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { useRecommendations } from "./withRecommendations";
 import { usePaginatedResolver } from "../hooks/usePaginatedResolver";
 import { MAX_CONTENT_WIDTH } from "../posts/TableOfContents/ToCColumn";
+import classNames from "classnames";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -25,6 +26,9 @@ const styles = (theme: ThemeType) => ({
   section: {
     maxWidth: MAX_CONTENT_WIDTH,
     margin: "0 auto 60px",
+  },
+  digestAd: {
+    marginTop: -30
   },
   sectionHeading: {
     fontFamily: theme.palette.fonts.sansSerifStack,
@@ -96,7 +100,7 @@ const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
           notHideable
         >
           <div>
-            <NoSSR><DigestAd className={classes.section} /></NoSSR>
+            <NoSSR><DigestAd largeVersion className={classNames(classes.section, classes.digestAd)} /></NoSSR>
             {hasUserPosts &&
               <div className={classes.section}>
                 <div className={classes.sectionHeading}>

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import NoSSR from "react-no-ssr";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { Link } from "../../lib/reactRouterWrapper";
 import { userGetProfileUrl } from "../../lib/collections/users/helpers";
@@ -13,6 +14,13 @@ const styles = (theme: ThemeType) => ({
     background: theme.palette.grey[55],
     padding: "60px 0 80px 0",
     marginTop: 60,
+    [theme.breakpoints.down('sm')]: {
+      // make the background flush with the sides of the screen on mobile
+      paddingLeft: 8,
+      paddingRight: 8,
+      marginLeft: -8,
+      marginRight: -8,
+    },
   },
   section: {
     maxWidth: MAX_CONTENT_WIDTH,
@@ -40,7 +48,7 @@ const styles = (theme: ThemeType) => ({
 const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision,
   hasTableOfContents?: boolean,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const {
     recommendationsLoading: moreFromAuthorLoading,
@@ -77,8 +85,9 @@ const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
     (moreFromAuthorLoading || !!moreFromAuthorPosts?.length);
 
   const {
-    PostsLoading, ToCColumn, EAPostsItem, EALargePostsItem, UserTooltip,
+    PostsLoading, ToCColumn, EAPostsItem, EALargePostsItem, UserTooltip, DigestAd
   } = Components;
+
   return (
     <AnalyticsContext pageSectionContext="postPageFooterRecommendations">
       <div className={classes.root}>
@@ -87,6 +96,7 @@ const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
           notHideable
         >
           <div>
+            <NoSSR><DigestAd className={classes.section} /></NoSSR>
             {hasUserPosts &&
               <div className={classes.section}>
                 <div className={classes.sectionHeading}>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -36,6 +36,7 @@ importComponent("PostsAnalyticsPage", () => require('../components/analytics/Pos
 importComponent("AnalyticsDisclaimers", () => require('../components/analytics/AnalyticsDisclaimers'));
 importComponent("DateRangeModal", () => require('../components/analytics/DateRangeModal'));
 
+importComponent("DigestAd", () => require('../components/ea-forum/DigestAd'));
 importComponent("EAHome", () => require('../components/ea-forum/EAHome'));
 importComponent("EAHomeMainContent", () => require('../components/ea-forum/EAHomeMainContent'));
 importComponent("EAHomeCommunityPosts", () => require('../components/ea-forum/EAHomeCommunityPosts'));


### PR DESCRIPTION
Most of this PR is just moving the homepage RHS digest ad to a separate file. This way I could reuse it in the post page footer. Based on [this comment thread](https://docs.google.com/document/d/1BmbGKMlkFAILwoc9298kEAM5DW2AGKb1ygu9z0vGQ6I/edit?disco=AAAA9u9CuSE).

<img width="674" alt="Screen Shot 2024-01-10 at 9 31 26 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/92e13a51-e17b-4a0c-87b5-24078cd91a79">

-----
Maybe it looks better with a max width:

<img width="674" alt="Screen Shot 2024-01-10 at 9 36 38 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/26890e95-2a9f-46ad-a1cc-885a2272c970">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206324629482403) by [Unito](https://www.unito.io)
