### PR TITLE
Ensure userIds are associated with clientIds every time a pair is newly encountered

### DIFF
--- a/packages/lesswrong/server/clientIdMiddleware.ts
+++ b/packages/lesswrong/server/clientIdMiddleware.ts
@@ -52,7 +52,7 @@ export const addClientIdMiddleware = (addMiddleware: AddMiddlewareType) => {
         void clientIdsRepo.ensureClientId({
           clientId,
           userId,
-          referrer: referrer,
+          referrer,
           landingPage: url,
         });
         setHasSeen({clientId, userId})

--- a/packages/lesswrong/server/clientIdMiddleware.ts
+++ b/packages/lesswrong/server/clientIdMiddleware.ts
@@ -5,8 +5,16 @@ import express from 'express';
 import { responseIsCacheable } from './cacheControlMiddleware';
 import { ClientIdsRepo } from './repos';
 import LRU from 'lru-cache';
+import { getUserFromReq } from './vulcan-lib';
 
+// Cache of seen (clientId, userId) pairs
 const seenClientIds = new LRU<string, boolean>({ max: 10_000, maxAge: 1000 * 60 * 60 });
+
+const hasSeen = ({ clientId, userId }: { clientId: string; userId?: string }) =>
+  seenClientIds.get(`${clientId}_${userId}`);
+
+const setHasSeen = ({ clientId, userId }: { clientId: string; userId?: string }) =>
+  seenClientIds.set(`${clientId}_${userId}`, true);
 
 const isApplicableUrl = (url: string) =>
   url !== "/robots.txt" && url.indexOf("/api/") < 0;
@@ -14,6 +22,7 @@ const isApplicableUrl = (url: string) =>
 /**
  * - Assign a client id if there isn't one currently assigned
  * - Ensure the client id is stored in our DB (it may have been generated externally)
+ * - Ensure the clientId and userId are associated
  */
 export const addClientIdMiddleware = (addMiddleware: AddMiddlewareType) => {
   addMiddleware(function addClientId(req: express.Request, res: express.Response, next: express.NextFunction) {
@@ -37,14 +46,16 @@ export const addClientIdMiddleware = (addMiddleware: AddMiddlewareType) => {
 
     // 2. If there is a client id, ensure (asynchronously) that it is stored in the DB
     const clientId = existingClientId ?? newClientId;
-    if (clientId && isApplicableUrl(req.url) && !isNotRandomId(clientId) && !seenClientIds.get(clientId)) {
+    const userId = getUserFromReq(req)?._id;
+    if (clientId && isApplicableUrl(req.url) && !isNotRandomId(clientId) && !hasSeen({clientId, userId})) {
       try {
         void clientIdsRepo.ensureClientId({
           clientId,
-          firstSeenReferrer: referrer,
-          firstSeenLandingPage: url,
+          userId,
+          referrer: referrer,
+          landingPage: url,
         });
-        seenClientIds.set(clientId, true);
+        setHasSeen({clientId, userId})
       } catch(e) {
         //eslint-disable-next-line no-console
         console.error(e);

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -360,23 +360,6 @@ function registerLoginEvent(user: DbUser, req: AnyBecauseTodo) {
     currentUser: user,
     validate: false,
   })
-  
-  const clientId = getCookieFromReq(req, "clientId");
-  if (clientId) {
-    void recordAssociationBetweenUserAndClientID(clientId, user);
-  }
-}
-
-async function recordAssociationBetweenUserAndClientID(clientId: string, user: DbUser) {
-  const clientIdEntry = await ClientIds.findOne({clientId});
-  if (clientIdEntry) {
-    const userId = user._id;
-    if (!clientIdEntry.userIds?.includes(userId)) {
-      await ClientIds.rawUpdateOne({clientId}, {$set: {
-        userIds: [...(clientIdEntry.userIds??[]), userId],
-      }});
-    }
-  }
 }
 
 const reCaptchaSecretSetting = new DatabaseServerSetting<string | null>('reCaptcha.secret', null) // ReCaptcha Secret


### PR DESCRIPTION
Previously we only associated users with client ids on login, which was not 100% reliable. This changes it to associate them in the `clientIdMiddleware` which is hit on every request.

I removed the existing code to associate them on login because it should now be redundant.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207840614566295) by [Unito](https://www.unito.io)
