### PR TITLE
skip looking up manifold cache entries when missing market id

### DIFF
--- a/packages/lesswrong/server/posts/annualReviewMarkets.ts
+++ b/packages/lesswrong/server/posts/annualReviewMarkets.ts
@@ -123,6 +123,10 @@ async function refreshMarketInfoInCache(post: DbPost) {
 }
 
 export const getPostMarketInfo = async (post: DbPost): Promise<AnnualReviewMarketInfo | undefined>  => {
+  if (!post.manifoldReviewMarketId) {
+    return undefined;
+  }
+  
   const cacheItem = await ManifoldProbabilitiesCaches.findOne({
     marketId: post.manifoldReviewMarketId
   });


### PR DESCRIPTION
We're currently doing a whole bunch of useless-at-best lookups when we don't have a `manifoldReviewMarketId` on a post.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206617630005171) by [Unito](https://www.unito.io)
