### PR TITLE
improve frontpage default tab selection

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -193,7 +193,12 @@ function useDefaultSettingsVisibility<T extends Platform>(currentUser: UsersCurr
 };
  
 const getDefaultTab = (currentUser: UsersCurrent|null, enabledTabs: TabRecord[]) => {
-  const defaultTab = homepagePostFeedsSetting.get()[0].name;
+  if (!currentUser) {
+    return 'forum-classic'
+  }
+
+  //find the tab from the list which tab the property defaultTab set to true
+  const defaultTab = enabledTabs.find(tab => tab.defaultTab)?.name ?? 'forum-classic';
 
   // If the user has a selected tab that is not in the list of enabled tabs, default to the first enabled tab
   if (!!currentUser?.frontpageSelectedTab && !enabledTabs.map(tab => tab.name).includes(currentUser.frontpageSelectedTab)) {

--- a/packages/lesswrong/components/common/TabPicker.tsx
+++ b/packages/lesswrong/components/common/TabPicker.tsx
@@ -172,6 +172,7 @@ export interface TabRecord {
   showLabsIcon?: boolean,
   showSparkleIcon?: boolean,
   isInfiniteScroll?: boolean,
+  defaultTab?: boolean
 }
 
 /**


### PR DESCRIPTION
Default tab now selected based on property in json of available tabs.
Logged-out users put onto `forum-classic` superceding any other logic

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207625565196346) by [Unito](https://www.unito.io)
