### PR TITLE
Fix Quicktakes toooltip

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -76,7 +76,7 @@ const QuickTakesSection = ({classes}: {
   const titleText = preferredHeadingCase("Quick Takes");
   const titleTooltip = (
     <div>
-      A feed of quick takes by other users, sorted by recency.
+      A feed of quick takes by other users, sorted by recency and karma.
     </div>
   );
   const title = isFriendlyUI


### PR DESCRIPTION
It said "sorted by recency", now it says "recency and karma"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208306935927211) by [Unito](https://www.unito.io)
