### PR TITLE
Fix turndown conversion of LaTeX and footnotes

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -398,7 +398,7 @@ export const sanitize = function(s: string): string {
       'neuronpedia.org'
     ],
     allowedClasses: {
-      span: [ 'footnote-reference', 'footnote-label', 'footnote-back-link' ],
+      span: [ 'footnote-reference', 'footnote-label', 'footnote-back-link', "math-tex" ],
       div: [
         'spoilers',
         'footnote-content',

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -42,7 +42,7 @@ turndownService.addRule('footnote', {
   filter: (node, options) => node.classList?.contains('footnote-item'),
   replacement: (content, node) => {
     // Use the data-footnote-id attribute to get the footnote id
-    const id = (node as Element).getAttribute('data-footnote-id')
+    const id = (node as Element).getAttribute('data-footnote-id') || 'missing-id'
 
     // Get the content of the footnote by getting the content of the footnote-content div
     const text = (node as Element).querySelector('.footnote-content')?.textContent || ''

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -66,7 +66,7 @@ turndownService.addRule('latex-spans', {
   filter: (node, options) => node.classList?.contains('math-tex'),
   replacement: (content) => {
     // Leave the first three and last three characters alone, and then replace every escaped markdown control character with its unescaped version
-    return content.slice(0, 3) + content.slice(3, -3).replace(/\\([ \\!"#$%&'()*+,.\/:;<=>?@[\]^_`{|}~-])/g, '$1') + content.slice(-3)
+    return content.slice(0, 3) + content.slice(3, -3).replace(/\\([ \\!"#$%&'()*+,./:;<=>?@[\]^_`{|}~-])/g, '$1') + content.slice(-3)
   }
 })
 

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -33,7 +33,7 @@ turndownService.addRule('footnote-ref', {
   filter: (node, options) => node.classList?.contains('footnote-reference'),
   replacement: (content, node) => {
     // Use the data-footnote-id attribute to get the footnote id
-    const id = (node as Element).getAttribute('data-footnote-id') || 'missing-id'
+    const id = (node as Element).getAttribute('data-footnote-id') || 'MISSING-ID'
     return `[^${id}]`
   }
 })
@@ -42,7 +42,7 @@ turndownService.addRule('footnote', {
   filter: (node, options) => node.classList?.contains('footnote-item'),
   replacement: (content, node) => {
     // Use the data-footnote-id attribute to get the footnote id
-    const id = (node as Element).getAttribute('data-footnote-id') || 'missing-id'
+    const id = (node as Element).getAttribute('data-footnote-id') || 'MISSING-ID'
 
     // Get the content of the footnote by getting the content of the footnote-content div
     const text = (node as Element).querySelector('.footnote-content')?.textContent || ''

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -33,7 +33,7 @@ turndownService.addRule('footnote-ref', {
   filter: (node, options) => node.classList?.contains('footnote-reference'),
   replacement: (content, node) => {
     // Use the data-footnote-id attribute to get the footnote id
-    const id = (node as Element).getAttribute('data-footnote-id')
+    const id = (node as Element).getAttribute('data-footnote-id') || 'missing-id'
     return `[^${id}]`
   }
 })


### PR DESCRIPTION
Right now, if you create a LW editor document with LaTeX or footnotes, the resulting markdown will be invalid markdown, because Turndown does not understand the relevant syntax.

This fixes that and allows for round-tripping for both LaTeX and footnotes. These implementations are not enormously robust, but worked well-enough for the cases I looked at.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208195326864904) by [Unito](https://www.unito.io)
