### PR TITLE
Fix color of ellipsis for read posts in friendly UI

### DIFF
--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -207,17 +207,17 @@ const PostsTitle = ({
     {shared && <span className={classes.tag}>[Shared]</span>}
     {post.isEvent && shouldRenderEventsTag && <span className={classes.tag}>[Event]</span>}
 
-    <span className={classNames({[classes.read]: read && isFriendlyUI})}>
-      <Wrapper>{post.title}</Wrapper>
-    </span>
+    <Wrapper>{post.title}</Wrapper>
   </span>
 
   return (
-    <span className={classNames(classes.root, {
-      [classes.read]: read && !isFriendlyUI,
-      [classes.wrap]: wrap,
-      [classes.strikethroughTitle]: strikethroughTitle
-    }, className)}>
+    <span className={classNames(
+      classes.root,
+      read && classes.read,
+      wrap && classes.wrap,
+      strikethroughTitle && classes.strikethroughTitle,
+      className,
+    )}>
       {showIcons && curatedIconLeft && post.curatedDate && <span className={classes.leftCurated}>
         <InteractionWrapper className={classes.interactionWrapper}>
           <CuratedIcon hasColor />


### PR DESCRIPTION
EA Forum specific bug reported by Agnes: for read posts in posts lists, the color of the ellipsis doesn't match the text.

Before:

<img width="800" alt="Screenshot 2024-04-19 at 15 59 12" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/b824ee3b-c5cf-4ac1-bdbc-5d3c8dcc6d80">

<img width="816" alt="Screenshot 2024-04-19 at 15 58 58" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/b2411274-85e4-406e-b330-991ba18eacae">

After:
<img width="809" alt="Screenshot 2024-04-19 at 16 00 13" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/8bc11473-09fb-4ab7-82a0-59fac1da9786">

<img width="796" alt="Screenshot 2024-04-19 at 15 58 20" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/0ad08b1e-b5a6-4739-9e1b-b4393fc37760">
