### PR TITLE
Use json-stringify-deterministic in allStyles url

### DIFF
--- a/packages/lesswrong/components/themes/useTheme.tsx
+++ b/packages/lesswrong/components/themes/useTheme.tsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 import { isEAForum } from '../../lib/instanceSettings';
 import { THEME_COOKIE } from '../../lib/cookies/cookies';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
+import stringify from 'json-stringify-deterministic';
 
 type ThemeContextObj = {
   theme: ThemeType,
@@ -97,12 +98,12 @@ export const ThemeContextProvider = ({options, children}: {
   const concreteTheme = abstractThemeToConcrete(themeOptions, prefersDarkMode);
 
   useEffect(() => {
-    if (JSON.stringify(themeOptions) !== JSON.stringify(window.themeOptions)) {
+    if (stringify(themeOptions) !== stringify(window.themeOptions)) {
       window.themeOptions = themeOptions;
       if (isEAForum) {
         removeCookie(THEME_COOKIE, {path: "/"});
       } else {
-        setCookie(THEME_COOKIE, JSON.stringify(themeOptions), {
+        setCookie(THEME_COOKIE, stringify(themeOptions), {
           path: "/",
           expires: moment().add(2, 'years').toDate(),
         });

--- a/packages/lesswrong/components/themes/useTheme.tsx
+++ b/packages/lesswrong/components/themes/useTheme.tsx
@@ -49,7 +49,7 @@ export const useSetTheme = () => {
 }
 
 const makeStylesheetUrl = (themeOptions: AbstractThemeOptions) =>
-  `/allStyles?theme=${encodeURIComponent(JSON.stringify(themeOptions))}`;
+  `/allStyles?theme=${encodeURIComponent(stringify(themeOptions))}`;
 
 type OnFinish = (error?: string | Event) => void;
 

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -17,6 +17,7 @@ import { getForumTheme } from '../themes/forumTheme';
 import { usedMuiStyles } from './usedMuiStyles';
 import { minify } from 'csso';
 import { requestedCssVarsToString } from '../themes/cssVars';
+import stringify from 'json-stringify-deterministic';
 
 const generateMergedStylesheet = (themeOptions: ThemeOptions): Buffer => {
   importAllComponents();
@@ -89,7 +90,7 @@ export const getMergedStylesheet = (theme: ThemeOptions): MergedStylesheet => {
     name: theme.name,
     forumTheme: getForumType(theme),
   };
-  const themeKey = JSON.stringify(themeKeyData);
+  const themeKey = stringify(themeKeyData);
   
   if (!mergedStylesheets[themeKey]) {
     mergedStylesheets[themeKey] = generateMergedStylesheetAndHash(theme);
@@ -98,7 +99,7 @@ export const getMergedStylesheet = (theme: ThemeOptions): MergedStylesheet => {
   
   return {
     css: mergedStylesheet.css,
-    url: `/allStyles?hash=${mergedStylesheet.hash}&theme=${encodeURIComponent(JSON.stringify(theme))}`,
+    url: `/allStyles?hash=${mergedStylesheet.hash}&theme=${encodeURIComponent(stringify(theme))}`,
     hash: mergedStylesheet.hash,
   };
 }

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -10,6 +10,7 @@ import { dogstatsd } from '../../datadog/tracer';
 import { healthCheckUserAgentSetting } from './renderUtil';
 import PageCacheRepo, { maxCacheAgeMs } from '../../repos/PageCacheRepo';
 import { DatabaseServerSetting } from '../../databaseSettings';
+import stringify from 'json-stringify-deterministic';
 
 // Page cache. This applies only to logged-out requests, and exists primarily
 // to handle the baseload of traffic going to the front page and to pages that
@@ -64,7 +65,7 @@ let keysToCheckForExpiredEntries: Array<string> = [];
 export const cacheKeyFromReq = (req: Request): string => {
   const timezoneCookie = getCookieFromReq(req, "timezone");
   const themeCookie = getCookieFromReq(req, "theme");
-  const themeOptions = themeCookie && isValidSerializedThemeOptions(themeCookie) ? themeCookie : JSON.stringify(getDefaultThemeOptions());
+  const themeOptions = themeCookie && isValidSerializedThemeOptions(themeCookie) ? themeCookie : stringify(getDefaultThemeOptions());
   const path = getPathFromReq(req);
   
   if (timezoneCookie)


### PR DESCRIPTION
I noticed that an extra 2 requests for allStyles were being made after a page had loaded, which differed only in the ordering of the theme options in the url. Using json-stringify-deterministic makes the second pair of requests go away.