### PR TITLE
Correct link to CC-BY license on user flows

### DIFF
--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingUserStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingUserStage.tsx
@@ -73,7 +73,7 @@ const newUserCompleteProfileMutation = gql`
 const links = {
   username: "https://jimpix.co.uk/words/random-username-generator.asp",
   termsOfUse: "/termsOfUse",
-  license: "https://creativecommons.org/licenses/by/2.0/",
+  license: "https://creativecommons.org/licenses/by/4.0/",
 } as const;
 
 const displayNameTakenQuery = gql`

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingUserStage.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingUserStage.tsx
@@ -168,7 +168,7 @@ export const EAOnboardingUserStage = ({classes, icon = lightbulbIcon}: {
               terms of use
             </Link>, including my content being available under a{" "}
             <Link to={links.license} target="_blank" rel="noopener noreferrer">
-              CC -BY
+              Creative Commons Attribution 4.0
             </Link> license.
           </div>
         </div>

--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -11,7 +11,7 @@ export const TosLink: FC<PropsWithChildren<{}>> = ({children}) =>
 
 export const LicenseLink: FC<PropsWithChildren<{}>> = ({children}) =>
   <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">
-    {children ?? "CC-BY"}
+    {children ?? "Creative Commons Attribution 4.0"}
   </a>
 
 const styles = (theme: ThemeType) => ({

--- a/packages/lesswrong/components/posts/PostsAcceptTos.tsx
+++ b/packages/lesswrong/components/posts/PostsAcceptTos.tsx
@@ -10,7 +10,7 @@ export const TosLink: FC<PropsWithChildren<{}>> = ({children}) =>
   <Link to="/termsOfUse" target="_blank" rel="noreferrer">{children ?? "terms of use"}</Link>
 
 export const LicenseLink: FC<PropsWithChildren<{}>> = ({children}) =>
-  <a href="https://creativecommons.org/licenses/by/2.0/" target="_blank" rel="noreferrer">
+  <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">
     {children ?? "CC-BY"}
   </a>
 


### PR DESCRIPTION
The "agree to terms of use" checkboxes currently contain a link to the CC-BY **2.0** license, which is an older version of the license; however, the intent of #6029 was to have users agree to license their new content under CC-BY **4.0**.

Legally speaking, IANAL but users may have been agreeing to license their work under the wrong version of CC-BY this whole time (or dual-license under 2.0 and 4.0).

This PR changes all license URLs that were https://creativecommons.org/licenses/by/2.0/ to https://creativecommons.org/licenses/by/4.0/.

Optional cosmetic change: I have also written out "Creative Commons Attribution 4.0" instead of just "CC-BY"; this may be easier to understand for users who are unfamiliar with the jargon of CC licenses.

I think we should also prominently display the CC-BY license on all affected posts as well as the site navbar. I'm happy to discuss the best way to implement that (whether it will require a database migration or just some runtime logic and a UI change), and I can create another PR for it if desired.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209027491490624) by [Unito](https://www.unito.io)
