### PR TITLE
Some links navigate on press, rather than on release

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
@@ -37,7 +37,7 @@ const AlignmentForumHome = ({classes}: {
       <SingleColumnSection>
         <SectionTitle title="AI Alignment Posts">
           { currentUser && userCanDo(currentUser, "posts.alignment.new") && 
-            <Link to={{pathname:"/newPost", search: `?af=true`}}>
+            <Link to={"/newPost?af=true"}>
               <SectionButton>
                 <AddIcon />
                 New Post

--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -6,12 +6,21 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 // eslint-disable-next-line no-restricted-imports
 import type { LinkProps } from 'react-router-dom';
+import { useNavigate } from '@/lib/routeUtil';
 
 type ScrollFunction = ((el: HTMLElement) => void);
 
-export type HashLinkProps = LinkProps & {
+export type HashLinkProps = {
+  to: string
+  id?: string,
+  nofollow?: boolean,
+  target?: string,
+  doOnDown?: boolean
+  onMouseDown?: React.MouseEventHandler<HTMLAnchorElement>
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
   scroll?: ScrollFunction,
   smooth?: boolean
+  children?: React.ReactNode,
 };
 
 let hashFragment = '';
@@ -59,21 +68,16 @@ function hashLinkScroll() {
   }, 0);
 }
 
-export function genericHashLink(props: HashLinkProps) {
+export function HashLink(props: HashLinkProps) {
+  const navigate = useNavigate();
+
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     reset();
     if (props.onClick) props.onClick(e);
-    if (typeof props.to === 'string') {
-      hashFragment = props.to
-        .split('#')
-        .slice(1)
-        .join('#');
-    } else if (
-      typeof props.to === 'object' &&
-      typeof props.to?.hash === 'string'
-    ) {
-      hashFragment = props.to.hash.replace('#', '');
-    }
+    hashFragment = props.to
+      .split('#')
+      .slice(1)
+      .join('#');
     if (hashFragment !== '') {
       scrollFunction =
         props.scroll ||
@@ -84,33 +88,36 @@ export function genericHashLink(props: HashLinkProps) {
       hashLinkScroll();
     }
   }
-  const { scroll, smooth, children, ...filteredProps } = props;
-  return (
-    <Link {...filteredProps} onClick={handleClick}>
+  const { scroll, smooth, children, doOnDown, to, ...filteredProps } = props;
+  if (doOnDown && !filteredProps.target) {
+    return <a
+      {...filteredProps}
+      href={to}
+      onMouseDown={(ev) => {
+        if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0) {
+          return;
+        }
+        navigate(to);
+        ev.preventDefault();
+      }}
+    >
+      {props.children}
+    </a>
+  } else {
+    return <Link to={to} {...filteredProps} onClick={handleClick}>
       {props.children}
     </Link>
-  );
-}
-
-export function HashLink(props: HashLinkProps) {
-  return genericHashLink(props);
+  }
 }
 
 export function getHashLinkOnClick(props: HashLinkProps) {
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     reset();
     if (props.onClick) props.onClick(e);
-    if (typeof props.to === 'string') {
-      hashFragment = props.to
-        .split('#')
-        .slice(1)
-        .join('#');
-    } else if (
-      typeof props.to === 'object' &&
-      typeof props.to?.hash === 'string'
-    ) {
-      hashFragment = props.to.hash.replace('#', '');
-    }
+    hashFragment = props.to
+      .split('#')
+      .slice(1)
+      .join('#');
     if (hashFragment !== '') {
       scrollFunction =
         props.scroll ||

--- a/packages/lesswrong/components/dropdowns/posts/DuplicateEventDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/DuplicateEventDropdownItem.tsx
@@ -13,16 +13,13 @@ const DuplicateEventDropdownItem = ({post}: {post: PostsBase}) => {
     return null;
   }
 
-  const link = {
-    pathname:'/newPost',
-    search:`?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`,
-  };
+  const linkUrl = `/newPost?${qs.stringify({eventForm: post.isEvent, templateId: post._id})}`;
 
   const {DropdownItem} = Components;
   return (
     <DropdownItem
       title={preferredHeadingCase("Duplicate Event")}
-      to={link}
+      to={linkUrl}
       icon="Edit"
     />
   );

--- a/packages/lesswrong/components/dropdowns/posts/EditPostDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/EditPostDropdownItem.tsx
@@ -16,14 +16,8 @@ const EditPostDropdownItem = ({post}: {post: PostsBase}) => {
   }
 
   const link = (isEditor || isPodcaster)
-    ? {
-      pathname:'/editPost',
-      search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`,
-    }
-    : {
-      pathname:'/collaborateOnPost',
-      search:`?${qs.stringify({postId: post._id})}`,
-    };
+    ? `/editPost?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`
+    : `/collaborateOnPost?${qs.stringify({postId: post._id})}`;
 
   const {DropdownItem} = Components;
   return (

--- a/packages/lesswrong/components/dropdowns/posts/PostAnalyticsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostAnalyticsDropdownItem.tsx
@@ -12,10 +12,7 @@ const PostAnalyticsDropdownItem = ({post}: {post: PostsBase}) => {
     return null;
   }
 
-  const link = {
-    pathname: "/postAnalytics",
-    search: `?${qs.stringify({postId: post._id})}`,
-  };
+  const link = `/postAnalytics?${qs.stringify({postId: post._id})}`;
 
   const {DropdownItem} = Components;
   return (

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -420,7 +420,7 @@ const LocalGroupPage = ({ classes, documentId: groupId }: {
             <SectionFooter className={classes.organizerActions}>
               {canCreateEvent &&
                 (!isEAForum || isAdmin || isGroupAdmin) && <SectionButton>
-                  <Link to={{pathname:"/newPost", search: `?${qs.stringify({eventForm: true, groupId})}`}}>
+                  <Link to={`/newPost?${qs.stringify({eventForm: true, groupId})}`}>
                     New event
                   </Link>
                 </SectionButton>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -226,7 +226,7 @@ const PostsTitle = ({
         </InteractionWrapper>
       </span>}
       <span className={!wrap ? classes.eaTitleDesktopEllipsis : undefined}>
-        {isLink ? <Link to={url} eventProps={linkEventProps}>{title}</Link> : title }
+        {isLink ? <Link to={url} doOnDown={true} eventProps={linkEventProps}>{title}</Link> : title }
       </span>
       {showIcons && <span className={classes.hideXsDown}>
         <InteractionWrapper className={classes.interactionWrapper}>
@@ -244,7 +244,7 @@ const PostsTitle = ({
             tagSlug={currentForumEvent.tag.slug}
             className={classes.highlightedTagTooltip}
           >
-            <Link to={tagGetUrl(currentForumEvent.tag)}>
+            <Link doOnDown={true} to={tagGetUrl(currentForumEvent.tag)}>
               <span
                 className={classes.eventTag}
                 style={{

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -408,7 +408,7 @@ const SpreadsheetPage = ({classes}: {
 
   if (loading) return <Loading />
 
-  const dataRows = _.filter(data.CoronaVirusData.values, (row: any): boolean => row.accepted === "Accept")
+  const dataRows = _.filter(data?.CoronaVirusData.values, (row: any): boolean => row.accepted === "Accept")
   const sortedRowsAdded = _.sortBy(dataRows, (row: any) => -row.dateAdded)
   const sortedRowsImp = _.sortBy(sortedRowsAdded, (row: any) => -row.imp)
 
@@ -583,7 +583,7 @@ const SpreadsheetPage = ({classes}: {
             }, rowNum) => (
               <TableRow key={`row-${rowNum}`} id={encodeURIComponent(url)} className={selectedCell === `#${encodeURIComponent(url)}` ? classes.selectedRow : ''} >
                 <TableCell classes={{root: classes.leftFixed0}}>
-                  <Link to={{hash: encodeURIComponent(url), search: `?${qs.stringify({tab: selectedTab})}`}}>{imp}</Link>
+                  <Link to={`/coronavirus-link-database?${qs.stringify({tab: selectedTab})}#${encodeURIComponent(url)}`}>{imp}</Link>
                 </TableCell>
                 <TableCell className={classes.leftFixed1}>
                   {linkCell(url, link, domain, type)}

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -11,6 +11,7 @@ import qs from 'qs'
 
 type LinkProps = {
   to?: HashLinkProps['to']|null
+  doOnDown?: boolean
   onMouseDown?: HashLinkProps['onMouseDown']
   onClick?: HashLinkProps['onClick']
   rel?: string


### PR DESCRIPTION
See: https://x.com/ID_AA_Carmack/status/1787850053912064005

Adds a prop `doOnDown` to our `Link` component which, if true, makes the link navigate on press rather than on release. Currently we apply this only to `PostsTitle` (which is used in `PostsItem`). Also refactor the `Link` component so that the `to` field is always a string, replacing a few cases where it was an object and was relying on `react-router-dom` to do string-munging to turn it into a link.

If feedback on this is positive, we may wish to change the default value of `doOnDown` to `true`, so that it applies to all links, not just post links. For now we're not doing that because there's some risk that some weird link we're not paying attention to interacts badly with it, eg a link with a custom `onClick` handler.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207546082818220) by [Unito](https://www.unito.io)
