### PR TITLE
[EA] Remove user flairs from the 2024 donation election

### DIFF
--- a/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
+++ b/packages/lesswrong/components/forumEvents/votingPortal/VotingPortalPage.tsx
@@ -793,7 +793,7 @@ const ThankYouScreen = ({
   const updateCurrentUser = useUpdateCurrentUser();
   const {captureEvent} = useTracking();
   const [addFlair, setAddFlair] = useState(
-    currentUser.givingSeason2024VotedFlair ?? false,
+    false,
   );
   const [confetti, setConfetti] = useState(true);
   const {width, height} = useWindowSize();

--- a/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
+++ b/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
@@ -498,22 +498,6 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
           <EAUsersProfileImage user={user} />
           <Typography variant="headline" className={classNames(classes.username, {[classes.deletedUsername]: user.deleted})}>
             <DisplayNameWithMarkers name={displayName} />{user.deleted && <span className={classes.accountDeletedText}>(account deleted)</span>}
-           {user.givingSeason2024DonatedFlair &&
-              <LWTooltip
-                placement="bottom-start"
-                title="Donated to the Donation Election fund"
-              >
-                <ForumIcon icon="GivingHand" className={classes.donationIcon} />
-              </LWTooltip>
-            }
-           {user.givingSeason2024VotedFlair &&
-              <LWTooltip
-                placement="bottom-start"
-                title="Voted in the Donation Election"
-              >
-                <ForumIcon icon="Voted" className={classes.votedIcon} />
-              </LWTooltip>
-            }
           </Typography>
           {(user.jobTitle || user.organization) && <ContentStyles contentType="comment" className={classes.roleAndOrg}>
             {user.jobTitle} {user.organization ? `@ ${user.organization}` : ''}

--- a/packages/lesswrong/components/users/UserCommentMarkers.tsx
+++ b/packages/lesswrong/components/users/UserCommentMarkers.tsx
@@ -50,10 +50,8 @@ const UserCommentMarkers = ({
 
   const showAuthorIcon = isFriendlyUI && isPostAuthor;
   const showNewUserIcon = isNewUser(user);
-  const showDonatedIcon = user.givingSeason2024DonatedFlair;
-  const showVotedIcon = user.givingSeason2024VotedFlair;
 
-  if (!showAuthorIcon && !showNewUserIcon && !showDonatedIcon && !showVotedIcon) {
+  if (!showAuthorIcon && !showNewUserIcon) {
     return null;
   }
 
@@ -76,24 +74,6 @@ const UserCommentMarkers = ({
           className={classes.iconWrapper}
         >
           <ForumIcon icon="Sprout" className={classes.sproutIcon} />
-        </LWTooltip>
-      }
-      {showDonatedIcon &&
-        <LWTooltip
-          placement="bottom-start"
-          title="Donated to the Donation Election fund"
-          className={classes.iconWrapper}
-        >
-          <ForumIcon icon="GivingHand" className={classes.donationIcon} />
-        </LWTooltip>
-      }
-      {showVotedIcon &&
-        <LWTooltip
-          placement="bottom-start"
-          title="Voted in the Donation Election"
-          className={classes.iconWrapper}
-        >
-          <ForumIcon icon="Voted" className={classes.votedIcon} />
         </LWTooltip>
       }
     </span>

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -25,8 +25,6 @@ registerFragment(`
     spamRiskScore
     tagRevisionCount
     reviewedByUserId
-    givingSeason2024DonatedFlair
-    givingSeason2024VotedFlair
   }
 `);
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3021,8 +3021,6 @@ interface UsersMinimumInfo { // fragment on Users
   readonly spamRiskScore: number,
   readonly tagRevisionCount: number,
   readonly reviewedByUserId: string,
-  readonly givingSeason2024DonatedFlair: boolean,
-  readonly givingSeason2024VotedFlair: boolean,
 }
 
 interface UsersProfile extends UsersMinimumInfo, SharedUserBooleans { // fragment on Users


### PR DESCRIPTION
I have left the fields for now, they can be cleaned up when we do a big PR to remove everything giving season related

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208967124466733) by [Unito](https://www.unito.io)
