### PR TITLE
[EA Forum only] fix onboarding digest subscription

### DIFF
--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
@@ -86,18 +86,18 @@ export const EAOnboardingThankYouStage = ({classes}: {
   classes: ClassesType<typeof styles>,
 }) => {
   const {captureEvent} = useTracking();
-  const {goToNextStage, currentUser, updateCurrentUser} = useEAOnboarding();
+  const {currentStage, goToNextStage, currentUser, updateCurrentUser} = useEAOnboarding();
   const [subscribed, setSubscribed] = useState(true);
 
   useEffect(() => {
     // Default to subscribing to the digest
-    if (!currentUser.subscribedToDigest) {
+    if (!currentUser.subscribedToDigest && currentStage === 'thankyou') {
       void updateCurrentUser({
         subscribedToDigest: true,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [currentStage]);
 
   const setSubscribedToDigest = useCallback((value: boolean) => {
     setSubscribed(value);


### PR DESCRIPTION
I was testing out the onboarding flow and I noticed that my new users weren't subscribed to the digest, even though I didn't touch the toggle.

My understanding of the bug is: we were setting `subscribedToDigest` to `true` when the onboarding flow was first rendered (because all steps get rendered immediately), and then setting it back to `false` after the user submitted the first step, so if the user didn't touch the toggle in the last step then they wouldn't actually get subscribed to the digest in the end.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206700289058635) by [Unito](https://www.unito.io)
