### PR TITLE
Some QOL tweaks

### DIFF
--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { useCurrentUser } from "../common/withUser";
 import { useTracking } from "../../lib/analyticsEvents";
-import {forumTitleSetting, isEAForum, isLW } from "../../lib/instanceSettings";
+import {forumTitleSetting, isEAForum, isLW, isLWorAF } from "../../lib/instanceSettings";
 import { isFriendlyUI } from '../../themes/forumTheme';
 import {requestFeedbackKarmaLevelSetting} from '../../lib/publicSettings.ts'
 
@@ -87,6 +87,9 @@ const PostSubmit = ({
 
   const onSubmitClick = requireConfirmation ? submitWithConfirmation : submitWithoutConfirmation;
   const requestFeedbackKarmaLevel = requestFeedbackKarmaLevelSetting.get()
+  // EA Forum title is Effective Altruism Forum, which is unecessarily long
+  const eaOrOtherFeedbackTitle = isEAForum ? 'the EA Forum team' : `the ${forumTitleSetting.get()} team`
+  const feedbackTitle = `Request feedback from ${isLWorAF ? 'our editor' : eaOrOtherFeedbackTitle}`
 
   return (
     <React.Fragment>
@@ -105,8 +108,7 @@ const PostSubmit = ({
       }
       <div className={classes.submitButtons}>
         {requestFeedbackKarmaLevel !== null && currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
-          // EA Forum title is Effective Altruism Forum, which is unecessarily long
-          title={isEAForum ? 'Request feedback from the EA Forum team' : 'Request feedback from our editor'}
+          title={feedbackTitle}
         >
           <Button type="submit"//treat as draft when draft is null
             className={classNames(classes.formButton, classes.secondaryButton, classes.feedback)}

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -106,7 +106,7 @@ const PostSubmit = ({
       <div className={classes.submitButtons}>
         {requestFeedbackKarmaLevel !== null && currentUser.karma >= requestFeedbackKarmaLevel && document.draft!==false && <LWTooltip
           // EA Forum title is Effective Altruism Forum, which is unecessarily long
-          title={`Request feedback from the ${isEAForum ? "EA Forum" : forumTitleSetting.get()} team.`}
+          title={isEAForum ? 'Request feedback from the EA Forum team' : 'Request feedback from our editor'}
         >
           <Button type="submit"//treat as draft when draft is null
             className={classNames(classes.formButton, classes.secondaryButton, classes.feedback)}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -4,6 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { useCurrentUser } from '../common/withUser';
 import classNames from 'classnames';
 import { isEAForum } from '../../lib/instanceSettings';
+import { Link } from '@/lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
   loadMorePadding: {
@@ -70,7 +71,7 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes, setCuration
   return (
     <div className={classes.root}>
       <SunshineListTitle>
-        Suggestions for Curated
+        <Link to={`/admin/curation`}>Suggestions for Curated</Link>
         <MetaInfo>
           <FormatDate date={curatedDate}/>
         </MetaInfo>


### PR DESCRIPTION
- There's reasonably often confusion about Justis' relationship to, for example, moderation decisions, so clarify that copy
- Make it so the curation sidebar links to the draft curation notices list

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208451366515052) by [Unito](https://www.unito.io)
