### PR TITLE
Fix flaky cypress tests

### DIFF
--- a/cypress/e2e/posts/organizers_can_edit_posts.cy.js
+++ b/cypress/e2e/posts/organizers_can_edit_posts.cy.js
@@ -17,7 +17,7 @@ describe('Groups', function() {
     cy.url().should('include', 'newPost');
     
     // Fill in some event fields and submit
-    cy.get('.EditTitle-root').type('Test event 123');
+    cy.get('.EditTitle-root').wait(100).type('Test event 123');
     cy.get('.ck-editor__editable').type('Test body 123');
     cy.contains("Submit").click();
     

--- a/cypress/e2e/voting/vote_on_post.cy.js
+++ b/cypress/e2e/voting/vote_on_post.cy.js
@@ -11,7 +11,7 @@ describe('Posts', function() {
     // First have testUser create a post
     cy.loginAs(this.testUser);
     cy.visit('/newPost');
-    cy.get('.EditTitle-root').type('Test post 123');
+    cy.get('.EditTitle-root').wait(100).type('Test post 123');
     cy.get('.ck-editor__editable').type('Test body 123');
     cy.contains("Submit").click();
     cy.url().should('include', 'test-post-123');


### PR DESCRIPTION
The organizers_can_edit_posts test just got ([example](https://github.com/ForumMagnum/ForumMagnum/actions/runs/8828927122/job/24238869413?pr=9174)) the bug introduced [here](https://github.com/ForumMagnum/ForumMagnum/pull/9127#issuecomment-2064129535) which caused the first letter typed into the title to be ignored. I have added a short wait to that and one other test to fix it

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207169613638606) by [Unito](https://www.unito.io)
