### PR TITLE
For LW, change the base of tag urls to 'w' from 'tag'

### DIFF
--- a/packages/lesswrong/components/editor/ctaButton/EditCTAButtonSettings.tsx
+++ b/packages/lesswrong/components/editor/ctaButton/EditCTAButtonSettings.tsx
@@ -8,6 +8,7 @@ import { makeSortableListComponent } from '@/components/form-components/sortable
 import { useSingle } from '@/lib/crud/withSingle';
 import { useTagBySlug } from '@/components/tagging/useTag';
 import classNames from 'classnames';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 const styles = defineStyles("EditCTAButtonSettings", (theme: ThemeType) => ({
   root: {
@@ -110,7 +111,7 @@ const EditReadingList = ({state, changeValue}: {
     setPages(newPages);
     
     if (newPages.length > 0) {
-      const firstPageLink = `/p/${newPages[0]}`;
+      const firstPageLink = tagGetUrl({slug: newPages[0]});
       const link = addArbitalPathToLink(firstPageLink, newPages);
       changeValue({...state, linkTo: link});
     } else {

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -18,6 +18,7 @@ import { Link, useNavigate } from '../../lib/reactRouterWrapper';
 import { QuestionIcon } from '../icons/questionIcon';
 import DeferRender from '../common/DeferRender';
 import { userCanCreateAndEditJargonTerms } from '@/lib/betas';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 // Also used by PostsEditForm
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -178,7 +179,7 @@ export const getPostEditorGuide = (classes: ClassesType) => {
           <div className={classes.editorGuide}>
             <QuestionIcon className={classes.editorGuideIcon} />
             <div className={classes.editorGuideLink}>
-              <Link to="/tag/guide-to-the-lesswrong-editor">Editor Guide / FAQ</Link>
+              <Link to={tagGetUrl({slug: "guide-to-the-lesswrong-editor"})}>Editor Guide / FAQ</Link>
             </div>
           </div>
         </LWTooltip>

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -12,6 +12,7 @@ import { useQuery, gql } from '@apollo/client';
 import { QueryLink, Link } from '../../lib/reactRouterWrapper'
 import { useLocation } from '../../lib/routeUtil';
 import qs from 'qs'
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 const cellStyle = () => ({
   maxWidth: 350,
@@ -499,7 +500,7 @@ const SpreadsheetPage = ({classes}: {
               Welcome to the Coronavirus Info-Database, an attempt to organize the disparate papers, articles and links that are spread all over the internet regarding the nCov pandemic. We sort, summarize and prioritize all links on a daily basis. You can submit new links by pressing the big green button.
             </p>
             <p>
-              You can find (and participate) in more LessWrong discussion of COVID-19 on <HoverPreviewLink href={"/tag/coronavirus"}>{"our tag page"}</HoverPreviewLink>.
+              You can find (and participate) in more LessWrong discussion of COVID-19 on <HoverPreviewLink href={tagGetUrl({slug: "coronavirus"})}>{"our tag page"}</HoverPreviewLink>.
             </p>
           </div>
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSc5uVDXrowWmhlaDbT3kukODdJotWOZXZivdlFmaHQ6n2gsKw/viewform" className={classes.submitButton}>

--- a/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
@@ -3,7 +3,8 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useLocation } from '../../lib/routeUtil';
 import { useTagBySlug } from '../tagging/useTag';
 import { useMulti } from '../../lib/crud/withMulti';
-import { tagGetRevisionLink, tagGetUrl, tagUrlBase } from '../../lib/collections/tags/helpers';
+import { tagGetRevisionLink, tagGetUrl } from '../../lib/collections/tags/helpers';
+import { tagUrlBaseSetting } from '../../lib/instanceSettings';
 import { Link, useNavigate } from '../../lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -36,7 +37,7 @@ const TagPageRevisionSelect = ({ classes }: {
   
   const compareRevs = useCallback(({before,after}: {before: RevisionMetadata, after: RevisionMetadata}) => {
     if (!tag) return;
-    navigate(`/compare/${tagUrlBase}/${tag.slug}?before=${before.version}&after=${after.version}`);
+    navigate(`/compare/${tagUrlBaseSetting.get()}/${tag.slug}?before=${before.version}&after=${after.version}`);
   }, [navigate, tag]);
 
   if (!tag) return null

--- a/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
+++ b/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
@@ -4,6 +4,7 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser'
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 const CoronavirusFrontpageWidget = ({settings}: {
   settings: RecommendationsAlgorithm & { hideCoronavirus?: boolean }
@@ -33,14 +34,14 @@ const CoronavirusFrontpageWidget = ({settings}: {
     <div>
       <SectionSubtitle>
         <LWTooltip title={"View all posts related to COVID-19"} placement="top-start">
-          <Link to="/tag/coronavirus">Coronavirus Tag</Link>
+          <Link to={tagGetUrl({slug: "coronavirus"})}>Coronavirus Tag</Link>
         </LWTooltip>
       </SectionSubtitle>
       <AnalyticsContext listContext={"coronavirusWidget"} capturePostItemOnMount>
         <RecommendationsList algorithm={samplingAlgorithm} />
       </AnalyticsContext>
       {!currentUser && <SectionFooter>
-        <Link to={"/tag/coronavirus"}>
+        <Link to={tagGetUrl({slug: "coronavirus"})}>
           View All Coronavirus Posts
         </Link>
       </SectionFooter>}

--- a/packages/lesswrong/components/tagging/PathInfo.tsx
+++ b/packages/lesswrong/components/tagging/PathInfo.tsx
@@ -7,6 +7,7 @@ import { useTagBySlug } from './useTag';
 import { Link } from '@/lib/reactRouterWrapper';
 import { TagLens } from '@/lib/arbital/useTagLenses';
 import { useTagOrLens } from '../hooks/useTagOrLens';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 
 const styles = defineStyles("PathInfo", (theme) => ({
@@ -112,7 +113,7 @@ const PathInfo = ({tag, lens}: {
       */}
     {pathInfo.previousPageId && <Link
       className={classes.pathNavigationBackButton}
-      to={`/w/${pathInfo.previousPageId}?pathId=${pathInfo.pathId}`}
+      to={tagGetUrl({slug: pathInfo.previousPageId}, {pathId: pathInfo.pathId})}
     >
       <ForumIcon icon="ArrowLeft" className={classes.pathNavigationBackButtonIcon} />
       Back
@@ -124,7 +125,7 @@ const PathInfo = ({tag, lens}: {
     </span>
     {pathInfo.nextPageId && <Link
       className={classes.pathNavigationNextButton}
-      to={`/w/${pathInfo.nextPageId}?pathId=${pathInfo.pathId}`}
+      to={tagGetUrl({slug: pathInfo.nextPageId}, {pathId: pathInfo.pathId})}
     >
       Continue
       <ForumIcon icon="ArrowRight" className={classes.pathNavigationNextButtonIcon} />

--- a/packages/lesswrong/components/tagging/RandomTagPage.tsx
+++ b/packages/lesswrong/components/tagging/RandomTagPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useQuery, gql } from '@apollo/client';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 const RandomTagPage = () => {
   const {PermanentRedirect, Loading, SingleColumnSection} = Components;
@@ -13,7 +14,7 @@ const RandomTagPage = () => {
   });
   const tag = data?.RandomTag;
   return <SingleColumnSection>
-    {tag && <PermanentRedirect status={302} url={`/tag/${tag.slug}`}/>}
+    {tag && <PermanentRedirect status={302} url={tagGetUrl({slug: tag.slug})}/>}
     {loading && <Loading/>}
   </SingleColumnSection>
 }

--- a/packages/lesswrong/components/tagging/RedlinkTagPage.tsx
+++ b/packages/lesswrong/components/tagging/RedlinkTagPage.tsx
@@ -4,6 +4,7 @@ import { defineStyles, useStyles } from '../hooks/useStyles';
 import { useMulti } from '@/lib/crud/withMulti';
 import { Link, useNavigate } from '../../lib/reactRouterWrapper';
 import Button from '@material-ui/core/Button';
+import { tagUrlBaseSetting } from '@/lib/instanceSettings';
 
 const styles = defineStyles("RedlinkTagPage", theme => ({
   title: {
@@ -51,7 +52,7 @@ const RedlinkTagPage = ({tag, slug}: {
   const navigate = useNavigate();
   const title = capitalizeFirstLetter(inferRedLinkTitle(tag, slug??null) ?? "Unnamed");
 
-  const createPageUrl = `/tag/create?name=${encodeURIComponent(title)}&type=wiki`
+  const createPageUrl = `/${tagUrlBaseSetting.get()}/create?name=${encodeURIComponent(title)}&type=wiki`
   function createPage() {
     navigate(createPageUrl);
   }

--- a/packages/lesswrong/components/tagging/RedlinkTagPage.tsx
+++ b/packages/lesswrong/components/tagging/RedlinkTagPage.tsx
@@ -5,6 +5,7 @@ import { useMulti } from '@/lib/crud/withMulti';
 import { Link, useNavigate } from '../../lib/reactRouterWrapper';
 import Button from '@material-ui/core/Button';
 import { tagUrlBaseSetting } from '@/lib/instanceSettings';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 const styles = defineStyles("RedlinkTagPage", theme => ({
   title: {
@@ -47,7 +48,7 @@ const RedlinkTagPage = ({tag, slug}: {
   slug?: string
 }) => {
   const classes = useStyles(styles);
-  const { SingleColumnSection, Typography, ContentStyles } = Components;
+  const { SingleColumnSection, Typography, ContentStyles, Error404 } = Components;
   const { results: pingbacks, loading: pingbacksLoading, error: pingbacksError } = useRedLinkPingbacks(tag?._id);
   const navigate = useNavigate();
   const title = capitalizeFirstLetter(inferRedLinkTitle(tag, slug??null) ?? "Unnamed");
@@ -57,9 +58,16 @@ const RedlinkTagPage = ({tag, slug}: {
     navigate(createPageUrl);
   }
 
+
+  const tagSlug = tag?.slug ?? slug;
+  // If the tag doesn't have a slug, and the slug is not provided, show a 404
+  if (!tagSlug) {
+    return <Error404 />
+  }
+
   return <SingleColumnSection>
     <Typography variant="display3">
-      <Link className={classes.title} to={`/w/${tag?.slug ?? slug}`}>{title}</Link>
+      <Link className={classes.title} to={tagGetUrl({slug: tagSlug})}>{title}</Link>
     </Typography>
 
     <ContentStyles contentType="tag">
@@ -70,7 +78,7 @@ const RedlinkTagPage = ({tag, slug}: {
         
         <ul className={classes.pingbacksList}>
           {pingbacks?.map(t => <li key={t._id}>
-            <Link to={`/w/${t.slug}`}>{t.name}</Link>
+            <Link to={tagGetUrl({slug: t.slug})}>{t.name}</Link>
           </li>)}
         </ul>
       </>}

--- a/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
+++ b/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
@@ -7,6 +7,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { ExpandedDate } from '../common/FormatDate';
 import moment from 'moment';
 import { isFriendlyUI } from '../../themes/forumTheme';
+import { tagUrlBaseSetting } from '@/lib/instanceSettings';
 
 export const POSTED_AT_WIDTH = 38
 
@@ -161,7 +162,7 @@ const SingleLineTagUpdates = ({tag, revisionIds, commentCount, commentIds, users
           <span>History</span>
         </Link>}
       
-      {revisionIds.length>0 && <Link to={`revisions/tag/${tag.slug}`} className={classes.subheading}>
+      {revisionIds.length>0 && <Link to={`revisions/${tagUrlBaseSetting.get()}/${tag.slug}`} className={classes.subheading}>
         Edits
       </Link>}
       {revisionIds.map(revId => <div className={classes.tagRevision} key={revId}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -732,7 +732,7 @@ let currentPathId: string | null = null;
 
 function startPath() {
   if (currentPathId) {
-    window.location.href = `/w/${currentPathId}/?startPath`;
+    window.location.href = tagGetUrl({slug: currentPathId}) + `/?startPath`;
   }
 }
 

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -1231,7 +1231,7 @@ const TagPage = () => {
   const tagHeader = (
     <div className={classNames(classes.header,classes.centralColumn)}>
       {query.flagId && <span>
-        <Link to={`/tags/dashboard?focus=${query.flagId}`}>
+        <Link to={`/${taggingNamePluralSetting.get()}/dashboard?focus=${query.flagId}`}>
           <TagFlagItem 
             itemType={["allPages", "myPages"].includes(query.flagId) ? tagFlagItemType[query.flagId] : "tagFlagId"}
             documentId={query.flagId}

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -116,7 +116,7 @@ const TagProgressBar = ({ classes }: {
             What's the Import?
             </Link>
           <SeparatorBullet />
-          <Link className={classes.allTagsBarColor} to="/tags/dashboard">
+          <Link className={classes.allTagsBarColor} to={`/${taggingNamePluralSetting.get()}/dashboard`}>
             Help Process Pages
           </Link>
         </PostsItem2MetaInfo>

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -7,6 +7,7 @@ import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog';
 import { useMessages } from '../common/withMessages';
+import { taggingNamePluralSetting } from '@/lib/instanceSettings';
 
 export const progressBarRoot = (theme: ThemeType) => ({
   background: theme.palette.panelBackground.default,

--- a/packages/lesswrong/components/tagging/TagTableOfContents.tsx
+++ b/packages/lesswrong/components/tagging/TagTableOfContents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
-import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
+import { taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import type { ToCDisplayOptions } from '../posts/TableOfContents/TableOfContentsList';
 import { tagGetDiscussionUrl, tagGetSubforumUrl } from '../../lib/collections/tags/helpers';
 
@@ -45,7 +45,7 @@ const TagTableOfContents = ({tag, expandAll, showContributors, onHoverContributo
         onClickSection={expandAll}
         displayOptions={displayOptions}
       />
-      <Link to="/tags/random" className={classes.randomTagLink}>
+      <Link to={`/${taggingNamePluralSetting.get()}/random`} className={classes.randomTagLink}>
         Random {taggingNameCapitalSetting.get()}
       </Link>
       {"contributors" in tag && (

--- a/packages/lesswrong/components/tagging/TagsTooltip.tsx
+++ b/packages/lesswrong/components/tagging/TagsTooltip.tsx
@@ -7,6 +7,7 @@ import classNames from "classnames";
 import { PopperPlacementType } from "@material-ui/core/Popper";
 import { defineStyles, useStyles } from "../hooks/useStyles";
 import { inferRedLinkTitle, useRedLinkPingbacks } from "./RedlinkTagPage";
+import { tagGetUrl } from "@/lib/collections/tags/helpers";
 
 type PreviewableTag =
   TagPreviewFragment |
@@ -103,16 +104,15 @@ const RedLinkTooltip = ({ tag, slug }: {
     <Typography variant='title'>
       {title}
     </Typography>
-    {/* TODO: this is a hardcoded example; when we implement the backend for red links we should fix this */}
     <ContentStyles contentType='tag'>
       This red link was used on {pingbacks ? pingbacks.length : <Loading/>} page{pingbacks ? (pingbacks.length > 1 ? "s" : "") : "(s)"}:
       <ul>
         {pingbacks?.map(pingback => <li key={pingback._id}>
           <TagHoverPreview
-            targetLocation={{ params: { slug: 'nash_equilibrium' }, hash: '', query: {} } as AnyBecauseTodo}
-            href='/tag/nash_equilibrium' noPrefetch
+            targetLocation={{ params: { slug: pingback.slug }, hash: '', query: {} } as AnyBecauseTodo}
+            href={tagGetUrl({slug: pingback.slug})} noPrefetch
           >
-            <Link to={`/w/${pingback.slug}`}>
+            <Link to={tagGetUrl({slug: pingback.slug})}>
               {pingback.name}
             </Link>
           </TagHoverPreview>

--- a/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
@@ -16,6 +16,7 @@ import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema
 import { useSubscribeUserToTag } from '../../../lib/filterSettings';
 import { defaultPostsLayout, isPostsLayout } from '../../../lib/collections/posts/dropdownOptions';
 import { getTagStructuredData } from '../TagPageRouter';
+import { taggingNamePluralSetting } from '@/lib/instanceSettings';
 
 export const styles = (theme: ThemeType): JssStyles => ({
   tabRow: {
@@ -252,7 +253,7 @@ const TagSubforumPage2 = ({classes}: {
     <div className={classNames(classes.header, classes.centralColumn)}>
       {query.flagId && (
         <span>
-          <Link to={`/tags/dashboard?focus=${query.flagId}`}>
+          <Link to={`/${taggingNamePluralSetting.get()}/dashboard?focus=${query.flagId}`}>
             <TagFlagItem
               itemType={["allPages", "myPages"].includes(query.flagId) ? tagFlagItemType[query.flagId] : "tagFlagId"}
               documentId={query.flagId}

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -1,6 +1,6 @@
 import qs from "qs";
 import { forumSelect } from "../../forumTypeUtils";
-import { siteUrlSetting, taggingNameIsSet, taggingNamePluralSetting } from "../../instanceSettings";
+import { siteUrlSetting, tagUrlBaseSetting } from "../../instanceSettings";
 import { combineUrls } from "../../vulcan-lib";
 import { TagCommentType } from "../comments/types";
 import Users from "../users/collection";
@@ -34,9 +34,8 @@ type GetUrlOptions = {
   from?: string,
 }
 
-export const tagUrlBase = taggingNameIsSet.get() ? taggingNamePluralSetting.get() : 'tag'
-export const tagCreateUrl = `/${tagUrlBase}/create`
-export const tagGradingSchemeUrl = `/${tagUrlBase}/tag-grading-scheme`
+export const tagCreateUrl = `/${tagUrlBaseSetting.get()}/create`
+export const tagGradingSchemeUrl = `/${tagUrlBaseSetting.get()}/tag-grading-scheme`
 
 export const tagGetUrl = (tag: {slug: string}, urlOptions?: GetUrlOptions, isAbsolute=false, hash?: string) => {
   const urlSearchParams = urlOptions
@@ -45,15 +44,15 @@ export const tagGetUrl = (tag: {slug: string}, urlOptions?: GetUrlOptions, isAbs
   const searchSuffix = search ? `?${search}` : ''
   const hashSuffix = hash ? `#${hash}` : ''
 
-  const url = `/${tagUrlBase}/${tag.slug}`
+  const url = `/${tagUrlBaseSetting.get()}/${tag.slug}`
   const urlWithSuffixes = `${url}${searchSuffix}${hashSuffix}`
   return isAbsolute ? combineUrls(siteUrlSetting.get(), urlWithSuffixes) : urlWithSuffixes
 }
 
-export const tagGetHistoryUrl = (tag: {slug: string}) => `/${tagUrlBase}/${tag.slug}/history`
+export const tagGetHistoryUrl = (tag: {slug: string}) => `/${tagUrlBaseSetting.get()}/${tag.slug}/history`
 
 export const tagGetDiscussionUrl = (tag: {slug: string}, isAbsolute=false) => {
-  const suffix = `/${tagUrlBase}/${tag.slug}/discussion`
+  const suffix = `/${tagUrlBaseSetting.get()}/${tag.slug}/discussion`
   return isAbsolute ? combineUrls(siteUrlSetting.get(), suffix) : suffix
 }
 
@@ -76,7 +75,7 @@ export const tagGetCommentLink = ({tagSlug, commentId, tagCommentType = "DISCUSS
 // TODO: Is this necessary if we instead have version as a search param in the main tagGetUrl function?
 export const tagGetRevisionLink = (tag: DbTag|TagBasicInfo, versionNumber: string, lens?: MultiDocumentContentDisplay|TagLens): string => {
   const lensParam = lens ? `lens=${lens.slug}&` : "";
-  return `/${tagUrlBase}/${tag.slug}?${lensParam}version=${versionNumber}`;
+  return `/${tagUrlBaseSetting.get()}/${tag.slug}?${lensParam}version=${versionNumber}`;
 }
 
 export const tagUserHasSufficientKarma = (user: UsersCurrent | DbUser | null, action: "new" | "edit"): boolean => {

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -32,6 +32,7 @@ type GetUrlOptions = {
   lens?: string
   tab?: string
   from?: string,
+  pathId?: string
 }
 
 export const tagCreateUrl = `/${tagUrlBaseSetting.get()}/create`

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -139,6 +139,16 @@ export const taggingNamePluralSetting = {get: () => pluralize(taggingNameSetting
 export const taggingNamePluralCapitalSetting = {get: () => pluralize(startCase(taggingNameSetting.get()))}
 export const taggingNameIsSet = {get: () => taggingNameSetting.get() !== 'tag'}
 
+/** Value for tags in the url schema, if set. This allows the url for tags to
+ * be something other than the tag name, e.g. LessWrong is setting this to "w",
+ * for example www.lesswrong.com/w/tagname.
+ * Defaults to tag setting name.
+ */
+const usePluralTagName = !isLWorAF && taggingNameIsSet.get();
+export const taggingUrlSchemaSetting = new PublicInstanceSetting<string>('taggingUrlSchema', taggingNameSetting.get(), 'optional')
+export const taggingUrlSchemaIsSet = {get: () => taggingUrlSchemaSetting.get() !== taggingNameSetting.get()}
+export const tagUrlBaseSetting = {get: () => `${taggingUrlSchemaSetting.get() || (usePluralTagName ? taggingNamePluralSetting.get() : taggingNameSetting.get())}`}
+
 // NB: Now that neither LW nor the EAForum use this setting, it's a matter of
 // time before it falls out of date. Nevertheless, I expect any newly-created
 // forums to use this setting.

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -138,18 +138,17 @@ export const taggingNameCapitalSetting = {get: () => startCase(taggingNameSettin
 export const taggingNamePluralSetting = {get: () => pluralize(taggingNameSetting.get())}
 export const taggingNamePluralCapitalSetting = {get: () => pluralize(startCase(taggingNameSetting.get()))}
 export const taggingNameIsSet = {get: () => taggingNameSetting.get() !== 'tag'}
-export const usePluralTagNameSetting = {get: () => !isLWorAF && taggingNameIsSet.get()};
-export const taggingNameCapitalizedWithCorrectPlural = { get: () => {
-  if (usePluralTagNameSetting.get()) {
+export const taggingNameIsPluralized = {get: () => !isLWorAF && taggingNameIsSet.get()};
+export const taggingNameCapitalizedWithPluralizationChoice = { get: () => {
+  if (taggingNameIsPluralized.get()) {
     return taggingNamePluralCapitalSetting.get();
   }
   return taggingNameCapitalSetting.get();
 }};
 
-/** Value for tags in the url schema, if set. This allows the url for tags to
+/** Value for tags in the urls, e.g. /w/:slug, or /tag/:slug or /topics/:slug, if set. This allows the url for tags to
  * be something other than the tag name, e.g. LessWrong is setting this to "w",
- * for example www.lesswrong.com/w/tagname.
- * Defaults to tag setting name.
+ * Defaults to tag setting name (with or without pluralization).
  */
 export const taggingUrlCustomBaseSetting = new PublicInstanceSetting<string|null>('taggingUrlCustomBase', null, 'optional')
 export const tagUrlBaseSetting = {get: () => {
@@ -157,7 +156,7 @@ export const tagUrlBaseSetting = {get: () => {
   if (customBase) {
     return customBase;
   }
-  if (usePluralTagNameSetting.get()) {
+  if (taggingNameIsPluralized.get()) {
     return taggingNamePluralSetting.get();
   }
   return taggingNameSetting.get();

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -138,16 +138,30 @@ export const taggingNameCapitalSetting = {get: () => startCase(taggingNameSettin
 export const taggingNamePluralSetting = {get: () => pluralize(taggingNameSetting.get())}
 export const taggingNamePluralCapitalSetting = {get: () => pluralize(startCase(taggingNameSetting.get()))}
 export const taggingNameIsSet = {get: () => taggingNameSetting.get() !== 'tag'}
+export const usePluralTagNameSetting = {get: () => !isLWorAF && taggingNameIsSet.get()};
+export const taggingNameCapitalizedWithCorrectPlural = { get: () => {
+  if (usePluralTagNameSetting.get()) {
+    return taggingNamePluralCapitalSetting.get();
+  }
+  return taggingNameCapitalSetting.get();
+}};
 
 /** Value for tags in the url schema, if set. This allows the url for tags to
  * be something other than the tag name, e.g. LessWrong is setting this to "w",
  * for example www.lesswrong.com/w/tagname.
  * Defaults to tag setting name.
  */
-const usePluralTagName = !isLWorAF && taggingNameIsSet.get();
-export const taggingUrlSchemaSetting = new PublicInstanceSetting<string>('taggingUrlSchema', taggingNameSetting.get(), 'optional')
-export const taggingUrlSchemaIsSet = {get: () => taggingUrlSchemaSetting.get() !== taggingNameSetting.get()}
-export const tagUrlBaseSetting = {get: () => `${taggingUrlSchemaSetting.get() || (usePluralTagName ? taggingNamePluralSetting.get() : taggingNameSetting.get())}`}
+export const taggingUrlCustomBaseSetting = new PublicInstanceSetting<string|null>('taggingUrlCustomBase', null, 'optional')
+export const tagUrlBaseSetting = {get: () => {
+  const customBase = taggingUrlCustomBaseSetting.get();
+  if (customBase) {
+    return customBase;
+  }
+  if (usePluralTagNameSetting.get()) {
+    return taggingNamePluralSetting.get();
+  }
+  return taggingNameSetting.get();
+}}
 
 // NB: Now that neither LW nor the EAForum use this setting, it's a matter of
 // time before it falls out of date. Nevertheless, I expect any newly-created

--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -30,6 +30,7 @@ import { Link } from './reactRouterWrapper';
 import { isFriendlyUI } from '../themes/forumTheme';
 import Sequences from './collections/sequences/collection';
 import { sequenceGetPageUrl } from './collections/sequences/helpers';
+import { tagGetUrl } from './collections/tags/helpers';
 
 // We need enough fields here to render the user tooltip
 type NotificationDisplayUser = Pick<
@@ -819,7 +820,7 @@ export const KarmaPowersGainedNotification = registerNotificationType({
     return "Your votes are stronger because your karma went up!"
   },
   getLink() {
-    return `/tag/vote-strength`;
+    return tagGetUrl({slug: 'vote-strength'});
   },
   getIcon() {
     return <Components.ForumIcon icon="Bell" style={iconStyles} />

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW } from './instanceSettings';
+import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlSchemaSetting, isLWorAF, tagUrlBaseSetting } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -373,146 +373,26 @@ addRoute(
   }
 );
 
-if (taggingNameIsSet.get()) {
+
+const usePluralTagName = !isLWorAF && taggingNameIsSet.get();
+const taggingNameCapitalized = usePluralTagName ? taggingNamePluralCapitalSetting.get() : taggingNameCapitalSetting.get();
+
   addRoute(
     {
-      name: 'tagsSingleCustomName',
-      path: `/${taggingNamePluralSetting.get()}/:slug`,
+      name: 'tagsSingle',
+      path: `/${tagUrlBaseSetting.get()}/:slug`,
       componentName: 'TagPageRouter',
       titleComponentName: 'TagPageTitle',
       subtitleComponentName: 'TagPageTitle',
       previewComponentName: 'TagHoverPreview',
       enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-    },
-    {
-      name: 'tagsSingleRedirectCustomName',
-      path: '/tag/:slug',
-      redirect: ({ params }) => `/${taggingNamePluralSetting.get()}/${params.slug}`,
-      background: "#fffeee",
+      background: isLW ? "white" : "#fffeee",
       getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    },
-    {
-      name: 'tagDiscussionCustomName',
-      path: `/${taggingNamePluralSetting.get()}/:slug/discussion`,
-      componentName: 'TagDiscussionPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      // background: "white",
-      noIndex: true,
-    },
-    {
-      name: 'tagDiscussionCustomNameRedirect',
-      path: '/tag/:slug/discussion',
-      redirect: ({params}) => `/${taggingNamePluralSetting.get()}/${params.slug}/discussion`
-    },
-    {
-      name: 'tagHistoryCustomName',
-      path: `/${taggingNamePluralSetting.get()}/:slug/history`,
-      componentName: 'TagHistoryPage',
-      titleComponentName: 'TagHistoryPageTitle',
-      subtitleComponentName: 'TagHistoryPageTitle',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-      noIndex: true,
-    },
-    {
-      name: 'tagHistoryCustomNameRedirect',
-      path: '/tag/:slug/history',
-      redirect: ({params}) => `/${taggingNamePluralSetting.get()}/${params.slug}/history`
-    },
-    {
-      name: 'tagEditCustomName',
-      path: `/${taggingNamePluralSetting.get()}/:slug/edit`,
-      componentName: 'EditTagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-    },
-    {
-      name: 'tagEditCustomNameRedirect',
-      path: '/tag/:slug/edit',
-      redirect: ({params}) => `/${taggingNamePluralSetting.get()}/${params.slug}/edit`
-    },
-    {
-      name: 'tagCreateCustomName',
-      path: `/${taggingNamePluralSetting.get()}/create`,
-      title: `New ${taggingNameCapitalSetting.get()}`,
-      componentName: 'NewTagPage',
-      subtitleComponentName: 'TagPageTitle',
-      background: "white"
-    },
-    {
-      name: 'tagCreateCustomNameRedirect',
-      path: '/tag/create',
-      redirect: () => `/${taggingNamePluralSetting.get()}/create`
-    },
-    {
-      name: 'randomTagCustomName',
-      path: `/${taggingNamePluralSetting.get()}/random`,
-      componentName: 'RandomTagPage',
-    },
-    {
-      name: 'randomTagCustomNameRedirect',
-      path: '/tags/random',
-      redirect: () => `/${taggingNamePluralSetting.get()}/random`
-    },
-    {
-      name: 'tagActivityCustomName',
-      path: `/${taggingNamePluralSetting.get()}Activity`,
-      componentName: 'TagVoteActivity',
-      title: `${taggingNamePluralCapitalSetting.get()} Voting Activity`
-    },
-    {
-      name: 'tagActivityCustomNameRedirect',
-      path: '/tagActivity',
-      redirect: () => `/${taggingNamePluralSetting.get()}Activity`
-    },
-    {
-      name: 'tagFeedCustomName',
-      path: `/${taggingNamePluralSetting.get()}Feed`,
-      componentName: 'TagActivityFeed',
-      title: `${taggingNamePluralCapitalSetting.get()} Activity`
-    },
-    {
-      name: 'tagFeedCustomNameRedirect',
-      path: '/tagFeed',
-      redirect: () => `/${taggingNamePluralSetting.get()}Feed`
-    },
-    {
-      name: 'taggingDashboardCustomName',
-      path: `/${taggingNamePluralSetting.get()}/dashboard`,
-      componentName: "TaggingDashboard",
-      title: `${taggingNamePluralCapitalSetting.get()} Dashboard`,
-      ...taggingDashboardSubtitle
-    },
-    {
-      name: 'taggingDashboardCustomNameRedirect',
-      path: '/tags/dashboard',
-      redirect: () => `/${taggingNamePluralSetting.get()}/dashboard`
-    }
-  )
-} else {
-  addRoute(
-    {
-      name: 'tags.single',
-      path: '/tag/:slug',
-      componentName: 'TagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-      background: "white",
-    },
-    // Temporary arbital routes
-    {
-      name: 'tag.arbital.w.guideRedirect',
-      path: '/w/:slug',
-      componentName: 'TagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-      background: "white",
       redirect: (location) => {
+        if (!isLWorAF) {
+          return null;
+        }
+
         const { params: { slug }, query } = location;
         if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
           const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
@@ -520,8 +400,142 @@ if (taggingNameIsSet.get()) {
         }
         return null;
       },
+    },
+    {
+      name: 'tagDiscussion',
+      path: `/${tagUrlBaseSetting.get()}/:slug/discussion`,
+      componentName: 'TagDiscussionPage',
+      titleComponentName: 'TagPageTitle',
+      subtitleComponentName: 'TagPageTitle',
+      previewComponentName: 'TagHoverPreview',
+      background: isLW ? "white" : undefined,
+      noIndex: true,
       getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     },
+    {
+      name: 'tagHistory',
+      path: `/${tagUrlBaseSetting.get()}/:slug/history`,
+      componentName: 'TagHistoryPage',
+      titleComponentName: 'TagHistoryPageTitle',
+      subtitleComponentName: 'TagHistoryPageTitle',
+      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+      noIndex: true,
+    },
+    {
+      name: 'tagEdit',
+      path: `/${tagUrlBaseSetting.get()}/:slug/edit`,
+      componentName: 'EditTagPage',
+      titleComponentName: 'TagPageTitle',
+      subtitleComponentName: 'TagPageTitle',
+    },
+    {
+      name: 'tagCreate',
+      path: `/${tagUrlBaseSetting.get()}/create`,
+      title: `New ${taggingNameCapitalSetting.get()}`,
+      componentName: 'NewTagPage',
+      subtitleComponentName: 'TagPageTitle',
+      background: "white"
+    },
+    {
+      name: 'randomTag',
+      path: `/${tagUrlBaseSetting.get()}/random`,
+      componentName: 'RandomTagPage',
+    },
+    {
+      name: 'tagActivity',
+      path: `/${tagUrlBaseSetting.get()}Activity`,
+      componentName: 'TagVoteActivity',
+      title: `${taggingNameCapitalized} Voting Activity`
+    },
+    {
+      name: 'tagFeed',
+      path: `/${tagUrlBaseSetting.get()}Feed`,
+      componentName: 'TagActivityFeed',
+      title: `${taggingNameCapitalized} Activity`
+    },
+    {
+      name: 'taggingDashboard',
+      path: `/${tagUrlBaseSetting.get()}/dashboard`,
+      componentName: "TaggingDashboard",
+      title: `${taggingNameCapitalized} Dashboard`,
+      ...taggingDashboardSubtitle
+    }
+  )
+
+  if (tagUrlBaseSetting.get() !== 'tag') {
+    addRoute(
+      {
+        name: 'tagsSingleRedirect',
+        path: '/tag/:slug',
+        redirect: ({ params }) => `/${tagUrlBaseSetting.get()}/${params.slug}`,
+        background: isLW? "white" : "#fffeee",
+        getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+      },
+      {
+        name: 'tagDiscussionRedirect',
+        path: '/tag/:slug/discussion',
+        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/discussion`
+      },
+      {
+        name: 'tagHistoryRedirect',
+        path: '/tag/:slug/history',
+        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/history`
+      },
+      {
+        name: 'tagEditRedirect',
+        path: '/tag/:slug/edit',
+        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/edit`
+      },
+      {
+        name: 'tagCreateRedirect',
+        path: '/tag/create',
+        redirect: () => `/${tagUrlBaseSetting.get()}/create`
+      },
+      {
+        name: 'randomTagRedirect',
+        path: '/tags/random',
+        redirect: () => `/${tagUrlBaseSetting.get()}/random`
+      },
+      {
+        name: 'tagActivityRedirect',
+        path: '/tagActivity',
+        redirect: () => `/${tagUrlBaseSetting.get()}Activity`
+      },
+      {
+        name: 'tagFeedRedirect',
+        path: '/tagFeed',
+        redirect: () => `/${tagUrlBaseSetting.get()}Feed`
+      },
+      {
+        name: 'taggingDashboardRedirect',
+        path: '/tags/dashboard',
+        redirect: () => `/${tagUrlBaseSetting.get()}/dashboard`
+      }
+    )
+  }
+
+// Temporary arbital routes
+if (isLWorAF) {
+  addRoute(
+    // {
+    //   name: 'tag.arbital.w.guideRedirect',
+    //   path: '/w/:slug',
+    //   componentName: 'TagPage',
+    //   titleComponentName: 'TagPageTitle',
+    //   subtitleComponentName: 'TagPageTitle',
+    //   previewComponentName: 'TagHoverPreview',
+    //   enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+    //   background: "white",
+    //   redirect: (location) => {
+    //     const { params: { slug }, query } = location;
+    //     if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
+    //       const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
+    //       return `/w/${firstPathPageId}?pathId=${slug}`;
+    //     }
+    //     return null;
+    //   },
+    //   getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    // },
     // {
     //   name: 'tag.arbital.w',
     //   path: '/w/:slug',
@@ -533,74 +547,22 @@ if (taggingNameIsSet.get()) {
     //   background: "white",
     //  getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     // },
+    // {
+    //   name: 'tag.arbital.p',
+    //   path: '/p/:slug',
+    //   componentName: 'TagPage',
+    //   titleComponentName: 'TagPageTitle',
+    //   subtitleComponentName: 'TagPageTitle',
+    //   previewComponentName: 'TagHoverPreview',
+    //   enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+    //   background: "white",
+    //   getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    // },
     {
-      name: 'tag.arbital.p',
+      name: 'tag.arbital.p.redirect',
       path: '/p/:slug',
-      componentName: 'TagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-      background: "white",
-      getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    },
-    // End of temporary arbital routes
-    {
-      name: 'tagDiscussion',
-      path: '/tag/:slug/discussion',
-      componentName: 'TagDiscussionPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      background: "white",
-      getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    },
-    {
-      name: 'tagHistory',
-      path: '/tag/:slug/history',
-      componentName: 'TagHistoryPage',
-      titleComponentName: 'TagHistoryPageTitle',
-      subtitleComponentName: 'TagHistoryPageTitle',
-    },
-    {
-      name: 'tagEdit',
-      path: '/tag/:slug/edit',
-      componentName: 'EditTagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-    },
-    {
-      name: 'tagCreate',
-      path: '/tag/create',
-      componentName: 'NewTagPage',
-      title: "New Tag",
-      subtitleComponentName: 'TagPageTitle',
-      background: "white"
-    },
-    {
-      name: 'randomTag',
-      path: '/tags/random',
-      componentName: 'RandomTagPage',
-    },
-    {
-      name: 'tagActivity',
-      path: '/tagActivity',
-      componentName: 'TagVoteActivity',
-      title: 'Tag Voting Activity'
-    },
-    {
-      name: 'tagFeed',
-      path: '/tagFeed',
-      componentName: 'TagActivityFeed',
-      title: 'Tag Activity'
-    },
-    {
-      name: 'taggingDashboard',
-      path: '/tags/dashboard',
-      componentName: "TaggingDashboard",
-      title: "Tagging Dashboard",
-      ...taggingDashboardSubtitle
-    },
+      redirect: ({params}) => `${tagUrlBaseSetting}/${params.slug}`
+    }
   )
 }
 

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -13,7 +13,7 @@ import { hasPostRecommendations, hasSurveys } from './betas';
 import {isFriendlyUI} from '../themes/forumTheme'
 import { postRouteWillDefinitelyReturn200 } from './collections/posts/helpers';
 import { sequenceRouteWillDefinitelyReturn200 } from './collections/sequences/helpers';
-import { tagRouteWillDefinitelyReturn200 } from './collections/tags/helpers';
+import { tagGetUrl, tagRouteWillDefinitelyReturn200 } from './collections/tags/helpers';
 import { GUIDE_PATH_PAGES_MAPPING } from './arbital/paths';
 
 const knownTagNames = ['tag', 'topic', 'concept']
@@ -396,7 +396,7 @@ const taggingNameCapitalized = usePluralTagName ? taggingNamePluralCapitalSettin
         const { params: { slug }, query } = location;
         if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
           const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
-          return `/w/${firstPathPageId}?pathId=${slug}`;
+          return tagGetUrl({slug: firstPathPageId}, {pathId: slug});
         }
         return null;
       },

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, usePluralTagNameSetting, taggingNameCapitalizedWithCorrectPlural } from './instanceSettings';
+import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, usePluralTagNameSetting, taggingNameCapitalizedWithCorrectPlural as taggingNameCapitalizedWithPluralilizationChoice } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -373,9 +373,6 @@ addRoute(
   }
 );
 
-
-const taggingNameCapitalized = taggingNameCapitalizedWithCorrectPlural.get();
-
 addRoute(
   {
     name: 'tagsSingle',
@@ -408,7 +405,7 @@ addRoute(
     subtitleComponentName: 'TagPageTitle',
     previewComponentName: 'TagHoverPreview',
     background: isLW ? "white" : undefined,
-    noIndex: true,
+    noIndex: isEAForum,
     getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
   },
   {
@@ -444,19 +441,19 @@ addRoute(
     name: 'tagActivity',
     path: `/${tagUrlBaseSetting.get()}Activity`,
     componentName: 'TagVoteActivity',
-    title: `${taggingNameCapitalized} Voting Activity`
+    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Voting Activity`
   },
   {
     name: 'tagFeed',
     path: `/${tagUrlBaseSetting.get()}Feed`,
     componentName: 'TagActivityFeed',
-    title: `${taggingNameCapitalized} Activity`
+    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Activity`
   },
   {
     name: 'taggingDashboard',
     path: `/${tagUrlBaseSetting.get()}/dashboard`,
     componentName: "TaggingDashboard",
-    title: `${taggingNameCapitalized} Dashboard`,
+    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Dashboard`,
     ...taggingDashboardSubtitle
   }
 )
@@ -467,13 +464,13 @@ if (tagUrlBaseSetting.get() !== 'tag') {
       name: 'tagsSingleRedirect',
       path: '/tag/:slug',
       redirect: ({ params }) => `/${tagUrlBaseSetting.get()}/${params.slug}`,
-      background: isLW ? "white" : "#fffeee",
       getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     },
     {
       name: 'tagDiscussionRedirect',
       path: '/tag/:slug/discussion',
-      redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/discussion`
+      redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/discussion`,
+      getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     },
     {
       name: 'tagHistoryRedirect',
@@ -512,7 +509,6 @@ if (tagUrlBaseSetting.get() !== 'tag') {
     }
   )
 }
-
 
 // All tags page
 addRoute(

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,7 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, taggingNameIsPluralized, taggingNameCapitalizedWithCorrectPlural as taggingNameCapitalizedWithPluralizationChoice } from './instanceSettings';
+import { 
+  forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet,
+  taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting,
+  isLW, isLWorAF, tagUrlBaseSetting, taggingNameCapitalizedWithPluralizationChoice } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlSchemaSetting, isLWorAF, tagUrlBaseSetting } from './instanceSettings';
+import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, usePluralTagNameSetting, taggingNameCapitalizedWithCorrectPlural } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -374,197 +374,145 @@ addRoute(
 );
 
 
-const usePluralTagName = !isLWorAF && taggingNameIsSet.get();
-const taggingNameCapitalized = usePluralTagName ? taggingNamePluralCapitalSetting.get() : taggingNameCapitalSetting.get();
+const taggingNameCapitalized = taggingNameCapitalizedWithCorrectPlural.get();
 
+addRoute(
+  {
+    name: 'tagsSingle',
+    path: `/${tagUrlBaseSetting.get()}/:slug`,
+    componentName: 'TagPageRouter',
+    titleComponentName: 'TagPageTitle',
+    subtitleComponentName: 'TagPageTitle',
+    previewComponentName: 'TagHoverPreview',
+    enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+    background: isLW ? "white" : "#fffeee",
+    getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    redirect: (location) => {
+      if (!isLWorAF) {
+        return null;
+      }
+
+      const { params: { slug }, query } = location;
+      if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
+        const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
+        return tagGetUrl({slug: firstPathPageId}, {pathId: slug});
+      }
+      return null;
+    },
+  },
+  {
+    name: 'tagDiscussion',
+    path: `/${tagUrlBaseSetting.get()}/:slug/discussion`,
+    componentName: 'TagDiscussionPage',
+    titleComponentName: 'TagPageTitle',
+    subtitleComponentName: 'TagPageTitle',
+    previewComponentName: 'TagHoverPreview',
+    background: isLW ? "white" : undefined,
+    noIndex: true,
+    getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+  },
+  {
+    name: 'tagHistory',
+    path: `/${tagUrlBaseSetting.get()}/:slug/history`,
+    componentName: 'TagHistoryPage',
+    titleComponentName: 'TagHistoryPageTitle',
+    subtitleComponentName: 'TagHistoryPageTitle',
+    enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+    noIndex: true,
+  },
+  {
+    name: 'tagEdit',
+    path: `/${tagUrlBaseSetting.get()}/:slug/edit`,
+    componentName: 'EditTagPage',
+    titleComponentName: 'TagPageTitle',
+    subtitleComponentName: 'TagPageTitle',
+  },
+  {
+    name: 'tagCreate',
+    path: `/${tagUrlBaseSetting.get()}/create`,
+    title: `New ${taggingNameCapitalSetting.get()}`,
+    componentName: 'NewTagPage',
+    subtitleComponentName: 'TagPageTitle',
+    background: "white"
+  },
+  {
+    name: 'randomTag',
+    path: `/${tagUrlBaseSetting.get()}/random`,
+    componentName: 'RandomTagPage',
+  },
+  {
+    name: 'tagActivity',
+    path: `/${tagUrlBaseSetting.get()}Activity`,
+    componentName: 'TagVoteActivity',
+    title: `${taggingNameCapitalized} Voting Activity`
+  },
+  {
+    name: 'tagFeed',
+    path: `/${tagUrlBaseSetting.get()}Feed`,
+    componentName: 'TagActivityFeed',
+    title: `${taggingNameCapitalized} Activity`
+  },
+  {
+    name: 'taggingDashboard',
+    path: `/${tagUrlBaseSetting.get()}/dashboard`,
+    componentName: "TaggingDashboard",
+    title: `${taggingNameCapitalized} Dashboard`,
+    ...taggingDashboardSubtitle
+  }
+)
+
+if (tagUrlBaseSetting.get() !== 'tag') {
   addRoute(
     {
-      name: 'tagsSingle',
-      path: `/${tagUrlBaseSetting.get()}/:slug`,
-      componentName: 'TagPageRouter',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
+      name: 'tagsSingleRedirect',
+      path: '/tag/:slug',
+      redirect: ({ params }) => `/${tagUrlBaseSetting.get()}/${params.slug}`,
       background: isLW ? "white" : "#fffeee",
       getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-      redirect: (location) => {
-        if (!isLWorAF) {
-          return null;
-        }
-
-        const { params: { slug }, query } = location;
-        if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
-          const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
-          return tagGetUrl({slug: firstPathPageId}, {pathId: slug});
-        }
-        return null;
-      },
     },
     {
-      name: 'tagDiscussion',
-      path: `/${tagUrlBaseSetting.get()}/:slug/discussion`,
-      componentName: 'TagDiscussionPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
-      previewComponentName: 'TagHoverPreview',
-      background: isLW ? "white" : undefined,
-      noIndex: true,
-      getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+      name: 'tagDiscussionRedirect',
+      path: '/tag/:slug/discussion',
+      redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/discussion`
     },
     {
-      name: 'tagHistory',
-      path: `/${tagUrlBaseSetting.get()}/:slug/history`,
-      componentName: 'TagHistoryPage',
-      titleComponentName: 'TagHistoryPageTitle',
-      subtitleComponentName: 'TagHistoryPageTitle',
-      enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-      noIndex: true,
+      name: 'tagHistoryRedirect',
+      path: '/tag/:slug/history',
+      redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/history`
     },
     {
-      name: 'tagEdit',
-      path: `/${tagUrlBaseSetting.get()}/:slug/edit`,
-      componentName: 'EditTagPage',
-      titleComponentName: 'TagPageTitle',
-      subtitleComponentName: 'TagPageTitle',
+      name: 'tagEditRedirect',
+      path: '/tag/:slug/edit',
+      redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/edit`
     },
     {
-      name: 'tagCreate',
-      path: `/${tagUrlBaseSetting.get()}/create`,
-      title: `New ${taggingNameCapitalSetting.get()}`,
-      componentName: 'NewTagPage',
-      subtitleComponentName: 'TagPageTitle',
-      background: "white"
+      name: 'tagCreateRedirect',
+      path: '/tag/create',
+      redirect: () => `/${tagUrlBaseSetting.get()}/create`
     },
     {
-      name: 'randomTag',
-      path: `/${tagUrlBaseSetting.get()}/random`,
-      componentName: 'RandomTagPage',
+      name: 'randomTagRedirect',
+      path: '/tags/random',
+      redirect: () => `/${tagUrlBaseSetting.get()}/random`
     },
     {
-      name: 'tagActivity',
-      path: `/${tagUrlBaseSetting.get()}Activity`,
-      componentName: 'TagVoteActivity',
-      title: `${taggingNameCapitalized} Voting Activity`
+      name: 'tagActivityRedirect',
+      path: '/tagActivity',
+      redirect: () => `/${tagUrlBaseSetting.get()}Activity`
     },
     {
-      name: 'tagFeed',
-      path: `/${tagUrlBaseSetting.get()}Feed`,
-      componentName: 'TagActivityFeed',
-      title: `${taggingNameCapitalized} Activity`
+      name: 'tagFeedRedirect',
+      path: '/tagFeed',
+      redirect: () => `/${tagUrlBaseSetting.get()}Feed`
     },
     {
-      name: 'taggingDashboard',
-      path: `/${tagUrlBaseSetting.get()}/dashboard`,
-      componentName: "TaggingDashboard",
-      title: `${taggingNameCapitalized} Dashboard`,
-      ...taggingDashboardSubtitle
-    }
-  )
-
-  if (tagUrlBaseSetting.get() !== 'tag') {
-    addRoute(
-      {
-        name: 'tagsSingleRedirect',
-        path: '/tag/:slug',
-        redirect: ({ params }) => `/${tagUrlBaseSetting.get()}/${params.slug}`,
-        background: isLW? "white" : "#fffeee",
-        getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-      },
-      {
-        name: 'tagDiscussionRedirect',
-        path: '/tag/:slug/discussion',
-        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/discussion`
-      },
-      {
-        name: 'tagHistoryRedirect',
-        path: '/tag/:slug/history',
-        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/history`
-      },
-      {
-        name: 'tagEditRedirect',
-        path: '/tag/:slug/edit',
-        redirect: ({params}) => `/${tagUrlBaseSetting.get()}/${params.slug}/edit`
-      },
-      {
-        name: 'tagCreateRedirect',
-        path: '/tag/create',
-        redirect: () => `/${tagUrlBaseSetting.get()}/create`
-      },
-      {
-        name: 'randomTagRedirect',
-        path: '/tags/random',
-        redirect: () => `/${tagUrlBaseSetting.get()}/random`
-      },
-      {
-        name: 'tagActivityRedirect',
-        path: '/tagActivity',
-        redirect: () => `/${tagUrlBaseSetting.get()}Activity`
-      },
-      {
-        name: 'tagFeedRedirect',
-        path: '/tagFeed',
-        redirect: () => `/${tagUrlBaseSetting.get()}Feed`
-      },
-      {
-        name: 'taggingDashboardRedirect',
-        path: '/tags/dashboard',
-        redirect: () => `/${tagUrlBaseSetting.get()}/dashboard`
-      }
-    )
-  }
-
-// Temporary arbital routes
-if (isLWorAF) {
-  addRoute(
-    // {
-    //   name: 'tag.arbital.w.guideRedirect',
-    //   path: '/w/:slug',
-    //   componentName: 'TagPage',
-    //   titleComponentName: 'TagPageTitle',
-    //   subtitleComponentName: 'TagPageTitle',
-    //   previewComponentName: 'TagHoverPreview',
-    //   enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-    //   background: "white",
-    //   redirect: (location) => {
-    //     const { params: { slug }, query } = location;
-    //     if ('startPath' in query && slug in GUIDE_PATH_PAGES_MAPPING) {
-    //       const firstPathPageId = GUIDE_PATH_PAGES_MAPPING[slug as keyof typeof GUIDE_PATH_PAGES_MAPPING][0];
-    //       return `/w/${firstPathPageId}?pathId=${slug}`;
-    //     }
-    //     return null;
-    //   },
-    //   getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    // },
-    // {
-    //   name: 'tag.arbital.w',
-    //   path: '/w/:slug',
-    //   componentName: 'TagPage',
-    //   titleComponentName: 'TagPageTitle',
-    //   subtitleComponentName: 'TagPageTitle',
-    //   previewComponentName: 'TagHoverPreview',
-    //   enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-    //   background: "white",
-    //  getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    // },
-    // {
-    //   name: 'tag.arbital.p',
-    //   path: '/p/:slug',
-    //   componentName: 'TagPage',
-    //   titleComponentName: 'TagPageTitle',
-    //   subtitleComponentName: 'TagPageTitle',
-    //   previewComponentName: 'TagHoverPreview',
-    //   enableResourcePrefetch: tagRouteWillDefinitelyReturn200,
-    //   background: "white",
-    //   getPingback: (parsedUrl) => getTagPingbackBySlug(parsedUrl, parsedUrl.params.slug),
-    // },
-    {
-      name: 'tag.arbital.p.redirect',
-      path: '/p/:slug',
-      redirect: ({params}) => `${tagUrlBaseSetting}/${params.slug}`
+      name: 'taggingDashboardRedirect',
+      path: '/tags/dashboard',
+      redirect: () => `/${tagUrlBaseSetting.get()}/dashboard`
     }
   )
 }
+
 
 // All tags page
 addRoute(

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,4 +1,4 @@
-import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, usePluralTagNameSetting, taggingNameCapitalizedWithCorrectPlural as taggingNameCapitalizedWithPluralilizationChoice } from './instanceSettings';
+import { forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet, taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting, isLW, taggingUrlCustomBaseSetting, isLWorAF, tagUrlBaseSetting, taggingNameIsPluralized, taggingNameCapitalizedWithCorrectPlural as taggingNameCapitalizedWithPluralizationChoice } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -47,7 +47,7 @@ const hpmorSubtitle = { subtitleLink: "/hpmor", subtitle: "HPMoR" };
 const codexSubtitle = { subtitleLink: "/codex", subtitle: "SlateStarCodex" };
 const leastWrongSubtitle = { subtitleLink: "/leastwrong", subtitle: "The Best of LessWrong" };
 
-const taggingDashboardSubtitle = { subtitleLink: '/tags/dashboard', subtitle: `${taggingNameIsSet.get() ? taggingNamePluralCapitalSetting.get() : 'Wiki-Tag'} Dashboard`}
+const taggingDashboardSubtitle = { subtitleLink: `/${taggingNamePluralSetting.get()}/dashboard`, subtitle: `${taggingNameIsSet.get() ? taggingNamePluralCapitalSetting.get() : 'Wiki-Tag'} Dashboard`}
 
 const faqPostIdSetting = new PublicInstanceSetting<string>('faqPostId', '2rWKkWuPrgTMpLRbp', "warning") // Post ID for the /faq route
 const contactPostIdSetting = new PublicInstanceSetting<string>('contactPostId', "ehcYkvyz7dh9L7Wt8", "warning")
@@ -441,19 +441,19 @@ addRoute(
     name: 'tagActivity',
     path: `/${tagUrlBaseSetting.get()}Activity`,
     componentName: 'TagVoteActivity',
-    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Voting Activity`
+    title: `${taggingNameCapitalizedWithPluralizationChoice.get()} Voting Activity`
   },
   {
     name: 'tagFeed',
     path: `/${tagUrlBaseSetting.get()}Feed`,
     componentName: 'TagActivityFeed',
-    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Activity`
+    title: `${taggingNameCapitalizedWithPluralizationChoice.get()} Activity`
   },
   {
     name: 'taggingDashboard',
     path: `/${tagUrlBaseSetting.get()}/dashboard`,
     componentName: "TaggingDashboard",
-    title: `${taggingNameCapitalizedWithPluralilizationChoice.get()} Dashboard`,
+    title: `${taggingNameCapitalizedWithPluralizationChoice.get()} Dashboard`,
     ...taggingDashboardSubtitle
   }
 )
@@ -490,7 +490,7 @@ if (tagUrlBaseSetting.get() !== 'tag') {
     {
       name: 'randomTagRedirect',
       path: '/tags/random',
-      redirect: () => `/${tagUrlBaseSetting.get()}/random`
+      redirect: () => `/${taggingNamePluralSetting.get()}/random`
     },
     {
       name: 'tagActivityRedirect',
@@ -506,7 +506,12 @@ if (tagUrlBaseSetting.get() !== 'tag') {
       name: 'taggingDashboardRedirect',
       path: '/tags/dashboard',
       redirect: () => `/${tagUrlBaseSetting.get()}/dashboard`
-    }
+    },
+    {
+      name: 'tags.revisioncompare.redirect',
+      path: `/compare/tag/:slug`,
+      redirect: ({params}) => `/compare/${tagUrlBaseSetting.get()}/${params.slug}`
+    },
   )
 }
 
@@ -1519,7 +1524,7 @@ addRoute(
   },
   {
     name: 'tags.revisioncompare',
-    path: '/compare/tag/:slug',
+    path: `/compare/${tagUrlBaseSetting.get()}/:slug`,
     componentName: 'TagCompareRevisions',
     titleComponentName: 'PostsPageHeaderTitle',
   },

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,7 +1,7 @@
 import { 
   forumTypeSetting, PublicInstanceSetting, hasEventsSetting, taggingNamePluralSetting, taggingNameIsSet,
   taggingNamePluralCapitalSetting, taggingNameCapitalSetting, isEAForum, taggingNameSetting, aboutPostIdSetting,
-  isLW, isLWorAF, tagUrlBaseSetting, taggingNameCapitalizedWithPluralizationChoice } from './instanceSettings';
+  isLW, isLWorAF, tagUrlBaseSetting, taggingNameIsPluralized, taggingNameCapitalizedWithPluralizationChoice } from './instanceSettings';
 import { blackBarTitle, legacyRouteAcronymSetting } from './publicSettings';
 import { addRoute, RouterLocation, Route } from './vulcan-lib/routes';
 import { REVIEW_YEAR } from './reviewUtils';
@@ -515,6 +515,11 @@ if (tagUrlBaseSetting.get() !== 'tag') {
       path: `/compare/tag/:slug`,
       redirect: ({params}) => `/compare/${tagUrlBaseSetting.get()}/${params.slug}`
     },
+    {
+      name: 'tags.revisionselect.redirect',
+      path: `/revisions/tag/:slug`,
+      redirect: ({params}) => `/revisions/${tagUrlBaseSetting.get()}/${params.slug}`
+    }
   )
 }
 
@@ -1539,7 +1544,7 @@ addRoute(
   },
   {
     name: 'tag.revisionsselect',
-    path: '/revisions/tag/:slug',
+    path: `/revisions/${tagUrlBaseSetting.get()}/:slug`,
     componentName: 'TagPageRevisionSelect',
     titleComponentName: 'TagPageTitle',
   },

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -20,6 +20,7 @@ import { captureEvent } from '../../lib/analyticsEvents';
 import { adminAccountSetting, recombeeEnabledSetting } from '../../lib/publicSettings';
 import { recombeeApi } from '../recombee/client';
 import { userShortformPostTitle } from '@/lib/collections/users/helpers';
+import { tagGetDiscussionUrl } from '@/lib/collections/tags/helpers';
 
 
 const MINIMUM_APPROVAL_KARMA = 5
@@ -302,7 +303,7 @@ async function commentsRejectSendPMAsync (comment: DbComment, currentUser: DbUse
     const tag = await Tags.findOne(comment.tagId)
     if (tag) {
       contentTitle = tag.name
-      rejectedContentLink = `<a href="https://lesswrong.com/tag/${tag.slug}/discussion?commentId=${comment._id}">comment on ${tag.name}</a>`
+      rejectedContentLink = `<a href=${tagGetDiscussionUrl({slug: tag.slug})}` + `commentId=${comment._id}">comment on ${tag.name}</a>`
     }
   } else if (comment.postId) {
     const post = await Posts.findOne(comment.postId)

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -303,7 +303,7 @@ async function commentsRejectSendPMAsync (comment: DbComment, currentUser: DbUse
     const tag = await Tags.findOne(comment.tagId)
     if (tag) {
       contentTitle = tag.name
-      rejectedContentLink = `<a href=${tagGetDiscussionUrl({slug: tag.slug})}` + `commentId=${comment._id}">comment on ${tag.name}</a>`
+      rejectedContentLink = `<a href=${tagGetDiscussionUrl({slug: tag.slug}, true)}` + `commentId=${comment._id}">comment on ${tag.name}</a>`
     }
   } else if (comment.postId) {
     const post = await Posts.findOne(comment.postId)

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -233,7 +233,7 @@ async function maybeCreateReviewMarket({newDocument, vote}: VoteDocTuple, collec
   if (post.postedAt.getFullYear() < (new Date()).getFullYear() - 1) return; // only make markets for posts that haven't had a chance to be reviewed
   if (post.manifoldReviewMarketId) return;
 
-  const annualReviewLink = tagGetUrl({slug: 'lesswrong-review'})
+  const annualReviewLink = tagGetUrl({slug: 'lesswrong-review'}, {}, true)
   const postLink = postGetPageUrl(post, true)
 
   const year = post.postedAt.getFullYear()

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -22,6 +22,7 @@ import { recomputeContributorScoresFor, voteUpdatePostDenormalizedTags } from '.
 import { updateModerateOwnPersonal, updateTrustedStatus } from './userCallbacks';
 import { increaseMaxBaseScore } from './postCallbacks';
 import { captureException } from '@sentry/core';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, collection: CollectionBase<VoteableCollectionName>, user: DbUser): Promise<void> {
   voteUpdatePostDenormalizedTags({newDocument});
@@ -232,7 +233,7 @@ async function maybeCreateReviewMarket({newDocument, vote}: VoteDocTuple, collec
   if (post.postedAt.getFullYear() < (new Date()).getFullYear() - 1) return; // only make markets for posts that haven't had a chance to be reviewed
   if (post.manifoldReviewMarketId) return;
 
-  const annualReviewLink = 'https://www.lesswrong.com/tag/lesswrong-review'
+  const annualReviewLink = tagGetUrl({slug: 'lesswrong-review'})
   const postLink = postGetPageUrl(post, true)
 
   const year = post.postedAt.getFullYear()

--- a/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
+++ b/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
@@ -20,6 +20,7 @@ import { convertImagesInHTML } from '../convertImagesToCloudinary';
 import type { ConditionalVisibilitySettings } from '@/components/editor/conditionalVisibilityBlock/conditionalVisibility';
 import { escapeHtml } from './util';
 import orderBy from 'lodash/orderBy';
+import { tagGetUrl } from '@/lib/collections/tags/helpers';
 
 
 const anyUrlMatch = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i;
@@ -230,7 +231,7 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
       return getCasedText(titlesByPageId[pageId], prefix);
     }
     function getNewPageUrl() {
-      return "/tag/new"; //TODO
+      return "/w/new"; //TODO
     }
     /*var getLinkHtml = function(editor: any, alias: string, options: {text?: string}) {
       var firstAliasChar = alias.substring(0, 1);
@@ -1040,7 +1041,7 @@ function pathToCtaButton(path: PathType, conversionContext: ArbitalConversionCon
   //const url = `/p/${slugs[0]}?path=${slugs.join(",")}`;*/
   
   // Version where URL uses Arbital path ID, which hackily maps to a hardcoded list of pages
-  const url = `/p/${slugs[0]}?pathId=${pathId}`;
+  const url = tagGetUrl({slug: slugs[0]}, {pathId});
   
   return `<a class="ck-cta-button" href="${url}">Start Reading</a>`;
 }

--- a/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
+++ b/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
@@ -21,6 +21,7 @@ import type { ConditionalVisibilitySettings } from '@/components/editor/conditio
 import { escapeHtml } from './util';
 import orderBy from 'lodash/orderBy';
 import { tagGetUrl } from '@/lib/collections/tags/helpers';
+import { tagUrlBaseSetting } from '@/lib/instanceSettings';
 
 
 const anyUrlMatch = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i;
@@ -230,8 +231,8 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
     function pageIdToTitle(pageId: string, prefix: string): string {
       return getCasedText(titlesByPageId[pageId], prefix);
     }
-    function getNewPageUrl() {
-      return "/w/new"; //TODO
+    function getNewPageUrl(){
+      return `/${tagUrlBaseSetting.get()}/new`; //TODO
     }
     /*var getLinkHtml = function(editor: any, alias: string, options: {text?: string}) {
       var firstAliasChar = alias.substring(0, 1);


### PR DESCRIPTION
This is accomplished by introducing a new optional instance setting for setting the base url.
As part of this PR, I refactored the tag routing to have less branching (i.e. single main branch that handles all configurations of what tags are named and what the base is.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209079151945853) by [Unito](https://www.unito.io)
