### PR TITLE
Two column layout emphasizes Reviews

### DIFF
--- a/packages/lesswrong/components/review/AnnualReviewPage.tsx
+++ b/packages/lesswrong/components/review/AnnualReviewPage.tsx
@@ -53,6 +53,9 @@ const styles = (theme: ThemeType) => ({
     width: "100%",
     maxWidth: SECTION_WIDTH,
   },
+  rightColumnExpandedPost: {
+    opacity: .175
+  },
   rightColumn: {
     width: "100%",
     maxWidth: SECTION_WIDTH,
@@ -183,7 +186,7 @@ export const AnnualReviewPage = ({classes}: {
       <div className={classNames(classes.leftColumn, expandedPost && classes.expandedPost)}>
         {expandedPost && <ReviewVotingExpandedPost key={expandedPost?._id} post={expandedPost} setExpandedPost={setExpandedPost}/>}
       </div>
-      <div className={classes.rightColumn}>
+      <div className={classNames(classes.rightColumn, expandedPost && classes.rightColumnExpandedPost)}>
         <FrontpageReviewWidget showFrontpageItems={false} reviewYear={reviewYear}/>
         <ReviewPhaseInformation reviewYear={reviewYear} reviewPhase={reviewPhase}/>
         <Tabs

--- a/packages/lesswrong/components/review/AnnualReviewPage.tsx
+++ b/packages/lesswrong/components/review/AnnualReviewPage.tsx
@@ -54,7 +54,7 @@ const styles = (theme: ThemeType) => ({
     maxWidth: SECTION_WIDTH,
   },
   rightColumnExpandedPost: {
-    opacity: .175
+    opacity: .25
   },
   rightColumn: {
     width: "100%",

--- a/packages/lesswrong/components/review/ReviewPostForm.tsx
+++ b/packages/lesswrong/components/review/ReviewPostForm.tsx
@@ -42,6 +42,7 @@ const ReviewPostForm = ({classes, post, onClose}: {
   const [ showPrompt, setShowPrompt ] = useState(true)
   
   return <PopupCommentEditor
+    key={post._id} // Force recreation when post changes
     title={<>
       Reviewing "<Link to={postGetPageUrl(post)}>{post.title}</Link>"
     </>}

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -202,7 +202,7 @@ const ReviewVoteTableRow = ({ post, index, dispatch, costTotal, classes, expande
   showKarmaVotes: boolean,
   classes: ClassesType,
   expandedPostId?: string|null,
-  handleSetExpandedPost: (post: PostsReviewVotingList) => void,
+  handleSetExpandedPost: (post: PostsReviewVotingList, openReviewBox?: boolean) => void,
   currentVote: SyntheticQualitativeVote|null,
   reviewPhase: ReviewPhase,
   reviewYear: ReviewYear,
@@ -275,7 +275,7 @@ const ReviewVoteTableRow = ({ post, index, dispatch, costTotal, classes, expande
             className={classNames(classes.expandPostButton, { [classes.expanded]: expanded })}
           />
         </div>
-        <div className={classNames(classes.postIndex, {[classes.top50]: index < 50})} onClick={() => handleSetExpandedPost(post)}>
+        <div className={classNames(classes.postIndex, {[classes.top50]: index < 50})} onClick={() => handleSetExpandedPost(post, true)}>
           {index + 1}
         </div>
         <div className={classNames(classes.post, {[classes.postVotingPhase]: reviewPhase === "VOTING"})}>

--- a/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
@@ -51,7 +51,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   backIcon: {
-    marginRight: 12
+    marginLeft: 12,
+    transform: "rotate(180deg)",
   },
   reviewVoting: {
     padding: theme.spacing.unit*2,
@@ -81,14 +82,11 @@ const ReviewVotingExpandedPost = ({classes, post, setExpandedPost}: {
 
   return <div className={classes.root}>
     <div className={classes.backButton} onClick={() => setExpandedPost(null)}>
-      <KeyboardBackspaceIcon className={classes.backIcon}/> Back
+      Back <KeyboardBackspaceIcon className={classes.backIcon}/> 
     </div>
     <Link to={postGetPageUrl(newPost)}  className={classes.postTitle}>
       {newPost.title}
     </Link>
-    <div className={classes.reviewVoting}>  
-      <PostPageReviewButton post={newPost} />
-    </div>
     {postWithContents && <PostsHighlight post={postWithContents} maxLengthWords={200} forceSeeMore />}
     {loading && <Loading/>}
 

--- a/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingExpandedPost.tsx
@@ -16,7 +16,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   postTitle: {
     ...postPageTitleStyles(theme),
     display: "block",
-    marginBottom: 12
+    marginBottom: 36
   },
   writeAReview: {
     paddingTop: 12,

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -19,6 +19,8 @@ import {tagStyle} from '@/components/tagging/FooterTag.tsx'
 import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { Link } from '@/lib/reactRouterWrapper';
 import { sortingInfo } from './ReviewVotingPageMenu';
+import { useCommentBox } from '../hooks/useCommentBox';
+import { useDialog } from '../common/withDialog';
 
 const isAF = forumTypeSetting.get() === 'AlignmentForum'
 
@@ -111,7 +113,8 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
   const currentUser = useCurrentUser()
   const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
   const { query } = useLocation()
-
+  const { openCommentBox } = useCommentBox();
+  const { openDialog } = useDialog();
 
   let reviewPhase = getReviewPhase(reviewYear)
   if (query.phase) {
@@ -360,6 +363,13 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
     if (expandedPost?._id === post._id) {
       setExpandedPost(null)
     } else {
+      // this component requires a currentUser so we don't need to do a login check
+      openCommentBox({
+        componentName: "ReviewPostForm",
+        componentProps: {
+          post: post
+        }
+      });
       setExpandedPost(post)
     }
   }

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -113,7 +113,7 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
   const currentUser = useCurrentUser()
   const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
   const { query } = useLocation()
-  const { openCommentBox } = useCommentBox();
+  const { openCommentBox, close } = useCommentBox();
   const { openDialog } = useDialog();
 
   let reviewPhase = getReviewPhase(reviewYear)
@@ -363,6 +363,8 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
     if (expandedPost?._id === post._id) {
       setExpandedPost(null)
     } else {
+      // Close any existing comment box before opening a new one
+      close();
       // this component requires a currentUser so we don't need to do a login check
       openCommentBox({
         componentName: "ReviewPostForm",


### PR DESCRIPTION
I updated the 2-column layout to emphasize writing reviews. I think this is the main point of it.
– clicking the "expand" button now opens up a review box immediately
– it also changes the right column to lower opacity, so you can focus on the Review box
– clicking the comments-icon now opens a regular post-item comment box

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/79af1a5b-de35-4a08-8a45-972c16b3a154" />

<img width="832" alt="image" src="https://github.com/user-attachments/assets/449d73c5-dc7b-4f5c-a292-caed2e8652fd" />

