### PR TITLE
Clickable users in sunshine reports

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
@@ -28,7 +28,7 @@ const ReportForm = ({ userId, postId, commentId, reportedUserId, onClose, onSubm
       <DialogContent>
         <Components.WrappedSmartForm
           collectionName="Reports"
-          mutationFragment={getFragment('unclaimedReportsList')}
+          mutationFragment={getFragment('UnclaimedReportsList')}
           prefilledProps={{
             userId: userId,
             postId: postId,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
@@ -18,12 +18,12 @@ const SunshineReportedContentList = ({ classes, currentUser }: {
   const { results, totalCount, loadMoreProps, refetch } = useMulti({
     terms: {view:"sunshineSidebarReports", limit: 30},
     collectionName: "Reports",
-    fragmentName: 'unclaimedReportsList',
+    fragmentName: 'UnclaimedReportsList',
     enableTotal: true,
   });
   const { mutate: updateReport } = useUpdate({
     collectionName: "Reports",
-    fragmentName: 'unclaimedReportsList',
+    fragmentName: 'UnclaimedReportsList',
   });
   
   if (results && results.length) {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -10,7 +10,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import PersonOutlineIcon from '@material-ui/icons/PersonOutline'
 import { Link } from '../../lib/reactRouterWrapper'
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (_theme: ThemeType) => ({
   reportedUser: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -25,11 +25,10 @@ const styles = (theme: ThemeType): JssStyles => ({
 const SunshineReportedItem = ({report, updateReport, classes, currentUser, refetch}: {
   report: UnclaimedReportsList,
   updateReport: WithUpdateFunction<"Reports">,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
   currentUser: UsersCurrent,
   refetch: () => void
 }) => {
-
   const { hover, anchorEl, eventHandlers } = useHover();
   const { mutate: updateComment } = useUpdate({
     collectionName: "Comments",
@@ -84,8 +83,11 @@ const SunshineReportedItem = ({report, updateReport, classes, currentUser, refet
   }
 
   const {comment, post, reportedUser} = report;
-  const { SunshineListItem, SidebarInfo, SidebarHoverOver, PostsTitle, PostsHighlight, SidebarActionMenu, SidebarAction, FormatDate, CommentsNode, Typography, SunshineCommentsItemOverview, SunshineNewUsersInfo } = Components
-
+  const {
+    SunshineListItem, SidebarInfo, SidebarHoverOver, PostsTitle, PostsHighlight,
+    SidebarActionMenu, SidebarAction, FormatDate, CommentsNode, Typography,
+    SunshineCommentsItemOverview, SunshineNewUsersInfo, UsersName,
+  } = Components;
   return (
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
@@ -115,11 +117,11 @@ const SunshineReportedItem = ({report, updateReport, classes, currentUser, refet
           </>}
           {reportedUser && <div>
             <Link to={report.link} className={classes.reportedUser}>
-              <strong>{ reportedUser.displayName }</strong>
+              <strong><UsersName user={reportedUser} /></strong>
               <PersonOutlineIcon className={classes.reportedUserIcon}/>
             </Link>
           </div>}
-          <em>"{ report.description }"</em> – {report.user && report.user.displayName}, <FormatDate date={report.createdAt}/>
+          <em>"{ report.description }"</em> – <UsersName user={report.user} />, <FormatDate date={report.createdAt}/>
         </SidebarInfo>
         {hover && <SidebarActionMenu>
           <SidebarAction title="Mark as Reviewed" onClick={handleReview}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const SunshineReportedItem = ({report, updateReport, classes, currentUser, refetch}: {
-  report: any,
+  report: UnclaimedReportsList,
   updateReport: WithUpdateFunction<"Reports">,
   classes: ClassesType,
   currentUser: UsersCurrent,

--- a/packages/lesswrong/lib/collections/reports/fragments.ts
+++ b/packages/lesswrong/lib/collections/reports/fragments.ts
@@ -5,10 +5,7 @@ registerFragment(`
     _id
     userId
     user {
-      _id
-      displayName
-      username
-      slug
+      ...UsersMinimumInfo
     }
     commentId
     comment {

--- a/packages/lesswrong/lib/collections/reports/fragments.ts
+++ b/packages/lesswrong/lib/collections/reports/fragments.ts
@@ -1,7 +1,7 @@
 import { registerFragment } from '../../vulcan-lib/fragments';
 
 registerFragment(`
-  fragment unclaimedReportsList on Report {
+  fragment UnclaimedReportsList on Report {
     _id
     userId
     user {
@@ -12,34 +12,17 @@ registerFragment(`
     }
     commentId
     comment {
-      _id
-      userId
-      user {
-        ...UsersMinimumInfo
-      }
-      baseScore
-      contents {
-        ...RevisionDisplay
-      }
-      postedAt
-      deleted
-      postId
+      ...CommentsList
       post {
-        _id
-        slug
-        title
-        isEvent
+        ...PostsMinimumInfo
+      }
+      tag {
+        ...TagBasicInfo
       }
     }
     postId
     post {
-      _id
-      slug
-      title
-      isEvent
-      contents {
-        ...RevisionDisplay
-      }
+      ...PostsList
     }
     reportedUser {
       ...SunshineUsersList

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1823,60 +1823,38 @@ interface ReportsDefaultFragment { // fragment on Reports
   readonly reportedAsSpam: boolean,
 }
 
-interface unclaimedReportsList { // fragment on Reports
+interface UnclaimedReportsList { // fragment on Reports
   readonly _id: string,
   readonly userId: string,
-  readonly user: unclaimedReportsList_user,
+  readonly user: UnclaimedReportsList_user,
   readonly commentId: string,
-  readonly comment: unclaimedReportsList_comment|null,
+  readonly comment: UnclaimedReportsList_comment|null,
   readonly postId: string,
-  readonly post: unclaimedReportsList_post|null,
+  readonly post: PostsList|null,
   readonly reportedUser: SunshineUsersList|null,
   readonly closedAt: Date | null,
   readonly createdAt: Date,
   readonly claimedUserId: string,
-  readonly claimedUser: unclaimedReportsList_claimedUser|null,
+  readonly claimedUser: UnclaimedReportsList_claimedUser|null,
   readonly link: string,
   readonly description: string,
   readonly reportedAsSpam: boolean,
   readonly markedAsSpam: boolean,
 }
 
-interface unclaimedReportsList_user { // fragment on Users
+interface UnclaimedReportsList_user { // fragment on Users
   readonly _id: string,
   readonly displayName: string,
   readonly username: string,
   readonly slug: string,
 }
 
-interface unclaimedReportsList_comment { // fragment on Comments
-  readonly _id: string,
-  readonly userId: string,
-  readonly user: UsersMinimumInfo|null,
-  readonly baseScore: number,
-  readonly contents: RevisionDisplay|null,
-  readonly postedAt: Date,
-  readonly deleted: boolean,
-  readonly postId: string,
-  readonly post: unclaimedReportsList_comment_post|null,
+interface UnclaimedReportsList_comment extends CommentsList { // fragment on Comments
+  readonly post: PostsMinimumInfo|null,
+  readonly tag: TagBasicInfo|null,
 }
 
-interface unclaimedReportsList_comment_post { // fragment on Posts
-  readonly _id: string,
-  readonly slug: string,
-  readonly title: string,
-  readonly isEvent: boolean,
-}
-
-interface unclaimedReportsList_post { // fragment on Posts
-  readonly _id: string,
-  readonly slug: string,
-  readonly title: string,
-  readonly isEvent: boolean,
-  readonly contents: RevisionDisplay|null,
-}
-
-interface unclaimedReportsList_claimedUser { // fragment on Users
+interface UnclaimedReportsList_claimedUser { // fragment on Users
   readonly _id: string,
   readonly displayName: string,
   readonly username: string,
@@ -3638,7 +3616,7 @@ interface FragmentTypes {
   newRSSFeedFragment: newRSSFeedFragment
   RSSFeedMutationFragment: RSSFeedMutationFragment
   ReportsDefaultFragment: ReportsDefaultFragment
-  unclaimedReportsList: unclaimedReportsList
+  UnclaimedReportsList: UnclaimedReportsList
   TagFlagFragment: TagFlagFragment
   TagFlagEditFragment: TagFlagEditFragment
   TagFlagsDefaultFragment: TagFlagsDefaultFragment
@@ -3796,7 +3774,7 @@ interface FragmentTypesByCollection {
   ModeratorActions: "ModeratorActionsDefaultFragment"|"ModeratorActionDisplay"
   Revisions: "RevisionDisplay"|"RevisionEdit"|"RevisionMetadata"|"RevisionMetadataWithChangeMetrics"|"RevisionHistoryEntry"|"RevisionTagFragment"|"RecentDiscussionRevisionTagFragment"|"WithVoteRevision"|"RevisionsDefaultFragment"
   RSSFeeds: "RSSFeedsDefaultFragment"|"RSSFeedMinimumInfo"|"newRSSFeedFragment"|"RSSFeedMutationFragment"
-  Reports: "ReportsDefaultFragment"|"unclaimedReportsList"
+  Reports: "ReportsDefaultFragment"|"UnclaimedReportsList"
   TagFlags: "TagFlagFragment"|"TagFlagEditFragment"|"TagFlagsDefaultFragment"
   GardenCodes: "GardenCodeFragment"|"GardenCodeFragmentEdit"|"GardenCodesDefaultFragment"
   Bans: "BansDefaultFragment"|"BansAdminPageFragment"
@@ -3917,7 +3895,7 @@ interface CollectionNamesByFragmentName {
   newRSSFeedFragment: "RSSFeeds"
   RSSFeedMutationFragment: "RSSFeeds"
   ReportsDefaultFragment: "Reports"
-  unclaimedReportsList: "Reports"
+  UnclaimedReportsList: "Reports"
   TagFlagFragment: "TagFlags"
   TagFlagEditFragment: "TagFlags"
   TagFlagsDefaultFragment: "TagFlags"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1826,7 +1826,7 @@ interface ReportsDefaultFragment { // fragment on Reports
 interface UnclaimedReportsList { // fragment on Reports
   readonly _id: string,
   readonly userId: string,
-  readonly user: UnclaimedReportsList_user,
+  readonly user: UsersMinimumInfo,
   readonly commentId: string,
   readonly comment: UnclaimedReportsList_comment|null,
   readonly postId: string,
@@ -1840,13 +1840,6 @@ interface UnclaimedReportsList { // fragment on Reports
   readonly description: string,
   readonly reportedAsSpam: boolean,
   readonly markedAsSpam: boolean,
-}
-
-interface UnclaimedReportsList_user { // fragment on Users
-  readonly _id: string,
-  readonly displayName: string,
-  readonly username: string,
-  readonly slug: string,
 }
 
 interface UnclaimedReportsList_comment extends CommentsList { // fragment on Comments


### PR DESCRIPTION
Request from Lizka in Slack. Make the user names for reported content clickable and hoverable in the sunshine side bar. Also, fix some broken fragments that were covered up by an `any`.

<img width="691" alt="Screenshot 2024-01-27 at 00 48 45" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/e440e122-bf01-4521-9084-2139c5e161ba">
<img width="496" alt="Screenshot 2024-01-27 at 00 48 30" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/7cb53477-a41a-41cf-afcc-1b5da04d774c">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206455416754554) by [Unito](https://www.unito.io)
