### PR TITLE
Fix tag-hover on LW

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -75,7 +75,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     )
   },
   tooltip: {
-    marginTop: 6,
+    marginTop: isFriendlyUI ? 6 : undefined,
   },
   core: {
     ...coreTagStyle(theme),


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/commit/f1998c5a18caf05b4e6afe42e86a4fd5c4f3728c added top-margin to the `FooterTag` tooltip, creating a 6px gap between the button and its tooltip. This made it so you can't use the hover, since it will close when the cursor crosses the gap (unless you have a low-dpi mouse and cross the gap in a single frame).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206745318304678) by [Unito](https://www.unito.io)
