### PR TITLE
Fix `getTagBotUserId` retaining and leaking a ResolverContext

### DIFF
--- a/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
+++ b/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
@@ -208,6 +208,13 @@ let tagBotUserIdPromise: Promise<void>|null = null;
 // If undefined, hasn't been fetched yet; if null, the account doesn't exist.
 let tagBotUserId: string|null|undefined = undefined;
 
+/**
+ * Get the ID of the tag-bot account, with caching. The first call to this will
+ * fetch the tagger account (using the tagBotAccountSlug config setting); all
+ * subsequent calls will return a cached value. If called while that first
+ * fetch is in-flight, waits for that request to finish, rather than starting a
+ * duplicate (this affects server-startup performance during development).
+ */
 export async function getTagBotUserId(context: ResolverContext): Promise<string|null> {
   if (tagBotUserId === undefined) {
     if (!tagBotUserIdPromise) {
@@ -215,6 +222,13 @@ export async function getTagBotUserId(context: ResolverContext): Promise<string|
         void (async () => {
           const tagBotAccount = await getTagBotAccount(context);
           tagBotUserId = tagBotAccount?._id ?? null;
+          
+          // Discard the promise after we're done with it. Previously we didn't
+          // do this, and kept the promise in a global variable forever after it
+          // was resolved. That made this function simpler, but caused a memory
+          // leak: the promise captures its context, including the
+          // ResolverContext we got passed, which retains everything from the
+          // whole pageload.
           tagBotUserIdPromise = null;
           resolve();
         })();


### PR DESCRIPTION
The performance impact of this one isn't super high, but the pattern is interesting to watch out for.

The first time `getTagBotUserId` is called, it fetches a user by slug and returns its ID; on subsequent calls, it reuses the result of that fetch and returns the same ID. In the course of doing this, it creates a promise and stores it in a global variable (so subsequent calls can wait for the first call to finish, rather than starting their own DB fetches).

After everything is settled, that promise was retained in a global variable. It turns out, retaining the promise (even in a resolved state) retains everything captured by the promise's execution context, which means that the first call to this function takes its arguments (a ResolverContext) and leaks them. (When I found it in a heap snapshot, the debugger claimed it was retaining 23MB. This amount of memory is not a big deal, but there may be contexts in which the amount leaked much larger.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207052960762093) by [Unito](https://www.unito.io)
