### PR TITLE
[EA Forum only] take down the Forum user survey banner

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -460,7 +460,6 @@ const Layout = ({currentUser, children, classes}: {
       CloudinaryImage2,
       ForumEventBanner,
       GlobalHotkeys,
-      EASurveyBanner,
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -547,7 +546,6 @@ const Layout = ({currentUser, children, classes}: {
               {/* enable during ACX Everywhere */}
               {renderCommunityMap && <span className={classes.hideHomepageMapOnMobile}><HomepageCommunityMap dontAskUserLocation={true}/></span>}
               {renderPetrovDay() && <PetrovDayWrapper/>}
-              {isEAForum && <EASurveyBanner />}
 
               <div className={classNames(classes.standaloneNavFlex, {
                 [classes.spacedGridActivated]: shouldUseGridLayout && !unspacedGridLayout,

--- a/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/EASurveyBanner.tsx
@@ -65,24 +65,7 @@ const styles = (theme: ThemeType) => ({
 
 /**
  * This banner is now disabled but the code is left here in case we want to
- * do something similar again in the future. If so, there are a couple of bugs
- * to fix:
- *   1) We had some users complaining that the banner didn't get hidden properly
- *      or that it would open again when revisiting the page. The most important
- *      thing is that the cookie must be marked as "necessary" to ensure it works
- *      for users who don't accept cookies. We still had some users who reported
- *      it wasn't working properly though - maybe we should just disable the
- *      banner entirely or users who don't accept cookies?
- *   2) The banner currently obscures the autocomplete window that popups up
- *      when typing in the search box. We probably just need to add some kind
- *      of top margin or offset.
- *   3) We also removed the old cookie, so a new cookie name needs to be added
- *      below. We previously used:
- *      export const HIDE_EA_FORUM_SURVEY_BANNER_COOKIE = registerCookie({
- *        name: "hide_ea_forum_survey_banner",
- *        type: "necessary",
- *        description: "Don't show the EA Forum survey banner",
- *      });
+ * do something similar again in the future.
  */
 const EASurveyBanner = ({classes}: {classes: ClassesType}) => {
   const [cookies, setCookie] = useCookiesWithConsent([HIDE_EA_FORUM_SURVEY_BANNER_COOKIE]);


### PR DESCRIPTION
We're closing the survey at the end of today, so will take down the banner from the site. I'll just merge this in this evening.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208136274729732) by [Unito](https://www.unito.io)
