### PR TITLE
non-LW sites default to sending an email for "new post by user" notifications

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1368,6 +1368,11 @@ const schema: SchemaType<"Users"> = {
   notificationSubscribedUserPost: {
     label: "Posts by users I'm subscribed to",
     ...notificationTypeSettingsField(),
+    onCreate: () => {
+      if (!isLWorAF) {
+        return {...defaultNotificationTypeSettings, channel: 'both'}
+      }
+    }
   },
   notificationSubscribedUserComment: {
     label: "Comments by users I'm subscribed to",


### PR DESCRIPTION
This PR changes the default setting for "new post by user" notifications, so that it notifies you both on-site and via email. I left it as on-site only for LW since they seemed to prefer that. [See discussion in slack](https://cea-core.slack.com/archives/CJY3ZKP62/p1712175682781679).

I think getting notified via email is what a user would expect, and it is particularly important for the EA Forum because we have a step in our onboarding flow that prompts users to subscribe to a select list of authors.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207005076465534) by [Unito](https://www.unito.io)
