### PR TITLE
Fix styling of Calendly embeds

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -409,7 +409,8 @@ export const sanitize = function(s: string): string {
         'estimaker-preview',
         'viewpoints-preview',
         'ck-cta-button',
-        'ck-cta-button-centered'
+        'ck-cta-button-centered',
+        'calendly-preview',
       ],
       iframe: [ 'thoughtSaverFrame' ],
       ol: [ 'footnotes', 'footnote-section' ],


### PR DESCRIPTION
Fixes it for future posts/messages; you have to edit/re-save for the fix to take effect.

Was caused by a missing style in the HTML sanitizer.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207234738980304) by [Unito](https://www.unito.io)
