### PR TITLE
Downsample datadog custom metrics

### DIFF
--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -14,7 +14,8 @@ tracer.use('express', {
 
 export const dogstatsd = new StatsD({
   host: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
-  prefix: 'forummagnum.'
+  prefix: 'forummagnum.',
+  sampleRate: 0.1
 });
 
 export default tracer;


### PR DESCRIPTION
We got a high bill for custom metrics last month, which are billed per unique combination of tags. It looks like this was due to lots of distinct urls being counted, possibly the same but with different query strings (I can only see the count).

We only use custom metrics to count the cache hit rate, and I don't want to spend too much time looking into this, so I'm just reducing the sample rate for now which should hopefully help.