### PR TITLE
Continue Reading accepts limit and shuffle params + recommendationsTab stickied posts

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -378,7 +378,7 @@ const LWHomePosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
               
               {/* CONTINUE READING */}
               {(selectedTab === 'forum-continue-reading') && (continueReading?.length > 0) && <AnalyticsContext feedType={selectedTab}>
-                <ContinueReadingList continueReading={continueReading}/>
+                <ContinueReadingList continueReading={continueReading} limit={6} shuffle />
               </AnalyticsContext>}
 
               {/* SUBSCRIBED */}

--- a/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
+++ b/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
@@ -3,12 +3,15 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useDismissRecommendation } from './withDismissRecommendation';
 import { captureEvent, AnalyticsContext } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
+import { ContinueReading } from './withContinueReading';
 
-const MAX_ENTRIES = 3;
 
-const ContinueReadingList = ({ continueReading, continueReadingLoading }: {
-  continueReading: any,
+const ContinueReadingList = ({ continueReading, continueReadingLoading, limit=3, shuffle }: {
+  continueReading: ContinueReading[],
   continueReadingLoading?: boolean,
+  limit?: number,
+  // randomly select posts from your reading list if your reading list is longer than the limit
+  shuffle?: boolean,
 }) => {
   const dismissRecommendation = useDismissRecommendation();
   const [dismissedRecommendations, setDismissedRecommendations] = useState<any>({});
@@ -23,7 +26,7 @@ const ContinueReadingList = ({ continueReading, continueReadingLoading }: {
     captureEvent("continueReadingDismissed", {"postId": postId});
   }
   
-  const limitResumeReading = (resumeReadingList: Array<any>): { entries: Array<any>, showAllLink: boolean } => {
+  const limitResumeReading = (resumeReadingList: ContinueReading[]): { entries: ContinueReading[], showAllLink: boolean } => {
     // Filter out dismissed recommendations
     const filtered = _.filter(resumeReadingList, r=>!dismissedRecommendations[r.nextPost._id]);
     
@@ -32,14 +35,22 @@ const ContinueReadingList = ({ continueReading, continueReadingLoading }: {
     sorted.reverse(); //in-place
     
     // Limit to the three most recent
-    if (showAll || sorted.length <= MAX_ENTRIES) {
+    if (showAll || sorted.length <= limit) {
       return {
         entries: sorted,
         showAllLink: false,
       };
+    } else if (shuffle) {
+      const sampled = _.sample(sorted, limit) as ContinueReading[]; // _.sample doesn't preserve type
+      sorted = _.sortBy(sampled, r =>r.lastReadTime); // need to sort again because _.sample doesn't guarantee order
+      sorted.reverse();
+      return {
+        entries: sorted,
+        showAllLink: true,
+      }
     } else {
       return {
-        entries: sorted.slice(0, MAX_ENTRIES),
+        entries: sorted.slice(0, limit),
         showAllLink: true,
       }
     }

--- a/packages/lesswrong/components/recommendations/withContinueReading.ts
+++ b/packages/lesswrong/components/recommendations/withContinueReading.ts
@@ -1,15 +1,17 @@
 import { useQuery, gql } from '@apollo/client';
 import { fragmentTextForQuery } from '../../lib/vulcan-lib/fragments';
 
+export interface ContinueReading {
+  sequence: SequenceContinueReadingFragment,
+  collection: CollectionContinueReadingFragment,
+  nextPost: PostsListWithVotes,
+  numRead: number,
+  numTotal: number,
+  lastReadTime: Date,
+}
+
 export const useContinueReading = (): {
-  continueReading: Array<{
-    sequence: SequenceContinueReadingFragment,
-    collection: CollectionContinueReadingFragment,
-    nextPost: PostsList,
-    numRead: number,
-    numTotal: number,
-    lastReadTime: Date,
-  }>,
+  continueReading: ContinueReading[],
   loading: boolean,
   error: any,
 }=> {
@@ -23,14 +25,14 @@ export const useContinueReading = (): {
           ...CollectionContinueReadingFragment
         }
         nextPost {
-          ...PostsList
+          ...PostsListWithVotes
         }
         numRead
         numTotal
         lastReadTime
       }
     }
-    ${fragmentTextForQuery(["SequenceContinueReadingFragment","CollectionContinueReadingFragment","PostsList"])}
+    ${fragmentTextForQuery(["SequenceContinueReadingFragment","CollectionContinueReadingFragment","PostsListWithVotes"])}
   `;
   
   const { data, loading, error } = useQuery(continueReadingQuery, {

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -176,9 +176,8 @@ export const alwaysShowAnonymousReactsSetting = new DatabasePublicSetting<boolea
 
 export const hasGoogleDocImportSetting = new DatabasePublicSetting<boolean>('googleDocImport.enabled', false);
 
-// TODO: Delete after fully migrated to new settings
-export const latestPostsAlgorithmsSetting = new DatabasePublicSetting<string[]>('latestPosts.algorithms', []);
 
 export const recombeeEnabledSetting = new DatabasePublicSetting<boolean>('recombee.enabled', false);
+export const recommendationsTabManuallyStickiedPostIdsSetting = new DatabasePublicSetting<string[]>('recommendationsTab.manuallyStickiedPostIds', []);
 
 export const blackBarTitle = new DatabasePublicSetting<string | null>('blackBarTitle', null)

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -51,7 +51,7 @@ import ElasticController from './search/elastic/ElasticController';
 import type { ApolloServerPlugin, GraphQLRequestContext, GraphQLRequestListener } from 'apollo-server-plugin-base';
 import { asyncLocalStorage, closePerfMetric, openPerfMetric, perfMetricMiddleware, setAsyncStoreValue } from './perfMetrics';
 import { addAdminRoutesMiddleware } from './adminRoutesMiddleware'
-import { createAnonymousContext } from './vulcan-lib';
+import { createAnonymousContext } from './vulcan-lib/query';
 import { DatabaseServerSetting } from './databaseSettings';
 
 /**

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -349,7 +349,7 @@ const recombeeApi = {
         return { post, recommId };
       } else {
         const stickied = stickiedPostIds.includes(postId) || manuallyStickiedPostIds.includes(postId);
-        if ( stickied ) {
+        if (stickied) {
           post.sticky = true;
         }
 


### PR DESCRIPTION
Under the current state of things, we have a frontpage tab that shows max of 3 posts. Not quite enough. This PR enables us to show 6, and allows us to vary them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207155627262453) by [Unito](https://www.unito.io)
