### PR TITLE
add github action to make uploading ckeditor bundle if needed a blocking step for deploys

### DIFF
--- a/.github/actions/uploadCkEditorBundle/lwAction.yaml
+++ b/.github/actions/uploadCkEditorBundle/lwAction.yaml
@@ -1,0 +1,29 @@
+name: 'Upload ckEditor bundle'
+description: 'Upload ckEditor bundle'
+inputs:
+  mode:
+    description: 'Migrations mode: one of dev or prod'
+    required: true
+  credentials-repo:
+    description: 'Github credentials repo name'
+    required: true
+  credentials-pat:
+    description: 'Github personal access token for credentials repo'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup Environment
+      uses: ./.github/actions/setupEnvironment
+
+    - name: Clone credentials
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.credentials-repo }}
+        path: LessWrong-Credentials
+        token: ${{ inputs.credentials-pat }}
+        persist-credentials: false
+
+    - name: Upload ckEditor bundle
+      shell: bash
+      run: yarn upload-ckeditor-bundle ${{ inputs.mode }} lw

--- a/.github/workflows/deployLWAFProd.yaml
+++ b/.github/workflows/deployLWAFProd.yaml
@@ -18,9 +18,20 @@ jobs:
         mode: prod
         credentials-repo: ${{ secrets.LW_CREDENTIALS_REPO }}
         credentials-pat: ${{ secrets.LW_CREDENTIALS_REPO_PAT }}
+  upload-ckeditor-bundle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Upload ckEditor bundle
+      if: github.ref == 'refs/heads/lw-deploy'
+      uses: ./.github/actions/uploadCkEditorBundle/lwAction.yaml
+      with:
+        mode: prod
+        credentials-repo: ${{ secrets.LW_CREDENTIALS_REPO }}
+        credentials-pat: ${{ secrets.LW_CREDENTIALS_REPO_PAT }}
   deploy: 
     runs-on: ubuntu-latest
-    needs: migrate
+    needs: [migrate, upload-ckeditor-bundle]
     strategy:
       matrix: 
         node-version: [18.x]

--- a/deployCkEditorBundle.js
+++ b/deployCkEditorBundle.js
@@ -1,0 +1,128 @@
+// @ts-check
+/**
+ * Usage: yarn migrate up|down|pending|executed [dev|staging|prod] [forumType]
+ *
+ * If no environment is specified, you can use the environment variables PG_URL
+ * and SETTINGS_FILE
+ */
+require("ts-node/register");
+const { getDatabaseConfig, startSshTunnel } = require("./scripts/startup/buildUtil");
+
+const initGlobals = (args, isProd) => {
+  global.bundleIsServer = true;
+  global.bundleIsTest = false;
+  global.bundleIsCypress = false;
+  global.bundleIsProduction = isProd;
+  global.bundleIsMigrations = true;
+  global.defaultSiteAbsoluteUrl = "";
+  global.serverPort = 5001;
+  global.estrellaPid = -1;
+
+  const { getInstanceSettings } = require("./packages/lesswrong/lib/executionEnvironment");
+  getInstanceSettings(args); // These args will be cached for later
+}
+
+const fetchImports = (args, isProd) => {
+  initGlobals(args, isProd);
+
+  const { ckEditorApi: { checkEditorBundle, uploadEditorBundle } } = require('./packages/lesswrong/server/ckEditor/ckEditorApi');
+  const { ckEditorBundleVersion } = require('./packages/lesswrong/lib/wrapCkEditor')
+
+  return { ckEditorBundleVersion, checkEditorBundle, uploadEditorBundle };
+}
+
+const credentialsPath = (forumType) => {
+  const memorizedBases = {
+    lw: "..",
+    ea: "..",
+  };
+  const base = process.env.GITHUB_WORKSPACE ?? memorizedBases[forumType] ?? ".";
+  const memorizedRepoNames = {
+    lw: 'LessWrong-Credentials',
+    ea: 'ForumCredentials',
+  };
+  const repoName = memorizedRepoNames[forumType];
+  if (!repoName) {
+    return base;
+  }
+  return `${base}/${repoName}`;
+}
+
+const settingsFilePath = (fileName, forumType) => {
+  return `${credentialsPath(forumType)}/${fileName}`;
+}
+
+const databaseConfig = (mode, forumType) => {
+  if (!mode) {
+    return {};
+  }
+  const memorizedConfigPaths = {
+    lw: {
+      db: `${credentialsPath(forumType)}/connectionConfigs/${mode}.json`,
+    },
+    ea: {
+      postgresUrlFile: `${credentialsPath(forumType)}/${mode}-pg-conn.txt`,
+    },
+  };
+  const configPath = memorizedConfigPaths[forumType] || {
+    postgresUrlFile: `${credentialsPath(forumType)}/${mode}-pg-conn.txt`,
+  };
+  return getDatabaseConfig(configPath);
+};
+
+const settingsFileName = (mode, forumType) => {
+  if (!mode) {
+    // With the state of the code when this comment was written, this indicates
+    // an error condition, but it will be handled later, around L60
+    return '';
+  }
+  if (forumType === 'lw') {
+    if (mode === 'prod') {
+      return 'settings-production-lesswrong.json';
+    }
+    return 'settings-local-dev-devdb.json'
+  }
+  return `settings-${mode}.json`;
+};
+
+(async () => {
+  let mode = process.argv[2];
+  if (mode === "development") {
+    mode = "dev";
+  } else if (mode === "production") {
+    mode = "prod";
+  }
+
+  const forumType = process.argv[3];
+
+  const dbConf = databaseConfig(mode, forumType);
+  if (dbConf.postgresUrl) {
+    process.env.PG_URL = dbConf.postgresUrl;
+  }
+  const args = {
+    postgresUrl: process.env.PG_URL,
+    settingsFileName: settingsFilePath(settingsFileName(mode, forumType), forumType),
+    shellMode: false,
+  };
+  
+  await startSshTunnel(databaseConfig(mode, forumType).sshTunnelCommand);
+
+  const { ckEditorBundleVersion, checkEditorBundle, uploadEditorBundle } = fetchImports(args, mode === "prod");
+
+  const {initServer} = require("./packages/lesswrong/server/serverStartup");
+  await initServer(args);
+
+  let exitCode = 0;
+
+  try {
+    const { exists } = await checkEditorBundle(ckEditorBundleVersion);
+    if (!exists) {
+      await uploadEditorBundle(ckEditorBundleVersion);
+    }
+  } catch (e) {
+    console.error("An error occurred while running checking or uploading the ckEditor bundle version:", e);
+    exitCode = 1;
+  }
+
+  process.exit(exitCode);
+})();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint": "eslint --max-warnings 0 --cache --ext .jsx,js,tsx,ts packages",
     "build": "./build.js",
     "migrate": "node migrate",
