### PR TITLE
[EA Forum only] karma gate "New sequence" button on user profile

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -21,6 +21,7 @@ import Button from '@material-ui/core/Button';
 import { nofollowKarmaThreshold } from '../../../lib/publicSettings';
 import classNames from 'classnames';
 import { getUserStructuredData } from '../../users/UsersSingle';
+import { SHOW_NEW_SEQUENCE_KARMA_THRESHOLD } from '../../../lib/collections/sequences/permissions';
 
 const styles = (theme: ThemeType) => ({
   section: {
@@ -311,7 +312,7 @@ const EAUsersProfile = ({terms, slug, classes}: {
       </AnalyticsContext>
       <div className={classes.sectionSubHeadingRow}>
         <Typography variant="headline" className={classes.sectionSubHeading}>Draft/hidden sequences</Typography>
-        {ownPage && <Link to="/sequencesnew">
+        {ownPage && currentUser.karma >= SHOW_NEW_SEQUENCE_KARMA_THRESHOLD && <Link to="/sequencesnew">
           <SectionButton>
             <LibraryAddIcon /> New sequence
           </SectionButton>


### PR DESCRIPTION
This copies the karma gating that the user dropdown menu uses for the "New sequence" button, to also hide it on the user profile page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206454787729909) by [Unito](https://www.unito.io)
