### PR TITLE
Make datadog processes data collection configurable via a setting

### DIFF
--- a/.ebextensions/99datadog.config
+++ b/.ebextensions/99datadog.config
@@ -24,7 +24,7 @@ files:
       # Enable process_collection to see the cpu and memory usage of individual processes
       process_config:
         process_collection:
-          enabled: "false"
+          enabled: PROCESS_COLLECTION_ENABLED_PLACEHOLDER
 
   "/datadog_install_script.sh":
     mode: "000700"
@@ -35,5 +35,7 @@ files:
 container_commands:
     04patch_api_key:
         command: "sed -i.bak \"s/DD_API_KEY$/$DD_API_KEY/\" /etc/datadog-agent/datadog.yaml"
-    05setup_datadog:
+    05patch_process_collection:
+        command: "sed -i.bak \"s/PROCESS_COLLECTION_ENABLED_PLACEHOLDER/$DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED/\" /etc/datadog-agent/datadog.yaml"
+    06setup_datadog:
         command: "/datadog_install_script.sh; sed -i 's/ install_script/ ebs_install_script/' /etc/datadog-agent/install_info"


### PR DESCRIPTION
This enables us to set the `DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED` environment variable to turn on [live processes monitoring](https://docs.datadoghq.com/infrastructure/process/?tab=docker) in datadog. This gives you the CPU and memory usage for every process running on the servers:

![Screenshot 2024-03-01 at 13 37 57](https://github.com/ForumMagnum/ForumMagnum/assets/77623106/296b62c5-2aa9-4102-a2e7-ac770d06a386)

I found this very useful in debugging the issue described in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/8847). It costs $9/mo/instance though so I think we should have it turned off most of the time, and just turn it on when needed.


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206738745400577) by [Unito](https://www.unito.io)
