### PR TITLE
Fix null `tagRelevance` dereference in post page forum event banner

### DIFF
--- a/packages/lesswrong/components/forumEvents/ForumEventPostPageBanner.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPostPageBanner.tsx
@@ -62,7 +62,7 @@ export const ForumEventPostPageBanner = ({classes}: {
     return null;
   }
 
-  const relevance = post?.tagRelevance[currentForumEvent.tagId] ?? 0;
+  const relevance = post?.tagRelevance?.[currentForumEvent.tagId] ?? 0;
   if (relevance < 1) {
     return null;
   }


### PR DESCRIPTION
We currently have a live and nasty bug where some posts aren't shown as we have a derefence of `tagRelevance` without checking if it's null. Typescript doesn't catch this because `tagRelevance` is typed as `any` - probably we should add a way for blackbox types to define an explicit Typescript type (which should be `Record<string, number> | null` in this case).