### PR TITLE
save updated jargon prompts in localstorage

### DIFF
--- a/packages/lesswrong/components/hooks/useLocalStorageState.tsx
+++ b/packages/lesswrong/components/hooks/useLocalStorageState.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+import { getBrowserLocalStorage } from "../editor/localStorageHandlers";
+import { capitalize } from "@/lib/vulcan-lib/utils";
+
+type LocalPromptExample<Suffix extends string> = {
+  [K in Suffix]: string | undefined;
+} & {
+  [K in `set${Capitalize<Suffix>}`]: React.Dispatch<string>;
+};
+
+/**
+ * A React hook for managing state that persists in localStorage.
+ * 
+ * This hook creates a state variable that is synchronized with localStorage, allowing state to persist
+ * across page refreshes and browser sessions. It returns an object with the current value and a setter
+ * function, similar to useState.
+ * 
+ * The hook takes a key suffix and a function to generate the full storage key, allowing for namespaced
+ * storage keys (e.g. prefixed with user IDs). If the value is set to the default, it will be removed
+ * from localStorage. This is so that if we change the default value, we don't have to worry about
+ * migrating old values that were stored under the old default.
+ * 
+ * @param key - The suffix for the localStorage key
+ * @param getStorageKey - Function to generate the full storage key
+ * @param defaultValue - Default value to use if nothing exists in localStorage
+ * @returns An object with the current value and a setter function, with keys determined by the suffix
+ * 
+ * @example
+ * const { myValue, setMyValue } = useLocalStorageState(
+ *   "myValue",
+ *   (key) => `user_${userId}_${key}`,
+ *   "default"
+ * );
+ */
+
+export function useLocalStorageState<Suffix extends string>(key: Suffix, getStorageKey: (key: string) => string, defaultValue: string): LocalPromptExample<Suffix> {
+  const ls = getBrowserLocalStorage();
+  const storageKey = getStorageKey(key);
+  const [value, setValue] = useState<string | undefined>(defaultValue);
+
+  const lsSetValue = useCallback((value: string) => {
+    setValue(value);
+    if (value === defaultValue) {
+      ls?.removeItem(storageKey);
+    } else {
+      ls?.setItem(storageKey, value);
+    }
+  }, [ls, storageKey, defaultValue]);
+
+  const capitalizedSuffix = capitalize(key);
+
+  useEffect(() => {
+    const storedValue = ls?.getItem(storageKey);
+    if (storedValue) setValue(storedValue);
+  }, [storageKey, ls]);
+
+  return {
+    [key]: value,
+    [`set${capitalizedSuffix}`]: lsSetValue,
+  } as LocalPromptExample<Suffix>;
+}


### PR DESCRIPTION
Save user-modified jargon bot prompts in local storage.  Also, we now have a hook to manage the pattern of "stick something into localStorage while also handling it as a piece of react state", which comes up sometimes.  It makes the marginally-opinionated choice to clear the value stored in LS if it gets set to whatever the "default" value is, in order to avoid the problem of users making some change and then undoing it, and then getting stuck on the old default in case we ever ship a new one.  (Which we might very well do with JargonBot.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208721580690974) by [Unito](https://www.unito.io)
