### PR TITLE
Avoid using slow momentjs functions

### DIFF
--- a/packages/lesswrong/components/common/FormatDate.tsx
+++ b/packages/lesswrong/components/common/FormatDate.tsx
@@ -3,48 +3,12 @@ import React from 'react';
 import moment from 'moment';
 import { useTimezone } from '../common/withTimezone';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
+import { formatRelative } from '../../lib/utils/timeFormat';
 
 export const ExpandedDate = ({date}: {date: Date | string}) => {
   const { timezone } = useTimezone();
   return <>{moment(new Date(date)).tz(timezone).format("LLL z")}</>
 };
-
-const formatRelative = (
-  date: Date | string,
-  now: Date,
-  includeAgo?: boolean,
-): string => {
-  //const formatted = formatRelativeMoment(new Date(date), now);
-  const formatted = formatRelativeFast(new Date(date), now);
-  return includeAgo && formatted !== "now" ? formatted + " ago" : formatted;
-}
-
-const formatRelativeMoment = (date: Date, now: Date): string => {
-  return moment(date).from(now);
-}
-
-const formatRelativeFast = (date: Date, now: Date): string => {
-  const msApart = Math.abs(now.getTime() - date.getTime());
-  const secondsApart = msApart / 1000;
-  if (secondsApart < 44) {
-    return "now";
-  } else if (secondsApart < 45*60) {
-    const minutes = Math.round(secondsApart/60.0);
-    return `${minutes}m`;
-  } else if (secondsApart < 22*60*60) {
-    const hours = Math.round(secondsApart/(60.0*60.0));
-    return `${hours}h`;
-  } else if (secondsApart < 26*24*60*60) {
-    const days = Math.round(secondsApart/(24*60*60.0));
-    return `${days}d`;
-  } else if (secondsApart < 335) {
-    const months = Math.round(secondsApart/(30.4*24*60*60.0));
-    return `${months}mo`;
-  } else {
-    const years = Math.round(secondsApart/(365*24*60*60.0));
-    return `${years}y`;
-  }
-}
 
 /// A relative time/date, like "4d". If tooltip is true (default), hover over
 /// for the actual (non-relative) date/time.

--- a/packages/lesswrong/components/common/FormatDate.tsx
+++ b/packages/lesswrong/components/common/FormatDate.tsx
@@ -1,6 +1,6 @@
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import React from 'react';
-import moment from '../../lib/moment-timezone';
+import moment from 'moment';
 import { useTimezone } from '../common/withTimezone';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
 
@@ -14,8 +14,36 @@ const formatRelative = (
   now: Date,
   includeAgo?: boolean,
 ): string => {
-  const formatted = moment(date).from(now);
+  //const formatted = formatRelativeMoment(new Date(date), now);
+  const formatted = formatRelativeFast(new Date(date), now);
   return includeAgo && formatted !== "now" ? formatted + " ago" : formatted;
+}
+
+const formatRelativeMoment = (date: Date, now: Date): string => {
+  return moment(date).from(now);
+}
+
+const formatRelativeFast = (date: Date, now: Date): string => {
+  const msApart = Math.abs(now.getTime() - date.getTime());
+  const secondsApart = msApart / 1000;
+  if (secondsApart < 44) {
+    return "now";
+  } else if (secondsApart < 45*60) {
+    const minutes = Math.round(secondsApart/60.0);
+    return `${minutes}m`;
+  } else if (secondsApart < 22*60*60) {
+    const hours = Math.round(secondsApart/(60.0*60.0));
+    return `${hours}h`;
+  } else if (secondsApart < 26*24*60*60) {
+    const days = Math.round(secondsApart/(24*60*60.0));
+    return `${days}d`;
+  } else if (secondsApart < 335) {
+    const months = Math.round(secondsApart/(30.4*24*60*60.0));
+    return `${months}mo`;
+  } else {
+    const years = Math.round(secondsApart/(365*24*60*60.0));
+    return `${years}y`;
+  }
 }
 
 /// A relative time/date, like "4d". If tooltip is true (default), hover over

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2680,7 +2680,9 @@ const schema: SchemaType<"Posts"> = {
     resolver: async (post: DbPost, args: {commentsLimit?: number|null, maxAgeHours?: number, af?: boolean}, context: ResolverContext) => {
       const { commentsLimit, maxAgeHours=18, af=false } = args;
       const { currentUser, Comments } = context;
-      const timeCutoff = moment(post.lastCommentedAt).subtract(maxAgeHours, 'hours').toDate();
+      const oneHourInMs = 60*60*1000;
+      const lastCommentedOrNow = post.lastCommentedAt ?? new Date();
+      const timeCutoff = new Date(lastCommentedOrNow.getTime() - (maxAgeHours*oneHourInMs));
       const loaderName = af?"recentCommentsAf" : "recentComments";
       const filter: MongoSelector<DbComment> = {
         ...getDefaultViewSelector("Comments"),

--- a/packages/lesswrong/lib/utils/timeFormat.ts
+++ b/packages/lesswrong/lib/utils/timeFormat.ts
@@ -4,7 +4,6 @@ export const formatRelative = (
   now: Date,
   includeAgo?: boolean,
 ): string => {
-  //const formatted = formatRelativeMoment(new Date(date), now);
   const formatted = formatRelativeFast(new Date(date), now);
   return includeAgo && formatted !== "now" ? formatted + " ago" : formatted;
 }

--- a/packages/lesswrong/lib/utils/timeFormat.ts
+++ b/packages/lesswrong/lib/utils/timeFormat.ts
@@ -1,0 +1,33 @@
+
+export const formatRelative = (
+  date: Date | string,
+  now: Date,
+  includeAgo?: boolean,
+): string => {
+  //const formatted = formatRelativeMoment(new Date(date), now);
+  const formatted = formatRelativeFast(new Date(date), now);
+  return includeAgo && formatted !== "now" ? formatted + " ago" : formatted;
+}
+
+const formatRelativeFast = (date: Date, now: Date): string => {
+  const msApart = Math.abs(now.getTime() - date.getTime());
+  const secondsApart = msApart / 1000;
+  if (secondsApart < 44) {
+    return "now";
+  } else if (secondsApart < 45*60) {
+    const minutes = Math.round(secondsApart/60.0);
+    return `${minutes}m`;
+  } else if (secondsApart < 22*60*60) {
+    const hours = Math.round(secondsApart/(60.0*60.0));
+    return `${hours}h`;
+  } else if (secondsApart < 26*24*60*60) {
+    const days = Math.round(secondsApart/(24*60*60.0));
+    return `${days}d`;
+  } else if (secondsApart < 335*24*60*60) {
+    const months = Math.round(secondsApart/(30.4*24*60*60.0));
+    return `${months}mo`;
+  } else {
+    const years = Math.round(secondsApart/(365*24*60*60.0));
+    return `${years}y`;
+  }
+}

--- a/packages/lesswrong/unitTests/timeframeUtils.tests.ts
+++ b/packages/lesswrong/unitTests/timeframeUtils.tests.ts
@@ -1,6 +1,11 @@
 import { getDateRange } from '../components/posts/timeframeUtils'
 import { withNoLogs } from '../integrationTests/utils';
 import chai from 'chai';
+import moment from 'moment';
+import { formatRelative } from '../lib/utils/timeFormat';
+
+// This file side-effectfully configured momentjs
+import '../components/momentjs';
 
 chai.should();
 
@@ -61,3 +66,41 @@ describe('getDateRange', () => {
     ) as any).should.throw(Error, /Invalid timeBlock/)
   })
 })
