### PR TITLE
Right-align karma in CommentsTableOfContents

### DIFF
--- a/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
+++ b/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
@@ -26,6 +26,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   commentKarma: {
     width: 20,
+    textAlign: "right",
+    marginRight: 4,
   },
   commentAuthor: {
   },


### PR DESCRIPTION
Potential styling change of the comments table of contents in the side-bar, right-aligning the karma count. I think it makes it look less cluttered and makes it easier to visually scan.

| Current | Proposed |
| -------- | ------- |
| <img width="239" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3543224/155c4471-fa21-4763-b80a-737a2799ecff"> | <img width="252" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3543224/eebd0e26-4256-478a-bcbc-4d73cc30625d"> |

Note I'm not actually running a local version of the forum, I just tried out the styles in my browser:
<img width="302" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3543224/7dc2ad47-79b8-492b-a6a4-be27389e053c">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206800170428896) by [Unito](https://www.unito.io)
