### PR TITLE
make useOnNotificationsChanged generic on event type

### DIFF
--- a/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
+++ b/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
@@ -45,14 +45,12 @@ export const DebateTypingIndicator = ({classes, post}: {
     }
   }, INCIDATOR_UPDATE_PERIOD));
 
-  useOnNotificationsChanged(currentUser, (message) => {
-    if (message.eventType === 'typingIndicator') {
-      const typingIndicators = message.typingIndicators
-      const filteredIndicators = typingIndicators.filter((typingIndicator) => {
-        return typingIndicator.documentId === post._id
-      })
-      setTypingIndicators(filteredIndicators)
-    }
+  useOnNotificationsChanged('typingIndicator', currentUser, (message) => {
+    const typingIndicators = message.typingIndicators
+    const filteredIndicators = typingIndicators.filter((typingIndicator) => {
+      return typingIndicator.documentId === post._id
+    })
+    setTypingIndicators(filteredIndicators)
   });
 
   if (!currentUser) return null;

--- a/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
+++ b/packages/lesswrong/components/comments/DebateTypingIndicator.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import { fragmentTextForQuery, registerComponent } from '../../lib/vulcan-lib';
-import {useOnNotificationsChanged} from '../hooks/useUnreadNotifications';
+import {useOnServerSentEvent} from '../hooks/useUnreadNotifications';
 import {useCurrentUser} from '../common/withUser';
 import {useGlobalKeydown} from '../common/withGlobalKeydown';
 import {gql, useMutation} from '@apollo/client';
@@ -45,7 +45,7 @@ export const DebateTypingIndicator = ({classes, post}: {
     }
   }, INCIDATOR_UPDATE_PERIOD));
 
