### PR TITLE
Make clicking on checkbox work for 'hide community' in quick takes section

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -75,9 +75,9 @@ const QuickTakesSection = ({classes}: {
           placement="left"
           hideOnTouchScreens
         >
-          <div className={classes.communityToggle}>
-            <Checkbox checked={showCommunity} onChange={toggleShowCommunity} />
-            <span onClick={toggleShowCommunity}>Show community</span>
+          <div className={classes.communityToggle} onClick={toggleShowCommunity}>
+            <Checkbox checked={showCommunity} />
+            <span>Show community</span>
           </div>
         </LWTooltip>
       )}


### PR DESCRIPTION
Clicking on the checkbox itself wasn't working to show/hide community posts, but clicking on the text did work. I would guess this was due to the tooltip, I've just moved the `onClick` up a level to cover both of these now

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206579760184880) by [Unito](https://www.unito.io)
