### PR TITLE
Linkpost Icon on LW

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -5,6 +5,7 @@ import { extractVersionsFromSemver } from '../../../lib/editor/utils';
 import classNames from 'classnames';
 import { getHostname, getProtocol } from './PostsPagePostHeader';
 import { postGetLink, postGetLinkTarget } from '@/lib/collections/posts/helpers';
+import LinkIcon from '@material-ui/icons/Link'
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -109,6 +110,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   readTime: {
     marginRight: 20,
+  },
+  linkIcon: {
+    fontSize: 14,
+    position: 'relative',
+    top: 2,
+    transform: 'rotate(-45deg)'
   }
 }); 
 
@@ -141,7 +148,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
   const linkpostTooltip = <div>This is a linkpost:<br/>{post.url}</div>;
   const linkpostNode = post.url && feedDomain !== linkpostDomain ? <LWTooltip title={linkpostTooltip}>
     <a href={postGetLink(post)} target={postGetLinkTarget(post)}>
-      {linkpostDomain}
+      <LinkIcon className={classes.linkIcon}/> {linkpostDomain}
     </a>
   </LWTooltip> : null;
 


### PR DESCRIPTION
I didn't originally do this because I expected Oli to find it too jarring. He said it might be okay. 

I gave some alternate options in slack: https://lworg.slack.com/archives/CJY3ZKP62/p1724965815831009 
 
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/0c8a56b1-57e1-4fdc-b204-af592ba84932">
