### PR TITLE
Make all hookToHocs create a forward ref

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -364,7 +364,6 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
         button.setAttribute('href', validateUrl(dataHref));
       }
       button.addEventListener('click', () => {
-        // Note: there is some concern about this 
         this.props.captureEvent("ctaButtonClicked", {href: dataHref})
       })
     }
@@ -451,9 +450,6 @@ const addNofollowToHTML = (html: string): string => {
 
 
 const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
-  // This component can't have HoCs because it's used with a ref, to call
-  // methods on it from afar, and many HoCs won't pass the ref through.
-  // TODO clarify in PR review
   hocs: [withTracking]
 });
 

--- a/packages/lesswrong/lib/hocUtils.tsx
+++ b/packages/lesswrong/lib/hocUtils.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
 
-// Given a hook function, return a higher-order component which calls it and
-// adds the result as extra props. If componentPropsToHookParams is given, calls
-// it on the component's props and passes the result as an argument to hookFn;
-// otherwise hookFn is assumed to take no arguments.
-export function hookToHoc(hookFn: any, componentPropsToHookParams?: (props: Record<string,any>) => Record<string,any>) {
-  return (Component: AnyBecauseTodo) => (props: AnyBecauseTodo) => {
-    const hookProps = componentPropsToHookParams ? hookFn(componentPropsToHookParams(props)) : hookFn();
-    return <Component {...props} {...hookProps}/>;
+/**
+ * Given a hook function, return a higher-order component which calls it and
+ * adds the result as extra props. If componentPropsToHookParams is given, calls
+ * it on the component's props and passes the result as an argument to hookFn;
+ * otherwise hookFn is assumed to take no arguments.
+ *
+ * Components may or may not accept a ref. If they are, we need to forward the
+ * ref to the underlying component, so we use forwardRef here.
+ */
+export function hookToHoc<P, HP, HR>(
+  hookFn: (hookParams?: HP) => HR,
+  componentPropsToHookParams?: (props: P) => HP
+) {
+  return (Component: React.ComponentType<P & HR>) => {
+    const WithHook = (props: P, ref: React.Ref<any>) => {
+      const hookParams = componentPropsToHookParams ? componentPropsToHookParams(props) : undefined;
+      const hookProps = hookParams !== undefined ? hookFn(hookParams) : hookFn();
+      return <Component ref={ref} {...props} {...hookProps} />;
+    };
+    return React.forwardRef(WithHook);
   }
 }


### PR DESCRIPTION
This is a bit of cleanup I missed in https://github.com/ForumMagnum/ForumMagnum/pull/8704#discussion_r1476120430 , there was a comment in the ContentItemBody code about not using HoCs in components that might need to accept a ref. I didn't find any problems with doing this when testing the original PR, so I did add a `withTracking` HoC. Upon testing further, I have now found a console error that occurs as a result of this, and this will possibly break things like side comments that use a ref to the content of a post (EDIT: it appears side comments were not actually broken by the previous change).

In this PR I have made it so `hookToHoc` forwards a ref to the underlying component by default. At first I made this a separate function, but then I tried replacing the original and it appears it doesn't cause any problems to wrap components in a `forwardRef`. It probably would cause a problem if you tried to pass a ref to a HoC where the underlying component can't accept it, but hopefully this would be obvious (because that wouldn't work even without the HoC)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206554344685711) by [Unito](https://www.unito.io)
