### PR TITLE
Don't crash when sorting drafts by word count

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -790,11 +790,13 @@ Posts.addView("drafts", (terms: PostsViewTerms) => {
   
   switch (terms.sortDraftsBy) {
     case 'wordCountAscending': {
-      query.options.sort = {"contents.wordCount": 1, modifiedAt: -1, createdAt: -1}
+      // FIXME: This should have "contents.wordCount": 1, but that crashes
+      query.options.sort = {modifiedAt: -1, createdAt: -1}
       break
     }
     case 'wordCountDescending': {
-      query.options.sort = {"contents.wordCount": -1, modifiedAt: -1, createdAt: -1}
+      // FIXME: This should have "contents.wordCount": -1, but that crashes
+      query.options.sort = {modifiedAt: -1, createdAt: -1}
       break
     }
     case 'lastModified': {


### PR DESCRIPTION
This changes the bug from "you can't see any of your drafts" to "the drafts are sorted by last modified instead of wordcount", which is less bad.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208108263500347) by [Unito](https://www.unito.io)
