### PR TITLE
Fix alignment issues in authorAndSecondaryInfo

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -20,7 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   authorAndSecondaryInfo: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'baseline',
     columnGap: 20,
     ...theme.typography.commentStyle,
     flexWrap: 'wrap',


### PR DESCRIPTION
the "group types" on LessWrong events were looking slightly off. Changing the alignment from "center" to "baseline" seems to improve it and looks okay in non-event contexts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208194296794068) by [Unito](https://www.unito.io)
