### PR TITLE
update styles in new post email

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -10,13 +10,18 @@ import filter from 'lodash/filter';
 import { tagGetSubforumUrl, tagGetDiscussionUrl } from '../../lib/collections/tags/helpers';
 import { commentGetPageUrl } from '../../lib/collections/comments/helpers';
 import startCase from 'lodash/startCase';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   headingLink: {
     color: theme.palette.text.maxIntensity,
     textDecoration: "none",
     fontWeight: "normal",
-    fontFamily: "Arial, sans-serif"
+    fontFamily: theme.typography.headerStyle.fontFamily,
+    ...(isFriendlyUI ? {
+      fontSize: "2.4rem",
+      lineHeight: '1.25em'
+    } : {}),
   },
   commentHr: {
     marginLeft: 5,

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
-import { isEAForum, siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    ...(isEAForum ? {
-      fontFamily: theme.typography.fontFamily,
-      fontSize: 14,
-      lineHeight: "22px",
-    } : {}),
+    ...(isFriendlyUI ? {...theme.typography.smallText} : {}),
     "& img": {
       maxWidth: "100%",
     }

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -7,6 +7,7 @@ import './EmailPostAuthors';
 import './EmailContentItemBody';
 import './EmailPostDate';
 import './EmailFooterRecommendations';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   heading: {
@@ -29,7 +30,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.text.maxIntensity,
     textDecoration: "none",
     fontWeight: "normal",
-    fontFamily: "Arial, sans-serif"
+    fontFamily: theme.typography.headerStyle.fontFamily,
+    ...(isFriendlyUI ? {
+      fontSize: "2.4rem",
+      lineHeight: '1.25em'
+    } : {}),
   },
   
   headingHR: {
@@ -86,7 +91,7 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
       version: 'String'
     }
   });
-  const { EmailPostAuthors, EmailContentItemBody, EmailPostDate, EmailFooterRecommendations } = Components;
+  const { EmailPostAuthors, EmailContentItemBody, EmailPostDate, EmailFooterRecommendations, ContentStyles } = Components;
   if (!document) return null;
   
   // event location - for online events, attempt to show the meeting link
@@ -131,9 +136,11 @@ const NewPostEmail = ({documentId, reason, hideRecommendations, classes}: {
       <hr />
     </div>}
     
-    {document.contents && <EmailContentItemBody className="post-body" dangerouslySetInnerHTML={{
-      __html: document.contents.html
-    }} />}
+    {document.contents && <ContentStyles contentType="post">
+      <EmailContentItemBody className="post-body" dangerouslySetInnerHTML={{
+        __html: document.contents.html
+      }} />
+    </ContentStyles>}
     
     <a href={postGetPageUrl(document, true)}>Discuss</a>
     


### PR DESCRIPTION
I recently added some default styling to `EmailWrapper` but that messed up styling in some emails, like the line height in the post title of `NewPostEmail` was too small. So I'm cleaning up the styling in that email a bit:

![Screen Shot 2024-06-20 at 5 55 25 PM](https://github.com/ForumMagnum/ForumMagnum/assets/9057804/4722c3eb-da6d-4c93-814d-f2f091cef088)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207625673360730) by [Unito](https://www.unito.io)
