### PR TITLE
[EA Forum only] fixes for audio "play from heading"

### DIFF
--- a/.github/workflows/deployEABeta.yaml
+++ b/.github/workflows/deployEABeta.yaml
@@ -3,7 +3,7 @@ concurrency: deploy-ea-beta
 on:
   workflow_dispatch:
   push:
-    branches: [floating-audio-player]
+    branches: [audio-play-from-heading-fixes]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -330,7 +330,7 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       showOnCompressed: true
     }, {
       id: 'community',
-      title: 'Join a group',
+      title: 'Groups directory',
       link: communityPath,
       iconComponent: GroupsIcon,
       selectedIconComponent: GroupsSelectedIcon,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -217,6 +217,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
   postBody: {
     width: "max-content",
   },
+  audioPlayerHidden: {
+    // Only show the play button next to headings if the audio player is visible
+    '& .t3a-heading-play-button': {
+      display: 'none !important'
+    },
+  },
   postContent: {
     marginBottom: isFriendlyUI ? 40 : undefined
   },
@@ -683,7 +689,11 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
   // the same time.
 
   const postBodySection =
-    <div id="postBody" className={classNames(classes.centralColumn, classes.postBody)}>
+    <div id="postBody" className={classNames(
+      classes.centralColumn,
+      classes.postBody,
+      !showEmbeddedPlayer && classes.audioPlayerHidden
+    )}>
       {showSplashPageHeader && !commentId && !isDebateResponseLink && <h1 className={classes.secondSplashPageHeader}>
         {post.title}
       </h1>}

--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -393,7 +393,8 @@ const audioPlayerStyles = (theme: ThemeType): JssStyles => ({
       marginRight: -1, // The margins here have been changed from the default to fit the EA Forum
     },
     /* Refine this to match the dimensions of your heading typeface */
-    'h2 .t3a-heading-play-button': { marginTop: 9 },
+    'h1 .t3a-heading-play-button': { marginTop: 10 },
+    'h2 .t3a-heading-play-button': { marginTop: 8 },
     'h3 .t3a-heading-play-button': { marginTop: 3 },
   }
 })


### PR DESCRIPTION
A few fixes to the "play from heading" feature:
1. Only show the play buttons if the audio player is visible
2. Peter updated the styling on their side, so some CSS updates to match

Again you can preview on [this post](https://beta.effectivealtruism.org/posts/A7kDruJ4orqZw4uFv/beneficentric-virtue-ethics).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207508999754664) by [Unito](https://www.unito.io)
