### PR TITLE
Forumgate Posts By Vote

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsByVote.tsx
+++ b/packages/lesswrong/components/posts/LWPostsByVote.tsx
@@ -1,8 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 
-const PostsByVote = ({postIds, year, limit, showMostValuableCheckbox=false, hideEmptyStateText=false, postItemClassName}: {
+const styles = (theme: ThemeType): JssStyles => ({
+  checkboxRow: {
+    display: 'flex',
+    justifyContent: 'space-around',
+    marginBottom: 24
+  }
+})
+
+const LWPostsByVote = ({classes, postIds, year, limit, showMostValuableCheckbox=false, hideEmptyStateText=false, postItemClassName}: {
   classes: ClassesType,
   postIds: Array<string>,
   year: number | '≤2020',
@@ -11,7 +19,9 @@ const PostsByVote = ({postIds, year, limit, showMostValuableCheckbox=false, hide
   hideEmptyStateText?: boolean,
   postItemClassName?: string,
 }) => {
-  const { PostsItem, ErrorBoundary, Loading, Typography, LoadMore } = Components
+  const { PostsItem, ErrorBoundary, Loading, Typography, LoadMore, SectionFooterCheckbox, LWTooltip } = Components
+  const [requiredUnnominated, setRequiredUnnominated] = useState(true)
+  const [requiredFrontpage, setRequiredFrontpage] = useState(true)
 
   const before = year === '≤2020' ? '2021-01-01' : `${year + 1}-01-01`
   const after = `${year}-01-01`
@@ -20,6 +30,8 @@ const PostsByVote = ({postIds, year, limit, showMostValuableCheckbox=false, hide
     terms: {
       view: "nominatablePostsByVote",
       postIds,
+      requiredUnnominated,
+      requiredFrontpage,
       before,
       ...(year === '≤2020' ? {} : {after}),
     },
@@ -36,6 +48,14 @@ const PostsByVote = ({postIds, year, limit, showMostValuableCheckbox=false, hide
 
   return <ErrorBoundary>
     <div>
+      <div className={classes.checkboxRow}>
+        <LWTooltip title="Only show posts that don't have 2+ nomination votes yet.">
+          <SectionFooterCheckbox value={requiredUnnominated} onClick={() => setRequiredUnnominated(!requiredUnnominated)} label="Required unnominated" />
+        </LWTooltip>
+        <LWTooltip title="Only show frontpage posts (frontpage posts filtered for 'timelessness').">
+          <SectionFooterCheckbox value={requiredFrontpage} onClick={() => setRequiredFrontpage(!requiredFrontpage)} label="Required frontpage" />
+        </LWTooltip>
+      </div>
       {posts.map(post => {
         return <PostsItem key={post._id} post={post} showMostValuableCheckbox={showMostValuableCheckbox} className={postItemClassName} />
       })}
@@ -44,10 +64,10 @@ const PostsByVote = ({postIds, year, limit, showMostValuableCheckbox=false, hide
   </ErrorBoundary>
 }
 
-const PostsByVoteComponent = registerComponent("PostsByVote", PostsByVote);
+const LWPostsByVoteComponent = registerComponent("LWPostsByVote", LWPostsByVote, {styles});
 
 declare global {
   interface ComponentTypes {
-    PostsByVote: typeof PostsByVoteComponent
+    LWPostsByVote: typeof LWPostsByVoteComponent
   }
 }

--- a/packages/lesswrong/components/posts/PostsByVoteWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsByVoteWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { isLWorAF } from '@/lib/instanceSettings';
 
 const PostsByVoteWrapper = ({voteType, year, limit, showMostValuableCheckbox=false, hideEmptyStateText=false, postItemClassName}: {
   voteType: string,
@@ -10,7 +11,7 @@ const PostsByVoteWrapper = ({voteType, year, limit, showMostValuableCheckbox=fal
   hideEmptyStateText?: boolean,
   postItemClassName?: string,
 }) => {
-  const { PostsByVote, ErrorBoundary, Loading, Typography } = Components
+  const { PostsByVote, ErrorBoundary, Loading, Typography, LWPostsByVote } = Components
 
   // const before = year === '≤2020' ? '2021-01-01' : `${year + 1}-01-01`
   const after = `${year}-01-01`
@@ -33,14 +34,21 @@ const PostsByVoteWrapper = ({voteType, year, limit, showMostValuableCheckbox=fal
   const postIds = (votes ?? []).map(vote=>vote.documentId)
 
   return <ErrorBoundary>
-    <PostsByVote
+    {isLWorAF ? <LWPostsByVote
       postIds={postIds}
       year={year}
       limit={limit}
       showMostValuableCheckbox={showMostValuableCheckbox}
       hideEmptyStateText={hideEmptyStateText}
       postItemClassName={postItemClassName}
-    />
+    /> : <PostsByVote
+      postIds={postIds}
+      year={year}
+      limit={limit}
+      showMostValuableCheckbox={showMostValuableCheckbox}
+      hideEmptyStateText={hideEmptyStateText}
+      postItemClassName={postItemClassName}
+    />}
   </ErrorBoundary>
 }
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -486,6 +486,7 @@ importComponent("PostsList2", () => require('../components/posts/PostsList2'));
 importComponent("PostsListViewToggle", () => require('../components/posts/PostsListViewToggle'));
 importComponent("ResolverPostsList", () => require('../components/posts/ResolverPostsList'));
 importComponent("PostsByVote", () => require('../components/posts/PostsByVote'));
+importComponent("LWPostsByVote", () => require('../components/posts/LWPostsByVote'));
 importComponent("PostsByVoteWrapper", () => require('../components/posts/PostsByVoteWrapper'));
 importComponent("PostsTimeBlock", () => require('../components/posts/PostsTimeBlock'));
 importComponent("PostsNewForm", () => require('../components/posts/PostsNewForm'));


### PR DESCRIPTION
I'd merged in some changes to PostsByVote without realizing EA Forum also uses that component.

We're both using it in somewhat opinionated review-y contexts and this seemed like a pretty good time to just split it into two separate components, which we could optimize separately.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208977766339379) by [Unito](https://www.unito.io)
