### PR TITLE
Fix search bar layout shift

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -379,9 +379,7 @@ const Header = ({
 
   // the items on the right-hand side (search, notifications, user menu, login/sign up buttons)
   const rightHeaderItemsNode = <div className={classes.rightHeaderItems}>
-    <NoSSR onSSR={<div className={classes.searchSSRStandin} />} >
-      <SearchBar onSetIsActive={setSearchOpen} searchResultsArea={searchResultsArea} />
-    </NoSSR>
+    <SearchBar onSetIsActive={setSearchOpen} searchResultsArea={searchResultsArea} />
     {!isFriendlyUI && usersMenuNode}
     {!currentUser && <UsersAccountMenu />}
     {hasKarmaChangeNotifier && <KarmaChangeNotifier

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -192,7 +192,7 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
              // @ts-ignore */}
             {inputOpen && <SearchBox reset={null} focusShortcuts={[]} autoFocus={true} />}
           </div>
-          { searchOpen && <div className={classes.searchBarClose} onClick={closeSearch}>
+          { inputOpen && <div className={classes.searchBarClose} onClick={closeSearch}>
             <CloseIcon className={classes.closeSearchIcon}/>
           </div>}
           <div>


### PR DESCRIPTION
This was being NoSSR-ed. I tried removing this and I can't find any downside, it doesn't complain when running on the server and doesn't even seem to make any requests until you type something. I also can't see any performance hit, and other places that use InstantSearch don't have a NoSSR, so I think it's fine.

Maybe this used to be necessary when we used algolia (cc @oetherington ?) but isn't anymore. Anyway I've removed it here to fix the layout shift of the icon not appearing immediately. If the NoSSR is necessary I can do this in another way.

cc @b0b3rt in case you still use Algolia