### PR TITLE
Compile synthetic fields when generating SQL projections

### DIFF
--- a/packages/lesswrong/lib/sql/ProjectionContext.ts
+++ b/packages/lesswrong/lib/sql/ProjectionContext.ts
@@ -290,15 +290,21 @@ class ProjectionContext<N extends CollectionNameString = CollectionNameString> {
     return `${type.toUpperCase()} JOIN "${table}" "${prefix}" ON ${selector}`;
   }
 
-  compileQuery(): {sql: string, args: unknown[]} {
-    const projection = this.projections.join(", ");
-    const joins = this.joins.map((join) => this.compileJoin(join)).join(" ");
-    const table = this.getTableName();
-    const prefix = this.primaryPrefix;
-    const sql = `SELECT ${projection} FROM ${table} "${prefix}" ${joins}`;
+  compileQueryParts() {
     return {
-      sql,
+      projection: this.projections.join(", "),
+      table: this.getTableName(),
+      prefix: this.primaryPrefix,
+      joins: this.joins.map((join) => this.compileJoin(join)).join(" "),
       args: this.args,
+    };
+  }
+
+  compileQuery(): {sql: string, args: unknown[]} {
+    const {projection, table, prefix, joins, args} = this.compileQueryParts();
+    return {
+      sql: `SELECT ${projection} FROM ${table} "${prefix}" ${joins}`,
+      args,
     };
   }
 }

--- a/packages/lesswrong/lib/sql/Query.ts
+++ b/packages/lesswrong/lib/sql/Query.ts
@@ -291,8 +291,13 @@ abstract class Query<T extends DbObject> {
       }
     }
 
-    if (this.getField(field) || this.syntheticFields[field]) {
+    if (this.getField(field)) {
       return this.prefixify(`"${field}"`);
+    }
+
+    if (this.syntheticFields[field]) {
+      // Don't prefixify synthetic fields
+      return `"${field}"`;
     }
 
     throw new Error(`Cannot resolve field name: ${field}`);

--- a/packages/lesswrong/lib/sql/SelectQuery.ts
+++ b/packages/lesswrong/lib/sql/SelectQuery.ts
@@ -245,7 +245,7 @@ class SelectQuery<T extends DbObject> extends Query<T> {
     }
   }
 
-  private getSyntheticFields(addFields: Record<string, any>, leadingComma = true): Atom<T>[] {
+  protected getSyntheticFields(addFields: Record<string, any>, leadingComma = true): Atom<T>[] {
     for (const field in addFields) {
       this.syntheticFields[field] = new UnknownType();
     }
@@ -254,7 +254,7 @@ class SelectQuery<T extends DbObject> extends Query<T> {
     ).slice(leadingComma ? 0 : 1);
   }
 
-  private disambiguateSyntheticFields(addFields?: any, projection?: MongoProjection<T>) {
+  protected disambiguateSyntheticFields(addFields?: any, projection?: MongoProjection<T>) {
     if (addFields) {
       const fields = Object.keys(addFields);
       for (const field of fields) {

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -147,6 +147,7 @@ interface MergedViewQueryAndOptions<T extends DbObject> {
     skip?: number
     hint?: string
   }
+  syntheticFields?: Partial<Record<keyof T, MongoSelector<T>>>
 }
 
 export type MongoSelector<T extends DbObject> = any; //TODO

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -115,6 +115,7 @@ export function getDefaultResolvers<N extends CollectionNameString>(
             currentUser,
             terms,
             parameters.selector,
+            parameters.syntheticFields,
             parameters.options,
           );
           const compiledQuery = query.compile();
@@ -222,6 +223,7 @@ export function getDefaultResolvers<N extends CollectionNameString>(
             currentUser,
             terms,
             selector,
+            undefined,
             {limit: 1},
           );
           const compiledQuery = query.compile();

--- a/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
@@ -10,7 +10,8 @@ describe("SelectFragmentQuery", () => {
         {_id: "test-user-id"} as DbUser,
         null,
         {_id: "test-document-id"},
-        {},
+        undefined,
+        undefined,
         () => "q",
       ),
       expectedSql: `
@@ -35,7 +36,8 @@ describe("SelectFragmentQuery", () => {
         {_id: "test-user-id"} as DbUser,
         {testCollection2Id: "some-test-id"},
         {_id: "test-document-id"},
-        {},
+        undefined,
+        undefined,
         () => "q",
       ),
       expectedSql: `


### PR DESCRIPTION
Regression fix from #8314 - we're not currently compiling synthetic fields when we generate SQL projections. Thankfully this feature is very rarely used so the damage is limited - pretty much just showing empty post lists if you sort by inflation-adjusted karma.

It's probably now possible to simply rewrite the synthetic fields as resolver-only fields in the schema that define a SQL resolver, but for for the sake of expediency I just added the existing projection copmilation into the generation of `SelectFragmentQuery`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206506407197856) by [Unito](https://www.unito.io)
