### PR TITLE
[EA] Fix for analytics custom date range modal closing immediately

### DIFF
--- a/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
+++ b/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
@@ -157,7 +157,10 @@ const ForumDropdownMultiselect = ({
             key={option}
             value={option}
             onClick={() => {
-              setAnchorEl(null);
+              // setTimeout here is a fix for a bug where clicking an option opened a dialog,
+              // and then the LWClickAwayListener was triggered immediately, closing the dialog.
+              // I don't understand exactly why this fixes it
+              setTimeout(() => setAnchorEl(null), 0);
               onSelect?.(option);
             }}
             className={classes.menuItem}


### PR DESCRIPTION
Previously the "Custom" date range modal on the user analytics page would close as soon as it is opened. I believe this was introduced recently because I was testing it the other day (for https://github.com/ForumMagnum/ForumMagnum/pull/9156), I think it was probably a side effect of the upgrade to React 18, specifically the vendoring of ClickAwayListener.

I don't understand the underlying cause here, I've made a [ticket](https://app.asana.com/0/628521446211730/1207255671655403/f) to look into that and see if we can find similar problems elsewhere. I checked a few obvious cases of dropdowns opening modals and didn't find anything similar.

Update: this appears to be part of a broader class of bug, although this does fix this specific case so I think it's worth merging still

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207256488985880) by [Unito](https://www.unito.io)
