### PR TITLE
[EA Forum only] add default analytics to EAButton

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAButton.tsx
+++ b/packages/lesswrong/components/ea-forum/EAButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import classNames from 'classnames';
+import { useTracking } from '../../lib/analyticsEvents';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -41,12 +42,24 @@ const styles = (theme: ThemeType): JssStyles => ({
  * Button component with the standard EA Forum styling
  * (see login and sign up site header buttons for example)
  */
-const EAButton = ({style, variant="contained", className, children, classes, ...buttonProps}: {
+const EAButton = ({style, variant="contained", eventProps, className, children, classes, ...buttonProps}: {
   style?: 'primary'|'grey',
+  eventProps?: Record<string, string>,
   className?: string,
   children: React.ReactNode,
   classes: ClassesType
 } & ButtonProps) => {
+  const { captureEvent } = useTracking();
+
+  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (buttonProps.href) {
+      captureEvent('linkClicked', {to: buttonProps.href, ...eventProps})
+    } else {
+      captureEvent('buttonClicked', eventProps)
+    }
+    
+    buttonProps.onClick?.(e)
+  }
 
   return (
     <Button
@@ -57,6 +70,7 @@ const EAButton = ({style, variant="contained", className, children, classes, ...
         [classes.greyContained]: variant === 'contained' && style === 'grey'
       })}
       {...buttonProps}
+      onClick={handleClick}
     >
       {children}
     </Button>


### PR DESCRIPTION
Previously the `EAButton` component was just adding styling. This is to help us track things more easily by default.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206378000525956) by [Unito](https://www.unito.io)
