### PR TITLE
Fix z-index of the top-right post UI on LW, which made the triple-dot menu unclickable at certain screen widths

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -15,7 +15,11 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down('sm')]: {
       top: 8,
       right: 8
-    }
+    },
+    
+    // Ensure this is above the side-items column, which extends to the top of
+    // the page.
+    zIndex: 100,
   },
   vote: {
     display: 'flex',


### PR DESCRIPTION
Tested: The triple-dot menu is now clickable at the relevant screen size; the UI is still underneath all nearby things that it should be underneath, particularly the notifications sidebar, karma notifier popup, and user menu.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208645057903849) by [Unito](https://www.unito.io)
