### PR TITLE
hide "Load more" if there are no more quick takes

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesList.tsx
@@ -23,6 +23,7 @@ const QuickTakesList = ({showCommunity, tagId, maxAgeDays, className}: {
     limit: 5,
     collectionName: "Comments",
     fragmentName: "ShortformComments",
+    enableTotal: true,
   });
   const {QuickTakesListItem, Loading, SectionFooter, LoadMore} = Components;
   return (


### PR DESCRIPTION
(In response to a bug report via [slack](https://cea-core.slack.com/archives/C038J512SD8/p1721226419147569))

This is to improve a specific case: when there are exactly 5 quick takes that qualify for the frontpage section, we show the "Load more" button but clicking it does nothing because we are showing them all already. If we `enableTotal`, then `useMulti()` properly accounts for this case.