### PR TITLE
Fix a weird timing-dependent issue where sidenotes could have their links missing

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Card from '@material-ui/core/Card';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useHover } from '../common/withHover';
@@ -145,37 +145,14 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
   });
   const { eventHandlers: sidenoteEventHandlers, hover: sidenoteHovered } = useHover();
   const eitherHovered = anchorHovered || sidenoteHovered;
+  const [footnoteHTML,setFootnoteHTML] = useState<string|null>(null);
   
-  let footnoteContentsNonempty = false;
-  let footnoteHTML = "";
-  
-  // Get the contents of the linked footnote.
-  // This has a try-catch-ignore around it because the link doesn't necessarily
-  // make a valid CSS selector; eg there are some posts in the DB with internal
-  // links to anchors like "#fn:1" which will crash this because it has a ':' in
-  // it.
-  try {
-    // `href` is (probably) an anchor link, of the form `#fn1234`. Since it starts
-    // with a hash it can also be used as a CSS selector, which finds its contents
-    // in the footer.
-    const footnoteContentsElement = document.querySelector(href);
-    footnoteHTML = footnoteContentsElement?.innerHTML || "";
-    
-    // Decide whether the footnote is nonempty. This is tricky because while there
-    // are consistently formatted footnotes created by our editor plugins, there
-    // are also wacky irregular footnotes present in imported HTML and similar
-    // things. Eg https://www.lesswrong.com/posts/ACGeaAk6KButv2xwQ/the-halo-effect
-    // We can't just condition on the footnote containing non-whitespace text,
-    // because footnotes sometimes have their number and backlink in a place that
-    // would be mistaken for their body. Our current heuristic is that a footnote
-    // is nonempty if it contains at least one <p> which contains non-whitespace
-    // text, which might false-negative on rare cases like an image-only footnote
-    // but which seems to work in practice.
-    footnoteContentsNonempty = !!footnoteContentsElement
-      && !!Array.from(footnoteContentsElement.querySelectorAll("p"))
-        .reduce((acc, p) => acc + p.textContent, "").trim();
-  // eslint-disable-next-line no-empty
-  } catch(e) { }
+  useEffect(() => {
+    const extractedFootnoteHTML = extractFootnoteHTML(href);
+    if (extractedFootnoteHTML) {
+      setFootnoteHTML((oldFootnoteHTML) => oldFootnoteHTML ?? extractedFootnoteHTML);
+    }
+  }, [href]);
   
   // TODO: Getting the footnote content from the DOM didn't necessarily work;
   // for example if the page was only showing an excerpt (with the rest hidden
@@ -186,7 +163,7 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
   // information isn't wired to pass through the hover-preview system.
 
   const onClick = useCallback((ev: React.MouseEvent) => {
-    if (isRegularClick(ev) && isMobile()) {
+    if (isRegularClick(ev) && isMobile() && footnoteHTML !== null) {
       setDisableHover(true);
       openDialog({
         componentName: "FootnoteDialog",
@@ -209,7 +186,7 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
 
   return (
     <span>
-      {footnoteContentsNonempty && !disableHover && <LWPopper
+      {footnoteHTML !== null && !disableHover && <LWPopper
         open={anchorHovered && !sidenoteIsVisible}
         anchorEl={anchorEl}
         placement="bottom-start"
@@ -222,7 +199,7 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
         </Card>
       </LWPopper>}
       
-      {hasSidenotes && !sidenotesDisabledOnPost && footnoteContentsNonempty &&
+      {hasSidenotes && !sidenotesDisabledOnPost && footnoteHTML !== null &&
         <SideItem options={{offsetTop: -6}}>
           <div
             {...sidenoteEventHandlers}
@@ -255,6 +232,44 @@ const FootnotePreview = ({classes, href, id, rel, children}: {
       </a>
     </span>
   );
+}
+
+function extractFootnoteHTML(href: string): string|null {
+  // Get the contents of the linked footnote.
+  // This has a try-catch-ignore around it because the link doesn't necessarily
+  // make a valid CSS selector; eg there are some posts in the DB with internal
+  // links to anchors like "#fn:1" which will crash this because it has a ':' in
+  // it.
+  try {
+    // `href` is (probably) an anchor link, of the form `#fn1234`. Since it starts
+    // with a hash it can also be used as a CSS selector, which finds its contents
+    // in the footer.
+    const footnoteContentsElement = document.querySelector(href);
+    const footnoteHTML = footnoteContentsElement?.innerHTML ?? null;
+    
+    // Decide whether the footnote is nonempty. This is tricky because while there
+    // are consistently formatted footnotes created by our editor plugins, there
+    // are also wacky irregular footnotes present in imported HTML and similar
+    // things. Eg https://www.lesswrong.com/posts/ACGeaAk6KButv2xwQ/the-halo-effect
+    // We can't just condition on the footnote containing non-whitespace text,
+    // because footnotes sometimes have their number and backlink in a place that
+    // would be mistaken for their body. Our current heuristic is that a footnote
+    // is nonempty if it contains at least one <p> which contains non-whitespace
+    // text, which might false-negative on rare cases like an image-only footnote
+    // but which seems to work in practice.
+    const footnoteContentsNonempty = !!footnoteContentsElement
+      && !!Array.from(footnoteContentsElement.querySelectorAll("p"))
+        .reduce((acc, p) => acc + p.textContent, "").trim();
+    
+    if (footnoteContentsNonempty) {
+      return footnoteHTML;
+    } else {
+      return null;
+    }
+  // eslint-disable-next-line no-empty
+  } catch(e) {
+    return null;
+  }
 }
 
 const SidenoteDisplay = ({footnoteHref, footnoteHTML, classes}: {

--- a/packages/lesswrong/lib/utils/rawDom.tsx
+++ b/packages/lesswrong/lib/utils/rawDom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { isClient } from "../executionEnvironment";
 
 
@@ -40,7 +40,10 @@ export function rawDomNodeToReactComponent(node: Node) {
   function DomNodeComponent(props: {}) {
     const containerRef = useRef<HTMLSpanElement|null>(null);
     
-    useEffect(() => {
+    // Insert contents in `useLayoutEffect` so that the screen can't paint with
+    // substituted content missing, and so that it precedes any `useEffect`s
+    // (most notably the footnote-extraction useEffect in `FootnotePreview`).
+    useLayoutEffect(() => {
       if (containerRef.current) {
         // If this has been attached somewhere else, detach it
         if (node.parentElement && node.parentElement !== containerRef.current) {


### PR DESCRIPTION
Affected test post: http://localhost:3000/posts/53b9woahSTPQFtB2i/notes-on-self-control

`FootnotePreview` was extracting the footnote contents from the DOM in its render function, which has a subtle timing issue: if render functions and effects run in a particular order, it could extract the footnote contents in between when link-previews in the footnotes get replaced by portals, and when previewable-links get rendered into those portals. The practical upshot of which is that on at least one post (but not the majority of posts), sidenotes are missing their links, at least until something causes them to rerender.

Fix this by moving the content insertion in `rawDomNodeToReactComponent` from `useEffect` to `useLayoutEffect`, guaranteeing that it will happen before any `useEffect`s happen, and move the extraction in `FootnotePreview` from the render function (in which the state of the DOM is undefined) to a `useEffect`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208683075509408) by [Unito](https://www.unito.io)
