### PR TITLE
Filter search by user or tag

### DIFF
--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -5,7 +5,7 @@ import type { SearchState } from 'react-instantsearch/connectors';
 import { Hits, Configure, SearchBox, Pagination, connectStats, connectScrollTo } from 'react-instantsearch-dom';
 import { InstantSearch } from '../../lib/utils/componentsWithChildren';
 import { useLocation } from '../../lib/routeUtil';
-import { isEAForum, taggingNameIsSet, taggingNamePluralCapitalSetting } from '../../lib/instanceSettings';
+import { isEAForum, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameSetting } from '../../lib/instanceSettings';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import InfoIcon from '@material-ui/icons/Info';
@@ -387,7 +387,7 @@ const SearchPageTabbed = ({classes}: {
             </div>
           </div>
           <LWTooltip
-            title={`"Quotes" and -minus signs are supported. Use "user:username" or "tag:tagname" to filter by user or tag.`}
+            title={`"Quotes" and -minus signs are supported. Use user:"Jane Doe" or ${taggingNameSetting.get()}:"Expected value" to filter by user or ${taggingNameSetting.get()}.`}
             className={classes.searchHelp}
           >
             <InfoIcon className={classes.infoIcon}/>

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -387,7 +387,7 @@ const SearchPageTabbed = ({classes}: {
             </div>
           </div>
           <LWTooltip
-            title={`"Quotes" and -minus signs are supported.`}
+            title={`"Quotes" and -minus signs are supported. Use "user:username" or "tag:tagname" to filter by user or tag.`}
             className={classes.searchHelp}
           >
             <InfoIcon className={classes.infoIcon}/>

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -415,7 +415,14 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         p."lastCommentedAt",
         COALESCE(p."draft", FALSE) AS "draft",
         COALESCE(p."af", FALSE) AS "af",
-        fm_post_tag_ids(p."_id") AS "tags",
+        (SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+          '_id', t."_id",
+          'slug', t."slug",
+          'name', t."name"
+        )) FROM "Tags" t WHERE
+          t."_id" = ANY(fm_post_tag_ids(p."_id")) AND
+          t."deleted" IS NOT TRUE
+        ) AS "tags",
         CASE
           WHEN author."deleted" THEN NULL
           ELSE author."slug"

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -235,7 +235,11 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
       body: fullTextMapping,
       feedLink: keywordMapping,
       slug: keywordMapping,
-      tags: keywordMapping,
+      tags: objectMapping({
+        _id: keywordMapping,
+        slug: keywordMapping,
+        name: keywordMapping,
+      }),
       url: keywordMapping,
       userId: keywordMapping,
     },

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -281,9 +281,6 @@ class ElasticExporter {
                     "lowercase",
                     "decimal_digit",
                   ],
-                  char_filter: [
-                    "fm_punctuation_filter",
-                  ],
                 },
                 fm_synonym_analyzer: {
                   type: "custom",

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -216,31 +216,23 @@ class ElasticQuery {
     }
 
     const userFilters: QueryDslQueryContainer[] = [];
+    const tagFilters: QueryDslQueryContainer[] = [];
     for (const {type, token} of tokens) {
       if (type === "user") {
-        userFilters.push({
-          term: {
-            "authorSlug.sort": token,
-          },
-        });
-        userFilters.push({
-          term: {
-            "authorDisplayName.sort": token,
-          },
-        });
-        userFilters.push({
-          term: {
-            "userId": token,
-          },
-        });
+        userFilters.push(
+          {term: {"authorSlug.sort": token}},
+          {term: {"authorDisplayName.sort": token}},
+          {term: {userId: token}},
+        );
+      } else if (type === "tag") {
+        tagFilters.push({term: {tags: token}});
       }
     }
     if (userFilters.length) {
-      terms.push({
-        bool: {
-          should: userFilters,
-        },
-      });
+      terms.push({bool: {should: userFilters}});
+    }
+    if (tagFilters.length) {
+      terms.push({bool: {should: tagFilters}});
     }
 
     return terms.length ? terms : undefined;
@@ -371,7 +363,8 @@ class ElasticQuery {
         should.push(this.getDefaultQuery(token, fields));
         break;
       case "user":
-        // Do nothing - this is handled by compileFilters
+      case "tag":
+        // Do nothing - this is handled by `this.compileFilters`
         break;
       }
     }

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -388,19 +388,21 @@ class ElasticQuery {
       };
     }
 
