### PR TITLE
Fix accidental display of spotlight metadata [hotfix]

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -501,7 +501,7 @@ export const SpotlightItem = ({
           </LWTooltip>}
         </div>}
       </div>
-      {edit ? <div className={classes.form}>
+      {edit && <div className={classes.form}>
             <SpotlightEditorStyles>
             <WrappedSmartForm
               collectionName="Spotlights"
@@ -512,8 +512,8 @@ export const SpotlightItem = ({
             />
             </SpotlightEditorStyles>
           </div>
-           :
-          <div className={classes.metaData}>
+      }
+      {!edit && showAdminInfo &&  <div className={classes.metaData}>
             {spotlight.draft && <MetaInfo>[Draft]</MetaInfo>}
             <MetaInfo>{spotlight.position}</MetaInfo>
             <MetaInfo><FormatDate date={spotlight.lastPromotedAt} format="YYYY-MM-DD"/></MetaInfo>

--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -56,7 +56,7 @@ export const lessWrongTheme: SiteThemeSpecification = {
     },
     link: {
       color: "#327E09",
-      visited: "#798754"
+      visited: "#957950",
     },
   }),
   make: (palette: ThemePalette) => ({


### PR DESCRIPTION
In a previous commit, I made it so that admins could edit spotlights from the frontpage, but accidentally also exposed some metadata.

This PR updates it to properly only shows the editor (which is accessible only if you're an admin)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208218616097032) by [Unito](https://www.unito.io)
