### PR TITLE
Add cron job to refresh analytics views

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -9,6 +9,7 @@ import './server/cronUtil';
 import './server/startupSanityChecks';
 
 import './server/postgresView';
+import './server/analyticsViews';
 
 import './server/database-import/database_import_new';
 import './server/rss-integration/cron';

--- a/packages/lesswrong/server/analyticsViews.ts
+++ b/packages/lesswrong/server/analyticsViews.ts
@@ -1,0 +1,25 @@
+import { isEAForum } from "../lib/instanceSettings";
+import { getAnalyticsConnection } from "./analytics/postgresConnection";
+import { addCronJob } from "./cronUtil";
+
+const maintenanceQueries = [
+  "REFRESH MATERIALIZED VIEW CONCURRENTLY view_and_hours_logged_in_by_day",
+  "REFRESH MATERIALIZED VIEW CONCURRENTLY views_and_hours_by_post_by_day"
+]
+
+addCronJob({
+  name: "maintainAnalyticsViews",
+  interval: "every 24 hours",
+  job: async () => {
+    if (!isEAForum) return;
+
+    const db = getAnalyticsConnection()
+
+    if (!db) return;
+
+    for (const query of maintenanceQueries) {
+      // Run these concurrently and don't wait, as they can take ~hours
+      void db.none(query)
+    }
+  },
+});

--- a/packages/lesswrong/server/analyticsViews.ts
+++ b/packages/lesswrong/server/analyticsViews.ts
@@ -12,7 +12,7 @@ const maintenanceQueries = forumSelect({
 
 addCronJob({
   name: "maintainAnalyticsViews",
-  interval: "every 30 seconds",
+  interval: "every 24 hours",
   job: async () => {
     if (!maintenanceQueries.length) return;
 

--- a/packages/lesswrong/server/analyticsViews.ts
+++ b/packages/lesswrong/server/analyticsViews.ts
@@ -1,17 +1,20 @@
-import { isEAForum } from "../lib/instanceSettings";
+import { forumSelect } from "../lib/forumTypeUtils";
 import { getAnalyticsConnection } from "./analytics/postgresConnection";
 import { addCronJob } from "./cronUtil";
 
-const maintenanceQueries = [
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY view_and_hours_logged_in_by_day",
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY views_and_hours_by_post_by_day"
-]
+const maintenanceQueries = forumSelect({
+  EAForum: [
+    "REFRESH MATERIALIZED VIEW CONCURRENTLY view_and_hours_logged_in_by_day",
+    "REFRESH MATERIALIZED VIEW CONCURRENTLY views_and_hours_by_post_by_day",
+  ],
+  default: [],
+});
 
 addCronJob({
   name: "maintainAnalyticsViews",
-  interval: "every 24 hours",
+  interval: "every 30 seconds",
   job: async () => {
-    if (!isEAForum) return;
+    if (!maintenanceQueries.length) return;
 
     const db = getAnalyticsConnection()
 


### PR DESCRIPTION
These used to refresh automatically, but in the process of fixing a bug in them the other week this I broke this. This is apparently how they used to refresh, I'm not sure why it stopped working:
<img width="650" alt="Screenshot 2024-02-20 at 13 52 11" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/512aa260-4a8f-4594-a041-2a8cdb94933d">

I've now added a cron job in the main code to refresh them. Possibly it would be more correct to add this to https://github.com/centre-for-effective-altruism/ForumAnalytics , but given that the code in there hasn't been touched for a long time I decided it wasn't worth the hassle of bringing it up to date

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206645219612302) by [Unito](https://www.unito.io)
