### PR TITLE
Create separate NativeThemeType to prevent missing theme options

### DIFF
--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -4,9 +4,6 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import classnames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
-  labelColor: {
-    color: theme.secondary
-  },
   textField: {
     fontSize: "15px",
     width: 350,

--- a/packages/lesswrong/components/notifications/CommentOnYourDraftNotificationHover.tsx
+++ b/packages/lesswrong/components/notifications/CommentOnYourDraftNotificationHover.tsx
@@ -7,7 +7,7 @@ import {useCurrentUser} from "../common/withUser";
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: 16,
-    ...theme.typography.commentStyles,
+    ...theme.typography.commentStyle,
     ...theme.typography.body2,
     maxWidth: 600,
   },

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -100,7 +100,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[500]
   },
   postTitle: {
-    ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
     display: "block"
   },

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -44,7 +44,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     borderTop: theme.palette.border.extraFaint,
     paddingTop: 6,
     display: "flex",
-    ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
     color: theme.palette.lwTertiary.main,
     marginTop: 6,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -70,7 +70,7 @@ export const zIndexes = {
 export const baseTheme: BaseThemeSpecification = {
   shadePalette: defaultShadePalette(),
   componentPalette: (shadePalette: ThemeShadePalette) => defaultComponentPalette(shadePalette),
-  make: (palette: ThemePalette): PartialDeep<ThemeType> => {
+  make: (palette: ThemePalette): NativeThemeType => {
     const spacingUnit = 8
   
     return {
@@ -95,12 +95,20 @@ export const baseTheme: BaseThemeSpecification = {
         quickTakesEntry: 3,
       },
       typography: {
+        fontFamily: palette.fonts.sansSerifStack,
         cloudinaryFont: {
           stack: "'Merriweather', serif",
           url: "https://fonts.googleapis.com/css?family=Merriweather",
         },
         postStyle: {
           fontFamily: palette.fonts.sansSerifStack,
+        },
+        commentStyle: {
+          fontFamily: palette.fonts.sansSerifStack,
+        },
+        errorStyle: {
+          color: palette.error.main,
+          fontFamily: palette.fonts.sansSerifStack
         },
         contentNotice: {
           fontStyle: "italic",
@@ -121,6 +129,7 @@ export const baseTheme: BaseThemeSpecification = {
           fontSize: '1.1rem',
           lineHeight: '1.5rem',
         },
+        headline: {},
         postsItemTitle: {
           fontSize: "1.3rem"
         },
@@ -234,6 +243,7 @@ export const baseTheme: BaseThemeSpecification = {
           fontSize:15,
           color: palette.grey[600]
         },
+        headerStyle: {},
         subtitle: {
           fontSize: 16,
           fontWeight: 600,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -6,7 +6,7 @@ import type { UnionOf } from '../lib/utils/typeGuardUtils';
 import { userThemeNames, userThemeSettings, muiThemeNames, ThemeOptions } from './themeNames';
 
 declare global {
-  type BreakpointName = "xs"|"sm"|"md"|"lg"|"xl"|"tiny"
+  type BreakpointName = "xs"|"sm"|"md"|"lg"|"xl"
   type ColorString = string;
 
   /**
@@ -563,7 +563,7 @@ declare global {
     palette: ThemePalette,
     typography: {
       fontFamily: string,
-      fontDownloads: string[],
+      fontDownloads?: string[],
       cloudinaryFont: {
         stack: string,
         url: string,
@@ -571,7 +571,6 @@ declare global {
 
       postStyle: JssStyles,
       commentStyle: JssStyles,
-      commentStyles: JssStyles,
       commentBlockquote: JssStyles,
       commentHeader: JssStyles,
       errorStyle: JssStyles,
@@ -595,12 +594,10 @@ declare global {
       codeblock: JssStyles,
       contentNotice: JssStyles,
       uiSecondary: JssStyles,
-      smallFont: JssStyles,
       smallText: JssStyles,
       tinyText: JssStyles,
       caption: JssStyles,
       blockquote: JssStyles,
-      uiStyle: JssStyles,
       italic: JssStyles,
       smallCaps: JssStyles,
     },
@@ -608,7 +605,6 @@ declare global {
     overrides: any,
     postImageStyles: JssStyles,
     voting: {strongVoteDelay: number},
-    secondary: any,
     
     // Used by material-UI. Not used by us directly (for our styles use
     // `theme.palette.boxShadow` which defines shadows semantically rather than
@@ -617,20 +613,22 @@ declare global {
     
     rawCSS: string[],
   };
+
+  type NativeThemeType = Omit<ThemeType,"palette"|"forumType"|"themeOptions"|"breakpoints"> & { breakpoints: Omit<ThemeType["breakpoints"], "up"|"down"> };
   
   type BaseThemeSpecification = {
     shadePalette: ThemeShadePalette,
     componentPalette: (shadePalette: ThemeShadePalette) => ThemeComponentPalette,
-    make: (palette: ThemePalette) => PartialDeep<Omit<ThemeType,"palette">>
+    make: (palette: ThemePalette) => NativeThemeType
   };
   type SiteThemeSpecification = {
     shadePalette?: PartialDeep<ThemeShadePalette>,
     componentPalette?: (shadePalette: ThemeShadePalette) => PartialDeep<ThemeComponentPalette>,
-    make?: (palette: ThemePalette) => PartialDeep<Omit<ThemeType,"palette">>
+    make?: (palette: ThemePalette) => PartialDeep<NativeThemeType>
   };
   type UserThemeSpecification = {
     shadePalette?: PartialDeep<ThemeShadePalette>,
     componentPalette?: (shadePalette: ThemeShadePalette) => PartialDeep<ThemeComponentPalette>,
-    make?: (palette: ThemePalette) => PartialDeep<Omit<ThemeType,"palette">>
+    make?: (palette: ThemePalette) => PartialDeep<NativeThemeType>
   };
 }

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -301,7 +301,7 @@ export const darkModeTheme: UserThemeSpecification = {
       },
     },
   }, forumComponentPalette(shadePalette)),
-  make: (palette: ThemePalette): PartialDeep<ThemeType> => ({
+  make: (palette: ThemePalette): PartialDeep<NativeThemeType> => ({
     postImageStyles: {
       // Override image background color to white (so that transparent isn't
       // black). Necessary because there are a handful of posts with images that


### PR DESCRIPTION
A recent [PR](https://github.com/ForumMagnum/ForumMagnum/pull/9430) exposed an issue in our theme types, which permitted the implementation of a theme field which was missing across all of the base theme, site theme, and user theme (and so was missing in the final merged theme).  This caused a crash-on-start on the AlignmentForum when one attempted to access a _nested_ field within the missing field, since that access was not null-safe (due to the incorrect type assumptions).  In practice, we had a fair number of other missing fields, some of which were even used in our styles, but until now there was no access of a nested field which would cause a `cannot access property ${fieldName} of undefined` exception.

This PR fixes the types to separate the "inputs" to the theme from the "ouput" type, so that we can switch to making all of the inputs required (instead of having them be `PartialDeep`), at least for the base theme.  We also fill in the base theme with all of the missing fields, except in cases where we know MUI provides them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207672149337601) by [Unito](https://www.unito.io)
