### PR TITLE
Collected small changes

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -361,8 +361,6 @@ const Layout = ({currentUser, children, classes}: {
   const theme = useTheme();
   const {currentRoute, pathname} = useLocation();
   const layoutOptionsState = React.useContext(LayoutOptionsContext);
-  const { explicitConsentGiven: cookieConsentGiven, explicitConsentRequired: cookieConsentRequired } = useCookiePreferences();
-  const showCookieBanner = cookieConsentRequired === true && !cookieConsentGiven;
   const {headerVisible, headerAtTop} = useHeaderVisible();
 
   // enable during ACX Everywhere
@@ -445,9 +443,7 @@ const Layout = ({currentUser, children, classes}: {
       BasicOnboardingFlow,
       CommentOnSelectionPageWrapper,
       SidebarsWrapper,
-      IntercomWrapper,
       HomepageCommunityMap,
-      CookieBanner,
       AdminToggle,
       SunshineSidebar,
       EAHomeRightHandSide,
@@ -529,7 +525,7 @@ const Layout = ({currentUser, children, classes}: {
               <GlobalHotkeys/>
               {/* Only show intercom after they have accepted cookies */}
               <DeferRender ssr={false}>
-                {showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>}
+                <MaybeCookieBanner />
               </DeferRender>
 
               <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
@@ -636,6 +632,14 @@ const Layout = ({currentUser, children, classes}: {
     )
   };
   return render();
+}
+
+function MaybeCookieBanner() {
+  const { IntercomWrapper, CookieBanner } = Components;
+  const { explicitConsentGiven: cookieConsentGiven, explicitConsentRequired: cookieConsentRequired } = useCookiePreferences();
+  const showCookieBanner = cookieConsentRequired === true && !cookieConsentGiven;
+
+  return showCookieBanner ? <CookieBanner /> : <IntercomWrapper/>;
 }
 
 const LayoutComponent = registerComponent('Layout', Layout, {styles});

--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import CommentIcon from '@material-ui/icons/ModeComment';
 import { useCurrentUser } from '../common/withUser';
@@ -60,6 +60,11 @@ const CommentOnSelectionPageWrapper = ({children}: {
 }) => {
   const { SelectedTextToolbar } = Components;
   const [toolbarState,setToolbarState] = useState<SelectedTextToolbarState>({open: false});
+  
+  const closeToolbar = useCallback(() => {
+    // When changing toolbarState, do it in a way where if this is {open: false}, we reuse the previous value to avoid triggering a rerender.
+    setToolbarState((prevState) => prevState.open ? {open: false} : prevState);
+  }, []);
  
   useEffect(() => {
     const selectionChangedHandler = () => {
@@ -68,7 +73,7 @@ const CommentOnSelectionPageWrapper = ({children}: {
       
       // Is this selection non-empty?
       if (!selection || !selectionText?.length) {
-        setToolbarState({open: false});
+        closeToolbar();
         return;
       }
       
@@ -89,7 +94,7 @@ const CommentOnSelectionPageWrapper = ({children}: {
       }
       
       if (!commonWrapper || !hasCommonWrapper) {
-        setToolbarState({open: false});
+        closeToolbar();
         return;
       }
       
@@ -109,10 +114,10 @@ const CommentOnSelectionPageWrapper = ({children}: {
     return () => {
       document.removeEventListener('selectionchange', selectionChangedHandler);
     };
-  }, []);
+  }, [closeToolbar]);
   
   useOnNavigate(() => {
-    setToolbarState({open: false});
+    closeToolbar();
   });
   
   const onClickComment = () => {

--- a/packages/lesswrong/components/hooks/useLoginPopoverContext.tsx
+++ b/packages/lesswrong/components/hooks/useLoginPopoverContext.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, createContext, useCallback, useContext, useState } from "react";
+import React, { FC, ReactNode, createContext, useCallback, useContext, useState, useMemo } from "react";
 
 export type LoginAction = "login" | "signup";
 
@@ -17,13 +17,16 @@ export const LoginPopoverContextProvider: FC<{
   const [loginAction, setLoginAction] = useState<LoginAction | null>(null);
   const onLogin = useCallback(() => setLoginAction("login"), []);
   const onSignup = useCallback(() => setLoginAction("signup"), []);
+  
+  const providedContext: LoginPopoverContext = useMemo(() => ({
+    loginAction,
+    setLoginAction,
+    onLogin,
+    onSignup,
+  }), [loginAction, setLoginAction, onLogin, onSignup]);
+  
   return (
-    <loginPopoverContext.Provider value={{
-      loginAction,
-      setLoginAction,
-      onLogin,
-      onSignup,
-    }}>
+    <loginPopoverContext.Provider value={providedContext}>
       {children}
     </loginPopoverContext.Provider>
   );

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, createContext, useCallback, useContext, useEffect } from 'react';
+import React, { FC, ReactNode, createContext, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useOnNavigate } from '../hooks/useOnNavigate';
 import { useOnFocusTab } from '../hooks/useOnFocusTab';
@@ -68,7 +68,6 @@ const notificationsCheckedAtLocalStorageKey = "notificationsCheckedAt";
 type UnreadNotificationsContext = {
   unreadNotifications: number,
   unreadPrivateMessages: number,
-  checkedAt: Date|null,
   notificationsOpened: () => Promise<void>,
   faviconBadgeNumber: number,
   refetchUnreadNotifications: () => Promise<void>,
@@ -77,7 +76,6 @@ type UnreadNotificationsContext = {
 const unreadNotificationsContext = createContext<UnreadNotificationsContext>({
   unreadNotifications: 0,
   unreadPrivateMessages: 0,
-  checkedAt: null,
   notificationsOpened: async () => {},
   faviconBadgeNumber: 0,
   refetchUnreadNotifications: async () => {},
@@ -199,15 +197,16 @@ export const UnreadNotificationsContextProvider: FC<{
     window.localStorage.setItem(notificationsCheckedAtLocalStorageKey, now.toISOString());
   }, [refetchBoth, updateCurrentUser]);
 
+  const providedContext = useMemo(() => ({
+    unreadNotifications,
+    unreadPrivateMessages,
+    faviconBadgeNumber,
+    notificationsOpened,
+    refetchUnreadNotifications: refetchBoth,
+  }), [ unreadNotifications, unreadPrivateMessages, faviconBadgeNumber, notificationsOpened, refetchBoth ]);
+
   return (
-    <unreadNotificationsContext.Provider value={{
-      unreadNotifications,
-      unreadPrivateMessages,
-      faviconBadgeNumber,
-      checkedAt,
-      notificationsOpened,
-      refetchUnreadNotifications: refetchBoth,
-    }}>
+    <unreadNotificationsContext.Provider value={providedContext}>
       {children}
     </unreadNotificationsContext.Provider>
   );

--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -5,9 +5,11 @@ import moment from '../../lib/moment-timezone';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import classNames from 'classnames';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
+import { formatRelative } from '@/lib/utils/timeFormat';
 
 export const POSTED_AT_WIDTH = 38
 export const START_TIME_WIDTH = 72
+const HOUR_IN_MS = 60*60*1000;
 
 const customStyles = (theme: ThemeType) => isFriendlyUI
   ? {}
@@ -106,12 +108,12 @@ const PostsItemDate = ({post, noStyles, includeAgo, useCuratedDate, emphasizeIfN
   const dateToDisplay = useCuratedDate
     ? post.curatedDate || post.postedAt
     : post.postedAt;
-  const timeFromNow = moment(new Date(dateToDisplay)).fromNow();
+  const timeFromNow = formatRelative(new Date(dateToDisplay), now);
   const ago = includeAgo && timeFromNow !== "now"
     ? <span className={classes.xsHide}>&nbsp;ago</span>
     : null;
 
-  const isEmphasized = emphasizeIfNew && moment(now).diff(post.postedAt, 'hours') < 48;
+  const isEmphasized = emphasizeIfNew && Math.abs(new Date(post.postedAt).getTime() - now.getTime()) < 48*HOUR_IN_MS
 
   const dateElement = (
     <PostsItem2MetaInfo className={classNames(classes.postedAt, {[classes.isNew]: isEmphasized})}>

--- a/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
@@ -149,7 +149,7 @@ const LWQuickTakesCollapsedListItem = ({ quickTake, setExpanded, classes }: {
   const body = (
     <div className={classes.bodyWrapper} onClick={expand} {...eventHandlers}>
       <div  className={classes.body}>
-        {htmlToTextDefault(quickTake.contents?.html)}
+        {quickTake.contents?.plaintextMainText}
       </div>
     </div>
   );

--- a/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
@@ -198,7 +198,7 @@ const QuickTakesCollapsedListItem = ({quickTake, setExpanded, classes}: {
         </div>
       </div>
       <div {...eventHandlers} className={classes.body}>
-        {htmlToTextDefault(quickTake.contents?.html)}
+        {quickTake.contents?.plaintextMainText}
       </div>
       <LWPopper
         open={displayHoverOver}

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -44,10 +44,16 @@ const schema: SchemaType<"Spotlights"> = {
       // TODO: try a graphql union type?
       type: 'Post!',
       resolver: async (spotlight: DbSpotlight, args: void, context: ResolverContext): Promise<Partial<DbPost | DbSequence | DbCollection> | null> => {
-        const collectionName = graphqlTypeToCollectionName(spotlight.documentType) as "Posts"|"Sequences";
-        const collection = context[collectionName];
-        const document = await collection.findOne(spotlight.documentId);
-        return accessFilterSingle(context.currentUser, collection, document, context);
+        switch(spotlight.documentType) {
+          case "Post": {
+            const document = await context.loaders.Posts.load(spotlight.documentId);
+            return accessFilterSingle(context.currentUser, context.Posts, document, context);
+          }
+          case "Sequence": {
+            const document = await context.loaders.Sequences.load(spotlight.documentId);
+            return accessFilterSingle(context.currentUser, context.Sequences, document, context);
+          }
+        }
       }
     },
   },

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -55,7 +55,6 @@ export async function runServerOnStartupFunctions() {
   serverInitSentry();
   startMemoryUsageMonitor();
   initSyncedCron();
-  startSyncedCron();
   initLegacyRoutes();
   await startupSanityChecks();
   addAllEditableCallbacks();
@@ -71,6 +70,8 @@ export async function runServerOnStartupFunctions() {
   createVoteableUnionType();
   initGraphQL();
   registerElasticCallbacks();
+
+  startSyncedCron();
 }
 
 


### PR DESCRIPTION
 * Fix a leak in pending-callback tracking
 * Move startSyncredCron to the end of runServerOnStartupFunctions
 * Prevent some spurious react-rerendering related to the comment-on-selection toolbar
 * Factor MaybeCookieBanner out of Layout. (This prevents spurious rerendering on operations that affect the cookie-store.)
 * Speed up PostsItemDate by avoiding momentjs
 * Avoid calling htmlToTextDefault in QuickTakesCollapsedListItem. (The html-to-text conversion already happened server side, in the plaintextMainText resolver, with approximately the same conversion settings.)
 * Add memoization to two context providers to reduce rerenders
 * Loading the current spotlight uses loaders
