### PR TITLE
Execute code resolvers in `fetchFragment` 

### DIFF
--- a/packages/lesswrong/integrationTests/editorUtils.tests.ts
+++ b/packages/lesswrong/integrationTests/editorUtils.tests.ts
@@ -40,7 +40,7 @@ describe("syncDocumentWithLatestRevision", () => {
     const postAfterUpdate = await fetchFragmentSingle({
       collectionName: "Posts",
       fragmentName: "PostsOriginalContents",
-      currentUser: null,
+      currentUser: user,
       selector: {_id: post._id},
     });
     if (!postAfterUpdate) {
@@ -60,7 +60,7 @@ describe("syncDocumentWithLatestRevision", () => {
     const postAfterSync = await fetchFragmentSingle({
       collectionName: "Posts",
       fragmentName: "PostsOriginalContents",
-      currentUser: null,
+      currentUser: user,
       selector: {_id: post._id},
     });
     if (!postAfterSync) {

--- a/packages/lesswrong/integrationTests/fetchFragment.tests.ts
+++ b/packages/lesswrong/integrationTests/fetchFragment.tests.ts
@@ -1,0 +1,84 @@
+import "./integrationTestSetup";
+import { createDummyPost } from "./utils";
+import { fetchFragmentSingle } from "@/server/fetchFragment";
+
+describe("fetchFragment", () => {
+  it("fetches the entire DB object", async () => {
+    const post = await createDummyPost();
+    const fetched = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsMinimumInfo",
+      currentUser: null,
+      selector: post._id,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched!._id).toBe(post._id);
+    // baseScore is on the DB object, but not in PostsMinimumInfo
+    expect(fetched!.baseScore).toBe(1);
+  });
+  it("fetches SQL resolver fields", async () => {
+    const post = await createDummyPost();
+    const fetched = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsListBase",
+      currentUser: null,
+      selector: post._id,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched!._id).toBe(post._id);
+    // readTimeMinutes is a SQL resolver field included in PostsListBase
+    expect(fetched!.readTimeMinutes).toBe(1);
+  });
+  it("fetches code resolver fields", async () => {
+    const post = await createDummyPost();
+    const fetched = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsDetails",
+      currentUser: null,
+      selector: post._id,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched!._id).toBe(post._id);
+    // sourcePostRelations is a code resolver field included in PostsDetails
+    expect(fetched!.sourcePostRelations).toStrictEqual([]);
+  });
+  it("excludes resolver-only fields missing from the fragment", async () => {
+    const post = await createDummyPost();
+    const fetched = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsMinimumInfo",
+      currentUser: null,
+      selector: post._id,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched!._id).toBe(post._id);
+    // sourcePostRelations is a code resolver field not included in PostsMinimumInfo
+    expect((fetched as any).sourcePostRelations).toBeUndefined();
+  });
+  it("permissions filter out forbidden fields", async () => {
+    const post = await createDummyPost();
+
+    const fetchedFiltered = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsMinimumInfo",
+      currentUser: null,
+      selector: post._id,
+    });
+    expect(fetchedFiltered).not.toBeNull();
+    expect(fetchedFiltered!._id).toBe(post._id);
+    // clickCount is an admin-only field so it should be filtered out
+    expect(fetchedFiltered!.clickCount).toBeUndefined();
+
+    // Now turn off filtering and we should have the field
+    const fetchedUnfiltered = await fetchFragmentSingle({
+      collectionName: "Posts",
+      fragmentName: "PostsMinimumInfo",
+      currentUser: null,
+      selector: post._id,
+      skipFiltering: true,
+    });
+    expect(fetchedUnfiltered).not.toBeNull();
+    expect(fetchedUnfiltered!._id).toBe(post._id);
+    expect(fetchedUnfiltered!.clickCount).toBe(0);
+  });
+});

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -2,7 +2,7 @@ import { addCallback, getCollection } from '../vulcan-lib';
 import { restrictViewableFieldsSingle, restrictViewableFieldsMultiple } from '../vulcan-users/permissions';
 import SimpleSchema from 'simpl-schema'
 import { loadByIds, getWithLoader } from "../loaders";
