### PR TITLE
Remove footer from all routes using `PostsSingle` component

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1472,7 +1472,8 @@ if (hasEventsSetting.get()) {
       subtitle: forumTypeSetting.get() === 'EAForum' ? 'Events' : 'Community',
       subtitleLink: forumTypeSetting.get() === 'EAForum' ? '/events' : communityPath,
       getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
-      background: postBackground
+      background: postBackground,
+      noFooter: hasPostRecommendations,
     },
     {
       name: 'groups.post',
@@ -1482,6 +1483,7 @@ if (hasEventsSetting.get()) {
       background: postBackground,
       ...communitySubtitle,
       getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
+      noFooter: hasPostRecommendations,
     },
   );
 }
@@ -1670,6 +1672,7 @@ addRoute(
     titleComponentName: 'PostsPageHeaderTitle',
     previewComponentName: "PostCommentLinkPreviewGreaterWrong",
     noIndex: true,
+    noFooter: hasPostRecommendations,
     // TODO: Handle pingbacks leading to comments.
   }
 );


### PR DESCRIPTION
We currently have a bug where an extra 150px of empty space is shown underneath the recommendations sections on event pages and post pages for posts in a group (see attached screenshot). We already remove this space on normal post pages by adding `noFooter: hasPostRecommendations` to the route definition, but it seems we need to add this to all the other routes that use the `PostsSingle` component.

<img width="1512" alt="Screenshot 2024-12-04 at 14 30 25" src="https://github.com/user-attachments/assets/76b52512-0f25-4446-9552-a6310af2e586">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208903566788884) by [Unito](https://www.unito.io)
