### PR TITLE
forum-gate SettingsButton color

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -171,7 +171,7 @@ const HomeLatestPosts = ({classes}: {classes: ClassesType}) => {
                 filterSettingsToggleLabels.desktopHidden}
               showIcon={false}
               onClick={changeShowTagFilterSettingsDesktop}
-              textShadow
+              textShadow={isLWorAF}
             />
             <SettingsButton
               className={classes.hideOnDesktop}


### PR DESCRIPTION
So that it's no longer black on EAF

<img width="709" alt="Screen Shot 2024-03-29 at 11 42 21 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/39484eba-cfcd-49c7-88b1-309158b3eb43">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206958932512781) by [Unito](https://www.unito.io)
