### PR TITLE
Post page can show a partial/preload state using cache entries from the front page

### DIFF
--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -92,7 +92,7 @@ const BadgeWrapper = ({commentCount, classes, children}: {
 
 const SideCommentIcon = ({commentIds, post, classes}: {
   commentIds: string[]
-  post: PostsDetails
+  post: PostsList
   classes: ClassesType
 }) => {
   const {LWPopper, SideCommentHover} = Components;
@@ -158,7 +158,7 @@ const SideCommentIcon = ({commentIds, post, classes}: {
 
 const SideCommentHover = ({commentIds, post, classes}: {
   commentIds: string[],
-  post: PostsDetails
+  post: PostsList
   classes: ClassesType,
 }) => {
   const { SideCommentSingle } = Components;
@@ -181,7 +181,7 @@ const SideCommentHover = ({commentIds, post, classes}: {
 
 const SideCommentSingle = ({commentId, post, dontTruncateRoot=false, classes}: {
   commentId: string,
-  post: PostsDetails,
+  post: PostsList,
   classes: ClassesType,
   dontTruncateRoot?: boolean,
 }) => {

--- a/packages/lesswrong/components/posts/PostsPage/CrosspostHeaderIcon.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/CrosspostHeaderIcon.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const CrosspostHeaderIcon = ({post, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsList,
   classes: ClassesType,
 }) => {
   if (!post.fmCrosspost) {

--- a/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBody.tsx
@@ -12,7 +12,7 @@ import { inlineReactsHoverEnabled } from '../../../lib/betas';
 const enableInlineReactsOnPosts = inlineReactsHoverEnabled;
 
 const PostBody = ({post, html, sideCommentMode}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsListWithVotes,
   html: string,
   sideCommentMode?: SideCommentMode
 }) => {

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -69,7 +69,7 @@ const forumNewUserProcessingTime = forumSelect({
 })
 
 const PostBodyPrefix = ({post, query, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsList,
   query?: any,
   classes: ClassesType,
 }) => {

--- a/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
@@ -40,12 +40,12 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const isRequestedCoauthor = (
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsList,
   currentUser: UsersCurrent|null
 ) => currentUser && post.coauthorStatuses?.find?.(({ userId, confirmed }) => userId === currentUser._id && !confirmed);
 
 const PostCoauthorRequest = ({post, currentUser, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsList,
   currentUser: UsersCurrent|null,
   classes: ClassesType,
 }) => {

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const PostsAuthors = ({classes, post, pageSectionContext}: {
   classes: ClassesType,
-  post: PostsDetails,
+  post: PostsList,
   pageSectionContext?: string,
 }) => {
   const { UsersName, UserCommentMarkers, PostsCoauthor, Typography } = Components

--- a/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsCoauthor.tsx
@@ -9,7 +9,7 @@ const styles = (_: ThemeType): JssStyles => ({
 });
 
 const PostsCoauthor = ({ post, coauthor, pageSectionContext, classes }: {
-  post: PostsDetails,
+  post: PostsList,
   coauthor: UsersMinimumInfo,
   pageSectionContext?: string,
   classes: ClassesType,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -316,12 +316,15 @@ export const postsCommentsThreadMultiOptions = {
   enableTotal: true,
 }
 
-const PostsPage = ({post, eagerPostComments, refetch, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}: {
   eagerPostComments?: EagerPostComments,
   refetch: () => void,
   classes: ClassesType,
-}) => {
+} & (
+  { fullPost: PostsWithNavigation|PostsWithNavigationAndRevision, postPreload: undefined }
+  | { fullPost: undefined, postPreload: PostsListWithVotes }
+)) => {
+  const post = fullPost ?? postPreload;
   const location = useSubscribedLocation();
   const navigate = useNavigate();
   const currentUser = useCurrentUser();
@@ -338,7 +341,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   // Show the podcast player if the user opened it on another post, hide it if they closed it (and by default)
   const [showEmbeddedPlayer, setShowEmbeddedPlayer] = useState(showEmbeddedPlayerCookie);
 
-  const toggleEmbeddedPlayer = postHasAudioPlayer(post) ? () => {
+  const toggleEmbeddedPlayer = fullPost && postHasAudioPlayer(fullPost) ? () => {
     const action = showEmbeddedPlayer ? "close" : "open";
     const newCookieValue = showEmbeddedPlayer ? "false" : "true";
     captureEvent("toggleAudioPlayer", { action });
@@ -379,7 +382,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
 
   const getSequenceId = () => {
     const { params } = location;
-    return params.sequenceId || post?.canonicalSequenceId;
+    return params.sequenceId || fullPost?.canonicalSequenceId || null;
   }
 
   const { query, params } = location;
@@ -387,26 +390,29 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   // We don't want to show the splash header if the user is on a `/s/:sequenceId/p/:postId` route
   // We explicitly don't use `getSequenceId` because that also gets the post's canonical sequence ID,
   // and we don't want to hide the splash header for any post that _is_ part of a sequence, since that's many review winners
-  const showSplashPageHeader = isLWorAF && !!post.reviewWinner && !params.sequenceId;
+  const isReviewWinner = ('reviewWinner' in post) && post.reviewWinner;
+  const showSplashPageHeader = isLWorAF && !!isReviewWinner && !params.sequenceId;
 
   useEffect(() => {
     if (!query[SHARE_POPUP_QUERY_PARAM]) return;
 
-    openDialog({
-      componentName: "SharePostPopup",
-      componentProps: {
-        post,
-      },
-      noClickawayCancel: true,
-      closeOnNavigate: true,
-    });
+    if (fullPost) {
+      openDialog({
+        componentName: "SharePostPopup",
+        componentProps: {
+          post: fullPost,
+        },
+        noClickawayCancel: true,
+        closeOnNavigate: true,
+      });
+    }
 
     // Remove "sharePopup" from query once the popup is open, to prevent accidentally
     // sharing links with the popup open
     const currentQuery = isEmpty(query) ? {} : query
     const newQuery = {...currentQuery, [SHARE_POPUP_QUERY_PARAM]: undefined}
     navigate({...location.location, search: `?${qs.stringify(newQuery)}`})
-  }, [navigate, location.location, openDialog, post, query]);
+  }, [navigate, location.location, openDialog, fullPost, query]);
 
   const sortBy: CommentSortingMode = (query.answersSorting as CommentSortingMode) || "top";
   const { results: answersAndReplies } = useMulti({
@@ -458,7 +464,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     collectionName: "Comments",
     fragmentName: 'CommentsList',
     fetchPolicy: 'cache-and-network',
-    skip: !post.debate
+    skip: !post.debate || !fullPost
   });
 
   const { HeadTags, CitationTags, PostsPagePostHeader, PostsPagePostFooter, PostBodyPrefix,
@@ -483,7 +489,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   const isOldVersion = query.revision && post.contents;
   
   const defaultSideCommentVisibility = hasSideComments
-    ? (post.sideCommentVisibility ?? "highKarma")
+    ? (fullPost?.sideCommentVisibility ?? "highKarma")
     : "hidden";
   const [sideCommentMode,setSideCommentMode] = useState<SideCommentMode>(defaultSideCommentVisibility as SideCommentMode);
   const sideCommentModeContext: SideCommentVisibilityContextType = useMemo(
@@ -492,8 +498,8 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
   );
   
   const sequenceId = getSequenceId();
-  const sectionData = (post as PostsWithNavigationAndRevision).tableOfContentsRevision || (post as PostsWithNavigation).tableOfContents;
-  const htmlWithAnchors = sectionData?.html || post.contents?.html;
+  const sectionData = (fullPost as PostsWithNavigationAndRevision)?.tableOfContentsRevision || (post as PostsWithNavigation)?.tableOfContents;
+  const htmlWithAnchors = sectionData?.html || fullPost?.contents?.html || postPreload?.contents?.htmlHighlight || "";
 
   const showRecommendations = hasPostRecommendations &&
     !currentUser?.hidePostsRecommendations &&
@@ -509,9 +515,9 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
 
   const commentId = query.commentId || params.commentId
 
-  const description = getPostDescription(post)
+  const description = fullPost ? getPostDescription(fullPost) : null
   const ogUrl = postGetPageUrl(post, true) // open graph
-  const canonicalUrl = post.canonicalSource || ogUrl
+  const canonicalUrl = fullPost?.canonicalSource || ogUrl
   // For imageless posts this will be an empty string
   let socialPreviewImageUrl = post.socialPreviewData?.imageUrl ?? "";
   if (post.isEvent && post.eventImageId) {
@@ -554,16 +560,18 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     ? <TableOfContents sectionData={sectionData} title={post.title} postedAt={post.postedAt} fixedPositionToc={isLWorAF} />
     : null;
 
-  const noIndex = post.noIndex || post.rejected;
+  const noIndex = fullPost?.noIndex || post.rejected;
 
   const marketInfo = getMarketInfo(post)
 
   const header = <>
-    {!commentId && <>
+    {fullPost && !commentId && <>
       <HeadTags
         ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl}
-        title={post.title} description={description} noIndex={noIndex}
-        structuredData={getStructuredData({post, description})}
+        title={post.title}
+        description={description}
+        noIndex={noIndex}
+        structuredData={getStructuredData({post: fullPost, description})}
       />
       <CitationTags
         title={post.title}
@@ -578,7 +586,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     <AnalyticsContext pageSectionContext="postHeader">
       <div className={classNames(classes.title, {[classes.titleWithMarket] : highlightMarket(marketInfo)})}>
         <div className={classes.centralColumn}>
-          {commentId && !isDebateResponseLink && <CommentPermalink documentId={commentId} post={post} />}
+          {fullPost && commentId && !isDebateResponseLink && <CommentPermalink documentId={commentId} post={fullPost} />}
           {post.eventImageId && <div className={classNames(classes.headerImageContainer, {[classes.headerImageContainerWithComment]: commentId})}>
             <CloudinaryImage2
               publicId={post.eventImageId}
@@ -609,7 +617,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
 
   const rightColumnChildren = (welcomeBox || (showRecommendations && recommendationsPosition === "right")) && <>
     {welcomeBox}
-    {showRecommendations && recommendationsPosition === "right" && <PostSideRecommendations post={post} />}
+    {showRecommendations && recommendationsPosition === "right" && fullPost && <PostSideRecommendations post={fullPost} />}
   </>;
 
   // check for deep equality between terms and eagerPostComments.terms
@@ -643,8 +651,8 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
         {post.title}
       </h1>}
       {/* Body */}
-      <PostsAudioPlayerWrapper showEmbeddedPlayer={showEmbeddedPlayer} post={post}/>
-      { post.isEvent && post.activateRSVPs &&  <RSVPs post={post} /> }
+      {fullPost && <PostsAudioPlayerWrapper showEmbeddedPlayer={showEmbeddedPlayer} post={fullPost}/>}
+      {fullPost && post.isEvent && fullPost.activateRSVPs &&  <RSVPs post={fullPost} />}
       {!post.debate && <ContentStyles contentType="post" className={classNames(classes.postContent, "instapaper_body")}>
         <PostBodyPrefix post={post} query={query}/>
         <AnalyticsContext pageSectionContext="postBody">
@@ -673,10 +681,10 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
         </div>
       </Row>}
 
-      {post.debate && debateResponses && debateResponseReplies &&
+      {post.debate && debateResponses && debateResponseReplies && fullPost &&
         <DebateBody
           debateResponses={getDebateResponseBlocks(debateResponses, debateResponseReplies)}
-          post={post}
+          post={fullPost}
         />}
 
     </div>
@@ -706,24 +714,24 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
       {/* Answers Section */}
       {post.question && <div className={classes.centralColumn}>
         <div id="answers"/>
-        <AnalyticsContext pageSectionContext="answersSection">
-          <PostsPageQuestionContent post={post} answersTree={answersTree ?? []} refetch={refetch}/>
-        </AnalyticsContext>
+        {fullPost && <AnalyticsContext pageSectionContext="answersSection">
+          <PostsPageQuestionContent post={fullPost} answersTree={answersTree ?? []} refetch={refetch}/>
+        </AnalyticsContext>}
       </div>}
       {/* Comments Section */}
       <div className={classes.commentsSection}>
         <AnalyticsContext pageSectionContext="commentsSection">
-          <CommentsListSection
+          {fullPost && <CommentsListSection
             comments={results ?? []}
             loadMoreComments={loadMore}
             totalComments={totalCount as number}
             commentCount={commentCount}
             loadingMoreComments={loadingMore}
-            post={post}
+            post={fullPost}
             newForm={!post.question && (!post.shortform || post.userId===currentUser?._id)}
             highlightDate={highlightDate ?? undefined}
             setHighlightDate={setHighlightDate}
-          />
+          />}
           {isAF && <AFUnreviewedCommentCount post={post}/>}
         </AnalyticsContext>
         {isFriendlyUI && post.commentCount < 1 &&
@@ -734,25 +742,26 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
         }
       </div>
     </AnalyticsInViewTracker>
-  const commentsToC =
-    <CommentsTableOfContents
-      commentTree={commentTree}
-      answersTree={answersTree}
-      post={post}
-      highlightDate={highlightDate ?? undefined}
-    />
 
-  return (
-  <AnalyticsContext pageContext="postsPage" postId={post._id}>
-    <PostsPageContext.Provider value={post}>
+  const commentsToC = fullPost
+    ? <CommentsTableOfContents
+        commentTree={commentTree}
+        answersTree={answersTree}
+        post={fullPost}
+        highlightDate={highlightDate ?? undefined}
+      />
+    : undefined
+
+  return <AnalyticsContext pageContext="postsPage" postId={post._id}>
+    <PostsPageContext.Provider value={fullPost ?? null}>
     <ImageProvider>
     <SideCommentVisibilityContext.Provider value={sideCommentModeContext}>
     <div ref={readingProgressBarRef} className={classes.readingProgressBar}></div>
-    {showSplashPageHeader && !commentId && !isDebateResponseLink && <PostsPageSplashHeader
+    {fullPost && showSplashPageHeader && !commentId && !isDebateResponseLink && <PostsPageSplashHeader
       // We perform this seemingly redundant spread because `showSplashPageHeader` checks that `post.reviewWinner` exists,
       // and Typescript is only smart enough to narrow the type for you if you access the field directly like this
-      post={{...post, reviewWinner: post.reviewWinner}}
-      showEmbeddedPlayer={showEmbeddedPlayer} 
+      post={{...fullPost, reviewWinner: fullPost.reviewWinner!}}
+      showEmbeddedPlayer={showEmbeddedPlayer}
       toggleEmbeddedPlayer={toggleEmbeddedPlayer}
     />}
     {commentsTableOfContentsEnabled
@@ -785,7 +794,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     }
   
     {isEAForum && showDigestAd && <NoSSR><StickyDigestAd /></NoSSR>}
-    {hasPostRecommendations && <AnalyticsInViewTracker eventProps={{inViewType: "postPageFooterRecommendations"}}>
+    {hasPostRecommendations && fullPost && <AnalyticsInViewTracker eventProps={{inViewType: "postPageFooterRecommendations"}}>
       <PostBottomRecommendations
         post={post}
         hasTableOfContents={hasTableOfContents}
@@ -795,7 +804,6 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     </ImageProvider>
     </PostsPageContext.Provider>
   </AnalyticsContext>
-  );
 }
 
 export type PostParticipantInfo = Partial<Pick<PostsDetails, "userId"|"debate"|"hasCoauthorPermission" | "coauthorStatuses">>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -66,7 +66,12 @@ const PostsPageCrosspostWrapper = ({post, eagerPostComments, refetch, fetchProps
 
   return (
     <crosspostContext.Provider value={contextValue}>
-      <PostsPage post={contextValue.combinedPost ?? post} eagerPostComments={eagerPostComments} refetch={refetch} />
+      <PostsPage
+        fullPost={contextValue.combinedPost ?? post}
+        postPreload={undefined}
+        eagerPostComments={eagerPostComments}
+        refetch={refetch}
+      />
     </crosspostContext.Provider>
   );
 }

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -69,8 +69,8 @@ const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const PostsPagePostFooter = ({post, sequenceId, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
-  sequenceId: string,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsListWithVotes,
+  sequenceId: string|null,
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
@@ -117,9 +117,9 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
       </>
     }
     {sequenceId && <div className={classes.bottomNavigation}>
-      <AnalyticsContext pageSectionContext="bottomSequenceNavigation">
+      {('sequence' in post) && <AnalyticsContext pageSectionContext="bottomSequenceNavigation">
         <BottomNavigation post={post}/>
-      </AnalyticsContext>
+      </AnalyticsContext>}
     </div>}
 
     {userHasPingbacks(currentUser) && <AnalyticsContext pageSectionContext="pingbacks">

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -204,7 +204,7 @@ const countAnswersAndDescendents = (answers: CommentsList[]) => {
 }
 
 const getResponseCounts = (
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsList,
   answers: CommentsList[],
 ) => {
   // answers may include some which are deleted:true, deletedPublic:true (in which
@@ -244,7 +244,7 @@ const CommentsLink: FC<{
 /// PostsPagePostHeader: The metadata block at the top of a post page, with
 /// title, author, voting, an actions menu, etc.
 const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEmbeddedPlayer, toggleEmbeddedPlayer, hideMenu, hideTags, annualReviewMarketInfo, classes}: {
-  post: PostsWithNavigation|PostsWithNavigationAndRevision,
+  post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsListWithVotes,
   answers?: CommentsList[],
   dialogueResponses?: CommentsList[],
   showEmbeddedPlayer?: boolean,
@@ -271,10 +271,10 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const feedLinkDescription = post.feed?.url && getHostname(post.feed.url)
-  const feedLink = post.feed?.url && `${getProtocol(post.feed.url)}//${getHostname(post.feed.url)}`;
-  const { major } = extractVersionsFromSemver(post.version)
-  const hasMajorRevision = major > 1
+  const rssFeedSource = ('feed' in post) ? post.feed : null;
+  const feedLinkDescription = rssFeedSource?.url && getHostname(rssFeedSource.url)
+  const feedLink = rssFeedSource?.url && `${getProtocol(rssFeedSource.url)}//${getHostname(rssFeedSource.url)}`;
+  const hasMajorRevision = ('version' in post) && extractVersionsFromSemver(post.version).major > 1
 
   const crosspostNode = post.fmCrosspost?.isCrosspost && !post.fmCrosspost.hostedHere &&
     <CrosspostHeaderIcon post={post} />
@@ -405,7 +405,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   return <>
     {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}
     <AnalyticsContext pageSectionContext="topSequenceNavigation">
-      <PostsTopSequencesNav post={post} />
+      {('sequence' in post) && <PostsTopSequencesNav post={post} />}
     </AnalyticsContext>
     <div className={classNames(classes.header, {[classes.eventHeader]: post.isEvent})}>
       <div className={classes.headerLeft}>
@@ -415,9 +415,9 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
             <div className={classes.authors}>
               <PostsAuthors post={post} pageSectionContext="post_header" />
             </div>
-            {post.feed && post.feed.user &&
+            {rssFeedSource && rssFeedSource.user &&
               <LWTooltip title={`Crossposted from ${feedLinkDescription}`} className={classes.feedName}>
-                <a href={feedLink}>{post.feed.nickname}</a>
+                <a href={feedLink}>{rssFeedSource.nickname}</a>
               </LWTooltip>
             }
           </div>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -60,10 +60,11 @@ const styles = (theme: ThemeType) => ({
 })
 
 const PostsPageTitle = ({classes, post}: {
-  post: PostsDetails,
+  post: PostsDetails|PostsList,
   classes: ClassesType<typeof styles>,
 }) => {
-  const parentPost = post.sourcePostRelations?.filter(rel => !!rel.sourcePost)?.[0]?.sourcePost;
+  const sourcePostRelations = ('sourcePostRelations' in post) ? post.sourcePostRelations : null;
+  const parentPost = sourcePostRelations?.filter(rel => !!rel.sourcePost)?.[0]?.sourcePost;
   const { Typography, ForumIcon, LWTooltip } = Components;
   const showLinkIcon = post.url && isFriendlyUI;
   const showDialogueIcon = post.collabEditorDialogue && isFriendlyUI;

--- a/packages/lesswrong/components/posts/PostsPage/PostsRevisionMessage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsRevisionMessage.tsx
@@ -14,10 +14,12 @@ interface PostsRevisionMessageFragment {
 }
 
 const PostsRevisionMessage = ({post, classes}: {
-  post: PostsRevisionMessageFragment,
+  post: PostsRevisionMessageFragment|PostsList,
   classes: ClassesType,
 }) => {
-  if (!post.contents)
+  if (!post.contents )
+    return null;
+  if (!("editedAt" in post.contents))
     return null;
 
   const { FormatDate } = Components

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -45,7 +45,7 @@ const styles = (theme: ThemeType) => ({
 });
 
 const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
-  post: PostsWithNavigation | PostsWithNavigationAndRevision,
+  post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList,
   hasTableOfContents?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -81,13 +81,16 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
   }
 }
 
-export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
+export const commentGetDefaultView = (post: PostsDetails|PostsList|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
   const fallback = forumSelect({
     AlignmentForum: "afPostCommentsTop",
     EAForum: "postCommentsMagic",
     default: "postCommentsTop",
   });
-  return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
+  const postSortOrder = (post && 'commentSortOrder' in post) ? post.commentSortOrder : null;
+  return (postSortOrder as CommentsViewName)
+    || (currentUser?.commentSorting as CommentsViewName)
+    || fallback;
 }
 
 export const commentGetKarma = (comment: CommentsList|DbComment): number => {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -593,7 +593,7 @@ registerFragment(`
 
 registerFragment(`
   fragment PostsRecentDiscussion on Post {
-    ...PostsList
+    ...PostsListWithVotes
     recentComments(commentsLimit: $commentsLimit, maxAgeHours: $maxAgeHours, af: $af) {
       ...CommentsList
     }
@@ -602,7 +602,7 @@ registerFragment(`
 
 registerFragment(`
   fragment ShortformRecentDiscussion on Post {
-    ...PostsList
+    ...PostsListWithVotes
     recentComments(commentsLimit: $commentsLimit, maxAgeHours: $maxAgeHours, af: $af) {
       ...CommentsListWithTopLevelComment
     }

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -213,7 +213,7 @@ registerFragment(`
     tableOfContents
     postsDefaultSortOrder
     subforumIntroPost {
-      ...PostsList
+      ...PostsListWithVotes
     }
     subforumWelcomeText {
       _id
@@ -247,7 +247,7 @@ registerFragment(`
     tableOfContents(version: $version)
     postsDefaultSortOrder
     subforumIntroPost {
-      ...PostsList
+      ...PostsListWithVotes
     }
     subforumWelcomeText {
       _id

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1463,11 +1463,11 @@ interface PostsRevisionsList { // fragment on Posts
   readonly revisions: Array<RevisionMetadata>,
 }
 
-interface PostsRecentDiscussion extends PostsList { // fragment on Posts
+interface PostsRecentDiscussion extends PostsListWithVotes { // fragment on Posts
   readonly recentComments: Array<CommentsList>,
 }
 
-interface ShortformRecentDiscussion extends PostsList { // fragment on Posts
+interface ShortformRecentDiscussion extends PostsListWithVotes { // fragment on Posts
   readonly recentComments: Array<CommentsListWithTopLevelComment>,
 }
 
@@ -2481,7 +2481,7 @@ interface TagWithFlagsAndRevisionFragment extends TagRevisionFragment { // fragm
 interface TagPageFragment extends TagWithFlagsFragment { // fragment on Tags
   readonly tableOfContents: any,
   readonly postsDefaultSortOrder: string,
-  readonly subforumIntroPost: PostsList|null,
+  readonly subforumIntroPost: PostsListWithVotes|null,
   readonly subforumWelcomeText: TagPageFragment_subforumWelcomeText|null,
   readonly contributors: any,
   readonly canVoteOnRels: Array<"userOwns" | "userOwnsOnlyUpvote" | "guests" | "members" | "admins" | "sunshineRegiment" | "alignmentForumAdmins" | "alignmentForum" | "alignmentVoters" | "podcasters" | "canBypassPostRateLimit" | "trustLevel1" | "canModeratePersonal" | "canSuggestCuration" | "debaters" | "realAdmins">,
@@ -2499,7 +2499,7 @@ interface AllTagsPageFragment extends TagWithFlagsFragment { // fragment on Tags
 interface TagPageWithRevisionFragment extends TagWithFlagsAndRevisionFragment { // fragment on Tags
   readonly tableOfContents: any,
   readonly postsDefaultSortOrder: string,
-  readonly subforumIntroPost: PostsList|null,
+  readonly subforumIntroPost: PostsListWithVotes|null,
   readonly subforumWelcomeText: TagPageWithRevisionFragment_subforumWelcomeText|null,
   readonly contributors: any,
   readonly canVoteOnRels: Array<"userOwns" | "userOwnsOnlyUpvote" | "guests" | "members" | "admins" | "sunshineRegiment" | "alignmentForumAdmins" | "alignmentForum" | "alignmentVoters" | "podcasters" | "canBypassPostRateLimit" | "trustLevel1" | "canModeratePersonal" | "canSuggestCuration" | "debaters" | "realAdmins">,


### PR DESCRIPTION
This branch makes `PostsPage` take two different versions of the post, `fullPost` and `postPreload`, with different fragments. The preload fragment is read from the Apollo cache by `PostsPageWrapper`, if present, but is not fetched. The practical upshot of this is that when you click on a post on the front page, part of the post (the title, text that was in the highlight, and most of the metadata) is visible immediately, without waiting for any response from the server.

In order to make this work, a lot of components that are used on the post page were modified to work with a `PostsListWithVotes` fragment rather than a `PostsWithNavigation` fragment. Some components of post pages, such as the table of contents, event RSVPs, and the Type3 audio player are not included in the preload, which can cause layout shifts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206743927025411) by [Unito](https://www.unito.io)
