### PR TITLE
Set up a version of personalized latest posts sorting for LessWrong

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -6,14 +6,14 @@ import { showReviewOnFrontPageIfActive } from '../../lib/publicSettings';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
 import moment from 'moment';
-import { userGetsDynamicFrontpage } from '../../lib/betas';
+import { visitorGetsDynamicFrontpage } from '../../lib/betas';
 
 const LWHome = () => {
   const { DismissibleSpotlightItem, RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, LWRecommendations, FrontpageReviewWidget, SingleColumnSection, FrontpageBestOfLWWidget, EAPopularCommentsSection, QuickTakesSection } = Components
   const [_, setCookie] = useCookiesWithConsent([LAST_VISITED_FRONTPAGE_COOKIE]);
 
   useEffect(() => {
-    if (userGetsDynamicFrontpage(null)) {
+    if (visitorGetsDynamicFrontpage(null)) {
       setCookie(LAST_VISITED_FRONTPAGE_COOKIE, new Date().toISOString(), { path: "/", expires: moment().add(1, 'year').toDate() });
     }
   }, [setCookie])

--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -1,11 +1,22 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { getReviewPhase, reviewIsActive, REVIEW_YEAR } from '../../lib/reviewUtils';
 import { showReviewOnFrontPageIfActive } from '../../lib/publicSettings';
+import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
+import { LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
+import moment from 'moment';
+import { userGetsDynamicFrontpage } from '../../lib/betas';
 
 const LWHome = () => {
   const { DismissibleSpotlightItem, RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, LWRecommendations, FrontpageReviewWidget, SingleColumnSection, FrontpageBestOfLWWidget, EAPopularCommentsSection, QuickTakesSection } = Components
+  const [_, setCookie] = useCookiesWithConsent([LAST_VISITED_FRONTPAGE_COOKIE]);
+
+  useEffect(() => {
+    if (userGetsDynamicFrontpage(null)) {
+      setCookie(LAST_VISITED_FRONTPAGE_COOKIE, new Date().toISOString(), { path: "/", expires: moment().add(1, 'year').toDate() });
+    }
+  }, [setCookie])
   
   return (
       <AnalyticsContext pageContext="homePage">

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -14,6 +14,7 @@ import {
   hasSideCommentsSetting, 
   hasDialoguesSetting, 
   hasPostInlineReactionsSetting,
+  isLW,
 } from './instanceSettings'
 import { userOverNKarmaOrApproved } from "./vulcan-users/permissions";
 import {isFriendlyUI} from '../themes/forumTheme'
@@ -53,6 +54,8 @@ export const userHasEagProfileImport = disabled;
 export const userHasEAHomeRHS = isEAForum ? shippedFeature : disabled;
 
 export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabled;
+
+export const userGetsDynamicFrontpage = isLW ? shippedFeature : disabled;
 
 // Non-user-specific features
 export const dialoguesEnabled = hasDialoguesSetting.get();

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -55,7 +55,7 @@ export const userHasEAHomeRHS = isEAForum ? shippedFeature : disabled;
 
 export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabled;
 
-export const userGetsDynamicFrontpage = isLW ? shippedFeature : disabled;
+export const visitorGetsDynamicFrontpage = isLW ? shippedFeature : disabled;
 
 // Non-user-specific features
 export const dialoguesEnabled = hasDialoguesSetting.get();

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -13,6 +13,7 @@ import { INITIAL_REVIEW_THRESHOLD, getPositiveVoteThreshold, QUICK_REVIEW_SCORE_
 import { jsonArrayContainsSelector } from '../../utils/viewUtils';
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../tags/collection';
 import { filter, isEmpty, pick } from 'underscore';
+import { visitorGetsDynamicFrontpage } from '../../betas';
 
 export const DEFAULT_LOW_KARMA_THRESHOLD = -10
 export const MAX_LOW_KARMA_THRESHOLD = -1000
@@ -363,7 +364,7 @@ function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsView
     t => (t.filterMode!=="Hidden" && t.filterMode!=="Required" && t.filterMode!=="Default" && t.filterMode!==0)
   );
 
-  const useSlowerFrontpage = !!context?.currentUser && isEAForum
+  const useSlowerFrontpage = !!context && ((!!context.currentUser && isEAForum) || visitorGetsDynamicFrontpage(context.currentUser ?? null));
 
   const syntheticFields = {
     filteredScore: {$divide:[

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -120,6 +120,12 @@ export const HIDE_2021_BOOK_BANNER_COOKIE = registerCookie({
   description: "Don't show the 2021 book banner",
 });
 
+export const LAST_VISITED_FRONTPAGE_COOKIE = registerCookie({
+  name: "last_visited_frontpage",
+  type: "functional",
+  description: "Stores the date of the user's last visit to the frontpage",
+});
+
 
 // Third party cookies
 

--- a/packages/lesswrong/server/useractivities/cron.ts
+++ b/packages/lesswrong/server/useractivities/cron.ts
@@ -2,7 +2,7 @@
 /* See lib/collections/useractivities/collection.ts for a high-level overview */
 import chunk from 'lodash/fp/chunk';
 import max from 'lodash/fp/max';
-import { isEAForum } from '../../lib/instanceSettings';
+import { isEAForum, isLW } from '../../lib/instanceSettings';
 import { randomId } from '../../lib/random';
 import { getSqlClientOrThrow } from '../../lib/sql/sqlClient';
 import { addCronJob } from '../cronUtil';
@@ -361,7 +361,7 @@ export async function backfillUserActivities() {
 }
 
 
-if (isEAForum) {
+if (isEAForum || isLW ) {
   addCronJob({
     name: 'updateUserActivitiesCron',
     interval: 'every 3 hours',

--- a/packages/lesswrong/server/useractivities/getUserActivityData.ts
+++ b/packages/lesswrong/server/useractivities/getUserActivityData.ts
@@ -22,7 +22,9 @@ const liveEnvDescriptions = forumSelect<Record<string, string>>({
   LessWrong: {
     "production": 'lesswrong.com',
     "dev": 'development',
-    "local-dev-prod-db": 'development', // prod running locally
+    // this setting applies to localhost running against prod db – set to 'lesswrong.com' to use analytics events produced in prod, 
+    // or 'development' to use events produced when a server is running locally
+    "local-dev-prod-db": 'lesswrong.com', 
   },
   default: {
     "production": 'production',

--- a/packages/lesswrong/server/useractivities/getUserActivityData.ts
+++ b/packages/lesswrong/server/useractivities/getUserActivityData.ts
@@ -1,4 +1,5 @@
 /* See lib/collections/useractivities/collection.ts for a high-level overview */
+import { forumSelect } from "../../lib/forumTypeUtils";
 import { getAnalyticsConnection } from "../analytics/postgresConnection";
 import { environmentDescriptionSetting } from "../analyticsWriter";
 
@@ -10,13 +11,27 @@ export interface ActivityWindowData {
 /*
  * When running this script locally we want it to use the real analytics events
  */
-const liveEnvDescriptions: Record<string, string> = {
-  "production": 'production',
-  "staging": 'staging',
-  "dev": 'development',
-  "local-dev-prod-db": 'production', // prod running locally
-  "local-dev-staging-db": 'staging', // staging running locally
-}
+const liveEnvDescriptions = forumSelect<Record<string, string>>({
+  EAForum: {
+    "production": 'production',
+    "staging": 'staging',
+    "dev": 'development',
+    "local-dev-prod-db": 'production', // prod running locally
+    "local-dev-staging-db": 'staging', // staging running locally
+  },
+  LessWrong: {
+    "production": 'lesswrong.com',
+    "dev": 'development',
+    "local-dev-prod-db": 'development', // prod running locally
+  },
+  default: {
+    "production": 'production',
+    "staging": 'staging',
+    "dev": 'development',
+    "local-dev-prod-db": 'production', // prod running locally
+    "local-dev-staging-db": 'staging', // staging running locally
+  }
+})
 
 /**
  * Get an array of ActivityWindowData, one for each user or client that was active between startDate and endDate.

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
@@ -25,6 +25,7 @@ import { getCookieFromReq } from '../../utils/httpUtil';
 import { isEAForum } from '../../../lib/instanceSettings';
 import { userChangedCallback } from '../../../lib/vulcan-lib/callbacks';
 import { asyncLocalStorage } from '../../perfMetrics';
+import { visitorGetsDynamicFrontpage } from '../../../lib/betas';
 
 // From https://github.com/apollographql/meteor-integration/blob/master/src/server.js
 export const getUser = async (loginToken: string): Promise<DbUser|null> => {
@@ -109,7 +110,7 @@ export function requestIsFromGreaterWrong(req?: Request): boolean {
 export const computeContextFromUser = async (user: DbUser|null, req?: Request, res?: Response): Promise<ResolverContext> => {
   let visitorActivity: DbUserActivity|null = null;
   const clientId = req ? getCookieFromReq(req, "clientId") : null;
-  if ((user || clientId) && isEAForum) {
+  if ((user || clientId) && (isEAForum || visitorGetsDynamicFrontpage(user))) {
     visitorActivity = user ?
       await UserActivities.findOne({visitorId: user._id, type: 'userId'}) :
       await UserActivities.findOne({visitorId: clientId, type: 'clientId'});

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -35,7 +35,7 @@ import { getForwardedWhitelist } from '../../forwarded_whitelist';
 import PriorityBucketQueue, { RequestData } from '../../../lib/requestPriorityQueue';
 import { onStartup, isAnyTest } from '../../../lib/executionEnvironment';
 import { LAST_VISITED_FRONTPAGE_COOKIE } from '../../../lib/cookies/cookies';
-import { userGetsDynamicFrontpage } from '../../../lib/betas';
+import { visitorGetsDynamicFrontpage } from '../../../lib/betas';
 
 const slowSSRWarnThresholdSetting = new DatabaseServerSetting<number>("slowSSRWarnThreshold", 3000);
 
@@ -116,7 +116,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
   const lastVisitedFrontpage = getCookieFromReq(req, LAST_VISITED_FRONTPAGE_COOKIE);
   // For LW, skip the cache on users who have visited the frontpage before, including logged out. 
   // Doing this so we can show dynamic latest posts list with varying HN decay parameters based on visit frequency (see useractivities/cron.ts).
-  const showDynamicFrontpage = !!lastVisitedFrontpage && userGetsDynamicFrontpage(user) && url === "/";
+  const showDynamicFrontpage = !!lastVisitedFrontpage && visitorGetsDynamicFrontpage(user) && url === "/";
   
   if ((!isHealthCheck && (user || isExcludedFromPageCache(url, abTestGroups))) || isSlackBot || showDynamicFrontpage) {
     // When logged in, don't use the page cache (logged-in pages have notifications and stuff)

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -114,6 +114,8 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
   const userDescription = user?.username ?? `logged out ${ip} (${userAgent})`;
   
   const lastVisitedFrontpage = getCookieFromReq(req, LAST_VISITED_FRONTPAGE_COOKIE);
+  // For LW, skip the cache on users who have visited the frontpage before, including logged out. 
+  // Doing this so we can show dynamic latest posts list with varying HN decay parameters based on visit frequency (see useractivities/cron.ts).
   const showDynamicFrontpage = !!lastVisitedFrontpage && userGetsDynamicFrontpage(user) && url === "/";
   
   if ((!isHealthCheck && (user || isExcludedFromPageCache(url, abTestGroups))) || isSlackBot || showDynamicFrontpage) {


### PR DESCRIPTION
The EA forum build personalization of the HN parameters on frontpage but LW hadn't enabled this. We're enabling it now but with some changes to have it also active for logged-out users. Specifically, we'll show a slowed-down (slower drop-off) frontpage for any user who is visiting the frontpage for the first time. We have a new cookie that tracks visits to frontpage, we just look at whether that's set to determine first visit or not (can't used clientId cookie because it gets set on the first request).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206742386647781) by [Unito](https://www.unito.io)
