### PR TITLE
Fix bug with 'Comment not found' appearing when navigating to heading

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -4,6 +4,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useSingle } from '../../lib/crud/withSingle';
 import { isLWorAF } from '../../lib/instanceSettings';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { isNotRandomId } from '@/lib/random';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -38,26 +39,33 @@ const getCommentDescription = (comment: CommentWithRepliesFragment) => {
   }- ${comment.contents?.plaintextMainText}`
 }
 
-const CommentPermalink = ({ documentId, post, classes }: {
+const CommentPermalink = ({
+  documentId,
+  post,
+  silentLoading=false,
+  classes
+}: {
   documentId: string,
   post?: PostsDetails,
+  silentLoading?: boolean,
   classes: ClassesType,
 }) => {
   const { document: comment, data, loading, error } = useSingle({
     documentId,
     collectionName: "Comments",
     fragmentName: 'CommentWithRepliesFragment',
+    skip: isNotRandomId(documentId)
   });
   const refetch = data?.refetch;
   const { Loading, Divider, CommentOnPostWithReplies, HeadTags, CommentWithReplies } = Components;
+
+  if (silentLoading && !comment) return null;
 
   if (error || (!comment && !loading)) return <div>Comment not found</div>
   
   if (loading) return <Loading />
 
-  if (!comment) {return null}
-
-  if (!documentId) return null
+  if (!comment || !documentId) return null
   
   // if the site is currently hiding comments by unreviewed authors, check if we need to hide this comment
   if (commentIsHidden(comment) && !comment.rejected) return <div className={classes.root}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -638,6 +638,8 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
   ), [hashCommentId, loading, results]);
 
   const [permalinkedCommentId, setPermalinkedCommentId] = useState(fullPost && !isDebateResponseLink ? queryCommentId : null)
+  // Don't show loading state if we are are getting the id from the hash, because it might be a hash referencing a non-comment id in the page
+  const silentLoadingPermalink = permalinkedCommentId === hashCommentId;
   useEffect(() => { // useEffect required because `location.hash` isn't sent to the server
     if (fullPost && !isDebateResponseLink) {
       if (queryCommentId) {
@@ -672,7 +674,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     <AnalyticsContext pageSectionContext="postHeader">
       <div className={classNames(classes.title, {[classes.titleWithMarket] : highlightMarket(marketInfo)})}>
         <div className={classes.centralColumn}>
-          {permalinkedCommentId && <CommentPermalink documentId={permalinkedCommentId} post={fullPost} />}
+          {permalinkedCommentId && <CommentPermalink documentId={permalinkedCommentId} post={fullPost} silentLoading={silentLoadingPermalink} />}
           {post.eventImageId && <div className={classNames(classes.headerImageContainer, {[classes.headerImageContainerWithComment]: permalinkedCommentId})}>
             <CloudinaryImage2
               publicId={post.eventImageId}


### PR DESCRIPTION
Fix for a bug introduced in https://github.com/ForumMagnum/ForumMagnum/pull/9522, when there is a hash in the url (e.g. a heading link) that doesn't match a comment there is a "Comment not found" message:
<img width="1332" alt="Screenshot 2024-07-23 at 18 35 40" src="https://github.com/user-attachments/assets/214ad7fd-3ffd-43e9-aa82-1d245fe047d8">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207881322317360) by [Unito](https://www.unito.io)