+    "deploy-ckeditor-bundle": "node deployCkEditorBundle",
     "branchdb": "ts-node scripts/branchDb.ts",
     "start": "yarn start-local-db",
     "start-local-db": "./build.js -run --watch --lint --settings settings-dev.json",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint --max-warnings 0 --cache --ext .jsx,js,tsx,ts packages",
     "build": "./build.js",
     "migrate": "node migrate",
-    "deploy-ckeditor-bundle": "node deployCkEditorBundle",
+    "upload-ckeditor-bundle": "node deployCkEditorBundle",
     "branchdb": "ts-node scripts/branchDb.ts",
     "start": "yarn start-local-db",
     "start-local-db": "./build.js -run --watch --lint --settings settings-dev.json",

--- a/packages/lesswrong/server/ckEditor/ckEditorApi.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorApi.ts
@@ -85,7 +85,7 @@ function logAndThrow(message: string) {
   throw new Error(message);
 }
 
-async function fetchCkEditorRestAPI<const T extends boolean = false>(method: string, uri: string, body?: any, returnRawResponse?: T): Promise<T extends true ? Response : string> {
+async function fetchCkEditorRestAPI<T extends boolean = false>(method: string, uri: string, body?: any, returnRawResponse?: T): Promise<T extends true ? Response : string> {
   const apiPrefix = getCkEditorApiPrefix()!;
   // See: https://ckeditor.com/docs/cs/latest/guides/security/request-signature.html
   const timestamp = new Date().getTime();

--- a/packages/lesswrong/server/ckEditor/ckEditorApi.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorApi.ts
@@ -64,7 +64,28 @@ function generateSignature(apiKey: string, method: string, uri: string, timestam
   return hmac.digest('hex');
 }
 
-async function fetchCkEditorRestAPI(method: string, uri: string, body?: any): Promise<string> {
+async function extractCkEditorResponseErrorInfo(response: Response) {
+  let reason;
+  try {
+    const responseBody = await response.json();
+    reason = responseBody.data?.reasons?.[0];
+    // eslint-disable-next-line no-console
+    console.log({ reason });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(`Failed to extract error info from non-ok ckEditor response`, { err });
+  }
+
+  return reason;
+}
+
+function logAndThrow(message: string) {
+  // eslint-disable-next-line no-console
+  console.log(message);
+  throw new Error(message);
+}
+
+async function fetchCkEditorRestAPI<const T extends boolean = false>(method: string, uri: string, body?: any, returnRawResponse?: T): Promise<T extends true ? Response : string> {
   const apiPrefix = getCkEditorApiPrefix()!;
   // See: https://ckeditor.com/docs/cs/latest/guides/security/request-signature.html
   const timestamp = new Date().getTime();
@@ -78,20 +99,18 @@ async function fetchCkEditorRestAPI(method: string, uri: string, body?: any): Pr
       "X-CS-Timestamp": "" + timestamp,
     },
   });
+  if (returnRawResponse) {
+    return response as (T extends true ? Response : string);
+  }
   if (!response.ok) {
-
-    let explanation;
-    try {
-      const responseBody = await response.json();
-      explanation = responseBody.data?.reasons?.[0]?.explanation;
-    } catch (err) { /* empty */ }
-
-    if (explanation)
-      throw new Error(`CkEditor REST API call FAILED (${response.status}): ${method} ${fullURI}\n${explanation}`);
-    throw new Error(`CkEditor REST API call FAILED (${response.status}): ${method} ${fullURI}`);
+    const errorReason = await extractCkEditorResponseErrorInfo(response);
+    if (errorReason) {
+      logAndThrow(`CkEditor REST API call FAILED (${response.status}): ${method} ${fullURI}\n${JSON.stringify(errorReason)}`);
+    }
+    logAndThrow(`CkEditor REST API call FAILED (${response.status}): ${method} ${fullURI}`);
   }
   const responseBody = await response.text();
-  return responseBody;
+  return responseBody as (T extends true ? Response : string);
 }
 
 
