### PR TITLE
A bunch of UI smalls

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
@@ -4,13 +4,12 @@ import { extractVersionsFromSemver } from '../../../lib/editor/utils';
 import HistoryIcon from '@material-ui/icons/History';
 import { QueryLink } from '../../../lib/reactRouterWrapper';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   outdatedWarning: {
     float: "right",
     position: 'relative',
     [theme.breakpoints.down('xs')]: {
       float: "none",
-      marginTop: 7,
       display: 'block'
     }
   },
@@ -44,7 +43,7 @@ function postHadMajorRevision(comment: CommentsList, post: PostsMinimumInfo|Post
 const CommentOutdatedWarning = ({comment, post, classes}: {
   comment: CommentsList,
   post: PostsMinimumInfo,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   if (!postHadMajorRevision(comment, post))
     return null;

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -96,7 +96,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       padding: 1.5,
     }
     : {
-      fontSize: 12
+      "--icon-size": "12px",
     },
   title: {
     ...theme.typography.display2,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -114,7 +114,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     display: "flex",
   },
   linkIcon: {
-    fontSize: "1.2rem",
+    "--icon-size": "15.6px",
     verticalAlign: "top",
     color: theme.palette.icon.dim,
     margin: "0 4px",

--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -9,12 +9,27 @@ import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import classNames from 'classnames';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   button: {
     color: theme.palette.lwTertiary.main
   },
   commentsListLoadingSpacer: {
     minHeight: '100vh',
+  },
+  expandOptions: {
+    fontSize: 14,
+    clear: 'both',
+    marginTop: 24,
+    marginBottom: 10,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    color: theme.palette.grey[600]
+  },
+  settingsLabel: {
+    [theme.breakpoints.down('xs')]: {
+      display: "none",
+    },
   },
 })
 
@@ -29,20 +44,20 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
   defaultNestingLevel?: number,
   parentCommentId?: string,
   loading?: boolean,
-  classes: ClassesType,
+  classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser();
   const [expandAllThreads,setExpandAllThreads] = useState(false);
   
   useOnSearchHotkey(() => setExpandAllThreads(true));
 
-  const { CommentsNode, SettingsButton, CommentsListMeta, LoginPopupButton, LWTooltip } = Components
+  const { CommentsNode, SettingsButton, LoginPopupButton, LWTooltip } = Components
   
   const renderExpandOptions = () => {
     if  (totalComments > POST_COMMENT_COUNT_TRUNCATE_THRESHOLD) {
       const expandTooltip = `Posts with more than ${POST_COMMENT_COUNT_TRUNCATE_THRESHOLD} comments automatically truncate replies with less than ${TRUNCATION_KARMA_THRESHOLD} karma. Click or press ⌘F to expand all.`
 
-      return <CommentsListMeta>
+      return <div className={classes.expandOptions}>
         <span>
           Some comments are truncated due to high volume. <LWTooltip title={expandTooltip}>
             <a className={!expandAllThreads ? classes.button : undefined} onClick={()=>setExpandAllThreads(true)}>(⌘F to expand all)</a>
@@ -51,14 +66,22 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
         {currentUser 
           ? <LWTooltip title="Go to your settings page to update your Comment Truncation Options">
               <Link to="/account">
-                <SettingsButton label="Change default truncation settings" />
+                <SettingsButton label={
+                  <span className={classes.settingsLabel}>
+                    Change default truncation settings
+                  </span>
+                }/>
               </Link>
             </LWTooltip>
           : <LoginPopupButton title={"Login to change default truncation settings"}>
-              <SettingsButton label="Change truncation settings" />
+              <SettingsButton label={
+                <span className={classes.settingsLabel}>
+                  Change truncation settings
+                </span>
+              }/>
             </LoginPopupButton>
         }
-      </CommentsListMeta>
+      </div>
     }
   }
 

--- a/packages/lesswrong/components/comments/CommentsListMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsListMeta.tsx
@@ -5,7 +5,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontSize: 14,
     clear: 'both',
-    overflow: 'auto',
     marginTop: 24,
     marginBottom: 10,
     display: 'flex',

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -39,9 +39,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[600],
     marginLeft: 10
   },
