### PR TITLE
fix answers sorting functionality

### DIFF
--- a/packages/lesswrong/components/questions/AnswersSorting.tsx
+++ b/packages/lesswrong/components/questions/AnswersSorting.tsx
@@ -6,23 +6,15 @@ import * as _ from 'underscore';
 import type { Option } from '../common/InlineSelect';
 import { getCommentViewOptions } from '../../lib/commentViewOptions';
 import { useNavigate } from '../../lib/reactRouterWrapper';
+import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
 
-const viewOptions = getCommentViewOptions();
-
-const sortOrder = [
-  'postCommentsTop',
-  'postCommentsMagic',
-  'postCommentsNew',
-  'postCommentsOld',
-  'postCommentsRecentReplies'
-];
-
-viewOptions.sort((a, b) => sortOrder.indexOf(a.value) - sortOrder.indexOf(b.value));
-
-const sortingNames = viewOptions.reduce((sortingName: Record<string, string>, viewOption) => {
-  sortingName[viewOption.value] = viewOption.label;
-  return sortingName;
-}, {});
+const sortingNames = {
+  'top': isFriendlyUI ? 'Top' : 'top scoring',
+  'magic': isFriendlyUI ? 'New & upvoted' : 'magic (new & upvoted)',
+  'newest': isFriendlyUI ? 'New' : 'newest',
+  'oldest': isFriendlyUI ? 'Old' : 'oldest',
+  'recentComments': preferredHeadingCase('latest reply'),
+}
 
 const AnswersSorting = ({ post, classes }: {
   post?: PostsList,

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -462,16 +462,16 @@ Comments.addView('repliesToAnswer', (terms: CommentsViewTerms) => {
 });
 ensureIndex(Comments, augmentForDefaultView({parentAnswerId:1, baseScore:-1}));
 
-Comments.addView('answersAndReplies', ({postId}: CommentsViewTerms) => {
+Comments.addView('answersAndReplies', (terms: CommentsViewTerms) => {
   return {
     selector: {
-      postId,
+      postId: terms.postId,
       $or: [
         { answer: true },
         { parentAnswerId: {$exists: true} },
       ],
     },
-    options: {sort: {baseScore: -1}}
+    options: {sort: questionAnswersSortings[terms.sortBy || "top"]}
   };
 });
 


### PR DESCRIPTION
Currently sorting answers doesn't work at all. It seems like this was at least partly from the [giant "better stamp" PR](https://github.com/ForumMagnum/ForumMagnum/pull/7908), so doesn't have an explanation for the relevant changes made in there. This PR should fix it.

I think there is a more thorough version of a bug fix here but it's past 6 PM on Friday so I'm going to call it now. Maybe I'll look at this more next week.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206743075210627) by [Unito](https://www.unito.io)
