### PR TITLE
Fix linkpost clickability

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -4,6 +4,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { extractVersionsFromSemver } from '../../../lib/editor/utils';
 import classNames from 'classnames';
 import { getHostname, getProtocol } from './PostsPagePostHeader';
+import { postGetLink, postGetLinkTarget } from '@/lib/collections/posts/helpers';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -138,7 +139,11 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
 
   const linkpostDomain = post.url && new URL(post.url).hostname;
   const linkpostTooltip = <div>This is a linkpost:<br/>{post.url}</div>;
-  const linkpostNode = post.url && feedDomain !== linkpostDomain ? <LWTooltip title={linkpostTooltip}><a href={post.url} target="_blank" rel="noopener noreferrer">{linkpostDomain}</a></LWTooltip> : null;
+  const linkpostNode = post.url && feedDomain !== linkpostDomain ? <LWTooltip title={linkpostTooltip}>
+    <a href={postGetLink(post)} target={postGetLinkTarget(post)}>
+      {linkpostDomain}
+    </a>
+  </LWTooltip> : null;
 
   return <div className={classNames(classes.root, {[classes.eventHeader]: post.isEvent})}>
       {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -138,7 +138,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
 
   const linkpostDomain = post.url && new URL(post.url).hostname;
   const linkpostTooltip = <div>This is a linkpost:<br/>{post.url}</div>;
-  const linkpostNode = post.url && feedDomain !== linkpostDomain ? <LWTooltip title={linkpostTooltip}>{linkpostDomain}</LWTooltip> : null;
+  const linkpostNode = post.url && feedDomain !== linkpostDomain ? <LWTooltip title={linkpostTooltip}><a href={post.url} target="_blank" rel="noopener noreferrer">{linkpostDomain}</a></LWTooltip> : null;
 
   return <div className={classNames(classes.root, {[classes.eventHeader]: post.isEvent})}>
       {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}


### PR DESCRIPTION
When making the recent #9597 "RSS style linkposts and AF post metadata" I accidentally made linkpost-indicators unclickable on posts. This fixes it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208184454697421) by [Unito](https://www.unito.io)
