### PR TITLE
moving triple dot menu from right to left side on mobile

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -497,7 +497,7 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
             <div className={classes.mobileSecondRowSpacer}/>
 
             {<div className={classes.mobileActions}>
-              {!resumeReading && <PostActionsButton post={post} />}
+              {!resumeReading && <PostActionsButton post={post} autoPlace />}
             </div>}
 
             {showIcons && <div className={classes.nonMobileIcons}>

--- a/packages/lesswrong/components/posts/PostsItemTrailingButtons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemTrailingButtons.tsx
@@ -93,7 +93,7 @@ const PostsItemTrailingButtons = ({
     <>
       {(showDismissButton || resumeReading || isBookUI) && <div className={classes.actions}>
         <DismissButton {...{showDismissButton, onDismiss}} />
-        {isBookUI && !resumeReading && currentUser && <PostActionsButton post={post} vertical />}
+        {isBookUI && !resumeReading && currentUser && <PostActionsButton post={post} vertical autoPlace />}
       </div>}
       {showArchiveButton && <div className={classes.archiveButton}>
         { post.deletedDraft ?


### PR DESCRIPTION
This PR fixes the problem where on mobile, the triple dot menu for posts opens mostly offscreen. It moves the menu from opening on the right to opening on the left. This doesn't fully solve the problem in cases where there are multiple icons (e.g. curated star, alignment forum crosspost, etc), but it is still an improvement. TODO in future PR: make the popup div smaller or reorder the icons (or another fix) to have the full menu appear onscreen. 