### PR TITLE
Remove "all" tab on Review Leaderboard

### DIFF
--- a/packages/lesswrong/components/review/ReviewsPage.tsx
+++ b/packages/lesswrong/components/review/ReviewsPage.tsx
@@ -41,7 +41,6 @@ export const ReviewsPage = ({classes, reviewYear}: {classes: ClassesType<typeof 
 
   return <SingleColumnSection>
     <div className={classes.yearLinks}>
-      <Link className={classNames(classes.yearLink, {[classes.selected]: "all" === params.year})} to="/reviews/all">All</Link>
       {reviewYears.map(year => <Link className={classNames(classes.yearLink, {[classes.selected]: year === reviewYear})} to={`/reviews/${year}`} key={year}>
         {year}
       </Link>)}


### PR DESCRIPTION
It doesn't work properly because "all" isn't a valid year. I just tried fixing it but actually it just loads crazy slowly and doesn't seem worth supporting it anymore.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209129534480852) by [Unito](https://www.unito.io)