-import { isServer } from '../executionEnvironment';
+import { isAnyTest } from '../executionEnvironment';
 import { asyncFilter } from './asyncUtils';
 import type { GraphQLScalarType } from 'graphql';
 import DataLoader from 'dataloader';
@@ -368,7 +368,7 @@ export function denormalizedCountOfReferences<
   
   if (bundleIsServer) {
     const resync = (documentId: string) => {
-      if (resyncElastic) {
+      if (resyncElastic && !isAnyTest) {
         // eslint-disable-next-line import/no-restricted-paths
         const {elasticSyncDocument} = require("../../server/search/elastic/elasticCallbacks");
         elasticSyncDocument(collectionName, documentId);

--- a/packages/lesswrong/server/sql/SelectFragmentQuery.ts
+++ b/packages/lesswrong/server/sql/SelectFragmentQuery.ts
@@ -1,7 +1,6 @@
 import SelectQuery from "./SelectQuery";
 import { getSqlFragment } from "../vulcan-lib";
 import type { CodeResolverMap, PrefixGenerator } from "./ProjectionContext";
-import type { GraphQLResolveInfo } from "graphql";
 
 /**
  * `SelectFragmentQuery` is the main external interface for running select
@@ -107,16 +106,9 @@ class SelectFragmentQuery<
    * passed to the front-end via GraphQL as Apollo will fill in the missing
    * fields for us automatically (set `getFields` in `initGraphQL.ts`).
    */
-  /**
-   * This is commented out for now as it's not needed (due to Apollo filling
-   * in any missing fields) and it has no test coverage.
-   * TODO: Do we actually need this, or can we delete?
-   */
-  /*
   async executeCodeResolvers<T extends DbObject>(
     obj: T,
     context: ResolverContext,
-    info: GraphQLResolveInfo,
     resolvers = this.codeResolvers,
   ): Promise<T> {
     const promises: Promise<unknown>[] = [];
@@ -130,7 +122,6 @@ class SelectFragmentQuery<
             obj as AnyBecauseTodo,
             this.resolverArgs,
             context,
-            info,
           );
           obj[resolverName as keyof T] = result;
         }
@@ -145,7 +136,6 @@ class SelectFragmentQuery<
       promises.push(this.executeCodeResolvers(
         obj[subresolverName as keyof T] as DbObject,
         context,
-        info,
         subresolvers[subresolverName],
       ));
     }
@@ -154,7 +144,6 @@ class SelectFragmentQuery<
 
     return obj;
   }
-  */
 }
 
 export default SelectFragmentQuery;

--- a/packages/lesswrong/server/sql/SelectFragmentQuery.ts
+++ b/packages/lesswrong/server/sql/SelectFragmentQuery.ts
@@ -104,13 +104,17 @@ class SelectFragmentQuery<
    *
    * Note that it is not necessary to call this function if the result will be
    * passed to the front-end via GraphQL as Apollo will fill in the missing
-   * fields for us automatically (set `getFields` in `initGraphQL.ts`).
+   * fields for us automatically (see `getFields` in `initGraphQL.ts`).
    */
   async executeCodeResolvers<T extends DbObject>(
-    obj: T,
+    obj: T | null,
     context: ResolverContext,
     resolvers = this.codeResolvers,
-  ): Promise<T> {
+  ): Promise<T | null> {
+    if (!obj) {
+      return null;
+    }
+
     const promises: Promise<unknown>[] = [];
     const subresolvers: Record<string, CodeResolverMap> = {};
 
@@ -120,7 +124,7 @@ class SelectFragmentQuery<
         const generator = async () => {
           const result = await resolver(
             obj as AnyBecauseTodo,
-            this.resolverArgs,
+            this.resolverArgs ?? {},
             context,
           );
           obj[resolverName as keyof T] = result;


### PR DESCRIPTION
Currently, `fetchFragment` only returns resolver-only fields that have SQL resolvers. This PR implements executing the code resolvers for fields without SQL resolvers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208173461130215) by [Unito](https://www.unito.io)
