### PR TITLE
Show own user's recent comments first when using magic sorting

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -659,7 +659,7 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
 
   // If the user has just posted a comment, and they are sorting by magic, put it at the top of the list for them
   const results = useMemo(() => {
-    if (!rawResults || commentTerms.view !== "postCommentsMagic") return rawResults;
+    if (!isEAForum || !rawResults || commentTerms.view !== "postCommentsMagic") return rawResults;
 
     const recentUserComments = rawResults
       .filter((c) => c.userId === currentUser?._id && now.getTime() - new Date(c.postedAt).getTime() < 60000)


### PR DESCRIPTION
It can be a bit jarring to post a comment and have it appear halfway down the list, this makes it so your own comments always appear at the top for 1 minute when using magic sorting. The other ways of sorting are too clearly defined for this fudging to be useful.

@jimrandomh @b0b3rt This is currently forum-gated but I could remove that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208600556211827) by [Unito](https://www.unito.io)
