### PR TITLE
Unify mention experience to suggest users, posts and tags on `@` 

### DIFF
--- a/packages/lesswrong/components/search/UsersSearchAutocompleteHit.tsx
+++ b/packages/lesswrong/components/search/UsersSearchAutocompleteHit.tsx
@@ -2,38 +2,36 @@ import {Components, registerComponent} from '../../lib/vulcan-lib'
 import React from 'react'
 import {styles as metaInfo} from '../common/MetaInfo'
 
-const specificityFmClass = 'forum-magnum'
-const specificityCkClass = 'ck-override'
 const styles = (theme: ThemeType): JssStyles => ({
   userHitLabel: {
-    // A specificity hack to work around https://github.com/ckeditor/ckeditor5/issues/3424
-    [`&.${specificityFmClass}.${specificityCkClass}, &.${specificityFmClass}.${specificityCkClass} *`]: {
-      ...theme.typography.body2,
-      ...metaInfo(theme).root,
-      marginLeft: theme.spacing.unit,
+    ...theme.typography.body2,
+    ...metaInfo(theme).root,
+    marginLeft: theme.spacing.unit,
+
+    // To properly switch color on item being selected
+    [`.ck-on &`]: {
+      color: 'inherit',
     },
+  },
+  
+  root: {
+    color: 'inherit',
   },
 })
 
-
-interface UsersSearchAutocompleteHitProps {
+const UsersSearchAutocompleteHit = ({hit, classes}: {
+  hit: SearchUser
   classes: ClassesType
-  name: string
-  createdAt: Date
-  karma?: number
-}
-
-const UsersSearchAutocompleteHit = (props: UsersSearchAutocompleteHitProps) => {
+}) => {
   const {MetaInfo, FormatDate} = Components
 
-  const metaClassName = `${props.classes.userHitLabel} ${specificityFmClass} ${specificityCkClass}`
-  return <span>
-    {props.name}
-    <MetaInfo className={metaClassName}>
-      <FormatDate date={props.createdAt} tooltip={false} />
+  return <span className={classes.root}>
+    {hit.displayName}
+    <MetaInfo className={classes.userHitLabel}>
+      <FormatDate date={hit.createdAt} tooltip={false}/>
     </MetaInfo>
-    <MetaInfo className={metaClassName}>
-      {props.karma || 0} karma
+    <MetaInfo className={classes.userHitLabel}>
+      {hit.karma || 0} karma
     </MetaInfo>
   </span>
 }


### PR DESCRIPTION
This unifies Mention mechanism to suggest all different mentionable things when you type `@` as discussed in https://lworg.slack.com/archives/CJY3ZKP62/p1714432896659669

Also adds support for mentioning tags and improves display of user mentions (previously selected items were hard to see)

Demo: https://www.loom.com/share/173c93d928534f6c8715dc73dff82de7 

2 things I mention in the video I’m unhappy about:
1. rn the results are returned in the users > tags > posts order, ideally one would sort them based on relevance or smth, but I’m not sure if I have that information in the search result anywhere?
1. search would return results that are too fuzzy (in this case one probably wants direct name match 95%+ of the time) but probably other things get taken into account and so results are less relevant sometimes. is there a way to configure search to be more strict in this specific case?

1 is more annoying bc 2 is a thing

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208703654681371) by [Unito](https://www.unito.io)
