### PR TITLE
Add UsersCurrent to UsersEdit

### DIFF
--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -408,7 +408,7 @@ registerFragment(`
 
 registerFragment(`
   fragment UsersEdit on User {
-    ...UsersProfile
+    ...UsersCurrent
     biography {
       ...RevisionEdit
     }


### PR DESCRIPTION
This adds the UsersCurrent fragment to the UsersEdit fragment (replacing UsersProfile – UsersCurrent is a superset of that).

This a) fixes an immediate bug where the "hide sunshine sidebar" admin setting can't be updated once you set it, and b)  hopefully prevents a class of errors where people add fields to UsersCurrent but forget to update them in UsersEdit

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206760138604346) by [Unito](https://www.unito.io)
