### PR TITLE
Reduced size of user menu; added dialogue button to user profile

### DIFF
--- a/packages/lesswrong/components/dropdowns/DropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownItem.tsx
@@ -35,7 +35,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     flexGrow: 1,
-    overflow: "hidden",
+    overflowX: "clip",
     textOverflow: "ellipsis",
   },
   afterIcon: {

--- a/packages/lesswrong/components/posts/NewDialogueDialog.tsx
+++ b/packages/lesswrong/components/posts/NewDialogueDialog.tsx
@@ -45,14 +45,15 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const NewDialogueDialog = ({onClose, classes}: {
+const NewDialogueDialog = ({initialParticipantIds, onClose, classes}: {
+  initialParticipantIds?: string[],
   onClose: () => void,
   classes: ClassesType,
 }) => {
   const { UserMultiselect, LWDialog, Loading, EAButton } = Components;
   const [title, setTitle] = useState("");
   const {flash} = useMessages();
-  const [participants, setParticipants] = useState<string[]>([]);
+  const [participants, setParticipants] = useState<string[]>(initialParticipantIds ?? []);
   const {create: createPost, loading} = useCreate({ collectionName: "Posts", fragmentName: "PostsEdit" });
   const navigate = useNavigate();
 

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -210,9 +210,11 @@ const UsersMenu = ({classes}: {
         : null,
   } as const;
 
+  const hasBookmarks = (currentUser?.bookmarkedPostsMetadata.length ?? 0) >= 1;
+
   const order: (keyof typeof items)[] = isFriendlyUI
     ? ["newPost", "newShortform", "newQuestion", "newDialogue", "divider", "newEvent", "newSequence"]
-    : ["newQuestion", "newPost", "newDialogue", "newShortform", "divider", "newEvent", "newSequence"];
+    : ["newShortform", "newPost", "newEvent"];
 
   return (
     <div className={classes.root} {...eventHandlers}>
@@ -270,14 +272,6 @@ const UsersMenu = ({classes}: {
                   }
                 />
               }
-              {!isEAForum &&
-                <DropdownItem
-                  title={preferredHeadingCase("My Drafts")}
-                  to="/drafts"
-                  icon="Edit"
-                  iconClassName={classes.icon}
-                />
-              }
               {!currentUser.deleted &&
                 <DropdownItem
                   title={preferredHeadingCase("User Profile")}
@@ -286,6 +280,15 @@ const UsersMenu = ({classes}: {
                   iconClassName={classes.icon}
                 />
               }
+               {!isEAForum &&
+                <DropdownItem
+                  title={preferredHeadingCase("My Drafts")}
+                  to="/drafts"
+                  icon="Edit"
+                  iconClassName={classes.icon}
+                />
+              }
+              {!isFriendlyUI && messagesNode}
               {userHasThemePicker(currentUser) &&
                 <ThemePickerMenu>
                   <DropdownItem
@@ -306,15 +309,14 @@ const UsersMenu = ({classes}: {
                 icon="BarChart"
                 iconClassName={classes.icon}
               />}
-              {!isFriendlyUI && accountSettingsNode}
-              {!isFriendlyUI && messagesNode}
-              <DropdownItem
+              {hasBookmarks &&<DropdownItem
                 title={isFriendlyUI ? "Saved & read" : "Bookmarks"}
                 to={isFriendlyUI ? "/saved" : "/bookmarks"}
                 icon="Bookmarks"
                 iconClassName={classes.icon}
-              />
-              {currentUser.shortformFeedId &&
+              />}
+              {!isFriendlyUI && accountSettingsNode}
+              {isFriendlyUI && currentUser.shortformFeedId &&
                 <DropdownItem
                   // TODO: get Habryka's take on what the title here should be
                   title={preferredHeadingCase("Your Quick Takes")}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -25,6 +25,7 @@ import CopyIcon from '@material-ui/icons/FileCopy'
 import { getUserStructuredData } from './UsersSingle';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { COMMENT_SORTING_MODES } from '@/lib/collections/comments/views';
+import { useDialog } from '../common/withDialog';
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -103,7 +104,11 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('xs')]: {
       marginRight: 0,
     },
-  }
+  },
+  dialogueButton: {
+    display: 'flex',
+    alignItems: 'center',
+  },
 })
 
 export const getUserFromResults = <T extends UsersMinimumInfo>(results: Array<T>|null|undefined): T|null => {
@@ -130,6 +135,8 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const user = getUserFromResults(results)
   
   const { query } = useLocation()
+
+  const { openDialog } = useDialog();
 
   const displaySequenceSection = (canEdit: boolean, user: UsersProfile) => {
     if (isAF) {
@@ -201,7 +208,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, LocalGroupsList,
       PostsListSettings, PostsList2, NewConversationButton, TagEditsByUser, DialogGroup,
       SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags,
-      Typography, ContentStyles, ReportUserButton, LWTooltip, UserNotifyDropdown, CommentsSortBySelector } = Components
+      Typography, ContentStyles, ReportUserButton, LWTooltip, UserNotifyDropdown, CommentsSortBySelector, NewDialogueDialog } = Components
 
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
@@ -307,6 +314,17 @@ const UsersProfileFn = ({terms, slug, classes}: {
               { showMessageButton && <NewConversationButton user={user} currentUser={currentUser}>
                 <a>Message</a>
               </NewConversationButton> }
+              { showMessageButton && (
+                <div
+                  className={classes.subscribeButton}
+                  onClick={() => openDialog({ 
+                    componentName: "NewDialogueDialog", 
+                    componentProps: { initialParticipantIds: [user._id] } 
+                  })}
+                >
+                  <a>Dialogue</a>
+                </div>
+              )}
               { <UserNotifyDropdown 
                 user={user} 
                 popperPlacement="bottom-end"


### PR DESCRIPTION
On LW removed buttons from the long user menu that were not getting any use. We still need some way to make dialogues, so every user profile has a 'dialogue' button to start a dialogue with them. Made bookmarks only appear conditional on having at least 1 bookmark. Also fixed a bug in the menu where the bottom of the g of 'log out' was clipped. Forum gated, shouldn't affect EA Forum menu.

Before and after images here.

![image](https://github.com/user-attachments/assets/f9273c55-2483-4bab-ad7e-9c25b9aa607c)

<img width="228" alt="Screenshot 2024-10-31 at 6 07 38 PM" src="https://github.com/user-attachments/assets/8a22298f-a888-494a-a882-9c66249b607c">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208672899210479) by [Unito](https://www.unito.io)
