### PR TITLE
Fix Android mobile author rendering

### DIFF
--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
@@ -9,7 +9,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   lengthLimited: {
     maxWidth: 310,
     textOverflow: "ellipsis",
-    overflowX: "hidden",
+    overflowX: "clip",
     textAlign: "right",
     [theme.breakpoints.down('xs')]: {
       maxWidth: 160


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/24e6c881-fb13-4349-b450-f5152d5fed08)

After: 
<img width="335" alt="image" src="https://github.com/user-attachments/assets/3d89034b-dab8-4293-b71b-ebb13a5e27a5">

I also tested this at other sizes, and sanity-checked the differences between hidden and clip. Seems like we would generally prefer clip.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208651723178392) by [Unito](https://www.unito.io)
