### PR TITLE
[EA] Fix social media icon wrapping in the people directory

### DIFF
--- a/packages/lesswrong/components/peopleDirectory/PeopleDirectorySocialMediaCell.tsx
+++ b/packages/lesswrong/components/peopleDirectory/PeopleDirectorySocialMediaCell.tsx
@@ -9,6 +9,8 @@ const styles = (theme: ThemeType) => ({
   root: {
     display: "flex",
     gap: "12px",
+    flexWrap: "wrap",
+    rowGap: "2px",
   },
   link: {
     color: theme.palette.grey[600],
@@ -36,7 +38,7 @@ export const PeopleDirectorySocialMediaCell = ({user, classes}: {
   const {captureEvent} = useTracking();
 
   const urls = user.socialMediaUrls ?? {};
-  const keys = objectKeys(urls)
+  const keys = objectKeys(urls);
 
   const {SocialMediaIcon} = Components;
   return (

--- a/packages/lesswrong/components/peopleDirectory/peopleDirectoryColumns.ts
+++ b/packages/lesswrong/components/peopleDirectory/peopleDirectoryColumns.ts
@@ -80,7 +80,7 @@ export const peopleDirectoryColumns: PeopleDirectoryColumn<CellComponentName>[] 
   },
   {
     label: "Social media",
-    columnWidth: "100px",
+    columnWidth: "140px",
     componentName: "PeopleDirectorySocialMediaCell",
     hideable: true,
     hidden: false,


### PR DESCRIPTION
The social media icons currently overlap on small screens for users with many different links.

Before:
<img width="350" alt="Screenshot 2024-06-05 at 12 50 54" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/2adba65b-5ed9-4b33-ab61-52641493b394">

After:
<img width="335" alt="Screenshot 2024-06-05 at 12 49 12" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/63354186-2ad1-4786-b5fa-8ec9fe26ea67">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207494034602426) by [Unito](https://www.unito.io)
