### PR TITLE
Fix collab-editor crash with realtimecollaborationclient-editor-setdata-and-editor-data-set-are-forbidden-in-real-time-collaboration

### DIFF
--- a/packages/lesswrong/components/editor/CKCommentEditor.tsx
+++ b/packages/lesswrong/components/editor/CKCommentEditor.tsx
@@ -69,6 +69,7 @@ const CKCommentEditor = ({
         ...cloudinaryConfig,
       }}
       data={data}
+      isCollaborative={false}
     />
   </div>
 }

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -495,6 +495,7 @@ const CKPostEditor = ({
       onFocus={onFocus}
       editor={isCollaborative ? PostEditorCollaboration : PostEditor}
       data={data}
+      isCollaborative={!!isCollaborative}
       onInit={(editor: Editor) => {
         if (isCollaborative) {
           // Uncomment this line and the import above to activate the CKEditor debugger

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -21,6 +21,7 @@ import isEqual from 'lodash/isEqual';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useCallbackDebugRerenders } from '../hooks/useCallbackDebugRerenders';
 import { useDebouncedCallback, useStabilizedCallback } from '../hooks/useDebouncedCallback';
+import { useMessages } from '../common/withMessages';
 
 const autosaveInterval = 3000; //milliseconds
 const remoteAutosaveInterval = 1000 * 60 * 5; // 5 minutes in milliseconds
@@ -63,6 +64,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   const { commentEditor, collectionName, hideControls } = (form || {});
   const { editorHintText, maxHeight } = (formProps || {});
   const { updateCurrentValues, submitForm } = context;
+  const { flash } = useMessages()
   const currentUser = useCurrentUser();
   const editorRef = useRef<Editor|null>(null);
   const hasUnsavedDataRef = useRef({hasUnsavedData: false});
@@ -339,8 +341,13 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   }, [fieldName, hasUnsavedDataRef]);
   
   const onRestoreLocalStorage = useCallback((newState: EditorContents) => {
-    wrappedSetContents({contents: newState, autosave: false});
-    // TODO: Focus editor
+    if (isCollabEditor) {
+      // If in collab editing mode, we can't edit the editor contents.
+      flash("Restoring from local storage is not supported in the collaborative editor. Use the Version History button to restore old versions.");
+    } else {
+      wrappedSetContents({contents: newState, autosave: false});
+      // TODO: Focus editor
+    }
   }, [wrappedSetContents]);
   
   useEffect(() => {

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -348,7 +348,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
       wrappedSetContents({contents: newState, autosave: false});
       // TODO: Focus editor
     }
-  }, [wrappedSetContents]);
+  }, [wrappedSetContents, flash, isCollabEditor]);
   
   useEffect(() => {
     if (editorRef.current) {

--- a/packages/lesswrong/components/editor/ReactCKEditor.tsx
+++ b/packages/lesswrong/components/editor/ReactCKEditor.tsx
@@ -17,6 +17,7 @@ interface CKEditorProps {
   onFocus?: (event: AnyBecauseTodo, editor: AnyBecauseTodo) => void,
   onBlur?: any,
   config?: any,
+  isCollaborative: boolean,
 }
 
 // Copied from and modified: https://github.com/ckeditor/ckeditor5-react/blob/master/src/ckeditor.jsx
@@ -43,7 +44,22 @@ export default class CKEditor extends React.Component<CKEditorProps,{}> {
     }
     
     if ( this._shouldUpdateContent( nextProps ) ) {
-      this.editor.setData( nextProps.data );
+      if (!this.props.isCollaborative) {
+        // HACK: In collaborative editing mode, ignore prop changes to `data`.
+        // In collab editing mode, that will crash the editor with
+        //   `realtimecollaborationclient-editor-setdata-and-editor-data-set-are-forbidden-in-real-time-collaboration`
+        //
+        // In theory, the `data` prop getting passed around and the document
+        // state inside the editor are supposed to be kept in sync. In practice,
+        // due to debouncing and subtleties of render timing, there are race
+        // conditions/corner cases where they aren't.
+        //
+        // This means that changing the editor contents from outside the editor
+        // won't work (eg, clearing the input, restoring from local storage). In
+        // practice, scenarios where this is supposed to happen don't overlap
+        // much with scenarios where this is in collaborative editing mode.
+        this.editor.setData( nextProps.data );
+      }
     }
     
     if ( 'disabled' in nextProps ) {


### PR DESCRIPTION
Hackily fix a crash in the CkEditor collaborative editor, which happens in a race-condition-like circumstance of some sort.

This works very hackily, by making the `ReactCKEditorWrapper` ignore downward-flowing changes to its `data` prop, if collaborative editing is enabled. This means that changes to the contents of the editor can't be initiated from outside the editor. It turns out that cases where collab-editing is enabled, and cases where we need to edit the editor contents from outside, don't overlap very much, so this should be ok.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207280033327637) by [Unito](https://www.unito.io)
