### PR TITLE
Option: Grey visited links

### DIFF
--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -56,7 +56,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
     },
     link: {
       color: "#327E09",
-      visited: "#957950",
+      visited: shadePalette.grey[500],
     },
   }),
   make: (palette: ThemePalette) => ({


### PR DESCRIPTION
I'm making a few PRs with visited links of different colors. Oli can approve whichever one he thinks best.

This one does have lower-than-ideal contrast ratio, but, I think is overall my preferred set of tradeoffs (or at least, the set of tradeoffs I'd prefer trying next). 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a800c681-350d-4bf9-83f6-7f56b10018b4">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208185170814434) by [Unito](https://www.unito.io)
