### PR TITLE
[EA] Fix bugs causing the notifications popover to stay open

### DIFF
--- a/packages/lesswrong/components/notifications/CommentOnYourDraftNotificationHover.tsx
+++ b/packages/lesswrong/components/notifications/CommentOnYourDraftNotificationHover.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
-import { Link } from '../../lib/reactRouterWrapper';
 import {useCurrentUser} from "../common/withUser";
+import { NotifPopoverLink } from './useNotificationsPopoverContext';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,9 +35,9 @@ const CommentOnYourDraftNotificationHover = ({notification, classes}: {
     <div>
       {senderUserId ? <UsersName documentId={notification.extraData.senderUserID}/> : "Someone"}
       {(currentUser?._id !== post?.userId) ? " replied to your comment on " : ` commented on your draft ${postOrDraft}`}
-      <Link to={postEditUrl}>
+      <NotifPopoverLink to={postEditUrl}>
         {post ? post.title : <Loading/>}
-      </Link>
+      </NotifPopoverLink>
     </div>
     
     {notification.extraData && <blockquote dangerouslySetInnerHTML={{__html: notification.extraData.commentHtml}}/>}

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -196,69 +196,71 @@ const FriendlyNotificationsMenuButton = ({
   }, [toggle]);
 
   const {
-    LWTooltip, LWPopper, LWClickAwayListener, ForumIcon, NotificationsPopover,
+    LWPopper, LWClickAwayListener, ForumIcon, NotificationsPopover,
   } = Components;
   return (
     <div ref={anchorEl}>
-      <LWTooltip
-        title="Notifications"
-        placement="bottom"
-        popperClassName={classes.tooltip}
+      <Badge
+        classes={{
+          root: classNames(classes.badgeContainer, className),
+          badge: classNames(classes.badge, {
+            [classes.badgeBackground]: hasBadge,
+            [classes.badge1Char]: badgeText.length === 1,
+            [classes.badge2Chars]: badgeText.length === 2,
+          })
+        }}
+        badgeContent={
+          <>
+            {badgeText}
+            {showKarmaStar &&
+              <ForumIcon
+                icon="Star"
+                className={classNames(classes.karmaStar, {
+                  [classes.karmaStarWithBadge]: hasBadge,
+                  [classes.karmaStarWithoutBadge]: !hasBadge,
+                })}
+              />
+            }
+          </>
+        }
       >
-        <Badge
-          classes={{
-            root: classNames(classes.badgeContainer, className),
-            badge: classNames(classes.badge, {
-              [classes.badgeBackground]: hasBadge,
-              [classes.badge1Char]: badgeText.length === 1,
-              [classes.badge2Chars]: badgeText.length === 2,
-            })
-          }}
-          badgeContent={
-            <>
-              {badgeText}
-              {showKarmaStar &&
-                <ForumIcon
-                  icon="Star"
-                  className={classNames(classes.karmaStar, {
-                    [classes.karmaStarWithBadge]: hasBadge,
-                    [classes.karmaStarWithoutBadge]: !hasBadge,
-                  })}
-                />
-              }
-            </>
-          }
-        >
-          <IconButton
-            classes={{root: classNames(classes.buttonClosed, {
-              [classes.buttonActive]: pathname.indexOf("/notifications") === 0,
-            })}}
-            onClick={onClick}
-          >
-            <ForumIcon icon="BellBorder" />
-          </IconButton>
-        </Badge>
-      </LWTooltip>
-      <DeferRender ssr={false}>
-        <LWPopper
-          open={open}
-          anchorEl={anchorEl.current}
-          placement="bottom"
-          tooltip={false}
-          overflowPadding={16}
-          clickable
-        >
-          {open &&
-            <LWClickAwayListener onClickAway={() => setOpen(false)}>
+        {/*
+          * `LWClickAwayListener` is outside the `LWPopper` so that clicks on the notification bell
+          * itself don't trigger the clickaway listener (which would result in the popper closing and
+          * then reopening).
+          *
+          * Note that this violates a general rule in favour of putting the clickaway listener inside
+          * `LWPopper` see this PR description for why that rule exists: https://github.com/ForumMagnum/ForumMagnum/pull/9331
+          */}
+        <LWClickAwayListener onClickAway={() => setOpen(false)}>
+          <>
+            <IconButton
+              classes={{root: classNames(classes.buttonClosed, {
+                [classes.buttonActive]: pathname.indexOf("/notifications") === 0,
+              })}}
+              onClick={onClick}
+            >
+              <ForumIcon icon="BellBorder" />
+            </IconButton>
+            <DeferRender ssr={false}>
+              <LWPopper
+                open={open}
+                anchorEl={anchorEl.current}
+                placement="bottom"
+                tooltip={false}
+                overflowPadding={16}
+                clickable
+              >
                 <NotificationsPopover
                   karmaChanges={showKarmaStar ? karmaChanges?.karmaChanges : undefined}
                   markAllAsRead={markAllAsRead}
                   closePopover={closePopover}
                 />
-            </LWClickAwayListener>
-          }
-        </LWPopper>
-      </DeferRender>
+              </LWPopper>
+            </DeferRender>
+          </>
+        </LWClickAwayListener>
+      </Badge>
     </div>
   );
 }

--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from "react";
 import { Components, registerComponent } from "../../../lib/vulcan-lib";
 import { postGetPageUrl } from "../../../lib/collections/posts/helpers";
-import { Link } from "../../../lib/reactRouterWrapper";
 import type {
   CommentKarmaChange,
   EAReactionChanges,
@@ -17,6 +16,7 @@ import {
 } from "../../../lib/voting/eaEmojiPalette";
 import { captureException } from "@sentry/core";
 import { userGetProfileUrlFromSlug } from "../../../lib/collections/users/helpers";
+import { NotifPopoverLink } from "../useNotificationsPopoverContext";
 
 const logAndCaptureError = (error: Error) => {
   // eslint-disable-next-line no-console
@@ -54,7 +54,7 @@ type AddedReactions = {
 }
 
 const userLink = (user: {displayName: string, slug: string}) => (
-  <Link to={userGetProfileUrlFromSlug(user.slug)}>{user.displayName}</Link>
+  <NotifPopoverLink to={userGetProfileUrlFromSlug(user.slug)}>{user.displayName}</NotifPopoverLink>
 );
 
 const formatUsers = (users: {displayName: string, slug: string}[], max = 3) => {
@@ -144,9 +144,9 @@ export const NotificationsPageKarmaChange = ({
     reactions = getAddedReactions(postKarmaChange.eaAddedReacts);
     display = (
       <PostsTooltip postId={postKarmaChange._id}>
-        <Link to={postGetPageUrl(postKarmaChange)} className={classes.link}>
+        <NotifPopoverLink to={postGetPageUrl(postKarmaChange)} className={classes.link}>
           {postKarmaChange.title}
-        </Link>
+        </NotifPopoverLink>
       </PostsTooltip>
     );
   } else if (commentKarmaChange) {
@@ -160,7 +160,7 @@ export const NotificationsPageKarmaChange = ({
             postId={commentKarmaChange.postId}
             commentId={commentKarmaChange._id}
           >
-            <Link
+            <NotifPopoverLink
               to={commentGetPageUrlFromIds({
                 ...commentKarmaChange,
                 commentId: commentKarmaChange._id,
@@ -168,23 +168,23 @@ export const NotificationsPageKarmaChange = ({
               className={classes.link}
             >
               comment
-            </Link>
+            </NotifPopoverLink>
           </PostsTooltip>
           {" "}on{" "}
           <PostsTooltip postId={commentKarmaChange.postId}>
-            <Link
+            <NotifPopoverLink
               to={postGetPageUrl({_id: postId, slug: postSlug})}
               className={classes.link}
             >
               {postTitle}
-            </Link>
+            </NotifPopoverLink>
           </PostsTooltip>
         </>
       );
     } else if (tagSlug) {
       display = (
         <>
-          <Link
+          <NotifPopoverLink
             to={commentGetPageUrlFromIds({
               ...commentKarmaChange,
               commentId: commentKarmaChange._id,
@@ -192,13 +192,13 @@ export const NotificationsPageKarmaChange = ({
             className={classes.link}
           >
             comment
-          </Link> on{" "}
-          <Link
+          </NotifPopoverLink> on{" "}
+          <NotifPopoverLink
             to={tagGetUrl({slug: tagSlug})}
             className={classes.link}
           >
             {tagName}
-          </Link>
+          </NotifPopoverLink>
         </>
       );
     } else {
@@ -212,12 +212,12 @@ export const NotificationsPageKarmaChange = ({
     }
     karmaChange = tagRevisionKarmaChange.scoreChange;
     display = (
-      <Link
+      <NotifPopoverLink
         to={tagGetUrl({slug: tagRevisionKarmaChange.tagSlug})}
         className={classes.link}
       >
         {tagRevisionKarmaChange.tagName}
-      </Link>
+      </NotifPopoverLink>
     );
   } else {
     logAndCaptureError(new Error(`Invalid karma change: ${JSON.stringify({postKarmaChange, commentKarmaChange, tagRevisionKarmaChange})}`));

--- a/packages/lesswrong/components/notifications/NotificationsPopover.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPopover.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
-import { Link } from "@/lib/reactRouterWrapper";
 import { HEADER_HEIGHT } from "../common/Header";
 import { useCurrentUser } from "../common/withUser";
 import { styles as popoverStyles } from "../common/FriendlyHoverOver";
@@ -10,6 +9,7 @@ import type { NotificationDisplay } from "@/lib/notificationTypes";
 import type { KarmaChanges } from "@/lib/collections/users/karmaChangesGraphQL";
 import type { KarmaChangeUpdateFrequency } from "@/lib/collections/users/schema";
 import { AnalyticsContext } from "@/lib/analyticsEvents";
+import { NotificationsPopoverContext, NotifPopoverLink } from "./useNotificationsPopoverContext";
 
 const notificationsSettingsLink = "/account?highlightField=auto_subscribe_to_my_posts";
 
@@ -105,7 +105,7 @@ const NotificationsPopover = ({karmaChanges, markAllAsRead, closePopover, classe
 
   const closeMenu = useCallback(() => setIsOpen(false), []);
 
-  const closeAll = useCallback(() => {
+  const closeNotifications = useCallback(() => {
     closeMenu();
     closePopover?.();
   }, [closePopover, closeMenu]);
@@ -142,87 +142,87 @@ const NotificationsPopover = ({karmaChanges, markAllAsRead, closePopover, classe
   } = Components;
   return (
     <AnalyticsContext pageSectionContext="notificationsPopover">
-      <div className={classes.root}>
-        <div className={classes.title}>Notifications</div>
-        <div className={classes.menuContainer}>
-          <div className={classes.menu} onClick={toggleMenu} ref={anchorEl}>
-            <ForumIcon icon="EllipsisVertical" />
-          </div>
-          <PopperCard
-            open={isOpen}
-            anchorEl={anchorEl.current}
-            placement="bottom-end"
-          >
-            <LWClickAwayListener onClickAway={closeMenu}>
-              <DropdownMenu>
-                <DropdownItem
-                  title="Mark all as read"
-                  onClick={markAllAsRead}
-                />
-                <DropdownItem
-                  title="Notification settings"
-                  to={notificationsSettingsLink}
-                  onClick={closeAll}
-                />
-              </DropdownMenu>
-            </LWClickAwayListener>
-          </PopperCard>
-        </div>
-        {showNotifications
-          ? (
-            <>
-              <SectionTitle
-                title="Karma & reacts"
-                titleClassName={classes.sectionTitle}
-              />
-              {cachedKarmaChanges &&
-                <NotificationsPageKarmaChangeList
-                  karmaChanges={cachedKarmaChanges}
-                />
-              }
-              {!cachedKarmaChanges &&
-                <div className={classes.noKarma}>
-                  No new karma or reacts{getKarmaFrequency(updateFrequency)}.{" "}
-                  <Link
-                    to={karmaSettingsLink}
-                    onClick={closeAll}
-                    className={classes.link}
-                  >
-                    Change settings
-                  </Link>
-                </div>
-              }
-              <SectionTitle
-                title="Posts & comments"
-                titleClassName={classes.sectionTitle}
-              />
-              <div className={classes.notifications}>
-                {notifs.current.map((notification) =>
-                  <NotificationsPopoverNotification
-                    key={notification._id}
-                    notification={notification}
-                    onClick={closeAll}
+      <NotificationsPopoverContext.Provider value={{ closeNotifications }}>
+        <div className={classes.root}>
+          <div className={classes.title}>Notifications</div>
+          <div className={classes.menuContainer}>
+            <div className={classes.menu} onClick={toggleMenu} ref={anchorEl}>
+              <ForumIcon icon="EllipsisVertical" />
+            </div>
+            <PopperCard
+              open={isOpen}
+              anchorEl={anchorEl.current}
+              placement="bottom-end"
+            >
+              <LWClickAwayListener onClickAway={closeMenu}>
+                <DropdownMenu>
+                  <DropdownItem
+                    title="Mark all as read"
+                    onClick={markAllAsRead}
                   />
-                )}
-                <LoadMore
-                  loadMore={loadMore}
-                  loading={notificationsLoading}
-                  loadingClassName={classes.loading}
-                />
-              </div>
-            </>
-          )
-          : notificationsLoading
+                  <DropdownItem
+                    title="Notification settings"
+                    to={notificationsSettingsLink}
+                    onClick={closeNotifications}
+                  />
+                </DropdownMenu>
+              </LWClickAwayListener>
+            </PopperCard>
+          </div>
+          {showNotifications
             ? (
-              <Loading className={classes.mainLoading} />
+              <>
+                <SectionTitle
+                  title="Karma & reacts"
+                  titleClassName={classes.sectionTitle}
+                />
+                {cachedKarmaChanges &&
+                  <NotificationsPageKarmaChangeList
+                    karmaChanges={cachedKarmaChanges}
+                  />
+                }
+                {!cachedKarmaChanges &&
+                  <div className={classes.noKarma}>
+                    No new karma or reacts{getKarmaFrequency(updateFrequency)}.{" "}
+                    <NotifPopoverLink
+                      to={karmaSettingsLink}
+                      className={classes.link}
+                    >
+                      Change settings
+                    </NotifPopoverLink>
+                  </div>
+                }
+                <SectionTitle
+                  title="Posts & comments"
+                  titleClassName={classes.sectionTitle}
+                />
+                <div className={classes.notifications}>
+                  {notifs.current.map((notification) =>
+                    <NotificationsPopoverNotification
+                      key={notification._id}
+                      notification={notification}
+                    />
+                  )}
+                  <LoadMore
+                    loadMore={loadMore}
+                    loading={notificationsLoading}
+                    loadingClassName={classes.loading}
+                  />
+                </div>
+              </>
             )
-            : (
-              <NoNotificationsPlaceholder
-                subscribedToDigest={subscribedToDigest}
-              />
-            )
-        }
-      </div>
+            : notificationsLoading
+              ? (
+                <Loading className={classes.mainLoading} />
+              )
+              : (
+                <NoNotificationsPlaceholder
+                  subscribedToDigest={subscribedToDigest}
+                />
+              )
+          }
+        </div>
+      </NotificationsPopoverContext.Provider>
     </AnalyticsContext>
   );
 }

--- a/packages/lesswrong/components/notifications/NotificationsPopoverNotification.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPopoverNotification.tsx
@@ -7,6 +7,7 @@ import { useCurrentUser } from "../common/withUser";
 import type { NotificationDisplay } from "@/lib/notificationTypes";
 import classNames from "classnames";
 import moment from "moment";
+import { useNotificationsPopoverContext } from "./useNotificationsPopoverContext";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -88,9 +89,8 @@ const formatNotificationType = (type: string): string => {
   }
 }
 
-const NotificationsPopoverNotification = ({notification, onClick, classes}: {
+const NotificationsPopoverNotification = ({notification, classes}: {
   notification: NotificationDisplay,
-  onClick?: () => void,
   classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser();
@@ -100,8 +100,10 @@ const NotificationsPopoverNotification = ({notification, onClick, classes}: {
     (currentUser?.lastNotificationsCheck ?? new Date()) > notification.createdAt,
   );
 
+  const { closeNotifications } = useNotificationsPopoverContext();
+
   const onSelect = useCallback((ev: MouseEvent<HTMLDivElement>) => {
-    onClick?.();
+    closeNotifications();
     setIsRead(true);
     captureEvent("notificationClick", {
       notification: {
@@ -110,7 +112,7 @@ const NotificationsPopoverNotification = ({notification, onClick, classes}: {
       },
     });
     redirect(ev);
-  }, [redirect, onClick, captureEvent, notification]);
+  }, [closeNotifications, captureEvent, notification._id, notification.link, redirect]);
 
   if (!currentUser) {
     return null;

--- a/packages/lesswrong/components/notifications/useNotificationsPopoverContext.tsx
+++ b/packages/lesswrong/components/notifications/useNotificationsPopoverContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useCallback, useContext } from 'react';
+import { Link, LinkProps } from '../../lib/reactRouterWrapper';
+
+export const NotificationsPopoverContext = createContext<{ closeNotifications: () => void }>({
+  closeNotifications: () => {},
+});
+
+export const useNotificationsPopoverContext = () => {
+  return useContext(NotificationsPopoverContext);
+};
+
+/**
+ * Wrapper for `<Link>` that closes the notification popover when a link is clicked.
+ * Safe to err on the side of using because it will only close if the link is within
+ * the `NotificationsPopoverContext`.
+ */
+export const NotifPopoverLink= ({...props}: LinkProps) => {
+  const { closeNotifications } = useNotificationsPopoverContext();
+
+  const { onClick } = props;
+
+  const handleClick = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (onClick) onClick(e);
+    closeNotifications();
+  }, [onClick, closeNotifications]);
+
+  return (
+    <Link {...props} onClick={handleClick} />
+  );
+};

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -9,7 +9,7 @@ import { classifyHost, getUrlClass } from './routeUtil';
 import { parseQuery } from './vulcan-core/appContext'
 import qs from 'qs'
 
-type LinkProps = {
+export type LinkProps = {
   to?: HashLinkProps['to']|null
   doOnDown?: boolean
   onMouseDown?: HashLinkProps['onMouseDown']


### PR DESCRIPTION
This fixes two bugs which were causing the popover to stay open when it should close:
1. Clicks on the notification bell triggered the clickaway listener, which closed the popover, and then triggered the `onClick` of the bell itself which re-opened it. This only happened intermittently and mainly (only?) on mobile. I've wrapped the bell button inside the `LWClickAwayListener` to fix this
2. Not all of the links in the popover closed it when clicked. I've added a `NotificationsPopoverContext` which exposes the `closeNotifications` function to make it easier to handle this in deeply nested components (and used it for all the links that are there)

A lot of the diff is due to changed levels of nesting, so it's probably best viewed side by side.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208498044378665) by [Unito](https://www.unito.io)
