### PR TITLE
Fix unnecessary flicker for crossposts hosted here

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageCrosspostWrapper.tsx
@@ -51,7 +51,7 @@ const PostsPageCrosspostWrapper = ({post, eagerPostComments, refetch, fetchProps
   // from rendering the post if we have it locally
   if (error && !post.fmCrosspost.hostedHere && !isMissingDocumentError(error) && !isOperationNotAllowedError(error)) {
     throw new Error(error.message);
-  } else if (loading) {
+  } else if (loading && !post.fmCrosspost.hostedHere) {
     return <div><Loading/></div>
   } else if (!post.fmCrosspost.hostedHere && !foreignPost && !post.draft) {
     return <Error404/>


### PR DESCRIPTION
Thanks to Jim's recent PR (https://github.com/ForumMagnum/ForumMagnum/pull/8863) posts that are navigated to from the frontpage now no longer need to show a loading state. Crossposts still show loading dots while the foreign post is loading, but this is not only necessary when `hostedHere` is false