### PR TITLE
change age offset of HN sort algorithm for LessWrong on frontpage

### DIFF
--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -1,4 +1,5 @@
 import { calculateActivityFactor } from './collections/useractivities/utils';
+import { isLW } from './instanceSettings';
 import { DatabasePublicSetting } from './publicSettings';
 
 /**
@@ -141,6 +142,10 @@ export const frontpageTimeDecayExpr = (props: TimeDecayExprProps, context: Resol
   return { $pow: [{ $add: [ageInHours, startingAgeHours] }, timeDecayFactor] };
 }
 
+// SCORE_BIAS is used in updateScores.ts which is used for all votable documents, this here is used for frontpage posts only. SCORE_BIAS is weirdly name. 
+// It is just adding to the age of the post to make the score decay faster, preventing low karma posts getting on the frontpage for very long.
+const AGE_OFFSET = (isLW) ? 6 : SCORE_BIAS 
+
 export const timeDecayExpr = () => {
   return {$pow: [
     {$add: [
@@ -150,7 +155,7 @@ export const timeDecayExpr = () => {
         ]},
         60 * 60 * 1000
       ] }, // Age in hours
-      SCORE_BIAS,
+      AGE_OFFSET
     ]},
     TIME_DECAY_FACTOR.get()
   ]}

--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -144,7 +144,7 @@ export const frontpageTimeDecayExpr = (props: TimeDecayExprProps, context: Resol
 
 // SCORE_BIAS is used in updateScores.ts which is used for all votable documents, this here is used for frontpage posts only. SCORE_BIAS is weirdly name. 
 // It is just adding to the age of the post to make the score decay faster, preventing low karma posts getting on the frontpage for very long.
-const AGE_OFFSET = (isLW) ? 6 : SCORE_BIAS 
+const AGE_OFFSET = isLW ? 6 : SCORE_BIAS 
 
 export const timeDecayExpr = () => {
   return {$pow: [


### PR DESCRIPTION
In the HackerNews algorithm that we use for sorting LatestPosts, there's a parameter to add an offset to the age of posts. Having a positive value for this parameter means posts are always treated as older, and therefore very low karma posts won't appear on the frontpage (whereas they will briefly if there was no offset). 

We actually had a value of 2 hours, but LatestPosts actually seems better with a value of 6 given some quick testing.

This will also affect the karma posts get, further changing their visibility, so we should keep an eye on that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206732163779853) by [Unito](https://www.unito.io)
