### PR TITLE
Bump calibri up font stack

### DIFF
--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -2,8 +2,8 @@ import { blackBarTitle } from "../../lib/publicSettings";
 
 const sansSerifStack = [
   'GreekFallback', // Ensures that greek letters render consistently
-  'gill-sans-nova',
   'Calibri',
+  'gill-sans-nova',
   '"Gill Sans"',
   '"Gill Sans MT"',
   "Myriad Pro",


### PR DESCRIPTION
Gill Sans Nova rendering seems broken on Windows. Use Calibri ahead of it to patch the problem until we can debug

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208654852372309) by [Unito](https://www.unito.io)
