### PR TITLE
Fix line-wrapping of links to sequences with hover-previews

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesTooltip.tsx
+++ b/packages/lesswrong/components/sequences/SequencesTooltip.tsx
@@ -27,6 +27,7 @@ export const SequencesTooltip = ({
         />
       }
       tooltip={false}
+      inlineBlock={false}
       flip={!allowOverflow}
       placement={placement}
       clickable


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/commit/b7d9c94de1989945d5b6308865617b5a8e98f1bb

Caused by a footgun in `LWTooltip`/`HoverOver`, where the `inlineBlock` attribute has arguably the wrong default value.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206721294852129) by [Unito](https://www.unito.io)
