### PR TITLE
Performance optimizations

### DIFF
--- a/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
+++ b/packages/lesswrong/components/dialogues/ActiveDialogues.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import Visibility from '@material-ui/icons/Visibility';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
+import isEqual from 'lodash/isEqual';
 
 
 const styles = (theme: ThemeType) => ({
@@ -107,7 +108,10 @@ export const ActiveDialogues = ({classes}: {
   useOnServerSentEvent('activeDialoguePartners', currentUser, (message) => {
     if (currentUser?._id && message.data) {  
       const otherActiveDialogues = message.data.filter((dialogue) => !location.pathname.includes(dialogue.postId) && !(location.query.postId === dialogue.postId)) // don't show a dialogue as active on its own page
-      setActiveDialogues(otherActiveDialogues);
+      setActiveDialogues((activeDialogues) =>
+        isEqual(activeDialogues, otherActiveDialogues)
+          ? activeDialogues : otherActiveDialogues
+      );
     }
   });
 

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import moment from 'moment';
 import { DatabasePublicSetting, localeSetting } from '../../lib/publicSettings';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { EnvironmentOverride, EnvironmentOverrideContext } from '../../lib/utils/timeUtil';
 // eslint-disable-next-line no-restricted-imports
 import { useLocation, withRouter } from 'react-router';
 import { useQueryCurrentUser } from '../../lib/crud/withCurrentUser';
@@ -25,10 +24,9 @@ export const siteImageSetting = new DatabasePublicSetting<string>('siteImage', '
 interface ExternalProps {
   apolloClient: AnyBecauseTodo,
   serverRequestStatus?: ServerRequestStatusContextType,
-  envOverride: EnvironmentOverride,
 }
 
-const App = ({serverRequestStatus, envOverride, history}: ExternalProps & {
+const App = ({serverRequestStatus, history}: ExternalProps & {
   history: History
 }) => {
   const {currentUser, refetchCurrentUser, currentUserLoading} = useQueryCurrentUser();
@@ -106,7 +104,6 @@ const App = ({serverRequestStatus, envOverride, history}: ExternalProps & {
     <NavigationContext.Provider value={navigationContext.current}>
     <SubscribeLocationContext.Provider value={subscribeLocationContext.current}>
     <ServerRequestStatusContext.Provider value={serverRequestStatus||null}>
-    <EnvironmentOverrideContext.Provider value={envOverride}>
     <RefetchCurrentUserContext.Provider value={refetchCurrentUser}>
       <MessageContextProvider>
         <Components.HeadTags image={siteImageSetting.get()} />
@@ -116,7 +113,6 @@ const App = ({serverRequestStatus, envOverride, history}: ExternalProps & {
         </Components.Layout>
       </MessageContextProvider>
     </RefetchCurrentUserContext.Provider>
-    </EnvironmentOverrideContext.Provider>
     </ServerRequestStatusContext.Provider>
     </SubscribeLocationContext.Provider>
     </NavigationContext.Provider>

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -365,12 +365,14 @@ const helpers = {
     // Unfortunately, passing in an empty array translates to something like `NOT (_id IN (SELECT NULL::VARCHAR(27)))`, which filters out everything
     const notPostIdsArg = excludedAndHiddenPostIds.length ? { notPostIds: excludedAndHiddenPostIds } : {};
     const filterSettings: FilterSettings = context.currentUser?.frontpageFilterSettings ?? getDefaultFilterSettings();
+    const ninetyDaysAgo = new Date(new Date().getTime() - (90*24*60*60*1000));
 
     const postsTerms: PostsViewTerms = {
       view: "magic",
       forum: true,
       limit,
       filterSettings,
+      after: ninetyDaysAgo,
       ...notPostIdsArg,
       ...loadMoreCountArg,
     };

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
@@ -10,7 +10,7 @@ import { CookiesProvider } from 'react-cookie';
 import { ABTestGroupsUsedContext, RelevantTestGroupAllocation } from '../../../../lib/abTestImpl';
 import { ServerRequestStatusContextType } from '../../../../lib/vulcan-core/appContext';
 import { getAllCookiesFromReq } from '../../../utils/httpUtil';
-import type { SSRMetadata } from '../../../../lib/utils/timeUtil';
+import { SSRMetadata, EnvironmentOverrideContext } from '../../../../lib/utils/timeUtil';
 import { LayoutOptionsContextProvider } from '../../../../components/hooks/useLayoutOptions';
 
 // Server-side wrapper around the app. There's another AppGenerator which is
@@ -32,14 +32,15 @@ const AppGenerator = ({ req, apolloClient, foreignApolloClient, serverRequestSta
           <CookiesProvider cookies={getAllCookiesFromReq(req)}>
             <ABTestGroupsUsedContext.Provider value={abTestGroupsUsed}>
               <LayoutOptionsContextProvider>
-                <Components.App
-                  apolloClient={apolloClient}
-                  serverRequestStatus={serverRequestStatus}
-                  envOverride={{
-                    ...ssrMetadata,
-                    matchSSR: true
-                  }}
-                />
+                <EnvironmentOverrideContext.Provider value={{
+                  ...ssrMetadata,
+                  matchSSR: true
+                }}>
+                  <Components.App
+                    apolloClient={apolloClient}
+                    serverRequestStatus={serverRequestStatus}
+                  />
+                </EnvironmentOverrideContext.Provider>
               </LayoutOptionsContextProvider>
             </ABTestGroupsUsedContext.Provider>
           </CookiesProvider>


### PR DESCRIPTION
 * Save ~30ms of spurious rerendering on front page load by refactoring EnvironmentOverrideContext
 * Don't rerender when receiving an active-dialogues server-sent event with no changes in it
 * Front-page Enriched recommendations filter the Latest portion to the last 90 days

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208264399669790) by [Unito](https://www.unito.io)
