### PR TITLE
[EA Forum only] update EA Forum survey banner

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -455,6 +455,7 @@ const Layout = ({currentUser, children, classes}: {
       CloudinaryImage2,
       ForumEventBanner,
       GlobalHotkeys,
+      EASurveyBanner,
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -541,6 +542,7 @@ const Layout = ({currentUser, children, classes}: {
               {/* enable during ACX Everywhere */}
               {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap dontAskUserLocation={true}/></span>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
+              {isEAForum && <EASurveyBanner />}
 
               <div className={classNames(classes.standaloneNavFlex, {
                 [classes.spacedGridActivated]: shouldUseGridLayout && !unspacedGridLayout,

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -83,7 +83,7 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
     setCookie(HIDE_EA_FORUM_SURVEY_BANNER_COOKIE, "true", {
       expires: moment().add(3, "months").toDate(),
     });
-  }, [HIDE_EA_FORUM_SURVEY_BANNER_COOKIE, setCookie]);
+  }, [setCookie]);
 
   const onDismissBanner = useCallback(() => {
     hideBanner();
@@ -107,7 +107,7 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
         <Link
           to="https://forms.cea.community/test?utm_source=ea_forum&utm_medium=banner"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           onClick={onSubmitSurvey}
           className={classes.button}
         >

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -1,17 +1,18 @@
 import React, { useCallback } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
-import { TypeformPopupEmbed } from "../common/TypeformEmbeds";
 import { useCurrentUser } from "../common/withUser";
 import { useTracking } from "../../lib/analyticsEvents";
 import { useCookiesWithConsent } from "../hooks/useCookiesWithConsent";
 import moment from "moment";
 import DeferRender from "../common/DeferRender";
+import { Link } from "@/lib/reactRouterWrapper";
+import { HIDE_EA_FORUM_SURVEY_BANNER_COOKIE } from "@/lib/cookies/cookies";
 
 const styles = (theme: ThemeType) => ({
   root: {
     position: "sticky",
     top: 0,
-    zIndex: 10000, // The typeform popup has z-index 10001
+    zIndex: 10, // The typeform popup has z-index 10001
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
@@ -21,6 +22,7 @@ const styles = (theme: ThemeType) => ({
     background: theme.palette.buttons.alwaysPrimary,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: 15,
+    lineHeight: '21px',
     fontWeight: 450,
     color: theme.palette.text.alwaysWhite,
     [theme.breakpoints.down("sm")]: {
@@ -73,16 +75,15 @@ const styles = (theme: ThemeType) => ({
  *      });
  */
 const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
-  const cookieName = ""; // TODO: Insert new cookie name
-  const [cookies, setCookie] = useCookiesWithConsent([cookieName]);
+  const [cookies, setCookie] = useCookiesWithConsent([HIDE_EA_FORUM_SURVEY_BANNER_COOKIE]);
   const {captureEvent} = useTracking();
   const currentUser = useCurrentUser();
 
   const hideBanner = useCallback(() => {
-    setCookie(cookieName, "true", {
+    setCookie(HIDE_EA_FORUM_SURVEY_BANNER_COOKIE, "true", {
       expires: moment().add(3, "months").toDate(),
     });
-  }, [cookieName, setCookie]);
+  }, [HIDE_EA_FORUM_SURVEY_BANNER_COOKIE, setCookie]);
 
   const onDismissBanner = useCallback(() => {
     hideBanner();
@@ -94,7 +95,7 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
     captureEvent("ea_forum_survey_closed");
   }, [hideBanner, captureEvent]);
 
-  if (cookies[cookieName] === "true") {
+  if (cookies[HIDE_EA_FORUM_SURVEY_BANNER_COOKIE] === "true") {
     return null;
   }
 
@@ -102,15 +103,16 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
   return (
     <DeferRender ssr={!!currentUser}>
       <div className={classes.root}>
-        Take the 4 minute EA Forum Survey to help inform our strategy and funding decisions
-        <TypeformPopupEmbed
-          widgetId="Z1wH4v8v"
-          domain="cea-core.typeform.com"
-          title="EA Forum survey"
-          label="Take the survey"
-          onSubmit={onSubmitSurvey}
+        Take the 2024 EA Forum Survey to help inform our strategy and priorities
+        <Link
+          to="https://forms.cea.community/test?utm_source=ea_forum&utm_medium=banner"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onSubmitSurvey}
           className={classes.button}
-        />
+        >
+          Take the survey
+        </Link>
         <ForumIcon
           icon="Close"
           onClick={onDismissBanner}

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -105,7 +105,7 @@ const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
       <div className={classes.root}>
         Take the 2024 EA Forum Survey to help inform our strategy and priorities
         <Link
-          to="https://forms.cea.community/test?utm_source=ea_forum&utm_medium=banner"
+          to="https://forms.cea.community/forum-survey-2024?utm_source=ea_forum&utm_medium=banner"
           target="_blank"
           rel="noopener"
           onClick={onSubmitSurvey}

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -176,6 +176,12 @@ export const HIDE_EAG_BANNER_COOKIE = registerCookie({
   description: "Don't show any EAG(x) banners",
 });
 
+export const HIDE_EA_FORUM_SURVEY_BANNER_COOKIE = registerCookie({
+  name: "hide_ea_forum_survey_banner",
+  type: "necessary",
+  description: "Don't show the EA Forum survey banner",
+});
+
 export const NAV_MENU_FLAG_COOKIE_PREFIX = "nav_menu_flag_";
 registerCookie({
   name: `${NAV_MENU_FLAG_COOKIE_PREFIX}[*]`,


### PR DESCRIPTION
This PR preps the existing EA Forum survey banner for our [upcoming 2024 user survey](https://docs.google.com/document/d/1IOLoGJV9jDNKlwloOuCk0bUNuobNy0ujM9LSL9-sTmY/edit). I mostly kept it the same as before.

I plan to deploy this on August 1 when I publish the [announcement post](https://docs.google.com/document/d/1VPIg72__VQdZGqsDg2TnsWCcQ6phl1_5UQFs1mY03NY/edit). I'll remove it from the site when I close the survey, which depends on how many responses we get.

<img width="1440" alt="Screen Shot 2024-07-30 at 2 58 47 PM" src="https://github.com/user-attachments/assets/5870dc3a-bc31-4a30-b9fa-a2d640e224e3">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207936264586699) by [Unito](https://www.unito.io)
