### PR TITLE
Fix clickaway bugs

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -273,7 +273,6 @@ const CommentsNewForm = ({
         openDialog({
           componentName: 'NewUserGuidelinesDialog',
           componentProps: dialogProps,
-          noClickawayCancel: true
         });
       }
       if (isLWorAF) {

--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -144,17 +144,17 @@ const SideCommentIcon = ({commentIds, post, classes}: {
       </span>}
       {isOpen && <span className={classes.extendHoverTarget}/>}
     </span>
-    {isOpen && <LWClickAwayListener onClickAway={onClickAway}>
-      <LWPopper
+    <LWPopper
         open={isOpen} anchorEl={anchorEl}
         className={classes.popper}
         clickable={true}
         allowOverflow={true}
         placement={"bottom-start"}
       >
+      <LWClickAwayListener onClickAway={onClickAway}>
         <SideCommentHover post={post} commentIds={commentIds}/>
-      </LWPopper>
-    </LWClickAwayListener>}
+      </LWClickAwayListener>
+    </LWPopper>
   </div>
 }
 

--- a/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
+++ b/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
@@ -157,10 +157,7 @@ const ForumDropdownMultiselect = ({
             key={option}
             value={option}
             onClick={() => {
-              // setTimeout here is a fix for a bug where clicking an option opened a dialog,
-              // and then the LWClickAwayListener was triggered immediately, closing the dialog.
-              // I don't understand exactly why this fixes it
-              setTimeout(() => setAnchorEl(null), 0);
+              setAnchorEl(null);
               onSelect?.(option);
             }}
             className={classes.menuItem}

--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -7,10 +7,9 @@ import { useOnNavigate } from '../hooks/useOnNavigate';
 export type CloseableComponent = ComponentWithProps<{ onClose?: any }>
 
 export interface OpenDialogContextType {
-  openDialog: <T extends CloseableComponent>({componentName, componentProps, noClickawayCancel}: {
+  openDialog: <T extends CloseableComponent>({componentName, componentProps}: {
     componentName: T,
     componentProps?: Omit<React.ComponentProps<typeof Components[T]>,"onClose"|"classes">,
-    noClickawayCancel?: boolean,
     closeOnNavigate?: boolean,
   }) => void,
   closeDialog: () => void,
@@ -22,7 +21,6 @@ export const DialogManager = ({children}: {
   children: React.ReactNode,
 }) => {
   const [componentNameWithProps, setComponentNameWithProps] = useState<{componentName: CloseableComponent, componentProps: any} | null>(null);
-  const [noClickawayCancel, setNoClickawayCancel] = useState<any>(false);
   const [closeOnNavigate, setCloseOnNavigate] = useState<boolean>(false);
   const {captureEvent} = useTracking();
   const isOpen = !!componentNameWithProps?.componentName;
@@ -35,10 +33,9 @@ export const DialogManager = ({children}: {
   const ModalComponent = isOpen ? (Components[componentNameWithProps?.componentName]) : null;
   
   const providedContext = useMemo((): OpenDialogContextType => ({
-    openDialog: ({componentName, componentProps, noClickawayCancel, closeOnNavigate}) => {
+    openDialog: ({componentName, componentProps, closeOnNavigate}) => {
       captureEvent("dialogBox", {open: true, dialogName: componentName})
       setComponentNameWithProps({componentName, componentProps});
-      setNoClickawayCancel(noClickawayCancel || false)
       setCloseOnNavigate(closeOnNavigate || false)
     },
     closeDialog: closeDialog
@@ -48,19 +45,11 @@ export const DialogManager = ({children}: {
     if (closeOnNavigate) closeDialog()
   })
 
-  const { LWClickAwayListener } = Components
-
   const modal = (ModalComponent && isOpen) && <ModalComponent {...componentNameWithProps?.componentProps} onClose={closeDialog} />
-  const withClickaway = isOpen && (noClickawayCancel
-    ? modal
-    : <LWClickAwayListener onClickAway={closeDialog}>
-        <>{modal}</>
-      </LWClickAwayListener>
-  );
   return (
     <OpenDialogContext.Provider value={providedContext}>
       {children}
-      {isOpen && <span>{withClickaway}</span>}
+      {isOpen && <span>{modal}</span>}
     </OpenDialogContext.Provider>
   );
 }

--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -166,7 +166,6 @@ const PostSharingSettings = ({document, formType, value, classes}: {
         },
         initialShareWithUsers: document.shareWithUsers || [],
       },
-      noClickawayCancel: true,
     });
   }, [openDialog, closeDialog, formType, document, updateCurrentValues, initialSharingSettings, flash, submitForm]);
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -417,7 +417,6 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
         componentProps: {
           post: fullPost,
         },
-        noClickawayCancel: true,
         closeOnNavigate: true,
       });
     }
@@ -584,7 +583,6 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
       componentProps: {
         post, initialHtml: html
       },
-      noClickawayCancel: true,
     })
   }, [openDialog, post]);
 

--- a/packages/lesswrong/components/sunshineDashboard/NewModeratorActionDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/NewModeratorActionDialog.tsx
@@ -17,7 +17,7 @@ const NewModeratorActionDialog = ({classes, onClose, userId}: {
   const { WrappedSmartForm, LWDialog } = Components;
   
   return (
-    <LWDialog open={true}>
+    <LWDialog open={true} onClose={onClose}>
       <DialogTitle>
         New Moderator Action
       </DialogTitle>

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
@@ -50,18 +50,18 @@ export const RejectContentButton = ({contentWrapper, classes}: {
     {!content.rejected && content.authorIsUnreviewed && <span className={classes.button} onClick={() => setShowRejectionDialog(true)}>
       <RejectedIcon className={classes.icon}/> <MetaInfo>Reject</MetaInfo>
     </span>}
-    {showRejectionDialog && <LWClickAwayListener onClickAway={() => setShowRejectionDialog(false)}>
-      <LWPopper
-        open={showRejectionDialog}
-        anchorEl={anchorEl}
-        className={classes.popper}
-        clickable={true}
-        allowOverflow={true}
-        placement={"right"}
-      >
+    <LWPopper
+      open={showRejectionDialog}
+      anchorEl={anchorEl}
+      className={classes.popper}
+      clickable={true}
+      allowOverflow={true}
+      placement={"right"}
+    >
+      <LWClickAwayListener onClickAway={() => setShowRejectionDialog(false)}>
         <RejectContentDialog rejectContent={handleRejectContent}/>
-      </LWPopper>
-    </LWClickAwayListener>}
+      </LWClickAwayListener>
+    </LWPopper>
   </span>
 }
 

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -187,7 +187,7 @@ const UsersMenu = ({classes}: {
         ? (
           <DropdownItem
             title={preferredHeadingCase("New Quick Take")}
-            onClick={() => openDialog({componentName:"NewShortformDialog", noClickawayCancel: true})}
+            onClick={() => openDialog({componentName:"NewShortformDialog"})}
           />
         )
       : null,

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -534,16 +534,15 @@ export const AddReactionButton = ({voteProps, classes}: {
       className={classNames(classes.addReactionButton, "react-hover-style")}
     >
       <AddReactionIcon />
-      {open && <LWClickAwayListener onClickAway={() => {
-        setOpen(false)
-        captureEvent("reactPaletteStateChanged", {open: false})
-      }}>
-        <PopperCard
-          open={open} anchorEl={buttonRef.current}
-          placement="bottom-end"
-          allowOverflow={true}
-          
-        >
+      <PopperCard
+        open={open} anchorEl={buttonRef.current}
+        placement="bottom-end"
+        allowOverflow={true}
+      >
+        <LWClickAwayListener onClickAway={() => {
+          setOpen(false)
+          captureEvent("reactPaletteStateChanged", {open: false})
+        }}>
           <div className={classes.hoverBallot}>
             <ReactionsPalette
               quote={null}
@@ -551,8 +550,8 @@ export const AddReactionButton = ({voteProps, classes}: {
               toggleReaction={handleToggleReaction}
             />
           </div>
-        </PopperCard>
-      </LWClickAwayListener>}
+        </LWClickAwayListener>
+      </PopperCard>
     </span>
   </LWTooltip>
 }

--- a/packages/lesswrong/components/votes/withVote.ts
+++ b/packages/lesswrong/components/votes/withVote.ts
@@ -40,7 +40,6 @@ export const useVote = <T extends VoteableTypeClient>(document: T, collectionNam
     openDialog({
       componentName: "VotingPatternsWarningPopup",
       componentProps: {},
-      noClickawayCancel: true,
       closeOnNavigate: true,
     });
   }, [openDialog]);


### PR DESCRIPTION
This is the specific bug this is fixing (before), there were a couple of other bugs like this which have already been worked around:

https://github.com/ForumMagnum/ForumMagnum/assets/77623106/eddf785d-6196-443a-ae7d-05c3cc8b667f

The fix in this PR is essentially this line:
```typescript
   // Events from MUI form components have the base event under the "nativeEvent" field
   bubbledEventTarget.current = ('nativeEvent' in event) ? event.nativeEvent.target : event.target;
```

There are also some changes related to how `LWClickAwayListener` interacts with [portals](https://react.dev/reference/react-dom/createPortal) (where an element is created at the root level of the document rather than in the place it is instantiated) to hopefully make it a bit more robust.

## Details of the `bubbledEventTarget` fix

This is the bit of code that handles document-level click events (i.e. events anywhere on the page), to decide whether they count as a clickaway for the particular element that is wrapped in `LWClickAwayListener`:

```typescript
const handleEvents = (event: ClickAwayEvent): void => {
      if (!mountedRef.current) return;

      const isContainedByNode = node.current && node.current.contains(event.target as Node);
      const isBubbledEventTarget = bubbledEventTarget.current === event.target;
      const notContainedInDocument = !nodeDocument.contains(event.target as Node);

      if (isContainedByNode || isBubbledEventTarget || notContainedInDocument) {
        return;
      }

      onClickAway(event);
    };
```

`isContainedByNode` is checking whether the clicked element is a child of the `LWClickAwayListener` wrapped element _in the DOM tree_ (i.e. in the actual html), `isBubbledEventTarget` is supposed to check whether the clicked element is a child of the wrapped element _in the React tree_.

In the case where portals (Dialogs, Poppers) are involved as the wrapped element, these can be different, because a portal creates the element at the root level of the document, so it won't be a DOM-child of the `LWClickAwayListener`. It will be a React-child however, because [portals are designed to maintain the logical tree structure by bubbling events up through nested portals even if they end up separated in the DOM](https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals).

The bug was that clicks on various MUI components generate a synthetic event that doesn't have a proper `target` field, so `bubbledEventTarget.current` wouldn't be set properly and `isBubbledEventTarget` would wrongly be `false`. Hence this change to use the "nativeEvent" in that case:
```typescript
   // Events from MUI form components have the base event under the "nativeEvent" field
   bubbledEventTarget.current = ('nativeEvent' in event) ? event.nativeEvent.target : event.target;
```

## Details of the other changes related to portals

Given the fix above, the case where `isContainedByNode` is false, but `isBubbledEventTarget` is true (sufficient to correctly not trigger the clickaway) would be in situations like this where there is a `LWClickAwayListener` _outside_ a portal-generating component (in this case `LWPopper`):
```jsx
      {isOpen && <LWClickAwayListener onClickAway={onClickAway}>
        <LWPopper
          open={isOpen}
          anchorEl={anchorEl}
          className={classes.popper}
          clickable={true}
          allowOverflow={true}
          placement={"bottom-start"}
        >
          <SideCommentHover post={post} commentIds={commentIds} />
        </LWPopper>
      </LWClickAwayListener>}
```

The `LWPopper` will be portal-ed away somewhere else so won't be a DOM child of the `LWClickAwayListener`. I've changed all cases like this to instead have the `LWClickAwayListener` inside the portal-generating component like so:
```jsx
    <LWPopper
        open={isOpen} anchorEl={anchorEl}
        className={classes.popper}
        clickable={true}
        allowOverflow={true}
        placement={"bottom-start"}
      >
      <LWClickAwayListener onClickAway={onClickAway}>
        <SideCommentHover post={post} commentIds={commentIds}/>
      </LWClickAwayListener>
    </LWPopper>
```
This way it's always the case that the clickaway-able component is both a DOM child and a React child of the clickaway listener. This should make things easier to think about, and also potentially prevent bugs in future where there is some issue with the click event being bubbled all the way up to `LWClickAwayListener`, because it will then just fall back to the `isContainedByNode` in most cases (except when there are also nested portals involved). This would have independently prevented the specific bug in the video above.

...

Separately, there are also various MUI components that create portals (e.g. `Dialog`, `Select`), and these have their own way of handling clickaways for themselves[1]. In the case of `useDialog` we were adding a `LWClickAwayListener` (controlled by `noClickawayCancel`) on top of the clickaway already provided by the MUI `Dialog`. I thought it was better to leave it to the default MUI behaviour in that case, so I have removed the `noClickawayCancel` option and made it so the dialog is responsible for disabling the clickaway itself (by not passing an `onClose` prop to the dialog).

[1] The logic in this case appears to be that only the _topmost_ MUI portal element will ever be considered for a clickaway. So if there is a `Select` open over a `Dialog` the first clickaway will only close the `Select` even if it's outside the `Dialog` bounds also.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207402351397209) by [Unito](https://www.unito.io)
