### PR TITLE
Exclude default summaries from Arbital Import

### DIFF
--- a/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
+++ b/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
@@ -189,8 +189,8 @@ type CreateSummariesForPageArgs = {
   lensMultiDocumentId: string;
 })
 
-function isDefaultSummary(summary: PageSummariesRow, pageText: string): boolean {
-  if (!summary.text.trim()) return false;
+function isDefaultSummaryOrEmpty(summary: PageSummariesRow, pageText: string): boolean {
+  if (!summary.text.trim()) return true;
   
   return pageText.startsWith(summary.text);
 }
@@ -200,7 +200,7 @@ async function createSummariesForPage({ pageId, importedRecordMaps, pageCreator,
   const allPageSummaries = summariesByPageId[pageId] ?? [];
   
   const nonDefaultSummaries = allPageSummaries.filter(summary => 
-    !isDefaultSummary(summary, liveRevision.text)
+    !isDefaultSummaryOrEmpty(summary, liveRevision.text)
   );
 
   if (allPageSummaries.length !== nonDefaultSummaries.length) {


### PR DESCRIPTION
If the summary is just the start of the main page, we don't need to import that as our preview code will grab it already (and keep it updated to boot)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209145896362200) by [Unito](https://www.unito.io)
