### PR TITLE
fix post page titles

### DIFF
--- a/packages/lesswrong/components/titles/PostsPageHeaderTitle.tsx
+++ b/packages/lesswrong/components/titles/PostsPageHeaderTitle.tsx
@@ -13,7 +13,6 @@ const PostsPageHeaderTitle = ({siteName}: {
     documentId: _id || postId,
     collectionName: "Posts",
     fragmentName: "PostsBase",
-    fetchPolicy: 'cache-only',
   });
 
   if (!post || loading) return null;


### PR DESCRIPTION
EAF no longer generates a page title on the post page (LW doesn't seem to have this bug). This is especially annoying when linking to a post, because the social preview lacks a title. I'm not sure what caused this bug or when it started, but this PR seems to fix it, and changing the `fetchPolicy` from `cache-only` to the default (`cache-first`) doesn't seem that bad.

<img width="533" alt="Screenshot 2024-09-19 at 3 45 46 PM" src="https://github.com/user-attachments/assets/670d6d3e-5262-40db-8435-0fd2c7a15a48">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208365766907685) by [Unito](https://www.unito.io)
