### PR TITLE
Fix older versions of Safari

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -119,12 +119,13 @@ export const overrideRoute = (...routes: Route[]): void => {
   addRoute(...routes);
 }
 
-export const getRouteMatchingPathname = (pathname: string): Route | undefined  =>
-  Object.values(Routes).findLast((route) => matchPath(pathname, {
+export const getRouteMatchingPathname = (pathname: string): Route | undefined  => {
+  return Object.values(Routes).reverse().find((route) => matchPath(pathname, {
     path: route.path,
     exact: true,
     strict: false,
   }))
+}
 
 export const userCanAccessRoute = (user?: UsersCurrent | DbUser | null, route?: Route | null): boolean => {
   if (!route) return true // Anyone can access a non-existent route (which would 404)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es2023", "dom"],
+    "lib": ["es2019", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/8568/files added a usage of `Array.findLast` which broke compatibility with older versions of Safari. After thinking this was likely fine, I found out Robert's laptop was in fact running an affected version, so versions that old are in fact still present in the wild.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206424808732263) by [Unito](https://www.unito.io)
