### PR TITLE
[EA] Add new tag info box

### DIFF
--- a/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
+++ b/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
@@ -6,7 +6,10 @@ import type { ForumIconName } from "../common/ForumIcon";
 import { useDismissable } from "../hooks/useDismissable";
 import { HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE } from "../../lib/cookies/cookies";
 
-const styles = (theme: ThemeType): JssStyles => ({
+/**
+ * Styles are shared with `NewTagInfoBox`
+ */
+export const styles = (theme: ThemeType) => ({
   root: {
     width: 280,
     margin: "60px 20px 0 -60px",
@@ -74,7 +77,7 @@ const guides: HowToGuide[] = [
 ];
 
 export const NewPostHowToGuides = ({classes}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const {dismissed, dismiss} = useDismissable(HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE);
   if (dismissed) {

--- a/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
+++ b/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
@@ -11,16 +11,16 @@ const wikiFaqLink = "/topics/ea-wiki-faq";
 const styles = (theme: ThemeType) => ({
   ...postInfoStyles(theme),
   width: {
-    width: 250,
     marginRight: 0,
     "@media (max-width: 1400px)": {
-      width: 200,
+      width: 220,
     },
   },
   content: {
     fontWeight: 500,
     fontSize: 14,
     lineHeight: "140%",
+    marginTop: -6,
     "& li": {
       marginLeft: -16,
       "&:not(:last-child)": {
@@ -30,6 +30,10 @@ const styles = (theme: ThemeType) => ({
     "& a": {
       fontWeight: 600,
       color: theme.palette.primary.main,
+      textDecoration: "underline",
+      "&:hover": {
+        textDecoration: "none",
+      },
     },
   },
 });
@@ -40,12 +44,9 @@ const NewTagInfoBox = ({classes}: {classes: ClassesType<typeof styles>}) => {
     <AnalyticsContext pageElementContext="newTagInfoBox">
       <div className={classNames(classes.root, classes.width)}>
         <div className={classes.title}>
-          Adding a new {tag}
+          Your {tag} may be rejected if:
         </div>
         <div className={classes.content}>
-          <p>
-            Your {tag} may be rejected if:
-          </p>
           <ol>
             <li>
               A similar {tag} already exists.

--- a/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
+++ b/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
@@ -4,11 +4,19 @@ import { styles as postInfoStyles } from "../posts/NewPostHowToGuides";
 import { AnalyticsContext } from "@/lib/analyticsEvents";
 import { taggingNameSetting } from "@/lib/instanceSettings";
 import { Link } from "@/lib/reactRouterWrapper";
+import classNames from "classnames";
 
 const wikiFaqLink = "/topics/ea-wiki-faq";
 
 const styles = (theme: ThemeType) => ({
   ...postInfoStyles(theme),
+  width: {
+    width: 250,
+    marginRight: 0,
+    "@media (max-width: 1400px)": {
+      width: 200,
+    },
+  },
   content: {
     fontWeight: 500,
     fontSize: 14,
@@ -30,7 +38,7 @@ const NewTagInfoBox = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const tag = taggingNameSetting.get();
   return (
     <AnalyticsContext pageElementContext="newTagInfoBox">
-      <div className={classes.root}>
+      <div className={classNames(classes.root, classes.width)}>
         <div className={classes.title}>
           Adding a new {tag}
         </div>

--- a/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
+++ b/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { registerComponent } from "../../lib/vulcan-lib";
+import { styles as postInfoStyles } from "../posts/NewPostHowToGuides";
+import { AnalyticsContext } from "@/lib/analyticsEvents";
+import { taggingNameSetting } from "@/lib/instanceSettings";
+import { Link } from "@/lib/reactRouterWrapper";
+
+const styleGuideLink = "/topics/style-guide";
+const wikiFaqLink = "/topics/ea-wiki-faq";
+
+const styles = (theme: ThemeType) => ({
+  ...postInfoStyles(theme),
+  content: {
+    fontWeight: 500,
+    fontSize: 14,
+    lineHeight: "140%",
+    "& li": {
+      marginLeft: -16,
+      "&:not(:last-child)": {
+        marginBottom: 8,
+      },
+    },
+    "& a": {
+      fontWeight: 600,
+      color: theme.palette.primary.main,
+    },
+  },
+});
+
+const NewTagInfoBox = ({classes}: {
+  classes: ClassesType<typeof styles>,
+}) => {
+  return (
+    <AnalyticsContext pageElementContext="newTagInfoBox">
+      <div className={classes.root}>
+        <div className={classes.title}>
+          Adding a new {taggingNameSetting.get()}
+        </div>
+        <div className={classes.content}>
+          <p>
+            When you add a new topic, ensure that:
+          </p>
+          <ol>
+            <li>
+              The topic, or a very similar topic, does not already exist. If a
+              very similar topic already exists, consider adding detail to that
+              topic wiki page rather than creating a new topic.
+            </li>
+            <li>
+              Your topic tag is relevant to at least three existing Forum posts
+              by different authors (not including yourself). Please tag these posts
+              after you create your topic. The topic must describe a central theme
+              in each post. If you cannot yet tag three relevant posts, the Forum
+              probably doesn’t need this topic yet.
+            </li>
+            <li>
+              You’ve added at least a couple of sentences to define the term and
+              explain how the topic tag should be used. If you like, you can write
+              a full wiki page in line with this{" "}
+              <Link to={styleGuideLink}>style guide</Link>. However, we won’t
+              reject otherwise useful new topics because they don’t have a full
+              entry.
+            </li>
+          </ol>
+          <p>
+            Topics that don’t meet this criteria will likely be rejected. More
+            information can be found in <Link to={wikiFaqLink}>the Wiki FAQ</Link>.
+          </p>
+        </div>
+      </div>
+    </AnalyticsContext>
+  );
+}
+
+const NewTagInfoBoxComponent = registerComponent(
+  "NewTagInfoBox",
+  NewTagInfoBox,
+  {styles},
+);
+
+declare global {
+  interface ComponentTypes {
+    NewTagInfoBox: typeof NewTagInfoBoxComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
+++ b/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
@@ -5,7 +5,6 @@ import { AnalyticsContext } from "@/lib/analyticsEvents";
 import { taggingNameSetting } from "@/lib/instanceSettings";
 import { Link } from "@/lib/reactRouterWrapper";
 
-const styleGuideLink = "/topics/style-guide";
 const wikiFaqLink = "/topics/ea-wiki-faq";
 
 const styles = (theme: ThemeType) => ({
@@ -27,44 +26,33 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const NewTagInfoBox = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
+const NewTagInfoBox = ({classes}: {classes: ClassesType<typeof styles>}) => {
+  const tag = taggingNameSetting.get();
   return (
     <AnalyticsContext pageElementContext="newTagInfoBox">
       <div className={classes.root}>
         <div className={classes.title}>
-          Adding a new {taggingNameSetting.get()}
+          Adding a new {tag}
         </div>
         <div className={classes.content}>
           <p>
-            When you add a new topic, ensure that:
+            Your {tag} may be rejected if:
           </p>
           <ol>
             <li>
-              The topic, or a very similar topic, does not already exist. If a
-              very similar topic already exists, consider adding detail to that
-              topic wiki page rather than creating a new topic.
+              A similar {tag} already exists.
             </li>
             <li>
-              Your topic tag is relevant to at least three existing Forum posts
-              by different authors (not including yourself). Please tag these posts
-              after you create your topic. The topic must describe a central theme
-              in each post. If you cannot yet tag three relevant posts, the Forum
-              probably doesn’t need this topic yet.
+              The {tag} isn’t applied to three relevant posts by different
+              authors (not counting your own) after you create it.
             </li>
             <li>
-              You’ve added at least a couple of sentences to define the term and
-              explain how the topic tag should be used. If you like, you can write
-              a full wiki page in line with this{" "}
-              <Link to={styleGuideLink}>style guide</Link>. However, we won’t
-              reject otherwise useful new topics because they don’t have a full
-              entry.
+              You haven’t included at least a sentence defining the {tag}.
             </li>
           </ol>
           <p>
-            Topics that don’t meet this criteria will likely be rejected. More
-            information can be found in <Link to={wikiFaqLink}>the Wiki FAQ</Link>.
+            Check out the <Link to={wikiFaqLink}>Wiki FAQ</Link> for more tips
+            and explanations.
           </p>
         </div>
       </div>

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -2,14 +2,27 @@ import React from 'react';
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
 import { tagGetUrl, tagMinimumKarmaPermissions, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
-import { taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
+import { isEAForum, taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import { useNavigate } from '../../lib/reactRouterWrapper';
 
-const NewTagPage = () => {
+export const styles = (_theme: ThemeType) => ({
+  root: {
+    position: "relative",
+  },
+  guide: {
+    position: "absolute",
+    top: -50,
+    right: -320,
+  },
+});
+
+const NewTagPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const navigate = useNavigate();
   const currentUser = useCurrentUser();
-  const { SingleColumnSection, SectionTitle, WrappedSmartForm } = Components;
-  
+  const {
+    SingleColumnSection, SectionTitle, WrappedSmartForm, NewTagInfoBox,
+  } = Components;
+
   if (!currentUser) {
     return (
       <SingleColumnSection>
@@ -34,7 +47,7 @@ const NewTagPage = () => {
   }
   
   return (
-    <SingleColumnSection>
+    <SingleColumnSection className={classes.root}>
       <SectionTitle title={`New ${taggingNameCapitalSetting.get()}`}/>
       <WrappedSmartForm
         collectionName="Tags"
@@ -43,11 +56,16 @@ const NewTagPage = () => {
           navigate({pathname: tagGetUrl(tag)});
         }}
       />
+      {isEAForum &&
+        <div className={classes.guide}>
+          <NewTagInfoBox />
+        </div>
+      }
     </SingleColumnSection>
   );
 }
 
-const NewTagPageComponent = registerComponent('NewTagPage', NewTagPage);
+const NewTagPageComponent = registerComponent('NewTagPage', NewTagPage, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -12,9 +12,9 @@ export const styles = (_theme: ThemeType) => ({
   guide: {
     position: "absolute",
     top: -50,
-    right: -280,
+    right: -300,
     "@media (max-width: 1400px)": {
-      right: -220,
+      right: -240,
     },
   },
 });

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -12,7 +12,10 @@ export const styles = (_theme: ThemeType) => ({
   guide: {
     position: "absolute",
     top: -50,
-    right: -320,
+    right: -280,
+    "@media (max-width: 1400px)": {
+      right: -220,
+    },
   },
 });
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -837,6 +837,7 @@ importComponent("FooterTag", () => require('../components/tagging/FooterTag'));
 importComponent("TruncatedTagsList", () => require('../components/tagging/TruncatedTagsList'));
 importComponent("CoreTagIcon", () => require('../components/tagging/CoreTagIcon'));
 importComponent("NewTagPage", () => require('../components/tagging/NewTagPage'));
+importComponent("NewTagInfoBox", () => require('../components/tagging/NewTagInfoBox'));
 importComponent("RandomTagPage", () => require('../components/tagging/RandomTagPage'));
 importComponent("EditTagPage", () => require('../components/tagging/EditTagPage'));
 importComponent("EditTagsDialog", () => require('../components/tagging/EditTagsDialog'));


### PR DESCRIPTION
Adds an info box to the new tag page for EA forum.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207941281084056) by [Unito](https://www.unito.io)
