### PR TITLE
Fix tabId being lost due to initialization-order issue with the client bundle

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -53,6 +53,7 @@ import { asyncLocalStorage, closePerfMetric, openPerfMetric, perfMetricMiddlewar
 import { addAdminRoutesMiddleware } from './adminRoutesMiddleware'
 import { createAnonymousContext } from './vulcan-lib/query';
 import { DatabaseServerSetting } from './databaseSettings';
+import { randomId } from '../lib/random';
 
 /**
  * Try to set the response status, but log an error if the headers have already been sent.
@@ -389,6 +390,11 @@ export function startWebserver() {
     cloudfrontCachingExperiment({ user, response })
     
     const faviconHeader = `<link rel="shortcut icon" href="${faviconUrlSetting.get()}"/>`;
+
+    // Inject a tab ID into the page, by injecting a script fragment that puts
+    // it into a global variable.
+    const tabId = randomId();
+    const tabIdHeader = `<script>var tabId = "${tabId}"</script>`;
     
     // The part of the header which can be sent before the page is rendered.
     // This includes an open tag for <html> and <head> but not the matching
@@ -403,7 +409,12 @@ export function startWebserver() {
         + externalStylesPreload
         + instanceSettingsHeader
         + faviconHeader
-        + publicSettingsHeader // Must come before clientScript
+        // Embedded script tags that must precede the client bundle
+        + publicSettingsHeader
+        + tabIdHeader
+        // The client bundle. Because this uses <script async>, its load order
+        // relative to any scripts that come later than this is undetermined and
+        // varies based on timings and the browser cache.
         + clientScript
     );
 
@@ -416,8 +427,8 @@ export function startWebserver() {
     });
 
     const renderResultPromise = performanceMetricLoggingEnabled.get()
-      ? asyncLocalStorage.run({}, () => renderWithCache(request, response, user))
-      : renderWithCache(request, response, user);
+      ? asyncLocalStorage.run({}, () => renderWithCache(request, response, user, tabId))
+      : renderWithCache(request, response, user, tabId);
 
     const [prefetchingResources, renderResult] = await Promise.all([prefetchResourcesPromise, renderResultPromise]);
 

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -76,19 +76,12 @@ interface RenderPriorityQueueSlot extends RequestData {
   renderRequestParams: RenderRequestParams;
 }
 
-export const renderWithCache = async (req: Request, res: Response, user: DbUser|null) => {
+export const renderWithCache = async (req: Request, res: Response, user: DbUser|null, tabId: string) => {
   const startTime = new Date();
   
   const ip = getIpFromRequest(req)
   const userAgent = req.headers["user-agent"];
   
-  // Inject a tab ID into the page, by injecting a script fragment that puts
-  // it into a global variable. In previous versions of Vulcan this would've
-  // been handled by InjectData, but InjectData didn't surive the 1.12 version
-  // upgrade (it injects into the page template in a way that requires a
-  // response object, which the onPageLoad/sink API doesn't offer).
-  const tabId = randomId();
-  const tabIdHeader = `<script>var tabId = "${tabId}"</script>`;
   const url = getPathFromReq(req);
   
   const clientId = getCookieFromReq(req, "clientId");
@@ -161,7 +154,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     
     return {
       ...rendered,
-      headers: [...rendered.headers, tabIdHeader],
+      headers: [...rendered.headers],
     };
   } else {
     if (performanceMetricLoggingEnabled.get()) {
@@ -220,7 +213,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     
     return {
       ...rendered,
-      headers: [...rendered.headers, tabIdHeader],
+      headers: [...rendered.headers],
     };
   }
 };


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/pull/9134

We inject a script tag into the page that sets `tabId` on `window` to a value that identifies the pageload, for analytics. That injected script tag needs to run before the client bundle does, or it will look for the tabId on initialization and it won't be there. The previous PR changed the client-bundle import from `defer` to `async`, which changed the execution order, and we started getting analytics events with `tabId` missing.

A similar workaround to this was already applied for `publicSettings`, but `tabId` was missed.

Tested by: Putting a `console.log` in `client/logging.ts` that reports `tabId`, observing that it was `undefined`, making the changes in this PR and rerunning the test, and getting a valued `tabId` at that point instead.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207176300984500) by [Unito](https://www.unito.io)
