### PR TITLE
Negative karma users can show up in search

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -267,7 +267,6 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
     ],
     tiebreaker: "karma",
     filters: [
-      {range: {karma: {gte: 0}}},
       {term: {deleted: false}},
       {term: {deleteContent: false}},
     ],


### PR DESCRIPTION
Tested that the ranking was sensible and no reindexing is needed by searching for part of the name of a preexisting negative karma user, and seeing that they appeared in the results and were ranked behind a similarly-named positive-karma users.

(Specifically, searched for "GPT", which matches two novelty accounts from two different April Fools jokes on LW.)

Co-Authored-By: Sarah Cheng <sarah.cheng@centreforeffectivealtruism.org>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206341654331959) by [Unito](https://www.unito.io)
