### PR TITLE
fix longterm senior downvoters check when no results

### DIFF
--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -620,8 +620,8 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     `, [userId, postId, excludedDocumentId]);
   }
 
-  getLongtermDownvoteScore(userId: string): Promise<LongtermScoreResult> {
-    return this.getRawDb().one(`
+  getLongtermDownvoteScore(userId: string): Promise<LongtermScoreResult | null> {
+    return this.getRawDb().oneOrNone(`
       SELECT
         COUNT(DISTINCT senior_downvoter) AS "longtermSeniorDownvoterCount",
         COUNT(c."userId") as "commentCount",


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207662890406947) by [Unito](https://www.unito.io)
