### PR TITLE
Streamlined GlossaryEditor, improved Tooltips

### DIFF
--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -388,13 +388,13 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
       <LWTooltip title="Enable all glossary hoverovers for readers of this post">
         <div className={classNames(classes.headerButton, sortedApprovedTerms.length !== 0 && classes.disabled)} 
           onClick={() => handleSetApproveAll(true)}>
-          ENABLE ALL
+          ENABLE ALL { sortedUnapprovedTerms.length > 0 && `(${sortedUnapprovedTerms.length})`}
         </div>
       </LWTooltip>
       <LWTooltip title="Disable all glossary hoverovers for readers of this post">
         <div className={classNames(classes.headerButton, sortedUnapprovedTerms.length !== 0 && classes.disabled)} 
           onClick={() => handleSetApproveAll(false)}>
-          DISABLE ALL
+          DISABLE ALL { sortedApprovedTerms.length > 0 && `(${sortedApprovedTerms.length})`}
         </div>
       </LWTooltip>
       <LWTooltip title={<div><p>Hide all terms that aren't currently enabled</p><p>(you can unhide them later)</p></div>}>
@@ -402,7 +402,7 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
       </LWTooltip>
       <LWTooltip title="Unhide all deleted terms">
         <div className={classNames(classes.headerButton, deletedTerms.length === 0 && classes.disabled)} onClick={handleUnhideAll}>
-          UNHIDE ALL ({deletedTerms.length})
+          UNHIDE ALL { deletedTerms.length > 0 && `(${deletedTerms.length})`}
         </div>
       </LWTooltip>
     </div>

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -65,7 +65,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: -16,
   },
   window: {
-    maxHeight: 230,
+    maxHeight: 215,
     overflowY: 'scroll',
     display: 'flex',
     justifyContent: 'space-between',
@@ -183,7 +183,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.primary.main,
     fontSize: 25,
     fontWeight: 900,
-    paddingLeft: 7,
+    paddingLeft: 1,
     paddingRight: 7
   },
   newTermButtonCancel: {

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -453,13 +453,14 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
             key={item._id} 
             jargonTerm={item} 
             instancesOfJargonCount={getCount(item)}
+            setShowMoreTerms={setShowMoreTerms}
           />;
         })}
         {deletedTerms.length > 0 && <div className={classes.button} onClick={() => setShowDeletedTerms(!showDeletedTerms)}>
           {showDeletedTerms ? "Hide deleted terms" : `Show deleted terms (${deletedTerms.length})`}
         </div>}
         {deletedTerms.length > 0 && showDeletedTerms && deletedTerms.map((item) => {
-          return <JargonEditorRow key={item._id} jargonTerm={item} instancesOfJargonCount={getCount(item)}/>
+          return <JargonEditorRow key={item._id} jargonTerm={item} instancesOfJargonCount={getCount(item)} setShowMoreTerms={setShowMoreTerms}/>
         })}
 
       </div>

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -388,13 +388,13 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
       <LWTooltip title="Enable all glossary hoverovers for readers of this post">
         <div className={classNames(classes.headerButton, sortedApprovedTerms.length !== 0 && classes.disabled)} 
           onClick={() => handleSetApproveAll(true)}>
-          ENABLE ALL { sortedUnapprovedTerms.length > 0 && `(${sortedUnapprovedTerms.length})`}
+          ENABLE ALL{ sortedUnapprovedTerms.length > 0 ? ` (${sortedUnapprovedTerms.length})` : '' }
         </div>
       </LWTooltip>
       <LWTooltip title="Disable all glossary hoverovers for readers of this post">
         <div className={classNames(classes.headerButton, sortedUnapprovedTerms.length !== 0 && classes.disabled)} 
           onClick={() => handleSetApproveAll(false)}>
