### PR TITLE
Quick takes autosave

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -145,10 +145,11 @@ export type CommentsNewFormProps = {
   fragment?: FragmentName,
   formProps?: any,
   enableGuidelines?: boolean,
-  padding?: boolean
-  formStyle?: FormDisplayMode
-  classes: ClassesType
-  className?: string
+  padding?: boolean,
+  formStyle?: FormDisplayMode,
+  overrideHintText?: string,
+  classes: ClassesType,
+  className?: string,
 }
 
 const CommentsNewForm = ({
@@ -166,6 +167,7 @@ const CommentsNewForm = ({
   enableGuidelines=true,
   padding=true,
   formStyle="default",
+  overrideHintText,
   classes,
   className,
 }: CommentsNewFormProps) => {
@@ -316,7 +318,10 @@ const CommentsNewForm = ({
   const hideDate = hideUnreviewedAuthorCommentsSettings.get()
   const commentWillBeHidden = hideDate && new Date(hideDate) < new Date() &&
     currentUser && !currentUser.isReviewed 
-  const extraFormProps = isMinimalist ? {commentMinimalistStyle: true, editorHintText: "Reply..."} : {}
+  const extraFormProps = {
+    ...(isMinimalist ? {commentMinimalistStyle: true, editorHintText: "Reply..."} : {}),
+    ...(overrideHintText ? {editorHintText: overrideHintText} : {})
+  }
   const parentDocumentId = post?._id || tag?._id
 
   useEffect(() => {

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -27,12 +27,12 @@ const styles = (theme: ThemeType) => ({
     border: `1px solid ${theme.palette.grey[200]}`,
   },
   commentEditor: {
-    padding: "1px 10px",
+    padding: isFriendlyUI ? "1px 10px" : undefined,
     background: theme.palette.grey[100],
     borderTopLeftRadius: getBorderRadius(theme),
     borderTopRightRadius: getBorderRadius(theme),
     "& .ck-placeholder::before": {
-      color: theme.palette.grey[600],
+      color: isFriendlyUI ? theme.palette.grey[600] : undefined,
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 14,
       fontWeight: 500,
@@ -71,6 +71,32 @@ const styles = (theme: ThemeType) => ({
     marginRight: 8,
   },
   ...submitButtonStyles(theme),
+  commentForm: {
+    '& .form-input': {
+      margin: 0,
+      minHeight: 30
+    },
+    '& .ck.ck-editor__editable_inline': {
+      border: "none !important",
+    },
+    '& .EditorTypeSelect-select': {
+      display: 'none',
+    },
+  },
+  commentFormCollapsed: {
+    '& .EditorFormComponent-commentEditorHeight': {
+      minHeight: 'unset'
+    },
+    '& .EditorFormComponent-commentEditorHeight .ck.ck-content': {
+      minHeight: 'unset'
+    },
+    '& .LocalStorageCheck-root': {
+      display: 'none',
+    },
+    '& .ck .ck-placeholder': {
+      position: 'unset'
+    },
+  },
 });
 
 // TODO: decide on copy for LW
@@ -176,10 +202,9 @@ const QuickTakesEntry = ({
 
   const onCancel = useCallback(async (ev?: MouseEvent) => {
     ev?.preventDefault();
-    editorRef.current?.clear(currentUser);
     setExpanded(false);
     void cancelCallback?.();
-  }, [currentUser, cancelCallback]);
+  }, [cancelCallback]);
 
 
   const onFocus = useCallback(() => setExpanded(true), []);
@@ -217,7 +242,7 @@ const QuickTakesEntry = ({
     return null;
   }
 
-  const {Editor, Loading, TagsChecklist} = Components;
+  const {Editor, Loading, TagsChecklist, CommentsNewForm} = Components;
 
   const cancelButton = (
     <Button
@@ -276,6 +301,31 @@ const QuickTakesEntry = ({
         </div>
       )
   );
+
+  if (!isFriendlyUI) {
+    const innerClassName = classNames(classes.commentEditor, {
+      [classes.collapsed]: !expanded,
+    });
+
+    return <div className={classNames(classes.root, className)}>
+      <div className={innerClassName} onFocus={onFocus}>
+        <CommentsNewForm
+          type='reply'
+          prefilledProps={{
+            shortform: true,
+            shortformFrontpage: frontpage,
+            relevantTagIds: selectedTagIds,
+          }}
+          enableGuidelines={false}
+          className={classNames(classes.commentForm, { [classes.commentFormCollapsed]: !expanded })}
+          cancelCallback={onCancel}
+          successCallback={successCallback}
+          overrideHintText={placeholder}
+        />
+      </div>
+      {expanded && isFriendlyUI && tagList}
+    </div>
+  }
 
   return (
     <form

--- a/packages/lesswrong/components/shortform/NewShortformDialog.tsx
+++ b/packages/lesswrong/components/shortform/NewShortformDialog.tsx
@@ -9,7 +9,7 @@ const styles = (_theme: ThemeType) => ({
     // This subselector is needed to beat the specificity of the default
     // MUI styles
     "&:first-child": {
-      padding: isFriendlyUI ? 0 : undefined,
+      padding: isFriendlyUI ? 0 : "0 20px 20px",
     },
   },
   dialogPaper: {

--- a/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
+++ b/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
@@ -29,7 +29,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: isFriendlyUI ? 700 : 500,
     fontSize: 20,
     color: theme.palette.grey[1000],
-    margin: 20,
+    margin: isFriendlyUI ? 20 : '16px 20px 16px 0px',
   },
   quickTakesRoot: {
     background: "transparent",


### PR DESCRIPTION
This PR switches LessWrong to using `CommentsNewForm` in `QuickTakesEntry` instead of using `Editor` directly, as well as fixing a long-standing bug with the "Cancel" button which prevented it from closing the form when clicking on the first time in some contexts.

For the EA Forum: this PR attempts to forum-gate both the functional change and also the styling changes.  The main difference that'd be present if you just ungated the functional change is that we no longer rely on the `submitButtonAtBottom` styling in the `NewShortformDialog > ShortformSubmitForm` context when rendering `QuickTakesEntry`.  The tag selection list looks fine (to me) in the frontpage section, so that probably doesn't need much work; I think the main thing required would be to pipe it into `CommentsNewForm` and add it to the `SubmitComponent` to preserve the "in between the input and the submit buttons" styling.