### PR TITLE
Add (beta) to the label for experimental features

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -2205,7 +2205,7 @@ const schema: SchemaType<"Users"> = {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     tooltip: "Get early access to new in-development features",
     group: formGroups.siteCustomizations,
-    label: "Opt into experimental features",
+    label: "Opt into experimental (beta) features",
     order: 70,
   },
   reviewVotesQuadratic: {


### PR DESCRIPTION
Suggested by Lizka, and seems uncontroversial. So that people can Ctrl-f for the word "beta" (because we often refer to it by that name when telling people about it)