### PR TITLE
Make "unsubscribe from all" account settings option actually unsubscribe you from all site emails

### DIFF
--- a/packages/lesswrong/components/ea-forum/DigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/DigestAd.tsx
@@ -173,8 +173,7 @@ const DigestAd = ({largeVersion, className, classes}: {
     if (currentUser) {
       try {
         await updateCurrentUser({
-          subscribedToDigest: true,
-          unsubscribeFromAll: false
+          subscribedToDigest: true
         })
       } catch(e) {
         flash('There was a problem subscribing you to the digest. Please try again later.')

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -7,7 +7,7 @@ import { Posts } from '../lib/collections/posts';
 import { postStatuses } from '../lib/collections/posts/constants';
 import { getConfirmedCoauthorIds, postGetPageUrl, postIsApproved } from '../lib/collections/posts/helpers';
 import { Comments } from '../lib/collections/comments/collection'
-import { reasonUserCantReceiveEmails, wrapAndSendEmail } from './emails/renderEmail';
+import { wrapAndSendEmail } from './emails/renderEmail';
 import './emailComponents/EmailWrapper';
 import './emailComponents/NewPostEmail';
 import './emailComponents/PostNominatedEmail';
@@ -64,16 +64,11 @@ const sendPostByEmail = async ({users, postId, reason, subject}: {
   let post = await Posts.findOne(postId);
   if (!post) throw Error(`Can't find post to send by email: ${postId}`)
   for(let user of users) {
-    if(!reasonUserCantReceiveEmails(user)) {
-      await wrapAndSendEmail({
-        user,
-        subject: subject ?? post.title,
-        body: <Components.NewPostEmail documentId={post._id} reason={reason}/>
-      });
-    } else {
-      //eslint-disable-next-line no-console
-      console.log(`Skipping user ${user.username} when emailing: ${reasonUserCantReceiveEmails(user)}`);
-    }
+    await wrapAndSendEmail({
+      user,
+      subject: subject ?? post.title,
+      body: <Components.NewPostEmail documentId={post._id} reason={reason}/>
+    });
   }
 }
 


### PR DESCRIPTION
The previous behaviour was that `unsubscribeFromAll` would only stop you from receiving post emails. The new behaviour is that it stops you receiving all emails, including the digest.

This is still a bit confusing, in that all of your notification settings will still say "notify me by email", but the email won't actually send (see screenshot).

For the digest this would be especially confusing, because you can subscribe from other places (e.g. the ad on the front page), so we added a workaround where in that case setting `unsubscribeFromAll` will unsubscribe you from the digest, but you can then resubscribe without unchecking `unsubscribeFromAll`.

![Screenshot 2024-01-18 at 17 02 08](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/0f124e69-2c20-45f5-afee-f48f3a46be96)

I think an ideal solution would involve making it obvious in the UI that all the other email notification settings were disabled by checking `unsubscribeFromAll`
