### PR TITLE
Allow karma awards of 100 or 1000

### DIFF
--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -5,8 +5,8 @@ import type { VotingSystem } from './votingSystems';
 import { collectionNameToTypeName } from '../vulcan-lib';
 import { DatabasePublicSetting } from '../publicSettings';
 
-const karmaRewarderId100 = new DatabasePublicSetting<string | null>('karmaRewarderId100', null)
-const karmaRewarderId1000 = new DatabasePublicSetting<string | null>('karmaRewarderId1000', null)
+export const karmaRewarderId100 = new DatabasePublicSetting<string | null>('karmaRewarderId100', null)
+export const karmaRewarderId1000 = new DatabasePublicSetting<string | null>('karmaRewarderId1000', null)
 
 
 export interface VoteDocTuple {

--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -3,6 +3,11 @@ import { recalculateScore } from '../scoring';
 import { calculateVotePower, isValidVoteType } from './voteTypes';
 import type { VotingSystem } from './votingSystems';
 import { collectionNameToTypeName } from '../vulcan-lib';
+import { DatabaseServerSetting } from '@/server/databaseSettings';
+
+const karmaRewarderId100 = new DatabaseServerSetting<string | null>('karmaRewarderId100', null)
+const karmaRewarderId1000 = new DatabaseServerSetting<string | null>('karmaRewarderId1000', null)
+
 
 export interface VoteDocTuple {
   newDocument: DbVoteableType
@@ -100,7 +105,6 @@ const cancelVoteClient = ({document, collectionName, user, votingSystem}: {
   return newDocument;
 }
 
-
 // Determine a user's voting power for a given operation.
 // If power is a function, call it on user
 export const getVotePower = ({ user, voteType, document }: {
@@ -109,6 +113,8 @@ export const getVotePower = ({ user, voteType, document }: {
   document: VoteableType,
 }) => {
   const userKarma = user.karma;
+  if (user._id === karmaRewarderId100.get()) return 100;
+  if (user._id === karmaRewarderId1000.get()) return 1000;
   return calculateVotePower(userKarma, voteType);
 };
 

--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -3,10 +3,10 @@ import { recalculateScore } from '../scoring';
 import { calculateVotePower, isValidVoteType } from './voteTypes';
 import type { VotingSystem } from './votingSystems';
 import { collectionNameToTypeName } from '../vulcan-lib';
-import { DatabaseServerSetting } from '@/server/databaseSettings';
+import { DatabasePublicSetting } from '../publicSettings';
 
-const karmaRewarderId100 = new DatabaseServerSetting<string | null>('karmaRewarderId100', null)
-const karmaRewarderId1000 = new DatabaseServerSetting<string | null>('karmaRewarderId1000', null)
+const karmaRewarderId100 = new DatabasePublicSetting<string | null>('karmaRewarderId100', null)
+const karmaRewarderId1000 = new DatabasePublicSetting<string | null>('karmaRewarderId1000', null)
 
 
 export interface VoteDocTuple {

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -1,0 +1,31 @@
+import Users from "@/lib/vulcan-users";
+import { performVoteServer } from "../voteServer"
+import { createMutator, Globals } from "../vulcan-lib"
+import { Posts } from "@/lib/collections/posts";
+import { karmaRewarderId100, karmaRewarderId1000 } from "@/lib/voting/vote";
+
+const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, reason: string) => {
+  const user = await Users.findOne({_id: userId});
+  if (!user) return
+
+  const karmaAwardGivingUser = karmaAmount === 100 ? await Users.findOne({_id: karmaRewarderId100.get()}) : await Users.findOne({_id: karmaRewarderId1000.get()})
+
+  if (!karmaAwardGivingUser) return
+
+  const post = await createMutator({
+    collection: Posts,
+    document: { userId: user._id, draft: true, deletedDraft: true, title: `100 karma award for ${reason}` },
+    currentUser: user,
+    validate: false,
+  });
+
+  performVoteServer({documentId: post.data._id, voteType: "upvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
+}
+
+const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) {
+  for (const userId of userIds) {
+    createKarmaAwardForUser(userId, karmaAmount, reason);
+  }
+}
+
+Globals.grantKarmaAwards = createKarmaAwards

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -6,7 +6,11 @@ import { karmaRewarderId100, karmaRewarderId1000 } from "@/lib/voting/vote";
 
 const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, reason: string) => {
   const user = await Users.findOne({_id: userId});
-  if (!user) return
+  if (!user) {
+    // eslint-disable-next-line no-console
+    console.log("ERROR: Couldn't find user")
+    return
+  }
 
   let karmaAwardGivingUser: DbUser|null = null;
   if (karmaAmount === 100) {
@@ -16,11 +20,17 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
     karmaAwardGivingUser = await Users.findOne({_id: karmaRewarderId1000.get()})
   }
 
-  if (!karmaAwardGivingUser) return
+  if (!karmaAwardGivingUser) {
+    // eslint-disable-next-line no-console
+    console.log("ERROR: Couldn't find karma award giving user")
+    return
+  }
+  const postInfo = `${karmaAmount} karma award for ${reason}`
+  const contents = {originalContents: { data: postInfo, type: "ckEditorMarkup" }} as EditableFieldContents
 
   const post = await createMutator({
     collection: Posts,
-    document: { userId: user._id, draft: true, deletedDraft: true, title: `100 karma award for ${reason}` },
+    document: { userId: user._id, draft: true, deletedDraft: true, title: postInfo, contents } as Partial<DbInsertion<DbPost>>,
     currentUser: user,
     validate: false,
   });
@@ -30,7 +40,7 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
 
 const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) => {
   for (const userId of userIds) {
-    createKarmaAwardForUser(userId, karmaAmount, reason);
+    void createKarmaAwardForUser(userId, karmaAmount, reason);
   }
 }
 

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -26,7 +26,7 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
     return
   }
   const postInfo = `${karmaAmount} karma award for ${reason}`
-  const contents = {originalContents: { data: postInfo, type: "ckEditorMarkup" }} as EditableFieldContents
+  const contents = {originalContents: { data: postInfo, type: "ckEditorMarkup" }}
 
   const post = await createMutator({
     collection: Posts,

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -35,7 +35,7 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
     validate: false,
   });
 
-  performVoteServer({documentId: post.data._id, voteType: "upvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
+  void performVoteServer({documentId: post.data._id, voteType: "upvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
 }
 
 const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) => {

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -8,7 +8,13 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
   const user = await Users.findOne({_id: userId});
   if (!user) return
 
-  const karmaAwardGivingUser = karmaAmount === 100 ? await Users.findOne({_id: karmaRewarderId100.get()}) : await Users.findOne({_id: karmaRewarderId1000.get()})
+  let karmaAwardGivingUser: DbUser|null = null;
+  if (karmaAmount === 100) {
+    karmaAwardGivingUser = await Users.findOne({_id: karmaRewarderId100.get()})
+  }
+  if (karmaAmount === 1000) {
+    karmaAwardGivingUser = await Users.findOne({_id: karmaRewarderId1000.get()})
+  }
 
   if (!karmaAwardGivingUser) return
 

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -28,7 +28,7 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
   performVoteServer({documentId: post.data._id, voteType: "upvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
 }
 
-const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) {
+const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) => {
   for (const userId of userIds) {
     createKarmaAwardForUser(userId, karmaAmount, reason);
   }


### PR DESCRIPTION
We're giving karma awards for Petrov Day 2024. For now, we're implementing a somewhat ad-hoc way of making the award. If we decide to give out more karma-awards later we may build a more dedicated KarmaAwards collection.

The solution here after chatting with @b0b3rt is to make two users who are hardcoded to give higher than usual vote power (100 and 1000, respectively), and then create some votes from them on some secret archived posts for each user.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208424072361637) by [Unito](https://www.unito.io)
