### PR TITLE
Fix comment toc height bug

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -110,8 +110,10 @@ const styles = (theme: ThemeType) => ({
   '@global': {
     // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global
     [`body:has(.headroom--pinned) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}, body:has(.headroom--unfixed) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}`]: {
-      top: HEADER_HEIGHT,
-      height: `calc(100vh - ${HEADER_HEIGHT}px - ${FIXED_TOC_COMMENT_COUNT_HEIGHT}px)`
+      '&&': {
+        top: HEADER_HEIGHT,
+        height: `calc(100vh - ${HEADER_HEIGHT}px - ${FIXED_TOC_COMMENT_COUNT_HEIGHT}px)`
+      }
     }
   },
   stickyBlock: {


### PR DESCRIPTION
This fixes the thing where the commentToc shrinks weirdly when you scroll up. It was happening because another style ends up overriding the "top" css attribute.

![image](https://github.com/user-attachments/assets/22fb4d1a-1105-41d0-bc26-c5aef5f6656f)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208130834181675) by [Unito](https://www.unito.io)
