### PR TITLE
[EA] Use post contents rather than customHighlight as the excerpt in recent discussion

### DIFF
--- a/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
@@ -11,13 +11,13 @@ const isSunshine = (post: PostsList | SunshinePostsList): post is SunshinePostsL
 
 const PostExcerpt = ({
   post,
-  preferCustomHighlight=true,
+  useCustomHighlight=true,
   hash,
   ...commonExcerptProps
 }: CommonExcerptProps & {
   post: PostsList | SunshinePostsList,
   /** Whether to prefer showing `customHighlight` (can be set by admins) vs a snippet of the post body */
-  preferCustomHighlight?: boolean,
+  useCustomHighlight?: boolean,
   hash?: string | null,
 }) => {
   // Get the post body, accounting for whether or not this is a crosspost
@@ -61,7 +61,7 @@ const PostExcerpt = ({
 
   const contentHtml =
     postHighlight?.contents?.htmlHighlightStartingAtHash ||
-    (preferCustomHighlight && customHighlight ? customHighlight : postDefaultHighlight);
+    (useCustomHighlight && customHighlight ? customHighlight : postDefaultHighlight);
   if (!contentHtml) {
     return null;
   }

--- a/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
+++ b/packages/lesswrong/components/common/excerpts/PostExcerpt.tsx
@@ -11,10 +11,13 @@ const isSunshine = (post: PostsList | SunshinePostsList): post is SunshinePostsL
 
 const PostExcerpt = ({
   post,
+  preferCustomHighlight=true,
   hash,
   ...commonExcerptProps
 }: CommonExcerptProps & {
   post: PostsList | SunshinePostsList,
+  /** Whether to prefer showing `customHighlight` (can be set by admins) vs a snippet of the post body */
+  preferCustomHighlight?: boolean,
   hash?: string | null,
 }) => {
   // Get the post body, accounting for whether or not this is a crosspost
@@ -53,11 +56,12 @@ const PostExcerpt = ({
     console.error("Error loading excerpt body:", error);
   }
 
+  const customHighlight = post.customHighlight?.html;
+  const postDefaultHighlight: string | undefined = postContents?.htmlHighlight || (postContents as AnyBecauseHard)?.html;
+
   const contentHtml =
     postHighlight?.contents?.htmlHighlightStartingAtHash ||
-    post.customHighlight?.html ||
-    postContents?.htmlHighlight ||
-    (postContents as AnyBecauseHard)?.html;
+    (preferCustomHighlight && customHighlight ? customHighlight : postDefaultHighlight);
   if (!contentHtml) {
     return null;
   }

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -150,6 +150,7 @@ const EARecentDiscussionThread = ({
       <PostExcerpt
         post={post}
         lines={comments?.length ? 3 : 10}
+        preferCustomHighlight={false}
         className={classNames({
           [classes.excerptBottomMargin]: nestedComments.length,
         })}

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -150,7 +150,7 @@ const EARecentDiscussionThread = ({
       <PostExcerpt
         post={post}
         lines={comments?.length ? 3 : 10}
-        preferCustomHighlight={false}
+        useCustomHighlight={false}
         className={classNames({
           [classes.excerptBottomMargin]: nestedComments.length,
         })}


### PR DESCRIPTION
Before:
![Screenshot 2024-07-25 at 11 38 39](https://github.com/user-attachments/assets/fc6bd1f5-538a-4f20-bcc3-63060dd773b3)

After:
![Screenshot 2024-07-25 at 11 36 51](https://github.com/user-attachments/assets/44d91cfa-1cd0-4e4e-b467-25e333f229e3)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207896177717233) by [Unito](https://www.unito.io)
