### PR TITLE
LocalStorageCheck tells you upfront what text you'll be restoring

### DIFF
--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { SerializedEditorContents, deserializeEditorContents, EditorContents, nonAdminEditors, adminEditors } from './Editor';
 import { useCurrentUser } from '../common/withUser';
+import { htmlToTextDefault } from '@/lib/htmlToText';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -20,7 +21,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: 8,
     
     "& a": {
-      textDecoration: "underline",
       '&:hover': {
         color: theme.palette.primary.dark,
         opacity: 1
@@ -29,10 +29,20 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   restoreLink: {
     color: theme.palette.text.primaryAlert,
+    whiteSpace: 'nowrap',
+  },
+  restoreBody: {
+    color: theme.palette.grey[500],
+    maxHeight: '1.5em',
+    lineHeight: '1.5em',
+    fontSize: '1.1rem',
+    overflow: 'hidden',
+    padding: '0 4px',
   },
   closeIcon: {
     fontSize: 16,
     cursor: 'pointer',
+    marginLeft: 'auto',
     '&:hover': {
       color: theme.palette.primary.dark,
     }
@@ -83,9 +93,10 @@ const LocalStorageCheck = ({getLocalStorageHandlers, onRestore, classes}: {
   if (!restorableState)
     return null;
   
+  const displayedRestore = htmlToTextDefault(deserializeEditorContents(restorableState.savedDocument)?.value ?? '');
+
   return <div className={classes.root}>
     <div>
-      You have autosaved text.{" "}
       <a className={classes.restoreLink} onClick={() => {
         setRestorableState(null);
         const restored = deserializeEditorContents(restorableState.savedDocument);
@@ -95,8 +106,10 @@ const LocalStorageCheck = ({getLocalStorageHandlers, onRestore, classes}: {
           // eslint-disable-next-line no-console
           console.error("Error restoring from localStorage");
         }
-      }}>Restore</a>
+      }}>Restore Autosave</a>
     </div>
+    <div className={classes.restoreBody}> {displayedRestore} </div>
+
     <Components.ForumIcon icon="Close" className={classes.closeIcon} onClick={() => setRestorableState(null)}/>
   </div>
 }

--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -30,6 +30,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   restoreLink: {
     color: theme.palette.text.primaryAlert,
     whiteSpace: 'nowrap',
+    paddingLeft: 6,
+    paddingRight: 2
   },
   restoreBody: {
     color: theme.palette.grey[500],

--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -3,13 +3,14 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { SerializedEditorContents, deserializeEditorContents, EditorContents, nonAdminEditors, adminEditors } from './Editor';
 import { useCurrentUser } from '../common/withUser';
 import { htmlToTextDefault } from '@/lib/htmlToText';
+import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    columnGap: 10,
+    columnGap: isFriendlyUI ? 8 : 10,
     fontFamily: theme.typography.commentStyle.fontFamily,
     color: theme.palette.text.primaryAlert,
     fontSize: 14,
@@ -31,15 +32,24 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.text.primaryAlert,
     whiteSpace: 'nowrap',
     paddingLeft: 6,
-    paddingRight: 2
+    paddingRight: 2,
+    fontWeight: isFriendlyUI ? 600 : undefined,
   },
   restoreBody: {
-    color: theme.palette.grey[500],
     maxHeight: '1.5em',
     lineHeight: '1.5em',
     fontSize: '1.1rem',
     overflow: 'hidden',
-    padding: '0 4px',
+    ...(isFriendlyUI
+      ? {
+        color: theme.palette.text.primaryAlert,
+        fontWeight: 500,
+        opacity: 0.75,
+      }
+      : {
+        color: theme.palette.grey[500],
+        padding: '0 4px',
+      }),
   },
   closeIcon: {
     fontSize: 16,
@@ -108,7 +118,7 @@ const LocalStorageCheck = ({getLocalStorageHandlers, onRestore, classes}: {
           // eslint-disable-next-line no-console
           console.error("Error restoring from localStorage");
         }
-      }}>Restore Autosave</a>
+      }}>{preferredHeadingCase("Restore Autosave")}</a>
     </div>
     <div className={classes.restoreBody}> {displayedRestore} </div>
 


### PR DESCRIPTION
This updates the LocalStorageCheck to look like this:

<img width="736" alt="image" src="https://github.com/user-attachments/assets/da931259-a0aa-4c6a-9a2d-e99d6888b67d">

It uses htmlToTextDefault to convert it, which I'm not too familiar with but seemed to be available on the client.

It looks like `deserializeEditorContents` should automatically handle draftJS and I'm guessing htmlToTextDefault'll work fine with markdown, but I tried for 2 minutes to get markdown into my localStorage and it didn't quite work. My models say it should be fine, I can test harder if people think it's not fine.

I did do a horizontal resize test.
