### PR TITLE
Normalise migration href quotes

### DIFF
--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -225,7 +225,7 @@ voteCallbacks.castVoteAsync.add(async ({newDocument, vote}: VoteDocTuple, collec
 
 const makeMarketComment = async (postId: string, year: number, marketUrl: string, botUser: DbUser) => {
 
-  const commentString = `<p>The <a href="https://www.lesswrong.com/bestoflesswrong">LessWrong Review</a> runs every year to select the posts that have most stood the test of time. This post is not yet eligible for review, but will be at the end of ${year+1}. The top fifty or so posts are featured prominently on the site throughout the year.</p><p>Hopefully, the review is better than karma at judging enduring value. If we have accurate prediction markets on the review results, maybe we can have better incentives on LessWrong today. <a href=${marketUrl}>Will this post make the top fifty?</a></p>
+  const commentString = `<p>The <a href="https://www.lesswrong.com/bestoflesswrong">LessWrong Review</a> runs every year to select the posts that have most stood the test of time. This post is not yet eligible for review, but will be at the end of ${year+1}. The top fifty or so posts are featured prominently on the site throughout the year.</p><p>Hopefully, the review is better than karma at judging enduring value. If we have accurate prediction markets on the review results, maybe we can have better incentives on LessWrong today. <a href="${marketUrl}">Will this post make the top fifty?</a></p>
   `
 
   const result = await createMutator({

--- a/packages/lesswrong/server/manualMigrations/2024-06-05-rewriteOldReviewBotComments.ts
+++ b/packages/lesswrong/server/manualMigrations/2024-06-05-rewriteOldReviewBotComments.ts
@@ -32,7 +32,7 @@ registerMigration({
         continue
       }
 
-      const newContent = `<p>The <a href="https://www.lesswrong.com/bestoflesswrong">LessWrong Review</a> runs every year to select the posts that have most stood the test of time. This post is not yet eligible for review, but will be at the end of ${year}. The top fifty or so posts are featured prominently on the site throughout the year.</p><p>Hopefully, the review is better than karma at judging enduring value. If we have accurate prediction markets on the review results, maybe we can have better incentives on LessWrong today. <a href=${manifoldUrl}>Will this post make the top fifty?</a></p>`;
+      const newContent = `<p>The <a href="https://www.lesswrong.com/bestoflesswrong">LessWrong Review</a> runs every year to select the posts that have most stood the test of time. This post is not yet eligible for review, but will be at the end of ${year}. The top fifty or so posts are featured prominently on the site throughout the year.</p><p>Hopefully, the review is better than karma at judging enduring value. If we have accurate prediction markets on the review results, maybe we can have better incentives on LessWrong today. <a href="${manifoldUrl}">Will this post make the top fifty?</a></p>`;
 
       if (newContent === comment.contents.html) continue;
 


### PR DESCRIPTION
A small fix that makes the migration actually idempotent.

I don't think the change in `votingCallbacks` has any meaningful affect, because I think the revision creation normalises the href to have quotes around it, but seemed nice for consistency.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207517414948462) by [Unito](https://www.unito.io)
