### PR TITLE
Use `facetFilters` instead of `filters` for `AddTag` wiki filter

### DIFF
--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -96,7 +96,7 @@ const AddTag = ({onTagSelected, isVotingContext, classes}: {
        // @ts-ignore */}
       <SearchBox reset={null} focusShortcuts={[]}/>
       <Configure
-        filters="wikiOnly:false"
+        facetFilters={[["wikiOnly:false"]]}
         hitsPerPage={searchOpen ? 12 : 6}
       />
       <Hits hitComponent={({hit}) =>


### PR DESCRIPTION
Bug reported on slack where wiki only tags are showing up when searching for tags to add to a post. See #7861 for why this fix works.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208665081948043) by [Unito](https://www.unito.io)
