### PR TITLE
remove welcome box

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -705,6 +705,8 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
     </AnalyticsContext>
   </>;
 
+
+// The new post page made the UI look broken. It only gets ~20 clicks per day, so we commented it out until after the sidenotes branch is merged in. (—Ben & Ray)
   const welcomeBox = (
     <DeferRender ssr={false}>
       <WelcomeBox />
@@ -712,7 +714,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
   );
 
   const rightColumnChildren = (welcomeBox || (showRecommendations && recommendationsPosition === "right")) && <>
-    {welcomeBox}
+    {/* {welcomeBox} */}
     {showRecommendations && recommendationsPosition === "right" && fullPost && <PostSideRecommendations post={fullPost} />}
   </>;
 


### PR DESCRIPTION
The welcome box UI on the new post page is kind of jank-looking. We attempted to fix but it interfaces with new sidenotes work. We checked analytics and it only gets 20 clicks per day, so for now we are just removing it (commented out), and may revisit after sidenotes branch is merged back in.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208096848285544) by [Unito](https://www.unito.io)
