### PR TITLE
Forum gate `annualReviewMarketInfo`

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -355,7 +355,7 @@ const FooterTagList = ({
       )}
       {!hidePostTypeTag && postType}
       {eventTag}
-      {annualReviewMarketInfo && (
+      {isLWorAF && annualReviewMarketInfo && (
         <PostsAnnualReviewMarketTag post={post} annualReviewMarketInfo={annualReviewMarketInfo} />
       )}
       {tagRight && currentUser && !hideAddTag && addTagButton}


### PR DESCRIPTION
Fixes a regression from #9749 (which I missed in code review 😬)

<img width="500" alt="Screenshot 2024-09-17 at 17 51 07" src="https://github.com/user-attachments/assets/937d008c-0225-4403-b985-dfa1ceefe298">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208334809094104) by [Unito](https://www.unito.io)
