### PR TITLE
[FriendlyUI only] post item ghost loading state in more places

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -31,6 +31,11 @@ const titleWrapper = isLWorAF ? {
 };
 
 const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    '& .FriendlyPlaceholderPostsItem-root:nth-of-type(3)': {
+      marginBottom: 8
+    }
+  },
   titleWrapper,
   title: {
     ...sectionTitleStyle(theme),
@@ -158,7 +163,7 @@ const HomeLatestPosts = ({classes}: {classes: ClassesType}) => {
 
   return (
     <AnalyticsContext pageSectionContext="latestPosts">
-      <SingleColumnSection>
+      <SingleColumnSection className={classes.root}>
         <SectionTitle title={latestPostsName} noTopMargin={isFriendlyUI} noBottomPadding>
           <LWTooltip
             title={`Use these buttons to increase or decrease the visibility of posts based on ${taggingNameSetting.get()}. Use the "+" button at the end to add additional ${taggingNamePluralSetting.get()} to boost or reduce them.`}

--- a/packages/lesswrong/components/common/HomeTagBar.tsx
+++ b/packages/lesswrong/components/common/HomeTagBar.tsx
@@ -8,6 +8,7 @@ import {useNavigate} from '../../lib/reactRouterWrapper.tsx'
 import {useLocation} from '../../lib/routeUtil.tsx'
 import { useCurrentForumEvent } from '../hooks/useCurrentForumEvent.tsx'
 import qs from 'qs'
+import range from 'lodash/range'
 
 const eventTabStyles = (invertColors: boolean) => ({
   backgroundColor: invertColors
@@ -140,6 +141,23 @@ const styles = (theme: ThemeType) => ({
   activeEventTab: {
     ...eventTabStyles(theme.themeOptions.name !== "dark"),
   },
+  placeholderTab: {
+    flex: 'none',
+    height: 31,
+    width: 110,
+    background: theme.palette.panelBackground.placeholderGradient,
+    backgroundSize: "300% 100%",
+    animation: "profile-image-loader 1.8s infinite",
+    cursor: 'default',
+    '&:hover': {
+      background: theme.palette.panelBackground.placeholderGradient,
+      backgroundSize: "300% 100%",
+    },
+    '@media (max-width: 840px)': {
+      height: 26,
+      width: 100,
+    },
+  },
   tagDescriptionTooltip: {
     margin: 8,
   }
@@ -185,7 +203,7 @@ const HomeTagBar = (
   // we store the topic bar scrollLeft offsets that correspond to displaying each "set" of topics
   const offsets = useRef<Array<number>>([0])
 
-  const {results: coreTopics} = useMulti({
+  const {results: coreTopics, loading: coreTopicsLoading} = useMulti({
     terms: {view: 'coreTags'},
     collectionName: 'Tags',
     fragmentName: 'TagFragment',
@@ -323,7 +341,7 @@ const HomeTagBar = (
                     const isActive = tab._id === activeTab._id;
                     const isEventTab = tab._id === currentForumEvent?.tag?._id;
                     return <LWTooltip
-                      title={showDescriptionOnHover ? tab.description?.plaintextDescription : null} 
+                      title={showDescriptionOnHover ? tab.description?.plaintextDescription : null}
                       popperClassName={classes.tagDescriptionTooltip}
                       key={tabName}
                     >
@@ -346,6 +364,9 @@ const HomeTagBar = (
                         {tabName}
                       </button>
                     </LWTooltip>
+                  })}
+                  {!coreTopics?.length && coreTopicsLoading && range(0, 6).map(i => {
+                    return <div key={i} className={classNames(classes.tab, classes.placeholderTab)}></div>
                   })}
                 </div>
               </div>

--- a/packages/lesswrong/components/posts/AllPostsList.tsx
+++ b/packages/lesswrong/components/posts/AllPostsList.tsx
@@ -19,6 +19,7 @@ import {
   DatabasePublicSetting,
 } from "../../lib/publicSettings";
 import type { PostsTimeBlockShortformOption } from "./PostsTimeBlock";
+import { isFriendlyUI } from "../../themes/forumTheme";
 
 // Number of weeks to display in the timeframe view
 const forumAllPostsNumWeeksSetting = new DatabasePublicSetting<number>("forum.numberOfWeeks", 4);
@@ -79,7 +80,8 @@ const AllPostsList = ({
             ...baseTerms,
             limit: 50
           }}
-          dimWhenLoading={showSettings}
+          dimWhenLoading={showSettings && !isFriendlyUI}
+          showLoading={isFriendlyUI}
         />
       </AnalyticsContext>
     );
@@ -134,7 +136,7 @@ const AllPostsList = ({
             timeframe={currentTimeframe as TimeframeType}
             postListParameters={postListParameters}
             numTimeBlocks={numTimeBlocks}
-            dimWhenLoading={showSettings}
+            dimWhenLoading={showSettings && !isFriendlyUI}
             after={after}
             before={before}
             reverse={query.reverse === "true"}

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -40,12 +40,14 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
     maybeMorePosts,
     orderedResults,
     itemProps,
+    limit,
+    placeholderCount,
   }= usePostsList(props);
 
-  const { Loading, LoadMore, PostsNoResults, SectionFooter, PostsItem } = Components;
+  const { PostsLoading, LoadMore, PostsNoResults, SectionFooter, PostsItem } = Components;
 
   if (!orderedResults && loading) {
-    return <Loading />
+    return <PostsLoading placeholderCount={placeholderCount || limit} />
   }
 
   if (!orderedResults?.length && !showNoResults) {
@@ -67,7 +69,7 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
   return (
     <div className={classNames({[classes.itemIsLoading]: loading && dimWhenLoading})}>
       {error && <Error error={decodeIntlError(error)} />}
-      {loading && showLoading && (topLoading || dimWhenLoading) && <Loading />}
+      {loading && showLoading && (topLoading || dimWhenLoading) && <PostsLoading placeholderCount={placeholderCount || limit} />}
       {orderedResults && !orderedResults.length && <PostsNoResults />}
 
       <div className={boxShadow ? classes.posts : undefined}>

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -325,7 +325,7 @@ const ContentType = ({classes, className, type, label}: {
   }
 
   const innerComponent = isFriendlyUI
-    ? <SectionTitle title={label} className={classes.sectionTitle} noBottomPadding />
+    ? <SectionTitle title={label} className={classNames(classes.sectionTitle, className)} noTopMargin noBottomPadding />
     : <span>
       <contentData.Icon className={classes.icon} />{label ? " "+label : ""}
     </span>;

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -26,7 +26,6 @@ const styles = (theme: ThemeType): JssStyles => ({
         fontWeight: 600,
         fontSize: 18,
         color: theme.palette.grey[1000],
-        marginBottom: -12,
         marginTop: 25,
       }
       : {
@@ -59,12 +58,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   posts: {
     boxShadow: theme.palette.boxShadow.default,
+    marginBottom: isFriendlyUI ? 8 : 0,
   },
+  subtitle: isFriendlyUI ? {
+    marginTop: 12,
+  } : {},
   frontpageSubtitle: {
     marginBottom: 6
   },
   otherSubtitle: {
-    marginTop: isFriendlyUI ? -4 : 6,
+    marginTop: isFriendlyUI ? 0 : 6,
     marginBottom: 6
   },
   divider: {/* Exists only to get overriden by the eaTheme */}
@@ -179,7 +182,7 @@ const PostsTimeBlock = ({
 
   const {
     PostsItem, LoadMore, ShortformTimeBlock, TagEditsTimeBlock, ContentType,
-    Divider, Typography, PostsTagsList,
+    Divider, Typography, PostsTagsList, PostsLoading,
   } = Components;
   const timeBlock = timeframeToTimeBlock[timeframe];
 
@@ -230,18 +233,21 @@ const PostsTimeBlock = ({
         </div> }
         {displayPostsTagsList && <PostsTagsList posts={posts ?? null} currentFilter={tagFilter} handleFilter={handleTagFilter} expandedMinCount={0}/>}
         {postGroups.map(({name, filteredPosts, label}) => {
-          if (filteredPosts?.length > 0) return <div key={name}>
-            <div
-              className={name === 'frontpage' ? classes.frontpageSubtitle : classes.otherSubtitle}
-            >
-              <ContentType type={name} label={label} />
+          if (filteredPosts?.length > 0 || (loading && isFriendlyUI)) {
+            return <div key={name}>
+              <div
+                className={name === 'frontpage' ? classes.frontpageSubtitle : classes.otherSubtitle}
+              >
+                <ContentType type={name} label={label} className={classes.subtitle} />
+              </div>
+              <div className={classes.posts}>
+                {!filteredPosts?.length && isFriendlyUI && <PostsLoading placeholderCount={10} />}
+                {filteredPosts.map((post, i) =>
+                  <PostsItem key={post._id} post={post} index={i} dense showBottomBorder={i < filteredPosts!.length -1}/>
+                )}
+              </div>
             </div>
-            <div className={classes.posts}>
-              {filteredPosts.map((post, i) =>
-                <PostsItem key={post._id} post={post} index={i} dense showBottomBorder={i < filteredPosts!.length -1}/>
-              )}
-            </div>
-          </div>
+          }
         })}
 
         {(filteredPosts && filteredPosts.length < totalCount!) && <div className={classes.loadMore}>

--- a/packages/lesswrong/components/posts/usePostsList.ts
+++ b/packages/lesswrong/components/posts/usePostsList.ts
@@ -46,6 +46,7 @@ export type PostsListConfig = {
   dense?: boolean,
   defaultToShowUnreadComments?: boolean,
   itemsPerPage?: number,
+  placeholderCount?: number,
   hideAuthor?: boolean,
   hideTag?: boolean,
   hideTrailingButtons?: boolean,
@@ -82,6 +83,7 @@ export const usePostsList = ({
   dense,
   defaultToShowUnreadComments,
   itemsPerPage = 25,
+  placeholderCount,
   hideAuthor = false,
   hideTag = false,
   hideTrailingButtons = false,
@@ -242,5 +244,7 @@ export const usePostsList = ({
     maybeMorePosts,
     orderedResults,
     itemProps,
+    limit,
+    placeholderCount,
   };
 }

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -5,7 +5,7 @@ import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
 
 const styles = (_: ThemeType): JssStyles => ({
   shortformGroup: {
-    marginTop: isFriendlyUI ? -10 : 12,
+    marginTop: isFriendlyUI ? 20 : 12,
   },
   subtitle: {
     marginTop: 6,

--- a/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
+++ b/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
@@ -10,7 +10,7 @@ const INITIAL_LIMIT = 5
 
 const styles = (_: ThemeType): JssStyles => ({
   subtitle: {
-    marginTop: isFriendlyUI ? -4 : 6,
+    marginTop: isFriendlyUI ? 20 : 6,
     marginBottom: 6
   },
 });


### PR DESCRIPTION
This PR adds the [post item ghost loading state](https://github.com/ForumMagnum/ForumMagnum/pull/9091) to more places, primarily the "All posts" page and home page. It also adds a ghost loading state for the home page topic tabs.

https://github.com/ForumMagnum/ForumMagnum/assets/9057804/05e50323-40d3-4ab3-a91d-2db481f2a8ad

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207090516071320) by [Unito](https://www.unito.io)
