### PR TITLE
use filter settings for latest posts in enriched tab to fix filteredScore synthetic field

### DIFF
--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -18,6 +18,7 @@ import { randomId } from '../../lib/random';
 import { createAdminContext } from '../vulcan-lib/query';
 import Globals from '@/lib/vulcan-lib/config';
 import util from 'util';
+import { FilterSettings, getDefaultFilterSettings } from '@/lib/filterSettings';
 
 export const getRecombeeClientOrThrow = (() => {
   let client: ApiClient;
@@ -347,10 +348,13 @@ const helpers = {
     const loadMoreCountArg = loadMoreCount ? { offset: loadMoreCount * fixedArmCount } : {};
     // Unfortunately, passing in an empty array translates to something like `NOT (_id IN (SELECT NULL::VARCHAR(27)))`, which filters out everything
     const notPostIdsArg = excludedPostIds.length ? { notPostIds: excludedPostIds } : {};
+    const filterSettings: FilterSettings = context.currentUser?.frontpageFilterSettings ?? getDefaultFilterSettings();
+
     const postsTerms: PostsViewTerms = {
       view: "magic",
       forum: true,
       limit,
+      filterSettings,
       ...notPostIdsArg,
       ...loadMoreCountArg,
     };


### PR DESCRIPTION
Not having `filterSettings` in the post view terms means that `filteredScore` ends up being an aliased `score` rather than the actual synthetic expression.  As an upside, adding them means that we obey the user's filter settings in the `Enriched` tab at least for the native latest posts half of it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207641529494082) by [Unito](https://www.unito.io)
