### PR TITLE
Add basic font styles for `ErrorAccessDenied` component

### DIFF
--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -2,8 +2,22 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from './withUser';
 import { useServerRequestStatus } from '../../lib/routeUtil'
+import { isFriendlyUI } from '../../themes/forumTheme';
 
-const ErrorAccessDenied = ({explanation}: {explanation?: string}) => {
+const styles = (theme: ThemeType) => ({
+  root: isFriendlyUI
+    ? {
+      fontFamily: theme.palette.fonts.sansSerifStack,
+      fontSize: 14,
+      fontWeight: 500,
+    }
+    :{},
+});
+
+const ErrorAccessDenied = ({explanation, classes}: {
+  explanation?: string,
+  classes: ClassesType<typeof styles>,
+}) => {
   const { SingleColumnSection, Typography } = Components;
   const serverRequestStatus = useServerRequestStatus()
   const currentUser = useCurrentUser();
@@ -12,11 +26,11 @@ const ErrorAccessDenied = ({explanation}: {explanation?: string}) => {
   if (currentUser) {
     const message = `Sorry, you don't have access to this page.${(explanation ? ` ${explanation}` : "")}`
     return <SingleColumnSection>
-      <div>{message}</div>
+      <div className={classes.root}>{message}</div>
     </SingleColumnSection>
   } else {
     return <SingleColumnSection>
-      <Typography variant='body1'>
+      <Typography variant='body1' className={classes.root}>
         Please log in to access this page.
       </Typography>
       <Components.LoginForm startingState='login'/>
@@ -24,7 +38,11 @@ const ErrorAccessDenied = ({explanation}: {explanation?: string}) => {
   }
 }
 
-const ErrorAccessDeniedComponent = registerComponent("ErrorAccessDenied", ErrorAccessDenied);
+const ErrorAccessDeniedComponent = registerComponent(
+  "ErrorAccessDenied",
+  ErrorAccessDenied,
+  {styles},
+);
 
 declare global {
   interface ComponentTypes {


### PR DESCRIPTION
For example, [http://localhost:3000/posts/7Pmv23kPH7oMvQsmZ](http://localhost:3000/posts/7Pmv23kPH7oMvQsmZ)

Before:

<img width="980" alt="Screenshot 2024-02-01 at 17 39 51" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/d93464e8-fe02-4ab0-90ca-b591f4e12344">

<img width="1060" alt="Screenshot 2024-02-01 at 17 41 26" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/056e30d3-1acb-494f-9faa-df3c88cfc0a3">

After:

<img width="978" alt="Screenshot 2024-02-01 at 17 40 44" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/c86f125d-4b5c-4c6b-b117-6f620fe2efca">

<img width="1058" alt="Screenshot 2024-02-01 at 17 41 54" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/7fa53a2f-1549-44dc-828b-623c455abaec">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206497054205242) by [Unito](https://www.unito.io)
