### PR TITLE
Add additional special case for slug-based post redirect

### DIFF
--- a/packages/lesswrong/components/posts/PostsSingle.tsx
+++ b/packages/lesswrong/components/posts/PostsSingle.tsx
@@ -7,7 +7,7 @@ const PostsSingle = () => {
   const { params, query } = useLocation();
   const version = query?.revision;
 
-  if ((params._id.length !== 17 || params._id.includes("-")) && isLWorAF) { 
+  if (((params._id.length !== 17 && params._id.length !== 24) || params._id.includes("-")) && isLWorAF) { 
     return <Components.PermanentRedirect status={307} url={'/posts/slug/' + params._id}/>
   }
 


### PR DESCRIPTION
Some posts we imported from the AIAF has _id length 24. 17 and 24 are the only two ID lengths in the DB, so this should handle all cases. Probably will still want to remove this whole thing in a few weeks.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206882449789290) by [Unito](https://www.unito.io)
