### PR TITLE
Fix side items resizeobserver loop

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -154,7 +154,7 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
   const postPageContext = usePostsPageContext();
   const post = postPageContext?.fullPost ?? postPageContext?.postPreload;
   const sidenotesDisabledOnPost = post?.disableSidenotes;
-  const screenIsWideEnoughForSidenotes = useIsAboveBreakpoint("md");
+  const screenIsWideEnoughForSidenotes = useIsAboveBreakpoint("lg");
   const sidenoteIsVisible = hasSidenotes && !sidenotesDisabledOnPost && screenIsWideEnoughForSidenotes;
 
   return (


### PR DESCRIPTION
Fixed a bug where side-items recomputed heights every frame, making the post page sluggish (especially but not exclusively under Safari) and using lots of CPU.

Also: Fix a breakpoint mismatch which made it so there was one breakpoint with neither footnote hover preview nor sidenotes.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208194963869095) by [Unito](https://www.unito.io)