+    const highlightQueryString = tokens.filter(
+      ({type}) => type !== "user" && type !== "tag",
+    ).map(({token}) => token).join(" ");
+    const highlightQuery = this.getDefaultQuery(
+      highlightQueryString,
+      this.config.fields,
+    );
+
     return {
       tokens,
       searchQuery,
       snippetName: snippet,
-      snippetQuery: this.getDefaultQuery(
-        this.queryData.search,
-        this.config.fields,
-      ),
+      snippetQuery: highlightQuery,
       highlightName: highlight,
-      highlightQuery: this.getDefaultQuery(
-        this.queryData.search,
-        this.config.fields,
-      ),
+      highlightQuery,
     };
   }
 

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -225,7 +225,11 @@ class ElasticQuery {
           {term: {userId: token}},
         );
       } else if (type === "tag") {
-        tagFilters.push({term: {tags: token}});
+        tagFilters.push(
+          {term: {"tags._id": token}},
+          {term: {"tags.slug": token}},
+          {term: {"tags.name": token}},
+        );
       }
     }
     if (userFilters.length) {

--- a/packages/lesswrong/server/search/elastic/parseQuery.ts
+++ b/packages/lesswrong/server/search/elastic/parseQuery.ts
@@ -1,3 +1,4 @@
+import { taggingNameSetting } from "@/lib/instanceSettings";
 import trim from "lodash/trim";
 
 export type QueryToken = {
@@ -39,7 +40,7 @@ export const parseQuery = (query: string): QueryParserResult => {
     } else if (prefix === "user:") {
       type = "user";
       isAdvanced = true;
-    } else if (prefix === "tag:") {
+    } else if (prefix === `${taggingNameSetting.get()}:`) {
       type = "tag";
       isAdvanced = true;
     }

--- a/packages/lesswrong/server/search/elastic/parseQuery.ts
+++ b/packages/lesswrong/server/search/elastic/parseQuery.ts
@@ -1,7 +1,7 @@
 import trim from "lodash/trim";
 
 export type QueryToken = {
-  type: "should" | "must" | "not" | "user",
+  type: "should" | "must" | "not" | "user" | "tag",
   token: string,
 }
 
@@ -39,11 +39,14 @@ export const parseQuery = (query: string): QueryParserResult => {
     } else if (prefix === "user:") {
       type = "user";
       isAdvanced = true;
+    } else if (prefix === "tag:") {
+      type = "tag";
+      isAdvanced = true;
     }
 
     // Replace dashes and underscores with spaces, and remove anything else that
     // isn't whitespace or a word
-    if (type !== "user") {
+    if (type !== "user" && type !== "tag") {
       token = token.replace(/[-_]/g, " ").replace(/[^\w\s]/g, "");
     }
 

--- a/packages/lesswrong/server/search/elastic/parseQuery.ts
+++ b/packages/lesswrong/server/search/elastic/parseQuery.ts
@@ -1,7 +1,7 @@
 import trim from "lodash/trim";
 
 export type QueryToken = {
-  type: "should" | "must" | "not",
+  type: "should" | "must" | "not" | "user",
   token: string,
 }
 
@@ -36,11 +36,16 @@ export const parseQuery = (query: string): QueryParserResult => {
     if (prefix === '-') {
       type = "not";
       isAdvanced = true;
+    } else if (prefix === "user:") {
+      type = "user";
+      isAdvanced = true;
     }
 
     // Replace dashes and underscores with spaces, and remove anything else that
     // isn't whitespace or a word
-    token = token.replace(/[-_]/g, " ").replace(/[^\w\s]/g, "");
+    if (type !== "user") {
+      token = token.replace(/[-_]/g, " ").replace(/[^\w\s]/g, "");
+    }
 
     tokens.push({type, token});
   }

--- a/packages/lesswrong/server/search/searchDocuments.d.ts
+++ b/packages/lesswrong/server/search/searchDocuments.d.ts
@@ -91,7 +91,7 @@ interface SearchPost extends SearchBase {
   lastCommentedAt: string | null,
   draft: boolean,
   af: boolean,
-  tags: Array<string>,
+  tags: {_id: string, slug: string, name: string}[] | null,
   authorSlug?: string | null,
   authorDisplayName?: string | null,
   authorFullName?: string | null,


### PR DESCRIPTION
Adds `user:name` and `tag:name` syntax to search queries. For both we accept a slug, name or id. Names with multiple words can be entered with quotes like `user:"jp addison"`.

Multiple filters of the same type are OR'd together. Multiple filters of different types are AND'd together.

After deploying, we need to run:
```
./scripts/serverShellCommand.sh "Globals.elasticDeleteIndex('Posts')"
./scripts/serverShellCommand.sh "Globals.elasticConfigureIndex('Posts')"
./scripts/serverShellCommand.sh "Globals.elasticExportCollection('Posts')"
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208571899474226) by [Unito](https://www.unito.io)
