### PR TITLE
Prefetch resources on most post pages

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -484,10 +484,8 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     PermanentRedirect, DebateBody, PostsPageRecommendationsList, PostSideRecommendations,
     PostBottomRecommendations, NotifyMeDropdownItem, Row, AnalyticsInViewTracker,
     PostsPageQuestionContent, AFUnreviewedCommentCount, CommentsListSection, CommentsTableOfContents,
-    StickyDigestAd, PostsPageSplashHeader, PostsAudioPlayerWrapper, RecombeeInViewTracker, Error404
+    StickyDigestAd, PostsPageSplashHeader, PostsAudioPlayerWrapper, RecombeeInViewTracker
   } = Components
-
-  return <Error404 />
 
   useEffect(() => {
     const recommId = query[RECOMBEE_RECOMM_ID_QUERY_PARAM];

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -484,8 +484,10 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     PermanentRedirect, DebateBody, PostsPageRecommendationsList, PostSideRecommendations,
     PostBottomRecommendations, NotifyMeDropdownItem, Row, AnalyticsInViewTracker,
     PostsPageQuestionContent, AFUnreviewedCommentCount, CommentsListSection, CommentsTableOfContents,
-    StickyDigestAd, PostsPageSplashHeader, PostsAudioPlayerWrapper, RecombeeInViewTracker
+    StickyDigestAd, PostsPageSplashHeader, PostsAudioPlayerWrapper, RecombeeInViewTracker, Error404
   } = Components
+
+  return <Error404 />
 
   useEffect(() => {
     const recommId = query[RECOMBEE_RECOMM_ID_QUERY_PARAM];

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -9,6 +9,8 @@ import Localgroups from '../localgroups/collection';
 import moment from '../../moment-timezone';
 import { max } from "underscore";
 import { TupleSet, UnionOf } from '../../utils/typeGuardUtils';
+import type { Request, Response } from 'express';
+import pathToRegexp from "path-to-regexp";
 
 export const postCategories = new TupleSet(['post', 'linkpost', 'question'] as const);
 export type PostCategory = UnionOf<typeof postCategories>;
@@ -461,3 +463,13 @@ export const extractGoogleDocId = (urlOrId: string): string | null => {
 export const googleDocIdToUrl = (docId: string): string => {
   return `https://docs.google.com/document/d/${docId}/edit`;
 };
+
+export const postRouteWillDefinitelyReturn200 = async (req: Request, res: Response, context: ResolverContext) => {
+  const matchPostPath = pathToRegexp('/posts/:_id/:slug?');
+  const [_, postId] = matchPostPath.exec(req.path) ?? [];
+
+  if (postId) {
+    return await context.repos.posts.postRouteWillDefinitelyReturn200(postId);
+  }
+  return false;
+}

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -11,6 +11,7 @@ import { eaSequencesHomeDescription } from '../components/ea-forum/EASequencesHo
 import { pluralize } from './vulcan-lib';
 import { forumSpecificRoutes } from './forumSpecificRoutes';
 import { hasPostRecommendations } from './betas';
+import { postRouteWillDefinitelyReturn200 } from './collections/posts/helpers';
 
 const knownTagNames = ['tag', 'topic', 'concept']
 const useShortAllTagsPath = isEAForum;
@@ -1427,6 +1428,7 @@ addRoute(
     getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
     background: postBackground,
     noFooter: hasPostRecommendations,
+    enableResourcePrefetch: postRouteWillDefinitelyReturn200,
   },
   {
     name:'posts.slug.single',

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -1,6 +1,7 @@
 import * as _ from 'underscore';
 // eslint-disable-next-line no-restricted-imports
 import {matchPath} from 'react-router'
+import type { Request, Response } from 'express';
 
 export type PingbackDocument = {
   collectionName: CollectionNameString,
@@ -51,19 +52,16 @@ export type Route = {
   fullscreen?: boolean // if true, the page contents are put into a flexbox with the header such that the page contents take up the full height of the screen without scrolling
   unspacedGrid?: boolean // for routes with standalone navigation, setting this to true allows the page body to be full-width (the default is to have empty columns providing padding)
   
-  // enablePrefetch: Start loading stylesheet and JS bundle before the page is
+  // enableResourcePrefetch: Start loading stylesheet and JS bundle before the page is
   // rendered. This requires sending headers before rendering, which means
   // that the page can't return an HTTP error status or an HTTP redirect. In
   // exchange, loading time is significantly improved for users who don't have
   // the stylesheet and JS bundle already in their cache.
   //
-  // This should only be set for routes which are guaranteed to be valid, ie,
-  // they don't have a post-ID or anything variable in them.
-  //
-  // Currently used for / and for /allPosts which is where this matters most.
-  // Not used for post-pages because we don't know whether a post page is going
-  // to be a 404 until we render it.
-  enableResourcePrefetch?: boolean
+  // This should only return true for routes which are *guaranteed* to return a 200 status code.
+  // I.e. it is better to give false negatives (not prefetching on a route that actually returns
+  // a 200) than false positives.
+  enableResourcePrefetch?: boolean | ((req: Request, res: Response, context: ResolverContext) => Promise<boolean>),
   isAdmin?: boolean
 };
 

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -60,8 +60,8 @@ import { createAnonymousContext } from './vulcan-lib';
 const trySetResponseStatus = ({ response, status }: { response: express.Response, status: number; }) => {
   if (!response.headersSent) {
     response.status(status);
-  } else {
-    const message = `Tried to set status to ${status} but headers have already been sent with status ${response.statusCode}`;
+  } else if (response.statusCode !== status) {
+    const message = `Tried to set status to ${status} but headers have already been sent with status ${response.statusCode}. This may be due to enableResourcePrefetch wrongly being set to true.`;
     if (isProduction) {
       // eslint-disable-next-line no-console
       console.error(message);

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -74,7 +74,7 @@ const trySetResponseStatus = ({ response, status }: { response: express.Response
 }
 
 /**
- * If allowed (because we are sure what headers are needed), write the prefetchPrefix to the response so the client can start downloading resources
+ * If allowed, write the prefetchPrefix to the response so the client can start downloading resources
  */
 const maybePrefetchResources = async ({
   request,

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -5,6 +5,7 @@ import LRU from "lru-cache";
 import { getViewablePostsSelector } from "./helpers";
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from "../../lib/collections/tags/collection";
 import { recordPerfMetrics } from "./perfMetricWrapper";
+import { isAF } from "../../lib/instanceSettings";
 
 type MeanPostKarma = {
   _id: number,
@@ -32,6 +33,19 @@ const commentEmojiReactorCache = new LRU<string, Promise<CommentEmojiReactors>>(
 class PostsRepo extends AbstractRepo<"Posts"> {
   constructor() {
     super(Posts);
+  }
+
+  async postRouteWillDefinitelyReturn200(id: string): Promise<boolean> {
+    const res = await this.getRawDb().oneOrNone<{exists: boolean}>(`
+      -- PostsRepo.postRouteWillDefinitelyReturn200
+      SELECT EXISTS(
+        SELECT 1
+        FROM "Posts"
+        WHERE "_id" = $1 AND ${getViewablePostsSelector()} AND "af" = $2
+      )
+    `, [id, isAF]);
+
+    return res?.exists ?? false;
   }
 
   async getEarliestPostTime(): Promise<Date> {


### PR DESCRIPTION
On the frontpage we already send the `<head>` tag with the urls for bundle.js and allStyles ahead of the main SSR body, so that these can be downloaded and parsed while the page is rendering on the server. We weren't doing this for the posts page, because sending these ahead means you have to lock in the status code you are going to send (to 200), which for posts we don't know for sure until the page is rendered (it may be a 404 or 301).

This PR adds the option to run a function in parallel to the main SSR to check what the status code will be, and then send the prefetch section if we are sure it will be a 200.

It's not 100% clear that the performance impact of this will be positive, there are these competing considerations:
- For non-cached loads of the posts page, there is generally at least 500ms of dead time while the SSR is being calculated, where there is nothing being downloaded. Using the network or CPU in this time is "free", but using them after the html starts downloading is not free and might trade off against the time to first render (by using up bandwidth or CPU that could be used to render the page)
- Loading allStyles blocks rendering, so downloading this ahead of time will generally speed things up, and at worst (network bound) shouldn't be any slower. CPU usage isn't really a consideration here
- Loading bundle.js doesn't block rendering, so downloading it ahead of time will generally speed up _time to interactive_, but not time to visually load the page ("first contentful paint", although see below it doesn't necessarily affect the first paint only). It is much larger than the other resources, and uses a lot of CPU once it starts running, so prefetching it might slow down the visual loading of the page

So any negative performance impact would result in the visual loading time being delayed (in exchange for faster time to interactive) due to:
1. Using (main thread) CPU which could be used to render the page (based on html + css) to run bundle.js
2. Using bandwidth which could be used to download the post or allStyles to download bundle.js

The first one does seem to be a problem, and the second one not so much

### 1. Using (main thread) CPU which could be used to render the page (based on html + css) to run bundle.js

It looks like sometimes this is quite a significant problem. This performance profile shows an example of a page load that was affected (how to interpret this is described below):

<img width="532" alt="Screenshot 2024-04-15 at 16 46 57" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/50746088-411c-4150-b432-b082aeb449c9">

_Pink in the graph at the top is CPU work spent on rendering (i.e. the browser running [Layout](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing) to get the size of everything, not GPU-style rendering of the pixels), yellow is CPU work spent on running bundle.js. The line below that has a timelapse of screenshots of the page as it loads._

You can see that it gets stuck in a half rendered state (where one frame has been calculated, but with no text content) while all the CPU goes to running the bundle, this can last for about a second, so it is quite bad. Without preloading bundle.js it would be almost impossible for this to happen because the page would generally be rendered while the bundle is still downloading. This makes the loading time worse for the user, but it doesn't show up in First Contentful Paint because the half-rendered version counts for that (it does usually show up in Largest Contentful Paint).

This can happen on the frontpage too, although more rarely (can't reproduce an example now) because the layout is simpler (i.e. fewer actual DOM nodes due to no post body) so rendering tends to fully finish before the execution of bundle.js picks up. Now I've seen what it looks like though I'm pretty sure I've seen it happen when browsing on my phone, the page appears to "fill in" after a second rather than being crisp immediately.

I have found a solution to this, which is force it to wait until after the first frame has rendered before starting like so:
```typescript
function startupAfterRendering() {
  requestAnimationFrame(() => {
    requestAnimationFrame(() => {
      void clientStartup();
    });
  });
}
```

I'm going to but this in a separate PR though because it's independent of the change here (and quite fiddly on its own).

### 2. Using bandwidth which could be used to download the post or allStyles to download bundle.js

I'm fairly convinced this won't be a problem, Chrome gives bundle.js "Low" priority to download, and it gives "Highest" priority to the html of the page. Testing on a throttled connection it only takes slightly longer to render the page when bundle.js is preloaded, and on a reasonably fast connection it would be downloaded in the "dead time" where the body of the page isn't ready.

