### PR TITLE
[EA] Improve checkboxes in people directory dropdowns

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -131,6 +131,7 @@ import { LabBeakerIcon } from "../icons/LabBeakerIcon";
 import { SparkleIcon } from "../icons/sparkleIcon";
 import { ListViewIcon } from "../icons/ListViewIcon";
 import { CardViewIcon } from "../icons/CardViewIcon";
+import { CheckSmallIcon } from "../icons/CheckSmallIcon";
 
 /**
  * This exists to allow us to easily use different icon sets on different
@@ -191,6 +192,7 @@ export type ForumIconName =
   "Plus" |
   "Check" |
   "CheckCircle" |
+  "CheckSmall" |
   "Card" |
   "List" |
   "PlusSmall" |
@@ -299,6 +301,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Puzzle: MuiPuzzleIcon,
     Check: MuiCheckIcon,
     CheckCircle: CheckCircleIcon,
+    CheckSmall: CheckSmallIcon,
     Card: CardIcon,
     List: ListIcon,
     SoftUpArrow: SoftUpArrowIcon,
@@ -394,6 +397,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Puzzle: PuzzleIcon,
     Check: CheckIcon,
     CheckCircle: CheckCircleIcon,
+    CheckSmall: CheckSmallIcon,
     Card: CardIcon,
     List: ListIcon,
     SoftUpArrow: SoftUpArrowIcon,

--- a/packages/lesswrong/components/icons/CheckSmallIcon.tsx
+++ b/packages/lesswrong/components/icons/CheckSmallIcon.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const CheckSmallIcon = (props: React.HTMLAttributes<SVGElement>) =>
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect width="16" height="16" rx="4" fill="currentColor"/>
+    <path fillRule="evenodd" clipRule="evenodd" d="M12.7889 5.08952C13.0243 5.23596 13.0697 5.51047 12.8904 5.70266L7.17611 11.8276C7.08242 11.9281 6.94018 11.9905 6.78594 11.999C6.6317 12.0075 6.48049 11.9611 6.37118 11.8719L3.15691 9.24687C2.9477 9.07601 2.9477 8.79901 3.15691 8.62815C3.36612 8.4573 3.70531 8.4573 3.91452 8.62815L6.69536 10.8992L12.0381 5.17238C12.2174 4.98018 12.5536 4.94309 12.7889 5.08952Z" fill="white" stroke="white" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>

--- a/packages/lesswrong/components/peopleDirectory/PeopleDirectorySelectOption.tsx
+++ b/packages/lesswrong/components/peopleDirectory/PeopleDirectorySelectOption.tsx
@@ -23,13 +23,15 @@ const styles = (theme: ThemeType) => ({
     height: 16,
   },
   selected: {
-    background: theme.palette.primary.main,
-    color: theme.palette.text.alwaysWhite,
+    border: "none",
+    marginLeft: 1,
+    marginRight: -1,
   },
   icon: {
     width: 16,
     height: 16,
     marginLeft: -1,
+    color: theme.palette.primary.main,
   },
 });
 
@@ -58,7 +60,7 @@ export const PeopleDirectorySelectOption = ({state, className, classes}: {
   return (
     <div onClick={onClick} className={classNames(classes.root, className)}>
       <div className={classNames(classes.check, {[classes.selected]: selected})}>
-        {selected && <ForumIcon icon="Check" className={classes.icon} />}
+        {selected && <ForumIcon icon="CheckSmall" className={classes.icon} />}
       </div>
       {label}
     </div>


### PR DESCRIPTION
New design for checkboxes in the people directory ([Figma](https://www.figma.com/design/qAHRGADVOGojqKpqbGMFFu/2024-Q2?node-id=809-1290&m=dev)).

Before:
<img width="207" alt="Screenshot 2024-06-05 at 17 03 05" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/364e9610-9e8b-4886-b1bc-71b5664c8be6">


After:
<img width="213" alt="Screenshot 2024-06-05 at 16 57 53" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/5f416576-ee2d-4b35-962a-94dc8b87d0e6">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207496638063210) by [Unito](https://www.unito.io)
