### PR TITLE
Fix conflict in `fetchFragment` caused by order of PR merges

### DIFF
--- a/packages/lesswrong/server/fetchFragment.ts
+++ b/packages/lesswrong/server/fetchFragment.ts
@@ -64,7 +64,10 @@ export const fetchFragment = async <
   context: maybeContext,
   skipFiltering,
 }: FetchFragmentOptions<CollectionName, FragmentName>): Promise<FetchedFragment<FragmentName>[]> => {
-  const context = maybeContext ?? await computeContextFromUser(currentUser);
+  const context = maybeContext ?? await computeContextFromUser({
+    user: currentUser,
+    isSSR: false,
+  });
 
   const query = new SelectFragmentQuery(
     fragmentName as FragmentName,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208205628277599) by [Unito](https://www.unito.io)
