### PR TITLE
Include post id in `SocialPreviewType` to avoid breaking the Apollo cache

### DIFF
--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -212,6 +212,7 @@ registerFragment(`
       html
     }
     lastPromotedComment {
+      _id
       user {
         ...UsersMinimumInfo
       }
@@ -223,6 +224,7 @@ registerFragment(`
       ...TagPreviewFragment
     }
     socialPreviewData {
+      _id
       imageUrl
     }
 
@@ -274,6 +276,7 @@ registerFragment(`
     noIndex
     viewCount
     socialPreviewData {
+      _id
       text
       imageUrl
     }
@@ -308,6 +311,7 @@ registerFragment(`
     podcastEpisode {
       title
       podcast {
+        _id
         title
         applePodcastLink
         spotifyPodcastLink
@@ -502,6 +506,7 @@ registerFragment(`
     socialPreviewImageId
     socialPreview
     socialPreviewData {
+      _id
       imageId
       text
     }
@@ -676,6 +681,7 @@ registerFragment(`
       _id
       title
       podcast {
+        _id
         title
         applePodcastLink
         spotifyPodcastLink
@@ -684,6 +690,7 @@ registerFragment(`
       externalEpisodeId
     }
     socialPreviewData {
+      _id
       text
       imageUrl
     }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -83,6 +83,7 @@ const rsvpType = new SimpleSchema({
 
 addGraphQLSchema(`
   type SocialPreviewType {
+    _id: String
     imageId: String
     imageUrl: String
     text: String
@@ -1405,6 +1406,7 @@ const schema: SchemaType<"Posts"> = {
         const { imageId, text } = post.socialPreview || {};
         const imageUrl = getSocialPreviewImage(post);
         return {
+          _id: post._id,
           imageId,
           imageUrl,
           text,

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -6,6 +6,7 @@ registerFragment(`
     title
     canonicalCollectionSlug
     canonicalCollection {
+      _id
       title
     }
   }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1129,6 +1129,7 @@ interface PostsListBase_customHighlight { // fragment on Revisions
 }
 
 interface PostsListBase_lastPromotedComment { // fragment on Comments
+  readonly _id: string,
   readonly user: UsersMinimumInfo|null,
 }
 
@@ -1223,6 +1224,7 @@ interface PostsDetails_podcastEpisode { // fragment on PodcastEpisodes
 }
 
 interface PostsDetails_podcastEpisode_podcast { // fragment on Podcasts
+  readonly _id: string,
   readonly title: string,
   readonly applePodcastLink: string | null,
   readonly spotifyPodcastLink: string | null,
@@ -1483,6 +1485,7 @@ interface PostsBestOfList_podcastEpisode { // fragment on PodcastEpisodes
 }
 
 interface PostsBestOfList_podcastEpisode_podcast { // fragment on Podcasts
+  readonly _id: string,
   readonly title: string,
   readonly applePodcastLink: string | null,
   readonly spotifyPodcastLink: string | null,
@@ -2103,6 +2106,7 @@ interface SequencesPageTitleFragment { // fragment on Sequences
 }
 
 interface SequencesPageTitleFragment_canonicalCollection { // fragment on Collections
+  readonly _id: string,
   readonly title: string,
 }
 


### PR DESCRIPTION
There's currently a bug on the EA best of page where the whole page will be reloaded when a sequence tooltip finishes loading the list of posts. This is because it refetches `PostsList` fragments which contain `socialPreviewData` which doesn't have a unique id, which makes the Apollo cache unable to merge the new data with the old data.

This PR adds an `_id` field to `SocialPreviewType` which is just a copy of the related post id, and allows the Apollo cache to perform a merge. I also added `_id`s to a couple of other fragments that I found along the way whilst investigating the bug.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206362866933342) by [Unito](https://www.unito.io)
