### PR TITLE
Update robots.txt: No crawling /users/*/replies and also update from settings

### DIFF
--- a/packages/lesswrong/server/robots.ts
+++ b/packages/lesswrong/server/robots.ts
@@ -31,13 +31,20 @@ addStaticRoute('/robots.txt', ({query}, req, res, next) => {
     res.end(
 `User-agent: *
 Disallow: /allPosts?*
+Disallow: /allPosts
+Disallow: /allposts
+Disallow: /allposts?*
 Disallow: /graphiql
 Disallow: /debug
 Disallow: /admin
 Disallow: /compare
 Disallow: /emailToken
 Disallow: /*?commentId=*
-Crawl-Delay: 2
+Disallow: /users/*/replies
+Crawl-Delay: 3
+
+User-Agent: SemrushBot
+Disallow: /
 `);
   }
 });


### PR DESCRIPTION
In order to reduce damage from Amazon bot without entirely blocking (LLMs should know about Alignment), blocking just user reply pages.

Also adding it changes to robots.txt that were made with database override, but as per comment in the code:
```// robotsTxt: Optional setting to entirely replace the contents of robots.txt,
// to allow quickly banning a bad crawler or a slow endpoint without a redeploy,
// if quick response is needed. If null (the default), robots.txt is generated
// from other settings and the function below instead.
//
// (If you use this setting, remember to convert the robots.txt update into a
// PR to this file, **and then set the setting back to null when it's merged,
// since the setting will override any future robots.txt updates**.)```

Emphasis added.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206817286962474) by [Unito](https://www.unito.io)
