### PR TITLE
New users can quick take

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -40,7 +40,7 @@ const CommentBottomCaveats = ({comment, classes}: {
     }
     {commentIsHidden(comment) && !comment.rejected
       && <Components.MetaInfo className={classes.caveatText}>
-        [This comment will not be visible to other users until the moderation team checks it for spam or norm violations.]
+        [This comment will not be visible to other users until the moderation team has reviewed it.]
       </Components.MetaInfo>
     }
   </>

--- a/packages/lesswrong/components/editor/RateLimitWarning.tsx
+++ b/packages/lesswrong/components/editor/RateLimitWarning.tsx
@@ -54,7 +54,7 @@ const RateLimitWarning = ({lastRateLimitExpiry, rateLimitMessage, classes}: {
     return `${diffInWeeks} week${diffInWeeks > 1 ? 's' : ''}`
   }
 
-  let message = `<p>You can post again in ${getTimeUntilNextPost()}.</p> ${rateLimitMessage ?? ''}`
+  let message = `<p>You can submit again in ${getTimeUntilNextPost()}.</p> ${rateLimitMessage ?? ''}`
   if (isEAForum) {
     message = `You've written more than 3 comments in the last 30 minutes. Please wait ${getTimeUntilNextPost()} before commenting again. ${rateLimitMessage ?? ''}`
   }

--- a/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
@@ -3,7 +3,6 @@ import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useHover } from "../common/withHover";
 import { isMobile } from "../../lib/utils/isMobile";
 import { postGetPageUrl } from "../../lib/collections/posts/helpers";
-import { htmlToTextDefault } from "../../lib/htmlToText";
 import classNames from "classnames";
 import { commentBodyStyles } from "../../themes/stylePiping";
 
@@ -60,7 +59,7 @@ const LWQuickTakesCollapsedListItem = ({ quickTake, setExpanded, classes }: {
   setExpanded: (expanded: boolean) => void,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { ForumIcon, LWPopper, CommentsNode, CommentsItemMeta } = Components;
+  const { ForumIcon, LWPopper, CommentsNode, CommentsItemMeta, CommentBottomCaveats } = Components;
 
   const {eventHandlers, hover, anchorEl} = useHover({
     eventProps: {
@@ -177,6 +176,7 @@ const LWQuickTakesCollapsedListItem = ({ quickTake, setExpanded, classes }: {
         }}
       />
       {body}
+      <CommentBottomCaveats comment={quickTake} />
       {tooltip}
     </div>
   );

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -8,6 +8,7 @@ import {
 } from "../comments/CommentsNewForm";
 import classNames from "classnames";
 import { isFriendlyUI } from "../../themes/forumTheme";
+import { useDialog } from "../common/withDialog";
 
 const COLLAPSED_HEIGHT = 40;
 
@@ -30,8 +31,10 @@ const styles = (theme: ThemeType) => ({
     },
   },
   collapsed: {
-    height: COLLAPSED_HEIGHT + (2 * COMMENTS_NEW_FORM_PADDING),
-    overflow: "hidden",
+    '& .quickTakesForm': {
+      height: COLLAPSED_HEIGHT + (2 * COMMENTS_NEW_FORM_PADDING),
+      overflow: "hidden",
+    },
   },
   commentForm: {
     '& .form-input': {
@@ -100,6 +103,7 @@ const QuickTakesEntry = ({
   classes: ClassesType<typeof styles>,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const { openDialog } = useDialog();
   const [expanded, setExpanded] = useState(defaultExpanded);
   const {
     frontpage,
@@ -112,7 +116,15 @@ const QuickTakesEntry = ({
     void cancelCallback?.();
   }, [cancelCallback]);
 
-  const onFocus = useCallback(() => setExpanded(true), []);
+  const onFocus = useCallback(() => {
+    if (!currentUser) {
+      openDialog({
+        componentName: "LoginPopup",
+        componentProps: {}
+      });
+    }
+    setExpanded(true);
+  }, [currentUser, openDialog]);
 
   useEffect(() => {
     setTimeout(() => {

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -67,6 +67,14 @@ const styles = (theme: ThemeType) => ({
       display: 'none'
     }
   },
+  userNotApprovedMessage: {
+    background: 'none',
+    border: 'none',
+    padding: '10px 10px 0 10px',
+    fontSize: 14,
+    color: theme.palette.grey[600],
+    fontStyle: 'italic',
+  },
 });
 
 // TODO: decide on copy for LW
@@ -126,8 +134,12 @@ const QuickTakesEntry = ({
     return null;
   }
 
+  const userIsNotApproved = !currentUser?.reviewedByUserId;
+
   const {CommentsNewForm} = Components;
   return <div className={classNames(classes.root, className)} ref={ref}>
+    {/* TODO: Write a better message for new users */}
+    {expanded && userIsNotApproved && <div className={classes.userNotApprovedMessage}>Quick Takes is an excellent place for your first contribution!</div>}
     <div
       className={classNames(classes.commentEditor, {[classes.collapsed]: !expanded})}
       onFocus={onFocus}

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -146,12 +146,13 @@ const QuickTakesEntry = ({
     return null;
   }
 
-  const userIsNotApproved = !currentUser?.reviewedByUserId;
+  // is true when user is logged out or has not been reviewed yet, i.e. has made no contributions yet
+  const showNewUserMessage = !currentUser?.reviewedByUserId;
 
   const {CommentsNewForm} = Components;
   return <div className={classNames(classes.root, className)} ref={ref}>
     {/* TODO: Write a better message for new users */}
-    {expanded && userIsNotApproved && <div className={classes.userNotApprovedMessage}>Quick Takes is an excellent place for your first contribution!</div>}
+    {expanded && showNewUserMessage && <div className={classes.userNotApprovedMessage}>Quick Takes is an excellent place for your first contribution!</div>}
     <div
       className={classNames(classes.commentEditor, {[classes.collapsed]: !expanded})}
       onFocus={onFocus}

--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -3,7 +3,7 @@ import Checkbox from "@material-ui/core/Checkbox";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useCurrentUser } from "../common/withUser";
 import { useExpandedFrontpageSection } from "../hooks/useExpandedFrontpageSection";
-import { userIsAdminOrMod } from "../../lib/vulcan-users";
+import { userCanQuickTake } from "../../lib/vulcan-users";
 import {
   SHOW_QUICK_TAKES_SECTION_COOKIE,
   SHOW_QUICK_TAKES_SECTION_COMMUNITY_COOKIE,
@@ -105,22 +105,6 @@ const QuickTakesSection = ({classes}: {
   : undefined;
 
 
-  // this is approximately the same as userCanComment, but we don't exclude a user who is unreviewed
-  const userCanWriteQuickTakes = (currentUser: UsersCurrent | null) => {
-    if (!currentUser) {
-     return false;
-    }
-
-    if (userIsAdminOrMod(currentUser)) {
-      return true;
-    }
-
-    if (currentUser.allCommentingDisabled) {
-      return false;
-    }
-
-    return true;
-  }
 
 
   return (
@@ -132,8 +116,7 @@ const QuickTakesSection = ({classes}: {
       afterTitleTo={afterTitleTo}
       AfterTitleComponent={AfterTitleComponent}
     >
-      {/* TODO: Maybe better visible to logged out users with modal upon clicking, like vote buttons */}
-      {userCanWriteQuickTakes(currentUser) &&
+      {(userCanQuickTake(currentUser) || !currentUser) &&
         <QuickTakesEntry currentUser={currentUser} />
       }
       

--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -3,7 +3,7 @@ import Checkbox from "@material-ui/core/Checkbox";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { useCurrentUser } from "../common/withUser";
 import { useExpandedFrontpageSection } from "../hooks/useExpandedFrontpageSection";
-import { userCanComment } from "../../lib/vulcan-users";
+import { userIsAdminOrMod } from "../../lib/vulcan-users";
 import {
   SHOW_QUICK_TAKES_SECTION_COOKIE,
   SHOW_QUICK_TAKES_SECTION_COMMUNITY_COOKIE,
@@ -104,6 +104,25 @@ const QuickTakesSection = ({classes}: {
     )
   : undefined;
 
+
+  // this is approximately the same as userCanComment, but we don't exclude a user who is unreviewed
+  const userCanWriteQuickTakes = (currentUser: UsersCurrent | null) => {
+    if (!currentUser) {
+     return false;
+    }
+
+    if (userIsAdminOrMod(currentUser)) {
+      return true;
+    }
+
+    if (currentUser.allCommentingDisabled) {
+      return false;
+    }
+
+    return true;
+  }
+
+
   return (
     <ExpandableSection
       pageSectionContext="quickTakesSection"
@@ -113,7 +132,8 @@ const QuickTakesSection = ({classes}: {
       afterTitleTo={afterTitleTo}
       AfterTitleComponent={AfterTitleComponent}
     >
-      {userCanComment(currentUser) &&
+      {/* TODO: Maybe better visible to logged out users with modal upon clicking, like vote buttons */}
+      {userCanWriteQuickTakes(currentUser) &&
         <QuickTakesEntry currentUser={currentUser} />
       }
       

--- a/packages/lesswrong/components/shortform/ShortformThreadList.tsx
+++ b/packages/lesswrong/components/shortform/ShortformThreadList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useCurrentUser } from '../common/withUser';
-import { userCanComment } from '../../lib/vulcan-users/permissions';
+import { userCanQuickTake } from '../../lib/vulcan-users/permissions';
 import { isFriendlyUI } from '../../themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -31,7 +31,7 @@ const ShortformThreadList = ({ classes }: {
   
   return (
     <div>
-      {userCanComment(currentUser) &&
+      {(userCanQuickTake(currentUser) || !currentUser) &&
         <QuickTakesEntry currentUser={currentUser} successCallback={refetch} />
       }
 

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -1,7 +1,7 @@
 import React, { MouseEvent, useContext } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
-import { userCanComment, userCanDo, userIsMemberOf, userOverNKarmaOrApproved } from '../../lib/vulcan-users/permissions';
+import { userCanDo, userCanQuickTake, userIsMemberOf, userOverNKarmaOrApproved } from '../../lib/vulcan-users/permissions';
 import { userGetAnalyticsUrl, userGetDisplayName } from '../../lib/collections/users/helpers';
 import { dialoguesEnabled, userHasThemePicker } from '../../lib/betas';
 
@@ -183,7 +183,7 @@ const UsersMenu = ({classes}: {
       * Long-term, we should fix these issues and reenable this option.
       */
     newShortform: () =>
-      showNewButtons && userCanComment(currentUser)
+      showNewButtons && userCanQuickTake(currentUser)
         ? (
           <DropdownItem
             title={preferredHeadingCase("New Quick Take")}

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -563,7 +563,7 @@ Comments.addView('shortformFrontpage', (terms: CommentsViewTerms, _, context?: R
           : {},
         {
           $or: [
-            {reviewedByUserId: {$exists: true}},
+            {authorIsUnreviewed: false},
             {userId: currentUserId},
           ]
         },

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -164,6 +164,23 @@ export const userCanComment = (user: PermissionableUser|DbUser|null): boolean =>
   return true;
 }
 
+// Same as userCanComment, but without the unreviewed author check
+export const userCanQuickTake = (user: PermissionableUser|DbUser|null): boolean => {
+  if (!user) {
+    return false;
+  }
+
+  if (userIsAdminOrMod(user)) {
+    return true;
+  }
+
+  if (user.allCommentingDisabled) {
+    return false;
+  }
+
+  return true;
+}
+
 export const userOverNKarmaFunc = (n: number) => {
     return (user: UsersMinimumInfo|DbUser|null): boolean => {
       if (!user) return false


### PR DESCRIPTION
Quick takes can be initiated in three places: (1) the frontpage collapsible quick takes section, (2) the user menu, (3) the quick takes page at /quicktakes

Previously: non-approved users are not shown any of these options, even though it's a good way to get into submitting (perhaps better than posting).

**This PR** makes it so they have these options. In fact, the submission box is shown to logged out users but triggers a log-in popup.

Quick takes submitted for non-approved users will appear only for them, marked as such.

<img width="867" alt="LessWrong 2024-10-25 11-32-42" src="https://github.com/user-attachments/assets/00b54a90-1f7e-45ac-95f1-2eccbc742d15">

<img width="913" alt="LessWrong 2024-10-25 11-33-32" src="https://github.com/user-attachments/assets/a20659d8-4a5f-4ac5-8cc6-628baf6d9258">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208630308469816) by [Unito](https://www.unito.io)
