### PR TITLE
Add linkSharingKey to the link in notifications for comments on draft posts

### DIFF
--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -81,6 +81,9 @@ const PostCollaborationEditor = ({ classes }: {
 
   // If the post has a link-sharing key which is not in the URL, redirect to add
   // the link-sharing key to the URL
+  // NOTE: this only works if you're the primary author, an admin, or have already been added to `linkSharingKeyUsedBy`
+  // by previously accessing the post using the link-sharing key, due to the linkSharingKey read permissions.
+  // If someone else knows the post ID, they shouldn't be able to view the post.
   if (post.linkSharingKey && !key) {
     return <PermanentRedirect url={getPostCollaborateUrl(post._id, false, post.linkSharingKey)} status={302}/>
   }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -26,7 +26,7 @@ import { forumSelect } from '../../forumTypeUtils';
 import * as _ from 'underscore';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
 import { documentIsNotDeleted, userOverNKarmaOrApproved, userOwns } from '../../vulcan-users/permissions';
-import { userCanCommentLock, userCanModeratePost } from '../users/helpers';
+import { userCanCommentLock, userCanModeratePost, userIsSharedOn } from '../users/helpers';
 import { sequenceGetNextPostID, sequenceGetPrevPostID, sequenceContainsPost, getPrevPostIdFromPrevSequence, getNextPostIdFromNextSequence } from '../sequences/helpers';
 import { userOverNKarmaFunc } from "../../vulcan-users";
 import { allOf } from '../../utils/functionUtils';
@@ -2542,7 +2542,7 @@ const schema: SchemaType<"Posts"> = {
   // of a post. Only populated if some form of link sharing is (or has been) enabled.
   linkSharingKey: {
     type: String,
-    canRead: [userOwns, 'admins'],
+    canRead: [userIsSharedOn, userOwns, 'admins'],
     canUpdate: ['admins'],
     optional: true,
     nullable: true,

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -889,7 +889,12 @@ export const NewCommentOnDraftNotification = registerNotificationType({
     documentId: string|null,
     extraData: any
   }): string => {
-    return `/editPost?postId=${documentId}`;
+    if (!documentId) {
+      throw new Error("NewCommentOnDraftNotification documentId is missing");
+    }
+    const { linkSharingKey } = extraData;
+    const url = postGetEditUrl(documentId, false, linkSharingKey);
+    return url;
   },
   Display: ({Post}) => <>New comments on your draft <Post /></>,
 });

--- a/packages/lesswrong/server/ckEditor/ckEditorWebhook.ts
+++ b/packages/lesswrong/server/ckEditor/ckEditorWebhook.ts
@@ -199,6 +199,7 @@ async function notifyCkEditorCommentAdded({commenterUserId, commentHtml, postId,
     extraData: {
       senderUserID: commenterUserId,
       commentHtml: commentHtml,
+      linkSharingKey: post.linkSharingKey,
     },
   });
 }

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -707,9 +707,12 @@ export const NewCommentOnDraftNotification = serverRegisterNotificationType({
   },
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const firstNotification = notifications[0];
+    if (!firstNotification.documentId) {
+      throw new Error("NewCommentOnDraftNotification documentId is missing");
+    }
     const post = await Posts.findOne({_id: firstNotification.documentId});
     const postTitle = post?.title;
-    const postLink = makeAbsolute(`/editPost?postId=${firstNotification.documentId}`);
+    const postLink = postGetEditUrl(firstNotification.documentId, true, firstNotification.extraData?.linkSharingKey);
     const { EmailUsernameByID } = Components;
     
     return <div>


### PR DESCRIPTION
If a user leaves a comment on a shared post, and then someone else responds to that comment, the link in the notification going back to the post will be missing the linkSharingKey.  When followed, that link leads to the post collaboration form with no post in it, because:
1. `Posts.checkAccess` thinks the user has access to that post, since they'd been added to the `linkSharingKeyUsedBy` array from when they originally accessed the post,
2. They didn't have access to the `linkSharingKey` because of its read permissions, and so couldn't get redirected to the URL with that key in it by `PostCollaborationEditor`,
3. And therefore couldn't successfully get a token from ckEditor to access to collaborative session with that post.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209054148101869) by [Unito](https://www.unito.io)
