### PR TITLE
Fix forum specific schemas

### DIFF
--- a/.github/workflows/runTests.yaml
+++ b/.github/workflows/runTests.yaml
@@ -45,6 +45,7 @@ jobs:
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
       SLOW_QUERY_REPORT_CUTOFF_MS: "-1"
+      PG_URL: postgres://postgres:password@localhost:5433/postgres
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -61,14 +62,21 @@ jobs:
         tail: true
         log-output: true
         log-output-resume: stderr
-    - name: Run code generation
-      env:
-        PG_URL: postgres://postgres:password@localhost:5433/postgres
+    - name: Run code generation (EA Forum)
       run: |
         yarn ea-command-ci 'Globals.generateTypesAndSQLSchema()'
         yarn graphql-codegen --config codegen.yml
     - name: Throw if code changed
       run: if [[ `git status --porcelain ./schema ./packages` ]]; then git status --porcelain ./schema ./packages; echo "Changes detected - run yarn generate"; exit 1; fi
+    - name: Switch forum type
+      run: |
+        sed -i -e 's/"forumType": "EAForum"/"forumType": "LessWrong"/g' settings-test.json
+    - name: Run code generation (LessWrong)
+      run: |
+        yarn ea-command-ci 'Globals.generateTypesAndSQLSchema()'
+        yarn graphql-codegen --config codegen.yml
+    - name: Throw if forum schemas differ
+      run: if [[ `git status --porcelain ./schema ./packages` ]]; then git status --porcelain ./schema ./packages; echo "LessWrong/EA Forum database schemas differ"; exit 1; fi
 
   runPlaywrightTests:
     # Pin Ubuntu to 22.04 to avoid a problem installing browser dependencies.

--- a/packages/lesswrong/lib/forumTypeUtils.ts
+++ b/packages/lesswrong/lib/forumTypeUtils.ts
@@ -25,6 +25,10 @@ export function forumSelect<T>(forumOptions: ForumOptions<T>, forumType?: ForumT
 export class DeferredForumSelect<T> {
   constructor(private forumOptions: ForumOptions<T>) {}
 
+  getDefault() {
+    return "default" in this.forumOptions ? this.forumOptions.default : undefined;
+  }
+
   get(forumType?: ForumTypeString): NonUndefined<T> {
     return forumSelect(this.forumOptions, forumType);
   }

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -413,13 +413,15 @@ export function googleLocationToMongoLocation(gmaps: AnyBecauseTodo) {
 export function schemaDefaultValue<N extends CollectionNameString>(
   defaultValue: any,
 ): Partial<CollectionFieldSpecification<N>> {
+  const isForumSpecific = defaultValue instanceof DeferredForumSelect;
+
   // Used for both onCreate and onUpdate
   const fillIfMissing = ({ newDocument, fieldName }: {
     newDocument: ObjectsByCollectionName[N];
     fieldName: string;
   }) => {
     if (newDocument[fieldName as keyof ObjectsByCollectionName[N]] === undefined) {
-      return defaultValue instanceof DeferredForumSelect ? defaultValue.get() : defaultValue;
+      return isForumSpecific ? defaultValue.get() : defaultValue;
     } else {
       return undefined;
     }
@@ -438,7 +440,7 @@ export function schemaDefaultValue<N extends CollectionNameString>(
   };
 
   return {
-    defaultValue: defaultValue,
+    defaultValue: isForumSpecific ? defaultValue.getDefault() : defaultValue,
     onCreate: fillIfMissing,
     onUpdate: throwIfSetToNull,
     canAutofillDefault: true,

--- a/packages/lesswrong/server/migrations/20241025T181733.fix_ea_forum_default_theme.ts
+++ b/packages/lesswrong/server/migrations/20241025T181733.fix_ea_forum_default_theme.ts
@@ -1,0 +1,10 @@
+import Users from "@/lib/vulcan-users";
+import { updateDefaultValue } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  await updateDefaultValue(db, Users, "theme");
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await updateDefaultValue(db, Users, "theme");
+}

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3095,7 +3095,7 @@ CREATE TABLE "Users" (
   "noindex" BOOL NOT NULL DEFAULT FALSE,
   "groups" TEXT[],
   "lwWikiImport" BOOL,
-  "theme" JSONB NOT NULL DEFAULT '{"name":"auto"}'::JSONB,
+  "theme" JSONB NOT NULL DEFAULT '{"name":"default"}'::JSONB,
   "lastUsedTimezone" TEXT,
   "whenConfirmationEmailSent" TIMESTAMPTZ,
   "legacy" BOOL NOT NULL DEFAULT FALSE,


### PR DESCRIPTION
- If a schema default value uses `DeferredForumSelect`, always use the "default" value for the database-level default in postgres (setting the forum-specific values is already handled by `onInsert`)
- Update the SQL schema and add a migration to fix the one field this currently affects (users theme on EA Forum)
- Update `checkCodeGeneration` CI workflow to fail if the SQL schema for EA Forum and LessWrong don't match (see https://github.com/ForumMagnum/ForumMagnum/actions/runs/11523803720/job/32082591746 for a hypothetical failure)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208630221796492) by [Unito](https://www.unito.io)
