### PR TITLE
[EA] Make tooltips in EAF karma notifications clickable

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageKarmaChange.tsx
@@ -159,6 +159,7 @@ export const NotificationsPageKarmaChange = ({
           <PostsTooltip
             postId={commentKarmaChange.postId}
             commentId={commentKarmaChange._id}
+            clickable
           >
             <NotifPopoverLink
               to={commentGetPageUrlFromIds({
@@ -171,7 +172,7 @@ export const NotificationsPageKarmaChange = ({
             </NotifPopoverLink>
           </PostsTooltip>
           {" "}on{" "}
-          <PostsTooltip postId={commentKarmaChange.postId}>
+          <PostsTooltip postId={commentKarmaChange.postId} clickable>
             <NotifPopoverLink
               to={postGetPageUrl({_id: postId, slug: postSlug})}
               className={classes.link}


### PR DESCRIPTION
The tooltips for non-karma notifications are clickable, and I sometimes vote from them, so I think this is useful to have.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208965812347718) by [Unito](https://www.unito.io)
