### PR TITLE
Improve top of page ToC

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -69,7 +69,7 @@ const styles = (theme: ThemeType) => ({
     '& .TableOfContentsRow-title': {
       borderBottom: "none",
     },
-    transition: 'opacity .5s, transform .5s',
+    transition: 'opacity .5s, transform .5s, min-height 0.4s ease-in-out',
   },
   fadeOut: {
     opacity: 0,

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -10,6 +10,7 @@ const sectionOffsetStyling = (fullHeightToCEnabled ? {
 } : {});
 
 const TITLE_CONTAINER_CLASS_NAME = 'ToCTitleContainer';
+const FIXED_POSITION_TOC_CLASS_NAME = 'FixedPositionToC-root';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -111,6 +112,9 @@ const styles = (theme: ThemeType) => ({
       maxHeight: 84,
       minHeight: 64
     },
+    [`body:has(.headroom--unfixed) .${FIXED_POSITION_TOC_CLASS_NAME}`]: {
+      minHeight: 'calc(100vh - 64px)'
+    }
   }
 });
 


### PR DESCRIPTION
Recent changes me and Robert made causes the ToC to be slightly too tall when you are at the top of the post page, causing you to not see the bottom of it (and the number of comments)

This PR fixes that, in-exchange for the ToC being a bit short when you refresh while being scrolled down.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206761897051112) by [Unito](https://www.unito.io)
