### PR TITLE
Upgrade version of postgres-array

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,7 +359,8 @@
   "resolutions": {
     "graphql": "^14.5.8",
     "graphql-tools": "^4.0.7",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "postgres-array": "^3.0.2"
   },
   "engines": {
     "node": "18.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13507,10 +13507,10 @@ postcss@^8.3.11:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postgres-array@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
-  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+postgres-array@^3.0.2, postgres-array@~2.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-3.0.2.tgz#68d6182cb0f7f152a7e60dc6a6889ed74b0a5f98"
+  integrity sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==
 
 postgres-bytea@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Postgres-array is a dependency of pg-types which is a depndency of pg. It's responsible for parsing jsonb fields in the results of queries we run in postgres. This version upgrade causes us to get the changes in https://github.com/bendrucker/postgres-array/pull/16 , which makes that particular function ~2-3x faster. I observed that this function was ~2% of our server CPU time (on a benchmark where I was SSRing a post page with lots of comments in a loop), and after this upgrade I saw the time spent in it reduce accordingly.

The version is a major version only because they dropped compatibility with some old nodejs versions.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207051997219750) by [Unito](https://www.unito.io)
