### PR TITLE
change width/etc to minWidth/etc for tables published from ckeditor to fix all tags display

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -387,8 +387,8 @@ const baseBodyStyles = (theme: ThemeType): JssStyles => ({
   },
   // CKEditor wraps tables in a figure element
   '& figure.table': {
-    width: 'fit-content !important',
-    height: 'fit-content !important',
+    minWidth: 'fit-content !important',
+    minHeight: 'fit-content !important',
   },
   // Many column tables should overflow instead of squishing
   //  - NB: As of Jan 2023, this does not work on firefox, so ff users will have


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/6322 caused the tables in https://www.lesswrong.com/tags/all to be too narrow:
<img width="1728" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/8d3e1d88-df51-45a7-9300-f6db69ae4327">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206586512433147) by [Unito](https://www.unito.io)
