### PR TITLE
Use `void` instead of `await` in lwevents_ip_index migration

### DIFF
--- a/packages/lesswrong/server/migrations/20240906T192038.lwevents_ip_index.ts
+++ b/packages/lesswrong/server/migrations/20240906T192038.lwevents_ip_index.ts
@@ -48,7 +48,9 @@ export const acceptsSchemaHash = "4478fe67319e5ebbe8327768fc26f5f4";
 import { updateCustomIndexes } from "./meta/utils"
 
 export const up = async ({dbOutsideTransaction}: MigrationContext) => {
-  await updateCustomIndexes(dbOutsideTransaction);
+  // `void` instead of `await` when using `dbOutsideTransaction` to avoid a
+  // nasty deadlock
+  void updateCustomIndexes(dbOutsideTransaction);
 }
 
 export const down = async ({db}: MigrationContext) => {


### PR DESCRIPTION
This avoids an annoying deadlock because we're using `dbOutsideTransaction` (see https://github.com/ForumMagnum/ForumMagnum/actions/runs/10784644922/job/29913276692?pr=9733)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208270159114095) by [Unito](https://www.unito.io)
