### PR TITLE
[FriendlyUI] adjust the positioning of the home page center column

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -6,8 +6,22 @@ import classNames from 'classnames';
 import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
 import { communityPath } from '../../../lib/routes';
 import { isLWorAF } from '../../../lib/instanceSettings';
+import { isFriendlyUI } from '../../../themes/forumTheme';
+import { HOME_RHS_MAX_SCREEN_WIDTH } from '../../ea-forum/EAHomeRightHandSide';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  // This wrapper is on friendly sites so that when this sidebar is hidden
+  // and the right-hand sidebar is visible,
+  // the center column is positioned slightly closer to the center of the screen.
+  sidebarWrapper: {
+    minWidth: 100,
+    [`@media(max-width: ${HOME_RHS_MAX_SCREEN_WIDTH}px)`]: {
+      minWidth: 0,
+    },
+    [theme.breakpoints.down('md')]: {
+      display: "none"
+    },
+  },
   sidebar: {
     width: TAB_NAVIGATION_MENU_WIDTH,
     [theme.breakpoints.down('md')]: {
@@ -55,21 +69,23 @@ const NavigationStandalone = ({
   const background = location.pathname === communityPath;
 
   return <>
-    <Slide
-      direction='right'
-      in={!sidebarHidden}
-      appear={false}
-      mountOnEnter
-      unmountOnExit
-    >
-      <div className={classNames(classes.sidebar, className, {[classes.background]: background, [classes.navSidebarTransparent]: unspacedGridLayout})}>
-        {/* In the unspaced grid layout the sidebar can appear on top of other componenents, so make the background transparent */}
-        <TabNavigationMenu
-          transparentBackground={unspacedGridLayout}
-          noTopMargin={noTopMargin}
-        />
-      </div>
-    </Slide>
+    <div className={classNames({[classes.sidebarWrapper]: isFriendlyUI})}>
+      <Slide
+        direction='right'
+        in={!sidebarHidden}
+        appear={false}
+        mountOnEnter
+        unmountOnExit
+      >
+        <div className={classNames(classes.sidebar, className, {[classes.background]: background, [classes.navSidebarTransparent]: unspacedGridLayout})}>
+          {/* In the unspaced grid layout the sidebar can appear on top of other componenents, so make the background transparent */}
+          <TabNavigationMenu
+            transparentBackground={unspacedGridLayout}
+            noTopMargin={noTopMargin}
+          />
+        </div>
+      </Slide>
+    </div>
     {isLWorAF && <div className={classNames(classes.footerBar, className)}>
       <TabNavigationMenuFooter />
     </div>}

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -19,12 +19,17 @@ import { userHasEAHomeRHS } from '../../lib/betas';
 import { useRecentOpportunities } from '../hooks/useRecentOpportunities';
 import { podcastPost, podcasts } from '../../lib/eaPodcasts';
 
+/**
+ * The max screen width where the Home RHS is visible
+ */
+export const HOME_RHS_MAX_SCREEN_WIDTH = 1370
+
 const styles = (theme: ThemeType) => ({
   root: {
     paddingRight: 50,
     marginTop: 10,
     marginLeft: 50,
-    '@media(max-width: 1370px)': {
+    [`@media(max-width: ${HOME_RHS_MAX_SCREEN_WIDTH}px)`]: {
       display: 'none'
     }
   },
@@ -43,7 +48,7 @@ const styles = (theme: ThemeType) => ({
       width: 34,
       backgroundColor: theme.palette.grey[250],
     },
-    '@media(max-width: 1370px)': {
+    [`@media(max-width: ${HOME_RHS_MAX_SCREEN_WIDTH}px)`]: {
       display: 'none'
     }
   },
@@ -274,7 +279,14 @@ export const EAHomeRightHandSide = ({classes}: {
     </LWTooltip>
   </div>
   
-  if (isHidden) return sidebarToggleNode
+  if (isHidden) {
+    // We include an empty root here so that when the sidebar is hidden,
+    // the center column is slightly closer to the center of the screen.
+    return <AnalyticsContext pageSectionContext="homeRhs">
+      {sidebarToggleNode}
+      <div className={classes.root}></div>
+    </AnalyticsContext>
+  }
   
   // NoSSR sections that could affect the logged out user cache
   let digestAdNode = <SidebarDigestAd className={classes.digestAd} />


### PR DESCRIPTION
Per request via [slack](https://cea-core.slack.com/archives/C038J512SD8/p1710516623267249). This also fixes a tiny bug where the RHS toggle moves up and down when you open and close the RHS.

Before:
<img width="1520" alt="Screen Shot 2024-03-15 at 1 08 37 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/aedec473-c094-4fd8-b072-a9e943760d94">

After:
<img width="1520" alt="Screen Shot 2024-03-15 at 1 08 26 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/3a3ca700-f88a-4c36-83fb-c4646abbc109">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206853836717284) by [Unito](https://www.unito.io)
