### PR TITLE
Avoid loading the LW background image on mobile

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -586,11 +586,18 @@ const Layout = ({currentUser, children, classes}: {
                   </ErrorBoundary>
                   {!currentRoute?.fullscreen && !currentRoute?.noFooter && <Footer />}
                 </div>
-                {isLW && <>
-                  {standaloneNavigation && <div className={classes.imageColumn}>
-                    <CloudinaryImage2 className={classes.backgroundImage} publicId="ohabryka_Topographic_aquarelle_book_cover_by_Thomas_W._Schaller_f9c9dbbe-4880-4f12-8ebb-b8f0b900abc1_m4k6dy_734413" darkPublicId={"ohabryka_Topographic_aquarelle_book_cover_by_Thomas_W._Schaller_f9c9dbbe-4880-4f12-8ebb-b8f0b900abc1_m4k6dy_734413_copy_lnopmw"}/>
-                  </div>}
-                </>}
+                {isLW && standaloneNavigation && <div className={classes.imageColumn}>
+                  {/* Background image shown in the top-right corner of LW. The
+                    * loading="lazy" prevents downloading the image if the
+                    * screen-size is such that the image will be hidden by a
+                    * breakpoint. */}
+                  <CloudinaryImage2
+                    loading="lazy"
+                    className={classes.backgroundImage}
+                    publicId="ohabryka_Topographic_aquarelle_book_cover_by_Thomas_W._Schaller_f9c9dbbe-4880-4f12-8ebb-b8f0b900abc1_m4k6dy_734413"
+                    darkPublicId={"ohabryka_Topographic_aquarelle_book_cover_by_Thomas_W._Schaller_f9c9dbbe-4880-4f12-8ebb-b8f0b900abc1_m4k6dy_734413_copy_lnopmw"}
+                  />
+                </div>}
                 {!renderSunshineSidebar &&
                   friendlyHomeLayout &&
                   <StickyWrapper

--- a/packages/lesswrong/components/common/CloudinaryImage2.tsx
+++ b/packages/lesswrong/components/common/CloudinaryImage2.tsx
@@ -138,7 +138,7 @@ const CloudinaryImage2 = ({
       media="(prefers-color-scheme: dark)"
     />}
     <img
-      loading="lazy"
+      loading={loading}
       src={basicImageUrl}
       style={imageStyle}
       className={className}

--- a/packages/lesswrong/components/common/CloudinaryImage2.tsx
+++ b/packages/lesswrong/components/common/CloudinaryImage2.tsx
@@ -39,6 +39,7 @@ const CloudinaryImage2 = ({
   fullWidthHeader,
   className,
   wrapperClassName,
+  loading,
 }: {
   /** Overridden if fullWidthHeader is true */
   width?: number|string,
@@ -51,6 +52,7 @@ const CloudinaryImage2 = ({
   fullWidthHeader?: boolean,
   className?: string,
   wrapperClassName?: string,
+  loading?: "lazy"|"eager",
 }) => {
   const themeOptions = useThemeOptions() // Danger, Will Robinson! (It'll be ok, see below.)
 
@@ -136,6 +138,7 @@ const CloudinaryImage2 = ({
       media="(prefers-color-scheme: dark)"
     />}
     <img
+      loading="lazy"
       src={basicImageUrl}
       style={imageStyle}
       className={className}


### PR DESCRIPTION
LW has a background image in the top-right corner, which is visible only on desktop breakpoints. However, mobile browsers wind up downloading it anyways, because they can't tell that it's going to be hidden until the stylesheet has loaded, but they (usually) see the `<img>` tag before they finish downloading the stylesheet.

Add the attribute `loading="lazy"` to the background image. This defers loading until the image is actually visible. On mobile, where it will never be visible, this saves 615kb of download (cacheable, but quite a lot). On desktop, this delays the start of downloading the background image until later in the loading process--it starts after first paint, rather than when it's first seen in HTML. It doesn't delay first-contentful-paint; in the profiler timeline, the page paints with the background image missing and fills it in when the download finishes. This is probably an improvement since downloading the image is lower priority than downloading the fonts and JS bundle.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208374906264806) by [Unito](https://www.unito.io)
