### PR TITLE
[FriendlyUI only] sequence editors can also see the notification button

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -115,6 +115,9 @@ const styles = (theme: ThemeType): JssStyles => ({
       textAlign: 'left'
     }
   },
+  edit: {
+    marginTop: 12,
+  },
   imageScrim: {
     ...sequencesImageScrim(theme)
   }
@@ -222,12 +225,14 @@ const SequencesPage = ({ documentId, classes }: {
                   <span className={classes.metaItem}><FormatDate date={document.createdAt} format="MMM DD, YYYY"/></span>
                   {document.user && <span className={classes.metaItem}> by <UsersName user={document.user} /></span>}
                 </div>
-                {canEdit && <span className={classes.leftAction}><SectionSubtitle>
-                  <a onClick={showEdit}>edit</a>
-                </SectionSubtitle></span>}
+                {!allowSubscribeToSequencePosts && canEdit && <span className={classes.leftAction}>
+                  <SectionSubtitle>
+                    <a onClick={showEdit}>edit</a>
+                  </SectionSubtitle>
+                </span>}
               </SectionFooter>
             </div>
-            {allowSubscribeToSequencePosts && !canEdit && <div className={classes.notifyCol}>
+            {allowSubscribeToSequencePosts && <div className={classes.notifyCol}>
               <AnalyticsContext pageElementContext="notifyMeButton">
                 <NotifyMeButton
                   document={document}
@@ -239,6 +244,11 @@ const SequencesPage = ({ documentId, classes }: {
                   hideFlashes
                 />
               </AnalyticsContext>
+              {canEdit && <SectionFooter className={classes.edit}>
+                <SectionSubtitle>
+                  <a onClick={showEdit}>Edit sequence</a>
+                </SectionSubtitle>
+              </SectionFooter>}
             </div>}
           </section>
           


### PR DESCRIPTION
I noticed that when I was in admin mode, sequence pages didn't have the "Notify me" button. I fixed that, and updated the edit button copy to "Edit sequence" which I think is clearer.

<img width="723" alt="Screen Shot 2024-07-23 at 6 19 19 PM" src="https://github.com/user-attachments/assets/5cdb58eb-3b83-4726-a2ab-1281c9227032">
