### PR TITLE
Add `maxAllowedApiSkip` instance setting

### DIFF
--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -210,3 +210,5 @@ export const isElasticEnabled = !isAnyTest && !disableElastic.get();
 export const requireReviewToFrontpagePostsSetting = new PublicInstanceSetting<boolean>('posts.requireReviewToFrontpage', !isEAForum, "optional")
 export const manifoldAPIKeySetting = new PublicInstanceSetting<string | null>('manifold.reviewBotKey', null, "optional")
 export const reviewUserBotSetting = new PublicInstanceSetting<string | null>('reviewBotId', null, "optional")
+
+export const maxAllowedApiSkip = new PublicInstanceSetting<number | null>("maxAllowedApiSkip", 2000, "optional")


### PR DESCRIPTION
We limit the maximum offset (currently 2000) in the default multi resolver to prevent arbitrarily slow queries. This PR adds an instance setting to make this configurable so that we can allow larger offsets for the EA forum bot site where this doesn't matter as much.

I already updated the credentials repo to set the value to `null`, completely disabling the check. It might be better to set it to something like 100000 though.