### PR TITLE
When Intercom page-view event recording fails with a 401, don't fail the /graphql with a 401

### DIFF
--- a/packages/lesswrong/server/callbacks/intercomCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/intercomCallbacks.ts
@@ -1,25 +1,37 @@
+import { captureException } from '@sentry/core';
 import { getIntercomClient } from '../intercomSetup';
 import { getCollectionHooks } from '../mutationCallbacks';
 
 getCollectionHooks("LWEvents").newAsync.add(async function sendIntercomEvent (event: DbLWEvent, user: DbUser) {
-  const intercomClient = getIntercomClient();
-  if (!intercomClient) {
-    return;
+  try {
+    const intercomClient = getIntercomClient();
+    if (!intercomClient) {
+      return;
+    }
+    if (!user || !event?.intercom) {
+      return;
+    }
+    // Append documentId to metadata passed to intercom
+    event.properties = {
+      ...event.properties,
+      documentId: event.documentId,
+    }
+    let currentTime = new Date();
+    let intercomEvent = {
+      event_name: event.name ?? undefined,
+      created_at: Math.floor((currentTime.getTime()/1000)),
+      user_id: user._id,
+      metadata: event.properties
+    };
+    await intercomClient.events.create(intercomEvent);
+  } catch(e) {
+    // `intercomClient.events.create` involves a request to Intercom's servers,
+    // which can fail. We had an issue where the request to Intercom's server
+    // would fail with a 401 (unauthorized), the exception would bubble out of
+    // this callback, and an LW user's request to `/graphql`, containing a
+    // page-view event and also some requests for data, would return that 401.
+    // This would cause the user to see a spurious login prompt, and also the
+    // request itself would fail.
+    captureException(e);
   }
-  if (!user || !event?.intercom) {
-    return;
-  }
-  // Append documentId to metadata passed to intercom
-  event.properties = {
-    ...event.properties,
-    documentId: event.documentId,
-  }
-  let currentTime = new Date();
-  let intercomEvent = {
-    event_name: event.name ?? undefined,
-    created_at: Math.floor((currentTime.getTime()/1000)),
-    user_id: user._id,
-    metadata: event.properties
-  };
-  await intercomClient.events.create(intercomEvent);
 });


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207805919863494) by [Unito](https://www.unito.io)
