### PR TITLE
[EA] Reduce size of footnotes in tables

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -174,6 +174,9 @@ const tableStyles = (theme: ThemeType): JssStyles => ({
       fontSize: 14,
       lineHeight: "1.4em",
     },
+    "& sup *": {
+      fontSize: 10,
+    },
     "& ul, & ol": {
       paddingLeft: "1.5em",
     },


### PR DESCRIPTION
Before:
<img width="217" alt="Screenshot 2024-02-28 at 21 46 03" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/d05fbfe3-f1ba-4212-a2b0-b71ff23f8826">


After:
<img width="187" alt="Screenshot 2024-02-28 at 21 43 57" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/43769045-5d30-4aa2-bda2-94f9f6f65669">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206719555766372) by [Unito](https://www.unito.io)
