### PR TITLE
implement functionality to toggle visibility of unapproved jargon terms on posts

### DIFF
--- a/packages/lesswrong/lib/collections/jargonTerms/fragments.ts
+++ b/packages/lesswrong/lib/collections/jargonTerms/fragments.ts
@@ -21,6 +21,7 @@ registerFragment(`
     term
     humansAndOrAIEdited
     approved
+    deleted
     altTerms
     contents {
       ...RevisionDisplay

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -859,8 +859,8 @@ const schema: SchemaType<"Posts"> = {
         return [];
       }
 
-      const approvedClause = userCanViewUnapprovedJargonTerms(context.currentUser) ? {} : { approved: true };
-      const jargonTerms = await context.JargonTerms.find({ postId: post._id, deleted: false, ...approvedClause }, { sort: { term: 1 }}).fetch();
+      // const approvedClause = userCanViewUnapprovedJargonTerms(context.currentUser) ? {} : { approved: true };
+      const jargonTerms = await context.JargonTerms.find({ postId: post._id }, { sort: { term: 1 }}).fetch();
 
       return await accessFilterMultiple(context.currentUser, context.JargonTerms, jargonTerms, context);
     },
@@ -868,11 +868,6 @@ const schema: SchemaType<"Posts"> = {
       SELECT ARRAY_AGG(ROW_TO_JSON(jt.*) ORDER BY jt."term" ASC)
       FROM "JargonTerms" jt
       WHERE jt."postId" = ${field('_id')}
-      AND CASE WHEN ${currentUserField('isAdmin')} IS NOT TRUE 
-        THEN jt."approved" IS TRUE 
-        ELSE TRUE 
-      END
-      AND jt."deleted" IS NOT TRUE
       LIMIT 1
     )`
   }),

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -4211,6 +4211,7 @@ interface JargonTermsPost { // fragment on JargonTerms
   readonly term: string,
   readonly humansAndOrAIEdited: "humans" | "AI" | "humansAndAI" | null,
   readonly approved: boolean,
+  readonly deleted: boolean,
   readonly altTerms: Array<string>,
   readonly contents: RevisionDisplay|null,
 }


### PR DESCRIPTION
Adds both a new button and hotkey (opt + shift + G) that allows users to "enable" unapproved & deleted terms on posts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208672272923115) by [Unito](https://www.unito.io)
