### PR TITLE
Fix logic for scrolling to footnotes when section is collapsed

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -4,9 +4,9 @@ import { Components, registerComponent, validateUrl } from '../../lib/vulcan-lib
 import { captureException }from '@sentry/core';
 import { linkIsExcludedFromPreview } from '../linkPreview/HoverPreviewLink';
 import { toRange } from '../../lib/vendor/dom-anchor-text-quote';
-import { isLWorAF } from '../../lib/instanceSettings';
 import { rawExtractElementChildrenToReactComponent, reduceRangeToText, splitRangeIntoReplaceableSubRanges, wrapRangeWithSpan } from '../../lib/utils/rawDom';
 import { withTracking } from '../../lib/analyticsEvents';
+import { hasCollapsedFootnotes } from '@/lib/betas';
 
 interface ExternalProps {
   /**
@@ -272,7 +272,7 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
 
 
   collapseFootnotes = (body: HTMLElement) => {
-    if (isLWorAF || !body) {
+    if (!hasCollapsedFootnotes || !body) {
       return;
     }
 

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Card from '@material-ui/core/Card';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useHover } from '../common/withHover';
 import { EXPAND_FOOTNOTES_EVENT } from '../posts/PostsPage/CollapsedFootnotes';
+import { hasCollapsedFootnotes } from '@/lib/betas';
 
 const footnotePreviewStyles = (theme: ThemeType): JssStyles => ({
   hovercard: {
@@ -64,7 +65,11 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
   // context, figuring out what that network request *is* is pretty complicated;
   // it could be anything with a content-editable field in it, and that
   // information isn't wired to pass through the hover-preview system.
-  
+
+  const onClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent(EXPAND_FOOTNOTES_EVENT, {detail: href}));
+  }, [href]);
+
   return (
     <span {...eventHandlers}>
       {footnoteContentsNonempty && <LWPopper
@@ -81,10 +86,10 @@ const FootnotePreview = ({classes, href, onsite=false, id, rel, children}: {
       </LWPopper>}
 
       <a
-        href={href}
+        href={hasCollapsedFootnotes ? undefined : href}
         id={id}
         rel={rel}
-        onClick={() => window.dispatchEvent(new Event(EXPAND_FOOTNOTES_EVENT))}
+        onClick={onClick}
       >
         {children}
       </a>

--- a/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
@@ -6,6 +6,8 @@ import { InteractionWrapper } from "../../common/useClickableCell";
 import Collapse from "@material-ui/core/Collapse";
 import classNames from "classnames";
 
+const TRANSITION_DURATION = 200;
+
 export const EXPAND_FOOTNOTES_EVENT = "expand-footnotes";
 
 export const locationHashIsFootnote = (hash: string) =>
@@ -77,10 +79,15 @@ const CollapsedFootnotes = ({
   const ref = useRef<HTMLOListElement>(null);
 
   useEffect(() => {
-    const handler = () => setCollapsed(false);
+    const handler = (e: AnyBecauseTodo) => {
+      setCollapsed(false);
+      setTimeout(() => {
+        document.querySelector(e.detail)?.scrollIntoView();
+      }, fullyExpanded ? 0 : TRANSITION_DURATION);
+    };
     window.addEventListener(EXPAND_FOOTNOTES_EVENT, handler);
     return () => window.removeEventListener(EXPAND_FOOTNOTES_EVENT, handler);
-  }, []);
+  }, [fullyExpanded]);
 
   useOnSearchHotkey(() => setCollapsed(false));
 
@@ -98,6 +105,7 @@ const CollapsedFootnotes = ({
       <Collapse
         in={!collapsed}
         onEntered={() => setFullyExpanded(true)}
+        timeout={TRANSITION_DURATION}
         className={classNames(
           classes.collapse,
           {[classes.fullyExpanded]: fullyExpanded},

--- a/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
@@ -79,7 +79,7 @@ const CollapsedFootnotes = ({
   const ref = useRef<HTMLOListElement>(null);
 
   useEffect(() => {
-    const handler = (e: AnyBecauseTodo) => {
+    const handler = (e: CustomEvent<string>) => {
       setCollapsed(false);
       setTimeout(() => {
         document.querySelector(e.detail)?.scrollIntoView();

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -90,6 +90,7 @@ export const useElicitApi = false;
 export const commentsTableOfContentsEnabled = hasCommentsTableOfContentSetting.get();
 export const fullHeightToCEnabled = isLWorAF;
 export const hasForumEvents = isEAForum;
+export const hasCollapsedFootnotes = !isLWorAF;
 export const useCurationEmailsCron = isLW;
 
 // EA Forum disabled the author's ability to moderate posts. We disregard this

--- a/packages/lesswrong/server/loadDatabaseSettings.ts
+++ b/packages/lesswrong/server/loadDatabaseSettings.ts
@@ -59,7 +59,7 @@ const loadDatabaseSettings = async (): Promise<DatabaseSettings> => {
       return await loadDatabaseSettingsPostgres();
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error("Failed to load database settings from Postgres");
+      console.error("Failed to load database settings from Postgres", e);
     }
   }
   return {


### PR DESCRIPTION
If you click a footnote in the body of a post whilst the footnotes section is collapsed we automatically open the footnotes section and scroll to the relevant footnote. However, there's a transition to open the footnotes section, so sometimes we scroll to the wrong footnote if the section is very large and takes a long time to open (especially on slow devices). The is easily reproducible in [this prod-db post](http://localhost:3000/posts/LpkXtFXdsRd4rG8Kb/reducing-long-term-risks-from-malevolent-actors), for instance.

This PR adds a timeout so we only scroll to the footnote after the animation is complete. This reproducibly fixes the bug, even with a 6x CPU throttle in dev tools.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207493910281102) by [Unito](https://www.unito.io)
