### PR TITLE
Misc fixes from new forum setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ psql forummagnum -f ./schema/accepted_schema.sql
 TODOs:
 
 * You won't have any database settings yet. TODO: add instructions.
+  * Start server and run it for ~30 sec which would create DB indexes 😅
+  * Then run `yarn ea-load-dev-db <settings file>` to load the database settings from the file. (TODO: example of the file)
 * You won't be able to run migrations yet. TODO: fix migrations so they can be
   run on a new db (NB: goal is still to have the db have the accepted_schema).
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -378,14 +378,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnMobileStandalone: true,
       showOnCompressed: true,
     }, {
-      id: 'library',
-      title: 'Library',
-      link: '/library',
-      iconComponent: LocalLibrary,
-      tooltip: eaSequencesHomeDescription,
-      showOnMobileStandalone: true,
-      showOnCompressed: true,
-    }, {
       id: 'events',
       title: 'Community and Events',
       mobileTitle: 'Events',

--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -8,7 +8,13 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { userCanDo } from '../../../lib/vulcan-users/permissions';
 import { userCanEditUser, userGetDisplayName, userGetProfileUrlFromSlug } from "../../../lib/collections/users/helpers";
 import { getBrowserLocalStorage } from '../../editor/localStorageHandlers';
-import { siteNameWithArticleSetting, taggingNameIsSet, taggingNameCapitalSetting, taglineSetting } from '../../../lib/instanceSettings';
+import {
+  siteNameWithArticleSetting,
+  taggingNameIsSet,
+  taggingNameCapitalSetting,
+  taglineSetting,
+  isEAForum,
+} from '../../../lib/instanceSettings'
 import { DEFAULT_LOW_KARMA_THRESHOLD } from '../../../lib/collections/posts/views'
 import { SORT_ORDER_OPTIONS } from '../../../lib/collections/posts/dropdownOptions';
 import { PROGRAM_PARTICIPATION } from '../../../lib/collections/users/schema';
@@ -441,7 +447,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
     <AnalyticsContext pageContext="userPage">
       <SingleColumnSection>
         <div className={classNames(classes.section, classes.mainSection)}>
-          {userCanEditUser(currentUser, user) &&
+          {isEAForum && userCanEditUser(currentUser, user) &&
             <div className={classes.editProfile}>
               <Button
                 type="submit"

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -11,6 +11,7 @@ import { mapboxAPIKeySetting } from '../../lib/publicSettings';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import PersonIcon from '@material-ui/icons/Person';
 import classNames from 'classnames';
+import {isFriendlyUI} from '../../themes/forumTheme'
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
@@ -54,7 +55,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   mapButtons: {
     alignItems: "flex-end",
     position: "absolute",
-    top: 10,
+    top: isFriendlyUI ? 40 : 10,
     right: 10,
     display: "flex",
     flexDirection: "column",
@@ -180,7 +181,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
         {...viewport}
         width="100%"
         height="100%"
-        mapStyle={isEAForum ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
+        mapStyle={isFriendlyUI ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
         onViewportChange={viewport => setViewport(viewport)}
         mapboxApiAccessToken={mapboxAPIKeySetting.get() || undefined}
       >

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -22,6 +22,7 @@ import { without } from 'underscore';
 import { isEAForum } from '../../lib/instanceSettings';
 import { userIsAdmin } from '../../lib/vulcan-users';
 import { useNavigate } from '../../lib/reactRouterWrapper';
+import {isFriendlyUI} from '../../themes/forumTheme'
 
 const availableFilters = groupTypes.map(t => t.shortName);
 
@@ -274,7 +275,7 @@ const CommunityMapFilter = ({
 
   return (
     <Paper>
-      {!isEAForum && <div className={classes.filters}>
+      {!isFriendlyUI && <div className={classes.filters}>
         {availableFilters.map((value, i) => {
           const checked = filters.includes(value)
           return (

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -5,6 +5,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { createStyles } from '@material-ui/core/styles';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import classNames from 'classnames';
+import {isFriendlyUI} from '../../themes/forumTheme'
 
 
 // just the "f", used for the FB Group link
@@ -149,7 +150,7 @@ const GroupLinks = ({ document, noMargin, classes }: {
 
   return(
     <div className={classes.root}>
-      {!isEAForum && <div className={noMargin ? classNames(classes.groupTypes, classes.noMargin) : classes.groupTypes}>
+      {!isFriendlyUI && <div className={noMargin ? classNames(classes.groupTypes, classes.noMargin) : classes.groupTypes}>
         {document.types && document.types.map(type => {
           return (
             <Tooltip

--- a/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
+++ b/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
@@ -6,6 +6,7 @@ import { Helmet } from 'react-helmet'
 import * as _ from 'underscore';
 import { mapboxAPIKeySetting } from '../../lib/publicSettings';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import {isFriendlyUI} from '../../themes/forumTheme'
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   previewWrapper: {
@@ -69,7 +70,7 @@ class SmallMapPreview extends Component<SmallMapPreviewProps,SmallMapPreviewStat
         {...viewport}
         width="100%"
         height="100%"
-        mapStyle={isEAForum ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
+        mapStyle={isFriendlyUI ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
         onViewportChange={viewport => this.setState({ viewport })}
         mapboxApiAccessToken={mapboxAPIKeySetting.get()}
       >

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -53,7 +53,7 @@ const AllTagsPage = ({classes}: {
 }) => {
   const { openDialog } = useDialog()
   const currentUser = useCurrentUser()
-  const { tag } = useTagBySlug("portal", "AllTagsPageFragment");
+  const { tag, loading } = useTagBySlug("portal", "AllTagsPageFragment");
   const [ editing, setEditing ] = useState(false)
 
   const { AllTagsAlphabetical, SectionButton, SectionTitle, ContentItemBody, ContentStyles, ToCColumn, TagTableOfContents, Loading } = Components;
@@ -119,7 +119,8 @@ const AllTagsPage = ({classes}: {
               </SectionTitle>}
             >
               <ContentStyles contentType="comment" className={classes.portal}>
-                {!tag && <Loading/>}
+                {loading && <Loading/>}
+                {!loading && !tag && <div>Create tag named "portal" to initialize tag page</div>}
                 {userCanEditTagPortal(currentUser) && <a onClick={() => setEditing(true)} className={classes.edit}>
                   Edit
                 </a>}

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -115,7 +115,8 @@ const TagPageButtonRow = ({ tag, editing, setEditing, className, classes }: {
   const noEditKarmaTooLow = !restricted && currentUser && !tagUserHasSufficientKarma(currentUser, "edit")
   const canEdit = !editing && !noEditKarmaTooLow && !noEditNotAuthor
 
-  const editTooltip = <>
+  const editTooltipHasContent = noEditNotAuthor || noEditKarmaTooLow || numFlags
+  const editTooltip = editTooltipHasContent && <>
     {noEditNotAuthor && <>
       <div>
       This article can only be edited by the authors, please comment in the discussion to suggest changes

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -16,6 +16,7 @@ import {
   hasPostInlineReactionsSetting,
 } from './instanceSettings'
 import { userOverNKarmaOrApproved } from "./vulcan-users/permissions";
+import {isFriendlyUI} from '../themes/forumTheme'
 
 // States for in-progress features
 const adminOnly = (user: UsersCurrent|DbUser|null): boolean => !!user?.isAdmin; // eslint-disable-line no-unused-vars
@@ -41,7 +42,7 @@ export const userHasDefaultProfilePhotos = disabled
 
 export const userHasAutosummarize = adminOnly
 
-export const userHasThemePicker = isEAForum ? adminOnly : shippedFeature;
+export const userHasThemePicker = isFriendlyUI ? adminOnly : shippedFeature;
 
 export const userHasShortformTags = isEAForum ? shippedFeature : disabled;
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1184,10 +1184,10 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       background: postBackground
     },
     {
-      name: 'bookmarks',
-      path: '/bookmarks',
+      name: 'savedAndRead',
+      path: '/saved',
       componentName: 'BookmarksPage',
-      title: 'Bookmarks',
+      title: 'Saved & read',
     },
   ],
 })


### PR DESCRIPTION
- Add a note on having to run server before `ea-load-dev-db` works on a new DB
- Routes: update default to be savedAndRead instead of bookmarks to match what is actually displayed with `isFriendlyUI` default
- Remove Library from default side menu, as it leads to 404
- Edit profile button doesn't lead anywhere in `isFriendlyUI` context. Making it EA-forum only
- Change `isEAForum` to `isFriendlyUI` in a bunch of places
- All tags page: add a message instead of infinite loading if "portal" tag is missing
- TagPageButtonRow.tsx: don't show empty tooltip
- CommunityMap.tsx: add larger margin for filter buttons in friendly UI mode bc otherwise they overlap with top sidebar


