### PR TITLE
Don't try to refetch a current forum event if it's feature-flagged off

### DIFF
--- a/packages/lesswrong/components/hooks/useCurrentForumEvent.tsx
+++ b/packages/lesswrong/components/hooks/useCurrentForumEvent.tsx
@@ -41,7 +41,9 @@ export const CurrentForumEventProvider: FC<{
     : true;
 
   useEffect(() => {
-    void refetch();
+    if (hasForumEvents) {
+      void refetch();
+    }
   }, [refetch, eventEnded]);
 
   const value = useMemo(() => {


### PR DESCRIPTION
`useCurrentForumEvent` is feature-flagged to EA Forum only, and the feature flag is checked in th `useMulti`, but it will wind up running this query anyways because `refetch` ignores `skip`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208129086277318) by [Unito](https://www.unito.io)
