### PR TITLE
Various perf fixes

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -311,10 +311,9 @@ function addEditableCallbacks<N extends CollectionNameString>({collection, optio
    * It's fine to leave it here just in case though
    */
   getCollectionHooks(collectionName).editAsync.add(async (doc: DbObject, oldDoc: DbObject) => {
-    const isPostContentsContext = collectionName === 'Posts' && fieldName === 'contents';
-    const hasChanged = (oldDoc as DbPost)?.contents?.html !== (doc as DbPost)?.contents?.html;
+    const hasChanged = (oldDoc as AnyBecauseHard)?.[fieldName]?.html !== (doc as AnyBecauseHard)?.[fieldName]?.html;
     
-    if (isPostContentsContext && !hasChanged) return;
+    if (!hasChanged) return;
 
     await Globals.convertImagesInObject(collectionName, doc._id, fieldName);
   })

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -304,7 +304,7 @@ augmentFieldsDict(Posts, {
         if (!isLWorAF) {
           return 0;
         }
-        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader);
+        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader(context));
         return market?.probability
       }
     }
@@ -316,7 +316,7 @@ augmentFieldsDict(Posts, {
         if (!isLWorAF) {
           return false;
         }
-        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader)
+        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader(context))
         return market?.isResolved
       }
     }
@@ -328,7 +328,7 @@ augmentFieldsDict(Posts, {
         if (!isLWorAF) {
           return 0;
         }
-        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader)
+        const market = await getWithCustomLoader(context, 'manifoldMarket', post._id, marketInfoLoader(context))
         return market?.year
       }
     }


### PR DESCRIPTION
- skip cloudinary image upload attempt for fields that didn't update
- curry `marketInfoLoader` to give it a resolver context, so we can avoid doing a second round trip to the database to get the same list of posts we already fetched

The first was a blocking operation for any update on a collection with makeEditable fields, with each such field causing (even if the field itself wasn't changed):
1. a raw Collection.findOne for the record which was just updated
2. fetching the latest revision for that record
...in sequence, adding at least 2 round trips to the DB.  That wouldn't matter most of the time, but most relevant collections have several editable fields, which greatly increases the chances that one of those sets of operations runs into some random cause of additional latency.

The second was a blocking operation (on LW) whenever we fetched any posts with a fragment that included `PostsBase`, which is pretty much all post lists.  Probably added at least 100-200ms of extra latency, since fetching posts from the DB actually takes a bit of time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207183854743494) by [Unito](https://www.unito.io)
