### PR TITLE
Add group-subscriptions to event page & remove date from top of page

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -158,9 +158,9 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
               <PostsAuthors post={post} pageSectionContext="post_header" />
             </div>
             {crosspostNode}
-            <div className={classes.date}>
+            {!post.isEvent && <div className={classes.date}>
               <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />
-            </div>
+            </div>}
             {rssFeedSource && rssFeedSource.user &&
               <LWTooltip title={`Crossposted from ${feedLinkDescription}`} className={classes.feedName}>
                 <a href={feedLink}>{rssFeedSource.nickname}</a>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -839,7 +839,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
         </div>
       </Row>}
 
-      {post.isEvent && post.group &&
+      {post.isEvent && post.group && isBookUI &&
           <Row justifyContent="center">
             <div className={classes.bottomOfPostSubscribe}>
               <LWTooltip title={<div>Get emails for future events by <div>{post.group?.name}</div></div>} placement='bottom'>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -347,7 +347,7 @@ export const styles = (theme: ThemeType) => ({
       },
     },
   },
-  notifyMe: {
+  subscribeToGroup: {
     padding: '8px 16px',
     ...theme.typography.body2,
   },
@@ -848,7 +848,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
                     document={post.group}
                     subscribeMessage="Subscribe to group"
                     unsubscribeMessage="Unsubscribe from group"
-                    className={classes.notifyMe}
+                    className={classes.subscribeToGroup}
                 />
               </LWTooltip>
             </div>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -842,7 +842,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
       {post.isEvent && post.group && isBookUI &&
           <Row justifyContent="center">
             <div className={classes.bottomOfPostSubscribe}>
-              <LWTooltip title={<div>Get emails for future events by <div>{post.group?.name}</div></div>} placement='bottom'>
+              <LWTooltip title={<div>Subscribed users get emails for future events by<div>{post.group?.name}</div></div>} placement='bottom'>
                 <NotifyMeButton
                     showIcon
                     document={post.group}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -810,7 +810,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
         <AnalyticsContext pageSectionContext="postBody">
           <HoveredReactionContextProvider voteProps={voteProps}>
           <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>
-            {htmlWithAnchors && <div>
+            {htmlWithAnchors && <>
               <PostBody
                 post={post}
                 html={htmlWithAnchors}
@@ -819,7 +819,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
               />
               {post.isEvent && isBookUI && <p className={classes.dateAtBottom}>Posted on: <PostsPageDate post={post} hasMajorRevision={false} /></p>
               }
-              </div>
+              </>
             }
           </CommentOnSelectionContentWrapper>
           </HoveredReactionContextProvider>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -40,6 +40,8 @@ import { HoveredReactionContextProvider } from '@/components/votes/lwReactions/H
 import { useVote } from '@/components/votes/withVote';
 import { getVotingSystemByName } from '@/lib/voting/votingSystems';
 import DeferRender from '@/components/common/DeferRender';
+import { LWUserTooltipContent } from '@/components/users/LWUserTooltipContent';
+import { extractVersionsFromSemver } from '@/lib/editor/utils';
 
 const HIDE_TOC_WORDCOUNT_LIMIT = 300
 export const MAX_COLUMN_WIDTH = 720
@@ -312,7 +314,7 @@ export const styles = (theme: ThemeType) => ({
       display: 'none'
     }
   },
-  subscribeToDialogue: {
+  bottomOfPostSubscribe: {
     marginBottom: 40,
     marginTop: 40,
     border: theme.palette.border.commentBorder,
@@ -345,6 +347,15 @@ export const styles = (theme: ThemeType) => ({
       },
     },
   },
+  notifyMe: {
+    padding: '8px 16px',
+    ...theme.typography.body2,
+  },
+  dateAtBottom: {
+    color: theme.palette.text.dim3,
+    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    cursor: 'default'
+  }
 })
 
 const getDebateResponseBlocks = (responses: CommentsList[], replies: CommentsList[]) => responses.map(debateResponse => ({
@@ -531,7 +542,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
     PostBottomRecommendations, NotifyMeDropdownItem, Row, AnalyticsInViewTracker,
     PostsPageQuestionContent, AFUnreviewedCommentCount, CommentsListSection, CommentsTableOfContents,
     StickyDigestAd, PostsPageSplashHeader, PostsAudioPlayerWrapper, AttributionInViewTracker,
-    ForumEventPostPagePollSection
+    ForumEventPostPagePollSection, NotifyMeButton, LWTooltip, PostsPageDate
   } = Components
 
   useEffect(() => {
@@ -799,13 +810,16 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
         <AnalyticsContext pageSectionContext="postBody">
           <HoveredReactionContextProvider voteProps={voteProps}>
           <CommentOnSelectionContentWrapper onClickComment={onClickCommentOnSelection}>
-            {htmlWithAnchors &&
+            {htmlWithAnchors && <div>
               <PostBody
                 post={post}
                 html={htmlWithAnchors}
                 sideCommentMode={isOldVersion ? "hidden" : sideCommentMode}
                 voteProps={voteProps}
               />
+              {post.isEvent && isBookUI && <p className={classes.dateAtBottom}>Posted on: <PostsPageDate post={post} hasMajorRevision={false} /></p>
+              }
+              </div>
             }
           </CommentOnSelectionContentWrapper>
           </HoveredReactionContextProvider>
@@ -813,7 +827,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
       </ContentStyles>}
 
       {showSubscribeToDialogueButton && <Row justifyContent="center">
-        <div className={classes.subscribeToDialogue}>
+        <div className={classes.bottomOfPostSubscribe}>
           <NotifyMeDropdownItem
             document={post}
             enabled={!!post.collabEditorDialogue}
@@ -824,6 +838,22 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
           />
         </div>
       </Row>}
+
+      {post.isEvent && post.group &&
+          <Row justifyContent="center">
+            <div className={classes.bottomOfPostSubscribe}>
+              <LWTooltip title={<div>Get emails for future events by <div>{post.group?.name}</div></div>} placement='bottom'>
+                <NotifyMeButton
+                    showIcon
+                    document={post.group}
+                    subscribeMessage="Subscribe to group"
+                    unsubscribeMessage="Unsubscribe from group"
+                    className={classes.notifyMe}
+                />
+              </LWTooltip>
+            </div>
+          </Row>
+      }
 
       {post.debate && debateResponses && debateResponseReplies && fullPost &&
         <DebateBody


### PR DESCRIPTION
This PR does 2 things:

1. You can now subscribe to a meetup group from any of the event pages for that group. Scroll to the bottom to see a subscribe-to-group button.
2. On event pages, the top of the page used to be confusing, in that it showed two dates: the publish date, and the event date. We removed the publish date, and now show it at the bottom of the post (it read "Posted at: <date>").

These changes are Forum Gated.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208172832071162) by [Unito](https://www.unito.io)
