### PR TITLE
show quick takes on tag pages

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -20,6 +20,7 @@ import truncateTagDescription from "../../lib/utils/truncateTagDescription";
 import { getTagStructuredData } from "./TagPageRouter";
 import { HEADER_HEIGHT } from "../common/Header";
 import { isFriendlyUI } from "../../themes/forumTheme";
+import DeferRender from "../common/DeferRender";
 
 export const tagPageHeaderStyles = (theme: ThemeType) => ({
   postListMeta: {
@@ -210,7 +211,7 @@ const TagPage = ({classes}: {
     PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, Typography,
     PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection,
     TagPageButtonRow, ToCColumn, SubscribeButton, CloudinaryImage2, TagIntroSequence,
-    TagTableOfContents, TagVersionHistoryButton, ContentStyles,
+    TagTableOfContents, TagVersionHistoryButton, ContentStyles, CommentsListCondensed,
   } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
@@ -446,17 +447,35 @@ const TagPage = ({classes}: {
             tag={tag}
           />}
           {tag.sequence && <TagIntroSequence tag={tag} />}
-          {!tag.wikiOnly && <AnalyticsContext pageSectionContext="tagsSection">
-            <PostsListHeading tag={tag} query={query} classes={classes} />
-            <PostsList2
-              terms={terms}
-              enableTotal
-              tagId={tag._id}
-              itemsPerPage={200}
-            >
-              <AddPostsToTag tag={tag} />
-            </PostsList2>
-          </AnalyticsContext>}
+          {!tag.wikiOnly && <>
+            <AnalyticsContext pageSectionContext="tagsSection">
+              <PostsListHeading tag={tag} query={query} classes={classes} />
+              <PostsList2
+                terms={terms}
+                enableTotal
+                tagId={tag._id}
+                itemsPerPage={200}
+              >
+                <AddPostsToTag tag={tag} />
+              </PostsList2>
+            </AnalyticsContext>
+            <DeferRender ssr={false}>
+              <AnalyticsContext pageSectionContext="quickTakesSection">
+                <CommentsListCondensed
+                  label="Quick takes"
+                  terms={{
+                    view: "tagSubforumComments" as const,
+                    tagId: tag._id,
+                    sortBy: 'new',
+                  }}
+                  initialLimit={8}
+                  itemsPerPage={20}
+                  showTotal
+                  hideTag
+                />
+              </AnalyticsContext>
+            </DeferRender>
+          </>}
         </div>
       </ToCColumn>
     </div>


### PR DESCRIPTION
I've copied over the "Quick takes" section from the core topic page (ex. [this one](https://forum.effectivealtruism.org/topics/global-health-and-development)) to the bottom of the standard topic/tag page. This is primarily so that quick takes associated with Forum events can be found on the relevant page, such as [AI Welfare Debate Week](http://localhost:3000/topics/ai-welfare-debate-week).

This section should almost never otherwise appear. Normally on the EA Forum, the list of core topics and the list of topics that you can tag your quick take with are equivalent. And I think LW doesn't allow users to tag their quick takes.

<img width="682" alt="Screen Shot 2024-07-24 at 3 31 20 PM" src="https://github.com/user-attachments/assets/a4d93b35-e46f-420c-8cc6-8935ecd62759">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207893513719272) by [Unito](https://www.unito.io)
