### PR TITLE
Enable correct fragments for calls to `usePostContents`

### DIFF
--- a/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
@@ -19,19 +19,8 @@ const PostExcerpt = ({
 }) => {
   // Get the post body, accounting for whether or not this is a crosspost
   const {postContents, loading, error} = usePostContents({
-    /*
-     * TODO: This should use the `fragmentName` logic below, however, this
-     * requires a backend change that needs to be deployed to both LessWrong
-     * and the EA Forum before it will work. For now, we can just use `PostsList`
-     * with a cast, then at some point in the near future once it's deployed we
-     * can change it.
-     */
-    /*
     post,
     fragmentName: isSunshine(post) ? "SunshinePostsList" : "PostsList",
-     */
-    post: post as PostsList,
-    fragmentName: "PostsList",
     skip: !!hash,
   });
 

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -123,15 +123,8 @@ const EALargePostsItem = ({
   });
 
   const {postContents, loading, error} = usePostContents({
-    /*
-     * TODO: This should be `PostsList` instead of `PostsWithNavigation`, however,
-     * this requires a backend change that needs to be deployed to both LessWrong
-     * and the EA Forum before it will work. For now, we can just use
-     * `PostsWithNavigation` with a cast, then at some point in the near future
-     * once it's deployed we can change it.
-     */
-    post: post as PostsWithNavigation,
-    fragmentName: "PostsWithNavigation",
+    post: post,
+    fragmentName: "PostsPage",
   });
 
   const timeFromNow = moment(new Date(post.postedAt)).fromNow();


### PR DESCRIPTION
I added `PostsPage` and `SunshinePostsList` to the list of supported fragments when making cross-site requests for crosspost bodies in #8619. However, these fragments couldn't actually be used until that PR was deployed to prod for both the EA Forum and LessWrong. This has now been done (in #8630 and #8634) so this PR makes the changes needed to actually use the correct fragments.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206338724786321) by [Unito](https://www.unito.io)
