### PR TITLE
Remove 5 karma leeway from twitter admin karma cutoff

### DIFF
--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -765,8 +765,7 @@ createPaginatedResolver({
 
       // 8 days ago
       const since = new Date(Date.now() - (8 * 24 * 60 * 60 * 1000));
-      // Slightly below the threshold we're aiming for to make it easier to queue up tweets
-      const threshold = twitterBotKarmaThresholdSetting.get() - 5;
+      const threshold = twitterBotKarmaThresholdSetting.get();
 
       const postIds = await repos.tweets.getUntweetedPostsCrossingKarmaThreshold({ since, threshold });
       return await Posts.find({ _id: { $in: postIds } }, { sort: { postedAt: -1 } }).fetch();


### PR DESCRIPTION
I added this because I thought it would be useful to see what posts are coming up, but in practice it's just annoying to not be able to copy the list as is

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208600573055511) by [Unito](https://www.unito.io)
