### PR TITLE
Auto-restart worker processes when they die

### DIFF
--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -25,6 +25,7 @@ const numCPUs = cpus().length;
  */
 export const clusterSetting = new PublicInstanceSetting<boolean>('cluster.enabled', false, 'optional')
 export const numWorkersSetting = new PublicInstanceSetting<number>('cluster.numWorkers', numCPUs, 'optional')
+const processRestartDelay = 5000;
 
 // Do this here to avoid a dependency cycle
 Globals.dropAndCreatePg = dropAndCreatePg;
@@ -144,6 +145,7 @@ export const serverStartup = async () => {
 
     cluster.on('exit', (worker, _code, _signal) => {
       console.log(`Worker ${worker.process.pid} died`);
+      setTimeout(() => cluster.fork(), processRestartDelay);;
     });
   } else {
     if (clusterRole !== "standalone") {

--- a/packages/lesswrong/server/serverStartup.ts
+++ b/packages/lesswrong/server/serverStartup.ts
@@ -145,7 +145,7 @@ export const serverStartup = async () => {
 
     cluster.on('exit', (worker, _code, _signal) => {
       console.log(`Worker ${worker.process.pid} died`);
-      setTimeout(() => cluster.fork(), processRestartDelay);;
+      setTimeout(() => cluster.fork(), processRestartDelay);
     });
   } else {
     if (clusterRole !== "standalone") {


### PR DESCRIPTION
On prod, we have a primary process and two worker processes. If a worker process dies (such as by running out of memory), we previously wouldn't notice this, so if a server lost a worker process this way it would silently lose half its capacity. (Then if it lost its other worker, it would stop being able to service requests at all, and the load balancer would stop sending it any requests.)

NOTE: We (LW) got an error message from AWS that suggests we may be unable to start instances until we complete some sort of account verification. Do not deploy this until that's taken care of. https://lworg.slack.com/archives/C75BWSNBH/p1725557401746459

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208239145980945) by [Unito](https://www.unito.io)
