### PR TITLE
realigned text, and now appears conditionally

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -531,13 +531,9 @@ const LWHomePosts = ({ children, classes }: {
     [classes.hideOnMobile]: !mobileSettingsVisible,
   });
 
-  // const hasSetAnyFilters = filterSettings.tags.length !== 6 || filterSettings.tags.some(setting => setting.filterMode !== "Default")
-  
+  // TODO: Make this also work for logged out users
   const currentFilterSettings = currentUser?.frontpageFilterSettings
   const hasSetAnyFilters = currentFilterSettings === undefined ? false : true;
-  
-  // If they're different, then the user has made a change
-
 
   const filterSettingsElement = (
     <AnalyticsContext pageSectionContext="tagFilterSettings">

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -27,7 +27,6 @@ import { userHasSubscribeTabFeed } from '@/lib/betas';
 import { useSingle } from '@/lib/crud/withSingle';
 import { isServer } from '@/lib/executionEnvironment';
 import isEqual from 'lodash/isEqual';
-import { getDefaultFilterSettings } from '../../lib/filterSettings.ts';
 
 // Key is the algorithm/tab name
 type RecombeeCookieSettings = [string, RecombeeConfiguration][];

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -27,6 +27,7 @@ import { userHasSubscribeTabFeed } from '@/lib/betas';
 import { useSingle } from '@/lib/crud/withSingle';
 import { isServer } from '@/lib/executionEnvironment';
 import isEqual from 'lodash/isEqual';
+import { getDefaultFilterSettings } from '../../lib/filterSettings.ts';
 
 // Key is the algorithm/tab name
 type RecombeeCookieSettings = [string, RecombeeConfiguration][];
@@ -530,7 +531,13 @@ const LWHomePosts = ({ children, classes }: {
     [classes.hideOnMobile]: !mobileSettingsVisible,
   });
 
-  const hasSetAnyFilters = filterSettings.tags.length !== 6 || filterSettings.tags.some(setting => setting.filterMode !== "Default")
+  // const hasSetAnyFilters = filterSettings.tags.length !== 6 || filterSettings.tags.some(setting => setting.filterMode !== "Default")
+  
+  const currentFilterSettings = currentUser?.frontpageFilterSettings
+  const hasSetAnyFilters = currentFilterSettings === undefined ? false : true;
+  
+  // If they're different, then the user has made a change
+
 
   const filterSettingsElement = (
     <AnalyticsContext pageSectionContext="tagFilterSettings">

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -122,10 +122,11 @@ const styles = (theme: ThemeType) => ({
     }
   },
   enrichedTagFilterNotice: {
-    ...theme.typography.italic,
     ...theme.typography.commentStyle,
     color: theme.palette.text.slightlyDim2,
-    marginBottom: 5,
+    marginBottom: 10,
+    marginTop: 10,
+    marginLeft: 3,
   },
 });
 
@@ -529,6 +530,8 @@ const LWHomePosts = ({ children, classes }: {
     [classes.hideOnMobile]: !mobileSettingsVisible,
   });
 
+  const hasSetAnyFilters = filterSettings.tags.length !== 6 || filterSettings.tags.some(setting => setting.filterMode !== "Default")
+
   const filterSettingsElement = (
     <AnalyticsContext pageSectionContext="tagFilterSettings">
       <div className={settingsVisibileClassName}>
@@ -539,9 +542,10 @@ const LWHomePosts = ({ children, classes }: {
           removeTagFilter={removeTagFilter} 
           flexWrapEndGrow={false}
         />
-        {selectedTab === 'recombee-hybrid' && <div className={classes.enrichedTagFilterNotice}>
-          Your settings only affect the "latest" posts on the Enriched tab.
+        {selectedTab === 'recombee-hybrid' && hasSetAnyFilters && <div className={classes.enrichedTagFilterNotice}>
+          In the Enriched tab, filters apply only to "Latest" posts, not "Recommended" posts.
         </div>}
+  
       </div>
     </AnalyticsContext>
   );


### PR DESCRIPTION

https://github.com/user-attachments/assets/77fb9f8d-f8e0-4313-bbed-d98786a7704b

I have realigned the text and made it appear conditional on any tag filters having actually been used.

See the video to see what it looks like (ignore the misaligned 'enriched' tab which is not part of the code I shipped).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208097802366568) by [Unito](https://www.unito.io)
