### PR TITLE
User profile page lets you sort comments by Magic (New & Upvoted)

### DIFF
--- a/packages/lesswrong/components/comments/CommentsSortBySelector.tsx
+++ b/packages/lesswrong/components/comments/CommentsSortBySelector.tsx
@@ -18,6 +18,7 @@ export const CommentsSortBySelector = ({setRestoreScrollPos}: {
 
   const sortByOptions = [
     {value: "top", label: "Top"},
+    {value: "magic", label: "Magic (New & Upvoted)"},
     {value: "new", label: "Newest"},
     {value: "old", label: "Oldest"},
     {value: "recentComments", label: "Recent Replies"}

--- a/packages/lesswrong/components/comments/RecentComments.tsx
+++ b/packages/lesswrong/components/comments/RecentComments.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
+import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles =>  ({
   root: {
     [theme.breakpoints.up('sm')]: {
       marginRight: theme.spacing.unit*4,
     }
-  }
+  },
+  verticalHeightSpacer: {
+    minHeight: "100vh",
+  },
 })
 
 const RecentComments = ({classes, terms, truncated=false, showPinnedOnProfile=false, noResultsMessage="No Comments Found"}: {
@@ -17,7 +21,7 @@ const RecentComments = ({classes, terms, truncated=false, showPinnedOnProfile=fa
   showPinnedOnProfile?: boolean,
   noResultsMessage?: string,
 }) => {
-  const { loadingInitial, loadMoreProps, results } = useMulti({
+  const { loadingInitial, loadMoreProps, loading, results } = useMulti({
     terms,
     collectionName: "Comments",
     fragmentName: 'CommentsListWithParentMetadata',
@@ -30,30 +34,30 @@ const RecentComments = ({classes, terms, truncated=false, showPinnedOnProfile=fa
     return (<Components.Typography variant="body2">{noResultsMessage}</Components.Typography>)
   }
   if (loadingInitial || !validResults) {
-    return <Components.Loading />
+    return <div className={classes.verticalHeightSpacer}>
+      <Components.Loading />
+    </div>
   }
   
-  return (
-    <div className={classes.root}>
-      {validResults.map(comment =>
-        <div key={comment._id}>
-          <Components.CommentsNode
-            treeOptions={{
-              condensed: false,
-              post: comment.post || undefined,
-              tag: comment.tag || undefined,
-              showPostTitle: true,
-              forceNotSingleLine: true
-            }}
-            comment={comment}
-            startThreadTruncated={truncated}
-            showPinnedOnProfile={showPinnedOnProfile}
-          />
-        </div>
-      )}
-      <Components.LoadMore {...loadMoreProps} />
-    </div>
-  )
+  return <div className={classes.root}>
+    {validResults.map(comment =>
+      <div key={comment._id}>
+        <Components.CommentsNode
+          treeOptions={{
+            condensed: false,
+            post: comment.post || undefined,
+            tag: comment.tag || undefined,
+            showPostTitle: true,
+            forceNotSingleLine: true
+          }}
+          comment={comment}
+          startThreadTruncated={truncated}
+          showPinnedOnProfile={showPinnedOnProfile}
+        />
+      </div>
+    )}
+    <Components.LoadMore {...loadMoreProps} />
+  </div>
 }
 
 const RecentCommentsComponent = registerComponent('RecentComments', RecentComments, {styles});

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -140,6 +140,8 @@ const USER_SETTING_NAMES = {
   hideCommunity: 'allPostsHideCommunity'
 }
 
+export const postListSettingUrlParameterNames = Object.keys(USER_SETTING_NAMES);
+
 const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, currentSorting, currentFilter, currentShowLowKarma, currentIncludeEvents, currentHideCommunity = false, timeframes=defaultTimeframes, sortings=SORT_ORDER_OPTIONS, showTimeframe, classes}: {
   persistentSettings?: any,
   hidden: boolean,

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -1,6 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
@@ -26,6 +26,8 @@ import { getUserStructuredData } from './UsersSingle';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { COMMENT_SORTING_MODES } from '@/lib/collections/comments/views';
 import { useDialog } from '../common/withDialog';
+import pick from 'lodash/pick';
+import { postListSettingUrlParameterNames } from '../posts/PostsListSettings';
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -146,6 +148,14 @@ const UsersProfileFn = ({terms, slug, classes}: {
     }
   }
 
+  const [restoreScrollPos, setRestoreScrollPos] = useState(-1);
+  useEffect(() => {
+    if (restoreScrollPos === -1) return;
+
+    window.scrollTo({top: restoreScrollPos})
+    setRestoreScrollPos(-1);
+  }, [restoreScrollPos])
+
   const renderMeta = () => {
     if (!user) return null
     const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma, tagRevisionCount } = user;
@@ -242,14 +252,19 @@ const UsersProfileFn = ({terms, slug, classes}: {
 
     const unlistedTerms: PostsViewTerms = {view: "unlisted", userId: user._id, limit: 20}
     const afSubmissionTerms: PostsViewTerms = {view: "userAFSubmissions", userId: user._id, limit: 4}
-    const terms: PostsViewTerms = {view: "userPosts", ...query, userId: user._id, authorIsUnreviewed: null};
+    const postTerms: PostsViewTerms = {
+      view: "userPosts",
+      ...pick(query, postListSettingUrlParameterNames),
+      userId: user._id,
+      authorIsUnreviewed: null
+    };
     const sequenceTerms: SequencesViewTerms = {view: "userProfile", userId: user._id, limit:9}
     const sequenceAllTerms: SequencesViewTerms = {view: "userProfileAll", userId: user._id, limit:9}
 
     // maintain backward compatibility with bookmarks
     const postQueryMode = (query.sortedBy || query.view ||  "new")
     const currentPostSortingMode = POST_SORTING_MODES.has(postQueryMode) ? postQueryMode : "new"
-    terms.sortedBy = currentPostSortingMode
+    postTerms.sortedBy = currentPostSortingMode
     
     const currentFilter = query.filter ||  "all"
     
@@ -260,7 +275,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const ownPage = currentUser?._id === user._id
     const currentShowLowKarma = (parseInt(query.karmaThreshold) !== DEFAULT_LOW_KARMA_THRESHOLD)
     const currentIncludeEvents = (query.includeEvents === 'true')
-    terms.excludeEvents = !currentIncludeEvents && currentFilter !== 'events'
+    postTerms.excludeEvents = !currentIncludeEvents && currentFilter !== 'events'
     
 
     const username = userGetDisplayName(user)
@@ -390,7 +405,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
             />}
             <AnalyticsContext listContext={"userPagePosts"}>
               {user.shortformFeedId && <Components.ProfileShortform user={user}/>}
-              <PostsList2 terms={terms} hideAuthor />
+              <PostsList2 terms={postTerms} hideAuthor />
             </AnalyticsContext>
           </SingleColumnSection>
           {/* Groups Section */
@@ -420,11 +435,11 @@ const UsersProfileFn = ({terms, slug, classes}: {
               <Components.RecentComments terms={{view: 'afSubmissions', authorIsUnreviewed: null, limit: 5, userId: user._id}} />
             </SingleColumnSection>}
             <SingleColumnSection>
-                <SectionTitle title={<Link to={`${userGetProfileUrl(user)}/replies`}>Comments</Link>} rootClassName={classes.commentSorting}>
-                  <AnalyticsContext pageElementContext='userProfileCommentSort'>
-                    Sorted by <CommentsSortBySelector />
-                  </AnalyticsContext>
-                </SectionTitle>
+              <SectionTitle title={<Link to={`${userGetProfileUrl(user)}/replies`}>Comments</Link>} rootClassName={classes.commentSorting}>
+                <AnalyticsContext pageElementContext='userProfileCommentSort'>
+                  Sorted by <CommentsSortBySelector setRestoreScrollPos={setRestoreScrollPos} />
+                </AnalyticsContext>
+              </SectionTitle>
               <Components.RecentComments
                 terms={{view: 'profileComments', sortBy: currentCommentSortBy, authorIsUnreviewed: null, limit: 10, userId: user._id}}
                 showPinnedOnProfile

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -302,6 +302,7 @@ Comments.addView("postLWComments", (terms: CommentsViewTerms) => {
 
 export const profileCommentsSortings: Partial<Record<CommentSortingMode,MongoSelector<DbComment>>> = {
   "new" :  { isPinnedOnProfile: -1, postedAt: -1},
+  "magic": { score: -1 },
   "top" : { baseScore: -1},
   "old": {postedAt: 1},
   "recentComments": { lastSubthreadActivity: -1 },


### PR DESCRIPTION
Makes the user profile page let you sort comments by Magic (New & Upvoted). Also preserve scroll position and don't refresh posts when changing sort mode.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208721645261992) by [Unito](https://www.unito.io)
