### PR TITLE
Recombee improvement: record more post views, include lastCommentedAt, pad list with already read

### DIFF
--- a/packages/lesswrong/components/hooks/useRecordPostView.tsx
+++ b/packages/lesswrong/components/hooks/useRecordPostView.tsx
@@ -3,6 +3,8 @@ import { useMutation, gql } from '@apollo/client';
 import { useCurrentUser } from '../common/withUser';
 import { useNewEvents } from '../../lib/events/withNewEvents';
 import { hookToHoc } from '../../lib/hocUtils';
+import { recombeeApi } from '../../lib/recombee/client';
+import { recombeeEnabledSetting } from '../../lib/publicSettings';
 
 export type ItemsReadContextType = {
   postsRead: Record<string,boolean>,
@@ -20,7 +22,18 @@ export const withItemsRead = hookToHoc(useItemsRead);
 
 type ViewablePost = Pick<PostsBase, "_id" | "isRead" | "title">;
 
-export const useRecordPostView = (post: ViewablePost): {recordPostView: any, isRead: boolean} => {
+interface RecombeeOptions {
+  recommId?: string;
+  skipRecombee?: boolean;
+}
+
+interface RecordPostViewArgs {
+  post: ViewablePost;
+  extraEventProperties?: Record<string,any>;
+  recombeeOptions?: RecombeeOptions;
+}
+
+export const useRecordPostView = (post: ViewablePost) => {
   const [increasePostViewCount] = useMutation(gql`
     mutation increasePostViewCountMutation($postId: String) {
       increasePostViewCount(postId: $postId)
@@ -34,7 +47,8 @@ export const useRecordPostView = (post: ViewablePost): {recordPostView: any, isR
   const {postsRead, setPostRead} = useItemsRead();
   const isRead = post && !!((post._id in postsRead) ? postsRead[post._id] : post.isRead)
   
-  const recordPostView = useCallback(async ({post, extraEventProperties}) => {
+  const recordPostView = useCallback(async ({post, extraEventProperties, recombeeOptions}: RecordPostViewArgs) => {
+    
     try {
       if (!post) throw new Error("Tried to record view of null post");
       
@@ -59,16 +73,15 @@ export const useRecordPostView = (post: ViewablePost): {recordPostView: any, isR
           userId: currentUser._id,
           important: false,
           intercom: true,
-          ...extraEventProperties
-        };
-
-        eventProperties = {
-          ...eventProperties,
+          ...extraEventProperties,
           documentId: post._id,
           postTitle: post.title,
         };
         
         recordEvent('post-view', true, eventProperties);
+        if (recombeeEnabledSetting.get() && !recombeeOptions?.skipRecombee) {
+          void recombeeApi.createDetailView(post._id, currentUser._id, recombeeOptions?.recommId);
+        }
       }
     } catch(error) {
       console.log("recordPostView error:", error); // eslint-disable-line

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -38,7 +38,6 @@ import NoSSR from 'react-no-ssr';
 import { getMarketInfo, highlightMarket } from '../../../lib/annualReviewMarkets';
 import isEqual from 'lodash/isEqual';
 import { usePostReadProgress } from '../usePostReadProgress';
-import { recombeeApi } from '../../../lib/recombee/client';
 import { RecombeeRecommendationsContextWrapper } from '../../recommendations/RecombeeRecommendationsContextWrapper';
 
 export const MAX_COLUMN_WIDTH = 720
@@ -340,7 +339,6 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
   const [cookies, setCookie] = useCookiesWithConsent([SHOW_PODCAST_PLAYER_COOKIE]);
   const { query, params } = location;
   const [recommId, setRecommId] = useState<string | undefined>();
-  const [alreadySentRecombeeEvent, setAlreadySentRecombeeEvent] = useState(false);
 
   const showEmbeddedPlayerCookie = cookies[SHOW_PODCAST_PLAYER_COOKIE] === "true";
 
@@ -418,21 +416,6 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     navigate({...location.location, search: `?${qs.stringify(newQuery)}`})
   }, [navigate, location.location, openDialog, fullPost, query]);
 
-  useEffect(() => {
-    const recommId = query[RECOMBEE_RECOMM_ID_QUERY_PARAM];
-    if (alreadySentRecombeeEvent || !currentUser || !recombeeEnabledSetting.get()) return;
-
-    void recombeeApi.createDetailView(post._id, currentUser._id, recommId);
-    setRecommId(recommId);
-    setAlreadySentRecombeeEvent(true);
-
-    // Remove "recombeeRecommId" from query once the recommId has stored to state and initial event fired off, to prevent accidentally
-    // sharing links with a recommId
-    const currentQuery = isEmpty(query) ? {} : query;
-    const newQuery = {...currentQuery, [RECOMBEE_RECOMM_ID_QUERY_PARAM]: undefined};
-    navigate({...location.location, search: `?${qs.stringify(newQuery)}`}, { replace: true });  
-  }, [alreadySentRecombeeEvent, navigate, location.location, query, currentUser, post._id]);
-
   const sortBy: CommentSortingMode = (query.answersSorting as CommentSortingMode) || "top";
   const { results: answersAndReplies } = useMulti({
     terms: {
@@ -496,12 +479,28 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
   } = Components
 
   useEffect(() => {
-    recordPostView({
+    const recommId = query[RECOMBEE_RECOMM_ID_QUERY_PARAM];
+
+    void recordPostView({
       post: post,
       extraEventProperties: {
         sequenceId: getSequenceId()
+      },
+      recombeeOptions: {
+        recommId
       }
+
     });
+
+    if (!currentUser || !recombeeEnabledSetting.get()) return;
+    setRecommId(recommId);
+
+    // Remove "recombeeRecommId" from query once the recommId has stored to state and initial event fired off, to prevent accidentally
+    // sharing links with a recommId
+    const currentQuery = isEmpty(query) ? {} : query;
+    const newQuery = {...currentQuery, [RECOMBEE_RECOMM_ID_QUERY_PARAM]: undefined};
+    navigate({...location.location, search: `?${qs.stringify(newQuery)}`}, { replace: true });  
+
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [post._id]);
   

--- a/packages/lesswrong/components/posts/usePostsItem.tsx
+++ b/packages/lesswrong/components/posts/usePostsItem.tsx
@@ -138,19 +138,19 @@ export const usePostsItem = ({
 
   const toggleComments = useCallback(
     () => {
-      recordPostView({post, extraEventProperties: {type: "toggleComments"}})
+      void recordPostView({post, extraEventProperties: {type: "toggleComments"}, recombeeOptions: {recommId: recombeeRecommId}})
       setShowComments(!showComments);
       setReadComments(true);
     },
-    [post, recordPostView, setShowComments, showComments, setReadComments],
+    [post, recordPostView, setShowComments, showComments, setReadComments, recombeeRecommId],
   );
 
   const toggleDialogueMessages = useCallback(
     () => {
-      recordPostView({post, extraEventProperties: {type: "toggleDialogueMessages"}})
+      void recordPostView({post, extraEventProperties: {type: "toggleDialogueMessages"}, recombeeOptions: {recommId: recombeeRecommId}})
       setShowDialogueMessages(!showDialogueMessages);
     },
-    [post, recordPostView, setShowDialogueMessages, showDialogueMessages],
+    [post, recordPostView, setShowDialogueMessages, showDialogueMessages, recombeeRecommId],
   );
 
   const compareVisitedAndCommentedAt = (

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -25,7 +25,7 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
     () => {
       setMarkedAsVisitedAt(new Date());
       setExpandAllThreads(true);
-      recordPostView({post, extraEventProperties: {type: "recentDiscussionClick"}})
+      void recordPostView({post, extraEventProperties: {type: "recentDiscussionClick"}, recombeeOptions: {skipRecombee: true}})
     },
     [setMarkedAsVisitedAt, setExpandAllThreads, recordPostView, post],
   );

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -182,7 +182,7 @@ const ReviewVoteTableRow = ({ post, dispatch, costTotal, classes, expandedPostId
   const [markedVisitedAt, setMarkedVisitedAt] = useState<Date|null>(null);
   const { recordPostView } = useRecordPostView(post);
   const markAsRead = () => {
-    recordPostView({post, extraEventProperties: {type: "markAsRead"}})
+    void recordPostView({post, extraEventProperties: {type: "markAsRead"}})
     setMarkedVisitedAt(new Date()) 
   }
 

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -18,7 +18,8 @@ import ReadStatuses from '../../lib/collections/readStatus/collection';
 import { isAnyTest } from '../../lib/executionEnvironment';
 import { REJECTED_COMMENT } from '../../lib/collections/moderatorActions/schema';
 import { captureEvent } from '../../lib/analyticsEvents';
-import { adminAccountSetting } from '../../lib/publicSettings';
+import { adminAccountSetting, recombeeEnabledSetting } from '../../lib/publicSettings';
+import { recombeeApi } from '../recombee/client';
 
 
 const MINIMUM_APPROVAL_KARMA = 5
@@ -85,7 +86,7 @@ getCollectionHooks("Comments").newValidate.add(async function createShortformPos
   return comment
 });
 
-getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations (comment: DbComment) {
+getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations (comment: DbComment, _, context: ResolverContext) {
   // update lastCommentedAt field on post or tag
   if (comment.postId) {
     const lastCommentedAt = new Date()
@@ -112,6 +113,16 @@ getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations 
       updateLastCommentedAtPromise,
       updateReadStatusesPromise
     ])
+
+    // update the lastCommentedAt field in Recombee version of post
+    if (recombeeEnabledSetting.get()  && !comment.debateResponse) {
+      const post = await context.loaders.Posts.load(comment.postId)
+      if (post) {
+        // eslint-disable-next-line no-console
+        console.log("recombee lastCommentedAt update firing", comment.postId)
+        void recombeeApi.upsertPost(post, context).catch(e => console.log('Error when sending commented on post to recombee', { e }));  
+      }
+    }
 
   } else if (comment.tagId) {
     const fieldToSet = comment.tagCommentType === "SUBFORUM" ? "lastSubforumCommentAt" : "lastCommentedAt"

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -119,7 +119,6 @@ getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations 
       const post = await context.loaders.Posts.load(comment.postId)
       if (post) {
         // eslint-disable-next-line no-console
-        console.log("recombee lastCommentedAt update firing", comment.postId)
         void recombeeApi.upsertPost(post, context).catch(e => console.log('Error when sending commented on post to recombee', { e }));  
       }
     }

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -115,7 +115,7 @@ getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations 
     ])
 
     // update the lastCommentedAt field in Recombee version of post
-    if (recombeeEnabledSetting.get()  && !comment.debateResponse) {
+    if (recombeeEnabledSetting.get() && !comment.debateResponse) {
       const post = await context.loaders.Posts.load(comment.postId)
       if (post) {
         // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/mutationCallbacks.ts
+++ b/packages/lesswrong/server/mutationCallbacks.ts
@@ -32,7 +32,7 @@ export class CollectionMutationCallbacks<N extends CollectionNameString> {
   newValidate: CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>
   createBefore: CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>
   newBefore: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
-  newSync: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
+  newSync: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null,ResolverContext]>
   createAfter: CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>
   newAfter: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
   createAsync: CallbackHook<[CreateCallbackProperties<N>]>
@@ -67,7 +67,7 @@ export class CollectionMutationCallbacks<N extends CollectionNameString> {
     this.newValidate = new CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>(`${collectionName.toLowerCase()}.new.validate`);
     this.createBefore = new CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>(`${typeName.toLowerCase()}.create.before`);
     this.newBefore = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.new.before`);
-    this.newSync = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.new.sync`);
+    this.newSync = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null,ResolverContext]>(`${collectionName.toLowerCase()}.new.sync`);
     this.createAfter = new CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>(`${typeName.toLowerCase()}.create.after`);
     this.newAfter = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.new.after`);
     this.createAsync = new CallbackHook<[CreateCallbackProperties<N>]>(`${typeName.toLowerCase()}.create.async`);

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -76,6 +76,7 @@ const recombeeRequestHelpers = {
       curated: !!post.curatedDate,
       frontpage: !!post.frontpageDate,
       draft: !!post.draft,
+      lastCommentedAt: post.lastCommentedAt,
     }, { cascadeCreate: true });
   },
 

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -122,7 +122,7 @@ const recombeeApi = {
    * WARNING: this does not do permissions checks on the posts it returns.  The caller is responsible for this.
    */
   async getRecommendationsForUser(userId: string, count: number, lwAlgoSettings: RecombeeRecommendationArgs, context: ResolverContext) {
-    const modifiedCount = Math.ceil(count * 3);
+    const modifiedCount = Math.ceil(count * 2);
 
     const client = getRecombeeClientOrThrow();
     const request = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, modifiedCount, lwAlgoSettings);
@@ -130,7 +130,7 @@ const recombeeApi = {
     const response = await client.send(request);
 
     // remove posts read more than a week ago
-    const oneWeekAgo = moment(new Date()).subtract(1, 'week').toDate();
+    const twoWeeksAgo = moment(new Date()).subtract(2, 'week').toDate();
     const postIds = response.recomms.map(rec => rec.id);
     const [
       posts,
@@ -141,15 +141,19 @@ const recombeeApi = {
         postId: { $in: postIds }, 
         userId, 
         isRead: true, 
-        lastUpdated: { $lt: oneWeekAgo } 
+        lastUpdated: { $lt: twoWeeksAgo } 
       }).fetch()
     ])
 
