### PR TITLE
Hovering inline-reacted text in the central column doesn't highlight it

### DIFF
--- a/packages/lesswrong/components/common/withHover.tsx
+++ b/packages/lesswrong/components/common/withHover.tsx
@@ -12,7 +12,18 @@ type UseHoverProps = {
   onLeave?: () => void,
 }
 
-export const useHover = ({eventProps, onEnter, onLeave}: UseHoverProps = {}) => {
+export type UseHoverEventHandlers = {
+  onMouseOver: (ev: React.MouseEvent) => void,
+  onMouseLeave: (ev: React.MouseEvent) => void,
+}
+
+export const useHover = ({eventProps, onEnter, onLeave}: UseHoverProps = {}): {
+  eventHandlers: UseHoverEventHandlers,
+  hover: boolean,
+  everHovered: boolean,
+  anchorEl: any,
+  forceUnHover: () => void,
+} => {
   const [hover, setHover] = useState(false)
   const [everHovered, setEverHovered] = useState(false)
   const [anchorEl, setAnchorEl] = useState<any>(null)

--- a/packages/lesswrong/components/ea-forum/EASequenceOrCollectionCard.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequenceOrCollectionCard.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
 import { Link } from "../../lib/reactRouterWrapper";
 import classNames from "classnames";
+import { UseHoverEventHandlers } from "../common/withHover";
 
 const SEQUENCE_CARD_IMAGE_HEIGHT = 162;
 const Z_IMAGE = 1;
@@ -95,10 +96,7 @@ const EASequenceOrCollectionCard = ({
   readCount: number,
   imageId: string,
   href: string,
-  eventHandlers: {
-    onMouseOver: (event: MouseEvent<HTMLDivElement>) => void,
-    onMouseLeave: () => void,
-  },
+  eventHandlers: UseHoverEventHandlers,
   className?: string,
   classes: ClassesType,
 }) => {

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -4,7 +4,7 @@ import { QuoteLocator, NamesAttachedReactionsList, getNormalizedReactionsListFro
 import classNames from 'classnames';
 import { HoveredReactionListContext, InlineReactVoteContext, SetHoveredReactionContext } from './HoveredReactionContextProvider';
 import sumBy from 'lodash/sumBy';
-import { useHover } from '@/components/common/withHover';
+import { useHover, UseHoverEventHandlers } from '@/components/common/withHover';
 import type { VotingProps } from '../votingProps';
 import { useCurrentUser } from '@/components/common/withUser';
 import { defaultInlineReactsMode, SideItemVisibilityContext } from '@/components/dropdowns/posts/SetSideItemVisibility';
@@ -90,37 +90,30 @@ const InlineReactHoverableHighlight = ({quote, reactions, isSplitContinuation=fa
     return null;
   }
 
-  return <LWTooltip
-    title={<InlineReactHoverInfo
-      quote={quote}
-      reactions={reactions}
-      voteProps={voteProps}
-    />}
-    placement="top-start"
-    tooltip={false}
-    flip={false}
-    inlineBlock={false}
-    clickable={true}
-  >
-    <span {...eventHandlers} className={classNames({
+  return (
+    <span className={classNames({
       [classes.highlight]: shouldUnderline,
       [classes.reactionTypeHovered]: isHovered
     })}>
       {!isSplitContinuation && sideItemIsVisible && <SideItem options={{format: "icon"}}>
-        <SidebarInlineReact quote={quote} reactions={reactions} voteProps={voteProps} classes={classes} />
+        <SidebarInlineReact
+          hoverEventHandlers={eventHandlers}
+          quote={quote} reactions={reactions} voteProps={voteProps} classes={classes}
+        />
       </SideItem>}
       {children}
     </span>
-  </LWTooltip>
+  );
 }
 
-const SidebarInlineReact = ({quote,reactions, voteProps, classes}: {
+const SidebarInlineReact = ({quote,reactions, voteProps, hoverEventHandlers, classes}: {
   quote: QuoteLocator,
   reactions: NamesAttachedReactionsList,
   voteProps: VotingProps<VoteableTypeClient>,
+  hoverEventHandlers: UseHoverEventHandlers,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { SideItemLine } = Components;
+  const { SideItemLine, LWTooltip, InlineReactHoverInfo } = Components;
   const currentUser = useCurrentUser();
   const normalizedReactions = getNormalizedReactionsListFromVoteProps(voteProps)?.reacts ?? {};
   const reactionsUsed = Object.keys(normalizedReactions).filter(react =>
@@ -129,9 +122,22 @@ const SidebarInlineReact = ({quote,reactions, voteProps, classes}: {
   
   return <>
     <SideItemLine colorClass={classes.inlineReactSidebarLine}/>
-    <span className={classes.sidebarInlineReactIcons}>
+    <span {...hoverEventHandlers} className={classes.sidebarInlineReactIcons}>
       {reactionsUsed.map(r => <span key={r}>
-        <Components.ReactionIcon react={r}/>
+        <LWTooltip
+          title={<InlineReactHoverInfo
+            quote={quote}
+            reactions={reactions}
+            voteProps={voteProps}
+          />}
+          placement="bottom-start"
+          tooltip={false}
+          flip={true}
+          inlineBlock={false}
+          clickable={true}
+        >
+          <Components.ReactionIcon react={r}/>
+        </LWTooltip>
       </span>)}
     </span>
   </>

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -380,9 +380,9 @@ const HoverableReactionIcon = ({reactionRowRef, react, numberShown, voteProps, q
     onMouseOver(e);
   }
   
-  function handleMouseLeave () {
+  function handleMouseLeave (ev: React.MouseEvent) {
     setHoveredReaction?.({reactionName: react, isHovered: false, quote: null});
-    onMouseLeave();
+    onMouseLeave(ev);
   }
 
   return <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>


### PR DESCRIPTION
Moves the hover-dialog for inline reacts from the central column to the icon.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208573174440502) by [Unito](https://www.unito.io)
