### PR TITLE
Add missing `act` to `useDebouncedCallback` unit test

### DIFF
--- a/packages/lesswrong/unitTests/useDebouncedCallback.tests.tsx
+++ b/packages/lesswrong/unitTests/useDebouncedCallback.tests.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import React, { useEffect, ReactElement } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { DebouncedCallbackOptions, useDebouncedCallback } from '../components/hooks/useDebouncedCallback';
@@ -87,7 +86,9 @@ describe('useDebouncedCallback', () => {
     expect(fn).toHaveBeenCalledTimes(0);
     
     // Unmount. Should cause it to be called.
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     expect(fn).toHaveBeenCalledTimes(1);
     
     // Attempt to call it. Should be blocked because allowExplicitCallAfterUnmount is false.


### PR DESCRIPTION
There's currently an ugly error message in the unit tests about this missing call to `act`. The test still passes so I'm not sure if it's actually necessary, but it seems worth it to keep the logs clean.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207345449323380) by [Unito](https://www.unito.io)
