### PR TITLE
Add max width to card post meta when there's an image

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -243,6 +243,9 @@ export const styles = (theme: ThemeType) => ({
       minWidth: 100,
     },
   },
+  cardMeta: {
+    maxWidth: `calc(100% - ${CARD_IMG_WIDTH}px)`,
+  },
 });
 
 const cloudinaryBase = `${cloudinaryCloudNameSetting.get()}/image/upload/`;
@@ -447,7 +450,11 @@ const EAPostsItem = ({
                 )}
               />
               <div className={classes.meta}>
-                <EAPostMeta post={post} useCuratedDate={useCuratedDate} />
+                <EAPostMeta
+                  post={post}
+                  useCuratedDate={useCuratedDate}
+                  className={cardView && hasImage ? classes.cardMeta : undefined}
+                />
                 <div className={classNames(
                   classes.secondaryContainer,
                   classes.onlyMobile,


### PR DESCRIPTION
Fixes a bug where the meta text can end up on top of the image in card view for posts with a lot of authors.

Before:
<img width="872" alt="Screenshot 2024-08-06 at 12 29 51" src="https://github.com/user-attachments/assets/83f6ce92-0072-4de0-88a0-9233312112df">

After:
<img width="866" alt="Screenshot 2024-08-06 at 12 31 02" src="https://github.com/user-attachments/assets/eded33ab-3022-4252-8ccf-d448e4cf59c7">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207988864724587) by [Unito](https://www.unito.io)
