### PR TITLE
Exclude non-letter characters from user profile image initials fallback

### DIFF
--- a/packages/lesswrong/components/users/UsersProfileImage.tsx
+++ b/packages/lesswrong/components/users/UsersProfileImage.tsx
@@ -64,8 +64,11 @@ const InitialFallback: FC<{
   classes: ClassesType,
 }> = memo(({displayName, size, className, classes}) => {
   displayName ??= "";
-  const initials = displayName.split(/[\s-_.()]/).map((s) => s?.[0]?.toUpperCase());
-  const text = initials.filter((s) => s?.length).join("").slice(0, 3);
+  const initials = displayName
+    .split(/[\s-_.()]/)
+    .map((s) => s?.[0]?.toUpperCase())
+    .filter((s) => s?.length && s?.match(/\p{L}/u));
+  const text = initials.join("").slice(0, 3);
   const background = userBackground(displayName);
   return (
     <svg


### PR DESCRIPTION
Exclude non-letter characters from fallback user profile images.

Some users have started including emoji characters in their user names and this renders incorrectly in profile image fallbacks:

![image](https://github.com/user-attachments/assets/d110bfed-5907-4947-aa6f-a9abd6b362b5)

This PR filters out these characters. See /users/felix-wolf for a relevant example.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207844723110042) by [Unito](https://www.unito.io)
