### PR TITLE
More 2024 voting portal tweaks

### DIFF
--- a/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
+++ b/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
@@ -330,6 +330,8 @@ const styles = (theme: ThemeType) => ({
     fontSize: 14,
     fontWeight: 600,
     transition: "background 0.3s ease",
+    whiteSpace: "wrap",
+    textAlign: "center",
   },
   buttonLarge: {
     padding: "12px 24px",
@@ -450,7 +452,8 @@ const styles = (theme: ThemeType) => ({
     textAlign: "left",
     padding: "0px 48px 0px 0px",
     borderRadius: theme.borderRadius.default,
-    maxWidth: 600,
+    width: 600,
+    maxWidth: "100%",
     margin: "0 auto 0 0",
     flexBasis: "30%",
     [theme.breakpoints.down(GIVING_SEASON_MOBILE_WIDTH)]: {
@@ -476,7 +479,17 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down(GIVING_SEASON_MOBILE_WIDTH)]: {
       marginBottom: 16
     },
-  }
+  },
+  noMobile: {
+    [theme.breakpoints.down("sm")]: {
+      display: "none",
+    },
+  },
+  onlyMobile: {
+    [theme.breakpoints.up("md")]: {
+      display: "none",
+    },
+  },
 });
 
 const scrollIntoViewHorizontally = (

--- a/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
+++ b/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
@@ -480,16 +480,6 @@ const styles = (theme: ThemeType) => ({
       marginBottom: 16
     },
   },
-  noMobile: {
-    [theme.breakpoints.down("sm")]: {
-      display: "none",
-    },
-  },
-  onlyMobile: {
-    [theme.breakpoints.up("md")]: {
-      display: "none",
-    },
-  },
 });
 
 const scrollIntoViewHorizontally = (

--- a/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
+++ b/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
@@ -201,6 +201,8 @@ const styles = (theme: ThemeType) => ({
   candidateImage: {
     width: 44,
     height: 44,
+    minWidth: 44,
+    minHeight: 44,
     borderRadius: theme.borderRadius.small,
     backgroundColor: theme.palette.text.alwaysWhite,
     backgroundPosition: "center",


### PR DESCRIPTION
- Prevent button overflow on election banner on mobile
- Prevent candidate logos being squished on mobile

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208796297145903) by [Unito](https://www.unito.io)
