### PR TITLE
[EA] Only run prod migrations on prod deploy, not when deploying API site

### DIFF
--- a/.github/workflows/deployEAProd.yaml
+++ b/.github/workflows/deployEAProd.yaml
@@ -20,7 +20,7 @@ jobs:
         python-version: '>=3.5 <3.12' # Version range or exact version of a Python version to use, using SemVer's version range syntax
     - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
     - name: Run Migrations
-      if: github.ref == 'refs/heads/ea-deploy'
+      if: github.ref == 'refs/heads/ea-deploy' && matrix.environment == 'EAForum-Production-2'
       uses: ./.github/actions/runMigrations
       with:
         mode: prod


### PR DESCRIPTION
We deploy the main prod site and the API bot site at the same time. Currently, both deploys try to run the migrations. This usually works but occasionally it fails with a "deadlock detected" error. This doesn't cause any damage (you can just rerun the failed workflow) but it is annoying.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206499496449381) by [Unito](https://www.unito.io)