-          DISABLE ALL { sortedApprovedTerms.length > 0 && `(${sortedApprovedTerms.length})`}
+          DISABLE ALL{ sortedApprovedTerms.length > 0 ?  ` (${sortedApprovedTerms.length})` : '' }
         </div>
       </LWTooltip>
       <LWTooltip title={<div><p>Hide all terms that aren't currently enabled</p><p>(you can unhide them later)</p></div>}>
@@ -402,7 +402,7 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
       </LWTooltip>
       <LWTooltip title="Unhide all deleted terms">
         <div className={classNames(classes.headerButton, deletedTerms.length === 0 && classes.disabled)} onClick={handleUnhideAll}>
-          UNHIDE ALL { deletedTerms.length > 0 && `(${deletedTerms.length})`}
+          UNHIDE ALL{ deletedTerms.length > 0 ? ` (${deletedTerms.length})` : '' }
         </div>
       </LWTooltip>
     </div>

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -261,7 +261,10 @@ export const JargonEditorRow = ({classes, jargonTerm, instancesOfJargonCount, se
           approved={jargonTerm.approved}
           forceTooltip={true}
         >
-          <div className={classNames(classes.explanationContainer, !jargonTerm.approved && classes.unapproved)} onClick={() => {setShowMoreTerms(true); setEdit(true)}}>
+          <div className={classNames(classes.explanationContainer, !jargonTerm.approved && classes.unapproved)} onClick={() => {
+            setShowMoreTerms(true);
+            setEdit(true);
+          }}>
             <ContentItemBody className={classes.definition} dangerouslySetInnerHTML={{ __html: jargonDefinition }} />
           </div>
         </JargonTooltip>}

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -41,6 +41,9 @@ const styles = (theme: ThemeType) => ({
   },
   unapproved: {
     opacity: .5,
+    '&:hover': {
+      opacity: 1
+    }
   },
   editButton: {
     cursor: 'pointer',

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -32,12 +32,8 @@ const styles = (theme: ThemeType) => ({
     ...commentBodyStyles(theme, true),
     marginTop: 0,
     padding: '0 6px',
-    borderBottom: theme.palette.border.commentBorder,
     display: 'flex',
     alignItems: 'center',
-    '&:last-child': {
-      borderBottom: 'none',
-    },
     '&:hover $bottomButton': {
       opacity: .5
     }
@@ -120,14 +116,17 @@ const styles = (theme: ThemeType) => ({
   },
   explanationContainer: {
     cursor: 'text',
-    paddingTop: 6,
-    paddingBottom: 10
+    paddingBottom: 4
   },
   checkbox: {
-    width: 30,
-    height: 30,
-    paddingRight: 28,
-    paddingLeft: 22,
+    width: 24,
+    height: 24,
+    paddingRight: 24,
+    paddingLeft: 14,
+    '& svg': {
+      width: 16,
+      height: 16,
+    }
   },
   instancesOfJargonCount: {
     width: 30,
@@ -140,7 +139,8 @@ const styles = (theme: ThemeType) => ({
     height: '1.6rem',
     overflow: 'hidden',
     minWidth: 100,
-    color: theme.palette.grey[600],
+    paddingRight: 8,
+    color: theme.palette.grey[500],
     '& strong': {
       color: theme.palette.grey[900],
       marginRight: 8

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -16,6 +16,7 @@ export const formStyles = {
   },
   '& .form-component-EditorFormComponent': {
     marginBottom: 0,
+    marginTop: 0,
     width: '100%',
   },
   '& .form-component-default, & .MuiTextField-textField': {
@@ -141,7 +142,7 @@ const styles = (theme: ThemeType) => ({
     minWidth: 100,
     paddingRight: 8,
     color: theme.palette.grey[500],
-    '& strong': {
+    '& strong, & b': {
       color: theme.palette.grey[900],
       marginRight: 8
     }
@@ -186,10 +187,11 @@ const JargonSubmitButton = ({ submitForm, cancelCallback, classes }: FormButtonP
 
 // Jargon editor row
 
-export const JargonEditorRow = ({classes, jargonTerm, instancesOfJargonCount}: {
+export const JargonEditorRow = ({classes, jargonTerm, instancesOfJargonCount, setShowMoreTerms}: {
   classes: ClassesType<typeof styles>,
   jargonTerm: JargonTerms,
   instancesOfJargonCount?: number,
+  setShowMoreTerms: (expanded: boolean) => void,
 }) => {
 
   const [edit, setEdit] = useState(false);
@@ -256,7 +258,7 @@ export const JargonEditorRow = ({classes, jargonTerm, instancesOfJargonCount}: {
           approved={jargonTerm.approved}
           forceTooltip={true}
         >
-          <div className={classNames(classes.explanationContainer, !jargonTerm.approved && classes.unapproved)} onClick={() => setEdit(true)}>
+          <div className={classNames(classes.explanationContainer, !jargonTerm.approved && classes.unapproved)} onClick={() => {setShowMoreTerms(true); setEdit(true)}}>
             <ContentItemBody className={classes.definition} dangerouslySetInnerHTML={{ __html: jargonDefinition }} />
           </div>
         </JargonTooltip>}

--- a/packages/lesswrong/components/jargon/JargonTooltip.tsx
+++ b/packages/lesswrong/components/jargon/JargonTooltip.tsx
@@ -5,11 +5,12 @@ import { commentBodyStyles } from '@/themes/stylePiping';
 import { ContentReplacedSubstringComponentInfo } from '../common/ContentItemBody';
 import { PopperPlacementType } from '@material-ui/core/Popper';
 import { useGlossaryPinnedState } from '../hooks/useUpdateGlossaryPinnedState';
+import { ForumIconName } from '../common/ForumIcon';
 
 const styles = (theme: ThemeType) => ({
   card: {
     padding: 16,
-    paddingBottom: 12,
+    paddingBottom: 10,
     backgroundColor: theme.palette.background.pageActiveAreaBackground,
     maxWidth: 350,
     ...commentBodyStyles(theme),
@@ -27,7 +28,7 @@ const styles = (theme: ThemeType) => ({
       color: theme.palette.text.jargonTerm,
     },
   },
-  altTerms: {
+  metadata: {
     marginTop: 8,
     display: 'flex',
     justifyContent: 'space-between',
@@ -41,6 +42,12 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[600],
     fontSize: "0.8em",
     marginBottom: 8,
+  },
+  icon: {
+    width: 12,
+    height: 12,
+    color: theme.palette.grey[400],
+    marginRight: 4,
   }
 });
 
@@ -57,29 +64,30 @@ export const JargonTooltip = ({definitionHTML, approved, altTerms, humansAndOrAI
   tooltipTitleClassName?: string,
   forceTooltip?: boolean,
 }) => {
-  const { LWTooltip, ContentItemBody } = Components;
+  const { LWTooltip, ContentItemBody, ForumIcon } = Components;
 
   const { postGlossariesPinned } = useGlossaryPinnedState();
 
   let humansAndOrAIEditedText = 'AI Generated'
+  let icons = <ForumIcon icon="Sparkles" className={classes.icon}/>;
   if (humansAndOrAIEdited === 'humans') {
     humansAndOrAIEditedText = 'Edited by Human';
+    icons = <ForumIcon icon="Pencil" className={classes.icon}/>;
   } else if (humansAndOrAIEdited === 'humansAndAI') {
     humansAndOrAIEditedText = 'Edited by AI and Human';
+    icons = <> <ForumIcon icon="Sparkles" className={classes.icon}/> <ForumIcon icon="Pencil" className={classes.icon}/> </>;
   }
 
   const tooltip = <Card className={classes.card}>
-    {!approved && <div className={classes.unapprovedLabel}>Unapproved [admin only]</div>}
     <ContentItemBody
       dangerouslySetInnerHTML={{ __html: definitionHTML }}
     />
-    <div className={classes.altTerms}>
-      <div>
-        {altTerms.map((term: string) => (
-        <span className={classes.altTerm} key={term}>{term}</span>
-        ))}
-      </div>
-      {humansAndOrAIEditedText && <div><span className={classes.altTerm}>{humansAndOrAIEditedText}</span></div>}
+    <div className={classes.metadata}>
+      {humansAndOrAIEditedText && <div><span className={classes.altTerm}>
+        {icons}{humansAndOrAIEditedText}
+      </span></div>}
+
+      {!approved && <div className={classes.unapprovedLabel}>Unapproved [admin only]</div>}
     </div>
   </Card>
 

--- a/packages/lesswrong/components/jargon/JargonTooltip.tsx
+++ b/packages/lesswrong/components/jargon/JargonTooltip.tsx
@@ -32,6 +32,7 @@ const styles = (theme: ThemeType) => ({
     marginTop: 8,
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
   },
   altTerm: {
     color: theme.palette.grey[600],
@@ -48,6 +49,8 @@ const styles = (theme: ThemeType) => ({
     height: 12,
     color: theme.palette.grey[400],
     marginRight: 4,
+    position: 'relative',
+    top: 1,
   }
 });
 

--- a/packages/lesswrong/components/jargon/JargonTooltip.tsx
+++ b/packages/lesswrong/components/jargon/JargonTooltip.tsx
@@ -78,7 +78,10 @@ export const JargonTooltip = ({definitionHTML, approved, altTerms, humansAndOrAI
     icons = <ForumIcon icon="Pencil" className={classes.icon}/>;
   } else if (humansAndOrAIEdited === 'humansAndAI') {
     humansAndOrAIEditedText = 'Edited by AI and Human';
-    icons = <> <ForumIcon icon="Sparkles" className={classes.icon}/> <ForumIcon icon="Pencil" className={classes.icon}/> </>;
+    icons = <>
+      <ForumIcon icon="Sparkles" className={classes.icon}/>
+      <ForumIcon icon="Pencil" className={classes.icon}/>
+    </>;
   }
 
   const tooltip = <Card className={classes.card}>


### PR DESCRIPTION
I made the JargonEditorRow more like a dense glossary than like a postItem, so that it was easier to fit them all on the screen at once. On net, I think this is less overwhelming, although not strictly so.

<img width="806" alt="image" src="https://github.com/user-attachments/assets/0e84ece2-43f3-44fb-b73f-032523740ff8">

<img width="818" alt="image" src="https://github.com/user-attachments/assets/f488e663-4beb-4e2c-90cd-9a30ef3b071f">

(this post has more terms than we'd ideally like, which we are also working on cutting down, but, this shows the diff in how it feels for a larger glossary)

<img width="842" alt="image" src="https://github.com/user-attachments/assets/eecc5825-b59a-4526-a4a2-6d1ce2a01b1a">

<img width="841" alt="image" src="https://github.com/user-attachments/assets/a3f019ba-fadb-4f97-92e1-038c27973f4b">



Adds icons to the "AI generated"
<img width="412" alt="image" src="https://github.com/user-attachments/assets/a711f84f-7f1a-4fd5-be4b-4dbd614c0b76">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208664504944264) by [Unito](https://www.unito.io)
