### PR TITLE
[EA Forum only] add digest ad inview events and update A/B test weights

### DIFF
--- a/packages/lesswrong/components/ea-forum/digestAd/SidebarDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/SidebarDigestAd.tsx
@@ -102,7 +102,7 @@ const SidebarDigestAd = ({className, classes}: {
   
   if (!showDigestAd) return null
   
-  const { ForumIcon, EAButton } = Components
+  const { AnalyticsInViewTracker, ForumIcon, EAButton } = Components
   
   const buttonProps = loading ? {disabled: true} : {}
   const arrow = <ForumIcon icon="ArrowRight" className={classes.formBtnArrow} />
@@ -139,16 +139,18 @@ const SidebarDigestAd = ({className, classes}: {
   }
   
   return <AnalyticsContext pageSubSectionContext="digestAd">
-    <div className={classNames(classes.root, className)}>
-      <div className={classes.headingRow}>
-        <h2 className={classes.heading}>{DIGEST_AD_HEADLINE_TEXT}</h2>
-        <ForumIcon icon="Close" className={classes.close} onClick={handleClose} />
+    <AnalyticsInViewTracker eventProps={{inViewType: "sidebarDigestAd"}}>
+      <div className={classNames(classes.root, className)}>
+        <div className={classes.headingRow}>
+          <h2 className={classes.heading}>{DIGEST_AD_HEADLINE_TEXT}</h2>
+          <ForumIcon icon="Close" className={classes.close} onClick={handleClose} />
+        </div>
+        <div className={classes.body}>
+          {DIGEST_AD_BODY_TEXT}
+        </div>
+        {formNode}
       </div>
-      <div className={classes.body}>
-        {DIGEST_AD_BODY_TEXT}
-      </div>
-      {formNode}
-    </div>
+    </AnalyticsInViewTracker>
   </AnalyticsContext>
 }
 

--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -139,7 +139,7 @@ const StickyDigestAd = ({className, classes}: {
   
   if (!showDigestAd) return null
   
-  const { ForumIcon, EAButton } = Components
+  const { AnalyticsInViewTracker, ForumIcon, EAButton } = Components
   
   const buttonProps = loading ? {disabled: true} : {}
   const noThanksBtn = (
@@ -186,15 +186,17 @@ const StickyDigestAd = ({className, classes}: {
   }
   
   return <AnalyticsContext pageSubSectionContext="digestAd">
-    <div className={classNames(classes.root, className)}>
-      <div className={classes.textCol}>
-        <h2 className={classes.heading}>{DIGEST_AD_HEADLINE_TEXT}</h2>
-        <div className={classNames(classes.body)}>
-          {DIGEST_AD_BODY_TEXT}
+    <AnalyticsInViewTracker eventProps={{inViewType: "stickyDigestAd"}}>
+      <div className={classNames(classes.root, className)}>
+        <div className={classes.textCol}>
+          <h2 className={classes.heading}>{DIGEST_AD_HEADLINE_TEXT}</h2>
+          <div className={classNames(classes.body)}>
+            {DIGEST_AD_BODY_TEXT}
+          </div>
         </div>
+        {formNode}
       </div>
-      {formNode}
-    </div>
+    </AnalyticsInViewTracker>
   </AnalyticsContext>
 }
 

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -239,11 +239,11 @@ export const postPageFixedDigestAd = new ABTest({
   groups: {
     noShow: {
       description: "Don't show digest ad",
-      weight: 8,
+      weight: 1,
     },
     show: {
       description: "Show digest ad",
-      weight: 2,
+      weight: 1,
     },
   },
 });


### PR DESCRIPTION
This PR adds some analytics so we can track the click rate for the ads, and shows the sticky ad to more visitors.