### PR TITLE
Remove http->https redirect from nginx config

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -44,9 +44,13 @@ http {
 
         access_log    /var/log/nginx/access.log main;
 
-        if ($http_x_forwarded_proto = 'http'){
-            return 301 https://$host$request_uri;
-        }
+        # Uncomment for an http->https redirect. Commented out because when
+        # adding Cloudfront to the LW development test server, this resulted in
+        # a redirect loop. There is already an http->https redirect happening
+        # somewhere in our hosting stack.
+        #if ($http_x_forwarded_proto = 'http'){
+        #    return 301 https://$host$request_uri;
+        #}
 
         location / {
             proxy_pass            http://docker;


### PR DESCRIPTION
When I added Cloudfront as a caching proxy in front of an LW development staging server (baserates.org), it resulted in a redirect loop, because some request forwarding within AWS infra was http, even though the external connection was https. Looking at how our http->https redirects work in general, this redirector seems to be redundant; on all of LW, AF, and EA Forum, clients get redirected from http->https before the request gets far enough for nginx to see it; we can tell that the https redirection that's triggering is not this one, because that https redirection uses a 307 status code rather than 301.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208683768193994) by [Unito](https://www.unito.io)
