### PR TITLE
[LW] Remove bottom tags, add + to top tags

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -54,7 +54,7 @@ export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, 
   return <div className={classes.root}>
       <AnalyticsContext pageSectionContext="tagHeader">
         <div className={classes.tagList}>
-          <FooterTagList post={post} hideScore useAltAddTagButton hideAddTag={true} align="right" noBackground neverCoreStyling />
+          <FooterTagList post={post} hideScore useAltAddTagButton align="right" noBackground neverCoreStyling />
         </div>
       </AnalyticsContext>
       <div className={classes.audioToggle}>

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -54,7 +54,7 @@ export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, 
   return <div className={classes.root}>
       <AnalyticsContext pageSectionContext="tagHeader">
         <div className={classes.tagList}>
-          <FooterTagList post={post} hideScore useAltAddTagButton align="right" noBackground neverCoreStyling />
+          <FooterTagList post={post} hideScore useAltAddTagButton align="right" noBackground neverCoreStyling tagRight={false} />
         </div>
       </AnalyticsContext>
       <div className={classes.audioToggle}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -7,6 +7,7 @@ import { MAX_COLUMN_WIDTH } from './PostsPage';
 import { isLW, isLWorAF } from '../../../lib/instanceSettings';
 import { getVotingSystemByName } from '../../../lib/voting/votingSystems';
 import { isFriendlyUI } from '../../../themes/forumTheme';
+import classNames from 'classnames';
 
 
 
@@ -62,10 +63,10 @@ const styles = (theme: ThemeType): JssStyles => ({
       maxWidth: MAX_COLUMN_WIDTH
     }
   },
