### PR TITLE
Fix footnote hover-previews having giant images, spoilers, backlink arrow

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -15,6 +15,10 @@ const footnotePreviewStyles = (theme: ThemeType): JssStyles => ({
     '& a': {
       color: theme.palette.primary.main,
     },
+    
+    "& .footnote-back-link": {
+      display: "none",
+    },
   },
 })
 
@@ -26,7 +30,7 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
   rel?: string,
   children: React.ReactNode,
 }) => {
-  const { LWPopper } = Components
+  const { ContentStyles, LWPopper } = Components
   
   const { eventHandlers, hover, anchorEl } = useHover({
     pageElementContext: "linkPreview",
@@ -36,7 +40,7 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
   });
   
   let footnoteContentsNonempty = false;
-  let footnoteMinusBacklink = "";
+  let footnoteHTML = "";
   
   // Get the contents of the linked footnote.
   // This has a try-catch-ignore around it because the link doesn't necessarily
@@ -45,11 +49,7 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
   // it.
   try {
     // Grab contents of linked footnote if it exists
-    const footnoteHTML = document.querySelector(href)?.innerHTML;
-    // Remove the backlink anchor tag. Note that this regex is deliberately very narrow;
-    // a more permissive regex would introduce risk of XSS, since we're not re-validating
-    // after this transform.
-    footnoteMinusBacklink = footnoteHTML?.replace(/<a href="#fnref[a-zA-Z0-9]*">\^<\/a>/g, '') || "";
+    footnoteHTML = document.querySelector(href)?.innerHTML || "";
     // Check whether the footnotehas nonempty contents
     footnoteContentsNonempty = !!Array.from(document.querySelectorAll(`${href} p`)).reduce((acc, p) => acc + p.textContent, "").trim();
   // eslint-disable-next-line no-empty
@@ -72,9 +72,9 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
         allowOverflow
       >
         <Card>
-          <div className={classes.hovercard}>
-            <div dangerouslySetInnerHTML={{__html: footnoteMinusBacklink || ""}} />
-          </div>
+          <ContentStyles contentType="postHighlight" className={classes.hovercard}>
+            <div dangerouslySetInnerHTML={{__html: footnoteHTML || ""}} />
+          </ContentStyles>
         </Card>
       </LWPopper>}
 


### PR DESCRIPTION
Footnote hover-preview didn't use <ContentStyles> so it didn't have a width limit for images, and missed some other misc bits of styling (eg hiding spoilers). Fix that. Also, there was complicated code to remove the backlink from the preview, which wasn't working; rewrite that to a much simpler thing.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206341522616742) by [Unito](https://www.unito.io)
