### PR TITLE
add type constraints for various sql fragment functions

### DIFF
--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -32,9 +32,9 @@ export const apolloCacheVoteablePossibleTypes = () => {
   }
 }
 
-const currentUserVoteResolver = (
-  resolver: SqlResolverJoin["resolver"],
-): SqlResolver => ({field, currentUserField, join}) => join({
+const currentUserVoteResolver = <N extends CollectionNameString>(
+  resolver: SqlResolverJoin<'Votes'>["resolver"],
+): SqlResolver<N> => ({field, currentUserField, join}) => join({
   table: "Votes",
   type: "left",
   on: {

--- a/packages/lesswrong/lib/sql/tests/testHelpers.ts
+++ b/packages/lesswrong/lib/sql/tests/testHelpers.ts
@@ -152,7 +152,7 @@ export const TestCollection4 = {
       graphqlArguments: "testCollection2Id: String",
       resolver: async () => null,
       sqlResolver: ({resolverArg, join}) => join({
-        table: "TestCollection2",
+        table: "TestCollection2" as CollectionNameString,
         type: "left",
         on: {
           _id: resolverArg("testCollection2Id"),

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -217,6 +217,8 @@ interface HasIdType {
   _id: string
 }
 
+type HasIdCollectionNames = Exclude<Extract<ObjectsByCollectionName[CollectionNameString], HasIdType>['__collectionName'], undefined>;
+
 // Common base type for everything with a userId field
 interface HasUserIdType {
   userId: string | null

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -23,31 +23,33 @@ interface CollectionFieldPermissions {
 
 type FormInputType = 'text' | 'number' | 'url' | 'email' | 'textarea' | 'checkbox' | 'checkboxgroup' | 'radiogroup' | 'select' | 'datetime' | 'date' | keyof ComponentTypes;
 
-type SqlFieldFunction = (fieldName: string) => string;
+type FieldName<N extends CollectionNameString> = (keyof ObjectsByCollectionName[N] & string) | '*';
 
-type SqlJoinBase = {
-  table: string,
+type SqlFieldFunction<N extends CollectionNameString> = (fieldName: FieldName<N>) => string;
+
+type SqlJoinBase<N extends CollectionNameString> = {
+  table: N,
   type?: "inner" | "full" | "left" | "right",
-  on: Record<string, string>,
+  on: Partial<Record<FieldName<N>, string>>,
 }
 
-type SqlResolverJoin = SqlJoinBase & {
-  resolver: (field: SqlFieldFunction) => string,
+type SqlResolverJoin<N extends CollectionNameString> = SqlJoinBase<N> & {
+  resolver: (field: SqlFieldFunction<N>) => string,
 };
 
-type SqlJoinSpec = SqlJoinBase & {
+type SqlJoinSpec<N extends CollectionNameString = CollectionNameString> = SqlJoinBase<N> & {
   prefix: string,
 };
 
-type SqlResolverArgs = {
-  field: SqlFieldFunction,
-  currentUserField: SqlFieldFunction,
-  join: (args: SqlResolverJoin) => string,
+type SqlResolverArgs<N extends CollectionNameString> = {
+  field: SqlFieldFunction<N>,
+  currentUserField: SqlFieldFunction<'Users'>,
+  join: <J extends CollectionNameString>(args: SqlResolverJoin<J>) => string,
   arg: (value: unknown) => string,
   resolverArg: (name: string) => string,
 }
 
-type SqlResolver = (args: SqlResolverArgs) => string;
+type SqlResolver<N extends CollectionNameString> = (args: SqlResolverArgs<N>) => string;
 
 interface CollectionFieldSpecification<N extends CollectionNameString> extends CollectionFieldPermissions {
   type?: any,
@@ -65,7 +67,7 @@ interface CollectionFieldSpecification<N extends CollectionNameString> extends C
     addOriginalField?: boolean,
     arguments?: string|null,
     resolver: (root: ObjectsByCollectionName[N], args: any, context: ResolverContext, info?: any)=>any,
-    sqlResolver?: SqlResolver,
+    sqlResolver?: SqlResolver<N>,
   },
   blackbox?: boolean,
   denormalized?: boolean,

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -146,11 +146,11 @@ export const foreignKeyField = <CollectionName extends CollectionNameString>({
         nullable,
       }),
       ...(autoJoin ? {
-        sqlResolver: ({field, join}: SqlResolverArgs) => join({
+        sqlResolver: ({field, join}: SqlResolverArgs<CollectionName>) => join<HasIdCollectionNames>({
           table: collectionName,
           type: nullable ? "left" : "inner",
           on: {
-            _id: field(idFieldName),
+            _id: field(idFieldName as FieldName<CollectionName>),
           },
           resolver: (foreignField) => foreignField("*"),
         })
@@ -207,7 +207,7 @@ export const simplSchemaToGraphQLtype = (type: any): string|null => {
 
 interface ResolverOnlyFieldArgs<N extends CollectionNameString> extends CollectionFieldSpecification<N> {
   resolver: (doc: ObjectsByCollectionName[N], args: any, context: ResolverContext) => any,
-  sqlResolver?: SqlResolver,
+  sqlResolver?: SqlResolver<N>,
   graphQLtype?: string|GraphQLScalarType|null,
   graphqlArguments?: string|null,
 }

--- a/packages/lesswrong/unitTests/sql/ProjectionContext.tests.ts
+++ b/packages/lesswrong/unitTests/sql/ProjectionContext.tests.ts
@@ -34,20 +34,20 @@ describe("ProjectionContext", () => {
   });
   it("detects duplicate joins", () => {
     const context = new ProjectionContext(TestCollection);
-    const join1: SqlResolverJoin = {
-      table: "TestTable2",
+    const join1: SqlResolverJoin<CollectionNameString> = {
+      table: "TestTable2" as CollectionNameString,
       type: "left",
       on: {
         _id: "_id",
       },
       resolver: () => "",
     };
-    const join2: SqlResolverJoin = {
-      table: "TestTable2",
+    const join2: SqlResolverJoin<CollectionNameString> = {
+      table: "TestTable2" as CollectionNameString,
       type: "left",
       on: {
         userId: "userId",
-      },
+      } as AnyBecauseHard,
       resolver: () => "",
     };
     expect(context.getJoins()).toHaveLength(0);


### PR DESCRIPTION
Adds some generic type constraints to various functions in the parent branch, so as to make life a bit easier & prevent typos/etc.

The main thing I'm not sure about here is the type of `on` in `SqlJoinBase`: `Partial<Record<FieldName<N>, string>>` technically allows `{ _id: undefined }`.   (The previous `Record<string, string>` did not.)

There isn't an easy way that I can find to represent a generic type constraint which allows an arbitrary selection of keys from a union type, where the value of those keys must not be undefined if the key is in the object (but any individual key is not required to be in the object).  https://github.com/microsoft/TypeScript/issues/13195 introduced `--strictOptionalProperties` but we can't enable that; too much stuff breaks.

I think it's worth the trade-off here but :shrug:

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206435963465117) by [Unito](https://www.unito.io)
