### PR TITLE
remove a couple old fields from UsersCurrent

### DIFF
--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -136,7 +136,7 @@ const StickyDigestAd = ({className, classes}: {
   const ls = getBrowserLocalStorage()
   
   // We only show this after the client has viewed a few posts.
-  if (!showDigestAd || !ls?.getItem('postReadCount') || ls?.getItem('postReadCount') < 5) return null
+  if (!showDigestAd || !ls?.getItem('postReadCount') || ls?.getItem('postReadCount') < 10) return null
   
   const { AnalyticsInViewTracker, ForumIcon, EAButton } = Components
   

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -200,8 +200,6 @@ registerFragment(`
     subforumPreferredLayout
     
     hideJobAdUntil
-    experiencedIn
-    interestedIn
     
     allowDatadogSessionReplay
     hideFrontpageBook2020Ad

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3000,8 +3000,6 @@ interface UsersCurrent extends UsersProfile, SharedUserBooleans { // fragment on
   },
   readonly subforumPreferredLayout: "card" | "list",
   readonly hideJobAdUntil: Date | null,
-  readonly experiencedIn: Array<string> | null,
-  readonly interestedIn: Array<string> | null,
   readonly allowDatadogSessionReplay: boolean,
   readonly hideFrontpageBook2020Ad: boolean,
   readonly hideDialogueFacilitation: boolean,


### PR DESCRIPTION
`experiencedIn` and `interestedIn` were used in the old job ads - now they are no longer used so I'll drop the fields

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207059617139817) by [Unito](https://www.unito.io)
