### PR TITLE
don't block reviewed users from creating many conversations

### DIFF
--- a/packages/lesswrong/server/callbacks/conversationCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/conversationCallbacks.ts
@@ -79,7 +79,7 @@ async function flagOrBlockUserOnManyDMs({
     validate: false,
   });
   
-  if (allUsersEverContacted.length > MAX_ALLOWED_CONTACTS_BEFORE_BLOCK) {
+  if (allUsersEverContacted.length > MAX_ALLOWED_CONTACTS_BEFORE_BLOCK && !currentUser.reviewedAt) {
     logger('Blocking user')
     throw new Error(`You cannot message more than ${MAX_ALLOWED_CONTACTS_BEFORE_BLOCK} users before your account has been reviewed. Please contact us if you'd like to message more people.`)
   }


### PR DESCRIPTION
It seems like this code was incorrectly blocking users from creating more than `MAX_ALLOWED_CONTACTS_BEFORE_BLOCK` conversations, even if they were already reviewed.  (We only create the mod action indicating they were flagged if they weren't reviewed, and the error message in the block case suggests it should only apply to unreviewed users.)

cc @jpaddison3

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207499493581591) by [Unito](https://www.unito.io)
