### PR TITLE
flag users getting downvoted by senior users on net-negative comments

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -22,6 +22,7 @@ export const REJECTED_POST = 'rejectedPost';
 export const REJECTED_COMMENT = 'rejectedComment';
 export const POTENTIAL_TARGETED_DOWNVOTING = 'potentialTargetedDownvoting';
 export const EXEMPT_FROM_RATE_LIMITS = 'exemptFromRateLimits';
+export const RECEIVED_SENIOR_DOWNVOTES_ALERT = 'receivedSeniorDownvotesAlert';
 
 export const postRateLimits = [] as const
 
@@ -66,6 +67,7 @@ export const MODERATOR_ACTION_TYPES = {
   [REJECTED_COMMENT]: 'Rejected Comment',
   [POTENTIAL_TARGETED_DOWNVOTING]: 'Suspected targeted downvoting of a specific user',
   [EXEMPT_FROM_RATE_LIMITS]: 'Exempt from rate limits',
+  [RECEIVED_SENIOR_DOWNVOTES_ALERT]: 'Received too many downvotes on net-negative comments from senior users',
 };
 
 /** The max # of users an unapproved account is allowed to DM before being flagged */

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -586,7 +586,7 @@ type ModeratorActionsCollection = CollectionBase<"ModeratorActions">;
 interface DbModeratorAction extends DbObject {
   __collectionName?: "ModeratorActions"
   userId: string
-  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits"
+  type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits" | "receivedSeniorDownvotesAlert"
   endedAt: Date | null
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1003,7 +1003,7 @@ interface MessagesDefaultFragment { // fragment on Messages
 
 interface ModeratorActionsDefaultFragment { // fragment on ModeratorActions
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits" | "receivedSeniorDownvotesAlert",
   readonly endedAt: Date | null,
 }
 
@@ -3492,7 +3492,7 @@ interface ModeratorActionDisplay { // fragment on ModeratorActions
   readonly _id: string,
   readonly user: UsersMinimumInfo|null,
   readonly userId: string,
-  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits",
+  readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits" | "receivedSeniorDownvotesAlert",
   readonly active: boolean,
   readonly createdAt: Date,
   readonly endedAt: Date | null,

--- a/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
@@ -1,4 +1,4 @@
-import { isActionActive, MODERATOR_ACTION_TYPES } from '../../lib/collections/moderatorActions/schema';
+import { isActionActive, MODERATOR_ACTION_TYPES, RECEIVED_SENIOR_DOWNVOTES_ALERT } from '../../lib/collections/moderatorActions/schema';
 import { appendToSunshineNotes } from '../../lib/collections/users/helpers';
 import { loggerConstructor } from '../../lib/utils/logging';
 import { getCollectionHooks } from '../mutationCallbacks';
@@ -8,7 +8,7 @@ getCollectionHooks('ModeratorActions').createAsync.add(async function triggerRev
   const moderatorAction = newDocument;
   const logger = loggerConstructor('callbacks-moderatoractions');
   logger('ModeratorAction created, triggering review if necessary')
-  if (isActionActive(moderatorAction)) {
+  if (isActionActive(moderatorAction) || moderatorAction.type === RECEIVED_SENIOR_DOWNVOTES_ALERT) {
     logger('isActionActive truthy')
     void triggerReview(moderatorAction.userId);
   }

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -18,7 +18,6 @@ import Tags from '../../lib/collections/tags/collection';
 import { isProduction } from '../../lib/executionEnvironment';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { createManifoldMarket } from '../posts/annualReviewMarkets';
-import { ModeratorActions } from '../../lib/collections/moderatorActions';
 import { RECEIVED_SENIOR_DOWNVOTES_ALERT } from '../../lib/collections/moderatorActions/schema';
 
 export const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
@@ -278,7 +277,7 @@ voteCallbacks.castVoteAsync.add(async ({ newDocument, vote }, collection, user, 
 
   if (commentCount > 20 && longtermSeniorDownvoterCount >= 3 && longtermScore < 0) {
     void createMutator({
-      collection: ModeratorActions,
+      collection: context.ModeratorActions,
       document: {
         type: RECEIVED_SENIOR_DOWNVOTES_ALERT,
         userId: userId,

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -252,7 +252,7 @@ const makeMarketComment = async (postId: string, year: number, marketUrl: string
 }
 
 voteCallbacks.castVoteAsync.add(async ({ newDocument, vote }, collection, user, context) => {
-  if (vote.collectionName !== 'Comments' || !newDocument.userId) {
+  if (!isLWorAF || vote.collectionName !== 'Comments' || !newDocument.userId) {
     return;
   }
 


### PR DESCRIPTION
https://github.com/ForumMagnum/ForumMagnum/pull/8635 but just flag those users for review with a moderator action rather than applying an automatic rate limit.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206826331160456) by [Unito](https://www.unito.io)
