### PR TITLE
clean up console and sentry log spam

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -487,8 +487,6 @@ const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBo
     "dangerouslySetInnerHTML": "deep",
     replacedSubstrings: "deep"
   },
-
-  debugRerenders: true,
 });
 
 declare global {


### PR DESCRIPTION
The `ContentItemBody` change was a debugging diff incorrectly left in from a previously PR, and recombee is just pretty noisy when it comes to letting us know that it can't register some events because it doesn't know about the relevant user or post.  That happens often enough for innocuous reasons that we don't need to see it Sentry.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207817431807591) by [Unito](https://www.unito.io)
