### PR TITLE
Fix missing navigation footer

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -38,19 +38,6 @@ import { userHasLlmChat } from '@/lib/betas';
 
 const STICKY_SECTION_TOP_MARGIN = 20;
 
-// These routes will have the standalone TabNavigationMenu (aka sidebar)
-//
-// Refer to routes.js for the route names. Or console log in the route you'd
-// like to include
-const standaloneNavMenuRouteNames: ForumOptions<string[]> = {
-  'LessWrong': [
-    'home', 'allPosts', 'questions', 'library', 'Shortform', 'Sequences', 'collections', 'nominations', 'reviews',
-  ],
-  'AlignmentForum': ['alignment.home', 'library', 'allPosts', 'questions', 'Shortform'],
-  'EAForum': ['home', 'allPosts', 'questions', 'Shortform', 'eaLibrary', 'tagsSubforum'],
-  'default': ['home', 'allPosts', 'questions', 'Community', 'Shortform',],
-}
-
 /**
  * When a new user signs up, their profile is 'incomplete' (ie; without a display name)
  * and we require them to fill this in using the onboarding flow before continuing.
@@ -477,10 +464,10 @@ const Layout = ({currentUser, children, classes}: {
       // then it should.
       // FIXME: This is using route names, but it would be better if this was
       // a property on routes themselves.
-      standaloneNavigation: !currentRoute || forumSelect(standaloneNavMenuRouteNames).includes(currentRoute.name),
+      standaloneNavigation: !currentRoute || !!currentRoute.hasStandaloneNav,
       renderSunshineSidebar: !!currentRoute?.sunshineSidebar && !!(userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins')) && !currentUser?.hideSunshineSidebar,
       renderLanguageModelChatLauncher: !!currentUser && userHasLlmChat(currentUser),
-      shouldUseGridLayout: !currentRoute || forumSelect(standaloneNavMenuRouteNames).includes(currentRoute.name),
+      shouldUseGridLayout: !currentRoute || !!currentRoute.hasStandaloneNav,
       unspacedGridLayout: !!currentRoute?.unspacedGrid,
     }
 

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -455,7 +455,9 @@ const Layout = ({currentUser, children, classes}: {
       ForumEventBanner,
       GlobalHotkeys,
       LanguageModelLauncherButton,
-      LlmChatWrapper
+      LlmChatWrapper,
+      TabNavigationMenuFooter
+      
     } = Components;
 
     const baseLayoutOptions: LayoutOptions = {
@@ -464,10 +466,10 @@ const Layout = ({currentUser, children, classes}: {
       // then it should.
       // FIXME: This is using route names, but it would be better if this was
       // a property on routes themselves.
-      standaloneNavigation: !currentRoute || !!currentRoute.hasStandaloneNav,
+      standaloneNavigation: !currentRoute || !!currentRoute.hasLeftNavigationColumn,
       renderSunshineSidebar: !!currentRoute?.sunshineSidebar && !!(userCanDo(currentUser, 'posts.moderate.all') || currentUser?.groups?.includes('alignmentForumAdmins')) && !currentUser?.hideSunshineSidebar,
       renderLanguageModelChatLauncher: !!currentUser && userHasLlmChat(currentUser),
-      shouldUseGridLayout: !currentRoute || !!currentRoute.hasStandaloneNav,
+      shouldUseGridLayout: !currentRoute || !!currentRoute.hasLeftNavigationColumn,
       unspacedGridLayout: !!currentRoute?.unspacedGrid,
     }
 
@@ -478,6 +480,7 @@ const Layout = ({currentUser, children, classes}: {
     const renderLanguageModelChatLauncher = overrideLayoutOptions.renderLanguageModelChatLauncher ?? baseLayoutOptions.renderLanguageModelChatLauncher
     const shouldUseGridLayout = overrideLayoutOptions.shouldUseGridLayout ?? baseLayoutOptions.shouldUseGridLayout
     const unspacedGridLayout = overrideLayoutOptions.unspacedGridLayout ?? baseLayoutOptions.unspacedGridLayout
+    const navigationFooterBar = !currentRoute || currentRoute.navigationFooterBar;
     // The friendly home page has a unique grid layout, to account for the right hand side column.
     const friendlyHomeLayout = isFriendlyUI && currentRoute?.name === 'home'
 
@@ -570,6 +573,7 @@ const Layout = ({currentUser, children, classes}: {
                     </DeferRender>
                   </StickyWrapper>
                 }
+                {isLWorAF && navigationFooterBar && <TabNavigationMenuFooter />}
                 <div ref={searchResultsAreaRef} className={classes.searchResultsArea} />
                 <div className={classNames(classes.main, {
                   [classes.whiteBackground]: useWhiteBackground,

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -35,17 +35,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   navSidebarTransparent: {
     zIndex: 10,
   },
-  footerBar: {
-    [theme.breakpoints.up('lg')]: {
-      display: "none"
-    },
-    position: "fixed",
-    bottom: 0,
-    left: 0,
-    backgroundColor: theme.palette.grey[300],
-    width: "100%",
-    zIndex: theme.zIndexes.footerNav
-  },
   "@media print": {
     display: "none"
   },
@@ -58,16 +47,14 @@ const NavigationStandalone = ({
   sidebarHidden,
   unspacedGridLayout,
   noTopMargin,
-  className,
   classes,
 }: {
   sidebarHidden: boolean,
   unspacedGridLayout?: boolean,
   noTopMargin?: boolean,
-  className?: string,
   classes: ClassesType,
 }) => {
-  const { TabNavigationMenu, TabNavigationMenuFooter } = Components
+  const { TabNavigationMenu } = Components
   const { location } = useLocation();
 
   const background = location.pathname === communityPath;
@@ -81,7 +68,7 @@ const NavigationStandalone = ({
         mountOnEnter
         unmountOnExit
       >
-        <div className={classNames(classes.sidebar, className, {[classes.background]: background, [classes.navSidebarTransparent]: unspacedGridLayout})}>
+        <div className={classNames(classes.sidebar, {[classes.background]: background, [classes.navSidebarTransparent]: unspacedGridLayout})}>
           {/* In the unspaced grid layout the sidebar can appear on top of other componenents, so make the background transparent */}
           <TabNavigationMenu
             transparentBackground={unspacedGridLayout}
