### PR TITLE
show active rate limits in mod dashboard

### DIFF
--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -142,7 +142,7 @@ function getRateLimitName (rateLimit: AutoRateLimit) {
 
 function getActiveRateLimits<T extends AutoRateLimit>(user: UserKarmaInfo & { recentKarmaInfo: RecentKarmaInfo }, autoRateLimits: T[]) {
   const nonUniversalLimits = autoRateLimits.filter(rateLimit => rateLimit.rateLimitType !== "universal")
-  return nonUniversalLimits.filter(rateLimit => (!rateLimit.isActive(user, {...user.recentKarmaInfo, downvoteRatio: getDownvoteRatio(user)})))
+  return nonUniversalLimits.filter(rateLimit => rateLimit.isActive(user, {...user.recentKarmaInfo, downvoteRatio: getDownvoteRatio(user)}))
 }
 
 export function getActiveRateLimitNames(user: SunshineUsersList, autoRateLimits: AutoRateLimit[]) {


### PR DESCRIPTION
I have no idea how this happened.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206791401548147) by [Unito](https://www.unito.io)
