### PR TITLE
[EA] Sentence case for collections page title

### DIFF
--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -7,6 +7,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser';
 import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { makeCloudinaryImageUrl } from '../common/CloudinaryImage2';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 const PADDING = 36
 const COLLECTION_WIDTH = SECTION_WIDTH + (PADDING * 2)
@@ -49,7 +50,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   title: {
     ...theme.typography.headerStyle,
     fontWeight: "bold",
-    textTransform: "uppercase",
+    textTransform: isFriendlyUI ? undefined : "uppercase",
     borderTopStyle: "solid",
     borderTopWidth: 4,
     paddingTop: 10,
@@ -58,7 +59,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   description: {
     marginTop: 30,
-    marginBottom: 25,
+    marginBottom: isFriendlyUI ? 0 : 25,
     lineHeight: 1.25,
     maxWidth: 700,
   },


### PR DESCRIPTION
[Request from Slack](https://cea-core.slack.com/archives/C03R2G12W2K/p1728061504351019): sentence case the title on the collections page (currently only used on the EA Forum for the EA handbook). I also removed the bottom margin from the description as there's already padding on the container, so it looked a bit lop-sided.

Before:
<img width="1158" alt="Screenshot 2024-10-07 at 17 58 50" src="https://github.com/user-attachments/assets/c8f2c916-07b1-412e-9ca5-89c02a23e7c1">

After:
<img width="1161" alt="Screenshot 2024-10-07 at 17 55 24" src="https://github.com/user-attachments/assets/93e5b3ad-c2ba-4b69-8e6f-4f1ec47d7f9a">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208494255311976) by [Unito](https://www.unito.io)
