### PR TITLE
[EA Forum only] fix core topic page sidebar

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -15,6 +15,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   // the center column is positioned slightly closer to the center of the screen.
   sidebarWrapper: {
     minWidth: 100,
+    zIndex: theme.zIndexes.footerNav,
     [`@media(max-width: ${HOME_RHS_MAX_SCREEN_WIDTH}px)`]: {
       minWidth: 0,
     },


### PR DESCRIPTION
Currently the left sidebar on the core topic page is hidden behind the banner - this fixes that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206956245206200) by [Unito](https://www.unito.io)
