### PR TITLE
use ckeditor by default for mobile comments

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -1,5 +1,4 @@
-import bowser from 'bowser';
-import { isClient, isServer } from '../../executionEnvironment';
+import { isServer } from '../../executionEnvironment';
 import {forumTypeSetting, isEAForum, verifyEmailsSetting} from '../../instanceSettings'
 import { combineUrls, getSiteUrl } from '../../vulcan-lib/utils';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
@@ -10,7 +9,6 @@ import { Components } from '../../vulcan-lib/components';
 import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
 import { hasAuthorModeration } from '../../betas';
-import { isFriendlyUI } from '@/themes/forumTheme';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -369,22 +367,7 @@ export const userGetAnalyticsUrl = (user: {slug: string}, isAbsolute=false): str
 }
 
 
-
-const clientRequiresMarkdown = (): boolean => {
-  if (isClient &&
-      window &&
-      window.navigator &&
-      window.navigator.userAgent) {
-
-      return (bowser.mobile || bowser.tablet)
-  }
-  return false
-}
-
 export const userUseMarkdownPostEditor = (user: UsersCurrent|null): boolean => {
-  if (!isFriendlyUI && clientRequiresMarkdown()) {
-    return true
-  }
   if (!user) {
     return false;
   }

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -10,6 +10,7 @@ import { Components } from '../../vulcan-lib/components';
 import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
 import { hasAuthorModeration } from '../../betas';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -381,7 +382,7 @@ const clientRequiresMarkdown = (): boolean => {
 }
 
 export const userUseMarkdownPostEditor = (user: UsersCurrent|null): boolean => {
-  if (clientRequiresMarkdown()) {
+  if (!isFriendlyUI && clientRequiresMarkdown()) {
     return true
   }
   if (!user) {


### PR DESCRIPTION
CKEditor seems to be a good experience on mobile now, so we're removing this override. @b0b3rt happy to not forum-gate this if you want it too

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209002585788353) by [Unito](https://www.unito.io)
