### PR TITLE
Return "postedAt" to annual review posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageSplashHeader.tsx
@@ -365,7 +365,7 @@ const PostsPageSplashHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, 
   toggleEmbeddedPlayer?: () => void,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { UsersName, CommentBody, LWPopper, ImageCropPreview, SplashHeaderImageOptions, PostsAudioPlayerWrapper, LWPostsPageHeaderTopRight } = Components;
+  const { UsersName, CommentBody, LWPopper, ImageCropPreview, SplashHeaderImageOptions, PostsAudioPlayerWrapper, LWPostsPageHeaderTopRight, FormatDate } = Components;
   
   const { selectedImageInfo } = useImageContext();
   const { setToCVisible } = useContext(SidebarsContext)!;
@@ -446,10 +446,13 @@ const PostsPageSplashHeader = ({post, showEmbeddedPlayer, toggleEmbeddedPlayer, 
   const topLeftSection = (
     <div className={classes.leftSection}>
       <Link className={classes.reviewNavigation} to="/leastwrong?sort=year">
-        Ranked #{post.reviewWinner.reviewRanking + 1} of {post.reviewWinner.competitorCount} posts in {post.reviewWinner.reviewYear}
+        {/* Ranked #{post.reviewWinner.reviewRanking + 1} of {post.reviewWinner.competitorCount} posts in {post.reviewWinner.reviewYear} */}
+        <FormatDate date={post.postedAt} format="MMMM DD, YYYY" tooltip={false}/>
+        <em> (Ranked #{post.reviewWinner.reviewRanking + 1} of {post.reviewWinner.competitorCount} posts)</em>
       </Link>
       <Link className={classes.reviewNavigationMobile} to="/leastwrong?sort=year">
-        #{post.reviewWinner.reviewRanking + 1} in {post.reviewWinner.reviewYear} Review
+        <FormatDate date={post.postedAt} format="MMMM DD, YYYY" tooltip={false}/>
+        <em> (#{post.reviewWinner.reviewRanking + 1} of {post.reviewWinner.competitorCount})</em>
       </Link>
     </div>
   );


### PR DESCRIPTION
The published date of annual reviews got lost in a redesign. Putting them back.

Before
<img width="864" alt="Staring into the abyss as a core life skill — LessWrong 2024-11-08 13-13-48" src="https://github.com/user-attachments/assets/66dcb2b9-555c-4840-b958-9fc9ca581545">

<img width="425" alt="Staring into the abyss as a core life skill — LessWrong 2024-11-08 13-13-35" src="https://github.com/user-attachments/assets/a4d37299-6177-48c5-995b-e194377bb24f">

After
<img width="848" alt="Staring into the abyss as a core life skill — LessWrong 2024-11-08 13-12-41" src="https://github.com/user-attachments/assets/b0315fa4-8563-4906-97c9-57336c6ff93b">

<img width="451" alt="Staring into the abyss as a core life skill — LessWrong 2024-11-08 13-13-17" src="https://github.com/user-attachments/assets/c8d5efb6-df3a-4df3-bb72-802d54989088">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208730261355839) by [Unito](https://www.unito.io)
