### PR TITLE
[FriendlyUI only] add posts item ghost loading state

### DIFF
--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -93,10 +93,7 @@ const LoadMore = ({
 }) => {
   const { captureEvent } = useTracking()
 
-  /**
-   * To avoid hydration errors, set loading to false if this is the initial render and we have
-   * a non-zero count that graphql cached during SSR.
-   */
+  // Don't show the loading animation on the initial render
   const isFirstRender = useIsFirstRender();
   loading = loading && !isFirstRender;
 

--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -98,7 +98,7 @@ const LoadMore = ({
    * a non-zero count that graphql cached during SSR.
    */
   const isFirstRender = useIsFirstRender();
-  loading = loading && !(isFirstRender && (count ?? 0) > 0);
+  loading = loading && !isFirstRender;
 
   const { Loading } = Components
   const handleClickLoadMore = (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/packages/lesswrong/components/common/queryStatusUtils.ts
+++ b/packages/lesswrong/components/common/queryStatusUtils.ts
@@ -1,6 +1,6 @@
 // Simple utility to check if a network status means the associated apollo query is updating
 //
-// https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
+// https://github.com/apollographql/apollo-client/blob/main/src/core/networkStatus.ts
 // 1-4 indicate query is in flight
 // We deliberately ignore 6, which is merely a polling query and should not
 // indicate likelihood of updating.

--- a/packages/lesswrong/components/posts/FriendlyPlaceholderPostsItem.tsx
+++ b/packages/lesswrong/components/posts/FriendlyPlaceholderPostsItem.tsx
@@ -11,39 +11,28 @@ const styles = (theme: ThemeType) => ({
     minWidth: "100%",
     maxWidth: "100%",
     background: theme.palette.grey[0],
-    padding: 15,
+    padding: '15px 17px',
     border: `1px solid ${theme.palette.grey[100]}`,
     borderRadius: theme.borderRadius.default,
     [theme.breakpoints.down("xs")]: {
-      paddingBottom: 14,
+      padding: '14px 17px 12px',
     },
   },
   placeholder: {
     height: 10,
     background: theme.palette.panelBackground.placeholderGradient,
     backgroundSize: "300% 100%",
-    animation: "profile-image-loader 1s infinite",
+    animation: "profile-image-loader 1.8s infinite",
     borderRadius: 3,
   },
-  karmaCol: {
-    flex: 'none',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '5px',
-    paddingLeft: 2,
-  },
-  arrow: {
-    width: 10
-  },
   karma: {
+    flex: 'none',
     width: 16,
   },
   titleCol: {
     flexGrow: 1,
   },
   title: {
-    height: 12,
     width: '100%',
     maxWidth: 434,
     marginBottom: 10,
@@ -58,18 +47,15 @@ const styles = (theme: ThemeType) => ({
     flexGrow: 1,
   },
   author: {
-    height: 8,
     width: '100%',
     maxWidth: 183,
   },
   commentIcon: {
     flex: 'none',
-    height: 12,
     width: 33,
     marginRight: 4,
   },
   commentIconMobile: {
-    height: 8,
     [theme.breakpoints.up("sm")]: {
       display: "none",
     },
@@ -78,10 +64,8 @@ const styles = (theme: ThemeType) => ({
     flex: 'none',
     height: 15,
     width: 10,
-    marginRight: 2,
   },
   threeDotsIconMobile: {
-    height: 10,
     [theme.breakpoints.up("sm")]: {
       display: "none",
     },
@@ -97,10 +81,7 @@ const FriendlyPlaceholderPostsItem = ({classes}: {
   classes: ClassesType,
 }) => {
   return <div className={classes.root}>
-    <div className={classes.karmaCol}>
-      <div className={classNames(classes.placeholder, classes.arrow)}></div>
-      <div className={classNames(classes.placeholder, classes.karma)}></div>
-    </div>
+    <div className={classNames(classes.placeholder, classes.karma)}></div>
     <div className={classes.titleCol}>
       <div className={classNames(classes.placeholder, classes.title)}></div>
       <div className={classes.metaRow}>

--- a/packages/lesswrong/components/posts/FriendlyPlaceholderPostsItem.tsx
+++ b/packages/lesswrong/components/posts/FriendlyPlaceholderPostsItem.tsx
@@ -1,0 +1,125 @@
+import classNames from 'classnames';
+import React from 'react';
+import { registerComponent } from "../../lib/vulcan-lib";
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    columnGap: 18,
+    minWidth: "100%",
+    maxWidth: "100%",
+    background: theme.palette.grey[0],
+    padding: 15,
+    border: `1px solid ${theme.palette.grey[100]}`,
+    borderRadius: theme.borderRadius.default,
+    [theme.breakpoints.down("xs")]: {
+      paddingBottom: 14,
+    },
+  },
+  placeholder: {
+    height: 10,
+    background: theme.palette.panelBackground.placeholderGradient,
+    backgroundSize: "300% 100%",
+    animation: "profile-image-loader 1s infinite",
+    borderRadius: 3,
+  },
+  karmaCol: {
+    flex: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '5px',
+    paddingLeft: 2,
+  },
+  arrow: {
+    width: 10
+  },
+  karma: {
+    width: 16,
+  },
+  titleCol: {
+    flexGrow: 1,
+  },
+  title: {
+    height: 12,
+    width: '100%',
+    maxWidth: 434,
+    marginBottom: 10,
+  },
+  metaRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    columnGap: 18,
+  },
+  authorWrapper: {
+    flexGrow: 1,
+  },
+  author: {
+    height: 8,
+    width: '100%',
+    maxWidth: 183,
+  },
+  commentIcon: {
+    flex: 'none',
+    height: 12,
+    width: 33,
+    marginRight: 4,
+  },
+  commentIconMobile: {
+    height: 8,
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
+    },
+  },
+  threeDotsIcon: {
+    flex: 'none',
+    height: 15,
+    width: 10,
+    marginRight: 2,
+  },
+  threeDotsIconMobile: {
+    height: 10,
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
+    },
+  },
+  hideOnMobile: {
+    [theme.breakpoints.down("xs")]: {
+      display: "none",
+    },
+  },
+})
+
+const FriendlyPlaceholderPostsItem = ({classes}: {
+  classes: ClassesType,
+}) => {
+  return <div className={classes.root}>
+    <div className={classes.karmaCol}>
+      <div className={classNames(classes.placeholder, classes.arrow)}></div>
+      <div className={classNames(classes.placeholder, classes.karma)}></div>
+    </div>
+    <div className={classes.titleCol}>
+      <div className={classNames(classes.placeholder, classes.title)}></div>
+      <div className={classes.metaRow}>
+        <div className={classes.authorWrapper}>
+          <div className={classNames(classes.placeholder, classes.author)}></div>
+        </div>
+        <div className={classNames(classes.placeholder, classes.commentIcon, classes.commentIconMobile)}></div>
+        <div className={classNames(classes.placeholder, classes.threeDotsIcon, classes.threeDotsIconMobile)}></div>
+      </div>
+    </div>
+    <div className={classNames(classes.placeholder, classes.commentIcon, classes.hideOnMobile)}></div>
+    <div className={classNames(classes.placeholder, classes.threeDotsIcon, classes.hideOnMobile)}></div>
+  </div>
+}
+
+const FriendlyPlaceholderPostsItemComponent = registerComponent('FriendlyPlaceholderPostsItem', FriendlyPlaceholderPostsItem, {styles});
+
+declare global {
+  interface ComponentTypes {
+    FriendlyPlaceholderPostsItem: typeof FriendlyPlaceholderPostsItemComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsLoading.tsx
+++ b/packages/lesswrong/components/posts/PostsLoading.tsx
@@ -1,11 +1,12 @@
 import range from 'lodash/range';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
+import { isFriendlyUI } from '../../themes/forumTheme';
 
 const PostsLoading = ({placeholderCount}: {
   placeholderCount?: number
 }) => {
-  if (placeholderCount) {
+  if (placeholderCount && isFriendlyUI) {
     return <>
       {range(0, placeholderCount)
         .map(i => <Components.FriendlyPlaceholderPostsItem

--- a/packages/lesswrong/components/posts/PostsLoading.tsx
+++ b/packages/lesswrong/components/posts/PostsLoading.tsx
@@ -1,8 +1,20 @@
+import range from 'lodash/range';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const PostsLoading = () => {
-  return <div className="posts-load-more-loading"><Components.Loading/></div>
+const PostsLoading = ({placeholderCount}: {
+  placeholderCount?: number
+}) => {
+  if (placeholderCount) {
+    return <>
+      {range(0, placeholderCount)
+        .map(i => <Components.FriendlyPlaceholderPostsItem
+          key={i}
+        />)}
+    </>
+  } else {
+    return <Components.Loading />
+  }
 };
 
 const PostsLoadingComponent = registerComponent('PostsLoading', PostsLoading);

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -409,6 +409,7 @@ importComponent("PingbacksList", () => require('../components/posts/PingbacksLis
 importComponent("PostsItemMeta", () => require('../components/posts/PostsItemMeta'));
 importComponent("PostsItem", () => require('../components/posts/PostsItem.tsx'));
 importComponent("LWPostsItem", () => require('../components/posts/LWPostsItem.tsx'));
+importComponent("FriendlyPlaceholderPostsItem", () => require('../components/posts/FriendlyPlaceholderPostsItem.tsx'));
 importComponent("EAPostsItem", () => require('../components/posts/EAPostsItem.tsx'));
 importComponent("EALargePostsItem", () => require('../components/posts/EALargePostsItem.tsx'));
 importComponent("EAPostMeta", () => require('../components/ea-forum/EAPostMeta.tsx'));

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -406,6 +406,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     reviewGold: 'lch(68 34.48 85.39 / 76%)',
     onboardingSection: "#f5f5f5",
     onboardingPodcast: "#e7e7e7",
+    placeholderGradient: 'linear-gradient(90deg, #EEE 33%, #E5E5E5 50%, #EEE 66%)',
   },
   boxShadow: {
     default: `0 1px 5px ${shades.boxShadowColor(.025)}`,

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -406,7 +406,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     reviewGold: 'lch(68 34.48 85.39 / 76%)',
     onboardingSection: "#f5f5f5",
     onboardingPodcast: "#e7e7e7",
-    placeholderGradient: 'linear-gradient(90deg, #EEE 33%, #E5E5E5 50%, #EEE 66%)',
+    placeholderGradient: 'linear-gradient(90deg, #EEE 33%, #E6E6E6 50%, #EEE 66%)',
   },
   boxShadow: {
     default: `0 1px 5px ${shades.boxShadowColor(.025)}`,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -327,6 +327,7 @@ declare global {
       reviewGold: ColorString
       onboardingSection: ColorString,
       onboardingPodcast: ColorString,
+      placeholderGradient: ColorString,
     },
     boxShadow: {
       default: string,

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -149,6 +149,7 @@ const forumComponentPalette = (shadePalette: ThemeShadePalette) =>
         loginInputHovered: "#3f3f3f",
         onboardingSection: "#424242",
         onboardingPodcast: "#525252",
+        placeholderGradient: 'linear-gradient(90deg, #3f3f3f 33%, #525252 50%, #3f3f3f 66%)',
       },
       background: {
         primaryTranslucent: "rgba(12,134,155,0.4)",

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -149,7 +149,7 @@ const forumComponentPalette = (shadePalette: ThemeShadePalette) =>
         loginInputHovered: "#3f3f3f",
         onboardingSection: "#424242",
         onboardingPodcast: "#525252",
-        placeholderGradient: 'linear-gradient(90deg, #3f3f3f 33%, #525252 50%, #3f3f3f 66%)',
+        placeholderGradient: 'linear-gradient(90deg, #3f3f3f 33%, #4a4a4a 50%, #3f3f3f 66%)',
       },
       background: {
         primaryTranslucent: "rgba(12,134,155,0.4)",


### PR DESCRIPTION
This PR adds a ghost loading state for the post list item. Right now it's only used in `BookmarksList` but we'll add it to more places in subsequent PRs. A bunch of this is borrowed from the `service-worker-prototype` branch, so hopefully the merge is not too bad.

Desktop, light mode:

https://github.com/ForumMagnum/ForumMagnum/assets/9057804/c9c4a5d6-f424-4196-a653-9dec943c55b7

Mobile, dark mode:

https://github.com/ForumMagnum/ForumMagnum/assets/9057804/d068c515-dbcb-4f2a-b4d1-92d97365b113




┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207050154489980) by [Unito](https://www.unito.io)
