### PR TITLE
prevent votes on content >6 months old from putting users back in review

### DIFF
--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -23,6 +23,11 @@ import { captureException } from '@sentry/core';
 
 export const collectionsThatAffectKarma = ["Posts", "Comments", "Revisions"]
 
+function votesCanTriggerReview(content: DbPost | DbComment) {
+  const sixMonthsAgo = moment().subtract(6, 'months');
+  return moment(content.postedAt).isBefore(sixMonthsAgo);
+}
+
 /**
  * @summary Update the karma of the item's owner
  * @param {object} item - The item being operated on
@@ -48,7 +53,8 @@ voteCallbacks.castVoteAsync.add(async function updateKarma({newDocument, vote}: 
     }
   }
 
-  if (!!newDocument.userId && isLWorAF && ['Posts', 'Comments'].includes(vote.collectionName)) {
+  
+  if (!!newDocument.userId && isLWorAF && ['Posts', 'Comments'].includes(vote.collectionName) && votesCanTriggerReview(newDocument as DbPost | DbComment)) {
     void checkForStricterRateLimits(newDocument.userId, context);
   }
 });


### PR DESCRIPTION
We keep getting users in the review queue who have stricter rate limits triggered for votes on content that they posted a long time ago (e.g. 15 years).  We... really don't need to be reviewing those users again.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207689465589028) by [Unito](https://www.unito.io)
