### PR TITLE
Show readtime and comments on LW Post Page mobile

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -296,7 +296,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     Map: MapIcon,
     Pencil: PencilIcon,
     PencilSquare: PencilSquareIcon,
-    Comment: MuiCommentIcon,
+    Comment: CommentIcon,
     CommentFilled: CommentFilledIcon,
     ChatBubbleLeftRight: ChatBubbleLeftRightIcon,
     ChatBubbleLeftRightFilled: MuiForumIcon,

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -144,7 +144,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
       </AnalyticsContext>
       <div>
         {!post.shortform && <span className={classes.topRight}>
-          <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
+          <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer}/>
         </span>}
         {post && <span className={classes.audioPlayerWrapper}>
           <PostsAudioPlayerWrapper showEmbeddedPlayer={!!showEmbeddedPlayer} post={post}/>

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -28,8 +28,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   authorInfo: {
     maxWidth: "calc(100% - 60px)",
-    [theme.breakpoints.down('sm')]: {
-      maxWidth: "calc(100% - 60px)",
+    [theme.breakpoints.down('xs')]: {
+      width: "100%",
+      marginBottom: 8,
       fontSize: theme.typography.body2.fontSize,
     },
   },
@@ -83,6 +84,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   mobileHeaderVote: {
     textAlign: 'center',
     fontSize: 42,
+    marginTop: -55,
+    marginLeft: 12,
     [theme.breakpoints.up("sm")]: {
       display: 'none'
     }
@@ -102,18 +105,23 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginRight: 12,
     display: "flex",
     opacity: 0.75
+  },
+  readTime: {
+    marginRight: 20,
   }
 }); 
 
 /// LWPostsPageHeader: The metadata block at the top of a post page, with
 /// title, author, voting, an actions menu, etc.
-const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, classes}: {
+const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, classes, dialogueResponses, answerCount}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsListWithVotes,
   showEmbeddedPlayer?: boolean,
   toggleEmbeddedPlayer?: () => void,
