### PR TITLE
don't show the login prompt for an inaccessible post page

### DIFF
--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from './withUser';
 import { useServerRequestStatus } from '../../lib/routeUtil'
 import { isFriendlyUI } from '../../themes/forumTheme';
+import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI
@@ -10,12 +11,26 @@ const styles = (theme: ThemeType) => ({
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 14,
       fontWeight: 500,
+      lineHeight: '24px',
+      textWrap: 'pretty',
+      marginTop: 30
     }
     :{},
 });
 
-const ErrorAccessDenied = ({explanation, classes}: {
+/**
+ * Show a simple "you don't have access" message if the user is logged in,
+ * or a "please log in" message if the user is logged out.
+ *
+ * Most of the time, we use this when a page is meant to be accessed by only a subset of
+ * logged in users, so by default this prompts the user to log in if they are logged out.
+ *
+ * However, for pages that are normally meant to be publicly accessible (like the post page),
+ * we skip the login prompt and just display the "you don't have access" message.
+ */
+const ErrorAccessDenied = ({explanation, skipLoginPrompt, classes}: {
   explanation?: string,
+  skipLoginPrompt?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {
   const { SingleColumnSection, Typography } = Components;
@@ -23,7 +38,7 @@ const ErrorAccessDenied = ({explanation, classes}: {
   const currentUser = useCurrentUser();
   if (serverRequestStatus) serverRequestStatus.status = 403
   
-  if (currentUser) {
+  if (currentUser || skipLoginPrompt) {
     const message = `Sorry, you don't have access to this page.${(explanation ? ` ${explanation}` : "")}`
     return <SingleColumnSection>
       <div className={classes.root}>{message}</div>

--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -7,9 +7,8 @@ import { isFriendlyUI } from '../../themes/forumTheme';
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI
     ? {
-      maxWidth: 600,
       fontFamily: theme.palette.fonts.sansSerifStack,
-      fontSize: 15,
+      fontSize: 16,
       fontWeight: 500,
       lineHeight: '26px',
       textWrap: 'pretty',

--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -7,10 +7,11 @@ import { isFriendlyUI } from '../../themes/forumTheme';
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI
     ? {
+      maxWidth: 600,
       fontFamily: theme.palette.fonts.sansSerifStack,
-      fontSize: 14,
+      fontSize: 15,
       fontWeight: 500,
-      lineHeight: '24px',
+      lineHeight: '26px',
       textWrap: 'pretty',
       marginTop: 30
     }

--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -3,7 +3,6 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from './withUser';
 import { useServerRequestStatus } from '../../lib/routeUtil'
 import { isFriendlyUI } from '../../themes/forumTheme';
-import { isEAForum } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -62,7 +62,7 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
     if (isMissingDocumentError(error)) {
       return <Error404/>
     } else if (isOperationNotAllowedError(error)) {
-      return <Components.ErrorAccessDenied explanation={"This is usually because the post in question has been removed by the author."}/>
+      return <Components.ErrorAccessDenied explanation={"This is usually because the post in question has been removed by the author."} skipLoginPrompt />
     } else {
       throw new Error(error.message);
     }


### PR DESCRIPTION
Currently, if a logged out user goes to a post page that is inaccessible (like a draft), then they will first get prompted to log in, and then after logging in the page will say that the post is inaccessible. This PR makes it so that logged out users don't get prompted to log in in this case, and only see the second message. Also I cleaned up the styling a bit.

<img width="917" alt="Screen Shot 2024-03-07 at 7 11 40 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/432cceaf-8410-4e90-ba5e-5e07cf7d113d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206791495318768) by [Unito](https://www.unito.io)
