### PR TITLE
fix infinite loop when creating a new message from a template in the admin dashboard

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -5,6 +5,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import EmailIcon from '@material-ui/icons/Email';
 import { Link } from '../../lib/reactRouterWrapper';
+import isEqual from 'lodash/isEqual';
 
 const styles = (theme: JssStyles) => ({
   row: {
@@ -31,9 +32,12 @@ export const SunshineUserMessages = ({classes, user, currentUser}: {
 
   const { captureEvent } = useTracking()
 
-  const embedConversation = (conversationId: string, templateQueries: TemplateQueryStrings) => {
-    setEmbeddedConversationId(conversationId)
-    setTemplateQueries(templateQueries)
+  const embedConversation = (conversationId: string, newTemplateQueries: TemplateQueryStrings) => {
+    setEmbeddedConversationId(conversationId);
+    // Downstream components rely on referential equality of the templateQueries object in a useEffect; we get an infinite loop here if we don't check for value equality
+    if (!isEqual(newTemplateQueries, templateQueries)) {
+      setTemplateQueries(newTemplateQueries);
+    }
   }
 
   const { results } = useMulti({


### PR DESCRIPTION
`NewConversationButton` was calling `embedConversation` with a `templateQueries` object created by `SunshineSendMessageWithDefaults`, while also depending on that same `templateQueries` object in the `useEffect` where that `embedConversation` was called.  _Something_ about this was (I suspect) causing `SunshineSendMessageWithDefaults` to rerender, meaning the `templateQueries` prop it was passing to `NewConversationButton` was referentially unstable, so calling `embedConversation` triggered an infinite loop.

This explanation doesn't seem quite right since `SunshineSendMessageWithDefaults` only depends on `user` and `embedConversation`, neither of which should have changed as a result of calling `embedConversation`.  Maybe embedding the conversation caused `SunshineUserMessages` itself to get rerendered?  🤷

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206779496027042) by [Unito](https://www.unito.io)
