### PR TITLE
only get post relations for questions

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -613,6 +613,8 @@ const schema: SchemaType<"Posts"> = {
     graphQLtype: '[PostRelation!]!',
     canRead: ['guests'],
     resolver: async (post: DbPost, args: void, context: ResolverContext) => {
+      if (!post.question) return [];
+
       const result = await PostRelations.find({targetPostId: post._id}).fetch()
       return await accessFilterMultiple(context.currentUser, PostRelations, result, context);
     }
@@ -627,6 +629,8 @@ const schema: SchemaType<"Posts"> = {
     graphQLtype: '[PostRelation!]!',
     canRead: ['guests'],
     resolver: async (post: DbPost, args: void, context: ResolverContext) => {
+      if (!post.question) return [];
+
       const {currentUser, repos} = context;
       const postRelations = await repos.postRelations.getPostRelationsByPostId(post._id);
       if (!postRelations || postRelations.length < 1) return []


### PR DESCRIPTION
From examining our new perf metrics, it turns out that `PostRelationsRepo.getPostRelationsByPostId` makes up a good ~15% of named queries (i.e. those in Repos) talking to our database.  This seems a bit gratuitous when it's only used for question-posts, which are a tiny fraction of all posts.  (I assume there's a comparable volume of queries generated by `sourcePostRelations` as `targetPostRelations`.)  At first I tried to do this by factoring the two fields out of the `PostsDetails` fragment, but this proved fairly annoying, so I just gated it at the field resolver level, since in practice we only have one type of PostRelation and it's for question parent-child relationships.

<img width="856" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/b5e6a028-17ca-4f5e-b58e-d2409bb74a49">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206354838475658) by [Unito](https://www.unito.io)
