### PR TITLE
filter out terms that are probably familiar to LW audiences and clean up some other prompting

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "brigader-check": "ts-node -r tsconfig-paths/register scripts/brigaderCheck.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.26.0",
+    "@anthropic-ai/sdk": "^0.30.1",
     "@apollo/client": "^3.2.0",
     "@aws-sdk/client-cloudfront": "^3.577.0",
     "@babel/runtime": "^7.12.1",
@@ -308,7 +308,8 @@
     "universal-cookie-express": "^2.2.0",
     "url": "^0.11.0",
     "uuid": "^7.0.0",
-    "zod": "^3.22.3"
+    "zod": "^3.22.3",
+    "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
     "@babel/core": "7.12.3",

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -10,13 +10,13 @@ import { formStyles } from './JargonEditorRow';
 import { isFriendlyUI } from '@/themes/forumTheme';
 import { useJargonCounts } from '@/components/hooks/useJargonCounts';
 
-export const defaultGlossaryPrompt = `You're a Glossary AI. Your goal is to make good explanations for technical jargon terms. You are trying to produce a useful hoverover tooltip in an essay on LessWrong.com, accessible to a smart, widely read layman. 
+export const defaultGlossaryPrompt = `You're a LessWrong Glossary AI. Your goal is to make good explanations for technical jargon terms. You are trying to produce a useful hoverover tooltip in an essay on LessWrong.com, accessible to a smart, widely read layman. 
 
-We're about to provide you with the text of an essay, followed by a list of jargon terms for that essay. 
+We're about to provide you with the text of an essay, followed by a jargon term present in that essay. 
 
-For each term, provide:
+For that term, provide:
   
-The term itself (wrapped in a strong tag), followed by a concise one-line definition. Then, on a separate paragraph, explain how the term is used in this context. Include where the term is originally from (whether it's established from an academic field, new to LessWrong or this particular post, or something else. Note what year it was first used in this context if possible).
+The term itself (wrapped in a strong tag), followed by a concise one-line definition. Then, on a separate paragraph, explain how the term is used in this context. If the term has a well-established origin, briefly mention it.
 
 Ensure that your explanations are clear and accessible to someone who may not be familiar with the subject matter. Follow Strunk and White guidelines. 
 
@@ -26,18 +26,16 @@ Include a set of altTerms that are slight variations of the term, such as plural
 
 Do NOT emphasize that the term is important, but DO explain how it's used in this context. Make sure to put the "contextual explanation" in a separate paragraph from the opening term definition. Make sure to make the term definition a short sentence.
 
-Do NOT use the phrase "In this context", "In this post", or anything like that. Just explain the term.
-`
+Do NOT use the phrase "In this context", "In this post", or anything like that.`;
 
-export const defaultExamplePost = `Suppose two Bayesian agents are presented with the same spreadsheet - IID samples of data in each row, a feature in each column. Each agent develops a generative model of the data distribution. We'll assume the two converge to the same predictive distribution, but may have different generative models containing different latent variables. We'll also assume that the two agents develop their models independently, i.e. their models and latents don't have anything to do with each other informationally except via the data. Under what conditions can a latent variable in one agent's model be faithfully expressed in terms of the other agent's latents?`
+export const defaultExamplePost = `Suppose two Bayesian agents are presented with the same spreadsheet - IID samples of data in each row, a feature in each column. Each agent develops a generative model of the data distribution. We'll assume the two converge to the same predictive distribution, but may have different generative models containing different latent variables. We'll also assume that the two agents develop their models independently, i.e. their models and latents don't have anything to do with each other informationally except via the data. Under what conditions can a latent variable in one agent's model be faithfully expressed in terms of the other agent's latents?`;
 
-export const defaultExampleLateX = `Now for the question: under what conditions on agent 1's latent(s) (Lambda^1) can we *guarantee* that (Lambda^1) is expressible in terms of (Lambda^2), no matter what generative model agent 2 uses (so long as the agents agree on the predictive distribution (P[X]))? In particular, let's require that (Lambda^1) be a function of (Lambda^2). (Note that we'll weaken this later.) So, when is (Lambda^1) *guaranteed* to be a function of (Lambda^2), for *any* generative model (M_2) which agrees on the predictive distribution (P[X])? Or, worded in terms of latents: when is (Lambda^1) *guaranteed* to be a function of (Lambda^2), for *any* latent(s) (Lambda^2) which account for all interactions between features in the predictive distribution (P[X])?
-`
+export const defaultExampleLateX = `Now for the question: under what conditions on agent 1's latent(s) (Lambda^1) can we *guarantee* that (Lambda^1) is expressible in terms of (Lambda^2), no matter what generative model agent 2 uses (so long as the agents agree on the predictive distribution (P[X]))? In particular, let's require that (Lambda^1) be a function of (Lambda^2). (Note that we'll weaken this later.) So, when is (Lambda^1) *guaranteed* to be a function of (Lambda^2), for *any* generative model (M_2) which agrees on the predictive distribution (P[X])? Or, worded in terms of latents: when is (Lambda^1) *guaranteed* to be a function of (Lambda^2), for *any* latent(s) (Lambda^2) which account for all interactions between features in the predictive distribution (P[X])?`;
 
 export interface ExampleJargonGlossaryEntry {
   term: string;
   altTerms: string[];
-  text: string;
+  htmlContent: string;
 }
 
 export const defaultExampleTerm = 'latent variables'
@@ -52,7 +50,7 @@ export const defaultExampleGlossary: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": defaultExampleTerm,
       "altTerms": [defaultExampleAltTerm],
-      "text": defaultExampleDefinition
+      "htmlContent": defaultExampleDefinition
     },
   ]
 };
