### PR TITLE
Fix font size in email post-bodies

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -121,17 +121,17 @@ export const baseTheme: BaseThemeSpecification = {
           wordBreak: "break-word"
         },
         body1: {
-          fontSize: '1.4rem',
-          lineHeight: '2rem'
+          fontSize: 18.2,
+          lineHeight: "26px"
         },
         body2: {
           fontWeight: 400,
-          fontSize: '1.1rem',
-          lineHeight: '1.5rem',
+          fontSize: 14.3,
+          lineHeight: "19.5px",
         },
         headline: {},
         postsItemTitle: {
-          fontSize: "1.3rem"
+          fontSize: 16.9
         },
         chapterTitle: {
           fontSize: "1.2em",
@@ -139,25 +139,25 @@ export const baseTheme: BaseThemeSpecification = {
           color: palette.grey[600]
         },
         largeChapterTitle: {
-          fontSize: '1.4rem',
+          fontSize: 18.2,
           margin: "1.5em 0 .5em 0",
           color: palette.grey[800]
         },
         smallText: {
           fontFamily: palette.fonts.sansSerifStack,
           fontWeight: 400,
-          fontSize: "1rem",
-          lineHeight: '1.4rem'
+          fontSize: 13,
+          lineHeight: "18.2px"
         },
         tinyText: {
           fontWeight: 400,
-          fontSize: ".75rem",
-          lineHeight: '1.4rem'
+          fontSize: 9.75,
+          lineHeight: "18.2px"
         },
         // used by h3
         display0: {
           color: palette.grey[700],
-          fontSize: '1.6rem',
+          fontSize: 20.8,
           marginTop: '1em',
           // added by MUI to display1, which we're imitating
           fontWeight: 400,
@@ -165,18 +165,18 @@ export const baseTheme: BaseThemeSpecification = {
         },
         display1: {
           color: palette.grey[800],
-          fontSize: '2rem',
+          fontSize: 26,
           marginTop: '1em'
         },
         display2: {
           color: palette.grey[800],
-          fontSize: '2.8rem',
+          fontSize: 36.4,
           marginTop: '1em'
         },
         display3: {
           color: palette.grey[800],
           marginTop: '1.2em',
-          fontSize: '3rem'
+          fontSize: 39
         },
         display4: {
           color: palette.grey[800],
@@ -192,7 +192,7 @@ export const baseTheme: BaseThemeSpecification = {
           fontFamily: palette.fonts.sansSerifStack,
         },
         caption: {
-          fontSize: ".9rem"
+          fontSize: 11.7,
         },
         blockquote: {
           fontWeight: 400,
@@ -217,7 +217,7 @@ export const baseTheme: BaseThemeSpecification = {
           backgroundColor: palette.grey[100],
           borderRadius: "5px",
           border: `solid 1px ${palette.grey[300]}`,
-          padding: '1rem',
+          padding: 13,
           whiteSpace: 'pre-wrap',
           margin: "1em 0",
         },
@@ -232,10 +232,10 @@ export const baseTheme: BaseThemeSpecification = {
           lineHeight: 1.42
         },
         li: {
-          marginBottom: '.5rem',
+          marginBottom: '6.5px',
         },
         commentHeader: {
-          fontSize: '1.5rem',
+          fontSize: 19.5,
           marginTop: '.5em',
           fontWeight:500,
         },
@@ -247,7 +247,7 @@ export const baseTheme: BaseThemeSpecification = {
         subtitle: {
           fontSize: 16,
           fontWeight: 600,
-          marginBottom: ".5rem"
+          marginBottom: "6.5px"
         },
         italic: {
           fontStyle: "italic",
@@ -316,15 +316,15 @@ export const baseTheme: BaseThemeSpecification = {
         MuiFormControlLabel: {
           label: {
             fontFamily: palette.fonts.sansSerifStack,
-            fontSize: "1.1rem",
+            fontSize: 14.3,
             fontWeight: 400,
-            lineHeight: "1.5rem",
+            lineHeight: "19.5px",
           }
         },
         MuiTableCell: {
           body: {
-            fontSize: '1.1rem',
-            lineHeight: '1.5rem',
+            fontSize: 14.3,
+            lineHeight: "19.5px",
             paddingLeft: 16,
             paddingRight: 16,
             paddingTop: 12,

--- a/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
@@ -98,7 +98,7 @@ export const alignmentForumTheme: SiteThemeSpecification = {
       },
       MuiTooltip: {
         tooltip: {
-          fontSize: "1rem"
+          fontSize: 13
         }
       },
       PostsVoteDefault: {

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -148,24 +148,24 @@ export const eaForumTheme: SiteThemeSpecification = {
         fontFamily: sansSerifStack,
         body1: {
           ...basicText,
-          fontSize: "1.2rem",
+          fontSize: 16.9,
           fontFamily: serifStack,
         },
         body2: {
-          fontSize: "1.1rem",
+          fontSize: 14.3,
           lineHeight: "1.5em",
           fontWeight: 450,
         },
         smallText: {
           fontFamily: palette.fonts.sansSerifStack,
           fontWeight: 450,
-          fontSize: "1rem",
-          lineHeight: '1.4rem'
+          fontSize: 13,
+          lineHeight: "18.2px"
         },
         tinyText: {
           fontWeight: 450,
-          fontSize: ".75rem",
-          lineHeight: '1.4rem'
+          fontSize: 9.75,
+          lineHeight: "18.2px"
         },
         postStyle: {
           ...basicText,
@@ -198,7 +198,7 @@ export const eaForumTheme: SiteThemeSpecification = {
           color: palette.grey[800],
           fontFamily: titleStack,
           fontWeight: 600,
-          fontSize: '1.6rem',
+          fontSize: 20.8,
           lineHeight: '1.25em',
         },
         // used by h2
@@ -206,7 +206,7 @@ export const eaForumTheme: SiteThemeSpecification = {
           color: palette.grey[800],
           fontFamily: titleStack,
           fontWeight: 650,
-          fontSize: '2rem',
+          fontSize: 26,
           lineHeight: '1.25em',
         },
         // used by h1
@@ -214,7 +214,7 @@ export const eaForumTheme: SiteThemeSpecification = {
           color: palette.grey[800],
           fontFamily: titleStack,
           fontWeight: 600,
-          fontSize: '2.4rem',
+          fontSize: 31.2,
           lineHeight: '1.25em',
         },
         // used by page title
@@ -235,7 +235,7 @@ export const eaForumTheme: SiteThemeSpecification = {
           fontWeight: 500,
         },
         largeChapterTitle: {
-          fontSize: "2.2rem"
+          fontSize: 28.6
         },
         italic: {
           fontStyle: "normal",
@@ -247,8 +247,8 @@ export const eaForumTheme: SiteThemeSpecification = {
       overrides: {
         MuiTooltip: {
           tooltip: {
-            fontSize: "1rem",
-            padding: ".7rem",
+            fontSize: 13,
+            padding: "9.1px",
           }
         },
         MetaInfo: {
@@ -357,7 +357,7 @@ export const eaForumTheme: SiteThemeSpecification = {
           root: {
             fontFamily: sansSerifStack,
             fontWeight: 500,
-            fontSize: "1.1rem",
+            fontSize: 14.3,
             color: palette.grey[900],
           }
         },

--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -67,7 +67,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
         fontSize: '.85em'
       },
       body2: {
-        fontSize: "1.16rem"
+        fontSize: 15.1
       },
       commentStyle: {
         fontFamily: sansSerifStack,
@@ -101,15 +101,15 @@ export const lessWrongTheme: SiteThemeSpecification = {
       },
       MuiTooltip: {
         tooltip: {
-          fontSize: "1rem",
-          padding: ".7rem",
+          fontSize: 13,
+          padding: "9.1px",
           zIndex: 10000000
         }
       },
       MuiDialogContent: {
         root: {
           fontFamily: sansSerifStack,
-          fontSize: "1.16rem",
+          fontSize: 15.1,
           lineHeight: "1.5em"
         }
       },
@@ -117,7 +117,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
         root: {
           fontFamily: sansSerifStack,
           color: palette.grey[800],
-          fontSize: "1.1rem",
+          fontSize: 14.3,
           lineHeight: "1.1em"
         }
       },

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -220,7 +220,7 @@ const hrStyles = (theme: ThemeType): JssStyles => ({
   '&:after': {
     marginLeft: 12,
     color: theme.palette.icon.horizRuleDots,
-    fontSize: "1rem",
+    fontSize: 13,
     letterSpacing: "12px", /* increase space between dots */
     content: '"•••"',
   }
@@ -305,7 +305,7 @@ const collapsibleSectionStyles = (theme: ThemeType): JssStyles => ({
     position: "relative",
     paddingLeft: isFriendlyUI ? 20 : 24,
     fontFamily: theme.palette.fonts.sansSerifStack,
-    fontSize: isFriendlyUI ? "1.6rem" : undefined,
+    fontSize: isFriendlyUI ? "20.8px" : undefined,
     lineHeight: isFriendlyUI ? "1.25em" : undefined,
     fontWeight: isFriendlyUI ? 600 : undefined,
   },
@@ -627,8 +627,8 @@ export const emailBodyStyles = baseBodyStyles
 export const smallPostStyles = (theme: ThemeType) => {
   return {
     ...theme.typography.body2,
-    fontSize: isFriendlyUI ? "1.1rem" : "1.28rem",
-    lineHeight: "1.75rem",
+    fontSize: isFriendlyUI ? 14.3 : 16.64,
+    lineHeight: "22.75px",
     ...theme.typography.postStyle,
     '& blockquote': {
       ...theme.typography.body2,
@@ -640,8 +640,8 @@ export const smallPostStyles = (theme: ThemeType) => {
     '& li': {
       ...theme.typography.body2,
       ...theme.typography.postStyle,
-      fontSize: isFriendlyUI ? "1.1rem" : "1.28rem",
-      lineHeight: "1.8rem",
+      fontSize: isFriendlyUI ? 14.3 : 16.64,
+      lineHeight: "23.4px",
     }
   };
 }
@@ -771,7 +771,7 @@ export const ckEditorStyles = (theme: ThemeType): JssStyles => {
         },
         '& .ck-annotation__info-name, & .ck-annotation__info-time': {
           color: theme.palette.grey[600],
-          fontSize: "1rem"
+          fontSize: 13
         },
         '& .ck-annotation__user, & .ck-thread__user': {
           display: "none"


### PR DESCRIPTION
The font size in LW curation emails was gigantic (22.4px).

The underlying issue is that some (but not all) font-sizes are specified in `rem`, which is a unit which is a multiplier of the root-element's font size. On-site, that's theme.baseFontSize, which 13px and is the same across all site themes, so a size of 1.4rem, which is used for most post text, is 1.4*13px=18.2px. In email contexts, however, the root element isn't under our control, can vary between email clients, and in the case of gmail, is 16px, resulting in a post font size of 22.4px. This is too big, especially when juxtaposed with font sizes for post metadata that are specified in px.

Until recently, most site styles weren't being used in emails, which prevented this from coming up. However commit
d2b9840b1a5fb1c2fefb48409cb48664c3897afd made `NewPostEmail` use `ContentStyles`, introducing a bunch of theme styles that use `rem`. (This was done because posts can contain a lot of different sorts of elements that need styling, and this is the only way to reliably get all those styles).

Change the units in all theme files to not use `rem`, using `px` instead. Since the base font size doesn't vary between site themes, this will only affect font sizes in emails, not on-site. It will make the font size consistent between email clients, and (where styles are shared) between email and web. This changes the effective post font size (in the LW theme) gmail from 22.4px to 18.2px.

(This is still very much on the high end of email font sizes, but no longer ridiculously so. We might consider un-sharing that part of the styles between the site and emails.)

EA forum note: I applied this change to all site themes, including EA forum, on the theory that consistent-with-the-site is better than varying-between-email-clients, and changing `baseTheme` and changing some site themes without changing others would be more likely to create clashes. You may wish to take a look at `http://localhost:3000/debug/notificationEmailPreview?postId=...` and make sure it looks good.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207839346716792) by [Unito](https://www.unito.io)
