### PR TITLE
Convert various buttons, links and pseudolinks from activate-on-release to activate-on-press

### DIFF
--- a/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
+++ b/packages/lesswrong/components/comments/CommentsTableOfContents.tsx
@@ -174,7 +174,7 @@ const ToCCommentBlock = ({commentTree, indentLevel, highlightedCommentId, highli
       highlighted={highlightedCommentId===comment._id}
       dense
       href={"#"+comment._id}
-      onClick={ev => {
+      onMouseDown={ev => {
         const commentTop = getLandmarkY(commentIdToLandmark(comment._id));
         if (commentTop) {
           // Add window.scrollY because window.scrollTo takes a relative scroll distance

--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -77,7 +77,7 @@ const ExpandableSection = ({
               >
                 <ForumIcon
                   icon="ThickChevronRight"
-                  onClick={toggleExpanded}
+                  onMouseDown={toggleExpanded}
                   className={classNames(classes.expandIcon, {
                     [classes.chevronExpanded]: expanded,
                   })}

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -521,6 +521,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
 export type IconProps = {
   className: string,
   onClick: MouseEventHandler<SVGElement>,
+  onMouseDown: MouseEventHandler<SVGElement>,
 }
 
 export type IconComponent = ComponentType<Partial<IconProps>>;

--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -1,6 +1,6 @@
 // Modified From: https://github.com/rafrex/react-router-hash-link/blob/master/src/index.js
 
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-restricted-imports
 import { Link } from 'react-router-dom';
@@ -70,6 +70,7 @@ function hashLinkScroll() {
 
 export function HashLink(props: HashLinkProps) {
   const navigate = useNavigate();
+  const allowDefaultOnClick = useRef(false);
 
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     reset();
@@ -97,11 +98,26 @@ export function HashLink(props: HashLinkProps) {
         // Run any custom onMouseDown logic, including event tracking (such as that passed in from `Link`) before checking for modifier keys
         // This is necessary to capture e.g. `linkClicked` events when cmd-clicking to open links in a new tab
         filteredProps.onMouseDown?.(ev);
-        if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0) {
+
+        // If any modifier key is held, do nothing on down, and let the
+        // default behavior happen on the click event (ie on mouse up).
+        // Clicking on links with a modifier may mean opening in a new
+        // tab, or saving the destination of a page, but the exact behavior
+        // is browser-dependent.
+        if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0 || allowDefaultOnClick.current) {
+          allowDefaultOnClick.current = true;
           return;
         }
         navigate(to);
         ev.preventDefault();
+      }}
+      onClick={(ev) => {
+        filteredProps.onClick?.(ev);
+        if (allowDefaultOnClick.current) {
+          allowDefaultOnClick.current = false;
+        } else {
+          ev.preventDefault();
+        }
       }}
     >
       {props.children}

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -328,7 +328,7 @@ const Header = ({
                 )}
                 color="inherit"
                 aria-label="Menu"
-                onClick={()=>setNavigationOpen(true)}
+                onMouseDown={()=>setNavigationOpen(true)}
               >
                 <ForumIcon icon="Menu" />
               </IconButton>
@@ -341,7 +341,7 @@ const Header = ({
                 )}
                 color="inherit"
                 aria-label="Menu"
-                onClick={()=>setNavigationOpen(true)}
+                onMouseDown={()=>setNavigationOpen(true)}
               >
                 <TocIcon />
               </IconButton>
@@ -354,7 +354,7 @@ const Header = ({
             )}
             color="inherit"
             aria-label="Menu"
-            onClick={()=>setNavigationOpen(true)}
+            onMouseDown={()=>setNavigationOpen(true)}
           >
             <ForumIcon icon="Menu" />
           </IconButton>
@@ -366,7 +366,7 @@ const Header = ({
         )}
         color="inherit"
         aria-label="Menu"
-        onClick={toggleStandaloneNavigation}
+        onMouseDown={toggleStandaloneNavigation}
       >
         {(isFriendlyUI && !sidebarHidden) ? <ForumIcon icon="CloseMenu" /> : <ForumIcon icon="Menu" />}
       </IconButton>}
@@ -468,7 +468,7 @@ const Header = ({
               <Typography className={classes.title} variant="title">
                 <div className={classes.hideSmDown}>
                   <div className={classes.titleSubtitleContainer}>
-                    <Link to="/" className={classes.titleLink}>
+                    <Link to="/" className={classes.titleLink} doOnDown>
                       {hasProminentLogoSetting.get() && <div className={classes.siteLogo}><SiteLogo eaWhite={useWhiteText}/></div>}
                       {forumHeaderTitleSetting.get()}
                     </Link>

--- a/packages/lesswrong/components/common/LWClickAwayListener.tsx
+++ b/packages/lesswrong/components/common/LWClickAwayListener.tsx
@@ -7,8 +7,17 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
  * Without it, this would be a "onMouseUp" event, which happens BEFORE "onClick",
  * and resulted in some annoying behavior. Also MUI v5 defaults this to "onClick".
  */
-const LWClickAwayListener = ({onClickAway, children}: {
+const LWClickAwayListener = ({onClickAway, doOnDown=false, children}: {
   onClickAway: (ev: ClickAwayEvent) => void,
+  
+  /**
+   * If set, triggers on mousedown/touchstart rather than click/touchend. Use
+   * this if the clickaway closes something that was opened on-down, so that
+   * releasing the mouse button from doesn't close the popup that pressing the
+   * mouse button opened.
+   */
+  doOnDown?: boolean,
+
   children: React.ReactElement,
 }) => {
   return (
@@ -16,6 +25,10 @@ const LWClickAwayListener = ({onClickAway, children}: {
       onClickAway={ev => {
         onClickAway(ev);
       }}
+      {...(doOnDown && {
+        mouseEvent: "mousedown",
+        touchEvent: "touchstart",
+      })}
     >
       <span>
         {children}

--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -99,7 +99,6 @@ const LoadMore = ({
 
   const { Loading } = Components
   const handleClickLoadMore = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault();
     void loadMore();
     captureEvent("loadMoreClicked")
   }
@@ -118,7 +117,8 @@ const LoadMore = ({
         [classes.afterPostsListMarginTop]: afterPostsListMarginTop,
       })}
       href="#"
-      onClick={handleClickLoadMore}
+      onMouseDown={handleClickLoadMore}
+      onClick={ev => ev.preventDefault()}
     >
       {totalCount ? `${message} (${count}/${totalCount})` : `${message}`}
     </a>

--- a/packages/lesswrong/components/common/Menus.tsx
+++ b/packages/lesswrong/components/common/Menus.tsx
@@ -22,14 +22,16 @@ const MenuItem = ({value, disabled, disableRipple, dense, onClick, className, ch
   </MuiMenuItem>;
 }
 
-const MenuItemLink = ({to, className, rootClass, disabled, disableGutters, disableTouchRipple, onClick, children}: {
+const MenuItemLink = ({to, doOnDown=false, className, rootClass, disabled, disableGutters, disableTouchRipple, onClick, onMouseDown, children}: {
   to: string,
+  doOnDown?: boolean,
   className?: string,
   rootClass?: string,
   disabled?: boolean,
   disableGutters?: boolean,
   disableTouchRipple?: boolean,
   onClick?: (event: React.MouseEvent) => void,
+  onMouseDown?: (event: React.MouseEvent) => void,
   children: React.ReactNode,
 }) => {
   // MenuItem takes a component and passes unrecognized props to that component,
@@ -40,12 +42,14 @@ const MenuItemLink = ({to, className, rootClass, disabled, disableGutters, disab
   return <MuiMenuItemUntyped
     component={Link}
     to={to}
+    doOnDown={doOnDown}
     className={className}
     classes={{root: rootClass}}
     disabled={disabled}
     disableGutters={disableGutters}
     disableTouchRipple={disableTouchRipple}
     onClick={onClick}
+    onMouseDown={onMouseDown}
   >
     {children}
   </MuiMenuItemUntyped>

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -74,12 +74,7 @@ type TabNavigationFooterItemProps = {
 const TabNavigationFooterItem = ({tab, classes}: TabNavigationFooterItemProps) => {
   const { TabNavigationSubItem } = Components
   const { pathname } = useLocation()
-  // React router links don't handle external URLs, so use a
-  // normal HTML a tag if the URL is external
   const externalLink = /https?:\/\//.test(tab.link);
-  const Element = externalLink ?
-    ({to, ...rest}: { to: string, className: string }) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
-    : Link;
 
   const isSelected = pathname === tab.link;
   const hasIcon = tab.icon || tab.iconComponent || tab.selectedIconComponent;
@@ -88,10 +83,15 @@ const TabNavigationFooterItem = ({tab, classes}: TabNavigationFooterItemProps) =
     : tab.iconComponent;
 
   return <Tooltip placement='top' title={tab.tooltip || ''}>
-    <Element
+    <Link
       to={tab.link}
       className={classNames(classes.navButton, {
         [classes.selected]: isSelected,
+      })}
+      doOnDown
+      {...(externalLink && {
+        target: "_blank",
+        rel: "noopener noreferrer"
       })}
     >
       {hasIcon && <span
@@ -108,7 +108,7 @@ const TabNavigationFooterItem = ({tab, classes}: TabNavigationFooterItemProps) =
           { tab.mobileTitle || tab.title }
         </span>
       }
-    </Element>
+    </Link>
   </Tooltip>
 }
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -211,11 +211,12 @@ const TabNavigationItem = ({tab, onClick, className, classes}: TabNavigationItem
     className={classes.tooltip}
   >
     <MenuItemLink
-      onClick={handleClick}
+      onMouseDown={handleClick}
       // We tried making this [the 'component' of the underlying material-UI
       // MenuItem component] a function that return an a tag once. It made the
       // entire sidebar fail on iOS. True story.
       to={tab.link}
+      doOnDown
       disableGutters
       rootClass={classNames(classes.menuItem, className, {
         [classes.navButton]: !tab.subItem,

--- a/packages/lesswrong/components/common/TabPicker.tsx
+++ b/packages/lesswrong/components/common/TabPicker.tsx
@@ -294,7 +294,7 @@ const TabPicker = <T extends TabRecord[]>(
   return (
     <SingleColumnSection className={classes.tabsSection}>
       <div className={classes.tabsRow}>
-        {leftArrowVisible && <div onClick={scrollLeft} className={classNames(classes.arrow, classes.leftArrow)}>
+        {leftArrowVisible && <div onMouseDown={scrollLeft} className={classNames(classes.arrow, classes.leftArrow)}>
           <ForumIcon icon="ThickChevronLeft" className={classes.arrowIcon}/>
         </div>}
         <div className={classNames(classes.tabsWindowContainer, {
@@ -313,7 +313,7 @@ const TabPicker = <T extends TabRecord[]>(
                 hideOnTouchScreens
               >
                 <button
-                  onClick={() => updateActiveTab(tab.name)}
+                  onMouseDown={() => updateActiveTab(tab.name)}
                   className={classNames(classes.tab, { [classes.activeTab]: isActive, [classes.inactiveTab]: !isActive })}
                 >
                   {tab.label}
@@ -324,7 +324,7 @@ const TabPicker = <T extends TabRecord[]>(
             })}
           </div>
         </div>
-        {rightArrowVisible && <div onClick={scrollRight} className={classNames(classes.arrow, classes.rightArrow)}>
+        {rightArrowVisible && <div onMouseDown={scrollRight} className={classNames(classes.arrow, classes.rightArrow)}>
           <ForumIcon icon="ThickChevronRight" className={classes.arrowIcon}/>
         </div>}
       </div>

--- a/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
@@ -68,7 +68,10 @@ const PostActionsButton = ({post, vertical, popperGap, autoPlace, flip, includeB
 
   return <div className={classNames(classes.root, className)}>
     <div ref={anchorEl}>
-      <Icon className={classes.icon} onClick={(ev) => handleSetOpen(!isOpen)}/>
+      <Icon
+        className={classes.icon}
+        onMouseDown={(ev) => handleSetOpen(!isOpen)}
+      />
     </div>
     <PopperCard
       open={isOpen}
@@ -79,13 +82,15 @@ const PostActionsButton = ({post, vertical, popperGap, autoPlace, flip, includeB
       style={gapStyle}
     >
       {/*FIXME: ClickAwayListener doesn't handle portals correctly, which winds up making submenus inoperable. But we do still need clickaway to close.*/}
-      <LWClickAwayListener onClickAway={() => handleSetOpen(false)}>
+      <LWClickAwayListener
+        onClickAway={() => handleSetOpen(false)}
+        doOnDown
+      >
         <PostActions post={post} closeMenu={() => handleSetOpen(false)} includeBookmark={includeBookmark} />
       </LWClickAwayListener>
     </PopperCard>
   </div>
 }
-
 
 const PostActionsButtonComponent = registerComponent('PostActionsButton', PostActionsButton, {styles});
 

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -307,12 +307,12 @@ const FixedPositionToc = ({tocSections, title, onClickSection, displayOptions, c
             scale={0}
             fullHeight
             highlighted={currentSection === "above"}
-            onClick={ev => {
+            onMouseDown={ev => {
               if (isRegularClick(ev)) {
-              void handleClick(ev, () => {
-                navigate("#");
-                jumpToY(0)
-              });
+                void handleClick(ev, () => {
+                  navigate("#");
+                  jumpToY(0)
+                });
               }
             }}
           >
@@ -337,7 +337,7 @@ const FixedPositionToc = ({tocSections, title, onClickSection, displayOptions, c
         href={"#"+section.anchor}
         scale={section.scale}
         highlighted={section.anchor === currentSection}
-        onClick={(ev) => {
+        onMouseDown={(ev) => {
           if (isRegularClick(ev)) {
             void handleClick(ev, () => {
               jumpToAnchor(section.anchor)

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -110,7 +110,7 @@ const TableOfContentsList = ({tocSections, title, onClickSection, displayOptions
   return <div>
     <TableOfContentsRow key="postTitle"
       href="#"
-      onClick={ev => {
+      onMouseDown={ev => {
         if (isRegularClick(ev)) {
           void handleClick(ev, () => {
             navigate("#");
@@ -132,7 +132,7 @@ const TableOfContentsList = ({tocSections, title, onClickSection, displayOptions
           divider={section.divider}
           highlighted={section.anchor === currentSection}
           href={"#"+section.anchor}
-          onClick={(ev) => {
+          onMouseDown={(ev) => {
             if (isRegularClick(ev)) {
               void handleClick(ev, () => {
                 jumpToAnchor(section.anchor)

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import classNames from 'classnames';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import { fullHeightToCEnabled } from '../../../lib/betas';
+import { Link } from '@/lib/reactRouterWrapper';
 
 const sectionOffsetStyling = (fullHeightToCEnabled ? {
   display: 'flex',
@@ -118,12 +119,12 @@ const levelToClassName = (level: number, classes: ClassesType<typeof styles>) =>
 }
 
 const TableOfContentsRow = ({
-  indentLevel=0, highlighted=false, href, onClick, children, classes, title, divider, answer, dense, scale, fullHeight, commentToC
+  indentLevel=0, highlighted=false, href, onMouseDown, children, classes, title, divider, answer, dense, scale, fullHeight, commentToC
 }: {
   indentLevel?: number,
   highlighted?: boolean,
   href: string,
-  onClick?: (ev: any) => void,
+  onMouseDown?: (ev: any) => void,
   children?: React.ReactNode,
   classes: ClassesType<typeof styles>,
   title?: boolean,
@@ -152,13 +153,13 @@ const TableOfContentsRow = ({
     )}
     style={scaleStyling}
   >
-    <a href={href} onClick={onClick} className={classNames(classes.link, {
+    <Link doOnDown to={href} onMouseDown={onMouseDown} className={classNames(classes.link, {
       [classes.title]: title,
       [classes.highlightDot]: !answer,
       [classes.dense]: dense
     })}>
       {children}
-    </a>
+    </Link>
   </div>
 }
 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -219,7 +219,7 @@ const RecentDiscussionThread = ({
           <div className={classes.postItem}>
             {post.group && <PostsGroupDetails post={post} documentId={post.group._id} inRecentDiscussion={true} />}
             <div className={classes.titleAndActions}>
-              <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})} eventProps={{intent: 'expandPost'}}>
+              <Link doOnDown to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})} eventProps={{intent: 'expandPost'}}>
                 {post.title}
               </Link>
               {isSubforumIntroPost && currentUser ? <Button

--- a/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
@@ -266,7 +266,7 @@ const KarmaChangeNotifier = ({currentUser, className, classes}: {
     return <AnalyticsContext pageSection="karmaChangeNotifer">
       <div className={classNames(classes.root, className)}>
         <div ref={anchorEl}>
-          <IconButton onClick={handleToggle} className={classes.karmaNotifierButton}>
+          <IconButton onMouseDown={handleToggle} className={classes.karmaNotifierButton}>
             {starIsHollow
               ? <ForumIcon icon="KarmaOutline" className={classes.starIcon}/>
               : <Badge badgeContent={
@@ -285,7 +285,7 @@ const KarmaChangeNotifier = ({currentUser, className, classes}: {
           placement="bottom-end"
           className={classes.karmaNotifierPopper}
         >
-          <LWClickAwayListener onClickAway={handleClose}>
+          <LWClickAwayListener onClickAway={handleClose} doOnDown>
             <Paper className={classes.karmaNotifierPaper}>
               <KarmaChangesDisplay karmaChanges={karmaChanges} classes={classes} handleClose={handleClose} />
             </Paper>

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -121,6 +121,7 @@ const UsersNameDisplay = ({
               noKibitz && classes.noKibitz,
               nowrap && classes.nowrap,
             )}
+            doOnDown
             {...(nofollow ? {rel:"nofollow"} : {})}
           >
             {displayName}


### PR DESCRIPTION
This is a continuation of sorts for https://github.com/ForumMagnum/ForumMagnum/pull/9394 . In that PR, we made `PostsTitle` (the link part of `PostsItem`) activate on press, rather than release. This PR extends that change to a bunch of other links and buttons throughout the site. At this point I am _not_ doing this as a bulk find-replace; I checked each link in the UI when changing it, and a fair number of these turned out to have idiosyncratic issues. Rather, this is meant to cover a mix of the cases where snappiness is most important, and cases that are good representatives of corner cases that will arise when making act-on-press the default for everything.