@@ -226,7 +224,7 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
     terms: {
       view: "postEditorJargonTerms",
       postId: document._id,
-      limit: 100
+      limit: 500
     },
     collectionName: "JargonTerms",
     fragmentName: 'JargonTerms',

--- a/packages/lesswrong/server/languageModels/llmApiWrapper.ts
+++ b/packages/lesswrong/server/languageModels/llmApiWrapper.ts
@@ -1,33 +1,51 @@
 import type { ChatModel as OpenAIModel, ChatCompletionSystemMessageParam as OpenAISystemMessage } from 'openai/resources/chat';
 import type { ChatCompletionCreateParamsBase as OpenAISendMessagesParams } from 'openai/resources/chat/completions';
 import type { Model as AnthropicModel } from '@anthropic-ai/sdk/resources/messages';
-import type { MessageCreateParamsBase as AnthropicSendMessagesParams, PromptCachingBetaMessageParam as AnthropicMessage, PromptCachingBetaTextBlockParam as AnthropicMessageTextBlock } from '@anthropic-ai/sdk/resources/beta/prompt-caching/messages';
+import type { MessageCreateParamsBase as AnthropicSendMessagesParams, PromptCachingBetaMessageParam as AnthropicMessage, PromptCachingBetaToolUseBlockParam as AnthropicMessageToolUseBlock, PromptCachingBetaToolResultBlockParam as AnthropicMessageToolResultBlock, PromptCachingBetaTextBlockParam as AnthropicMessageTextBlock, PromptCachingBetaTool } from '@anthropic-ai/sdk/resources/beta/prompt-caching/messages';
 
 import { getOpenAI } from './languageModelIntegration';
 import { getAnthropicPromptCachingClientOrThrow } from './anthropicClient';
