### PR TITLE
move mobile post actions menu to be next to comment count

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -502,12 +502,12 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
 
             <div className={classes.mobileSecondRowSpacer}/>
 
-            {<div className={classes.mobileActions}>
-              {!resumeReading && <PostActionsButton post={post} autoPlace />}
-            </div>}
-
             {showIcons && <div className={classes.nonMobileIcons}>
               <PostsItemIcons post={post}/>
+            </div>}
+
+            {<div className={classes.mobileActions}>
+              {!resumeReading && <PostActionsButton post={post} autoPlace />}
             </div>}
 
             {!resumeReading && <div className={classes.commentsIcon}>


### PR DESCRIPTION
On mobile, the post actions menu is currently to the left of various post icons (when they're present).  It should always just be next to the comment count icon, instead.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206618069911720) by [Unito](https://www.unito.io)
