### PR TITLE
[EA Forum only] remove user interview prompt from onboarding

### DIFF
--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
@@ -191,21 +191,6 @@ export const EAOnboardingThankYouStage = ({classes}: {
             <EAOnboardingPodcast podcast={getPodcastDataByName("Apple Podcasts")} />
           </div>
         </div>
-        <div className={classNames(classes.section, classes.interviewSection, classes.mobileColumn)}>
-          <div>
-            <div className={classes.heading}>
-              Sign up for a user interview
-            </div>
-            <div className={classes.interviewDescription}>
-              We’d love to learn why you joined and how you got involved with EA. We’ll also answer any questions you have.
-            </div>
-          </div>
-          <div className={classes.interviewButtonWrapper}>
-            <EAButton href="https://savvycal.com/cea/forum-team" target="_blank" rel="noreferrer" style="grey" className={classes.interviewButton}>
-              Book a call
-            </EAButton>
-          </div>
-        </div>
       </div>
     </EAOnboardingStage>
   );

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingThankYouStage.tsx
@@ -38,13 +38,6 @@ const styles = (theme: ThemeType) => ({
       flexGrow: 1,
     },
   },
-  interviewSection: {
-    background: 'none',
-    borderTop: theme.palette.border.normal,
-    borderRadius: 0,
-    padding: '24px 0 0',
-    marginTop: 24,
-  },
   heading: {
     color: theme.palette.grey[1000],
     fontSize: 14,
@@ -54,14 +47,6 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[600],
     fontSize: 14,
     fontWeight: 500,
-  },
-  interviewDescription: {
-    color: theme.palette.grey[600],
-    fontSize: 13,
-    lineHeight: '140%',
-    fontWeight: 500,
-    textWrap: 'pretty',
-    marginTop: 4,
   },
   toggle: {
     [theme.breakpoints.down("xs")]: {
@@ -77,18 +62,6 @@ const styles = (theme: ThemeType) => ({
         flexBasis: "50%",
       },
     },
-  },
-  interviewButtonWrapper: {
-    flex: 'none',
-    [theme.breakpoints.down("xs")]: {
-      alignSelf: 'center',
-      marginTop: 8,
-    },
-  },
-  interviewButton: {
-    fontWeight: 600,
-    textDecoration: 'none !important',
-    padding: '12px 16px',
   },
   footer: {
     textAlign: 'center',


### PR DESCRIPTION
I was the person most interested in this and now I have much less time for it, so we are removing this option. We will probably add it back in some other place, such as in the email drip campaign.

<img width="597" alt="Screenshot 2024-08-29 at 12 14 00 AM" src="https://github.com/user-attachments/assets/7b866fca-3db3-4304-8b7d-a30988916ad6">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208177700848000) by [Unito](https://www.unito.io)
