### PR TITLE
Remove nossr settings for frontpage sections

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -15,10 +15,6 @@ const showEventBannerSetting = new DatabasePublicSetting<boolean>('showEventBann
 const showMaintenanceBannerSetting = new DatabasePublicSetting<boolean>('showMaintenanceBanner', false)
 const isBotSiteSetting = new PublicInstanceSetting<boolean>('botSite.isBotSite', false, 'optional');
 
-// TODO remove these once we have measured the effect (or after 2024-04-14)
-const noSSRPopularCommentsSetting = new DatabasePublicSetting<boolean>('noSSRPopularComments', true)
-const noSSRRecentDiscussionSetting = new DatabasePublicSetting<boolean>('noSSRRecentDiscussion', true)
-
 /**
  * Build structured data to help with SEO.
  */

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -90,10 +90,10 @@ const EAHome = ({classes}: {classes: ClassesType}) => {
           <HomeLatestPosts />
           {!currentUser?.hideCommunitySection && <EAHomeCommunityPosts />}
           {isEAForum && <QuickTakesSection />}
-          <ForumNoSSR if={!!currentUser && noSSRPopularCommentsSetting.get()}>
+          <ForumNoSSR if={!!currentUser}>
             <EAPopularCommentsSection />
           </ForumNoSSR>
-          <ForumNoSSR if={!!currentUser && noSSRRecentDiscussionSetting.get()}>
+          <ForumNoSSR if={!!currentUser}>
             <RecentDiscussionFeed
               title="Recent discussion"
               af={false}


### PR DESCRIPTION
I was planning to experiment with changing these to see the effect on Frontpage load speed, subject to it sometimes being annoying that they didn't load immediately. As it happens, I have never noticed it them not loading immediately, so I've decided it to keep them as is without doing any experiments

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207152083686618) by [Unito](https://www.unito.io)
