### PR TITLE
Recombee Hybrid: tracking each half

### DIFF
--- a/packages/lesswrong/components/posts/RecombeePostsList.tsx
+++ b/packages/lesswrong/components/posts/RecombeePostsList.tsx
@@ -103,6 +103,7 @@ export const RecombeePostsList = ({ algorithm, settings, limit = 15, classes }: 
 
   useOnMountTracking({
     eventType: "postList",
+    // TODO: Remove postIds which is redundant once analytics dashboard written to use postIdsWithScenario
     eventProps: { postIds, postIdsWithScenario, algorithm },
     captureOnMount: (eventProps) => eventProps.postIds.length > 0,
     skip: !postIds.length || loading,

--- a/packages/lesswrong/components/posts/RecombeePostsList.tsx
+++ b/packages/lesswrong/components/posts/RecombeePostsList.tsx
@@ -10,6 +10,7 @@ import { isServer } from '../../lib/executionEnvironment';
 // Would be nice not to duplicate in postResolvers.ts but unfortunately the post types are different
 interface RecombeeRecommendedPost {
   post: PostsListWithVotes,
+  scenario: string,
   recommId: string,
   curated?: never,
   stickied?: never,
@@ -17,6 +18,7 @@ interface RecombeeRecommendedPost {
 
 type RecommendedPost = RecombeeRecommendedPost | {
   post: PostsListWithVotes,
+  scenario?: never,
   recommId?: never,
   curated: boolean,
   stickied: boolean,
@@ -40,6 +42,7 @@ const getRecombeePostsQuery = (resolverName: RecombeeResolver) => gql`
         post {
           ...PostsListWithVotes
         }
+        scenario
         recommId
         curated
         stickied
@@ -75,7 +78,7 @@ export const RecombeePostsList = ({ algorithm, settings, limit = 15, classes }: 
   limit?: number,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { Loading, LoadMore, PostsItem, SectionFooter, PostsLoading } = Components;
+  const { LoadMore, PostsItem, SectionFooter, PostsLoading } = Components;
 
   const recombeeSettings = { ...settings, scenario: algorithm };
 
@@ -96,10 +99,11 @@ export const RecombeePostsList = ({ algorithm, settings, limit = 15, classes }: 
 
   const results: RecommendedPost[] | undefined = data?.[resolverName]?.results;
   const postIds = results?.map(({post}) => post._id) ?? [];
+  const postIdsWithScenario = results?.map(({post, scenario}) => ({postId: post._id, scenario: scenario ?? 'none'})) ?? [];
 
   useOnMountTracking({
     eventType: "postList",
-    eventProps: { postIds },
+    eventProps: { postIds, postIdsWithScenario, algorithm },
     captureOnMount: (eventProps) => eventProps.postIds.length > 0,
     skip: !postIds.length || loading,
   });

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -636,6 +636,7 @@ createPaginatedResolver({
 addGraphQLSchema(`
   type RecombeeRecommendedPost {
     post: Post!
+    scenario: String
     recommId: String
     curated: Boolean
     stickied: Boolean


### PR DESCRIPTION
Currently, we don't track which post comes from which scenario in the recombee hybrid scenario. This PR passes through info to let us do that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207165353375749) by [Unito](https://www.unito.io)
