### PR TITLE
Turn on react/no-unstable-components lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,17 @@ module.exports = {
     "react/no-unescaped-entities": 0,
     "react/display-name": 0,
     "react/jsx-no-comment-textnodes": 1,
+
+    // Warn if defining a component inside a function, which results in the
+    // component's subtree and its state being destroyed on every render
+    "react/no-unstable-nested-components": [1, {
+      // Allow it if the component is passed directly as a prop. This is still
+      // potentially a bug, but components passed directly as props are often
+      // leaf-nodes with no state, like icons, so it's annoying to have to
+      // handle them properly and these are lower-priority to fix than the ones
+      // that aren't.
+      allowAsProps: true,
+    }],
     "react/no-unknown-property": ["error", {ignore: ["test-id"]}],
 
     // Differs from no-mixed-operators default only in that "??" is added to the first group

--- a/packages/lesswrong/components/books/Book2019FrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/Book2019FrontpageWidget.tsx
@@ -144,6 +144,8 @@ const Book2019FrontpageWidget = ({ classes }: {
     }
   }
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const BookMarketingText = ({title, subtitle, description, buttons}: {
     title: string;
     subtitle: string;

--- a/packages/lesswrong/components/books/Book2020FrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/Book2020FrontpageWidget.tsx
@@ -129,6 +129,8 @@ const Book2020FrontpageWidget = ({ classes }: {
     }
   }
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const BookMarketingText = ({title, subtitle, description, buttons}: {
     title: string;
     subtitle: string;

--- a/packages/lesswrong/components/books/BookFrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/BookFrontpageWidget.tsx
@@ -149,6 +149,8 @@ const BookFrontpageWidget = ({ classes }: {
     }
   }
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const BookMarketingText = ({title, subtitle, description, buttons}: {
     title: string;
     subtitle: string;

--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -88,6 +88,8 @@ const CommentUserName = ({
       </span>
     );
   } else if (isFriendlyUI) {
+    // FIXME: Unstable component will lose state on rerender
+    // eslint-disable-next-line react/no-unstable-nested-components
     const Wrapper = ({children}: {children: ReactNode}) => simple
       ? (
         <div className={classes.mainWrapper}>

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -27,6 +27,8 @@ const ModerationGuidelinesEditForm = ({ commentType = "post", documentId, onClos
   classes: ClassesType,
 }) => {
   const isPost = commentType === "post"
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const SubmitComponent = ({submitLabel = "Submit"}) => {
     return <div className="form-submit">
       <Button

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -197,6 +197,8 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
 
   const { NewConversationButton, SearchResultsMap, ContentStyles, ForumIcon } = Components
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const SearchBox: React.FunctionComponent<SearchBoxProvided> = ({currentRefinement, refine}) => {
     return <div className={classes.keywordSearch}>
       <OutlinedInput
@@ -220,6 +222,8 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
   }
   const CustomSearchBox = connectSearchBox(SearchBox)
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const StateResults: React.FunctionComponent<StateResultsProvided<BasicDoc>> = ({ searchResults }) => {
     return (!searchResults || !searchResults.nbHits) ? <div className={classes.noResults}>
       <div className={classes.noResultsText}>No public profiles matching your search</div>
@@ -227,6 +231,8 @@ const CommunityMembers = ({currentUser, userLocation, distanceUnit='km', locatio
   }
   const CustomStateResults = connectStateResults(StateResults)
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const CommunityMember = ({hit}: {
     hit: SearchUser,
   }) => {

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -261,12 +261,18 @@ const CommunityMapFilter = ({
     flash({messageString: "Hid map from Frontpage", action: undoAction})
   }, [currentUser, flash, setShowMap, updateCurrentUser]);
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const GroupIcon = () => isEAForum
     ? <StarIcon className={classes.eaButtonIcon}/>
     : <GroupIconSVG className={classes.buttonIcon}/>;
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const EventIcon = () => isEAForum
     ? <RoomIcon className={classes.eaButtonIcon}/>
     : <ArrowSVG className={classes.buttonIcon}/>;
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const PersonIcon = () => isEAForum
     ? <PersonPinIcon className={classes.eaButtonIcon}/>
     : <PersonSVG className={classes.buttonIcon}/>;

--- a/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
@@ -40,6 +40,8 @@ const LocalEventMarker = ({ event, handleMarkerClick, handleInfoWindowClose, inf
   
   const htmlBody = {__html: htmlHighlight};
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const EventIcon = () => forumTypeSetting.get() === 'EAForum' ? 
     <RoomIcon className={classes.eaIcon}/> : 
     <ArrowSVG className={classes.icon}/>;

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -38,6 +38,8 @@ const LocalGroupMarker = ({ group, handleMarkerClick, handleInfoWindowClose, inf
   const { StyledMapPopup, GroupLinks } = Components
   const htmlBody = {__html: html};
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const GroupIcon = () => forumTypeSetting.get() === 'EAForum'
     ? <Components.ForumIcon icon="Star" className={classes.eaIcon}/>
     : <GroupIconSVG className={classes.icon}/>;

--- a/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
@@ -24,6 +24,8 @@ const LocalGroupsList = ({terms, children, classes, showNoResults=true, heading}
   });
   const { LocalGroupsItem, Loading, PostsNoResults, SectionFooter, LoadMore, SingleColumnSection, SectionTitle } = Components
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const MaybeTitleWrapper = ({children}: { children: ReactNode }) => heading ?
     <SingleColumnSection>
       <SectionTitle title={heading} />

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -391,6 +391,8 @@ const EAPostsItem = ({
   // normally requiring the user to press back twice to get to where they
   // started so we need to wrap that whole thing in an `InteractionWrapper`
   // too.
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const TitleWrapper: FC<PropsWithChildren<{}>> = ({children}) => (
     <PostsItemTooltipWrapper post={post} placement={tooltipPlacement} As="span" disabled={viewType === 'card'}>
       <InteractionWrapper className={classes.titleWrapper}>

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -105,6 +105,8 @@ const PostsEditForm = ({ documentId, version, classes }: {
     return <ForeignCrosspostEditForm post={document} />;
   }
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const EditPostsSubmit = (props: SubmitToFrontpageCheckboxProps & PostSubmitProps) => {
     return <div className={classes.formSubmit}>
       {!document.isEvent && <SubmitToFrontpageCheckbox {...props} />}

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -296,6 +296,8 @@ const PostsNewForm = ({classes}: {
     return <Loading />
   }
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const NewPostsSubmit = (props: SubmitToFrontpageCheckboxProps & PostSubmitProps) => {
     return <div className={classes.formSubmit}>
       {!eventForm && <SubmitToFrontpageCheckbox {...props} />}

--- a/packages/lesswrong/components/questions/NewAnswerForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerForm.tsx
@@ -52,6 +52,8 @@ const NewAnswerForm = ({post, classes}: {
     fragmentName: 'CommentsList',
   });
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const SubmitComponent = ({submitLabel = "Submit"}) => {
     const submitBtnProps: BtnProps = isFriendlyUI ? {variant: 'contained', color: 'primary'} : {}
     return <div className={classes.submit}>

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -215,6 +215,8 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     setLoading(false);
   }
   
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const AnalyticsWrapper = ({children, branch}: {children: React.ReactNode, branch: string}) => {
     return <AnalyticsContext pageElementContext="subscribeReminder" branch={branch}>
       <AnalyticsInViewTracker eventProps={{inViewType: "subscribeReminder"}}>

--- a/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
+++ b/packages/lesswrong/components/recommendations/PostsPageRecommendationItem.tsx
@@ -96,6 +96,8 @@ const PostsPageRecommendationItem = ({
     PostActionsButton,
   } = Components;
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const TitleWrapper: FC<PropsWithChildren<{}>> = ({children}) => (
     <PostsItemTooltipWrapper post={post} As="span">
       <Link to={postLink}>{children}</Link>

--- a/packages/lesswrong/components/review/ReviewPhaseInformation.tsx
+++ b/packages/lesswrong/components/review/ReviewPhaseInformation.tsx
@@ -38,6 +38,8 @@ export const ReviewPhaseInformation = ({classes, reviewYear, reviewPhase}: {
   const { UserReviewsProgressBar, ContentStyles, LWTooltip, ReviewVotingProgressBar } = Components
 
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const FaqCard = ({linkText, children}: {
     linkText: React.ReactNode,
     children: React.ReactNode,

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -252,6 +252,8 @@ const FooterTagList = ({
     }
   }, [setIsAwaiting, mutate, refetch, post._id, captureEvent, flash]);
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const MaybeLink = ({to, children, className}: {
     to: string|null,
     children: React.ReactNode,

--- a/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
@@ -63,6 +63,8 @@ export const GardenCodeWidget = ({classes, type}: {classes: ClassesType, type: s
     }
   });
 
+  // FIXME: Unstable component will lose state on rerender
+  // eslint-disable-next-line react/no-unstable-nested-components
   const SubmitComponent = () => <div className={classNames("form-submit", classes.formSubmitRow)}>
       <Button onClick={()=>setOpen(false)}>
         Cancel


### PR DESCRIPTION
Turns on a lint rule for unstable components, which lose state on rerender. Rather than fix outstanding instances of the warning, this PR just marks them with FIXME and eslint-disable-next-line. I do believe a significant portion of those FIXMEs (though not all) are real bugs.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208393814310407) by [Unito](https://www.unito.io)
