### PR TITLE
[EA] Twitter admin tweaks

### DIFF
--- a/packages/lesswrong/components/admin/TwitterAdmin.tsx
+++ b/packages/lesswrong/components/admin/TwitterAdmin.tsx
@@ -101,15 +101,16 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
     TruncatedAuthorsList,
     ForumIcon,
     LWTooltip,
+    LoadMore
   } = Components;
 
   const { flash } = useMessages();
 
-  const { results, loading, error } = usePaginatedResolver({
+  const { results, loading, error, loadMoreProps } = usePaginatedResolver({
     resolverName: 'CrossedKarmaThreshold',
-    fragmentName: 'PostsListWithVotes',
-    limit: 100,
-    itemsPerPage: 200,
+    fragmentName: 'PostsTwitterAdmin',
+    limit: 20,
+    itemsPerPage: 20,
   });
 
   const authorExpandContainer = useRef(null);
@@ -117,10 +118,10 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
   if (!userIsAdmin(currentUser)) {
     return <Error404 />;
   }
-  if (loading || !results) return <Loading />;
-  if (error) return <div>Error loading posts</div>;
+  if (loading && !results) return <Loading />;
+  if (error || !results) return null;
 
-  const getAuthorsLinks = (post: PostsListWithVotes) => {
+  const getAuthorsLinks = (post: PostsTwitterAdmin) => {
     if (post.user) {
       const author = post.user;
       const authorUrl = userGetProfileUrl(author);
@@ -130,19 +131,44 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
     return 'Unknown';
   };
 
-  const copyPostsToClipboard = async (posts: PostsListWithVotes[]) => {
+  const copyPostsToClipboard = async (posts: PostsTwitterAdmin[]) => {
     const currentTime = readableDate(new Date());
     let tsvContent = '';
 
     for (const post of posts) {
-      const postUrl = `${window.location.origin}${postGetPageUrl(post)}`;
+      const postUrl = `${postGetPageUrl(post, true)}`;
       const titleCell = `=HYPERLINK("${postUrl}", "${post.title.replace(/"/g, '""')}")`;
       const authorsLink = getAuthorsLinks(post);
       const postedAt = readableDate(new Date(post.postedAt));
       const karma = post.baseScore;
       const commentCount = post.commentCount;
 
-      const row = `${titleCell}\t${authorsLink}\t${postedAt}\t${currentTime}\t${karma}\t${commentCount}\n`;
+      const authors = ([post.user, ...(post.coauthors || [])]
+        .filter(author => author) as UsersSocialMediaInfo[])
+        .map((author) => {
+          const userSetTwitterHandle = author.twitterProfileURL
+          const adminSetTwitterHandle = author.twitterProfileURLAdmin
+
+          const anyHandleSet = (userSetTwitterHandle || adminSetTwitterHandle)
+          const unambiguousHandle =
+            anyHandleSet &&
+            (!userSetTwitterHandle || !adminSetTwitterHandle || userSetTwitterHandle === adminSetTwitterHandle);
+
+          const twitterHandleStr = unambiguousHandle
+            ? ` (@${userSetTwitterHandle || adminSetTwitterHandle})`
+            : anyHandleSet
+            ? ` (ADMIN: @${adminSetTwitterHandle}, USER: @${userSetTwitterHandle})`
+            : "";
+
+          return `${author!.displayName}${twitterHandleStr}`
+        })
+        .join(', ');
+
+      // Note: These quotes are currently stripped when pasting into Google sheets
+      const standardTweet1 = `"${post.title}" by ${authors}`;
+      const standardTweet2 = `Full post: ${postUrl}`;
+
+      const row = `${titleCell}\t${authorsLink}\t${postedAt}\t${currentTime}\t${karma}\t${commentCount}\t${standardTweet1}\t${standardTweet2}\n`;
       tsvContent += row;
     }
 
@@ -156,7 +182,7 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
     }
   };
 
-  const handleCopyRow = async (post: PostsListWithVotes) => {
+  const handleCopyRow = async (post: PostsTwitterAdmin) => {
     await copyPostsToClipboard([post]);
   };
 
@@ -219,7 +245,8 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
               </td>
               <td>
                 <TruncatedAuthorsList
-                  post={post}
+                  // TODO make it work with the real type
+                  post={post as PostsListWithVotes}
                   expandContainer={authorExpandContainer}
                 />
               </td>
@@ -241,6 +268,7 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType }) => {
           ))}
         </tbody>
       </table>
+      <LoadMore {...loadMoreProps} />
     </div>
   );
 };

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -849,3 +849,15 @@ registerFragment(`
     }
   }
 `)
