### PR TITLE
Maintain scroll position when changing comment sort order

### DIFF
--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -7,16 +7,20 @@ import { useCurrentUser } from '../common/withUser';
 import withErrorBoundary from '../common/withErrorBoundary';
 import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   button: {
     color: theme.palette.lwTertiary.main
   },
+  commentsListLoadingSpacer: {
+    minHeight: '100vh',
+  },
 })
 
 export const POST_COMMENT_COUNT_TRUNCATE_THRESHOLD = 70
 
-const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTruncated, parentAnswerId, defaultNestingLevel=1, parentCommentId, classes}: {
+const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTruncated, parentAnswerId, defaultNestingLevel=1, parentCommentId, loading, classes}: {
   treeOptions: CommentTreeOptions,
   comments: Array<CommentTreeNode<CommentsList>>,
   totalComments?: number,
@@ -24,6 +28,7 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
   parentAnswerId?: string,
   defaultNestingLevel?: number,
   parentCommentId?: string,
+  loading?: boolean,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
@@ -64,7 +69,9 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
   }
   return <Components.ErrorBoundary>
     {renderExpandOptions()}
-    <div>
+    {/* commentsListLoadingSpacer makes the comments list keep a minimum height while reloading a different comment
+        sorting view, so that the scroll position doesn't move. */}
+    <div className={classNames({[classes.commentsListLoadingSpacer]: loading})}>
       {comments.map(comment =>
         <CommentsNode
           treeOptions={treeOptions}

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
 import moment from 'moment';
@@ -87,6 +87,7 @@ const CommentsListSection = ({
   totalComments,
   loadMoreComments,
   loadingMoreComments,
+  loading,
   comments,
   parentAnswerId,
   startThreadTruncated,
@@ -103,6 +104,7 @@ const CommentsListSection = ({
   totalComments: number,
   loadMoreComments: any,
   loadingMoreComments: boolean,
+  loading?: boolean,
   comments: CommentsList[],
   parentAnswerId?: string,
   startThreadTruncated?: boolean,
@@ -142,20 +144,29 @@ const CommentsListSection = ({
     setAnchorEl(null);
   }
 
+  const [restoreScrollPos, setRestoreScrollPos] = useState(-1);
+
+  useEffect(() => {
+    if (restoreScrollPos === -1) return;
+
+    window.scrollTo({top: restoreScrollPos})
+    setRestoreScrollPos(-1);
+  }, [restoreScrollPos])
+
   const renderTitleComponent = () => {
     const { CommentsListMeta, Typography, MenuItem } = Components
     const suggestedHighlightDates = [moment(now).subtract(1, 'day'), moment(now).subtract(1, 'week'), moment(now).subtract(1, 'month'), moment(now).subtract(1, 'year')]
     const newLimit = commentCount + (loadMoreCount || commentCount)
     let commentSortNode = (commentCount < totalComments) ?
       <span>
-        Rendering {commentCount}/{totalComments} comments, sorted by <Components.CommentsViews post={post} />
+        Rendering {commentCount}/{totalComments} comments, sorted by <Components.CommentsViews post={post} setRestoreScrollPos={setRestoreScrollPos} />
         {loadingMoreComments ? <Components.Loading /> : <a onClick={() => loadMoreComments(newLimit)}> (show more) </a>}
       </span> :
       <span>
-        {postGetCommentCountStr(post, totalComments)}, sorted by <Components.CommentsViews post={post} />
+        {postGetCommentCountStr(post, totalComments)}, sorted by <Components.CommentsViews post={post} setRestoreScrollPos={setRestoreScrollPos} />
       </span>
     if (isFriendlyUI) {
-      commentSortNode = <>Sorted by <Components.CommentsViews post={post} /></>
+      commentSortNode = <>Sorted by <Components.CommentsViews post={post} setRestoreScrollPos={setRestoreScrollPos} /></>
     }
 
     const contentType = isEAForum && post?.shortform
@@ -271,6 +282,7 @@ const CommentsListSection = ({
         comments={commentTree}
         startThreadTruncated={startThreadTruncated}
         parentAnswerId={parentAnswerId}
+        loading={loading}
       />
       <PostsPageCrosspostComments />
       {!isEAForum && <Row justifyContent="flex-end">

--- a/packages/lesswrong/components/comments/CommentsViews.tsx
+++ b/packages/lesswrong/components/comments/CommentsViews.tsx
@@ -10,7 +10,7 @@ import type { Option } from '../common/InlineSelect';
 import { getCommentViewOptions } from '../../lib/commentViewOptions';
 import { useNavigate } from '../../lib/reactRouterWrapper';
 
-const CommentsViews = ({post}: {post?: PostsDetails}) => {
+const CommentsViews = ({post, setRestoreScrollPos}: {post?: PostsDetails, setRestoreScrollPos?: Function}) => {
   const currentUser = useCurrentUser();
   const navigate = useNavigate();
   const location = useLocation();
@@ -18,11 +18,29 @@ const CommentsViews = ({post}: {post?: PostsDetails}) => {
 
   const {InlineSelect} = Components
 
+  // permalinkedCommentHeight() finds the height of the comment at the top of comment permalink pages
+  // on the EA Forum and LessWrong. This is used when the user changes the comment sort order, which
+  // changes the page from a comment permalink page to a regular post page, and we want to preserve
+  // the user's (apparent) scroll position. With that top comment removed, we need to scroll up by its
+  // height.
+  // (If there is no permalinked comment at the top, whether because we're in a regular post page or
+  // because we're on Waking Up, which doesn't put permalinked comments at the top, this function
+  // returns zero.)
+  const permalinkedCommentHeight = () => {
+    const commentHeight = document.querySelector('.CommentPermalink-root')?.scrollHeight || 0;
+    const dividerEl = document.querySelector('.CommentPermalink-dividerMargins');
+    const dividerMarginBottom = dividerEl ? parseInt(getComputedStyle(dividerEl).marginBottom) : 0;
+    return commentHeight + dividerMarginBottom;
+  }
+
   const handleViewClick = (opt: Option & {value: CommentsViewName}) => {
     const view = opt.value
     const { query } = location;
     const currentQuery = isEmpty(query) ? {view: 'postCommentsTop'} : query
-    const newQuery = {...currentQuery, view: view, postId: post ? post._id : undefined}
+    const { commentId = undefined, ...newQuery } =  {...currentQuery, view: view, postId: post ? post._id : undefined}
+    if (setRestoreScrollPos) {
+      setRestoreScrollPos(window.scrollY - permalinkedCommentHeight());
+    }
     navigate({...location.location, search: `?${qs.stringify(newQuery)}`})
   };
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -699,6 +699,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
             totalComments={totalCount as number}
             commentCount={commentCount}
             loadingMoreComments={loadingMore}
+            loading={loading}
             post={post}
             newForm={!post.question && (!post.shortform || post.userId===currentUser?._id)}
             highlightDate={highlightDate}


### PR DESCRIPTION
Prior to this change, the navigation that occurs when you change the comment sort order would either:
1) Re-navigate to the permalinked comment, if you're on a comment permalink page, or
2) Scroll to the top.

This change maintains the current scroll position when the sort order is changed. This required a little finessing; when the comment sort order is changed, the comment list section has a zero height while the comments reload, which could jolt the scroll position up, so now we track whether comments are loading and add a minimum height while they are.

Also, LW and EAForum put permalinked comments at the top of the page. When changing the sort order on such a page, we change to a regular post page, removing this top element, which would cause an apparent jolt to the scroll position. So we record the height of that element and adjust the scroll position by that amount.


