### PR TITLE
don't show deleted tags in the sunshine sidebar

### DIFF
--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -153,7 +153,8 @@ ensureIndex(Tags, {deleted: 1, createdAt: 1});
 Tags.addView('unreviewedTags', (terms: TagsViewTerms) => {
   return {
     selector: {
-      needsReview: true
+      needsReview: true,
+      deleted: false
     },
     options: {
       sort: {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206587517973553) by [Unito](https://www.unito.io)
