### PR TITLE
[EA] Card view quick improvements

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -7,6 +7,7 @@ import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
+import { cloudinaryCloudNameSetting } from "../../lib/publicSettings";
 
 const KARMA_WIDTH = 50;
 
@@ -220,6 +221,11 @@ export const styles = (theme: ThemeType) => ({
   },
 });
 
+const cloudinaryBase = `${cloudinaryCloudNameSetting.get()}/image/upload/`;
+
+const formatImageUrl = (url: string) =>
+  url.replace(cloudinaryBase, `${cloudinaryBase}c_fill,w_124,h_70,dpr_2,`);
+
 export type EAPostsItemProps = PostsItemConfig & {
   hideSecondaryInfo?: boolean,
   classes: ClassesType<typeof styles>,
@@ -416,7 +422,7 @@ const EAPostsItem = ({
               </div>
               {hasImage &&
                 <img
-                  src={post.socialPreviewData.imageUrl}
+                  src={formatImageUrl(post.socialPreviewData.imageUrl)}
                   alt={post.title}
                   className={classes.cardImage}
                 />

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -8,6 +8,7 @@ import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
 import { cloudinaryCloudNameSetting } from "../../lib/publicSettings";
+import { usePostContents } from "../hooks/useForeignCrosspost";
 
 const KARMA_WIDTH = 50;
 
@@ -270,6 +271,11 @@ const EAPostsItem = ({
   } = usePostsItem(props);
   const {onClick} = useClickableCell({href: postLink});
   const cardView = viewType === "card";
+  const {postContents} = usePostContents({
+    post,
+    fragmentName: "PostsList",
+    skip: !cardView,
+  });
 
   if (isRepeated) {
     return null;
@@ -323,7 +329,11 @@ const EAPostsItem = ({
     </PostsItemTooltipWrapper>
   );
 
-  const hasBody = (post.contents?.plaintextDescription ?? "").trim().length > 0;
+  const body =
+    postContents?.plaintextDescription ||
+    post.contents?.plaintextDescription ||
+    "";
+  const hasBody = body.trim().length > 0;
   const hasImage = !!post.socialPreviewData.imageUrl;
 
   return (
@@ -418,7 +428,7 @@ const EAPostsItem = ({
                 hasImage && classes.cardTextWithImage,
                 !hasImage && classes.cardTextNoImage,
               )}>
-                {post.contents?.plaintextDescription}
+                {body}
               </div>
               {hasImage &&
                 <img

--- a/packages/lesswrong/components/posts/PostsListViewToggle.tsx
+++ b/packages/lesswrong/components/posts/PostsListViewToggle.tsx
@@ -23,6 +23,9 @@ const styles = (theme: ThemeType) => ({
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: 11,
     fontWeight: 600,
+    [theme.breakpoints.down("sm")]: {
+      display: "none",
+    },
   },
   flagPoint: {
     position: "absolute",


### PR DESCRIPTION
- Hide the "NEW" flag on small screens
- Load post bodies for foreign crossposts (note that this won't actually work until after the next LW deploy as `plaintextDescription` was only added to the `PostsList` fragment in the main card view PR which was only merged a couple of hours ago, after the last LW deploy)
- Load thumbnail images instead of fullsize images

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207213525046119) by [Unito](https://www.unito.io)
