### PR TITLE
[EA] Tweaks to twitter bot: proceed on error, use instance rather than db settings

### DIFF
--- a/packages/lesswrong/server/twitterBot.ts
+++ b/packages/lesswrong/server/twitterBot.ts
@@ -1,6 +1,5 @@
 import { addCronJob } from "./cronUtil";
 import TweetsRepo from "./repos/TweetsRepo";
-import { DatabaseServerSetting } from "./databaseSettings";
 import { loggerConstructor } from "@/lib/utils/logging";
 import { Posts } from "@/lib/collections/posts";
 import Tweets from "@/lib/collections/tweets/collection";
@@ -9,14 +8,14 @@ import { TwitterApi } from 'twitter-api-v2';
 import { getConfirmedCoauthorIds, postGetPageUrl } from "@/lib/collections/posts/helpers";
 import Users from "@/lib/vulcan-users";
 import { dogstatsd } from "./datadog/tracer";
-import { isProduction } from "@/lib/executionEnvironment";
+import { PublicInstanceSetting } from "@/lib/instanceSettings";
 
-const enabledSetting = new DatabaseServerSetting<boolean>("twitterBot.enabled", false);
-const karmaThresholdSetting = new DatabaseServerSetting<number>("twitterBot.karmaTreshold", 40);
-const apiKeySetting = new DatabaseServerSetting<string | null>("twitterBot.apiKey", null);
-const apiKeySecretSetting = new DatabaseServerSetting<string | null>("twitterBot.apiKeySecret", null);
-const accessTokenSetting = new DatabaseServerSetting<string | null>("twitterBot.accessToken", null);
-const accessTokenSecretSetting = new DatabaseServerSetting<string | null>("twitterBot.accessTokenSecret", null);
+const enabledSetting = new PublicInstanceSetting<boolean>("twitterBot.enabled", false, "optional");
+const karmaThresholdSetting = new PublicInstanceSetting<number>("twitterBot.karmaTreshold", 40, "optional");
+const apiKeySetting = new PublicInstanceSetting<string | null>("twitterBot.apiKey", null, "optional");
+const apiKeySecretSetting = new PublicInstanceSetting<string | null>("twitterBot.apiKeySecret", null, "optional");
+const accessTokenSetting = new PublicInstanceSetting<string | null>("twitterBot.accessToken", null, "optional");
+const accessTokenSecretSetting = new PublicInstanceSetting<string | null>("twitterBot.accessTokenSecret", null, "optional");
 
 const TWEET_MAX_LENGTH = 279;
 const URL_LENGTH = 24;
@@ -136,9 +135,6 @@ addCronJob({
   name: "runTwitterBot",
   interval: "every 31 minutes",
   job: async () => {
-    // Make sure this doesn't tweet http://localhost/ urls
-    if (!isProduction) return;
-
     await runTwitterBot();
   },
 });


### PR DESCRIPTION
Fixes for a couple of issues I noticed after deploying:
- If an attempt to post a tweet fails for some reason it keeps retrying with the same post
- Using db level settings rather than instance settings meant other instances (e.g. the beta site or bot site) would try to post tweets too

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207725476625498) by [Unito](https://www.unito.io)
