### PR TITLE
remove quick takes section from AF home page, since it's usually empty

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
@@ -47,7 +47,6 @@ const AlignmentForumHome = ({classes}: {
         </SectionTitle>
         <PostsList2 terms={recentPostsTerms} />
       </SingleColumnSection>
-      <QuickTakesSection />
       <EAPopularCommentsSection />
       <SingleColumnSection>
         <RecentDiscussionThreadsList


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206836999545379) by [Unito](https://www.unito.io)
