### PR TITLE
Fix Review page left column scrollability

### DIFF
--- a/packages/lesswrong/components/review/AnnualReviewPage.tsx
+++ b/packages/lesswrong/components/review/AnnualReviewPage.tsx
@@ -37,7 +37,7 @@ const styles = (theme: ThemeType) => ({
     height: "90vh",
     paddingLeft: 24,
     paddingRight: 36,
-    overflow: "hidden",
+    overflow: "scroll",
     [theme.breakpoints.down('sm')]: {
       paddingLeft: 0,
       paddingRight: 0,


### PR DESCRIPTION
I accidentally had made it so you couldn't scroll in the ReviewVoting page left column. This fixes that:

<img width="1637" alt="image" src="https://github.com/user-attachments/assets/f0c78179-03dc-4a75-bfba-001ddbc88c48">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208941665582732) by [Unito](https://www.unito.io)
