### PR TITLE
Triple dot menu contains abilty to dislike recommendations

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -639,7 +639,6 @@ const LWHomePosts = ({ children, classes }: {
               {/* ENRICHED LATEST POSTS */}
               {selectedTab === 'recombee-hybrid' && <AnalyticsContext feedType={selectedTab}>
                 <RecombeePostsList 
-                  showRecommendationIcon
                   algorithm={'recombee-hybrid'} 
                   settings={{
                     ...scenarioConfig,
@@ -653,7 +652,7 @@ const LWHomePosts = ({ children, classes }: {
 
               {/* JUST RECOMMENDATIONS */}
               {selectedTab === 'recombee-lesswrong-custom' && <AnalyticsContext feedType={selectedTab}>
-                <RecombeePostsList algorithm={'recombee-lesswrong-custom'} settings={scenarioConfig} showRecommendationIcon />
+                <RecombeePostsList algorithm={'recombee-lesswrong-custom'} settings={scenarioConfig} />
               </AnalyticsContext>}
 
               {/* VERTEX RECOMMENDATIONS */}

--- a/packages/lesswrong/components/dropdowns/posts/DislikeRecommendationDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/DislikeRecommendationDropdownItem.tsx
@@ -10,7 +10,7 @@ import { recombeeEnabledSetting } from '@/lib/publicSettings';
 import { recombeeApi } from '@/lib/recombee/client';
 import { isRecombeeRecommendablePost } from '@/lib/collections/posts/helpers';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.icon.dim3,
@@ -60,7 +60,7 @@ const DislikeRecommendationDropdownItem = ({post}: {post: PostsBase}) => {
   );
 }
 
-const HideFrontPageButtonComponent = registerComponent(
+const DislikeRecommendationDropdownItemComponent = registerComponent(
   'DislikeRecommendationDropdownItem',
   DislikeRecommendationDropdownItem,
   {
@@ -71,6 +71,6 @@ const HideFrontPageButtonComponent = registerComponent(
 
 declare global {
   interface ComponentTypes {
-    DislikeRecommendationDropdownItem: typeof HideFrontPageButtonComponent
+    DislikeRecommendationDropdownItem: typeof DislikeRecommendationDropdownItemComponent
   }
 }

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -8,6 +8,9 @@ import { hasCuratedPostsSetting } from '../../../lib/instanceSettings';
 // through ~4 layers of hierarchy
 export const AllowHidingFrontPagePostsContext = React.createContext<boolean>(false);
 
+// Same as above context provider but for whether a post is being served as a recommendation
+export const IsRecommendationContext = React.createContext<boolean>(false);
+
 const styles = (_theme: ThemeType): JssStyles => ({
   root: {
     minWidth: isFriendlyUI ? undefined : 300,
@@ -32,6 +35,7 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
     EditTagsDropdownItem, EditPostDropdownItem, DuplicateEventDropdownItem,
     PostAnalyticsDropdownItem, ExcludeFromRecommendationsDropdownItem,
     ApproveNewUserDropdownItem, SharePostSubmenu, PostSubscriptionsDropdownItem,
+    DislikeRecommendationDropdownItem
   } = Components;
 
   if (!post) return null;
@@ -57,6 +61,7 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
       {includeBookmark && <BookmarkDropdownItem post={post} />}
       <SetSideCommentVisibility />
       <HideFrontpagePostDropdownItem post={post} />
+      <DislikeRecommendationDropdownItem post={post} />
       <ReportPostDropdownItem post={post}/>
       {currentUser && <EditTagsDropdownItem post={post} closeMenu={closeMenu} />}
       <SummarizeDropdownItem post={post} closeMenu={closeMenu} />

--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -391,8 +391,6 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
     curatedIconLeft,
     strikethroughTitle,
     bookmark,
-    isRecommendation,
-    showRecommendationIcon,
     emphasizeIfNew,
     className,
   } = usePostsItem(props);
@@ -472,7 +470,6 @@ const LWPostsItem = ({classes, ...props}: PostsList2Props) => {
                     {...(showPersonalIcon ? {showPersonalIcon} : {})}
                     curatedIconLeft={curatedIconLeft}
                     strikethroughTitle={strikethroughTitle}
-                    showRecommendationIcon={isRecommendation && showRecommendationIcon}
                     postItemHovered={hover}
                   />
                 </AnalyticsTracker>

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import { isRecombeeRecommendablePost, postGetPageUrl } from '../../lib/collections/posts/helpers';
@@ -11,6 +11,7 @@ import { useSetIsHiddenMutation } from '../dropdowns/posts/useSetIsHidden';
 import { recombeeEnabledSetting } from '@/lib/publicSettings';
 import { recombeeApi } from '@/lib/recombee/client';
 import { useCurrentUser } from '../common/withUser';
+import { IsRecommendationContext } from '../dropdowns/posts/PostActions';
 
 const styles = (theme: ThemeType) => ({
   iconSet: {
@@ -133,15 +134,15 @@ const RecommendedPostIcon = ({post, hover, classes}: {
 }
 
 
-const PostsItemIcons = ({post, hover, classes, hideCuratedIcon, hidePersonalIcon, showRecommendationIcon}: {
+const PostsItemIcons = ({post, hover, classes, hideCuratedIcon, hidePersonalIcon}: {
   post: PostsBase,
   hover?: boolean,
   hideCuratedIcon?: boolean,
   hidePersonalIcon?: boolean
-  showRecommendationIcon?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {
   const { OmegaIcon, LWTooltip, CuratedIcon, ForumIcon } = Components;
+  const showRecommendationIcon = useContext(IsRecommendationContext)
 
   return <span className={classes.iconSet}>
     {post.curatedDate && !hideCuratedIcon && <CuratedIcon/>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -158,7 +158,6 @@ const PostsTitle = ({
   isLink=true,
   curatedIconLeft=true,
   strikethroughTitle=false,
-  showRecommendationIcon=false,
   Wrapper=DefaultWrapper,
   showEventTag,
   linkEventProps,
@@ -177,7 +176,6 @@ const PostsTitle = ({
   isLink?: boolean,
   curatedIconLeft?: boolean
   strikethroughTitle?: boolean
-  showRecommendationIcon?: boolean
   Wrapper?: FC<PropsWithChildren<{}>>,
   showEventTag?: boolean,
   linkEventProps?: Record<string, string>,
@@ -236,7 +234,6 @@ const PostsTitle = ({
             post={post} 
             hideCuratedIcon={curatedIconLeft} 
             hidePersonalIcon={!showPersonalIcon}
-            showRecommendationIcon={showRecommendationIcon}
             hover={postItemHovered}
           />
         </InteractionWrapper>

--- a/packages/lesswrong/components/posts/RecombeePostsList.tsx
+++ b/packages/lesswrong/components/posts/RecombeePostsList.tsx
@@ -8,6 +8,7 @@ import { filterNonnull } from '../../lib/utils/typeGuardUtils';
 import moment from 'moment';
 import { useCurrentUser } from '../common/withUser';
 import { aboutPostIdSetting } from '@/lib/instanceSettings';
+import { IsRecommendationContext } from '../dropdowns/posts/PostActions';
 
 // Would be nice not to duplicate in postResolvers.ts but unfortunately the post types are different
 interface RecombeeRecommendedPost {
@@ -194,15 +195,16 @@ export const RecombeePostsList = ({ algorithm, settings, limit = 15, showRecomme
 
   return <div>
     <div className={classes.root}>
-      {filteredResults.map(({ post, recommId, curated, stickied }) => <PostsItem 
-        key={post._id} 
-        post={post} 
-        recombeeRecommId={recommId} 
-        curatedIconLeft={curated} 
-        showRecommendationIcon={showRecommendationIcon}
-        emphasizeIfNew={true}
-        terms={stickied ? stickiedPostTerms : undefined}
-      />)}
+      {filteredResults.map(({ post, recommId, curated, stickied }) => <IsRecommendationContext.Provider key={post._id} value={!!recommId}>
+        <PostsItem 
+          post={post} 
+          recombeeRecommId={recommId} 
+          curatedIconLeft={curated} 
+          showRecommendationIcon={showRecommendationIcon}
+          emphasizeIfNew={true}
+          terms={stickied ? stickiedPostTerms : undefined}
+        />
+      </IsRecommendationContext.Provider>)}
     </div>
     <SectionFooter>
       <LoadMore

--- a/packages/lesswrong/components/posts/RecombeePostsList.tsx
+++ b/packages/lesswrong/components/posts/RecombeePostsList.tsx
@@ -118,11 +118,10 @@ export const stickiedPostTerms: PostsViewTerms = {
   forum: true
 };
 
-export const RecombeePostsList = ({ algorithm, settings, limit = 15, showRecommendationIcon = false, classes }: {
+export const RecombeePostsList = ({ algorithm, settings, limit = 15, classes }: {
   algorithm: string,
   settings: RecombeeConfiguration,
   limit?: number,
-  showRecommendationIcon?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {
   const { LoadMore, PostsItem, SectionFooter, PostsLoading } = Components;
@@ -200,7 +199,6 @@ export const RecombeePostsList = ({ algorithm, settings, limit = 15, showRecomme
           post={post} 
           recombeeRecommId={recommId} 
           curatedIconLeft={curated} 
-          showRecommendationIcon={showRecommendationIcon}
           emphasizeIfNew={true}
           terms={stickied ? stickiedPostTerms : undefined}
         />

--- a/packages/lesswrong/components/posts/usePostsItem.tsx
+++ b/packages/lesswrong/components/posts/usePostsItem.tsx
@@ -87,7 +87,6 @@ export type PostsItemConfig = {
   isVoteable?: boolean,
   recombeeRecommId?: string,
   vertexAttributionId?: string,
-  showRecommendationIcon?: boolean,
   /** Whether or not to make new post items have bold post item dates */
   emphasizeIfNew?: boolean,
   className?: string,
@@ -137,7 +136,6 @@ export const usePostsItem = ({
   isVoteable = false,
   recombeeRecommId,
   vertexAttributionId,
-  showRecommendationIcon = false,
   emphasizeIfNew = false,
   className,
 }: PostsItemConfig) => {
@@ -281,7 +279,6 @@ export const usePostsItem = ({
     bookmark,
     isVoteable,
     isRecommendation,
-    showRecommendationIcon,
     emphasizeIfNew,
     className,
   };

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -165,6 +165,7 @@ importComponent("EditTagsDropdownItem", () => require('../components/dropdowns/p
 importComponent("ReportPostDropdownItem", () => require('../components/dropdowns/posts/ReportPostDropdownItem'));
 importComponent("DuplicateEventDropdownItem", () => require('../components/dropdowns/posts/DuplicateEventDropdownItem'));
 importComponent("HideFrontpagePostDropdownItem", () => require('../components/dropdowns/posts/HideFrontpagePostDropdownItem'));
+importComponent("DislikeRecommendationDropdownItem", () => require('../components/dropdowns/posts/DislikeRecommendationDropdownItem'));
 importComponent("BookmarkDropdownItem", () => require('../components/dropdowns/posts/BookmarkDropdownItem'));
 importComponent("EditPostDropdownItem", () => require('../components/dropdowns/posts/EditPostDropdownItem'));
 importComponent("EditPostDropdownItem", () => require('../components/dropdowns/posts/EditPostDropdownItem'));


### PR DESCRIPTION
Only present on items being served as recommendations. Supercedes "hide from frontpage" when present since it includes that and that would be a bit redundant

<img width="384" alt="Screen Shot 2024-07-01 at 6 35 00 PM" src="https://github.com/ForumMagnum/ForumMagnum/assets/7250541/a646d3f3-b3c0-465a-964a-c69e0285d090">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207712105098130) by [Unito](https://www.unito.io)
