### PR TITLE
Add a unique index on UserJobAds (underlying problem may still be there)

### DIFF
--- a/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
@@ -203,7 +203,7 @@ const TargetedJobAdSection = () => {
         adState: 'seen'
       }
     }).finally(refetchUserJobAds)
-  }, [currentUser, userJobAds, userJobAdsLoading, activeJob, entry, createUserJobAd])
+  }, [currentUser, userJobAds, userJobAdsLoading, refetchUserJobAds, activeJob, entry, createUserJobAd])
   
   const dismissJobAd = useCallback(() => {
     captureEvent('hideJobAd')

--- a/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAdSection.tsx
@@ -51,7 +51,7 @@ const TargetedJobAdSection = () => {
     collectionName: 'UserJobAds',
     fragmentName: 'UserJobAdsMinimumInfo',
   })
-  const { results: userJobAds, loading: userJobAdsLoading } = useMulti({
+  const { results: userJobAds, loading: userJobAdsLoading, refetch: refetchUserJobAds } = useMulti({
     terms: {view: 'adsByUser', userId: currentUser?._id},
     collectionName: 'UserJobAds',
     fragmentName: 'UserJobAdsMinimumInfo',
@@ -202,7 +202,7 @@ const TargetedJobAdSection = () => {
         jobName: activeJob,
         adState: 'seen'
       }
-    })
+    }).finally(refetchUserJobAds)
   }, [currentUser, userJobAds, userJobAdsLoading, activeJob, entry, createUserJobAd])
   
   const dismissJobAd = useCallback(() => {

--- a/packages/lesswrong/lib/collections/userJobAds/collection.ts
+++ b/packages/lesswrong/lib/collections/userJobAds/collection.ts
@@ -2,6 +2,7 @@ import schema from './schema';
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields, getDefaultResolvers } from '../../collectionUtils'
 import { getDefaultMutations } from '../../vulcan-core/default_mutations';
+import { ensureIndex } from '../../collectionIndexUtils';
 
 export const UserJobAds: UserJobAdsCollection = createCollection({
   collectionName: 'UserJobAds',
@@ -12,6 +13,7 @@ export const UserJobAds: UserJobAdsCollection = createCollection({
   logChanges: true,
 });
 
+ensureIndex(UserJobAds, {userId: 1, jobName: 1}, {unique: true});
 addUniversalFields({collection: UserJobAds})
 
 export default UserJobAds;

--- a/packages/lesswrong/server/migrations/20240314T123630.dedup_UserJobAds.ts
+++ b/packages/lesswrong/server/migrations/20240314T123630.dedup_UserJobAds.ts
@@ -1,0 +1,35 @@
+export const up = async ({db}: MigrationContext) => {
+  await db.none(`
+    WITH RankedUserJobAds AS (
+        SELECT
+            _id,
+            "userId",
+            "jobName",
+            "adState",
+            "reminderSetAt",
+            "lastUpdated",
+            ROW_NUMBER() OVER (
+                PARTITION BY "userId", "jobName"
+                ORDER BY
+                    CASE WHEN "reminderSetAt" IS NOT NULL THEN 0 ELSE 1 END,
+                    CASE "adState"
+                        WHEN 'reminderSet' THEN 1
+                        WHEN 'applied' THEN 2
+                        WHEN 'expanded' THEN 3
+                        WHEN 'seen' THEN 4
+                        ELSE 5
+                    END,
+                    "lastUpdated" DESC
+            ) AS rn
+        FROM "UserJobAds"
+    )
+    DELETE FROM "UserJobAds"
+    WHERE _id IN (
+        SELECT _id FROM RankedUserJobAds WHERE rn > 1
+    )
+  `)
+}
+
+export const down = async ({db}: MigrationContext) => {
+  // noop
+}


### PR DESCRIPTION
There is some issue that is resulting in duplicate records in the `UserJobAds` table. There should only be a single record per user+job pair. Though we haven't gotten to the root issue, this should fix it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206844129699403) by [Unito](https://www.unito.io)
