### PR TITLE
decrease social preview img min size

### DIFF
--- a/packages/lesswrong/components/hooks/useImageUpload.tsx
+++ b/packages/lesswrong/components/hooks/useImageUpload.tsx
@@ -158,10 +158,10 @@ const cloudinaryArgsByImageType = {
     uploadPreset: cloudinaryUploadPresetProfileSetting.get(),
   },
   socialPreviewImageId: {
-    minImageHeight: 400,
-    minImageWidth: 700,
+    minImageHeight: 270,
+    minImageWidth: 500,
     croppingAspectRatio: 1.91,
-    croppingDefaultSelectionRatio: 1,
+    croppingDefaultSelectionRatio: 1.91,
     uploadPreset: cloudinaryUploadPresetSocialPreviewSetting.get(),
   },
   eventImageId: {


### PR DESCRIPTION
Someone asked about the min size requirement via Intercom. I don't know of any particular reason we chose 700 as the min width, and I think it's better for these params to be the same as `eventImageId`, so I just changed it to match that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208382591848804) by [Unito](https://www.unito.io)
