### PR TITLE
[EA] Remove ability for authors to moderate posts

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -20,6 +20,7 @@ import { isAdmin, userOverNKarmaOrApproved } from "./vulcan-users/permissions";
 import {isFriendlyUI} from '../themes/forumTheme'
 import { recombeeEnabledSetting } from './publicSettings';
 import { useLocation } from './routeUtil';
+import { isAnyTest } from './executionEnvironment';
 
 // States for in-progress features
 const adminOnly = (user: UsersCurrent|DbUser|null): boolean => !!user?.isAdmin; // eslint-disable-line no-unused-vars
@@ -90,6 +91,11 @@ export const commentsTableOfContentsEnabled = hasCommentsTableOfContentSetting.g
 export const fullHeightToCEnabled = isLWorAF;
 export const hasForumEvents = isEAForum;
 export const useCurationEmailsCron = isLW;
+
+// EA Forum disabled the author's ability to moderate posts. We disregard this
+// check in tests as the tests run in EA Forum mode, but we want to be able to
+// test the moderation features.
+export const hasAuthorModeration = !isEAForum || isAnyTest;
 
 // Shipped Features
 export const userCanManageTags = shippedFeature;

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -7,6 +7,7 @@ import { canUserEditPostMetadata, userIsPostGroupOrganizer } from './helpers';
 import { makeEditable } from '../../editor/make_editable';
 import { formGroups } from './formGroups';
 import { isFriendlyUI } from '../../../themes/forumTheme';
+import { hasAuthorModeration } from '../../betas';
 
 export const userCanPost = (user: UsersCurrent|DbUser) => {
   if (user.deleted) return false;
@@ -48,6 +49,9 @@ export const Posts = createCollection({
 });
 
 const userHasModerationGuidelines = (currentUser: DbUser|null): boolean => {
+  if (!hasAuthorModeration) {
+    return false;
+  }
   return !!(currentUser && ((currentUser.moderationGuidelines && currentUser.moderationGuidelines.html) || currentUser.moderationStyle))
 }
 

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -9,6 +9,7 @@ import { getBrowserLocalStorage } from '../../../components/editor/localStorageH
 import { Components } from '../../vulcan-lib';
 import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
+import { hasAuthorModeration } from '../../betas';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -109,6 +110,9 @@ export const userCanEditUsersBannedUserIds = (currentUser: DbUser|null, targetUs
 }
 
 const postHasModerationGuidelines = (post: PostsBase | DbPost) => {
+  if (!hasAuthorModeration) {
+    return false;
+  }
   // Because of a bug in Vulcan that doesn't adequately deal with nested fields
   // in document validation, we check for originalContents instead of html here,
   // which causes some problems with empty strings, but should overall be fine


### PR DESCRIPTION
Follow up to #9126 where we hid the options for the UI. Users who already set default moderation guidelines will still have those guidelines applied to their new posts - the changes in this PR make it so that we just ignore the moderation guidelines completely.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207205792361859) by [Unito](https://www.unito.io)