+
+describe('formatRelative', () => {
+  it('formats dates in the past the same way as momentjs did', () => {
+    const now = new Date();
+
+    function assertSameFormat(when: Date) {
+      const formattedByMoment = moment(when).from(now);
+      const formattedByUs = formatRelative(when, now);
+      formattedByMoment.should.equal(formattedByUs);
+    }
+    
+    assertSameFormat(now);
+
+    // Exact offsets
+    assertSameFormat(moment(now).subtract(2, 'minutes').toDate());
+    assertSameFormat(moment(now).subtract(2, 'hours').toDate());
+    assertSameFormat(moment(now).subtract(2, 'days').toDate());
+    assertSameFormat(moment(now).subtract(2, 'months').toDate());
+    assertSameFormat(moment(now).subtract(2, 'years').toDate());
+    assertSameFormat(moment(now).add(2, 'minutes').toDate());
+    assertSameFormat(moment(now).add(2, 'hours').toDate());
+    assertSameFormat(moment(now).add(2, 'days').toDate());
+    assertSameFormat(moment(now).add(2, 'months').toDate());
+    assertSameFormat(moment(now).add(2, 'years').toDate());
+
+    // Inexact offsets - off by one in either direction of the next unit down
+    assertSameFormat(moment(now).subtract(2, 'minutes').subtract(1, 'seconds').toDate());
+    assertSameFormat(moment(now).subtract(2, 'hours'  ).subtract(1, 'minutes').toDate());
+    assertSameFormat(moment(now).subtract(2, 'days'   ).subtract(1, 'hours'  ).toDate());
+    assertSameFormat(moment(now).subtract(2, 'months' ).subtract(1, 'days'   ).toDate());
+    assertSameFormat(moment(now).subtract(2, 'years'  ).subtract(1, 'months' ).toDate());
+    assertSameFormat(moment(now).subtract(2, 'minutes').add(1, 'seconds').toDate());
+    assertSameFormat(moment(now).subtract(2, 'hours'  ).add(1, 'minutes').toDate());
+    assertSameFormat(moment(now).subtract(2, 'days'   ).add(1, 'hours'  ).toDate());
+    assertSameFormat(moment(now).subtract(2, 'months' ).add(1, 'days'   ).toDate());
+    assertSameFormat(moment(now).subtract(2, 'years'  ).add(1, 'months' ).toDate());
+  });
+});


### PR DESCRIPTION
This introduces a replacement for momentjs's .from() (which is also used under the name .fromNow()), which was _remarkably_ slow for what it is. Also replaces some moment-based date calculations with `Date` instead.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207052695289780) by [Unito](https://www.unito.io)
