### PR TITLE
Comments can only be undeleted by mods or the user who deleted them

### DIFF
--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
@@ -6,6 +6,7 @@ import { useDialog } from '../../common/withDialog'
 import { useModerateComment } from './withModerateComment';
 import { useCurrentUser } from '../../common/withUser';
 import { preferredHeadingCase } from '../../../themes/forumTheme';
+import { userIsAdminOrMod } from '../../../lib/vulcan-users';
 
 
 const DeleteCommentDropdownItem = ({comment, post, tag}: {
@@ -62,16 +63,18 @@ const DeleteCommentDropdownItem = ({comment, post, tag}: {
         onClick={showDeleteDialog}
       />
     );
-  //} else if (comment.deletedByUserId === currentUser._id) {
-  } else {
+  } else if (
+    userIsAdminOrMod(currentUser)
+    || comment.deletedByUserId === currentUser._id
+  ) {
     return (
       <DropdownItem
         title={preferredHeadingCase("Undo Delete")}
         onClick={handleUndoDelete}
       />
     );
-  //} else {
-  //  return null;
+  } else {
+    return null;
   }
 }
 

--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
@@ -29,21 +29,27 @@ const DeleteCommentDropdownItem = ({comment, post, tag}: {
     });
   }
 
-  const handleUndoDelete = (event: React.MouseEvent) => {
+  const handleUndoDelete = async (event: React.MouseEvent) => {
     event.preventDefault();
-    void moderateCommentMutation({
-      commentId: comment._id,
-      deleted:false,
-      deletedReason:"",
-    }).then(() => flash({
-      messageString: "Successfully restored comment",
-      type: "success",
-    })).catch(/* error */);
+    try {
+      await moderateCommentMutation({
+        commentId: comment._id,
+        deleted:false,
+        deletedReason:"",
+      })
+      flash({
+        messageString: "Successfully restored comment",
+        type: "success",
+      });
+    } catch(e) {
+      flash(e.message);
+    }
   }
 
   if (
-    (!post && !tag) ||
-    !userCanModerateComment(currentUser, post ?? null, tag ?? null, comment)
+    !currentUser
+    || (!post && !tag)
+    || !userCanModerateComment(currentUser, post ?? null, tag ?? null, comment)
   ) {
     return null;
   }
@@ -56,14 +62,17 @@ const DeleteCommentDropdownItem = ({comment, post, tag}: {
         onClick={showDeleteDialog}
       />
     );
+  //} else if (comment.deletedByUserId === currentUser._id) {
+  } else {
+    return (
+      <DropdownItem
+        title={preferredHeadingCase("Undo Delete")}
+        onClick={handleUndoDelete}
+      />
+    );
+  //} else {
+  //  return null;
   }
-
-  return (
-    <DropdownItem
-      title={preferredHeadingCase("Undo Delete")}
-      onClick={handleUndoDelete}
-    />
-  );
 }
 
 const DeleteCommentDropdownItemComponent = registerComponent(

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -28,6 +28,7 @@ registerFragment(`
     userId
     deleted
     deletedPublic
+    deletedByUserId
     deletedReason
     hideAuthor
     authorIsUnreviewed

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1603,6 +1603,7 @@ interface CommentsList { // fragment on Comments
   readonly userId: string,
   readonly deleted: boolean,
   readonly deletedPublic: boolean,
+  readonly deletedByUserId: string,
   readonly deletedReason: string,
   readonly hideAuthor: boolean,
   readonly authorIsUnreviewed: boolean,

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -5,7 +5,7 @@ import Messages from '../../lib/collections/messages/collection';
 import { Posts } from "../../lib/collections/posts/collection";
 import { Tags } from "../../lib/collections/tags/collection";
 import Users from "../../lib/collections/users/collection";
-import { userCanDo } from '../../lib/vulcan-users/permissions';
+import { userCanDo, userIsAdminOrMod } from '../../lib/vulcan-users/permissions';
 import { performVoteServer } from '../voteServer';
 import { updateMutator, createMutator, deleteMutator } from '../vulcan-lib';
 import { getCommentAncestorIds } from '../utils/commentTreeUtils';
@@ -404,39 +404,63 @@ getCollectionHooks("Comments").newAfter.add(async function LWCommentsNewUpvoteOw
   return {...comment, ...votedComment} as DbComment;
 });
 
-getCollectionHooks("Comments").editSync.add(async function validateDeleteOperations (modifier, comment: DbComment, currentUser: DbUser) {
-  if (modifier.$set) {
-    const { deleted, deletedPublic, deletedReason } = modifier.$set
-    if (deleted || deletedPublic || deletedReason) {
-      if (deletedPublic && !deleted) {
-        throw new Error("You cannot publicly delete a comment without also deleting it")
-      }
+getCollectionHooks("Comments").updateBefore.add(async function validateDeleteOperations (data, properties) {
+  // Validate changes to comment deletion fields (deleted, deletedPublic,
+  // deletedReason). This could be deleting a comment, undoing a delete, or
+  // changing the reason/public-ness of the deletion.
+  //
+  // Note that this is normally called via the mutaiton inside the
+  // moderateComment mutator, which has already enforced some things; in
+  // particular it will have checked `userCanModerateComment` and filled in
+  // deletedByUserId and deletedDate.
 
-      if (
-        (comment.deleted || comment.deletedPublic) &&
-        (deletedPublic || deletedReason) &&
-        !userCanDo(currentUser, 'comments.remove.all') &&
-        comment.deletedByUserId !== currentUser._id) {
-          throw new Error("You cannot edit the deleted status of a comment that's been deleted by someone else")
-      }
-
-      if (deletedReason && !deleted && !deletedPublic) {
-        throw new Error("You cannot set a deleted reason without deleting a comment")
-      }
-
-      const childrenComments = await Comments.find({parentCommentId: comment._id}).fetch()
+  // First check that anything relevant to deletion has changed
+  if (properties.oldDocument.deleted !== properties.newDocument.deleted
+   || properties.oldDocument.deletedPublic !== properties.newDocument.deletedPublic
+   || properties.oldDocument.deletedReason !== properties.newDocument.deletedReason
+  ) {
+    if (properties.newDocument.deletedPublic && !properties.newDocument.deleted) {
+      throw new Error("You cannot publicly delete a comment without also deleting it")
+    }
+    
+    if (properties.newDocument.deleted && !properties.oldDocument.deleted) {
+      // Deletion
+      const childrenComments = await Comments.find({parentCommentId: properties.newDocument._id}).fetch()
       const filteredChildrenComments = _.filter(childrenComments, (c) => !(c && c.deleted))
       if (
         filteredChildrenComments &&
         (filteredChildrenComments.length > 0) &&
-        (deletedPublic || deleted) &&
-        !userCanDo(currentUser, 'comment.remove.all')
+        !userCanDo(properties.currentUser, 'comment.remove.all')
       ) {
         throw new Error("You cannot delete a comment that has children")
       }
+    } else if (properties.oldDocument.deleted && !properties.newDocument.deleted) {
+      // Undeletion
+      //
+      // Deletions can be undone by mods and by the person who did the deletion
+      // (regardless of whether they would still have permission to do that
+      // deletion now).
+      if (
+        !userIsAdminOrMod(properties.currentUser)
+        && properties.oldDocument.deletedByUserId !== properties.currentUser?._id
+      ) {
+        throw new Error("You cannot undo deletion of a comment deleted by someone else");
+      }
+    } else if (properties.newDocument.deleted) {
+      // Changing metadata on a deleted comment requires the same permissions as
+      // undeleting (either a moderator, or was the person who did the deletion
+      // in the first place)
+      if (
+        properties.newDocument.deleted
+        && properties.currentUser?._id !== properties.oldDocument.deletedByUserId
+        && !userIsAdminOrMod(properties.currentUser)
+      ) {
+        throw new Error("You cannot edit the deleted status of a comment that's been deleted by someone else")
+      }
     }
   }
-  return modifier
+
+  return data;
 });
 
 getCollectionHooks("Comments").editSync.add(async function moveToAnswers (modifier, comment: DbComment) {


### PR DESCRIPTION
Rewrites the server-side validation callback for comment-deletion, so that it now handles undeletion sensibly. Also fix the error handling, so that if the server sends you an access-denied error message you can see it.

(Note that much of the logic that determines whether deletion is allowed does not live here, it lives in the `moderateComment` mutator, which is in another file and isn't changed. That's why there's conspicuously no call to `userCanModerateComment` in either the old or the new version.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206928579919846) by [Unito](https://www.unito.io)
