### PR TITLE
Fix off-by-one in sidenote numbering on some posts

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -267,11 +267,17 @@ function getFootnoteIndex(href: string, html: string): string|null {
       const olStartAttr = parentElement.getAttribute("start");
       const olStart = olStartAttr ? parseInt(olStartAttr) : 1;
 
+      let numPrecedingLiElements = 0;
       for (let i=0; i<parentElement.children.length; i++) {
-        if (parentElement.children.item(i) === footnoteElement) {
-          return ""+(i+olStart);
+        const elem = parentElement.children.item(i);
+        if (elem?.tagName === 'LI') {
+          numPrecedingLiElements++;
+        }
+        if (elem === footnoteElement) {
+          break;
         }
       }
+      return ""+(numPrecedingLiElements+olStart);
     }
   }
   


### PR DESCRIPTION
Example affected post: https://www.lesswrong.com/posts/YsFZF3K9tuzbfrLxo/counting-arguments-provide-no-evidence-for-ai-doom

When footnote links don't contain numbering metadata, we find the corresponding `<li>` element in the post footer, count the elements before it in the `<ol>`, and use that as its footnote number. However, if any `<span>`s got mixed into the `<ol>`, they will count as though they were numbered footnotes (even though they don't increment the CSS number counter), causing footnote numbering to be off by one. Fix this by only counting `<li>` elements in that case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208216710916910) by [Unito](https://www.unito.io)
