### PR TITLE
Don't hide footnote hover if sidenotes are enabled by have no column available

### DIFF
--- a/packages/lesswrong/components/contents/SideItems.tsx
+++ b/packages/lesswrong/components/contents/SideItems.tsx
@@ -250,6 +250,10 @@ const SideItem = ({options, children}: {
   </span>
 }
 
+export const useHasSideItemsSidebar = (): boolean => {
+  return !!useContext(SideItemsPlacementContext);
+}
+
 const SideItemsContainerComponent = registerComponent('SideItemsContainer', SideItemsContainer, {styles});
 const SideItemsSidebarComponent = registerComponent('SideItemsSidebar', SideItemsSidebar, {styles});
 const SideItemComponent = registerComponent('SideItem', SideItem, {});

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -9,6 +9,7 @@ import { parseDocumentFromString } from '@/lib/domParser';
 import { usePostsPageContext } from '../posts/PostsPage/PostsPageContext';
 import { RIGHT_COLUMN_WIDTH_WITH_SIDENOTES, sidenotesHiddenBreakpoint } from '../posts/PostsPage/PostsPage';
 import { useIsAboveBreakpoint } from '../hooks/useScreenWidth';
+import { useHasSideItemsSidebar } from '../contents/SideItems';
 
 const footnotePreviewStyles = (theme: ThemeType) => ({
   hovercard: {
@@ -155,7 +156,8 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
   const post = postPageContext?.fullPost ?? postPageContext?.postPreload;
   const sidenotesDisabledOnPost = post?.disableSidenotes;
   const screenIsWideEnoughForSidenotes = useIsAboveBreakpoint("lg");
-  const sidenoteIsVisible = hasSidenotes && !sidenotesDisabledOnPost && screenIsWideEnoughForSidenotes;
+  const hasSideItemsSidebar = useHasSideItemsSidebar();
+  const sidenoteIsVisible = hasSidenotes && hasSideItemsSidebar && !sidenotesDisabledOnPost && screenIsWideEnoughForSidenotes;
 
   return (
     <span>


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208216772429901) by [Unito](https://www.unito.io)
