### PR TITLE
Remove per-post setting for swr caching

### DIFF
--- a/packages/lesswrong/lib/collections/clientIds/schema.ts
+++ b/packages/lesswrong/lib/collections/clientIds/schema.ts
@@ -4,8 +4,6 @@ const schema: SchemaType<"ClientIds"> = {
   clientId: {
     type: String,
     canRead: ['sunshineRegiment','admins'],
-    /** Not actually nullable, but attempting to add the NOT NULL constraint causes the table to lock */
-    nullable: true
   },
   firstSeenReferrer: {
     type: String,

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -578,7 +578,6 @@ registerFragment(`
     coauthors {
       ...UsersMinimumInfo
     }
-    swrCachingEnabled
   }
 `);
 

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2995,8 +2995,7 @@ const schema: SchemaType<"Posts"> = {
   },
 
   /**
-   * Setting to enable stale-while-revalidate caching for this post. Remove this field once
-   * swr caching is enabled on all posts.
+   * @deprecated Remove after 2024-06-14
    */
   swrCachingEnabled: {
     type: Boolean,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -96,7 +96,7 @@ type ClientIdsCollection = CollectionBase<"ClientIds">;
 
 interface DbClientId extends DbObject {
   __collectionName?: "ClientIds"
-  clientId: string
+  clientId: string | null
   firstSeenReferrer: string | null
   firstSeenLandingPage: string | null
   userIds: Array<string> | null

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -18,7 +18,7 @@ interface CollectionsDefaultFragment { // fragment on Collections
 }
 
 interface ClientIdsDefaultFragment { // fragment on ClientIds
-  readonly clientId: string,
+  readonly clientId: string | null,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
   readonly userIds: Array<string> | null,
@@ -26,7 +26,7 @@ interface ClientIdsDefaultFragment { // fragment on ClientIds
 
 interface ModeratorClientIDInfo { // fragment on ClientIds
   readonly _id: string,
-  readonly clientId: string,
+  readonly clientId: string | null,
   readonly createdAt: Date,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
@@ -1490,7 +1490,6 @@ interface PostsEdit extends PostsDetails, PostSideComments { // fragment on Post
   readonly user: UsersMinimumInfo|null,
   readonly usersSharedWith: Array<UsersMinimumInfo>,
   readonly coauthors: Array<UsersMinimumInfo>,
-  readonly swrCachingEnabled: boolean,
 }
 
 interface PostsEditQueryFragment extends PostsEdit { // fragment on Posts
@@ -3133,7 +3132,7 @@ interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
 }
 
 interface SunshineUsersList_associatedClientIds { // fragment on ClientIds
-  readonly clientId: string,
+  readonly clientId: string | null,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
   readonly userIds: Array<string> | null,

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -18,7 +18,7 @@ interface CollectionsDefaultFragment { // fragment on Collections
 }
 
 interface ClientIdsDefaultFragment { // fragment on ClientIds
-  readonly clientId: string | null,
+  readonly clientId: string,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
   readonly userIds: Array<string> | null,
@@ -26,7 +26,7 @@ interface ClientIdsDefaultFragment { // fragment on ClientIds
 
 interface ModeratorClientIDInfo { // fragment on ClientIds
   readonly _id: string,
-  readonly clientId: string | null,
+  readonly clientId: string,
   readonly createdAt: Date,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
@@ -3132,7 +3132,7 @@ interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
 }
 
 interface SunshineUsersList_associatedClientIds { // fragment on ClientIds
-  readonly clientId: string | null,
+  readonly clientId: string,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
   readonly userIds: Array<string> | null,

--- a/packages/lesswrong/server/cacheControlMiddleware.ts
+++ b/packages/lesswrong/server/cacheControlMiddleware.ts
@@ -3,22 +3,7 @@ import { parsePath, parseRoute } from '../lib/vulcan-core/appContext';
 import { getUserFromReq } from './vulcan-lib/apollo-server/context';
 import express from 'express';
 import { getCookieFromReq } from './utils/httpUtil';
-import { RouterLocation } from './vulcan-lib';
-import { Posts } from '../lib/collections/posts';
 import { swrCachingEnabledSetting } from './cache/swr';
-
-/**
- * Whether stale-while-revalidate caching is enabled on this specific route. To be removed once
- * the kinks have been worked out
- */
-const experimentalCachingEnabled = async (parsedRoute: RouterLocation): Promise<boolean> => {
-  if (parsedRoute.currentRoute?.name !== "posts.single") return false;
-  const postId = parsedRoute.params?._id
-  if (!postId) return false;
-
-  const post = await Posts.findOne({_id: postId}, {}, {swrCachingEnabled: 1})
-  return !!post?.swrCachingEnabled
-}
 
 /**
  * Returns whether the Cache-Control header indicates that this response may be cached by a shared
@@ -40,7 +25,7 @@ const privateCacheHeader = "private, no-cache, no-store, must-revalidate, max-ag
 const swrCacheHeader = "max-age=1, s-max-age=1, stale-while-revalidate=86400"
 
 export const addCacheControlMiddleware = (addMiddleware: AddMiddlewareType) => {
-  addMiddleware(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  addMiddleware((req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (!swrCachingEnabledSetting.get()) {
       next();
       return;
@@ -56,9 +41,7 @@ export const addCacheControlMiddleware = (addMiddleware: AddMiddlewareType) => {
     const theme = getCookieFromReq(req, "theme");
 
     if (parsedRoute.currentRoute?.swrCaching === "logged-out" && !user && !theme) {
-      if (await experimentalCachingEnabled(parsedRoute)) {
-        res.setHeader("Cache-Control", swrCacheHeader);
-      }
+      res.setHeader("Cache-Control", swrCacheHeader);
     } else if (user) {
       res.setHeader("Cache-Control", privateCacheHeader)
     }


### PR DESCRIPTION
For debugging purposes, we were checking a flag on individual posts to see if CDN caching was allowed. This isn't needed any more, and it has a small performance overhead (adds 1 round trip, probably ~10ms to all post page loads).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207382900715608) by [Unito](https://www.unito.io)
