### PR TITLE
[EA] Cache donation election vote counts

### DIFF
--- a/packages/lesswrong/components/forumEvents/DonationElectionLeaderboard.tsx
+++ b/packages/lesswrong/components/forumEvents/DonationElectionLeaderboard.tsx
@@ -18,7 +18,7 @@ const styles = (theme: ThemeType) => ({
   },
   header: {
     fontSize: 18,
-    marginBottom: 26,
+    marginBottom: 4,
     fontWeight: 600
   },
   candidateWrapper: {

--- a/packages/lesswrong/components/forumEvents/useGivingSeasonEvents.tsx
+++ b/packages/lesswrong/components/forumEvents/useGivingSeasonEvents.tsx
@@ -154,9 +154,8 @@ export const shouldShowLeaderboard = ({
 }) => {
   if (currentEvent?.name !== "Donation Election") return false;
 
-  // const totalVotes = Object.values(voteCounts?.[DONATION_ELECTION_NUM_WINNERS] ?? {}).reduce((acc, count) => acc + count, 0);
-  // return totalVotes >= DONATION_ELECTION_SHOW_LEADERBOARD_CUTOFF;
-  return true;
+  const totalVotes = Object.values(voteCounts?.[DONATION_ELECTION_NUM_WINNERS] ?? {}).reduce((acc, count) => acc + count, 0);
+  return totalVotes >= DONATION_ELECTION_SHOW_LEADERBOARD_CUTOFF;
 }
 
 export const GivingSeasonEventsProvider = ({children}: {children: ReactNode}) => {


### PR DESCRIPTION
It looks like the resolver that calculates the vote counts is using a lot of resources (CPU probably), this adds caching with a 1 min timeout.

Because these are cached independently on different servers this does mean the counts can get out of sync (such that refreshing could give you a different count), but the rate of voting is low enough that I don't expect this to be a problem.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208817445133135) by [Unito](https://www.unito.io)
