### PR TITLE
Show ToC when scrolled to the very top, and fix AllPostsPage SettingsButton

### DIFF
--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -24,20 +24,24 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 14,
     color: isFriendlyUI ? theme.palette.grey[600] : 'white',
     ...(isFriendlyUI ? {fontWeight: 600} : {}),
+  },
+  blackLabel: {
+    color: theme.palette.text.primary,
   }
 })
 
-const SettingsButton = ({classes, className, onClick, showIcon=true, label=""}: {
+const SettingsButton = ({classes, className, onClick, showIcon=true, label="", color = "white"}: {
   classes: ClassesType,
   className?: string,
   onClick?: any,
   label?: string,
-  showIcon?: boolean
+  showIcon?: boolean,
+  color?: "black" | "white"
 }) => {
   if (label) {
     return <span className={classNames(classes.iconWithLabelGroup, className)} onClick={onClick}>
       {showIcon && <Settings className={classNames(classes.icon, classes.iconWithLabel)}/>}
-      <span className={classes.label}>{ label }</span>
+      <span className={classNames(classes.label, {[classes.blackLabel]: color === 'black'})}>{ label }</span>
     </span>
   }
   return <Settings className={classNames(classes.icon, className)} onClick={onClick}/>

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -94,7 +94,7 @@ const AllPostsPage = ({classes}: {classes: ClassesType}) => {
               <SectionTitle title={preferredHeadingCase("All Posts")}>
                 {isFriendlyUI ?
                   <SortButton label={formatSort(currentSorting)} /> :
-                  <SettingsButton label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
+                  <SettingsButton color="black" className={classes.settingsButton} label={`Sorted by ${ SORT_ORDER_OPTIONS[currentSorting].label }`}/>
                 }
               </SectionTitle>
             </div>

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -102,7 +102,7 @@ const styles = (theme: ThemeType) => ({
     minHeight: 70,
     display: 'flex',
     flexDirection: 'column-reverse',
-    transition: 'opacity 0.4s ease-in-out, max-height 0.4s ease-in-out',
+    transition: 'opacity 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
   },
   '@global': {
     // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global
@@ -110,7 +110,7 @@ const styles = (theme: ThemeType) => ({
       opacity: 0,
     },
     [`body:has(.headroom--unfixed) .${TITLE_CONTAINER_CLASS_NAME}`]: {
-      opacity: 0,
+      marginTop: 64
     }
   }
 });


### PR DESCRIPTION
This makes it so that the full-height ToC shows the title when scrolled to the very top: 

<img width="1440" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/2e9c2b7e-ada6-4e1e-bc8a-066475d1c561">

Also fixes a small color bug with the settings button on the All Posts page

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206712423270567) by [Unito](https://www.unito.io)
