### PR TITLE
Fix timezone bug in author analytics

### DIFF
--- a/packages/lesswrong/server/repos/IncrementalViewRepo.ts
+++ b/packages/lesswrong/server/repos/IncrementalViewRepo.ts
@@ -1,5 +1,13 @@
 import AbstractRepo from "./AbstractRepo";
 
+export type IncrementalViewDataType<N extends CollectionNameString> = Omit<
+  ObjectsByCollectionName[N],
+  "_id" | "schemaVersion" | "createdAt" | "legacyData" | "windowStart" | "windowEnd"
+> & {
+  windowStart: string;
+  windowEnd: string;
+};
+
 /**
  * `IncrementalViewRepo` is designed for collections that operate as materialized views,
  * with "Incremental View Maintenance" (e.g. for cases where REFRESH MATERIALIZED VIEW is too slow).
@@ -15,9 +23,11 @@ export default abstract class IncrementalViewRepo<N extends CollectionNameString
   }: {
     startDate: Date;
     endDate: Date;
-  }): Promise<Omit<ObjectsByCollectionName[N], "_id" | "schemaVersion" | "createdAt" | "legacyData">[]>;
+  }): Promise<IncrementalViewDataType<N>[]>;
 
-  abstract upsertData({ data }: { data: Omit<ObjectsByCollectionName[N], "_id" | "schemaVersion" | "createdAt" | "legacyData">[] }): void
+  abstract deleteRange({ startDate, endDate }: { startDate: Date; endDate: Date }): Promise<void>;
 
-  abstract getDateBounds(): Promise<{ earliestWindowStart: Date | null; latestWindowEnd: Date | null }>
+  abstract upsertData({ data }: { data: IncrementalViewDataType<N>[] }): void;
+
+  abstract getDateBounds(): Promise<{ earliestWindowStart: Date | null; latestWindowEnd: Date | null }>;
 }

--- a/packages/lesswrong/server/repos/PostViewTimesRepo.ts
+++ b/packages/lesswrong/server/repos/PostViewTimesRepo.ts
@@ -4,7 +4,7 @@ import { getAnalyticsConnectionOrThrow } from "../analytics/postgresConnection";
 import { randomId } from "../../lib/random";
 import chunk from "lodash/chunk";
 import PostViewTimes from "../../lib/collections/postViewTimes/collection";
-import IncrementalViewRepo from "./IncrementalViewRepo";
+import IncrementalViewRepo, { IncrementalViewDataType } from "./IncrementalViewRepo";
 
 class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
   constructor() {
@@ -17,10 +17,10 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
   }: {
     startDate: Date;
     endDate: Date;
-  }): Promise<Omit<DbPostViewTime, "_id" | "schemaVersion" | "createdAt" | "legacyData">[]> {
+  }): Promise<IncrementalViewDataType<"PostViewTimes">[]> {
     // Round startDate (endDate) down (up) to the nearest UTC date boundary
-    const windowStart = moment.utc(startDate).startOf("day").toDate();
-    const windowEnd = moment.utc(endDate).endOf("day").toDate();
+    const startDateFormatted = moment.utc(startDate).startOf("day").format('YYYY-MM-DD HH:mm:ss');
+    const endDateFormatted = moment.utc(endDate).endOf("day").format('YYYY-MM-DD HH:mm:ss');
 
     const analyticsDb = getAnalyticsConnectionOrThrow();
 
@@ -49,12 +49,24 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
         post_id,
         date_trunc('day', timestamp)
     `,
-      [windowStart, windowEnd]
+      [startDateFormatted, endDateFormatted]
     );
 
-    // Manually convert the number fields from string to number (as this isn't handled automatically)
+    // Manually convert:
+    // - The number fields from string to number (as this isn't handled automatically)
+    // - The date fields to UTC strings (NOTE: this actually changes the time represented, because in the conversion
+    //   from postgres to JS the timezone of the server is applied to the raw date, so 2023-04-01 00:00:00 becomes e.g.
+    //   2023-04-01 00:00:00+0100 (BST), which is wrong)
     const typedResults = results.map((views) => ({
       ...views,
+      windowStart: moment(views.windowStart)
+        .add(moment(views.windowStart).utcOffset(), "minutes")
+        .utc()
+        .format("YYYY-MM-DD HH:mm:ss"),
+      windowEnd: moment(views.windowEnd)
+        .add(moment(views.windowEnd).utcOffset(), "minutes")
+        .utc()
+        .format("YYYY-MM-DD HH:mm:ss"),
       viewCount: parseInt(views.viewCount),
       uniqueViewCount: parseInt(views.uniqueViewCount),
     }));
@@ -62,7 +74,32 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
     return typedResults;
   }
 
-  async upsertData({ data }: { data: Omit<DbPostViewTime, "_id" | "schemaVersion" | "createdAt" | "legacyData">[] }) {
+  /**
+   * Delete rows where there is any overlap with the given (startDate, endDate) range
+   */
+  async deleteRange({
+    startDate,
+    endDate,
+  }: {
+    startDate: Date;
+    endDate: Date;
+  }): Promise<void> {
+    // Round startDate (endDate) down (up) to the nearest UTC date boundary
+    const startDateFormatted = moment.utc(startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss');
+    const endDateFormatted = moment.utc(endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss');
+
+    await this.getRawDb().none(
+      `
+      DELETE FROM "PostViewTimes"
+      WHERE
+        ("windowEnd" > $1 AND "windowEnd" < $2)
+        OR ("windowStart" > $1 AND "windowStart" < $2)
+      `,
+      [startDateFormatted, endDateFormatted]
+    );
+  }
+
+  async upsertData({ data }: { data: IncrementalViewDataType<"PostViewTimes">[] }) {
     const dataWithIds = data.map((item) => ({
       ...item,
       _id: randomId(),
@@ -75,7 +112,7 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
       const values = chunk
         .map(
           (row) =>
-            `('${row._id}', '${row.clientId}', '${row.postId}', '${row.windowStart.toISOString()}', '${row.windowEnd.toISOString()}', ${
+            `('${row._id}', '${row.clientId}', '${row.postId}', '${row.windowStart}', '${row.windowEnd}', ${
               row.totalSeconds
             }, NOW(), NOW())`
         )
@@ -127,11 +164,12 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
     postIds,
   }: {
     postIds: string[];
-  }): Promise<{ postId: string; totalReads: number; }[]> {
-    const results = await this.getRawDb().any<{ postId: string; totalReads: string; }>(`
+  }): Promise<{ postId: string; totalReads: number; meanReadTime: number }[]> {
+    const results = await this.getRawDb().any<{ postId: string; totalReads: string; meanReadTime: string }>(`
       SELECT
         "postId",
-        sum(CASE WHEN "totalSeconds" >= 30 THEN 1 ELSE 0 END) AS "totalReads"
+        sum(CASE WHEN "totalSeconds" >= 30 THEN 1 ELSE 0 END) AS "totalReads",
+        avg("totalSeconds") AS "meanReadTime"
       FROM
         "PostViewTimes"
       WHERE
@@ -146,6 +184,7 @@ class PostViewTimesRepo extends IncrementalViewRepo<"PostViewTimes"> {
     const typedResults = results.map((views) => ({
       ...views,
       totalReads: parseInt(views.totalReads),
+      meanReadTime: parseFloat(views.meanReadTime),
     }));
 
     return typedResults

--- a/packages/lesswrong/server/repos/PostViewsRepo.ts
+++ b/packages/lesswrong/server/repos/PostViewsRepo.ts
@@ -4,7 +4,7 @@ import moment from "moment";
 import { getAnalyticsConnectionOrThrow } from "../analytics/postgresConnection";
 import { randomId } from "../../lib/random";
 import chunk from "lodash/chunk";
-import IncrementalViewRepo from "./IncrementalViewRepo";
+import IncrementalViewRepo, { IncrementalViewDataType } from "./IncrementalViewRepo";
 
 class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
   constructor() {
@@ -17,10 +17,12 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
   }: {
     startDate: Date;
     endDate: Date;
-  }): Promise<Omit<DbPostViews, "_id" | "schemaVersion" | "createdAt" | "legacyData">[]> {
+  }): Promise<
+    IncrementalViewDataType<"PostViews">[]
+  > {
     // Round startDate (endDate) down (up) to the nearest UTC date boundary
-    const windowStart = moment.utc(startDate).startOf("day").toDate();
-    const windowEnd = moment.utc(endDate).endOf("day").toDate();
+    const startDateFormatted = moment.utc(startDate).startOf("day").format("YYYY-MM-DD HH:mm:ss");
+    const endDateFormatted = moment.utc(endDate).endOf("day").format("YYYY-MM-DD HH:mm:ss");
 
     const analyticsDb = getAnalyticsConnectionOrThrow();
 
@@ -47,12 +49,24 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
         post_id,
         date_trunc('day', timestamp)
     `,
-      [windowStart, windowEnd]
+      [startDateFormatted, endDateFormatted]
     );
 
-    // Manually convert the number fields from string to number (as this isn't handled automatically)
+    // Manually convert:
+    // - The number fields from string to number (as this isn't handled automatically)
+    // - The date fields to UTC strings (NOTE: this actually changes the time represented, because in the conversion
+    //   from postgres to JS the timezone of the server is applied to the raw date, so 2023-04-01 00:00:00 becomes e.g.
+    //   2023-04-01 00:00:00+0100 (BST), which is wrong)
     const typedResults = results.map((views) => ({
       ...views,
+      windowStart: moment(views.windowStart)
+        .add(moment(views.windowStart).utcOffset(), "minutes")
+        .utc()
+        .format("YYYY-MM-DD HH:mm:ss"),
+      windowEnd: moment(views.windowEnd)
+        .add(moment(views.windowEnd).utcOffset(), "minutes")
+        .utc()
+        .format("YYYY-MM-DD HH:mm:ss"),
       viewCount: parseInt(views.viewCount),
       uniqueViewCount: parseInt(views.uniqueViewCount),
     }));
@@ -60,7 +74,32 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
     return typedResults;
   }
 
-  async upsertData({ data }: { data: Omit<DbPostViews, "_id" | "schemaVersion" | "createdAt" | "legacyData">[] }) {
+  /**
+   * Delete rows where there is any overlap with the given (startDate, endDate) range
+   */
+  async deleteRange({
+    startDate,
+    endDate,
+  }: {
+    startDate: Date;
+    endDate: Date;
+  }): Promise<void> {
+    // Round startDate (endDate) down (up) to the nearest UTC date boundary
+    const startDateFormatted = moment.utc(startDate).startOf('day').format('YYYY-MM-DD HH:mm:ss');
+    const endDateFormatted = moment.utc(endDate).endOf('day').format('YYYY-MM-DD HH:mm:ss');
+
+    await this.getRawDb().none(
+      `
+      DELETE FROM "PostViews"
+      WHERE
+        ("windowEnd" > $1 AND "windowEnd" < $2)
+        OR ("windowStart" > $1 AND "windowStart" < $2)
+      `,
+      [startDateFormatted, endDateFormatted]
+    );
+  }
+
+  async upsertData({ data }: { data: IncrementalViewDataType<"PostViews">[] }) {
     const dataWithIds = data.map((item) => ({
       ...item,
       _id: randomId(),
@@ -73,7 +112,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
       const values = chunk
         .map(
           (row) =>
-            `('${row._id}', '${row.postId}', '${row.windowStart.toISOString()}', '${row.windowEnd.toISOString()}', ${
+            `('${row._id}', '${row.postId}', '${row.windowStart}', '${row.windowEnd}', ${
               row.viewCount
             }, ${row.uniqueViewCount}, NOW(), NOW())`
         )
@@ -126,7 +165,8 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
   }: {
     postIds: string[];
   }): Promise<{ postId: string; totalViews: number; totalUniqueViews: number }[]> {
-    const results = await this.getRawDb().any<{ postId: string; totalViews: string; totalUniqueViews: string }>(`
+    const results = await this.getRawDb().any<{ postId: string; totalViews: string; totalUniqueViews: string }>(
+      `
       SELECT
         "postId",
         sum("viewCount") AS "totalViews",
@@ -139,7 +179,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
         "postId"
       `,
       [postIds]
-    )
+    );
 
     // Manually convert the number fields from string to number (as this isn't handled automatically)
     const typedResults = results.map((views) => ({
@@ -148,7 +188,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
       totalUniqueViews: parseInt(views.totalUniqueViews),
     }));
 
-    return typedResults
+    return typedResults;
   }
 
   async viewsByDate({
@@ -160,7 +200,8 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
     startDate?: Date;
     endDate: Date;
   }): Promise<{ date: string; totalViews: number }[]> {
-    const results = await this.getRawDb().any<{ date: string; viewCount: string }>(`
+    const results = await this.getRawDb().any<{ date: string; viewCount: string }>(
+      `
       SELECT
         to_char(date_trunc('day', "windowStart"), 'YYYY-MM-DD') AS "date",
         sum("viewCount") AS "viewCount"

--- a/packages/lesswrong/server/repos/PostViewsRepo.ts
+++ b/packages/lesswrong/server/repos/PostViewsRepo.ts
@@ -165,8 +165,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
   }: {
     postIds: string[];
   }): Promise<{ postId: string; totalViews: number; totalUniqueViews: number }[]> {
-    const results = await this.getRawDb().any<{ postId: string; totalViews: string; totalUniqueViews: string }>(
-      `
+    const results = await this.getRawDb().any<{ postId: string; totalViews: string; totalUniqueViews: string }>(`
       SELECT
         "postId",
         sum("viewCount") AS "totalViews",
@@ -179,7 +178,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
         "postId"
       `,
       [postIds]
-    );
+    )
 
     // Manually convert the number fields from string to number (as this isn't handled automatically)
     const typedResults = results.map((views) => ({
@@ -188,7 +187,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
       totalUniqueViews: parseInt(views.totalUniqueViews),
     }));
 
-    return typedResults;
+    return typedResults
   }
 
   async viewsByDate({
@@ -200,8 +199,7 @@ class PostViewsRepo extends IncrementalViewRepo<"PostViews"> {
     startDate?: Date;
     endDate: Date;
   }): Promise<{ date: string; totalViews: number }[]> {
-    const results = await this.getRawDb().any<{ date: string; viewCount: string }>(
-      `
+    const results = await this.getRawDb().any<{ date: string; viewCount: string }>(`
       SELECT
         to_char(date_trunc('day', "windowStart"), 'YYYY-MM-DD') AS "date",
         sum("viewCount") AS "viewCount"

--- a/packages/lesswrong/server/resolvers/analyticsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/analyticsResolvers.ts
@@ -231,7 +231,7 @@ addGraphQLResolvers({
       const viewsById = Object.fromEntries(viewsResults.map((row) => [row.postId, row.totalViews]));
       const uniqueViewsById = Object.fromEntries(viewsResults.map((row) => [row.postId, row.totalUniqueViews]));
       const readsById = Object.fromEntries(readsResults.map((row) => [row.postId, row.totalReads]));
-      const meanReadingTimeById = Object.fromEntries(readsResults.map((row) => [row.postId, row.totalReads]));
+      const meanReadingTimeById = Object.fromEntries(readsResults.map((row) => [row.postId, row.meanReadTime]));
 
       let sortedAndLimitedPostIds: string[] = postIds;
       if (INDIRECTLY_SORTABLE_FIELDS.includes(sortBy)) {


### PR DESCRIPTION
There was a timezone bug in the cron job that populates the analytics data, this caused some posts (e.g. [this one](https://forum.effectivealtruism.org/postAnalytics?postId=fovDwkBQgTqRMoHZM)) to undercount views, and then this could mean they were inconsistent with reads and you end up with a negative bounce rate. This only affected days during British daylight savings time.

The job takes a while to rerun, so I'll fix the 2023 data today and then run the rest of the time range overnight tonight (update: I have now done this).

I also noticed that "Mean reading time" was way too high, because I forgot to calculate it and was just using the read count as a number of seconds 🤦‍♂️.

### Full description of the timezone bug

The bug was in this function:
```typescript
const results = await analyticsDb.any<
      Omit<DbPostViews, "_id" | "schemaVersion" | "createdAt" | "legacyData"> & {
        viewCount: string;
        uniqueViewCount: string;
      }
    >(
      `
      SELECT
        count(*) AS "viewCount",
        count(DISTINCT client_id) AS "uniqueViewCount",
        post_id as "postId",
        (date_trunc('day', timestamp)) AS "windowStart",
        (date_trunc('day', timestamp) + interval '1 day') AS "windowEnd"
      FROM
        page_view
      WHERE
        timestamp >= $1
        AND timestamp <= $2
        AND post_id IS NOT NULL
      GROUP BY
        post_id,
        date_trunc('day', timestamp)
    `,
      [windowStart, windowEnd]
    );
```

`windowStart` and `windowEnd` would be in the timezone of the server and then be converted into UTC before evaluating the `WHERE` clause. This meant that (for me in the UK) in daylight savings time they would be like `2023-04-07 23:00:00+00`, `2023-04-08 23:00:00+00` so it would include an hour from the previous day. This would then overwrite the  data for the _entire_ day which had previously calculated, resulting in views being low but usually not 0. This didn't effect reads because they are further broken down but client id so only those client ids that were included in the overlapping hour would be overwritten

Also in this PR is a separate fix for where I forgot to calculate `meanReadTime`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206442253124946) by [Unito](https://www.unito.io)
