### PR TITLE
Disable custom metrics for cache hits

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -284,16 +284,16 @@ export function recordDatadogCacheEvent(cacheEvent: {path: string, userAgent: st
 }
 
 export function recordCacheHit(cacheEvent: {path: string, userAgent: string}) {
-  recordDatadogCacheEvent({...cacheEvent, type: "hit"});
+  // recordDatadogCacheEvent({...cacheEvent, type: "hit"}); // Useful for debugging, but expensive to track all the time
   cacheHits++;
   cacheQueriesTotal++;
 }
 export function recordCacheMiss(cacheEvent: {path: string, userAgent: string}) {
-  recordDatadogCacheEvent({...cacheEvent, type: "miss"});
+  // recordDatadogCacheEvent({...cacheEvent, type: "miss"}); // Useful for debugging, but expensive to track all the time
   cacheQueriesTotal++;
 }
 export function recordCacheBypass(cacheEvent: {path: string, userAgent: string}) {
-  recordDatadogCacheEvent({...cacheEvent, type: "bypass"});
+  // recordDatadogCacheEvent({...cacheEvent, type: "bypass"}); // Useful for debugging, but expensive to track all the time
   cacheQueriesTotal++;
 }
 export function getCacheHitRate() {


### PR DESCRIPTION
I previously [reduced the sampling rate](https://github.com/ForumMagnum/ForumMagnum/pull/8724) of these events to save money. It's still relatively expensive to track them (will be >>$100/mo) and we don't really need them since they were mainly added to debug the db level page cache, which has been working for a while now, so I'm now disabling them completely

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206559950206558) by [Unito](https://www.unito.io)
