### PR TITLE
Update autotagging for OpenAI API changes

### DIFF
--- a/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
+++ b/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
@@ -72,21 +72,20 @@ import type { PostIsCriticismRequest } from '../resolvers/postResolvers';
  *        named ml/tagClassification.TAG.{train,test}.jsonl
  *    Take a look at a few of these and make sure they look right.
  *
-   7. Install the OpenAI command-line API (if it isn't already installed.) with:
-           pip install --upgrade openai
-      (Depending on your system this might be `pip3` instead. If this succeeds
-      you should be able to run `openai` from the command line in any directory.)
+ * 7. Install the OpenAI command-line API (if it isn't already installed.) with:
+ *         pip install --upgrade openai
+ *    (Depending on your system this might be `pip3` instead. If this succeeds
+ *    you should be able to run `openai` from the command line in any directory.)
+ *    Check the version number with
+ *         pip show openai
+ *    This should be 1.7.1 or later.
  *
- * 8. Run fine-tuning jobs. First put the API key into your environment, then start the fine-tuning job using the OpenAI CLI.
+ * 8. Run fine-tuning jobs. First put the API key into your environment, then start the fine-tuning job with
           export OPENAI_API_KEY=YOURAPIKEYHERE
-          openai api fine_tunes.create \
-            -m babbage --compute_classification_metrics --classification_positive_class " yes" \
-            -t ml/tagClassification.${TAG}.train.jsonl \
-            -v ml/tagClassification.${TAG}.test.jsonl
-      Substituting in ${TAG}, and repeat for each tag.
-      You can check each job with:
-          openai api fine_tunes.follow -i ${id}
-      Update on 2023-11-27: You can now just do this all via their web UI, see https://platform.openai.com/docs/guides/fine-tuning
+          scripts/fineTuneTagClassifiers.py \
+            --train ml/tagClassification.${TAG}.train.jsonl \
+            --test ml/tagClassification.${TAG}.test.jsonl \
+ *    Substituting in ${TAG}, and repeat for each tag.
  *
  * 9. Retrieve the fine-tuned model IDs. Run
  *        openai api fine_tunes.list
@@ -141,7 +140,7 @@ export async function postToPrompt({template, post, promptSuffix, postBodyCache,
   
   const linkpostMeta = ('url' in post && post.url) ? `\nThis is a linkpost for ${post.url}` : '';
   
-  return substituteIntoTemplate({
+  const withTemplate = substituteIntoTemplate({
     template,
     maxLengthTokens: parseInt(header["max-length-tokens"]),
     truncatableVariable: "text",
@@ -152,6 +151,11 @@ export async function postToPrompt({template, post, promptSuffix, postBodyCache,
       tagPrompt: promptSuffix,
     }
   });
+  
+  // Replace the string <|endoftext|> with __endoftext__ because the former is
+  // special to the tokenizer (and will cause input-validation to fail), and it
+  // tends to appear in posts that talk about LLMs.
+  return withTemplate.replace(/<\|endoftext\|>/g, "__endoftext__");
 }
 
 function preprocessPostHtml(postHtml: string): string {

--- a/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
+++ b/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
@@ -86,6 +86,8 @@ import type { PostIsCriticismRequest } from '../resolvers/postResolvers';
             --train ml/tagClassification.${TAG}.train.jsonl \
             --test ml/tagClassification.${TAG}.test.jsonl \
  *    Substituting in ${TAG}, and repeat for each tag.
+ *    You can also do this with their web UI; see see
+ *        https://platform.openai.com/docs/guides/fine-tuning
  *
  * 9. Retrieve the fine-tuned model IDs. Run
  *        openai api fine_tunes.list

--- a/scripts/fineTuneTagClassifiers.py
+++ b/scripts/fineTuneTagClassifiers.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import argparse
+import time
+from openai import OpenAI
+
+client = OpenAI()
+
+parser = argparse.ArgumentParser(prog='progname')
+parser.add_argument('--train', action='store', dest='trainFile', help='training file name')
+parser.add_argument('--test', action='store', dest='testFile', help='testing file name')
+args = parser.parse_args()
+
+trainFile = args.trainFile
+testFile = args.testFile
+
+print('Train File: ', trainFile)
+print('Test File: ', testFile)
+
+def startFineTuningJob():
+  print("Uploading files")
+  uploadedTrain = client.files.create(
+    file=open(trainFile, "rb"),
+    purpose="fine-tune"
+  )
+  print("    Uploaded train file: %s" % uploadedTrain)
+  
+  uploadedTest = client.files.create(
+    file=open(testFile, "rb"),
+    purpose="fine-tune"
+  )
+  print("    Uploaded test file: %s" % uploadedTest)
+  
+  
+  print("Starting fine-tuning job")
+  createdJob = client.fine_tuning.jobs.create(
+    training_file=uploadedTrain.id,
+    validation_file=uploadedTest.id,
+    model="babbage-002"
+  )
+  
+  fineTuneJobId = createdJob.id
+  print("Created fine-tuning job: %s" % fineTuneJobId)
+  return fineTuneJobId 
+
+def monitorFineTuningJob(jobId):
+  while True:
+    status = client.fine_tuning.jobs.retrieve(jobId)
+    if status.status == 'running' or status.status == 'validating_files':
+      print("  Fine-tune is running...")
+      time.sleep(10)
+    else:
+      print(status)
+      break;
+  print("Finished");
+
+jobId = startFineTuningJob()
+monitorFineTuningJob(jobId)
+


### PR DESCRIPTION
Updates autotagging to reflect API changes on OpenAI's end. In particular, the instructions no longer recommend their CLI tool (which doesn't work anymore), there's a Python script instead; and filter `<|endoftext|>` out of the training data, since that causes it to fail input validation.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206332167588435) by [Unito](https://www.unito.io)