+
+registerFragment(`
+  fragment PostsTwitterAdmin on Post {
+    ...PostsListWithVotes
+    user {
+      ...UsersSocialMediaInfo
+    }
+    coauthors {
+      ...UsersSocialMediaInfo
+    }
+  }
+`)

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -517,6 +517,8 @@ registerFragment(`
 
     deleted
     permanentDeletionRequestedAt
+
+    twitterProfileURLAdmin
   }
 `)
 
@@ -600,5 +602,12 @@ registerFragment(`
     karma
     jobTitle
     organization
+  }
+`);
+
+registerFragment(`
+  fragment UsersSocialMediaInfo on User {
+    ...UsersProfile
+    twitterProfileURLAdmin
   }
 `);

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -2691,6 +2691,10 @@ const schema: SchemaType<"Users"> = {
     group: formGroups.socialMedia,
     order: 2,
   },
+  /**
+   * Twitter profile URL that the user can set in their public profile. "URL" is a bit of a misnomer here,
+   * if entered correctly this will be *just* the handle (e.g. "eaforumposts" for the account at https://twitter.com/eaforumposts)
+   */
   twitterProfileURL: {
     type: String,
     hidden: true,
@@ -2705,6 +2709,27 @@ const schema: SchemaType<"Users"> = {
     },
     group: formGroups.socialMedia,
     order: 3,
+  },
+  /**
+   * Twitter profile URL that can only be set by mods/admins. for when a more reliable reference is needed than
+   * what the user enters themselves (e.g. for tagging authors from the EA Forum twitter account)
+   */
+  twitterProfileURLAdmin: {
+    type: String,
+    optional: true,
+    nullable: true,
+    hidden: !isEAForum,
+    control: 'PrefixedInput',
+    canCreate: ['members'],
+    canRead: ['sunshineRegiment', 'admins'],
+    canUpdate: ['sunshineRegiment', 'admins'],
+    form: {
+      inputPrefix: SOCIAL_MEDIA_PROFILE_FIELDS.twitterProfileURL,
+      heading: "Social media (private, for admin use)",
+      smallBottomMargin: false,
+    },
+    group: formGroups.adminOptions,
+    order: 11
   },
   githubProfileURL: {
     type: String,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -1896,6 +1896,7 @@ interface DbUser extends DbObject {
   linkedinProfileURL: string | null
   facebookProfileURL: string | null
   twitterProfileURL: string | null
+  twitterProfileURLAdmin: string | null
   githubProfileURL: string | null
   profileTagIds: Array<string>
   organizerOfGroupIds: Array<string>

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -415,6 +415,7 @@ interface UsersDefaultFragment { // fragment on Users
   readonly linkedinProfileURL: string,
   readonly facebookProfileURL: string,
   readonly twitterProfileURL: string,
+  readonly twitterProfileURLAdmin: string | null,
   readonly githubProfileURL: string,
   readonly profileTagIds: Array<string>,
   readonly organizerOfGroupIds: Array<string>,
@@ -1744,6 +1745,11 @@ interface PostForReviewWinnerItem_spotlight { // fragment on Spotlights
 interface PostForReviewWinnerItem_reviewWinner { // fragment on ReviewWinners
   readonly _id: string,
   readonly category: "rationality" | "modeling" | "optimization" | "ai strategy" | "ai safety" | "practical",
+}
+
+interface PostsTwitterAdmin extends PostsListWithVotes { // fragment on Posts
+  readonly user: UsersSocialMediaInfo|null,
+  readonly coauthors: Array<UsersSocialMediaInfo>,
 }
 
 interface CommentsList { // fragment on Comments
@@ -3533,6 +3539,7 @@ interface UsersEdit extends UsersCurrent { // fragment on Users
   readonly hideFrontpageBook2020Ad: boolean,
   readonly deleted: boolean,
   readonly permanentDeletionRequestedAt: Date | null,
+  readonly twitterProfileURLAdmin: string | null,
 }
 
 interface UsersAdmin { // fragment on Users
@@ -3595,6 +3602,10 @@ interface UserOnboardingAuthor { // fragment on Users
   readonly karma: number,
   readonly jobTitle: string,
   readonly organization: string,
+}
+
+interface UsersSocialMediaInfo extends UsersProfile { // fragment on Users
+  readonly twitterProfileURLAdmin: string | null,
 }
 
 interface PetrovDayLaunchsDefaultFragment { // fragment on PetrovDayLaunchs
@@ -4332,6 +4343,7 @@ interface FragmentTypes {
   PostsHTML: PostsHTML
   PostsForAutocomplete: PostsForAutocomplete
   PostForReviewWinnerItem: PostForReviewWinnerItem
+  PostsTwitterAdmin: PostsTwitterAdmin
   CommentsList: CommentsList
   CommentsListWithTopLevelComment: CommentsListWithTopLevelComment
   ShortformComments: ShortformComments
@@ -4468,6 +4480,7 @@ interface FragmentTypes {
   UsersCrosspostInfo: UsersCrosspostInfo
   UsersOptedInToDialogueFacilitation: UsersOptedInToDialogueFacilitation
   UserOnboardingAuthor: UserOnboardingAuthor
+  UsersSocialMediaInfo: UsersSocialMediaInfo
   PetrovDayLaunchsDefaultFragment: PetrovDayLaunchsDefaultFragment
   PetrovDayLaunchInfo: PetrovDayLaunchInfo
   PetrovDayActionsDefaultFragment: PetrovDayActionsDefaultFragment
@@ -4541,7 +4554,7 @@ interface FragmentTypesByCollection {
   Collections: "CollectionsDefaultFragment"|"CollectionContinueReadingFragment"|"CollectionsPageFragment"|"CollectionsEditFragment"|"CollectionsBestOfFragment"
   ClientIds: "ClientIdsDefaultFragment"|"ModeratorClientIDInfo"
   Localgroups: "LocalgroupsDefaultFragment"|"localGroupsBase"|"localGroupsHomeFragment"|"localGroupsEdit"|"localGroupsIsOnline"
-  Users: "UsersDefaultFragment"|"SuggestAlignmentUser"|"UsersMinimumInfo"|"UsersProfile"|"UsersCurrent"|"UsersCurrentCommentRateLimit"|"UsersCurrentPostRateLimit"|"UserBookmarkedPosts"|"UserKarmaChanges"|"UsersBannedFromUsersModerationLog"|"SunshineUsersList"|"UserAltAccountsFragment"|"SharedUserBooleans"|"UsersMapEntry"|"UsersEdit"|"UsersAdmin"|"UsersWithReviewInfo"|"UsersProfileEdit"|"UsersCrosspostInfo"|"UsersOptedInToDialogueFacilitation"|"UserOnboardingAuthor"
+  Users: "UsersDefaultFragment"|"SuggestAlignmentUser"|"UsersMinimumInfo"|"UsersProfile"|"UsersCurrent"|"UsersCurrentCommentRateLimit"|"UsersCurrentPostRateLimit"|"UserBookmarkedPosts"|"UserKarmaChanges"|"UsersBannedFromUsersModerationLog"|"SunshineUsersList"|"UserAltAccountsFragment"|"SharedUserBooleans"|"UsersMapEntry"|"UsersEdit"|"UsersAdmin"|"UsersWithReviewInfo"|"UsersProfileEdit"|"UsersCrosspostInfo"|"UsersOptedInToDialogueFacilitation"|"UserOnboardingAuthor"|"UsersSocialMediaInfo"
   Comments: "CommentsDefaultFragment"|"CommentsList"|"CommentsListWithTopLevelComment"|"ShortformComments"|"CommentWithRepliesFragment"|"CommentEdit"|"DeletedCommentsMetaData"|"DeletedCommentsModerationLog"|"CommentsListWithParentMetadata"|"StickySubforumCommentFragment"|"WithVoteComment"|"CommentsListWithModerationMetadata"|"CommentsListWithModGPTAnalysis"|"CommentsForAutocomplete"|"CommentsForAutocompleteWithParents"|"SuggestAlignmentComment"
   UserTagRels: "UserTagRelsDefaultFragment"|"UserTagRelDetails"
   Tags: "TagsDefaultFragment"|"TagBasicInfo"|"TagDetailsFragment"|"TagFragment"|"TagHistoryFragment"|"TagCreationHistoryFragment"|"TagRevisionFragment"|"TagPreviewFragment"|"TagSectionPreviewFragment"|"TagSubforumFragment"|"TagSubtagFragment"|"TagSubforumSidebarFragment"|"TagDetailedPreviewFragment"|"TagWithFlagsFragment"|"TagWithFlagsAndRevisionFragment"|"TagPageFragment"|"AllTagsPageFragment"|"TagPageWithRevisionFragment"|"TagFullContributorsList"|"TagEditFragment"|"TagRecentDiscussion"|"SunshineTagFragment"|"UserOnboardingTag"|"TagName"
@@ -4560,7 +4573,7 @@ interface FragmentTypesByCollection {
   Revisions: "RevisionsDefaultFragment"|"RevisionDisplay"|"RevisionHTML"|"RevisionEdit"|"RevisionMetadata"|"RevisionMetadataWithChangeMetrics"|"RevisionHistoryEntry"|"RevisionTagFragment"|"RecentDiscussionRevisionTagFragment"|"WithVoteRevision"
   PostEmbeddings: "PostEmbeddingsDefaultFragment"
   PostRecommendations: "PostRecommendationsDefaultFragment"
-  Posts: "PostsDefaultFragment"|"PostsMinimumInfo"|"PostsTopItemInfo"|"PostsBase"|"PostsWithVotes"|"PostsListWithVotes"|"PostsListWithVotesAndSequence"|"PostsReviewVotingList"|"PostsModerationGuidelines"|"PostsAuthors"|"PostsListBase"|"PostsList"|"PostsListTag"|"PostsListTagWithVotes"|"PostsDetails"|"PostsExpandedHighlight"|"PostsPlaintextDescription"|"PostsRevision"|"PostsRevisionEdit"|"PostsWithNavigationAndRevision"|"PostsWithNavigation"|"PostSequenceNavigation"|"PostsPage"|"PostsEdit"|"PostsEditQueryFragment"|"PostsEditMutationFragment"|"PostsRevisionsList"|"PostsRecentDiscussion"|"ShortformRecentDiscussion"|"UsersBannedFromPostsModerationLog"|"SunshinePostsList"|"WithVotePost"|"HighlightWithHash"|"PostWithDialogueMessage"|"PostSideComments"|"PostWithGeneratedSummary"|"PostsBestOfList"|"PostsRSSFeed"|"PostsOriginalContents"|"PostsHTML"|"PostsForAutocomplete"|"PostForReviewWinnerItem"|"SuggestAlignmentPost"
+  Posts: "PostsDefaultFragment"|"PostsMinimumInfo"|"PostsTopItemInfo"|"PostsBase"|"PostsWithVotes"|"PostsListWithVotes"|"PostsListWithVotesAndSequence"|"PostsReviewVotingList"|"PostsModerationGuidelines"|"PostsAuthors"|"PostsListBase"|"PostsList"|"PostsListTag"|"PostsListTagWithVotes"|"PostsDetails"|"PostsExpandedHighlight"|"PostsPlaintextDescription"|"PostsRevision"|"PostsRevisionEdit"|"PostsWithNavigationAndRevision"|"PostsWithNavigation"|"PostSequenceNavigation"|"PostsPage"|"PostsEdit"|"PostsEditQueryFragment"|"PostsEditMutationFragment"|"PostsRevisionsList"|"PostsRecentDiscussion"|"ShortformRecentDiscussion"|"UsersBannedFromPostsModerationLog"|"SunshinePostsList"|"WithVotePost"|"HighlightWithHash"|"PostWithDialogueMessage"|"PostSideComments"|"PostWithGeneratedSummary"|"PostsBestOfList"|"PostsRSSFeed"|"PostsOriginalContents"|"PostsHTML"|"PostsForAutocomplete"|"PostForReviewWinnerItem"|"PostsTwitterAdmin"|"SuggestAlignmentPost"
   RecommendationsCaches: "RecommendationsCachesDefaultFragment"
   ReviewWinners: "ReviewWinnersDefaultFragment"|"ReviewWinnerEditDisplay"|"ReviewWinnerTopPostsDisplay"|"ReviewWinnerAll"|"ReviewWinnerTopPostsPage"
   ReviewWinnerArts: "ReviewWinnerArtsDefaultFragment"|"ReviewWinnerArtImages"
@@ -4695,6 +4708,7 @@ interface CollectionNamesByFragmentName {
   PostsHTML: "Posts"
   PostsForAutocomplete: "Posts"
   PostForReviewWinnerItem: "Posts"
+  PostsTwitterAdmin: "Posts"
   CommentsList: "Comments"
   CommentsListWithTopLevelComment: "Comments"
   ShortformComments: "Comments"
@@ -4831,6 +4845,7 @@ interface CollectionNamesByFragmentName {
   UsersCrosspostInfo: "Users"
   UsersOptedInToDialogueFacilitation: "Users"
   UserOnboardingAuthor: "Users"
+  UsersSocialMediaInfo: "Users"
   PetrovDayLaunchsDefaultFragment: "PetrovDayLaunchs"
   PetrovDayLaunchInfo: "PetrovDayLaunchs"
   PetrovDayActionsDefaultFragment: "PetrovDayActions"

--- a/packages/lesswrong/server/migrations/20241203T135759.add_twitterProfileURLAdmin.ts
+++ b/packages/lesswrong/server/migrations/20241203T135759.add_twitterProfileURLAdmin.ts
@@ -1,0 +1,10 @@
+import Users from "@/lib/collections/users/collection";
+import { addField, dropField } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  await addField(db, Users, "twitterProfileURLAdmin");
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await dropField(db, Users, "twitterProfileURLAdmin");
+}

--- a/packages/lesswrong/server/repos/TweetsRepo.ts
+++ b/packages/lesswrong/server/repos/TweetsRepo.ts
@@ -11,7 +11,7 @@ class TweetsRepo extends AbstractRepo<"Tweets"> {
   /**
    * @returns {string[]} The ids of posts that have crossed `threshold` karma since `since`
    */
-  async getUntweetedPostsCrossingKarmaThreshold({threshold, since}: {threshold: number, since: Date}): Promise<string[]> {
+  async getUntweetedPostsCrossingKarmaThreshold({threshold, limit}: {threshold: number, limit: number}): Promise<string[]> {
     const res = await this.getRawDb().any<{postId: string}>(`
       -- TweetsRepo.getPostsCrossingKarmaThreshold
       WITH KarmaChanges AS (
@@ -41,7 +41,6 @@ class TweetsRepo extends AbstractRepo<"Tweets"> {
           WHERE
             "collectionName" = 'Posts'
             AND cancelled = FALSE
-            AND "votedAt" > $2
             AND ${getViewablePostsSelector("p")}
             AND t._id IS NULL
             AND p."frontpageDate" IS NOT NULL
@@ -54,8 +53,9 @@ class TweetsRepo extends AbstractRepo<"Tweets"> {
         KarmaChanges
       WHERE
         prior_karma < $1
-        AND post_karma >= $1;
-    `, [threshold, since]);
+        AND post_karma >= $1
+      LIMIT $2;
+    `, [threshold, limit]);
 
     return res?.map(r => r.postId) ?? []
   }

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -816,11 +816,9 @@ createPaginatedResolver({
         throw new Error("You must be an admin to use this resolver")
       }
 
-      // 8 days ago
-      const since = new Date(Date.now() - (8 * 24 * 60 * 60 * 1000));
       const threshold = twitterBotKarmaThresholdSetting.get();
 
-      const postIds = await repos.tweets.getUntweetedPostsCrossingKarmaThreshold({ since, threshold });
+      const postIds = await repos.tweets.getUntweetedPostsCrossingKarmaThreshold({ limit, threshold });
       return await Posts.find({ _id: { $in: postIds } }, { sort: { postedAt: -1 } }).fetch();
     },
   cacheMaxAgeMs: 0

--- a/packages/lesswrong/server/twitterBot.ts
+++ b/packages/lesswrong/server/twitterBot.ts
@@ -89,13 +89,10 @@ async function runTwitterBot() {
   const repo = new TweetsRepo();
   const logger = loggerConstructor("twitter-bot");
 
-  // Get posts that have crossed `twitterBotKarmaThresholdSetting` in the last
-  // 7 days, and haven't already been tweeted. Then tweet the top one.
-  const since = new Date(Date.now() - (7 * 24 * 60 * 60 * 1000));
   const threshold = twitterBotKarmaThresholdSetting.get();
 
   logger(`Checking for posts newly crossing ${threshold} karma`);
-  const postIds = await repo.getUntweetedPostsCrossingKarmaThreshold({ since, threshold });
+  const postIds = await repo.getUntweetedPostsCrossingKarmaThreshold({ limit: 20, threshold });
 
   if (postIds.length < 1) {
     logger(`No posts found, returning`);

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3303,6 +3303,7 @@ CREATE TABLE "Users" (
   "linkedinProfileURL" TEXT,
   "facebookProfileURL" TEXT,
   "twitterProfileURL" TEXT,
+  "twitterProfileURLAdmin" TEXT,
   "githubProfileURL" TEXT,
   "profileTagIds" VARCHAR(27) [] NOT NULL DEFAULT '{}',
   "organizerOfGroupIds" VARCHAR(27) [] NOT NULL DEFAULT '{}',


### PR DESCRIPTION
- Add standard tweet format to the output of the copy action
  -  Add a field on users for admins to keep track of their twitter handles
- Use a limit + load more rather than a date cutoff
- Slightly better loading state


I added this section to account settings for keeping track of the twitter handle:
![Screenshot 2024-12-03 at 14 53 27](https://github.com/user-attachments/assets/0e3e733c-2d3e-4d47-a454-0a424c57c6d6)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208895046089836) by [Unito](https://www.unito.io)
