### PR TITLE
Fix rerender-flash when you vote on a comment that has a YouTube embed in it

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -314,7 +314,7 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
       this.replaceElement(linkTag, replacementElement);
     }
   }
-
+  
   markElicitBlocks = (element: HTMLElement) => {
     const elicitBlocks = this.getElementsByClassname(element, "elicit-binary-prediction");
     for (const elicitBlock of elicitBlocks) {
@@ -465,14 +465,18 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
   }
 }
 
-
 const addNofollowToHTML = (html: string): string => {
   return html.replace(/<a /g, '<a rel="nofollow" ')
 }
 
 
 const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
-  hocs: [withTracking]
+  hocs: [withTracking],
+  areEqual: {
+    ref: "ignore",
+    "dangerouslySetInnerHTML": "deep",
+    replacedSubstrings: (before, after) => Object.keys(before).length===0 && Object.keys(after).length===0,
+  },
 });
 
 declare global {


### PR DESCRIPTION
(...unless the comment also has an inline reaction, in which case it will still flash. The amount of workin involved in making it not flash in that case looked like it was going to be excessive relative to how often that comes up.)
