### PR TITLE
update readstatus lastUpdated when users interact with comments in subscribed feed

### DIFF
--- a/packages/lesswrong/components/hooks/useRecordPostView.tsx
+++ b/packages/lesswrong/components/hooks/useRecordPostView.tsx
@@ -128,7 +128,7 @@ export const useRecordPostView = (post: ViewablePost) => {
         // Set the value to true even if technically we might be saving isRead: false on the server, if the post hasn't been read before, to get the correct UI update.
         setPostRead(post._id, true);
 
-        // Only send update to server the first time a user interacts with the comments after the page is rendered (and the client-side cache isn't populated yet).
+        // Calling `setPostRead` above ensures we only send an update to server the first time this is triggered.
         // Otherwise it becomes much more likely that someone else posts a comment after the first time we send this,
         // but then we send it again because e.g. the user clicked on another comment (from the initial render).
         void markPostCommentsRead({

--- a/packages/lesswrong/components/hooks/useRecordPostView.tsx
+++ b/packages/lesswrong/components/hooks/useRecordPostView.tsx
@@ -58,6 +58,14 @@ export const useRecordPostView = (post: ViewablePost) => {
   `, {
     ignoreResults: true
   });
+
+  const [markPostCommentsRead] = useMutation(gql`
+    mutation markPostCommentsRead($postId: String!) {
+      markPostCommentsRead(postId: $postId)
+    }
+  `, {
+    ignoreResults: true
+  });
   
   const {recordEvent} = useNewEvents()
   const currentUser = useCurrentUser();
@@ -112,8 +120,25 @@ export const useRecordPostView = (post: ViewablePost) => {
       console.log("recordPostView error:", error); // eslint-disable-line
     }
   }, [postsRead, setPostRead, increasePostViewCount, sendVertexViewItemEvent, currentUser, recordEvent]);
+
+  const recordPostCommentsView = ({ post }: Pick<RecordPostViewArgs, 'post'>) => {
+    if (currentUser) {
+      if (!postsRead[post._id]) {
+        // Update the client-side read status cache.
+        // Set the value to true even if technically we might be saving isRead: false on the server, if the post hasn't been read before, to get the correct UI update.
+        setPostRead(post._id, true);
+
+        // Only send update to server the first time a user interacts with the comments after the page is rendered (and the client-side cache isn't populated yet).
+        // Otherwise it becomes much more likely that someone else posts a comment after the first time we send this,
+        // but then we send it again because e.g. the user clicked on another comment (from the initial render).
+        void markPostCommentsRead({
+          variables: { postId: post._id }
+        });
+      }
+    }
+  };
   
-  return { recordPostView, isRead };
+  return { recordPostView, recordPostCommentsView, isRead };
 }
 
 

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Components,
   registerComponent,
@@ -14,6 +14,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
+import { useEventListener } from '../hooks/useEventListener';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -189,6 +190,7 @@ const FeedPostCommentsCard = ({
     lastVisitedAt,
     nestedComments,
     treeOptions,
+    markCommentsAsRead,
   } = useRecentDiscussionThread({
     post,
     comments,
@@ -222,7 +224,7 @@ const FeedPostCommentsCard = ({
             />
         </div>
 
-        {nestedComments.length > 0 && <div className={classes.commentsList}>
+        {nestedComments.length > 0 && <div className={classes.commentsList} onMouseDown={markCommentsAsRead}>
           {nestedComments.map((comment: CommentTreeNode<CommentsList>) => {
             return <FeedPostCommentsBranch
               key={comment.item._id}

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Components,
   registerComponent,
@@ -14,7 +14,6 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
-import { useEventListener } from '../hooks/useEventListener';
 
 const styles = (theme: ThemeType) => ({
   root: {

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -19,7 +19,7 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   const [highlightVisible, setHighlightVisible] = useState(false);
   const [markedAsVisitedAt, setMarkedAsVisitedAt] = useState<Date|null>(null);
   const [expandAllThreads, setExpandAllThreads] = useState(initialExpandAllThreads ?? false);
-  const {recordPostView} = useRecordPostView(post);
+  const {recordPostView, recordPostCommentsView} = useRecordPostView(post);
 
   const markAsRead = useCallback(
     () => {
@@ -35,6 +35,14 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
       markAsRead();
     },
     [setHighlightVisible, highlightVisible, markAsRead],
+  );
+
+  const markCommentsAsRead = useCallback(
+    () => {
+      setMarkedAsVisitedAt(new Date());
+      void recordPostCommentsView({ post });
+    },
+    [recordPostCommentsView, post]
   );
 
   const lastCommentId = comments && comments[0]?._id;
@@ -70,6 +78,7 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   return {
     isSkippable,
     showHighlight,
+    markCommentsAsRead,
     expandAllThreads,
     lastVisitedAt,
     nestedComments,

--- a/packages/lesswrong/server/markAsUnread.ts
+++ b/packages/lesswrong/server/markAsUnread.ts
@@ -1,3 +1,4 @@
+import { defineMutation } from './utils/serverGraphqlUtil';
 import { addGraphQLMutation, addGraphQLResolvers } from './vulcan-lib';
 
 addGraphQLMutation('markAsReadOrUnread(postId: String, isRead:Boolean): Boolean');
@@ -13,5 +14,20 @@ addGraphQLResolvers({
       
       return isRead;
     }
+  }
+});
+
+defineMutation({
+  name: 'markPostCommentsRead',
+  argTypes: '(postId: String!)',
+  resultType: 'Boolean',
+  fn: async (_, { postId }: { postId: string }, context) => {
+    const { currentUser, repos } = context;
+
+    if (!currentUser) {
+      throw new Error('You need to be logged in to mark post comments read');
+    }
+
+    await context.repos.readStatuses.upsertReadStatus(currentUser._id, postId, false, { skipIsReadUpdateOnUpsert: true });
   }
 });

--- a/packages/lesswrong/server/repos/ReadStatusesRepo.ts
+++ b/packages/lesswrong/server/repos/ReadStatusesRepo.ts
@@ -3,12 +3,23 @@ import { randomId } from "../../lib/random";
 import AbstractRepo from "./AbstractRepo";
 import { recordPerfMetrics } from "./perfMetricWrapper";
 
+interface UpsertReadStatusOptions {
+  skipIsReadUpdateOnUpsert?: boolean;
+}
+
 class ReadStatusesRepo extends AbstractRepo<"ReadStatuses"> {
   constructor() {
     super(ReadStatuses);
   }
 
-  upsertReadStatus(userId: string, postId: string, isRead: boolean): Promise<DbReadStatus> {
+  /**
+   * In the case where we're upserting a read status because the comments were read (but not the post),
+   * `skipIsReadUpdateOnUpsert` prevents us from updating any existing `isRead` value, and only sets `isRead: false` during the insert
+   */
+  upsertReadStatus(userId: string, postId: string, isRead: boolean, options: UpsertReadStatusOptions = {}): Promise<DbReadStatus> {
+    const { skipIsReadUpdateOnUpsert } = options;
+    const updateIsReadClause = skipIsReadUpdateOnUpsert ? '' : '"isRead" = $(isRead),';
+
     return this.one(`
       INSERT INTO "ReadStatuses" (
         "_id",
@@ -25,7 +36,7 @@ class ReadStatusesRepo extends AbstractRepo<"ReadStatuses"> {
         COALESCE("tagId", '')
       )
       DO UPDATE SET
-        "isRead" = $(isRead),
+        ${updateIsReadClause}
         "lastUpdated" = $(lastUpdated)
       RETURNING *
       `, {


### PR DESCRIPTION
This reintroduces functionality somewhat similar to what was removed in https://github.com/ForumMagnum/ForumMagnum/pull/6309, except only for the Subscribed feed, and if there isn't already a ReadStatus for a post we create it with `isRead: false` (since in the case where a user e.g. clicks on a comment on a feed item for a post that they haven't read yet, it'd be wrong to set `isRead: true`, while updating an existing ReadStatus should avoid changing the `isRead` value).
┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207556787974795) by [Unito](https://www.unito.io)
