### PR TITLE
forum-gate font for global textarea:focus style

### DIFF
--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -32,7 +32,7 @@ const clearStyle = (theme: ThemeType): JssStyles => ({
   "textarea, textarea:focus, input, input:focus": {
     border: "none",
     outline: "none",
-    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
     color: theme.palette.text.maxIntensity,
   },
   


### PR DESCRIPTION
Small change slipped through; causes the font to change when a user focuses on e.g. a post title in the post editor.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206779290371381) by [Unito](https://www.unito.io)
