### PR TITLE
Fix for user mention UI appearing behind modals

### DIFF
--- a/packages/lesswrong/themes/globalStyles/miscStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/miscStyles.ts
@@ -130,6 +130,11 @@ html {
    * necessary to ensure it works on modal dialogs
    * (also tried adding it to Layout.jsx's JSS, and to the styles file in the ckeditor folder)
    */
+  --ck-z-panel: 10000000002 !important;
+  /**
+   * --ck-z-modal was renamed to --ck-z-panel in https://github.com/ckeditor/ckeditor5/pull/15285
+   * it's here for backwards compatibility only
+   */
   --ck-z-modal: 10000000002 !important;
 }
 


### PR DESCRIPTION
Before/after:
<img width="861" alt="Screenshot 2024-07-04 at 12 50 49" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/cc94576b-aff1-4f9e-95ac-79bf9bc87a00">
<img width="861" alt="Screenshot 2024-07-04 at 12 48 54" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/9808f527-52dd-4525-b615-38383b7ebf2b">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207737669644744) by [Unito](https://www.unito.io)
