### PR TITLE
2024 EA Forum Wrapped sidebar ad

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeRightHandSide.tsx
@@ -59,6 +59,25 @@ const styles = (theme: ThemeType) => ({
     fontFamily: theme.typography.fontFamily,
     marginBottom: 32,
   },
+  wrappedAd: {
+    backgroundColor: theme.palette.wrapped.background,
+    color: theme.palette.text.alwaysWhite,
+    padding: '12px 24px',
+    borderRadius: theme.borderRadius.default,
+    '&:hover': {
+      opacity: 1,
+      backgroundColor: theme.palette.wrapped.darkBackground,
+    }
+  },
+  wrappedAdHeading: {
+    fontWeight: 600,
+    fontSize: 16,
+    lineHeight: '22px',
+    margin: 0
+  },
+  wrappedAdHighlight: {
+    color: theme.palette.wrapped.highlightText,
+  },
   digestAd: {
     maxWidth: 280,
     marginBottom: 32,
@@ -109,6 +128,24 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
+
+const WrappedAd = ({classes}: {
+  classes: ClassesType<typeof styles>,
+}) => {
+  const currentUser = useCurrentUser()
+  if (!currentUser) return null
+
+  return <AnalyticsContext pageSubSectionContext="wrappedAd">
+    <div className={classes.section}>
+      <Link to="/wrapped" className={classes.wrappedAd}>
+        <h2 className={classes.wrappedAdHeading}>
+          Your 2024 EA Forum
+          <div className={classes.wrappedAdHighlight}>Wrapped</div>
+        </h2>
+      </Link>
+    </div>
+  </AnalyticsContext>
+}
 
 /**
  * This is a list of upcoming (nearby) events. It uses logic similar to EventsList.tsx.
@@ -239,6 +276,7 @@ export const EAHomeRightHandSide = ({classes}: {
   return <AnalyticsContext pageSectionContext="homeRhs">
     {!!currentUser && sidebarToggleNode}
     <div className={classes.root}>
+      <WrappedAd classes={classes} />
       {digestAdNode}
       
       {!!opportunityPosts?.length && <AnalyticsContext pageSubSectionContext="opportunities">


### PR DESCRIPTION
Adapted from last year (https://github.com/ForumMagnum/ForumMagnum/pull/8590). Separate PR so that we can deploy this after doing some testing on prod, if we want to.

<img width="632" alt="Screenshot 2024-12-31 at 6 49 28 PM" src="https://github.com/user-attachments/assets/0a1d4aa2-ce17-4478-945c-daf726adedea" />
<img width="567" alt="Screenshot 2024-12-31 at 6 40 03 PM" src="https://github.com/user-attachments/assets/f6c7ad94-c4cb-4a65-bbe2-652234f67060" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209065480406948) by [Unito](https://www.unito.io)
