### PR TITLE
Improve the Claims plugin

### DIFF
--- a/ckEditor/src/claims.ts
+++ b/ckEditor/src/claims.ts
@@ -3,6 +3,7 @@ import { ButtonView } from '@ckeditor/ckeditor5-ui';
 import insertClaimIcon from './ckeditor5-insert-claim-icon.svg';
 import type { ClaimsPluginConfiguration } from "../../packages/lesswrong/components/editor/claims/claimsConfigType";
 import type { Element, DowncastConversionApi } from '@ckeditor/ckeditor5-engine';
+import { toWidget } from "@ckeditor/ckeditor5-widget/src/utils";
 
 export class ClaimsPlugin extends Plugin {
   init() {
@@ -61,9 +62,7 @@ export class ClaimsPlugin extends Plugin {
             config.renderClaimPreviewInto(domElement, claimId);
           }
         );
-        return downcastWriter.createContainerElement('div', {}, [
-          reactWrapper
-        ]);
+        return toWidget(downcastWriter.createContainerElement('div', {}, [reactWrapper]), downcastWriter);
       }
     });
     conversion.for('dataDowncast').elementToStructure({
@@ -89,7 +88,6 @@ export class InsertClaimCommand extends Command {
 
     // Get the selected range, and convert it to text
     const selection = this.editor.model.document.selection;
-    if (selection.isCollapsed) return;
     const range = selection.getFirstRange();
 
     // Gather the text content from text nodes.
@@ -110,7 +108,6 @@ export class InsertClaimCommand extends Command {
         // Replace the selection with an embedded claim
         this.editor.model.change(writer => {
           writer.remove(range);
-          //writer.insertText(claim.title, range.start);
           
           const claimElement = writer.createElement("claim", {
             claimId: claim._id,
@@ -119,7 +116,6 @@ export class InsertClaimCommand extends Command {
         });
       },
       onCancel: () => {
-        console.log("Cancelled");
       },
     });
   }

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -338,6 +338,7 @@ const postEditorToolbarConfig = {
       'mediaEmbed',
       ...(isEAForum ? ['ctaButtonToolbarItem'] : ['collapsibleSectionButton']),
       'footnote',
+      ...(isLWorAF ? ['insertClaimButton'] : []),
     ],
     
     /* At some point the default icon for the block toolbar changed from a

--- a/packages/lesswrong/components/editor/claims/CreateClaimDialog.tsx
+++ b/packages/lesswrong/components/editor/claims/CreateClaimDialog.tsx
@@ -63,11 +63,17 @@ const CreateClaimDialog = ({initialTitle, onSubmit, onCancel, onClose}: CreateCl
       <Typography variant="display1">Create Claim</Typography>
       
       <div className={classes.titleInput}>
-        <Input value={title} onChange={ev => setTitle(ev.currentTarget.value)}/>
+        <Input placeholder="Prediction or claim" value={title} onChange={ev => setTitle(ev.currentTarget.value)}/>
       </div>
       
       <div className={classes.buttons}>
-        <Button className={classes.button} onClick={submit}>Submit</Button>
+        <Button
+          disabled={!title.length}
+          className={classes.button}
+          onClick={submit}
+        >
+          Submit
+        </Button>
         <Button className={classes.button} onClick={onCloseAndCancel}>Cancel</Button>
       </div>
     </div>

--- a/packages/lesswrong/lib/wrapCkEditor.ts
+++ b/packages/lesswrong/lib/wrapCkEditor.ts
@@ -26,4 +26,4 @@ export const getCkPostEditor = (isCollaborative: boolean) => {
   }
 }
 
-export const ckEditorBundleVersion = "43.1.3";
+export const ckEditorBundleVersion = "43.1.4";


### PR DESCRIPTION
 * Add the create-claim button is in the block toolbar, in addition to the selection toolbar
 * Wrap claims in the editor in a CkEditor widget

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209057166140397) by [Unito](https://www.unito.io)
