### PR TITLE
Various small styling adjustments for full-height ToC

### DIFF
--- a/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
+++ b/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
@@ -10,6 +10,8 @@ import { commentsTableOfContentsEnabled } from '../../lib/betas';
 import { useNavigate } from '../../lib/reactRouterWrapper';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
 import classNames from 'classnames';
+import { useTimezone } from '../common/withTimezone';
+import moment from 'moment';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -49,6 +51,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     ...theme.typography.smallCaps,
     fontSize: "1.3rem",
     marginBottom: 8,
+    display: 'block'
+  },
+  tocPostedAt: {
+    color: theme.palette.link.tocLink
   },
   highlightUnread: {
     paddingLeft: 4,
@@ -65,6 +71,7 @@ const CommentsTableOfContents = ({commentTree, answersTree, post, highlightDate,
   classes: ClassesType,
 }) => {
   const { TableOfContentsRow } = Components;
+  const { timezone } = useTimezone();
   const flattenedComments = flattenCommentTree([
     ...(answersTree ?? []),
     ...(commentTree ?? [])
@@ -96,6 +103,9 @@ const CommentsTableOfContents = ({commentTree, answersTree, post, highlightDate,
       <span className={classes.postTitle}>
         {post.title?.trim()}
       </span>
+      {post.postedAt && <div className={classes.tocPostedAt}>
+        {moment(new Date(post.postedAt)).tz(timezone).format("Do MMM YYYY")}
+      </div>}
     </TableOfContentsRow>
 
     {answersTree && answersTree.map(answer => <>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -771,7 +771,8 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
               isCommentToC: true
             },
           ]}
-          tocRowMap={[1, 1, 2, 3]}
+          tocRowMap={[1, 1, 1, 3]}
+          showSplashPageHeader={showSplashPageHeader}
         />
       : <ToCColumn
           tableOfContents={tableOfContents}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
@@ -494,7 +494,7 @@ const PostsPageSplashHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, 
     <div className={classes.rightSection}>
       <AnalyticsContext pageSectionContext="tagHeader">
         <div className={classes.rightSectionTopRow}>
-          <FooterTagList post={post} hideScore useAltAddTagButton hideAddTag={false} appendElement={postActionsButton} />
+          <FooterTagList post={post} hideScore useAltAddTagButton hideAddTag={false} appendElement={postActionsButton} align="right" />
         </div>
       </AnalyticsContext>
       <div className={classes.rightSectionBottomRow}>

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -121,7 +121,8 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down('sm')]: {
       marginLeft: -8,
       marginRight: -8
-    }
+    },
+    paddingBottom: 12
   },
   nonTitleRows: {
     display: 'flex',

--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -35,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     position: 'unset',
     width: 'unset',
     left: -DEFAULT_TOC_MARGIN,
-    marginTop: fullHeightToCEnabled ? '-100vh' : -TOC_OFFSET_TOP,
+    marginTop: fullHeightToCEnabled ? 'calc(-64px - 50px)' : -TOC_OFFSET_TOP,
     marginBottom: fullHeightToCEnabled ? undefined : -TOC_OFFSET_BOTTOM,
 
     [theme.breakpoints.down('sm')]:{
@@ -44,14 +44,16 @@ const styles = (theme: ThemeType) => ({
       marginBottom: 0,
     },
   },
+  splashPageHeaderToc: {
+    marginTop: '-100vh'
+  },
   commentToCMargin: {
     marginTop: 'unset',
   },
   // This is needed for an annoying IntersectionObserver hack to prevent the title from being hidden when scrolling up
   commentToCIntersection: {
     // And unfortunately we need !important because otherwise this style gets overriden by the `top: 0` in `stickyBlockScroller`
-    top: '-1px !important',
-    paddingTop: 12
+    top: '-1px !important'
   },
   stickyBlockScroller: {
     position: "sticky",
@@ -115,10 +117,11 @@ export type ToCLayoutSegment = {
   isCommentToC?: boolean,
 };
 
-const MultiToCLayout = ({segments, classes, tocRowMap = []}: {
+const MultiToCLayout = ({segments, classes, tocRowMap = [], showSplashPageHeader = false}: {
   segments: ToCLayoutSegment[],
   classes: ClassesType<typeof styles>,
-  tocRowMap?: number[] // This allows you to specify which row each ToC should be in
+  tocRowMap?: number[], // This allows you to specify which row each ToC should be in, where maybe you want a ToC to span more than one row
+  showSplashPageHeader?: boolean,
 }) => {
   const tocVisible = true;
   const gridTemplateAreas = segments
@@ -127,7 +130,7 @@ const MultiToCLayout = ({segments, classes, tocRowMap = []}: {
   return <div className={classNames(classes.root)} style={{ gridTemplateAreas }}>
     {segments.map((segment,i) => <React.Fragment key={i}>
       {segment.toc && tocVisible && <>
-        <div className={classNames(classes.toc, { [classes.commentToCMargin]: segment.isCommentToC })} style={{ "gridArea": `toc${i}` }} >
+        <div className={classNames(classes.toc, { [classes.commentToCMargin]: segment.isCommentToC, [classes.splashPageHeaderToc]: showSplashPageHeader })} style={{ "gridArea": `toc${i}` }} >
           <div className={classNames(classes.stickyBlockScroller, { [classes.commentToCIntersection]: segment.isCommentToC })}>
             <div className={classes.stickyBlock}>
               {segment.toc}

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -99,16 +99,17 @@ const styles = (theme: ThemeType) => ({
   },
   titleContainer: {
     maxHeight: 200,
-    minHeight: 70,
+    minHeight: 30,
     display: 'flex',
     flexDirection: 'column-reverse',
-    transition: 'opacity 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
+    transition: 'opacity 0.4s ease-in-out, max-height 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
   },
   '@global': {
     // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global
     [`body:has(.headroom--pinned) .${TITLE_CONTAINER_CLASS_NAME}`]: {
       opacity: 0,
-      maxHeight: 64
+      maxHeight: 64,
+      minHeight: 64
     },
     [`body:has(.headroom--unfixed) .${TITLE_CONTAINER_CLASS_NAME}`]: {
       marginTop: 64

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -29,6 +29,9 @@ const styles = (theme: ThemeType) => ({
     justifyContent: 'flex-start',
     alignItems: 'center',
   },
+  alignRight: {
+    justifyContent: 'flex-end',
+  },
   allowTruncate: {
     display: isFriendlyUI ? "block" : "inline-flex",
     // Truncate to 3 rows (webkit-line-clamp would be ideal here but it adds an ellipsis
@@ -124,7 +127,8 @@ const FooterTagList = ({
   overrideMargins=false,
   appendElement,
   annualReviewMarketInfo,
-  classes
+  classes,
+  align = "left"
 }: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
   hideScore?: boolean,
@@ -139,6 +143,7 @@ const FooterTagList = ({
   overrideMargins?: boolean,
   appendElement?: ReactNode,
   annualReviewMarketInfo?: AnnualReviewMarketInfo,
+  align?: "left" | "right",
   classes: ClassesType<typeof styles>,
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
@@ -344,7 +349,7 @@ const FooterTagList = ({
   return <>
     <span
       ref={rootRef}
-      className={classNames(classes.root, {[classes.allowTruncate]: !showAll}, {[classes.overrideMargins] : overrideMargins})}
+      className={classNames(classes.root, {[classes.allowTruncate]: !showAll}, {[classes.overrideMargins] : overrideMargins, [classes.alignRight]: align === "right"})}
     >
       {innerContent}
       {appendElement}


### PR DESCRIPTION
Adds the date to the comment ToC for more consistency and to avoid having to shrink or grow it as much when the header comes down:  

<img width="330" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/24732240-be04-4633-a3ee-4e289d548dc5">

Also fixes some spacing issues on very short posts where the ToC sticks out at the top: 

<img width="1161" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/c4a6d615-2e10-48ad-9abd-f2adedeb6a46">

Also makes it so the post-ToC scrolls until the commentToC starts: 

<img width="1172" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/9f001641-52ed-4bd5-8972-c07a3cb6be47">

Also some other smaller fixes

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206745368770974) by [Unito](https://www.unito.io)
