### PR TITLE
character counts on llm conversation viewing page

### DIFF
--- a/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
+++ b/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
@@ -52,13 +52,13 @@ const styles = (theme: ThemeType) => ({
   conversationRowSelected: {
     backgroundColor: theme.palette.grey[300],
   },
-  conversationRowLeftAligned: {
+  conversationRowGroup: {
     display: "flex",
     alignItems: "center",
   },
   conversationRowUsername: {
     ...theme.typography.commentStyle,
-    width: 100,
+    width: 90,
     fontWeight: 400,
     fontSize: "0.95rem",
     marginRight: 10,
@@ -69,7 +69,7 @@ const styles = (theme: ThemeType) => ({
   },
   conversationRowTitle: {
     ...theme.typography.commentStyle,
-    maxWidth: 450,
+    maxWidth: 375,
     fontWeight: 500,
     fontSize: "1.15rem",
     overflow: "hidden",
@@ -82,11 +82,20 @@ const styles = (theme: ThemeType) => ({
     fontWeight: 400,
     fontSize: "0.9rem",
     opacity: 0.8
-  }
+  },
+  conversationRowWordCount: {
+    ...theme.typography.commentStyle,
+    padding: 2,
+    fontWeight: 400,
+    fontSize: "0.9rem",
+    fontStyle: "italic",
+    opacity: 0.7,
+    marginRight: 10,
+  },
 });
 
 const LlmConversationRow = ({conversation, currentConversationId, setCurrentConversationId, classes}: {
-  conversation: LlmConversationsWithUserInfoFragment
+  conversation: LlmConversationsViewingPageFragment
   currentConversationId?: string
   setCurrentConversationId: (conversationId: string) => void,
   classes: ClassesType<typeof styles>,
@@ -98,11 +107,14 @@ const LlmConversationRow = ({conversation, currentConversationId, setCurrentConv
     className={classNames(classes.conversationRow, {[classes.conversationRowSelected]: isCurrentlySelected})}
     onClick={()=> setCurrentConversationId(conversation._id)}
     >
-    <span className={classes.conversationRowLeftAligned}>
+    <span className={classes.conversationRowGroup}>
       <span className={classes.conversationRowUsername}>{userGetDisplayName(user)}</span>
       <span className={classes.conversationRowTitle}>{title}</span>
     </span>
-    <span className={classes.conversationRowNumLastUpdated}><Components.FormatDate date={lastUpdatedAt ?? createdAt}/></span>
+    <span className={classes.conversationRowGroup}>
+      <span className={classes.conversationRowWordCount}>{conversation.approxWordCount} words</span>
+      <span className={classes.conversationRowNumLastUpdated}><Components.FormatDate date={lastUpdatedAt ?? createdAt}/></span>
+    </span>
   </div>
 }
 
@@ -115,7 +127,7 @@ const LlmConversationSelector = ({currentConversationId, setCurrentConversationI
 }) => {
   const { results, loading } = useMulti({
     collectionName: "LlmConversations",
-    fragmentName: "LlmConversationsWithUserInfoFragment",
+    fragmentName: "LlmConversationsViewingPageFragment",
     terms: { view: "llmConversationsAll" },
     limit: 200,
   });

--- a/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
+++ b/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
@@ -112,7 +112,7 @@ const LlmConversationRow = ({conversation, currentConversationId, setCurrentConv
       <span className={classes.conversationRowTitle}>{title}</span>
     </span>
     <span className={classes.conversationRowGroup}>
-      <Components.LWTooltip title="Character count" placement='top'>
+      <Components.LWTooltip title={`Character count, estimated ${Math.round((conversation.totalCharacterCount ?? 0)/4.4)} tokens`} placement='top'>
         <span className={classes.conversationRowWordCount}>{conversation.totalCharacterCount}</span>
       </Components.LWTooltip>
       <span className={classes.conversationRowNumLastUpdated}><Components.FormatDate date={lastUpdatedAt ?? createdAt}/></span>

--- a/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
+++ b/packages/lesswrong/components/languageModels/LlmConversationsViewingPage.tsx
@@ -112,7 +112,9 @@ const LlmConversationRow = ({conversation, currentConversationId, setCurrentConv
       <span className={classes.conversationRowTitle}>{title}</span>
     </span>
     <span className={classes.conversationRowGroup}>
-      <span className={classes.conversationRowWordCount}>{conversation.approxWordCount} words</span>
+      <Components.LWTooltip title="Character count" placement='top'>
+        <span className={classes.conversationRowWordCount}>{conversation.totalCharacterCount}</span>
+      </Components.LWTooltip>
       <span className={classes.conversationRowNumLastUpdated}><Components.FormatDate date={lastUpdatedAt ?? createdAt}/></span>
     </span>
   </div>

--- a/packages/lesswrong/lib/collections/llmConversations/fragments.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/fragments.ts
@@ -14,7 +14,7 @@ registerFragment(`
 registerFragment(`
   fragment LlmConversationsViewingPageFragment on LlmConversation {
     ...LlmConversationsFragment
-    approxWordCount
+    totalCharacterCount
     user {
       ...UsersMinimumInfo
     }

--- a/packages/lesswrong/lib/collections/llmConversations/fragments.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/fragments.ts
@@ -12,8 +12,9 @@ registerFragment(`
 `);
 
 registerFragment(`
-  fragment LlmConversationsWithUserInfoFragment on LlmConversation {
+  fragment LlmConversationsViewingPageFragment on LlmConversation {
     ...LlmConversationsFragment
+    approxWordCount
     user {
       ...UsersMinimumInfo
     }

--- a/packages/lesswrong/lib/collections/llmConversations/schema.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/schema.ts
@@ -75,6 +75,23 @@ const schema: SchemaType<"LlmConversations"> = {
     canUpdate: [userOwns, "admins"], 
     ...schemaDefaultValue(false),
   },
-}
+  // Word count not calculated via same means used elsewhere, but is only a rough idea
+  approxWordCount: resolverOnlyField({
+    type: Number,
+    nullable: false,
+    canRead: [userOwns, "admins"],
+    resolver: async (document, args, context) => {
+      const { LlmMessages } = context;
+      const messages = await LlmMessages.find({conversationId: document._id}, {projection: {content: 1}}).fetch();
+      return Math.round(messages.reduce((acc, message) => acc + message.content.length, 0)/6);
+    },
+    sqlResolver: ({field}) => `(
+    SELECT ROUND(SUM(LENGTH(lm."content"))/6)
+    FROM "LlmMessages" lm
+    WHERE lm."conversationId" = ${field("_id")}
+    )`
+  }),
+};
+
 
 export default schema;

--- a/packages/lesswrong/lib/collections/llmConversations/schema.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/schema.ts
@@ -85,9 +85,9 @@ const schema: SchemaType<"LlmConversations"> = {
       return messages.reduce((acc, message) => acc + message.content.length, 0);
     },
     sqlResolver: ({field}) => `(
-    SELECT SUM(LENGTH(lm."content"))
-    FROM "LlmMessages" lm
-    WHERE lm."conversationId" = ${field("_id")}
+      SELECT SUM(LENGTH(lm."content"))
+      FROM "LlmMessages" lm
+      WHERE lm."conversationId" = ${field("_id")}
     )`
   }),
 };

--- a/packages/lesswrong/lib/collections/llmConversations/schema.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/schema.ts
@@ -75,18 +75,17 @@ const schema: SchemaType<"LlmConversations"> = {
     canUpdate: [userOwns, "admins"], 
     ...schemaDefaultValue(false),
   },
-  // Word count not calculated via same means used elsewhere, but is only a rough idea
-  approxWordCount: resolverOnlyField({
+  totalCharacterCount: resolverOnlyField({
     type: Number,
     nullable: false,
     canRead: [userOwns, "admins"],
     resolver: async (document, args, context) => {
       const { LlmMessages } = context;
       const messages = await LlmMessages.find({conversationId: document._id}, {projection: {content: 1}}).fetch();
-      return Math.round(messages.reduce((acc, message) => acc + message.content.length, 0)/6);
+      return messages.reduce((acc, message) => acc + message.content.length, 0);
     },
     sqlResolver: ({field}) => `(
-    SELECT ROUND(SUM(LENGTH(lm."content"))/6)
+    SELECT SUM(LENGTH(lm."content"))
     FROM "LlmMessages" lm
     WHERE lm."conversationId" = ${field("_id")}
     )`

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -4100,7 +4100,8 @@ interface LlmConversationsFragment { // fragment on LlmConversations
   readonly deleted: boolean,
 }
 
-interface LlmConversationsWithUserInfoFragment extends LlmConversationsFragment { // fragment on LlmConversations
+interface LlmConversationsViewingPageFragment extends LlmConversationsFragment { // fragment on LlmConversations
+  readonly approxWordCount: number|null,
   readonly user: UsersMinimumInfo|null,
 }
 
@@ -4414,7 +4415,7 @@ interface FragmentTypes {
   SurveyScheduleEdit: SurveyScheduleEdit
   LlmConversationsDefaultFragment: LlmConversationsDefaultFragment
   LlmConversationsFragment: LlmConversationsFragment
-  LlmConversationsWithUserInfoFragment: LlmConversationsWithUserInfoFragment
+  LlmConversationsViewingPageFragment: LlmConversationsViewingPageFragment
   LlmConversationsWithMessagesFragment: LlmConversationsWithMessagesFragment
   LlmMessagesDefaultFragment: LlmMessagesDefaultFragment
   LlmMessagesFragment: LlmMessagesFragment
@@ -4489,7 +4490,7 @@ interface FragmentTypesByCollection {
   CkEditorUserSessions: "CkEditorUserSessionsDefaultFragment"|"CkEditorUserSessionInfo"
   SurveyQuestions: "SurveyQuestionsDefaultFragment"|"SurveyQuestionMinimumInfo"
   SurveyResponses: "SurveyResponsesDefaultFragment"|"SurveyResponseMinimumInfo"
-  LlmConversations: "LlmConversationsDefaultFragment"|"LlmConversationsFragment"|"LlmConversationsWithUserInfoFragment"|"LlmConversationsWithMessagesFragment"
+  LlmConversations: "LlmConversationsDefaultFragment"|"LlmConversationsFragment"|"LlmConversationsViewingPageFragment"|"LlmConversationsWithMessagesFragment"
   LlmMessages: "LlmMessagesDefaultFragment"|"LlmMessagesFragment"
   SubscribedPostAndCommentses: "SubscribedPostAndCommentsFeed"
 }
@@ -4765,7 +4766,7 @@ interface CollectionNamesByFragmentName {
   SurveyScheduleEdit: "SurveySchedules"
   LlmConversationsDefaultFragment: "LlmConversations"
   LlmConversationsFragment: "LlmConversations"
-  LlmConversationsWithUserInfoFragment: "LlmConversations"
+  LlmConversationsViewingPageFragment: "LlmConversations"
   LlmConversationsWithMessagesFragment: "LlmConversations"
   LlmMessagesDefaultFragment: "LlmMessages"
   LlmMessagesFragment: "LlmMessages"

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -4101,7 +4101,7 @@ interface LlmConversationsFragment { // fragment on LlmConversations
 }
 
 interface LlmConversationsViewingPageFragment extends LlmConversationsFragment { // fragment on LlmConversations
-  readonly approxWordCount: number|null,
+  readonly totalCharacterCount: number|null,
   readonly user: UsersMinimumInfo|null,
 }
 


### PR DESCRIPTION
Helps us understand usage

<img width="1204" alt="LLM Conversations Viewer — LessWrong 2024-08-29 14-50-19" src="https://github.com/user-attachments/assets/ef32490e-b0cf-4737-8802-a6c34295563a">


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208185997035711) by [Unito](https://www.unito.io)
