### PR TITLE
Remove `childContextTypes` and `contextTypes` from `FormComponentNumber`

### DIFF
--- a/packages/lesswrong/components/form-components/FormComponentNumber.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentNumber.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 
 const FormComponentNumber = (props: FormComponentProps<number>) => {
@@ -18,13 +17,6 @@ const FormComponentNumber = (props: FormComponentProps<number>) => {
     }
   />
 }
-
-(FormComponentNumber as any).contextTypes = {
-  updateCurrentValues: PropTypes.func,
-};
-(FormComponentNumber as any).childContextTypes = {
-  updateCurrentValues: PropTypes.func,
-};
 
 // Replaces FormComponentNumber from vulcan-ui-bootstrap
 const FormComponentNumberComponent = registerComponent("FormComponentNumber", FormComponentNumber);


### PR DESCRIPTION
These should only be used for class components (this is a functional component), and they produce an annoying console error with an enormous stack trace.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207941593204885) by [Unito](https://www.unito.io)
