### PR TITLE
fixed events not being shown for a few hours after they've finished

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1099,15 +1099,12 @@ ensureIndex(Posts,
 );
 
 Posts.addView("events", (terms: PostsViewTerms) => {
-  console.log(JSON.stringify(terms, null, 2))
-  console.log(eventBuffer)
   const timeSelector = {
     $or: [
       { startTime: { $gt: moment().subtract(eventBuffer.startBuffer, 'hours').toDate() } },
       { endTime: { $gt: moment().subtract(eventBuffer.endBuffer, 'hours').toDate() } },
     ],
   };
-  console.log(JSON.stringify(timeSelector, null, 2))
   const twoMonthsAgo = moment().subtract(60, 'days').toDate();
   // make sure that, by default, events are not global
   let globalEventSelector: {} = terms.globalEvent ? {globalEvent: true} : {};
@@ -1116,7 +1113,6 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       {globalEvent: false}, {globalEvent: {$exists:false}}
     ]}
   }
-  console.log(JSON.stringify(globalEventSelector, null, 2))
   
   let onlineEventSelector: {} = terms.onlineEvent ? {onlineEvent: true} : {}
   if (terms.onlineEvent === false) {
@@ -1124,7 +1120,6 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       {onlineEvent: false}, {onlineEvent: {$exists: false}}
     ]}
   }
-  console.log(JSON.stringify(onlineEventSelector, null, 2))
   
   return {
     selector: {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -19,7 +19,9 @@ import { TupleSet, UnionOf } from '@/lib/utils/typeGuardUtils';
 export const DEFAULT_LOW_KARMA_THRESHOLD = -10
 export const MAX_LOW_KARMA_THRESHOLD = -1000
 
-const eventBuffer = isEAForum ? {startBuffer: '1 hour', endBuffer: null} : {startBuffer: '6 hours', endBuffer: '3 hours'}
+const eventBuffer = isEAForum
+  ? { startBuffer: 1, endBuffer: null }
+  : { startBuffer: 6, endBuffer: 3 };
 
 export const POST_SORTING_MODES = new TupleSet([
   "magic", "top", "topAdjusted", "new", "old", "recentComments"
@@ -1097,10 +1099,15 @@ ensureIndex(Posts,
 );
 
 Posts.addView("events", (terms: PostsViewTerms) => {
-  const timeSelector = {$or: [
-    {startTime: {$gt: moment().subtract(eventBuffer.startBuffer).toDate()}},
-    {endTime: {$gt: moment().subtract(eventBuffer.endBuffer).toDate()}}
-  ]}
+  console.log(JSON.stringify(terms, null, 2))
+  console.log(eventBuffer)
+  const timeSelector = {
+    $or: [
+      { startTime: { $gt: moment().subtract(eventBuffer.startBuffer, 'hours').toDate() } },
+      { endTime: { $gt: moment().subtract(eventBuffer.endBuffer, 'hours').toDate() } },
+    ],
+  };
+  console.log(JSON.stringify(timeSelector, null, 2))
   const twoMonthsAgo = moment().subtract(60, 'days').toDate();
   // make sure that, by default, events are not global
   let globalEventSelector: {} = terms.globalEvent ? {globalEvent: true} : {};
@@ -1109,6 +1116,7 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       {globalEvent: false}, {globalEvent: {$exists:false}}
     ]}
   }
+  console.log(JSON.stringify(globalEventSelector, null, 2))
   
   let onlineEventSelector: {} = terms.onlineEvent ? {onlineEvent: true} : {}
   if (terms.onlineEvent === false) {
@@ -1116,6 +1124,7 @@ Posts.addView("events", (terms: PostsViewTerms) => {
       {onlineEvent: false}, {onlineEvent: {$exists: false}}
     ]}
   }
+  console.log(JSON.stringify(onlineEventSelector, null, 2))
   
   return {
     selector: {


### PR DESCRIPTION
A simple syntax error in the post views file was preventing the buffer from working.

This applied to anywhere the posts views 'events' 'nearbyEvents' and 'globalEvents' were called. It's supposed to still return events for a few hours after they've finished, but it wasn't.

—Ben Pace

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208645383686791) by [Unito](https://www.unito.io)
