### PR TITLE
exclude neutral votes from voteCount

### DIFF
--- a/packages/lesswrong/lib/make_voteable.ts
+++ b/packages/lesswrong/lib/make_voteable.ts
@@ -143,7 +143,7 @@ export const makeVoteable = <N extends VoteableCollectionName>(
         foreignCollectionName: "Votes",
         foreignTypeName: "vote",
         foreignFieldName: "documentId",
-        filterFn: (vote: DbVote) => !vote.cancelled && vote.voteType !== 'neutral' &&vote.collectionName===collection.collectionName
+        filterFn: (vote: DbVote) => !vote.cancelled && vote.voteType !== 'neutral' && vote.collectionName === collection.collectionName
       }),
       canRead: ['guests'],
     },

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -552,10 +552,10 @@ function voteTypeIsDown(voteType: string): boolean {
 }
 
 function voteHasAnyEffect(votingSystem: VotingSystem, vote: DbVote, af: boolean) {
-  if (votingSystem.name !== "default") {
-    // If using a non-default voting system, include neutral votes in the vote
-    // count, because they may have an effect that's not captured in their power.
-    return true;
+  // Exclude neutral votes (i.e. those without a karma change) from the vote count,
+  // because it causes confusion in the UI
+  if (vote.voteType === 'neutral') {
+    return false;
   }
   
   if (af) {


### PR DESCRIPTION
I think that `voteCount` (which is the # of Votes shown in the tooltip on score) should only include up/down votes on karma, and should not include neutral votes (such as reactions only). I think that the inflated vote count has caused confusion on EAF, where people thought there were more downvotes than in reality.
<img width="307" alt="Screenshot 2025-01-14 at 2 25 01 PM" src="https://github.com/user-attachments/assets/00d5c56a-b0a8-4c41-87fe-e9f78360f706" />

----
I'm not sure if it was an intentional choice by LW to include neutral votes in the `voteCount`? If so then I can forum-gate this change.

I also don't know why we are updating `voteCount` twice, perhaps we don't need to do the `denormalizedCountOfReferences` on `voteCount`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209153913377538) by [Unito](https://www.unito.io)
