### PR TITLE
Fix the ToC on posts with LaTeX in the first heading block

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -103,7 +103,13 @@ export function extractTableOfContents({
       continue;
     }
 
+    // Get title from element text
     let title = elementToToCTitle(element);
+    // Cap the length at 300 chars
+    if (title.length > 300) {
+      title = title.substring(0, 300) + '...';
+    }
+
     if (title && title.trim() !== "") {
       let anchor = titleToAnchor(title, usedAnchors);
       usedAnchors[anchor] = true;

--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -103,7 +103,7 @@ export function extractTableOfContents({
       continue;
     }
 
-    let title = element.textContent;
+    let title = elementToToCTitle(element);
     if (title && title.trim() !== "") {
       let anchor = titleToAnchor(title, usedAnchors);
       usedAnchors[anchor] = true;
@@ -141,6 +141,28 @@ export function extractTableOfContents({
     html: document.body.innerHTML,
     sections: headings,
   };
+}
+
+/**
+ * Generate a (string) section heading from a heading element. This means
+ * taking text from text nodes (with element.textContent), except with a
+ * special case to make sure `<style>` nodes aren't included. This comes up
+ * if the MathJax stylesheet happens to be in the same block as the heading,
+ * which happens if the heading contains the first usage of LaTeX in the post.
+ * (eg: https://www.lesswrong.com/s/Gmc7vtnpyKZRHWdt5/p/tCex9F9YptGMpk2sT)
+ */
+function elementToToCTitle(element: HTMLElement): string {
+  // Check whether there's a <style> element. Usually there isn't.
+  const styleSelector = element.querySelector("style");
+  if (styleSelector) {
+    // If there's a <style>, clone the subtree, then remove style nodes from the clone
+    const elementClone: HTMLElement = element.cloneNode(true) as HTMLElement; //pass true to make the copy be deep
+    const cloneStyleSelector = elementClone.querySelectorAll("style");
+    cloneStyleSelector.forEach(i => i.remove());
+    return elementClone.textContent ?? "";
+  } else {
+    return element.textContent ?? "";
+  }
 }
 
 type CommentType = CommentsList | DbComment


### PR DESCRIPTION
If the first usage of LaTeX inside a post falls inside of a section heading, the heading has the MathJax stylesheet embedded in it. Eg: https://www.lesswrong.com/s/Gmc7vtnpyKZRHWdt5/p/tCex9F9YptGMpk2sT . This was introduced in https://github.com/ForumMagnum/ForumMagnum/pull/8971 ; this rewrote ToC extraction code and in the process accidentally dropped the functionality of `elementToToCText` which would strip that out. Add the functionality back in (with JSDOM APIs). Also, as a general safeguard against misdetected ToC headings, limit them to 300 chars so that one bad heading can't fill up the entire ToC column.

(This is orthogonal to https://github.com/ForumMagnum/ForumMagnum/pull/9100 ; I have tested that the fix works both with and without 9100 merged in.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207086020306525) by [Unito](https://www.unito.io)
