### PR TITLE
Remove NOT NULL constraint for client ids

### DIFF
--- a/packages/lesswrong/lib/collections/clientIds/schema.ts
+++ b/packages/lesswrong/lib/collections/clientIds/schema.ts
@@ -4,7 +4,8 @@ const schema: SchemaType<"ClientIds"> = {
   clientId: {
     type: String,
     canRead: ['sunshineRegiment','admins'],
-    nullable: false
+    /** Not actually nullable, but attempting to add the NOT NULL constraint causes the table to lock */
+    nullable: true
   },
   firstSeenReferrer: {
     type: String,

--- a/packages/lesswrong/server/migrations/20240513T135549.set_not_null_clientId.ts
+++ b/packages/lesswrong/server/migrations/20240513T135549.set_not_null_clientId.ts
@@ -34,7 +34,7 @@ import { updateIndexes } from "./meta/utils";
  * - [ ] Uncomment `acceptsSchemaHash` below
  * - [ ] Run `yarn acceptmigrations` to update the accepted schema hash (running makemigrations again will also do this)
  */
-export const acceptsSchemaHash = "76b9efb31df58ad0051fc439e9f527dd";
+export const acceptsSchemaHash = "aa1eac5798b9679483aaff7b85ba1e8e";
 
 export const up = async ({db}: MigrationContext) => {
   await updateIndexes(ClientIds);

--- a/packages/lesswrong/server/migrations/20240513T135549.set_not_null_clientId.ts
+++ b/packages/lesswrong/server/migrations/20240513T135549.set_not_null_clientId.ts
@@ -37,10 +37,7 @@ import { updateIndexes } from "./meta/utils";
 export const acceptsSchemaHash = "76b9efb31df58ad0051fc439e9f527dd";
 
 export const up = async ({db}: MigrationContext) => {
-  await db.none(`ALTER TABLE "ClientIds" ALTER COLUMN "clientId" SET NOT NULL;`)
   await updateIndexes(ClientIds);
 }
 
-export const down = async ({db}: MigrationContext) => {
-  await db.none(`ALTER TABLE "ClientIds" ALTER COLUMN "clientId" DROP NOT NULL;`)
-}
+export const down = async ({db}: MigrationContext) => {}

--- a/schema/schema_changelog.json
+++ b/schema/schema_changelog.json
@@ -660,7 +660,7 @@
     "timestamp": "2024-05-13T11:52:14.000Z"
   },
   {
-    "acceptsSchemaHash": "76b9efb31df58ad0051fc439e9f527dd",
+    "acceptsSchemaHash": "aa1eac5798b9679483aaff7b85ba1e8e",
     "acceptedByMigration": "20240513T135549.set_not_null_clientId.ts",
     "timestamp": "2024-05-13T13:55:49.000Z"
   }


### PR DESCRIPTION
This caused a problem on prod when running the migration (see [here](https://github.com/ForumMagnum/ForumMagnum/actions/runs/9112568460/job/25052093377)). It appears `SET NOT NULL` always locks the table, I tried this [workaround](https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128) but it didn't work (possibly due to running in a transaction) so I'm giving up and removing the constraint as it isn't actually required.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207335689112253) by [Unito](https://www.unito.io)
