### PR TITLE
fix clearing "Organizer of" profile field

### DIFF
--- a/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
@@ -210,7 +210,10 @@ class FormComponent<T extends DbObject> extends Component<FormComponentWrapperPr
       event.preventDefault();
       event.stopPropagation();
     }
-    void this.props.updateCurrentValues({ [this.props.path]: null });
+    // To avoid issues with non-nullable fields, we set the localgroup multiselect to [] rather than null when cleared
+    // @ts-ignore (anything can get passed in to props via the "form" schema value)
+    const newVal = (this.props.input === 'SelectLocalgroup' && this.props.multiselect) ? [] : null;
+    void this.props.updateCurrentValues({ [this.props.path]: newVal });
     if (this.showCharsRemaining()) {
       this.updateCharacterCount(null);
     }


### PR DESCRIPTION
When editing your user profile, clicking on the "x" to clear the "Organizer of" field causes this error on submit: "null value in column "organizerOfGroupIds" of relation "Users" violates not-null constraint".

This is related to how we recently made a bunch of fields non-nullable in the DB, together with how `clearField()` works. Most form fields don't use the option to add the "x" to clear the field, but this particular one does, and clicking it would cause the form to set the value to `null`. So I've carved out an exception for the localgroup multiselect case. (When used as a single select, we still want it to set the value to `null`.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206501018414883) by [Unito](https://www.unito.io)
