### PR TITLE
Fix ToC incorrectly appearing on hover over the gap between the post and the right column

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -59,7 +59,7 @@ const styles = (theme: ThemeType) => ({
       `
     },
   },
-  gap1: {},
+  gap1: {gridArea: "gap1"},
   toc: {
     position: 'unset',
     width: 'unset',


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208130807081240) by [Unito](https://www.unito.io)
