### PR TITLE
Fix LW splash art positioning

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -140,6 +140,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: '57vw',
     maxWidth: '1000px',
     top: '-57px',
+    right: '-334px',
     '-webkit-mask-image': `radial-gradient(ellipse at center top, ${theme.palette.text.alwaysBlack} 55%, transparent 70%)`,
     
     [theme.breakpoints.up(2000)]: {

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -151,7 +151,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: '79vh',
     objectFit: 'cover',
     transform: 'scaleX(-1)',
-    '-webkit-mask-image': `radial-gradient(ellipse at center center, ${theme.palette.text.alwaysBlack} 53%, transparent 70%)`
+    '-webkit-mask-image': `radial-gradient(ellipse at center center, ${theme.palette.text.alwaysBlack} 53%, transparent 70%)`,
+    zIndex: -2,
+    position: 'relative',
   },
   bannerText: {
     ...theme.typography.postStyle,
@@ -160,9 +162,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
     ['@media(max-width: 1325px)']: {
       width: 200
-    },
-    ['@media(max-width: 1275px)']: {
-      width: 150
     },
     ['@media(max-width: 1200px)']: {
       display: "none"
@@ -193,7 +192,13 @@ const styles = (theme: ThemeType): JssStyles => ({
       fontSize: '18px',
       margin: 0,
       lineHeight: '1.2',
-      marginBottom: 14
+      marginBottom: 14,
+      textShadow: `
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}
+      `,
     },
     '& button': {
       ...theme.typography.commentStyle,
@@ -224,6 +229,15 @@ const styles = (theme: ThemeType): JssStyles => ({
     '& p': {
       margin: 4
     }
+  },
+  backgroundGradient: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    height: '100vh',
+    width: '50vw',
+    background: `linear-gradient(to top, ${theme.palette.background.default} 230px, transparent calc(230px + 30%))`,
+    zIndex: -1,
   },
   lessOnlineBannerDateAndLocation: {
     ...theme.typography.commentStyle,
@@ -569,6 +583,7 @@ const Layout = ({currentUser, children, classes}: {
                           Ticket prices raise $100 on May 13th                       
                         </div>
                       </div>
+                      <div className={classes.backgroundGradient}/>
                     </div> 
                     : 
                       (standaloneNavigation && <div className={classes.imageColumn}>

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -127,10 +127,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   imageColumn: {
-    gridArea: 'imageGap',
-    position: 'relative',
+    position: 'absolute',
+    top: 0,
+    right: 0,
     height: "100vh",
-    ['@media(max-width: 1375px)']: {
+    ['@media(max-width: 1000px)']: {
       display: 'none'
     },
   },
@@ -138,7 +139,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     position: 'absolute',
     width: '57vw',
     maxWidth: '1000px',
-    top: '-140px',
+    top: '-57px',
     '-webkit-mask-image': `radial-gradient(ellipse at center top, ${theme.palette.text.alwaysBlack} 55%, transparent 70%)`,
     
     [theme.breakpoints.up(2000)]: {
@@ -154,15 +155,21 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   bannerText: {
     ...theme.typography.postStyle,
+    ['@media(max-width: 1375px)']: {
+      width: 250
+    },
+    ['@media(max-width: 1325px)']: {
+      width: 200
+    },
+    ['@media(max-width: 1275px)']: {
+      width: 150
+    },
+    ['@media(max-width: 1200px)']: {
+      display: "none"
+    },
     position: 'absolute',
     right: 16,
-    bottom: 140,
-    textShadow: `
-      0 0 20px ${theme.palette.background.pageActiveAreaBackground}, 
-      0 0 100px ${theme.palette.background.pageActiveAreaBackground}, 
-      0 0 5px ${theme.palette.background.pageActiveAreaBackground}, 
-      0 0 50px ${theme.palette.background.pageActiveAreaBackground}
-    `,
+    bottom: 79,
     color: theme.palette.grey[900],
     textAlign: 'right',
     width: '300px',
@@ -172,6 +179,12 @@ const styles = (theme: ThemeType): JssStyles => ({
       fontWeight: 600,
       marginTop: 20,
       marginBottom: 10,
+      textShadow: `
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}, 
+        0 0 15px ${theme.palette.background.pageActiveAreaBackground}
+      `,
       '& a:hover': {
         opacity: 1
       }
@@ -549,7 +562,7 @@ const Layout = ({currentUser, children, classes}: {
                       <div className={classes.bannerText}>
                         <h2><a href="http://less.online">Fooming Shoggoths Dance Concert</a></h2>
                         <h3>June 1st at LessOnline</h3>
-                        <p>After their debut album <Link to="/posts/YMo5PuXnZDwRjhHhE/lesswrong-s-first-album-i-have-been-a-good-bing"><b>I Have Been A Good Bing</b></Link>, the Fooming Shoggoths are performing at the LessOnline festival. They'll be unveiling several previously unpublished tracks, such as<br/> "Nothing is Mere", feat. Richard Feynman.</p>
+                        <p>After their debut album <Link to="/posts/YMo5PuXnZDwRjhHhE/lesswrong-s-first-album-i-have-been-a-good-bing"><b>I Have Been A Good Bing</b></Link>, the Fooming Shoggoths are performing at the LessOnline festival. They'll be unveiling several previously unpublished tracks, such as "Nothing is Mere", feat. Richard Feynman.</p>
                         <a href="http://less.online/#tickets-section"><button>Buy Ticket</button></a>
 
                         <div className={classes.ticketPricesRaise}>


### PR DESCRIPTION
The splash art on the frontpage was previously limited by the existence of the image column. (i.e. people with slightly smaller screens or slightly lower resolution wouldn't see the image, at a screen size where there should clearly still be some image visible)

This PR changes the image to not use the image column. I think this probably means the image column is no longer in use. I'm not using the image column in my spotlights PR and don't think we really need it, so maybe should completely remove it, but I wasn't sure about all the ramifications.

Previous image:
<img width="1701" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/9e53c21b-5229-4f6e-8ad7-23d097e1b1ac">

Now:
<img width="1702" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/7e2ab1e0-5dbd-4efc-b0ca-d613101822ef">

Text appears as small as this:
<img width="1327" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/4ef5fda9-9c37-4dca-b25d-8f81f6b0c010">

Image continues to render as small as this:
<img width="1109" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/47564ab0-892a-49ce-bcf2-3b429a79d939">

At extremely wide/short screens there was some overlap so I added a gradient overlay:
<img width="1728" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/099912fb-77a5-43e0-aada-9cf31bf088dc">

I made sure the All Post image was still visible:
<img width="1723" alt="image" src="https://github.com/ForumMagnum/ForumMagnum/assets/3246710/964db1e8-6c27-4064-bae8-df25907925da">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207261332771859) by [Unito](https://www.unito.io)
