### PR TITLE
fix inline react context usage breaking old dialogues

### DIFF
--- a/packages/lesswrong/components/comments/DebateResponse.tsx
+++ b/packages/lesswrong/components/comments/DebateResponse.tsx
@@ -92,7 +92,7 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
   responses: DebateResponseWithReplies[],
   post: PostsWithNavigation | PostsWithNavigationAndRevision,
 }) => {
-    const { CommentUserName, CommentsItemDate, CommentBody, CommentsEditForm, CommentsMenu, DebateCommentsListSection } = Components;
+    const { CommentUserName, CommentsItemDate, CommentBody, CommentsEditForm, CommentsMenu, DebateCommentsListSection, HoveredReactionContextProvider } = Components;
 
     const [showReplyState, setShowReplyState] = useState(false);
     const [showEdit, setShowEdit] = useState(false);
@@ -104,10 +104,7 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
 
     const VoteBottomComponent = votingSystem.getCommentBottomComponent?.() ?? null;
 
-
     const fullParticipantSet = new Set([post.userId, ...(post.coauthorStatuses ?? []).map(coauthor => coauthor.userId)]);
-
-
 
     const currentUser = useCurrentUser();
 
@@ -166,30 +163,32 @@ export const DebateResponse = ({classes, comment, replies, idx, responseCount, o
     const replyState = showReplyState && showReplyLink && replyCommentList;
 
     return (
-      <div
-        key={`debate-comment-${comment._id}`}
-        id={`debate-comment-${comment._id}`}
-        className={classNames(classes.innerDebateComment, borderStyle, { [classes.blockMargin]: addBottomMargin })}
-      >
-        {header}
-        {menu}
-        <div className={classes.commentWithReplyButton}>
-          {commentBodyOrEditor}
+      <HoveredReactionContextProvider voteProps={voteProps}>
+        <div
+          key={`debate-comment-${comment._id}`}
+          id={`debate-comment-${comment._id}`}
+          className={classNames(classes.innerDebateComment, borderStyle, { [classes.blockMargin]: addBottomMargin })}
+        >
+          {header}
+          {menu}
+          <div className={classes.commentWithReplyButton}>
+            {commentBodyOrEditor}
+          </div>
+          {replyState}
+          <div className={classes.bottomUI}>
+            {VoteBottomComponent && <VoteBottomComponent
+              document={comment}
+              hideKarma={post.hideCommentKarma}
+              collectionName="Comments"
+              votingSystem={votingSystem}
+              commentBodyRef={commentBodyRef}
+              voteProps={voteProps}
+              post={post}
+            />}
+            {replyLink}
+          </div>
         </div>
-        {replyState}
-        <div className={classes.bottomUI}>
-          {VoteBottomComponent && <VoteBottomComponent
-            document={comment}
-            hideKarma={post.hideCommentKarma}
-            collectionName="Comments"
-            votingSystem={votingSystem}
-            commentBodyRef={commentBodyRef}
-            voteProps={voteProps}
-            post={post}
-          />}
-          {replyLink}
-        </div>
-      </div>
+      </HoveredReactionContextProvider>
     );
   }
 

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -55,7 +55,7 @@ const InlineReactHoverableHighlight = ({quote, reactions, isSplitContinuation=fa
   const { InlineReactHoverInfo, SideItem, LWTooltip } = Components;
 
   const hoveredReactions = useContext(HoveredReactionListContext);
-  const voteProps = useContext(InlineReactVoteContext)!;
+  const voteProps = useContext(InlineReactVoteContext);
 
   const isHovered = hoveredReactions
     && Object.keys(reactions).some(reaction =>
@@ -97,6 +97,10 @@ const InlineReactHoverableHighlight = ({quote, reactions, isSplitContinuation=fa
   // 1) the quote itself is hovered over, or
   // 2) if the post/comment is hovered over, and the react has net-positive agreement across all users
   const shouldUnderline = isHovered || anyPositive;
+
+  if (!voteProps) {
+    return null;
+  }
 
   return <LWTooltip
     title={<InlineReactHoverInfo


### PR DESCRIPTION
Old dialogues weren't using the hoverable inline react context, which led to them breaking at some point.  This adds the context provider.  (Separately, returning `null` from `InlineReactHoverableHighlight` when `InlineReactVoteContext` was missing also seemed to "fix" the issue, though I think made inline reacts unavailable.  It seems like a safer default than passing in `null` VoteProps to downstream components which break the entire page, but not sure.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208198561870999) by [Unito](https://www.unito.io)
