### PR TITLE
update merge accounts script

### DIFF
--- a/packages/lesswrong/lib/sql/UpdateQuery.ts
+++ b/packages/lesswrong/lib/sql/UpdateQuery.ts
@@ -167,18 +167,31 @@ class UpdateQuery<T extends DbObject> extends Query<T> {
     value: any,
     format: (resolvedField: string, updateValue: Atom<T>[]) => Atom<T>[],
   ): Atom<T>[] {
-    try {
-      // If we're updating the value of a JSON blob without totally replacing
-      // it then we need to wrap the update in a call to `JSONB_SET`.
-      if (field.includes(".")) {
-        const updateValue = this.compileUpdateExpression(value, { skipTypeHint: true });
-        const {column, path} = this.buildJsonUpdatePath(field);
-        return format(
-          column,
-          ["JSONB_SET(", column, ",", path, "::TEXT[],", ...updateValue, ", TRUE)"],
-        );
+    // If we're updating the value of a JSON blob without totally replacing
+    // it then we need to wrap the update in a call to `JSONB_SET`.
+    if (field.includes(".")) {
+      const updateValue = this.compileUpdateExpression(value);
+      const {column, path} = this.buildJsonUpdatePath(field);
+      // Check if we're trying to unset the field (currently you can only unset fields in the first level)
+      if (value === null) {
+        const fieldTokens = field.split(".")
+        if (fieldTokens.length === 2) {
+          return format(
+            column,
+            [column, ` - '${fieldTokens[1]}'`],
+          );
+        } else {
+          throw new Error(`Unsetting a field past the first level of a JSON blob is not yet supported`)
+        }
       }
-  
+      
+      return format(
+        column,
+        ["JSONB_SET(", column, ",", path, "::TEXT[], TO_JSONB(", ...updateValue, "), TRUE)"],
+      );
+    }
+    
+    try {
       const fieldType = this.getField(field);
       const arrayValueInNonArrayJsonbField = fieldType && !fieldType.isArray() && fieldType.toConcrete() instanceof JsonType && Array.isArray(value);
       const typeForArg = arrayValueInNonArrayJsonbField ? new JsonType() : undefined;

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -7,7 +7,7 @@ import { Votes } from '../../lib/collections/votes/index';
 import { Conversations } from '../../lib/collections/conversations/collection'
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 import sumBy from 'lodash/sumBy';
-import { ConversationsRepo, LocalgroupsRepo, VotesRepo } from '../repos';
+import { ConversationsRepo, LocalgroupsRepo, PostsRepo, VotesRepo } from '../repos';
 import Localgroups from '../../lib/collections/localgroups/collection';
 import { collectionsThatAffectKarma } from '../callbacks/votingCallbacks';
 import { filterNonnull, filterWhereFieldsNotNull } from '../../lib/utils/typeGuardUtils';
@@ -189,6 +189,10 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}: {
 
   // Transfer posts
   await transferCollection({sourceUserId, targetUserId, collectionName: "Posts", dryRun})
+  // Transfer post co-authorship
+  if (!dryRun) {
+    await new PostsRepo().moveCoauthorshipToNewUser(sourceUserId, targetUserId)
+  }
 
   // Transfer comments
   await transferCollection({sourceUserId, targetUserId, collectionName: "Comments", dryRun})
@@ -207,11 +211,20 @@ Vulcan.mergeAccounts = async ({sourceUserId, targetUserId, dryRun}: {
 
   // Transfer reports (i.e. user reporting a comment/tag/etc)
   await transferCollection({sourceUserId, targetUserId, collectionName: "Reports", dryRun})
+  
+  // Transfer election votes
+  await transferCollection({sourceUserId, targetUserId, collectionName: "ElectionVotes", dryRun})
+  
+  // Transfer moderator actions
+  await transferCollection({sourceUserId, targetUserId, collectionName: "ModeratorActions", dryRun})
+  
+  // Transfer user rate limits
+  await transferCollection({sourceUserId, targetUserId, collectionName: "UserRateLimits", dryRun})
 
   try {
     const [sourceConversationsCount, targetConversationsCount] = await Promise.all([
       Conversations.find({participantIds: sourceUserId}).count(),
-      Conversations.find({participantIds: sourceUserId}).count()
+      Conversations.find({participantIds: targetUserId}).count()
     ])
     // eslint-disable-next-line no-console
     console.log(`conversations from source user: ${sourceConversationsCount}`)

--- a/packages/lesswrong/unitTests/sql/UpdateQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/UpdateQuery.tests.ts
@@ -66,8 +66,19 @@ describe("UpdateQuery", () => {
     {
       name: "can set a value inside a JSON blob",
       getQuery: () => new UpdateQuery<DbTestObject>(testTable, {a: 3}, {$set: {"c.d.e": "hello world"}}),
-      expectedSql: `UPDATE "TestCollection" SET "c" = JSONB_SET( "c" , '{d, e}' ::TEXT[], $1 , TRUE) WHERE "a" = $2 RETURNING "_id"`,
+      expectedSql: `UPDATE "TestCollection" SET "c" = JSONB_SET( "c" , '{d, e}' ::TEXT[], TO_JSONB( $1::TEXT ), TRUE) WHERE "a" = $2 RETURNING "_id"`,
       expectedArgs: ["hello world", 3],
+    },
+    {
+      name: "can delete a value at the first level of a JSON blob",
+      getQuery: () => new UpdateQuery<DbTestObject>(testTable, {a: 3}, {$set: {"c.d": null}}),
+      expectedSql: `UPDATE "TestCollection" SET "c" = "c" - 'd' WHERE "a" = $1 RETURNING "_id"`,
+      expectedArgs: [3],
+    },
+    {
+      name: "throws an error when trying to delete a value at a further level of a JSON blob",
+      getQuery: () => new UpdateQuery<DbTestObject>(testTable, {a: 3}, {$set: {"c.d.e": null}}),
+      expectedError: 'Unsetting a field past the first level of a JSON blob is not yet supported',
     },
     {
       name: "can add a value to a set (native arrays)",


### PR DESCRIPTION
I noticed a few issues when I tried to merge two accounts, so here is my attempt to fix them:
1. The post coauthorship values didn't get transferred to the new account
2. The `userId` field in message `contents` didn't get updated to the new account, although the message `userId` values **did** get properly updated (but this may cause issues if we normalize the `contents` field)
3. Some newer/minor collections didn't get transferred (like election votes)