### PR TITLE
Google Doc import: handle bullets that have been copy-pasted from another list

### DIFF
--- a/packages/lesswrong/unitTests/__snapshots__/googleDocImport.tests.ts.snap
+++ b/packages/lesswrong/unitTests/__snapshots__/googleDocImport.tests.ts.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertImportedGoogleDoc Regression: Handle nested bullets with different  1`] = `
+"<p><span>Paragraph</span></p><ul><li><span>Bullet 1</span></li><li><span>Bullet 2</span></li></ul><h2 data-internal-id=\\"Header\\"><span>Header</span></h2><ul><li><span>Start of a second list</span></li></ul><ul><li><span>Bullet copy-pasted from the first list</span><ul><li><span>Sub-bullet 1</span></li><li><span>Sub-bullet 2</span></li></ul></li></ul>
+    "
+`;

--- a/packages/lesswrong/unitTests/__snapshots__/googleDocImport.tests.ts.snap
+++ b/packages/lesswrong/unitTests/__snapshots__/googleDocImport.tests.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`convertImportedGoogleDoc Regression: Handle nested bullets with different  1`] = `
+exports[`convertImportedGoogleDoc Regression: Handle nested bullets with different list ids 1`] = `
 "<p><span>Paragraph</span></p><ul><li><span>Bullet 1</span></li><li><span>Bullet 2</span></li></ul><h2 data-internal-id=\\"Header\\"><span>Header</span></h2><ul><li><span>Start of a second list</span></li></ul><ul><li><span>Bullet copy-pasted from the first list</span><ul><li><span>Sub-bullet 1</span></li><li><span>Sub-bullet 2</span></li></ul></li></ul>
     "
 `;

--- a/packages/lesswrong/unitTests/googleDocImport.tests.ts
+++ b/packages/lesswrong/unitTests/googleDocImport.tests.ts
@@ -1,0 +1,32 @@
+import { convertImportedGoogleDoc } from '@/server/editor/conversionUtils';
+
+describe("convertImportedGoogleDoc", () => {
+
+  it("Regression: Handle nested bullets with different list ids", async () => {
+    const htmlInput = `
+      <html>
+        <body>
+          <p><span></span></p>
+          <p><span>Paragraph</span></p>
+          <ul class="lst-kix_gia5zvmdml9o-0 start">
+            <li><span>Bullet 1</span></li>
+            <li><span>Bullet 2</span></li>
+          </ul>
+          <h2 data-internal-id="Header"><span>Header</span></h2>
+          <ul class="lst-kix_82zwahk8jahu-0 start">
+            <li><span>Start of a second list</span></li>
+          </ul>
+          <ul class="lst-kix_gia5zvmdml9o-0">
+            <li><span>Bullet copy-pasted from the first list</span></li>
+          </ul>
+          <ul class="lst-kix_gia5zvmdml9o-1 start">
+            <li><span>Sub-bullet 1</span></li>
+            <li><span>Sub-bullet 2</span></li>
+          </ul>
+        </body>
+      </html>
+    `;
+    const htmlOutput = await convertImportedGoogleDoc({html: htmlInput.replace(/\s+</g, '<'), postId: 'dummy'});
+    expect(htmlOutput).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
`<ul>` and `<ol>` elements imported from Google docs come with a class like `lst-kix_gwukp0509sil-0`. Previously we were assuming that the id "gwukp0509sil" is a reliable indicator of which overall bullet list that a nested group of bullets belong to. However if you copy paste part of one list into another then the pasted portion keeps the _original_ id, which meant this portion would get inserted back in the original list when imported.

I have changed the logic to rely on only the ordering of elements to decide which list a nested group belongs to.

You can use [this doc](https://docs.google.com/document/d/1g3XRUdjfocOXdWn78IvuXygmEel_lejrr5XQh6XGL4w/edit) for testing (approximately matches what is in the unit test)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207612231376463) by [Unito](https://www.unito.io)
