### PR TITLE
Fix audio player mobile display

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -19,6 +19,14 @@ const styles = (theme: ThemeType): JssStyles => ({
       marginBottom: 38
     },
   },
+  rootWithAudioPlayer: {
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: LW_POST_PAGE_PADDING - 48,
+    },
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: 16,
+    },
+  },
   eventHeader: {
     marginBottom: 0,
   },
@@ -65,9 +73,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 15,
     display: 'flex',
     [theme.breakpoints.down('sm')]: {
-      top: 8,
-      right: 8
-    }
+      position: 'relative',
+      justifyContent: 'flex-end',
+      marginLeft: 8,
+      marginRight: -64,
+    },
+    [theme.breakpoints.down('xs')]: {
+      justifyContent: 'flex-start',
+    },
   },
   sequenceNav: {
     marginBottom: 8,
@@ -158,7 +171,7 @@ const LWPostsPageHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, clas
     </a>
   </LWTooltip> : null;
 
-  return <div className={classNames(classes.root, {[classes.eventHeader]: post.isEvent})}>
+  return <div className={classNames(classes.root, {[classes.eventHeader]: post.isEvent, [classes.rootWithAudioPlayer]: !!showEmbeddedPlayer})}>
       {post.group && <PostsGroupDetails post={post} documentId={post.group._id} />}
       <AnalyticsContext pageSectionContext="topSequenceNavigation">
         {('sequence' in post) && !!post.sequence && <div className={classes.sequenceNav}>

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -157,7 +157,7 @@ const styles = (theme: ThemeType) => ({
     justifyContent: 'space-evenly',
     '--scrollAmount': '0%',
     marginRight: -4,
-    marginBottom: 20,
+    marginBottom: 0,
     width: 1,
     background: theme.palette.grey[400],
     overflowY: 'clip',

--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -85,6 +85,13 @@ const styles = (theme: ThemeType) => ({
     // And unfortunately we need !important because otherwise this style gets overriden by the `top: 0` in `stickyBlockScroller`
     top: '-1px !important'
   },
+  '@global': {
+    // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global
+    [`body:has(.headroom--pinned) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}, body:has(.headroom--unfixed) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}`]: {
+      top: HEADER_HEIGHT,
+      height: `calc(100vh - ${HEADER_HEIGHT}px - ${FIXED_TOC_COMMENT_COUNT_HEIGHT}px)`
+    }
+  },
   stickyBlockScroller: {
     position: "sticky",
     fontSize: 12,
@@ -106,15 +113,6 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down('sm')]:{
       display:'none'
     },
-  },
-  '@global': {
-    // Hard-coding this class name as a workaround for one of the JSS plugins being incapable of parsing a self-reference ($titleContainer) while inside @global
-    [`body:has(.headroom--pinned) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}, body:has(.headroom--unfixed) .${STICKY_BLOCK_SCROLLER_CLASS_NAME}`]: {
-      '&&': {
-        top: HEADER_HEIGHT,
-        height: `calc(100vh - ${HEADER_HEIGHT}px - ${FIXED_TOC_COMMENT_COUNT_HEIGHT}px)`
-      }
-    }
   },
   stickyBlock: {
     // Cancels the direction:rtl in stickyBlockScroller


### PR DESCRIPTION
Previously: 
<img width="786" alt="image" src="https://github.com/user-attachments/assets/6c1769f2-dfbd-4888-ac67-d87bc253ca22">
<img width="496" alt="image" src="https://github.com/user-attachments/assets/f0aeeb53-759c-4827-b6e7-01adc666e89c">


Now: 
<img width="789" alt="image" src="https://github.com/user-attachments/assets/320e0911-4fce-447c-85ad-9919480143bc">
<img width="497" alt="image" src="https://github.com/user-attachments/assets/a842ff4f-123a-46cd-81c3-97fb4308a782">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208442479743102) by [Unito](https://www.unito.io)
