### PR TITLE
Enable progressive-enhancement inside sidenote bodies; remove backlinkds from some sidenotes

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -42,7 +42,7 @@ const footnotePreviewStyles = (theme: ThemeType) => ({
     [sidenotesHiddenBreakpoint(theme)]: {
       display: "none",
     },
-    "& .footnote-back-link": {
+    "& .footnote-back-link, & a[href^=\"#fnref\"]": {
       display: "none",
     },
 
@@ -261,7 +261,7 @@ const SidenoteDisplay = ({footnoteHref, footnoteHTML, classes}: {
   footnoteHTML: string,
   classes: ClassesType,
 }) => {
-  const { ContentStyles } = Components;
+  const { ContentItemBody, ContentStyles } = Components;
   const footnoteIndex = getFootnoteIndex(footnoteHref, footnoteHTML);
 
   return (
@@ -271,7 +271,7 @@ const SidenoteDisplay = ({footnoteHref, footnoteHTML, classes}: {
           {footnoteIndex}{"."}
         </span>}
         <div className={classes.sidenoteContent}>
-          <div dangerouslySetInnerHTML={{__html: footnoteHTML}} />
+          <ContentItemBody dangerouslySetInnerHTML={{__html: footnoteHTML}} />
           <div className={classes.overflowFade} />
         </div>
       </span>


### PR DESCRIPTION
Turns on progressive enhancement (ie link previews) in sidenotes, by using `ContentItemBody`. As currently written, this doesn't seem to handle horizontally-scrollable blocks (everything is treated as not-scrollable, even if it's wide enough to get a scroller in the post body). It also doesn't handle inline reactions (if you inline-react to a footnote, it will show up at the bottom of the post, but not near the sidenote).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208337071824453) by [Unito](https://www.unito.io)