-  footerTagList: {
-    marginTop: 16,
-    marginBottom: 66,
-  },
+  lwVote: {
+    marginTop: 66,
+    marginBottom: 70,
+  }
 });
 
 const PostsPagePostFooter = ({post, sequenceId, classes}: {
@@ -82,17 +83,10 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   const isEAEmojis = votingSystemName === "eaEmojis";
 
   return <>
-    {isLWorAF && !post.shortform && !post.isEvent &&
-      <AnalyticsContext pageSectionContext="tagFooter">
-        <div className={classes.footerTagList}>
-          <FooterTagList post={post}/>
-        </div>
-      </AnalyticsContext>
-    }
     {!post.shortform && (isLW || isEAEmojis) &&
       <>
         <div className={classes.footerSection}>
-          <div className={classes.voteBottom}>
+          <div className={classNames(classes.voteBottom, isLWorAF && classes.lwVote)}>
             <AnalyticsContext pageSectionContext="lowerVoteButton">
               <PostsVote post={post} useHorizontalLayout={isFriendlyUI} isFooter />
             </AnalyticsContext>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -90,15 +90,15 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   const isEAEmojis = votingSystemName === "eaEmojis";
 
   return <>
+    {isLWorAF && !post.shortform && !post.isEvent &&
+      <AnalyticsContext pageSectionContext="tagFooter">
+        <div className={classes.footerTagList}>
+          <FooterTagList post={post}/>
+        </div>
+      </AnalyticsContext>
+    }
     {!post.shortform && (isLW || isEAEmojis) &&
       <>
-        {isLWorAF && !post.shortform && !post.isEvent &&
-          <AnalyticsContext pageSectionContext="tagFooter">
-            <div className={classes.footerTagList}>
-              <FooterTagList post={post}/>
-            </div>
-          </AnalyticsContext>
-        }
         <div className={classes.footerSection}>
           <div className={classNames(classes.voteBottom, isLWorAF && classes.lwVote)}>
             <AnalyticsContext pageSectionContext="lowerVoteButton">

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -66,6 +66,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   lwVote: {
     marginTop: 66,
     marginBottom: 70,
+  },
+  footerTagList: {
+    marginTop: 16,
+    marginBottom: 66,
+    [theme.breakpoints.up('sm')]: {
+      display: 'none',
+    }
   }
 });
 
@@ -85,6 +92,13 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   return <>
     {!post.shortform && (isLW || isEAEmojis) &&
       <>
+        {isLWorAF && !post.shortform && !post.isEvent &&
+          <AnalyticsContext pageSectionContext="tagFooter">
+            <div className={classes.footerTagList}>
+              <FooterTagList post={post}/>
+            </div>
+          </AnalyticsContext>
+        }
         <div className={classes.footerSection}>
           <div className={classNames(classes.voteBottom, isLWorAF && classes.lwVote)}>
             <AnalyticsContext pageSectionContext="lowerVoteButton">

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../common/withUser';
 import { userCanUseTags } from '../../lib/betas';
 import { useTracking } from "../../lib/analyticsEvents";
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
-import { preferredHeadingCase } from '../../themes/forumTheme';
+import { isBookUI, preferredHeadingCase } from '../../themes/forumTheme';
 import { PopperPlacementType } from '@material-ui/core/Popper';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -32,48 +32,53 @@ const AddTagButton = ({onTagSelected, tooltipPlacement = "bottom-start", isVotin
   const anchorEl = useRef<HTMLAnchorElement|null>(null);
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking()
-  const { LWPopper, AddTag, LWClickAwayListener } = Components
+  const { LWPopper, AddTag, LWClickAwayListener, LWTooltip } = Components
 
   if (!userCanUseTags(currentUser)) {
     return null;
   }
 
-  return <a
-    onClick={() => {
-      setIsOpen(true);
-      captureEvent("addTagClicked")
-    }}
-    className={classes.addTagButton}
-    ref={anchorEl}
-  >
-    {children
-      ? children
-      : <span className={classes.defaultButton}>
-        + {preferredHeadingCase(`Add ${taggingNameCapitalSetting.get()}`)}
-      </span>
-    }
-
-    <LWPopper
-      open={isOpen}
-      anchorEl={anchorEl.current}
-      placement={tooltipPlacement}
-      allowOverflow
+  const button = <a onClick={() => {
+        setIsOpen(true);
+        captureEvent("addTagClicked")
+      }}
+      className={classes.addTagButton}
+      ref={anchorEl}
     >
-      <LWClickAwayListener
-        onClickAway={() => setIsOpen(false)}
-      >
-        <Paper>
-          <AddTag
-            onTagSelected={({tagId, tagName}: {tagId: string, tagName: string}) => {
-              setIsOpen(false);
-              onTagSelected({tagId, tagName});
-            }}
-            isVotingContext={isVotingContext}
-          />
-        </Paper>
-      </LWClickAwayListener>
-    </LWPopper>
-  </a>;
+      {children
+        ? children
+        : <span className={classes.defaultButton}>
+          + {preferredHeadingCase(`Add ${taggingNameCapitalSetting.get()}`)}
+        </span>
+      }
+        <LWPopper
+          open={isOpen}
+          anchorEl={anchorEl.current}
+          placement={tooltipPlacement}
+          allowOverflow
+        >
+          <LWClickAwayListener
+            onClickAway={() => setIsOpen(false)}
+          >
+            <Paper>
+              <AddTag
+                onTagSelected={({tagId, tagName}: {tagId: string, tagName: string}) => {
+                  setIsOpen(false);
+                  onTagSelected({tagId, tagName});
+                }}
+                isVotingContext={isVotingContext}
+              />
+            </Paper>
+          </LWClickAwayListener>
+        </LWPopper>
+    </a>
+  
+  if (isBookUI) {
+    return <LWTooltip title="Add a tag">
+      {button}
+    </LWTooltip>
+  }
+  return button;
 }
 
 const AddTagButtonComponent = registerComponent("AddTagButton", AddTagButton, {styles});

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -132,7 +132,8 @@ const FooterTagList = ({
   classes,
   align = "left",
   noBackground = false,
-  neverCoreStyling = false
+  neverCoreStyling = false,
+  tagRight = true,
 }: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
   hideScore?: boolean,
@@ -150,7 +151,8 @@ const FooterTagList = ({
   align?: "left" | "right",
   classes: ClassesType<typeof styles>,
   noBackground?: boolean,
-  neverCoreStyling?: boolean
+  neverCoreStyling?: boolean,
+  tagRight?: boolean,
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
   const rootRef = useRef<HTMLSpanElement>(null);
@@ -329,7 +331,7 @@ const FooterTagList = ({
 
   const innerContent = (
     <>
-      {!isFriendlyUI && currentUser && !hideAddTag && addTagButton}
+      {!tagRight && currentUser && !hideAddTag && addTagButton}
       {showCoreTags && (
         <div>
           <CoreTagsChecklist existingTagIds={tagIds} onTagSelected={onTagSelected} />
@@ -356,7 +358,7 @@ const FooterTagList = ({
       {annualReviewMarketInfo && highlightMarket(annualReviewMarketInfo) && (
         <PostsAnnualReviewMarketTag post={post} annualReviewMarketInfo={annualReviewMarketInfo} />
       )}
-      {isFriendlyUI && currentUser && !hideAddTag && addTagButton}
+      {tagRight && currentUser && !hideAddTag && addTagButton}
       {isAwaiting && <Loading />}
     </>
   );

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -323,8 +323,13 @@ const FooterTagList = ({
 
   const tooltipPlacement = useAltAddTagButton ? "bottom-end" : undefined;
 
+  const addTagButton = <AddTagButton onTagSelected={onTagSelected} isVotingContext tooltipPlacement={tooltipPlacement}>
+    {useAltAddTagButton && <span className={classNames(classes.altAddTagButton, noBackground && classes.noBackground)}>+</span>}
+  </AddTagButton>
+
   const innerContent = (
     <>
+      {!isFriendlyUI && currentUser && !hideAddTag && addTagButton}
       {showCoreTags && (
         <div>
           <CoreTagsChecklist existingTagIds={tagIds} onTagSelected={onTagSelected} />
@@ -351,11 +356,7 @@ const FooterTagList = ({
       {annualReviewMarketInfo && highlightMarket(annualReviewMarketInfo) && (
         <PostsAnnualReviewMarketTag post={post} annualReviewMarketInfo={annualReviewMarketInfo} />
       )}
-      {currentUser && !hideAddTag && (
-        <AddTagButton onTagSelected={onTagSelected} isVotingContext tooltipPlacement={tooltipPlacement}>
-          {useAltAddTagButton && <span className={classNames(classes.altAddTagButton, noBackground && classes.noBackground)}>+</span>}
-        </AddTagButton>
-      )}
+      {isFriendlyUI && currentUser && !hideAddTag && addTagButton}
       {isAwaiting && <Loading />}
     </>
   );


### PR DESCRIPTION
This removes tags from the bottom of LW posts, except for on mobile. It adds an "Add Tag" button in the LW Top Right area. It adds a tooltip to the Add Tag button for LW users.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5ef603fb-b204-4948-88eb-7b52b7ee48e0">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208080020772499) by [Unito](https://www.unito.io)
