### PR TITLE
Fix comment footnotes

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -497,7 +497,7 @@ export const commentBodyStyles = (theme: ThemeType, dontIncludePointerEvents?: B
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
 
-    '& .footnotes': {
+    '& .footnotes': isFriendlyUI ? {} : {
       marginTop: 0,
       paddingTop: 0,
     },

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -515,7 +515,6 @@ export const commentBodyStyles = (theme: ThemeType, dontIncludePointerEvents?: B
       ...theme.typography.commentHeader,
       ...theme.typography.commentStyle
     },
-
     // spoiler styles
     // HACK FIXME: Playing with pointer events is a horrible idea in general, and probably also in this context
     // but it's the only way I was able to make this weird stuff work.

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -497,6 +497,11 @@ export const commentBodyStyles = (theme: ThemeType, dontIncludePointerEvents?: B
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
 
+    '& .footnotes': {
+      marginTop: 0,
+      paddingTop: 0,
+    },
+
     '& blockquote': {
       ...theme.typography.commentBlockquote,
       ...theme.typography.body2,
@@ -510,6 +515,7 @@ export const commentBodyStyles = (theme: ThemeType, dontIncludePointerEvents?: B
       ...theme.typography.commentHeader,
       ...theme.typography.commentStyle
     },
+
     // spoiler styles
     // HACK FIXME: Playing with pointer events is a horrible idea in general, and probably also in this context
     // but it's the only way I was able to make this weird stuff work.


### PR DESCRIPTION
Spacing on comment footnotes has been off since forever, this fixes that. 

Now: 
<img width="734" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/219c34c5-4fe1-4f2e-86e5-ba4afe3df020">

Before: 
<img width="733" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/5298f2bb-5851-42c9-9fda-6ddcac84c8df">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206762330274709) by [Unito](https://www.unito.io)
