### PR TITLE
create marginal jargon as deleted terms by default

### DIFF
--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -16,7 +16,7 @@ We're about to provide you with the text of an essay, followed by a list of jarg
 
 For each term, provide:
   
-The term itself (wrapped in a <strong> tag), followed by a concise one-line definition. Then, on a separate paragraph, explain how the term is used here. If the term has a well-established origin, briefly mention it.
+The term itself (wrapped in a <strong> tag), followed by a concise one-line definition. Then, on a separate paragraph, explain how the term is used here.
 
 Ensure that your explanations are clear and accessible to someone who may not be familiar with the subject matter. Follow Strunk and White guidelines. 
 

--- a/packages/lesswrong/server/resolvers/jargonResolvers/jargonPrompts.ts
+++ b/packages/lesswrong/server/resolvers/jargonResolvers/jargonPrompts.ts
@@ -4,4 +4,6 @@ Also avoid including terms that are 3+ word phrases unless it is a complete noun
 
 Then, use the "reasoning" field to reason about which terms should be excluded if you were to optimize even harder for avoiding "false positives" - terms which are most likely to already be known to LessWrong readers, which are therefore least likely to be beneficial to display in a glossary.
 
-Finally, return that second list of terms in the "likelyKnownJargonTerms" field.  It's fine if the second list is empty, if the first list is composed entirely of terms that are highly technical.`;
+Next, return that second list of terms in the "likelyKnownJargonTerms" field.  It's fine if the second list is empty, if the first list is composed entirely of terms that are highly technical.
+
+Finally, return a third list of terms in the "marginalTerms" field.  This should be a list of two to five terms that are not in the first list, but are the next most likely candidates for inclusion in a glossary.`;


### PR DESCRIPTION
Get some additional "marginal" terms, and create all the "likely known" and "marginal" terms as deleted terms by default.  This give authors access to them if they want more without overwhelming their default view.