### PR TITLE
Remove jargon callbacks

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -721,6 +721,6 @@ async function createNewJargonTermsCallback(post: DbPost, callbackProperties: Cr
   return post;
 }
 
-getCollectionHooks("Posts").createAfter.add(createNewJargonTermsCallback);
+// getCollectionHooks("Posts").createAfter.add(createNewJargonTermsCallback);
 
-getCollectionHooks("Posts").updateAfter.add(createNewJargonTermsCallback);
+// getCollectionHooks("Posts").updateAfter.add(createNewJargonTermsCallback);


### PR DESCRIPTION
It was pointed out it wasn't super cool of us to start sending private drafts to LLMs. This reverts the callback for now.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208674133217526) by [Unito](https://www.unito.io)
