### PR TITLE
ReactionHoverTopRow: Guarantee margin between reaction description and user names

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/ReactionHoverTopRow.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionHoverTopRow.tsx
@@ -30,7 +30,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   hoverBallotLabel: {
     verticalAlign: "middle",
     display: "inline-block",
-    minWidth: 80,
+    minWidth: 70,
+    marginRight: 10,
     marginBottom: 4
   },
   hoverBallotReactDescription: {


### PR DESCRIPTION
If a reaction description used up all of the allocated width, there would be no margin between it and the name of the user who reacted, resulting in a hover that looks like this:

![screenshot_2024-08-26_at_2 23 04___pm](https://github.com/user-attachments/assets/91cd11e1-2194-4bfa-882b-18ac0d6337f3)

Fix that by converting some of the min-width into margin. https://lworg.slack.com/archives/CJUN2UAFN/p1724707412485539

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208218960307276) by [Unito](https://www.unito.io)
