### PR TITLE
filter out posts from being sent to recombee more consistently

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -605,7 +605,12 @@ getCollectionHooks("Posts").updateAfter.add(async (post: DbPost, props: UpdateCa
 /* Recombee callbacks */
 
 function isNonRecommendablePost(post: DbPost): boolean {
-  return post.shortform || post.unlisted || post.rejected || post.isEvent || !!post.groupId || post.isFuture || post.disableRecommendation || post.status !== 2;
+  // We explicitly don't check `isFuture` here, because the cron job that "publishes" those posts does a raw update
+  // So it won't trigger any of the callbacks, and if we exclude those posts they'll never get recommended
+  // `Posts.checkAccess` already filters out posts with `isFuture` unless you're a mod or otherwise own the post
+  // So we're not really in any danger of showing those posts to regular users
+  // TODO: figure out how to handle this more gracefully
+  return post.shortform || post.unlisted || post.rejected || post.isEvent || !!post.groupId || post.disableRecommendation || post.status !== 2;
 }
 
 postPublishedCallback.add((post, context) => {


### PR DESCRIPTION
@Discordius saw an unlisted post show up in his recommendations, probably because our logic to filter them out before sending them to recombee wasn't being consistently applied (it was missing from the voting callback).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207635388548991) by [Unito](https://www.unito.io)