-  useOnNotificationsChanged('typingIndicator', currentUser, (message) => {
+  useOnServerSentEvent('typingIndicator', currentUser, (message) => {
     const typingIndicators = message.typingIndicators
     const filteredIndicators = typingIndicators.filter((typingIndicator) => {
       return typingIndicator.documentId === post._id

--- a/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
+++ b/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useTracking } from "../../lib/analyticsEvents";
-import { ActiveDialogue, useOnNotificationsChanged } from '../hooks/useUnreadNotifications';
+import { ActiveDialogue, useOnServerSentEvent } from '../hooks/useUnreadNotifications';
 import { useCurrentUser } from '../common/withUser';
 import { postGetEditUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -104,7 +104,7 @@ export const ActiveDialogues = ({classes}: {
 
   const location = useLocation();
 
-  useOnNotificationsChanged('activeDialoguePartners', currentUser, (message) => {
+  useOnServerSentEvent('activeDialoguePartners', currentUser, (message) => {
     if (currentUser?._id && message.data) {  
       const otherActiveDialogues = message.data.filter((dialogue) => !location.pathname.includes(dialogue.postId) && !(location.query.postId === dialogue.postId)) // don't show a dialogue as active on its own page
       setActiveDialogues(otherActiveDialogues);

--- a/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
+++ b/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
@@ -104,8 +104,8 @@ export const ActiveDialogues = ({classes}: {
 
   const location = useLocation();
 
-  useOnNotificationsChanged(currentUser, (message) => {
-    if (message.eventType === 'activeDialoguePartners' && currentUser?._id && message.data) {  
+  useOnNotificationsChanged('activeDialoguePartners', currentUser, (message) => {
+    if (currentUser?._id && message.data) {  
       const otherActiveDialogues = message.data.filter((dialogue) => !location.pathname.includes(dialogue.postId) && !(location.query.postId === dialogue.postId)) // don't show a dialogue as active on its own page
       setActiveDialogues(otherActiveDialogues);
     }

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
@@ -59,6 +59,10 @@ export type NotificationCheckMessage = {
 
 export type ServerSentEventsMessage = ActiveDialoguePartnersMessage | TypingIndicatorMessage | NotificationCheckMessage;
 
+type EventType = ServerSentEventsMessage['eventType'];
+type MessageOfType<T extends EventType> = Extract<ServerSentEventsMessage, { eventType: T }>;
+type NotificationEventListener<T extends EventType> = (message: Extract<ServerSentEventsMessage, { eventType: T }>) => void;
+
 const notificationsCheckedAtLocalStorageKey = "notificationsCheckedAt";
 
 type UnreadNotificationsContext = {
@@ -177,16 +181,14 @@ export const UnreadNotificationsContextProvider: FC<{
   useOnNavigate(refetchBoth);
   useOnFocusTab(refetchBoth);
   
-  const refetchIfNewNotifications = useCallback((message: ServerSentEventsMessage) => {
-    if (message.eventType === 'notificationCheck') {
-      const timestamp = message.newestNotificationTime;
-      if (!checkedAt || (timestamp && new Date(timestamp) > new Date(checkedAt))) {
-        void refetchBoth();
-      }
+  const refetchIfNewNotifications = useCallback((message: NotificationCheckMessage) => {
+    const timestamp = message.newestNotificationTime;
+    if (!checkedAt || (timestamp && new Date(timestamp) > new Date(checkedAt))) {
+      void refetchBoth();
     }
   }, [checkedAt, refetchBoth]);
   
-  useOnNotificationsChanged(currentUser, refetchIfNewNotifications);
+  useOnNotificationsChanged('notificationCheck', currentUser, refetchIfNewNotifications);
   
   const notificationsOpened = useCallback(async () => {
     const now = new Date();
@@ -213,28 +215,30 @@ export const UnreadNotificationsContextProvider: FC<{
 
 export const useUnreadNotifications = () => useContext(unreadNotificationsContext);
 
-export const useOnNotificationsChanged = (currentUser: UsersCurrent|null, cb: (message: ServerSentEventsMessage) => void) => {
+export const useOnNotificationsChanged = <T extends EventType>(eventType: T, currentUser: UsersCurrent|null, cb: NotificationEventListener<T>) => {
   useEffect(() => {
     if (!currentUser)
       return;
-    const onServerSentNotification = (message: ServerSentEventsMessage) => {
+    const onServerSentNotification = (message: MessageOfType<T>) => {
       void cb(message);
     }
-    notificationEventListeners.push(onServerSentNotification);
+    getEventListenersOfType(eventType).push(onServerSentNotification);
     serverSentEventsAPI.setServerSentEventsActive?.(true);
     
     return () => {
-      notificationEventListeners = notificationEventListeners.filter(l=>l!==onServerSentNotification);
+      // Typescript really thinks `notificationEventListenersByType[eventType]` must a union of arrays, which makes it impossible to assign to normally
+      const remainingListenersOfType = getEventListenersOfType(eventType).filter(l=>l!==onServerSentNotification);
+      Object.assign(notificationEventListenersByType, { [eventType]: remainingListenersOfType });
       
       // When removing a server-sent event listener, wait 200ms (just in case this
       // is a rerender with a remove-and-immediately-add-back) then check whether
       // there are zero event listeners.
       setTimeout(() => {
-        if (!notificationEventListeners.length)
+        if (Object.values(notificationEventListenersByType).every(listeners => !listeners.length))
           serverSentEventsAPI.setServerSentEventsActive?.(false);
       }, 200);
     }
-  }, [currentUser, cb]);
+  }, [eventType, currentUser, cb]);
 }
 
 /**
@@ -260,10 +264,35 @@ function setFaviconBadge(notificationCount: number) {
   }
 }
 
-let notificationEventListeners: Array<(message: ServerSentEventsMessage) => void> = [];
+let notificationEventListenersByType = {
+  notificationCheck: [] as NotificationEventListener<'notificationCheck'>[],
+  activeDialoguePartners: [] as NotificationEventListener<'activeDialoguePartners'>[],
+  typingIndicator: [] as NotificationEventListener<'typingIndicator'>[],
+};
 
-export function onServerSentNotificationEvent(message: ServerSentEventsMessage) {
-  for (let listener of [...notificationEventListeners]) {
+function getEventListenersOfType<T extends EventType>(eventType: T): NotificationEventListener<T>[] {
+  return notificationEventListenersByType[eventType] as unknown as NotificationEventListener<T>[];
+}
+
+function listenToMessage<T extends EventType>(message: MessageOfType<T>, listeners: NotificationEventListener<T>[]) {
+  for (let listener of listeners) {
     listener(message);
   }
 }
+
+export function onServerSentNotificationEvent(message: ServerSentEventsMessage) {
+  // Unfortunately typescript isn't smart enough to track that the invariant is correct in a distributed way,
+  // so we need to narrow each individual case even if they're identical
+  switch (message.eventType) {
+    case 'notificationCheck':
+      listenToMessage(message, [...notificationEventListenersByType[message.eventType]]);
+      break;
+    case 'activeDialoguePartners':
+      listenToMessage(message, [...notificationEventListenersByType[message.eventType]]);
+      break;
+    case 'typingIndicator':
+      listenToMessage(message, [...notificationEventListenersByType[message.eventType]]);
+      break;
+  }
+}
+

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
@@ -188,7 +188,7 @@ export const UnreadNotificationsContextProvider: FC<{
     }
   }, [checkedAt, refetchBoth]);
   
-  useOnNotificationsChanged('notificationCheck', currentUser, refetchIfNewNotifications);
+  useOnServerSentEvent('notificationCheck', currentUser, refetchIfNewNotifications);
   
   const notificationsOpened = useCallback(async () => {
     const now = new Date();
@@ -215,7 +215,7 @@ export const UnreadNotificationsContextProvider: FC<{
 
 export const useUnreadNotifications = () => useContext(unreadNotificationsContext);
 
-export const useOnNotificationsChanged = <T extends EventType>(eventType: T, currentUser: UsersCurrent|null, cb: NotificationEventListener<T>) => {
+export const useOnServerSentEvent = <T extends EventType>(eventType: T, currentUser: UsersCurrent|null, cb: NotificationEventListener<T>) => {
   useEffect(() => {
     if (!currentUser)
       return;

--- a/packages/lesswrong/components/messaging/ConversationContents.tsx
+++ b/packages/lesswrong/components/messaging/ConversationContents.tsx
@@ -103,9 +103,7 @@ const ConversationContents = ({
     }
   }, [stateSignatureRef, results?.length, scrollRef, conversation._id]);
 
-  // TODO: re-enable this once we have a dedicated event type indicating a newly-received message.
-  // As-is, this was causing users to get rate limited since it polled our API once per second.
-  // useOnNotificationsChanged(currentUser, () => refetch());
+  useOnNotificationsChanged('notificationCheck', currentUser, () => refetch());
 
   // try to attribute this sent message to where the user came from
   const profileViewedFrom = useRef("");

--- a/packages/lesswrong/components/messaging/ConversationContents.tsx
+++ b/packages/lesswrong/components/messaging/ConversationContents.tsx
@@ -5,7 +5,7 @@ import withErrorBoundary from "../common/withErrorBoundary";
 import { useLocation } from "../../lib/routeUtil";
 import { useTracking } from "../../lib/analyticsEvents";
 import { getBrowserLocalStorage } from "../editor/localStorageHandlers";
-import { useOnNotificationsChanged } from "../hooks/useUnreadNotifications";
+import { useOnServerSentEvent } from "../hooks/useUnreadNotifications";
 import stringify from "json-stringify-deterministic";
 import {isFriendlyUI} from '../../themes/forumTheme.ts'
 
@@ -78,7 +78,7 @@ const ConversationContents = ({
 
   // Whenever either the number of messages changes, or the conversationId changes,
   // scroll to the bottom. This happens on pageload, and also happens when the messages
-  // list is refreshed because of the useOnNotificationsChanged() call below, if the refresh
+  // list is refreshed because of the useOnServerSentEvent() call below, if the refresh
   // increased the message count.
   //
   // Note, if you're refreshing (as opposed to navigating or opening a new
@@ -103,7 +103,7 @@ const ConversationContents = ({
     }
   }, [stateSignatureRef, results?.length, scrollRef, conversation._id]);
 
-  useOnNotificationsChanged('notificationCheck', currentUser, () => refetch());
+  useOnServerSentEvent('notificationCheck', currentUser, () => refetch());
 
   // try to attribute this sent message to where the user came from
   const profileViewedFrom = useRef("");

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -28,7 +28,7 @@ import { tagGetUrl } from '../../../lib/collections/tags/helpers';
 import isEmpty from 'lodash/isEmpty';
 import qs from 'qs';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
-import { useOnNotificationsChanged } from '../../hooks/useUnreadNotifications';
+import { useOnServerSentEvent } from '../../hooks/useUnreadNotifications';
 import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema';
 import isEqual from 'lodash/isEqual';
 import { unflattenComments } from '../../../lib/utils/unflatten';
@@ -443,7 +443,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     limit: 1000
   });
   
-  useOnNotificationsChanged('notificationCheck', currentUser, (message) => {
+  useOnServerSentEvent('notificationCheck', currentUser, (message) => {
     if (currentUser && isDialogueParticipant(currentUser._id, post)) {
       refetchDebateResponses();
     }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -443,11 +443,9 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     limit: 1000
   });
   
-  useOnNotificationsChanged(currentUser, (message) => {
-    if (message.eventType === 'notificationCheck') {
-      if (currentUser && isDialogueParticipant(currentUser._id, post)) {
-        refetchDebateResponses();
-      }
+  useOnNotificationsChanged('notificationCheck', currentUser, (message) => {
+    if (currentUser && isDialogueParticipant(currentUser._id, post)) {
+      refetchDebateResponses();
     }
   });
 


### PR DESCRIPTION
We've had intermittent reports of people getting 403s for a few months.  The root cause turned out to be the usage of `useOnNotificationsChanged` (now renamed to the more accurate `useOnServerSentEvent`) in `ConversationContents`, which was originally written back when there was only one type of server-sent event.  It invoked a `refetch`.  When we added a new SSE that informed users of any active dialogue participants, this caused anyone on a DM page to send one request per second to our API.  That just barely snuck under our original rate limit threshold.

This PR refactors the client-side hook to require an event type parameter, and enforces a generic constraint such that the event listener passed in must be able to handle that event type.  It then only runs the event listeners corresponding to each received SSE's type.  Every other listener passed into `useOnServerSentEvent` was already checking for a specific event type; this reduces the need for boilerplate and prevents it from being as much of a footgun.