### PR TITLE
fix post autosave so it doesn't save a bunch of duplicates

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -20,7 +20,7 @@ import { DynamicTableOfContentsContext } from '../posts/TableOfContents/DynamicT
 import isEqual from 'lodash/isEqual';
 
 const autosaveInterval = 3000; //milliseconds
-const remoteAutosaveInterval = 1000 * 20; // 5 minutes in milliseconds
+const remoteAutosaveInterval = 1000 * 60 * 5; // 5 minutes in milliseconds
 
 export function isCollaborative(post: DbPost, fieldName: string): boolean {
   if (!post) return false;

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -20,7 +20,7 @@ import { DynamicTableOfContentsContext } from '../posts/TableOfContents/DynamicT
 import isEqual from 'lodash/isEqual';
 
 const autosaveInterval = 3000; //milliseconds
-const remoteAutosaveInterval = 1000 * 60 * 5; // 5 minutes in milliseconds
+const remoteAutosaveInterval = 1000 * 20; // 5 minutes in milliseconds
 
 export function isCollaborative(post: DbPost, fieldName: string): boolean {
   if (!post) return false;
@@ -202,6 +202,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     ${getFragment('RevisionEdit')}
   `);
 
+  // TODO: this currently clobbers the title if a new post had its contents edited before the title was edited
   const saveRemoteBackup = useCallback(async (newContents: EditorContents) => {
     // If a post hasn't ever been saved before, "submit" the form in order to create a draft post
     // Afterwards, check whatever revision was loaded for display
@@ -277,7 +278,8 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     if (autosave) {
       throttledSaveBackup(newContents);
       // Don't do server-side autosave if using the collaborative editor, since it autosaves through the ckEditor webhook
-      if (!isCollabEditor) void throttledSaveRemoteBackup(newContents);
+      // TODO: come back to this after the React 18 upgrade and test it properly
+      // if (!isCollabEditor) void throttledSaveRemoteBackup(newContents);
     }
     
     // We only check posts that have >300 characters, which is ~a few sentences.
@@ -295,7 +297,6 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
     fieldName,
     throttledSetContentsValue,
     throttledSaveBackup,
-    throttledSaveRemoteBackup,
     contents,
     throttledCheckIsCriticismLargeDiff,
     throttledCheckIsCriticism,

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -312,7 +312,7 @@ const PostsNewForm = ({classes}: {
                 successCallback={(post: any, options: any) => {
                   if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
                   if (options?.submitOptions?.noReload) {
-                    window.history.replaceState('', '', postGetEditUrl(post._id, true));
+                    navigate(postGetEditUrl(post._id, true), { replace: true });
                   } else if (options?.submitOptions?.redirectToEditor) {
                     navigate(postGetEditUrl(post._id));
                   } else {

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -34,7 +34,7 @@ const App = ({serverRequestStatus, timeOverride, history}: ExternalProps & {
   const reactDomLocation = useLocation();
   const locationContext = useRef<RouterLocation | null>(null);
   const subscribeLocationContext = useRef<RouterLocation | null>(null);
-  const navigationContext = useRef<any>();
+  const navigationContext = useRef<{ history: History<unknown> } | null>();
 
   const locale = localeSetting.get();
 

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -5,6 +5,7 @@ import { LocationContext, ServerRequestStatusContext, SubscribeLocationContext, 
 import type { RouterLocation } from './vulcan-lib/routes';
 import * as _ from 'underscore';
 import { ForumOptions, forumSelect } from './forumTypeUtils';
+import type { LocationDescriptor } from 'history';
 
 // React Hook which returns the page location (parsed URL and route).
 // Return value contains:
@@ -48,20 +49,20 @@ export const useSubscribedLocation = (): RouterLocation => {
   return useContext(SubscribeLocationContext)!;
 }
 
-export type NavigateFunction = AnyBecauseTodo
+export type NavigateFunction = ReturnType<typeof useNavigate>
 /**
  * React Hook which returns an acessor-object for page navigation. Contains one
  * field, `history`. See https://github.com/ReactTraining/history for
  * documentation on it.
  * Use of this hook will never trigger rerenders.
  */
-export const useNavigate = (): NavigateFunction => {
-  const { history } = useContext(NavigationContext);
-  return useCallback((url: string, options?: {replace?: boolean}) => {
+export const useNavigate = () => {
+  const { history } = useContext(NavigationContext)!;
+  return useCallback((locationDescriptor: LocationDescriptor, options?: {replace?: boolean}) => {
     if (options?.replace) {
-      history.replace(url);
+      history.replace(locationDescriptor);
     } else {
-      history.push(url);
+      history.push(locationDescriptor);
     }
   }, [history]);
 }

--- a/packages/lesswrong/lib/sql/PgCollection.ts
+++ b/packages/lesswrong/lib/sql/PgCollection.ts
@@ -145,16 +145,17 @@ class PgCollection<
   find(
     selector?: MongoSelector<ObjectsByCollectionName[N]>,
     options?: MongoFindOptions<ObjectsByCollectionName[N]>,
+    projection?: MongoProjection<ObjectsByCollectionName[N]>,
   ): FindResult<ObjectsByCollectionName[N]> {
     return {
       fetch: async () => {
-        const select = new SelectQuery<ObjectsByCollectionName[N]>(this.getTable(), selector, options);
-        const result = await this.executeReadQuery(select, {selector, options});
+        const select = new SelectQuery<ObjectsByCollectionName[N]>(this.getTable(), selector, { ...options, projection });
+        const result = await this.executeReadQuery(select, {selector, options, projection});
         return result;
       },
       count: async () => {
-        const select = new SelectQuery(this.getTable(), selector, options, {count: true});
-        const result = await this.executeReadQuery(select, {selector, options});
+        const select = new SelectQuery(this.getTable(), selector, { ...options, projection }, {count: true});
+        const result = await this.executeReadQuery(select, {selector, options, projection});
         return parseInt(result?.[0].count ?? 0);
       },
     };

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -6,6 +6,7 @@ import qs from 'qs'
 import { captureException } from '@sentry/core';
 import { isClient } from '../executionEnvironment';
 import type { RouterLocation, Route } from '../vulcan-lib/routes';
+import type { History } from 'history'
 
 export interface ServerRequestStatusContextType {
   status?: number
@@ -20,7 +21,7 @@ interface SegmentedUrl {
 
 export const LocationContext = React.createContext<RouterLocation|null>(null);
 export const SubscribeLocationContext = React.createContext<RouterLocation|null>(null);
-export const NavigationContext = React.createContext<any>(null);
+export const NavigationContext = React.createContext<{ history: History<unknown> }|null>(null);
 export const ServerRequestStatusContext = React.createContext<ServerRequestStatusContextType|null>(null);
 
 // From react-router-v4

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -73,6 +73,7 @@ import "./server/scripts/importEAGUserInterests";
 import "./server/scripts/importLocalgroups";
 import "./server/scripts/setUserTagFilters";
 import "./server/scripts/randomRecommendationSamples";
+import './server/scripts/cleanUpDuplicatePostAutosaves';
 import "./server/scripts/generativeModels/generateTaggingPostSets";
 import "./server/scripts/generativeModels/testModGPTOnComments";
 // doesn't pass unit tests but works fine. Leaving commented out for now

--- a/packages/lesswrong/server/scripts/cleanUpDuplicatePostAutosaves.ts
+++ b/packages/lesswrong/server/scripts/cleanUpDuplicatePostAutosaves.ts
@@ -27,6 +27,7 @@ Globals.cleanUpDuplicatePostAutosaves = async (adminUserId: string) => {
         GROUP BY "userId", title
         HAVING COUNT(*) > 1
       )
+      AND "deletedDraft" IS NOT TRUE
       ORDER BY "userId", "title", "postedAt" DESC
     )
     SELECT "userId", slug AS "userSlug", title, _id AS "postId", "postedAt", draft, "deletedDraft"

--- a/packages/lesswrong/server/scripts/cleanUpDuplicatePostAutosaves.ts
+++ b/packages/lesswrong/server/scripts/cleanUpDuplicatePostAutosaves.ts
@@ -1,0 +1,96 @@
+import { Posts } from "../../lib/collections/posts";
+import { Globals, computeContextFromUser, createMutator, updateMutator } from "../vulcan-lib";
+import Users from "../../lib/collections/users/collection";
+import Conversations from "../../lib/collections/conversations/collection";
+import groupBy from "lodash/groupBy";
+import { getSqlClientOrThrow } from "../../lib/sql/sqlClient";
+import Messages from "../../lib/collections/messages/collection";
+
+Globals.cleanUpDuplicatePostAutosaves = async (adminUserId: string) => {
+  const db = getSqlClientOrThrow();
+  const adminUser = await Users.findOne(adminUserId);
+  if (!adminUser?.isAdmin) {
+    throw new Error('Admin user id provided does not find an admin account!');
+  }
+
+  const adminContext = await computeContextFromUser(adminUser);
+
+  const query = `
+    WITH duplicate_posts AS (
+      SELECT "userId", (SELECT slug FROM "Users" WHERE _id = "userId") AS slug, "title", "postedAt", _id, draft, "deletedDraft"
+      FROM "Posts"
+      WHERE "postedAt" > NOW() - INTERVAL '4 days'
+      AND ("userId", title) IN (
+        SELECT "userId", title
+        FROM "Posts"
+        WHERE "postedAt" > NOW() - INTERVAL '4 days'
+        GROUP BY "userId", title
+        HAVING COUNT(*) > 1
+      )
+      ORDER BY "userId", "title", "postedAt" DESC
+    )
+    SELECT "userId", slug AS "userSlug", title, _id AS "postId", "postedAt", draft, "deletedDraft"
+    FROM duplicate_posts
+    WHERE (slug, "postedAt") NOT IN (
+      SELECT slug, MAX("postedAt")
+      FROM duplicate_posts
+      GROUP BY slug
+    )
+  `;
+
+  const posts = await db.any<{ userId: string, userSlug: string, title: string, postId: string, postedAt: Date, draft: boolean, deletedDraft: boolean }>(query);
+
+  const postsByUsers = groupBy(posts, (row) => row.userId);
+
+  for (let [userId, userPosts] of Object.entries(postsByUsers)) {
+    for (let duplicatePost of userPosts) {
+      await updateMutator({
+        collection: Posts,
+        context: adminContext,
+        currentUser: adminUser,
+        documentId: duplicatePost.postId,
+        data: {
+          draft: true,
+          deletedDraft: true
+        }
+      })
+    }
+
+    const conversationData: CreateMutatorParams<"Conversations">['document'] = {
+      participantIds: [userId, adminUser._id],
+      title: `Bug fix - cleaning up duplicated posts`,
+    };
+
+    const conversation = await createMutator({
+      collection: Conversations,
+      document: conversationData,
+      currentUser: adminUser,
+      validate: false
+    });
+
+    const messageContents = `
+      <p>There was recently a bug related to new post auto-saving functionality which caused some duplicate posts.  You were one of the users affected by this.</p>
+      <p>I've gone ahead and automatically archived all but the most recent copy of any posts of yours caused by this bug.  If this was a mistake or you want to access them for other reasons, you can see all your drafts (including archived ones) here: <a href="https://www.lesswrong.com/drafts?includeArchived=true">https://www.lesswrong.com/drafts?includeArchived=true</a></p>
+      <p>Please let me know if you run into any other issues.</p>
+    `;
+
+    const messageData = {
+      userId: adminUser._id,
+      contents: {
+        originalContents: {
+          type: "html",
+          data: messageContents
+        }
+      },
+      conversationId: conversation.data._id,
+      noEmail: true
+    };
+
+    await createMutator({
+      collection: Messages,
+      document: messageData,
+      currentUser: adminUser,
+      validate: false
+    });
+  }
+};


### PR DESCRIPTION
The autosaving functionality had a very silly bug where `contents` was included in the dependency list of `saveRemoteBackup`, which meant that when it was throttled in `throttledSaveRemoteBackup`, the throttling didn't do much, since `saveRemoteBackup` kept getting re-created each time `contents` changed (every ~3 seconds, per another throttled function).  This resulted in users having a bunch of queued-up posts to be created after they'd been working on a new draft for five minutes.

The fix is to compare to a ref of the previous contents (from before the last successful autosave) without having that in the dependency list.

EDIT: since @jimrandomh is rewriting this component for the React 18 upgrade, I've gone ahead and instead commented out the code which actually invokes the autosave.  Also now included in this PR is a cleanup script.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206333276472903) by [Unito](https://www.unito.io)
