### PR TITLE
move review winner highlight threshold and minimum karma to settings,and change threshold default

### DIFF
--- a/packages/lesswrong/lib/annualReviewMarkets.ts
+++ b/packages/lesswrong/lib/annualReviewMarkets.ts
@@ -1,6 +1,4 @@
-export const PROBABILITY_REVIEW_WINNER_THRESHOLD = 0.5
-
-export const MINIMUM_KARMA_REVIEW_MARKET_CREATION = 100;
+import { highlightReviewWinnerThresholdSetting } from "./instanceSettings";
 
 export type AnnualReviewMarketInfo = {
   probability: number;
@@ -20,4 +18,4 @@ export const getMarketInfo = (post: PostsBase): AnnualReviewMarketInfo | undefin
 }
 
 export const highlightMarket = (info: AnnualReviewMarketInfo | undefined): boolean =>
-  !!info && !info.isResolved && info.probability > PROBABILITY_REVIEW_WINNER_THRESHOLD
+  !!info && !info.isResolved && info.probability > highlightReviewWinnerThresholdSetting.get()

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -211,5 +211,10 @@ export const requireReviewToFrontpagePostsSetting = new PublicInstanceSetting<bo
 export const manifoldAPIKeySetting = new PublicInstanceSetting<string | null>('manifold.reviewBotKey', null, "optional")
 export const reviewUserBotSetting = new PublicInstanceSetting<string | null>('reviewBotId', null, "optional")
 
+/** Karma threshold upon which we automatically create a market for whether this post will be a winner in the review for its year */
+export const reviewMarketCreationMinimumKarmaSetting = new PublicInstanceSetting<number>('annualReviewMarket.marketCreationMinimumKarma', 100, "optional");
+/** Minimum market odds required to highlight this post (e.g. make its karma gold) as a potential review winner */
+export const highlightReviewWinnerThresholdSetting = new PublicInstanceSetting<number>('annualReviewMarket.highlightReviewWinnerThreshold', 0.25, "optional");
+
 export const myMidjourneyAPIKeySetting = new PublicInstanceSetting<string | null>('myMidjourney.apiKey', null, "optional");
 export const maxAllowedApiSkip = new PublicInstanceSetting<number | null>("maxAllowedApiSkip", 2000, "optional")

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Notifications from '../../lib/collections/notifications/collection';
 import { Posts } from '../../lib/collections/posts/collection';
 import Users from '../../lib/collections/users/collection';
-import { isLWorAF, reviewUserBotSetting } from '../../lib/instanceSettings';
+import { isLWorAF, reviewMarketCreationMinimumKarmaSetting, reviewUserBotSetting } from '../../lib/instanceSettings';
 import { voteCallbacks, VoteDocTuple } from '../../lib/voting/vote';
 import { userSmallVotePower } from '../../lib/voting/voteTypes';
 import { postPublishedCallback } from '../notificationCallbacks';
@@ -16,7 +16,6 @@ import { createAdminContext } from '../vulcan-lib';
 import { addOrUpvoteTag } from '../tagging/tagsGraphQL';
 import Tags from '../../lib/collections/tags/collection';
 import { isProduction } from '../../lib/executionEnvironment';
-import { MINIMUM_KARMA_REVIEW_MARKET_CREATION } from '../../lib/annualReviewMarkets';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { createManifoldMarket } from '../posts/annualReviewMarkets';
 
@@ -187,7 +186,7 @@ voteCallbacks.castVoteAsync.add(async ({newDocument, vote}: VoteDocTuple, collec
 
   if (collection.collectionName !== "Posts") return;
   if (vote.power <= 0 || vote.cancelled) return; // In principle it would be fine to make a market here, but it should never be first created here
-  if (newDocument.baseScore < MINIMUM_KARMA_REVIEW_MARKET_CREATION) return;
+  if (newDocument.baseScore < reviewMarketCreationMinimumKarmaSetting.get()) return;
   const post = await Posts.findOne({_id: newDocument._id})
   if (!post) return;
   if (post.postedAt.getFullYear() < (new Date()).getFullYear() - 1) return; // only make markets for posts that haven't had a chance to be reviewed


### PR DESCRIPTION
Moved the consts to instance settings and changed the probability threshold for highlighting posts to 25%.

<img width="477" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/552225d8-d584-4fb4-b22a-87d9e7722846">
 

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206791319530799) by [Unito](https://www.unito.io)
