### PR TITLE
Fix post width layout shift

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -211,6 +211,14 @@ export const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: CENTRAL_COLUMN_WIDTH,
     marginLeft: 'auto',
     marginRight: 'auto',
+    [theme.breakpoints.down('sm')]: {
+      // This can only be used when display: "block" is applied, otherwise the 100% confuses the
+      // grid layout into adding loads of left margin
+      maxWidth: `min(100%, ${CENTRAL_COLUMN_WIDTH}px)`,
+    }
+  },
+  postBody: {
+    width: "max-content",
   },
   postContent: { //Used by a Cypress test
     marginBottom: isFriendlyUI ? 40 : undefined


### PR DESCRIPTION
Improved version of the change that was reverted [here](https://github.com/ForumMagnum/ForumMagnum/pull/9109), which caused the post body to overflow on mobile.

The layout shift this is fixing is that on medium sized screens (where the toc and post body are competing for space), the post width increases once recommendations load. This makes it so it is always at full width