### PR TITLE
[EA Forum only] fix bot site banner link

### DIFF
--- a/packages/lesswrong/components/common/BotSiteBanner.tsx
+++ b/packages/lesswrong/components/common/BotSiteBanner.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
-import { Link } from "../../lib/reactRouterWrapper";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -28,7 +27,7 @@ const BotSiteBanner = ({ classes }: { classes: ClassesType }) => {
     <SingleColumnSection className={classes.root}>
       <div>
         Welcome to the EA Forum bot site. If you are trying to access the Forum programmatically (either by scraping or
-        via the api) please use this site rather than <Link to={"https://forum.effectivealtruism.org"}>forum.effectivealtruism.org</Link>.
+        via the api) please use this site rather than <a href="https://forum.effectivealtruism.org">forum.effectivealtruism.org</a>.
         <br />
         <br />
         This site has the same content as the main site, but is run in a separate environment to avoid bots overloading the main site


### PR DESCRIPTION
Someone reported that the link to the main Forum site in the banner [here](https://forum-bots.effectivealtruism.org/) is broken, so adding a quick fix for that

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209019780461771) by [Unito](https://www.unito.io)
