### PR TITLE
Only show top two tags in LW frontpage post tooltip

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
@@ -196,7 +196,8 @@ const LWPostsPreviewTooltip = ({
   if (post.isEvent && post.location) {
     eventLocation = <div>{post.location}</div>
   }
-  const postCategory: string|null = getPostCategory(post);
+
+  const postTags = post.tags?.slice(0,2)
 
   return <AnalyticsContext pageElementContext={POST_PREVIEW_ELEMENT_CONTEXT}>
       <Card className={classes.root}>
@@ -209,9 +210,7 @@ const LWPostsPreviewTooltip = ({
               { postsList && <span>
                 {post.startTime && <EventTime post={post} />}
                 {eventLocation}
-                {postCategory}
-                {postCategory && (post.tags?.length > 0) && " – "}
-                {post.tags?.map((tag, i) => <span key={tag._id}>{tag.name}{(i !== (post.tags?.length - 1)) ? ",  " : ""}</span>)}
+                {postTags.map((tag, i) => <span key={tag._id}>{tag.name}{(i !== (postTags?.length - 1)) ? ",  " : ""}</span>)}
                 {renderWordCount && <span>{" "}<span className={classes.wordCount}>({wordCount} words)</span></span>}
               </span>}
               { !postsList && <>


### PR DESCRIPTION
The tags in the frontpage post tooltip feel more overwhelming than helpful. I experimented with getting rid of all of them, and ended up feeling like it was better to leave the top-two, since they probably do help you orient to "what type of of post is this?", and without them, the wordcount felt awkward/orphaned (and I've heard people talk about using the wordcount part).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208078980783052) by [Unito](https://www.unito.io)
