### PR TITLE
Optional ssr metadata

### DIFF
--- a/packages/lesswrong/client/AppGenerator.tsx
+++ b/packages/lesswrong/client/AppGenerator.tsx
@@ -22,13 +22,13 @@ const AppGenerator = ({ apolloClient, foreignApolloClient, abTestGroupsUsed, the
   foreignApolloClient: ApolloClient<NormalizedCacheObject>,
   abTestGroupsUsed: RelevantTestGroupAllocation,
   themeOptions: AbstractThemeOptions,
-  ssrMetadata: SSRMetadata,
+  ssrMetadata?: SSRMetadata,
 }) => {
-  const [timeOverride, setTimeOverride] = useState<TimeOverride | null>({
+  const [timeOverride, setTimeOverride] = useState<TimeOverride | null>(ssrMetadata ? {
     currentTime: new Date(ssrMetadata.renderedAt),
     cacheFriendly: ssrMetadata.cacheFriendly,
     timezone: ssrMetadata.timezone
-  });
+  } : null);
 
   useEffect(() => {
     setTimeOverride(null);

--- a/packages/lesswrong/lib/types/windowObjectExtensions.ts
+++ b/packages/lesswrong/lib/types/windowObjectExtensions.ts
@@ -10,7 +10,7 @@ declare global {
   interface Window {
     tabId: string | null;
     themeOptions: AbstractThemeOptions,
-    ssrMetadata: SSRMetadata
+    ssrMetadata?: SSRMetadata
     /** TODO Remove after 2024-05-14, here for backwards compatibility */
     ssrRenderedAt: string,
     publicSettings: any,

--- a/packages/lesswrong/lib/utils/timeUtil.ts
+++ b/packages/lesswrong/lib/utils/timeUtil.ts
@@ -39,7 +39,7 @@ export function useCurrentTime(): Date {
 
 export const useSsrRenderedAt = () => {
   const currentTime = useCurrentTime();
-  return typeof window === "undefined"
+  return typeof window === "undefined" || !window.ssrMetadata
     ? currentTime
     : new Date(window.ssrMetadata.renderedAt);
 }


### PR DESCRIPTION
Not sure if it's a one-time issue for users with old clients, but https://github.com/ForumMagnum/ForumMagnum/pull/9204 seems to be causing a fair number of errors like `Cannot read properties of undefined (reading 'renderedAt')` in sentry.  In any case, it seems like there are empirically cases where there is no `ssrMetadata` on `window`, which causes some problems.