### PR TITLE
Fix comment id in tooltip for new comment notifications

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageNotification.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageNotification.tsx
@@ -105,7 +105,7 @@ export const NotificationsPageNotification = ({
   const Comment: FC = useCallback(() => comment
     ? (
       <Components.PostsTooltip
-        postId={displayPost?._id}
+        postId={comment.post?._id ?? displayPost?._id}
         commentId={comment._id}
         tagRelId={tagRelId}
       >


### PR DESCRIPTION
The tooltip over the word "comment" is currently broken for notifications for new comments on a subscribed post.

<img width="567" alt="Screenshot 2024-03-12 at 20 08 47" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/1209acac-ba9f-4c45-bbe5-c8186e5beaa4">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206826043721506) by [Unito](https://www.unito.io)
