### PR TITLE
Cleanup email verification logic so EAF never sends verification emails

### DIFF
--- a/packages/lesswrong/components/common/SubscribeDialog.tsx
+++ b/packages/lesswrong/components/common/SubscribeDialog.tsx
@@ -169,20 +169,13 @@ class SubscribeDialog extends Component<SubscribeDialogProps,SubscribeDialogStat
     event.target && 'select' in event.target && event.target.select();
   }
 
-  sendVerificationEmail() {
-    const { updateCurrentUser, currentUser } = this.props;
-    if (!currentUser) return;
-    
-    void updateCurrentUser({
-      whenConfirmationEmailSent: new Date()
-    });
-  }
-
   subscribeByEmail() {
     let mutation: Partial<DbUser> = { emailSubscribedToCurated: true }
     const { currentUser, updateCurrentUser, captureEvent } = this.props;
     if (!currentUser) return;
 
+    // TODO !userEmailAddressIsVerified will always be false for EAF (via assumeUserEmailVerifiedSetting). !isLWorAF will always be false for LW or AF, so this
+    // path can only be hit on other instances. Ask Vlad if he is using it and cut it if not
     if (!isLWorAF && !userEmailAddressIsVerified(currentUser)) {
       // Combine mutations into a single update call.
       // (This reduces the number of server-side callback

--- a/packages/lesswrong/components/common/SubscribeDialog.tsx
+++ b/packages/lesswrong/components/common/SubscribeDialog.tsx
@@ -174,9 +174,7 @@ class SubscribeDialog extends Component<SubscribeDialogProps,SubscribeDialogStat
     const { currentUser, updateCurrentUser, captureEvent } = this.props;
     if (!currentUser) return;
 
-    // TODO !userEmailAddressIsVerified will always be false for EAF (via assumeUserEmailVerifiedSetting). !isLWorAF will always be false for LW or AF, so this
-    // path can only be hit on other instances. Ask Vlad if he is using it and cut it if not
-    if (!isLWorAF && !userEmailAddressIsVerified(currentUser)) {
+    if (!userEmailAddressIsVerified(currentUser)) {
       // Combine mutations into a single update call.
       // (This reduces the number of server-side callback
       // invocations. In a past version this worked around

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -201,8 +201,6 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // since they chose to subscribe to an email, make sure this is false
     userSubscriptionData.unsubscribeFromAll = false;
 
-    // TODO update comment
-    // EA Forum does not care about email verification
     if (!userEmailAddressIsVerified(currentUser)) {
       userSubscriptionData.whenConfirmationEmailSent = new Date();
     }
@@ -314,8 +312,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
               userSubscriptionData.unsubscribeFromAll = false;
               await updateCurrentUser(userSubscriptionData);
 
-              // FIXME I think this should use !userEmailAddressIsVerified(currentUser) (and therefore always bypass on EAF)
-              if (isEAForum) {
+              if (!userEmailAddressIsVerified(currentUser)) {
                 // Confirmation-email mutation is separate from the send-verification-email
                 // mutation because otherwise it goes to the old email address (aka null)
                 await updateCurrentUser({

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -201,8 +201,9 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // since they chose to subscribe to an email, make sure this is false
     userSubscriptionData.unsubscribeFromAll = false;
 
+    // TODO update comment
     // EA Forum does not care about email verification
-    if (!isEAForum && !userEmailAddressIsVerified(currentUser)) {
+    if (!userEmailAddressIsVerified(currentUser)) {
       userSubscriptionData.whenConfirmationEmailSent = new Date();
     }
 
@@ -313,6 +314,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
               userSubscriptionData.unsubscribeFromAll = false;
               await updateCurrentUser(userSubscriptionData);
 
+              // FIXME I think this should use !userEmailAddressIsVerified(currentUser) (and therefore always bypass on EAF)
               if (isEAForum) {
                 // Confirmation-email mutation is separate from the send-verification-email
                 // mutation because otherwise it goes to the old email address (aka null)
@@ -386,7 +388,8 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
         {dontAskAgainButton}
       </div>
     </AnalyticsWrapper>
-  } else if ((!isEAForum && !userEmailAddressIsVerified(currentUser)) || adminBranch===4) {
+
+  } else if (!userEmailAddressIsVerified(currentUser) || adminBranch===4) {
     // User is subscribed, but they haven't verified their email address. Show
     // a resend-verification-email button.
     return <AnalyticsWrapper branch="needs-email-verification">

--- a/packages/lesswrong/components/users/UsersEmailVerification.tsx
+++ b/packages/lesswrong/components/users/UsersEmailVerification.tsx
@@ -37,6 +37,7 @@ class UsersEmailVerification extends PureComponent<UsersEmailVerificationProps,U
   sendConfirmationEmail() {
     const { updateCurrentUser, currentUser } = this.props;
     if (!currentUser) return;
+    // TODO this is hit via the bell notification warning people that they need to verify their email
     void updateCurrentUser({
       whenConfirmationEmailSent: new Date()
     });

--- a/packages/lesswrong/components/users/UsersEmailVerification.tsx
+++ b/packages/lesswrong/components/users/UsersEmailVerification.tsx
@@ -37,7 +37,6 @@ class UsersEmailVerification extends PureComponent<UsersEmailVerificationProps,U
   sendConfirmationEmail() {
     const { updateCurrentUser, currentUser } = this.props;
     if (!currentUser) return;
-    // TODO this is hit via the bell notification warning people that they need to verify their email
     void updateCurrentUser({
       whenConfirmationEmailSent: new Date()
     });

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -1,6 +1,6 @@
 import bowser from 'bowser';
 import { isClient, isServer } from '../../executionEnvironment';
-import {assumeUserEmailVerifiedSetting, forumTypeSetting, isEAForum} from '../../instanceSettings'
+import {forumTypeSetting, isEAForum, verifyEmailsSetting} from '../../instanceSettings'
 import { combineUrls, getSiteUrl } from '../../vulcan-lib/utils';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
 import React, { useEffect, useState } from 'react';
@@ -296,9 +296,10 @@ export const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post
 // Return true if the user's account has at least one verified email address.
 export const userEmailAddressIsVerified = (user: UsersCurrent|DbUser|null): boolean => {
   // Some forums don't do their own email verification
-  if (assumeUserEmailVerifiedSetting.get()) {
+  if (!verifyEmailsSetting.get()) {
     return true
   }
+
   if (!user || !user.emails)
     return false;
   for (let email of user.emails) {

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -5,7 +5,7 @@ import { userGetEditUrl } from '../../vulcan-users/helpers';
 import { userGroups, userOwns, userIsAdmin, userHasntChangedName } from '../../vulcan-users/permissions';
 import { formGroups } from './formGroups';
 import * as _ from 'underscore';
-import { hasEventsSetting, isAF, isEAForum, isLW, isLWorAF, taggingNamePluralSetting } from "../../instanceSettings";
+import { hasEventsSetting, isAF, isEAForum, isLW, isLWorAF, taggingNamePluralSetting, verifyEmailsSetting } from "../../instanceSettings";
 import { accessFilterMultiple, arrayOfForeignKeysField, denormalizedCountOfReferences, denormalizedField, foreignKeyField, googleLocationToMongoLocation, resolverOnlyField, schemaDefaultValue } from '../../utils/schemaUtils';
 import { postStatuses } from '../posts/constants';
 import GraphQLJSON from 'graphql-type-json';
@@ -622,13 +622,10 @@ const schema: SchemaType<"Users"> = {
     group: formGroups.emails,
     control: 'UsersEmailVerification',
     canRead: ['members'],
-    // EA Forum does not care about email verification
-    // FIXME iiiinteresting, there are cases where it can be edited
-    // TODO change to the verifyEmails setting
-    canUpdate: isEAForum
-      ? []
-      : [userOwns, 'sunshineRegiment', 'admins'],
-    // Jim changed this on 21st June, and fixed the issue: https://github.com/ForumMagnum/ForumMagnum/commit/39efbd507cd7c064fbfdc19c8e6a0f805c67e4be
+    // Editing this triggers a verification email, so don't allow editing on instances (like EAF) that don't use email verification
+    canUpdate: verifyEmailsSetting.get()
+      ? [userOwns, 'sunshineRegiment', 'admins']
+      : [],
     canCreate: ['members'],
   },
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -624,9 +624,11 @@ const schema: SchemaType<"Users"> = {
     canRead: ['members'],
     // EA Forum does not care about email verification
     // FIXME iiiinteresting, there are cases where it can be edited
+    // TODO change to the verifyEmails setting
     canUpdate: isEAForum
       ? []
       : [userOwns, 'sunshineRegiment', 'admins'],
+    // Jim changed this on 21st June, and fixed the issue: https://github.com/ForumMagnum/ForumMagnum/commit/39efbd507cd7c064fbfdc19c8e6a0f805c67e4be
     canCreate: ['members'],
   },
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -623,6 +623,7 @@ const schema: SchemaType<"Users"> = {
     control: 'UsersEmailVerification',
     canRead: ['members'],
     // EA Forum does not care about email verification
+    // FIXME iiiinteresting, there are cases where it can be edited
     canUpdate: isEAForum
       ? []
       : [userOwns, 'sunshineRegiment', 'admins'],

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -185,9 +185,8 @@ export const tabLongTitleSetting = new PublicInstanceSetting<string | null>('for
 
 export const noIndexSetting = new PublicInstanceSetting<boolean>('noindex', false, "optional")
 
-// TODO combine with email.assumeVerified
 /** Whether this forum verifies user emails */
-export const verifyEmailsSetting = new PublicInstanceSetting<boolean>("verifyEmails", true, "optional");
+export const verifyEmailsSetting = new PublicInstanceSetting<boolean>("verifyEmails", !isEAForum, "optional");
 
 export const hasCuratedPostsSetting = new PublicInstanceSetting<boolean>("hasCuratedPosts", false, "optional");
 
@@ -256,9 +255,6 @@ export const homepagePostFeedsSetting = new PublicInstanceSetting<PostFeedDetail
     },
   ]
   , 'optional')
-
-// TODO probably can be combined with the other email verification setting
-export const assumeUserEmailVerifiedSetting = new PublicInstanceSetting<boolean>('email.assumeVerified', isEAForum, 'optional')
 
 /**
  * This is a filepath that is _relative_ to the location of the instance settings file itself.

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -185,6 +185,7 @@ export const tabLongTitleSetting = new PublicInstanceSetting<string | null>('for
 
 export const noIndexSetting = new PublicInstanceSetting<boolean>('noindex', false, "optional")
 
+// TODO combine with email.assumeVerified
 /** Whether this forum verifies user emails */
 export const verifyEmailsSetting = new PublicInstanceSetting<boolean>("verifyEmails", true, "optional");
 
@@ -256,6 +257,7 @@ export const homepagePostFeedsSetting = new PublicInstanceSetting<PostFeedDetail
   ]
   , 'optional')
 
+// TODO probably can be combined with the other email verification setting
 export const assumeUserEmailVerifiedSetting = new PublicInstanceSetting<boolean>('email.assumeVerified', isEAForum, 'optional')
 
 /**

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -77,7 +77,7 @@ getCollectionHooks("Users").editSync.add(function maybeSendVerificationEmail (mo
       && (!user.whenConfirmationEmailSent
           || user.whenConfirmationEmailSent.getTime() !== modifier.$set.whenConfirmationEmailSent.getTime()))
   {
-    // FIXME should skip on EAF
+    // Note: This is still gated by verifyEmailsSetting because `canUpdate` of whenConfirmationEmailSent is controlled by verifyEmailsSetting
     void sendVerificationEmail(user);
   }
 });
@@ -154,14 +154,7 @@ getCollectionHooks("Users").editSync.add(function clearKarmaChangeBatchOnSetting
 });
 
 getCollectionHooks("Users").newAsync.add(async function subscribeOnSignup (user: DbUser) {
-  // Regardless of the config setting, try to confirm the user's email address
-  // (But not in unit-test contexts, where this function is unavailable and sending
-  // emails doesn't make sense.)
-  // FIXME use sendVerificationEmailConditional
-  if (!isAnyTest && verifyEmailsSetting.get()) {
-    void sendVerificationEmail(user);
-    await bellNotifyEmailVerificationRequired(user);
-  }
+  await sendVerificationEmailConditional(user);
 });
 
 getCollectionHooks("Users").editAsync.add(async function handleSetShortformPost (newUser: DbUser, oldUser: DbUser) {

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -77,6 +77,7 @@ getCollectionHooks("Users").editSync.add(function maybeSendVerificationEmail (mo
       && (!user.whenConfirmationEmailSent
           || user.whenConfirmationEmailSent.getTime() !== modifier.$set.whenConfirmationEmailSent.getTime()))
   {
+    // FIXME should skip on EAF
     void sendVerificationEmail(user);
   }
 });
@@ -156,6 +157,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeOnSignup (user:
   // Regardless of the config setting, try to confirm the user's email address
   // (But not in unit-test contexts, where this function is unavailable and sending
   // emails doesn't make sense.)
+  // FIXME use sendVerificationEmailConditional
   if (!isAnyTest && verifyEmailsSetting.get()) {
     void sendVerificationEmail(user);
     await bellNotifyEmailVerificationRequired(user);

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -77,8 +77,7 @@ getCollectionHooks("Users").editSync.add(function maybeSendVerificationEmail (mo
       && (!user.whenConfirmationEmailSent
           || user.whenConfirmationEmailSent.getTime() !== modifier.$set.whenConfirmationEmailSent.getTime()))
   {
-    // Note: This is still gated by verifyEmailsSetting because `canUpdate` of whenConfirmationEmailSent is controlled by verifyEmailsSetting
-    void sendVerificationEmail(user);
+    void sendVerificationEmailConditional(user);
   }
 });
 

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -311,13 +311,6 @@ const authenticationResolvers = {
       else
         return `Failed to send password reset email. The account might not have a valid email address configured.`;
     },
-    async verifyEmail(root: void, { userId }: {userId: string}, context: ResolverContext) {
-      if (!userId) throw Error("User ID is required for validating your email")
-      const user = await Users.findOne({_id: userId})
-      if (!user) throw Error("Can't find user with given ID")
-      await sendVerificationEmail(user)
-      return `Successfully sent verification email to ${user.displayName}`
-    }
   } 
 };
 
@@ -326,8 +319,6 @@ addGraphQLMutation('login(username: String, password: String): LoginReturnData')
 addGraphQLMutation('signup(username: String, email: String, password: String, subscribeToCurated: Boolean, reCaptchaToken: String, abTestKey: String): LoginReturnData');
 addGraphQLMutation('logout: LoginReturnData');
 addGraphQLMutation('resetPassword(email: String): String');
-// FIXME I think this mutation version isn't used
-addGraphQLMutation('verifyEmail(userId: String): String');
 
 async function insertHashedLoginToken(userId: string, hashedToken: string) {
   const tokenWithMetadata = {

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -326,6 +326,7 @@ addGraphQLMutation('login(username: String, password: String): LoginReturnData')
 addGraphQLMutation('signup(username: String, email: String, password: String, subscribeToCurated: Boolean, reCaptchaToken: String, abTestKey: String): LoginReturnData');
 addGraphQLMutation('logout: LoginReturnData');
 addGraphQLMutation('resetPassword(email: String): String');
+// FIXME I think this mutation version isn't used
 addGraphQLMutation('verifyEmail(userId: String): String');
 
 async function insertHashedLoginToken(userId: string, hashedToken: string) {


### PR DESCRIPTION
We had a case of our [bot site](https://forum-bots.effectivealtruism.org/) sending a verification email the other day, which shouldn't have happened as we have email verification disabled. I think this specific problem will already have been fixed by [Jim's change here](https://github.com/ForumMagnum/ForumMagnum/commit/39efbd507cd7c064fbfdc19c8e6a0f805c67e4be), but the code for deciding whether to send verification emails was (is) still a bit of a mess so I have cleaned up some other near-bugs.

There are 3 ways we have blocked sending verification emails over the years on the backend:
1. By checking `isEAForum`
2. This was superseded by `verifyEmailsSetting`
3. There was then a duplicate setting `assumeUserEmailVerifiedSetting` introduced

All of these were still being used in some places. I have changed them to only use `verifyEmailsSetting` in the cases I could find.

On the frontend, we trigger sending a verification email by setting `whenConfirmationEmailSent: new Date()`. This should independently be blocked so we don't hit the error on the backend by trying to set it. I have made sure these are all gated behind a `!userEmailAddressIsVerified(currentUser)` (most of them were already).


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207836999855408) by [Unito](https://www.unito.io)