+import { z } from 'zod';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
-export interface SendOpenAIMessages {
+interface SendToolUseRequest<T> {
+  zodParser: z.ZodType<T>;
+  name: string;
+}
+
+interface SendNonToolUseRequest {
+  zodParser?: undefined;
+  name?: undefined;
+}
+
+type SendMaybeToolUseRequest<T extends boolean, ZodType> = T extends true 
+  ? SendToolUseRequest<ZodType> 
+  : SendNonToolUseRequest;
+
+export type SendOpenAIMessages<ToolUse extends boolean = false, ZodType = never> = SendMaybeToolUseRequest<ToolUse, ZodType> & {
   provider: 'openai';
   model: OpenAIModel;
   messages: OpenAISendMessagesParams['messages'];
   maxTokens: OpenAISendMessagesParams['max_tokens'];
-  tools?: AnthropicSendMessagesParams['tools'];
-  toolChoice?: AnthropicSendMessagesParams['tool_choice'];
   system?: AnthropicSendMessagesParams['system'];
 }
 
-export interface SendAnthropicMessages {
+export type SendAnthropicMessages<ToolUse extends boolean = false, ZodType = never> = SendMaybeToolUseRequest<ToolUse, ZodType> & {
   provider: 'anthropic';
   model: AnthropicModel;
-  messages: Array<Omit<AnthropicMessage, 'content'> & { content: string | AnthropicMessageTextBlock[] }>;
+  messages: Array<Omit<AnthropicMessage, 'content'> & { content: string | (AnthropicMessageTextBlock | AnthropicMessageToolUseBlock | AnthropicMessageToolResultBlock)[] }>;
   maxTokens: AnthropicSendMessagesParams['max_tokens'];
   system?: AnthropicSendMessagesParams['system'];
-  tools?: AnthropicSendMessagesParams['tools'];
-  toolChoice?: AnthropicSendMessagesParams['tool_choice'];
   customApiKey?: string;
 }
 
-export type SendLLMMessagesArgs = SendOpenAIMessages | SendAnthropicMessages;
+export type SendLLMMessagesArgs<
+  ToolUse extends boolean = boolean,
+  ZodType = any
+> = SendOpenAIMessages<ToolUse, ZodType> | SendAnthropicMessages<ToolUse, ZodType>;
+
+type SendLLMMessageReturnTypes<T extends SendLLMMessagesArgs> = T['zodParser'] extends undefined ? string : z.infer<Exclude<T['zodParser'], undefined>> | null;
 
 function convertAnthropicToolsToOpenAI(tools: Exclude<AnthropicSendMessagesParams['tools'], undefined>): OpenAISendMessagesParams['tools'] {
   return tools.map(tool => {
@@ -63,26 +81,59 @@ function convertAnthropicSystemMessageToOpenAI(system: Exclude<AnthropicSendMess
   };
 }
 
-export async function sendMessagesToLlm<T extends SendLLMMessagesArgs>(args: T) {
+export function convertZodParserToAnthropicTool(zodParser: z.ZodType<any>, name: string): PromptCachingBetaTool {
+  const jsonSchema = zodToJsonSchema(zodParser, name);
+  const inputSchema = jsonSchema.definitions?.[name];
+  if (!inputSchema) {
+    throw new Error(`Couldn't find tool definition for ${name}!`);
+  }
+
+  if (!('type' in inputSchema) || inputSchema.type !== 'object') {
+    throw new Error(`Missing 'type' field in input schema for ${name}!`);
+  }
+
+  return {
+    name,
+    input_schema: inputSchema as PromptCachingBetaTool['input_schema'],
+    description: zodParser.description
+  };
+}
+
+export async function sendMessagesToLlm<T extends SendLLMMessagesArgs>(args: T): Promise<SendLLMMessageReturnTypes<T>> {
   if (args.provider === 'openai') {
     const client = await getOpenAI();
     if (!client) {
       throw new Error(`Couldn't get OpenAI Client!`);
     }
 
-    const { maxTokens, model, messages, system, tools, toolChoice } = args;
+    const { maxTokens, model, messages, system, zodParser, name } = args;
 
     const allMessages = [...messages];
     if (system) {
       allMessages.unshift(convertAnthropicSystemMessageToOpenAI(system));
     }
 
-    const response = await client.chat.completions.create({
+    if (zodParser) {
+      const response = await client.beta.chat.completions.parse({
+        model,
+        max_tokens: maxTokens,
+        messages: allMessages,
+        response_format: zodResponseFormat(zodParser, name),
+      });
+
+      const [firstContentBlock] = response.choices;
+
+      if (!firstContentBlock) {
+        throw new Error('Response from OpenAI has no content blocks!');
+      }
+
+      return firstContentBlock.message.parsed as SendLLMMessageReturnTypes<T>;
+    }
+
+    const response = await client.beta.chat.completions.parse({
       model,
       max_tokens: maxTokens,
       messages: allMessages,
-      tools: tools ? convertAnthropicToolsToOpenAI(tools) : undefined,
-      tool_choice: toolChoice ? convertAnthropicToolChoiceToOpenAI(toolChoice) : undefined,
     });
 
     const [firstContentBlock] = response.choices;
@@ -91,12 +142,45 @@ export async function sendMessagesToLlm<T extends SendLLMMessagesArgs>(args: T) 
       throw new Error('Response from OpenAI has no content blocks!');
     }
 
-    return firstContentBlock.message.content;
+    return firstContentBlock.message.content as SendLLMMessageReturnTypes<T>;
   }
   
   const client = getAnthropicPromptCachingClientOrThrow(args.customApiKey);
 
-  const { maxTokens, messages, model, system } = args;
+  const { maxTokens, messages, model, system, zodParser, name } = args;
+
+  if (zodParser) {
+    const tool = convertZodParserToAnthropicTool(zodParser, name);
+    const tools = [tool];
+    const toolChoice: AnthropicSendMessagesParams['tool_choice'] = { name, type: 'tool' };
+
+    const response = await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      messages,
+      system,
+      tools,
+      tool_choice: toolChoice,
+    });
+
+    const [firstContentBlock] = response.content;
+
+    if (!firstContentBlock) {
+      throw new Error('Response from Anthropic has no content blocks!');
+    }
+
+    if (firstContentBlock.type !== 'tool_use') {
+      throw new Error('Got unexpected non-tool-use response from Anthropic!');
+    }
+
+    const responseContent = firstContentBlock.input;
+    const validatedTerm = zodParser.safeParse(responseContent);
+    if (!validatedTerm.success) {
+      throw new Error('Invalid tool use response from Anthropic!');
+    }
+
+    return validatedTerm.data as SendLLMMessageReturnTypes<T>;
+  }
 
   const response = await client.messages.create({
     model,

--- a/packages/lesswrong/server/resolvers/jargonResolvers/exampleJargonPost.ts
+++ b/packages/lesswrong/server/resolvers/jargonResolvers/exampleJargonPost.ts
@@ -1775,7 +1775,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     { 
       "term": "Moloch", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Moloch:</b> A metaphorical entity representing destructive systems and incentives in society.</p>
         <p>Here, Scott uses Moloch to symbolize the collective forces that lead to negative outcomes despite no individual wanting them. It represents the idea that competition and unaligned incentives can compel individuals or groups to act in ways that ultimately harm everyone, sacrificing important values for survival or power.</p>
       </div>`
@@ -1783,7 +1783,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Multipolar trap", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Multipolar trap:</b> A situation where competing agents are forced into destructive behavior despite negative collective outcomes.</p>
         <p>This concept describes scenarios where individual rational actions lead to collectively suboptimal results. It often occurs in situations with multiple competing parties, where the incentives to defect or exploit are strong, even though cooperation would benefit everyone more in the long run.</p>
       </div>`
@@ -1791,7 +1791,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Race to the bottom", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Race to the bottom:</b> A competitive situation where standards are continuously lowered to gain advantage.</p>
         <p>This phenomenon occurs when competitors progressively reduce costs, wages, safety standards, or other factors to gain a market advantage. The end result is often a degradation of conditions for all involved, as the competition forces everyone to adopt the lowest standards to remain competitive.</p>
       </div>`
@@ -1799,7 +1799,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Gnon", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Gnon:</b> Short for "Nature and Nature's God," representing amoral natural laws and forces.</p>
         <p>Gnon is used to describe the harsh realities of nature, evolution, and the universe that operate without regard for human values or desires. It represents the idea that there are fundamental, unchangeable laws of reality that humans must contend with, often in conflict with our moral intuitions.</p>
       </div>`
@@ -1807,7 +1807,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Orthogonality thesis",
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Orthogonality thesis:</b> The idea that an AI's intelligence level is independent of its goals or values.</p>
         <p>This concept suggests that a highly intelligent AI could have any set of goals, not necessarily ones aligned with human values. It's crucial in discussions about AI safety, as it implies that creating a superintelligent AI doesn't automatically ensure it will have benevolent or human-friendly goals.</p>
       </div>`
@@ -1815,7 +1815,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Singleton", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Singleton:</b> A hypothetical single decision-making agency at the highest level of global power.</p>
         <p>A singleton refers to a scenario where one entity (such as an AI, world government, or corporation) has the ability to make and enforce decisions on a global scale. This could potentially solve many coordination problems but also poses significant risks if the singleton's goals are not aligned with human welfare.</p>
       </div>`
@@ -1823,7 +1823,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Utility maximization", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Utility maximization:</b> The process of making decisions to achieve the best possible outcome according to specific values or preferences.</p>
         <p>In decision theory and AI, utility maximization refers to the idea that agents act to maximize some utility function. This concept is central to understanding how AIs might make decisions, and the challenges in ensuring those decisions align with human values.</p>
       </div>`
@@ -1831,7 +1831,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Coordination problem", 
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Coordination problem:</b> A situation where multiple agents fail to cooperate despite potential mutual benefits.</p>
         <p>Coordination problems arise when individuals or groups could achieve better outcomes by working together, but fail to do so due to conflicting incentives, lack of trust, or communication difficulties. These problems are common in many areas of human society and are a key focus in game theory and economics.</p>
       </div>`
@@ -1839,7 +1839,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Existential risk", 
       "altTerms": ["x-risk"],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Existential risk:</b> A threat that could cause human extinction or permanently cripple human civilization.</p>
         <p>Existential risks are potential future events that could either annihilate humanity or permanently and severely curtail its potential. These include risks from advanced technologies (like misaligned AI), natural disasters (like asteroid impacts), or human-caused catastrophes (like nuclear war or extreme climate change).</p>
       </div>`
@@ -1847,7 +1847,7 @@ export const exampleJargonGlossary2: { glossaryItems: ExampleJargonGlossaryEntry
     {
       "term": "Superintelligence", 
       "altTerms": ["ASI"],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Superintelligence:</b> An intelligence (typically an AI) far surpassing human cognitive abilities across virtually all domains.</p>
         <p>Superintelligence refers to a hypothetical future AI that would exceed human intelligence not just in specific areas, but in nearly all cognitive tasks. The development of superintelligence is seen as a potential transformative event for humanity, bringing both immense opportunities and significant risks.</p>
       </div>`
@@ -1861,7 +1861,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     { 
       "term": "Data distribution", 
       "altTerms": ['data distributions'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Data distribution:</b> The distribution which an agent models data points as being drawn from.</p>
         <p>Importantly distinct from an agent's whole world model, which may include many other "latent" variables in addition to variables representing the data.</p>
       </div>`
@@ -1869,7 +1869,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Latent variables",
       "altTerms": ['latents'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Latent variables:</b> Variables which an agent's world model includes but which are not directly observed.</p>
         <p>These variables are not part of the data distribution, but can help explain the data distribution.</p>
       </div>`
@@ -1877,14 +1877,14 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Graphical structure",
       "altTerms": ['graphical structures'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Graphical structure:</b> In probabilistic modeling, graphical structures (like Bayes networks) use nodes to represent variables and edges to represent dependencies between variables. They provide a compact way to represent complex probability distributions.</p>
       </div>`
     },
     {
       "term": "Fundamental Theorem of Natural Latents",
       "altTerms": ['entropy'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Fundamental Theorem of Natural Latents:</b> Every mediator contains every redund.</p>
         <p>A mediator between two observables has to carry all information shared by the two.  A redund between two observables is redundantly shared across the two. So, any mediator must contain every redund.  The Fundamental Theorem of Natural Latents formalizes this intuition and handles approximations.</p>
       </div>`
@@ -1892,7 +1892,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Entropy",
       "altTerms": ['entropy'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Entropy:</b> A measure of uncertainty or randomness in a system.</p>
         <p>In information theory, entropy quantifies the average number of bits needed to represent a value of a random variable. Lower entropy indicates more predictability, while higher entropy suggests more uncertainty or randomness.</p>
       </div>`
@@ -1900,7 +1900,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Generative model",
       "altTerms": ['generative models'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Generative model:</b> A statistical model which hypothesizes how data is generated.</p>
         <p>In machine learning and statistics, a generative model attempts to explain the underlying process that produces observed data. It can be used to generate new, synthetic data points that are similar to the observed data.</p>
       </div>`
@@ -1908,7 +1908,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "IID samples",
       "altTerms": ['IID sample', 'Independent and Identically Distributed'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>IID samples:</b> Independent and Identically Distributed.
         In statistics, IID samples are observations that are both Independent of each other and drawn from the same (Identical) probability Distribution.</p>
       </div>`
@@ -1916,7 +1916,7 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "KL-divergence",
       "altTerms": ['kl-divergence'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>KL-divergence:</b> Kullback-Leibler divergence, a measure of difference between probability distributions.</p>
         <p>In information theory, KL-divergence quantifies the minimum number of bits of evidence required to update from one distribution to another. It's can also be used as a unified foundation to define many other standard information-theoretic quantities.</p>
       </div>`
@@ -1924,14 +1924,14 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Mediation",
       "altTerms": ['mediator'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Mediation:</b> A variable Y "mediates" between X and Z iff X and Z are independent given Y. Intuitively, this means that X and Z can only interact through Y.</p>
       </div>`
     },
     {
       "term": "Redundancy",
       "altTerms": ['redundancy'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Redundancy:</b> The state of having duplicate or overlapping information.</p>
         <p>In information theory and the context of this post, redundancy refers to the property where information about a latent variable is represented multiple times across observed variables.</p>
       </div>`
@@ -1939,14 +1939,14 @@ export const exampleJargonLatentsGlossary: { glossaryItems: ExampleJargonGlossar
     {
       "term": "Stochastic function",
       "altTerms": ['stochastic functions'],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Stochastic function:</b> A function that involves randomness in its output. In particular, the randomness must be independent of any randomness in the function's inputs.</p>
       </div>`
     },
     {
       "term": "Tiny mixtures problem",
       "altTerms": [],
-      "text": `<div>
+      "htmlContent": `<div>
         <p><b>Tiny mixtures problem:</b> A situation where small differences in observable distributions can lead to large failures in natural latent guarantees.</p>
         <p>This problem arises in certain statistical scenarios where seemingly negligible differences between distributions can cause significant issues in the application of theoretical results.</p>
       </div>`

--- a/packages/lesswrong/server/resolvers/jargonResolvers/jargonPrompts.ts
+++ b/packages/lesswrong/server/resolvers/jargonResolvers/jargonPrompts.ts
@@ -1,6 +1,5 @@
-export const initialGlossaryPrompt = `Please provide a list of all the jargon terms (technical terms, acronyms, words used unusually in this context) in the following post that are not common knowledge on LessWrong. The output should be an array of strings. It should be comprehensive, covering all terms that might be be unfamiliar to an educated layman, with particular focus on terms unique to the communities of LessWrong, AI Alignment, or Effective Altruism.
+export const initialGlossaryPrompt = `Please provide a list of all the jargon terms (technical terms, acronyms, words used unusually in this context) in the following post that are not common knowledge on LessWrong. The output should be an array of strings. It should be comprehensive, covering all terms that might be be unfamiliar to an educated layman.
 
 Avoid including terms that are 3+ word phrases unless it is a complete noun-phrase where all the words are an important part of the term.
 
-Do not include any basic LessWrong terms such as 'LessWrong', 'Rationality', 'Effective Altruism', etc.
-`
+Then, return a second list of terms that are most likely to be known to LessWrong readers, or which are effectively duplicates of other terms.  It's fine if the second list is empty, if the first list is composed entirely of terms that are highly technical.`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,10 +116,10 @@
     "@algolia/logger-common" "4.8.2"
     "@algolia/requester-common" "4.8.2"
 
-"@anthropic-ai/sdk@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.26.0.tgz#efdd305c08977efb0fa84eb24dbe1d7e389edf58"
-  integrity sha512-vNbZ2rnnMfk8Bf4OdeVy6GA4EXao8tGC0tLEoSAl1NZrip9oOxnEGUkXl3FsPQgeBM5hmpGE1tSLuu9HEVJiHg==
+"@anthropic-ai/sdk@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.30.1.tgz#fbd13ae3d94525fb4453a07d07b2b94e168b33e7"
+  integrity sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"
@@ -18686,6 +18686,11 @@ zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zod-to-json-schema@^3.23.5:
+  version "3.23.5"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.5.tgz#ec23def47dcafe3a4d640eba6a346b34f9a693a5"
+  integrity sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==
 
 zod@^3.22.3:
   version "3.22.3"


### PR DESCRIPTION
Ask Claude to tell us which of the terms its giving us are most likely to be familiar to LW readers, so that we can filter them out.  Later, we might want to move in the direction of having a "common"/"shared" glossary, or something more Arbital-like, where users with different levels of familiarity/domain expertise can have different experiences depending on their preferences.

Also set up some better scaffolding for having a common internal API between using OpenAI and Anthropic models, including (optionally) tool use.  This is probably totally redundant with OpenRouter, but we'd need to switch to using OpenRouter for that.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208654392302066) by [Unito](https://www.unito.io)
