### PR TITLE
Fix a bug where on Firefox Mobile, posts opened in background tabs would have spurious horiz scrollers

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -242,7 +242,18 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
       const block = allTopLevelBlocks[i];
       if (block.nodeType === Node.ELEMENT_NODE) {
         const blockAsElement = block as HTMLElement;
-        if (blockAsElement.scrollWidth > this.bodyRef.current!.clientWidth+1) {
+        
+        // Check whether this block is wider than the content-block it's inside
+        // of, and if so, wrap it in a horizontal scroller. This makes wide
+        // LaTeX formulas and tables functional on mobile.
+        // We also need to check that this element has nonzero width, because of
+        // an odd bug in Firefox where, when you open a tab in the background,
+        // it runs JS but doesn't do page layout (or does page layout as-if the
+        // page was zero width?) Without this check, you would sometimes get a
+        // spurious horizontal scroller on every paragraph-block.
+        if (blockAsElement.scrollWidth > this.bodyRef.current!.clientWidth+1
+          && this.bodyRef.current!.clientWidth > 0)
+        {
           this.addHorizontalScrollIndicators(blockAsElement);
         }
       }
@@ -476,7 +487,6 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
 const addNofollowToHTML = (html: string): string => {
   return html.replace(/<a /g, '<a rel="nofollow" ')
 }
-
 
 const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
   hocs: [withTracking],


### PR DESCRIPTION
User report at: https://www.lesswrong.com/posts/jvewFE9hvQfrxeiBc/open-thread-summer-2024#TfHC5X3aCF8Tg8HRf

Fix tested on Browserstack. Note that this replaces the obvious bug with a more subtle/minor one, which is that elements that _do_ need the scrollers (ie, wide tables/formulas) may not have them, if the tab loaded in mobile Firefox in the background.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208370639032602) by [Unito](https://www.unito.io)
