### PR TITLE
Make sidebar warning for google doc import only show for admins (not mods)

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineGoogleServiceAccount.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineGoogleServiceAccount.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useCurrentUser } from '../common/withUser';
 import { Link } from '../../lib/reactRouterWrapper';
-import { userIsAdminOrMod } from '../../lib/vulcan-users';
+import { userIsAdmin } from '../../lib/vulcan-users';
 import { hasGoogleDocImportSetting } from '../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -38,7 +38,7 @@ const SunshineGoogleServiceAccount = ({ classes }: {
 
   const shouldWarn = !estimatedExpiry || (new Date(estimatedExpiry).getTime() - Date.now()) < WARN_THRESHOLD
 
-  if (loading || !userIsAdminOrMod(currentUser) || !hasGoogleDocImportSetting.get() || !shouldWarn) {
+  if (loading || !userIsAdmin(currentUser) || !hasGoogleDocImportSetting.get() || !shouldWarn) {
     return null;
   }
 


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206736881181969) by [Unito](https://www.unito.io)
