### PR TITLE
[EA Forum only] banner for upcoming EAG(x) near you

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -70,6 +70,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     // but almost all pages are bigger than this anyway so it's not that important
     minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
     gridArea: 'main',
+    [theme.breakpoints.down('md')]: {
+      paddingTop: isFriendlyUI ? 0 : theme.spacing.mainLayoutPaddingTop,
+    },
     [theme.breakpoints.down('sm')]: {
       paddingTop: isFriendlyUI ? 0 : 10,
       paddingLeft: 8,

--- a/packages/lesswrong/components/common/CookieBanner/geolocation.ts
+++ b/packages/lesswrong/components/common/CookieBanner/geolocation.ts
@@ -67,7 +67,7 @@ function setCountryCodeToLocalStorage(countryCode: string) {
   ls.setItem('countryCodeTimestamp', timestamp.toString());
 }
 
-function getCachedUserCountryCode() {
+export function getCachedUserCountryCode() {
   if (isServer) return null;
 
   const cachedCountryCode = getCountryCodeFromLocalStorage();

--- a/packages/lesswrong/components/ea-forum/EAGBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EAGBanner.tsx
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Components, registerComponent } from "../../lib/vulcan-lib";
+import { useCurrentUser } from "../common/withUser";
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
+import { useCookiesWithConsent } from "../hooks/useCookiesWithConsent";
+import moment from "moment";
+import ForumNoSSR from "../common/ForumNoSSR";
+import { HIDE_EAG_BANNER_COOKIE } from "@/lib/cookies/cookies";
+import { Link } from "@/lib/reactRouterWrapper";
+import { useUserLocation } from "@/lib/collections/users/helpers";
+import { distance } from "../community/modules/LocalGroups";
+import { getCachedUserCountryCode } from "../common/CookieBanner/geolocation";
+import { lightbulbIcon } from "../icons/lightbulbIcon";
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    display: "flex",
+    justifyContent: "space-between",
+    columnGap: "10px",
+    padding: '10px 10px 10px 12px',
+    backgroundColor: theme.palette.grey[200],
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontSize: 15,
+    lineHeight: '22px',
+    fontWeight: 450,
+    borderRadius: theme.borderRadius.default,
+    marginBottom: 20,
+  },
+  lightbulb: {
+    flex: 'none',
+    height: 30,
+    width: 30,
+    alignSelf: 'center',
+    color: theme.palette.buttons.alwaysPrimary,
+  },
+  content: {
+    flexGrow: 1,
+  },
+  topRow: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: 6,
+    fontSize: 13,
+    lineHeight: '17px',
+    opacity: 0.5,
+    marginBottom: 2,
+  },
+  infoIcon: {
+    fontSize: 14,
+    transform: 'translateY(2px)',
+  },
+  bold: {
+    fontWeight: 700,
+  },
+  link: {
+    textDecoration: 'underline',
+  },
+  applyLink: {
+    color: theme.palette.buttons.alwaysPrimary,
+    fontWeight: 600,
+    textDecoration: 'underline',
+    textUnderlineOffset: '3px',
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      textDecoration: 'underline',
+      opacity: 0.75,
+    },
+  },
+  close: {
+    flex: 'none',
+    fontSize: 20,
+    cursor: "pointer",
+    marginLeft: 13,
+    "&:hover": {
+      opacity: 0.75,
+    },
+  },
+});
+
+// This is the data for the next EAGx (Toronto, CA)
+const eagName = 'EAGxToronto'
+const eagLocation = {
+  lat: 43.6532,
+  lng: -79.3832,
+}
+const eagCountry = 'CA'
+const eagPostLink = "/events/WGeby2GfMHH8jXmMY/eagxtoronto"
+const eagLink = "https://www.effectivealtruism.org/ea-global/events/eagxtoronto-2024"
+const applicationDeadline = moment('2024-07-31', 'YYYY-MM-DD')
+
+
+/**
+ * This is an experimental banner at the top of the EA Forum homepage.
+ * We are considering displaying a small banner when an EAG(x) application deadline is near,
+ * visible only to users who we think are in a relevant location for that conference.
+ */
+const EAGBanner = ({classes}: {classes: ClassesType}) => {
+  const [cookies, setCookie] = useCookiesWithConsent([HIDE_EAG_BANNER_COOKIE]);
+  const {captureEvent} = useTracking();
+  const currentUser = useCurrentUser();
+  
+  // Try to get the user's location from:
+  // 1. (logged in user) user settings
+  // 2. (logged out user) browser's local storage
+  // 3. country code in local storage, which is also used by the cookie banner
+  const userLocation = useUserLocation(currentUser, true)
+  const [countryCode, setCountryCode] = useState<string|null>(null)
+  useEffect(() => {
+    // Get the country code from local storage
+    setCountryCode(getCachedUserCountryCode())
+  }, [])
+
+  const hideBanner = useCallback(() => {
+    setCookie(HIDE_EAG_BANNER_COOKIE, "true", {
+      expires: moment().add(1, "months").toDate(),
+    });
+  }, [setCookie]);
+
+  const onDismissBanner = useCallback(() => {
+    hideBanner();
+    captureEvent("eag_banner_dismissed");
+  }, [hideBanner, captureEvent]);
+
+  // This EAG(x) is relevant to the user if they are within 500 miles of it,
+  // or they live in relevant/nearby countries.
+  const userLocationNearby = distance(eagLocation, userLocation, 'mi') < 500
+  const userInCountry = countryCode === eagCountry
+  const isRelevant = userLocationNearby || userInCountry
+  if (
+    moment().isAfter(applicationDeadline) ||
+    cookies[HIDE_EAG_BANNER_COOKIE] === "true" ||
+    !isRelevant
+  ) {
+    return null;
+  }
+
+  const {AnalyticsInViewTracker, SingleColumnSection, LWTooltip, HoverPreviewLink, ForumIcon} = Components;
+  
+  const inViewEventProps = {
+    inViewType: `${eagName}Banner`,
+    reason: userLocationNearby && userInCountry ? 'both' : userLocationNearby ? 'nearby' : 'country'
+  }
+
+  return (
+    <ForumNoSSR if={!currentUser}>
+      <AnalyticsContext pageElementContext="EAGBanner">
+        <AnalyticsInViewTracker eventProps={inViewEventProps}>
+          <SingleColumnSection className={classes.root}>
+            <div className={classes.lightbulb}>{lightbulbIcon}</div>
+            <div className={classes.content}>
+              <div className={classes.topRow}>
+                Upcoming conference near you
+                <LWTooltip title={
+                    <>
+                      You're seeing this recommendation because of your location.{" "}
+                      {userLocationNearby && <>
+                        You can update your account location via your{" "}
+                        <Link to="/account?highlightField=googleLocation" className={classes.link}>
+                          account settings
+                        </Link>.
+                      </>}
+                    </>
+                  }
+                  clickable={userLocationNearby}
+                >
+                  <ForumIcon icon="QuestionMarkCircle" className={classes.infoIcon} />
+                </LWTooltip>
+              </div>
+              <div className={classes.bottomRow}>
+                <HoverPreviewLink href={eagPostLink}>
+                  <span className={classes.bold}>{eagName}</span>
+                </HoverPreviewLink>{" "}
+                applications close on {applicationDeadline.format('ddd MMMM D')} &#8212;{" "}
+                <Link to={eagLink} className={classes.applyLink}>
+                  apply now
+                </Link>
+              </div>
+            </div>
+            <ForumIcon
+              icon="Close"
+              onClick={onDismissBanner}
+              className={classes.close}
+            />
+          </SingleColumnSection>
+        </AnalyticsInViewTracker>
+      </AnalyticsContext>
+    </ForumNoSSR>
+  );
+}
+
+const EAGBannerComponent = registerComponent(
+  "EAGBanner",
+  EAGBanner,
+  {styles},
+);
+
+declare global {
+  interface ComponentTypes {
+    EAGBanner: typeof EAGBannerComponent
+  }
+}

