### PR TITLE
Fix SSR mismatch/rerender if 90-days-ago crosses a DST boundary

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -128,7 +128,7 @@ const HomeLatestPosts = ({classes}: {classes: ClassesType}) => {
   const limit = parseInt(query.limit) || defaultLimit;
 
   const now = useCurrentTime();
-  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get(), 'days').startOf('hour').toISOString()
+  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get()*24, 'hours').startOf('hour').toISOString()
 
   const recentPostsTerms = {
     ...query,

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -332,7 +332,8 @@ const LWHomePosts = ({children, classes}: {
   }
 
   const limit = parseInt(query.limit) || defaultLimit;
-  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get(), 'days').startOf('hour').toISOString();
+  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get()*24, 'hours').startOf('hour').toISOString();
+  console.log(dateCutoff);
 
   const recentPostsTerms = {
     ...query,

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -333,7 +333,6 @@ const LWHomePosts = ({children, classes}: {
 
   const limit = parseInt(query.limit) || defaultLimit;
   const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get()*24, 'hours').startOf('hour').toISOString();
-  console.log(dateCutoff);
 
   const recentPostsTerms = {
     ...query,

--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -33,7 +33,7 @@ const EAHomeCommunityPosts = ({classes}: {classes: ClassesType}) => {
   const now = useCurrentTime();
   const {filterSettings: userFilterSettings} = useFilterSettings()
 
-  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get(), 'days').startOf('hour').toISOString()
+  const dateCutoff = moment(now).subtract(frontpageDaysAgoCutoffSetting.get()*24, 'hours').startOf('hour').toISOString()
 
   const recentPostsTerms = {
     view: "magic",

--- a/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
+++ b/packages/lesswrong/components/ea-forum/TargetedJobAd.tsx
@@ -9,6 +9,7 @@ import OpenInNew from '@material-ui/icons/OpenInNew';
 import moment from 'moment';
 import { Link } from '../../lib/reactRouterWrapper';
 import { CareerStageValue } from '../../lib/collections/users/schema';
+import { useCurrentTime } from '../../lib/utils/timeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -319,6 +320,7 @@ const TargetedJobAd = ({jobName, userJobAd, onDismiss, onApply, onRemindMe, clas
   classes: ClassesType<typeof styles>,
 }) => {
   const adData = JOB_AD_DATA[jobName]
+  const now = useCurrentTime();
   
   const { HoverPreviewLink, LWTooltip, ForumIcon, EAButton } = Components
   
@@ -328,7 +330,7 @@ const TargetedJobAd = ({jobName, userJobAd, onDismiss, onApply, onRemindMe, clas
   
   // Only show the "Remind me" button if the job's deadline is more than 3 days away
   // and the current user hasn't already set a reminder for this job.
-  const showRemindMe = adData.deadline && moment().add(3, 'days').isBefore(adData.deadline) && !userJobAd?.reminderSetAt
+  const showRemindMe = adData.deadline && moment(now).add(3*24, 'hours').isBefore(adData.deadline) && !userJobAd?.reminderSetAt
   
   return <AnalyticsContext pageSubSectionContext="targetedJobAd">
     <div className={classes.root}>

--- a/packages/lesswrong/components/hooks/useRecentOpportunities.ts
+++ b/packages/lesswrong/components/hooks/useRecentOpportunities.ts
@@ -51,7 +51,7 @@ export const useRecentOpportunities =<
   }));
 
   const now = useCurrentTime();
-  const dateCutoff = moment(now).subtract(maxAgeInDays, "days").startOf('hour').toISOString();
+  const dateCutoff = moment(now).subtract(maxAgeInDays*24, "hours").startOf('hour').toISOString();
   const { results, ...useMultiResult } = useMulti<FragmentTypeName, "Posts">({
     collectionName: "Posts",
     terms: {

--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -111,7 +111,7 @@ const PostsItemDate = ({post, noStyles, includeAgo, useCuratedDate, emphasizeIfN
     ? <span className={classes.xsHide}>&nbsp;ago</span>
     : null;
 
-  const isEmphasized = emphasizeIfNew && moment(now).diff(post.postedAt, 'days') < 2;
+  const isEmphasized = emphasizeIfNew && moment(now).diff(post.postedAt, 'hours') < 48;
 
   const dateElement = (
     <PostsItem2MetaInfo className={classNames(classes.postedAt, {[classes.isNew]: isEmphasized})}>

--- a/packages/lesswrong/components/posts/PostsTimeframeListExponential.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeListExponential.tsx
@@ -34,39 +34,39 @@ const PostsTimeframeListExponential = ({postListParameters, classes}: {
   const timeframes: TimeBlockRange[] = [
     // Today and Yesterday
     {
-      after: moment(now).add(-1,'d').startOf('day'),
+      after: moment(now).add(-24,'hours').startOf('day'),
       before: moment(now).endOf('day'),
       timeframe: "daily",
       getTitle: (size) => preferredHeadingCase("Today and Yesterday"),
     },
     // Past week
     {
-      after: moment(now).add(-7,'d').startOf('day'),
-      before: moment(now).add(-1,'d').startOf('day'),
+      after: moment(now).add(-7*24,'hours').startOf('day'),
+      before: moment(now).add(-24,'hours').startOf('day'),
       timeframe: "weekly",
       getTitle: (size) => preferredHeadingCase("Past week"),
     },
     // Past two weeks
     {
-      after: moment(now).add(-14,'d').startOf('day'),
-      before: moment(now).add(-7,'d').startOf('day'),
+      after: moment(now).add(-14*24,'hours').startOf('day'),
+      before: moment(now).add(-7*24,'hours').startOf('day'),
       timeframe: "weekly",
       getTitle: (size) => preferredHeadingCase("Past 14 days"),
     },
     // Past month
     {
-      after: moment(now).add(-31,'d').startOf('day'),
-      before: moment(now).add(-14,'d').startOf('day'),
+      after: moment(now).add(-31*24,'hours').startOf('day'),
+      before: moment(now).add(-14*24,'hours').startOf('day'),
       timeframe: "monthly",
       getTitle: (size) => preferredHeadingCase("Past 31 days"),
     }
   ];
   
   // Past two months, round to earlier month boundary
-  const roundedMonthStart = moment(now).add(-31,'d').startOf('month').add(-1,'M');
+  const roundedMonthStart = moment(now).add(-31*24,'hours').startOf('month').add(-1,'M');
   timeframes.push({
     after: roundedMonthStart,
-    before: moment(now).add(-31,'d').startOf('day'),
+    before: moment(now).add(-31*24,'hours').startOf('day'),
     timeframe: "monthly",
     // Not calling preferredHeadingCase because month names are always capitalized
     getTitle: (size) => `Since ${roundedMonthStart.format("MMMM Do")}`,

--- a/packages/lesswrong/components/recommendations/CuratedPostsList.tsx
+++ b/packages/lesswrong/components/recommendations/CuratedPostsList.tsx
@@ -10,7 +10,7 @@ const CuratedPostsList = ({overrideLimit}: {overrideLimit?: number}) => {
   const currentCuratedPostCount = useCurrentCuratedPostCount();
   const now = useCurrentTime();
 
-  const fiveDaysAgo = moment(now).subtract(5, 'days').startOf("hour").toISOString();
+  const fiveDaysAgo = moment(now).subtract(5*24, 'hours').startOf("hour").toISOString();
 
   return (
     <AnalyticsContext listContext="curatedPosts" pageSubSectionContext="curatedPosts">

--- a/packages/lesswrong/components/recommendations/RecommendationsSamplePage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsSamplePage.tsx
@@ -99,8 +99,8 @@ const RecommendationsSamplePage = ({classes}: {
   const {results, loading, loadMoreProps} = useMulti({
     terms: {
       after: moment(now).subtract(
-        frontpageDaysAgoCutoffSetting.get(),
-        "days",
+        frontpageDaysAgoCutoffSetting.get()*24,
+        "hours",
       ).startOf("hour").toISOString(),
       view: "magic",
       forum: true,

--- a/packages/lesswrong/components/recommendations/WelcomePostItem.tsx
+++ b/packages/lesswrong/components/recommendations/WelcomePostItem.tsx
@@ -5,9 +5,11 @@ import { useCurrentUser } from "../common/withUser";
 import { useItemsRead } from "../hooks/useRecordPostView";
 import moment from "moment";
 import { useDisplayedPost } from "../posts/usePost";
+import { useCurrentTime } from "../../lib/utils/timeUtil";
 
 const WelcomePostItem = () => {
   const currentUser = useCurrentUser();
+  const now = useCurrentTime();
   const welcomePostId = aboutPostIdSetting.get();
 
   const { document: post } = useDisplayedPost(welcomePostId, null);
@@ -23,7 +25,7 @@ const WelcomePostItem = () => {
     return null;
   }
 
-  const userAgeInDays = currentUser ? moment().diff(moment(currentUser.createdAt), 'days') : 0;
+  const userAgeInDays = currentUser ? (moment(now).diff(moment(currentUser.createdAt), 'hours')/24) : 0;
 
   // Don't display user has read post or has been a user for more than 90 days
   if (isRead || userAgeInDays > 90) {


### PR DESCRIPTION
Question: It is May 14, 16:50, Pacific time. What time was it 90 days ago? Answer: It depends what timezone you do the computation in! If it crosses a DST boundary, this will be 90\*24+1 hours ago instead of 90*24 hours ago.

This causes the `after` filter in `LWHomePosts` to be different when the client computes it (in the client timezone) than when the server computes it (in the server timezone), which causes the post list to display, then turn blank and refresh.

This is closely related to the bug that f549fdd777700193bbf7322a3f331a77d2940934 tried to fix.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207320124740510) by [Unito](https://www.unito.io)
