### PR TITLE
Fix custom filtering from frontpage filter settings

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -152,7 +152,8 @@ export const filters: Record<string,any> = {
  * sorting, do not try to supply your own.
  */
 export const sortings: Record<PostSortingMode,MongoSelector<DbPost>> = {
-  magic: { score: -1 },
+  // filteredScore is added as a synthetic field by filterSettingsToParams
+  magic: { filteredScore: -1 },
   top: { baseScore: -1 },
   topAdjusted: { karmaInflationAdjustedScore: -1 },
   new: { postedAt: -1 },
@@ -357,7 +358,7 @@ function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsView
   const useSlowerFrontpage = !!context?.currentUser && isEAForum
 
   const syntheticFields = {
-    score: {$divide:[
+    filteredScore: {$divide:[
       {$multiply: [
         {$add:[
           "$baseScore",

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -232,6 +232,14 @@ Posts.addDefaultView((terms: PostsViewTerms, _, context?: ResolverContext) => {
       options: { ...params.options, ...filterParams.options },
       syntheticFields: { ...params.syntheticFields, ...filterParams.syntheticFields },
     };
+  } else {
+    // The "magic" sorting needs a `filteredScore` to use when ordering. This
+    // is normally filled in using the filter settings, but we need to just
+    // copy over the normal score when filter settings are not supplied.
+    params.syntheticFields = {
+      ...params.syntheticFields,
+      filteredScore: "$score",
+    };
   }
   if (terms.sortedBy) {
     if (terms.sortedBy === 'topAdjusted') {


### PR DESCRIPTION
We use the filters to create a synthetic field to use for sorting called “score” which shadows the “score” field that exists in the database. When we recently implemented joins in the query builder we had to start qualifying the table name for fields in expressions, so `ORDER BY "score" DESC` became `ORDER BY "p"."score" DESC` which means we’re now sorting based on the actual field in the database instead of the synthetic field that it shadows. The simplest fix is to rename the synthetic field to avoid shadowing.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206709774495359) by [Unito](https://www.unito.io)
