### PR TITLE
Spotlight images have explicit size, preventing them from being huge downloads

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -453,7 +453,9 @@ export const SpotlightItem = ({
           </Typography>}
           <SpotlightStartOrContinueReading spotlight={spotlight} className={classes.startOrContinue} />
         </div>
-        {spotlight.spotlightSplashImageUrl && <div className={classes.splashImageContainer}><img src={spotlight.spotlightSplashImageUrl} className={classNames(classes.image, classes.imageFade, classes.splashImage)}/></div>}
+        {spotlight.spotlightSplashImageUrl && <div className={classes.splashImageContainer}>
+          <img src={spotlight.spotlightSplashImageUrl} className={classNames(classes.image, classes.imageFade, classes.splashImage)}/>
+        </div>}
         {spotlight.spotlightImageId && <CloudinaryImage2
           publicId={spotlight.spotlightImageId}
           darkPublicId={spotlight.spotlightDarkImageId}
@@ -461,6 +463,8 @@ export const SpotlightItem = ({
             [classes.imageFade]: spotlight.imageFade && !spotlight.imageFadeColor,
             [classes.imageFadeCustom]: spotlight.imageFade && spotlight.imageFadeColor,
           })}
+          imgProps={{w: "500"}}
+          loading="lazy"
         />}
         {hideBanner && (
           isFriendlyUI

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -211,6 +211,7 @@ const schema: SchemaType<"Spotlights"> = {
     canCreate: ['admins', 'sunshineRegiment'],
     optional: true,
     nullable: true,
+    tooltip: "Note: Large images can cause slow loading of the front page. Consider using the Cloudinary uploader instead (which will automatically resize the image)",
     order: 88,
   },
   draft: {


### PR DESCRIPTION
Spotlight items can have their images defined in one of two ways: as a URL, or as a Cloudinary ID. In both cases, there was a risk of using an image that's way too high resolution, slowing down the load time of the front page. Previously, the image for the current spotlight ("The Curse Of The Counterfactual") was 1.3MB.

I edited the URL for that spotlight in the prod DB to give it an explicit width of 500, using Cloudinary's URL syntax (it was entered as a URL rather than as a cloudinary ID). When Cloudinary IDs are used, load them with `w: 500`. Also add `loading="lazy"` to maybe deprioritize loading the image rather than the JS bundle and other things.

The width of 500 is approximate; we don't actually know how big it will be when it's displayed. This is both because of variation in DPI, and also because the spotlight item component is variable-height dependeing on text wrapping. If you zoom in further than the default you can see some blurriness, but at default zoom it looks pretty good.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208645515673981) by [Unito](https://www.unito.io)
