### PR TITLE
Prevent estrella from running tsc as a lint step when deployed in production

### DIFF
--- a/build.js
+++ b/build.js
@@ -110,6 +110,7 @@ build({
   banner: {
     js: clientBundleBanner,
   },
+  tslint: !isProduction,
   run: false,
   onStart: (config, changedFiles, ctx) => {
     setClientRebuildInProgress(true);
@@ -166,6 +167,7 @@ build({
   sourcemap: true,
   sourcesContent: true,
   minify: false,
+  tslint: !isProduction,
   run: cliopts.run && serverCli,
   onStart: (config, changedFiles, ctx) => {
     setServerRebuildInProgress(true);


### PR DESCRIPTION
According to @jimrandomh's investigation, this seemed to be causing a lot of memory pressure, at times knocking instances over when they were in the process of standing up.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208107813901143) by [Unito](https://www.unito.io)
