### PR TITLE
[EA Forum only] add "book a call" link into new onboarding flow

### DIFF
--- a/cypress/e2e/set_username.cy.js
+++ b/cypress/e2e/set_username.cy.js
@@ -15,7 +15,7 @@ describe('Basic Login and Signup', function() {
     cy.get('.EAOnboardingStage-footer > button').click();
     cy.get('a[test-id=ea-onboarding-skip-subscribe]').click();
     cy.get('a[test-id=ea-onboarding-skip-work]').click();
-    cy.get('.EAOnboardingThankYouStage-button').click();
+    cy.get('.EAOnboardingThankYouStage-footerButton').click();
     // This is not a great test, but it should work -
     // the notifications icon should only appear after the user has set their username.
     cy.get(`button.NotificationsMenuButton-buttonClosed`).should('exist');

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingStage.tsx
@@ -113,6 +113,7 @@ export const EAOnboardingStage = ({
   footer,
   hideHeader,
   hideFooter,
+  hideFooterButton,
   thin,
   children,
   className,
@@ -126,6 +127,7 @@ export const EAOnboardingStage = ({
   footer?: ReactNode,
   hideHeader?: boolean,
   hideFooter?: boolean,
+  hideFooterButton?: boolean,
   thin?: boolean,
   children?: ReactNode,
   className?: string,
@@ -183,16 +185,18 @@ export const EAOnboardingStage = ({
                 Skip for now
               </a>
             }
-            <EAButton
-              onClick={wrappedOnContinue}
-              disabled={!canContinue || nextStageIsLoading}
-              className={classes.continue}
-            >
-              {nextStageIsLoading
-                ? <Loading className={classes.spinner} />
-                : <>Continue -&gt;</>
-              }
-            </EAButton>
+            {!hideFooterButton &&
+              <EAButton
+                onClick={wrappedOnContinue}
+                disabled={!canContinue || nextStageIsLoading}
+                className={classes.continue}
+              >
+                {nextStageIsLoading
+                  ? <Loading className={classes.spinner} />
+                  : <>Continue -&gt;</>
+                }
+              </EAButton>
+            }
           </div>
         }
       </div>

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
@@ -9,9 +9,6 @@ const styles = (theme: ThemeType) => ({
     padding: 40,
     display: "flex",
     flexDirection: "column",
-    [theme.breakpoints.down("xs")]: {
-      height: "100%",
-    },
   },
   content: {
     [theme.breakpoints.down("xs")]: {
@@ -34,11 +31,19 @@ const styles = (theme: ThemeType) => ({
     padding: "12px 16px",
     marginBottom: 12,
     display: "flex",
+    gap: '20px',
     alignItems: "center",
     textAlign: "left",
     "& > *:first-child": {
       flexGrow: 1,
     },
+  },
+  interviewSection: {
+    background: 'none',
+    borderTop: theme.palette.border.normal,
+    borderRadius: 0,
+    padding: '24px 0 0',
+    marginTop: 24,
   },
   heading: {
     color: theme.palette.grey[1000],
@@ -49,6 +54,14 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[600],
     fontSize: 14,
     fontWeight: 500,
+  },
+  interviewDescription: {
+    color: theme.palette.grey[600],
+    fontSize: 13,
+    lineHeight: '140%',
+    fontWeight: 500,
+    textWrap: 'pretty',
+    marginTop: 4,
   },
   toggle: {
     [theme.breakpoints.down("xs")]: {
@@ -65,10 +78,25 @@ const styles = (theme: ThemeType) => ({
       },
     },
   },
-  button: {
+  interviewButtonWrapper: {
+    flex: 'none',
+    [theme.breakpoints.down("xs")]: {
+      alignSelf: 'center',
+      marginTop: 8,
+    },
+  },
+  interviewButton: {
+    fontWeight: 600,
+    textDecoration: 'none !important',
+    padding: '12px 16px',
+  },
+  footer: {
+    textAlign: 'center',
+  },
+  footerButton: {
     width: "100%",
+    maxWidth: 500,
     padding: "12px 20px",
-    marginTop: 28,
     fontSize: 14,
     fontWeight: 600,
   },
@@ -120,7 +148,14 @@ export const EAOnboardingThankYouStage = ({classes}: {
       title="Thanks for joining the discussion"
       className={classes.root}
       hideHeader
-      hideFooter
+      footer={
+        <div className={classes.footer}>
+          <EAButton onClick={onComplete} className={classes.footerButton}>
+            Go to the Forum -&gt;
+          </EAButton>
+        </div>
+      }
+      hideFooterButton
     >
       <div className={classes.content}>
         <div className={classes.thanks}>
@@ -156,10 +191,22 @@ export const EAOnboardingThankYouStage = ({classes}: {
             <EAOnboardingPodcast podcast={getPodcastDataByName("Apple Podcasts")} />
           </div>
         </div>
+        <div className={classNames(classes.section, classes.interviewSection, classes.mobileColumn)}>
+          <div>
+            <div className={classes.heading}>
+              Sign up for a user interview
+            </div>
+            <div className={classes.interviewDescription}>
+              We’d love to learn why you joined and how you got involved with EA. We’ll also answer any questions you have.
+            </div>
+          </div>
+          <div className={classes.interviewButtonWrapper}>
+            <EAButton href="https://savvycal.com/cea/forum-team" target="_blank" rel="noreferrer" style="grey" className={classes.interviewButton}>
+              Book a call
+            </EAButton>
+          </div>
+        </div>
       </div>
-      <EAButton onClick={onComplete} className={classes.button}>
-        Go to the Forum -&gt;
-      </EAButton>
     </EAOnboardingStage>
   );
 }


### PR DESCRIPTION
This PR adds in the "Book a call with us" link that was in the old onboarding page.

This is branched off https://github.com/ForumMagnum/ForumMagnum/pull/8816 so that testing is easier. [Figma here](https://www.figma.com/file/IRUVQ5D2mKxoW0xZnhXIWv/2024-Q1?node-id=887%3A3181&mode=dev). I moved the "Go to the Forum" button into the footer so that the body can scroll, since it's taller now.

<img width="600" alt="Screen Shot 2024-02-27 at 4 25 35 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/fccc99cf-8f6e-4f18-b492-c19815802162">

<img width="270" alt="Screen Shot 2024-02-27 at 4 13 27 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/f9f46129-2a27-4a65-9188-37750bbca134">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206709704343015) by [Unito](https://www.unito.io)
