### PR TITLE
Temporarily hide links to the people directory

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -299,6 +299,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       ${taggingNamePluralSetting.get()} in EA and collects posts tagged with those ${taggingNamePluralSetting.get()}.`,
       showOnMobileStandalone: true,
       showOnCompressed: true,
+      /*
     }, {
       id: 'peopleDirectory',
       title: 'People directory',
@@ -311,6 +312,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       flag: "beta",
       desktopOnly: true,
       betaOnly: true,
+       */
     }, {
       id: 'takeAction',
       title: 'Take action',

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -58,7 +58,7 @@ export const userHasEAHomeRHS = isEAForum ? shippedFeature : disabled;
 export const visitorGetsDynamicFrontpage = isLW ? shippedFeature : disabled;
 
 export const userHasPeopleDirectory = (user: UsersCurrent|DbUser|null) =>
-  isEAForum && !!user?.beta;
+  false;// isEAForum && !!user?.beta;
 
 //defining as Hook so as to combine with ABTest
 export const useRecombeeFrontpage = (currentUser: UsersCurrent|DbUser|null) => {


### PR DESCRIPTION
Backfilling the `profileUpdatedAt` field is slower than expected so this commit hides all links to the people directory so we can deploy the code without advertising the new feature whilst running the migrations, then revert this commit after to release the feature.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207176193927785) by [Unito](https://www.unito.io)