--- a/packages/lesswrong/components/ea-forum/EAGBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EAGBanner.tsx
@@ -86,7 +86,7 @@ const eagLocation = {
 const eagCountry = 'CA'
 const eagPostLink = "/events/WGeby2GfMHH8jXmMY/eagxtoronto"
 const eagLink = "https://www.effectivealtruism.org/ea-global/events/eagxtoronto-2024"
-const applicationDeadline = moment('2024-07-31', 'YYYY-MM-DD')
+const applicationDeadline = moment.utc('2024-07-31', 'YYYY-MM-DD')
 
 
 /**
@@ -127,7 +127,7 @@ const EAGBanner = ({classes}: {classes: ClassesType}) => {
   const userInCountry = countryCode === eagCountry
   const isRelevant = userLocationNearby || userInCountry
   if (
-    moment().isAfter(applicationDeadline) ||
+    moment.utc().isAfter(applicationDeadline, 'day') ||
     cookies[HIDE_EAG_BANNER_COOKIE] === "true" ||
     !isRelevant
   ) {

--- a/packages/lesswrong/components/ea-forum/EAGBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EAGBanner.tsx
@@ -16,8 +16,8 @@ const styles = (theme: ThemeType) => ({
   root: {
     display: "flex",
     justifyContent: "space-between",
-    columnGap: "10px",
-    padding: '10px 10px 10px 12px',
+    columnGap: "6px",
+    padding: '10px 10px 10px 9px',
     backgroundColor: theme.palette.grey[200],
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: 15,
@@ -28,8 +28,8 @@ const styles = (theme: ThemeType) => ({
   },
   lightbulb: {
     flex: 'none',
-    height: 30,
-    width: 30,
+    height: 37,
+    width: 37,
     alignSelf: 'center',
     color: theme.palette.buttons.alwaysPrimary,
   },
@@ -61,6 +61,7 @@ const styles = (theme: ThemeType) => ({
     textDecoration: 'underline',
     textUnderlineOffset: '3px',
     whiteSpace: 'nowrap',
+    marginLeft: 4,
     '&:hover': {
       textDecoration: 'underline',
       opacity: 0.75,
@@ -70,7 +71,7 @@ const styles = (theme: ThemeType) => ({
     flex: 'none',
     fontSize: 20,
     cursor: "pointer",
-    marginLeft: 13,
+    marginLeft: 16,
     "&:hover": {
       opacity: 0.75,
     },
@@ -170,9 +171,9 @@ const EAGBanner = ({classes}: {classes: ClassesType}) => {
                 <HoverPreviewLink href={eagPostLink}>
                   <span className={classes.bold}>{eagName}</span>
                 </HoverPreviewLink>{" "}
-                applications close on {applicationDeadline.format('ddd MMMM D')} &#8212;{" "}
+                applications close on {applicationDeadline.format('ddd MMMM D')}.{" "}
                 <Link to={eagLink} className={classes.applyLink}>
-                  apply now
+                  Apply now
                 </Link>
               </div>
             </div>

--- a/packages/lesswrong/components/ea-forum/EAGBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EAGBanner.tsx
@@ -123,7 +123,7 @@ const EAGBanner = ({classes}: {classes: ClassesType}) => {
 
   // This EAG(x) is relevant to the user if they are within 500 miles of it,
   // or they live in relevant/nearby countries.
-  const userLocationNearby = distance(eagLocation, userLocation, 'mi') < 500
+  const userLocationNearby = userLocation.known && (distance(eagLocation, userLocation, 'mi') < 500)
   const userInCountry = countryCode === eagCountry
   const isRelevant = userLocationNearby || userInCountry
   if (

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -94,6 +94,7 @@ const EAHome = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const {
     EAHomeMainContent, SmallpoxBanner, EventBanner, MaintenanceBanner,
     FrontpageReviewWidget, SingleColumnSection, HeadTags, BotSiteBanner,
+    EAGBanner,
   } = Components
   return (
     <AnalyticsContext pageContext="homePage">
@@ -102,6 +103,7 @@ const EAHome = ({classes}: {classes: ClassesType<typeof styles>}) => {
       {shouldRenderSmallpox && <SmallpoxBanner/>}
       {shouldRenderEventBanner && <EventBanner />}
       {shouldRenderBotSiteBanner && <BotSiteBanner />}
+      {isEAForum && <EAGBanner />}
 
       {reviewIsActive() && <SingleColumnSection>
         <FrontpageReviewWidget reviewYear={REVIEW_YEAR}/>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -57,6 +57,7 @@ importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHa
 importComponent("EAHomeRightHandSide", () => require('../components/ea-forum/EAHomeRightHandSide'));
 importComponent("EAForumWrappedPage", () => require('../components/ea-forum/wrapped/EAForumWrappedPage'));
 importComponent("EASurveyBanner", () => require('../components/ea-forum/EASurveyBanner'));
+importComponent("EAGBanner", () => require('../components/ea-forum/EAGBanner'));
 importComponent("Digests", () => require('../components/ea-forum/digest/Digests'));
 importComponent("EditDigest", () => require('../components/ea-forum/digest/EditDigest'));
 importComponent("EditDigestHeader", () => require('../components/ea-forum/digest/EditDigestHeader'));

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -170,6 +170,12 @@ export const SELECTED_FRONTPAGE_TAB_COOKIE = registerCookie({
   description: "Stores the selected tab for logged out users"
 });
 
+export const HIDE_EAG_BANNER_COOKIE = registerCookie({
+  name: "hide_eag_banner",
+  type: "necessary",
+  description: "Don't show any EAG(x) banners",
+});
+
 // Third party cookies
 
 // Intercom


### PR DESCRIPTION
The Events Team is interested in seeing if they can get additional applications via a location-based banner on the Forum. This is an experiment, and based on the results we'll either remove this code or update it to work for future events.

See [slack thread](https://cea-core.slack.com/archives/C0342BY5TK8/p1720691346075829) for additional context, including messages from the Events Team.

<img width="1439" alt="Screen Shot 2024-07-16 at 4 25 05 PM" src="https://github.com/user-attachments/assets/4aa01a4b-be0d-4d2e-9098-7fe068568a74">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207827404476789) by [Unito](https://www.unito.io)
