### PR TITLE
add setting to skip ssr for routes

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, useState, useCallback, useEffect, FC, ReactNode, useMemo} from 'react';
-import { Components, registerComponent } from '../lib/vulcan-lib';
+import { Components, registerComponent, skipSsrForRoute } from '../lib/vulcan-lib';
 import { useUpdate } from '../lib/crud/withUpdate';
 import classNames from 'classnames'
 import { useTheme } from './themes/useTheme';
@@ -399,6 +399,8 @@ const Layout = ({currentUser, children, classes}: {
   // <body> is outside the React tree entirely. An alternative way to do this would be to change
   // overflow properties so that `<body>` isn't scrollable but a `<div>` in here is.)
   const useWhiteBackground = currentRoute?.background === "white";
+
+  const skipRouteComponentSsr = skipSsrForRoute(currentRoute);
   
   const { captureEvent } = useTracking();
   
@@ -579,7 +581,10 @@ const Layout = ({currentUser, children, classes}: {
                     <FlashMessages />
                   </ErrorBoundary>
                   <ErrorBoundary>
-                    {children}
+                    {skipRouteComponentSsr
+                      ? <DeferRender ssr={false}>{children}</DeferRender>
+                      : children
+                    }
                     {!isIncompletePath && isEAForum ? <EAOnboardingFlow/> : <BasicOnboardingFlow/>}
                   </ErrorBoundary>
                   {!currentRoute?.fullscreen && !currentRoute?.noFooter && <Footer />}

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -188,3 +188,5 @@ export const vertexEnabledSetting = new DatabasePublicSetting<boolean>('googleVe
 
 /** Whether to show permalinked (?commentId=...) comments at the top of the page, vs scrolling to show them in context */
 export const commentPermalinkStyleSetting = new DatabasePublicSetting<'top' | 'in-context'>('commentPermalinkStyle', isEAForum ? 'in-context' : 'top');
+
+export const noSsrRoutesSetting = new DatabasePublicSetting<string[]>('noSsrRoutes', []);

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -2,6 +2,7 @@ import * as _ from 'underscore';
 // eslint-disable-next-line no-restricted-imports
 import {matchPath} from 'react-router'
 import type { Request, Response } from 'express';
+import { noSsrRoutesSetting } from '../publicSettings';
 
 export type PingbackDocument = {
   collectionName: CollectionNameString,
@@ -137,4 +138,9 @@ export const userCanAccessRoute = (user?: UsersCurrent | DbUser | null, route?: 
   if (user?.isAdmin) return true
 
   return !route.isAdmin
+}
+
+export const skipSsrForRoute = (route: Route | null) => {
+  const noSsrRoutes = noSsrRoutesSetting.get();
+  return !!route && noSsrRoutes.includes(route.path);
 }


### PR DESCRIPTION
Sometimes we get hit by some bots/scrapers that are annoying to block.  This lets us turn off SSRs for any specified route (by `path`) by updating a database setting.  Known downside: many routes have `HeadTags` inside their route components, which also end up getting deferred (if this is turned on).  That doesn't seem like a huge deal and while I can imagine ways to work around it, they involve a lot of refactoring.

This PR is more of a "proposal" than something I'm strongly convinced needs to be in the codebase.  Maybe there are better ways of accomplishing the same thing.