### PR TITLE
fix google doc imports on the alignmentforum

### DIFF
--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -20,7 +20,7 @@ import { cheerioParse } from '../utils/htmlUtil';
 import { isDialogueParticipant } from '../../components/posts/PostsPage/PostsPage';
 import { marketInfoLoader } from '../posts/annualReviewMarkets';
 import { getWithCustomLoader } from '../../lib/loaders';
-import { isLWorAF } from '../../lib/instanceSettings';
+import { isLWorAF, isAF } from '../../lib/instanceSettings';
 import { hasSideComments } from '../../lib/betas';
 import SideCommentCaches from '../../lib/collections/sideCommentCaches/collection';
 import { drive } from "@googleapis/drive";
@@ -34,7 +34,6 @@ import { RecommendedPost, recombeeApi } from '../recombee/client';
 import { HybridRecombeeConfiguration, RecombeeRecommendationArgs } from '../../lib/collections/users/recommendationSettings';
 import { googleVertexApi } from '../google-vertex/client';
 import { userCanDo, userIsAdmin } from '../../lib/vulcan-users/permissions';
-import { isAF } from '../../lib/instanceSettings';
 
 /**
  * Extracts the contents of tag with provided messageId for a collabDialogue post, extracts using Cheerio


### PR DESCRIPTION
Posts created via google doc import in the AF context would previously not be created with the appropriate AF fields: `af: true` if the user already had permission to post to AF, and `suggestForAlignmentUserIds` with the user's id if they didn't.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207517475938939) by [Unito](https://www.unito.io)
