### PR TITLE
Fix CORS errors on API routes when vite is enabled

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -161,6 +161,15 @@ export function startWebserver() {
   const config = { path: '/graphql' };
   const expressSessionSecret = expressSessionSecretSetting.get()
 
+  if (enableVite) {
+    // When vite is running the backend is proxied which means we have to
+    // enable CORS for API routes to work
+    app.use((_req, res, next) => {
+      res.set("Access-Control-Allow-Origin", "*");
+      next();
+    });
+  }
+
   app.use(universalCookiesMiddleware());
 
   // Required for passport-auth0, and for login redirects


### PR DESCRIPTION
When vite is running the backend is proxied which means we have to enable CORS for API routes to work. Notably, logging in to the EA Forum is currently broken when vite is enabled because of this issue.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1208998653377878) by [Unito](https://www.unito.io)
