### PR TITLE
[EA Forum only] bring back the "Publish" button for the on-site digest

### DIFF
--- a/packages/lesswrong/components/ea-forum/EADigestPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EADigestPage.tsx
@@ -237,10 +237,8 @@ const EADigestPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
   const {
     Error404, HeadTags, PostsLoading, EAPostsItem, CloudinaryImage2, ForumIcon, LWTooltip, EAButton
   } = Components;
-  
-  // TODO: Probably we'll want to check the publishedDate instead of the endDate, but we haven't been using it.
-  // If we do start using it, we'll need to backfill the publishedDate values and update this condition.
-  const isPublished = digest && digest.endDate
+
+  const isPublished = digest && digest.publishedDate
   
   // 404 if there is no matching digest, or if the matching one is still in progress and the user is not an admin
   if ((!digest && !digestLoading) || (!isPublished && !currentUser?.isAdmin)) {
@@ -291,13 +289,14 @@ const EADigestPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
     </LWTooltip>
   }
   
+  const digestName = `EA Forum Digest #${digestNum}`
   const startDate = digest?.startDate ? moment(digest.startDate).format('MMM D, YYYY') : null
   const endDate = digest?.endDate ? moment(digest.endDate).format('MMM D, YYYY') : null
 
   return (
     <>
       <HeadTags
-        title={`EA Forum Digest #${digestNum}`}
+        title={digestName}
         description={pageDescription}
         image={digest?.onsiteImageId ? makeCloudinaryImageUrl(digest.onsiteImageId, socialImageCloudinaryProps) : undefined}
       />
@@ -312,7 +311,7 @@ const EADigestPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
                   <span className={classes.date}>{endDate}</span>
                 </div>}
                 <h1 className={classes.pageTitle}>
-                  EA Forum Digest #{digestNum}
+                  {digestName}
                   {!isPublished && <span className={classes.previewLabel}>[Preview]</span>}
                 </h1>
                 <div className={classes.pageDescription}>

--- a/packages/lesswrong/components/ea-forum/digest/ConfirmPublishDialog.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/ConfirmPublishDialog.tsx
@@ -18,6 +18,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     marginBottom: 14
   },
