### PR TITLE
Better mobile footnotes

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnoteDialog.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnoteDialog.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Components, registerComponent } from '@/lib/vulcan-lib/components';
+
+const styles = (theme: ThemeType) => ({
+  dialogPaper: {
+    marginTop: 48,
+    marginBottom: 100,
+    marginLeft: 18,
+    marginRight: 18,
+  },
+  content: {
+    margin: 16,
+    
+    "& .footnote-content": {
+      width: "auto",
+    },
+    "& .footnote-back-link": {
+      display: "none",
+    },
+  },
+})
+
+const FootnoteDialog = ({ footnoteHTML, onClose, classes }: {
+  footnoteHTML: string,
+  onClose: () => void,
+  classes: ClassesType<typeof styles>
+}) => {
+  const { ContentStyles, LWDialog } = Components;
+
+  return <LWDialog open onClose={onClose} dialogClasses={{ paper: classes.dialogPaper }}>
+    <ContentStyles contentType="postHighlight" className={classes.content}>
+      <div dangerouslySetInnerHTML={{__html: footnoteHTML || ""}} />
+    </ContentStyles>
+  </LWDialog>
+}
+
+
+const FootnoteDialogComponent = registerComponent('FootnoteDialog', FootnoteDialog, {styles});
+
+declare global {
+  interface ComponentTypes {
+    FootnoteDialog: typeof FootnoteDialogComponent
+  }
+}
+

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -55,6 +55,17 @@ const footnotePreviewStyles = (theme: ThemeType) => ({
     },
   },
 
+  footnoteMobileIndicator: {
+    display: "none",
+    [sidenotesHiddenBreakpoint(theme)]: {
+      display: "inline-block",
+    },
+  },
+  
+  lineColor: {
+    background: theme.palette.sideItemIndicator.footnote,
+  },
+
   sidenoteWithIndex: {
     display: "flex",
   },
@@ -114,13 +125,13 @@ const footnotePreviewStyles = (theme: ThemeType) => ({
 })
 
 const FootnotePreview = ({classes, href, id, rel, children}: {
-  classes: ClassesType,
+  classes: ClassesType<typeof footnotePreviewStyles>,
   href: string,
   id?: string,
   rel?: string,
   children: React.ReactNode,
 }) => {
-  const { ContentStyles, SideItem, LWPopper } = Components
+  const { ContentStyles, SideItem, SideItemLine, LWPopper } = Components
   const { openDialog } = useDialog();
   const [disableHover, setDisableHover] = useState(false);
   const theme = useTheme();
@@ -210,21 +221,26 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
         </Card>
       </LWPopper>}
       
-      {hasSidenotes && !sidenotesDisabledOnPost && footnoteContentsNonempty && <SideItem options={{offsetTop: -6}}>
-        <div
-          {...sidenoteEventHandlers}
-          className={classNames(
-            classes.sidenote,
-            eitherHovered && classes.sidenoteHover
-          )}
-        >
-          <SidenoteDisplay
-            footnoteHref={href}
-            footnoteHTML={footnoteHTML}
-            classes={classes}
-          />
-        </div>
-      </SideItem>}
+      {hasSidenotes && !sidenotesDisabledOnPost && footnoteContentsNonempty &&
+        <SideItem options={{offsetTop: -6}}>
+          <div
+            {...sidenoteEventHandlers}
+            className={classNames(
+              classes.sidenote,
+              eitherHovered && classes.sidenoteHover
+            )}
+          >
+            <SidenoteDisplay
+              footnoteHref={href}
+              footnoteHTML={footnoteHTML}
+              classes={classes}
+            />
+          </div>
+          <span className={classes.footnoteMobileIndicator} onClick={onClick}>
+            <SideItemLine colorClass={classes.lineColor}/>
+          </span>
+        </SideItem>
+      }
 
       <a
         {...anchorEventHandlers}

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -197,7 +197,7 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
       });
       ev.preventDefault();
     }
-  }, [href, footnoteHTML, openDialog, theme]);
+  }, [href, footnoteHTML, openDialog]);
   
   const postPageContext = usePostsPageContext();
   const post = postPageContext?.fullPost ?? postPageContext?.postPreload;

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -68,7 +68,7 @@ const HoverPreviewLink = ({ href, contentSourceDescription, id, rel, noPrefetch,
 
   // Within-page relative link?
   if (href.startsWith("#")) {
-    if (locationHashIsFootnote(href) && !isMobile()){
+    if (locationHashIsFootnote(href)){
       return <Components.FootnotePreview href={href} id={id} rel={rel}>
         {children}
       </Components.FootnotePreview>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -343,6 +343,7 @@ importComponent("SubscribeDialog", () => require('../components/common/Subscribe
 
 importComponent("HoverPreviewLink", () => require('../components/linkPreview/HoverPreviewLink'));
 importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview", "OWIDPreview", "MetaculusPreview", "ManifoldPreview", "NeuronpediaPreview", "MetaforecastPreview", "ArbitalPreview", "SequencePreview", "EstimakerPreview", "ViewpointsPreview"], () => require('../components/linkPreview/PostLinkPreview'));
+importComponent("FootnoteDialog", () => require('../components/linkPreview/FootnoteDialog'));
 importComponent("FootnotePreview", () => require('../components/linkPreview/FootnotePreview'));
 importComponent("LinkToPost", () => require('../components/linkPreview/LinkToPost'));
 

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -480,6 +480,7 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
   sideItemIndicator: {
     sideComment: '#5f9b65',
     inlineReaction: 'lch(68 34.48 85.39 / 76%)',
+    footnote: shades.greyAlpha(0.4),
   },
   tag: {
     text: shades.greyAlpha(.9),

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -400,6 +400,7 @@ declare global {
     sideItemIndicator: {
       sideComment: ColorString,
       inlineReaction: ColorString,
+      footnote: ColorString,
     },
     tag: {
       text: ColorString,


### PR DESCRIPTION
On large screens, footnotes render as sidenotes. On smaller screens, footnotes have a preview when you hover with a mouse. On _touch_ screens, however, you can't hover, so the only interaction left was that clicking on a footnote would scroll to it in the footer, which kind works but isn't great.

Change it so that when you tap on a footnote on mobile ("mobile" defined according to the `bowser` library, should pretty closely match devices with touchscreens), you get the footnote contents in a modal dialog with a clickaway, rather than scrolling.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208290385662944) by [Unito](https://www.unito.io)
