### PR TITLE
Remove recombee oversampling

### DIFF
--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -125,7 +125,8 @@ const recombeeApi = {
   async getRecommendationsForUser(userId: string, count: number, lwAlgoSettings: RecombeeRecommendationArgs, context: ResolverContext) {
     const client = getRecombeeClientOrThrow();
 
-    const modifiedCount = count * 2;
+    // TODO: Now having Recombee filter out read posts, maybe clean up?
+    const modifiedCount = count * 1;
     const request = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, modifiedCount, lwAlgoSettings);
 
     // We need the type cast here because recombee's type definitions can't handle inferring response types for union request types, even if they have the same response type


### PR DESCRIPTION
Recombee enabled on their end what we need to prevent read posts being recommended for a user, so can remove the algorithm subverting oversampling. Single character change

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1206973399091710) by [Unito](https://www.unito.io)
