### PR TITLE
Make links in popular comments clickable

### DIFF
--- a/packages/lesswrong/components/comments/PopularComment.tsx
+++ b/packages/lesswrong/components/comments/PopularComment.tsx
@@ -131,7 +131,10 @@ const PopularComment = ({comment, classes}: {
     captureEvent("popularCommentToggleExpanded", {expanded: !expanded});
   }, [expanded, captureEvent]);
 
-  const {onClick} = useClickableCell({onClick: onClickCallback});
+  const {onClick} = useClickableCell({
+    onClick: onClickCallback,
+    ignoreLinks: true,
+  });
 
   const {UsersName, LWTooltip, SmallSideVote, CommentBody} = Components;
   return (


### PR DESCRIPTION
Fixes a bug where clicking links in popular comments toggles the expansion of the comment rather than redirecting to the link.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206584319866139) by [Unito](https://www.unito.io)
