### PR TITLE
Contents of inline reacts are highlighted even when split up by italics/etc

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -37,6 +37,7 @@ import { useDynamicTableOfContents } from '../../hooks/useDynamicTableOfContents
 import { RecombeeRecommendationsContextWrapper } from '../../recommendations/RecombeeRecommendationsContextWrapper';
 import { getBrowserLocalStorage } from '../../editor/localStorageHandlers';
 import ForumNoSSR from '../../common/ForumNoSSR';
+import { HoveredReactionContextProvider } from '@/components/votes/lwReactions/HoveredReactionContextProvider';
 
 export const MAX_COLUMN_WIDTH = 720
 export const CENTRAL_COLUMN_WIDTH = 682
@@ -703,6 +704,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
       {!post.debate && <ContentStyles contentType="post" className={classNames(classes.postContent, "instapaper_body")}>
         <PostBodyPrefix post={post} query={query}/>
         <AnalyticsContext pageSectionContext="postBody">
+          <HoveredReactionContextProvider>
           <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>
             {htmlWithAnchors &&
               <PostBody
@@ -712,6 +714,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
               />
             }
           </CommentOnSelectionContentWrapper>
+          </HoveredReactionContextProvider>
         </AnalyticsContext>
       </ContentStyles>}
 

--- a/packages/lesswrong/components/votes/lwReactions/HoveredReactionContextProvider.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/HoveredReactionContextProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib';
+import { QuoteLocator } from '@/lib/voting/namesAttachedReactions';
 
 /**
  * A list of reaction-types whose buttons are hovered. Passed around as a
@@ -7,7 +8,7 @@ import { registerComponent } from '../../../lib/vulcan-lib';
  * if you hover over reaction icons in a comment footer, the corresponding
  * reaction inside a comment will be highlighted.
  */
-export const HoveredReactionListContext = React.createContext<string[]|null>(null);
+export const HoveredReactionListContext = React.createContext<HoveredReaction[]|null>(null);
 
 /**
  * A callback function for reporting that a reaction-type has been hovered or
@@ -20,14 +21,20 @@ export const SetHoveredReactionContext = React.createContext<((change: HoveredRe
 
 type HoveredReactionChange = {
   reactionName: string,
+  quote: QuoteLocator | null,
   isHovered: boolean,
 };
 
-function hoveredReactionsReducer(hoveredReactions: string[], change: HoveredReactionChange): string[] {
-  if (change.isHovered && !hoveredReactions.find(r=>r===change.reactionName)) {
-    return [...hoveredReactions, change.reactionName];
-  } else if (!change.isHovered && hoveredReactions.find(r=>r===change.reactionName)) {
-    return (hoveredReactions.filter(r=>r!==change.reactionName));
+type HoveredReaction = {
+  reactionName: string,
+  quote: QuoteLocator | null,
+};
+
+function hoveredReactionsReducer(hoveredReactions: HoveredReaction[], change: HoveredReactionChange): HoveredReaction[] {
+  if (change.isHovered && !hoveredReactions.find(r=>r.reactionName===change.reactionName && r.quote===change.quote)) {
+    return [...hoveredReactions, { reactionName: change.reactionName, quote: change.quote }];
+  } else if (!change.isHovered && hoveredReactions.find(r=>r.reactionName===change.reactionName && r.quote===change.quote)) {
+    return (hoveredReactions.filter(r=>r.reactionName!==change.reactionName || r.quote!==change.quote));
   } else {
     return hoveredReactions;
   }

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -3,20 +3,17 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import type { NamesAttachedReactionsList, QuoteLocator } from '../../../lib/voting/namesAttachedReactions';
 import type { VotingProps } from '../votingProps';
 import classNames from 'classnames';
-import { HoveredReactionListContext } from './HoveredReactionContextProvider';
+import { HoveredReactionListContext, SetHoveredReactionContext } from './HoveredReactionContextProvider';
 import sumBy from 'lodash/sumBy';
+import { useHover } from '@/components/common/withHover';
 
-const styles = (theme: ThemeType): JssStyles => ({
-  highlight: {
-    "&:hover": {
-      backgroundColor: theme.palette.grey[200],
-    },
+const styles = (theme: ThemeType) => ({
+  reactionTypeHovered: {
+    backgroundColor: theme.palette.grey[200],
   },
   
-  reactionTypeHovered: {
-    backgroundColor: theme.palette.background.primaryTranslucentHeavy,
-  },
-
+  // Keeping this empty class around is necessary for the following @global style to work properly
+  highlight: {},
   // Comment or post hovered
   "@global": {
     [
@@ -37,18 +34,42 @@ const InlineReactHoverableHighlight = ({quote,reactions, voteProps, children, cl
   reactions: NamesAttachedReactionsList,
   voteProps: VotingProps<VoteableTypeClient>,
   children: React.ReactNode,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const { InlineReactHoverInfo, LWTooltip } = Components;
+
   const hoveredReactions = useContext(HoveredReactionListContext);
   const isHovered = hoveredReactions
     && Object.keys(reactions).some(reaction =>
-      hoveredReactions.find(r=>r===reaction)
+      hoveredReactions.find(r=>r.reactionName===reaction && (r.quote === quote || r.quote === null))
     );
+
+  const setHoveredReaction = useContext(SetHoveredReactionContext);
+
+  function updateHoveredReactions(isHovered: boolean) {
+    for (const [reactionName, documentReactionInfo] of Object.entries(reactions)) {
+      if (documentReactionInfo) {
+        for (const { quotes } of documentReactionInfo) {
+          const [reactQuote] = quotes ?? [];
+          if (quote === reactQuote) {
+            setHoveredReaction?.({ isHovered, quote: reactQuote, reactionName });
+          }
+        }
+      }
+    }
+  }
+
+  const { eventHandlers } = useHover({
+    onEnter: () => updateHoveredReactions(true),
+    onLeave: () => updateHoveredReactions(false)
+  });
   
   // (reactions is already filtered by quote, we don't have to filter it again for this)
   const anyPositive = atLeastOneQuoteReactHasPositiveScore(reactions);
   
+  // We underline any given inline react if either:
+  // 1) the quote itself is hovered over, or
+  // 2) if the post/comment is hovered over, and the react has net-positive agreement across all users
   const shouldUnderline = isHovered || anyPositive;
 
   return <LWTooltip
@@ -63,7 +84,7 @@ const InlineReactHoverableHighlight = ({quote,reactions, voteProps, children, cl
     inlineBlock={false}
     clickable={true}
   >
-    <span className={classNames({
+    <span {...eventHandlers} className={classNames({
       [classes.highlight]: shouldUnderline,
       [classes.reactionTypeHovered]: isHovered
     })}>

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -376,12 +376,12 @@ const HoverableReactionIcon = ({reactionRowRef, react, numberShown, voteProps, q
   }
 
   function handleMouseEnter (e: any) {
-    setHoveredReaction?.({reactionName: react, isHovered: true});
+    setHoveredReaction?.({reactionName: react, isHovered: true, quote: null});
     onMouseOver(e);
   }
   
   function handleMouseLeave () {
-    setHoveredReaction?.({reactionName: react, isHovered: false});
+    setHoveredReaction?.({reactionName: react, isHovered: false, quote: null});
     onMouseLeave();
   }
 


### PR DESCRIPTION
Previously, inline reacts had their highlight-on-hover split up by e.g. italics and links.  Now they are highlighted even when split up by italics/etc.