### PR TITLE
Add /my-stats url for going directly to your own stats page

### DIFF
--- a/packages/lesswrong/components/analytics/MyAnalyticsPage.tsx
+++ b/packages/lesswrong/components/analytics/MyAnalyticsPage.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { useCurrentUser } from '../common/withUser';
+import { userGetAnalyticsUrl } from '../../lib/collections/users/helpers';
+
+const MyAnalyticsPage = () => {
+  const {PermanentRedirect, SingleColumnSection, LoginForm} = Components;
+  const currentUser = useCurrentUser();
+
+  if (!currentUser) {
+    return (
+      <SingleColumnSection>
+        <LoginForm />
+      </SingleColumnSection>
+    );
+  }
+
+  return <PermanentRedirect url={userGetAnalyticsUrl(currentUser)}/>
+}
+
+const MyAnalyticsPageComponent = registerComponent('MyAnalyticsPage', MyAnalyticsPage);
+
+declare global {
+  interface ComponentTypes {
+    MyAnalyticsPage: typeof MyAnalyticsPageComponent
+  }
+}

--- a/packages/lesswrong/components/analytics/MyAnalyticsPage.tsx
+++ b/packages/lesswrong/components/analytics/MyAnalyticsPage.tsx
@@ -15,7 +15,7 @@ const MyAnalyticsPage = () => {
     );
   }
 
-  return <PermanentRedirect url={userGetAnalyticsUrl(currentUser)}/>
+  return <PermanentRedirect status={302} url={userGetAnalyticsUrl(currentUser)}/>
 }
 
 const MyAnalyticsPageComponent = registerComponent('MyAnalyticsPage', MyAnalyticsPage);

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -2,7 +2,7 @@ import React, { MouseEvent, useContext } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { userCanComment, userCanCreateField, userCanDo, userIsAdminOrMod, userIsMemberOf, userOverNKarmaOrApproved } from '../../lib/vulcan-users/permissions';
-import { userGetDisplayName } from '../../lib/collections/users/helpers';
+import { userGetAnalyticsUrl, userGetDisplayName } from '../../lib/collections/users/helpers';
 import { dialoguesEnabled, userHasThemePicker } from '../../lib/betas';
 
 import Paper from '@material-ui/core/Paper';
@@ -297,7 +297,7 @@ const UsersMenu = ({classes}: {
               }
               {isEAForum && <DropdownItem
                 title={"Post stats"}
-                to={`/users/${currentUser.slug}/stats`}
+                to={userGetAnalyticsUrl(currentUser)}
                 icon="BarChart"
                 iconClassName={classes.icon}
               />}

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -1,6 +1,6 @@
 import bowser from 'bowser';
 import { isClient, isServer } from '../../executionEnvironment';
-import { forumTypeSetting, isEAForum, isLW, lowKarmaUserVotingCutoffDateSetting, lowKarmaUserVotingCutoffKarmaSetting } from "../../instanceSettings";
+import { forumTypeSetting, isEAForum } from "../../instanceSettings";
 import { getSiteUrl } from '../../vulcan-lib/utils';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
 import React, { useEffect, useState } from 'react';
@@ -10,7 +10,6 @@ import { Components } from '../../vulcan-lib';
 import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
 import moment from 'moment';
-import { MODERATOR_ACTION_TYPES } from '../moderatorActions/schema';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -335,6 +334,16 @@ export const userGetProfileUrlFromSlug = (userSlug: string, isAbsolute=false): s
   
   const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
   return `${prefix}/users/${userSlug}`;
+}
+
+export const userGetAnalyticsUrl = (user: {slug: string}, isAbsolute=false): string => {
+  if (!user) return "";
+
+  if (user.slug) {
+    return `${userGetProfileUrlFromSlug(user.slug, isAbsolute)}/stats`;
+  } else {
+    return "";
+  }
 }
 
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -32,6 +32,7 @@ importComponent("AlignmentForumHome", () => require('../components/alignment-for
 
 importComponent("AnalyticsGraph", () => require('../components/analytics/AnalyticsGraph'))
 importComponent("AuthorAnalyticsPage", () => require('../components/analytics/AuthorAnalyticsPage'))
+importComponent("MyAnalyticsPage", () => require('../components/analytics/MyAnalyticsPage'))
 importComponent("PostsAnalyticsPage", () => require('../components/analytics/PostsAnalyticsPage'));
 importComponent("AnalyticsDisclaimers", () => require('../components/analytics/AnalyticsDisclaimers'));
 importComponent("DateRangeModal", () => require('../components/analytics/DateRangeModal'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -713,6 +713,11 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       componentName: "AuthorAnalyticsPage",
     },
     {
+      name: "myAnalytics",
+      path:'/my-stats',
+      componentName: "MyAnalyticsPage",
+    },
+    {
       name: 'EAGApplicationData',
       path: '/api/eag-application-data'
     },


### PR DESCRIPTION
This will be useful for nudging people to use the page in comments/DMs etc

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206546611557954) by [Unito](https://www.unito.io)
