### PR TITLE
Native node source map support

### DIFF
--- a/build.js
+++ b/build.js
@@ -151,7 +151,7 @@ build({
   },
 });
 
-let serverCli = ["node", "-r", "source-map-support/register", "--", `${getOutputDir()}/server/js/serverBundle.js`, "--settings", settingsFile]
+let serverCli = ["node", "--enable-source-maps", "--", `${getOutputDir()}/server/js/serverBundle.js`, "--settings", settingsFile]
 if (opts.shell)
   serverCli.push("--shell");
 if (opts.command) {

--- a/package.json
+++ b/package.json
@@ -298,7 +298,6 @@
     "setimmediate": "^1.0.5",
     "shallowequal": "^1.1.0",
     "simpl-schema": "^1.5.0",
-    "source-map-support": "^0.5.19",
     "speakingurl": "^9.0.0",
     "stripe": "^8.126.0",
     "tlds": "^1.203.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15004,7 +15004,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.19, source-map-support@^0.5.6:
+source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
Use native node source map functionality instead of the `source-map-support` library. This removes a CPU-bottleneck during server startup, and also considerably reduces memory usage.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206798881653550) by [Unito](https://www.unito.io)
