### PR TITLE
Pin ubuntu version to 22.04 for playwright tests CI

### DIFF
--- a/.github/workflows/runTests.yaml
+++ b/.github/workflows/runTests.yaml
@@ -27,7 +27,10 @@ jobs:
     - run: yarn run tsc
 
   runPlaywrightTests:
-    runs-on: ubuntu-latest
+    # Pin Ubuntu to 22.04 to avoid a problem installing browser dependencies.
+    # This can probably be changed back to ubuntu-latest in the future when the
+    # bugs are ironed out.
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +79,10 @@ jobs:
         path: test-results
 
   runCrosspostTests:
-    runs-on: ubuntu-latest
+    # Pin Ubuntu to 22.04 to avoid a problem installing browser dependencies.
+    # This can probably be changed back to ubuntu-latest in the future when the
+    # bugs are ironed out.
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     services:


### PR DESCRIPTION
Playwright tests started failing after Ubuntu 24.10 was released yesterday. I tried pinning the version to 24.04, but that was also broken (maybe related to https://github.com/microsoft/playwright/issues/30368) - I have no idea why it worked before. Pinning to 22.04 seems to work fine though, and I don't think there's really any downsides (for now at least).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208529312152495) by [Unito](https://www.unito.io)
