### PR TITLE
[EA Forum only] decrease tag karma thresholds

### DIFF
--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -11,8 +11,8 @@ import type { Request, Response } from 'express';
 export const tagMinimumKarmaPermissions = forumSelect({
   // Topic spampocalypse defense
   EAForum: {
-    new: 10,
-    edit: 10,
+    new: 1,
+    edit: 1,
   },
   LessWrong: {
     new: 1,


### PR DESCRIPTION
As discussed on [slack](https://cea-core.slack.com/archives/C04DM0BDQAY/p1727992439210479), seems like the threshold doesn't need to be this high so I've decreased it