### PR TITLE
[EA Forum only] update homepage RHS

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -37,6 +37,7 @@ import {
   PeopleDirectoryIcon,
   PeopleDirectorySelectedIcon,
 } from '../../icons/peopleDirectoryIcon';
+import { podcastPost } from '@/lib/eaPodcasts';
 
 // The sidebar / bottom bar of the Forum contain 10 or so similar tabs, unique to each Forum. The
 // tabs can appear in
@@ -342,11 +343,6 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       divider: true,
       showOnCompressed: true,
     }, {
-      id: 'shortform',
-      title: 'Quick takes',
-      link: '/quicktakes',
-      subItem: true,
-    }, {
       id: 'about',
       title: 'How to use the Forum',
       link: '/about',
@@ -354,18 +350,38 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       compressedIconComponent: Info,
       showOnCompressed: true,
     }, {
-      id: 'contact',
-      title: preferredHeadingCase('Contact Us'),
-      link: '/contact',
+      id: 'handbook',
+      title: 'EA Handbook',
+      link: '/handbook',
       subItem: true,
+      showOnCompressed: true,
+    }, {
+      id: 'podcasts',
+      title: 'EA Forum Podcast',
+      link: podcastPost,
+      subItem: true,
+      showOnCompressed: true,
+    }, {
+      id: 'shortform',
+      title: 'Quick takes',
+      link: '/quicktakes',
+      subItem: true,
+    }, {
+      id: 'subscribeWidget',
+      customComponentName: "SubscribeWidget",
     }, {
       id: 'cookies',
       title: preferredHeadingCase('Cookie Policy'),
       link: '/cookiePolicy',
       subItem: true,
     }, {
-      id: 'subscribeWidget',
-      customComponentName: "SubscribeWidget",
+      id: 'divider2',
+      divider: true,
+    }, {
+      id: 'contact',
+      title: preferredHeadingCase('Contact Us'),
+      link: '/contact',
+      subItem: true,
     }
   ],
   default: [

--- a/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
+++ b/packages/lesswrong/components/events/modules/VirtualProgramCard.tsx
@@ -8,6 +8,7 @@ import moment from 'moment';
 import { useTracking } from '../../../lib/analyticsEvents';
 import { useCurrentTime } from '../../../lib/utils/timeUtil';
 import { useTimezone } from '../../common/withTimezone';
+import { useEAVirtualPrograms } from '@/components/hooks/useEAVirtualPrograms';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   eventCard: {
@@ -109,24 +110,9 @@ const VirtualProgramCard = ({program, classes}: {
   classes: ClassesType,
 }) => {
   const { captureEvent } = useTracking();
-  const { timezone } = useTimezone();
-  const { FormatDate } = Components;
-  
-  // Find the next deadline for applying to the Intro VP, which is usually the 4th Sunday of every month
-  // (though it will sometimes move to the 3rd or 5th Sunday - this is not accounted for in the code).
-  // This defaults to the Sunday in the week of the 28th day of this month.
-  // NOTE: I changed it to the 1st Sunday since that's what they used for Apr 2024, but that might change back later.
   const now = useCurrentTime()
-  let deadline = moment(now).tz(timezone).date(7).day(0).endOf('day')
-  // If that Sunday is in the past, use next month's 4th Sunday.
-  if (deadline.isBefore(now)) {
-    deadline = moment(now).add(1, 'months').date(7).day(0)
-  }
-  
-  // VP starts 22 days after the deadline, on a Monday
-  const startOfVp = moment(deadline).add(22, 'days')
-  // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
-  const endOfVp = moment(startOfVp).add(8, 'weeks').subtract(1, 'day')
+  const { deadline, start, end } = useEAVirtualPrograms();
+  const { FormatDate } = Components;
 
   if (program === 'intro') {
     return <a
@@ -136,7 +122,7 @@ const VirtualProgramCard = ({program, classes}: {
     >
       <Card className={classNames(classes.eventCard, classes.introVPCard)}>
         <div className={classes.eventCardTime}>
-          <FormatDate date={startOfVp.toISOString()} format={"MMMM D"} granularity='date' /> – <FormatDate date={endOfVp.toISOString()} format={"MMMM D"} granularity='date' />
+          <FormatDate date={start.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} /> – <FormatDate date={end.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} />
         </div>
         <div className={classes.eventCardTitle}>
           Introductory EA Program
@@ -145,7 +131,7 @@ const VirtualProgramCard = ({program, classes}: {
         <div className={classes.eventCardDescription}>
           Explore key ideas in effective altruism through short readings and weekly discussions
         </div>
-        <div className={classes.eventCardDeadline}>Apply by <FormatDate date={deadline.toISOString()} format={"dddd, MMMM D"} granularity='date' /></div>
+        <div className={classes.eventCardDeadline}>Apply by <FormatDate date={deadline.toISOString()} format={"dddd, MMMM D"} granularity='date' tooltip={false} /></div>
       </Card>
     </a>
   }
@@ -155,11 +141,12 @@ const VirtualProgramCard = ({program, classes}: {
     // (as with the Intro/Advanced VP deadline, it will prob sometimes be off by a week or two).
     // The first confirmed deadline is Nov 19, 2023, so we assume the deadlines will be
     // ~the 3rd Sunday in Feb, May, Aug, and Nov each year. Start by checking Feb of this year.
-    // NOTE: I changed it to the 1st Sunday since that's what they used for May 2024, but that might change back later.
-    let precipiceDeadline = moment(now).month(1).date(7).day(0)
+    // NOTE: I changed it to the last Sunday of the prev month since that's what they used for Aug 2024,
+    // but that might change back later.
+    let precipiceDeadline = moment(now).month(1).date(0).day(0)
     // While that day is in the past, keep adding 3 months.
     while (precipiceDeadline.isBefore(now)) {
-      precipiceDeadline = moment(precipiceDeadline).add(3, 'months').date(7).day(0)
+      precipiceDeadline = moment(precipiceDeadline).add(3, 'months').date(0).day(0)
     }
     
     // VP starts 22 days after the deadline, on a Monday
@@ -175,7 +162,7 @@ const VirtualProgramCard = ({program, classes}: {
       >
         <div>
           <div className={classes.eventCardTime}>
-            <FormatDate date={startOfVp.toISOString()} format={"MMMM D"} granularity='date' /> – <FormatDate date={endOfVp.toISOString()} format={"MMMM D"} granularity='date' />
+            <FormatDate date={start.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} /> – <FormatDate date={end.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} />
           </div>
           <div className={classes.eventCardTitle}>
             In-Depth EA Program
@@ -193,7 +180,7 @@ const VirtualProgramCard = ({program, classes}: {
       >
         <div>
           <div className={classes.eventCardTime}>
-            <FormatDate date={startOfPrecipice.toISOString()} format={"MMMM D"} granularity='date' /> – <FormatDate date={endOfPrecipice.toISOString()} format={"MMMM D"} granularity='date' />
+            <FormatDate date={startOfPrecipice.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} /> – <FormatDate date={endOfPrecipice.toISOString()} format={"MMMM D"} granularity='date' tooltip={false} />
           </div>
           <div className={classes.eventCardTitle}>
             <em>The Precipice</em> Reading Group
@@ -201,7 +188,7 @@ const VirtualProgramCard = ({program, classes}: {
           <div className={classes.eventCardDescription}>
             Join weekly discussions about existential risks and safeguarding the future of humanity
           </div>
-          <div className={classes.eventCardDeadline}>Apply by <FormatDate date={precipiceDeadline.toISOString()} format={"dddd, MMMM D"} granularity='date' /></div>
+          <div className={classes.eventCardDeadline}>Apply by <FormatDate date={precipiceDeadline.toISOString()} format={"dddd, MMMM D"} granularity='date' tooltip={false} /></div>
         </div>
       </a>
     </Card>

--- a/packages/lesswrong/components/hooks/useEAVirtualPrograms.ts
+++ b/packages/lesswrong/components/hooks/useEAVirtualPrograms.ts
@@ -1,0 +1,28 @@
+import moment from "moment";
+import { useCurrentTime } from "@/lib/utils/timeUtil";
+import { useTimezone } from "../common/withTimezone";
+
+// See https://www.effectivealtruism.org/virtual-programs for more info,
+// including the current deadline / start / end dates.
+
+export const useEAVirtualPrograms = () => {
+  const { timezone } = useTimezone();
+  
+  // Find the next deadline for applying to the Intro VP, which is usually the 4th Sunday of every month
+  // (though it will sometimes move to the 3rd or 5th Sunday - this is not accounted for in the code).
+  // This defaults to the Sunday in the week of the 28th day of this month.
+  // NOTE: I changed it to the 5th Sunday since that's what they used for June 2024, but that might change later.
+  const now = useCurrentTime()
+  let deadline = moment(now).tz(timezone).date(35).day(0).endOf('day')
+  // If that Sunday is in the past, use next month's 4th Sunday.
+  if (deadline.isBefore(now)) {
+    deadline = moment(now).add(1, 'months').date(35).day(0)
+  }
+  
+  // VP starts 22 days after the deadline, on a Monday
+  const start = moment(deadline).add(22, 'days')
+  // VP ends 8 weeks after the start (subtract a day to end on a Sunday)
+  const end = moment(start).add(8, 'weeks').subtract(1, 'day')
+  
+  return {deadline, start, end}
+}


### PR DESCRIPTION
Based on [this figma](https://www.figma.com/design/qAHRGADVOGojqKpqbGMFFu/2024-Q2?node-id=255-15863):
1. Move Handbook and podcast links to the left side
2. Remove the Resources, Saved posts, and Podcasts sections from the RHS
3. Add a section for the VP Intro Program in the RHS

I also decided to reorganize the bottom links in the left side a bit since adding two new links made it rather long. I separated out the "Contact us" link because I think that's important, and I recently talked with an author who didn't know how to contact us. Honestly there are still a lot of links so maybe we should reorganize it another way. 🤷‍♀️ 

Left side:
<img width="300" alt="Screen Shot 2024-06-06 at 11 26 24 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/e597a818-ef29-4122-8829-d624df672491">

Right side:
<img width="300" alt="Screen Shot 2024-06-07 at 12 03 56 AM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/2e58defb-b0c4-41b1-b11c-f4d0f03f1aec">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207510084217435) by [Unito](https://www.unito.io)
