### PR TITLE
[EA Forum only] email authors when we curate their post

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { registerComponent } from "../../lib/vulcan-lib";
+import { postGetPageUrl } from "@/lib/collections/posts/helpers";
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    fontFamily: theme.typography.fontFamily,
+    fontSize: 15,
+    lineHeight: "22px",
+  },
+  link: {
+    color: theme.palette.primary.main,
+  },
+  hr: {
+    marginTop: 30,
+  }
+});
+
+const EmailCuratedAuthors = ({
+  user,
+  post,
+  classes,
+}: {
+  user: DbUser;
+  post: DbPost;
+  classes: ClassesType;
+}) => {
+
+  return (
+    <div className={classes.root}>
+      <p>
+        Hi {user.displayName},
+      </p>
+      <p>
+        Thank you for contributing to the EA Forum!
+        We were impressed with your post, <a href={postGetPageUrl(post, true)} className={classes.link}>{post.title}</a>,
+        and are excited to let you know that <strong>we’ve decided to curate it</strong>. ⭐️
+        Curated posts are pinned to the top of the Forum frontpage so that they can be viewed more widely,
+        and are included in our <a href="https://forum.effectivealtruism.org/recommendations" className={classes.link}>list of curated posts</a>.
+      </p>
+      <p>
+        Authors like you are essential to sustaining a healthy and valuable online space.
+        We genuinely appreciate you taking the time to contribute, and we look forward to seeing more from you in the future.
+      </p>
+      <p>
+        As a valued author, we’d love to hear your feedback! In particular, we’d be interested to hear
+        how you found the writing experience, and how we could improve it. Feel free to reply to this email,
+        or find other ways to contact us <a href="https://forum.effectivealtruism.org/contact" className={classes.link}>here</a>.
+      </p>
+      <p>
+        – The EA Forum Team
+      </p>
+      <hr className={classes.hr}/>
+    </div>
+  );
+};
+
+const EmailCuratedAuthorsComponent = registerComponent(
+  "EmailCuratedAuthors",
+  EmailCuratedAuthors,
+  { styles }
+);
+
+declare global {
+  interface ComponentTypes {
+    EmailCuratedAuthors: typeof EmailCuratedAuthorsComponent;
+  }
+}

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { isEAForum, siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
+    ...(isEAForum ? {
+      fontFamily: theme.typography.fontFamily,
+      fontSize: 14,
+      lineHeight: "22px",
+    } : {}),
     "& img": {
       maxWidth: "100%",
     }

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -195,9 +195,13 @@ export async function generateEmail({user, to, from, subject, bodyComponent, boi
     wordwrap: plainTextWordWrap
   });
   
-  const fromAddress = from || defaultEmailSetting.get()
+  const defaultFromEmail = defaultEmailSetting.get()
+  let fromAddress = from || defaultFromEmail
   if (!fromAddress) {
     throw new Error("No source email address configured. Make sure \"defaultEmail\" is set in your settings.json.");
+  }
+  if (isEAForum && fromAddress === defaultFromEmail) {
+    fromAddress = `The EA Forum <${defaultFromEmail}>`
   }
   
   const sitename = forumTitleSetting.get();
@@ -210,7 +214,7 @@ export async function generateEmail({user, to, from, subject, bodyComponent, boi
     user,
     to,
     from: fromAddress,
-    subject: taggedSubject,
+    subject: isEAForum ? subject : taggedSubject,
     html: emailDoctype + inlinedHTML,
     text: plaintext,
   }

--- a/packages/lesswrong/server/inactiveUserSurveyCron.tsx
+++ b/packages/lesswrong/server/inactiveUserSurveyCron.tsx
@@ -29,7 +29,7 @@ const sendInactiveUserSurveyEmails = async () => {
     try {
       void wrapAndSendEmail({
         user,
-        from: 'eaforum@centreforeffectivealtruism.org',
+        from: 'EA Forum Team <eaforum@centreforeffectivealtruism.org>',
         subject: `Help us improve the site`,
         body: <Components.EmailInactiveUserSurvey user={user} />,
       })

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -12,6 +12,7 @@ import './emailComponents/EmailWrapper';
 import './emailComponents/NewPostEmail';
 import './emailComponents/PostNominatedEmail';
 import './emailComponents/PrivateMessagesEmail';
+import './emailComponents/EmailCuratedAuthors';
 import { EventDebouncer } from './debouncer';
 import * as _ from 'underscore';
 import { Components } from '../lib/vulcan-lib/components';
@@ -368,8 +369,27 @@ const curationEmailDelay = new EventDebouncer({
   }
 });
 
+getCollectionHooks("Posts").editAsync.add(async function CuratedAuthorsNotification(post: DbPost, oldPost: DbPost) {
+  // On the EA Forum, when a post is curated, we send an email notifying all the post's authors
+  if (post.curatedDate && !oldPost.curatedDate && isEAForum) {
+    const coauthorIds = getConfirmedCoauthorIds(post)
+    const authorIds = [post.userId, ...coauthorIds]
+    const authors = await Users.find({
+      _id: {$in: authorIds}
+    }).fetch()
+    
+    void Promise.all(authors.map(author => {
+      wrapAndSendEmail({
+        user: author,
+        subject: "We’ve curated your post",
+        body: <Components.EmailCuratedAuthors user={author} post={post} />
+      })
+    }))
+  }
+})
+
 getCollectionHooks("Posts").editAsync.add(async function PostsCurateNotification (post: DbPost, oldPost: DbPost) {
-  if(post.curatedDate && !oldPost.curatedDate && isLWorAF) {
+  if (post.curatedDate && !oldPost.curatedDate && isLWorAF) {
     // Email admins immediately, everyone else after a 20-minute delay, so that
     // we get a chance to catch formatting issues with the email. (Admins get
     // emailed twice.)

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -378,13 +378,12 @@ getCollectionHooks("Posts").editAsync.add(async function CuratedAuthorsNotificat
       _id: {$in: authorIds}
     }).fetch()
     
-    void Promise.all(authors.map(author => {
-      wrapAndSendEmail({
+    void Promise.all(authors.map(author => wrapAndSendEmail({
         user: author,
         subject: "We’ve curated your post",
         body: <Components.EmailCuratedAuthors user={author} post={post} />
       })
-    }))
+    ))
   }
 })
 

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -454,7 +454,7 @@ export const NewUserNotification = serverRegisterNotificationType({
 });
 
 const newMessageEmails: ForumOptions<string | null> = {
-  EAForum: 'forum-noreply@effectivealtruism.org',
+  EAForum: 'The EA Forum <forum-noreply@effectivealtruism.org>',
   default: null,
 }
 const forumNewMessageEmail = forumSelect(newMessageEmails) ?? undefined


### PR DESCRIPTION
This PR adds a callback that emails authors when we curate their post. Since we currently rarely comment when we curate a post, the authors don't get notified when we curate their post, which is sad. I think ideally we would include a personalized note as to why we curated the post, but for now this is better than nothing.

I also made some changes to how EA Forum emails are formatted:
1. I updated the `from` values to include a name, so that they look nicer in email clients.
2. I removed the `[Effective Altruism Forum]` prefix from email subjects, because that takes up a huge chunk of horizontal space, and with the better sender name hopefully this is unnecessary.
3. I added some default text styling so that text is Inter by default.

Here's an example email body. Feel free to comment in the [doc](https://docs.google.com/document/d/1cugXuTWQ7Tizw3_ix17IrCBsvjZgf5UEQypyUNZhChQ/edit) where we drafted this.
![Screen Shot 2024-06-17 at 7 51 38 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/6ccaf49f-1c48-4909-a20d-dd9aeb47d3f8)
