### PR TITLE
[LW] Second Recombee Hybrid Tab for Admins

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -372,7 +372,7 @@ const LWHomePosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
                 <RecombeePostsList 
                 algorithm={'recombee-hybrid'} settings={{
                   ...scenarioConfig,
-                  hybridScenarios: ['recombee-emulate-hacker-news', 'recombee-personal']
+                  hybridScenarios: {fixed: 'recombee-emulate-hacker-news', configurable: 'recombee-personal'}
                 }} />
               </AnalyticsContext>}
 
@@ -380,7 +380,7 @@ const LWHomePosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
               {selectedTab === 'recombee-hybrid-2' && <AnalyticsContext feedType={selectedTab}>
                 <RecombeePostsList algorithm={'recombee-hybrid'} settings={{
                   ...scenarioConfig, 
-                  hybridScenarios: ['recombee-emulate-hacker-news', 'recombee-lesswrong-custom']
+                  hybridScenarios: {fixed: 'recombee-emulate-hacker-news', configurable: 'recombee-lesswrong-custom'}
                 }} 
                 />
               </AnalyticsContext>}

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -21,7 +21,7 @@ import { TabRecord } from './TabPicker';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { RECOMBEE_SETTINGS_COOKIE } from '../../lib/cookies/cookies';
 import { RecombeeConfiguration } from '../../lib/collections/users/recommendationSettings';
-import { homepagePostFeedsSetting } from '../../lib/instanceSettings';
+import { PostFeedDetails, homepagePostFeedsSetting } from '../../lib/instanceSettings';
 
 // Key is the algorithm/tab name
 type RecombeeCookieSettings = [string, RecombeeConfiguration][];
@@ -213,10 +213,11 @@ const LWHomePosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
     skip: !currentUser?._id,
   });
 
-  const availableTabs: TabRecord[] = homepagePostFeedsSetting.get()
+  const availableTabs: PostFeedDetails[] = homepagePostFeedsSetting.get()
 
   const enabledTabs = availableTabs
     .filter(feed => !feed.disabled
+      && !(feed.adminOnly && !userIsAdmin(currentUser))
       && !(feed.name.includes('recombee') && !currentUser)
       && !(feed.name === 'forum-bookmarks' && (countBookmarks ?? 0) < 1)
       && !(feed.name === 'forum-continue-reading' && continueReading?.length < 1)
@@ -367,8 +368,21 @@ const LWHomePosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
               </AnalyticsContext>}
               
               {/* RECOMBEE RECOMMENDATIONS */}
