### PR TITLE
Comment search relevance tweaks

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -147,7 +147,7 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
   Comments: {
     fields: [
       "body",
-      "authorDisplayName",
+      "authorDisplayName^11",
     ],
     snippet: "body",
     highlight: "authorDisplayName",

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -158,6 +158,12 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
         weight: 0.5,
         scoring: {type: "numeric", pivot: 20},
       },
+      {
+        field: "baseScore",
+        order: "desc",
+        weight: 1.5,
+        scoring: {type: "numeric", pivot: 50, min: 50},
+      },
     ],
     tiebreaker: "publicDateMs",
     filters: [


### PR DESCRIPTION
Suggested changes to comment search relevance - see discussion at https://cea-core.slack.com/archives/CJUN2UAFN/p1716316808809109

Increases relevance for author name, and gives an extra boost to comments with more than 50 karma. Sadly, we don't currently have a better way of tracking whether or not this is an improvement than just looking at results and saying "this looks better" or "this looks worse", but I think this looks better.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207375767455968) by [Unito](https://www.unito.io)
