### PR TITLE
Check styles created by `defineStyles` in the theme palette test

### DIFF
--- a/packages/lesswrong/unitTests/themePalette.tests.ts
+++ b/packages/lesswrong/unitTests/themePalette.tests.ts
@@ -2,6 +2,7 @@ import { importAllComponents, ComponentsTable } from '../lib/vulcan-lib/componen
 import { getForumTheme } from '../themes/forumTheme';
 import * as _ from 'underscore';
 import { themePaletteTestExcludedComponents } from '../server/register-mui-styles';
+import { topLevelStyleDefinitions } from '@/components/hooks/useStyles';
 
 // This component imports a lot of JSX files for plugins and our current build
 // setup for tests can't parse them correctly for some reason. For now we can
@@ -45,7 +46,15 @@ describe('JSS', () => {
         assertNoNonPaletteColors(componentName, styles, nonPaletteColors);
       }
     }
-    
+
+    for (const name in topLevelStyleDefinitions) {
+      const styleGetter = topLevelStyleDefinitions[name].styles;
+      const styles = styleGetter(fakeTheme);
+      if (styles && !ComponentsTable[name]?.options?.allowNonThemeColors) {
+        assertNoNonPaletteColors(name, styles, nonPaletteColors);
+      }
+    }
+
     if (nonPaletteColors.length > 0) {
       // eslint-disable-next-line no-console
       console.error(`Non-palette colors in JSS styles:\n${nonPaletteColors.join("\n")}`);


### PR DESCRIPTION
Currently the test only checks styles registered through `registerComponent`, not styles that are created by `defineStyles` to be used with `useStyles`.