### PR TITLE
Switch to using text-embedding-3-large and batch operations for post embeddings

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "mz": "^2.7.0",
     "node-abort-controller": "^3.1.1",
     "nodemailer": "^6.9.9",
-    "openai": "^4.18.0",
+    "openai": "^4.29.2",
     "papaparse": "^5.2.0",
     "passport": "^0.5.2",
     "passport-auth0": "^1.4.0",

--- a/packages/lesswrong/server/embeddings.ts
+++ b/packages/lesswrong/server/embeddings.ts
@@ -10,10 +10,15 @@ import { isAnyTest, isE2E } from "../lib/executionEnvironment";
 import { isEAForum } from "../lib/instanceSettings";
 import { addCronJob } from "./cronUtil";
 import { TiktokenModel, encoding_for_model } from "@dqbd/tiktoken";
+import mapValues from "lodash/mapValues";
+import chunk from "lodash/chunk";
+import { EMBEDDINGS_VECTOR_SIZE } from "../lib/collections/postEmbeddings/schema";
 
 export const HAS_EMBEDDINGS_FOR_RECOMMENDATIONS = isEAForum && !isE2E;
 
 export const DEFAULT_EMBEDDINGS_MODEL: TiktokenModel = "text-embedding-ada-002";
+const NEW_EMBEDDINGS_MODEL = "text-embedding-3-large";
+
 const DEFAULT_EMBEDDINGS_MODEL_MAX_TOKENS = 8191;
 
 type EmbeddingsResult = {
@@ -53,6 +58,74 @@ const trimText = (
   return text;
 }
 
+const getBatchEmbeddingsFromApi = async (inputs: Record<string, string>) => {
+  if (isAnyTest) {
+    return {
+      embeddings: {},
+      model: "test",
+    };
+  }
+  const api = await getOpenAI();
+  if (!api) {
+    throw new Error("OpenAI client is not configured");
+  }
+
+  // The NodeJS tokenizer library doesn't (yet) support the `text-embedding-3-large` model prefix:
+  // https://github.com/dqbd/tiktoken/blob/a7cce9922b10bca567be8453f1ef0489428fa02f/js/src/core.ts#L211
+  // But using the old one for tokenization works just fine, since it maps to the same encoding, according to the original python library:
+  // https://github.com/openai/tiktoken/blob/c0ba74c238d18b4824c25f3c27fc8698055b9a76/tiktoken/model.py#L31
+  const tokenizerModel = DEFAULT_EMBEDDINGS_MODEL;
+  const embeddingModel = NEW_EMBEDDINGS_MODEL;
+  const maxTokens = DEFAULT_EMBEDDINGS_MODEL_MAX_TOKENS;
+
+  const trimmedInputTuples: [string, string][] = [];
+  for (const [postId, postText] of Object.entries(inputs)) {
+    try {
+      const trimmedText = trimText(postText, tokenizerModel, maxTokens);
+      trimmedInputTuples.push([postId, trimmedText]);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to trim text for post ${postId}`);
+    }
+  }
+
+  const filteredInputTuples = trimmedInputTuples.filter(([_, trimmedText]) => !!trimmedText);
+  const filteredInputs = filteredInputTuples.map(([_, text]) => text);
+
+  if (filteredInputs.length === 0) {
+    return {
+      embeddings: {},
+      model: embeddingModel
+    };
+  }
+
+  const result = await api.embeddings.create({
+    input: filteredInputs,
+    model: embeddingModel,
+    dimensions: EMBEDDINGS_VECTOR_SIZE,
+  });
+
+  const embeddingResults = result?.data;
+  if (
+    !embeddingResults ||
+    !Array.isArray(embeddingResults) ||
+    embeddingResults.some(({ embedding }) => 
+      !embedding.length ||
+      typeof embedding[0] !== "number"
+    )
+  ) {
+    throw new Error(`Invalid API response: ${inspect(result, {depth: null})}`);
+  }
+
+  const orderedEmbeddings = embeddingResults.sort((a, b) => a.index - b.index).map(({ embedding }) => embedding);
+  const mappedEmbeddings = Object.fromEntries(filteredInputTuples.map(([postId], idx) => [postId, orderedEmbeddings[idx]] as const));
+
+  return {
+    embeddings: mappedEmbeddings,
+    model: embeddingModel
+  };
+}
+
 const getEmbeddingsFromApi = async (text: string): Promise<EmbeddingsResult> => {
   if (isAnyTest) {
     return {
@@ -86,9 +159,11 @@ const getEmbeddingsFromApi = async (text: string): Promise<EmbeddingsResult> => 
   };
 }
 
+type EmbeddingsWithHash = EmbeddingsResult & { hash: string };
+
 const getEmbeddingsForPost = async (
   postId: string,
-): Promise<EmbeddingsResult & {hash: string}> => {
+): Promise<EmbeddingsWithHash> => {
   const post = await Posts.findOne({_id: postId});
   if (!post) {
     throw new Error(`Can't find post with id ${postId}`);
@@ -99,10 +174,34 @@ const getEmbeddingsForPost = async (
   return {hash, ...embeddings};
 }
 
+const getEmbeddingsForPosts = async (
+  posts: DbPost[],
+): Promise<Record<string, EmbeddingsWithHash>> => {
+  const textMappings = Object.fromEntries(posts.map((post) => [post._id, htmlToTextDefault(post.contents?.html ?? "")] as const));
+  const hashMappings = mapValues(textMappings, (postText: string) => md5(postText));
+
+  const embeddingResult = await getBatchEmbeddingsFromApi(textMappings);
+
+  const embeddingsWithHashes: Record<string, EmbeddingsWithHash> = mapValues(embeddingResult.embeddings, (postEmbeddings, postId) => ({
+    hash: hashMappings[postId],
+    embeddings: postEmbeddings,
+    model: embeddingResult.model
+  }));
+
+  return embeddingsWithHashes;
+}
+
 export const updatePostEmbeddings = async (postId: string) => {
   const {hash, embeddings, model} = await getEmbeddingsForPost(postId);
   const repo = new PostEmbeddingsRepo();
   await repo.setPostEmbeddings(postId, hash, model, embeddings);
+}
+
+export const batchUpdatePostEmbeddings = async (posts: DbPost[]) => {
+  const repo = new PostEmbeddingsRepo();
+  const postEmbeddings = await getEmbeddingsForPosts(posts);
+  const updates = Object.entries(postEmbeddings).map(([postId, { hash, model, embeddings }]) => repo.setPostEmbeddings(postId, hash, model, embeddings));
+  await Promise.all(updates);
 }
 
 const updateAllPostEmbeddings = async () => {
@@ -122,13 +221,13 @@ const updateAllPostEmbeddings = async () => {
 
 export const updateMissingPostEmbeddings = async () => {
   const ids = await new PostsRepo().getPostIdsWithoutEmbeddings();
-  for (const id of ids) {
+  for (const idBatch of chunk(ids, 50)) {
     try {
-      // One at a time to avoid being rate limited by the API
-      await updatePostEmbeddings(id);
+      const posts = await Posts.find({ _id: { $in: idBatch } }).fetch();
+      await batchUpdatePostEmbeddings(posts);
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error((e as AnyBecauseIsInput).response ?? e);
+      console.error(`Failed to generated embeddings`, { error: e.response ?? e, idBatch });
     }
   }
 }

--- a/packages/lesswrong/server/embeddings.ts
+++ b/packages/lesswrong/server/embeddings.ts
@@ -210,7 +210,7 @@ const updateAllPostEmbeddings = async () => {
     batchSize: 100,
     callback: async (posts: DbPost[]) => {
       try {
-        await Promise.all(posts.map(({_id}) => updatePostEmbeddings(_id)));
+        await batchUpdatePostEmbeddings(posts);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("Error", e);
@@ -227,7 +227,7 @@ export const updateMissingPostEmbeddings = async () => {
       await batchUpdatePostEmbeddings(posts);
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error(`Failed to generated embeddings`, { error: e.response ?? e, idBatch });
+      console.error(`Failed to generate or update embeddings`, { error: e.response ?? e, idBatch });
     }
   }
 }

--- a/packages/lesswrong/server/recommendations/Feature.ts
+++ b/packages/lesswrong/server/recommendations/Feature.ts
@@ -1,5 +1,5 @@
 import { RecommendationFeatureName } from "../../lib/collections/users/recommendationSettings";
-import { DEFAULT_EMBEDDINGS_MODEL } from "../embeddings";
+import { embeddingsSettings } from "../embeddings";
 
 abstract class Feature {
   getJoin(): string {
@@ -71,7 +71,7 @@ class CollabFilterFeature extends Feature {
 
 class TextSimilarityFeature extends Feature {
   constructor(
-    private model = DEFAULT_EMBEDDINGS_MODEL,
+    private model = embeddingsSettings.embeddingModel,
   ) {
     super();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14049,16 +14049,15 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openai@^4.18.0:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-4.18.0.tgz#445f2001c2261ca3b4372039103fa5fc072d70bb"
-  integrity sha512-0C+waXoU7mvp/1QZzwnmPCkq4t02VJkjL1EXn0Pd7pFuTA0Y4y1LwzSZSiF/tpxw+Pr7diHVJjbfJ8QbdZnEcA==
+openai@^4.29.2:
+  version "4.51.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.51.0.tgz#8ab08bba2441375e8e4ce6161f9ac987d2b2c157"
+  integrity sha512-UKuWc3/qQyklqhHM8CbdXCv0Z0obap6T0ECdcO5oATQxAbKE5Ky3YCXFQY207z+eGG6ez4U9wvAcuMygxhmStg==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"
     abort-controller "^3.0.0"
     agentkeepalive "^4.2.1"
-    digest-fetch "^1.3.0"
     form-data-encoder "1.7.2"
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"


### PR DESCRIPTION
Porting over some functionality from https://github.com/ForumMagnum/ForumMagnum/pull/8978.

I don't actually remember what motivated me to upgrade to `text-embedding-3-large`... I vaguely feel like I was running into some issues trying to do batch operations using `text-embedding-ada-002`, and didn't want to spend a full day running the backfill, but not confident.

Anyways, if we update the embedding model, that might require the EA forum to run `updateAllPostEmbeddings`, since I'm not sure embeddings generated by different models can be usefully compared.  If you'd prefer to not have the headache I can go back and see if the batch API works with `text-embedding-ada-002` (in which case I can just forum-select the embedding model name), and if not I'll do some rewriting to forum-gate at a higher level.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207607050989498) by [Unito](https://www.unito.io)
