### PR TITLE
remove asymmetric bottom padding for new comment buttons

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -68,7 +68,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     boxShadow: 'none',
     marginLeft: 8,
   } : {
-    paddingBottom: "2px",
     fontSize: "16px",
     color: theme.palette.lwTertiary.main,
     marginLeft: "5px",


### PR DESCRIPTION
old:
<img width="1261" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/96ba6b13-3973-4d0a-9c21-39b00643914f">

new:
<img width="1261" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/2136984/f1a67e90-a668-406a-a4be-b890bf166e0f">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206791437052707) by [Unito](https://www.unito.io)
