### PR TITLE
flush analytics events beforeunload

### DIFF
--- a/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
+++ b/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { useTracking } from "../../lib/analyticsEvents";
+import { flushClientEvents, useTracking } from "../../lib/analyticsEvents";
 import { isClient } from '../../lib/executionEnvironment';
 import { useEventListener } from '../hooks/useEventListener';
 
 function useBeforeUnloadTracking() {
   const { captureEvent } = useTracking()
   const trackBeforeUnload = useCallback(
-    () => captureEvent("beforeUnloadFired"),
+    () => {
+      captureEvent("beforeUnloadFired")
+      flushClientEvents()
+    },
     [captureEvent]
   );
 

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -394,7 +394,7 @@ Globals.captureEvent = captureEvent;
 
 let pendingAnalyticsEvents: Array<any> = [];
 
-function flushClientEvents() {
+export function flushClientEvents() {
   if (!AnalyticsUtil.clientWriteEvents)
     return;
   if (!pendingAnalyticsEvents.length)


### PR DESCRIPTION
Sometimes we fire multiple analytics events right before, say, navigating to an external link. My understanding is that throttling causes only the first of those events to get saved, and the rest are lost. Hopefully this fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206602976553623) by [Unito](https://www.unito.io)
