### PR TITLE
[EA Forum only] only show post page digest ad after a few reads

### DIFF
--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -7,6 +7,7 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { useDigestAd } from './useDigestAd';
 import { DIGEST_AD_BODY_TEXT, DIGEST_AD_HEADLINE_TEXT } from './SidebarDigestAd';
+import { getBrowserLocalStorage } from '../../editor/localStorageHandlers';
 
 const styles = (theme: ThemeType) => ({
   '@keyframes digest-fade-in': {
@@ -44,15 +45,9 @@ const styles = (theme: ThemeType) => ({
       width: 500,
       maxWidth: '90%',
     },
-    // For now, we are not displaying this ad on small screens,
-    // since it takes up a larger percent of the screen
-    '@media (max-width: 435px)': {
-      display: 'none'
-    }
   },
   textCol: {
     flexGrow: 1,
-    minWidth: 'max-content',
   },
   heading: {
     fontWeight: 600,
@@ -78,7 +73,8 @@ const styles = (theme: ThemeType) => ({
     flexGrow: 1,
     display: 'flex',
     columnGap: 4,
-    rowGap: '12px'
+    rowGap: '8px',
+    flexWrap: 'wrap',
   },
   formInput: {
     minWidth: 240,
@@ -96,9 +92,10 @@ const styles = (theme: ThemeType) => ({
     '&::placeholder': {
       color: theme.palette.grey[600],
     },
-    '@media (max-width: 1000px)': {
-      minWidth: 0,
-    }
+  },
+  formBtns: {
+    display: 'flex',
+    columnGap: 4,
   },
   formBtn: {
     flex: 'none',
@@ -136,8 +133,10 @@ const StickyDigestAd = ({className, classes}: {
 }) => {
   const currentUser = useCurrentUser()
   const { showDigestAd, emailRef, showForm, loading, subscribeClicked, handleClose, handleUserSubscribe } = useDigestAd()
+  const ls = getBrowserLocalStorage()
   
-  if (!showDigestAd) return null
+  // We only show this after the client has viewed a few posts.
+  if (!showDigestAd || !ls?.getItem('postReadCount') || ls?.getItem('postReadCount') < 5) return null
   
   const { AnalyticsInViewTracker, ForumIcon, EAButton } = Components
   
@@ -157,18 +156,22 @@ const StickyDigestAd = ({className, classes}: {
   let formNode = (showForm || !currentUser) ? (
     <form action={eaForumDigestSubscribeURL} method="post" className={classes.form}>
       <input ref={emailRef} name="EMAIL" placeholder="Email address" className={classes.formInput} required={true} />
-      <EAButton type="submit" onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
-        Sign up
-      </EAButton>
-      {noThanksBtn}
+      <div className={classes.formBtns}>
+        <EAButton type="submit" onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
+          Sign up
+        </EAButton>
+        {noThanksBtn}
+      </div>
     </form>
   ) : (
     <div className={classes.form}>
       <input value={currentUser.email} className={classes.formInput} disabled={true} required={true} />
-      <EAButton onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
-        Sign up
-      </EAButton>
-      {noThanksBtn}
+      <div className={classes.formBtns}>
+        <EAButton onClick={handleUserSubscribe} className={classes.formBtn} {...buttonProps}>
+          Sign up
+        </EAButton>
+        {noThanksBtn}
+      </div>
     </div>
   )
   

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -370,7 +370,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
       const postReadCount = ls.getItem('postReadCount') ?? 0
       ls.setItem('postReadCount', parseInt(postReadCount) + 1)
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // On the EA Forum, show a digest ad at the bottom of the screen after the user scrolled down.
   useEffect(() => {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -10,11 +10,11 @@ import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import {forumTitleSetting, isAF, isEAForum, isLWorAF} from '../../../lib/instanceSettings';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import classNames from 'classnames';
-import { hasPostRecommendations, hasSideComments, commentsTableOfContentsEnabled } from '../../../lib/betas';
+import { hasPostRecommendations, hasSideComments, commentsTableOfContentsEnabled, hasDigests } from '../../../lib/betas';
 import { forumSelect } from '../../../lib/forumTypeUtils';
 import { welcomeBoxes } from './WelcomeBox';
 import { useABTest } from '../../../lib/abTestImpl';
-import { postPageFixedDigestAd, welcomeBoxABTest } from '../../../lib/abTests';
+import { welcomeBoxABTest } from '../../../lib/abTests';
 import { useDialog } from '../../common/withDialog';
 import { UseMultiResult, useMulti } from '../../../lib/crud/withMulti';
 import { SideCommentMode, SideCommentVisibilityContextType, SideCommentVisibilityContext } from '../../dropdowns/posts/SetSideCommentVisibility';
@@ -38,6 +38,7 @@ import NoSSR from 'react-no-ssr';
 import { getMarketInfo, highlightMarket } from '../../../lib/annualReviewMarkets';
 import isEqual from 'lodash/isEqual';
 import { usePostReadProgress } from '../usePostReadProgress';
+import { getBrowserLocalStorage } from '../../editor/localStorageHandlers';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -361,11 +362,19 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     updateProgressBar: (element, scrollPercent) => element.style.setProperty("--scrollAmount", `${scrollPercent}%`),
     disabled: disableProgressBar
   });
+  
+  // postReadCount is currently only used by StickyDigestAd, to only show the ad after the client has visited multiple posts.
+  const ls = getBrowserLocalStorage()
+  useEffect(() => {
+    if (ls && hasDigests) {
+      const postReadCount = ls.getItem('postReadCount') ?? 0
+      ls.setItem('postReadCount', parseInt(postReadCount) + 1)
+    }
+  }, [])
 
   // On the EA Forum, show a digest ad at the bottom of the screen after the user scrolled down.
-  const digestAdAbTestGroup = useABTest(postPageFixedDigestAd);
   useEffect(() => {
-    if (!isEAForum || isServer || post.isEvent || post.question || post.shortform || digestAdAbTestGroup !== 'show') return
+    if (!isEAForum || isServer || post.isEvent || post.question || post.shortform) return
 
     checkShowDigestAd()
     window.addEventListener('scroll', checkShowDigestAd)
@@ -375,7 +384,6 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     };
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
   const checkShowDigestAd = () => {
-    if (digestAdAbTestGroup !== 'show') return
     // Ad stays visible once shown
     setShowDigestAd((showAd) => showAd || window.scrollY > 1000)
   }

--- a/packages/lesswrong/lib/abTests.ts
+++ b/packages/lesswrong/lib/abTests.ts
@@ -230,37 +230,3 @@ export const offerToAddCalendlyLink = new ABTest({
     },
   },
 });
-
-export const postPageFixedDigestAd = new ABTest({
-  name: "postPageFixedDigestAd",
-  active: true,
-  affectsLoggedOut: true,
-  description: "Whether or not to display the digest ad that's fixed at the bottom of the screen on the post page",
-  groups: {
-    noShow: {
-      description: "Don't show digest ad",
-      weight: 1,
-    },
-    show: {
-      description: "Show digest ad",
-      weight: 1,
-    },
-  },
-});
-
-export const jobAdDescription = new ABTest({
-  name: "jobAdDescription",
-  active: false,
-  affectsLoggedOut: false,
-  description: "Which description to show in the job ad",
-  groups: {
-    control: {
-      description: "Show the description that our team wrote",
-      weight: 1,
-    },
-    '80k': {
-      description: "Show the description copied from the 80K job board",
-      weight: 1,
-    },
-  },
-});


### PR DESCRIPTION
The [previous version of the post page digest ad](https://github.com/ForumMagnum/ForumMagnum/pull/8740) got us [a few new subscribers per day](https://app.hex.tech/9e4abdcd-b18c-49ca-acfc-3ec5249ddb1a/app/b7b415b6-758a-4747-a851-0e1f565614ac/latest), but most people who saw it dismissed or ignored it. Based on the A/B test, users who saw the ad did not bounce at a higher rate, so it seems worth keeping.

For now, we are going to try only showing the ad after the user has viewed a few posts, so that we're more likely to show it to receptive users. I've also closed the A/B test, so now we are showing it on all clients.

And previously we did not show the ad on very small screens, but now that you need to read multiple posts before seeing the ad, I've enabled it on all screen sizes:

<img width="281" alt="Screen Shot 2024-03-14 at 5 25 55 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/f9b1b620-606e-4c7c-9106-66ff89746ba1">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206846813740749) by [Unito](https://www.unito.io)
