### PR TITLE
Gate loading datadog by forum type

### DIFF
--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -222,3 +222,5 @@ export const maxAllowedApiSkip = new PublicInstanceSetting<number | null>("maxAl
 export const recombeeDatabaseIdSetting = new PublicInstanceSetting<string | null>('recombee.databaseId', null, "optional");
 export const recombeePublicApiTokenSetting = new PublicInstanceSetting<string | null>('recombee.publicApiToken', null, "optional");
 export const recombeePrivateApiTokenSetting = new PublicInstanceSetting<string | null>('recombee.privateApiToken', null, "optional");
+
+export const isDatadogEnabled = isEAForum;

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -33,7 +33,7 @@ import expressSession from 'express-session';
 import MongoStore from './vendor/ConnectMongo/MongoStore';
 import { ckEditorTokenHandler } from './ckEditor/ckEditorToken';
 import { getEAGApplicationData } from './zohoUtils';
-import { faviconUrlSetting, isEAForum, testServerSetting, performanceMetricLoggingEnabled } from '../lib/instanceSettings';
+import { faviconUrlSetting, isEAForum, testServerSetting, performanceMetricLoggingEnabled, isDatadogEnabled } from '../lib/instanceSettings';
 import { parseRoute, parsePath } from '../lib/vulcan-core/appContext';
 import { globalExternalStylesheets } from '../themes/globalStyles/externalStyles';
 import { addCypressRoutes } from './testingSqlClient';
@@ -146,7 +146,9 @@ export function startWebserver() {
   addForumSpecificMiddleware(addMiddleware);
   addSentryMiddlewares(addMiddleware);
   addClientIdMiddleware(addMiddleware);
-  app.use(datadogMiddleware);
+  if (isDatadogEnabled) {
+    app.use(datadogMiddleware);
+  }
   app.use(pickerMiddleware);
   app.use(botRedirectMiddleware);
   app.use(hstsMiddleware);

--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -1,21 +1,26 @@
 import tracer from "dd-trace";
 import { StatsD } from "hot-shots";
+import { isDatadogEnabled } from "../../lib/instanceSettings";
 
-tracer.init({
-  hostname: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
-  sampleRate: 1,
-  // TODO: Enabling log injection would let us associate logs with traces, but this requires setting up a json
-  // logger rather than using console.log
-  // logInjection: true
-});
-tracer.use('express', {
-  service: 'forummagnum'
-})
+if (isDatadogEnabled) {
+  tracer.init({
+    hostname: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
+    sampleRate: 1,
+    // TODO: Enabling log injection would let us associate logs with traces, but this requires setting up a json
+    // logger rather than using console.log
+    // logInjection: true
+  });
+  tracer.use('express', {
+    service: 'forummagnum'
+  })
+}
 
-export const dogstatsd = new StatsD({
-  host: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
-  prefix: 'forummagnum.',
-  sampleRate: 0.1
-});
+export const dogstatsd = isDatadogEnabled
+  ? new StatsD({
+      host: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
+      prefix: 'forummagnum.',
+      sampleRate: 0.1
+    })
+  : null;
 
 export default tracer;

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -10,6 +10,7 @@ import { dogstatsd } from '../../datadog/tracer';
 import { healthCheckUserAgentSetting } from './renderUtil';
 import PageCacheRepo, { maxCacheAgeMs } from '../../repos/PageCacheRepo';
 import { DatabaseServerSetting } from '../../databaseSettings';
+import { isDatadogEnabled } from '../../../lib/instanceSettings';
 
 // Page cache. This applies only to logged-out requests, and exists primarily
 // to handle the baseload of traffic going to the front page and to pages that
@@ -280,7 +281,9 @@ export function recordDatadogCacheEvent(cacheEvent: {path: string, userAgent: st
   const userType = cacheEvent.userAgent === healthCheckUserAgentSetting.get() ? "health_check" : "likely_real_user";
 
   const expandedCacheEvent = {...cacheEvent, userType};
-  dogstatsd.increment("cache_event", expandedCacheEvent)
+  if (isDatadogEnabled && dogstatsd) {
+    dogstatsd.increment("cache_event", expandedCacheEvent)
+  }
 }
 
 export function recordCacheHit(cacheEvent: {path: string, userAgent: string}) {


### PR DESCRIPTION
Makes Datadog only initialize for EA Forum, which uses it, and not for LW, which doesn't. This saves LW some CPU overhead, as Datadog without an associated account spends a fair amount of CPU preparing information to send, only to discard it.

This replaces previous PR https://github.com/ForumMagnum/ForumMagnum/pull/8581 which didn't work; that version broke datadog data-sending for EA Forum, due to some sort of initialization-order issue. This version hopefully works, but someone from the EA Forum side will have to test it.