### PR TITLE
fix bugs in createKarmaAward

### DIFF
--- a/packages/lesswrong/integrationTests/utils.ts
+++ b/packages/lesswrong/integrationTests/utils.ts
@@ -303,7 +303,7 @@ const generateDummyVoteData = (user: DbUser, data?: Partial<DbVote>): DbVote => 
     _id: randomId(),
     documentId: randomId(),
     collectionName: "Posts" as const,
-    voteType: "smallUpvote",
+    voteType: "smallUpvote" as const,
     userId: user._id,
     authorIds: [],
     power: 1,

--- a/packages/lesswrong/lib/collections/votes/schema.ts
+++ b/packages/lesswrong/lib/collections/votes/schema.ts
@@ -75,6 +75,7 @@ const schema: SchemaType<"Votes"> = {
   // neutral if it doesn't.
   voteType: {
     type: String,
+    allowedValues: ['bigDownvote', 'bigUpvote', 'neutral', 'smallDownvote', 'smallUpvote'], 
     nullable: false,
     canRead: ['guests'],
   },

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -1950,7 +1950,7 @@ interface DbVote extends DbObject {
   collectionName: CollectionNameString
   userId: string
   authorIds: Array<string> | null
-  voteType: string
+  voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote"
   extendedVoteType: any /*{"definitions":[{"type":"JSON"}]}*/
   power: number
   afPower: number | null

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1001,7 +1001,7 @@ interface VotesDefaultFragment { // fragment on Votes
   readonly collectionName: string,
   readonly userId: string,
   readonly authorIds: Array<string>,
-  readonly voteType: string,
+  readonly voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote",
   readonly extendedVoteType: any /*{"definitions":[{"type":"JSON"}]}*/,
   readonly power: number,
   readonly afPower: number,
@@ -1870,7 +1870,7 @@ interface CommentsListWithModerationMetadata extends CommentWithRepliesFragment 
 }
 
 interface CommentsListWithModerationMetadata_allVotes { // fragment on Votes
-  readonly voteType: string,
+  readonly voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote",
 }
 
 interface CommentsListWithModGPTAnalysis extends CommentsList { // fragment on Comments
@@ -3608,7 +3608,7 @@ interface FeaturedResourcesFragment { // fragment on FeaturedResources
 interface TagRelVotes { // fragment on Votes
   readonly _id: string,
   readonly userId: string,
-  readonly voteType: string,
+  readonly voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote",
   readonly power: number,
   readonly documentId: string,
   readonly votedAt: Date,
@@ -3623,7 +3623,7 @@ interface TagVotingActivity extends TagRelVotes { // fragment on Votes
 interface UserVotes { // fragment on Votes
   readonly _id: string,
   readonly userId: string,
-  readonly voteType: string,
+  readonly voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote",
   readonly power: number,
   readonly cancelled: boolean,
   readonly documentId: string,

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -42,6 +42,7 @@ import './server/scripts/generateInflationAdjustedKarmaReport';
 import './server/scripts/voteMigration';
 import './server/scripts/slugDeduplication';
 import './server/scripts/debuggingScripts';
+import './server/scripts/createKarmaAward'
 import './server/scripts/rerunAFvotes';
 import './server/scripts/nullifyVotes';
 import './server/scripts/fillUserEmail';

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -228,7 +228,7 @@ async function maybeCreateReviewMarket({newDocument, vote}: VoteDocTuple, collec
   if (vote.power <= 0 || vote.cancelled) return; // In principle it would be fine to make a market here, but it should never be first created here
   if (newDocument.baseScore < reviewMarketCreationMinimumKarmaSetting.get()) return;
   const post = await Posts.findOne({_id: newDocument._id})
-  if (!post) return;
+  if (!post || post.draft || post.deletedDraft) return;
   if (post.postedAt.getFullYear() < (new Date()).getFullYear() - 1) return; // only make markets for posts that haven't had a chance to be reviewed
   if (post.manifoldReviewMarketId) return;
 

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -5,6 +5,8 @@ import { Posts } from "@/lib/collections/posts";
 import { karmaRewarderId100, karmaRewarderId1000 } from "@/lib/voting/vote";
 
 const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, reason: string) => {
+  // eslint-disable-next-line no-console
+  console.log("Creating karma award for user", userId, karmaAmount, reason)
   const user = await Users.findOne({_id: userId});
   if (!user) {
     // eslint-disable-next-line no-console
@@ -35,7 +37,7 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
     validate: false,
   });
 
-  void performVoteServer({documentId: post.data._id, voteType: "upvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
+  void performVoteServer({documentId: post.data._id, voteType: "bigUpvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
 }
 
 const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) => {
@@ -44,4 +46,4 @@ const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reaso
   }
 }
 
-Globals.grantKarmaAwards = createKarmaAwards
+Globals.createKarmaAwards = createKarmaAwards

--- a/packages/lesswrong/server/scripts/recomputeReceivedVoteCounts.ts
+++ b/packages/lesswrong/server/scripts/recomputeReceivedVoteCounts.ts
@@ -70,6 +70,8 @@ async function recalculateReceivedVoteCounts() {
             case 'bigDownvote':
               voteCounts.bigDownvoteReceivedCount++;
               break;
+            case 'neutral': // We weren't previously counting neutral votes when I added this to fix types. I don't think we need to start, but, flagging the inconsistency.
+              break;
           }
           voteCounts.voteReceivedCount++;
 

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -46,7 +46,7 @@ const getExistingVote = async ({ document, user }: {
 const addVoteServer = async ({ document, collection, voteType, extendedVote, user, voteId, context }: {
   document: DbVoteableType,
   collection: CollectionBase<VoteableCollectionName>,
-  voteType: string,
+  voteType: DbVote['voteType'],
   extendedVote: any,
   user: DbUser,
   voteId: string,
@@ -91,7 +91,7 @@ const addVoteServer = async ({ document, collection, voteType, extendedVote, use
 export const createVote = ({ document, collectionName, voteType, extendedVote, user, voteId }: {
   document: DbVoteableType,
   collectionName: CollectionNameString,
-  voteType: string,
+  voteType: DbVote['voteType'],
   extendedVote: any,
   user: DbUser|UsersCurrent,
   voteId?: string,
@@ -214,7 +214,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
 export const performVoteServer = async ({ documentId, document, voteType, extendedVote, collection, voteId = randomId(), user, toggleIfAlreadyVoted = true, skipRateLimits, context, selfVote = false }: {
   documentId?: string,
   document?: DbVoteableType|null,
-  voteType: string,
+  voteType: DbVote['voteType'],
   extendedVote?: any,
   collection: CollectionBase<VoteableCollectionName>,
   voteId?: string,

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -38,7 +38,7 @@ const voteResolver = {
     // compatibility.
     //
     // Returns the document that was voted upon, with its score updated.
-    async vote(root: void, args: {documentId: string, voteType: string, collectionName: CollectionNameString, voteId?: string}, context: ResolverContext) {
+    async vote(root: void, args: {documentId: string, voteType: DbVote['voteType'], collectionName: CollectionNameString, voteId?: string}, context: ResolverContext) {
       const {documentId, voteType, collectionName} = args;
       const { currentUser } = context;
       const collection = getCollection(collectionName);
@@ -82,7 +82,7 @@ function addVoteMutations(collection: CollectionBase<VoteableCollectionName>) {
     }
   `);
   
-  const performVoteMutation = async (args: {documentId: string, voteType: string|null, extendedVote?: any}, context: ResolverContext) => {
+  const performVoteMutation = async (args: {documentId: string, voteType: DbVote['voteType']|null, extendedVote?: any}, context: ResolverContext) => {
     const {documentId, voteType, extendedVote} = args;
     const {currentUser} = context;
     const document = await collection.findOne({_id: documentId});
@@ -111,11 +111,11 @@ function addVoteMutations(collection: CollectionBase<VoteableCollectionName>) {
   }
   addGraphQLResolvers({
     Mutation: {
-      [backCompatMutationName]: async (root: void, args: {documentId: string, voteType: string|null, extendedVote?: any}, context: ResolverContext) => {
+      [backCompatMutationName]: async (root: void, args: {documentId: string, voteType: DbVote['voteType']|null, extendedVote?: any}, context: ResolverContext) => {
         const {modifiedDocument, showVotingPatternWarning} = await performVoteMutation(args, context);
         return modifiedDocument;
       },
-      [mutationName]: async (root: void, args: {documentId: string, voteType: string|null, extendedVote?: any}, context: ResolverContext) => {
+      [mutationName]: async (root: void, args: {documentId: string, voteType: DbVote['voteType']|null, extendedVote?: any}, context: ResolverContext) => {
         const {modifiedDocument, showVotingPatternWarning} = await performVoteMutation(args, context);
         return {
           document: modifiedDocument,


### PR DESCRIPTION
There were a couple problems with the createKarmaAward function that Robert and I both missed.

One was that the new autogenerated posts we were creating/upvoting were generating ManifoldMarkets for the LW Review. This seems like a general problem where "draft posts that get 100 karma probably shouldn't get ManifoldMarkets", which I updated here.

I had also previously mistakenly listed the voteType as "upvote" instead of "smallUpvote" or "bigUpvote." At @b0b3rt's suggestion, In the process of fixing this I set the allowed values of the voteType field to be the specific vote types we use so this sort of error wouldn't happen again.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208426153151577) by [Unito](https://www.unito.io)
