### PR TITLE
More emoji banner tweaks

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
@@ -11,6 +11,7 @@ import { gql, useMutation, useQuery } from "@apollo/client";
 import ForumNoSSR from "../common/ForumNoSSR";
 import classNames from "classnames";
 import { siteUrlSetting } from "../../lib/instanceSettings";
+import { useMessages } from "../common/withMessages";
 
 if (isClient) {
   require("emoji-picker-element");
@@ -519,6 +520,7 @@ export const EAEmojisHeader = ({classes}: {
   const [insertEmoji, setInsertEmoji] = useState("👍");
   const [hoverPos, setHoverPos] = useState<Point | null>(null);
   const [insertPos, setInsertPos] = useState<Point | null>(null);
+  const {flash} = useMessages();
   const {captureEvent} = useTracking();
   const ref = useRef<HTMLDivElement>(null);
 
@@ -607,6 +609,10 @@ export const EAEmojisHeader = ({classes}: {
       onLogin();
       return;
     }
+    if (currentUser.banned || !currentUser.reviewedByUserId) {
+      flash("Only approved users can add emojis to the banner");
+      return;
+    }
     if (isValidTarget(target, clientX, clientY)) {
       const coords = normalizeCoords(clientX, clientY);
       if (coords) {
@@ -614,7 +620,7 @@ export const EAEmojisHeader = ({classes}: {
         setHoverPos(null);
       }
     }
-  }, [captureEvent, currentUser, onLogin, normalizeCoords]);
+  }, [captureEvent, flash, currentUser, onLogin, normalizeCoords]);
 
   const onCancelInsert = useCallback(() => setInsertPos(null), []);
 

--- a/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
@@ -172,7 +172,7 @@ const emojisQuery = gql`
   query BannerEmojis {
     BannerEmojis {
       id
-      userId
+      isCurrentUser
       displayName
       emoji
       link
@@ -202,7 +202,7 @@ const addEmojiMutation = gql`
       theta: $theta
     ) {
       id
-      userId
+      isCurrentUser
       displayName
       emoji
       x
@@ -216,7 +216,7 @@ const removeEmojiMutation = gql`
   mutation RemoveBannerEmoji($id: String!) {
     RemoveBannerEmoji(id: $id) {
       id
-      userId
+      isCurrentUser
       displayName
       emoji
       link
@@ -230,8 +230,8 @@ const removeEmojiMutation = gql`
 
 export type BannerEmoji = {
   id: string,
-  userId: string,
   displayName: string,
+  isCurrentUser: boolean,
   emoji: string,
   x: number,
   y: number,
@@ -323,11 +323,10 @@ const Emoji: FC<{
   emoji: BannerEmoji,
   children?: ReactNode,
 }> = ({
-  emoji: {id, userId, displayName, link, description, x, y, theta, emoji},
+  emoji: {id, isCurrentUser, displayName, link, description, x, y, theta, emoji},
   children,
 }) => {
   const {currentUser, removeEmoji, classes} = useEmojiContext();
-  const isCurrentUser = userId === currentUser?._id;
   const canModerate = isCurrentUser || userIsAdminOrMod(currentUser);
   const isPlaceholder = !displayName;
   const canRemove = canModerate && !isPlaceholder;
@@ -388,7 +387,7 @@ const EmojiPlaceholder: FC<{hoverPos: Point}> = ({hoverPos}) => {
     <Emoji emoji={{
       id: "",
       displayName: "",
-      userId: "",
+      isCurrentUser: false,
       theta: 0,
       emoji: "",
       link: "",
@@ -499,7 +498,7 @@ const AddEmoji: FC<{insertPos: Point}> = ({insertPos}) => {
       <Emoji emoji={{
         id: "",
         displayName: "",
-        userId: "",
+        isCurrentUser: false,
         theta: 0,
         emoji: insertEmoji,
         link: "",

--- a/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
+++ b/packages/lesswrong/components/ea-forum/EAEmojisHeader.tsx
@@ -17,13 +17,15 @@ if (isClient) {
   require("emoji-picker-element");
 }
 
+const LEFT_MARGIN = 350;
+
 const styles = (theme: ThemeType) => ({
   root: {
     zIndex: 1,
     position: "absolute",
-    left: 0,
+    left: LEFT_MARGIN,
     right: 0,
-    width: "100%",
+    width: `calc(100% - ${LEFT_MARGIN}px)`,
     height: "100%",
     overflow: "hidden",
     [theme.breakpoints.down("sm")]: {
@@ -149,7 +151,7 @@ const isValidTarget = (
     return false;
   }
 
-  clientX += window.scrollX;
+  clientX += window.scrollX - LEFT_MARGIN;
   clientY += window.scrollY;
 
   const startPadding = 25;
@@ -552,7 +554,7 @@ export const EAEmojisHeader = ({classes}: {
         clientY < bounds.bottom
       ) {
         return {
-          x: clientX / bounds.width,
+          x: (clientX - LEFT_MARGIN) / bounds.width,
           y: clientY / bounds.height,
         };
       }
@@ -600,10 +602,10 @@ export const EAEmojisHeader = ({classes}: {
   }, []);
 
   const onClick = useCallback(async ({target, clientX, clientY}: MouseEvent) => {
-    captureEvent("emojiBannerClick", {clientX, clientY});
     if ("tagName" in target && target.tagName === "A") {
       return;
     }
+    captureEvent("emojiBannerClick", {clientX, clientY});
     if (!currentUser) {
       onLogin();
       return;

--- a/packages/lesswrong/server/resolvers/eventEmojiResolvers.ts
+++ b/packages/lesswrong/server/resolvers/eventEmojiResolvers.ts
@@ -10,7 +10,7 @@ import { userIsAdminOrMod } from "../../lib/vulcan-users";
 addGraphQLSchema(`
   type BannerEmoji {
     id: String!
-    userId: String!
+    isCurrentUser: Boolean!
     displayName: String!
     emoji: String!
     link: String!
@@ -30,8 +30,9 @@ const bannerEmojiResolvers = {
     BannerEmojis: (
       _root: void,
       _: {},
-      {repos}: ResolverContext,
-    ): Promise<BannerEmoji[]> => repos.databaseMetadata.getBannerEmojis(),
+      {repos, currentUser}: ResolverContext,
+    ): Promise<BannerEmoji[]> =>
+      repos.databaseMetadata.getBannerEmojis(currentUser?._id),
   },
   Mutation: {
     AddBannerEmoji: async (

--- a/packages/lesswrong/server/resolvers/eventEmojiResolvers.ts
+++ b/packages/lesswrong/server/resolvers/eventEmojiResolvers.ts
@@ -46,7 +46,7 @@ const bannerEmojiResolvers = {
       },
       {currentUser, repos}: ResolverContext,
     ): Promise<BannerEmoji[]> => {
-      if (!currentUser) {
+      if (!currentUser || currentUser.banned || !currentUser.reviewedByUserId) {
         throw new Error("Permission denied");
       }
       if (!simpleEmojiRegex.test(emoji) && !complexEmojiRegex.test(emoji)) {


### PR DESCRIPTION
- Only approved users can add emojis to the banner
- Emojis are anonymous
  - This is slightly tricky because the code we borrowed from the banner in December uses the `displayName` to distinguish between the emoji that's being added client side and the pre-existing emojis returned by the server. For the sake of a quick fix, there's still a `displayName` field on the emojis returned from the server, but the name is always "a".
- Add a left margin so emojis can't be added underneath the text

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207275352966753) by [Unito](https://www.unito.io)