-              {selectedTab.includes('recombee') && <AnalyticsContext feedType={selectedTab}>
-                <RecombeePostsList algorithm={selectedTab} settings={scenarioConfig} />
+              {selectedTab === 'recombee-hybrid' && <AnalyticsContext feedType={selectedTab}>
+                <RecombeePostsList 
+                algorithm={'recombee-hybrid'} settings={{
+                  ...scenarioConfig,
+                  hybridScenarios: ['recombee-emulate-hacker-news', 'recombee-personal']
+                }} />
+              </AnalyticsContext>}
+
+              {/* RECOMBEE RECOMMENDATIONS 2 */}
+              {selectedTab === 'recombee-hybrid-2' && <AnalyticsContext feedType={selectedTab}>
+                <RecombeePostsList algorithm={'recombee-hybrid'} settings={{
+                  ...scenarioConfig, 
+                  hybridScenarios: ['recombee-emulate-hacker-news', 'recombee-lesswrong-custom']
+                }} 
+                />
               </AnalyticsContext>}
 
               {/* BOOKMARKS */}

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -107,13 +107,18 @@ export const recommendationsAlgorithmHasStrategy = (
 ): algorithm is RecommendationsAlgorithmWithStrategy =>
   "strategy" in algorithm;
 
+export interface HybridArmsConfig {
+  fixed: string,
+  configurable: string,
+}
+
 export interface RecombeeConfiguration {
   userId?: string,
   rotationRate?: number,
   rotationTime?: number,
   booster?: string,
   filter?: string,
-  hybridScenarios?: string[],
+  hybridScenarios?: HybridArmsConfig,
   refreshKey?: string,
   loadMore?: {
     prevRecommId: string,
@@ -128,7 +133,7 @@ export interface RecombeeRecommendationArgs extends RecombeeConfiguration {
 }
 
 export interface HybridRecombeeConfiguration {
-  hybridScenarios: string[],
+  hybridScenarios: HybridArmsConfig,
   userId?: string,
   rotationRate?: number,
   rotationTime?: number,

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -113,6 +113,7 @@ export interface RecombeeConfiguration {
   rotationTime?: number,
   booster?: string,
   filter?: string,
+  hybridScenarios?: string[],
   refreshKey?: string,
   loadMore?: {
     prevRecommId: string,
@@ -127,6 +128,7 @@ export interface RecombeeRecommendationArgs extends RecombeeConfiguration {
 }
 
 export interface HybridRecombeeConfiguration {
+  hybridScenarios: string[],
   userId?: string,
   rotationRate?: number,
   rotationTime?: number,

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -230,6 +230,7 @@ export type PostFeedDetails = {
   label: string,
   description?: string,
   disabled?: boolean,
+  adminOnly?: boolean,
   showLabsIcon?: boolean,
   slug?: string
 }

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -177,11 +177,16 @@ const recombeeRequestHelpers = {
     };
   },
 
-  convertHybridToRecombeeArgs(hybridArgs: HybridRecombeeConfiguration, hybridArm: keyof typeof HYBRID_SCENARIO_MAP, filter?: string) {
-    const { loadMore, userId, ...rest } = hybridArgs;
+  convertHybridToRecombeeArgs(hybridArgs: HybridRecombeeConfiguration, hybridArm: 'first' | 'second', filter?: string) {
+    const { loadMore, userId, hybridScenarios, ...rest } = hybridArgs;
 
-    const scenario = HYBRID_SCENARIO_MAP[hybridArm];
-    const isConfigurable = hybridArm === 'configurable';
+    if (hybridScenarios.length !== 2) {
+      // eslint-disable-next-line no-console
+      console.log('Hybrid scenario array must have exactly two elements');
+    }
+    const scenario = hybridScenarios[hybridArm === 'first' ? 0 : 1];
+
+    const isConfigurable = hybridArm === 'second';
     const clientConfig: Partial<Omit<HybridRecombeeConfiguration,"loadMore"|"userId">> = isConfigurable ? rest : {rotationRate: 0.1, rotationTime: 144};
     const prevRecommIdIndex = isConfigurable ? 0 : 1;
     const loadMoreConfig = loadMore
@@ -323,8 +328,8 @@ const recombeeApi = {
     const firstCount = Math.floor(modifiedCount * split);
     const secondCount = modifiedCount - firstCount;
 
-    const firstRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'configurable', excludedPostFilter);
-    const secondRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'fixed', excludedPostFilter);
+    const firstRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'first', excludedPostFilter);
+    const secondRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'second', excludedPostFilter);
 
     const firstRequest = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, firstCount, firstRequestSettings);
     const secondRequest = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, secondCount, secondRequestSettings);

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -1,5 +1,5 @@
 import { ApiClient, RecommendationResponse, requests } from 'recombee-api-client';
-import { HybridRecombeeConfiguration, RecombeeConfiguration, RecombeeRecommendationArgs } from '../../lib/collections/users/recommendationSettings';
+import { HybridArmsConfig, HybridRecombeeConfiguration, RecombeeConfiguration, RecombeeRecommendationArgs } from '../../lib/collections/users/recommendationSettings';
 import { loadByIds } from '../../lib/loaders';
 import { filterNonnull } from '../../lib/utils/typeGuardUtils';
 import { htmlToTextDefault } from '../../lib/htmlToText';
@@ -11,7 +11,6 @@ import { viewTermsToQuery } from '../../lib/utils/viewUtils';
 import { stickiedPostTerms } from '../../components/posts/RecombeePostsList';
 import groupBy from 'lodash/groupBy';
 import { recommendationsTabManuallyStickiedPostIdsSetting } from '../../lib/publicSettings';
-import { HybridArmsConfig } from '../../lib/collections/users/recommendationSettings';
 
 export const getRecombeeClientOrThrow = (() => {
   let client: ApiClient;

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -11,6 +11,7 @@ import { viewTermsToQuery } from '../../lib/utils/viewUtils';
 import { stickiedPostTerms } from '../../components/posts/RecombeePostsList';
 import groupBy from 'lodash/groupBy';
 import { recommendationsTabManuallyStickiedPostIdsSetting } from '../../lib/publicSettings';
+import { HybridArmsConfig } from '../../lib/collections/users/recommendationSettings';
 
 export const getRecombeeClientOrThrow = (() => {
   let client: ApiClient;
@@ -177,16 +178,12 @@ const recombeeRequestHelpers = {
     };
   },
 
-  convertHybridToRecombeeArgs(hybridArgs: HybridRecombeeConfiguration, hybridArm: 'first' | 'second', filter?: string) {
+  convertHybridToRecombeeArgs(hybridArgs: HybridRecombeeConfiguration, hybridArm: keyof HybridArmsConfig, filter?: string) {
     const { loadMore, userId, hybridScenarios, ...rest } = hybridArgs;
 
-    if (hybridScenarios.length !== 2) {
-      // eslint-disable-next-line no-console
-      console.log('Hybrid scenario array must have exactly two elements');
-    }
-    const scenario = hybridScenarios[hybridArm === 'first' ? 0 : 1];
+    const scenario = hybridScenarios[hybridArm];
 
-    const isConfigurable = hybridArm === 'second';
+    const isConfigurable = hybridArm === 'configurable';
     const clientConfig: Partial<Omit<HybridRecombeeConfiguration,"loadMore"|"userId">> = isConfigurable ? rest : {rotationRate: 0.1, rotationTime: 12};
     const prevRecommIdIndex = isConfigurable ? 1 : 0;
     const loadMoreConfig = loadMore
@@ -328,8 +325,8 @@ const recombeeApi = {
     const firstCount = Math.floor(modifiedCount * split);
     const secondCount = modifiedCount - firstCount;
 
-    const firstRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'first', excludedPostFilter);
-    const secondRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'second', excludedPostFilter);
+    const firstRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'configurable', excludedPostFilter);
+    const secondRequestSettings = recombeeRequestHelpers.convertHybridToRecombeeArgs(lwAlgoSettings, 'fixed', excludedPostFilter);
 
     const firstRequest = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, firstCount, firstRequestSettings);
     const secondRequest = recombeeRequestHelpers.createRecommendationsForUserRequest(userId, secondCount, secondRequestSettings);

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -187,8 +187,8 @@ const recombeeRequestHelpers = {
     const scenario = hybridScenarios[hybridArm === 'first' ? 0 : 1];
 
     const isConfigurable = hybridArm === 'second';
-    const clientConfig: Partial<Omit<HybridRecombeeConfiguration,"loadMore"|"userId">> = isConfigurable ? rest : {rotationRate: 0.1, rotationTime: 144};
-    const prevRecommIdIndex = isConfigurable ? 0 : 1;
+    const clientConfig: Partial<Omit<HybridRecombeeConfiguration,"loadMore"|"userId">> = isConfigurable ? rest : {rotationRate: 0.1, rotationTime: 12};
+    const prevRecommIdIndex = isConfigurable ? 1 : 0;
     const loadMoreConfig = loadMore
       ? { loadMore: { prevRecommId: loadMore.prevRecommIds[prevRecommIdIndex] } }
       : {};

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -185,7 +185,7 @@ const recombeeRequestHelpers = {
 
     const isConfigurable = hybridArm === 'configurable';
     const clientConfig: Partial<Omit<HybridRecombeeConfiguration,"loadMore"|"userId">> = isConfigurable ? rest : {rotationRate: 0.1, rotationTime: 12};
-    const prevRecommIdIndex = isConfigurable ? 1 : 0;
+    const prevRecommIdIndex = isConfigurable ? 0 : 1;
     const loadMoreConfig = loadMore
       ? { loadMore: { prevRecommId: loadMore.prevRecommIds[prevRecommIdIndex] } }
       : {};


### PR DESCRIPTION
Production has live a recombee recommendation list that's 50-50 emulate hacker news algo + recombee:personal logic.
This PR adds a second tab for comparison that's 50-50 emulate hacker news + custom-for-lw-recombee-logic that they made for us (has some tweakable parameters too in Recombee admin config on their site)

<img width="807" alt="LessWrong 2024-04-25 11-55-26" src="https://github.com/ForumMagnum/ForumMagnum/assets/7250541/0a3f85c6-1893-499f-a601-9c2c1aceb33d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207174902910582) by [Unito](https://www.unito.io)
