### PR TITLE
Expand button for llm chat

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -117,6 +117,8 @@ import MuiPlaylistAddIcon from "@material-ui/icons/PlaylistAdd";
 import PlusOneIcon from '@material-ui/icons/PlusOne';
 import UndoIcon from '@material-ui/icons/Undo';
 import ClearIcon from '@material-ui/icons/Clear';
+import FullscreenIcon from '@material-ui/icons/Fullscreen';
+import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
 
 
 /**
@@ -272,7 +274,9 @@ export type ForumIconName =
   "PlaylistAdd"|
   "PlusOne" |
   "Undo" |
-  "Clear" 
+  "Clear" |
+  "Fullscreen" |
+  "FullscreenExit"
   ;
 
 const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
@@ -390,7 +394,9 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     PlaylistAdd: MuiPlaylistAddIcon,
     PlusOne: PlusOneIcon,
     Undo: UndoIcon,
-    Clear: ClearIcon
+    Clear: ClearIcon,
+    Fullscreen: FullscreenIcon,
+    FullscreenExit: FullscreenExitIcon
   },
   default: {
     VolumeUp: SpeakerWaveIcon,
@@ -506,7 +512,9 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     PlaylistAdd: MuiPlaylistAddIcon,
     PlusOne: PlusOneIcon,
     Undo: UndoIcon,
-    Clear: ClearIcon
+    Clear: ClearIcon,
+    Fullscreen: FullscreenIcon,
+    FullscreenExit: FullscreenExitIcon
   },
 };
 

--- a/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
+++ b/packages/lesswrong/components/languageModels/LlmChatWrapper.tsx
@@ -164,7 +164,7 @@ const LlmChatWrapper = ({children}: {
     return sortBy(llmConversationsList, (conversation) => conversation.lastUpdatedAt ?? conversation.createdAt);
   }, [conversations]);
 
-  const [currentConversationId, setCurrentConversationId] = useState<string | undefined>(sortedConversations.slice(-1)[0]?._id);
+  const [currentConversationId, setCurrentConversationId] = useState<string>();
 
   const { document: currentConversationWithMessages } = useSingle({
     collectionName: "LlmConversations",

--- a/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
+++ b/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Paper from "@material-ui/core/Card"
 import CloseIcon from '@material-ui/icons/Close';
+import Fullscreen from '@material-ui/icons/Fullscreen';
+import FullscreenExit from '@material-ui/icons/FullscreenExit';
 import { useLlmChat } from './LlmChatWrapper';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
-import { SHOW_LLM_CHAT_COOKIE } from '@/lib/cookies/cookies';
+import { LLM_CHAT_EXPANDED, SHOW_LLM_CHAT_COOKIE } from '@/lib/cookies/cookies';
 import { AnalyticsContext } from '@/lib/analyticsEvents';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -19,6 +22,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('sm')]: {
       display: "none"
     }
+  },
+  expanded: {
+    width: 650,
   },
   title: {
     ...theme.typography.commentStyle,
@@ -40,10 +46,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: 350,
     fontSize: "0.9em"
   },
-  close: {
-    position: "absolute",
-    right: 8,
-    top: 10,
+  icon: {
+    marginLeft: 2,
     cursor: "pointer",
     color: theme.palette.grey[400],
     height: 20,
@@ -51,13 +55,20 @@ const styles = (theme: ThemeType): JssStyles => ({
       color: theme.palette.grey[600],
     }
   },
+  icons: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+  },
   header: {
     backgroundColor: theme.palette.grey[100],
     paddingLeft: 20,
     paddingRight: 20,
     paddingTop: 8,
     paddingBottom: 8,
-    position: "relative"
+    position: "relative",
+    display: "flex",
   },
   editor: {
     paddingLeft: 20,
@@ -76,7 +87,8 @@ const PopupLanguageModelChat = ({onClose, classes}: {
   const { LanguageModelChat, LWTooltip } = Components;
 
   const { currentConversation } = useLlmChat();
-  const [_, setCookie] = useCookiesWithConsent([SHOW_LLM_CHAT_COOKIE]);
+  const [cookies, setCookie] = useCookiesWithConsent([SHOW_LLM_CHAT_COOKIE, LLM_CHAT_EXPANDED]);
+  const expanded = cookies[LLM_CHAT_EXPANDED] === "true";
 
   const title = currentConversation?.title ?? PLACEHOLDER_TITLE;
 
@@ -85,7 +97,11 @@ const PopupLanguageModelChat = ({onClose, classes}: {
     onClose();
   }
 
-  return <Paper className={classes.root}>
+  const toggleExpanded = () => {
+    setCookie(LLM_CHAT_EXPANDED, expanded ? "false" : "true", { path: "/"})
+  }
+
+  return <Paper className={classNames(classes.root, {[classes.expanded]: expanded})}>
     <AnalyticsContext pageSectionContext='llmChatPopup'>
       <div className={classes.header}>
         <div className={classes.title}>
@@ -96,7 +112,13 @@ const PopupLanguageModelChat = ({onClose, classes}: {
             </div>
           </LWTooltip>
         </div>
-        <CloseIcon className={classes.close} onClick={handleClose} />
+        <div className={classes.icons}>
+          {expanded
+            ? <FullscreenExit className={classes.icon} onClick={toggleExpanded} />
+            : <Fullscreen className={classes.icon} onClick={toggleExpanded} />
+          }
+          <CloseIcon className={classes.icon} onClick={handleClose} />
+        </div>
       </div>
       <div className={classes.editor}>
         <LanguageModelChat />

--- a/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
+++ b/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
@@ -85,7 +85,7 @@ const PopupLanguageModelChat = ({onClose, classes}: {
   onClose: () => void,
   classes: ClassesType
 }) => {
-  const { LanguageModelChat, LWTooltip } = Components;
+  const { LanguageModelChat, LWTooltip, ForumIcon } = Components;
 
   const { currentConversation } = useLlmChat();
   const [cookies, setCookie] = useCookiesWithConsent([SHOW_LLM_CHAT_COOKIE, LLM_CHAT_EXPANDED]);
@@ -114,10 +114,7 @@ const PopupLanguageModelChat = ({onClose, classes}: {
           </LWTooltip>
         </div>
         <div className={classes.icons}>
-          {expanded
-            ? <FullscreenExit className={classes.icon} onClick={toggleExpanded} />
-            : <Fullscreen className={classes.icon} onClick={toggleExpanded} />
-          }
+          <ForumIcon icon={expanded ? "FullscreenExit" : "Fullscreen"} className={classes.icon} onClick={toggleExpanded} />
           <CloseIcon className={classes.icon} onClick={handleClose} />
         </div>
       </div>

--- a/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
+++ b/packages/lesswrong/components/languageModels/PopupLanguageModelChat.tsx
@@ -69,6 +69,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingBottom: 8,
     position: "relative",
     display: "flex",
+    justifyContent: "space-between",
   },
   editor: {
     paddingLeft: 20,

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -200,7 +200,13 @@ export const HIDE_LLM_CHAT_GUIDE_COOKIE = registerCookie({
   name: "llm_chat_guide_open",
   type: "functional",
   description: "Whether the LLM chat guide is open",
-});
+})
+
+export const LLM_CHAT_EXPANDED = registerCookie({
+  name: "llm_chat_expanded",
+  type: "functional",
+  description: "Whether the LLM chat has expanded size",
+})
 
 
 // Third party cookies


### PR DESCRIPTION
Had a user complain that when they wanted to use the LLM chat without caring about the current post, it was annoying/difficult to have the width be so narrow. This PR adds a button to allow for increasing the width of the LLM chat.

(Also changes it so that upon load, a new chat is opened rather than the most recently updated one.)

<img width="639" alt="LessWrong 2024-09-06 14-33-36" src="https://github.com/user-attachments/assets/d6cad08e-e2ef-4241-88e5-56380abff7c4">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208250100344385) by [Unito](https://www.unito.io)