+  textSection: {
+    marginTop: 12
+  }
 })
 
 const ConfirmPublishDialog = ({ digest, onClose, classes }: {
@@ -31,14 +34,13 @@ const ConfirmPublishDialog = ({ digest, onClose, classes }: {
   })
 
   const handlePublish = () => {
-    // this dialog should only appear if the digest has never been published,
-    // so we need to set its endDate as well
+    // Set the publishedDate, and also set the endDate if it doesn't have one yet
     const now = new Date()
     void updateDigest({
       selector: {_id: digest._id},
       data: {
         publishedDate: now,
-        endDate: now
+        endDate: !digest.endDate ? now : undefined
       }
     })
     onClose?.()
@@ -53,9 +55,12 @@ const ConfirmPublishDialog = ({ digest, onClose, classes }: {
           Are you sure you want to publish this digest?
         </div>
         <div>
-          That will set the cut-off date for this digest and automatically set up the next one.
+          That will make this week's on-site digest publicly accessible.
           You can still select / unselect posts from the table after publishing.
         </div>
+        {!digest.endDate && <div className={classes.textSection}>
+          It will also set the cut-off date for this digest and automatically set up the next one.
+        </div>}
       </DialogContent>
       <DialogActions>
         <EAButton variant="outlined" onClick={onClose}>

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestActionButtons.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestActionButtons.tsx
@@ -4,13 +4,6 @@ import { useUpdate } from '../../../lib/crud/withUpdate';
 import { useDialog } from '../../common/withDialog';
 
 const styles = (theme: ThemeType): JssStyles => ({
-  questionMark: {
-    alignSelf: 'center',
-    color: theme.palette.grey[600]
-  },
-  questionMarkIcon: {
-    fontSize: 20
-  },
   tooltipSection: {
     marginTop: 8
   }
@@ -42,16 +35,15 @@ const EditDigestActionButtons = ({digest, classes}: {
   }
   
   /**
-   * If the digest has been published before, set or unset the publishedDate.
+   * If the digest is published, unset the publishedDate.
    * Otherwise, open the publish confirmation dialog.
    */
   const handlePublish = () => {
-    // if the digest has an endDate set, then we know it's already been published
-    if (digest.endDate) {
+    if (isPublished) {
       void updateDigest({
         selector: {_id: digest._id},
         data: {
-          publishedDate: isPublished ? null : new Date()
+          publishedDate: null
         }
       })
     } else {
@@ -62,40 +54,32 @@ const EditDigestActionButtons = ({digest, classes}: {
     }
   }
   
-  const { EAButton, LWTooltip, ForumIcon } = Components
+  const { EAButton, LWTooltip } = Components
 
   return <>
-    {!digest.endDate && <LWTooltip title="This sets the cut-off date for this digest and automatically sets up the next digest.">
+    {!digest.endDate && <LWTooltip
+      title="This sets the cut-off date for this digest and automatically sets up the next digest."
+    >
       <EAButton variant='outlined' onClick={handleStartNewWeek}>
         Start new week
       </EAButton>
     </LWTooltip>}
-  
-    {/* TODO: Update this if/when we add an on-site version of the digest
-    <EAButton variant={isPublished ? 'outlined' : 'contained'} onClick={handlePublish}>
-      {isPublished ? 'Unpublish' : 'Publish'}
-    </EAButton>
 
     <LWTooltip
-      title={<>
+      title={!isPublished ? <>
         <div>
-          Don't worry, it's totally safe to click the "Publish" button!
+          Click when you're ready for this week's on-site digest to be public.
         </div>
         <div className={classes.tooltipSection}>
-          If the digest has never been published, clicking the button will bring up a confirmation modal.
-          Clicking "Publish" in there sets the cut-off date for this digest
-          (which determines which posts are eligible to appear in the table),
-          and automatically sets up the next digest.
+          You can still change which posts are in the digest, even after publishing.
+          You can also un-publish and later re-publish a digest.
         </div>
-        <div className={classes.tooltipSection}>
-          Both unpublishing and re-publishing do nothing. You can always change whether or not
-          the posts in this table are in the digest, even after publishing.
-        </div>
-      </>}
-      className={classes.questionMark}
+      </> : 'Click to unpublish the on-site digest.'}
     >
-      <ForumIcon icon="QuestionMarkCircle" className={classes.questionMarkIcon} />
-    </LWTooltip> */}
+      <EAButton variant={isPublished ? 'outlined' : 'contained'} onClick={handlePublish}>
+        {isPublished ? 'Unpublish' : 'Publish'}
+      </EAButton>
+    </LWTooltip>
   </>
 }
 

--- a/packages/lesswrong/lib/collections/digestPosts/collection.ts
+++ b/packages/lesswrong/lib/collections/digestPosts/collection.ts
@@ -22,9 +22,8 @@ DigestPosts.checkAccess = async (user: DbUser|null, document: DbDigestPost, cont
   if (!user || !document) return false
   if (user.isAdmin) return true
 
-  // Currently, digests become "public" once they have an end date.
-  // In the future, we might want to check the publishedDate instead.
-  return !!(await Digests.findOne({_id: document.digestId}))?.endDate
+  // Currently, digests become "public" once they have a published date.
+  return !!(await Digests.findOne({_id: document.digestId}))?.publishedDate
 };
 
 export default DigestPosts;

--- a/packages/lesswrong/lib/collections/digests/schema.ts
+++ b/packages/lesswrong/lib/collections/digests/schema.ts
@@ -18,8 +18,6 @@ const schema: SchemaType<"Digests"> = {
     control: 'datetime',
   },
   // the end of the range of eligible posts (just used to filter posts for the Edit Digest page)
-  // TODO: this is currently also used to determine when the on-site digest is publicly accessible,
-  // though probably we should use the publishedDate instead :shrug:
   endDate: {
     type: Date,
     optional: true,
@@ -29,7 +27,7 @@ const schema: SchemaType<"Digests"> = {
     canCreate: ['admins'],
     control: 'datetime',
   },
-  // when this digest was published (TODO: currently not used but probably should be)
+  // when this digest was published (if set, then the on-site digest is publicly accessible)
   publishedDate: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -9,7 +9,7 @@ getCollectionHooks("Digests").updateAsync.add(async ({newDocument, oldDocument, 
   const newerDigest = await Digests.findOne({ num: {$gt: newDocument.num ?? 0} })
   if (newerDigest) return
   
-  // when we first publish a digest, create the next one
+  // when we set the end date of a digest, create the next one
   void createMutator({
     collection: Digests,
     document: {


### PR DESCRIPTION
(Branched off of https://github.com/ForumMagnum/ForumMagnum/pull/9408 since I made some changes to the digest tool page there. No need to read that PR though.)

This PR brings back the concept of "publishing" a digest. We removed it because the `publishedDate` wasn't actually used anywhere and the button stressed Lizka out. But now, if we want to keep the on-site digest page, we'll want to use the `publishedDate` rather than the `endDate`, because the latter is just meant to filter which posts are eligible.

For example, I could imagine Toby making a shortlist of digest posts in the tool, clicking "Start new week" (which sets the `endDate`) and copying the list out to a Google Doc to finalize. Then after sending the email digest, he might return to the tool to finalize the on-site digest post list, and then click "Publish" at that point.

<img width="1029" alt="Screen Shot 2024-06-14 at 9 02 21 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/72b9147f-d5c6-4589-876e-c452393a9fb6">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207578061243962) by [Unito](https://www.unito.io)
