### PR TITLE
Fix memory leak on post pages

### DIFF
--- a/packages/lesswrong/components/hooks/useExternalScript.tsx
+++ b/packages/lesswrong/components/hooks/useExternalScript.tsx
@@ -21,6 +21,10 @@ declare global {
  * tab and this hook is no longer present. This is because removing a script
  * tag from the DOM will often not actually clean it up; repeatedly removing
  * a script tag and then adding it back is likely to be a memory leak.
+ *
+ * `scriptProps` adds props to the script tag; these should not be changed
+ * after first render (changes won't be applied as the tag has already been
+ * added).
  */
 export const useExternalScript = (href: string, scriptProps: Partial<Record<string,string>>): {
   ready: boolean
@@ -79,6 +83,8 @@ export const useExternalScript = (href: string, scriptProps: Partial<Record<stri
     } else {
       setReady(true);
     }
+  // Ignore `scriptProps` being missing from the useEffect dependency list
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [href]);
   
   return {ready};

--- a/packages/lesswrong/components/hooks/useExternalScript.tsx
+++ b/packages/lesswrong/components/hooks/useExternalScript.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { isClient } from '@/lib/executionEnvironment';
+
+type ExternalScriptState = {
+  loading: boolean
+  href: string
+  onReady: Array<() => void>
+};
+declare global {
+  interface Window {
+    externalScripts?: Array<ExternalScriptState>
+  }
+}
+
+/**
+ * Loads an external Javascript dependency, by injecting a <script> tag into
+ * the page header. Used for external client-side Javascript APIs such as
+ * Type3 Audio.
+ *
+ * Once a script is loaded this way, it stays loaded even if you navigate the
+ * tab and this hook is no longer present. This is because removing a script
+ * tag from the DOM will often not actually clean it up; repeatedly removing
+ * a script tag and then adding it back is likely to be a memory leak.
+ */
+export const useExternalScript = (href: string, scriptProps: Partial<Record<string,string>>): {
+  ready: boolean
+} => {
+  const [ready, setReady] = useState(() => {
+    if (isClient) {
+      const scriptState = window.externalScripts?.find(s => s.href === href)
+      if (!scriptState) return false;
+      return !scriptState.loading;
+    } else {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    const existingScriptState = window.externalScripts?.find(s => s.href === href)
+    
+    if (!existingScriptState) {
+      // If the script isn't loaded and its load hasn't been started it, start loading
+      if (!window.externalScripts) {
+        window.externalScripts = [];
+      }
+      const scriptState: ExternalScriptState = {loading: true,  href, onReady: []}
+      window.externalScripts.push(scriptState);
+      
+      const scriptTag = document.createElement("script");
+      scriptTag.async = true;
+      scriptTag.src = href;
+      for (let key of Object.keys(scriptProps)) {
+        (scriptTag as any)[key] = scriptProps[key];
+      }
+      scriptTag.onerror = () => {
+        // If the script fails to load, remove it from window.externalScripts
+        // so that if we navigate and return, it will try loading again.
+        if (window.externalScripts) {
+          window.externalScripts = window.externalScripts.filter(s => s.href !== href);
+        }
+      }
+      scriptTag.onload = () => {
+        for (let onReadyCallback of [...scriptState.onReady]) {
+          onReadyCallback();
+        }
+      }
+      scriptState.onReady.push(() => {
+        setReady(true);
+        scriptState.loading = false;
+        scriptTag.onload = scriptTag.onerror = null;
+      });
+      document.head.appendChild(scriptTag);
+    } else if (existingScriptState.loading) {
+      // If the script is already loading, add to its onload/onerror events so we
+      // get notified when it's ready
+      existingScriptState.onReady.push(() => {
+        setReady(true);
+      });
+    } else {
+      setReady(true);
+    }
+  }, [href]);
+  
+  return {ready};
+}

--- a/packages/lesswrong/components/hooks/useExternalScript.tsx
+++ b/packages/lesswrong/components/hooks/useExternalScript.tsx
@@ -53,8 +53,8 @@ export const useExternalScript = (href: string, scriptProps: Partial<Record<stri
       const scriptTag = document.createElement("script");
       scriptTag.async = true;
       scriptTag.src = href;
-      for (let key of Object.keys(scriptProps)) {
-        (scriptTag as any)[key] = scriptProps[key];
+      for (const key in scriptProps) {
+        scriptTag.setAttribute(key, scriptProps[key] ?? "");
       }
       scriptTag.onerror = () => {
         // If the script fails to load, remove it from window.externalScripts

--- a/packages/lesswrong/components/posts/PostsPage/T3AudioPlayer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/T3AudioPlayer.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib';
 import { useTracking } from "../../../lib/analyticsEvents";
 import classNames from 'classnames';
 import { useEventListener } from '../../hooks/useEventListener';
-import { Helmet } from '../../../lib/utils/componentsWithChildren';
 import { isEAForum } from '@/lib/instanceSettings';
 import { useExternalScript } from '@/components/hooks/useExternalScript';
 

--- a/packages/lesswrong/components/posts/PostsPage/T3AudioPlayer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/T3AudioPlayer.tsx
@@ -1,10 +1,11 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib';
 import { useTracking } from "../../../lib/analyticsEvents";
 import classNames from 'classnames';
 import { useEventListener } from '../../hooks/useEventListener';
 import { Helmet } from '../../../lib/utils/componentsWithChildren';
 import { isEAForum } from '@/lib/instanceSettings';
+import { useExternalScript } from '@/components/hooks/useExternalScript';
 
 const styles = (theme: ThemeType): JssStyles => ({
   embeddedPlayer: {
@@ -29,7 +30,7 @@ export const T3AudioPlayer = ({classes, showEmbeddedPlayer, postId}: {
   const setMouseOverDiv = (isMouseOver: boolean) => {
     mouseOverDiv.current = isMouseOver;
   };
-       
+
   // (Note: this was copied from PostsPodcastPlayer)
   // Dumb hack to let us figure out when the iframe inside the div was clicked on, as a (fuzzy) proxy for people clicking the play button
   // Inspiration: https://gist.github.com/jaydson/1780598
@@ -39,20 +40,25 @@ export const T3AudioPlayer = ({classes, showEmbeddedPlayer, postId}: {
       captureEvent('clickInsidePodcastPlayer', { postId, playerType: "t3-audio" });
     }
   });
+  
+  const { ready: type3scriptLoaded } = useExternalScript("https://embed.type3.audio/player.js", {
+    defer: "true",
+    type: "module",
+    "cross-origin": "anonymous",
+  });
 
   return <div
-      ref={divRef}
-      onMouseOver={() => setMouseOverDiv(true)}
-      onMouseOut={() => setMouseOverDiv(false)}
-    >
-      <Helmet>
-        <script defer type="module" src="https://embed.type3.audio/player.js" crossOrigin="anonymous"></script>
-      </Helmet>
-      <div className={classNames(classes.embeddedPlayer, { [classes.hideEmbeddedPlayer]: !showEmbeddedPlayer })} >
-         {/* @ts-ignore */}
-        {isEAForum ? <type-3-player analytics="custom" sticky="true" header-play-buttons="true" title=""></type-3-player> : <type-3-player analytics="custom"></type-3-player>}
-      </div>
+    ref={divRef}
+    onMouseOver={() => setMouseOverDiv(true)}
+    onMouseOut={() => setMouseOverDiv(false)}
+  >
+    <div className={classNames(classes.embeddedPlayer, { [classes.hideEmbeddedPlayer]: !showEmbeddedPlayer })}>
+      {type3scriptLoaded && (
+        /* @ts-ignore */
+        isEAForum ? <type-3-player analytics="custom" sticky="true" header-play-buttons="true" title=""></type-3-player> : <type-3-player analytics="custom"></type-3-player>
+      )}
     </div>
+  </div>
 }
 
 const T3AudioPlayerComponent = registerComponent('T3AudioPlayer', T3AudioPlayer, {styles});


### PR DESCRIPTION
Our T3AudioPlayer component is responsible for loading an external script from embed.type.audio. As written, it would delete and re-add this script tag whenever you navigated to and from post pages, meaning the external script's initialization would run repeatedly, leaking memory each time. The practical upshot of that was that if you read the site by navigating to post pages and then using the back button, the tab would leak 5MB of memory (as measured by the Chrome devtools memory profiler) for each post you looked at.

Change the script loading so that once the T3 embed script is added to the page, it stays there and is never removed. This fixes the memory leak.

I tested on localhost by using a hack that intercepts the `fetch` function and replaces the localhost domain in type3 API calls with lesswrong.com. I tested that you can land on an SSR'ed post page and then use the player (there is some loading-flicker if the player starts out expanded but that was already there), that you can start on a non-post page, navigate to a post, and use the player, and that you can navigate to multiple posts and the player still works after the first one.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207983482051445) by [Unito](https://www.unito.io)
