### PR TITLE
Tidy up mobile styles for EA survey banner

### DIFF
--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -28,7 +28,10 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down("sm")]: {
       flexDirection: "column",
       gap: "12px",
-      paddingRight: 60,
+      padding: "12px 48px",
+    },
+    [theme.breakpoints.down("xs")]: {
+      paddingTop: 20,
     },
   },
   button: {
@@ -49,6 +52,13 @@ const styles = (theme: ThemeType) => ({
     cursor: "pointer",
     "&:hover": {
       opacity: 0.75,
+    },
+    [theme.breakpoints.down("sm")]: {
+      right: 12,
+      top: 12,
+    },
+    [theme.breakpoints.down("xs")]: {
+      top: 20,
     },
   },
 });

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -26,6 +26,7 @@ const styles = (theme: ThemeType) => ({
     fontWeight: 450,
     color: theme.palette.text.alwaysWhite,
     [theme.breakpoints.down("sm")]: {
+      fontSize: 14,
       flexDirection: "column",
       gap: "12px",
       padding: "12px 48px",
@@ -38,7 +39,6 @@ const styles = (theme: ThemeType) => ({
     background: theme.palette.text.alwaysWhite,
     color: theme.palette.text.alwaysBlack,
     borderRadius: theme.borderRadius.default,
-    fontSize: 15,
     fontWeight: 500,
     padding: "8px 12px",
     cursor: "pointer",


### PR DESCRIPTION
Requested on Slack by Agnes:

<img width="1141" alt="Screenshot 2024-08-07 at 10 31 11" src="https://github.com/user-attachments/assets/73f9ef97-0cc5-48c6-93e2-6f034010d359">

<img width="750" alt="Screenshot 2024-08-07 at 10 31 06" src="https://github.com/user-attachments/assets/d28c7947-3106-4f47-94d2-d4122e69c4a5">

<img width="346" alt="Screenshot 2024-08-07 at 10 30 59" src="https://github.com/user-attachments/assets/7b8373c6-c300-40af-9b6c-ef072d3eae1e">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1207997922248612) by [Unito](https://www.unito.io)
