### PR TITLE
Change extractus to use "require"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@datadog/browser-rum": "^5.18.0",
     "@dqbd/tiktoken": "^1.0.7",
     "@elastic/elasticsearch": "^8.7.0",
-    "@extractus/article-extractor": "^8.0.16",
+    "@extractus/article-extractor": "^7.2.6",
     "@google-cloud/discoveryengine": "^1.4.1",
     "@googleapis/drive": "^8.7.0",
     "@googleapis/oauth2": "^1.0.5",

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -56,6 +56,7 @@ export const getReviewStart = (reviewYear: ReviewYear) => {
     : `${reviewYear+1}-12-02`;
   return moment.utc(startDateString).add(TIMEZONE_OFFSET, 'hours');
 };
+ 
 export const getNominationPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-14`).add(TIMEZONE_OFFSET, 'hours')
 export const getReviewPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-01-15`).add(TIMEZONE_OFFSET, 'hours')
 export const getVotingPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-01`).add(TIMEZONE_OFFSET, 'hours')

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -56,7 +56,6 @@ export const getReviewStart = (reviewYear: ReviewYear) => {
     : `${reviewYear+1}-12-02`;
   return moment.utc(startDateString).add(TIMEZONE_OFFSET, 'hours');
 };
- 
 export const getNominationPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-14`).add(TIMEZONE_OFFSET, 'hours')
 export const getReviewPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-01-15`).add(TIMEZONE_OFFSET, 'hours')
 export const getVotingPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-01`).add(TIMEZONE_OFFSET, 'hours')

--- a/packages/lesswrong/lib/types/libraryTypes.ts
+++ b/packages/lesswrong/lib/types/libraryTypes.ts
@@ -73,3 +73,7 @@ declare module "passport-auth0/lib/Profile" {
   const Profile: AnyBecauseTodo
   export default Profile;
 }
+
+declare module "@extractus/article-extractor" {
+  export const extract: AnyBecauseTodo
+}

--- a/packages/lesswrong/server/resolvers/importUrlAsDraftPost.ts
+++ b/packages/lesswrong/server/resolvers/importUrlAsDraftPost.ts
@@ -1,4 +1,4 @@
-import { extract } from '@extractus/article-extractor'
+const { extract } = require('@extractus/article-extractor')
 import { ArxivExtractor } from '../extractors/arxivExtractor'
 import { getLatestContentsRevision } from '@/lib/collections/revisions/helpers';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,16 +2345,16 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@extractus/article-extractor@^8.0.16":
-  version "8.0.16"
-  resolved "https://registry.yarnpkg.com/@extractus/article-extractor/-/article-extractor-8.0.16.tgz#2fbfc6c3c6749a16f521de0104cf3d7e5872bbf2"
-  integrity sha512-amxCKO2uerY0UPxDVSoTDdcTny0otpKsAIGC2q2CUDEhUX6EfxmpURttlKLx9uWFT9DRlNX9LSyMSP/2p7kFLg==
+"@extractus/article-extractor@^7.2.6":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@extractus/article-extractor/-/article-extractor-7.3.1.tgz#7c1113beeeb67c802120cf39762e7cdeb40f3e29"
+  integrity sha512-ExVYn6bRHPuT/CwDBXZk4BPAhMHYdolOCc9aaaUo+hcrHhI4Dogn4aTghfh+iV8hdbg81yBBgZEWVsA2urZ01g==
   dependencies:
-    "@mozilla/readability" "^0.5.0"
-    bellajs "^11.2.0"
+    "@mozilla/readability" "^0.4.4"
+    bellajs "^11.1.2"
     cross-fetch "^4.0.0"
-    linkedom "^0.18.5"
-    sanitize-html "2.13.1"
+    linkedom "^0.15.1"
+    sanitize-html "2.11.0"
 
 "@f/animate@^1.0.1":
   version "1.0.1"
@@ -3505,10 +3505,10 @@
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"
 
-"@mozilla/readability@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.5.0.tgz#a6d5055bbadd0f329cc3e72089d4f176ed96c1d5"
-  integrity sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==
+"@mozilla/readability@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.4.4.tgz#5d258b3436eba1d5fe31c4386e50a848d5cb5811"
+  integrity sha512-MCgZyANpJ6msfvVMi6+A0UAsvZj//4OHREYUB9f2087uXHVoU+H+SWhuihvb1beKpM323bReQPRio0WNk2+V6g==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -6771,7 +6771,7 @@ bcrypt@^5.0.1:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^3.1.0"
 
-bellajs@^11.2.0:
+bellajs@^11.1.2:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/bellajs/-/bellajs-11.2.0.tgz#f7196accc284cb7480d043192570be158fd661fc"
   integrity sha512-Wjss+Bc674ZABPr+SCKWTqA4V1pyYFhzDTjNBJy4jdmgOv0oGIGXeKBRJyINwP5tIy+iIZD9SfgZpztduzQ5QA==
@@ -13249,21 +13249,21 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linkedom@^0.16.11:
-  version "0.16.11"
-  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.16.11.tgz#2419649b178be5a627f6b8b2cfad521dfa726ae9"
-  integrity sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==
+linkedom@^0.15.1:
+  version "0.15.6"
+  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.15.6.tgz#474765941c92d6037fa38a2d053100ef587858cc"
+  integrity sha512-2Vt8fdP5BNWeIiV8B3ZxfY2Z8zB0u2nVP4JPS+cgeqUlNbY26IFdDot4FYM+pZ6dA2fTVrP6bi8Z4VNTlyurvA==
   dependencies:
     css-select "^5.1.0"
     cssom "^0.5.0"
     html-escaper "^3.0.3"
-    htmlparser2 "^9.1.0"
+    htmlparser2 "^8.0.1"
     uhyphen "^0.2.0"
 
-linkedom@^0.18.5:
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.18.5.tgz#d0583b5e2ed61906269c18115573da699ed740ca"
-  integrity sha512-JGLaGGtqtu+eOhYrC1wkWYTBcpVWL4AsnwAtMtgO1Q0gI0PuPJKI0zBBE+a/1BrhOE3Uw8JI/ycByAv5cLrAuQ==
+linkedom@^0.16.11:
+  version "0.16.11"
+  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.16.11.tgz#2419649b178be5a627f6b8b2cfad521dfa726ae9"
+  integrity sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==
   dependencies:
     css-select "^5.1.0"
     cssom "^0.5.0"
@@ -16681,10 +16681,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-html@2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.13.1.tgz#b4639b0a09574ab62b1b353cb99b1b87af742834"
-  integrity sha512-ZXtKq89oue4RP7abL9wp/9URJcqQNABB5GGJ2acW1sdO8JTVl92f4ygD7Yc9Ze09VAZhnt2zegeU0tbNsdcLYg==
+sanitize-html@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.11.0.tgz#9a6434ee8fcaeddc740d8ae7cd5dd71d3981f8f6"
+  integrity sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
This library was throwing errors in our migrate.ts process, which go away when we switch to using require. I chatted through this with Robert.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208906183358560) by [Unito](https://www.unito.io)
