### PR TITLE
add score and baseScore to postItemMount tracking

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -449,6 +449,7 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
             <span className={classNames(classes.title, {[classes.hasSmallSubtitle]: !!resumeReading})}>
               <AnalyticsTracker
                   eventType={"postItem"}
+                  eventProps={{mountedPostId: post._id, mountedPostScore: post.score, mountedPostBaseScore: post.baseScore}}
                   captureOnMount={(eventData) => eventData.capturePostItemOnMount}
                   captureOnClick={false}
               >

--- a/packages/lesswrong/components/posts/usePostsList.ts
+++ b/packages/lesswrong/components/posts/usePostsList.ts
@@ -183,10 +183,14 @@ export const usePostsList = ({
 
   const postIds = (orderedResults || []).map((post) => post._id);
 
+  const postIdsWithScores = (orderedResults || []).map((post) => {
+      return {postId: post._id, score: post.score, baseScore: post.baseScore}
+    });
+
   // Analytics Tracking
   useOnMountTracking({
     eventType: "postList",
-    eventProps: {postIds, postVisibility: hiddenPosts},
+    eventProps: {postIds, postVisibility: hiddenPosts, postMountData: postIdsWithScores},
     captureOnMount: (eventProps) => eventProps.postIds.length > 0,
     skip: !postIds.length || loading,
   });


### PR DESCRIPTION
We already track each time a postItem is displayed. This PR adds the current score and baseScore of posts to the collected data in case that's helpful in making frontpage algorithm tweaks.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206760873835744) by [Unito](https://www.unito.io)
