### PR TITLE
Remove treeShaking: "ignore-annotations" from build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -105,7 +105,6 @@ build({
   banner: {
     js: clientBundleBanner,
   },
-  treeShaking: "ignore-annotations",
   run: false,
   onStart: (config, changedFiles, ctx) => {
     setClientRebuildInProgress(true);


### PR DESCRIPTION
This option was added to our build script a long time ago to work around a problem with Algolia, which apparently had tree-shaking annotations in it that were incorrect. However, we are mostly not relying on Algolia anymore. Removing this annotation reduces the (minified, uncompressed) client bundle size by about 2%. We retested the client-side search UI and confirmed that it still works with this change.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207013246307760) by [Unito](https://www.unito.io)
