### PR TITLE
Update event title placeholder text

### DIFF
--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -26,8 +26,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const placeholders: Record<PostCategory, string> = {
+const placeholders: Record<PostCategory|"event", string> = {
   "post": "Post title",
+  "event": "Event name",
   "question": "Question title",
   "linkpost": "Linkpost title"
 }
@@ -46,9 +47,9 @@ const EditTitle = ({document, value, path, placeholder, updateCurrentValues, cla
     collectionName: "Posts",
     fragmentName: 'PostsMinimumInfo',
   });
-  const { question, postCategory } = document;
+  const { isEvent, question, postCategory } = document;
 
-  const effectiveCategory = question ? "question" as const : postCategory as PostCategory;
+  const effectiveCategory = isEvent ? "event" : question ? "question" as const : postCategory as PostCategory;
   const displayPlaceholder = placeholders[effectiveCategory];
 
   const handleChangeTitle = useCallback((event) => {


### PR DESCRIPTION
I was creating a new event and thought the placeholder text of "Post title" was confusing, so I updated it for events.

<img width="667" alt="Screen Shot 2024-02-09 at 3 26 27 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/e873cfe7-4c51-4696-bb4b-c82e66be76ba">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206567245247180) by [Unito](https://www.unito.io)
