### PR TITLE
don't use .at, it's an ES2022 api

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -201,7 +201,7 @@ function createDialoguePostFixer(editor: Editor, sortedCoauthors: UsersMinimumIn
       return true;
     }
 
-    const lastChild = children.at(-1);
+    const lastChild = children.slice(-1)?.[0];
     const inputWrapper = inputWrappers[0];
 
     // We check that the input wrapper is the last child of the root

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -19,6 +19,10 @@ import classNames from 'classnames';
 import { ToCDisplayOptions, adjustHeadingText, getAnchorY, isRegularClick, jumpToY, sectionsWithAnswersSorted } from './TableOfContentsList';
 
 function normalizeOffsets(sections: (ToCSection | ToCSectionWithOffset)[]): ToCSectionWithOffset[] {
+  if (sections.length === 0) {
+    return [];
+  }
+  
   const titleSection: ToCSectionWithOffset = { ...sections[0], offset: sections[0].offset ?? 0 };
 
   const remainingSections = sections.slice(1);
@@ -316,7 +320,7 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
     )
   });
 
-  const commentsRow = normalizedSections.at(-1)?.anchor === 'comments' ? rows.pop() : undefined;
+  const commentsRow = normalizedSections.slice(-1)?.[0]?.anchor === 'comments' ? rows.pop() : undefined;
 
   if (!tocSections || !hasLoaded)
     return <div/>


### PR DESCRIPTION
Noticed some errors in older safari versions on Sentry; turns out `.at` is an ES2022 api (which, [apparently unlike](https://github.com/ForumMagnum/ForumMagnum/pull/8683) `.findLast`, we can successfully use without bumping our tsconfig's `lib`?).  Switching back to using `.slice(-1)?.[0]` for fetching the last entry in an array in the two places where `.at` was used.

Unfortunately there doesn't seem to be e.g. a lint rule that'll warn on usage of ES-version-specific APIs, just syntax.  https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-unsupported-features/es-builtins.md is sort of that, but it doesn't have very good coverage.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206789826209823) by [Unito](https://www.unito.io)
