### PR TITLE
implement global hotkeys for theme switching and toggling the sunshine sidebar visibility

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -382,7 +382,7 @@ const Layout = ({currentUser, children, classes}: {
       EAHomeRightHandSide,
       CloudinaryImage2,
       ForumEventBanner,
-      GlobalHotkeys: ThemePickerHotkeys,
+      GlobalHotkeys,
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -447,7 +447,7 @@ const Layout = ({currentUser, children, classes}: {
               <AnalyticsClient/>
               <AnalyticsPageInitializer/>
               <NavigationEventSender/>
-              <ThemePickerHotkeys/>
+              <GlobalHotkeys/>
               {/* Only show intercom after they have accepted cookies */}
               <ForumNoSSR>
                 {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -382,6 +382,7 @@ const Layout = ({currentUser, children, classes}: {
       EAHomeRightHandSide,
       CloudinaryImage2,
       ForumEventBanner,
+      GlobalHotkeys: ThemePickerHotkeys,
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -446,6 +447,7 @@ const Layout = ({currentUser, children, classes}: {
               <AnalyticsClient/>
               <AnalyticsPageInitializer/>
               <NavigationEventSender/>
+              <ThemePickerHotkeys/>
               {/* Only show intercom after they have accepted cookies */}
               <ForumNoSSR>
                 {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}

--- a/packages/lesswrong/components/common/GlobalHotkeys.tsx
+++ b/packages/lesswrong/components/common/GlobalHotkeys.tsx
@@ -5,6 +5,7 @@ import { useSetTheme, useConcreteThemeOptions } from '../themes/useTheme';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { useCurrentUser } from './withUser';
 import { userIsAdmin } from '../../lib/vulcan-users';
+import { userHasDarkModeHotkey } from '../../lib/betas';
 
 export const GlobalHotkeys = () => {
   const currentThemeOptions = useConcreteThemeOptions();
@@ -15,7 +16,7 @@ export const GlobalHotkeys = () => {
   useGlobalKeydown((e) => {
     // Toggle Dark Mode
     // option+shift+d (mac) / alt+shift+d (everyone else)
-    if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.keyCode === 68) {
+    if (userHasDarkModeHotkey(currentUser) && e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.keyCode === 68) {
       e.preventDefault();
 
       const newThemeName = currentThemeOptions.name === 'dark' ? 'default' : 'dark';

--- a/packages/lesswrong/components/common/GlobalHotkeys.tsx
+++ b/packages/lesswrong/components/common/GlobalHotkeys.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib';
+import { useGlobalKeydown } from './withGlobalKeydown';
+import { useSetTheme, useConcreteThemeOptions } from '../themes/useTheme';
+import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
+import { useCurrentUser } from './withUser';
+import { userIsAdmin } from '../../lib/vulcan-users';
+
+export const GlobalHotkeys = () => {
+  const currentThemeOptions = useConcreteThemeOptions();
+  const setTheme = useSetTheme();
+  const currentUser = useCurrentUser();
+  const updateCurrentUser = useUpdateCurrentUser();
+
+  useGlobalKeydown((e) => {
+    // Toggle Dark Mode
+    // option+shift+d (mac) / alt+shift+d (everyone else)
+    if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.keyCode === 68) {
+      e.preventDefault();
+
+      const newThemeName = currentThemeOptions.name === 'dark' ? 'default' : 'dark';
+      setTheme({ ...currentThemeOptions, name: newThemeName });
+    }
+
+    // Toggle Sunshine Sidebar Visibility (admin-only)
+    // option+shift+s (mac) / alt+shift+s (everyone else)
+    if (userIsAdmin(currentUser) && e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.keyCode === 83) {
+      e.preventDefault();
+
+      void updateCurrentUser({
+        hideSunshineSidebar: !currentUser.hideSunshineSidebar
+      });
+    }
+  });
+
+  return <></>;
+}
+
+const GlobalHotkeysComponent = registerComponent('GlobalHotkeys', GlobalHotkeys);
+
+declare global {
+  interface ComponentTypes {
+    GlobalHotkeys: typeof GlobalHotkeysComponent
+  }
+}

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -69,6 +69,8 @@ export const useRecombeeFrontpage = (currentUser: UsersCurrent|DbUser|null) => {
   return isLW && (isAdmin(currentUser) || manualOptIn) && recombeeEnabledSetting.get()
 }
 
+export const userHasDarkModeHotkey = isEAForum ? adminOnly : shippedFeature;
+
 // Non-user-specific features
 export const dialoguesEnabled = hasDialoguesSetting.get();
 export const ckEditorUserSessionsEnabled = isLWorAF;

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -301,6 +301,7 @@ importComponent("Error404", () => require('../components/common/Error404'));
 importComponent("ErrorAccessDenied", () => require('../components/common/ErrorAccessDenied'));
 importComponent("PermanentRedirect", () => require('../components/common/PermanentRedirect'));
 importComponent("SeparatorBullet", () => require('../components/common/SeparatorBullet'));
+importComponent("GlobalHotkeys", () => require('../components/common/GlobalHotkeys'));
 
 importComponent("TabNavigationMenu", () => require('../components/common/TabNavigationMenu/TabNavigationMenu'));
 importComponent("TabNavigationMenuFooter", () => require('../components/common/TabNavigationMenu/TabNavigationMenuFooter'));


### PR DESCRIPTION
As the title says.  (Current not forum-gated, but happy to do that if the EA forum desires.)

Neither alt + shift + d nor alt + shift + s correspond to any shortcuts in Chrome, Firefox, and Safari, as far as we can tell.  This does make it impossible to type the two characters generated by those shortcuts, but they're weird unicode glyphs that people aren't going to be using anyways.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207095078173549) by [Unito](https://www.unito.io)
