### PR TITLE
Welcome box margin top

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -7,9 +7,11 @@ import { getHostname, getProtocol } from './PostsPagePostHeader';
 import { postGetLink, postGetLinkTarget } from '@/lib/collections/posts/helpers';
 import { BOOKUI_LINKPOST_WORDCOUNT_THRESHOLD } from './PostBodyPrefix';
 
+export const LW_POST_PAGE_PADDING = 110;
+
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    paddingTop: 110,
+    paddingTop: LW_POST_PAGE_PADDING,
     marginBottom: 96,
     [theme.breakpoints.down('xs')]: {
       paddingTop: 16,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -40,6 +40,7 @@ import { useVote } from '@/components/votes/withVote';
 import { getVotingSystemByName } from '@/lib/voting/votingSystems';
 import DeferRender from '@/components/common/DeferRender';
 import { SideItemVisibilityContextProvider } from '@/components/dropdowns/posts/SetSideItemVisibility';
+import { LW_POST_PAGE_PADDING } from './LWPostsPageHeader';
 
 const HIDE_TOC_WORDCOUNT_LIMIT = 300
 export const MAX_COLUMN_WIDTH = 720
@@ -308,6 +309,7 @@ export const styles = (theme: ThemeType) => ({
     display: "none"
   },
   welcomeBox: {
+    marginTop: LW_POST_PAGE_PADDING,
     [theme.breakpoints.down('md')]: {
       display: 'none'
     }
@@ -737,7 +739,9 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
 
   const welcomeBox = (
     <DeferRender ssr={false}>
-      <WelcomeBox />
+      <div className={classes.welcomeBox}>
+        <WelcomeBox />
+      </div>
     </DeferRender>
   );
   

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -310,6 +310,7 @@ export const styles = (theme: ThemeType) => ({
   },
   welcomeBox: {
     marginTop: LW_POST_PAGE_PADDING,
+    maxWidth: 220,
     [theme.breakpoints.down('md')]: {
       display: 'none'
     }


### PR DESCRIPTION
Fixes the padding of the welcome box.

I think we probably want to do something else with this because I think it shows up on either every lesswrong post for logged out users, or, some high percentage of them in an A/B test, and it kinda ruins the beautiful new page. But, will figure that out later.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/87959dcd-07fd-46ac-a58c-252c6e6f3385">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208232599224147) by [Unito](https://www.unito.io)
