### PR TITLE
Add FM_WATCH env var to allow turning off --watch CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,10 @@ monorepo codebase at a non-megacorp is that we can get good results just by
 searching for `hiddenRelatedQuestion` to find exactly how that database field is
 used.
 
-You might want to set `SLOW_QUERY_REPORT_CUTOFF_MS` to something other than the default (2000 ms),
-it can give a lot of false positives when you are running against a remote database.
+**Environment variables**
+
+- `SLOW_QUERY_REPORT_CUTOFF_MS`: You might want to set this to something other than the default (2000 ms), it can give a lot of false positives when you are running against a remote database.
+- `FM_WATCH`: Set this to `true` or `false` to override the `--watch` CLI flag for the build process. It can sometimes be annoying for the project to rebuild on every save.
 
 ### Debugging
 

--- a/build.js
+++ b/build.js
@@ -46,6 +46,12 @@ const isProduction = !!opts.production;
 const isE2E = !!opts.e2e;
 const settingsFile = opts.settings || "settings.json"
 
+// Allow FM_WATCH to override the --watch CLI flag that is passed in
+const watchEnvVar = process.env.FM_WATCH?.toLowerCase();
+if (watchEnvVar === 'true' || watchEnvVar === 'false') {
+  cliopts.watch = watchEnvVar === 'true';
+}
+
 const databaseConfig = getDatabaseConfig(opts);
 process.env.PG_URL = databaseConfig.postgresUrl;
 


### PR DESCRIPTION
I have recently been developing without the `--watch` flag, adding this variable so I don't have to keep editing the flags in `package.json` manually

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207824484965679) by [Unito](https://www.unito.io)
