### PR TITLE
[EA] Allow users to change their displayName with a rate limit

### DIFF
--- a/packages/lesswrong/integrationTests/collections/users.tests.ts
+++ b/packages/lesswrong/integrationTests/collections/users.tests.ts
@@ -6,19 +6,28 @@ import {
   catchGraphQLErrors,
   assertIsPermissionsFlavoredError,
   withNoLogs,
+  waitUntilCallbacksFinished,
 } from '../utils';
 
 describe('updateUser – ', () => {
   let graphQLerrors = catchGraphQLErrors(beforeEach, afterEach);
-  it("fails when user updates their displayName", async () => {
+  it("fails when user updates their displayName more than once", async () => {
     const user = await createDummyUser()
+    // Should succeed the first time
+    await userUpdateFieldSucceeds({
+      user:user,
+      document:user,
+      fieldName:'displayName',
+      collectionType:'User',
+    })
+    await waitUntilCallbacksFinished();
+    // Should hit the rate limit the second time
     await userUpdateFieldFails({
       user:user,
       document:user,
       fieldName:'displayName',
       collectionType:'User',
     })
-    assertIsPermissionsFlavoredError(graphQLerrors.getErrors());
   });
   it("fails when user updates their createdAt", async () => {
     const user = await createDummyUser()

--- a/packages/lesswrong/integrationTests/collections/users.tests.ts
+++ b/packages/lesswrong/integrationTests/collections/users.tests.ts
@@ -28,6 +28,7 @@ describe('updateUser – ', () => {
       fieldName:'displayName',
       collectionType:'User',
     })
+    graphQLerrors.getErrors(); // Ignore the details of the error
   });
   it("fails when user updates their createdAt", async () => {
     const user = await createDummyUser()

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -412,7 +412,8 @@ const schema: SchemaType<"Users"> = {
     type: String,
     optional: true,
     input: 'text',
-    canUpdate: ['sunshineRegiment', 'admins', userHasntChangedName],
+    // On the EA Forum name changing is rate limited in rateLimitCallbacks
+    canUpdate: ['sunshineRegiment', 'admins', isEAForum ? 'members' : userHasntChangedName],
     canCreate: ['sunshineRegiment', 'admins'],
     canRead: ['guests'],
     order: 10,

--- a/packages/lesswrong/server/repos/LWEventsRepo.ts
+++ b/packages/lesswrong/server/repos/LWEventsRepo.ts
@@ -1,0 +1,42 @@
+import { LWEvents } from "@/lib/collections/lwevents";
+import AbstractRepo from "./AbstractRepo";
+import { recordPerfMetrics } from "./perfMetricWrapper";
+
+class LWEventsRepo extends AbstractRepo<"LWEvents"> {
+  constructor() {
+    super(LWEvents);
+  }
+
+  async countDisplayNameChanges({
+    userId,
+    sinceDaysAgo,
+  }: {
+    userId: string;
+    sinceDaysAgo: number;
+  }): Promise<number> {
+    const res = await this.getRawDb().one<{nameChanges: string}>(
+      `
+      -- LWEventsRepo.countDisplayNameChanges30Days
+      SELECT
+        count(*) AS "nameChanges"
+      FROM
+        "LWEvents"
+      WHERE
+        "name" = 'fieldChanges'
+        AND "userId" = $1
+        AND "documentId" = $1
+        AND "createdAt" > now() - interval '$2 days'
+        AND properties -> 'before' ->> 'displayName' <> properties -> 'after' ->> 'displayName'
+        -- Don't count the case when they are first setting their username
+        AND coalesce(properties -> 'before' ->> 'usernameUnset', '') = coalesce(properties->'after'->>'usernameUnset', '');
+    `,
+      [userId, sinceDaysAgo]
+    );
+
+    return parseInt(res.nameChanges);
+  }
+}
+
+recordPerfMetrics(LWEventsRepo);
+
+export default LWEventsRepo;

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -91,6 +91,7 @@ export {
   ElectionVotesRepo,
   ForumEventsRepo,
   LocalgroupsRepo,
+  LWEventsRepo,
   ManifoldProbabilitiesCachesRepo,
   NotificationsRepo,
   PageCacheRepo,

--- a/packages/lesswrong/server/repos/index.ts
+++ b/packages/lesswrong/server/repos/index.ts
@@ -33,6 +33,7 @@ import TweetsRepo from "./TweetsRepo";
 import TypingIndicatorsRepo from "./TypingIndicatorsRepo";
 import UsersRepo from "./UsersRepo";
 import VotesRepo from "./VotesRepo";
+import LWEventsRepo from "./LWEventsRepo";
 
 declare global {
   type Repos = ReturnType<typeof getAllRepos>;
@@ -51,6 +52,7 @@ const getAllRepos = () => ({
   electionVotes: new ElectionVotesRepo(),
   forumEvents: new ForumEventsRepo(),
   localgroups: new LocalgroupsRepo(),
+  lwEvents: new LWEventsRepo(),
   notifications: new NotificationsRepo(),
   postEmbeddings: new PostEmbeddingsRepo(),
   pageCaches: new PageCacheRepo(),


### PR DESCRIPTION
Previously users were permanently disallowed from changing their name after changing it once, now they can do so after 30 days (cc @jpaddison3 lowered from 90).

@darkruby501 @b0b3rt Do you want this for LW? It's currently forum gated.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207826607529489) by [Unito](https://www.unito.io)
