### PR TITLE
Reindex content in elastic for deleted users

### DIFF
--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -1,5 +1,5 @@
 import { initializeSetting } from './publicSettings'
-import { isServer, isDevelopment, isAnyTest, getInstanceSettings, getAbsoluteUrl } from './executionEnvironment';
+import { isServer, isDevelopment, isAnyTest, getInstanceSettings, getAbsoluteUrl, isCypress } from './executionEnvironment';
 import { pluralize } from './vulcan-lib/pluralize';
 import startCase from 'lodash/startCase' // AKA: capitalize, titleCase
 import { TupleSet, UnionOf } from './utils/typeGuardUtils';
@@ -205,7 +205,7 @@ const disableElastic = new PublicInstanceSetting<boolean>(
   "optional",
 );
 
-export const isElasticEnabled = !isAnyTest && !disableElastic.get();
+export const isElasticEnabled = !isAnyTest && !isCypress && !disableElastic.get();
 
 export const requireReviewToFrontpagePostsSetting = new PublicInstanceSetting<boolean>('posts.requireReviewToFrontpage', !isEAForum, "optional")
 export const manifoldAPIKeySetting = new PublicInstanceSetting<string | null>('manifold.reviewBotKey', null, "optional")

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -58,7 +58,7 @@ import './server/scripts/removeRsvp';
 import './server/scripts/regenerateUnicodeSlugs';
 import './server/scripts/checkPostForSockpuppetVoting';
 import './server/scripts/convertAllPostsToEAEmojis';
-
+import './server/scripts/reindexDeletedUserContent';
 import './server/scripts/oneOffBanSpammers'
 import './server/scripts/ensureEmailInEmails';
 import './server/scripts/exportPostDetails';

--- a/packages/lesswrong/server/embeddings.ts
+++ b/packages/lesswrong/server/embeddings.ts
@@ -6,12 +6,12 @@ import { htmlToTextDefault } from "../lib/htmlToText";
 import { Globals } from "./vulcan-lib";
 import { inspect } from "util";
 import md5 from "md5";
-import { isAnyTest } from "../lib/executionEnvironment";
+import { isAnyTest, isCypress } from "../lib/executionEnvironment";
 import { isEAForum } from "../lib/instanceSettings";
 import { addCronJob } from "./cronUtil";
 import { TiktokenModel, encoding_for_model } from "@dqbd/tiktoken";
 
-export const HAS_EMBEDDINGS_FOR_RECOMMENDATIONS = isEAForum;
+export const HAS_EMBEDDINGS_FOR_RECOMMENDATIONS = isEAForum && !isCypress;
 
 export const DEFAULT_EMBEDDINGS_MODEL: TiktokenModel = "text-embedding-ada-002";
 const DEFAULT_EMBEDDINGS_MODEL_MAX_TOKENS = 8191;

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -227,9 +227,18 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
         c."postedAt",
         EXTRACT(EPOCH FROM c."postedAt") * 1000 AS "publicDateMs",
         COALESCE(c."af", FALSE) AS "af",
-        author."slug" AS "authorSlug",
-        author."displayName" AS "authorDisplayName",
-        author."username" AS "authorUserName",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."slug"
+        END AS "authorSlug",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."displayName"
+        END AS "authorDisplayName",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."username"
+        END AS "authorUserName",
         c."postId",
         post."title" AS "postTitle",
         post."slug" AS "postSlug",

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -365,9 +365,18 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         COALESCE(p."draft", FALSE) AS "draft",
         COALESCE(p."af", FALSE) AS "af",
         fm_post_tag_ids(p."_id") AS "tags",
-        author."slug" AS "authorSlug",
-        author."displayName" AS "authorDisplayName",
-        author."fullName" AS "authorFullName",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."slug"
+        END AS "authorSlug",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."displayName"
+        END AS "authorDisplayName",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."fullName"
+        END AS "authorFullName",
         rss."nickname" AS "feedName",
         p."feedLink",
         p."contents"->>'html' AS "body",

--- a/packages/lesswrong/server/repos/SequencesRepo.ts
+++ b/packages/lesswrong/server/repos/SequencesRepo.ts
@@ -24,9 +24,18 @@ class SequencesRepo extends AbstractRepo<"Sequences"> {
         COALESCE(s."hidden", FALSE) AS "hidden",
         COALESCE(s."af", FALSE) AS "af",
         s."bannerImageId",
-        author."displayName" AS "authorDisplayName",
-        author."username" AS "authorUserName",
-        author."slug" AS "authorSlug",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."slug"
+        END AS "authorSlug",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."displayName"
+        END AS "authorDisplayName",
+        CASE
+          WHEN author."deleted" THEN NULL
+          ELSE author."username"
+        END AS "authorUserName",
         s."contents"->>'html' AS "plaintextDescription",
         NOW() AS "exportedAt"
       FROM "Sequences" s

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -693,6 +693,27 @@ class UsersRepo extends AbstractRepo<"Users"> {
 
     return userIdRecords.map(({ _id }) => _id);
   }
+
+  async getAllUserPostIds(userId: string): Promise<string[]> {
+    const results = await this.getRawDb().any(`
+      SELECT "_id" FROM "Posts" WHERE "userId" = $1
+    `, [userId]);
+    return results.map(({_id}) => _id);
+  }
+
+  async getAllUserCommentIds(userId: string): Promise<string[]> {
+    const results = await this.getRawDb().any(`
+      SELECT "_id" FROM "Comments" WHERE "userId" = $1
+    `, [userId]);
+    return results.map(({_id}) => _id);
+  }
+
+  async getAllUserSequenceIds(userId: string): Promise<string[]> {
+    const results = await this.getRawDb().any(`
+      SELECT "_id" FROM "Sequences" WHERE "userId" = $1
+    `, [userId]);
+    return results.map(({_id}) => _id);
+  }
 }
 
 recordPerfMetrics(UsersRepo, { excludeMethods: ['getUserByLoginToken'] });

