### PR TITLE
Move the position of the dialogue matchmaking navigation item

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -185,6 +185,11 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       divider: true,
       showOnCompressed: true,
     }, {
+      id: 'dialogueMatchmaking',
+      title: 'Dialogue Matchmaking',
+      link: '/dialogueMatching',
+      subItem: true
+    }, {
       id: 'subscribeWidget',
       customComponentName: "SubscribeWidget",
     }, {
@@ -194,12 +199,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       subItem: true,
       compressedIconComponent: Info,
       showOnCompressed: true,
-    }, {
-      id: 'dialogueMatchmaking',
-      title: 'Dialogue Matchmaking',
-      link: '/dialogueMatching',
-      subItem: true
-    }, {
+    },  {
       id: 'faq',
       title: 'FAQ',
       link: '/faq',


### PR DESCRIPTION
The navigation items look visually best if they go from longest to shortest.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206343865812003) by [Unito](https://www.unito.io)
