### PR TITLE
Revert post width layout shift fix

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -212,9 +212,6 @@ export const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 'auto',
     marginRight: 'auto',
   },
-  postBody: {
-    width: 'max-content',
-  },
   postContent: { //Used by a Cypress test
     marginBottom: isFriendlyUI ? 40 : undefined
   },


### PR DESCRIPTION
This was causing text to overflow on mobile. Reverting for now while I find another way to fix it

<img width="415" alt="Screenshot 2024-04-12 at 19 24 31" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/5e714ebf-a346-4f9b-897d-6080bcd5cc41">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207067754036086) by [Unito](https://www.unito.io)
