### PR TITLE
Add SSL settings + certificate for analytics db

### DIFF
--- a/packages/lesswrong/server/analytics/postgresConnection.ts
+++ b/packages/lesswrong/server/analytics/postgresConnection.ts
@@ -2,18 +2,57 @@ import { isAnyTest } from "../../lib/executionEnvironment";
 import pgp, { IDatabase } from "pg-promise";
 import type { IClient } from "pg-promise/typescript/pg-subset";
 import { DatabaseServerSetting } from "../databaseSettings";
-import { isEAForum } from "../../lib/instanceSettings";
+import { PublicInstanceSetting, isEAForum } from "../../lib/instanceSettings";
+import { fs } from "mz";
+import { forumSelect } from "../../lib/forumTypeUtils";
+import { getInstanceSettingsFilePath } from "../commandLine";
+import path from "path";
 
 export const pgPromiseLib = pgp({});
 
 export const connectionStringSetting = new DatabaseServerSetting<string | null>("analytics.connectionString", null);
 export const mirrorConnectionSettingString = new DatabaseServerSetting<string | null>("analytics.mirrorConnectionString", null); //for streaming to two DB at once
 
+interface SSLSettings {
+  require?: boolean
+  allowUnauthorized?: boolean
+  ca?: string
+}
+
+const sslSetting = new DatabaseServerSetting<SSLSettings | null>(
+  "analytics.ssl",
+  forumSelect({
+    EAForum: {
+      require: true,
+      allowUnauthorized: false,
+    },
+    default: null,
+  })
+);
+/** Path of the certificate file *relative* to the instance settings file (so we don't have to store the full cert in instance settings) */
+const sslCAFileSetting = new PublicInstanceSetting<string | null>(
+  "analytics.caFilePath",
+  forumSelect({ EAForum: "./certs/us-east-1-bundle.cer", default: null }),
+  "optional"
+);
+
+const getFullCAFilePath = (): string | null => {
+  const caFilePath = sslCAFileSetting.get();
+  const instanceSettingsPath = getInstanceSettingsFilePath();
+
+  if (!caFilePath || !instanceSettingsPath) {
+    return null;
+  }
+
+  const instanceSettingsDirectory = path.dirname(instanceSettingsPath);
+  return path.resolve(instanceSettingsDirectory, caFilePath);
+}
+
 export type AnalyticsConnectionPool = IDatabase<{}, IClient>;
 let analyticsConnectionPools: Map<string, AnalyticsConnectionPool> = new Map();
 let missingConnectionStringWarned = false;
 
-function getAnalyticsConnectionFromString(connectionString: string | null): AnalyticsConnectionPool | null{
+function getAnalyticsConnectionFromString(connectionString: string | null): AnalyticsConnectionPool | null {
   if (isAnyTest && !isEAForum) {
     return null;
   }
@@ -27,7 +66,27 @@ function getAnalyticsConnectionFromString(connectionString: string | null): Anal
     }
     return null;
   }
-  if (!analyticsConnectionPools.get(connectionString)) analyticsConnectionPools.set(connectionString, pgPromiseLib(connectionString))
+
+  if (!analyticsConnectionPools.get(connectionString)) {
+    let ssl = sslSetting.get()
+    if (ssl) {
+      const caFilePath = getFullCAFilePath()
+      const ca = caFilePath ? fs.readFileSync(caFilePath).toString() : undefined
+
+      ssl = {
+        ...ssl,
+        ...(ca && {ca})
+      }
+    }
+
+    const connectionOptions = {
+      connectionString: connectionString,
+      ...(ssl && {ssl})
+    };
+
+    analyticsConnectionPools.set(connectionString, pgPromiseLib(connectionOptions));
+  }
+
   return analyticsConnectionPools.get(connectionString)!
 }
 


### PR DESCRIPTION
Upgrading our dev analytics db from Postgres 11 to 16 resulted in errors like this:
```
Error: self-signed certificate in certificate chain
```

This PR adds the ability to use root certificate from RDS as described [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions). I have also added the certificate for us-east-1 to the EAF credentials repo.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207371599210654) by [Unito](https://www.unito.io)
