### PR TITLE
fix link click tracking

### DIFF
--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -97,6 +97,7 @@ export function HashLink(props: HashLinkProps) {
         if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0) {
           return;
         }
+        filteredProps.onMouseDown?.(ev)
         navigate(to);
         ev.preventDefault();
       }}


### PR DESCRIPTION
#9394 introduced a bug for `linkClicked` analytics events, this PR fixes it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207594018081095) by [Unito](https://www.unito.io)
