### PR TITLE
[FriendlyUI only] truncate post tags further

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -34,9 +34,9 @@ const styles = (theme: ThemeType) => ({
   },
   allowTruncate: {
     display: isFriendlyUI ? "block" : "inline-flex",
-    // Truncate to 3 rows (webkit-line-clamp would be ideal here but it adds an ellipsis
+    // Truncate to 1 row (webkit-line-clamp would be ideal here but it adds an ellipsis
     // which can't be removed)
-    maxHeight: 104,
+    maxHeight: 33,
     overflow: "hidden",
   },
   overrideMargins: {


### PR DESCRIPTION
Truncate the post page tags at 1 row instead of 3

<img width="733" alt="Screenshot 2024-12-30 at 7 32 13 PM" src="https://github.com/user-attachments/assets/a1c6bbda-7252-4284-a7ec-a28d64ef40ef" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209062542386230) by [Unito](https://www.unito.io)
