### PR TITLE
Less whitespace in LW post

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { extractVersionsFromSemver } from '../../../lib/editor/utils';
@@ -7,12 +7,18 @@ import { getHostname, getProtocol } from './PostsPagePostHeader';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    paddingTop: 110,
-    marginBottom: 96,
+    paddingTop: 86,
+    marginBottom: 64,
+    [theme.breakpoints.down('md')]: {
+      paddingTop: 125
+    },
     [theme.breakpoints.down('xs')]: {
       paddingTop: 16,
       marginBottom: 38
     },
+  },
+  topRightIsWide: {
+    paddingTop: 125
   },
   eventHeader: {
     marginBottom: 0,
@@ -131,11 +137,21 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
 
   const crosspostNode = post.fmCrosspost?.isCrosspost && !post.fmCrosspost.hostedHere &&
     <CrosspostHeaderIcon post={post} />
+
+  const topRightRef = useRef<HTMLDivElement>(null);
+  const [topRightWidth, setTopRightWidth] = useState(0);
+  const topRightIsWide = topRightWidth > 500;
+
+  useEffect(() => {
+    if (topRightRef.current) {
+      setTopRightWidth(topRightRef.current.offsetWidth);
+    }
+  }, []);
   
   // TODO: If we are not the primary author of this post, but it was shared with
   // us as a draft, display a notice and a link to the collaborative editor.
 
-  return <div className={classNames(classes.root, {[classes.eventHeader]: post.isEvent})}>
+  return <div className={classNames(classes.root, post.isEvent && classes.eventHeader, topRightIsWide && classes.topRightIsWide)}>
       {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}
       <AnalyticsContext pageSectionContext="topSequenceNavigation">
         {('sequence' in post) && !!post.sequence && <div className={classes.sequenceNav}>
@@ -143,7 +159,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
         </div>}
       </AnalyticsContext>
       <div>
-        <span className={classes.topRight}>
+        <span className={classes.topRight} ref={topRightRef}>
           <LWPostsPageHeaderTopRight post={post} toggleEmbeddedPlayer={toggleEmbeddedPlayer} showEmbeddedPlayer={showEmbeddedPlayer}/>
         </span>
         {post && <span className={classes.audioPlayerWrapper}>

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -10,7 +10,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingTop: 86,
     marginBottom: 64,
     [theme.breakpoints.down('md')]: {
-      paddingTop: 125
+      paddingTop: 110
     },
     [theme.breakpoints.down('xs')]: {
       paddingTop: 16,
@@ -18,7 +18,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     },
   },
   topRightIsWide: {
-    paddingTop: 125
+    paddingTop: 110
   },
   eventHeader: {
     marginBottom: 0,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -26,7 +26,7 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
       fontSize: '3rem',
     }
     : {
-      fontSize: '4.5rem',
+      fontSize: '3.75rem',
       lineHeight: '1.1',
   }),
   [theme.breakpoints.down('xs')]: isFriendlyUI


### PR DESCRIPTION
We'd talked about this last week. I don't know exactly how Oli felt about it, but, here's a PR that:

– somewhat shrinks the post title on LW
– somewhat reduces the padding on LW
– padding is increased when the page size is medium, or when there are a lot of tags

Here's some examples:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/28765696-0f0c-4177-8701-3198dbfcd802">

for comparison, on the current site it looks like:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/63eaaaa9-17e0-4a99-8990-170c167d072b">

here it is at medium screen size:

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/ef72753b-6a77-4b16-a0ba-3b83ece45e26">

Meanwhile, here's one with 500px worth of TopRightCorner:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/40b95a1e-5619-4a30-8760-e771824cefa3">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208140775527760) by [Unito](https://www.unito.io)
