### PR TITLE
Fix error in PresenceList when logged-out (link-sharing) users are connected

### DIFF
--- a/packages/lesswrong/components/editor/PresenceList.tsx
+++ b/packages/lesswrong/components/editor/PresenceList.tsx
@@ -54,24 +54,39 @@ const PresenceList = ({connectedUsers, alwaysShownUserIds, classes}: {
     ? alwaysShownUserIds.filter(userId => !connectedUsersById[userId])
     : [];
 
+  console.log(`connectedUsers: ${JSON.stringify(connectedUsers)}`)
   return <div>
-    {connectedUsers.map(u => <PresenceListUser key={u._id} connected={true} userId={u._id} classes={classes}/>)}
-    {disconnectedUserIds.map(userId => <PresenceListUser key={userId} connected={false} userId={userId} classes={classes}/>)}
+    {connectedUsers.map(u => <PresenceListUser
+      key={u._id}
+      connected={true}
+      userId={u._id}
+      isLoggedOutUser={u.name==="Anonymous"}
+      classes={classes}
+    />)}
+    {disconnectedUserIds.map(userId => <PresenceListUser
+      key={userId}
+      connected={false}
+      userId={userId}
+      isLoggedOutUser={false}
+      classes={classes}
+    />)}
   </div>
 }
 
-const PresenceListUser = ({userId, connected, classes}: {
+const PresenceListUser = ({userId, isLoggedOutUser, connected, classes}: {
   userId: string,
+  isLoggedOutUser: boolean,
   connected: boolean,
   classes: ClassesType,
 }) => {
-  const { document: user } = useSingle({
+  const { document: user, loading } = useSingle({
     collectionName: "Users",
     fragmentName: "UsersMinimumInfo",
-    documentId: userId
+    documentId: userId,
+    skip: isLoggedOutUser,
   });
 
-  if (!user) {
+  if (loading) {
     return <span/>
   }
   return <span className={classNames(classes.user, {
@@ -81,7 +96,8 @@ const PresenceListUser = ({userId, connected, classes}: {
     <div className={classes.activeDot}>
     </div>
     <span className={classes.offlineIcon}>{!connected && <CloudOff/>}</span>
-    <Components.UsersName user={user}/>
+    {user && <Components.UsersName user={user}/>}
+    {isLoggedOutUser && <>Anonymous</>}
   </span>
 }
 

--- a/packages/lesswrong/components/editor/PresenceList.tsx
+++ b/packages/lesswrong/components/editor/PresenceList.tsx
@@ -54,7 +54,6 @@ const PresenceList = ({connectedUsers, alwaysShownUserIds, classes}: {
     ? alwaysShownUserIds.filter(userId => !connectedUsersById[userId])
     : [];
 
-  console.log(`connectedUsers: ${JSON.stringify(connectedUsers)}`)
   return <div>
     {connectedUsers.map(u => <PresenceListUser
       key={u._id}


### PR DESCRIPTION
When link sharing is enabled, logged-out users can connect to collaborative editing sessions. When this happens, for CkEditor cloud purposes, they get a random ID in place of a user ID. In the presence list, we were taking that random ID and trying to look it up as though it was a user ID, resulting in a lot of console errors, and anonymous users not being shown in the presence-list indicator.

This change handles anon users in the presence list properly; they now show up in the presence list when connected, and don't produce console/Sentry errors.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207279756421270) by [Unito](https://www.unito.io)
