### PR TITLE
Fix missing comment-reply notifications for comments on tag discussion pages

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -172,7 +172,9 @@ const NotificationsItem = ({notification, lastNotificationsCheck, currentUser, c
               {children}
             </PostsTooltip>
           )
-          : null;
+          : <>
+            {children}
+          </>
       case "message":
         return (
           <TooltipWrapper


### PR DESCRIPTION
If a comment was a reply to a comment on a tag discussion page, the on-site notification would be lost (it's technically in the DB and makes the bell-icon show a notification number, but the notification itself renders as an empty component).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208506107217200) by [Unito](https://www.unito.io)
