### PR TITLE
Fix tag voting permission check

### DIFF
--- a/packages/lesswrong/lib/collections/tags/permissions.ts
+++ b/packages/lesswrong/lib/collections/tags/permissions.ts
@@ -7,4 +7,4 @@ export const shouldHideTagForVoting = (
   user: UsersCurrent | null,
   tag: TagWithVotePermissons,
   post: {userId?: string} & CoauthoredPost|null,
-) => !canVoteOnTag(tag?.canVoteOnRels, user, post, 'smallUpvote');
+) => canVoteOnTag(tag?.canVoteOnRels, user, post, 'smallUpvote').fail;


### PR DESCRIPTION
As mentioned in the discussion at [this issue](https://github.com/ForumMagnum/ForumMagnum/issues/8610), this PR fixes tag voting permissions so that tags for voting are hidden when they're intended to be.

@oetherington I think you liked this change as referenced there, so if you approve this PR then that makes it official.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206366048643641) by [Unito](https://www.unito.io)
