### PR TITLE
[EA] Fix author analytics sorting

### DIFF
--- a/packages/lesswrong/components/analytics/AuthorAnalyticsPage.tsx
+++ b/packages/lesswrong/components/analytics/AuthorAnalyticsPage.tsx
@@ -225,8 +225,8 @@ const AuthorAnalyticsPage = ({ classes }: {
   const [totalCount, setTotalCount] = useState(loadMoreProps.totalCount);
 
   useEffect(() => {
-    if ((data?.posts?.length ?? 0) > posts.length) {
-      setPosts(data!.posts);
+    if (data?.posts) {
+      setPosts(data.posts);
     }
   }, [data, posts, loadMoreProps]);
 


### PR DESCRIPTION
There was a bug where clicking on a header to change the sorting wouldn't update the list (unless you refreshed the page). This fixes the problem, although I'm interested in if @oetherington has a better idea about how to do it based on what you were aiming for initially (i.e. is there a case where the data updates and we don't want to update the posts list)?