### PR TITLE
fix double spacing in imported google docs

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -675,6 +675,22 @@ function googleDocConvertLinks(html: string) {
 }
 
 /**
+ * To fix double spacing, remove all empty <p> tags that are immediate children of <body> from the HTML
+ */
+function removeEmptyBodyParagraphs(html: string): string {
+  const $ = cheerio.load(html);
+
+  $('body > p').each((_, element) => {
+    const p = $(element);
+    if (p.text().trim() === '') {
+      p.remove();
+    }
+  });
+
+  return $.html();
+}
+
+/**
  * We need to convert a few things in the raw html exported from google to make it work with ckeditor, this is
  * largely mirroring conversions we do on paste in the ckeditor code:
  * - Convert footnotes to our format
@@ -699,6 +715,7 @@ export async function convertImportedGoogleDoc({
     googleDocFormatting,
     googleDocConvertLinks,
     googleDocRemoveRedirects,
+    removeEmptyBodyParagraphs,
     async (html: string) => await dataToCkEditor(html, "html"),
   ];
 


### PR DESCRIPTION
This fixes double spacing by not allowing empty `<p>` tags in the top level of the document at all. People may actually want this sometimes, but I think this is a good simple rule to start with, which we can then change if we get any complaints

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206845019329483) by [Unito](https://www.unito.io)
