### PR TITLE
Manage long tocs

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { isServer } from '../../../lib/executionEnvironment';
@@ -65,8 +65,6 @@ const styles = (theme: ThemeType) => ({
   root: {
     left: 0,
     top: 0,
-    maxHeight: '100vh',
-    height: '100%',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-evenly',
@@ -76,6 +74,9 @@ const styles = (theme: ThemeType) => ({
     },
     wordBreak: 'break-word',
     transition: 'opacity .5s ease-in-out 0.5s, transform .5s ease-in-out 0.5s, height 0.4s ease-in-out, max-height 0.4s ease-in-out',
+  },
+  shorterToc: {
+    height: '100%',
   },
   fadeOut: {
     opacity: 0,
@@ -165,6 +166,9 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
   const { tocVisible } = useContext(SidebarsContext)!;
 
   const [normalizedSections, setNormalizedSections] = useState<ToCSectionWithOffset[]>([]);
+
+  const tocRef = useRef<HTMLDivElement>(null);
+  const [shorterToc, setShorterToc] = useState(false);
 
   const jumpToAnchor = (anchor: string) => {
     if (isServer) return;
@@ -259,6 +263,16 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
     }
   }, [filteredSections, normalizedSections, hasLoaded]);
 
+  useEffect(() => {
+    if (!tocRef.current) {
+      return;
+    }
+
+    if (tocRef.current.getBoundingClientRect().height < (window.innerHeight - 64)) {
+      setShorterToc(true);
+    }
+  }, [normalizedSections]);
+
   const postContext = usePostsPageContext();
   const disableProgressBar = (!postContext || isServer || postContext.shortform || postContext.readTimeMinutes < 2);
 
@@ -327,7 +341,7 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
   if (!tocSections || !hasLoaded)
     return <div/>
 
-  return <div className={classNames(classes.root, { [classes.fadeIn]: tocVisible, [classes.fadeOut]: !tocVisible })}>
+  return <div ref={tocRef} className={classNames(classes.root, { [classes.fadeIn]: tocVisible, [classes.fadeOut]: !tocVisible, [classes.shorterToc]: shorterToc })}>
     {titleRow}
     <div className={classes.belowTitle}>
       <div className={classes.progressBarContainer} ref={readingProgressBarRef}>

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -268,6 +268,7 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
       return;
     }
 
+    // We sometimes set a `maxHeight` of `calc(100vh - 64) in `TableOfContentsRow`, so we need to check not against the innerHeight but that minus 64 px.
     if (tocRef.current.getBoundingClientRect().height < (window.innerHeight - 64)) {
       setShorterToc(true);
     }

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { isServer } from '../../../lib/executionEnvironment';
@@ -65,18 +65,16 @@ const styles = (theme: ThemeType) => ({
   root: {
     left: 0,
     top: 0,
+    maxHeight: '100vh',
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-evenly',
     //Override bottom border of title row for FixedToC but not in other uses of TableOfContentsRow
     '& .TableOfContentsRow-title': {
       borderBottom: "none",
     },
     wordBreak: 'break-word',
     transition: 'opacity .5s ease-in-out 0.5s, transform .5s ease-in-out 0.5s, height 0.4s ease-in-out, max-height 0.4s ease-in-out',
-  },
-  shorterToc: {
-    height: '100%',
   },
   fadeOut: {
     opacity: 0,
@@ -166,9 +164,6 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
   const { tocVisible } = useContext(SidebarsContext)!;
 
   const [normalizedSections, setNormalizedSections] = useState<ToCSectionWithOffset[]>([]);
-
-  const tocRef = useRef<HTMLDivElement>(null);
-  const [shorterToc, setShorterToc] = useState(false);
 
   const jumpToAnchor = (anchor: string) => {
     if (isServer) return;
@@ -263,17 +258,6 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
     }
   }, [filteredSections, normalizedSections, hasLoaded]);
 
-  useEffect(() => {
-    if (!tocRef.current) {
-      return;
-    }
-
-    // We sometimes set a `maxHeight` of `calc(100vh - 64) in `TableOfContentsRow`, so we need to check not against the innerHeight but that minus 64 px.
-    if (tocRef.current.getBoundingClientRect().height < (window.innerHeight - 64)) {
-      setShorterToc(true);
-    }
-  }, [normalizedSections]);
-
   const postContext = usePostsPageContext();
   const disableProgressBar = (!postContext || isServer || postContext.shortform || postContext.readTimeMinutes < 2);
 
@@ -342,7 +326,7 @@ const FixedPositionToc = ({tocSections, title, postedAt, onClickSection, display
   if (!tocSections || !hasLoaded)
     return <div/>
 
-  return <div ref={tocRef} className={classNames(classes.root, { [classes.fadeIn]: tocVisible, [classes.fadeOut]: !tocVisible, [classes.shorterToc]: shorterToc })}>
+  return <div className={classNames(classes.root, { [classes.fadeIn]: tocVisible, [classes.fadeOut]: !tocVisible })}>
     {titleRow}
     <div className={classes.belowTitle}>
       <div className={classes.progressBarContainer} ref={readingProgressBarRef}>

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -100,10 +100,11 @@ const styles = (theme: ThemeType) => ({
     ...sectionOffsetStyling,
   },
   titleContainer: {
+    height: '100%',
     maxHeight: 200,
     display: 'flex',
     flexDirection: 'column-reverse',
-    transition: 'opacity 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
+    transition: 'opacity 0.4s ease-in-out, height 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
   },
   '@global': isFriendlyUI ? {} : {
     // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global


### PR DESCRIPTION
ToCs that are larger than one viewport end up being messed up by `height: 100%`, while ToCs that are shorter need it in order to not collapse to the minimum necessary for the section headers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206825483121036) by [Unito](https://www.unito.io)
