### PR TITLE
Fix shortform Schema.org

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -181,7 +181,7 @@ const getStructuredData = ({
     "@context": "http://schema.org",
     "@type": "DiscussionForumPosting",
     "url": postGetPageUrl(post, true),
-    "text": post.contents?.html,
+    "text": post.contents?.html ?? description,
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": postGetPageUrl(post, true),


### PR DESCRIPTION
Adds a fallback to the schema.org creation if the post content is empty (such as in shortforms)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208682224251137) by [Unito](https://www.unito.io)
