### PR TITLE
Review post page forum gates

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useCallback, useMemo, useRef, useContext } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useSubscribedLocation } from '../../../lib/routeUtil';
-import { getConfirmedCoauthorIds, isPostAllowedType3Audio, postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
+import { getConfirmedCoauthorIds, postCoauthorIsPending, postGetPageUrl } from '../../../lib/collections/posts/helpers';
 import { commentGetDefaultView } from '../../../lib/collections/comments/helpers'
 import { useCurrentUser } from '../../common/withUser';
 import withErrorBoundary from '../../common/withErrorBoundary'
@@ -387,7 +387,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   // We don't want to show the splash header if the user is on a `/s/:sequenceId/p/:postId` route
   // We explicitly don't use `getSequenceId` because that also gets the post's canonical sequence ID,
   // and we don't want to hide the splash header for any post that _is_ part of a sequence, since that's many review winners
-  const showSplashPageHeader = !!post.reviewWinner && !params.sequenceId;
+  const showSplashPageHeader = isLWorAF && !!post.reviewWinner && !params.sequenceId;
 
   useEffect(() => {
     if (!query[SHARE_POPUP_QUERY_PARAM]) return;

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -166,7 +166,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   tagSection: {
     flex: 1,
     display: "flex",
-    flexDirection: "row",
+    flexDirection: isFriendlyUI ? "column" : "row",
     height: "100%",
   }
 });

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -1128,6 +1128,9 @@ const schema: SchemaType<"Posts"> = {
     graphQLtype: "ReviewVote",
     canRead: ['members'],
     resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<Partial<DbReviewVote>|null> => {
+      if (!isLWorAF) {
+        return null;
+      }
       const { ReviewVotes, currentUser } = context;
       if (!currentUser) return null;
       const votes = await getWithLoader(context, ReviewVotes,
@@ -1157,6 +1160,9 @@ const schema: SchemaType<"Posts"> = {
     graphQLtype: "ReviewWinner",
     canRead: ['guests'],
     resolver: async (post: DbPost, args: void, context: ResolverContext) => {
+      if (!isLWorAF) {
+        return null;
+      }
       const { currentUser, ReviewWinners } = context;
       const winner = await getPostReviewWinnerInfo(post._id, context);
       return accessFilterSingle(currentUser, ReviewWinners, winner, context);

--- a/packages/lesswrong/server/resolvers/reviewWinnerResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewWinnerResolvers.ts
@@ -6,14 +6,17 @@ import { createAnonymousContext } from "../vulcan-lib";
 import Posts from "../../lib/collections/posts/collection";
 import { updateSplashArtCoordinateCache } from "../../lib/collections/splashArtCoordinates/cache";
 import { REVIEW_WINNER_CACHE, ReviewWinnerWithPost, updateReviewWinnerCache } from "../../lib/collections/reviewWinners/cache";
+import { isLWorAF } from "../../lib/instanceSettings";
 
 
 onStartup(async () => {
-  const context = createAnonymousContext();
-  await Promise.all([
-    updateReviewWinnerCache(context),
-    updateSplashArtCoordinateCache(context),
-  ]);
+  if (isLWorAF) {
+    const context = createAnonymousContext();
+    await Promise.all([
+      updateReviewWinnerCache(context),
+      updateSplashArtCoordinateCache(context),
+    ]);
+  }
 });
 
 function restrictReviewWinnerPostFields(reviewWinners: ReviewWinnerWithPost[], context: ResolverContext) {


### PR DESCRIPTION
Follow up for #8717 which didn't get EA forum approval:

1. The main issue is the `flexDirection` in `PostsPagePostHeader` which breaks the post page pretty badly for posts with a lot of tags
2. Forum gate a load of LW only database calls on server startup and some resolver only fields in the posts schema
3. I also added an `isLWorAF` in `PostsPage` which maybe is strictly necessary but it's good for peace of mind

I also saw a bug where the table of contents would render too high and then get hidden by the page header if you scrolled down and then back up again, but I couldn't repro it when I looked again later. Possibly it only affects some posts, or maybe I just got the page in a bad state somehow, but we should keep an eye out for it in the future.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206717977535999) by [Unito](https://www.unito.io)
