### PR TITLE
Make the tags search filter case insensitive

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -227,8 +227,8 @@ class ElasticQuery {
       } else if (type === "tag") {
         tagFilters.push(
           {term: {"tags._id": token}},
-          {term: {"tags.slug": token}},
-          {term: {"tags.name": token}},
+          {term: {"tags.slug": {value: token, case_insensitive: true}}},
+          {term: {"tags.name": {value: token, case_insensitive: true}}},
         );
       }
     }


### PR DESCRIPTION
Due to the way that tag names are indexed, the `topic:"Topic Name"` filter is currently case sensitive (I only realised this after reading the forum update post 😬). Thankfully this is easy to fix without reindexing. Usernames are indexed differently so they are already case insensitive.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208621743963048) by [Unito](https://www.unito.io)
