### PR TITLE
forum-gate checkForTypingIndicators

### DIFF
--- a/packages/lesswrong/server/serverSentEvents.ts
+++ b/packages/lesswrong/server/serverSentEvents.ts
@@ -77,8 +77,8 @@ export function addServerSentEventsEndpoint(app: Express) {
   });
   
   setInterval(checkForNotifications, 1000);
-  setInterval(checkForTypingIndicators, 1000);
   if (!isEAForum) {
+    setInterval(checkForTypingIndicators, 1000);
     setInterval(checkForActiveDialoguePartners, 1000);
   }
 }


### PR DESCRIPTION
I just noticed the `TypingIndicatorsRepo.getRecentTypingIndicators` query being logged in my terminal, seems reasonable to forum-gate this since we don't use this feature.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207185031153009) by [Unito](https://www.unito.io)
