### PR TITLE
Add flash message after successful voting portal comment submission

### DIFF
--- a/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
+++ b/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
@@ -10,11 +10,13 @@ import React, {
   useState,
 } from "react";
 import { Components, registerComponent } from "../../../lib/vulcan-lib";
-import { Link } from "@/lib/reactRouterWrapper";
+import { Link, useNavigate } from "@/lib/reactRouterWrapper";
 import { useSingle } from "@/lib/crud/withSingle";
 import { useLoginPopoverContext } from "@/components/hooks/useLoginPopoverContext";
+import { useMessages } from "@/components/common/withMessages";
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { isProduction } from "@/lib/executionEnvironment";
+import { commentGetPageUrlFromIds } from "@/lib/collections/comments/helpers";
 import { AnalyticsContext, useTracking } from "@/lib/analyticsEvents";
 import { useCurrentUser } from "@/components/common/withUser";
 import { useUpdateCurrentUser } from "@/components/hooks/useUpdateCurrentUser";
@@ -506,6 +508,12 @@ const styles = (theme: ThemeType) => ({
       display: "none",
     },
   },
+  commentFlash: {
+    color: theme.palette.text.normal,
+    "& a": {
+      color: theme.palette.primary.dark,
+    },
+  },
 });
 
 const WelcomeScreen = ({onNext, isTooYoung, classes}: {
@@ -707,11 +715,33 @@ const RankingScreen = ({items, setItems, classes}: {
   );
 }
 
-const CommentScreen = ({currentUser, commentsPost, classes}: {
+const CommentScreen = ({currentUser, commentsPost, onSubmitVote, classes}: {
   currentUser: UsersCurrent | null,
   commentsPost?: PostsMinimumInfo,
+  onSubmitVote: () => void,
   classes: ClassesType<typeof styles>,
 }) => {
+  const {flash} = useMessages();
+  const navigate = useNavigate();
+  const onViewComment = useCallback((comment: CommentsList) => {
+    const commentLink = commentGetPageUrlFromIds({
+      commentId: comment._id,
+      postId: comment.postId,
+    });
+    onSubmitVote();
+    navigate(commentLink);
+  }, [onSubmitVote, navigate]);
+  const onSuccess = useCallback((comment: CommentsList) => {
+    const onClick = onViewComment.bind(null, comment);
+    flash({
+      type: "success",
+      messageString: (
+        <div className={classes.commentFlash}>
+          Comment created. <a onClick={onClick}>Submit vote and view comment</a>.
+        </div>
+      ),
+    });
+  }, [flash, onViewComment, classes.commentFlash]);
   const {UsersProfileImage, CommentsNewForm} = Components;
   return (
     <div className={classes.commentRoot}>
@@ -733,6 +763,7 @@ const CommentScreen = ({currentUser, commentsPost, classes}: {
           overrideHintText="Type here..."
           type="submit"
           post={commentsPost}
+          successCallback={onSuccess}
           className={classes.commentForm}
         />
       </div>
@@ -1039,6 +1070,7 @@ const VotingPortalPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
             <CommentScreen
               currentUser={currentUser}
               commentsPost={commentsPost}
+              onSubmitVote={onSubmitVote}
               classes={classes}
             />
             <Footer


### PR DESCRIPTION
Requested by Agnes on Slack. Clicking the button to view the comment will automatically save the current vote.

<img width="931" alt="Screenshot 2024-11-21 at 15 47 12" src="https://github.com/user-attachments/assets/c896f0c8-7801-4c8a-a05c-877123ce750f">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208818537574031) by [Unito](https://www.unito.io)
