### PR TITLE
Fix EditTitle fontsize on LessWrong

### DIFF
--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -7,6 +7,7 @@ import { useUpdate } from '../../lib/crud/withUpdate';
 import { PostCategory } from '../../lib/collections/posts/helpers';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { isE2E } from '../../lib/executionEnvironment';
+import { LW_POST_TITLE_FONT_SIZE } from '../posts/PostsPage/PostsPageTitle';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -18,7 +19,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       marginBottom: 12,
       marginTop: 0,
     }: {
-      fontSize: "4.5rem",
+      fontSize: LW_POST_TITLE_FONT_SIZE,
       marginTop: 34,
       marginBottom: 64,
     }),

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -4,6 +4,8 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../../lib/collections/posts/helpers';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 
+export const LW_POST_TITLE_FONT_SIZE = "3.75rem";
+
 export const postPageTitleStyles = (theme: ThemeType) => ({
   ...theme.typography.display3,
   ...theme.typography.postStyle,
@@ -26,7 +28,7 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
       fontSize: '3rem',
     }
     : {
-      fontSize: '3.75em',
+      fontSize: LW_POST_TITLE_FONT_SIZE,
       lineHeight: '1.1',
   }),
   [theme.breakpoints.down('xs')]: isFriendlyUI


### PR DESCRIPTION
We changed the default size of post titles, just bringing the editor in line with it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208184398481332) by [Unito](https://www.unito.io)
