### PR TITLE
Fix hide-ToC button on EA forum being unclickable due to z-index at some scroll positions

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -119,6 +119,7 @@ export const styles = (theme: ThemeType): JssStyles => ({
     gap: "10px",
     userSelect: "none",
     cursor: "pointer",
+    zIndex: theme.zIndexes.hideTableOfContentsButton,
     [theme.breakpoints.down("sm")]: {
       display: "none",
     },

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -52,6 +52,7 @@ export const zIndexes = {
   postItemMenu: 1050,
   searchResults: 1100,
   tabNavigation: 1101,
+  hideTableOfContentsButton: 1200,
   header: 1300,
   karmaChangeNotifier: 1400,
   notificationsMenu: 1500,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207909807330793) by [Unito](https://www.unito.io)
