### PR TITLE
Fix creation of new topics

### DIFF
--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -432,6 +432,7 @@ const schema: SchemaType<"Tags"> = {
   tableOfContents: {
     type: Object,
     canRead: ['guests'],
+    optional: true,
   },
   
   htmlWithContributorAnnotations: {


### PR DESCRIPTION
Fixes a regression from commit 1363660 that broke the creation of new topics by making the resolver-only field `tableOfContents` a required field.


