### PR TITLE
Center full-height ToC page

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -11,6 +11,7 @@ export const MAX_CONTENT_WIDTH = 720;
 const TOC_OFFSET_TOP = 92
 const TOC_OFFSET_BOTTOM = 64
 const LEFT_COLUMN_WIDTH = fullHeightToCEnabled ? '0fr' : '1fr';
+const RIGHT_COLUMN_WIDTH = fullHeightToCEnabled ? '0fr' : '1.5fr';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -24,7 +25,7 @@ const styles = (theme: ThemeType) => ({
       minmax(0px, ${DEFAULT_TOC_MARGIN})
       min-content
       10px
-      1.5fr
+      ${RIGHT_COLUMN_WIDTH}
     `,
     [theme.breakpoints.down('sm')]: {
       display: 'block',


### PR DESCRIPTION
IMO the centering is off for the new ToC layout. This centers it. 

Before: 
<img width="1440" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/cc53923a-506e-437f-b744-b9f56cd08694">


After: 
<img width="1440" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/9090789/19f4101e-8b57-464d-adf8-d6fedbc48e6d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206847399948172) by [Unito](https://www.unito.io)
