### PR TITLE
Move SunshineNewPostsItem FooterTag tooltip to left-start

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -141,7 +141,7 @@ const SunshineNewPostsItem = ({post, refetch, classes}: {
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <FooterTagList post={post} showCoreTags highlightAutoApplied />
+          <FooterTagList post={post} showCoreTags highlightAutoApplied tagTooltipPlacement="left-end" />
           <div className={classes.buttonRow}>
             <Button onClick={handlePersonal}>
               <PersonIcon className={classes.icon} /> Personal {autoFrontpage === "hide" && <span className={classes.robotIcon}><ForumIcon icon="Robot" /></span>}

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -9,6 +9,7 @@ import { useCurrentUser } from '../common/withUser';
 import { coreTagIconMap } from './CoreTagIcon';
 import { isBookUI, isFriendlyUI } from '../../themes/forumTheme';
 import type { TagsTooltipPreviewWrapper } from './TagsTooltip';
+import { PopperPlacementType } from '@material-ui/core/Popper';
 
 const useExperimentalTagStyleSetting = new DatabasePublicSetting<boolean>('useExperimentalTagStyle', false)
 
@@ -132,6 +133,7 @@ const FooterTag = ({
   className,
   classes,
   noBackground = false, 
+  tagTooltipPlacement,
 }: {
   tag: TagPreviewFragment | TagSectionPreviewFragment | TagRecentDiscussion,
   tagRel?: TagRelMinimumFragment,
@@ -144,7 +146,8 @@ const FooterTag = ({
   neverCoreStyling?: boolean,
   hideRelatedTags?: boolean,
   className?: string,
-  noBackground?: boolean
+  noBackground?: boolean,
+  tagTooltipPlacement?: PopperPlacementType,
   classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser();
@@ -172,6 +175,7 @@ const FooterTag = ({
         PreviewWrapper={PreviewWrapper}
         hideRelatedTags={hideRelatedTags}
         popperClassName={classes.tooltip}
+        placement={tagTooltipPlacement}
       >
         <span className={classNames(classes.root, className, {
           [classes.core]: !neverCoreStyling && tag.core,

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -17,6 +17,7 @@ import { isFriendlyUI } from '../../themes/forumTheme';
 import { FRIENDLY_HOVER_OVER_WIDTH } from '../common/FriendlyHoverOver';
 import { AnnualReviewMarketInfo, highlightMarket } from '../../lib/collections/posts/annualReviewMarkets';
 import { stableSortTags } from '../../lib/collections/tags/helpers';
+import { PopperPlacementType } from '@material-ui/core/Popper';
 
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI ? {
@@ -134,6 +135,7 @@ const FooterTagList = ({
   noBackground = false,
   neverCoreStyling = false,
   tagRight = true,
+  tagTooltipPlacement
 }: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
   hideScore?: boolean,
@@ -153,6 +155,7 @@ const FooterTagList = ({
   noBackground?: boolean,
   neverCoreStyling?: boolean,
   tagRight?: boolean,
+  tagTooltipPlacement?: PopperPlacementType
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
   const rootRef = useRef<HTMLSpanElement>(null);
@@ -325,9 +328,9 @@ const FooterTagList = ({
 
   const {Loading, FooterTag, AddTagButton, CoreTagsChecklist, PostsAnnualReviewMarketTag} = Components;
 
-  const tooltipPlacement = useAltAddTagButton ? "bottom-end" : undefined;
+  const addTagTooltipPlacement = useAltAddTagButton ? "bottom-end" : undefined;
 
-  const addTagButton = <AddTagButton onTagSelected={onTagSelected} isVotingContext tooltipPlacement={tooltipPlacement}>
+  const addTagButton = <AddTagButton onTagSelected={onTagSelected} isVotingContext tooltipPlacement={addTagTooltipPlacement}>
     {useAltAddTagButton && <span className={classNames(classes.altAddTagButton, noBackground && classes.noBackground)}>+</span>}
   </AddTagButton>
 
@@ -348,6 +351,7 @@ const FooterTagList = ({
               tag={tag}
               hideScore={hideScore}
               smallText={smallText}
+              tagTooltipPlacement={tagTooltipPlacement}
               highlightAsAutoApplied={highlightAutoApplied && tagRel?.autoApplied}
               link={link}
               noBackground={noBackground}

--- a/packages/lesswrong/components/tagging/TagsTooltip.tsx
+++ b/packages/lesswrong/components/tagging/TagsTooltip.tsx
@@ -3,6 +3,7 @@ import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useTagPreview } from "./useTag";
 import { isFriendlyUI } from "../../themes/forumTheme";
 import classNames from "classnames";
+import { PopperPlacementType } from "@material-ui/core/Popper";
 
 type PreviewableTag =
   TagPreviewFragment |
@@ -85,6 +86,7 @@ const TagsTooltip = ({
   popperClassName,
   children,
   classes,
+  placement="bottom-end",
   ...tagsTooltipProps
 }: TagsTooltipTag & {
   tagRel?: TagRelMinimumFragment
@@ -99,6 +101,7 @@ const TagsTooltip = ({
   popperClassName?: string,
   children: ReactNode,
   classes: ClassesType<typeof styles>,
+  placement?: PopperPlacementType,
 }) => {
   const [everHovered, setEverHovered] = useState(false);
   const {tag, loading} = useTagsTooltipTag(
@@ -134,6 +137,7 @@ const TagsTooltip = ({
       className={className}
       popperClassName={classNames(classes.tooltip, popperClassName)}
       titleClassName={classes.tooltipTitle}
+      placement={placement}
     >
       {children}
     </HoverOver>


### PR DESCRIPTION
Having the tag hoverover appear _below_ the tag means I'm constantly accidentally moving my cursor over it, preventing it from disappearing, when I'm just trying to click the "frontpage" button. Now it mostly doesn't snag my cursor unless I want it to.

<img width="974" alt="image" src="https://github.com/user-attachments/assets/5c5512af-4480-4f30-a2cd-15a19884b714">
