### PR TITLE
Add admin page link to force-reload DB settings

### DIFF
--- a/packages/lesswrong/components/admin/AdminHome.tsx
+++ b/packages/lesswrong/components/admin/AdminHome.tsx
@@ -5,6 +5,7 @@ import { userIsAdmin } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
 import { hasDigests } from '../../lib/betas';
 import { taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { useRefreshDbSettings } from '../hooks/useRefreshDbSettings';
 
 // Also used in ModerationLog
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -27,14 +28,19 @@ export const styles = (theme: ThemeType): JssStyles => ({
   },
   link: {
     color: theme.palette.primary.main,
+    cursor: "pointer",
+    "&:hover": {
+      opacity: 0.8,
+    },
   },
 });
 
 const AdminHome = ({ classes }: {
   classes: ClassesType
 }) => {
-  const { SingleColumnSection, AdminMetadata } = Components;
+  const {SingleColumnSection, AdminMetadata, Loading} = Components;
   const currentUser = useCurrentUser();
+  const {refreshDbSettings, isRefreshingDbSettings} = useRefreshDbSettings();
   
   if (!userIsAdmin(currentUser)) {
     return <SingleColumnSection>
@@ -66,6 +72,8 @@ const AdminHome = ({ classes }: {
         <li><Link className={classes.link} to="/reviewAdmin">Review Admin (current year)</Link></li>
         <li><Link className={classes.link} to="/admin/migrations">Migrations</Link></li>
         <li><Link className={classes.link} to="/admin/synonyms">Search Synonyms</Link></li>
+        <li><span className={classes.link} onClick={refreshDbSettings}>Refresh DB Settings</span></li>
+        {isRefreshingDbSettings && <Loading />}
       </ul>
       
       <h3>Debug Tools</h3>

--- a/packages/lesswrong/components/hooks/useRefreshDbSettings.ts
+++ b/packages/lesswrong/components/hooks/useRefreshDbSettings.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+
+const refreshDbSettingsMutation = gql`
+  mutation RefreshDbSettings {
+    RefreshDbSettings
+  }
+`;
+
+export const useRefreshDbSettings = () => {
+  const [isRefreshingDbSettings, setIsRefreshingDbSettings] = useState(false);
+  const [mutation] = useMutation(refreshDbSettingsMutation);
+  const refreshDbSettings = useCallback(async () => {
+    setIsRefreshingDbSettings(true);
+    await mutation();
+    window.location.reload();
+  }, [mutation]);
+  return {
+    refreshDbSettings,
+    isRefreshingDbSettings,
+  };
+}

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -175,6 +175,7 @@ import './server/resolvers/analyticsResolvers';
 import './server/resolvers/moderationResolvers';
 import './server/resolvers/typingIndicatorsResolvers';
 import './server/resolvers/dialogueChecksResolvers';
+import './server/resolvers/databaseSettingsResolvers';
 
 
 import './server/intercomSetup';

--- a/packages/lesswrong/server/resolvers/databaseSettingsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/databaseSettingsResolvers.ts
@@ -1,0 +1,15 @@
+import { addGraphQLMutation, addGraphQLResolvers } from "../vulcan-lib";
+import { refreshSettingsCaches } from "../loadDatabaseSettings";
+
+addGraphQLMutation("RefreshDbSettings: Boolean");
+addGraphQLResolvers({
+  Mutation: {
+    async RefreshDbSettings(_: void, __: void, {currentUser}: ResolverContext) {
+      if (!currentUser?.isAdmin) {
+        throw new Error("You must be an admin to refresh the settings cache");
+      }
+      await refreshSettingsCaches();
+      return true;
+    }
+  }
+});


### PR DESCRIPTION
Whilst debugging something else I wanted to change some database settings on a running staging server without waiting for them to automatically refresh.

<img width="253" alt="Screenshot 2024-01-24 at 00 17 57" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/7f6f1e0b-b62e-4b45-80cc-8204616e76da">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206423468590199) by [Unito](https://www.unito.io)
