### PR TITLE
[EA] Fix wrapped notification emails

### DIFF
--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -30,6 +30,7 @@ import { Link } from './reactRouterWrapper';
 import { isFriendlyUI } from '../themes/forumTheme';
 import Sequences from './collections/sequences/collection';
 import { sequenceGetPageUrl } from './collections/sequences/helpers';
+import isEqual from 'lodash/isEqual';
 
 // We need enough fields here to render the user tooltip
 type NotificationDisplayUser = Pick<
@@ -155,8 +156,19 @@ const registerNotificationType = ({allowedChannels = ["none", "onsite", "email",
 
   const name = notificationTypeClass.name;
   notificationTypes[name] = notificationTypeClass;
-  if (notificationTypeClass.userSettingField)
-    notificationTypesByUserSetting[notificationTypeClass.userSettingField] = notificationTypeClass;
+
+  const {userSettingField} = notificationTypeClass;
+  if (userSettingField) {
+    // Due to a technical limitation notifications using the same user setting
+    // must also use the same channels
+    const currentValue = notificationTypesByUserSetting[userSettingField];
+    if (currentValue && !isEqual(currentValue.allowedChannels, notificationTypeClass.allowedChannels)) {
+      // eslint-disable-next-line no-console
+      console.error(`Error: Conflicting channels for notifications using "${userSettingField}"`);
+    }
+    notificationTypesByUserSetting[userSettingField] = notificationTypeClass;
+  }
+
   return notificationTypeClass;
 }
 
@@ -688,7 +700,6 @@ export const EmailVerificationRequiredNotification = registerNotificationType({
 export const PostSharedWithUserNotification = registerNotificationType({
   name: "postSharedWithUser",
   userSettingField: "notificationSharedWithMe",
-  allowedChannels: ["onsite", "email", "both"],
   async getMessage({documentType, documentId}: GetMessageProps) {
     let document = await getDocument(documentType, documentId) as DbPost;
     const name = await postGetAuthorName(document);

--- a/packages/lesswrong/server/notificationCallbacksHelpers.tsx
+++ b/packages/lesswrong/server/notificationCallbacksHelpers.tsx
@@ -10,7 +10,7 @@ import { DebouncerTiming } from './debouncer';
 import { ensureIndex } from '../lib/collectionIndexUtils';
 import {getDocument, getNotificationTypeByName, NotificationDocument} from '../lib/notificationTypes'
 import { notificationDebouncers } from './notificationBatching';
-import { defaultNotificationTypeSettings } from '../lib/collections/users/schema';
+import { defaultNotificationTypeSettings, NotificationTypeSettings } from '../lib/collections/users/schema';
 import * as _ from 'underscore';
 import { createMutator } from './vulcan-lib/mutators';
 import { createAnonymousContext } from './vulcan-lib/query';
@@ -149,26 +149,48 @@ const getLink = async (context: ResolverContext, notificationTypeName: string, d
   }
 }
 
-export const createNotification = async ({userId, notificationType, documentType, documentId, extraData, noEmail, context}: {
+export const createNotification = async ({
+  userId,
+  notificationType,
+  documentType,
+  documentId,
+  extraData,
+  noEmail,
+  fallbackNotificationTypeSettings = defaultNotificationTypeSettings,
+  context,
+}: {
   userId: string,
   notificationType: string,
   documentType: NotificationDocument|null,
   documentId: string|null,
-  
-  // extraData: something JSON-serializable that gets attached to the notification.
-  // May affect how it is displayed, but can't affect when it's delivered.
-  extraData?: any,
 
-  // noEmail: If set, this notification can never be sent by email (even if the user's
-  // config settings say that it would be).
+  /**
+   * extraData: something JSON-serializable that gets attached to the notification.
+   * May affect how it is displayed, but can't affect when it's delivered.
+   */
+  extraData?: AnyBecauseTodo,
+
+  /**
+   * noEmail: If set, this notification can never be sent by email (even if the
+   * user's config settings say that it would be).
+   */
   noEmail?: boolean|null,
-  
+
+  /**
+   * Fallback notification settings for if the user has no value set on their
+   * account, of if this notification type is not associated with a particular
+   * user setting
+   */
+  fallbackNotificationTypeSettings?: NotificationTypeSettings,
+
   context: ResolverContext,
 }) => {
   let user = await Users.findOne({ _id:userId });
   if (!user) throw Error(`Wasn't able to find user to create notification for with id: ${userId}`)
   const userSettingField = getNotificationTypeByName(notificationType).userSettingField;
-  const notificationTypeSettings = (userSettingField && user[userSettingField]) ? user[userSettingField] : defaultNotificationTypeSettings;
+  const notificationTypeSettings = (userSettingField && user[userSettingField])
+    ? user[userSettingField]
+    : fallbackNotificationTypeSettings;
 
   let notificationData = {
     userId: userId,
@@ -223,19 +245,51 @@ export const createNotification = async ({userId, notificationType, documentType
   }
 }
 
-export const createNotifications = async ({ userIds, notificationType, documentType, documentId, extraData, noEmail, context }: {
+export const createNotifications = ({
+  userIds,
+  notificationType,
+  documentType,
+  documentId,
+  extraData,
+  noEmail,
+  fallbackNotificationTypeSettings,
+  context,
+}: {
   userIds: Array<string>
   notificationType: string,
   documentType: NotificationDocument|null,
   documentId: string|null,
+  /**
+   * extraData: something JSON-serializable that gets attached to the notification.
+   * May affect how it is displayed, but can't affect when it's delivered.
+   */
   extraData?: any,
+  /**
+   * noEmail: If set, this notification can never be sent by email (even if the
+   * user's config settings say that it would be).
+   */
   noEmail?: boolean|null,
+  /**
+   * Fallback notification settings for if the user has no value set on their
+   * account, of if this notification type is not associated with a particular
+   * user setting
+   */
+  fallbackNotificationTypeSettings?: NotificationTypeSettings,
   context?: ResolverContext,
 }) => {
-  const nonnullContext = context || await createAnonymousContext();
+  const nonnullContext = context || createAnonymousContext();
   return Promise.all(
     userIds.map(async userId => {
-      await createNotification({userId, notificationType, documentType, documentId, extraData, noEmail, context: nonnullContext});
+      await createNotification({
+        userId,
+        notificationType,
+        documentType,
+        documentId,
+        extraData,
+        noEmail,
+        fallbackNotificationTypeSettings,
+        context: nonnullContext,
+      });
     })
   );
 }

--- a/packages/lesswrong/server/wrapped/sendWrappedNotifications.ts
+++ b/packages/lesswrong/server/wrapped/sendWrappedNotifications.ts
@@ -40,6 +40,12 @@ const sendWrappedNotifications = async (year: WrappedYear) => {
     documentId: null,
     documentType: null,
     extraData: {year},
+    fallbackNotificationTypeSettings: {
+      channel: "both",
+      batchingFrequency: "realtime",
+      timeOfDayGMT: 12,
+      dayOfWeekGMT: "Monday",
+    },
   });
 }
 


### PR DESCRIPTION
The wrapped notification has no user setting associated with it so it used the default settings which only includes an onsite notification and not an email. This PR overrides this to also send an email to relevant users. I've already sent the notifications on prod, this PR is just for the code.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209098693212612) by [Unito](https://www.unito.io)
