### PR TITLE
[EA Forum only] debate week homepage banner improvements

### DIFF
--- a/packages/lesswrong/components/forumEvents/ForumEventFrontpageBanner.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventFrontpageBanner.tsx
@@ -331,7 +331,7 @@ const ForumEventFrontpageBannerWithPoll = ({classes}: {
               icon={expanded ? "ThickChevronDown" : "ThickChevronRight"}
               className={classes.expandToggleIcon}
             />
-            {expanded ? 'Collapse' : `Debate week ${date}`}
+            {expanded ? 'Collapse' : `Most influential posts`}
           </button>
         </div>
         {expanded && <div className={classes.contentWithPoll}>

--- a/packages/lesswrong/components/forumEvents/ForumEventFrontpageBanner.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventFrontpageBanner.tsx
@@ -357,6 +357,7 @@ const ForumEventFrontpageBannerWithPoll = ({classes}: {
                 showKarma={false}
                 hideTag
                 showNoResults={false}
+                showPlacement
               />
               {tag && <div className={classes.postsSeeAll}>
                 See all eligible posts <Link to={tagGetUrl(tag)}>here</Link>

--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -322,7 +322,7 @@ export const ForumEventPoll = ({postId, hideViewResults, classes}: {
       userIds: event?.publicData ?
         Object.keys(event?.publicData).filter(userId => userId !== currentUser?._id) :
         [],
-      limit: 300,
+      limit: 500,
     },
     collectionName: "Users",
     fragmentName: 'UserOnboardingAuthor',

--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import classNames from "classnames";
 import { useCurrentUser } from "../common/withUser";
@@ -10,6 +10,8 @@ import ForumNoSSR from "../common/ForumNoSSR";
 import { AnalyticsContext } from "@/lib/analyticsEvents";
 import { useLoginPopoverContext } from "../hooks/useLoginPopoverContext";
 import { useCurrentForumEvent } from "../hooks/useCurrentForumEvent";
+import range from "lodash/range";
+import sortBy from "lodash/sortBy";
 
 export const POLL_MAX_WIDTH = 730;
 const SLIDER_MAX_WIDTH = 1000;
@@ -46,6 +48,8 @@ const styles = (theme: ThemeType) => ({
   },
   sliderLine: {
     position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
     width: '100%',
     height: 2,
     backgroundColor: theme.palette.text.alwaysWhite,
@@ -60,6 +64,21 @@ const styles = (theme: ThemeType) => ({
   sliderArrowRight: {
     marginLeft: -15,
   },
+  voteCluster: {
+    position: 'relative',
+    flexGrow: 1,
+    height: USER_IMAGE_SIZE + 6,
+    opacity: 0.3,
+    zIndex: 4,
+    '&:hover': {
+      background: `radial-gradient(${theme.palette.text.alwaysBlack} 60%, transparent)`,
+    }
+  },
+  voteClusterHoverOver: {
+    display: 'flex',
+    columnGap: '4px',
+    padding: 10,
+  },
   userVote: {
     position: 'absolute',
     top: -USER_IMAGE_SIZE/2,
@@ -68,7 +87,7 @@ const styles = (theme: ThemeType) => ({
   currentUserVote: {
     opacity: 0.6,
     cursor: 'grab',
-    zIndex: 2,
+    zIndex: 10,
     touchAction: 'none',
     '&:hover': {
       opacity: 1,
@@ -99,6 +118,9 @@ const styles = (theme: ThemeType) => ({
   },
   userImage: {
     outline: `2px solid ${theme.palette.text.alwaysWhite}`,
+  },
+  userImageBoxShadow: {
+    boxShadow: theme.palette.boxShadow.eaCard,
   },
   placeholderUserIcon: {
     // add a black background to the placeholder user circle icon
@@ -178,6 +200,47 @@ export const getForumEventVoteForUser = (
 ): number|null => {
   return user ? (event?.publicData?.[user._id]?.x ?? null) : null
 }
+
+type ForumEventVoteDisplayCluster = {
+  center: number,
+  votes: ForumEventVoteDisplay[]
+}
+type ForumEventVoteDisplay = {
+  x: number,
+  user: UserOnboardingAuthor,
+}
+
+/**
+ * Groups the given forum event votes into n equal-width clusters
+ */
+const clusterForumEventVotes = (
+  voters?: UserOnboardingAuthor[],
+  event?: ForumEventsDisplay|null,
+  numClusters = 15
+): ForumEventVoteDisplayCluster[] => {
+  if (!voters || !event || !event.publicData) return []
+  
+  let votes = voters.map(voter => {
+    const vote = event.publicData[voter._id].x
+    return {
+      x: vote,
+      user: voter,
+    }
+  })
+  votes = sortBy(votes, 'x')
+  
+  const clusterWidth = maxVotePos / numClusters
+  const clusters: ForumEventVoteDisplayCluster[] = range(0, numClusters).map(i => ({
+    center: (i + 0.5) * clusterWidth,
+    votes: [],
+  }))
+  votes.forEach(vote => {
+    const clusterIndex = Math.min(Math.floor(vote.x / clusterWidth), numClusters - 1)
+    clusters[clusterIndex].votes.push(vote)
+  })
+  return clusters
+}
+
 
 const PollQuestion = ({event, classes}: {
   event: ForumEventsDisplay,
@@ -266,6 +329,7 @@ export const ForumEventPoll = ({postId, hideViewResults, classes}: {
     enableTotal: false,
     skip: !event?.publicData,
   })
+  const voteClusters = useMemo(() => clusterForumEventVotes(voters, event), [voters, event])
   
   const [addVote] = useMutation(
     addForumEventVoteQuery,
@@ -387,7 +451,7 @@ export const ForumEventPoll = ({postId, hideViewResults, classes}: {
   ])
   useEventListener("pointerup", saveVotePos)
 
-  const {ForumIcon, LWTooltip, UsersProfileImage} = Components;
+  const {ForumIcon, LWTooltip, UsersProfileImage, HoverOver} = Components;
   
   if (!event) return null
 
@@ -403,10 +467,34 @@ export const ForumEventPoll = ({postId, hideViewResults, classes}: {
               {resultsVisible && voters && voters.map(user => {
                 const vote = event.publicData[user._id]
                 return <div key={user._id} className={classes.userVote} style={{left: `${vote.x * 100}%`}}>
-                  <LWTooltip title={<div className={classes.voteTooltipBody}>{user.displayName}</div>}>
-                    <UsersProfileImage user={user} size={USER_IMAGE_SIZE} className={classes.userImage} />
-                  </LWTooltip>
+                  <UsersProfileImage user={user} size={USER_IMAGE_SIZE} className={classes.userImage} />
                 </div>
+              })}
+              {resultsVisible && voteClusters.map(cluster => {
+                return <HoverOver
+                  key={cluster.center}
+                  title={
+                    <div className={classes.voteClusterHoverOver}>
+                      {cluster.votes.map(vote => (
+                        <LWTooltip
+                          key={vote.user._id}
+                          title={<div className={classes.voteTooltipBody}>{vote.user.displayName}</div>}
+                        >
+                          <UsersProfileImage
+                            user={vote.user}
+                            size={USER_IMAGE_SIZE}
+                            className={classNames(classes.userImage, classes.userImageBoxShadow)}
+                          />
+                        </LWTooltip>
+                      ))}
+                    </div>
+                  }
+                  placement="bottom"
+                  clickable
+                  className={classes.voteCluster}
+                >
+                  <div></div>
+                </HoverOver>
               })}
               <div
                 className={classNames(

--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -216,7 +216,7 @@ type ForumEventVoteDisplay = {
 const clusterForumEventVotes = (
   voters?: UserOnboardingAuthor[],
   event?: ForumEventsDisplay|null,
-  numClusters = 15
+  numClusters = 21
 ): ForumEventVoteDisplayCluster[] => {
   if (!voters || !event || !event.publicData) return []
   

--- a/packages/lesswrong/components/forumEvents/ForumEventPostPagePollSection.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPostPagePollSection.tsx
@@ -52,7 +52,7 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const announcementPostUrl = 'https://forum.effectivealtruism.org/posts/PeBNdpoRSq59kAfDW/announcing-ai-welfare-debate-week-july-1-7'
+const announcementPostUrl = '/posts/PeBNdpoRSq59kAfDW/announcing-ai-welfare-debate-week-july-1-7'
 
 /**
  * This is used on the post page to display the current forum event's poll,

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -14,8 +14,21 @@ const styles = (theme: ThemeType): JssStyles => ({
   itemIsLoading: {
     opacity: .4,
   },
-  posts: {
+  postsBoxShadow: {
     boxShadow: theme.palette.boxShadow.default,
+  },
+  postsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, min-content) minmax(10px, 1fr)',
+    columnGap: '20px',
+  },
+  placement: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: 16,
+    fontWeight: 700,
+    letterSpacing: '1px',
   },
 });
 
@@ -42,6 +55,7 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
     placeholderCount,
     showFinalBottomBorder,
     viewType,
+    showPlacement,
   } = usePostsList(props);
 
   const { LoadMore, PostsNoResults, SectionFooter, PostsItem, PostsLoading } = Components;
@@ -72,8 +86,16 @@ const PostsList2 = ({classes, ...props}: PostsList2Props) => {
       {orderedResults && !orderedResults.length && <PostsNoResults />}
 
       <AnalyticsContext viewType={viewType}>
-        <div className={boxShadow ? classes.posts : undefined}>
-          {itemProps?.map((props) => <PostsItem key={props.post._id} {...props} />)}
+        <div className={classNames(
+          boxShadow && classes.postsBoxShadow,
+          showPlacement && classes.postsGrid,
+        )}>
+          {itemProps?.map((props) => <React.Fragment key={props.post._id}>
+            {showPlacement && props.index !== undefined && <div className={classes.placement}>
+              #{props.index + 1}
+            </div>}
+            <PostsItem  {...props} />
+          </React.Fragment>)}
         </div>
       </AnalyticsContext>
 

--- a/packages/lesswrong/components/posts/usePostsList.ts
+++ b/packages/lesswrong/components/posts/usePostsList.ts
@@ -68,6 +68,11 @@ export type PostsListConfig = {
    */
   viewType?: PostsListViewType | "fromContext",
   /**
+   * If true, then display the number corresponding to the post
+   * item's placement in the list (i.e. index + 1) to the left of the row.
+   */
+  showPlacement?: boolean,
+  /**
    * An array of postIds. If provided, we reorder the results to match this order.
    */
   order?: string[],
@@ -110,6 +115,7 @@ export const usePostsList = ({
   hideShortform = false,
   loadMoreMessage,
   viewType: configuredViewType = "list",
+  showPlacement = false,
   order,
 }: PostsListConfig) => {
   const [haveLoadedMore, setHaveLoadedMore] = useState(false);
@@ -277,5 +283,6 @@ export const usePostsList = ({
     showFinalBottomBorder,
     placeholderCount,
     viewType,
+    showPlacement,
   };
 }

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -329,7 +329,7 @@ const schema: SchemaType<"Tags"> = {
     control: "ImageUpload",
     tooltip: "Minimum 200x600 px",
     group: formGroups.advancedOptions,
-    hidden: isEAForum,
+    hidden: !isEAForum,
   },
   // Cloudinary image id for the square image which shows up in the all topics page, this will usually be a cropped version of the banner image
   squareImageId: {
@@ -342,7 +342,7 @@ const schema: SchemaType<"Tags"> = {
     control: "ImageUpload",
     tooltip: "Minimum 200x200 px",
     group: formGroups.advancedOptions,
-    hidden: isEAForum,
+    hidden: !isEAForum,
   },
 
   tagFlagsIds: {


### PR DESCRIPTION
Designs adapted from [this Figma](https://www.figma.com/design/qAHRGADVOGojqKpqbGMFFu/2024-Q2?node-id=1943-560&m=dev)

1. Add the placement number next to each "most influential post"
<img width="927" alt="Screen Shot 2024-07-01 at 2 58 48 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/3cc7543e-6c83-4285-a2cc-6d82b01a7d76">

2. Add a way to view votes in each cluster, by hovering over it
<img width="1026" alt="Screen Shot 2024-07-01 at 4 44 10 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/9057804/f2c593a9-9dd8-4e86-9f6c-d849f680082f">

3. Fix a broken link on the post page section (see https://github.com/ForumMagnum/ForumMagnum/pull/9457)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207708686884285) by [Unito](https://www.unito.io)
