### PR TITLE
Fix Permalink Bug

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -218,7 +218,7 @@ export const styles = (theme: ThemeType) => ({
   centralColumn: {
     marginLeft: 'auto',
     marginRight: 'auto',
-    maxWidth: CENTRAL_COLUMN_WIDTH,
+    maxWidth: CENTRAL_COLUMN_WIDTH, // this necessary in both friendly and non-friendly UI to prevent Comment Permalinks from overflowing the page
     ...(isFriendlyUI && {
       [theme.breakpoints.down('sm')]: {
         // This can only be used when display: "block" is applied, otherwise the 100% confuses the

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -218,9 +218,8 @@ export const styles = (theme: ThemeType) => ({
   centralColumn: {
     marginLeft: 'auto',
     marginRight: 'auto',
-    
+    maxWidth: CENTRAL_COLUMN_WIDTH,
     ...(isFriendlyUI && {
-      maxWidth: CENTRAL_COLUMN_WIDTH,
       [theme.breakpoints.down('sm')]: {
         // This can only be used when display: "block" is applied, otherwise the 100% confuses the
         // grid layout into adding loads of left margin


### PR DESCRIPTION
During various post-page refactors, we introduced an edge-case where comment permalinks with SingleLineComments would stretch to fill the whole screen. 

It turned out PostsPage-centralColumn needed a "maxWidth" set, which we'd removed because most of the time it seemed superfluous. This adds it back in.