### PR TITLE
Remove jargonCount for unapproved glossaries

### DIFF
--- a/packages/lesswrong/components/jargon/GlossarySidebar.tsx
+++ b/packages/lesswrong/components/jargon/GlossarySidebar.tsx
@@ -309,7 +309,6 @@ const GlossarySidebar = ({post, showAllTerms, setShowAllTerms, approvedTermsCoun
     <LWTooltip title={<div>Pin to {displayAsPinned ? 'hide' : 'show'} a hacky AI generated glossary<br/> that the author doesn't endorse<div><em>(Opt/Alt + Shift + G)</em></div></div>} inlineBlock={false} placement='top-end' popperClassName={classes.titleRowTooltipPopper}>
       <div className={classes.titleRow} onClick={(e) => setShowAllTerms(e, !showAllTerms, 'unapprovedGlossaryClick')}  {...unapprovedHoverHandlers}>
         <ForumIcon icon="Dictionary" className={classNames(classes.pinIcon, classes.unapprovedPinIcon, displayAsPinned && classes.pinnedPinIcon)} /> 
-        {!displayAsPinned && <span className={classes.unapprovedTermsCount}>{unapprovedTermsCount}</span>}
         {displayAsPinned && <p className={classes.title}>Glossary (Auto)</p>}
       </div>
     </LWTooltip>


### PR DESCRIPTION
This just removes the number-of-jargon-terms for posts that don't have any approved terms, so it looks less like something you might need to click on.

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/320395c3-7739-4f99-8f67-06d68fd8020f" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209062460358330) by [Unito](https://www.unito.io)
