### PR TITLE
Proxy the instantiation of repos

### DIFF
--- a/packages/lesswrong/server/repos/AbstractRepo.ts
+++ b/packages/lesswrong/server/repos/AbstractRepo.ts
@@ -6,7 +6,7 @@ import PgCollection from "@/server/sql/PgCollection";
  * repositories are descended. Any common properties or functions
  * should be added here.
  *
- * To make the repo available in GraphQL resolvers, add it to `getAllRepos`
+ * To make the repo available in GraphQL resolvers, add it to `allRepos`
  * in index.ts
  */
 export default abstract class AbstractRepo<N extends CollectionNameString> {


### PR DESCRIPTION
The main `ResolverContext` type has a property called `repos` of type `Repos` (ie; a map from repo names to repo instances). However, _most_ requests do not use _most_ of the repos, and there's a lot of repos which need to be instantiated for every request. To avoid wasting resources we can instead replace the plain `repos` object with a proxy which intercepts accesses to repos and only instantiates repos as-and-when they're actually needed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208179772907243) by [Unito](https://www.unito.io)