@@ -198,6 +217,29 @@ const documentHelpers = {
 
 // See https://docs.cke-cs.com/api/v5/docs for documentation on ckEditor's api.
 const ckEditorApi = {
+  async getStorageDocument(ckEditorId: string) {
+    const rawResult = await fetchCkEditorRestAPI("GET", `/storage/${ckEditorId}`);
+    let parsedResult;
+    try {
+      parsedResult = JSON.parse(rawResult);
+    } catch (err) {
+      throw new Error(`Failure to parse response from ckEditor when fetching storage document. Returned data: ${rawResult}`);
+    }
+
+    return parsedResult;
+  },
+
+  async getAllStorageDocuments() {
+    const rawResult = await fetchCkEditorRestAPI("GET", `/storage?order=desc`);
+    let parsedResult;
+    try {
+      parsedResult = JSON.parse(rawResult);
+    } catch (err) {
+      throw new Error(`Failure to parse response from ckEditor when fetching all storage documents. Returned data: ${rawResult}`);
+    }
+
+    return parsedResult.data;
+  },
   async fetchCkEditorDocumentFromStorage(ckEditorId: string): Promise<DocumentResponse> {
     const rawResult = await fetchCkEditorRestAPI("GET", `/documents/${ckEditorId}`);
     let parsedResult;
@@ -219,12 +261,20 @@ const ckEditorApi = {
     return await fetchCkEditorRestAPI("GET", "/collaborations");
   },
 
+  async getCollaborationDetails(documentId: string) {
+    return await fetchCkEditorRestAPI("GET", `/collaborations/${documentId}/details`);
+  },
+
   async getAllConnectedUserIds(documentId: string) {
     return await fetchCkEditorRestAPI("GET", `/collaborations/${documentId}/users`);
   },
 
   async getAllDocuments() {
     return await fetchCkEditorRestAPI("GET", "/documents"); 
+  },
+
+  async getAllRevisionsForDocument(ckEditorId: string) {
+    return await fetchCkEditorRestAPI("GET", `/revisions?document_id=${ckEditorId}&order=desc`); 
   },
 
   async fetchCkEditorCommentThread(threadId: string): Promise<CkEditorComment[]> {
@@ -238,7 +288,7 @@ const ckEditorApi = {
     // won't subscribed after the 1000th comment, which is not a big problem.
     const limit = 1000;
     
-    const response = await fetchCkEditorRestAPI("GET", `/comments?thread_id=${threadId}&limit=${limit}`);
+    const response = await fetchCkEditorRestAPI("GET", `/comments?thread_id=${threadId}&limit=${limit}&include_deleted=true`);
     const parsedResponse: CkEditorGetCommentsResponse = JSON.parse(response);
     return parsedResponse.data;
   },
@@ -327,16 +377,30 @@ const ckEditorApi = {
         },
       },
       testData: "<p>Test</p>",
-    });
+    }, true);
+
+    if (result.status > 299 && result.status !== 409) {
+      logAndThrow(`Got a ${result.status} status code when uploading bundle version ${bundleVersion}`);
+    }
   },
 
-  async checkEditorBundle(bundleVersion: string): Promise<void> {
+  async checkEditorBundle(bundleVersion: string): Promise<{ exists: boolean }> {
     if (!bundleVersion)
       throw new Error("Missing argument: bundleVersion");
     
     const result = await fetchCkEditorRestAPI("GET", `/editors/${bundleVersion}/exists`);
-    // eslint-disable-next-line no-console
-    console.log(result);
+
+    let parsedResult;
+    try {
+      parsedResult = JSON.parse(result);
+      if (!('exists' in parsedResult)) {
+        logAndThrow('Missing "exists" field in response from ckEditor when checking if editor bundle exists');
+      }
+    } catch (err) {
+      logAndThrow(`Failure to parse response from ckEditor when checking if editor bundle ${bundleVersion} exists. Returned data: ${result}`);
+    }
+
+    return parsedResult;
   },
 
   async flushAllCkEditorCollaborations() {


### PR DESCRIPTION
We recently had some data loss caused by deploying without uploading an updated version of the ckEditor bundle.  This PR adds a github action which check if we need to upload the version which is specified in the codebase, and if so, attempts to upload it.  If this fails for any reason other than a 409 (conflict, because that version has already been uploaded), the action should fail and block the deployment.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206640359092494) by [Unito](https://www.unito.io)
