### PR TITLE
Filter out emoji's from Quick Take post title

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -635,5 +635,8 @@ export const socialMediaSiteNameToHref = (
 
 export const userShortformPostTitle = (user: Pick<DbUser, "displayName">) => {
   const shortformName = isEAForum ? "Quick takes" : "Shortform";
-  return `${user.displayName}'s ${shortformName}`;
+
+  // Emoji's aren't allowed in post titles, see `assertPostTitleHasNoEmojis`
+  const displayNameWithoutEmojis = user.displayName?.replace(/\p{Extended_Pictographic}/gu, '');
+  return `${displayNameWithoutEmojis}'s ${shortformName}`;
 }


### PR DESCRIPTION
Currently if you have an emoji in your name (which a lot of people on the EA Forum do, because of the 🔸 pledge diamond), you get an error when trying to create a quick take.

I'm not sure what the original reason was for disallowing emojis in post titles, but here I'm just filtering them out from the quick take post title.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208497921208421) by [Unito](https://www.unito.io)
