### PR TITLE
sequence grid image falls back to banner image

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -5,6 +5,8 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
 import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
 import { isFriendlyUI } from '../../themes/forumTheme';
+import { defaultSequenceBannerIdSetting } from './SequencesPage';
+import { isLWorAF } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -133,6 +135,13 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   let positionAdjustment = -35
   if (showAuthor) positionAdjustment -= 20
   if (sequence.title.length > 26) positionAdjustment -= 17
+  
+  let imageId: string|null = sequence.gridImageId
+  if (!imageId) {
+    // LW falls back to a specific image.
+    // Other sites fall back first to the sequence banner image, and otherwise to their own site-specific image
+    imageId = isLWorAF ? "sequences/vnyzzznenju0hzdv6pqb.jpg" : (sequence.bannerImageId || defaultSequenceBannerIdSetting.get())
+  }
 
   return <div className={classNames(classes.root, {[classes.bookItemContentStyle]:bookItemStyle})}>
     <LinkCard to={getCollectionOrSequenceUrl(sequence)} tooltip={
@@ -142,11 +151,11 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
     }>
       <div className={classes.image}>
         <NoSSR>
-          <Components.CloudinaryImage
-            publicId={sequence.gridImageId || "sequences/vnyzzznenju0hzdv6pqb.jpg"}
+          {imageId && <Components.CloudinaryImage
+            publicId={imageId}
             height={124}
             width={315}
-          />
+          />}
         </NoSSR>
       </div>
       <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor, [classes.bookItemContentStyle]: bookItemStyle})}>

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -21,7 +21,7 @@ export const sequencesImageScrim = (theme: ThemeType) => ({
   background: theme.palette.panelBackground.sequenceImageGradient,
 })
 
-const defaultSequenceBannerIdSetting = new DatabasePublicSetting<string|null>("defaultSequenceBannerId", null)
+export const defaultSequenceBannerIdSetting = new DatabasePublicSetting<string|null>("defaultSequenceBannerId", null)
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/sequences/SequencesSummary.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSummary.tsx
@@ -93,7 +93,7 @@ const SequencePosts = ({sequence, chapters, maxPosts, totalPosts, classes}: {
     const chapter = chapters[i];
     const posts = chapter.posts.slice(0, maxPosts - postsRendered);
     nodes.push(
-      <div>
+      <div key={chapter._id}>
         {chapter.title && <ChapterTitle title={chapter.title}/>}
         {posts.map(post => (
           <SequencesSmallPostLink

--- a/packages/lesswrong/lib/collections/sequences/views.ts
+++ b/packages/lesswrong/lib/collections/sequences/views.ts
@@ -1,5 +1,5 @@
 import { ensureIndex } from '../../collectionIndexUtils';
-import { isAF } from '../../instanceSettings';
+import { isAF, isLWorAF } from '../../instanceSettings';
 import Sequences from './collection';
 
 declare global {
@@ -103,17 +103,19 @@ Sequences.addView("curatedSequences", function (terms: SequencesViewTerms) {
 ensureIndex(Sequences, augmentForDefaultView({ curatedOrder:-1 }));
 
 Sequences.addView("communitySequences", function (terms: SequencesViewTerms) {
+  const gridImageFilter = isLWorAF ? {gridImageId: {$ne: null}} : undefined
+
   return {
     selector: {
       userId: terms.userId,
       curatedOrder: {$exists: false},
-      gridImageId: {$ne: null },
       isDeleted: false,
       draft: false,
       $or: [
         {canonicalCollectionSlug: ""},
         {canonicalCollectionSlug: {$exists: false}},
       ],
+      ...gridImageFilter,
     },
     options: {
       sort: {


### PR DESCRIPTION
This PR makes a couple sequence-related changes. I've gated them such that LW/AF are unaffected by these changes.

First, I made it so that the sequence grid image falls back to the banner image. This seemed to work fine in most cases, so seemed better than just directly falling back to the site-specific default image.

Before:
<img width="663" alt="Screen Shot 2024-03-28 at 7 22 33 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/a3f7549e-a16d-46e5-aba8-c9cc635aa12e">

After:
<img width="663" alt="Screen Shot 2024-03-28 at 7 17 33 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/e2ac8763-490e-40c6-b043-ed36f95e8648">

Second, I've updated the query on the `/library` page so that sequences without a grid image set are no longer filtered out. I think showing the sequences with the fall back options (either the sequence banner image or the galaxy image) is better than secretly not showing them at all.
<img width="705" alt="Screen Shot 2024-03-28 at 7 41 52 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/e17768e4-3454-47e7-bf61-f38fb6961594">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206955825869128) by [Unito](https://www.unito.io)
