### PR TITLE
set ttl for ckeditor tokens to prevent expired tokens from being used

### DIFF
--- a/packages/lesswrong/lib/ckEditorUtils.ts
+++ b/packages/lesswrong/lib/ckEditorUtils.ts
@@ -1,9 +1,11 @@
 import LRU from 'lru-cache';
 
 // This cache helps avoid multiple network load times when requesting
-// tokens in quick succession. We use the default TTL which is only
-// 5 minutes. CkEditor tokens are valid for 24 hours.
-const cache = new LRU<string, string>();
+// tokens in quick succession.
+// CkEditor tokens are valid for 24 hours, so we use a 12 hour TTL.
+const cache = new LRU<string, string>({
+  maxAge: 1000 * 60 * 60 * 12
+});
 
 export const getCKEditorDocumentId = (documentId: string|undefined, userId: string|undefined, formType: string|undefined) => {
   if (documentId) return `${documentId}-${formType}`


### PR DESCRIPTION
A user reported an issue when attempting to upload an image to a post they were editing.  Investigating in ckEditor's dashboard reveaeld that the token had passed its `maxAge`; inspecting the jwt itself revealed that it was ~6 days old (ckEditor tokens are only valid for 24 hours).

`lru-cache` does not actually have a default TTL, despite the previous comment.  I'm not sure how this is the first time the issue's come up since it's been a ~year since it was implemented, but I guess you'd need to get somewhat unlucky as a user to run into it - you'd need to hit a server instance you interacted with to generate a ckEditor token for the same post more than 24 hours ago (so that it'd still be cached).  This requires editing a post across multiple days with no deploys having gone out in the interim, and then still hitting a previously used instance.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207749946163506) by [Unito](https://www.unito.io)
