### PR TITLE
Clean Up ManageSubscriptions page

### DIFF
--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -9,25 +9,49 @@ import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { allowSubscribeToSequencePosts, allowSubscribeToUserComments, userHasSubscribeTabFeed } from '../../lib/betas';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
 import { isLW } from '../../lib/instanceSettings';
+import { Class } from 'type-fest';
+import { commentBodyStyles } from '@/themes/stylePiping';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
+  subscriptionsListRoot: {
+    ...commentBodyStyles(theme),
+  },
+  subscriptionListTitle: {
+    fontSize: "1.8rem !important",
+  },
   subscribedItem: {
+    marginLeft: -6,
     display: "flex",
-    ...theme.typography.commentStyle
+    padding: 6,
+    borderRadius: 3,
+    ...theme.typography.commentStyle,
+    '&:hover': {
+      backgroundColor: theme.palette.grey[200],
+    },
   },
   subscribedItemDescription: {
-    flexGrow: 1,
+    marginLeft: 8,
+    fontWeight: 500,
+  },
+  subscriptionTypeDescription: {
+    marginBottom: 10,
+    fontStyle: "italic",
+  },
+  unsubscribeButton: {
+    width: isFriendlyUI ? 87 :82,
+    opacity: 0.7
   },
 });
 
-const SubscriptionsList = ({collectionName, fragmentName, subscriptionType, noSubscriptionsMessage, renderDocument, title, classes}: {
+const SubscriptionsList = ({collectionName, fragmentName, subscriptionType, renderDocument, title, subscriptionTypeDescription, classes}: {
   collectionName: CollectionNameString,
   fragmentName: keyof FragmentTypes,
   subscriptionType: string,
-  noSubscriptionsMessage: string,
   renderDocument: (document: any) => ReactNode,
   title: React.ReactNode,
-  classes: ClassesType,
+  subscriptionTypeDescription?: String
+  classes: ClassesType<typeof styles>,
 }) => {
   const { SubscribedItem, SectionTitle, Loading, LoadMore } = Components;
   const currentUser = useCurrentUser();
@@ -38,10 +62,12 @@ const SubscriptionsList = ({collectionName, fragmentName, subscriptionType, noSu
       userId: currentUser?._id,
       collectionName: collectionName,
       subscriptionType: subscriptionType,
-      limit: 50
+      limit: 20,
     },
     collectionName: "Subscriptions",
     fragmentName: "SubscriptionState",
+    itemsPerPage: 100,
+    enableTotal: true
   });
   
   if (!currentUser)
@@ -50,9 +76,14 @@ const SubscriptionsList = ({collectionName, fragmentName, subscriptionType, noSu
     return <Loading/>
   if (!results)
     return null;
+  if (results.length === 0)
+    return null;
   
-  return <div>
-    <SectionTitle title={title}/>
+  return <div className={classes.subscriptionsListRoot}>
+    <SectionTitle title={title} className={classes.subscriptionListTitle}/>
+    {subscriptionTypeDescription && <div className={classes.subscriptionTypeDescription}>
+      {subscriptionTypeDescription}
+    </div>}
     {results.map(result =>
       <SubscribedItem
         key={result._id}
@@ -62,9 +93,6 @@ const SubscriptionsList = ({collectionName, fragmentName, subscriptionType, noSu
         renderDocument={renderDocument}
       />
     )}
-    {results.length===0 && <div className={classes.subscribedItem}>
-      {noSubscriptionsMessage}
-    </div>}
     {showLoadMore && <LoadMore {...loadMoreProps} />}
   </div>
 }
@@ -82,7 +110,7 @@ const SubscribedItem = ({collectionName, fragmentName, subscription, renderDocum
   fragmentName: keyof FragmentTypes,
   subscription: SubscriptionState,
   renderDocument: (document: any) => ReactNode,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>
 }) => {
   const { Loading, NotifyMeButton } = Components;
   const { document, loading } = useSingle({
@@ -94,15 +122,16 @@ const SubscribedItem = ({collectionName, fragmentName, subscription, renderDocum
   if (loading) return <Loading/>
   
   return <div className={classes.subscribedItem}>
-    <div className={classes.subscribedItemDescription}>
-    {renderDocument(document)}
-    </div>
     <NotifyMeButton
       document={document}
       subscriptionType={subscription.type}
       subscribeMessage="Resubscribe"
       unsubscribeMessage="Unsubscribe"
+      className={classes.unsubscribeButton}
     />
+    <div className={classes.subscribedItemDescription}>
+    {renderDocument(document)}
+    </div>
   </div>
   
 }
@@ -129,37 +158,37 @@ const ViewSubscriptionsPage = ({classes}: {
   
   return <SingleColumnSection>
     {userHasSubscribeTabFeed(currentUser) && <SubscriptionsList
-      title="Subscribed to Users for Subscribed Activity Feed"
+      title="Users You Are Following"
       collectionName="Users"
       subscriptionType="newActivityForFeed"
       fragmentName="UsersMinimumInfo"
-      renderDocument={(user: UsersMinimumInfo) => <UsersNameDisplay user={user}/>}
-      noSubscriptionsMessage="You are not subscribed to any users on your Subscribed Feed."
+      renderDocument={(user: UsersMinimumInfo) => <UsersNameDisplay user={user} tooltipPlacement='top' hideFollowButton />}
+      subscriptionTypeDescription="These users will appear in the feed on your frontpage Subscribed Tab"
     />}
     <SubscriptionsList
-      title="Subscribed to Posts By Users"
+      title="Notifications for New Posts by Users"
       collectionName="Users"
       subscriptionType="newPosts"
       fragmentName="UsersMinimumInfo"
       renderDocument={(user: UsersMinimumInfo) => <UsersNameDisplay user={user}/>}
-      noSubscriptionsMessage="You are not subscribed to any users' posts."
+      subscriptionTypeDescription="Manage onsite and offsite notification preferences in your account settings"
     />
     {allowSubscribeToUserComments && <SubscriptionsList
-      title="Subscribed to All Comments By Users"
+      title="Notifications for All New Comments by Users"
       collectionName="Users"
       subscriptionType="newUserComments"
       fragmentName="UsersMinimumInfo"
       renderDocument={(user: UsersMinimumInfo) => <UsersNameDisplay user={user}/>}
-      noSubscriptionsMessage="You are not subscribed to any users' comments."
+      subscriptionTypeDescription="Manage onsite and offsite (email) notification preferences in your account settings"
     />}
     
     <SubscriptionsList
-      title="Subscribed to Comments on Posts"
+      title="Notification of Comments on Posts"
       collectionName="Posts"
       subscriptionType="newComments"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to comments on any posts."
+      subscriptionTypeDescription="You will receive notifications for any new comments on these posts"
     />
 
     <SubscriptionsList
@@ -168,7 +197,7 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newPublishedDialogueMessages"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any dialogues as a reader."
+      subscriptionTypeDescription="You will be notified of new activity in these dialogues."
     />
 
     <SubscriptionsList
@@ -177,7 +206,7 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newDialogueMessages"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any dialogues as a participant."
+      subscriptionTypeDescription="You will be notified of new activity by your dialogue partners on these dialogues."
     />
   
     {isLW && <SubscriptionsList
@@ -186,7 +215,6 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newDebateComments"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any dialogues as a reader."
     />}
   
     <SubscriptionsList
@@ -195,18 +223,17 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newDebateReplies"
       fragmentName="PostsList"
       renderDocument={(post: PostsList) => post.title}
-      noSubscriptionsMessage="You are not subscribed to any dialogues as a participant."
     />
 
     <SubscriptionsList
-      title="Subscribed to Comment Replies"
+      title="Notification of Comment Replies"
       collectionName="Comments"
       subscriptionType="newReplies"
       fragmentName="CommentsListWithParentMetadata"
       renderDocument={(comment: CommentsListWithParentMetadata) => <Link to={commentGetPageUrlFromIds({postId: comment?.post?._id, postSlug: comment?.post?.slug, tagSlug: comment?.tag?.slug, tagCommentType: comment?.tagCommentType, commentId: comment?._id, permalink: true})}>
-        author: {comment?.user?.displayName} post: {comment?.post?.title}
+        author: {comment?.user?.displayName}, post: {comment?.post?.title}
       </Link>}
-      noSubscriptionsMessage="You are not subscribed to any comment replies."
+      subscriptionTypeDescription="You will get notifications on replies to these comments."
     />
 
     <SubscriptionsList
@@ -215,7 +242,7 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newEvents"
       fragmentName="localGroupsBase"
       renderDocument={(group: localGroupsBase) => group.name}
-      noSubscriptionsMessage="You are not subscribed to any local groups."
+      subscriptionTypeDescription="You will be notified of new events from these Local Groups"
     />
 
     <SubscriptionsList
@@ -224,7 +251,7 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newTagPosts"
       fragmentName="TagPreviewFragment"
       renderDocument={(tag: TagPreviewFragment) => <Link to={tagGetUrl(tag)}>{tag.name}</Link>}
-      noSubscriptionsMessage="You are not subscribed to any tags."
+      subscriptionTypeDescription="You will be notified when posts have these tags added"
     />
     
     {allowSubscribeToSequencePosts && <SubscriptionsList
@@ -233,7 +260,7 @@ const ViewSubscriptionsPage = ({classes}: {
       subscriptionType="newSequencePosts"
       fragmentName="SequencesPageTitleFragment"
       renderDocument={(sequence: SequencesPageTitleFragment) => <Link to={sequenceGetPageUrl(sequence)}>{sequence.title}</Link>}
-      noSubscriptionsMessage="You are not subscribed to any sequences."
+      subscriptionTypeDescription="You will be notified when new posts are added to these sequences"
     />}
     
   </SingleColumnSection>;

--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -9,7 +9,6 @@ import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { allowSubscribeToSequencePosts, allowSubscribeToUserComments, userHasSubscribeTabFeed } from '../../lib/betas';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
 import { isLW } from '../../lib/instanceSettings';
-import { Class } from 'type-fest';
 import { commentBodyStyles } from '@/themes/stylePiping';
 import { isFriendlyUI } from '@/themes/forumTheme';
 
@@ -39,7 +38,7 @@ const styles = (theme: ThemeType) => ({
     fontStyle: "italic",
   },
   unsubscribeButton: {
-    width: isFriendlyUI ? 87 :82,
+    minWidth: 82,
     opacity: 0.7
   },
 });
@@ -183,7 +182,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />}
     
     <SubscriptionsList
-      title="Notification of Comments on Posts"
+      title="Notifications of Comments on Posts"
       collectionName="Posts"
       subscriptionType="newComments"
       fragmentName="PostsList"
@@ -192,7 +191,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Subscribed to Dialogues (as a reader)"
+      title="Notification of Dialogue Activity (as a reader)"
       collectionName="Posts"
       subscriptionType="newPublishedDialogueMessages"
       fragmentName="PostsList"
@@ -201,7 +200,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Subscribed to Dialogues (as a participant)"
+      title="Notification of Dialogue Activity (as a participant)"
       collectionName="Posts"
       subscriptionType="newDialogueMessages"
       fragmentName="PostsList"
@@ -226,7 +225,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Notification of Comment Replies"
+      title="Notifications of Comment Replies"
       collectionName="Comments"
       subscriptionType="newReplies"
       fragmentName="CommentsListWithParentMetadata"
@@ -237,7 +236,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Subscribed to Local Groups"
+      title="Notifications of Local Groups Activity"
       collectionName="Localgroups"
       subscriptionType="newEvents"
       fragmentName="localGroupsBase"
@@ -246,7 +245,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
 
     <SubscriptionsList
-      title="Subscribed to Tags"
+      title="Notification of New Posts with Tags"
       collectionName="Tags"
       subscriptionType="newTagPosts"
       fragmentName="TagPreviewFragment"
@@ -255,7 +254,7 @@ const ViewSubscriptionsPage = ({classes}: {
     />
     
     {allowSubscribeToSequencePosts && <SubscriptionsList
-      title="Subscribed to Sequences"
+      title="Notifications of New Post Added to Sequences"
       collectionName="Sequences"
       subscriptionType="newSequencePosts"
       fragmentName="SequencesPageTitleFragment"

--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -10,7 +10,6 @@ import { allowSubscribeToSequencePosts, allowSubscribeToUserComments, userHasSub
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
 import { isLW } from '../../lib/instanceSettings';
 import { commentBodyStyles } from '@/themes/stylePiping';
-import { isFriendlyUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
   subscriptionsListRoot: {
@@ -38,8 +37,9 @@ const styles = (theme: ThemeType) => ({
     fontStyle: "italic",
   },
   unsubscribeButton: {
-    minWidth: 82,
-    opacity: 0.7
+    minWidth: 83,
+    opacity: 0.7,
+    wordBreak: "keep-all"
   },
 });
 


### PR DESCRIPTION
(this PR is built on my other Subscriptions PR, it should be merged after)

The manage subscriptions page was never really styled. I did a quick job to make it look a little better. 

- The largest change is not showing empty lists for subscription types a user doesn't have any subscriptions of. There are too many and it's cluttered and overwhelming.
- I've added an optional description for each subscription type
- I gave the subscription type new titles, focusing that most of them are notifications (to distinguish them from following/include in feed)

This work is not forum gated because I assume the EAF would like all these changes. Please confirm.

<img width="1723" alt="Manage Subscriptions — LessWrong 2024-06-10 13-27-50" src="https://github.com/ForumMagnum/ForumMagnum/assets/7250541/b0d3480e-cdb2-472f-955c-9d18d4941cba">

<img width="1967" alt="Manage Subscriptions — LessWrong 2024-06-10 13-34-28" src="https://github.com/ForumMagnum/ForumMagnum/assets/7250541/f6c8f500-ae6c-47b6-a5f4-02e2d7be5f48">

<img width="2044" alt="Manage Subscriptions — EA Forum 2024-06-10 13-36-49" src="https://github.com/ForumMagnum/ForumMagnum/assets/7250541/76b552d6-c757-412c-b23e-a43dc4cfd20d">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207534036460623) by [Unito](https://www.unito.io)
