### PR TITLE
Add automatic permissions checks for SQL resolvers

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-server/initGraphQL.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/initGraphQL.ts
@@ -27,7 +27,8 @@ import {
   deleteMutationTemplate,
 } from './graphqlTemplates';
 import type { GraphQLScalarType, GraphQLSchema } from 'graphql';
-import { pluralize, camelCaseify, camelToSpaces } from '../../../lib/vulcan-lib';
+import { pluralize, camelCaseify, camelToSpaces, getCollectionByTypeName } from '../../../lib/vulcan-lib';
+import { accessFilterMultiple, accessFilterSingle } from '../../../lib/utils/schemaUtils';
 import { userCanReadField } from '../../../lib/vulcan-users/permissions';
 import { getSchema } from '../../../lib/utils/getSchema';
 import deepmerge from 'deepmerge';
@@ -153,6 +154,33 @@ const getGraphQLType = <N extends CollectionNameString>(
   }
 };
 
+/**
+ * Get the data needed to apply an access filter based on a graphql resolver
+ * return type.
+ */
+const getSqlResolverPermissionsData = (type: string|GraphQLScalarType) => {
+  // We only have access filters for return types that correspond to a collection.
+  if (typeof type !== "string") {
+    return null;
+  }
+
+  // We need to use a multi access filter for arrays, or a single access filter
+  // otherwise. We only apply the automatic filter for single dimensional arrays.
+  const isArray = type.indexOf("[") === 0 && type.lastIndexOf("[") === 0;
+
+  // Remove all "!"s (denoting nullability) and any array brackets to leave behind
+  // a type name string.
+  const nullableScalarType = type.replace(/[![\]]+/g, "");
+
+  try {
+    // Get the collection corresponding to the type name string.
+    const collection = getCollectionByTypeName(nullableScalarType);
+    return collection ? {collection, isArray} : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
 export type SchemaGraphQLFieldArgument = {name: string, type: string|GraphQLScalarType|null}
 export type SchemaGraphQLFieldDescription = {
   description?: string
@@ -222,6 +250,8 @@ const getFields = <N extends CollectionNameString>(schema: SchemaType<N>, typeNa
           type: fieldGraphQLType,
         });
 
+        const permissionData = getSqlResolverPermissionsData(field.resolveAs!.type);
+
         // then build actual resolver object and pass it to addGraphQLResolvers
         const resolver = {
           [typeName]: {
@@ -241,6 +271,17 @@ const getFields = <N extends CollectionNameString>(schema: SchemaType<N>, typeNa
                 const typedName = resolverName as keyof ObjectsByCollectionName[N];
                 const existingValue = document[typedName];
                 if (existingValue !== undefined) {
+                  if (permissionData) {
+                    const filter = permissionData.isArray
+                      ? accessFilterMultiple
+                      : accessFilterSingle;
+                    return filter(
+                      context.currentUser,
+                      permissionData.collection,
+                      existingValue,
+                      context,
+                    );
+                  }
                   return existingValue;
                 }
               }


### PR DESCRIPTION
This PR adds automatic permissions checks using `accessFilterSingle` and `accessFilterMultiple` for DB objects returned by SQL resolvers. There are currently no fields that this affects, but this is required before we can merge #8769, otherwise that PR would introduce a vulnerability where the contents of deleted posts could be read by viewing the relevant side comments cache.

In the future we can (and probably should) expand this to include results of code resolvers as well, which should be a trivial addition. This would remove the need to use these filters manually in resolvers, which is often forgotten anyway.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206826435114499) by [Unito](https://www.unito.io)
