### PR TITLE
[EA] Minor tweaks to voting banner

### DIFF
--- a/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
+++ b/packages/lesswrong/components/forumEvents/GivingSeason2024Banner.tsx
@@ -455,7 +455,7 @@ const styles = (theme: ThemeType) => ({
     width: 600,
     maxWidth: "100%",
     margin: "0 auto 0 0",
-    flexBasis: "30%",
+    flexBasis: "35%",
     [theme.breakpoints.down(GIVING_SEASON_MOBILE_WIDTH)]: {
       padding: 0,
       flex: 1
@@ -742,7 +742,7 @@ const GivingSeason2024Banner = ({classes}: {
                 {name === currentEvent?.name && showRecentComments && (
                   <MixedTypeFeed
                     className={classes.recentComments}
-                    firstPageSize={3}
+                    firstPageSize={isDonationElection ? 5 : 3}
                     hideLoading
                     disableLoadMore
                     resolverName="GivingSeasonTagFeed"


### PR DESCRIPTION
- Make the left hand section a little wider so the text fits on two lines
- Show 5 recent discussion items

<img width="1255" alt="Screenshot 2024-11-20 at 10 11 47" src="https://github.com/user-attachments/assets/4a856b72-3465-4dff-90d2-f0e2820b3e13">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208804554084896) by [Unito](https://www.unito.io)
