### PR TITLE
run custom onMouseDown logic before doing an early return for modifier keys

### DIFF
--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -94,10 +94,12 @@ export function HashLink(props: HashLinkProps) {
       {...filteredProps}
       href={to}
       onMouseDown={(ev) => {
+        // Run any custom onMouseDown logic, including event tracking (such as that passed in from `Link`) before checking for modifier keys
+        // This is necessary to capture e.g. `linkClicked` events when cmd-clicking to open links in a new tab
+        filteredProps.onMouseDown?.(ev);
         if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0) {
           return;
         }
-        filteredProps.onMouseDown?.(ev)
         navigate(to);
         ev.preventDefault();
       }}


### PR DESCRIPTION
Run any custom onMouseDown logic, including event tracking (such as that passed in from `Link`) before checking for modifier keys. This is necessary to capture e.g. `linkClicked` events when cmd-clicking to open links in a new tab.

cc @jimrandomh

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207625879389503) by [Unito](https://www.unito.io)
