### PR TITLE
Set cache-control header to make reaction images immutable

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -220,7 +220,14 @@ export function startWebserver() {
   
   // Static files folder
   app.use(express.static(path.join(__dirname, '../../client')))
-  app.use(express.static(path.join(__dirname, '../../../public')))
+  app.use(express.static(path.join(__dirname, '../../../public'), {
+    setHeaders: (res, requestPath) => {
+      const relativePath = path.relative(__dirname, requestPath);
+      if (relativePath.startsWith("../../../public/reactionImages")) {
+        res.set("Cache-Control", "public, max-age=604800, immutable");
+      }
+    }
+  }))
   
   // Voyager is a GraphQL schema visual explorer
   app.use("/graphql-voyager", voyagerMiddleware({


### PR DESCRIPTION
This prevents a potentially large number of http requests when you open a bunch of post pages, and when using the reaction palette, when those requests are destined to just be 304 Not Modified. (These requests may have contributed to some users going over the rate limit when opening lots of post pages as part of review-voting.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206424170685267) by [Unito](https://www.unito.io)
