### PR TITLE
Fix white-on-white login button from incomplete revert of black bar

### DIFF
--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType) => ({
     fontSize: '14px',
     fontWeight: isFriendlyUI ? undefined : 400,
     opacity: .8,
-    color: isLW ? theme.palette.text.alwaysWhite : theme.palette.header.text,
+    color: theme.palette.header.text,
   },
   login: {
     marginLeft: 12,


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/commit/08d6a78c20b822cb0a7bd433d853840251473f6e

It looks like this was probably done as part of making the black bar for Vinge and Kahneman, then the black bar was reverted but this wasn't.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206962627372506) by [Unito](https://www.unito.io)
