### PR TITLE
Fix crash when using Claims in the collab editor

### DIFF
--- a/ckEditor/src/claims.ts
+++ b/ckEditor/src/claims.ts
@@ -59,7 +59,7 @@ export class ClaimsPlugin extends Plugin {
         const reactWrapper = downcastWriter.createRawElement('div', {},
           (domElement) => {
             const claimId = String(modelElement.getAttribute("claimId"));
-            config.renderClaimPreviewInto(domElement, claimId);
+            config?.renderClaimPreviewInto?.(domElement, claimId);
           }
         );
         return toWidget(downcastWriter.createContainerElement('div', {}, [reactWrapper]), downcastWriter);

--- a/packages/lesswrong/lib/wrapCkEditor.ts
+++ b/packages/lesswrong/lib/wrapCkEditor.ts
@@ -26,4 +26,4 @@ export const getCkPostEditor = (isCollaborative: boolean) => {
   }
 }
 
-export const ckEditorBundleVersion = "43.1.4";
+export const ckEditorBundleVersion = "43.1.5";


### PR DESCRIPTION
Adds a null check to the claim editor's call to `renderClaimPreviewInto`, in the editing downcast. In theory this should only run in the browser and only with a config that provides that function. In practice, for some reason it was sometimes missing, and an error on that line appeared at https://portal.ckeditor.com/organizations/c91893078825/subscriptions/d583d441fab3/environments?environmentId=rQvD3VnunXZu34m86e5f&environmentView=insights .

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209057368942166) by [Unito](https://www.unito.io)
