### PR TITLE
fix "Report user" button

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -2731,7 +2731,8 @@ const schema: SchemaType<"Users"> = {
   
   altAccountsDetected: resolverOnlyField({
     type: 'Boolean',
-    graphQLtype: 'Boolean!',
+    graphQLtype: 'Boolean',
+    nullable: true,
     canRead: ['sunshineRegiment', 'admins'],
     resolver: async (user: DbUser, args: void, context: ResolverContext): Promise<boolean> => {
       const clientIds = await context.ClientIds.find(

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2901,7 +2901,7 @@ interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
   readonly moderatorActions: Array<ModeratorActionDisplay>,
   readonly usersContactedBeforeReview: Array<string>,
   readonly associatedClientIds: Array<SunshineUsersList_associatedClientIds>,
-  readonly altAccountsDetected: boolean,
+  readonly altAccountsDetected: boolean|null,
   readonly voteReceivedCount: number,
   readonly smallUpvoteReceivedCount: number,
   readonly bigUpvoteReceivedCount: number,

--- a/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
+++ b/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
@@ -12,13 +12,13 @@
             "name": "TagRel"
           },
           {
+            "name": "Comment"
+          },
+          {
             "name": "Post"
           },
           {
             "name": "Revision"
-          },
-          {
-            "name": "Comment"
           }
         ]
       }


### PR DESCRIPTION
Currently, users can't report other users because they encounter this error when trying to submit the form: "Cannot return null for non-nullable field User.altAccountsDetected." This PR fixes that, plus has some bonus type changes from `yarn generate`.