### PR TITLE
Warn when calling `ensureIndex` before initializing Postgres tables

### DIFF
--- a/packages/lesswrong/lib/sql/PgCollection.ts
+++ b/packages/lesswrong/lib/sql/PgCollection.ts
@@ -254,6 +254,9 @@ class PgCollection<
     fieldOrSpec: MongoIndexFieldOrKey<ObjectsByCollectionName[N]>,
     options?: MongoEnsureIndexOptions<ObjectsByCollectionName[N]>,
   ) {
+    if (!this.table) {
+      throw new Error("Postgres tables must be initialized before calling ensureIndex");
+    }
     const key: MongoIndexKeyObj<ObjectsByCollectionName[N]> = typeof fieldOrSpec === "string"
       ? {[fieldOrSpec as keyof ObjectsByCollectionName[N]]: 1 as const} as MongoIndexKeyObj<ObjectsByCollectionName[N]>
       : fieldOrSpec;


### PR DESCRIPTION
Sometimes when making changes to to server startup or when server startup takes an unusually large amount of time for whatever reason you see an error message about calling `getIndex` on `undefined`. This happens when `ensureIndex` is called before Postgres tables are initialized. This PR adds a slightly more useful error message in this case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206756461750242) by [Unito](https://www.unito.io)
