### PR TITLE
Fix missing users on the community map, and drastically reduce download of /community

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -216,8 +216,11 @@ const PersonalMapLocationMarkers = ({users, handleClick, handleClose, openWindow
   
   const mapLocations = filterNonnull(users.map(user => {
     const location = user.mapLocationLatLng
-    if (!location?.lat || !location?.lng) return null
+    if (!location) return null
+    
     const {lat, lng} = location
+    if (typeof lat !== 'number' || typeof lng !== 'number') return null
+    
     return {
       lat, lng,
       data: user,

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -153,7 +153,7 @@ const CommunityMap = ({ groupTerms, eventTerms, keywordSearch, initialOpenWindow
     terms: {view: "usersMapLocations"},
     collectionName: "Users",
     fragmentName: "UsersMapEntry",
-    limit: 500,
+    limit: 5000,
     skip: !showUsers
   })
 
@@ -215,9 +215,9 @@ const PersonalMapLocationMarkers = ({users, handleClick, handleClose, openWindow
   const { StyledMapPopup } = Components
   
   const mapLocations = filterNonnull(users.map(user => {
-    const location = user.mapLocation
-    if (!location?.geometry?.location?.lat || !location?.geometry?.location?.lng) return null
-    const { geometry: {location: {lat, lng}}} = location
+    const location = user.mapLocationLatLng
+    if (!location?.lat || !location?.lng) return null
+    const {lat, lng} = location
     return {
       lat, lng,
       data: user,

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -393,19 +393,18 @@ registerFragment(`
   }
 `)
 
+// Fragment used for the map markers on /community. This is a much-larger-than-
+// usual number of users, so keep this fragment minimal.
 registerFragment(`
   fragment UsersMapEntry on User {
-    ...UsersMinimumInfo
-    createdAt
-    isAdmin
-    groups
-    location
-    googleLocation
-    mapLocation
+    _id
+    displayName
+    username
+    fullName
+    slug
+    mapLocationLatLng { lat lng }
     mapLocationSet
-    mapMarkerText
     htmlMapMarkerText
-    mongoLocation
   }
 `);
 

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -340,7 +340,7 @@ export function getDatadogUser (user: UsersCurrent | UsersEdit | DbUser): Datado
 }
 
 // Replaces Users.getProfileUrl from the vulcan-users package.
-export const userGetProfileUrl = (user: DbUser|UsersMinimumInfo|SearchUser|null, isAbsolute=false): string => {
+export const userGetProfileUrl = (user: DbUser|UsersMinimumInfo|SearchUser|UsersMapEntry|null, isAbsolute=false): string => {
   if (!user) return "";
   
   if (user.slug) {

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1887,11 +1887,12 @@ const schema: SchemaType<"Users"> = {
     canRead: ['guests'],
     resolver: (user: DbUser, _args: void, _context: ResolverContext) => {
       const mapLocation = user.mapLocation;
-      if (!mapLocation) return null;
-      return {
-        lat: mapLocation.geometry?.location?.lat,
-        lng: mapLocation.geometry?.location?.lng,
-      };
+      if (!mapLocation?.geometry?.location) return null;
+
+      const { lat, lng } = mapLocation.geometry.location;
+      if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+      
+      return { lat, lng };
     }
   }),
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3342,17 +3342,15 @@ interface SharedUserBooleans { // fragment on Users
   readonly usernameUnset: boolean,
 }
 
-interface UsersMapEntry extends UsersMinimumInfo { // fragment on Users
-  readonly createdAt: Date,
-  readonly isAdmin: boolean,
-  readonly groups: Array<string>,
-  readonly location: string,
-  readonly googleLocation: any /*{"definitions":[{"blackbox":true}]}*/,
-  readonly mapLocation: any /*{"definitions":[{"blackbox":true}]}*/,
+interface UsersMapEntry { // fragment on Users
+  readonly _id: string,
+  readonly displayName: string,
+  readonly username: string,
+  readonly fullName: string,
+  readonly slug: string,
+  readonly mapLocationLatLng: any,
   readonly mapLocationSet: boolean,
-  readonly mapMarkerText: string,
   readonly htmlMapMarkerText: string,
-  readonly mongoLocation: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UsersEdit extends UsersCurrent { // fragment on Users


### PR DESCRIPTION
The user-map-markers query on /community had a limit:500, but there are more than that in the DB, so some users would be missing (and adding yourself to the map would appear to fail). Fix that. Also, the download size of the page with the map was pretty chonky (4.3MB), because of the large list of users; solve that by trimming the UsersMapEntry fragment. In particular, the mapLocation field was a Google Maps API object with a bunch of random metadata about the location, but we only need the lat and lng, so make a resolver-only field that returns a minimal version of the location.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208994559672451) by [Unito](https://www.unito.io)
