### PR TITLE
Fix spurious scroll when opening footnotes on mobile

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -185,8 +185,6 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
   // information isn't wired to pass through the hover-preview system.
 
   const onClick = useCallback((ev: React.MouseEvent) => {
-    window.dispatchEvent(new CustomEvent(EXPAND_FOOTNOTES_EVENT, {detail: href}));
-    
     if (isRegularClick(ev) && isMobile()) {
       setDisableHover(true);
       openDialog({
@@ -196,6 +194,8 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
         },
       });
       ev.preventDefault();
+    } else {
+      window.dispatchEvent(new CustomEvent(EXPAND_FOOTNOTES_EVENT, {detail: href}));
     }
   }, [href, footnoteHTML, openDialog]);
   


### PR DESCRIPTION
This was EA Forum specific because LW doesn't have collapse-footnotes enabled.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208581143152027) by [Unito](https://www.unito.io)
