### PR TITLE
[EA Forum only] pause job ads, plus a few small copy changes

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -330,7 +330,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnCompressed: true
     }, {
       id: 'community',
-      title: 'Groups',
+      title: 'Join a group',
       link: communityPath,
       iconComponent: GroupsIcon,
       selectedIconComponent: GroupsSelectedIcon,

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -439,10 +439,10 @@ const Community = ({classes}: {
           />
           
           <div className={classes.localGroupsBtns}>
-            <Button href="https://resources.eagroups.org/start-a-group"
+            <Button href="https://resources.eagroups.org"
               variant="outlined" color="primary" target="_blank" rel="noopener noreferrer" className={classes.localGroupsBtn}
             >
-              Start your own group
+              Start a new group
               <OpenInNewIcon className={classes.localGroupsBtnIcon} />
             </Button>
             <Button href="https://docs.google.com/forms/d/e/1FAIpQLScMolewy1P1z9XNyFIN1mQFZQ1LE64QXJrIaX6enrfItWR9LQ/viewform"

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -33,7 +33,7 @@ const StickiedPosts = ({
       curatedIconLeft={false}
       placeholderCount={3}
     />
-    {isEAForum && <TargetedJobAdSection />}
+    {/* {isEAForum && <TargetedJobAdSection />} */}
   </SingleColumnSection>
 }
 

--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -9,6 +9,7 @@ import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_IMPORT_EAG_PROFILE } from '../../lib/cookies/cookies';
 import { userHasEagProfileImport } from '../../lib/betas';
 import moment from 'moment';
+import { preferredHeadingCase } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -118,7 +119,7 @@ const EditProfileForm = ({classes}: {
   return (
     <div className={classes.root}>
       <Typography variant="display3" className={classes.heading} gutterBottom>
-        {isEAForum ? "Edit profile" : "Edit Public Profile"}
+        {preferredHeadingCase("Edit Public Profile")}
       </Typography>
 
       {!isEAForum &&

--- a/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
+++ b/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
@@ -449,7 +449,7 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
                 href={`/profile/${user.slug}/edit`}
                 className={classes.editProfileButton}
               >
-                Edit profile
+                Edit public profile
               </Button>
             </div>
           }

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -683,10 +683,10 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       redirect: () => communityPath
     },
     {
-      name: 'Groups & people',
+      name: 'GroupsHome',
       path: communityPath,
       componentName: 'Community',
-      title: 'Groups & people',
+      title: 'Groups',
       description: "Discover local and online EA groups, or browse the members of the forum to find people to connect with.",
       ...communitySubtitle
     },


### PR DESCRIPTION
This PR has a handful of small changes:
1. Commenting out the job ad component for now, because I finally finished gathering data on the existing rounds. This will be re-enabled next octave with a new round.
2. Changed the LHS link "Groups" to be "Join a group" to see if that helps it get more clicks
3. Changed the title of that page to just be "Groups", since it's no longer called "Groups & people"
4. Changed the "Edit profile" link to be "Edit public profile", to try to be more distinct from "Account settings"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207396388928561) by [Unito](https://www.unito.io)
