### PR TITLE
drop criticismTipsDismissed field from Posts table

### DIFF
--- a/packages/lesswrong/server/migrations/20240930T215249.drop_criticismTipsDismissed_from_Posts.ts
+++ b/packages/lesswrong/server/migrations/20240930T215249.drop_criticismTipsDismissed_from_Posts.ts
@@ -1,0 +1,36 @@
+/**
+ * Generated on 2024-09-30T21:52:49.991Z by `yarn makemigrations`
+ * The following schema changes were detected:
+ * -------------------------------------------
+ * diff --git a/Users/sarah/EAForum/schema/accepted_schema.sql b/Users/sarah/EAForum/schema/schema_to_accept.sql
+ * index ddfc718677..e6d16060a1 100644
+ * --- a/Users/sarah/EAForum/schema/accepted_schema.sql
+ * +++ b/Users/sarah/EAForum/schema/schema_to_accept.sql
+ * @@ -6,4 +6,2 @@
+ *  
+ * --- Accepted on 2024-09-25T02:00:54.000Z by 20240925T020054.create_petrovDayAction.ts
+ * -
+ *  -- Extension "btree_gin", hash 7b207eefbb36f8109cca31911e6ab886
+ * 
+ * -------------------------------------------
+ * (run `git diff --no-index schema/accepted_schema.sql schema/schema_to_accept.sql` to see this more clearly)
+ *
+ * - [ ] Write a migration to represent these changes
+ * - [ ] Rename this file to something more readable
+ * - [ ] Uncomment `acceptsSchemaHash` below
+ * - [ ] Run `yarn acceptmigrations` to update the accepted schema hash (running makemigrations again will also do this)
+ */
+export const acceptsSchemaHash = "4176699fcd50a096b6fd2437aec71b01";
+
+import Posts from "@/lib/collections/posts/collection";
+import { addRemovedField, dropRemovedField } from "./meta/utils";
+import { BoolType } from "../sql/Type";
+
+export const up = async ({db}: MigrationContext) => {
+  await dropRemovedField(db, Posts, 'criticismTipsDismissed')
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await addRemovedField(db, Posts, 'criticismTipsDismissed', new BoolType())
+}
+

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -4,7 +4,7 @@
 --
 -- Overall schema hash: 4176699fcd50a096b6fd2437aec71b01
 
--- Accepted on 2024-09-25T02:00:54.000Z by 20240925T020054.create_petrovDayAction.ts
+-- Accepted on 2024-09-30T21:52:49.000Z by 20240930T215249.drop_criticismTipsDismissed_from_Posts.ts
 
 -- Extension "btree_gin", hash 7b207eefbb36f8109cca31911e6ab886
 CREATE EXTENSION IF NOT EXISTS "btree_gin" CASCADE;

--- a/schema/schema_changelog.json
+++ b/schema/schema_changelog.json
@@ -788,5 +788,10 @@
     "acceptsSchemaHash": "4176699fcd50a096b6fd2437aec71b01",
     "acceptedByMigration": "20240925T020054.create_petrovDayAction.ts",
     "timestamp": "2024-09-25T02:00:54.000Z"
+  },
+  {
+    "acceptsSchemaHash": "4176699fcd50a096b6fd2437aec71b01",
+    "acceptedByMigration": "20240930T215249.drop_criticismTipsDismissed_from_Posts.ts",
+    "timestamp": "2024-09-30T21:52:49.000Z"
   }
 ]


### PR DESCRIPTION
Follow up to https://github.com/ForumMagnum/ForumMagnum/pull/9765 where we moved the field to the `Users` table

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208442339835962) by [Unito](https://www.unito.io)
