### PR TITLE
Remove Giving Season banner event text z-index

### DIFF
--- a/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
+++ b/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
@@ -106,7 +106,6 @@ const styles = (theme: ThemeType) => ({
   timelineEvent: {
     cursor: "pointer",
     position: "relative",
-    zIndex: theme.zIndexes.header + 1,
     margin: "12px 0",
     fontWeight: 400,
     whiteSpace: "nowrap",


### PR DESCRIPTION
It currently appears above the left-hand-side menu on mobile. I can't remember why I added this z-index, but removing it doesn't _seem_ to break anything.

<img width="643" alt="Screenshot 2024-11-08 at 16 43 32" src="https://github.com/user-attachments/assets/70fb0863-9c78-46b4-b9fb-ddaf8af8dc55">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208726225389601) by [Unito](https://www.unito.io)
