### PR TITLE
Fix quick takes hover sidebar overflowing

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -8,6 +8,7 @@ import ForumNoSSR from "../common/ForumNoSSR";
 
 const styles = (_theme: ThemeType) => ({
   expandedRoot: {
+    position: "relative",
     "& .comments-node-root": {
       marginBottom: 8,
       ...(isLWorAF ? {


### PR DESCRIPTION
Before/after:
<img width="891" alt="Screenshot 2024-07-04 at 13 05 29" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/f6b52f16-d70f-4c99-bd3c-834711609a5a">
<img width="891" alt="Screenshot 2024-07-04 at 13 04 55" src="https://github.com/ForumMagnum/ForumMagnum/assets/77623106/5fb8aa1e-64eb-4f80-8939-5b5e3c830548">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207737702119003) by [Unito](https://www.unito.io)
