### PR TITLE
Use linkedom instead of JSDOM for ToC

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
     "jsonwebtoken": "^9.0.0",
     "juice": "^7.0.0",
     "later": "^1.2.0",
+    "linkedom": "^0.16.11",
     "logrocket": "^1.0.0",
     "lolex": "^3.0.0",
     "lru-cache": "^5.1.1",

--- a/packages/lesswrong/lib/domParser.ts
+++ b/packages/lesswrong/lib/domParser.ts
@@ -1,8 +1,10 @@
 import type { DOMWindow } from "jsdom";
 import { isServer } from "./executionEnvironment";
 
-// Note: isServer is defined as `const isServer = bundleIsServer`, but checking against isServer here causes irreparable build errors
-const { JSDOM = null } = bundleIsServer ? require('jsdom') : {};
+// Note: isServer is defined as `const isServer = bundleIsServer`, but checking
+// against isServer here isn't sufficient to prevent the require from making it
+// into the client bundle.
+const { parseHTML = null } = bundleIsServer ? require('linkedom') : {};
 
 /**
  * A window type that works with jsdom or the browser window
@@ -17,8 +19,8 @@ export function parseDocumentFromString(html: string): {
   window: WindowType;
 } {
   if (isServer) {
-    const { window } = new JSDOM(html);
-    return { window, document: window.document };
+    const { document, window } = parseHTML(`<html><body>${html}</body></html>`);
+    return { document, window };
   } else {
     const parser = new DOMParser();
     const document = parser.parseFromString(html, "text/html");

--- a/packages/lesswrong/unitTests/tableOfContents.tests.ts
+++ b/packages/lesswrong/unitTests/tableOfContents.tests.ts
@@ -3,6 +3,12 @@ import { parseDocumentFromString } from "../lib/domParser";
 
 const normalizeHtml = (html: string) => html.replace(/[\s\n]+/g, " ").trim();
 
+/*
+ * Note: these tests use &#160; rather than &nbsp; (these are the same) because
+ * 'linkedom' normalizes them to &#160. Which is a little unfortunate, since
+ * that name is less legible, but oh well.
+ */
+
 describe("extractTableOfContents", () => {
   it("handles a basic case correctly", () => {
     const html = normalizeHtml(`
@@ -49,20 +55,20 @@ describe("extractTableOfContents", () => {
     // cases like this I think it would be good to support though, E.g. I think <p><strong>Visit our </strong><a href="..."><strong>website</strong></a>
     // should be counted as a heading.
     const cases = [
-      normalizeHtml(`<p><strong>Here is some additional content (</strong><a href="https://www.youtube.com/watch?v=S7Cu59G1aSQ&amp;t=76s"><strong>11 min video</strong></a><strong>) to consider about if you are the right fit for founding.</strong></p>`),
+      normalizeHtml(`<p><strong>Here is some additional content (</strong><a href="https://www.youtube.com/watch?v=S7Cu59G1aSQ&t=76s"><strong>11 min video</strong></a><strong>) to consider about if you are the right fit for founding.</strong></p>`),
       normalizeHtml(`<p><a href="https://www.visitdubai.com/en/plan-your-trip/visa-information"><strong>Dubai Visa Information</strong></a><br><br><strong>Why is it such short notice?</strong></p>`),
       normalizeHtml(`
         <blockquote>
-          <p><strong>Also Read: </strong><a href="https://worlegram.com/read-blog/108231_learn-why-8gb-laptops-are-top-picks-in-the-market.html"><strong>Learn Why 8GB Laptops Are Top Picks in the Market</strong></a><br>&nbsp;</p>
+          <p><strong>Also Read: </strong><a href="https://worlegram.com/read-blog/108231_learn-why-8gb-laptops-are-top-picks-in-the-market.html"><strong>Learn Why 8GB Laptops Are Top Picks in the Market</strong></a><br>&#160;</p>
         </blockquote>
       `),
       normalizeHtml(`
-        <p><br>&nbsp;<strong>Please submit your ideas here:&nbsp;</strong><a href="https://docs.google.com/forms/d/e/1FAIpQLSf7yo1Bd4ZK6_u2nziuM_10bYYoJhAMjp-9b_MKG2tMX9PuWA/viewform"><strong><u>Submit your ideas</u></strong></a></p>
+        <p><br>&#160;<strong>Please submit your ideas here:&#160;</strong><a href="https://docs.google.com/forms/d/e/1FAIpQLSf7yo1Bd4ZK6_u2nziuM_10bYYoJhAMjp-9b_MKG2tMX9PuWA/viewform"><strong><u>Submit your ideas</u></strong></a></p>
       `),
-      normalizeHtml('<p><strong>Animal advocacy organisations&nbsp;</strong><a href="https://www.animaladvocacycareers.org/post/animal-advocacy-bottlenecks"><strong><u>listed</u></strong></a><strong> a lack of funding as the single most important thing that limited their organisations impact.</strong></p>'),
-      normalizeHtml('<p><strong>&nbsp;</strong><a href="https://genericaura.com/product/careprost-eye-drops/"><strong>Careprost</strong></a><strong> is an FDA-approved medicine that is used all over the world to reduce ocular blood pressure.&nbsp;</strong></p>'),
-      normalizeHtml('<p><strong>Click Here To Know More Info:&nbsp;</strong><a href="https://www.osiztechnologies.com/ai-development-company"><strong><u>https://www.osiztechnologies.com/ai-development-company</u></strong></a></p>'),
-      normalizeHtml('<p><strong>Read More :-&nbsp;</strong><a href="https://getairlineshelpdesk.com/blog/united-airlines-flight-status"><strong><u>United Airlines Flight Status</u></strong></a></p>')
+      normalizeHtml('<p><strong>Animal advocacy organisations&#160;</strong><a href="https://www.animaladvocacycareers.org/post/animal-advocacy-bottlenecks"><strong><u>listed</u></strong></a><strong> a lack of funding as the single most important thing that limited their organisations impact.</strong></p>'),
+      normalizeHtml('<p><strong>&#160;</strong><a href="https://genericaura.com/product/careprost-eye-drops/"><strong>Careprost</strong></a><strong> is an FDA-approved medicine that is used all over the world to reduce ocular blood pressure.&#160;</strong></p>'),
+      normalizeHtml('<p><strong>Click Here To Know More Info:&#160;</strong><a href="https://www.osiztechnologies.com/ai-development-company"><strong><u>https://www.osiztechnologies.com/ai-development-company</u></strong></a></p>'),
+      normalizeHtml('<p><strong>Read More :-&#160;</strong><a href="https://getairlineshelpdesk.com/blog/united-airlines-flight-status"><strong><u>United Airlines Flight Status</u></strong></a></p>')
     ];
 
     for (const html of cases) {
@@ -110,14 +116,14 @@ describe("extractTableOfContents", () => {
   });
 
   it("Regression: Trailing whitespace counts towards anchor", () => {
-    const html = `<p><strong>DanielFilan ($23,544):&nbsp; Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.&nbsp; </strong></p>`;
+    const html = `<p><strong>DanielFilan ($23,544):&#160; Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.&#160; </strong></p>`;
 
     const expectedAnchor = "DanielFilan___23_544____Funding_to_produce_12_more_AXRP_episodes__the_AI_X_risk_Podcast___"
 
     const { document, window } = parseDocumentFromString(html);
     const tocData = extractTableOfContents({ document, window });
     expect(tocData).toEqual({
-      html: `<p><strong id="${expectedAnchor}">DanielFilan ($23,544):&nbsp; Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.&nbsp; </strong></p>`,
+      html: `<p><strong id="${expectedAnchor}">DanielFilan ($23,544):&#160; Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.&#160; </strong></p>`,
       sections: [
         {
           title: "DanielFilan ($23,544):  Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.  ",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6458,6 +6458,17 @@ css-select@^4.1.2:
     domutils "^2.6.0"
     nth-check "^2.0.0"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz"
@@ -6498,6 +6509,11 @@ css-what@^5.0.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.0.tgz#f0bf4f8bac07582722346ab243f6a35b512cfc47"
   integrity sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==
 
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 csscolorparser@~1.0.2, csscolorparser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz"
@@ -6524,6 +6540,11 @@ cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 cssstyle@^1.0.0:
   version "1.4.0"
@@ -7228,6 +7249,15 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
 
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dot-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-1.1.2.tgz#1e73826900de28d6de5480bc1de31d0842b06bec"
@@ -7532,7 +7562,7 @@ entities@^4.2.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
-entities@^4.4.0:
+entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -9580,6 +9610,11 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-escaper@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
+  integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
+
 html-lexer@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/html-lexer/-/html-lexer-0.4.1.tgz#c123e20de10588de4f471913e1d6b87a7dcb1eeb"
@@ -9642,6 +9677,16 @@ htmlparser2@^8.0.0, htmlparser2@^8.0.1:
     domhandler "^5.0.3"
     domutils "^3.0.1"
     entities "^4.4.0"
+
+htmlparser2@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
+  integrity sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
 
 http-cache-semantics@^4.0.0:
   version "4.1.1"
@@ -11573,6 +11618,17 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkedom@^0.16.11:
+  version "0.16.11"
+  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.16.11.tgz#2419649b178be5a627f6b8b2cfad521dfa726ae9"
+  integrity sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==
+  dependencies:
+    css-select "^5.1.0"
+    cssom "^0.5.0"
+    html-escaper "^3.0.3"
+    htmlparser2 "^9.1.0"
+    uhyphen "^0.2.0"
+
 linkify-it@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz"
@@ -12638,6 +12694,13 @@ nth-check@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.0.tgz#1bb4f6dac70072fc313e8c9cd1417b5074c0a125"
   integrity sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
+  dependencies:
+    boolbase "^1.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
 
@@ -16099,6 +16162,11 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uhyphen@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/uhyphen/-/uhyphen-0.2.0.tgz#8fdf0623314486e020a3c00ee5cc7a12fe722b81"
+  integrity sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==
 
 uid-safe@~2.1.5:
   version "2.1.5"


### PR DESCRIPTION
In extractTableOfContents, we parse a post and find headings in it. Previously, this was done with cheerio. Recently it was modified to JSDOM so that the same code could run on the client (though in practice it's usually done server side). Unfortunately this was slower, especially on large posts; on an 11k-word real post, it was adding ~80ms of CPU time to per SSR (on my M1 Max).

There's a competing library linkedom which is a lot faster, with a similar API. Switch libraries, and smooth over a few small API differences.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207052305117059) by [Unito](https://www.unito.io)