--- a/packages/lesswrong/server/scripts/reindexDeletedUserContent.ts
+++ b/packages/lesswrong/server/scripts/reindexDeletedUserContent.ts
@@ -1,0 +1,46 @@
+import { Globals } from "../vulcan-lib";
+import { getSqlClientOrThrow } from "../../lib/sql/sqlClient"
+import ElasticClient from "../search/elastic/ElasticClient";
+import ElasticExporter from "../search/elastic/ElasticExporter";
+import chunk from "lodash/chunk";
+
+type DeletedUserDocument = {
+  collectionName: "Posts" | "Comments" | "Sequences",
+  documentId: string,
+}
+
+const reindexDeletedUserContent = async () => {
+  const db = getSqlClientOrThrow();
+  const docs = await db.any<DeletedUserDocument>(`
+    SELECT 'Posts' "collectionName", p."_id" "documentId"
+    FROM "Users" u
+    JOIN "Posts" p ON u."_id" = p."userId"
+    WHERE u."deleted" IS TRUE
+    UNION
+    SELECT 'Comments' "collectionName", c."_id" "documentId"
+    FROM "Users" u
+    JOIN "Comments" c ON u."_id" = c."userId"
+    WHERE u."deleted" IS TRUE
+    UNION
+    SELECT 'Sequences' "collectionName", s."_id" "documentId"
+    FROM "Users" u
+    JOIN "Sequences" s ON u."_id" = s."userId"
+    WHERE u."deleted" IS TRUE
+  `);
+
+  const client = new ElasticClient();
+  const exporter = new ElasticExporter(client);
+
+  const chunks = chunk(docs, 10);
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    // eslint-disable-next-line no-console
+    console.log(`Reindexing chunk ${i} of ${chunks.length}...`);
+    const promises = chunk.map(({collectionName, documentId}) => {
+      return exporter.updateDocument(collectionName, documentId);
+    });
+    await Promise.all(promises);
+  }
+}
+
+Globals.reindexDeletedUserContent = reindexDeletedUserContent;

--- a/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
+++ b/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
@@ -33,7 +33,7 @@ if (isElasticEnabled) {
     newUser: DbUser,
     oldUser: DbUser,
   ) {
-    if (newUser.deleted && !oldUser.deleted) {
+    if (!!newUser.deleted !== !!oldUser.deleted) {
       const repo = new UsersRepo();
       const [
         postIds,
@@ -47,18 +47,11 @@ if (isElasticEnabled) {
 
       const client = new ElasticClient();
       const exporter = new ElasticExporter(client);
-
-      for (const id of postIds) {
-        await exporter.updateDocument("Posts", id);
-      }
-
-      for (const id of commentIds) {
-        await exporter.updateDocument("Comments", id);
-      }
-
-      for (const id of sequenceIds) {
-        await exporter.updateDocument("Sequences", id);
-      }
+      await Promise.all([
+        ...postIds.map((id) => exporter.updateDocument("Posts", id)),
+        ...commentIds.map((id) => exporter.updateDocument("Comments", id)),
+        ...sequenceIds.map((id) => exporter.updateDocument("Sequences", id)),
+      ]);
     }
   });
 }

--- a/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
+++ b/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
@@ -3,6 +3,7 @@ import {
   searchIndexedCollectionNames,
 } from "../../../lib/search/searchUtil";
 import { getCollectionHooks } from "../../mutationCallbacks";
+import { UsersRepo } from "../../repos";
 import ElasticClient from "./ElasticClient";
 import ElasticExporter from "./ElasticExporter";
 import { isElasticEnabled } from "./elasticSettings";
@@ -27,4 +28,37 @@ if (isElasticEnabled) {
     getCollectionHooks(collectionName).createAfter.add(callback);
     getCollectionHooks(collectionName).updateAfter.add(callback);
   }
+
+  getCollectionHooks("Users").editAsync.add(async function reindexDeletedUserContent(
+    newUser: DbUser,
+    oldUser: DbUser,
+  ) {
+    if (newUser.deleted && !oldUser.deleted) {
+      const repo = new UsersRepo();
+      const [
+        postIds,
+        commentIds,
+        sequenceIds,
+      ] = await Promise.all([
+        repo.getAllUserPostIds(newUser._id),
+        repo.getAllUserCommentIds(newUser._id),
+        repo.getAllUserSequenceIds(newUser._id),
+      ]);
+
+      const client = new ElasticClient();
+      const exporter = new ElasticExporter(client);
+
+      for (const id of postIds) {
+        await exporter.updateDocument("Posts", id);
+      }
+
+      for (const id of commentIds) {
+        await exporter.updateDocument("Comments", id);
+      }
+
+      for (const id of sequenceIds) {
+        await exporter.updateDocument("Sequences", id);
+      }
+    }
+  });
 }


### PR DESCRIPTION
This PR reindexes content for deleted users in order to show "[[anonymous]]" instead of their display name in search results to match the rest of the site.

After deploying it is required to run `./scripts/serverShellCommand.sh "Globals.reindexDeletedUserContent()"` in order to reindex content for users who have already been deleted (this takes about 1.5 minutes on the EA dev database).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207197951693956) by [Unito](https://www.unito.io)
