### PR TITLE
[EA] Link to user profiles in react notifications

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
@@ -16,6 +16,7 @@ import {
   getEAPublicEmojiByName,
 } from "../../../lib/voting/eaEmojiPalette";
 import { captureException } from "@sentry/core";
+import { userGetProfileUrlFromSlug } from "../../../lib/collections/users/helpers";
 
 const logAndCaptureError = (error: Error) => {
   // eslint-disable-next-line no-console
@@ -38,7 +39,7 @@ const styles = (theme: ThemeType) => ({
 
 type ReactionUsers = {
   emoji: EmojiOption,
-  users: string[],
+  users: {displayName: string, slug: string}[],
   userCount?: never,
 } | {
   emoji: EmojiOption,
@@ -48,20 +49,33 @@ type ReactionUsers = {
 
 type AddedReactions = {
   emoji: EmojiOption,
-  users: string,
+  users: ReactNode,
   tooltip?: string,
 }
 
-const formatUsersText = (names: string[], max = 3) => {
-  if (names.length < 2) {
-    return names[0];
+// Helper function to create a Link component for a user
+const userLink = (user: {displayName: string, slug: string}) => (
+  <Link to={userGetProfileUrlFromSlug(user.slug)}>{user.displayName}</Link>
+);
+
+const formatUsers = (users: {displayName: string, slug: string}[], max = 3) => {
+  const userLinks = users.map(user => userLink(user));
+
+  if (userLinks.length < 2) {
+    return userLinks[0];
   }
-  if (names.length <= max) {
-    return names.slice(0, -1).join(", ") + " and " + names[names.length - 1];
-  }
-  const shownNames = names.slice(0, max).join(", ");
-  const remainder = names.length - max;
-  return `${shownNames} and ${remainder} more`;
+
+  // Join all but the last with commas, and add "and" before the last user or "and X more" if over 'max'
+  const displayedUserLinks = userLinks.slice(0, Math.min(max, userLinks.length - 1));
+  const lastUserOrCount = userLinks.length <= max ? userLinks[userLinks.length - 1] : `${userLinks.length - max} more`;
+
+  return (
+    <>
+      {displayedUserLinks.reduce((acc, elem) => (acc === null ? [elem] : [...acc, ', ', elem]), null)}
+      {' and '}
+      {lastUserOrCount}
+    </>
+  );
 }
 
 const getAddedReactions = (addedReactions?: EAReactionChanges): AddedReactions[] => {
@@ -87,7 +101,7 @@ const getAddedReactions = (addedReactions?: EAReactionChanges): AddedReactions[]
       if (emoji) {
         emojis[reactionType] = {
           emoji,
-          users: change.map(({displayName}) => displayName),
+          users: change.map(({displayName, slug}) => ({ displayName, slug })),
         };
       } else {
         // eslint-disable-next-line no-console
@@ -98,12 +112,14 @@ const getAddedReactions = (addedReactions?: EAReactionChanges): AddedReactions[]
   return Object.values(emojis).map(({emoji, users = [], userCount}) => {
     return {
       emoji,
-      users: users.length
-        ? formatUsersText(users)
-        : `${userCount} ${userCount === 1 ? "person" : "people"}`,
-      tooltip: users.length > 1
-        ? `${users.slice(0, -1).join(", ")} and ${users[users.length - 1]}`
-        : users[0],
+      users: users.length ? formatUsers(users) : `${userCount} ${userCount === 1 ? "person" : "people"}`,
+      tooltip:
+        users.length > 1
+          ? `${users
+              .slice(0, -1)
+              .map(({ displayName }) => displayName)
+              .join(", ")} and ${users[users.length - 1].displayName}`
+          : users[0]?.displayName,
     };
   });
 }

--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
@@ -53,7 +53,6 @@ type AddedReactions = {
   tooltip?: string,
 }
 
-// Helper function to create a Link component for a user
 const userLink = (user: {displayName: string, slug: string}) => (
   <Link to={userGetProfileUrlFromSlug(user.slug)}>{user.displayName}</Link>
 );

--- a/packages/lesswrong/lib/collections/users/karmaChangesGraphQL.ts
+++ b/packages/lesswrong/lib/collections/users/karmaChangesGraphQL.ts
@@ -86,7 +86,7 @@ export type ReactionChange = {
   userId?: string
 }
 
-export type EAReactionChange = number | {_id: string, displayName: string}[];
+export type EAReactionChange = number | {_id: string, displayName: string, slug: string}[];
 
 export type EAReactionChanges = Record<string, EAReactionChange>;
 

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -311,7 +311,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     const {publicEmojis, privateEmojis} = getEAEmojisForKarmaChanges(showNegative);
     const publicSelectors = publicEmojis.map((emoji) =>
       `'${emoji}', ARRAY_AGG(
-        DISTINCT JSONB_BUILD_OBJECT('_id', v."userId", 'displayName', u."displayName")
+        DISTINCT JSONB_BUILD_OBJECT('_id', v."userId", 'displayName', u."displayName", 'slug', u."slug")
       ) FILTER (WHERE
         v."cancelled" IS NOT TRUE AND
         v."isUnvote" IS NOT TRUE AND


### PR DESCRIPTION
We get the user display names here directly from a SQL query, which means we don't have the fields usually given by `UsersMinimumInfo`. Presumably this is why these weren't links in the first place.

I have added the user slug to the returned value, and made the names regular `Link`s to the user profile. This isn't ideal as it doesn't use `UsersNameDisplay` so this could introduce inconsistencies in future, also the user tooltip doesn't show on hover whereas it does for other notification types.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207265877686661) by [Unito](https://www.unito.io)
