### PR TITLE
Various bits of polish on side-items

### DIFF
--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType) => ({
   clickToPinMessage: {
     position: "absolute",
     display: "inline-block",
-    top: -2, left: 28,
+    top: -2, left: 36,
     fontSize: 13,
     color: theme.palette.text.dim45,
     fontFamily: theme.palette.fonts.sansSerifStack,

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -82,6 +82,10 @@ const footnotePreviewStyles = (theme: ThemeType) => ({
     "$sidenoteHover &": {
       color: theme.palette.text.normal,
     },
+    "& li": {
+      fontSize: "0.9em",
+      lineHeight: "1.4em",
+    },
   },
   
   overflowFade: {

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -16,12 +16,13 @@ const styles = (theme: ThemeType) => ({
 
   sidebarInlineReactIcons: {
     display: "none",
-    width: "100%",
     opacity: 0.5,
-    paddingLeft: 8,
+    marginLeft: 4,
+    paddingLeft: 4,
+    paddingRight: 4,
     
     [theme.breakpoints.up('sm')]: {
-      display: "block",
+      display: "inline-block",
     },
   },
   inlineReactSidebarLine: {
@@ -30,19 +31,6 @@ const styles = (theme: ThemeType) => ({
   
   // Keeping this empty class around is necessary for the following @global style to work properly
   highlight: {},
-
-  // Comment hovered (post uses side-icons instead)
-  "@global": {
-    [
-      ".CommentsItem-body:hover .InlineReactHoverableHighlight-highlight"
-      +", .Answer-answer:hover .InlineReactHoverableHighlight-highlight"
-    ]: {
-      textDecorationLine: 'underline',
-      textDecorationStyle: 'dashed',
-      textDecorationColor: theme.palette.text.dim4,
-      textUnderlineOffset: '3px'
-    },
-  }
 })
 
 const InlineReactHoverableHighlight = ({quote, reactions, isSplitContinuation=false, children, classes}: {


### PR DESCRIPTION
 * Inline reaction icons have a smaller hover area (not the full width of the side-item column)
 * Fix the spacing of the "Click to pin" text on side-comments
 * Inline reactions in comments no longer cause the text to be underlined
 * List item bullets in sidenotes no longer have an oversized font

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208233130735022) by [Unito](https://www.unito.io)
