### PR TITLE
Posts page SSR optimisations

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -182,6 +182,7 @@ const CommentsNewForm = ({
     extraVariablesValues: { postId: post?._id },
     fetchPolicy: "cache-and-network",
     skip: !currentUser,
+    ssr: false
   });
   const userNextAbleToComment = userWithRateLimit?.document?.rateLimitNextAbleToComment;
   const lastRateLimitExpiry: Date|null = (userNextAbleToComment && new Date(userNextAbleToComment.nextEligible)) ?? null;

--- a/packages/lesswrong/components/forumEvents/ForumEventPostPageBanner.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPostPageBanner.tsx
@@ -50,14 +50,15 @@ export const ForumEventPostPageBanner = ({classes}: {
   classes: ClassesType<typeof styles>,
 }) => {
   const {params} = useLocation();
+  const {currentForumEvent} = useCurrentForumEvent();
+
   const {document: post} = useSingle({
     collectionName: "Posts",
     fragmentName: "PostsDetails",
     documentId: params._id,
-    skip: !hasForumEvents || !params._id,
+    skip: !hasForumEvents || !params._id || !currentForumEvent?.tagId,
   });
 
-  const {currentForumEvent} = useCurrentForumEvent();
   if (!currentForumEvent || !post) {
     return null;
   }

--- a/packages/lesswrong/components/hooks/usePaginatedResolver.ts
+++ b/packages/lesswrong/components/hooks/usePaginatedResolver.ts
@@ -3,8 +3,8 @@ import { fragmentTextForQuery } from "../../lib/vulcan-lib";
 import { ApolloError, ApolloQueryResult, NetworkStatus, gql, useQuery } from "@apollo/client";
 import take from "lodash/take";
 import isEqual from "lodash/isEqual"
-import { isServer } from "../../lib/executionEnvironment";
 import type { LoadMoreCallback, LoadMoreProps } from "../../lib/crud/withMulti";
+import { apolloSSRFlag } from "../../lib/helpers";
 
 export type UsePaginatedResolverResult<
   FragmentTypeName extends keyof FragmentTypes,
@@ -65,7 +65,9 @@ export const usePaginatedResolver = <
     fetchMore,
     networkStatus,
   } = useQuery(query, {
-    ssr: ssr || !isServer,
+    // This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
+    // the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
+    ssr: apolloSSRFlag(ssr),
     notifyOnNetworkStatusChange: true,
     skip,
     pollInterval: 0,

--- a/packages/lesswrong/components/hooks/useRecentOpportunities.ts
+++ b/packages/lesswrong/components/hooks/useRecentOpportunities.ts
@@ -28,11 +28,13 @@ export const useRecentOpportunities =<
   limit = 3,
   maxAgeInDays = 7,
   post,
+  ssr,
 }: {
   fragmentName: FragmentTypeName,
   limit?: number,
   maxAgeInDays?: number,
   post?: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList,
+  ssr?: boolean,
 }): UseMultiResult<FragmentTypeName> & {coreTagLabel: string | null} => {
   const coreTags =
     post?.tags
@@ -67,6 +69,7 @@ export const useRecentOpportunities =<
     },
     fragmentName,
     enableTotal: false,
