### PR TITLE
Fix config for deploying the baserates branch

### DIFF
--- a/.github/workflows/deployBaserates.yaml
+++ b/.github/workflows/deployBaserates.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix: 
         node-version: [18.x]
-        environment: [baserates]
+        environment: [staging-baserates]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -20,7 +20,7 @@ jobs:
         python-version: '>=3.5 <3.12' # Version range or exact version of a Python version to use, using SemVer's version range syntax
     - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
     - name: Run EB Deploy
-      run: eb deploy --timeout 20 ${{ matrix.environment }}
+      run: scripts/deploy.sh LessWrongExpress ${{ matrix.environment }}
       env: 
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This fixes the github action config file for deploying LW's `baserates` testing/staging server by pushing to the corresponding branch. (It has already been tested by using this config on the `baserates` branch itself.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207110656210439) by [Unito](https://www.unito.io)
