### PR TITLE
Exclude current user from isDisplayNameTaken

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -589,13 +589,13 @@ class UsersRepo extends AbstractRepo<"Users"> {
     return result;
   }
 
-  async isDisplayNameTaken(displayName: string): Promise<boolean> {
+  async isDisplayNameTaken({ displayName, currentUserId }: { displayName: string; currentUserId: string; }): Promise<boolean> {
     const result = await this.getRawDb().one(`
       -- UsersRepo.isDisplayNameTaken
       SELECT COUNT(*) > 0 AS "isDisplayNameTaken"
       FROM "Users"
-      WHERE "displayName" = $1
-    `, [displayName]);
+      WHERE "displayName" = $1 AND NOT "_id" = $2
+    `, [displayName, currentUserId]);
     return result.isDisplayNameTaken;
   }
   

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -339,7 +339,7 @@ defineQuery({
     if (!currentUser) {
       throw new Error("You must be logged in to do this");
     }
-    const isTaken = await context.repos.users.isDisplayNameTaken(displayName);
+    const isTaken = await context.repos.users.isDisplayNameTaken({ displayName, currentUserId: currentUser._id });
     return isTaken;
   }
 });


### PR DESCRIPTION
When people sign up via google oauth the created user already has their full name as its `displayName`, which previously resulted in an error if the person tried to set their exact name as their display name during sign up. This fixes that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207541518043883) by [Unito](https://www.unito.io)
