### PR TITLE
Tweaks to the Manifold Markets bot

### DIFF
--- a/packages/lesswrong/lib/collections/posts/annualReviewMarkets.ts
+++ b/packages/lesswrong/lib/collections/posts/annualReviewMarkets.ts
@@ -96,7 +96,7 @@ export const postGetMarketInfoFromManifold = async (post: DbPost): Promise<Annua
   return { probability: fullMarket.probability, isResolved: fullMarket.isResolved, year: post.postedAt.getFullYear(), url: fullMarket.url }
 }
 
-export const createManifoldMarket = async (question: string, descriptionMarkdown: string, closeTime: Date, visibility: string, initialProb: number): Promise<LiteMarket | undefined> => {
+export const createManifoldMarket = async (question: string, descriptionMarkdown: string, closeTime: Date, visibility: string, initialProb: number, idKey?: string): Promise<LiteMarket | undefined> => {
   
   //eslint-disable-next-line no-console
   if (!manifoldAPIKey) console.error("Manifold API key not found");
@@ -116,6 +116,8 @@ export const createManifoldMarket = async (question: string, descriptionMarkdown
         closeTime: Number(closeTime),
         visibility,
         initialProb,
+        marketTier: "play",
+        idempotencyKey: idKey,
         groupIds: [manifoldLessWrongAnnualReviewTag]
       })
     })

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -242,7 +242,7 @@ async function maybeCreateReviewMarket({newDocument, vote}: VoteDocTuple, collec
   const closeTime = new Date(year + 2, 1, 1) // i.e. february 1st of the next next year (so if year is 2022, feb 1 of 2024)
   const visibility = isProduction ? "public" : "unlisted"
 
-  const liteMarket = await createManifoldMarket(question, descriptionMarkdown, closeTime, visibility, initialProb)
+  const liteMarket = await createManifoldMarket(question, descriptionMarkdown, closeTime, visibility, initialProb, post._id)
 
   // Return if market creation fails
   if (!liteMarket) return;


### PR DESCRIPTION
I haven't tested this but I think it's mergeable if tests pass (it's not so bad if this breaks for a little bit)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208631219390842) by [Unito](https://www.unito.io)
