### PR TITLE
Support nested bullets in imported google docs

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -677,7 +677,7 @@ function googleDocConvertLinks(html: string) {
 /**
  * In google docs nested bullets are handled through styling (each indentation level is actually
  * a separate list, with a margin-left creating the effect of nesting). In ckeditor, nested bullets are
- * actually <ul>s nested within each other. Convert this styling based nesting to genuined nesting
+ * actually <ul>s nested within each other. Convert this styling based nesting to genuine nesting
  */
 function googleDocConvertNestedBullets(html: string): string {
   const $ = cheerio.load(html);

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -675,6 +675,67 @@ function googleDocConvertLinks(html: string) {
 }
 
 /**
+ * In google docs nested bullets are handled through styling (each indentation level is actually
+ * a separate list, with a margin-left creating the effect of nesting). In ckeditor, nested bullets are
+ * actually <ul>s nested within each other. Convert this styling based nesting to genuined nesting
+ */
+function googleDocConvertNestedBullets(html: string): string {
+  const $ = cheerio.load(html);
+
+  // Each nesting level has a class like lst-kix_gwukp0509sil-0, or lst-kix_gwukp0509sil-1
+  // The id in the middle indicates the overall nested list that this level belongs to, and the number at the end
+  // indicates the level of indentation
+  const listGroups: Record<string, {element: cheerio.Cheerio, index: number}[]> = {};
+  $('ul[class*="lst-"], ol[class*="lst-"]').each((_, element) => {
+    const classNames = $(element).attr('class')?.split(/\s+/);
+    const listClass = classNames?.find(name => name.startsWith('lst-'));
+    if (!listClass) return;
+
+    const match = listClass.match(/lst-([a-z_0-9]+)-(\d+)/);
+    if (!match) return;
+
+    const [ , id, index] = match;
+    if (!listGroups[id]) {
+      listGroups[id] = [];
+    }
+    listGroups[id].push({ element: $(element), index: parseInt(index) });
+  });
+
+  // Adjust the indices to account for contraints in ckeditor, and convert to genuine nesting
+  for (const group of Object.values(listGroups)) {
+    // In ckeditor, lists aren't allowed to start indented
+    group[0].index = 0;
+
+    // Indices can only increase by 1 from element to element
+    for (let i = 1; i < group.length; i++) {
+      if (group[i].index > group[i-1].index + 1) {
+        group[i].index = group[i-1].index + 1;
+      }
+    }
+
+    // Convert to genuine nesting
+    group.forEach((item, i, arr) => {
+      if (i > 0) {
+        const prevItem = arr[i - 1];
+        if (item.index === prevItem.index + 1) { // If the current item is a nested list
+          // Append the current list to the previous list item
+          prevItem.element.children('li:last-child').append(item.element);
+        } else if (item.index <= prevItem.index) { // If the current item is at the same level or outdented
+          // Find the ancestor list that matches the current index
+          let ancestor = prevItem.element;
+          for (let j = 0; j < prevItem.index - item.index; j++) {
+            ancestor = ancestor.parent().closest('ul, ol');
+          }
+          ancestor.after(item.element); // Place the current list after the found ancestor list
+        }
+      }
+    });
+  };
+
+  return $.html();
+}
+
+/**
  * We need to convert a few things in the raw html exported from google to make it work with ckeditor, this is
  * largely mirroring conversions we do on paste in the ckeditor code:
  * - Convert footnotes to our format
@@ -699,6 +760,7 @@ export async function convertImportedGoogleDoc({
     googleDocFormatting,
     googleDocConvertLinks,
     googleDocRemoveRedirects,
+    googleDocConvertNestedBullets,
     async (html: string) => await dataToCkEditor(html, "html"),
   ];
 

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -717,16 +717,15 @@ function googleDocConvertNestedBullets(html: string): string {
     group.forEach((item, i, arr) => {
       if (i > 0) {
         const prevItem = arr[i - 1];
-        if (item.index === prevItem.index + 1) { // If the current item is a nested list
-          // Append the current list to the previous list item
+        if (item.index === prevItem.index + 1) {
           prevItem.element.children('li:last-child').append(item.element);
-        } else if (item.index <= prevItem.index) { // If the current item is at the same level or outdented
+        } else if (item.index <= prevItem.index) {
           // Find the ancestor list that matches the current index
           let ancestor = prevItem.element;
           for (let j = 0; j < prevItem.index - item.index; j++) {
             ancestor = ancestor.parent().closest('ul, ol');
           }
-          ancestor.after(item.element); // Place the current list after the found ancestor list
+          ancestor.after(item.element);
         }
       }
     });


### PR DESCRIPTION
Docstring sums up the logic here:
```
/**
 * In google docs nested bullets are handled through styling (each indentation level is actually
 * a separate list, with a margin-left creating the effect of nesting). In ckeditor, nested bullets are
 * actually <ul>s nested within each other. Convert this styling based nesting to genuine nesting
 */
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206845559949799) by [Unito](https://www.unito.io)
