### PR TITLE
Remove old event palette colours

### DIFF
--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -498,10 +498,6 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
     onboardingBackground: "rgba(0, 0, 0, 0.4)",
     onboardingBackgroundHover: "rgba(0, 0, 0, 0.2)",
     onboardingBackgroundSelected: "rgba(0, 0, 0, 0.5)",
-    eventLightGreen: 'rgba(154, 176, 137, 0.30)',
-    eventDarkGreen: 'rgba(154, 176, 137, 0.60)',
-    eventLightBlue: 'rgba(65, 131, 161, 0.30)',
-    eventDarkBlue: 'rgba(65, 131, 161, 0.60)',
   },
   tab: {
     inactive: {

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -432,10 +432,6 @@ declare global {
       onboardingBackground: ColorString,
       onboardingBackgroundHover: ColorString,
       onboardingBackgroundSelected: ColorString,
-      eventLightGreen: ColorString,
-      eventDarkGreen: ColorString,
-      eventLightBlue: ColorString,
-      eventDarkBlue: ColorString,
     },
     tab: {
       inactive: {


### PR DESCRIPTION
These palette colours are no longer used (they were added for an event in #9838)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208706493181580) by [Unito](https://www.unito.io)
