### PR TITLE
create a new revision even for update operations with no editable diff

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -223,32 +223,28 @@ function addEditableCallbacks<N extends CollectionNameString>({collection, optio
       const editedAt = new Date()
       const previousRev = await getLatestRev(newDocument._id, fieldName);
       const version = getNextVersion(previousRev, updateType, (newDocument as DbPost).draft)
+      const changeMetrics = htmlToChangeMetrics(previousRev?.html || "", html);
 
-      let newRevisionId;
-      if (await revisionIsChange(newDocument, fieldName)) {
-        const changeMetrics = htmlToChangeMetrics(previousRev?.html || "", html);
+      const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "extendedScore"| "score" | "inactive" | "autosaveTimeoutStart" | "afBaseScore" | "afExtendedScore" | "afVoteCount" | "legacyData" | "googleDocMetadata"> = {
+        documentId: document._id,
+        ...revision,
+        fieldName,
+        collectionName,
+        version,
+        draft: versionIsDraft(version, collectionName),
+        updateType,
+        commitMessage,
+        changeMetrics,
+        createdAt: editedAt,
+      };
+      
+      const newRevisionDoc = await createMutator({
+        collection: Revisions,
+        document: newRevision,
+        validate: false
+      });
 
-        const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "extendedScore"| "score" | "inactive" | "autosaveTimeoutStart" | "afBaseScore" | "afExtendedScore" | "afVoteCount" | "legacyData" | "googleDocMetadata"> = {
-          documentId: document._id,
-          ...revision,
-          fieldName,
-          collectionName,
-          version,
-          draft: versionIsDraft(version, collectionName),
-          updateType,
-          commitMessage,
-          changeMetrics,
-          createdAt: editedAt,
-        }
-        const newRevisionDoc = await createMutator({
-          collection: Revisions,
-          document: newRevision,
-          validate: false
-        });
-        newRevisionId = newRevisionDoc.data._id;
-      } else {
-        newRevisionId = previousRev!._id;
-      }
+      const newRevisionId = newRevisionDoc.data._id;
 
       if (newRevisionId) {
         await afterCreateRevisionCallback.runCallbacksAsync([{ revisionID: newRevisionId }]);


### PR DESCRIPTION
A user reported that https://www.lesswrong.com/posts/n3Q7F3v6wBLsioqt8/extended-interview-with-zhukeepa-on-religion was missing its table of contents.  However, the table of contents was still visible to admins!

After much investigation, it turned out that the root cause was the post's `contents_latest` field pointing to a revision with `draft: true` (one of the ckEditor autosave revisions).  How did this happen, given that ckEditor autosaves don't update the post itself?  Well, the `updateBefore` make_editable callback checked whether the update operation was effectively a no-op by comparing the contents sent by the client for the editable field to the most recent revision (regardless of draft status).  If there was any difference, it created a new revision and updated the contents_latest to point to that revision.  If there _wasn't_ a difference, it _still_ set the contents_latest to the most recent revision's _id, even if that revision was a cloud editor autosave (and thus had `draft: true`).

Later, when users actually looked at the post, we rely on `useDynamicTableOfContents` to extract the ToC from either `post.tableOfContents` (a resolver field) if it's present, and falling back to dynamically extracting it from `post?.contents?.html` if not... which, of course, for anyone other than admins or the post author, would be null, since the `contents` field was resolved via a join using `contents_latest`, and then run through proper permissions checks which see that we shouldn't be returning a draft revision to logged out users.  But actually this part worked fine, since the `fullPost` (rather than the prefetched post) uses a fragment which includes the `tableOfContents` resolver field, which uses `getToCforPost`, which (in this case) uses `getLatestContentsRevision`, which just does a revision lookup based on the post's `contents_latest` value and _doesn't_ do a permissions check (probably bad).  But in `PostsPage` we decide whether or not to show the ToC based on this: `toc: (post.contents?.wordCount || 0) > HIDE_TOC_WORDCOUNT_LIMIT && tableOfContents`.  Naturally that `post.contents` was null for logged out users, in this case.  (That line was added by either @Discordius or @Raemon when they were refactoring LessWrong's post page header.  Normally it's reasonable to assume that it'd be there, and also be consistent with everything else, but...)

A brief tl;dr of some issues that either I or @Discordius noticed while debugging this:
- there are a number of places where we don't properly check permissions for revision data (or things derived from it) before returning it to the user.  This includes many uses of `getLatestContentsRevision` (since it relies on `contents_latest` correctly pointing to non-draft revisions, but as we see this is not guaranteed to be true), which is what's used by default when calling `getToCforPost` without a version.  Examples are `tableOfContents`, `sideComments`, `dialogueMessageContents` (for dialogue tooltip previews), some legacy fields, etc.
- this also includes any sqlResolvers doing the same join.
- in general, it seems like `contents_latest` is a bit of a footgun which we don't actually need; unless we're missing it something it seems like we should just be able to always fetch the latest field revision for a given documentId, and in contexts where we want the latest published revision we also condition on `draft: false` (i.e. the `contents` field resolver, probably also ToCs, sideComments, etc), and in other contexts (like in the post editor) we don't condition on `draft: false`.  This accomplishes the same thing without the risk of `contents_latest` incorrectly pointing to a draft revision.
- `getLatestRev` should probably be called something like `getLatestRevEvenIfDraft`, and we should at some point audit all uses of it.  (I suspect we will find some bugs.)
- `getLatestContentsRevision` should be called something like `getLatestPublishedRevision`, and should get that documentId's `draft: false` revision with the most recent `editedAt` value (i.e. not rely on `contents_latest`).  Also audit all uses of it.