### PR TITLE
Fix footnotes in google doc import (handle them before internal links)

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -324,7 +324,6 @@ const footnoteAttributes = [
   'data-footnote-section',
   'data-footnote-back-link',
   'data-footnote-back-link-href',
-  'data-internal-id'
 ]
 
 export const sanitize = function(s: string): string {


### PR DESCRIPTION
Adding handling for internal links when importing Google docs broke the existing handling of footnotes. It didn't break in a way that is too critical, the links still work and the footnotes are readable, they just aren't in a separate box. This PR fixes that by making sure we handle footnotes before internal links

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206844821687466) by [Unito](https://www.unito.io)
