### PR TITLE
switch from using tag-tag-relationship to new coreTagId field on tags…

### DIFF
--- a/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
@@ -308,13 +308,13 @@ const AllWikiTagsPage = () => {
         {priorityTags.map((tag: ConceptItemFragment) => (
           tag && <WikiTagGroup
             key={tag._id}
-            parentTag={tag}
+            coreTag={tag}
             searchTagIds={currentQuery ? tagIds : null}
             showArbitalIcons={isArbitalRedirect}
           />
         ))}
         <WikiTagGroup
-          parentTag={uncategorizedRootTag}
+          coreTag={uncategorizedRootTag}
           searchTagIds={currentQuery ? tagIds : null}
           showArbitalIcons={isArbitalRedirect}
         />

--- a/packages/lesswrong/components/tagging/WikiTagGroup.tsx
+++ b/packages/lesswrong/components/tagging/WikiTagGroup.tsx
@@ -57,12 +57,12 @@ function splitItemsIntoColumns<T>(items: T[], itemsPerColumn: number): T[][] {
 }
 
 const WikiTagGroup = ({
-  parentTag,
+  coreTag,
   searchTagIds,
   initialLimit = 3 * MAX_ITEMS_PER_COLUMN,
   showArbitalIcons = false,
 }: {
-  parentTag: ConceptItemFragment
+  coreTag: ConceptItemFragment
   searchTagIds: string[] | null;
   initialLimit?: number;
   showArbitalIcons?: boolean;
@@ -70,16 +70,16 @@ const WikiTagGroup = ({
   const classes = useStyles(styles);
   const [limit, setLimit] = useState(initialLimit);
 
-  const parentTagId = parentTag._id === 'uncategorized-root' ? null : parentTag._id;
+  const coreTagId = coreTag._id === 'uncategorized-root' ? null : coreTag._id;
 
   const { data, loading, fetchMore, networkStatus } = useQuery(gql`
-    query GetTagsByParentId(
-      $parentTagId: String,
+    query GetTagsByCoreTagId(
+      $coreTagId: String,
       $limit: Int,
       $searchTagIds: [String]
     ) {
-      TagsByParentId(
-        parentTagId: $parentTagId,
+      TagsByCoreTagId(
+        coreTagId: $coreTagId,
         limit: $limit,
         searchTagIds: $searchTagIds
       ) {
@@ -95,15 +95,15 @@ const WikiTagGroup = ({
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-only',
     variables: {
-      parentTagId,
+      coreTagId,
       limit: initialLimit,
       searchTagIds,
     },
     notifyOnNetworkStatusChange: true,
   });
 
-  const pages = data?.TagsByParentId?.tags ?? [];
-  const totalCount = data?.TagsByParentId?.totalCount ?? 0;
+  const pages = data?.TagsByCoreTagId?.tags ?? [];
+  const totalCount = data?.TagsByCoreTagId?.totalCount ?? 0;
 
   // Split pages into columns with MAX_ITEMS_PER_COLUMN items each
   const columns: ConceptItemFragment[][] = splitItemsIntoColumns(pages, MAX_ITEMS_PER_COLUMN);
@@ -112,7 +112,7 @@ const WikiTagGroup = ({
     const newLimit = Math.min(limit * 2, limit + 300);
     void fetchMore({
       variables: {
-        parentTagId,
+        coreTagId,
         limit: newLimit,
         searchTagIds,
       },
@@ -139,7 +139,7 @@ const WikiTagGroup = ({
     <div className={classes.root}>
       <div className={classes.titleItem}>
         <ConceptItem
-          wikitag={parentTag}
+          wikitag={coreTag}
           isTitleItem
           showArbitalIcon={showArbitalIcons}
         />

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -799,18 +799,15 @@ const schema: SchemaType<"Tags"> = {
 
   arbitalLinkedPages: arbitalLinkedPagesField({ collectionName: 'Tags' }),
 
-  coreTagId: resolverOnlyField({
+  coreTagId: {
     type: String,
+    optional: true,
+    nullable: true,
     canRead: ['guests'],
-    resolver: async (tag, args, context) => {
-      // TODO: This is a temporary hack to just return the value we've cached; we should do something less dumb
-      if ('coreTagId' in tag) return tag.coreTagId;
-      const { ArbitalTagContentRels } = context;
-      // This is incorrect; we should be fetching the value from the cache
-      const rel = await ArbitalTagContentRels.findOne({ childDocumentId: tag._id, type: 'parent-is-tag-of-child' });
-      return rel?.parentDocumentId;
-    },
-  }),
+    canUpdate: ['admins', 'sunshineRegiment'],
+    canCreate: ['admins', 'sunshineRegiment'],
+    group: formGroups.advancedOptions,
+  },
 
   maxScore: resolverOnlyField({
     type: Number,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -1470,6 +1470,7 @@ interface DbTag extends DbObject {
   autoTagPrompt: string | null
   noindex: boolean
   isPlaceholderPage: boolean
+  coreTagId: string | null
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
   description: EditableFieldContents | null
@@ -1980,8 +1981,6 @@ interface DbUser extends DbObject {
   hideSunshineSidebar: boolean
   inactiveSurveyEmailSentAt: Date | null
   userSurveyEmailSentAt: Date | null
-  givingSeason2024DonatedFlair: boolean
-  givingSeason2024VotedFlair: boolean
   createdAt: Date
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
   moderationGuidelines: EditableFieldContents | null

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -443,8 +443,6 @@ interface UsersDefaultFragment { // fragment on Users
   readonly hideSunshineSidebar: boolean,
   readonly inactiveSurveyEmailSentAt: Date | null,
   readonly userSurveyEmailSentAt: Date | null,
-  readonly givingSeason2024DonatedFlair: boolean,
-  readonly givingSeason2024VotedFlair: boolean,
 }
 
 interface CommentsDefaultFragment { // fragment on Comments
@@ -565,6 +563,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly autoTagPrompt: string | null,
   readonly noindex: boolean,
   readonly isPlaceholderPage: boolean,
+  readonly coreTagId: string | null,
 }
 
 interface ConversationsDefaultFragment { // fragment on Conversations
@@ -2859,7 +2858,7 @@ interface ConceptItemFragment { // fragment on Tags
   readonly baseScore: number,
   readonly description: ConceptItemFragment_description|null,
   readonly isArbitalImport: boolean|null,
-  readonly coreTagId: string|null,
+  readonly coreTagId: string | null,
   readonly maxScore: number|null,
   readonly usersWhoLiked: any,
 }

--- a/packages/lesswrong/server/migrations/20250111T004408.add_coretagid_to_tags.ts
+++ b/packages/lesswrong/server/migrations/20250111T004408.add_coretagid_to_tags.ts
@@ -1,0 +1,10 @@
+import { Tags } from "@/lib/collections/tags/collection";
+import { addField, dropField } from "./meta/utils"
+
+export const up = async ({db}: MigrationContext) => {
+  await addField(db, Tags, 'coreTagId');
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await dropField(db, Tags, 'coreTagId');
+}

--- a/packages/lesswrong/server/repos/TagsRepo.ts
+++ b/packages/lesswrong/server/repos/TagsRepo.ts
@@ -187,6 +187,7 @@ class TagsRepo extends AbstractRepo<"Tags"> {
     whereClauses.push(
       `t."deleted" IS FALSE`,
       `t."isPlaceholderPage" IS FALSE`,
+      `t."core" IS NOT TRUE`,
     );
 
     if (coreTagId !== null) {

--- a/packages/lesswrong/server/repos/TagsRepo.ts
+++ b/packages/lesswrong/server/repos/TagsRepo.ts
@@ -171,10 +171,10 @@ class TagsRepo extends AbstractRepo<"Tags"> {
   }
 
   /**
-   * Fetch tags by parent tag using ArbitalTagContentRels, with optional limit, offset, and searchTagIds
+   * Fetch tags by core tag, with optional limit and searchTagIds
    */
-  async getTagsByParentTagId(
-    parentTagId: string | null,
+  async getTagsByCoreTagId(
+    coreTagId: string | null,
     limit: number,
     searchTagIds?: string[]
   ): Promise<{ tags: DbTag[]; totalCount: number }> {
@@ -183,32 +183,21 @@ class TagsRepo extends AbstractRepo<"Tags"> {
       limit,
     };
 
-    // Base condition: only select non-deleted tags
     whereClauses.push(
-      `t_child."deleted" IS FALSE`,
-      `t_child."isPlaceholderPage" IS FALSE`,
+      `t."deleted" IS FALSE`,
+      `t."isPlaceholderPage" IS FALSE`,
     );
 
-    if (parentTagId !== null) {
-      // Fetch tags that are children of the specified parent tag
-      queryParams.parentTagId = parentTagId;
-      whereClauses.push(
-        `acr."parentDocumentId" = $(parentTagId)`,
-        `acr."type" = 'parent-is-tag-of-child'`,
-        `acr."parentCollectionName" = 'Tags'`,
-        `acr."childCollectionName" = 'Tags'`
-      );
+    if (coreTagId !== null) {
+      queryParams.coreTagId = coreTagId;
+      whereClauses.push(`t."coreTagId" = $(coreTagId)`);
     } else {
-      // Fetch tags that do NOT have a parent tag
-      whereClauses.push(
-        `acr."parentDocumentId" IS NULL`,
-        `acr."type" IS NULL`,
-      );
+      whereClauses.push(`t."coreTagId" IS NULL`);
     }
 
     if (searchTagIds && searchTagIds.length > 0) {
       queryParams.searchTagIds = searchTagIds;
-      whereClauses.push(`t_child."_id" = ANY($(searchTagIds))`);
+      whereClauses.push(`t."_id" = ANY($(searchTagIds))`);
     }
 
     const whereClause = whereClauses.length > 0
@@ -216,20 +205,15 @@ class TagsRepo extends AbstractRepo<"Tags"> {
       : '';
 
     const query = `
-      -- TagsRepo.getTagsByParentTagId
+      -- TagsRepo.getTagsByCoreTagId
       SELECT
-        t_child.*,
+        t.*,
         COUNT(*) OVER() AS "totalCount"
-      FROM "Tags" t_child
-      LEFT JOIN "ArbitalTagContentRels" acr
-        ON t_child."_id" = acr."childDocumentId"
-        AND acr."type" = 'parent-is-tag-of-child'
-        AND acr."parentCollectionName" = 'Tags'
-        AND acr."childCollectionName" = 'Tags'
+      FROM "Tags" t
       LEFT JOIN LATERAL (
         SELECT MAX(md."baseScore") AS "maxBaseScore"
         FROM "MultiDocuments" md
-        WHERE md."parentDocumentId" = t_child."_id"
+        WHERE md."parentDocumentId" = t."_id"
           AND md."collectionName" = 'Tags'
           AND md."fieldName" = 'description'
           AND md."deleted" IS FALSE
@@ -237,10 +221,10 @@ class TagsRepo extends AbstractRepo<"Tags"> {
       ${whereClause}
       ORDER BY
         GREATEST(
-          t_child."baseScore",
+          t."baseScore",
           COALESCE(md."maxBaseScore", 0)
         ) DESC,
-        t_child."name" ASC
+        t."name" ASC
       LIMIT $(limit)
     `;
 

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -711,11 +711,22 @@ defineQuery({
   ) => {
     const { coreTagId, limit = 20, searchTagIds } = args;
 
-    const { tags, totalCount } = await context.repos.tags.getTagsByCoreTagId(
+    const { tags: unsortedTags, totalCount } = await context.repos.tags.getTagsByCoreTagId(
       coreTagId,
       limit,
       searchTagIds
     );
+    
+    const tags = searchTagIds?.length
+      ? (() => {
+          const searchTagIdOrder = new Map(searchTagIds.map((id, index) => [id, index]));
+          return [...unsortedTags].sort((a, b) => {
+            const indexA = searchTagIdOrder.get(a._id) ?? Infinity;
+            const indexB = searchTagIdOrder.get(b._id) ?? Infinity;
+            return indexA - indexB;
+          });
+        })()
+      : unsortedTags;
 
     return { tags, totalCount };
   },

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -691,7 +691,7 @@ augmentFieldsDict(TagRels, {
 });
 
 defineQuery({
-  name: "TagsByParentId",
+  name: "TagsByCoreTagId",
   schema: `
     type TagWithTotalCount {
       tags: [Tag!]!
@@ -699,20 +699,20 @@ defineQuery({
     }
   `,
   resultType: "TagWithTotalCount!",
-  argTypes: "(parentTagId: String, limit: Int, searchTagIds: [String])",
+  argTypes: "(coreTagId: String, limit: Int, searchTagIds: [String])",
   fn: async (
     _root: void,
     args: {
-      parentTagId: string | null;
+      coreTagId: string | null;
       limit?: number;
       searchTagIds?: string[];
     },
     context: ResolverContext
   ) => {
-    const { parentTagId, limit = 20, searchTagIds } = args;
+    const { coreTagId, limit = 20, searchTagIds } = args;
 
-    const { tags, totalCount } = await context.repos.tags.getTagsByParentTagId(
-      parentTagId,
+    const { tags, totalCount } = await context.repos.tags.getTagsByCoreTagId(
+      coreTagId,
       limit,
       searchTagIds
     );

--- a/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
+++ b/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
@@ -2131,18 +2131,18 @@ async function importCoreTagAssignments(coreTagAssignmentsFile: string) {
   console.log(`Found ${filteredTagAssignments.length} valid tag assignments with a single core tag.`);
 
   // Update each tag's coreTagId field
-  for (const ta of filteredTagAssignments) {
+  await executePromiseQueue(filteredTagAssignments.map(ta => async () => {
     const tag = await Tags.findOne({ slug: ta.slug });
     if (!tag) {
       console.warn(`Tag with slug "${ta.slug}" not found. Skipping.`);
-      continue;
+      return;
     }
 
     const coreTagName = ta.coreTagNames[0];
     const coreTagId = coreTagIdsByName[coreTagName];
     if (!coreTagId) {
       console.warn(`Core tag "${coreTagName}" not found. Skipping.`);
-      continue;
+      return;
     }
 
     // Update the tag's coreTagId field
@@ -2152,7 +2152,7 @@ async function importCoreTagAssignments(coreTagAssignmentsFile: string) {
     );
 
     console.log(`Assigned coreTagId "${coreTagId}" to tag "${tag.name}" (${tag.slug}).`);
-  }
+  }), 10);
 
   console.log(`Assigned core tags to ${filteredTagAssignments.length} tags.`);
 }

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -390,7 +390,6 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
         scoring: {type: "numeric", pivot: 10},
       },
     ],
-    karmaField: "baseScore",
     tiebreaker: "postCount",
     filters: [
       {term: {deleted: false}},

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -366,7 +366,7 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
   },
   Tags: {
     fields: [
-      "name^3",
+      "name^30",
       "description",
     ],
     snippet: "description",

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -2937,6 +2937,7 @@ CREATE TABLE "Tags" (
   "autoTagPrompt" TEXT,
   "noindex" BOOL NOT NULL DEFAULT FALSE,
   "isPlaceholderPage" BOOL NOT NULL DEFAULT FALSE,
+  "coreTagId" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
@@ -3017,9 +3018,6 @@ CREATE INDEX IF NOT EXISTS "idx_Tags_name" ON "Tags" USING btree ("name");
 
 -- Index "idx_Tags_name_legacyData__arbitalPageId"
 CREATE INDEX IF NOT EXISTS "idx_Tags_name_legacyData__arbitalPageId" ON "Tags" USING gin ("name", ("legacyData" -> 'arbitalPageId'));
-
--- Index "idx_Tags_pingbacks__Tags_baseScore"
-CREATE INDEX IF NOT EXISTS "idx_Tags_pingbacks__Tags_baseScore" ON "Tags" USING gin (("pingbacks" -> 'Tags'), "baseScore");
 
 -- Index "idx_Tags_parentTagId"
 CREATE INDEX IF NOT EXISTS "idx_Tags_parentTagId" ON "Tags" USING btree ("parentTagId");
@@ -3412,8 +3410,6 @@ CREATE TABLE "Users" (
   "hideSunshineSidebar" BOOL NOT NULL DEFAULT FALSE,
   "inactiveSurveyEmailSentAt" TIMESTAMPTZ,
   "userSurveyEmailSentAt" TIMESTAMPTZ,
-  "givingSeason2024DonatedFlair" BOOL NOT NULL DEFAULT FALSE,
-  "givingSeason2024VotedFlair" BOOL NOT NULL DEFAULT FALSE,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
@@ -3718,6 +3714,9 @@ WITH
   (fastupdate = TRUE)
 WHERE
   name = 'login';
+
+-- CustomIndex "idx_tags_pingbacks"
+CREATE INDEX IF NOT EXISTS idx_tags_pingbacks ON "Tags" USING gin (pingbacks);
 
 -- Function "fm_has_verified_email"
 CREATE OR


### PR DESCRIPTION
Previously coreTag assignments were being created as tag-relationships in ArbitalTagContentRels, now instead they're assigned to coreTagId on tags (denormalized field)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209129832392490) by [Unito](https://www.unito.io)
