### PR TITLE
[EA Forum only] small layout fix for sticky digest ad

### DIFF
--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -51,7 +51,8 @@ const styles = (theme: ThemeType) => ({
     }
   },
   textCol: {
-    flexGrow: 1
+    flexGrow: 1,
+    minWidth: 'max-content',
   },
   heading: {
     fontWeight: 600,


### PR DESCRIPTION
I just noticed that the layout in the ad shifts when a logged in user subscribes, so I fixed it.

Before:
<img width="905" alt="Screen Shot 2024-02-13 at 11 55 10 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/a93dd1fe-bba1-46f9-87ab-7e1dde988ea1">

After:
<img width="905" alt="Screen Shot 2024-02-13 at 11 57 24 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/ba68a826-dea1-4018-96d6-6064bdd1e066">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206593970809777) by [Unito](https://www.unito.io)
