### PR TITLE
Remove EA `footerBar` override for `NavigationStandalone`

### DIFF
--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -283,9 +283,6 @@ export const eaForumTheme: SiteThemeSpecification = {
           sidebar: {
             top: 26,
           },
-          footerBar: {
-            backgroundColor: palette.grey[200],
-          }
         },
         TabNavigationItem: {
           navButton: {


### PR DESCRIPTION
Commit be9dbc077a8c868d760b938317e0dc96865fe8b2 deleted the `footerBar` class from the `NavigationStandalone` component. The EA forum theme has an old override for this class that is now causing an annoying console error on server startup. There's no actualy bug here though since the EA Forum disabled the footer bar a couple of years ago.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208663064913902) by [Unito](https://www.unito.io)
