### PR TITLE
[WIP] Bundle-split react map gl

### DIFF
--- a/build.js
+++ b/build.js
@@ -148,6 +148,22 @@ build({
   },
 });
 
+build({
+  entryPoints: ['./packages/lesswrong/splits/react-map-gl.ts'],
+  bundle: true,
+  target: "es6",
+  sourcemap: true,
+  metafile: true,
+  sourcesContent: true,
+  outfile: `${getOutputDir()}/shared/js/react-map-gl.js`,
+  minify: isProduction,
+  banner: {
+    js: clientBundleBanner,
+  },
+  treeShaking: "ignore-annotations",
+  run: false,
+});
+
 let serverCli = ["node", "-r", "source-map-support/register", "--", `${getOutputDir()}/server/js/serverBundle.js`, "--settings", settingsFile]
 if (opts.shell)
   serverCli.push("--shell");

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { createStyles } from '@material-ui/core/styles';
-import ReactMapGL, { Marker } from 'react-map-gl';
 import { Helmet } from 'react-helmet'
 import { mapboxAPIKeySetting } from '../../../lib/publicSettings';
 import { connectHits } from 'react-instantsearch-dom';
@@ -9,6 +8,7 @@ import PersonIcon from '@material-ui/icons/PersonPin';
 import { Hit } from 'react-instantsearch-core';
 import classNames from 'classnames';
 import { isFriendlyUI } from '../../../themes/forumTheme';
