### PR TITLE
hide deleted sequences across the site

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/permissions.ts
+++ b/packages/lesswrong/lib/collections/sequences/permissions.ts
@@ -21,12 +21,12 @@ adminsGroup.can(adminActions);
 export const SHOW_NEW_SEQUENCE_KARMA_THRESHOLD = 100;
 
 Sequences.checkAccess = async (user, document) => {
-  if (!document) {
+  if (!document || document.isDeleted) {
     return false;
   }
   
-  // If it isn't a draft and isn't deleted, it's public
-  if (!document.draft && !document.isDeleted) {
+  // If it isn't a draft, it's public
+  if (!document.draft) {
     return true;
   }
   


### PR DESCRIPTION
A user reported an issue to us, where they could still see their sequence linked at the top of a post page even after they deleted the sequence. This was only visible to the sequence author and admins, but from the sequence author perspective this is really confusing.

When you delete a sequence, the UI implies that it's irreversible - if the user wanted a reversible version they could just move it back to draft. Given that, I think it's better to actually treat `isDeleted` as a soft delete that makes the sequence no longer visible to anyone on the site.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207781116103970) by [Unito](https://www.unito.io)
