### PR TITLE
Fix a couple of font sizes following rem to px conversion

### DIFF
--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -148,7 +148,7 @@ export const eaForumTheme: SiteThemeSpecification = {
         fontFamily: sansSerifStack,
         body1: {
           ...basicText,
-          fontSize: 16.9,
+          fontSize: 15.6,
           fontFamily: serifStack,
         },
         body2: {

--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -67,7 +67,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
         fontSize: '.85em'
       },
       body2: {
-        fontSize: 15.1
+        fontSize: 15.08
       },
       commentStyle: {
         fontFamily: sansSerifStack,
@@ -109,7 +109,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
       MuiDialogContent: {
         root: {
           fontFamily: sansSerifStack,
-          fontSize: 15.1,
+          fontSize: 15.08,
           lineHeight: "1.5em"
         }
       },


### PR DESCRIPTION
There was a mistake in https://github.com/ForumMagnum/ForumMagnum/pull/9518 which made the EA Forum post body font size slightly to big (16.9px rather than 15.6px)