### PR TITLE
add skip logic to pipeline query compilation

### DIFF
--- a/packages/lesswrong/lib/sql/Pipeline.ts
+++ b/packages/lesswrong/lib/sql/Pipeline.ts
@@ -15,6 +15,7 @@ class Unit<T extends DbObject> {
   private addFields: any;
   private sort?: any;
   private limit?: number;
+  private skip?: number;
   private selector?: any;
   private lookup?: any;
   private group?: any;
@@ -41,6 +42,7 @@ class Unit<T extends DbObject> {
       {
         sort: this.sort,
         limit: this.limit,
+        skip: this.skip,
         projection: this.project,
       },
       {
@@ -80,6 +82,10 @@ class Unit<T extends DbObject> {
 
   addLimitStage(data: number): Unit<T> {
     return this.addSimpleStage("limit", data);
+  }
+
+  addSkipStage(data: number): Unit<T> {
+    return this.addSimpleStage("skip", data);
   }
 
   addLookupStage(data: Lookup): Unit<T> {
@@ -151,6 +157,7 @@ class Pipeline<T extends DbObject> {
         case "$addFields": unit = unit.addAddFieldsStage(data); break;
         case "$sort":      unit = unit.addSortStage(data);      break;
         case "$limit":     unit = unit.addLimitStage(data);     break;
+        case "$skip":      unit = unit.addSkipStage(data);      break;
         case "$lookup":    unit = unit.addLookupStage(data);    break;
         case "$project":   unit = unit.addProjectStage(data);   break;
         case "$group":     unit = unit.addGroupStage(data);     break;

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -300,7 +300,7 @@ const performQueryFromViewParameters = async <N extends CollectionNameString>(
   };
 
   // I don't know if we ever get a `skip` value in `parameters.options`, but if we do, we've been running on that logic for years
-  // So defer to that instead of override it with the value from `terms.offset`
+  // So defer to that if it exists, instead of overriding it with the value from `terms.offset`
   parameters.options.skip ??= options.skip;
 
   if (parameters.syntheticFields && Object.keys(parameters.syntheticFields).length>0) {

--- a/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
+++ b/packages/lesswrong/lib/vulcan-core/default_resolvers.ts
@@ -232,7 +232,6 @@ export function getDefaultResolvers<N extends CollectionNameString>(
           );
           const compiledQuery = query.compile();
           const db = getSqlClientOrThrow();
-          console.log({ compiledQuery });
           doc = await db.oneOrNone(compiledQuery.sql, compiledQuery.args);
         } else {
           doc = await Utils.Connectors.get(collection, selector);


### PR DESCRIPTION
A follow-up to the [sqlFragments PR](https://github.com/ForumMagnum/ForumMagnum/pull/8718) had a bug in it which broke frontpage sorting, because it generated SQL which referenced the score field on posts by alias, rather than the "shadow" score field generated by the synthetic field selector.

The [fix](https://github.com/ForumMagnum/ForumMagnum/pull/8818) for that was to rename the synthetic field.  This caused `performQueryFromViewParameters` to begin to take the pipeline branch instead of the regular query branch, and the pipeline branch has had what looks like an extremely long-standing bug which ignores the offset if it's passed in via the query terms (since it references `parameters.options.skip`, while above we reassign `skip: terms.offset` to a new `options` object which we only use in the non-pipeline branch).  Probably we hadn't written logic which obviously relied on that parameter getting passed in for those cases in the past?

Trying to fix that the obvious way ran into an `Invalid pipeline stage: $skip` error, since $skip was never implemented in the query builder for pipelines/aggregations.

This PR implements logic for compiling `$skip` steps in pipelines and assigns the value we get from `offset` to the pipeline if there isn't already another value in the parameter options.  (This is deferring to existing behavior in any case where we somehow did have a value there from elsewhere.  I'm not sure if that ever happens or not, but it seems slightly safer than overwriting it.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206799605626452) by [Unito](https://www.unito.io)