-    const unreadPosts = posts.filter(post => !readStatuses.find(readStatus => (readStatus.postId === post._id)));
-    const filteredPosts = await accessFilterMultiple(context.currentUser, context.Posts, unreadPosts, context)
-    
-    // TODO: loop over the above if we don't get enough posts?
-    return filteredPosts.slice(0, count).map(post => ({post, recommId: response.recommId}));
+    //should basically never take any out
+    const filteredPosts = await accessFilterMultiple(context.currentUser, context.Posts, posts, context)
+
+    //sort the posts by read/unread but ensure otherwise preserving Recombee's returned order
+    const unreadOrRecentlyReadPosts = filteredPosts.filter(post => !readStatuses.find(readStatus => (readStatus.postId === post._id)));
+    const remainingPosts = filteredPosts.filter(post => readStatuses.find(readStatus => (readStatus.postId === post._id)));
+
+    //concatenate unread and read posts and return requested number
+    return unreadOrRecentlyReadPosts.concat(remainingPosts).slice(0, count).map(post => ({post, recommId: response.recommId}));
   },
 
 

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -227,7 +227,7 @@ export const createMutator: CreateMutator = async <N extends CollectionNameStrin
   logger('newSync')
   document = await hooks.newSync.runCallbacks({
     iterator: document as ObjectsByCollectionName[N], // Pretend this isn't Partial
-    properties: [currentUser]
+    properties: [currentUser, context]
   }) as Partial<DbInsertion<ObjectsByCollectionName[N]>>;
 
   /*


### PR DESCRIPTION
This PR makes a few improvements to our Recombee implementation
- recording `detailView`, e.g. post-view now happens in useRecordView so it happens not just on visiting a post, but also expanding comments on the post item, etc
- We now sync `lastCommentedAt` field of posts to Recombee so it can be factored into the algorithm
- Recombee is still not filtering out read posts for us, so we're oversampling. To ensure we always have enough recommendations without ridiculously oversampling, now padding the list of returned recommendations with read posts if we don't have enough unread

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206954140264471) by [Unito](https://www.unito.io)