-  classes: ClassesType<typeof styles>
+  classes: ClassesType<typeof styles>,
+  dialogueResponses: CommentsList[],
+  answerCount?: number,
 }) => {
-  const {PostsPageTitle, PostsAuthors, LWTooltip, PostsPageDate, CrosspostHeaderIcon, PostsGroupDetails, PostsTopSequencesNav, PostsPageEventData, AddToCalendarButton, GroupLinks, LWPostsPageHeaderTopRight, PostsAudioPlayerWrapper, PostsVote, AudioToggle, PostActionsButton } = Components;
+  const {PostsPageTitle, PostsAuthors, LWTooltip, PostsPageDate, CrosspostHeaderIcon, PostsGroupDetails, PostsTopSequencesNav, PostsPageEventData, AddToCalendarButton, GroupLinks, LWPostsPageHeaderTopRight, PostsAudioPlayerWrapper, PostsVote, AudioToggle, PostActionsButton, ReadTime, LWCommentCount } = Components;
   // eslint-disable-next-line react-hooks/exhaustive-deps
 
   const rssFeedSource = ('feed' in post) ? post.feed : null;
@@ -136,7 +144,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
       </AnalyticsContext>
       <div>
         {!post.shortform && <span className={classes.topRight}>
-          <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer}/>
+          <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
         </span>}
         {post && <span className={classes.audioPlayerWrapper}>
           <PostsAudioPlayerWrapper showEmbeddedPlayer={!!showEmbeddedPlayer} post={post}/>
@@ -161,6 +169,10 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
             {post.isEvent && <GroupLinks document={post} noMargin />}
             <AddToCalendarButton post={post} label="Add to calendar" hideTooltip />
             <div className={classes.mobileButtons}>
+              <div className={classes.readTime}>
+                <ReadTime post={post} dialogueResponses={dialogueResponses} />
+              </div>
+              <LWCommentCount answerCount={answerCount} commentCount={post.commentCount} label={false} />
               <div className={classes.audioToggle}>
                 <AudioToggle post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
               </div>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -461,7 +461,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
   // note: these are from a debate feature that was deprecated in favor of collabEditorDialogue.
   // we're leaving it for now to keep supporting the few debates that were made with it, but
   // may want to migrate them at some point.
-  const { results: debateResponses, refetch: refetchDebateResponses } = useMulti({
+  const { results: debateResponses=[], refetch: refetchDebateResponses } = useMulti({
     terms: {
       view: 'debateResponses',
       postId: post._id,
@@ -495,7 +495,7 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
     skip: !post.debate || !fullPost
   });
 
-  const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPagePostFooter, PostBodyPrefix,
+const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPagePostFooter, PostBodyPrefix,
     PostCoauthorRequest, CommentPermalink, ToCColumn, WelcomeBox, TableOfContents, RSVPs,
     CloudinaryImage2, ContentStyles, PostBody, CommentOnSelectionContentWrapper,
     PermanentRedirect, DebateBody, PostsPageRecommendationsList, PostSideRecommendations,
@@ -690,6 +690,8 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
           {!showSplashPageHeader && isBookUI && <LWPostsPageHeader
             post={post}
             showEmbeddedPlayer={showEmbeddedPlayer}
+            dialogueResponses={debateResponses}
+            answerCount={answerCount}
             toggleEmbeddedPlayer={toggleEmbeddedPlayer}/>}
           {!showSplashPageHeader && !isBookUI && <PostsPagePostHeader
             post={post}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -77,12 +77,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
     "@media print": { display: "none" },
   },
-  wordCount: {
-    fontWeight: isFriendlyUI ? 450 : undefined,
-    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
-    cursor: 'default',
-    "@media print": { display: "none" },
-  },
   actions: {
     color: isFriendlyUI ? undefined : theme.palette.grey[500],
     "&:hover": {
@@ -170,7 +164,7 @@ export function getHostname(url: string): string {
   return parser.hostname;
 }
 
-const CommentsLink: FC<{
+export const CommentsLink: FC<{
   anchor: string,
   children: React.ReactNode,
   className?: string,
@@ -209,7 +203,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const { PostsPageTitle, PostsAuthors, LWTooltip, PostsPageDate, CrosspostHeaderIcon,
     PostActionsButton, PostsVote, PostsGroupDetails, PostsTopSequencesNav,
     PostsPageEventData, FooterTagList, AddToCalendarButton, BookmarkButton, 
-    ForumIcon, GroupLinks, SharePostButton, AudioToggle } = Components;
+    ForumIcon, GroupLinks, SharePostButton, AudioToggle, ReadTime } = Components;
 
   const rssFeedSource = ('feed' in post) ? post.feed : null;
   const feedLinkDescription = rssFeedSource?.url && getHostname(rssFeedSource.url)
@@ -219,44 +213,12 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const crosspostNode = post.fmCrosspost?.isCrosspost && !post.fmCrosspost.hostedHere &&
     <CrosspostHeaderIcon post={post} />
 
-  const wordCount = useMemo(() => {
-    if (!post.debate || dialogueResponses.length === 0) {
-      return post.contents?.wordCount || 0;
-    }
-
-    return dialogueResponses.reduce((wordCount, response) => {
-      wordCount += response.contents?.wordCount ?? 0;
-      return wordCount;
-    }, 0);
-  }, [post, dialogueResponses]);
-
-  /**
-   * It doesn't make a ton of sense to fetch all the debate response comments in the resolver field, since we:
-   * 1. already have them here
-   * 2. need them to compute the word count in the debate case as well
-   */
-  const readTime = useMemo(() => {
-    if (!post.debate || dialogueResponses.length === 0) {
-      return post.readTimeMinutes ?? 1;
-    }
-
-    return Math.max(1, Math.round(wordCount / 250));
-  }, [post, dialogueResponses, wordCount]);
-
   const {
     answerCount,
     commentCount,
   } = useMemo(() => getResponseCounts({ post, answers }), [post, answers]);
 
   const minimalSecondaryInfo = post.isEvent || (isFriendlyUI && post.shortform);
-
-  const readingTimeNode = minimalSecondaryInfo
-    ? null
-    : (
-      <LWTooltip title={`${wordCount} words`}>
-        <span className={classes.wordCount}>{readTime} min read</span>
-      </LWTooltip>
-    );
 
   const answersNode = !post.question || minimalSecondaryInfo
     ? null
@@ -284,7 +246,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const secondaryInfoNode = <div className={classes.secondaryInfo}>
       <div className={classes.secondaryInfoLeft}>
         {!minimalSecondaryInfo && <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />}
-        {readingTimeNode}
+        {minimalSecondaryInfo && <ReadTime post={post} dialogueResponses={dialogueResponses} />}
         <AudioToggle post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
         {post.isEvent && <GroupLinks document={post} noMargin />}
         {answersNode}

--- a/packages/lesswrong/components/posts/PostsPage/ReadTime.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ReadTime.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo } from 'react';
+import { registerComponent } from '../../../lib/vulcan-lib';
+import { isFriendlyUI } from '@/themes/forumTheme';
+import { Components } from '@/lib/vulcan-lib/components';
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    fontWeight: isFriendlyUI ? 450 : undefined,
+    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    cursor: 'default',
+    "@media print": { display: "none" },
+  },
+});
+
+export const ReadTime = ({classes, post, dialogueResponses}: {
+  classes: ClassesType<typeof styles>,
+  post: PostsList,
+  dialogueResponses: CommentsList[],
+}) => {
+  const { LWTooltip } = Components
+  const wordCount = useMemo(() => {
+    if (!post.debate || dialogueResponses.length === 0) {
+      return post.contents?.wordCount || 0;
+    }
+
+    return dialogueResponses.reduce((wordCount, response) => {
+      wordCount += response.contents?.wordCount ?? 0;
+      return wordCount;
+    }, 0);
+  }, [post, dialogueResponses]);
+
+  /**
+   * It doesn't make a ton of sense to fetch all the debate response comments in the resolver field, since we:
+   * 1. already have them here
+   * 2. need them to compute the word count in the debate case as well
+   */
+  const readTime = useMemo(() => {
+    if (!post.debate || dialogueResponses.length === 0) {
+      return post.readTimeMinutes ?? 1;
+    }
+
+    return Math.max(1, Math.round(wordCount / 250));
+  }, [post, dialogueResponses, wordCount]);
+
+  return <LWTooltip title={`${wordCount} words`}>
+        <span className={classes.root}>{readTime} min read</span>
+      </LWTooltip>
+}
+
+const ReadTimeComponent = registerComponent('ReadTime', ReadTime, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ReadTime: typeof ReadTimeComponent
+  }
+}

--- a/packages/lesswrong/components/posts/PostsPage/index.ts
+++ b/packages/lesswrong/components/posts/PostsPage/index.ts
@@ -31,3 +31,4 @@ importComponent("RSVPForm", () => require('./RSVPForm'));
 importComponent("WelcomeBox", () => require('./WelcomeBox'));
 importComponent("CrosspostHeaderIcon", () => require('./CrosspostHeaderIcon'));
 importComponent("CollapsedFootnotes", () => require('./CollapsedFootnotes'));
+importComponent("ReadTime", () => require('./ReadTime'));

--- a/packages/lesswrong/components/posts/TableOfContents/LWCommentCount.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/LWCommentCount.tsx
@@ -3,30 +3,18 @@ import { registerComponent } from '../../../lib/vulcan-lib';
 import { Components } from '@/lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { FIXED_TOC_COMMENT_COUNT_HEIGHT, HOVER_CLASSNAME } from './MultiToCLayout';
+import { CommentsLink } from '../PostsPage/PostsPagePostHeader';
 
 const styles = (theme: ThemeType) => ({
   root: {
-    position: 'fixed',
-    paddingLeft: 12,
-    paddingTop: 12,
-    paddingBottom: 20,
-    height: FIXED_TOC_COMMENT_COUNT_HEIGHT,
-    bottom: 0,
-    left: 0,
-    width: 240,
-    backgroundColor: theme.palette.background.pageActiveAreaBackground,
-    zIndex: 1000,
-    [theme.breakpoints.down('sm')]: {
-      display: 'none',
-    },
-    '&:hover $commentsLabel': {
-      opacity: 1
-    }
+    display: "flex",
+    alignItems: "center",
+    color: theme.palette.text.dim3,
   },
   comments: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
-    color: theme.palette.link.tocLink,
+    color: theme.palette.grey[500],
     display: "flex",
     alignItems: "center",
     marginRight: 16,
@@ -34,7 +22,7 @@ const styles = (theme: ThemeType) => ({
   commentsIcon: {
     fontSize: 20,
     marginRight: 8,
-    color: theme.palette.grey[400],
+    color: theme.palette.grey[500],
     position: 'relative',
     top: 1
   },
@@ -47,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     fontFamily: "ETBookBold",
     fontWeight: 900,
     marginRight: 7,
-    color: theme.palette.grey[400]
+    color: theme.palette.text.dim3,
   },
   commentsLabel: {
     marginLeft: 6
@@ -61,37 +49,14 @@ const styles = (theme: ThemeType) => ({
   }
 });
 
-const CommentsLink: FC<{
-  anchor: string,
-  children: React.ReactNode,
-  className?: string,
-}> = ({anchor, children, className}) => {
-  const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    const elem = document.querySelector("#comments");
-    if (elem) {
-      // Match the scroll behaviour from TableOfContentsList
-      window.scrollTo({
-        top: window.scrollY + elem.getBoundingClientRect().top,
-        behavior: "smooth",
-      });
-    } 
-  }
-  return (
-    <a className={className} href={anchor} onClick={onClick}>
-      {children}
-    </a>
-  );
-}
-
-export const FixedTableOfContentsCommentCount = ({classes, answerCount, commentCount}: {
+export const LWCommentCount = ({classes, answerCount, commentCount, label=true}: {
   classes: ClassesType<typeof styles>,
   answerCount?: number,
   commentCount?: number,
+  label?: boolean,
 }) => {
-  const { Row, ForumIcon } = Components;
+  const { ForumIcon } = Components;
   return <div className={classes.root}>
-      <Row justifyContent="flex-start">
         {typeof answerCount === 'number' && <CommentsLink anchor="#answers" className={classes.comments}>
           <div className={classes.answerIcon}>A</div>
           {answerCount}
@@ -99,16 +64,15 @@ export const FixedTableOfContentsCommentCount = ({classes, answerCount, commentC
         <CommentsLink anchor="#comments" className={classNames(classes.comments, classes.wideClickTarget)}>
           <ForumIcon icon="Comment" className={classes.commentsIcon} />
           {commentCount}
-          {typeof answerCount !== 'number'  && <span className={classNames(classes.commentsLabel, HOVER_CLASSNAME, classes.rowOpacity)}>Comments</span>}
+          {typeof answerCount !== 'number' && label && <span className={classNames(classes.commentsLabel, HOVER_CLASSNAME, classes.rowOpacity)}>Comments</span>}
         </CommentsLink>
-      </Row>
-    </div>
+      </div>
 }
 
-const FixedTableOfContentsCommentCountComponent = registerComponent('FixedTableOfContentsCommentCount', FixedTableOfContentsCommentCount, {styles});
+const LWCommentCountComponent = registerComponent('LWCommentCount', LWCommentCount, {styles});
 
 declare global {
   interface ComponentTypes {
-    FixedTableOfContentsCommentCount: typeof FixedTableOfContentsCommentCountComponent
+    LWCommentCount: typeof LWCommentCountComponent
   }
 }

--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -138,7 +138,24 @@ const styles = (theme: ThemeType) => ({
   hideTocButtonHidden: {
     display: "none",
   },
-  commentCount: {}
+  commentCount: {
+    position: 'fixed',
+    paddingLeft: 12,
+    paddingTop: 12,
+    paddingBottom: 20,
+    height: FIXED_TOC_COMMENT_COUNT_HEIGHT,
+    bottom: 0,
+    left: 0,
+    width: 240,
+    backgroundColor: theme.palette.background.pageActiveAreaBackground,
+    zIndex: 1000,
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+    '&:hover $commentsLabel': {
+      opacity: 1
+    }
+  }
 });
 
 export type ToCLayoutSegment = {
@@ -156,7 +173,7 @@ const MultiToCLayout = ({segments, classes, tocRowMap = [], showSplashPageHeader
   answerCount?: number,
   commentCount?: number,
 }) => {
-  const { FixedTableOfContentsCommentCount } = Components;
+  const { LWCommentCount } = Components;
   const tocVisible = true;
   const gridTemplateAreas = segments
     .map((_segment,i) => `"... toc${tocRowMap[i] ?? i} gap1 content${i} gap2 rhs${i} gap3 ..."`)
@@ -188,7 +205,7 @@ const MultiToCLayout = ({segments, classes, tocRowMap = [], showSplashPageHeader
       </React.Fragment>)}
     </div>
     <div className={classes.commentCount}>
-      <FixedTableOfContentsCommentCount
+      <LWCommentCount
         answerCount={answerCount}
         commentCount={commentCount}
       />

--- a/packages/lesswrong/components/posts/TableOfContents/index.ts
+++ b/packages/lesswrong/components/posts/TableOfContents/index.ts
@@ -9,4 +9,4 @@ importComponent("AnswerTocRow", () => require('./AnswerTocRow'));
 importComponent("ToCColumn", () => require('./ToCColumn'));
 importComponent("MultiToCLayout", () => require('./MultiToCLayout'));
 importComponent("DynamicTableOfContents", () => require('./DynamicTableOfContents'));
-importComponent("FixedTableOfContentsCommentCount", () => require('./FixedTableOfContentsCommentCount'));
+importComponent("LWCommentCount", () => require('./LWCommentCount'));


### PR DESCRIPTION
This reverts commit 630b9b177f3949a8bb1d5ba130f2a21e52cae572 (which was itself a revert of me accidentally merging this feature into master, then reverted the commit. Now to actually merge it in a PR it looks like I need to make a revert-of-the-revert)

This adds a "read time" and "comments" button to the mobile version of the new LW post page, because the Table-of-contents version of those features don't exist on mobile.

<img width="588" alt="image" src="https://github.com/user-attachments/assets/1a58f51c-04e0-4204-a9f5-a178fda6a9af">



I felt like the solid-grey comment icon looked too intense next to the audio icon, so this also switches the comment icon to an outlined version. I think this looked reasonable in the bottom-left, so it also changes it there for consistency.



<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4bbc1bbf-77b1-4fb2-92ab-61e237341813">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208079645799069) by [Unito](https://www.unito.io)
