### PR TITLE
Merge getAuth0Id and getAuth0IdIfUsernamePassword

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -551,18 +551,11 @@ export const isMod = (user: UsersProfile|DbUser): boolean => {
   return (user.isAdmin || user.groups?.includes('sunshineRegiment')) ?? false
 }
 
-// TODO: I (JP) think this should be configurable in the function parameters
-/** Warning! Only returns *auth0*-provided auth0 Ids. If a user has an ID that
- * we get from auth0 but is ultimately from google this function will throw. */
-export const getAuth0IdIfUsernamePassword = (user: DbUser) => {
-  const auth0 = user.services?.auth0;
-  if (auth0 && auth0.provider === "auth0") {
-    const id = auth0.id ?? auth0.user_id;
-    if (id) {
-      return id;
-    }
-  }
-  throw new Error("User does not use username/password login or does not have an Auth0 user ID");
+/**
+ * @returns "auth0" | "google-oauth2" | "facebook" | null
+ */
+export const getAuth0Provider = (user: DbUser): string | null => {
+  return user.services?.auth0?.provider;
 }
 
 export const getAuth0Id = (user: DbUser) => {

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1,6 +1,6 @@
 import SimpleSchema from 'simpl-schema';
 import { Utils, slugify, getNestedProperty } from '../../vulcan-lib';
-import {userGetProfileUrl, getAuth0IdIfUsernamePassword, getUserEmail, userOwnsAndInGroup, SOCIAL_MEDIA_PROFILE_FIELDS } from "./helpers";
+import {userGetProfileUrl, getUserEmail, userOwnsAndInGroup, SOCIAL_MEDIA_PROFILE_FIELDS, getAuth0Provider } from "./helpers";
 import { userGetEditUrl } from '../../vulcan-users/helpers';
 import { userGroups, userOwns, userIsAdmin, userHasntChangedName } from '../../vulcan-users/permissions';
 import { formGroups } from './formGroups';
@@ -393,17 +393,13 @@ const schema: SchemaType<"Users"> = {
     blackbox: true,
     canRead: ownsOrIsAdmin
   },
+  /** hasAuth0Id: true if they use auth0 with username/password login, false otherwise */
   hasAuth0Id: resolverOnlyField({
     type: Boolean,
     // Mods cannot read because they cannot read services, which is a prerequisite
     canRead: [userOwns, 'admins'],
     resolver: (user: DbUser) => {
-      try {
-        getAuth0IdIfUsernamePassword(user);
-        return true;
-      } catch {
-        return false;
-      }
+      return getAuth0Provider(user) === 'auth0';
     },
   }),
   // The name displayed throughout the app. Can contain spaces and special characters, doesn't need to be unique

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -56,21 +56,6 @@ voteCallbacks.castVoteAsync.add(async function updateModerateOwnPersonal({newDoc
   }
 });
 
-getCollectionHooks("Users").editBefore.add(async function UpdateAuth0Email(modifier: MongoModifier<DbUser>, user: DbUser) {
-  const newEmail = modifier.$set?.email;
-  const oldEmail = user.email;
-  if (newEmail && newEmail !== oldEmail && isEAForum) {
-    await updateAuth0Email(user, newEmail);
-    /*
-     * Be careful here: DbUser does NOT includes services, so overwriting
-     * modifier.$set.services is both very easy and very bad (amongst other
-     * things, it will invalidate the user's session)
-     */
-    modifier.$set["services.auth0"] = await getAuth0Profile(user);
-  }
-  return modifier;
-});
-
 getCollectionHooks("Users").editSync.add(function maybeSendVerificationEmail (modifier, user: DbUser)
 {
   if(modifier.$set.whenConfirmationEmailSent
@@ -208,7 +193,7 @@ const sendVerificationEmailConditional = async  (user: DbUser) => {
 
 getCollectionHooks("Users").editSync.add(async function usersEditCheckEmail (modifier, user: DbUser) {
   // if email is being modified, update user.emails too
-  if (modifier.$set && modifier.$set.email) {
+  if (modifier.$set && modifier.$set.email && modifier.$set.email !== user.email) {
 
     const newEmail = modifier.$set.email;
 
@@ -229,6 +214,16 @@ getCollectionHooks("Users").editSync.add(async function usersEditCheckEmail (mod
     } else {
       modifier.$set.emails = [{address: newEmail, verified: false}];
       await sendVerificationEmailConditional(user)
+    }
+
+    if (isEAForum) {
+      await updateAuth0Email(user, newEmail);
+      /*
+       * Be careful here: DbUser does NOT includes services, so overwriting
+       * modifier.$set.services is both very easy and very bad (amongst other
+       * things, it will invalidate the user's session)
+       */
+      modifier.$set["services.auth0"] = await getAuth0Profile(user);
     }
   }
   return modifier;

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -56,6 +56,21 @@ voteCallbacks.castVoteAsync.add(async function updateModerateOwnPersonal({newDoc
   }
 });
 
+getCollectionHooks("Users").editBefore.add(async function UpdateAuth0Email(modifier: MongoModifier<DbUser>, user: DbUser) {
+  const newEmail = modifier.$set?.email;
+  const oldEmail = user.email;
+  if (newEmail && newEmail !== oldEmail && isEAForum) {
+    await updateAuth0Email(user, newEmail);
+    /*
+     * Be careful here: DbUser does NOT includes services, so overwriting
+     * modifier.$set.services is both very easy and very bad (amongst other
+     * things, it will invalidate the user's session)
+     */
+    modifier.$set["services.auth0"] = await getAuth0Profile(user);
+  }
+  return modifier;
+});
+
 getCollectionHooks("Users").editSync.add(function maybeSendVerificationEmail (modifier, user: DbUser)
 {
   if(modifier.$set.whenConfirmationEmailSent
@@ -193,7 +208,7 @@ const sendVerificationEmailConditional = async  (user: DbUser) => {
 
 getCollectionHooks("Users").editSync.add(async function usersEditCheckEmail (modifier, user: DbUser) {
   // if email is being modified, update user.emails too
-  if (modifier.$set && modifier.$set.email && modifier.$set.email !== user.email) {
+  if (modifier.$set && modifier.$set.email) {
 
     const newEmail = modifier.$set.email;
 
@@ -214,16 +229,6 @@ getCollectionHooks("Users").editSync.add(async function usersEditCheckEmail (mod
     } else {
       modifier.$set.emails = [{address: newEmail, verified: false}];
       await sendVerificationEmailConditional(user)
-    }
-
-    if (isEAForum) {
-      await updateAuth0Email(user, newEmail);
-      /*
-       * Be careful here: DbUser does NOT includes services, so overwriting
-       * modifier.$set.services is both very easy and very bad (amongst other
-       * things, it will invalidate the user's session)
-       */
-      modifier.$set["services.auth0"] = await getAuth0Profile(user);
     }
   }
   return modifier;


### PR DESCRIPTION
`getAuth0Id` originally threw an error if the user wasn't using username/password login. In a [previous PR](https://github.com/ForumMagnum/ForumMagnum/pull/9466), I renamed this to `getAuth0IdIfUsernamePassword` and added a new `getAuth0Id` function that doesn't have this restriction. This PR merges these back together to clean things up and uses `getAuth0Provider` to check the login method in the cases where we care about that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207893550001357) by [Unito](https://www.unito.io)
