### PR TITLE
add a max file size for image uploads

### DIFF
--- a/packages/lesswrong/components/hooks/useImageUpload.tsx
+++ b/packages/lesswrong/components/hooks/useImageUpload.tsx
@@ -256,6 +256,7 @@ export const useImageUpload = ({
           },
         },
       },
+      maxFileSize: 5_000_000, // 5 MB
       ...cloudinaryArgs,
       uploadPreset,
       croppingAspectRatio,


### PR DESCRIPTION
We had an issue where a post's preview image was erroring, because the file was so large (8.5 MB) that Cloudinary wasn't able to transform it and returned a 400. I basically picked a random max file size (I tested out a 3.5 MB image, which was still giant, and Cloudinary handled it fine).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206791035060692) by [Unito](https://www.unito.io)
