### PR TITLE
Use "wildcard" type for the ".sort" field in elastic full text mappings

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -106,8 +106,9 @@ const fullTextMapping: MappingProperty = {
       analyzer: "fm_exact_analyzer",
     },
     sort: {
-      type: "keyword",
-      normalizer: "fm_sortable_keyword",
+      // A wildcard is similar to a keyword, but supports data larger than 32KB
+      type: "wildcard",
+      null_value: "",
     },
   },
 };

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -500,4 +500,9 @@ Globals.elasticDeleteIndexByName = (indexName: string) =>
 Globals.elasticDeleteOrphanedIndexes = () =>
   new ElasticExporter().deleteOrphanedIndexes();
 
+Globals.elasticExportDocument = (
+  collectionName: SearchIndexCollectionName,
+  documentId: string,
+) => new ElasticExporter().updateDocument(collectionName, documentId);
+
 export default ElasticExporter;


### PR DESCRIPTION
We currently use "keyword" but this is limited to 32kb. Trying to index larger documents _throws an exception_ so the document doesn't get indexed at all. The "wildcard" type is similar to "keyword" functionally but has a maximum length a couple of orders of magnitude higher.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208610273521476) by [Unito](https://www.unito.io)
