### PR TITLE
Fix CSS syntax errors

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -19,6 +19,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   sidebarWrapper: {
     minWidth: 100,
     zIndex: theme.zIndexes.footerNav,
+    "@media print": {
+      display: "none"
+    },
     [`@media(max-width: ${HOME_RHS_MAX_SCREEN_WIDTH}px)`]: {
       minWidth: 0,
     },
@@ -34,9 +37,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   navSidebarTransparent: {
     zIndex: 10,
-  },
-  "@media print": {
-    display: "none"
   },
   background: {
     background: theme.palette.panelBackground.translucent3,

--- a/packages/lesswrong/components/dialogues/CalendlyIFrame.tsx
+++ b/packages/lesswrong/components/dialogues/CalendlyIFrame.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib'
 import { calendlyPreviewStyles } from '../../themes/stylePiping'
 
 const styles = (theme: ThemeType) => ({
-  ...calendlyPreviewStyles(theme),
   calendlyEmbed: {
     ...calendlyPreviewStyles(theme)["& div.calendly-preview"]
   }

--- a/packages/lesswrong/themes/globalStyles/miscStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/miscStyles.ts
@@ -187,9 +187,9 @@ select.form-control{
   right: 5px;
   color: #ddd;
   font-size: 80%;
-  &.danger{
-    color: #EF1642;
-  }
+}
+.form-control-limit.danger{
+  color: #EF1642;
 }
 
 /* //////////////////////////////////////////////////////////////////////// */


### PR DESCRIPTION
While debugging with pause-on-caught-exceptions, I noticed that our CSS minifier, csso, is parsing our CSS (mostly generated from JSS, with a little bit written raw), throwing an exception if there's a syntax error, and then swallowing that exception and continuing. I haven't figured out how to catch these parse errors properly (a unit test would be ideal), but I took the opportunity to fix the extant ones.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208337493126416) by [Unito](https://www.unito.io)
