### PR TITLE
Fix mobile styles for karma changes on the notifications page

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageFeed.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageFeed.tsx
@@ -48,11 +48,14 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 32,
     fontSize: 14,
     fontWeight: 500,
+    lineHeight: "140%",
     color: theme.palette.grey[600],
+    "& span:first-child": {
+      marginRight: 4,
+    },
     "& a": {
       color: theme.palette.primary.dark,
       fontWeight: 600,
-      marginLeft: 4,
     },
   },
   notifications: {
@@ -187,7 +190,7 @@ export const NotificationsPageFeed = ({
               />
             )}
             <div className={classes.karmaBatching}>
-              {batchingMessages[karmaChanges!.updateFrequency]}{" "}
+              <span>{batchingMessages[karmaChanges!.updateFrequency]}{" "}</span>
               <Link to="/account?highlightField=karmaChangeNotifierSettings">
                 Change settings
               </Link>

--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
@@ -22,14 +22,7 @@ const styles = (theme: ThemeType) => ({
   },
   link: {
     color: theme.palette.grey[1000],
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
     cursor: "pointer",
-  },
-  reactions: {
-    display: "flex",
-    gap: "4px",
   },
   tooltip: {
     background: theme.palette.panelBackground.tooltipBackground2,
@@ -224,17 +217,16 @@ export const NotificationsPageKarmaChange = ({
           iconTooltip={emoji.label}
           iconVariant="clear"
         >
-          <div className={classes.reactions}>
-            <LWTooltip
-              title={tooltip}
-              className={classes.link}
-              popperClassName={classes.tooltip}
-              placement="bottom"
-            >
-              {users}
-            </LWTooltip>{" "}
-            reacted to {display}
-          </div>
+          <LWTooltip
+            title={tooltip}
+            className={classes.link}
+            popperClassName={classes.tooltip}
+            placement="bottom"
+            inlineBlock={false}
+          >
+            {users}
+          </LWTooltip>{" "}
+          reacted to {commentKarmaChange && "your"} {display}
         </NotificationsPageItem>
       ))}
     </>


### PR DESCRIPTION
Fixes very broken styles for karma changes on the new notifications page when viewing on mobile.

Before:
<img width="321" alt="Screenshot 2024-02-02 at 01 21 24" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/6624adf5-98d5-45d4-81fc-b57729c6f083">

After:
<img width="319" alt="Screenshot 2024-02-02 at 01 20 34" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/256da196-3e73-43af-a582-77b4b9c00d74">

