### PR TITLE
Add Comment Permalink margin to avoid overflow

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -7,11 +7,15 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { isNotRandomId } from '@/lib/random';
 import { scrollFocusOnElement } from '@/lib/scrollUtils';
 import { commentPermalinkStyleSetting } from '@/lib/publicSettings';
+import { isBookUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
+    ...(isBookUI && {
+      marginTop: 64
+    })
   },
   dividerMargins: {
     marginTop: 150,

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -13,9 +13,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
-    ...(isBookUI && {
+    ...(isBookUI ? {
       marginTop: 64
-    })
+    } : {}),
   },
   dividerMargins: {
     marginTop: 150,


### PR DESCRIPTION
Before: 
<img width="645" alt="image" src="https://github.com/user-attachments/assets/ea458077-447d-4830-b7d5-298ab7bc195b">

Now: 
<img width="661" alt="image" src="https://github.com/user-attachments/assets/8895a918-3bc8-4b55-b480-ae907c791c1d">