@@ -90,9 +77,6 @@ const NavigationStandalone = ({
         </div>
       </Slide>
     </div>
-    {isLWorAF && <div className={classNames(classes.footerBar, className)}>
-      <TabNavigationMenuFooter />
-    </div>}
   </>
 }
 

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
@@ -6,7 +6,21 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import menuTabs from './menuTabs'
 import { forumSelect } from '../../../lib/forumTypeUtils';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
+  wrapper: {
+    [theme.breakpoints.up('lg')]: {
+      display: "none"
+    },
+    "@media print": {
+      display: "none"
+    },
+    position: "fixed",
+    bottom: 0,
+    left: 0,
+    backgroundColor: theme.palette.grey[300],
+    width: "100%",
+    zIndex: theme.zIndexes.footerNav,
+  },
   root: {
     display: "flex",
     justifyContent: "space-around",
@@ -16,11 +30,12 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const TabNavigationMenuFooter = ({classes}: {
-  classes: ClassesType
+  classes: ClassesType<typeof styles>
 }) => {
   const { TabNavigationFooterItem } = Components
 
   return (
+    <div className={classes.wrapper}>
       <AnalyticsContext pageSectionContext="tabNavigationFooter">
         <div className={classes.root}>
           {forumSelect(menuTabs).map(tab => {
@@ -35,6 +50,7 @@ const TabNavigationMenuFooter = ({classes}: {
           })}
         </div>
       </AnalyticsContext>
+    </div>
   )
 };
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting } from './instanceSettings';
+import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -309,7 +309,9 @@ addRoute(
   {
     name: 'collections',
     path: '/collections/:_id',
-    componentName: 'CollectionsSingle'
+    componentName: 'CollectionsSingle',
+    hasLeftNavigationColumn: isLW,
+    navigationFooterBar: true,
   },
   {
     name: 'highlights',
@@ -542,6 +544,8 @@ addRoute(
     componentName: isEAForum ? 'EAAllTagsPage' : 'AllTagsPage',
     title: isEAForum ? `${taggingNamePluralCapitalSetting.get()} — Main Page` : "Concepts Portal",
     description: isEAForum ? `Browse the core ${taggingNamePluralSetting.get()} discussed on the EA Forum and an organised wiki of key ${taggingNameSetting.get()} pages` : undefined,
+    hasLeftNavigationColumn: false,
+    navigationFooterBar: true,
   },
   // And all the redirects to it
   ...getAllTagsRedirectPaths().map((path, idx) => ({
@@ -584,7 +588,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       description: "Research, discussion, and updates on the world's most pressing problems. Including global health and development, animal welfare, AI safety, and biosecurity.",
       enableResourcePrefetch: true,
       sunshineSidebar: true,
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name:'about',
@@ -666,7 +671,9 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path: '/library',
       title: 'Library',
       description: eaSequencesHomeDescription,
-      componentName: 'EASequencesHome'
+      componentName: 'EASequencesHome',
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name: 'EventsHome',
@@ -761,6 +768,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       subtitleComponentName: 'TagPageTitle',
       previewComponentName: 'TagHoverPreview',
       unspacedGrid: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name: 'EAForumWrapped',
@@ -837,7 +846,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       enableResourcePrefetch: true,
       sunshineSidebar: true, 
       ...(blackBarTitle.get() ? { subtitleLink: "/tag/death", headerSubtitle: blackBarTitle.get()! } : {}),
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name: 'dialogues',
@@ -1047,7 +1057,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path: '/library',
       componentName: 'LibraryPage',
       title: "The Library",
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name: 'Sequences',
@@ -1095,7 +1106,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       componentName: 'AlignmentForumHome',
       enableResourcePrefetch: true,
       sunshineSidebar: true,
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name:'about',
@@ -1178,7 +1190,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       componentName: 'AFLibraryPage',
       enableResourcePrefetch: true,
       title: "The Library",
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name: 'Sequences',
@@ -1217,7 +1230,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       componentName: 'LWHome',
       enableResourcePrefetch: true,
       sunshineSidebar: true,
-      hasStandaloneNav: true,
+      hasLeftNavigationColumn: true,
+      navigationFooterBar: true,
     },
     {
       name:'about',
@@ -1334,7 +1348,8 @@ addRoute(
     path: '/quicktakes',
     componentName: 'ShortformPage',
     title: "Quick Takes",
-    hasStandaloneNav: true,
+    hasLeftNavigationColumn: true,
+    navigationFooterBar: true,
   },
   {
     name: 'ShortformRedirect',
@@ -1362,6 +1377,7 @@ if (hasEventsSetting.get()) {
       path: forumTypeSetting.get() === 'EAForum' ? '/community-old' : communityPath,
       componentName: 'CommunityHome',
       title: 'Community',
+      navigationFooterBar: true,
       ...communitySubtitle
     },
     {
@@ -1621,14 +1637,16 @@ addRoute(
     componentName: 'AllPostsPage',
     enableResourcePrefetch: true,
     title: "All Posts",
-    hasStandaloneNav: true,
+    hasLeftNavigationColumn: true,
+    navigationFooterBar: true,
   },
   {
     name: 'questions',
     path: '/questions',
     componentName: 'QuestionsPage',
     title: "All Questions",
-    hasStandaloneNav: true,
+    hasLeftNavigationColumn: true,
+    navigationFooterBar: true,
   },
   {
     name: 'recommendations',
@@ -1673,6 +1691,8 @@ addRoute(
     path:'/reviews/:year',
     componentName: 'ReviewsPage',
     title: "Reviews",
+    hasLeftNavigationColumn: true,
+    navigationFooterBar: true,
   },
   {
     name: 'reviewAdmin',

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -583,7 +583,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       componentName: 'EAHome',
       description: "Research, discussion, and updates on the world's most pressing problems. Including global health and development, animal welfare, AI safety, and biosecurity.",
       enableResourcePrefetch: true,
-      sunshineSidebar: true
+      sunshineSidebar: true,
+      hasStandaloneNav: true,
     },
     {
       name:'about',
@@ -836,6 +837,7 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       enableResourcePrefetch: true,
       sunshineSidebar: true, 
       ...(blackBarTitle.get() ? { subtitleLink: "/tag/death", headerSubtitle: blackBarTitle.get()! } : {}),
+      hasStandaloneNav: true,
     },
     {
       name: 'dialogues',
@@ -1044,13 +1046,14 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       name: 'library',
       path: '/library',
       componentName: 'LibraryPage',
-      title: "The Library"
+      title: "The Library",
+      hasStandaloneNav: true,
     },
     {
       name: 'Sequences',
       path: '/sequences',
       componentName: 'CoreSequences',
-      title: "Rationality: A-Z"
+      title: "Rationality: A-Z",
     },
     {
       name: 'Rationality',
@@ -1091,7 +1094,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path:'/',
       componentName: 'AlignmentForumHome',
       enableResourcePrefetch: true,
-      sunshineSidebar: true //TODO: remove this in production?
+      sunshineSidebar: true,
+      hasStandaloneNav: true,
     },
     {
       name:'about',
@@ -1173,14 +1177,15 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path: '/library',
       componentName: 'AFLibraryPage',
       enableResourcePrefetch: true,
-      title: "The Library"
+      title: "The Library",
+      hasStandaloneNav: true,
     },
     {
       name: 'Sequences',
       path: '/sequences',
       enableResourcePrefetch: true,
       componentName: 'CoreSequences',
-      title: "Rationality: A-Z"
+      title: "Rationality: A-Z",
     },
     {
       name: 'Rationality',
@@ -1211,7 +1216,8 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       path:'/',
       componentName: 'LWHome',
       enableResourcePrefetch: true,
-      sunshineSidebar: true //TODO: remove this in production?
+      sunshineSidebar: true,
+      hasStandaloneNav: true,
     },
     {
       name:'about',
@@ -1328,6 +1334,7 @@ addRoute(
     path: '/quicktakes',
     componentName: 'ShortformPage',
     title: "Quick Takes",
+    hasStandaloneNav: true,
   },
   {
     name: 'ShortformRedirect',
@@ -1614,12 +1621,14 @@ addRoute(
     componentName: 'AllPostsPage',
     enableResourcePrefetch: true,
     title: "All Posts",
+    hasStandaloneNav: true,
   },
   {
     name: 'questions',
     path: '/questions',
     componentName: 'QuestionsPage',
     title: "All Questions",
+    hasStandaloneNav: true,
   },
   {
     name: 'recommendations',

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -59,7 +59,8 @@ export type Route = {
   fullscreen?: boolean // if true, the page contents are put into a flexbox with the header such that the page contents take up the full height of the screen without scrolling
   unspacedGrid?: boolean // for routes with standalone navigation, setting this to true allows the page body to be full-width (the default is to have empty columns providing padding)
 
-  hasStandaloneNav?: boolean
+  hasLeftNavigationColumn?: boolean
+  navigationFooterBar?: boolean,
   
   // enableResourcePrefetch: Start loading stylesheet and JS bundle before the page is
   // rendered. This requires sending headers before rendering, which means

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -22,15 +22,21 @@ export type RouterLocation = {
 };
 
 export type Route = {
-  // Name of the route. Must be unique, but has no effect, except maybe
-  // appearing in debug logging occasionally.
+  /**
+   * Name of the route. Must be unique. In theory, should have no effect; in
+   * practice, some components are comparing route names to expected values,
+   * which we should refactor to make them not do anymore.
+   */
   name: string,
   
-  // URL pattern for this route. Syntax comes from the path-to-regexp library
-  // (via indirect dependency via react-router).
+  /**
+   * URL pattern for this route. Syntax comes from the path-to-regexp library
+   * (via indirect dependency via react-router).
+   */
   path: string,
   
   componentName?: keyof ComponentTypes,
+
   title?: string,
   titleComponentName?: keyof ComponentTypes,
   subtitle?: string,
@@ -52,6 +58,8 @@ export type Route = {
   staticHeader?: boolean // if true, the page header is not sticky to the top of the screen
   fullscreen?: boolean // if true, the page contents are put into a flexbox with the header such that the page contents take up the full height of the screen without scrolling
   unspacedGrid?: boolean // for routes with standalone navigation, setting this to true allows the page body to be full-width (the default is to have empty columns providing padding)
+
+  hasStandaloneNav?: boolean
   
   // enableResourcePrefetch: Start loading stylesheet and JS bundle before the page is
   // rendered. This requires sending headers before rendering, which means
@@ -107,22 +115,6 @@ export const addRoute = (...routes: Route[]): void => {
     };
   }
 };
-
-export const overrideRoute = (...routes: Route[]): void => {
-  // remove the old route if it exists, then call addRoute
-  for (let route of routes) {
-    const {name, path} = route;
-    delete Routes[name];
-
-    // @ts-ignore The @types/underscore signature for _.findWhere is narrower than the real function; this works fine
-    const routeWithSamePath = _.findWhere(Routes, { path });
-
-    if (routeWithSamePath) {
-      delete Routes[routeWithSamePath.name];
-    }
-  }
-  addRoute(...routes);
-}
 
 export const getRouteMatchingPathname = (pathname: string): Route | undefined  => {
   return Object.values(Routes).reverse().find((route) => matchPath(pathname, {


### PR DESCRIPTION
Makes it so the LW Concepts and Community pages (which are linked to from the bottom-bar) have bottom-bars themselves.

(Note: this UI is forum-gated to LW/AF only. That forum-gating doesn't change in this PR.)

Disentangles the concept of "having standalone navigation", which referred to both having left-side ToC-style navigation options at larger breakpoints, and having a bottom-bar at smaller breakpoints. That didn't work for the Concepts and Community pages, which have their own tables of contents and want the bottom-bar without the ToC-style page navigation.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208278812832940) by [Unito](https://www.unito.io)
