### PR TITLE
Add triple-dot back to shortform posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -135,9 +135,9 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
         </div>}
       </AnalyticsContext>
       <div>
-        {!post.shortform && <span className={classes.topRight}>
+        <span className={classes.topRight}>
           <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer}/>
-        </span>}
+        </span>
         {post && <span className={classes.audioPlayerWrapper}>
           <PostsAudioPlayerWrapper showEmbeddedPlayer={!!showEmbeddedPlayer} post={post}/>
         </span>}

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { AnalyticsContext } from '@/lib/analyticsEvents';
 import { getVotingSystemByName } from '@/lib/voting/votingSystems';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -25,6 +26,10 @@ const styles = (theme: ThemeType) => ({
     display: 'flex',
     alignItems: 'center',
     opacity: 0.3
+  },
+  postActionsButtonShortform: {
+    marginTop: 12,
+    marginRight: 8
   },
   tagList: {
     marginTop: 12,
@@ -52,18 +57,18 @@ export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, 
   const votingSystem = getVotingSystemByName(post.votingSystem ?? 'default');
 
   return <div className={classes.root}>
-      <AnalyticsContext pageSectionContext="tagHeader">
+      {!post.shortform && <AnalyticsContext pageSectionContext="tagHeader">
         <div className={classes.tagList}>
           <FooterTagList post={post} hideScore useAltAddTagButton hideAddTag={true} align="right" noBackground neverCoreStyling />
         </div>
-      </AnalyticsContext>
-      <div className={classes.audioToggle}>
+      </AnalyticsContext>}
+      {!post.shortform && <div className={classes.audioToggle}>
         <AudioToggle post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
-      </div>
-      <div className={classes.vote}>
+      </div>}
+      {!post.shortform && <div className={classes.vote}>
         <LWPostsPageTopHeaderVote post={post} votingSystem={votingSystem} /> 
-      </div>
-      <PostActionsButton post={post} className={classes.postActionsButton} flip />
+      </div>}
+      <PostActionsButton post={post} className={classNames(classes.postActionsButton, post.shortform && classes.postActionsButtonShortform)} flip />
   </div>;
 }
 


### PR DESCRIPTION
Triple-dot menu for shortform posts was accidentally removed during the #9556 PR. This adds it back.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/df8fc458-6335-46f7-a538-e043f0568c78">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208082205791529) by [Unito](https://www.unito.io)
