### PR TITLE
Add link to DM a specific user

### DIFF
--- a/packages/lesswrong/components/hooks/useInitiateConversation.ts
+++ b/packages/lesswrong/components/hooks/useInitiateConversation.ts
@@ -12,7 +12,11 @@ import { useTracking } from "../../lib/analyticsEvents";
  * Note: the initiateConversation callback doesn't return the created conversation, it is returned separately
  * by the hook
  */
-export const useInitiateConversation = (props?: { includeModerators?: boolean }) => {
+export const useInitiateConversation = (props?: {
+  includeModerators?: boolean;
+  /** If given the conversation will be initiated immediately */
+  userIds?: string[]
+}) => {
   const {captureEvent} = useTracking({
     eventType: "initiateConversation",
     eventProps: props,
@@ -21,7 +25,7 @@ export const useInitiateConversation = (props?: { includeModerators?: boolean })
 
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
-  const [userIds, setUserIds] = useState<string[] | null>(null);
+  const [userIds, setUserIds] = useState<string[] | null>(props?.userIds ?? null);
   const skip = !currentUser || !userIds?.length
 
   const alignmentFields = isAF ? { af: true } : {};
@@ -29,7 +33,7 @@ export const useInitiateConversation = (props?: { includeModerators?: boolean })
 
   const participantIds = skip ? [] : [currentUser._id, ...userIds];
 
-  const { results, error } = useMulti({
+  const { results, loading, error } = useMulti({
     terms: {
       view: "userGroupUntitledConversations",
       userId: currentUser?._id,
@@ -65,6 +69,7 @@ export const useInitiateConversation = (props?: { includeModerators?: boolean })
 
   return {
     conversation,
+    conversationLoading: loading,
     initiateConversation,
   };
 };

--- a/packages/lesswrong/components/messaging/MessageUser.tsx
+++ b/packages/lesswrong/components/messaging/MessageUser.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Components, registerComponent } from "../../lib/vulcan-lib";
+import { useLocation } from "../../lib/routeUtil";
+import { useCurrentUser } from "../common/withUser";
+import { useSingle } from "@/lib/crud/withSingle";
+import { useInitiateConversation } from "../hooks/useInitiateConversation";
+
+const MessageUserInner = ({ user }: { user: UsersMinimumInfo }) => {
+  const { Loading, PermanentRedirect, SingleColumnSection } = Components;
+
+  const { conversation, conversationLoading } = useInitiateConversation({
+    userIds: [user._id],
+  });
+
+  if (!conversation) {
+    return conversationLoading ? <Loading /> : <SingleColumnSection>Failed to create conversation: Unknown error.</SingleColumnSection>;
+  }
+
+  const url = `/inbox/${conversation._id}?from=magic_link`;
+  return <PermanentRedirect url={url} status={302} />;
+};
+
+const MessageUser = () => {
+  const currentUser = useCurrentUser();
+  const { params } = useLocation();
+  const { Loading, SingleColumnSection } = Components;
+
+  const { document: user, loading } = useSingle({
+    slug: params.slug,
+    collectionName: "Users",
+    fragmentName: "UsersMinimumInfo",
+    skip: !currentUser || !params.slug,
+  });
+
+  if (!currentUser) {
+    return <div>Log in to access private messages.</div>;
+  }
+
+  if (!user) {
+    return loading ? <Loading /> : <SingleColumnSection>Failed to create conversation: User could not be found.</SingleColumnSection>;
+  }
+
+  if (user._id === currentUser._id) {
+    return <SingleColumnSection>Failed to create conversation: You cannot create a converstaion with yourself.</SingleColumnSection>;
+  }
+
+  return <MessageUserInner user={user} />
+};
+
+const MessageUserComponent = registerComponent("MessageUser", MessageUser);
+
+declare global {
+  interface ComponentTypes {
+    MessageUser: typeof MessageUserComponent;
+  }
+}

--- a/packages/lesswrong/components/messaging/MessageUser.tsx
+++ b/packages/lesswrong/components/messaging/MessageUser.tsx
@@ -5,7 +5,17 @@ import { useCurrentUser } from "../common/withUser";
 import { useSingle } from "@/lib/crud/withSingle";
 import { useInitiateConversation } from "../hooks/useInitiateConversation";
 
-const MessageUserInner = ({ user }: { user: UsersMinimumInfo }) => {
+const styles = (theme: ThemeType) => ({
+  error: {
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontSize: 16,
+    fontWeight: 450,
+    marginTop: 16,
+    padding: 16
+  },
+});
+
+const MessageUserInner = ({ user, classes }: { user: UsersMinimumInfo; classes: ClassesType<typeof styles> }) => {
   const { Loading, PermanentRedirect, SingleColumnSection } = Components;
 
   const { conversation, conversationLoading } = useInitiateConversation({
@@ -13,14 +23,18 @@ const MessageUserInner = ({ user }: { user: UsersMinimumInfo }) => {
   });
 
   if (!conversation) {
-    return conversationLoading ? <Loading /> : <SingleColumnSection>Failed to create conversation: Unknown error.</SingleColumnSection>;
+    return conversationLoading ? (
+      <Loading />
+    ) : (
+      <SingleColumnSection className={classes.error}>Failed to create conversation: Unknown error.</SingleColumnSection>
+    );
   }
 
   const url = `/inbox/${conversation._id}?from=magic_link`;
   return <PermanentRedirect url={url} status={302} />;
 };
 
-const MessageUser = () => {
+const MessageUser = ({ classes }: { classes: ClassesType<typeof styles> }) => {
   const currentUser = useCurrentUser();
   const { params } = useLocation();
   const { Loading, SingleColumnSection } = Components;
@@ -33,21 +47,31 @@ const MessageUser = () => {
   });
 
   if (!currentUser) {
-    return <div>Log in to access private messages.</div>;
+    return <SingleColumnSection className={classes.error}>Log in to access private messages.</SingleColumnSection>;
   }
 
   if (!user) {
-    return loading ? <Loading /> : <SingleColumnSection>Failed to create conversation: User could not be found.</SingleColumnSection>;
+    return loading ? (
+      <Loading />
+    ) : (
+      <SingleColumnSection className={classes.error}>
+        Failed to create conversation: User could not be found.
+      </SingleColumnSection>
+    );
   }
 
   if (user._id === currentUser._id) {
-    return <SingleColumnSection>Failed to create conversation: You cannot create a converstaion with yourself.</SingleColumnSection>;
+    return (
+      <SingleColumnSection className={classes.error}>
+        Failed to create conversation: You cannot create a converstaion with yourself.
+      </SingleColumnSection>
+    );
   }
 
-  return <MessageUserInner user={user} />
+  return <MessageUserInner user={user} classes={classes} />;
 };
 
-const MessageUserComponent = registerComponent("MessageUser", MessageUser);
+const MessageUserComponent = registerComponent("MessageUser", MessageUser, { styles });
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -112,6 +112,7 @@ importComponent("InboxWrapper", () => require('../components/messaging/InboxWrap
 importComponent("ModeratorInboxWrapper", () => require('../components/messaging/ModeratorInboxWrapper'));
 importComponent("InboxNavigation", () => require('../components/messaging/InboxNavigation'));
 importComponent("MessagesMenuButton", () => require('../components/messaging/MessagesMenuButton'));
+importComponent("MessageUser", () => require('../components/messaging/MessageUser'));
 // "Friendly UI" messaging components
 importComponent("FriendlyInbox", () => require('../components/messaging/FriendlyInbox'));
 importComponent("FriendlyInboxNavigation", () => require('../components/messaging/FriendlyInboxNavigation'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1276,7 +1276,6 @@ addRoute(...forumSelect<Route[]>({
       fullscreen: true,
     },
   ],
-  
   default: [
     {
       name: 'inbox',
@@ -1308,6 +1307,12 @@ addRoute(...forumSelect<Route[]>({
     },
   ]
 }))
+
+addRoute({
+  name: 'userInitiateConversation',
+  path: '/message/:slug',
+  componentName: 'MessageUser',
+})
 
 addRoute({
   name: 'AllComments',


### PR DESCRIPTION
Requested by Toby, this makes it so going to `/message/:slug` will open/create a conversation with the given user as if you had pressed the "New message" button.

I'm adding this as a hidden feature initially, with the idea being that if other users notice and ask for it then we can add a way of getting the link in the UI somewhere.

Making the link copyable from the UI is easy for _other_ users (because we can make the message button a link), but not for your own user, we would likely have to add something to the profile page. I don't want to clutter that page too much, hence why I'm making this a hidden feature at first.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207908275624562) by [Unito](https://www.unito.io)