+    ssr,
     fetchPolicy: "cache-and-network",
   });
 

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -44,22 +44,26 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
+const PostBottomRecommendations = ({post, hasTableOfContents, ssr = false, classes}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList,
   hasTableOfContents?: boolean,
+  ssr?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {
   const {
     recommendationsLoading: moreFromAuthorLoading,
     recommendations: moreFromAuthorPosts,
   } = useRecommendations({
-    strategy: {
-      name: "moreFromAuthor",
-      postId: post._id,
-      context: "post-footer",
+    algorithm: {
+      strategy: {
+        name: "moreFromAuthor",
+        postId: post._id,
+        context: "post-footer",
+      },
+      count: 3,
+      disableFallbacks: true,
     },
-    count: 3,
-    disableFallbacks: true,
+    ssr
   });
 
   const {
@@ -69,6 +73,7 @@ const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
     fragmentName: "PostsPage",
     resolverName: "CuratedAndPopularThisWeek",
     limit: 3,
+    ssr
   });
 
   const {
@@ -78,7 +83,8 @@ const PostBottomRecommendations = ({post, hasTableOfContents, classes}: {
   } = useRecentOpportunities({
     fragmentName: "PostsListWithVotes",
     post,
-    maxAgeInDays: 60
+    maxAgeInDays: 60,
+    ssr
   });
 
   const profileUrl = userGetProfileUrl(post.user);

--- a/packages/lesswrong/components/recommendations/RecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.tsx
@@ -31,7 +31,7 @@ const RecommendationsList = ({
   classes: ClassesType,
 }) => {
   const {PostsLoading, Typography} = Components;
-  const {recommendationsLoading, recommendations} = useRecommendations(algorithm);
+  const {recommendationsLoading, recommendations} = useRecommendations({ algorithm });
 
   if (recommendationsLoading || !recommendations)
     return loadingFallback ?? <PostsLoading/>;

--- a/packages/lesswrong/components/recommendations/withRecommendations.ts
+++ b/packages/lesswrong/components/recommendations/withRecommendations.ts
@@ -2,28 +2,40 @@ import { useQuery, gql } from '@apollo/client';
 import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
 import { defaultAlgorithmSettings } from '../../lib/collections/users/recommendationSettings';
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
+import { apolloSSRFlag } from '../../lib/helpers';
 
-export const useRecommendations = (algorithm: RecommendationsAlgorithm): {
-  recommendationsLoading: boolean,
-  recommendations: PostsListWithVotesAndSequence[]|undefined,
-}=> {
-  const {data, loading} = useQuery(gql`
-    query RecommendationsQuery($count: Int, $algorithm: JSON) {
-      Recommendations(count: $count, algorithm: $algorithm) {
-        ...PostsListWithVotesAndSequence
+export const useRecommendations = ({
+  algorithm,
+  ssr = true,
+}: {
+  algorithm: RecommendationsAlgorithm;
+  ssr?: boolean;
+}): {
+  recommendationsLoading: boolean;
+  recommendations: PostsListWithVotesAndSequence[] | undefined;
+} => {
+  const { data, loading } = useQuery(
+    gql`
+      query RecommendationsQuery($count: Int, $algorithm: JSON) {
+        Recommendations(count: $count, algorithm: $algorithm) {
+          ...PostsListWithVotesAndSequence
+        }
       }
+      ${fragmentTextForQuery("PostsListWithVotesAndSequence")}
+    `,
+    {
+      variables: {
+        count: algorithm?.count || 10,
+        algorithm: algorithm || defaultAlgorithmSettings,
+        batchKey: "recommendations",
+      },
+      // This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
+      // the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
+      ssr: apolloSSRFlag(ssr),
     }
-    ${fragmentTextForQuery("PostsListWithVotesAndSequence")}
-  `, {
-    variables: {
-      count: algorithm?.count || 10,
-      algorithm: algorithm || defaultAlgorithmSettings,
-      batchKey: "recommendations"
-    },
-    ssr: true,
-  });
+  );
   return {
     recommendationsLoading: loading,
     recommendations: data?.Recommendations,
   };
-}
+};

--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -5,8 +5,8 @@ import * as _ from 'underscore';
 import { extractFragmentInfo, getFragment, getCollection, pluralize, camelCaseify } from '../vulcan-lib';
 import { useLocation } from '../routeUtil';
 import { invalidateQuery } from './cacheUpdates';
-import { isServer } from '../executionEnvironment';
 import { useNavigate } from '../reactRouterWrapper';
+import { apolloSSRFlag } from '../helpers';
 
 // Template of a GraphQL query for useMulti. A sample query might look
 // like:
@@ -184,7 +184,7 @@ export function useMulti<
     nextFetchPolicy: newNextFetchPolicy as WatchQueryFetchPolicy,
     // This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
     // the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
-    ssr: ssr || !isServer,
+    ssr: apolloSSRFlag(ssr),
     skip,
     notifyOnNetworkStatusChange: true
   }

--- a/packages/lesswrong/lib/crud/withSingle.ts
+++ b/packages/lesswrong/lib/crud/withSingle.ts
@@ -2,6 +2,7 @@ import { ApolloClient, NormalizedCacheObject, ApolloError, gql, useQuery, WatchQ
 import * as _ from 'underscore';
 import { extractFragmentInfo, getCollection } from '../vulcan-lib';
 import { camelCaseify } from '../vulcan-lib/utils';
+import { apolloSSRFlag } from '../helpers';
 
 // Template of a GraphQL query for useSingle. A sample query might look
 // like:
@@ -101,7 +102,7 @@ export type UseSingleProps<FragmentTypeName extends keyof FragmentTypes> = (
     notifyOnNetworkStatusChange?: boolean,
     allowNull?: boolean,
     skip?: boolean,
-    
+    ssr?: boolean,
     /**
      * Optional Apollo client instance to use for this request. If not provided,
      * uses the default client provided by React context. This should only be
@@ -131,6 +132,7 @@ export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
   notifyOnNetworkStatusChange,
   allowNull,
   skip=false,
+  ssr=true,
   apolloClient,
 }: UseSingleProps<FragmentTypeName>): TReturn<FragmentTypeName> {
   const collection: CollectionBase<CollectionNameString> = getCollection(collectionName);
@@ -148,7 +150,7 @@ export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
     fetchPolicy,
     nextFetchPolicy,
     notifyOnNetworkStatusChange,
-    ssr: true,
+    ssr: apolloSSRFlag(ssr),
     skip: skip || (!documentId && !slug),
     client: apolloClient,
   })

--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -1,6 +1,7 @@
 import { Utils, getCollection } from './vulcan-lib';
 import moment from 'moment';
 import { randomId } from './random';
+import { isServer } from './executionEnvironment';
 
 // Get relative link to conversation (used only in session)
 export const conversationGetLink = (conversation: HasIdType): string => {
@@ -191,3 +192,9 @@ export const setAtPath = <T extends {}, V extends AnyBecauseHard>(
   }
   return value;
 }
+
+/**
+ * This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
+ * the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
+ */
+export const apolloSSRFlag = (ssr?: boolean) => ssr || !isServer;

--- a/packages/lesswrong/lib/postSideRecommendations.tsx
+++ b/packages/lesswrong/lib/postSideRecommendations.tsx
@@ -85,7 +85,7 @@ const useGeneratorWithStrategy = (
   const {
     recommendations: posts = [],
     recommendationsLoading: loading,
-  } = useRecommendations(algorithm);
+  } = useRecommendations({ algorithm });
   return {
     loading,
     title,

--- a/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
@@ -29,7 +29,7 @@ const EmailFooterRecommendations = ({classes}: {
     curatedModifier: 50,
     onlyUnread: true,
   }
-  const {recommendationsLoading, recommendations} = useRecommendations(algorithm)
+  const {recommendationsLoading, recommendations} = useRecommendations({ algorithm })
   if (recommendationsLoading) return null
   return <>
     <h2 className={classes.recommendedPostsHeader}>Other Recommended Posts</h2>


### PR DESCRIPTION
In this PR:
1. NoSSR recommendations section
2. NoSSR a comment rate limit query
3. Make it so ForumEventPostPageBanner only checks the post if there is an active event

The first two ran after the main queries to fetch the post and comments (which themselves run in parallel), so removing them removes a bottleneck. The last one ran in parallel so may not make a huge difference, but it will still help with CPU usage etc.

Testing on [this post](https://forum.effectivealtruism.org/posts/JWz7JjuoRKrsWTsrZ/summary-mistakes-in-the-moral-mathematics-of-existential), this reduced the number of db queries required to load the page from 62 to 30 (logged in as my user, with admin powers off)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207057247194303) by [Unito](https://www.unito.io)
