### PR TITLE
[EA] NoSSR recent discussion and popular comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ const restrictedImportsPaths = [
   { name: "@material-ui/core/NoSsr", importNames: ["Popper"], message: "Don't use @material-ui/core/NoSsr/NoSsr; use react-no-ssr instead" },
   { name: "react-router", message: "Don't import react-router, use lib/reactRouterWrapper" },
   { name: "react-router-dom", message: "Don't import react-router-dom, use lib/reactRouterWrapper" },
+  { name: "react-no-ssr", message: "Don't import react-no-ssr, use ForumNoSSR" },
 ];
 const clientRestrictedImportPaths = [
   { name: "cheerio", message: "Don't import cheerio on the client" },

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -16,7 +16,7 @@ import { isAF, isEAForum, isLW, isLWorAF } from '../lib/instanceSettings';
 import { globalStyles } from '../themes/globalStyles/globalStyles';
 import { ForumOptions, forumSelect } from '../lib/forumTypeUtils';
 import { userCanDo } from '../lib/vulcan-users/permissions';
-import { Helmet, NoSSR } from '../lib/utils/componentsWithChildren';
+import { Helmet } from '../lib/utils/componentsWithChildren';
 import { DisableNoKibitzContext } from './users/UsersNameDisplay';
 import { LayoutOptions, LayoutOptionsContext } from './hooks/useLayoutOptions';
 // enable during ACX Everywhere
@@ -29,6 +29,7 @@ import { isFriendlyUI } from '../themes/forumTheme';
 import { requireCssVar } from '../themes/cssVars';
 import { UnreadNotificationsContextProvider } from './hooks/useUnreadNotifications';
 import { CurrentForumEventProvider } from './hooks/useCurrentForumEvent';
+import ForumNoSSR from './common/ForumNoSSR';
 
 
 export const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 0)
