### PR TITLE
Fix crash rendering ToC in SSR

### DIFF
--- a/packages/lesswrong/components/hooks/useScrollHighlight.ts
+++ b/packages/lesswrong/components/hooks/useScrollHighlight.ts
@@ -69,6 +69,7 @@ export function useScrollHighlight(landmarks: ScrollHighlightLandmark[]): {
  * screen where the current-post will transition when its heading passes.
  */
 export const getCurrentSectionMark = () => {
+  if (isServer) return 0;
   return window.innerHeight/5
 }
 


### PR DESCRIPTION
On some posts, SSRing a post page gave me a crash:

```
ReferenceError: window is not defined
    at getCurrentSectionMark (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/components/hooks/useScrollHighlight.ts:72:3)
    at /Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx:214:17
    at Array.map (<anonymous>)
    at FixedPositionToc (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx:210:25)
    at processChild (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/react-dom/cjs/
react-dom-server.node.development.js:3043:14)
    at resolve (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer2.render2 [as render] (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer2.read (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
    at renderToString3 (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/react-dom/cjs/react-dom-server.node.development.js:3988:27)
    at /Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/@apollo/client/react/ssr/getDataFromTree.js:20:21
    at new Promise (<anonymous>)
    at process8 (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/node_modules/@apollo/client/react/ssr/getDataFromTree.js:18:16)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at renderRequest (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx:404:19)
    at Object.callback (/Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx:250:20)
```

This is caused by `getCurrentSectionMark` attempting to use the window height, which is not available on the server. The symptoms of this aren't particularly serious (it means the ToC is excluded from the SSR, but it's added into the page correctly by the client after hydration).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207050659932526) by [Unito](https://www.unito.io)
