### PR TITLE
ensure we keep fields updated by callbacks when updating a crossposted post

### DIFF
--- a/packages/lesswrong/server/fmCrosspost/crosspost.ts
+++ b/packages/lesswrong/server/fmCrosspost/crosspost.ts
@@ -195,5 +195,5 @@ export async function handleCrosspostUpdate(
     return data;
   }
 
-  return performCrosspost(newDocument);
+  return performCrosspost({ ...newDocument, ...data });
 }


### PR DESCRIPTION
[This commit](https://github.com/ForumMagnum/ForumMagnum/commit/5dcec9b19d12315b17a7d555a19074f8d6c15e75#diff-e67d84766759211a6929fccf5cb97fa677a35c528fc380e131481b19da8f25ac) seems to have resulted in a bug which drops any field updates performed by post callback hooks when the post is a crosspost; those updates are only persisted in `data`, which is the "iterator" (not in `newDocument`, which is a snapshot of the post-update document taken at the very start of the `updateMutator`).

One way this bug presented was by making updates to a post appear to mysteriously act as no-ops, because the post contents were being pulled from the `sideCommentsCache`, which only gets invalidated when `modifiedAt` is updated.  And `modifiedAt` is a denormalized field updated via an `onUpdate`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208470907602673) by [Unito](https://www.unito.io)