-  inline: {
+  commentSorting: {
     display: 'inline',
     color: theme.palette.text.secondary,
+    marginRight: 12,
   },
   clickToHighlightNewSince: {
     display: 'inline',
@@ -177,7 +178,7 @@ const CommentsListSection = ({
       <Typography
         variant="body2"
         component='span'
-        className={classes.inline}
+        className={classes.commentSorting}
       >
         {commentSortNode}
       </Typography>

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -2,7 +2,7 @@ import React, { memo, ComponentType, MouseEventHandler, CSSProperties } from "re
 import { registerComponent } from "../../lib/vulcan-lib";
 import { forumSelect, ForumOptions } from "../../lib/forumTypeUtils";
 import classNames from "classnames";
-import SpeakerWaveIcon from "@heroicons/react/24/outline/SpeakerWaveIcon";
+import { SpeakerWaveIcon } from "../icons/speakerWaveIcon";
 import BookmarkIcon from "@heroicons/react/24/solid/BookmarkIcon";
 import SparklesIcon from "@heroicons/react/24/solid/SparklesIcon";
 import StarIcon from "@heroicons/react/24/solid/StarIcon";

--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -158,6 +158,7 @@ import { CrossReactionIcon } from "../icons/reactions/CrossReactionIcon";
 import { CrossReactionCapIcon } from "../icons/CrossReactionCapIcon";
 import { GivingHandIcon } from "../icons/GivingHandIcon";
 import { DictionaryIcon } from "../icons/Dictionary";
+import { defineStyles, useStyles } from "../hooks/useStyles";
 
 /**
  * This exists to allow us to easily use different icon sets on different
@@ -543,22 +544,22 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
   },
 };
 
-export type IconProps = {
-  className: string,
+type IconProps = {
+  className?: string,
   onClick?: MouseEventHandler<SVGElement>,
   onMouseDown?: MouseEventHandler<SVGElement>,
 }
 
-export type IconComponent = ComponentType<Partial<IconProps>>;
+type IconComponent = ComponentType<Partial<IconProps>>;
 
-const styles = (_: ThemeType) => ({
+const styles = defineStyles("ForumIcon", (_: ThemeType) => ({
   root: {
     userSelect: "none",
-    width: "1em",
-    height: "1em",
     display: "inline-block",
     flexShrink: 0,
-    fontSize: 24,
+    width: "var(--icon-size, 1em)",
+    height: "var(--icon-size, 1em)",
+    fontSize: "var(--icon-size, 24px)",
   },
   linkRotation: {
     transform: "rotate(-45deg)",
@@ -566,9 +567,11 @@ const styles = (_: ThemeType) => ({
       marginRight: 12
     }
   },
+}), {
+  stylePriority: -2,
 });
 
-type IconClassName = keyof ClassesType<typeof styles>;
+type IconClassName = "root"|"linkRotation"
 
 // This is a map from forum types to icon names to keys in the `styles` object.
 const CUSTOM_CLASSES: ForumOptions<Partial<Record<ForumIconName, IconClassName>>> = {
@@ -579,19 +582,36 @@ const CUSTOM_CLASSES: ForumOptions<Partial<Record<ForumIconName, IconClassName>>
   },
 };
 
-export type ForumIconProps = Partial<IconProps> & {
+type ForumIconProps = IconProps & {
   icon: ForumIconName,
   noDefaultStyles?: boolean,
   style?: CSSProperties,
 };
 
+/**
+ * An icon, drawn from a table of icons with some forum/theme-specific variants.
+ *
+ * WARNING: There is a Safari-specific bug, which affects what styles you can
+ * safely use in a `className` that you pass in. Historically, the default was
+ * that an icon had a default fontSize of 24px and a default width and height
+ * of 1em, which is equal to the font size, so you could override fontSize alone
+ * to get a square icon of any size. Unfortunately, in Safari, an `em` on an
+ * SVG is an inconsistent unit which fails to scale with the zoom level.
+ *
+ * In the common case of a square icon, you can override the CSS variable
+ * --icon-size and this will adjust all three attributes at once. Eg:
+ *     myClassname: {
+ *       "--icon-size": "18px"
+ *     }
+ * Note that you must specify the unit (px); a number alone will not work.
+ */
 const ForumIcon = ({
   icon,
   noDefaultStyles,
   className,
-  classes,
   ...props
-}: ForumIconProps & {classes: ClassesType<typeof styles>}) => {
+}: ForumIconProps) => {
+  const classes = useStyles(styles);
   const icons = forumSelect(ICONS);
   const Icon = icons[icon] ?? ICONS.default[icon];
   if (!Icon) {
@@ -602,17 +622,17 @@ const ForumIcon = ({
 
   const customClassKey = forumSelect(CUSTOM_CLASSES)[icon];
   const customClass = customClassKey ? classes[customClassKey] : undefined;
-  const fullClassName = classNames(className, {
-    [classes.root]: !noDefaultStyles,
-    [customClass as AnyBecauseHard]: !noDefaultStyles && customClass,
-  });
+  const fullClassName = classNames(
+    className,
+    !noDefaultStyles && classes.root,
+    !noDefaultStyles && customClass
+  );
 
   return <Icon className={fullClassName} {...props} />;
 }
 
-const ForumIconComponent = registerComponent("ForumIcon", memo(ForumIcon), {
-  styles,
-  stylePriority: -2,
+const ForumIconComponent = registerComponent("ForumIcon", ForumIcon, {
+  areEqual: "auto",
 });
 
 declare global {

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -184,6 +184,10 @@ export const styles = (theme: ThemeType) => ({
     marginLeft: -theme.spacing.unit,
     marginRight: theme.spacing.unit,
   },
+  icon: {
+    width: 24,
+    height: 24,
+  },
   siteLogo: {
     marginLeft:  -7,
     marginRight: 6,
@@ -431,7 +435,7 @@ const Header = ({
                 aria-label="Menu"
                 onClick={()=>setNavigationOpen(true)}
               >
-                <ForumIcon icon="Menu" />
+                <ForumIcon icon="Menu" className={classes.icon} />
               </IconButton>
             </div>
             <div className={classes.hideMdUp}>
@@ -444,7 +448,7 @@ const Header = ({
                 aria-label="Menu"
                 onClick={()=>setNavigationOpen(true)}
               >
-                <TocIcon />
+                <TocIcon className={classes.icon} />
               </IconButton>
             </div>
           </>
@@ -457,7 +461,7 @@ const Header = ({
             aria-label="Menu"
             onClick={()=>setNavigationOpen(true)}
           >
-            <ForumIcon icon="Menu" />
+            <ForumIcon icon="Menu" className={classes.icon} />
           </IconButton>
       }
       {standaloneNavigationPresent && unFixed && <IconButton
@@ -469,7 +473,9 @@ const Header = ({
         aria-label="Menu"
         onClick={toggleStandaloneNavigation}
       >
-        {(isFriendlyUI && !sidebarHidden) ? <ForumIcon icon="CloseMenu" /> : <ForumIcon icon="Menu" />}
+        {(isFriendlyUI && !sidebarHidden)
+          ? <ForumIcon icon="CloseMenu" className={classes.icon} />
+          : <ForumIcon icon="Menu" className={classes.icon} />}
       </IconButton>}
     </React.Fragment>
   )

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -70,7 +70,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     "&.open .ais-SearchBox-input": {
       display:"inline-block",
     },
-    "&.open .SearchBar-searchIcon": {
+    "&.open .SearchBar-searchIconButton": {
       position: 'fixed',
     },
   },
@@ -78,9 +78,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     minWidth: 34,
   } : {},
   searchIcon: {
+    "--icon-size": "24px",
+  },
+  searchIconButton: {
     color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.header.text,
   },
-  searchIconSmall: isFriendlyUI ? {
+  searchIconButtonSmall: isFriendlyUI ? {
     padding: 6,
     marginTop: 6,
   } : {},
@@ -185,8 +188,8 @@ const SearchBar = ({onSetIsActive, searchResultsArea, classes}: {
         )}>
           {isAF && <VirtualMenu attribute="af" defaultRefinement="true" />}
           <div onClick={handleSearchTap}>
-            <IconButton className={classNames(classes.searchIcon, {[classes.searchIconSmall]: !currentUser})}>
-              <ForumIcon icon="Search" />
+            <IconButton className={classNames(classes.searchIconButton, {[classes.searchIconButtonSmall]: !currentUser})}>
+              <ForumIcon icon="Search" className={classes.searchIcon} />
             </IconButton>
             {/* Ignored because SearchBox is incorrectly annotated as not taking null for its reset prop, when
               * null is the only option that actually suppresses the extra X button.

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -45,7 +45,7 @@ const SettingsButton = ({classes, className, onClick, showIcon=true, label="", u
   classes: ClassesType,
   className?: string,
   onClick?: any,
-  label?: string,
+  label?: React.ReactNode,
   showIcon?: boolean,
   useArrow?: 'up' | 'down'
   textShadow?: boolean,

--- a/packages/lesswrong/components/icons/speakerWaveIcon.tsx
+++ b/packages/lesswrong/components/icons/speakerWaveIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+// Vendored from @heroicons, then modified to fix a compatibility issue with
+// Safari which made the icon appear much too bold when zoomed in. (Fixed by
+// moving the `strokeWidth` from the <svg> element to a <g> tag.)
+export const SpeakerWaveIcon = ({className}: {
+  className?: string
+}) => {
+  return <svg xmlns="http://www.w3.org/2000/svg"
+    fill="none" viewBox="0 0 24 24"
+    aria-hidden={true}
+    className={className}
+  >
+    <g strokeWidth={1.5} stroke="currentColor">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z"
+    />
+    </g>
+  </svg>
+}

--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -3,18 +3,16 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
-
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    width: 270,
     overflowY: "auto",
     padding: 0,
   },
 
   empty: {
-    ...(isFriendlyUI ? theme.typography.body2 : {}),
+    ...theme.typography.body2,
     padding: 10
   },
 
@@ -26,7 +24,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     padding: 16,
     textAlign: "center",
     width: "100%",
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.palette.fonts.sansSerifStack,
   },
 });
 

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -40,16 +40,21 @@ const styles = (theme: ThemeType) => ({
   },
   icon: {
     color: theme.palette.icon.slightlyDim,
+    "$tabLabel:hover &": {
+      color: theme.palette.greyAlpha(1.0),
+    },
   },
-  hideButton: {
+  cancel: {
     position: "absolute",
     top: 0,
     right: 5,
-  },
-  cancel: {
-    color: theme.palette.icon.dim5,
     margin: "10px",
     cursor: "pointer",
+
+    color: theme.palette.icon.dim5,
+    "&:hover": {
+      color: theme.palette.icon.normal,
+    },
   },
   tabBar: {
     background: theme.palette.panelBackground.notificationMenuTabBar,
@@ -155,7 +160,7 @@ const NotificationsMenu = ({open, setIsOpen, hasOpened, classes}: {
                 */}
               <Tab className={classes.hiddenTab} />
             </Tabs>
-            <ClearIcon className={classNames(classes.hideButton, classes.cancel)} onClick={() => setIsOpen(false)} />
+            <ClearIcon className={classes.cancel} onClick={() => setIsOpen(false)} />
             <Components.NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser}/>
           </div>}
         </SwipeableDrawer>}

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import * as _ from 'underscore';
 import { isFriendlyUI } from '../../themes/forumTheme';
 
-const styles = (theme: ThemeType): JssStyles => ({
+const styles = (theme: ThemeType) => ({
   root: {
     display: "inline-block",
     verticalAlign: "top",
@@ -75,7 +75,6 @@ const NotificationsMenu = ({open, setIsOpen, hasOpened, classes}: {
   const {unreadPrivateMessages} = useUnreadNotifications();
   const [tab,setTab] = useState(0);
 
-  const [lastNotificationsCheck] = useState(currentUser?.lastNotificationsCheck ?? "");
   if (!currentUser) {
     return null;
   }

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -29,14 +29,15 @@ const styles = (theme: ThemeType) => ({
     // note: the specificity seems necessary to successfully override the OmegaIcon styling.
     // not sure if this is best way to do this
     '&&': {
-      fontSize: "1.2rem",
+      "--icon-size": "15.6px",
+      fontSize: "15.6px",
       color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
       position: "relative",
       top: 3,
     },
   },
   curatedIcon: {
-    fontSize: "1.2rem",
+    "--icon-size": "15.6px",
     color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
     position: "relative",
     top: isFriendlyUI ? 2 : 3,
@@ -45,7 +46,7 @@ const styles = (theme: ThemeType) => ({
     color: isFriendlyUI ? theme.palette.icon.yellow : theme.palette.primary.main,
   },
   question: {
-    fontSize: "1.2rem",
+    "--icon-size": "15.6px",
     color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
     fontWeight: '600'
   },
@@ -56,14 +57,13 @@ const styles = (theme: ThemeType) => ({
   },
   linkIcon: {
     position: "relative",
+    "--icon-size": "15.6px",
     ...(isFriendlyUI
       ? {
-        fontSize: "1.2rem",
         top: 1,
         color: theme.palette.grey[600],
       }
       : {
-        fontSize: "1.2rem",
         top: 3,
         color: theme.palette.icon.dim4,
       }),

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -53,7 +53,7 @@ const styles = (theme: ThemeType) => ({
       color: theme.palette.primary.main,
     }
     : {
-      fontSize: "1.2rem",
+      "--icon-size": "1.2rem",
     },
   primaryIcon: {
     color: theme.palette.icon.dim55,

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -95,7 +95,7 @@ const BooksProgressBar = ({ book, classes }: {
     <div className={classNames(classes.sequence, classes.progressText)}>
       <LWTooltip title={postsReadTooltip}>{postsReadText}</LWTooltip>
       <LoginToTrack className={classes.loginText}>
-        login to track progress
+        log in to track progress
       </LoginToTrack>
     </div>
   </div>;

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -21,10 +21,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const AddTagButton = ({onTagSelected, tooltipPlacement = "bottom-start", isVotingContext, classes, children}: {
+const AddTagButton = ({onTagSelected, menuPlacement="bottom-start", isVotingContext, hasTooltip=true, classes, children}: {
   onTagSelected: (props: {tagId: string, tagName: string}) => void,
-  tooltipPlacement?: PopperPlacementType,
+  menuPlacement?: PopperPlacementType,
   isVotingContext?: boolean,
+  hasTooltip?: boolean,
   classes: ClassesType,
   children?: ReactNode,
 }) => {
@@ -54,7 +55,7 @@ const AddTagButton = ({onTagSelected, tooltipPlacement = "bottom-start", isVotin
         <LWPopper
           open={isOpen}
           anchorEl={anchorEl.current}
-          placement={tooltipPlacement}
+          placement={menuPlacement}
           allowOverflow
         >
           <LWClickAwayListener
@@ -73,7 +74,7 @@ const AddTagButton = ({onTagSelected, tooltipPlacement = "bottom-start", isVotin
         </LWPopper>
     </a>
   
-  if (isBookUI) {
+  if (isBookUI && hasTooltip) {
     return <LWTooltip title="Add a tag">
       {button}
     </LWTooltip>

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -325,9 +325,9 @@ const FooterTagList = ({
 
   const {Loading, FooterTag, AddTagButton, CoreTagsChecklist, PostsAnnualReviewMarketTag} = Components;
 
-  const tooltipPlacement = useAltAddTagButton ? "bottom-end" : undefined;
+  const menuPlacement = useAltAddTagButton ? "bottom-end" : undefined;
 
-  const addTagButton = <AddTagButton onTagSelected={onTagSelected} isVotingContext tooltipPlacement={tooltipPlacement}>
+  const addTagButton = <AddTagButton onTagSelected={onTagSelected} isVotingContext menuPlacement={menuPlacement}>
     {useAltAddTagButton && <span className={classNames(classes.altAddTagButton, noBackground && classes.noBackground)}>+</span>}
   </AddTagButton>
 

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -114,7 +114,7 @@ const TagFilterSettings = ({
       />
 
       {<LWTooltip title={`Add ${taggingNameCapitalSetting.get()} Filter`}>
-          <AddTagButton onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {
+          <AddTagButton hasTooltip={false} onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {
             if (!filterSettings.tags.some(t=>t.tagId===tagId)) {
               const defaultFilterMode = userHasNewTagSubscriptions(currentUser) ? 25 : "Default"
               setTagFilter({tagId, tagName, filterMode: defaultFilterMode})


### PR DESCRIPTION
 * Fix there being a horiz scrollbar in the notifications menu, and terrible typography of its Load More
 * Add a slight hover effect to buttons on the notifications menu
 * Fix double-stacked tooltips on the Add Tag Filter button on the frontpage
 * Fix the post-audio icon appearing much too bold on Safari when zoomed in
 * Refactor ForumIcon, and add a comment explaining Safari icon-size issues
 * Fix some (not nearly all) icons being the wrong size in Safari when zoomed in
 * Fix a spurious vertical scrollbar appearing on the comments-section sorting line
 * UI cleanup of the "Some comments are truncated" notice when on mobile
 * Remove excessive top-margin on mobile on "Response to previous version" notice on old Sequences posts
  * Fix spelling in "log[]in to trace progress"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209005659552540) by [Unito](https://www.unito.io)
