### PR TITLE
stop notifications list (and menu) from rerendering when loading more

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -408,15 +408,14 @@ const Header = ({
   />
 
   // the right side notifications menu
-  const HeaderNotificationsMenu = () => currentUser && !hasNotificationsPage
-    ? (
+  const headerNotificationsMenu = currentUser && !hasNotificationsPage
+    && (
       <NotificationsMenu
         open={notificationOpen}
         hasOpened={notificationHasOpened}
         setIsOpen={handleSetNotificationDrawerOpen}
       />
-    )
-    : null;
+    );
 
   return (
     <AnalyticsContext pageSectionContext="header">
@@ -458,7 +457,7 @@ const Header = ({
           </header>
           <HeaderNavigationDrawer />
         </Headroom>
-        <HeaderNotificationsMenu />
+        {headerNotificationsMenu}
       </div>
     </AnalyticsContext>
   )


### PR DESCRIPTION
The notifications list (and menu) were rerendering when the "Load More" button was clicked (and also when the header was put into a pinned state from an unpinned state), which meant that it was basically impossible to see older notifications.

Copied over from slack: My current guess is that putting HeaderNotificationsMenu into a closure broke React's ability to avoid re-rendering it when rerendering Header, which it would normally be able to do because it could tell that neither the props nor state of HeaderNotificationsMenu had changed.  (But I'm not 100% sure that's the explanation.)