### PR TITLE
Adjust comment footnote styling a bit more

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -499,7 +499,9 @@ export const commentBodyStyles = (theme: ThemeType, dontIncludePointerEvents?: B
 
     '& .footnotes': isFriendlyUI ? {} : {
       marginTop: 0,
-      paddingTop: 0,
+      paddingTop: 8,
+      paddingLeft: 16,
+      marginBottom: 0
     },
 
     '& blockquote': {


### PR DESCRIPTION
Welp, turns out we have two types of footnotes, with slightly different styling. This finds a middle ground where both of them look OK, though it might be worth further tweaking. 