### PR TITLE
get user with fully hydrated moderation guidelines for prefilled props on a new post form

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -218,6 +218,13 @@ const PostsNewForm = ({classes}: {
     fragmentName: 'PostsEdit',
     skip: !templateId,
   });
+  // `UsersCurrent` doesn't have the editable field with their originalContents for performance reasons, so we need to fetch them explicitly
+  const { document: currentUserWithModerationGuidelines } = useSingle({
+    documentId: currentUser?._id,
+    collectionName: "Users",
+    fragmentName: "UsersEdit",
+    skip: !currentUser,
+  });
 
   const {
     PostSubmit, WrappedSmartForm, LoginForm, SubmitToFrontpageCheckbox,
@@ -225,7 +232,6 @@ const PostsNewForm = ({classes}: {
     NewPostModerationWarning, RateLimitWarning, DynamicTableOfContents,
   } = Components;
 
-  const userHasModerationGuidelines = !!currentUser?.moderationGuidelines?.html;
   const debateForm = !!(query && query.debate);
 
   const questionInQuery = query && !!query.question
@@ -246,7 +252,7 @@ const PostsNewForm = ({classes}: {
     af: isAF || (query && !!query.af),
     groupId: query && query.groupId,
     moderationStyle: currentUser && currentUser.moderationStyle,
-    moderationGuidelines: userHasModerationGuidelines ? currentUser!.moderationGuidelines : undefined,
+    moderationGuidelines: currentUserWithModerationGuidelines?.moderationGuidelines ?? undefined,
     debate: debateForm,
     postCategory
   }


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/8582 removed `originalContents` from various editable fields fetched by `UsersCurrent`, and didn't realize that `EditorFormComponent` relied on `originalContents`.  So moderation guidelines stopped getting pre-populated for users by default.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206781604695620) by [Unito](https://www.unito.io)
