### PR TITLE
Fix BestOfLW splash page title bug

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -44,7 +44,7 @@ const styles = (theme: ThemeType) => ({
     display: 'flex',
   },
   darkerOpacity: {
-    opacity: 0.8
+    opacity: 0.7
   }
 });
 

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -42,15 +42,18 @@ const styles = (theme: ThemeType) => ({
   audioToggle: {
     opacity: 0.55,
     display: 'flex',
+  },
+  darkerOpacity: {
+    opacity: 0.8
   }
 });
 
-export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, showEmbeddedPlayer}: {
+export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, showEmbeddedPlayer, higherContrast}: {
   classes: ClassesType<typeof styles>,
   post: PostsWithNavigation|PostsWithNavigationAndRevision|PostsListWithVotes,
   toggleEmbeddedPlayer?: () => void,
   showEmbeddedPlayer?: boolean,
-  hideVoteOnMobile?: boolean
+  higherContrast?: boolean
 }) => {
   const { FooterTagList, LWPostsPageTopHeaderVote, AudioToggle, PostActionsButton } = Components;
 
@@ -58,11 +61,11 @@ export const LWPostsPageHeaderTopRight = ({classes, post, toggleEmbeddedPlayer, 
 
   return <div className={classes.root}>
       {!post.shortform && <AnalyticsContext pageSectionContext="tagHeader">
-        <div className={classes.tagList}>
+        <div className={classNames(classes.tagList, higherContrast && classes.darkerOpacity)}>
           <FooterTagList post={post} hideScore useAltAddTagButton align="right" noBackground neverCoreStyling tagRight={false} />
         </div>
       </AnalyticsContext>}
-      {!post.shortform && <div className={classes.audioToggle}>
+      {!post.shortform && <div className={classNames(classes.audioToggle, higherContrast && classes.darkerOpacity)}>
         <AudioToggle post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
       </div>}
       {!post.shortform && <div className={classes.vote}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -692,7 +692,8 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
             showEmbeddedPlayer={showEmbeddedPlayer}
             dialogueResponses={debateResponses}
             answerCount={answerCount}
-            toggleEmbeddedPlayer={toggleEmbeddedPlayer}/>}
+            toggleEmbeddedPlayer={toggleEmbeddedPlayer}
+            />}
           {!showSplashPageHeader && !isBookUI && <PostsPagePostHeader
             post={post}
             answers={answers ?? []}
@@ -753,10 +754,10 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
       classes.postBody,
       !showEmbeddedPlayer && classes.audioPlayerHidden
     )}>
-      {showSplashPageHeader && !permalinkedCommentId && <h1 className={classes.secondSplashPageHeader}>
+      {isBookUI && header}
+      {showSplashPageHeader && <h1 className={classes.secondSplashPageHeader}>
         {post.title}
       </h1>}
-      {isBookUI && header}
       {/* Body */}
       {fullPost && isEAForum && <PostsAudioPlayerWrapper showEmbeddedPlayer={showEmbeddedPlayer} post={fullPost}/>}
       {fullPost && post.isEvent && fullPost.activateRSVPs &&  <RSVPs post={fullPost} />}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
@@ -66,7 +66,7 @@ const styles = (theme: ThemeType) => ({
       left: 0,
       height: '100%',
       width: '100%',
-      background: `linear-gradient(180deg, ${theme.palette.panelBackground.translucent} 64px, transparent 30%, transparent 48%, ${theme.palette.panelBackground.default} 97%)`,
+      background: `linear-gradient(180deg, ${theme.palette.panelBackground.translucent} 64px, transparent 40%, transparent 48%, ${theme.palette.panelBackground.default} 97%)`,
       pointerEvents: 'none'
     },
     transition: 'opacity 0.5s ease-in-out',
@@ -365,7 +365,7 @@ const PostsPageSplashHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, 
   toggleEmbeddedPlayer?: () => void,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { FooterTagList, UsersName, CommentBody, PostActionsButton, LWTooltip, LWPopper, ImageCropPreview, ForumIcon, SplashHeaderImageOptions, PostsAudioPlayerWrapper, LWPostsPageTopHeaderVote, LWPostsPageHeaderTopRight } = Components;
+  const { UsersName, CommentBody, LWPopper, ImageCropPreview, SplashHeaderImageOptions, PostsAudioPlayerWrapper, LWPostsPageHeaderTopRight } = Components;
   
   const { selectedImageInfo } = useImageContext();
   const { setToCVisible } = useContext(SidebarsContext)!;
@@ -536,7 +536,7 @@ const PostsPageSplashHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, 
     </div>}
     <div className={classes.top}>
       {topLeftSection}
-      <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} />
+      <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer} higherContrast={true} />
     </div>
     {audioPlayer}
     <div className={classes.rightSection}>


### PR DESCRIPTION
Previously, the title of a Best of LessWrong page had a bug where if you navigated using the table-of-contents, it would no longer show the title of the post at the top of the page. 

This was because we were hiding titles on pages with hashtags in the URL, since those often represented pages with CommentPermalink components rendered at the top. 

This moves the title to below the header area where the CommentPermalink gets rendered.

While working on this, I also noticed that the tags and audio icon on Splash Pages were too low-opacity. We'd set the opacity low based on how they looked on plain-white pages, but they need to be higher contrast on the splash-background.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208116219705486) by [Unito](https://www.unito.io)
