### PR TITLE
[EA] Show interested tags on the user profile

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -117,6 +117,7 @@ const FooterTag = ({
   tagRel,
   tag,
   hideScore=false,
+  hideIcon,
   smallText,
   PreviewWrapper,
   link=true,
@@ -129,6 +130,7 @@ const FooterTag = ({
   tag: TagPreviewFragment | TagSectionPreviewFragment | TagRecentDiscussion,
   tagRel?: TagRelMinimumFragment,
   hideScore?: boolean,
+  hideIcon?: boolean,
   smallText?: boolean,
   PreviewWrapper?: TagsTooltipPreviewWrapper,
   link?: boolean
@@ -142,7 +144,7 @@ const FooterTag = ({
 
   if (tag.adminOnly && !currentUser?.isAdmin) { return null }
 
-  const showIcon = Boolean(tag.core && !smallText && coreTagIconMap[tag.slug]);
+  const showIcon = Boolean(tag.core && !smallText && coreTagIconMap[tag.slug] && !hideIcon);
 
   const tagName = isFriendlyUI && smallText
     ? tag.shortName || tag.name

--- a/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
+++ b/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
@@ -160,6 +160,23 @@ const styles = (theme: ThemeType) => ({
     alignItems: 'baseline',
     marginBottom: 20
   },
+  interests: {
+    fontSize: 14,
+    fontWeight: 500,
+    color: theme.palette.grey[600],
+    marginTop: 14,
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: "2px",
+    overflowX: "hidden",
+    "& .FooterTag-root": {
+      margin: "0",
+    },
+    "& > :first-child": {
+      marginRight: 6,
+    },
+  },
 })
 
 const FriendlyUsersProfile = ({terms, slug, classes}: {
@@ -241,7 +258,7 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
     Typography, ContentStyles, EAUsersProfileTabbedSection, PostsListSettings,
     RecentComments, SectionButton, SequencesGridWrapper, ReportUserButton, DraftsList,
     ProfileShortform, EAUsersProfileImage, EAUsersMetaInfo, EAUsersProfileLinks,
-    UserNotifyDropdown
+    UserNotifyDropdown, FooterTag,
   } = Components
 
   if (loading) {
@@ -472,6 +489,16 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
             </NewConversationButton>
             <UserNotifyDropdown user={user} />
           </div>}
+
+          {user.profileTags?.length &&
+            <div className={classes.interests}>
+              <div>Interests:</div>
+              {user.profileTags.map((tag) =>
+                <FooterTag key={tag._id} tag={tag} neverCoreStyling hideIcon />
+              )}
+            </div>
+          }
+
           <EAUsersProfileLinks user={user} />
         </div>
 

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -47,7 +47,7 @@ registerFragment(`
     }
     profileTagIds
     profileTags {
-      ...TagBasicInfo
+      ...TagPreviewFragment
     }
     organizerOfGroupIds
     organizerOfGroups {

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -96,7 +96,7 @@ type ClientIdsCollection = CollectionBase<"ClientIds">;
 
 interface DbClientId extends DbObject {
   __collectionName?: "ClientIds"
-  clientId: string | null
+  clientId: string
   firstSeenReferrer: string | null
   firstSeenLandingPage: string | null
   userIds: Array<string> | null

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -960,12 +960,6 @@ interface VotesDefaultFragment { // fragment on Votes
   readonly silenceNotification: boolean,
 }
 
-interface MessagesDefaultFragment { // fragment on Messages
-  readonly userId: string,
-  readonly conversationId: string,
-  readonly noEmail: boolean,
-}
-
 interface LWEventsDefaultFragment { // fragment on LWEvents
   readonly userId: string,
   readonly name: string,
@@ -1866,6 +1860,12 @@ interface NotificationsList { // fragment on Notifications
   readonly type: string,
   readonly viewed: boolean,
   readonly extraData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface MessagesDefaultFragment { // fragment on Messages
+  readonly userId: string,
+  readonly conversationId: string,
+  readonly noEmail: boolean,
 }
 
 interface messageListFragment { // fragment on Messages
@@ -2842,7 +2842,7 @@ interface UsersProfile extends UsersMinimumInfo, SharedUserBooleans { // fragmen
   readonly howOthersCanHelpMe: RevisionDisplay|null,
   readonly howICanHelpOthers: RevisionDisplay|null,
   readonly profileTagIds: Array<string>,
-  readonly profileTags: Array<TagBasicInfo>,
+  readonly profileTags: Array<TagPreviewFragment>,
   readonly organizerOfGroupIds: Array<string>,
   readonly organizerOfGroups: Array<localGroupsBase>,
   readonly programParticipation: Array<string>,
@@ -3907,7 +3907,6 @@ interface FragmentTypes {
   TypingIndicatorsDefaultFragment: TypingIndicatorsDefaultFragment
   CronHistoriesDefaultFragment: CronHistoriesDefaultFragment
   VotesDefaultFragment: VotesDefaultFragment
-  MessagesDefaultFragment: MessagesDefaultFragment
   LWEventsDefaultFragment: LWEventsDefaultFragment
   newEventFragment: newEventFragment
   lastEventFragment: lastEventFragment
@@ -3973,6 +3972,7 @@ interface FragmentTypes {
   RecentDiscussionRevisionTagFragment: RecentDiscussionRevisionTagFragment
   WithVoteRevision: WithVoteRevision
   NotificationsList: NotificationsList
+  MessagesDefaultFragment: MessagesDefaultFragment
   messageListFragment: messageListFragment
   ConversationsMinimumInfo: ConversationsMinimumInfo
   ConversationsList: ConversationsList
@@ -4162,11 +4162,11 @@ interface FragmentTypesByCollection {
   TypingIndicators: "TypingIndicatorsDefaultFragment"|"TypingIndicatorInfo"
   CronHistories: "CronHistoriesDefaultFragment"
   Votes: "VotesDefaultFragment"|"TagRelVotes"|"TagVotingActivity"|"UserVotes"|"UserVotesWithDocument"
-  Messages: "MessagesDefaultFragment"|"messageListFragment"
   LWEvents: "LWEventsDefaultFragment"|"newEventFragment"|"lastEventFragment"|"lwEventsAdminPageFragment"|"emailHistoryFragment"
   GoogleServiceAccountSessions: "GoogleServiceAccountSessionsDefaultFragment"|"GoogleServiceAccountSessionInfo"|"GoogleServiceAccountSessionAdminInfo"
   Sessions: "SessionsDefaultFragment"
   Revisions: "RevisionDisplay"|"RevisionEdit"|"RevisionMetadata"|"RevisionMetadataWithChangeMetrics"|"RevisionHistoryEntry"|"RevisionTagFragment"|"RecentDiscussionRevisionTagFragment"|"WithVoteRevision"|"RevisionsDefaultFragment"
+  Messages: "MessagesDefaultFragment"|"messageListFragment"
   RSSFeeds: "RSSFeedsDefaultFragment"|"RSSFeedMinimumInfo"|"newRSSFeedFragment"|"RSSFeedMutationFragment"
   Reports: "ReportsDefaultFragment"|"UnclaimedReportsList"
   TagFlags: "TagFlagFragment"|"TagFlagEditFragment"|"TagFlagsDefaultFragment"
@@ -4229,7 +4229,6 @@ interface CollectionNamesByFragmentName {
   TypingIndicatorsDefaultFragment: "TypingIndicators"
   CronHistoriesDefaultFragment: "CronHistories"
   VotesDefaultFragment: "Votes"
-  MessagesDefaultFragment: "Messages"
   LWEventsDefaultFragment: "LWEvents"
   newEventFragment: "LWEvents"
   lastEventFragment: "LWEvents"
@@ -4295,6 +4294,7 @@ interface CollectionNamesByFragmentName {
   RecentDiscussionRevisionTagFragment: "Revisions"
   WithVoteRevision: "Revisions"
   NotificationsList: "Notifications"
+  MessagesDefaultFragment: "Messages"
   messageListFragment: "Messages"
   ConversationsMinimumInfo: "Conversations"
   ConversationsList: "Conversations"


### PR DESCRIPTION
Show interested tags on the user profile page ([Figma](https://www.figma.com/design/qAHRGADVOGojqKpqbGMFFu/2024-Q2?node-id=943-13756&m=dev)).

<img width="848" alt="Screenshot 2024-06-05 at 17 26 52" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/5e7d2fd9-123c-4a63-b8d5-85e0d41ec298">
<img width="351" alt="Screenshot 2024-06-05 at 17 27 12" src="https://github.com/ForumMagnum/ForumMagnum/assets/5075628/72c84c67-0d98-4cb6-9ef8-0f0e49bc2428">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207496996688047) by [Unito](https://www.unito.io)
