### PR TITLE
Raise max size of submitted POST requests (and hence max post size) from 1M to 10M

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -21,6 +21,7 @@ http {
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"';
+    client_max_body_size 10m;
 
     include  conf.d/*.conf;
 


### PR DESCRIPTION
A user with a very long post got a 413 when saving when their post was a little over 1MB. This just so happens to be the default value of `client_max_body_size` in nginx. I ran an nginx proxy locally using approximately the same config as what we have on our cloud servers, and submitted a post slightly over 1MB in (uncompressed) size, and got the same error. I added `client_max_body_size 10m;` to `nginx.conf` and was then able to submit that post. (Post submission took 17s, which is a bit unfortunate, presumably because of some on-save callbacks that are O(n) in the size of the post.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209113740509841) by [Unito](https://www.unito.io)
