### PR TITLE
Fix the add-inline-react button on Safari

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -520,7 +520,8 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
 
 export type IconProps = {
   className: string,
-  onClick: MouseEventHandler<SVGElement>,
+  onClick?: MouseEventHandler<SVGElement>,
+  onMouseDown?: MouseEventHandler<SVGElement>,
 }
 
 export type IconComponent = ComponentType<Partial<IconProps>>;

--- a/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
@@ -45,7 +45,9 @@ const AddInlineReactionButton = ({voteProps, classes, quote, disabled}: {
   const { getCurrentUserReactionVote, toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
   
   const handleOpen = (e: React.MouseEvent) => {
-    !disabled && setOpen(true)
+    if (!disabled) {
+      setOpen(true)
+    }
   }
 
   const handleToggleReaction = (reaction: string, quote: QuoteLocator) => {
@@ -63,7 +65,11 @@ const AddInlineReactionButton = ({voteProps, classes, quote, disabled}: {
     <span
       ref={buttonRef}
     >
-      {!open && <ForumIcon icon="AddReaction" onClick={handleOpen} className={classNames(classes.icon, { [classes.disabled]: disabled })}/>}
+      {/* This needs to trigger on mouse down, not on click, because in Safari
+        * (specifically), clicking outside of a text selection deselects on
+        * press, which makes the button disappear.
+        */}
+      {!open && <ForumIcon icon="AddReaction" onMouseDown={handleOpen} className={classNames(classes.icon, { [classes.disabled]: disabled })}/>}
       {open && <div className={classes.palette}>
         <ReactionsPalette
           getCurrentUserReactionVote={getCurrentUserReactionVote}


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208298443616758) by [Unito](https://www.unito.io)
