### PR TITLE
Fix bundle/stylesheet preload for AF-to-LW crossposts

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -63,14 +63,16 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   }
 
   async postRouteWillDefinitelyReturn200(id: string): Promise<boolean> {
+    const maybeRequireAF = isAF ? "AND af=true" : ""
     const res = await this.getRawDb().oneOrNone<{exists: boolean}>(`
       -- PostsRepo.postRouteWillDefinitelyReturn200
       SELECT EXISTS(
         SELECT 1
         FROM "Posts"
-        WHERE "_id" = $1 AND ${getViewablePostsSelector()} AND "af" = $2
+        WHERE "_id" = $1 AND ${getViewablePostsSelector()}
+        ${maybeRequireAF}
       )
-    `, [id, isAF]);
+    `, [id]);
 
     return res?.exists ?? false;
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -63,7 +63,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   }
 
   async postRouteWillDefinitelyReturn200(id: string): Promise<boolean> {
-    const maybeRequireAF = isAF ? "AND af=true" : ""
+    const maybeRequireAF = isAF ? "AND af IS TRUE" : ""
     const res = await this.getRawDb().oneOrNone<{exists: boolean}>(`
       -- PostsRepo.postRouteWillDefinitelyReturn200
       SELECT EXISTS(


### PR DESCRIPTION
When we start loading a post page, before we start rendering it in an SSR, we sometimes send the part of the header that tells the client to start downloading the stylesheet and javascript bundle. Before we can send that, we need to be sure the request is going to result in an http 200 (ie, not a 404 or a redirect). This is handled by `PostsRepo.postRouteWillDefinitelyReturn200`. However, this handled the AF flag incorrectly; rather than checking whether the user is loading a non-AF post on AF (which would trigger a redirect), it checks whether the user is loading an AF post (which can happen on either LW or AF, and will not trigger a redirect). This meant that AF posts didn't get the bundle/stylesheet preload, making them slower.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207293488263033) by [Unito](https://www.unito.io)
