### PR TITLE
Fix bugs in AF voting

### DIFF
--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -109,7 +109,7 @@ const OverallVoteAxis = ({
 
   const af = (document as any).af;
   const afDate = (document as any).afDate;
-  const afBaseScore = (document as any).afBaseScore;
+  const afBaseScore = voteProps.document.afBaseScore;
 
   const moveToAfInfo = userIsAdmin(currentUser) && !!moveToAlignnmentUserId && (
     <div className={classes.tooltipHelp}>

--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -1,6 +1,6 @@
 import { userCanDo } from '../vulcan-users/permissions';
 import { recalculateScore } from '../scoring';
-import { voteTypes, calculateVotePower } from './voteTypes';
+import { calculateVotePower, isValidVoteType } from './voteTypes';
 import type { VotingSystem } from './votingSystems';
 import { collectionNameToTypeName } from '../vulcan-lib';
 
@@ -108,8 +108,8 @@ export const getVotePower = ({ user, voteType, document }: {
   voteType: string,
   document: VoteableType,
 }) => {
-  const power = (voteTypes[voteType]?.power) || 1;
-  return typeof power === 'function' ? power(user, document) : power;
+  const userKarma = user.karma;
+  return calculateVotePower(userKarma, voteType);
 };
 
 // Optimistic response for votes
@@ -121,7 +121,7 @@ export const setVoteClient = async ({ document, collectionName, voteType = 'neut
   user: UsersCurrent,
   votingSystem: VotingSystem,
 }): Promise<VoteableTypeClient> => {
-  if (voteType && !voteTypes[voteType]) throw new Error(`Invalid vote type in setVoteClient: ${voteType}`);
+  if (voteType && !isValidVoteType(voteType)) throw new Error(`Invalid vote type in setVoteClient: ${voteType}`);
 
   // make sure item and user are defined
   if (!document || !user || (!extendedVote && voteType && voteType !== "neutral" && !userCanDo(user, `${collectionName.toLowerCase()}.${voteType}`))) {

--- a/packages/lesswrong/lib/voting/voteTypes.ts
+++ b/packages/lesswrong/lib/voting/voteTypes.ts
@@ -1,9 +1,4 @@
 
-interface VoteTypeOptions {
-  power: number|((user: DbUser|UsersCurrent, document: VoteableType) => number),
-}
-
-
 export const calculateVotePower = (karma: number, voteType: string): number => {
   if (voteType === "smallUpvote") { return userSmallVotePower(karma, 1)}
   if (voteType === "smallDownvote") { return userSmallVotePower(karma, -1)}
@@ -37,21 +32,5 @@ export const userBigVotePower = (karma: number, multiplier: number) => {
   return 1 * multiplier
 }
 
-// Define voting operations
-export const voteTypes: Partial<Record<string,VoteTypeOptions>> = {
-  smallUpvote: {
-    power: (user: DbUser|UsersCurrent) => userSmallVotePower(user.karma, 1),
-  },
-  smallDownvote: {
-    power: (user: DbUser|UsersCurrent) => userSmallVotePower(user.karma, -1),
-  },
-  bigUpvote: {
-    power: (user: DbUser|UsersCurrent) => userBigVotePower(user.karma, 1),
-  },
-  bigDownvote: {
-    power: (user: DbUser|UsersCurrent) => userBigVotePower(user.karma, -1),
-  },
-  neutral: {
-    power: (user: DbUser|UsersCurrent) => 0,
-  },
-}
+export const voteTypes: string[] = ["smallUpvote", "smallDownvote", "bigUpvote", "bigDownvote", "neutral"];
+export const isValidVoteType = (voteType: string) => voteTypes.includes(voteType);

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -23,7 +23,7 @@ async function updateAlignmentKarmaServer (newDocument: DbVoteableType, vote: Db
   if (!voter) throw Error(`Can't find voter to update Alignment Karma for vote: ${vote}`)
 
   if (userCanDo(voter, "votes.alignment")) {
-    const votePower = calculateVotePower(voter.afKarma, vote.voteType)
+    const votePower = calculateVotePower(voter.afKarma, vote.voteType) * (vote.isUnvote ? -1 : 1);
 
     await Votes.rawUpdateOne({_id:vote._id, documentId: newDocument._id}, {$set:{afPower: votePower}})
     const newAFBaseScore = await recalculateAFBaseScore(newDocument)
@@ -62,7 +62,7 @@ async function updateAlignmentUserServer (newDocument: DbVoteableType, vote: DbV
     const newAfKarma = (documentUser.afKarma || 0) + karmaUpdate;
     if (newAfKarma > 0) {
       await Users.rawUpdateOne({_id:newDocument.userId}, {
-        $set: {afKarma: newAfKarma },
+        $inc: {afKarma: karmaUpdate},
         $addToSet: {groups: 'alignmentVoters'}
       })
     } else {

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -50,7 +50,7 @@ export async function grantUserAFKarmaForVote ({newDocument, vote}: VoteDocTuple
   await updateUserAFKarmaForVote(newDocument, vote, 1)
 }
 
-export async function revoteUserAFKarmaForCancelledVote ({newDocument, vote}: VoteDocTuple) {
+export async function revokeUserAFKarmaForCancelledVote ({newDocument, vote}: VoteDocTuple) {
   await updateUserAFKarmaForVote(newDocument, vote, -1)
 
 }

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -17,7 +17,7 @@ import { isProduction } from '../../lib/executionEnvironment';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { createManifoldMarket } from '../../lib/collections/posts/annualReviewMarkets';
 import { RECEIVED_SENIOR_DOWNVOTES_ALERT } from '../../lib/collections/moderatorActions/schema';
-import { revoteUserAFKarmaForCancelledVote, grantUserAFKarmaForVote } from './alignment-forum/callbacks';
+import { revokeUserAFKarmaForCancelledVote, grantUserAFKarmaForVote } from './alignment-forum/callbacks';
 import { recomputeContributorScoresFor, voteUpdatePostDenormalizedTags } from '../tagging/tagCallbacks';
 import { updateModerateOwnPersonal, updateTrustedStatus } from './userCallbacks';
 import { increaseMaxBaseScore } from './postCallbacks';
@@ -27,7 +27,7 @@ export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, co
   voteUpdatePostDenormalizedTags({newDocument});
   cancelVoteKarma({newDocument, vote}, collection, user);
   void cancelVoteCount({newDocument, vote});
-  void revoteUserAFKarmaForCancelledVote({newDocument, vote});
+  void revokeUserAFKarmaForCancelledVote({newDocument, vote});
   
   
   if (vote.collectionName === "Revisions") {

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -17,18 +17,17 @@ import { isProduction } from '../../lib/executionEnvironment';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { createManifoldMarket } from '../../lib/collections/posts/annualReviewMarkets';
 import { RECEIVED_SENIOR_DOWNVOTES_ALERT } from '../../lib/collections/moderatorActions/schema';
-import { cancelAlignmentKarmaServerCallback, cancelAlignmentUserKarmaServer, updateAlignmentKarmaServerCallback, updateAlignmentUserServerCallback } from './alignment-forum/callbacks';
+import { revoteUserAFKarmaForCancelledVote, grantUserAFKarmaForVote } from './alignment-forum/callbacks';
 import { recomputeContributorScoresFor, voteUpdatePostDenormalizedTags } from '../tagging/tagCallbacks';
 import { updateModerateOwnPersonal, updateTrustedStatus } from './userCallbacks';
 import { increaseMaxBaseScore } from './postCallbacks';
 import { captureException } from '@sentry/core';
 
 export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, collection: CollectionBase<VoteableCollectionName>, user: DbUser): Promise<void> {
-  cancelAlignmentKarmaServerCallback({newDocument, vote});
   voteUpdatePostDenormalizedTags({newDocument});
   cancelVoteKarma({newDocument, vote}, collection, user);
   void cancelVoteCount({newDocument, vote});
-  void cancelAlignmentUserKarmaServer({newDocument, vote});
+  void revoteUserAFKarmaForCancelledVote({newDocument, vote});
   
   
   if (vote.collectionName === "Revisions") {
@@ -38,11 +37,8 @@ export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, co
     }
   }
 }
-export async function onCastVoteSync(voteDocTuple: VoteDocTuple, collection: CollectionBase<VoteableCollectionName>, user: DbUser): Promise<VoteDocTuple> {
-  return await updateAlignmentKarmaServerCallback(voteDocTuple);
-}
 export async function onCastVoteAsync(voteDocTuple: VoteDocTuple, collection: CollectionBase<VoteableCollectionName>, user: DbUser, context: ResolverContext): Promise<void> {
-  void updateAlignmentUserServerCallback(voteDocTuple);
+  void grantUserAFKarmaForVote(voteDocTuple);
   void updateTrustedStatus(voteDocTuple);
   void updateModerateOwnPersonal(voteDocTuple);
   void increaseMaxBaseScore(voteDocTuple);

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -178,6 +178,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
       cancelled: true,
       isUnvote: true,
       power: -vote.power,
+      afPower: -vote.afPower,
       votedAt: new Date(),
       silenceNotification,
     };

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -3,7 +3,7 @@ import { createMutator } from './vulcan-lib/mutators';
 import Votes from '../lib/collections/votes/collection';
 import { userCanDo } from '../lib/vulcan-users/permissions';
 import { recalculateScore } from '../lib/scoring';
-import { voteTypes } from '../lib/voting/voteTypes';
+import { isValidVoteType } from '../lib/voting/voteTypes';
 import { VoteDocTuple, getVotePower } from '../lib/voting/vote';
 import { getVotingSystemForDocument, VotingSystem } from '../lib/voting/votingSystems';
 import { createAnonymousContext } from './vulcan-lib/query';
@@ -246,7 +246,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
   if (!extendedVote && voteType && voteType !== "neutral" && !userCanDo(user, collectionVoteType)) {
     throw new Error(`Error casting vote: User can't cast votes of type ${collectionVoteType}.`);
   }
-  if (!voteTypes[voteType]) throw new Error(`Invalid vote type in performVoteServer: ${voteType}`);
+  if (!isValidVoteType(voteType)) throw new Error(`Invalid vote type in performVoteServer: ${voteType}`);
 
   if (!selfVote && collectionName === "Comments" && (document as DbComment).debateResponse) {
     const post = await Posts.findOne({_id: (document as DbComment).postId});

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -26,7 +26,8 @@ import {Posts} from '../lib/collections/posts';
 import { VotesRepo } from './repos';
 import { isLWorAF } from '../lib/instanceSettings';
 import { swrInvalidatePostRoute } from './cache/swr';
-import { onCastVoteAsync, onCastVoteSync, onVoteCancel } from './callbacks/votingCallbacks';
+import { onCastVoteAsync, onVoteCancel } from './callbacks/votingCallbacks';
+import { getVoteAFPower } from './callbacks/alignment-forum/callbacks';
 
 // Test if a user has voted on the server
 const getExistingVote = async ({ document, user }: {
@@ -109,6 +110,7 @@ export const createVote = ({ document, collectionName, voteType, extendedVote, u
     voteType: voteType,
     extendedVoteType: extendedVote,
     power: getVotePower({user, voteType, document}),
+    afPower: getVoteAFPower({user, voteType, document}),
     votedAt: new Date(),
     authorIds,
     cancelled: false,
@@ -294,7 +296,6 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
     }
 
     let voteDocTuple: VoteDocTuple = await addVoteServer({document, user, collection, voteType, extendedVote, voteId, context});
-    voteDocTuple = await onCastVoteSync(voteDocTuple, collection, user);
 
     document = voteDocTuple.newDocument;
     document = await clearVotesServer({


### PR DESCRIPTION
Simplify AF karma handling. Fix a race condition that would cause votes to be double-counted towards user votes. Fix inversion of afPower in unvotes, which would mess up the karma-change notifier on AF.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208385854001989) by [Unito](https://www.unito.io)
