### PR TITLE
Switch classNames from object-style to boolean-expr-style in high-usage-frequency components

### DIFF
--- a/packages/lesswrong/components/comments/CommentFrame.tsx
+++ b/packages/lesswrong/components/comments/CommentFrame.tsx
@@ -179,25 +179,23 @@ const CommentFrame = ({
     nestingLevelToClass(effectiveNestingLevel, classes),
     classes.node,
     className,
-    {
-      "af":comment.af,
-      [classes.highlightAnimation]: highlighted,
-      [classes.child]: isChild,
-      [classes.new]: isNewComment,
-      [classes.deleted]: comment.deleted,
-      [classes.isPinnedOnProfile]: isFriendlyUI && showPinnedOnProfile && comment.isPinnedOnProfile,
-      [classes.isAnswer]: comment.answer,
-      [classes.answerChildComment]: isReplyToAnswer,
-      [classes.childAnswerComment]: isChild && isReplyToAnswer,
-      [classes.oddAnswerComment]: (effectiveNestingLevel % 2 !== 0) && isReplyToAnswer,
-      [classes.answerLeafComment]: !hasChildren,
-      [classes.isSingleLine]: isSingleLine,
-      [classes.condensed]: condensed,
-      [classes.shortformTop]: postPage && shortform && (effectiveNestingLevel===1),
-      [classes.hoverPreview]: hoverPreview,
-      [classes.moderatorHat]: comment.hideModeratorHat ? false : comment.moderatorHat,
-      [classes.promoted]: comment.promoted
-    }
+    comment.af && "af",
+    highlighted && classes.highlightAnimation,
+    isChild && classes.child,
+    isNewComment && classes.new,
+    comment.deleted && classes.deleted,
+    isFriendlyUI && showPinnedOnProfile && comment.isPinnedOnProfile && classes.isPinnedOnProfile,
+    comment.answer && classes.isAnswer,
+    isReplyToAnswer && classes.answerChildComment,
+    isChild && isReplyToAnswer && classes.childAnswerComment,
+    (effectiveNestingLevel % 2 !== 0) && isReplyToAnswer && classes.oddAnswerComment,
+    !hasChildren && classes.answerLeafComment,
+    isSingleLine && classes.isSingleLine,
+    condensed && classes.condensed,
+    postPage && shortform && (effectiveNestingLevel===1) && classes.shortformTop,
+    hoverPreview && classes.hoverPreview,
+    comment.hideModeratorHat ? false : comment.moderatorHat && classes.moderatorHat,
+    comment.promoted && classes.promoted,
   )
   
   return <div className={nodeClass} onClick={onClick} id={id}>
@@ -206,21 +204,21 @@ const CommentFrame = ({
 }
 
 const nestingLevelToClass = (nestingLevel: number, classes: ClassesType): string => {
-  return classNames({
-    [classes.commentsNodeRoot] : nestingLevel === 1,
-    "comments-node-root" : nestingLevel === 1,
-    "comments-node-even" : nestingLevel % 2 === 0,
-    "comments-node-odd"  : nestingLevel % 2 !== 0,
-    "comments-node-its-getting-nested-here": nestingLevel > 8,
-    "comments-node-so-take-off-all-your-margins": nestingLevel > 12,
-    "comments-node-im-getting-so-nested": nestingLevel > 16,
-    "comments-node-im-gonna-drop-my-margins": nestingLevel > 20,
-    "comments-node-what-are-you-even-arguing-about": nestingLevel > 24,
-    "comments-node-are-you-sure-this-is-a-good-idea": nestingLevel > 28,
-    "comments-node-seriously-what-the-fuck": nestingLevel > 32,
-    "comments-node-are-you-curi-and-lumifer-specifically": nestingLevel > 36,
-    "comments-node-cuz-i-guess-that-makes-sense-but-like-really-tho": nestingLevel > 40,
-  });
+  return classNames(
+    (nestingLevel === 1)   && classes.commentsNodeRoot,
+    (nestingLevel === 1)   && "comments-node-root" ,
+    (nestingLevel%2 === 0) && "comments-node-even" ,
+    (nestingLevel%2 !== 0) && "comments-node-odd"  ,
+    (nestingLevel > 8)  && "comments-node-its-getting-nested-here",
+    (nestingLevel > 12) && "comments-node-so-take-off-all-your-margins",
+    (nestingLevel > 16) && "comments-node-im-getting-so-nested",
+    (nestingLevel > 20) && "comments-node-im-gonna-drop-my-margins",
+    (nestingLevel > 24) && "comments-node-what-are-you-even-arguing-about",
+    (nestingLevel > 28) && "comments-node-are-you-sure-this-is-a-good-idea",
+    (nestingLevel > 32) && "comments-node-seriously-what-the-fuck",
+    (nestingLevel > 36) && "comments-node-are-you-curi-and-lumifer-specifically",
+    (nestingLevel > 40) && "comments-node-cuz-i-guess-that-makes-sense-but-like-really-tho",
+  );
 }
 
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -60,10 +60,11 @@ const CommentBody = ({
   const { ContentItemBody, CommentDeletedMetadata, ContentStyles, InlineReactSelectionWrapper } = Components
   const { html = "" } = comment.contents || {}
 
-  const bodyClasses = classNames(className,
-    { [classes.commentStyling]: !comment.answer,
-      [classes.answerStyling]: comment.answer,
-      [classes.retracted]: comment.retracted }
+  const bodyClasses = classNames(
+    className,
+    !comment.answer && classes.commentStyling,
+    comment.answer && classes.answerStyling,
+    comment.retracted && classes.retracted,
   );
 
   if (comment.deleted) { return <CommentDeletedMetadata documentId={comment._id}/> }

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -68,10 +68,9 @@ const CommentBottom = ({comment, treeOptions, votingSystem, voteProps, commentBo
 
   return (
     <div className={classNames(
-      classes.bottom, {
-        [classes.answer]: comment.answer,
-        [classes.bottomWithReacts]: !!VoteBottomComponent
-      }
+      classes.bottom,
+      comment.answer && classes.answer,
+      !!VoteBottomComponent && classes.bottomWithReacts,
     )}>
       <CommentBottomCaveats comment={comment} />
       {showReplyButton && replyButton}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -280,7 +280,7 @@ export const CommentsItem = ({
       ? "comments-node-even" : "comments-node-odd"
 
     return (
-      <div className={classNames(classes.replyForm, levelClass, {[classes.replyFormMinimalist]: isMinimalist})}>
+      <div className={classNames(classes.replyForm, levelClass, isMinimalist && classes.replyFormMinimalist)}>
         <Components.CommentsNewForm
           post={treeOptions.post}
           parentComment={comment}
@@ -324,11 +324,9 @@ export const CommentsItem = ({
         classes.root,
         className,
         "recent-comments-node",
-        {
-          [classes.deleted]: comment.deleted && !comment.deletedPublic,
-          [classes.sideComment]: treeOptions.isSideComment,
-          [classes.subforumTop]: comment.tagCommentType === "SUBFORUM" && !comment.topLevelCommentId,
-        },
+        comment.deleted && !comment.deletedPublic && classes.deleted,
+        treeOptions.isSideComment && classes.sideComment,
+        comment.tagCommentType === "SUBFORUM" && !comment.topLevelCommentId && classes.subforumTop,
       )}>
         { comment.parentCommentId && showParentState && (
           <div className={classes.firstParentComment}>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -80,10 +80,11 @@ const CommentsItemDate = ({comment, preventDateFormatting, classes, ...rest}: Co
   </>);
   
   return (
-    <span className={classNames(classes.root, {
-      [classes.date]: !comment.answer,
-      [classes.answerDate]: comment.answer,
-    })}>
+    <span className={classNames(
+      classes.root,
+      !comment.answer && classes.date,
+      comment.answer && classes.answerDate,
+    )}>
       <ForumNoSSR if={isLWorAF} onSSR={linkContents}>
         <LinkWrapper>
           {linkContents}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -228,9 +228,10 @@ export const CommentsItemMeta = ({
   } = Components;
 
   return (
-    <div className={classNames(classes.root, {
-      [classes.sideCommentMeta]: isSideComment,
-    })}>
+    <div className={classNames(
+      classes.root,
+      isSideComment && classes.sideCommentMeta,
+    )}>
       {!parentCommentId && !comment.parentCommentId && isParentComment &&
         <div>○</div>
       }
@@ -255,8 +256,7 @@ export const CommentsItemMeta = ({
         <a className={classes.collapse} onClick={toggleCollapse}>
           {isFriendlyUI
             ? <ForumIcon icon="ThickChevronRight" className={classNames(
-                classes.collapseChevron,
-                {[classes.collapseChevronOpen]: !collapsed},
+                classes.collapseChevron, !collapsed && classes.collapseChevronOpen
               )} />
             : <>[<span className={classes.collapseCharacter}>{collapsed ? "+" : "-"}</span>]</>
           }

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -176,10 +176,11 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
     <div className={classes.root} {...eventHandlers}>
       <ContentStyles
         contentType={comment.answer ? "post" : "comment"}
-        className={classNames(classes.commentInfo, {
-          [classes.isAnswer]: comment.answer, 
-          [classes.odd]:((effectiveNestingLevel%2) !== 0),
-        })}
+        className={classNames(
+          classes.commentInfo,
+          comment.answer && classes.isAnswer,
+          ((effectiveNestingLevel%2) !== 0) && classes.odd,
+        )}
       >
         {post && <div className={classes.shortformIcon}><CommentShortformIcon comment={comment} post={post} simple={true} /></div>}
         {actuallyDisplayTagIcon && <div className={classes.tagIcon}>

--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -42,7 +42,7 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
   return <>
     <ContentItemBody
       dangerouslySetInnerHTML={{__html: truncatedHtml}}
-      className={classNames(className, {[classes.maxHeight]:!expanded})}
+      className={classNames(className, !expanded && classes.maxHeight)}
       description={description}
       nofollow={nofollow}
     />

--- a/packages/lesswrong/components/common/ContentStyles.tsx
+++ b/packages/lesswrong/components/common/ContentStyles.tsx
@@ -96,15 +96,14 @@ const ContentStyles = ({contentType, className, style, children, classes}: {
   classes: ClassesType,
 }) => {
   return <div style={style} className={classNames(
-    className, classes.base, "content", {
-      [classes.postBody]: contentType==="post",
-      [classes.postHighlight]: contentType==="postHighlight",
-      [classes.commentBody]: contentType==="comment",
-      [classes.commentBodyExceptPointerEvents]: contentType==="commentExceptPointerEvents",
-      [classes.answerBody]: contentType==="answer",
-      [classes.tagBody]: contentType==="tag",
-      [classes.debateResponseBody]: contentType==="debateResponse"
-    }
+    className, classes.base, "content",
+    contentType==="post" && classes.postBody,
+    contentType==="postHighlight" && classes.postHighlight,
+    contentType==="comment" && classes.commentBody,
+    contentType==="commentExceptPointerEvents" && classes.commentBodyExceptPointerEvents,
+    contentType==="answer" && classes.answerBody,
+    contentType==="tag" && classes.tagBody,
+    contentType==="debateResponse" && classes.debateResponseBody,
   )}>
     {children}
   </div>;

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -71,7 +71,10 @@ const LWTooltip = ({
 
   if (!title) return <>{children}</>
 
-  return <As className={classNames({[classes.root]: inlineBlock}, className)} {...eventHandlers}>
+  return <As className={classNames(
+    inlineBlock && classes.root,
+    className
+  )} {...eventHandlers}>
     { /* Only render the LWPopper if this element has ever been hovered. (But
          keep it in the React tree thereafter, so it can remember its state and
          can have a closing animation if applicable. */ }
@@ -85,7 +88,12 @@ const LWTooltip = ({
       hideOnTouchScreens={hideOnTouchScreens}
       className={popperClassName}
     >
-      <div className={classNames({[classes.tooltip]: tooltip}, titleClassName)}>{title}</div>
+      <div className={classNames(
+        tooltip && classes.tooltip,
+        titleClassName
+      )}>
+        {title}
+      </div>
     </LWPopper>}
 
     {children}

--- a/packages/lesswrong/components/common/MetaInfo.tsx
+++ b/packages/lesswrong/components/common/MetaInfo.tsx
@@ -26,7 +26,7 @@ const MetaInfo = ({children, classes, button, className}: {
 }) => {
   return <Components.Typography
     component='span'
-    className={classNames(classes.root, {[classes.button]: button}, className)}
+    className={classNames(classes.root, button && classes.button, className)}
     variant='body2'>
       {children}
   </Components.Typography>

--- a/packages/lesswrong/components/common/Typography.tsx
+++ b/packages/lesswrong/components/common/Typography.tsx
@@ -52,7 +52,12 @@ const Typography = ({children, variant, component, className, onClick, gutterBot
   return (
     <Component
       id={id}
-      className={classNames(classes.root, classes[variant], className, {[classes.gutterBottom]: gutterBottom})}
+      className={classNames(
+        classes.root,
+        classes[variant],
+        className,
+        gutterBottom && classes.gutterBottom,
+      )}
       onClick={onClick}
     >
       {children}

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -82,9 +82,10 @@ const UsersNameDisplay = ({
   if (simple) {
     return <span
       {...eventHandlers}
-      className={classNames(colorClass, className, {
-        [classes.noKibitz]: noKibitz
-      })}
+      className={classNames(
+        colorClass, className,
+        noKibitz && classes.noKibitz
+      )}
     >
       {displayName}
     </span>
@@ -105,7 +106,7 @@ const UsersNameDisplay = ({
         >
           <Link
             to={profileUrl}
-            className={classNames(colorClass, { [classes.noKibitz]: noKibitz, })}
+            className={classNames(colorClass, noKibitz && classes.noKibitz)}
             {...(nofollow ? {rel:"nofollow"} : {})}
           >
             {displayName}

--- a/packages/lesswrong/components/votes/VoteArrowIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIcon.tsx
@@ -109,7 +109,11 @@ const VoteArrowIcon = ({
 
   return (
     <IconButton
-      className={classNames(classes.root, classes[orientation], {[classes.disabled]: !enabled})}
+      className={classNames(
+        classes.root,
+        classes[orientation],
+        !enabled && classes.disabled,
+      )}
       onMouseDown={eventHandlers.handleMouseDown}
       onMouseUp={eventHandlers.handleMouseUp}
       onMouseOut={eventHandlers.clearState}
@@ -125,7 +129,12 @@ const VoteArrowIcon = ({
         {(state) => (
           <UpArrowIcon
             style={bigVoteCompleted || bigVoted ? {color: lightColor} : undefined}
-            className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
+            className={classNames(
+              classes.bigArrow,
+              bigVoteCompleted && classes.bigArrowCompleted,
+              solidArrow && classes.bigArrowSolid,
+              classes[state]
+            )}
             viewBox='6 6 12 12'
           />)}
       </Transition>


### PR DESCRIPTION
Slack thread: https://lworg.slack.com/archives/C75BWSNBH/p1713246308322869

This looks like an arbitrary choice of convention, but it turns out to have a performance impact. Switch usages of classNames from object-style to boolean-expression-style, saving a bunch of object allocations and hashmap operations.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207086122363931) by [Unito](https://www.unito.io)
