### PR TITLE
Remove default resolvers and mutations for `SideCommentCaches` collection

### DIFF
--- a/packages/lesswrong/lib/collections/sideCommentCaches/collection.ts
+++ b/packages/lesswrong/lib/collections/sideCommentCaches/collection.ts
@@ -1,6 +1,5 @@
 import { createCollection } from "../../vulcan-lib";
-import { addUniversalFields, getDefaultResolvers } from "../../collectionUtils"
-import { getDefaultMutations } from "../../vulcan-core/default_mutations";
+import { addUniversalFields } from "../../collectionUtils"
 import { ensureIndex } from "../../collectionIndexUtils";
 import schema from "./schema";
 
@@ -8,8 +7,8 @@ export const SideCommentCaches: SideCommentCachesCollection = createCollection({
   collectionName: "SideCommentCaches",
   typeName: "SideCommentCache",
   schema,
-  resolvers: getDefaultResolvers("SideCommentCaches"),
-  mutations: getDefaultMutations("SideCommentCaches"),
+  resolvers: {},
+  mutations: {},
   logChanges: false,
 });
 


### PR DESCRIPTION
We just deployed the new side comment cahes table. The collection has permission gates so there shouldn't be security issues, but this PR removes the default resolvers and mutations just to be safe (they're not needed as all accesses are done internally with direct SQL queries).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207035632365878) by [Unito](https://www.unito.io)
