### PR TITLE
Allow admins to read value of `hideSunshineSidebar`

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -2959,7 +2959,7 @@ const schema: SchemaType<"Users"> = {
   hideSunshineSidebar: {
     type: Boolean,
     optional: true,
-    canRead: [userOwns],
+    canRead: [userOwns, 'admins'],
     canUpdate: ['admins'],
     canCreate: ['admins'],
     group: formGroups.adminOptions,


### PR DESCRIPTION
Currently, when an admin tries to edit a user other than themselves they get an error when they submit. This is because they don't have permission to read `hideSunshineSidebar`, so they inadvertantly try to assign a value of `null` to a field with a default value which is not allowed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207118449498176) by [Unito](https://www.unito.io)
