### PR TITLE
[EA Forum] Add a "license info" link to the sidebar

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -373,6 +373,12 @@ export const menuTabs: ForumOptions<Array<MenuTab>> = {
       link: '/cookiePolicy',
       subItem: true,
     }, {
+      id: 'copyright',
+      title: preferredHeadingCase('Copyright and license info'),
+      link: '/posts/KK6AE8HzPkR2KnqSg/new-forum-license-creative-commons',
+      tooltip: 'Newer user content is available under a Creative Commons license; other terms may apply to older and third-party content.'
+      subItem: true,
+    }, {
       id: 'divider2',
       divider: true,
     }, {


### PR DESCRIPTION
Pursuant to #10224, this PR adds a menu item to the EA Forum sidebar with a link to the [forum announcement post](https://forum.effectivealtruism.org/posts/KK6AE8HzPkR2KnqSg/new-forum-license-creative-commons) regarding the CC-BY license policy. The link also has a tooltip concisely explaining that some forum content is under CC-BY.

Some possible variations:
- Link title:
  - Copyright and license info
  - License information
  - Creative Commons license
  - &copy; Some rights reserved _(see note)_
- Tooltip:
  - Newer user content is available under a Creative Commons Attribution license; other terms may apply to older and third-party content.
  - Community content since 1 December 2022 is available under a Creative Commons Attribution license; other terms may apply to older and third-party content.

This is a bit longer than the longest tooltip currently in the sidebar, which is "A sorted list of pages — “Topics” — in the EA Forum Wiki, which explains topics in EA and collects posts tagged with those topics."

Note: It is possible to replace the &copy; symbol with inline CC and BY "person in circle" icons, using Font Awesome or the [CC Symbols][ccsymbols] font which supports the official Unicode code points:
- Official Unicode characters: `&#x1F16D; &#x1F16F;`
- Font Awesome (private use characters): `&#xf25e; &#xf4e7;`

[This page][ccsymbols] shows some example CSS to link the CC Symbols font specifically for the CC icon code points.

I have been trying to set up a development server locally but with no luck, so I haven't been able to test what this looks like. I'm especially uncertain if the tooltip would work, so please let me know if this is broken.

[ccsymbols]: https://www.ctrl.blog/entry/creative-commons-unicode-fallback-font.html

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209102624275549) by [Unito](https://www.unito.io)
