### PR TITLE
Stop sending Type 3 regenerate requests when posts are deleted

### DIFF
--- a/packages/lesswrong/server/type3.ts
+++ b/packages/lesswrong/server/type3.ts
@@ -84,8 +84,8 @@ export const regenerateAllType3AudioForUser = async (userId: string) => {
   const posts: PostWithAudio[] = await Posts.find({
     userId,
     draft: false,
-    deleted: false,
-    deletedDraft: false
+    isFuture: false,
+    shortform: false,
   }, {
     projection: postWithAudioProjection,
   }).fetch();

--- a/packages/lesswrong/server/type3.ts
+++ b/packages/lesswrong/server/type3.ts
@@ -83,6 +83,9 @@ const deleteType3AudioForPostId = async (postId: string) => {
 export const regenerateAllType3AudioForUser = async (userId: string) => {
   const posts: PostWithAudio[] = await Posts.find({
     userId,
+    draft: false,
+    deleted: false,
+    deletedDraft: false
   }, {
     projection: postWithAudioProjection,
   }).fetch();


### PR DESCRIPTION
From Peter Hartree:
```
I've noticed that EA Forum sometimes sends "regenerate" requests for posts that have just been deleted. For example, we received "regenerate" requests for these in the last 24 hours:
https://forum.effectivealtruism.org/posts/kGkQtj6vjcrrAjK38/despair-about-ai-progressing-too-slowly
https://forum.effectivealtruism.org/posts/vuATadXMheRhBvXfi/sam-altman-safety-and-capabilities-are-not-these-two
https://forum.effectivealtruism.org/posts/CKCtnbu2s3gNzCGh6/tescreal-and-social-justice-a-synthesis
https://forum.effectivealtruism.org/posts/mKKoejaRQCFy4MN7W/cis-fragility
```

I believe the ideal behaviour here would be to delete the posts when they are converted to draft. This PR just prevents the spurious regenerate requests from being sent

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208893242787092) by [Unito](https://www.unito.io)
