### PR TITLE
Switch to onMouseUp with setTimeout to allow clicking on less stable child elements

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -4,7 +4,7 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser'
 import withErrorBoundary from '../common/withErrorBoundary'
-import { useDialog } from '../common/withDialog';
+import { OpenDialogContextType, useDialog } from '../common/withDialog';
 import { useSingle } from '../../lib/crud/withSingle';
 import { hideUnreviewedAuthorCommentsSettings } from '../../lib/publicSettings';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
@@ -150,6 +150,19 @@ const styles = (theme: ThemeType) => ({
   }
 });
 
+export type BtnProps = {
+  variant?: 'contained',
+  color?: 'primary',
+  disabled?: boolean
+}
+
+export type CommentSuccessCallback = (
+  comment: CommentsList,
+  otherArgs: {form: AnyBecauseTodo},
+) => void | Promise<void>;
+
+export type CommentCancelCallback = (...args: unknown[]) => void | Promise<void>;
+
 const shouldOpenNewUserGuidelinesDialog = (
   maybeProps: { user: UsersCurrent | null, post?: PostsMinimumInfo }
 ): maybeProps is Omit<ComponentProps<ComponentTypes['NewUserGuidelinesDialog']>, "onClose" | "classes"> => {
@@ -162,17 +175,77 @@ const getSubmitLabel = (isQuickTake: boolean) => {
   return isQuickTake ? 'Publish' : 'Comment'
 }
 
-export type BtnProps = {
-  variant?: 'contained',
-  color?: 'primary',
-  disabled?: boolean
-}
+const CommentSubmit = ({
+  isMinimalist,
+  formDisabledDueToRateLimit,
+  isQuickTake,
+  quickTakesSubmitButtonAtBottom,
+  type,
+  cancelCallback,
+  loading,
+  submitLabel = "Submit",
+  classes,
+}: {
+  isMinimalist: boolean;
+  formDisabledDueToRateLimit: boolean;
+  isQuickTake: boolean;
+  quickTakesSubmitButtonAtBottom?: boolean;
+  type: string;
+  cancelCallback?: CommentCancelCallback;
+  loading: boolean;
+  submitLabel?: React.ReactNode;
+  classes: ClassesType<typeof styles>;
+}) => {
+  const { Loading } = Components;
 
-export type CommentSuccessCallback = (
-  comment: CommentsList,
-  otherArgs: {form: AnyBecauseTodo},
-) => void | Promise<void>;
-export type CommentCancelCallback = (...args: unknown[]) => void | Promise<void>;
+  const currentUser = useCurrentUser();
+  const { openDialog } = useDialog();
+
+  const formButtonClass = isMinimalist ? classes.formButtonMinimalist : classes.formButton;
+  // by default, the EA Forum uses MUI contained buttons here
+  const cancelBtnProps: BtnProps = isFriendlyUI && !isMinimalist ? { variant: "contained" } : {};
+  const submitBtnProps: BtnProps = isFriendlyUI && !isMinimalist ? { variant: "contained", color: "primary" } : {};
+  if (formDisabledDueToRateLimit) {
+    submitBtnProps.disabled = true;
+  }
+
+  return (
+    <div
+      className={classNames(classes.submit, {
+        [classes.submitMinimalist]: isMinimalist,
+        [classes.submitQuickTakes]: isQuickTake && !(quickTakesSubmitButtonAtBottom && isFriendlyUI),
+        [classes.submitQuickTakesButtonAtBottom]: isQuickTake && quickTakesSubmitButtonAtBottom,
+      })}
+    >
+      {type === "reply" && !isMinimalist && (
+        <Button
+          onClick={cancelCallback}
+          className={classNames(formButtonClass, classes.cancelButton)}
+          {...cancelBtnProps}
+        >
+          Cancel
+        </Button>
+      )}
+      <Button
+        type="submit"
+        id="new-comment-submit"
+        className={classNames(formButtonClass, classes.submitButton)}
+        onClick={(ev) => {
+          if (!currentUser) {
+            openDialog({
+              componentName: "LoginPopup",
+              componentProps: {},
+            });
+            ev.preventDefault();
+          }
+        }}
+        {...submitBtnProps}
+      >
+        {loading ? <Loading /> : isMinimalist ? <ArrowForward /> : submitLabel}
+      </Button>
+    </div>
+  );
+}
 
 export type CommentsNewFormProps = {
   prefilledProps?: any,
@@ -239,7 +312,7 @@ const CommentsNewForm = ({
   // comment anyways, and this avoids an awkward interaction with the 15-second
   // rate limit that's only supposed to be there to prevent accidental double posts.
   // TODO
-  const formDisabledDueToRateLimit = lastRateLimitExpiry && isInFuture(moment(lastRateLimitExpiry).subtract(1,'minutes').toDate());
+  const formDisabledDueToRateLimit = !!lastRateLimitExpiry && isInFuture(moment(lastRateLimitExpiry).subtract(1,'minutes').toDate());
 
   const {flash} = useMessages();
   prefilledProps = {
@@ -324,47 +397,25 @@ const CommentsNewForm = ({
     };
   }
 
-  const SubmitComponent = useCallback(({submitLabel = "Submit"}) => {
-    const { Loading } = Components;
-    const formButtonClass = isMinimalist ? classes.formButtonMinimalist : classes.formButton
-    // by default, the EA Forum uses MUI contained buttons here
-    const cancelBtnProps: BtnProps = isFriendlyUI && !isMinimalist ? {variant: 'contained'} : {}
-    const submitBtnProps: BtnProps = isFriendlyUI && !isMinimalist ? {variant: 'contained', color: 'primary'} : {}
-    if (formDisabledDueToRateLimit) {
-      submitBtnProps.disabled = true
-    }
-
-    return <div className={classNames(classes.submit, {
-      [classes.submitMinimalist]: isMinimalist,
-      [classes.submitQuickTakes]: isQuickTake && !(quickTakesSubmitButtonAtBottom && isFriendlyUI),
-      [classes.submitQuickTakesButtonAtBottom]: isQuickTake && quickTakesSubmitButtonAtBottom,
-    })}>
-      {(type === "reply" && !isMinimalist) && <Button
-        onClick={cancelCallback}
-        className={classNames(formButtonClass, classes.cancelButton)}
-        {...cancelBtnProps}
-      >
-        Cancel
-      </Button>}
-      <Button
-        type="submit"
-        id="new-comment-submit"
-        className={classNames(formButtonClass, classes.submitButton)}
-        onClick={(ev) => {
-          if (!currentUser) {
-            openDialog({
-              componentName: "LoginPopup",
-              componentProps: {}
-            });
-            ev.preventDefault();
-          }
+  const SubmitComponent = useCallback(
+    (formSubmitProps: ComponentProps<ComponentTypes['FormSubmit']>) => (
+      <CommentSubmit
+        {...{
+          isMinimalist,
+          classes,
+          formDisabledDueToRateLimit,
+          isQuickTake,
+          quickTakesSubmitButtonAtBottom,
+          type,
+          loading,
+          ...formSubmitProps,
+          // We want to pass in this cancel callback, rather than whatever gets passed in to FormSubmit
+          cancelCallback,
         }}
-        {...submitBtnProps}
-      >
-        {loading ? <Loading /> : (isMinimalist ? <ArrowForward /> : submitLabel)}
-      </Button>
-    </div>
-  }, [classes, cancelCallback, currentUser, formDisabledDueToRateLimit, isMinimalist, isQuickTake, loading, openDialog, type, quickTakesSubmitButtonAtBottom]);
+      />
+    ),
+    [cancelCallback, classes, formDisabledDueToRateLimit, isMinimalist, isQuickTake, loading, quickTakesSubmitButtonAtBottom, type]
+  );
 
   const hideDate = hideUnreviewedAuthorCommentsSettings.get()
   const commentWillBeHidden = hideDate && new Date(hideDate) < new Date() &&
@@ -475,3 +526,4 @@ declare global {
     CommentsNewForm: typeof CommentsNewFormComponent,
   }
 }
+

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -223,7 +223,7 @@ const FeedPostCommentsCard = ({
             />
         </div>
 
-        {nestedComments.length > 0 && <div className={classes.commentsList} onMouseDown={markCommentsAsRead}>
+        {nestedComments.length > 0 && <div className={classes.commentsList} onMouseUp={markCommentsAsRead}>
           {nestedComments.map((comment: CommentTreeNode<CommentsList>) => {
             return <FeedPostCommentsBranch
               key={comment.item._id}

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -39,6 +39,8 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
 
   const markCommentsAsRead = useCallback(
     () => {
+      // We have a setTimeout here to punt running this until the rest of event listeners triggered by same click/mouseup event are done
+      // Necessary to avoid causing the child components those event listeners are on from rerendering before the event listeners run
       setTimeout(() => {
         setMarkedAsVisitedAt(new Date());
         void recordPostCommentsView({ post });  

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -39,8 +39,10 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
 
   const markCommentsAsRead = useCallback(
     () => {
-      setMarkedAsVisitedAt(new Date());
-      void recordPostCommentsView({ post });
+      setTimeout(() => {
+        setMarkedAsVisitedAt(new Date());
+        void recordPostCommentsView({ post });  
+      }, 0);
     },
     [recordPostCommentsView, post]
   );

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -39,7 +39,8 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
 
   const markCommentsAsRead = useCallback(
     () => {
-      // We have a setTimeout here to punt running this until the rest of event listeners triggered by same click/mouseup event are done
+      // This is meant to be passed to e.g. an event listener (currently only use is with `onMouseUp`)
+      // The setTimeout punts running this until the rest of event listeners triggered by same event are done
       // Necessary to avoid causing the child components those event listeners are on from rerendering before the event listeners run
       setTimeout(() => {
         setMarkedAsVisitedAt(new Date());


### PR DESCRIPTION
The new `markCommentsAsRead` functionality in the Subscribed tab made it impossible to click on either button in the comment submit form (cancel/submit), since the `SubmitComponent` relied on `cancelCallback`, which wasn't referentially stable and caused a rerender after `markCommentsAsRead` ran.  Fix in two parts:
1. Switch `markCommentsAsRead` from `onMouseDown` to `onMouseUp` (h/t @darkruby501), to both ensure that it doesn't run before any `onClick` handlers in child components (such as on the buttons), and also to ensure that any `preventDefault`/`stopPropagation` calls in children's `onClick` handlers don't stop it from running.
2. Add a `setTimeout(() => { ... }, 0)` wrapper to the functionality of `markCommentsAsRead`, since without that it still seems to cause the children to rerender before they do their own event handling. (h/t @jimrandomh)

It was also bothering me to have the `SubmitComponent` defined inline in `CommentsNewForm` so I factored that out, but it's functionally unchanged.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207624813127064) by [Unito](https://www.unito.io)
