### PR TITLE
hide sticked posts on recombee posts list and in subscribed tab if read

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -463,7 +463,7 @@ const LWHomePosts = ({children, classes}: {
         loadMoreSuggestedUsers={loadMoreSuggestedUsers}
         refetchFeed={refetchSubscriptionContent}
       />
-      {subscribedTabAnnouncementPost && <PostsItem post={subscribedTabAnnouncementPost} className={classes.subscribedAnnouncementPost} />}
+      {subscribedTabAnnouncementPost && !subscribedTabAnnouncementPost.isRead && <PostsItem post={subscribedTabAnnouncementPost} className={classes.subscribedAnnouncementPost} />}
     </div>
   );
 

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -503,8 +503,10 @@ const recombeeApi = {
     const reqIsLoadMore = helpers.isLoadMoreOperation(lwAlgoSettings);
     const { curatedPostIds, stickiedPostIds, excludedPostFilter } = await helpers.getOnsitePostInfo(lwAlgoSettings, context);
 
-    const curatedPostReadStatuses = await helpers.getCuratedPostsReadStatuses(lwAlgoSettings, curatedPostIds, userId, context);
-    const manuallyStickiedPostReadStatuses = await helpers.getManuallyStickiedPostsReadStatuses(lwAlgoSettings, userId, context);
+    const [curatedPostReadStatuses, manuallyStickiedPostReadStatuses] = await Promise.all([
+      helpers.getCuratedPostsReadStatuses(lwAlgoSettings, curatedPostIds, userId, context),
+      helpers.getManuallyStickiedPostsReadStatuses(lwAlgoSettings, userId, context)
+    ]);
 
     const includedCuratedPostIds = curatedPostIds.filter(id => !curatedPostReadStatuses.find(readStatus => readStatus.postId === id));
     const includedStickiedPostIds = stickiedPostIds.filter(id => !manuallyStickiedPostReadStatuses.find(readStatus => readStatus.postId === id))
@@ -542,12 +544,15 @@ const recombeeApi = {
 
     const { curatedPostIds, stickiedPostIds, excludedPostFilter } = await helpers.getOnsitePostInfo(lwAlgoSettings, context, false);
 
-    const curatedPostReadStatuses = await helpers.getCuratedPostsReadStatuses(lwAlgoSettings, curatedPostIds, userId, context);
-    const manuallyStickiedPostReadStatuses = await helpers.getManuallyStickiedPostsReadStatuses(lwAlgoSettings, userId, context);
+    const [curatedPostReadStatuses, manuallyStickiedPostReadStatuses] = await Promise.all([
+      helpers.getCuratedPostsReadStatuses(lwAlgoSettings, curatedPostIds, userId, context),
+      helpers.getManuallyStickiedPostsReadStatuses(lwAlgoSettings, userId, context)
+    ]);
+
     const reqIsLoadMore = helpers.isLoadMoreOperation(lwAlgoSettings);
     const includedCuratedPostIds = curatedPostIds.filter(id => !curatedPostReadStatuses.find(readStatus => readStatus.postId === id));
-    const includedManuallyStickiedPostIds = stickiedPostIds.filter(id => !manuallyStickiedPostReadStatuses.find(readStatus => readStatus.postId === id))
-    const excludeFromLatestPostIds = [...includedCuratedPostIds, ...includedManuallyStickiedPostIds];
+    const includedStickiedPostIds = stickiedPostIds.filter(id => !manuallyStickiedPostReadStatuses.find(readStatus => readStatus.postId === id))
+    const excludeFromLatestPostIds = [...includedCuratedPostIds, ...includedStickiedPostIds];
     // We only want to fetch the curated and stickied posts if this is the first load, not on any load more
     const includedCuratedAndStickiedPostIds = reqIsLoadMore
       ? []


### PR DESCRIPTION
Not typical behavior for stickies but seems better here

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207569509456797) by [Unito](https://www.unito.io)
