### PR TITLE
Truncated "Slow postgres queries" on dev servers

### DIFF
--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -10,7 +10,7 @@ import { recordSqlQueryPerfMetric } from "./perfMetrics";
 // Setting this to -1 disables slow query logging
 const SLOW_QUERY_REPORT_CUTOFF_MS = parseInt(process.env.SLOW_QUERY_REPORT_CUTOFF_MS ?? '') >= -1
   ? parseInt(process.env.SLOW_QUERY_REPORT_CUTOFF_MS ?? '')
-  : 2000;
+  : isDevelopment ? 3000 : 2000;
 
 const pgConnIdleTimeoutMsSetting = new PublicInstanceSetting<number>('pg.idleTimeoutMs', 10000, 'optional')
 

--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -1,7 +1,7 @@
 import pgp, { IDatabase, IEventContext } from "pg-promise";
 import type { IClient, IResult } from "pg-promise/typescript/pg-subset";
 import Query from "@/server/sql/Query";
-import { isAnyTest } from "../lib/executionEnvironment";
+import { isAnyTest, isDevelopment } from "../lib/executionEnvironment";
 import { PublicInstanceSetting } from "../lib/instanceSettings";
 import omit from "lodash/omit";
 import { logAllQueries } from "@/server/sql/sqlClient";
@@ -153,11 +153,11 @@ const logIfSlow = async <T>(
   originalQuery: string,
   quiet?: boolean,
 ) => {
-  const getDescription = (): string => {
+  const getDescription = (truncateLength?: number): string => {
     const describeString = typeof describe === "string" ? describe : describe();
     // Truncate this at a pretty high limit, just to avoid logging things like
     // entire rendered pages
-    return describeString.slice(0, 5000);
+    return describeString.slice(0, truncateLength ?? 5000)
   }
 
   const queryID = ++queriesExecuted;
@@ -177,8 +177,10 @@ const logIfSlow = async <T>(
     // eslint-disable-next-line no-console
     console.log(`Finished query #${queryID} (${milliseconds} ms) (${JSON.stringify(result).length}b)`);
   } else if (SLOW_QUERY_REPORT_CUTOFF_MS >= 0 && milliseconds > SLOW_QUERY_REPORT_CUTOFF_MS && !quiet && !isAnyTest) {
-    // eslint-disable-next-line no-console
-    console.trace(`Slow Postgres query detected (${milliseconds} ms): ${getDescription()}`);
+    const description = isDevelopment ? getDescription(50) : getDescription(200);
+    const message = `Slow Postgres query detected (${milliseconds} ms): ${description}`;
+        // eslint-disable-next-line no-console
+    isDevelopment ? console.error(message) : console.trace(message);
   }
 
   return result;

--- a/packages/lesswrong/server/sqlConnection.ts
+++ b/packages/lesswrong/server/sqlConnection.ts
@@ -177,7 +177,7 @@ const logIfSlow = async <T>(
     // eslint-disable-next-line no-console
     console.log(`Finished query #${queryID} (${milliseconds} ms) (${JSON.stringify(result).length}b)`);
   } else if (SLOW_QUERY_REPORT_CUTOFF_MS >= 0 && milliseconds > SLOW_QUERY_REPORT_CUTOFF_MS && !quiet && !isAnyTest) {
-    const description = isDevelopment ? getDescription(50) : getDescription(200);
+    const description = isDevelopment ? getDescription(50) : getDescription(5000);
     const message = `Slow Postgres query detected (${milliseconds} ms): ${description}`;
         // eslint-disable-next-line no-console
     isDevelopment ? console.error(message) : console.trace(message);


### PR DESCRIPTION
I found it quite annoying when there's a lost of Slow Postgres Query warnings on dev servers. I almost never take actions about it.

This PR truncates the response when `isDevelopment` is `true`. If you run into some slow queries on dev you want to debug better you can toggle it back.

It also increases the slow ms threshold somewhat on dev.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208645639301937) by [Unito](https://www.unito.io)
