### PR TITLE
Delayed clickable tooltip

### DIFF
--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useHover } from './withHover';
 import type { PopperPlacementType } from '@material-ui/core/Popper'
@@ -63,6 +63,7 @@ const LWTooltip = ({
   forceOpen,
 }: LWTooltipProps) => {
   const { LWPopper } = Components
+  const [delayedClickable, setDelayedClickable] = useState(false);
   const { hover, everHovered, anchorEl, eventHandlers } = useHover({
     eventProps: {
       pageElementContext: "tooltipHovered", // Can be overwritten by analyticsProps
@@ -71,8 +72,23 @@ const LWTooltip = ({
       ...otherEventProps,
     },
     onEnter: onShow,
-    onLeave: onHide,
+    onLeave: () => {
+      onHide?.();
+      setDelayedClickable(false);
+    },
   });
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+    if (hover && clickable) {
+      timeoutId = setTimeout(() => {
+        setDelayedClickable(true);
+      }, 200);
+    }
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [hover, clickable]);
 
   if (!title) return <>{children}</>
 
@@ -89,7 +105,7 @@ const LWTooltip = ({
       anchorEl={anchorEl}
       tooltip={tooltip}
       allowOverflow={!flip}
-      clickable={clickable}
+      clickable={delayedClickable}
       hideOnTouchScreens={hideOnTouchScreens}
       className={popperClassName}
     >

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -65,6 +65,15 @@ const LWTooltip = ({
   const { LWPopper } = Components
   const [delayedClickable, setDelayedClickable] = useState(false);
 
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearDelayTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
   const { hover, everHovered, anchorEl, eventHandlers } = useHover({
     eventProps: {
       pageElementContext: "tooltipHovered", // Can be overwritten by analyticsProps
@@ -75,6 +84,7 @@ const LWTooltip = ({
     onEnter: onShow,
     onLeave: () => {
       onHide?.();
+      clearDelayTimeout();
       setDelayedClickable(false);
     },
   });
@@ -82,16 +92,6 @@ const LWTooltip = ({
   // For the clickable case, we want to delay the opening of the tooltip by 200ms
   // so that users aren't interrupted when moving their mouse rapidly over
   // clickable elements
-
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const clearDelayTimeout = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-  }, []);
-
   useEffect(() => {
     if (hover && clickable) {
       clearDelayTimeout();

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState, useEffect, useRef, useCallback } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useHover } from './withHover';
 import type { PopperPlacementType } from '@material-ui/core/Popper'
@@ -64,6 +64,7 @@ const LWTooltip = ({
 }: LWTooltipProps) => {
   const { LWPopper } = Components
   const [delayedClickable, setDelayedClickable] = useState(false);
+
   const { hover, everHovered, anchorEl, eventHandlers } = useHover({
     eventProps: {
       pageElementContext: "tooltipHovered", // Can be overwritten by analyticsProps
@@ -78,17 +79,33 @@ const LWTooltip = ({
     },
   });
 
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout | null = null;
-    if (hover && clickable) {
-      timeoutId = setTimeout(() => {
-        setDelayedClickable(true);
-      }, 200);
+  // For the clickable case, we want to delay the opening of the tooltip by 200ms
+  // so that users aren't interrupted when moving their mouse rapidly over
+  // clickable elements
+
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearDelayTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
     }
-    return () => {
-      if (timeoutId) clearTimeout(timeoutId);
-    };
-  }, [hover, clickable]);
+  }, []);
+
+  useEffect(() => {
+    if (hover && clickable) {
+      clearDelayTimeout();
+      timeoutRef.current = setTimeout(() => {
+        setDelayedClickable(true);
+        timeoutRef.current = null;
+      }, 200);
+    } else {
+      clearDelayTimeout();
+      setDelayedClickable(false);
+    }
+    
+    return clearDelayTimeout;
+  }, [hover, clickable, clearDelayTimeout]);
 
   if (!title) return <>{children}</>
 


### PR DESCRIPTION
A number of tooltips/popups are clickable. This is often good, because it's nice, for say, a post preview to have clickable links... but also it's annoying, because if you're just trying to move your mouse across a page it can snag on all kinds of random UI elements.

This PR makes it so clickable links take 200ms to become "stable and clickable", which seemed to behave the way I wanted when I experimented with it. We may need to experiment with it a bit in more realistic conditions to figure out the ideal lag time but it seemed like a good starting point.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209121349493967) by [Unito](https://www.unito.io)
