### PR TITLE
Add Postgres bootstrap CI workflow

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -68,3 +68,33 @@ jobs:
       run: yarn create-integration-db-ci
     - name: yarn run integration-ci
       run: yarn run integration-ci
+
+  runPostgresBootstrap:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: ankane/pgvector
+        env:
+          POSTGRES_DB: bootstrap_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      PG_URL: postgres://postgres:postgres@localhost:5432/bootstrap_db
+      SETTINGS_FILE: ./settings-test.json
+      NODE_OPTIONS: "--max_old_space_size=4096"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Setup Environment
+      uses: ./.github/actions/setupEnvironment
+    - name: Execute Accepted Schema
+      run: psql $PG_URL -f ./schema/accepted_schema.sql
+    - name: Run Database Bootstrap
+      run: yarn migrate up

--- a/packages/lesswrong/server/migrations/20231205T204412.make_fields_not_nullable.ts
+++ b/packages/lesswrong/server/migrations/20231205T204412.make_fields_not_nullable.ts
@@ -1083,14 +1083,14 @@ const setNotnullCommands = `
 `
 
 const createNewIndexesForOnConflictConstraints = `
-  ALTER INDEX "idx_DatabaseMetadata_name"
+  ALTER INDEX IF EXISTS "idx_DatabaseMetadata_name"
     RENAME TO "idx_DatabaseMetadata_name_old";
 
   CREATE UNIQUE INDEX "idx_DatabaseMetadata_name"
     ON public."DatabaseMetadata" USING btree
     (name);
 
-  ALTER INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered"
+  ALTER INDEX IF EXISTS "idx_DebouncerEvents_dispatched_af_key_name_filtered"
     RENAME TO "idx_DebouncerEvents_dispatched_af_key_name_filtered_old";
 
   CREATE UNIQUE INDEX "idx_DebouncerEvents_dispatched_af_key_name_filtered"
@@ -1098,14 +1098,14 @@ const createNewIndexesForOnConflictConstraints = `
     (dispatched, af, key, name)
     WHERE (dispatched IS FALSE);
 
-  ALTER INDEX "idx_PageCache_path_abTestGroups_bundleHash"
+  ALTER INDEX IF EXISTS "idx_PageCache_path_abTestGroups_bundleHash"
     RENAME TO "idx_PageCache_path_abTestGroups_bundleHash_old";
 
   CREATE UNIQUE INDEX "idx_PageCache_path_abTestGroups_bundleHash"
     ON public."PageCache" USING btree
     (path, "abTestGroups", "bundleHash");
 
-  ALTER INDEX "idx_ReadStatuses_userId_postId_tagId"
+  ALTER INDEX IF EXISTS "idx_ReadStatuses_userId_postId_tagId"
     RENAME TO "idx_ReadStatuses_userId_postId_tagId_old";
 
   CREATE UNIQUE INDEX "idx_ReadStatuses_userId_postId_tagId"


### PR DESCRIPTION
We've had several instances recently (including by me) where we add migrations that accidentally break the process of bootstraping a new ForumMagnum instance. This PR adds a CI workflow that checks for this.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206349589246049) by [Unito](https://www.unito.io)
