### PR TITLE
Fix spurious indicators of comments being replies to older versions

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
@@ -33,7 +33,12 @@ function postHadMajorRevision(comment: CommentsList, post: PostsMinimumInfo|Post
   }
   const { major: origMajorPostVer } = extractVersionsFromSemver(comment.postVersion)
   const { major: currentMajorPostVer } = extractVersionsFromSemver((post as PostWithVersion).contents.version)
-  return origMajorPostVer < currentMajorPostVer
+
+  if (origMajorPostVer === 0) {
+    return currentMajorPostVer > 1;
+  } else {
+    return origMajorPostVer < currentMajorPostVer
+  }
 }
 
 const CommentOutdatedWarning = ({comment, post, classes}: {


### PR DESCRIPTION
Ay a migration changed post version numbers from 0.x to 1.x, causing spurious "reply to previous version" notices.


