### PR TITLE
Fix permalinks on notifications page comments

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageItem.tsx
@@ -97,7 +97,7 @@ export const NotificationsPageItem = ({
     skip: !showPreviewComment,
     documentId: previewCommentId,
     collectionName: "Comments",
-    fragmentName: "CommentsList",
+    fragmentName: "CommentsListWithParentMetadata",
   });
 
   const {ForumIcon, LWTooltip, CommentsNode, Loading} = Components;
@@ -139,7 +139,8 @@ export const NotificationsPageItem = ({
                   treeOptions={{
                     scrollOnExpand: true,
                     condensed: true,
-                    post,
+                    post: previewComment.post ?? post,
+                    tag: previewComment.tag ?? undefined,
                   }}
                   startThreadTruncated
                   expandAllThreads


### PR DESCRIPTION
Fixes a bug where the "link" button on the top right of preview comments on the notifications page links to the frontpage, instead of to the actual comment on the original post.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206486451079319) by [Unito](https://www.unito.io)
