### PR TITLE
Improve the wording of the collapsed moderator section on the user page

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -4,6 +4,7 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
 import NoSSR from 'react-no-ssr';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -32,7 +33,7 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   
   if (user.reviewedByUserId && !user.snoozedUntilContentCount && !expanded) {
     return <div className={classes.root} onClick={() => setExpanded(true)}>
-      <SectionButton>Expand Moderation Tools</SectionButton>
+      <SectionButton>{preferredHeadingCase("Expand Moderation Tools")}</SectionButton>
     </div>
   }
   

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -32,7 +32,7 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   
   if (user.reviewedByUserId && !user.snoozedUntilContentCount && !expanded) {
     return <div className={classes.root} onClick={() => setExpanded(true)}>
-      <SectionButton>Expand</SectionButton>
+      <SectionButton>Expand Moderation Tools</SectionButton>
     </div>
   }
   
@@ -50,5 +50,3 @@ declare global {
     SunshineNewUsersProfileInfo: typeof SunshineNewUsersProfileInfoComponent
   }
 }
-
-


### PR DESCRIPTION
Currently it says "Expand". I just watched a mod go to a user page and not know how to get to the mod tools. This should remedy that, but telling the moderators what they should expand. I've left this in for LW, as it seems to make the process of onboarding new mods very cheaply better. cc @Raemon.

<img width="1025" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/10352319/b9c12489-3bc6-4573-9f67-bdd576ced25a">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206445791546415) by [Unito](https://www.unito.io)
