### PR TITLE
Changes to support opportunities in the topic bar

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -24,6 +24,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 // The order in which the topics are displayed is slightly different from their default ordering
 const topicTabsOrder = [
+  'z8qFsGt5iXyZiLbjN', // Opportunities
   'sWcuTyTB5dP3nas2t', // Global health
   'QdH9f8TC6G8oGYdgt', // Animal welfare
   'oNiQsBHA3i837sySD', // AI safety

--- a/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentPostEditorTagging.tsx
@@ -80,6 +80,12 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     [postTypeResult.results],
   );
 
+  // Filter out core tags that are also post type tags (only show them as post types)
+  const filteredCoreTags = useMemo(() => {
+    const postTypeTagIds = new Set(postTypeTags.map(tag => tag._id));
+    return coreTags.filter(tag => !postTypeTagIds.has(tag._id));
+  }, [coreTags, postTypeTags]);
+
   const selectedTagIds = Object.keys(value || {});
 
   const [
@@ -87,8 +93,8 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     selectedPostTypeTagIds,
     selectedOtherTagIds,
   ] = splitBy([
-    (tagId: string) => !!coreTags?.find((tag) => tag._id === tagId),
-    (tagId: string) => !!postTypeTags?.find((tag) => tag._id === tagId),
+    (tagId: string) => !!filteredCoreTags.find((tag) => tag._id === tagId),
+    (tagId: string) => !!postTypeTags.find((tag) => tag._id === tagId),
     () => true,
   ], selectedTagIds);
 
@@ -183,11 +189,11 @@ const FormComponentPostEditorTagging = ({value, path, document, formType, update
     <div className={classes.root}>
       {showCoreAndTypesTopicSections && (
         <>
-          {!!coreTags.length &&
+          {!!filteredCoreTags.length &&
             <>
               <h3 className={classNames(classes.coreTagHeader, classes.header)}>Core topics</h3>
               <TagsChecklist
-                tags={coreTags}
+                tags={filteredCoreTags}
                 selectedTagIds={selectedTagIds}
                 onTagSelected={onTagSelected}
                 onTagRemoved={onTagRemoved}


### PR DESCRIPTION
In this PR:
- Show it first in the topic bar
- Fix an issue where it appeared as both a core topic and a post type (when `core` was set on it)

<img width="1098" alt="Screenshot 2024-01-25 at 21 40 01" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/8c123187-0bd0-46d3-8a58-25d9b5e22619">

_Crosspost of a slack comment for context_

> So, currently the thing that decides whether something is in the topic bar is whether it is a “core” topic. This also controls some other things, like whether it appears in the core topics section on the main topic page, and whether it appears as a core topic in the edit post page (note it would now appear twice as a post type and core topic, which is not ideal). (see 1st and 2nd image)
>
> Then there is a separate “Is subforum” option that controls the layout of the topic page itself, and when we did a refactor a while ago we made (approximately?) all the core topics have the subforum layout to reduce the overall complexity (so core and isSubforum are in practice the same now, although they can be set separately). (see 3rd image)
>
> And then another thing to consider is that by default clicking on a topic tab just opens the post list still on the frontpage, and doesn’t take you to the actual topic page (4th image)

> And then, on the question of how to handle it given all this, personally I think:
> - It would be fine/good to set both `core` and `isSubforum` on the opportunities topic. I think the subforum layout better suits it anyway (because the posts are more important than the wiki), and I think it’s the only topic with sub-topics that isn’t core/subforum, so it would be good to make it consistent
> - It’s also fine that it doesn’t link to the topic page itself, just shows the post list on the frontpage
> - We should fix the issue where it appears as both a core topic and a post type

<img width="1085" alt="Screenshot 2024-01-25 at 21 14 44" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/1a1f1749-ca66-4a73-af44-5e90a88400ac">
<img width="704" alt="Screenshot 2024-01-25 at 21 15 22" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/e76e872d-eda0-4e2d-bcc4-d8b84b0bc3f9">
<img width="1504" alt="Screenshot 2024-01-25 at 21 16 08" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/5c2cd3be-c11a-4bbb-875f-b1c36d752647">
![Uploading Screenshot 2024-01-25 at 21.21.25.png…]()


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206447298689467) by [Unito](https://www.unito.io)
