### PR TITLE
Fix race condition in pageLoadFinished event

### DIFF
--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -415,8 +415,15 @@ export function flushClientEvents() {
   const eventsToWrite = pendingAnalyticsEvents;
   pendingAnalyticsEvents = [];
   AnalyticsUtil.clientWriteEvents(eventsToWrite.map(event => ({
-    ...(isClient ? AnalyticsUtil.clientContextVars : null),
-    ...event
+    ...event,
+    props: {
+      // clientContextVars will almost always be present already, in
+      // which case adding them here will do nothing. This is to cover
+      // the edge case of events that fire before clientContextVars
+      // is initialized (e.g. "pageLoadFinished")
+      ...(isClient ? AnalyticsUtil.clientContextVars : null),
+      ...event.props
+    }
   })));
 }
 


### PR DESCRIPTION
Since https://github.com/ForumMagnum/ForumMagnum/pull/9134 there has been a race condition between the firing of the "pageLoadFinished" event (triggered by [load](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event)) and the initialization of `clientContextVars`. This has meant that `clientId` `tabId`, and `userId` are usually dropped from that event.

This PR makes it so that `clientContextVars` are also added when the events are submitted as a fallback. This was already intended to be the case, but because they were added in the wrong part of the event the values weren't being picked up

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207636000587413) by [Unito](https://www.unito.io)