@@ -446,9 +447,9 @@ const Layout = ({currentUser, children, classes}: {
               <AnalyticsPageInitializer/>
               <NavigationEventSender/>
               {/* Only show intercom after they have accepted cookies */}
-              <NoSSR>
+              <ForumNoSSR>
                 {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}
-              </NoSSR>
+              </ForumNoSSR>
 
               <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
               {/* Google Tag Manager i-frame fallback */}
@@ -540,9 +541,9 @@ const Layout = ({currentUser, children, classes}: {
                   </StickyWrapper>
                 }
                 {renderSunshineSidebar && <div className={classes.sunshine}>
-                  <NoSSR>
+                  <ForumNoSSR>
                     <SunshineSidebar/>
-                  </NoSSR>
+                  </ForumNoSSR>
                 </div>}
               </div>
             </CommentBoxManager>

--- a/packages/lesswrong/components/comments/DebateBody.tsx
+++ b/packages/lesswrong/components/comments/DebateBody.tsx
@@ -4,7 +4,7 @@ import groupBy from 'lodash/groupBy';
 import uniq from 'lodash/uniq'
 import moment from 'moment';
 import type { DebateResponseWithReplies } from './DebateResponseBlock';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -20,7 +20,7 @@ export const DebateBody = ({ debateResponses, post, classes }: {
   const { DebateResponseBlock, DebateTypingIndicator } = Components;
   const orderedParticipantList = uniq(debateResponses.map(({ comment }) => comment.userId));
 
-  return (<NoSSR>
+  return (<ForumNoSSR>
     <div className={classes.root}>
       {
         // First group all responses by day, for the client's timezone (which is why this is in a NoSSR block)
@@ -63,7 +63,7 @@ export const DebateBody = ({ debateResponses, post, classes }: {
     <div>
       <DebateTypingIndicator post={post} />
     </div>
-  </NoSSR>);
+  </ForumNoSSR>);
 }
 
 const DebateBodyComponent = registerComponent('DebateBody', DebateBody, {styles});

--- a/packages/lesswrong/components/common/ForumNoSSR.tsx
+++ b/packages/lesswrong/components/common/ForumNoSSR.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+// eslint-disable-next-line no-restricted-imports
+import { default as BadlyTypedNoSSR } from "react-no-ssr";
+import { componentWithChildren } from "../../lib/utils/componentsWithChildren";
+
+const NoSSRWithChildren = componentWithChildren(BadlyTypedNoSSR);
+type NoSSRProps = React.ComponentProps<typeof NoSSRWithChildren>;
+
+interface ForumNoSSRProps extends NoSSRProps {
+  if?: boolean;
+}
+
+const ForumNoSSR: React.FC<ForumNoSSRProps> = ({ children, if: condition = true, ...noSSRProps }) => {
+  return condition ? <NoSSRWithChildren {...noSSRProps}>{children}</NoSSRWithChildren> : <>{children}</>;
+};
+
+export default ForumNoSSR;

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -6,7 +6,7 @@ import { useCurrentUser } from '../common/withUser'
 import { reviewIsActive, REVIEW_YEAR } from '../../lib/reviewUtils'
 import { maintenanceTime } from '../common/MaintenanceBanner'
 import { AnalyticsContext } from '../../lib/analyticsEvents'
-import { userHasPopularCommentsSection } from '../../lib/betas'
+import ForumNoSSR from '../common/ForumNoSSR'
 
 const eaHomeSequenceIdSetting = new PublicInstanceSetting<string | null>('eaHomeSequenceId', null, "optional") // Sequence ID for the EAHomeHandbook sequence
 const showSmallpoxSetting = new DatabasePublicSetting<boolean>('showSmallpox', false)
@@ -14,6 +14,10 @@ const showHandbookBannerSetting = new DatabasePublicSetting<boolean>('showHandbo
 const showEventBannerSetting = new DatabasePublicSetting<boolean>('showEventBanner', false)
 const showMaintenanceBannerSetting = new DatabasePublicSetting<boolean>('showMaintenanceBanner', false)
 const isBotSiteSetting = new PublicInstanceSetting<boolean>('botSite.isBotSite', false, 'optional');
+
+// TODO remove these once we have measured the effect (or after 2024-04-14)
+const noSSRPopularCommentsSetting = new DatabasePublicSetting<boolean>('noSSRPopularComments', true)
+const noSSRRecentDiscussionSetting = new DatabasePublicSetting<boolean>('noSSRRecentDiscussion', true)
 
 /**
  * Build structured data to help with SEO.
@@ -86,13 +90,17 @@ const EAHome = ({classes}: {classes: ClassesType}) => {
           <HomeLatestPosts />
           {!currentUser?.hideCommunitySection && <EAHomeCommunityPosts />}
           {isEAForum && <QuickTakesSection />}
-          {userHasPopularCommentsSection(currentUser) && <EAPopularCommentsSection />}
-          <RecentDiscussionFeed
-            title="Recent discussion"
-            af={false}
-            commentsLimit={recentDiscussionCommentsPerPost}
-            maxAgeHours={18}
-          />
+          <ForumNoSSR if={!!currentUser && noSSRPopularCommentsSetting.get()}>
+            <EAPopularCommentsSection />
+          </ForumNoSSR>
+          <ForumNoSSR if={!!currentUser && noSSRRecentDiscussionSetting.get()}>
+            <RecentDiscussionFeed
+              title="Recent discussion"
+              af={false}
+              commentsLimit={recentDiscussionCommentsPerPost}
+              maxAgeHours={18}
+            />
+          </ForumNoSSR>
         </>
       } />
     </AnalyticsContext>

--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import moment from 'moment';
 import classNames from 'classnames';
 import sortBy from 'lodash/sortBy';
@@ -18,6 +17,7 @@ import { isPostWithForeignId } from '../hooks/useForeignCrosspost';
 import { userHasEAHomeRHS } from '../../lib/betas';
 import { useRecentOpportunities } from '../hooks/useRecentOpportunities';
 import { podcastPost, podcasts } from '../../lib/eaPodcasts';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 /**
  * The max screen width where the Home RHS is visible
@@ -292,8 +292,8 @@ export const EAHomeRightHandSide = ({classes}: {
   let digestAdNode = <SidebarDigestAd className={classes.digestAd} />
   let upcomingEventsNode = <UpcomingEventsSection classes={classes} />
   if (!currentUser) {
-    digestAdNode = <NoSSR>{digestAdNode}</NoSSR>
-    upcomingEventsNode = <NoSSR>{upcomingEventsNode}</NoSSR>
+    digestAdNode = <ForumNoSSR>{digestAdNode}</ForumNoSSR>
+    upcomingEventsNode = <ForumNoSSR>{upcomingEventsNode}</ForumNoSSR>
   }
 
   return <AnalyticsContext pageSectionContext="homeRhs">

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, Fragment } from "react";
+import React, { useCallback } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { TypeformPopupEmbed } from "../common/TypeformEmbeds";
 import { useCurrentUser } from "../common/withUser";
 import { useTracking } from "../../lib/analyticsEvents";
 import { useCookiesWithConsent } from "../hooks/useCookiesWithConsent";
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import moment from "moment";
+import ForumNoSSR from "../common/ForumNoSSR";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -98,11 +98,9 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
     return null;
   }
 
-  const Wrapper = currentUser ? Fragment : NoSSR;
-
   const {ForumIcon} = Components;
   return (
-    <Wrapper>
+    <ForumNoSSR if={!currentUser}>
       <div className={classes.root}>
         Take the 4 minute EA Forum Survey to help inform our strategy and funding decisions
         <TypeformPopupEmbed
@@ -119,7 +117,7 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
           className={classes.close}
         />
       </div>
-    </Wrapper>
+    </ForumNoSSR>
   );
 }
 

--- a/packages/lesswrong/components/ea-forum/wrapped/EAForumWrappedPage.tsx
+++ b/packages/lesswrong/components/ea-forum/wrapped/EAForumWrappedPage.tsx
@@ -31,7 +31,7 @@ import { useUpdateCurrentUser } from "../../hooks/useUpdateCurrentUser";
 import { TagCommentType } from "../../../lib/collections/comments/types";
 import { useLocation } from "../../../lib/routeUtil";
 import { TupleSet, UnionOf } from "../../../lib/utils/typeGuardUtils";
-import { NoSSR } from "../../../lib/utils/componentsWithChildren";
+import ForumNoSSR from "../../common/ForumNoSSR";
 
 const socialImageProps: CloudinaryPropsType = {
   dpr: "auto",
@@ -1548,7 +1548,7 @@ const RecommendationsSection = ({classes}: {
       <h1 className={classes.heading3}>
         Posts you missed that we think you’ll enjoy
       </h1>
-      <NoSSR>
+      <ForumNoSSR>
         <Components.RecommendationsList
           algorithm={{strategy: {name: 'bestOf', postId: '2023_wrapped'}, count: 5, disableFallbacks: true}}
           ListItem={
@@ -1561,7 +1561,7 @@ const RecommendationsSection = ({classes}: {
           }
           className={classes.recommendedPosts}
         />
-      </NoSSR>
+      </ForumNoSSR>
     </section>
   </AnalyticsContext>
 }
@@ -1591,12 +1591,12 @@ const MostValuablePostsSection = ({year, classes}: {
           <ForumIcon icon="HeartOutline" className={classes.mvpHeartIcon} />
         </div>
       </div>
-      <NoSSR>
+      <ForumNoSSR>
         <div className={classNames(classes.mvpList, classes.mt10)}>
           <PostsByVoteWrapper voteType="bigUpvote" year={year} postItemClassName={classes.mvpPostItem} showMostValuableCheckbox hideEmptyStateText />
           <PostsByVoteWrapper voteType="smallUpvote" year={year} limit={10} postItemClassName={classes.mvpPostItem} showMostValuableCheckbox hideEmptyStateText />
         </div>
-      </NoSSR>
+      </ForumNoSSR>
     </section>
   </AnalyticsContext>
 }

--- a/packages/lesswrong/components/editor/DraftJSEditor.tsx
+++ b/packages/lesswrong/components/editor/DraftJSEditor.tsx
@@ -19,10 +19,10 @@ import createLinkifyPlugin from './draftjs-plugins/linkifyPlugin'
 import ImageButton from './draftjs-plugins/image/ImageButton';
 import { Map } from 'immutable';
 import { createBlockStyleButton, ItalicButton, BoldButton, UnderlineButton, BlockquoteButton } from 'draft-js-buttons';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import { isClient } from '../../lib/executionEnvironment';
 import { styleMap } from "./draftJsEditorStyleMap";
 import * as _ from 'underscore';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 function customBlockStyleFn(contentBlock: AnyBecauseTodo) {
   const type = contentBlock.getType();
@@ -163,7 +163,7 @@ class DraftJSEditor extends Component<DraftJSEditorProps,{}> {
 
     return (
       <div>
-        <NoSSR>
+        <ForumNoSSR>
         <div className={this.props.className} onClick={this.focus}>
           <Editor
             editorState={editorState}
@@ -179,7 +179,7 @@ class DraftJSEditor extends Component<DraftJSEditorProps,{}> {
         </div>
         <InlineToolbar />
         <AlignmentTool />
-        </NoSSR>
+        </ForumNoSSR>
       </div>
     )
   }

--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -1,14 +1,14 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import React, { useState, } from 'react';
+import React from 'react';
 import { useCurrentUser } from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil';
 import { getPostCollaborateUrl, canUserEditPostMetadata, postGetEditUrl, isNotHostedHere } from '../../lib/collections/posts/helpers';
 import { editorStyles, ckEditorStyles } from '../../themes/stylePiping'
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import { isMissingDocumentError } from '../../lib/utils/errorUtil';
 import type { CollaborativeEditingAccessLevel } from '../../lib/collections/posts/collabEditingPermissions';
 import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
 import { useQuery, gql } from '@apollo/client';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
@@ -97,7 +97,7 @@ const PostCollaborationEditor = ({ classes }: {
       You are editing an already-published post. The primary author can push changes from the edited revision to the <Link to={postGetPageUrl(post)}>published revision</Link>.
     </div>*/}
     <ContentStyles className={classes.editor} contentType="post">
-      <NoSSR>
+      <ForumNoSSR>
         <Components.CKPostEditor
           documentId={postId}
           collectionName="Posts"
@@ -112,7 +112,7 @@ const PostCollaborationEditor = ({ classes }: {
           post={post}
           postId={postId}
         />
-      </NoSSR>
+      </ForumNoSSR>
     </ContentStyles>
   </SingleColumnSection>
 };

--- a/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
+++ b/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import * as _ from 'underscore';
 import { useMulti } from '../../lib/crud/withMulti';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const styles = (theme: ThemeType): JssStyles => ({
   
@@ -38,14 +38,14 @@ const TagFlagToggleList = ({ value, path }: {
   });
 
   if (loading) return <Loading />
-  return <NoSSR><div className="multi-select-buttons">
+  return <ForumNoSSR><div className="multi-select-buttons">
     {results?.map(({_id}) => {
       const selected = value && value.includes(_id);
       return <a key={_id} onClick={() => handleClick(_id)}>
         <TagFlagItem documentId={_id} style={selected ? "grey" : "white"} showNumber={false} />
       </a>
     })}
-  </div></NoSSR>
+  </div></ForumNoSSR>
 }
 
 (TagFlagToggleList as any).contextTypes = {

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
-import { ModerationTemplates } from '../../lib/collections/moderationTemplates';
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import { useLocation } from '../../lib/routeUtil';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
-
+import ForumNoSSR from '../common/ForumNoSSR';
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     border: theme.palette.border.commentBorder,
@@ -31,7 +29,7 @@ export const ModerationTemplateItem = ({classes, template}: {
 
   const {hash} = useLocation()
   
-  return <NoSSR><div className={classNames(classes.root, {[classes.deleted]: template.deleted, [classes.highlighted]: hash === `#${template._id}`})}>
+  return <ForumNoSSR><div className={classNames(classes.root, {[classes.deleted]: template.deleted, [classes.highlighted]: hash === `#${template._id}`})}>
     <Row>
       <h3>{template.name}{template.deleted && <> [Deleted]</>}</h3>
       <a onClick={() => setEdit(!edit)}><MetaInfo>Edit</MetaInfo></a>
@@ -55,7 +53,7 @@ export const ModerationTemplateItem = ({classes, template}: {
           </p>
         </div>
     }
-  </div></NoSSR>
+  </div></ForumNoSSR>
 }
 
 const ModerationTemplateItemComponent = registerComponent('ModerationTemplateItem', ModerationTemplateItem, {styles});

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -4,7 +4,6 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { useMessages } from '../common/withMessages';
 import { postGetPageUrl, postGetEditUrl, getPostCollaborateUrl, isNotHostedHere, canUserEditPostMetadata } from '../../lib/collections/posts/helpers';
 import { useLocation } from '../../lib/routeUtil'
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import { styles } from './PostsNewForm';
 import { useDialog } from "../common/withDialog";
 import {useCurrentUser} from "../common/withUser";
@@ -17,6 +16,7 @@ import { SHARE_POPUP_QUERY_PARAM } from './PostsPage/PostsPage';
 import { isEAForum } from '../../lib/instanceSettings';
 import type { Editor } from '@ckeditor/ckeditor5-core';
 import { useNavigate } from '../../lib/reactRouterWrapper';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const editor: Editor | null = null
 export const EditorContext = React.createContext<[Editor | null, (e: Editor) => void]>([editor, _ => {}]);
@@ -121,7 +121,7 @@ const PostsEditForm = ({ documentId, version, classes }: {
         <HeadTags title={document.title} />
         {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
         {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
-        <NoSSR>
+        <ForumNoSSR>
           <EditorContext.Provider value={[editorState, setEditorState]}>
             <WrappedSmartForm
               collectionName="Posts"
@@ -179,7 +179,7 @@ const PostsEditForm = ({ documentId, version, classes }: {
               addFields={(document.isEvent || !!document.collabEditorDialogue) ? [] : ['tagRelevance']}
             />
           </EditorContext.Provider>
-        </NoSSR>
+        </ForumNoSSR>
       </div>
     </DynamicTableOfContents>
   );

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -6,7 +6,6 @@ import pick from 'lodash/pick';
 import React from 'react';
 import { useCurrentUser } from '../common/withUser'
 import { useLocation } from '../../lib/routeUtil';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import { isAF, isEAForum, isLW, isLWorAF } from '../../lib/instanceSettings';
 import { useDialog } from "../common/withDialog";
 import { afNonMemberSuccessHandling } from "../../lib/alignment-forum/displayAFNonMemberPopups";
@@ -17,6 +16,7 @@ import type { PostSubmitProps } from './PostSubmit';
 import { SHARE_POPUP_QUERY_PARAM } from './PostsPage/PostsPage';
 import { Link, useNavigate } from '../../lib/reactRouterWrapper';
 import { QuestionIcon } from '../icons/questionIcon';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 // Also used by PostsEditForm
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -310,7 +310,7 @@ const PostsNewForm = ({classes}: {
           <PostsAcceptTos currentUser={currentUser} />
           {postWillBeHidden && <NewPostModerationWarning />}
           {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
-          <NoSSR>
+          <ForumNoSSR>
               <WrappedSmartForm
                 collectionName="Posts"
                 mutationFragment={getFragment('PostsPage')}
@@ -342,7 +342,7 @@ const PostsNewForm = ({classes}: {
                   FormSubmit: NewPostsSubmit
                 }}
               />
-          </NoSSR>
+          </ForumNoSSR>
         </RecaptchaWarning>
       </div>
     </DynamicTableOfContents>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -37,9 +37,9 @@ import { ImageProvider } from './ImageContext';
 import { getMarketInfo, highlightMarket } from '../../../lib/annualReviewMarkets';
 import isEqual from 'lodash/isEqual';
 import { usePostReadProgress } from '../usePostReadProgress';
-import { NoSSR } from '../../../lib/utils/componentsWithChildren';
 import { RecombeeRecommendationsContextWrapper } from '../../recommendations/RecombeeRecommendationsContextWrapper';
 import { getBrowserLocalStorage } from '../../editor/localStorageHandlers';
+import ForumNoSSR from '../../common/ForumNoSSR';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -823,7 +823,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
         </ToCColumn>
     }
   
-    {isEAForum && showDigestAd && <NoSSR><StickyDigestAd /></NoSSR>}
+    {isEAForum && showDigestAd && <ForumNoSSR><StickyDigestAd /></ForumNoSSR>}
     {hasPostRecommendations && fullPost && <AnalyticsInViewTracker eventProps={{inViewType: "postPageFooterRecommendations"}}>
       <PostBottomRecommendations
         post={post}

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -4,7 +4,7 @@ import { useTracking } from "../../lib/analyticsEvents";
 import { isFriendlyUI } from "../../themes/forumTheme";
 import { isLWorAF } from "../../lib/instanceSettings";
 import classNames from "classnames";
-import { NoSSR } from "../../lib/utils/componentsWithChildren";
+import ForumNoSSR from "../common/ForumNoSSR";
 
 const styles = (_theme: ThemeType) => ({
   expandedRoot: {
@@ -42,7 +42,7 @@ const QuickTakesListItem = ({quickTake, classes}: {
   // This is to eliminate a loading spinner (for the child comments) when someone expands a quick take,
   // while avoiding the impact to the home page SSR speed for the large % of users who won't interact with quick takes at all
   const expandedComment = (
-    <NoSSR>
+    <ForumNoSSR>
       <div className={classNames(classes.expandedRoot, { [classes.hidden]: !expanded })}>
         <CommentsNode
           treeOptions={{
@@ -56,7 +56,7 @@ const QuickTakesListItem = ({quickTake, classes}: {
           forceUnCollapsed
         />
       </div>
-    </NoSSR>
+    </ForumNoSSR>
   );
 
   const collapsedComment = (

--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationsList.tsx
@@ -7,7 +7,7 @@ import type {
   WeightedFeature,
 } from "../../lib/collections/users/recommendationSettings";
 import { CENTRAL_COLUMN_WIDTH, MAX_COLUMN_WIDTH } from "../posts/PostsPage/PostsPage";
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
+import ForumNoSSR from "../common/ForumNoSSR";
 
 const PADDING = (MAX_COLUMN_WIDTH - CENTRAL_COLUMN_WIDTH) / 4;
 const COUNT = 3;
@@ -81,7 +81,7 @@ const PostsPageRecommendationsList = ({
   return (
     <div className={classes.root}>
       {title && <SectionTitle title={title} className={classes.title} />}
-      <NoSSR onSSR={loadingFallback}>
+      <ForumNoSSR onSSR={loadingFallback}>
         <RecommendationsList
           algorithm={recommendationsAlgorithm}
           loadingFallback={loadingFallback}
@@ -99,7 +99,7 @@ const PostsPageRecommendationsList = ({
             )
           }
         />
-      </NoSSR>
+      </ForumNoSSR>
     </div>
   );
 }

--- a/packages/lesswrong/components/review/ReviewVotingCanvas.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import React, { FC, MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
@@ -10,7 +10,7 @@ import { useMulti } from "../../lib/crud/withMulti";
 import { REVIEW_YEAR, eligibleToNominate } from "../../lib/reviewUtils";
 import { TARGET_REVIEW_NUM } from "./ReviewVotingProgressBar";
 import { useMessages } from "../common/withMessages";
-import { NoSSR } from "../../lib/utils/componentsWithChildren";
+import ForumNoSSR from "../common/ForumNoSSR";
 
 export type GivingSeasonHeart = {
   userId: string,
@@ -400,7 +400,7 @@ const ReviewVotingCanvas = ({
         })}
       >
           <div className={classes.gsHearts}>
-            <NoSSR>
+            <ForumNoSSR>
               {hearts.map((heart) => (
                 <Heart
                   key={heart.userId}
@@ -419,7 +419,7 @@ const ReviewVotingCanvas = ({
                   disabled={!userHasVotedEnough}
                 />
               }
-            </NoSSR>
+            </ForumNoSSR>
           </div>
       </div>
     </AnalyticsContext>

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -1,5 +1,4 @@
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
@@ -7,6 +6,7 @@ import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/help
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { defaultSequenceBannerIdSetting } from './SequencesPage';
 import { isLWorAF } from '../../lib/instanceSettings';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -150,13 +150,13 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
       </div>
     }>
       <div className={classes.image}>
-        <NoSSR>
+        <ForumNoSSR>
           {imageId && <Components.CloudinaryImage
             publicId={imageId}
             height={124}
             width={315}
           />}
-        </NoSSR>
+        </ForumNoSSR>
       </div>
       <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor, [classes.bookItemContentStyle]: bookItemStyle})}>
         <div className={classes.title}>

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useRef } from 'react';
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
 import { userCanDo, userOwns } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
 import { sectionFooterLeftStyles } from '../users/UsersProfile'
@@ -12,6 +11,7 @@ import { HEADER_HEIGHT, MOBILE_HEADER_HEIGHT } from '../common/Header';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { makeCloudinaryImageUrl } from '../common/CloudinaryImage2';
 import { allowSubscribeToSequencePosts } from '../../lib/betas';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 export const sequencesImageScrim = (theme: ThemeType) => ({
   position: 'absolute',
@@ -180,7 +180,7 @@ const SequencesPage = ({ documentId, classes }: {
       />
       {bannerId && <div className={classes.banner}>
         <div className={classes.bannerWrapper}>
-          <NoSSR>
+          <ForumNoSSR>
             <div>
               <CloudinaryImage
                 publicId={bannerId}
@@ -189,7 +189,7 @@ const SequencesPage = ({ documentId, classes }: {
               />
               <div className={classes.imageScrim}/>
             </div>
-          </NoSSR>
+          </ForumNoSSR>
         </div>
       </div>}
       <SingleColumnSection>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -4,7 +4,7 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
 import { preferredHeadingCase } from '../../themes/forumTheme';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -38,9 +38,9 @@ const SunshineNewUsersProfileInfo = ({userId, classes}: {userId: string, classes
   }
   
   return <div className={classes.root}>
-    <NoSSR>
+    <ForumNoSSR>
       <SunshineNewUsersInfo user={user} currentUser={currentUser} refetch={refetch}/>
-    </NoSSR>
+    </ForumNoSSR>
   </div>
 }
 

--- a/packages/lesswrong/components/users/DialogueMatchingPage.tsx
+++ b/packages/lesswrong/components/users/DialogueMatchingPage.tsx
@@ -33,7 +33,7 @@ import { dialogueMatchingPageNoSSRABTest, offerToAddCalendlyLink, showRecommende
 import { PostYouveRead, RecommendedComment, TagWithCommentCount } from '../dialogues/DialogueRecommendationRow';
 import { validatedCalendlyUrl } from '../dialogues/CalendlyIFrame';
 import { useLocation } from '../../lib/routeUtil';
-import { NoSSR } from '../../lib/utils/componentsWithChildren';
+import ForumNoSSR from '../common/ForumNoSSR';
 
 export type UpvotedUser = {
   _id: string;
@@ -1712,10 +1712,11 @@ export const DialogueMatchingPage = ({classes}: {
   </AnalyticsContext>)
 }
 
-const NoSSRMatchingPage = (props: {classes: ClassesType<typeof styles>}) =>
-  useABTest(dialogueMatchingPageNoSSRABTest) === 'noSSR'
-  ? <NoSSR><DialogueMatchingPage {...props} /></NoSSR>
-  : <DialogueMatchingPage {...props} />
+const NoSSRMatchingPage = (props: { classes: ClassesType<typeof styles> }) => (
+  <ForumNoSSR if={useABTest(dialogueMatchingPageNoSSRABTest) === "noSSR"}>
+    <DialogueMatchingPage {...props} />
+  </ForumNoSSR>
+);
 
 const DialogueNextStepsButtonComponent = registerComponent('DialogueNextStepsButton', DialogueNextStepsButton, {styles});
 const MessageButtonComponent = registerComponent('MessageButton', MessageButton, {styles});

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -55,8 +55,6 @@ export const userHasEagProfileImport = disabled;
 
 export const userHasEAHomeRHS = isEAForum ? shippedFeature : disabled;
 
-export const userHasPopularCommentsSection = isEAForum ? shippedFeature : disabled;
-
 export const visitorGetsDynamicFrontpage = isLW ? shippedFeature : disabled;
 
 //defining as Hook so as to combine with ABTest

--- a/packages/lesswrong/lib/utils/componentsWithChildren.tsx
+++ b/packages/lesswrong/lib/utils/componentsWithChildren.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren } from 'react';
 
-import { default as BadlyTypedNoSSR } from 'react-no-ssr';
 import { default as BadlyTypedHelmet } from 'react-helmet';
 import {
   InstantSearch as BadlyTypedInstantSearch,
@@ -17,7 +16,6 @@ export function componentWithChildren<T>(component: React.ComponentType<T>): Rea
   return component as React.ComponentType<PropsWithChildren<T>>;
 }
 
-export const NoSSR = componentWithChildren(BadlyTypedNoSSR);
 export const Helmet = componentWithChildren(BadlyTypedHelmet);
 export const InstantSearch = componentWithChildren(BadlyTypedInstantSearch);
 export const Index = componentWithChildren(BadlyTypedIndex);


### PR DESCRIPTION
In this PR:
- Replaced all `NoSSR` with `ForumNoSSR` which allows conditional no-ssr-ing
- Wrapped the popular comments and recent discussion sections in `ForumNoSSR`, conditional on:
  - The user being logged in (so the cached version still gets the SSR-ed sections)
  - Settings for each section

I'm going to start with both settings turned on and see what the effect is on the number of queries and actual timing (plus see if I personally find it annoying that these sections don't show up immediately). Both tend to be among the slowest queries on the page so I am expecting them both to individually make a difference