### PR TITLE
[EA Forum only] hide frontpage curated section without recent curation

### DIFF
--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -4,6 +4,8 @@ import { decodeIntlError } from '../../lib/vulcan-lib/utils';
 import classNames from 'classnames';
 import { PostsListConfig, usePostsList } from './usePostsList';
 import FormattedMessage from '../../lib/vulcan-i18n/message';
+import moment from 'moment';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const Error = ({error}: any) => <div>
   <FormattedMessage id={error.id} values={{value: error.value}}/>{error.message}
@@ -25,6 +27,7 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
   const {
     children,
     showNoResults,
+    hideLastUnread,
     showLoadMore,
     showLoading,
     dimWhenLoading,
@@ -46,6 +49,18 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
   }
 
   if (!orderedResults?.length && !showNoResults) {
+    return null
+  }
+  
+  // If this is the EA Forum frontpage pinned curated posts list,
+  // and we haven't curated a post in the last 5 days,
+  // then hide this entire section.
+  if (
+    isEAForum &&
+    hideLastUnread &&
+    !!orderedResults?.[0].curatedDate &&
+    moment(orderedResults[0].curatedDate).isBefore(moment().subtract(5, 'days'))
+  ) {
     return null
   }
 

--- a/packages/lesswrong/components/posts/usePostsList.ts
+++ b/packages/lesswrong/components/posts/usePostsList.ts
@@ -222,6 +222,7 @@ export const usePostsList = ({
   return {
     children,
     showNoResults,
+    hideLastUnread,
     showLoadMore,
     showLoading,
     dimWhenLoading,


### PR DESCRIPTION
Requested by Lizka (see discussion in slack [here](https://cea-core.slack.com/archives/C02N5PKL021/p1705001473570429))

> if it’s been over 5 days since the last curation, the curations are no longer ~pinned on the Frontpage (even for people who haven’t read them)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206332415188419) by [Unito](https://www.unito.io)
