### PR TITLE
limit input tokens and handle errors via streams

### DIFF
--- a/packages/lesswrong/components/languageModels/LanguageModelChat.tsx
+++ b/packages/lesswrong/components/languageModels/LanguageModelChat.tsx
@@ -7,7 +7,7 @@ import { useMessages } from '../common/withMessages';
 import Select from '@material-ui/core/Select';
 import CloseIcon from '@material-ui/icons/Close';
 import { useLocation } from "../../lib/routeUtil";
-import { useLlmChat } from './LlmChatWrapper';
+import { NewLlmMessage, useLlmChat } from './LlmChatWrapper';
 import type { Editor } from '@ckeditor/ckeditor5-core';
 import CKEditor from '@/lib/vendor/ckeditor5-react/ckeditor';
 import { getCkCommentEditor } from '@/lib/wrapCkEditor';
@@ -104,6 +104,9 @@ const styles = (theme: ThemeType) => ({
   userMessage: {
     backgroundColor: theme.palette.grey[300],
   },
+  errorMessage: {
+    backgroundColor: theme.palette.error.light,
+  },
   messages: {
     overflowY: "scroll",
     flexGrow: 1,
@@ -143,15 +146,10 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-interface LlmConversationMessage {
-  role: string
-  content: string
-}
-
 const NEW_CONVERSATION_MENU_ITEM = "New Conversation";
 
 const LLMChatMessage = ({message, classes}: {
-  message: LlmConversationMessage,
+  message: LlmMessagesFragment | NewLlmMessage,
   classes: ClassesType<typeof styles>,
 }) => {
   const { ContentItemBody, ContentStyles } = Components;
@@ -160,10 +158,13 @@ const LLMChatMessage = ({message, classes}: {
 
   return <ContentStyles contentType="llmChat" className={classes.chatMessageContent}>
     <ContentItemBody
-      className={classNames(classes.chatMessage, {[classes.userMessage]: role==='user'})}
+      className={classNames(classes.chatMessage, {
+        [classes.userMessage]: role === 'user',
+        [classes.errorMessage]: role === 'error'
+      })}
       dangerouslySetInnerHTML={{__html: content}}
     />
-</ContentStyles>
+  </ContentStyles>
 }
 
 const LLMInputTextbox = ({onSubmit, classes}: {

--- a/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
+++ b/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
@@ -387,6 +387,14 @@ const LlmChatWrapper = ({children}: {
       return;
     }
     if (!response.body) {
+      handleLlmStreamError({
+        eventType: 'llmStreamError',
+        data: {
+          conversationId: (newMessage.conversationId ?? newConversationChannelId)!,
+          error: 'Missing response body for unknown reasons'
+        }
+      });
+      
       return; // TODO better error handling
     }
     const reader = response.body.getReader();

--- a/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
+++ b/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
@@ -394,8 +394,8 @@ const LlmChatWrapper = ({children}: {
           error: 'Missing response body for unknown reasons'
         }
       });
-      
-      return; // TODO better error handling
+
+      return;
     }
     const reader = response.body.getReader();
     const decoder = new TextDecoder();

--- a/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
+++ b/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
@@ -13,7 +13,6 @@ import markdownItContainer from "markdown-it-container";
 import markdownItFootnote from "markdown-it-footnote";
 import markdownItSub from "markdown-it-sub";
 import markdownItSup from "markdown-it-sup";
-import { useMessages } from '../common/withMessages';
 
 const mdi = markdownIt({ linkify: true });
 // mdi.use(markdownItMathjax()) // for performance, don't render mathjax
@@ -138,7 +137,6 @@ const LlmChatWrapper = ({children}: {
 }) => {
 
   const currentUser = useCurrentUser();
-  const { flash } = useMessages();
 
   const { mutate: updateConversation } = useUpdate({
     collectionName: "LlmConversations",

--- a/packages/lesswrong/server/languageModels/promptUtils.ts
+++ b/packages/lesswrong/server/languageModels/promptUtils.ts
@@ -30,12 +30,12 @@ export const documentToMarkdown = (document: PostsPage | DbComment | null) => {
 
 const mergeSortedArrays = (queue: CommentTreeNode<NestedComment>[], children: CommentTreeNode<NestedComment>[]): CommentTreeNode<NestedComment>[] => {
   const merged: CommentTreeNode<NestedComment>[] = [];
-  let queueIdk = 0, childrenIdx = 0;
+  let queueIdx = 0, childrenIdx = 0;
 
-  while (queueIdk < queue.length && childrenIdx < children.length) {
-    if (queue[queueIdk].item.karmaScore >= children[childrenIdx].item.karmaScore) {
-      merged.push(queue[queueIdk]);
-      queueIdk++;
+  while (queueIdx < queue.length && childrenIdx < children.length) {
+    if (queue[queueIdx].item.karmaScore >= children[childrenIdx].item.karmaScore) {
+      merged.push(queue[queueIdx]);
+      queueIdx++;
     } else {
       merged.push(children[childrenIdx]);
       childrenIdx++;
@@ -44,7 +44,7 @@ const mergeSortedArrays = (queue: CommentTreeNode<NestedComment>[], children: Co
 
   // Add any remaining elements
   return merged
-    .concat(queue.slice(queueIdk))
+    .concat(queue.slice(queueIdx))
     .concat(children.slice(childrenIdx));
 }
 

--- a/packages/lesswrong/server/languageModels/promptUtils.ts
+++ b/packages/lesswrong/server/languageModels/promptUtils.ts
@@ -54,6 +54,13 @@ const truncateRemainingTrees = (queue: CommentTreeNode<NestedComment>[]) => {
   }
 }
 
+/**
+ * Does a greedy karma-sorted breadth-first traversal over all the comment branches, and truncates them at the point where we estimate that we hit the token limit
+ * i.e. we take the highest karma comment from all the queue, increment token count, put its children into the queue, resort, do the operation again
+ * This means that we never have any gaps in comment branches.
+ * It does pessimize against comments that are children of lower-karma comments, but doing lookahead is annoying and that shouldn't be a problem most of the time.
+ * It might turn out that we want to prioritize full comment branches, in which case this will need to be replaced with a depth-first thing.
+ */
 const filterCommentTrees = (trees: CommentTreeNode<NestedComment>[], tokenCounter: TokenCounter) => {
   const tokenThreshold = 150_000;
   

--- a/packages/lesswrong/server/languageModels/promptUtils.ts
+++ b/packages/lesswrong/server/languageModels/promptUtils.ts
@@ -2,7 +2,7 @@ import { userGetDisplayName } from "@/lib/collections/users/helpers"
 import { htmlToMarkdown } from "../editor/conversionUtils";
 import { CommentTreeNode, unflattenComments } from "@/lib/utils/unflatten";
 import { z } from "zod";
-import { zodFunction, zodResponseFormat } from "openai/helpers/zod";
+import { zodResponseFormat } from "openai/helpers/zod";
 
 interface NestedComment {
   _id: string;
@@ -11,6 +11,13 @@ interface NestedComment {
   contents?: string;
   karmaScore: number;
 }
+
+interface TokenCounter {
+  tokenCount: number;
+}
+
+// Trying to be conservative, since we have a bunch of additional tokens coming from e.g. JSON.stringify
+const CHARS_PER_TOKEN = 3.5;
 
 export const documentToMarkdown = (document: PostsPage | DbComment | null) => {
   const html = document?.contents?.html;
@@ -21,6 +28,57 @@ export const documentToMarkdown = (document: PostsPage | DbComment | null) => {
   return htmlToMarkdown(html);
 }
 
+const mergeSortedArrays = (queue: CommentTreeNode<NestedComment>[], children: CommentTreeNode<NestedComment>[]): CommentTreeNode<NestedComment>[] => {
+  const merged: CommentTreeNode<NestedComment>[] = [];
+  let queueIdk = 0, childrenIdx = 0;
+
+  while (queueIdk < queue.length && childrenIdx < children.length) {
+    if (queue[queueIdk].item.karmaScore >= children[childrenIdx].item.karmaScore) {
+      merged.push(queue[queueIdk]);
+      queueIdk++;
+    } else {
+      merged.push(children[childrenIdx]);
+      childrenIdx++;
+    }
+  }
+
+  // Add any remaining elements
+  return merged
+    .concat(queue.slice(queueIdk))
+    .concat(children.slice(childrenIdx));
+}
+
+const truncateRemainingTrees = (queue: CommentTreeNode<NestedComment>[]) => {
+  for (let node of queue) {
+    node.children = [];
+  }
+}
+
+const filterCommentTrees = (trees: CommentTreeNode<NestedComment>[], tokenCounter: TokenCounter) => {
+  const tokenThreshold = 150_000;
+  
+  // Initialize the queue with root nodes, sorted by karma
+  let queue: CommentTreeNode<NestedComment>[] = trees.sort((a, b) => b.item.karmaScore - a.item.karmaScore);
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    const nodeTokens = (node.item.contents ?? '').length / CHARS_PER_TOKEN;
+
+    if (tokenCounter.tokenCount + nodeTokens > tokenThreshold) {
+      // We've reached the token limit, truncate remaining trees
+      truncateRemainingTrees(queue);
+      break;
+    }
+
+    tokenCounter.tokenCount += nodeTokens;
+
+    // Sort children and merge them with the existing sorted queue
+    if (node.children.length > 0) {
+      const sortedChildren = node.children.sort((a, b) => b.item.karmaScore - a.item.karmaScore);
+      queue = mergeSortedArrays(queue, sortedChildren);
+    }
+  }
+}
 
 const createCommentTree = (comments: DbComment[]): CommentTreeNode<NestedComment>[] => {
   return unflattenComments<NestedComment>(comments.map(comment => {
@@ -33,14 +91,15 @@ const createCommentTree = (comments: DbComment[]): CommentTreeNode<NestedComment
   }));
 }
 
-const formatCommentsForPost = async (post: PostsMinimumInfo, context: ResolverContext): Promise<string> => {
+const formatCommentsForPost = async (post: PostsMinimumInfo, tokenCounter: TokenCounter, context: ResolverContext): Promise<string> => {
     const comments = await context.Comments.find({postId: post._id}).fetch()
     if (!comments.length) {
       return ""
     }
 
-    const nestedComments = createCommentTree(comments)
-    const formattedComments = JSON.stringify(nestedComments, null, 2);
+    const nestedComments = createCommentTree(comments);
+    filterCommentTrees(nestedComments, tokenCounter);
+    const formattedComments = JSON.stringify(nestedComments);
 
     return `Comments for the post titled "${post.title}" with postId "${post._id}" are below.  Note that the comments are threaded (i.e. branching) and are formatted as a nested JSON structure for readability.  The threads of conversation (back and forth responses) might be relevant for answering some questions.
 
@@ -59,9 +118,27 @@ Score: ${post.baseScore}
 Content: ${markdown}`;
 }
 
-const formatAdditionalPostsForPrompt = (posts: PostsPage[]): string => {
+const formatAdditionalPostsForPrompt = (posts: PostsPage[], tokenCounter: TokenCounter): string => {
   const formattedPosts = posts.map(post => formatPostForPrompt(post));
-  return formattedPosts.map((post, index) => `Supplementary Post #${index}:\n${post}`).join('\n')
+  const includedPosts: string[] = [];
+
+  for (let [idx, formattedPost] of Object.entries(formattedPosts)) {
+    const approximatePostTokenCount = formattedPost.length / CHARS_PER_TOKEN;
+    const postInclusionTokenCount = tokenCounter.tokenCount + approximatePostTokenCount;
+    // Include at least one additional post, unless that takes us over the higher threshold
+    if (idx !== '0' && postInclusionTokenCount > 120_000) {
+      break;
+    }
+
+    if (idx === '0' && postInclusionTokenCount > 140_000) {
+      break;
+    }
+
+    includedPosts.push(formattedPost);
+    tokenCounter.tokenCount += approximatePostTokenCount;
+  }
+
+  return includedPosts.map((post, index) => `Supplementary Post #${index}:\n${post}`).join('\n')
 }
 
 export const generateLoadingMessagePrompt = (query: string, postTitle?: string): string => {
@@ -132,26 +209,10 @@ export const generateAssistantContextMessage = async (query: string, currentPost
   const currentPostLine = currentPost
     ? `The user is currently viewing the post titled "${currentPost.title}" with postId "${currentPost._id}".\n\n`
     : '';
-
-  const additionalPostsBlock = additionalPosts.length > 0
-    ? `The following posts have been provided as possibly relevant context: <AdditionalPosts>\n${formatAdditionalPostsForPrompt(additionalPosts)}\n</AdditionalPosts>\n\n`
-    : '';
   
   const currentPostContentBlock = currentPost
     ? `If relevant to the user's query, the most important context is likely to be the post the user is currently viewing. The full text of the current post is provided below:
 <CurrentPost>\n${formatPostForPrompt(currentPost)}\n</CurrentPost>\n\n`
-    : '';
-
-  const commentsOnPostBlock = includeComments && currentPost
-    ? `These are the comments on the current post:
-<CurrentPostComments>\n${await formatCommentsForPost(currentPost, context)}\n</CurrentPostComments>\n\n`
-    : '';
-
-  const contextBlock = contextIsProvided
-    ? `The following context is provided to help you answer the user's question. Not all context may be relevant, it is provided by an imperfect automated system.
-<Context>    
-${currentPostLine}${additionalPostsBlock}${currentPostContentBlock}${commentsOnPostBlock}
-</Context>`
     : '';
 
   const additionalInstructionContextLine = contextIsProvided
@@ -171,6 +232,31 @@ The postId and commentIds (the _id in each comment) are given in the search resu
 
   const repeatedPostTitleLine = currentPost
     ? `\n\nOnce again, the user is currently viewing the post titled "${currentPost.title}".`
+    : '';
+
+  const approximateUsedTokens = (
+    currentPostLine.length
+    + currentPostContentBlock.length
+    + additionalInstructions.length
+    + repeatedPostTitleLine.length
+  ) / CHARS_PER_TOKEN;
+
+  const tokenCounter = { tokenCount: approximateUsedTokens };
+
+  const additionalPostsBlock = additionalPosts.length > 0
+    ? `The following posts have been provided as possibly relevant context: <AdditionalPosts>\n${formatAdditionalPostsForPrompt(additionalPosts, tokenCounter)}\n</AdditionalPosts>\n\n`
+    : '';
+
+  const commentsOnPostBlock = includeComments && currentPost
+    ? `These are the comments on the current post:
+<CurrentPostComments>\n${await formatCommentsForPost(currentPost, tokenCounter, context)}\n</CurrentPostComments>\n\n`
+    : '';
+
+  const contextBlock = contextIsProvided
+    ? `The following context is provided to help you answer the user's question. Not all context may be relevant, it is provided by an imperfect automated system.
+<Context>    
+${currentPostLine}${additionalPostsBlock}${currentPostContentBlock}${commentsOnPostBlock}
+</Context>`
     : '';
 
   return `<SystemInstruction>You are interfacing with a user via chat window on LessWrong.com. The user has sent a query: "${query}".

--- a/packages/lesswrong/server/resolvers/anthropicResolvers.ts
+++ b/packages/lesswrong/server/resolvers/anthropicResolvers.ts
@@ -15,6 +15,7 @@ import { asyncMapSequential } from "@/lib/utils/asyncUtils";
 import { markdownToHtml, htmlToMarkdown } from "../editor/conversionUtils";
 import { getOpenAI } from "../languageModels/languageModelIntegration";
 import express, { Express } from "express";
+import { captureException } from "@sentry/core";
 
 interface InitializeConversationArgs {
   newMessage: ClientMessage;
@@ -587,6 +588,7 @@ export function addLlmChatEndpoint(app: Express) {
       
       await sendStreamEndEvent(conversationId, sendEventToClient);
     } catch (err) {
+      captureException(err);
       await sendStreamErrorEvent(conversationId, err.message, sendEventToClient);
     }
 


### PR DESCRIPTION
This PR does two main things:
1. tries to make sure we don't go over a conversations token limit when creating the initial message context
2. more gracefully handles errors both before and after we start the streaming response

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208186588563023) by [Unito](https://www.unito.io)
