### PR TITLE
Hide unlisted posts from site search

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -410,6 +410,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         COALESCE(p."isEvent", FALSE) AS "isEvent",
         COALESCE(p."rejected", FALSE) AS "rejected",
         COALESCE(p."authorIsUnreviewed", FALSE) AS "authorIsUnreviewed",
+        COALESCE(p."unlisted", FALSE) AS "unlisted",
         COALESCE(p."viewCount", 0) AS "viewCount",
         p."lastCommentedAt",
         COALESCE(p."draft", FALSE) AS "draft",

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -223,6 +223,7 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
       {term: {draft: false}},
       {term: {rejected: false}},
       {term: {authorIsUnreviewed: false}},
+      {term: {unlisted: false}},
       {term: {status: postStatuses.STATUS_APPROVED}},
       ...(isEAForum ? [] : [{range: {baseScore: {gte: 0}}}]),
     ],
@@ -240,6 +241,7 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
     },
     privateFields: [
       "authorIsUnreviewed",
+      "unlisted",
       "draft",
       "isFuture",
       "legacy",


### PR DESCRIPTION
I marked a user's post as "unlisted" per request, and I noticed that it still appeared in the search results. I'm guessing that's unintended.

I'm adding a filter on post search results, so sites will need to run `Globals.elasticExportCollection('Posts')` to populate the new field in order for any post search results to appear.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208239740974883) by [Unito](https://www.unito.io)