+import { useReactMapGL } from '../../../splits/useReactMapGl';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
@@ -66,6 +66,7 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, className, cl
   className?: string,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
   const [activeResultId, setActiveResultId] = useState('')
   
   const [viewport, setViewport] = useState({
@@ -103,6 +104,9 @@ const SearchResultsMap = ({center = defaultCenter, zoom = 2, hits, className, cl
   
   
   const { StyledMapPopup } = Components
+  
+  if (!ready) return <Components.Loading/>;
+  const { ReactMapGL, Marker } = reactMapGL;
   
   return <div className={classNames(classes.root, className)}>
     <Helmet>

--- a/packages/lesswrong/components/hooks/useFirstRender.tsx
+++ b/packages/lesswrong/components/hooks/useFirstRender.tsx
@@ -14,3 +14,8 @@ export const useForceRerender = () => {
   }, []);
   return isFirstRender;
 }
+
+export const useRerender = () => {
+  const [renderCount,setRenderCount] = useState(0);
+  return () => setRenderCount(renderCount+1);
+}

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -4,7 +4,6 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { createStyles } from '@material-ui/core/styles';
 import { userGetDisplayName, userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { useLocation } from '../../lib/routeUtil';
-import ReactMapGL, { Marker } from 'react-map-gl';
 import { Helmet } from 'react-helmet'
 import * as _ from 'underscore';
 import { mapboxAPIKeySetting } from '../../lib/publicSettings';
@@ -12,6 +11,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import PersonIcon from '@material-ui/icons/Person';
 import classNames from 'classnames';
 import {isFriendlyUI} from '../../themes/forumTheme'
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
@@ -87,6 +87,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
   hideLegend?: boolean,
   petrovButton?: boolean,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
   const { query } = useLocation()
   const groupQueryTerms: LocalgroupsViewTerms = groupTerms || {view: "all", filters: query?.filters || [], includeInactive: query?.includeInactive === 'true'}
 
@@ -173,6 +174,9 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
 
   if (!showMap) return null
 
+  if (!ready) return null;
+  const { ReactMapGL } = reactMapGL;
+  
   return <div className={classNames(classes.root, {[className]: className})}>
       <Helmet> 
         <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
@@ -206,6 +210,10 @@ const PersonalMapLocationMarkers = ({users, handleClick, handleClose, openWindow
   openWindows: any,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
+  if (!ready) return null;
+  const { Marker } = reactMapGL;
+  
   const { StyledMapPopup } = Components
   return <React.Fragment>
     {users.map(user => {

--- a/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
 import { ArrowSVG } from './Icons';
 import RoomIcon from '@material-ui/icons/Room';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   icon: {
@@ -30,6 +30,10 @@ const LocalEventMarker = ({ event, handleMarkerClick, handleInfoWindowClose, inf
   location: any,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
+  if (!ready) return null;
+  const { Marker } = reactMapGL;
+  
   if (!location?.geometry?.location?.lat || !location?.geometry?.location?.lng) return null
   const { geometry: {location: {lat, lng}}} = location
   const { htmlHighlight = "" } = event.contents || {}

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { GroupIconSVG } from './Icons'
-import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   icon: {
@@ -28,6 +28,10 @@ const LocalGroupMarker = ({ group, handleMarkerClick, handleInfoWindowClose, inf
   location: any,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
+  if (!ready) return null;
+  const { Marker } = reactMapGL;
+  
   if (!location?.geometry?.location?.lat || !location?.geometry?.location?.lng) return null
   const { geometry: {location: {lat, lng}}} = location
 

--- a/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
+++ b/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { createStyles } from '@material-ui/core/styles';
-import ReactMapGL from 'react-map-gl';
 import { Helmet } from 'react-helmet'
 import * as _ from 'underscore';
 import { mapboxAPIKeySetting } from '../../lib/publicSettings';
-import { forumTypeSetting } from '../../lib/instanceSettings';
 import {isFriendlyUI} from '../../themes/forumTheme'
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   previewWrapper: {
@@ -15,84 +14,66 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     maxWidth: 300
   }
 }));
-interface SmallMapPreviewProps extends WithStylesProps {
+
+const SmallMapPreview = ({post, group, zoom, classes}: {
   post: PostsList,
   group?: any,
   zoom?: number,
-}
-interface SmallMapPreviewState {
-  openWindows: Array<any>,
-  viewport: any,
-}
+  classes: ClassesType,
+}) => {
+  const { ready, reactMapGL } = useReactMapGL();
+  let document = (post || group);
+  const googleLocation = document.googleLocation
+  let center = googleLocation?.geometry?.location
+  const [openWindows, setOpenWindows] = useState<string[]>([]);
+  const [viewport, setViewport] = useState(center && {
+    latitude: center.lat,
+    longitude: center.lng,
+    zoom: zoom || 13
+  });
 
-class SmallMapPreview extends Component<SmallMapPreviewProps,SmallMapPreviewState> {
-  constructor(props: SmallMapPreviewProps) {
-    super(props);
-    let document = this.getDocument()
-    const googleLocation = document.googleLocation
-    let center = googleLocation?.geometry?.location
-    this.state = {
-      openWindows: [],
-      viewport: center && {
-        latitude: center.lat,
-        longitude: center.lng,
-        zoom: this.props.zoom || 13
-      }
-    }
+  const handleMarkerClick = (id: string) => {
+    setOpenWindows([...openWindows, id]);
   }
 
-  handleMarkerClick = (id: string) => {
-    this.setState({openWindows: [...this.state.openWindows, id]})
+  const handleInfoWindowClose = (id: string) => {
+    setOpenWindows(_.without(openWindows, id))
   }
 
-  handleInfoWindowClose = (id: string) => {
-    this.setState({openWindows: _.without(this.state.openWindows, id)})
-  }
+  if (!viewport) return null
+  if (!ready) return <Components.Loading/>;
+  const { ReactMapGL } = reactMapGL;
 
-  getDocument = () => {
-    const { post, group } = this.props;
-    return post || group
-  }
-
-  render() {
-    const { post, group, classes } = this.props
-    const { viewport } = this.state
-
-    const isEAForum = forumTypeSetting.get() === 'EAForum';
-    
-    if (!viewport) return null
-
-    return <div className={classes.previewWrapper}>
-      <Helmet> 
-        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
-      </Helmet>
-      <ReactMapGL
-        {...viewport}
-        width="100%"
-        height="100%"
-        mapStyle={isFriendlyUI ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
-        onViewportChange={viewport => this.setState({ viewport })}
-        mapboxApiAccessToken={mapboxAPIKeySetting.get()}
-      >
-          {post && <Components.LocalEventMarker
+  return <div className={classes.previewWrapper}>
+    <Helmet> 
+      <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
+    </Helmet>
+    <ReactMapGL
+      {...viewport}
+      width="100%"
+      height="100%"
+      mapStyle={isFriendlyUI ? undefined : "mapbox://styles/habryka/cilory317001r9mkmkcnvp2ra"}
+      onViewportChange={viewport => setViewport(viewport)}
+      mapboxApiAccessToken={mapboxAPIKeySetting.get()}
+    >
+        {post && <Components.LocalEventMarker
           key={post._id}
           event={post}
           location={post.googleLocation}
-          handleMarkerClick={this.handleMarkerClick}
-          handleInfoWindowClose={this.handleInfoWindowClose}
-          infoOpen={this.state.openWindows.includes(post._id)}
-                  /> }
-          {group && <Components.LocalGroupMarker
-            key={group._id}
-            group={group}
-            location={group.googleLocation}
-            handleMarkerClick={this.handleMarkerClick}
-            handleInfoWindowClose={this.handleInfoWindowClose}
-            infoOpen={this.state.openWindows.includes(group._id)}
-                    />}
-      </ReactMapGL>
-    </div>
-  }
+          handleMarkerClick={handleMarkerClick}
+          handleInfoWindowClose={handleInfoWindowClose}
+          infoOpen={openWindows.includes(post._id)}
+        />}
+        {group && <Components.LocalGroupMarker
+          key={group._id}
+          group={group}
+          location={group.googleLocation}
+          handleMarkerClick={handleMarkerClick}
+          handleInfoWindowClose={handleInfoWindowClose}
+          infoOpen={openWindows.includes(group._id)}
+        />}
+    </ReactMapGL>
+  </div>
 }
 
 const SmallMapPreviewComponent = registerComponent("SmallMapPreview", SmallMapPreview, {styles});

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -2,8 +2,8 @@ import React, { ReactNode } from 'react';
 import { createStyles } from '@material-ui/core/styles';
 import { Link } from '../../lib/reactRouterWrapper';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { Popup } from 'react-map-gl';
 import { isEAForum } from '../../lib/instanceSettings';
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 // Shared with LocalEventMarker
 export const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -60,6 +60,10 @@ const StyledMapPopup = ({
   offsetLeft?: number,
   hideBottomLinks?: boolean
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
+  if (!ready) return null;
+  const { Popup } = reactMapGL;
+  
   return <Popup
     latitude={lat}
     longitude={lng}

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageCommunityMap.tsx
@@ -3,7 +3,6 @@ import { useUserLocation } from '../../../lib/collections/users/helpers';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { useCurrentUser } from '../../common/withUser';
 import { Helmet } from 'react-helmet'
-import ReactMapGL, { Marker } from 'react-map-gl';
 import { defaultCenter } from '../../localGroups/CommunityMap';
 import { mapboxAPIKeySetting } from '../../../lib/publicSettings';
 import { ArrowSVG } from '../../localGroups/Icons';
@@ -12,6 +11,7 @@ import { useSingle } from '../../../lib/crud/withSingle';
 import { ACX_EVENTS_LAST_UPDATED, LocalEvent, localEvents } from './acxEvents';
 import classNames from 'classnames';
 import moment from 'moment';
+import { useReactMapGL } from '../../../splits/useReactMapGl';
 
 const styles = (theme: JssStyles) => ({
   root: {
@@ -100,6 +100,7 @@ const LocalEventMapMarkerWrappers = ({localEvents, classes}: {
   localEvents: Array<LocalEvent>,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
   const { LocalEventWrapperPopUp } = Components
   const [ openWindows, setOpenWindows ] = useState<string[]>([])
   const handleClick = useCallback(
@@ -117,6 +118,9 @@ const LocalEventMapMarkerWrappers = ({localEvents, classes}: {
   if (threeMonthsAgo.isAfter(ACX_EVENTS_LAST_UPDATED)) {
     return null;
   }
+  
+  if (!ready) return <Components.Loading/>;
+  const { Marker } = reactMapGL;
   
   return <React.Fragment>
     {localEvents.map(localEvent => {
@@ -146,6 +150,7 @@ export const HomepageCommunityMap = ({dontAskUserLocation = false, classes}: {
   dontAskUserLocation?: boolean,
   classes: ClassesType,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
   const { LocalEventMapMarkerWrappers, HomepageMapFilter } = Components
 
   const currentUser = useCurrentUser()
@@ -167,6 +172,9 @@ export const HomepageCommunityMap = ({dontAskUserLocation = false, classes}: {
       </div>
     </>
   }, [LocalEventMapMarkerWrappers, HomepageMapFilter, classes.mapButtons])
+  
+  if (!ready) return <Components.Loading/>;
+  const { ReactMapGL } = reactMapGL;
   
   return <div className={classes.root}>
     <Helmet> 

--- a/packages/lesswrong/components/seasonal/PetrovDayButton.tsx
+++ b/packages/lesswrong/components/seasonal/PetrovDayButton.tsx
@@ -5,7 +5,6 @@ import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser';
-import ReactMapGL from 'react-map-gl';
 import { Helmet } from 'react-helmet';
 import { DatabasePublicSetting, mapboxAPIKeySetting } from '../../lib/publicSettings';
 import { useMutation, gql } from '@apollo/client';
@@ -15,6 +14,7 @@ import {
   userCanLaunchPetrovMissile,
   usersAboveKarmaThresholdHardcoded20220922
 } from "../../lib/petrovHelpers";
+import { useReactMapGL } from '../../splits/useReactMapGl';
 
 export const petrovPostIdSetting = new DatabasePublicSetting<string>('petrov.petrovPostId', '')
 const petrovGamePostIdSetting = new DatabasePublicSetting<string>('petrov.petrovGamePostId', '')
@@ -144,6 +144,7 @@ const PetrovDayButton = ({classes, refetch, alreadyLaunched }: {
   refetch?: any,
   alreadyLaunched?: boolean,
 }) => {
+  const { ready, reactMapGL } = useReactMapGL();
   const currentUser = useCurrentUser()
   const { petrovPressedButtonDate } = (currentUser || {}) as any;
   const [pressed, setPressed] = useState(false) //petrovPressedButtonDate)
@@ -199,6 +200,8 @@ const PetrovDayButton = ({classes, refetch, alreadyLaunched }: {
   const beforePressMessage = <p>press button to initiate missile launch procedure</p>
   const afterPressMessage = disableLaunchButton ? <p>You are not authorized to initiate a missile strike at this time. Try again later.</p> : <p>enter launch code to initiate missile strike</p>
   
+  if (!ready) return <Components.Loading/>;
+  const { ReactMapGL } = reactMapGL;
 
   return (
     <div className={classes.root}>

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -20,6 +20,7 @@ import * as Sentry from '@sentry/node';
 import express from 'express'
 import { app } from './expressServer';
 import path from 'path'
+import fs from 'fs';
 import { getPublicSettingsLoaded } from '../lib/settingsCache';
 import { embedAsGlobalVar } from './vulcan-lib/apollo-ssr/renderUtil';
 import { addStripeMiddleware } from './stripeMiddleware';
@@ -215,6 +216,14 @@ export function startWebserver() {
       res.end(bundleBuffer);
     }
   });
+  addStaticRoute("/js/react-map-gl.js", ({query}, req, res, context) => {
+    // TODO: Pass around a hash, cache a copy, do the same invalidation stuff
+    // we do with the main bundle
+    const buffer = fs.readFileSync("build/shared/js/react-map-gl.js");
+    res.writeHead(200);
+    res.end(buffer);
+  });
+
   // Setup CKEditor Token
   app.use("/ckeditor-token", ckEditorTokenHandler)
   

--- a/packages/lesswrong/splits/react-map-gl.ts
+++ b/packages/lesswrong/splits/react-map-gl.ts
@@ -1,0 +1,3 @@
+import ReactMapGL, { Marker, Popup } from 'react-map-gl';
+
+(window as any).reactMapGL = { ReactMapGL, Marker, Popup };

--- a/packages/lesswrong/splits/useReactMapGl.ts
+++ b/packages/lesswrong/splits/useReactMapGl.ts
@@ -1,0 +1,55 @@
+import { useRerender } from '../components/hooks/useFirstRender';
+import { isClient } from '../lib/executionEnvironment';
+
+type WrappedReactMapGL = any;
+
+const libraryLoadStatus: Record<string, "loading"|"ready"> = {};
+
+function useLoadedLibrary<T>({path, windowField}: {
+  path: string,
+  windowField: string,
+}): { ready: false } | { ready: true, library: T } {
+  const rerender = useRerender();
+  
+  if (libraryLoadStatus[path] === 'ready') {
+    return {
+      ready: true,
+      library: (window as any)[windowField],
+    };
+  }
+
+  if (isClient) {
+    void (async () => {
+      if (!(path in libraryLoadStatus)) {
+        libraryLoadStatus[path] = "loading";
+        await loadScript(path);
+        libraryLoadStatus[path] = "ready";
+        rerender();
+      }
+    })();
+  }
+  
+  return { ready: false };
+}
+
+function loadScript(path: string): Promise<void> {
+  return new Promise((ready, error) => {
+    const head = document.head;
+    const scriptTag = document.createElement("script")
+    scriptTag.src = path;
+    scriptTag.onload = () => ready();
+    scriptTag.onerror = () => error();
+    head.appendChild(scriptTag);
+  });
+}
+
+export function useReactMapGL(): {
+  ready: boolean,
+  reactMapGL: WrappedReactMapGL,
+} {
+  const result =  useLoadedLibrary<WrappedReactMapGL>({
+    path: "/js/react-map-gl.js",
+    windowField: "reactMapGL",
+  });
+  return { ready: result.ready, reactMapGL: result.ready ? result.library : null };
+}


### PR DESCRIPTION
This splits `react-map-gl` (and its large dependency `mapbox`) into a separate Javascript file, so that pages which don't have a map on them don't need to download the corresponding Javascript. This decreases the uncompressed bundle size from 20710567 to 19220671 (about 7%).

This is primarily written as a proof-of-concept for the bundle-splitting technique, which I think can also be applied to other large libraries that aren't used on every page, most notably CKEditor and recharts. This is not yet what I would consider production-ready, but it actually works quite well for how simple it is.

Fundamental limitations of this technique:
 * The main limitation is that a segment that has been split off can export things that the main bundle will use, but imports can't go in the other direction. As a result, the split-off file `react-map-gl.js` contains a partial duplicative copy of React (tree-shaken down to ~50kb). This is worth it for things that are present on only a subset of pages and which have a dependency footprint that's mostly disjoint from what's used by the main bundle (which describes the things we want to split in practice), but means we can't go overboard with it.

Limitations that should be straightforward to fix:
 * Maps are excluded from SSR and only rendered client side. Fixing this requires a bit of extra plumbing but does not pose any fundamental challenges.
 * There's a bunch of handling with cache headers, pre-compression with brotli, and so on which we do for the client bundle, but which isn't being applied to the split-off bundle
 * Typescript types are lost at the bundle-split boundary

This is *not* the esbuild-based bundle-splitting technique that we explored  awhile ago and gave up on (IIRC because it would have required use to use ESM output format, which created other problems).