### PR TITLE
[EA Forum only] use gradients for the tag for the upcoming Forum event

### DIFF
--- a/packages/lesswrong/components/common/HomeTagBar.tsx
+++ b/packages/lesswrong/components/common/HomeTagBar.tsx
@@ -136,10 +136,19 @@ const styles = (theme: ThemeType) => ({
     },
   },
   eventTab: {
-    ...eventTabStyles(theme.themeOptions.name === "dark"),
+    // TODO after event: revert this back
+    // ...eventTabStyles(theme.themeOptions.name === "dark"),
+    background: 'linear-gradient(270deg, rgba(154, 176, 137, 0.30) 0%, rgba(65, 131, 161, 0.30) 100%)',
+    color: theme.palette.grey[1000],
   },
   activeEventTab: {
-    ...eventTabStyles(theme.themeOptions.name !== "dark"),
+    // TODO after event: revert this back
+    // ...eventTabStyles(theme.themeOptions.name !== "dark"),
+    background: `linear-gradient(270deg, rgba(154, 176, 137, 0.60) 0%, rgba(65, 131, 161, 0.60) 100%), ${theme.palette.grey[500]}`,
+    color: theme.palette.grey[0],
+    '&:hover': {
+      backgroundColor: theme.palette.grey[500],
+    },
   },
   placeholderTab: {
     flex: 'none',

--- a/packages/lesswrong/components/common/HomeTagBar.tsx
+++ b/packages/lesswrong/components/common/HomeTagBar.tsx
@@ -138,13 +138,13 @@ const styles = (theme: ThemeType) => ({
   eventTab: {
     // TODO after event: revert this back
     // ...eventTabStyles(theme.themeOptions.name === "dark"),
-    background: 'linear-gradient(270deg, rgba(154, 176, 137, 0.30) 0%, rgba(65, 131, 161, 0.30) 100%)',
+    background: `linear-gradient(270deg, ${theme.palette.tag.eventLightGreen} 0%, ${theme.palette.tag.eventLightBlue} 100%)`,
     color: theme.palette.grey[1000],
   },
   activeEventTab: {
     // TODO after event: revert this back
     // ...eventTabStyles(theme.themeOptions.name !== "dark"),
-    background: `linear-gradient(270deg, rgba(154, 176, 137, 0.60) 0%, rgba(65, 131, 161, 0.60) 100%), ${theme.palette.grey[500]}`,
+    background: `linear-gradient(270deg, ${theme.palette.tag.eventDarkGreen} 0%, ${theme.palette.tag.eventDarkBlue} 100%), ${theme.palette.grey[500]}`,
     color: theme.palette.grey[0],
     '&:hover': {
       backgroundColor: theme.palette.grey[500],

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -104,24 +104,29 @@ const styles = (theme: ThemeType) => ({
   strikethroughTitle: {
     textDecoration: "line-through"
   },
+  eventTagLink: {
+    '&:hover': {
+      opacity: 0.8
+    }
+  },
   eventTag: {
     ...tagStyle(theme),
     ...smallTagTextStyle(theme),
-    display: "inline-flex",
+    display: "flex",
     alignItems: "center",
     marginLeft: 10,
     padding: "0 6px",
     height: 20,
     border: "none",
-    backgroundColor: theme.themeOptions.name === "dark"
-      ? "var(--post-title-tag-foreground)"
-      : "var(--post-title-tag-background)",
-    color: theme.themeOptions.name === "dark"
-      ? "var(--post-title-tag-background)"
-      : "var(--post-title-tag-foreground)",
-    "&:hover": {
-      opacity: 0.9,
-    },
+    // TODO after event: revert this back
+    background: 'linear-gradient(270deg, rgba(154, 176, 137, 0.30) 0%, rgba(65, 131, 161, 0.30) 100%)',
+    color: theme.palette.grey[1000],
+    // backgroundColor: theme.themeOptions.name === "dark"
+    //   ? "var(--post-title-tag-foreground)"
+    //   : "var(--post-title-tag-background)",
+    // color: theme.themeOptions.name === "dark"
+    //   ? "var(--post-title-tag-background)"
+    //   : "var(--post-title-tag-foreground)",
   },
   highlightedTagTooltip: {
     marginTop: -2,
@@ -244,7 +249,7 @@ const PostsTitle = ({
             tagSlug={currentForumEvent.tag.slug}
             className={classes.highlightedTagTooltip}
           >
-            <Link doOnDown={true} to={tagGetUrl(currentForumEvent.tag)}>
+            <Link doOnDown={true} to={tagGetUrl(currentForumEvent.tag)} className={classes.eventTagLink}>
               <span
                 className={classes.eventTag}
                 style={{
@@ -252,7 +257,7 @@ const PostsTitle = ({
                   "--post-title-tag-foreground": currentForumEvent.darkColor,
                 } as CSSProperties}
               >
-                {currentForumEvent.tag.name}
+                {currentForumEvent.tag.shortName || currentForumEvent.tag.name}
               </span>
             </Link>
           </TagsTooltip>

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -119,7 +119,7 @@ const styles = (theme: ThemeType) => ({
     height: 20,
     border: "none",
     // TODO after event: revert this back
-    background: 'linear-gradient(270deg, rgba(154, 176, 137, 0.30) 0%, rgba(65, 131, 161, 0.30) 100%)',
+    background: `linear-gradient(270deg, ${theme.palette.tag.eventLightGreen} 0%, ${theme.palette.tag.eventLightBlue} 100%)`,
     color: theme.palette.grey[1000],
     // backgroundColor: theme.themeOptions.name === "dark"
     //   ? "var(--post-title-tag-foreground)"

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -496,6 +496,10 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     onboardingBackground: "rgba(0, 0, 0, 0.4)",
     onboardingBackgroundHover: "rgba(0, 0, 0, 0.2)",
     onboardingBackgroundSelected: "rgba(0, 0, 0, 0.5)",
+    eventLightGreen: 'rgba(154, 176, 137, 0.30)',
+    eventDarkGreen: 'rgba(154, 176, 137, 0.60)',
+    eventLightBlue: 'rgba(65, 131, 161, 0.30)',
+    eventDarkBlue: 'rgba(65, 131, 161, 0.60)',
   },
   tab: {
     inactive: {

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -430,6 +430,10 @@ declare global {
       onboardingBackground: ColorString,
       onboardingBackgroundHover: ColorString,
       onboardingBackgroundSelected: ColorString,
+      eventLightGreen: ColorString,
+      eventDarkGreen: ColorString,
+      eventLightBlue: ColorString,
+      eventDarkBlue: ColorString,
     },
     tab: {
       inactive: {


### PR DESCRIPTION
This PR adds some temporary code to style the Forum event tag with a custom gradient. I think we should just plan to undo it after because the baseline code uses the dark and light event colors which seems like a cleaner general solution.

Light mode:
<img width="1034" alt="Screenshot 2024-10-04 at 12 15 20 AM" src="https://github.com/user-attachments/assets/7e401516-4dc3-408a-9fa6-9e3fb650c6c9">
<img width="1034" alt="Screenshot 2024-10-04 at 12 15 14 AM" src="https://github.com/user-attachments/assets/d4e49daa-5fec-406e-a35e-eee82bedbbef">

Dark mode:
<img width="1034" alt="Screenshot 2024-10-04 at 12 15 29 AM" src="https://github.com/user-attachments/assets/bfe4d551-e4f0-4df3-b746-0c70392c91b1">
<img width="1034" alt="Screenshot 2024-10-04 at 12 15 34 AM" src="https://github.com/user-attachments/assets/3792a0b2-c9e2-4f73-a843-acabe0f0eedf">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208472758549619) by [Unito](https://www.unito.io)
