### PR TITLE
Fix missing sequence chapters on top posts page

### DIFF
--- a/packages/lesswrong/components/sequences/TopPostsPage.tsx
+++ b/packages/lesswrong/components/sequences/TopPostsPage.tsx
@@ -885,7 +885,7 @@ function TopSpotlightsSection({classes, yearGroupsInfo, sectionsInfo, reviewWinn
         })}
       </div>
       <div style={{ maxWidth: SECTION_WIDTH, paddingBottom: 1000 }}>
-        {filteredSpotlights.map((spotlight) => <span key={spotlight._id} className={classNames(classes.spotlightItem, !spotlight.document?.isRead && classes.spotlightIsNotRead )}><SpotlightItem spotlight={spotlight as any} showSubtitle={false}/></span>)}
+        {filteredSpotlights.map((spotlight) => <span key={spotlight._id} className={classNames(classes.spotlightItem, !spotlight.document?.isRead && classes.spotlightIsNotRead )}><SpotlightItem spotlight={spotlight} showSubtitle={false}/></span>)}
       </div>
     </div>
 }

--- a/packages/lesswrong/lib/collections/spotlights/fragments.ts
+++ b/packages/lesswrong/lib/collections/spotlights/fragments.ts
@@ -31,6 +31,9 @@ registerFragment(`
     description {
       html
     }
+    sequenceChapters {
+      ...ChaptersFragment
+    }
   }
 `);
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3704,6 +3704,7 @@ interface SpotlightMinimumInfo { // fragment on Spotlights
 
 interface SpotlightReviewWinner extends SpotlightMinimumInfo { // fragment on Spotlights
   readonly description: SpotlightReviewWinner_description|null,
+  readonly sequenceChapters: Array<ChaptersFragment>,
 }
 
 interface SpotlightReviewWinner_description { // fragment on Revisions


### PR DESCRIPTION
Regression from #9742 due to not running `yarn generate`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208786331208266) by [Unito](https://www.unito.io)
