### PR TITLE
no ssr comment permalinks to mitigate bad scrapers

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -3,6 +3,8 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { useCommentLink, UseCommentLinkProps } from './useCommentLink';
 import classNames from 'classnames';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
+import ForumNoSSR from '../../common/ForumNoSSR';
+import { isLWorAF } from '../../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -68,19 +70,25 @@ const CommentsItemDate = ({comment, preventDateFormatting, classes, ...rest}: Co
   } else {
     dateFormat = undefined;
   }
+
+  const linkContents = (<>
+    <FormatDate
+      date={comment.postedAt}
+      format={dateFormat}
+    />
+    {isBookUI && <ForumIcon icon="Link" className={classes.icon} />}
+  </>);
   
   return (
     <span className={classNames(classes.root, {
       [classes.date]: !comment.answer,
       [classes.answerDate]: comment.answer,
     })}>
-      <LinkWrapper>
-        <FormatDate
-          date={comment.postedAt}
-          format={dateFormat}
-        />
-        {isBookUI && <ForumIcon icon="Link" className={classes.icon} />}
-      </LinkWrapper>
+      <ForumNoSSR if={isLWorAF} onSSR={linkContents}>
+        <LinkWrapper>
+          {linkContents}
+        </LinkWrapper>
+      </ForumNoSSR>
     </span>
   );
 }


### PR DESCRIPTION
We've had some badly behaved bots/scrapers recently that hit `?commentId=` permalinks.  This change causes those to be NoSSR'd (forum-gated) while still SSRing the contents of the link that the user might see on initial page load (and the DOM rewrite should be basically instant since it's just replacing it with a link with the same contents, so no network requests).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207083109116559) by [Unito](https://www.unito.io)
