### PR TITLE
Restore Titles to Tag Previews and some other preview tweaks

### DIFF
--- a/packages/lesswrong/components/tagging/ConceptItem.tsx
+++ b/packages/lesswrong/components/tagging/ConceptItem.tsx
@@ -223,7 +223,8 @@ const ConceptItem = ({
           <TagsTooltip
             tagSlug={wikitag.slug}
             noPrefetch
-            previewPostCount={wikitag.description?.wordCount && wikitag.description?.wordCount > 0 ? 0 : 6}
+            // We have some empty descriptions that have wordcounts of 1.
+            previewPostCount={wikitag.description?.wordCount && wikitag.description?.wordCount > 2 ? 0 : 6}
             placement='bottom-start'
             popperClassName={classes.tooltipHoverTitle}
           >

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -77,9 +77,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
     flexGrow: 1,
   },
   postsWithoutDescription: {
-    // marginTop: 4,
     paddingTop: 8,
-    // borderTop: theme.palette.border.extraFaint,
     marginBottom: 8,
     overflow: "hidden",
   },
@@ -195,7 +193,6 @@ const TagPreview = ({
   };
 
   const showPosts = postCount > 0 && !!tag?._id && !isFriendlyUI;
-
   const {results} = useMulti({
     skip: !showPosts,
     terms: tagPostTerms(tag, {}),

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -11,6 +11,7 @@ import { isFriendlyUI } from '../../themes/forumTheme';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { getTagDescriptionHtmlHighlight } from './TagPreviewDescription';
+import startCase from 'lodash/startCase';
 
 const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
   root: {
@@ -131,7 +132,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
 }));
 
 /*
-/* If the text displayed on hover preview does containt the tag name in the first 100 characters, we use this flag to display a title.
+/* If the text displayed on hover preview doesn't contain the tag name in the first 100 characters, we use this flag to display a title.
 /* If summaries are present, we must check for the tag name in the first summary, otherwise we use the tag name 
 /* from the main description.
 */
@@ -215,7 +216,7 @@ const TagPreview = ({
       data-selected={activeTab === index}
       onClick={() => updateActiveTab(index)}
     >
-      {summary.tabTitle[0].toUpperCase() + summary.tabTitle.slice(1)}
+      {startCase(summary.tabTitle)}
     </div>
   )) ?? [];
 

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -30,11 +30,11 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
   rootEAWidth: {
     width: FRIENDLY_HOVER_OVER_WIDTH,
   },
-  nonTabPadding: {
+  mainContent: {
     ...(!isFriendlyUI && {
       paddingLeft: 16,
       paddingRight: 16,
-      maxHeight: 400,
+      maxHeight: 600,
       overflowY: 'auto',
     }),
   },
@@ -45,7 +45,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
     fontWeight: 600,
     paddingLeft: 16,
     paddingRight: 16,
-    paddingTop: 8,
+    paddingTop: 12,
   },
   extraTitleMargin: {
     marginBottom: 8,
@@ -128,7 +128,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
       borderLeft: 'none',
     },
   },
-  descriptionTop: {
+  description: {
     ...(isFriendlyUI && { marginTop: 16 }),
   },
 }));
@@ -139,9 +139,14 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
 /* from the main description.
 */
 const tagShowTitle = (tag: (TagPreviewFragment | TagSectionPreviewFragment) & { summaries?: MultiDocumentEdit[] }) => {
+  if (isFriendlyUI) {
+    return false;
+  }
+
   const firstSummaryText = tag.summaries?.[0]?.contents?.html
   const highlightText = truncate(getTagDescriptionHtmlHighlight(tag), getTagParagraphTruncationCount(tag), "paragraphs");
   const openingText: string | undefined = firstSummaryText ?? highlightText;
+
   if (!openingText) {
     return true;
   }
@@ -244,8 +249,8 @@ const TagPreview = ({
       {hasMultipleSummaries && <div className={classes.tabsContainer}>
        {summaryTabs}
       </div>}
-      <div className={classes.nonTabPadding}>
-        {hasDescription && <div className={classes.descriptionTop}>
+      <div className={classes.mainContent}>
+        {hasDescription && <div className={classes.description}>
           <TagPreviewDescription 
             tag={tag} 
             hash={hash} 

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -10,8 +10,7 @@ import { FRIENDLY_HOVER_OVER_WIDTH } from '../common/FriendlyHoverOver';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { truncate } from '../../lib/editor/ellipsize';
-import { getTagParagraphTruncationCount, getTagDescriptionHtmlHighlight } from './TagPreviewDescription';
+import { getTagDescriptionHtmlHighlight } from './TagPreviewDescription';
 
 const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
   root: {
@@ -142,7 +141,7 @@ const tagShowTitle = (tag: (TagPreviewFragment | TagSectionPreviewFragment) & { 
   }
 
   const firstSummaryText = tag.summaries?.[0]?.contents?.html
-  const highlightText = truncate(getTagDescriptionHtmlHighlight(tag), getTagParagraphTruncationCount(tag), "paragraphs");
+  const highlightText = getTagDescriptionHtmlHighlight(tag);
   const openingText: string | undefined = firstSummaryText ?? highlightText;
 
   if (!openingText) {

--- a/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
+++ b/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
@@ -26,7 +26,7 @@ const CoreTagCustomDescriptions: Record<string, string> = {
   'Community': 'The <strong>Community</strong> tag is for LessWrong/Rationality community events, analysis of community health, norms and directions of the community, and posts about understanding communities in general.' 
 };
 
-const getTagDescriptionHtmlHighlight = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
+export const getTagDescriptionHtmlHighlight = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
   if (!tag.description) {
     return undefined;
   } else if ('htmlHighlight' in tag.description) {
@@ -36,7 +36,7 @@ const getTagDescriptionHtmlHighlight = (tag: TagPreviewFragment | TagSectionPrev
   }
 }
 
-const getTagParagraphTruncationCount = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
+export const getTagParagraphTruncationCount = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
   if (!tag.description || 'htmlHighlight' in tag.description) return 1;
 
   // Show two paragraphs for links to tag section headers

--- a/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
+++ b/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
@@ -36,7 +36,7 @@ export const getTagDescriptionHtmlHighlight = (tag: TagPreviewFragment | TagSect
   }
 }
 
-export const getTagParagraphTruncationCount = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
+const getTagParagraphTruncationCount = (tag: TagPreviewFragment | TagSectionPreviewFragment) => {
   if (!tag.description || 'htmlHighlight' in tag.description) return 1;
 
   // Show two paragraphs for links to tag section headers


### PR DESCRIPTION
Some hoverovers have no description or a description that doesn't contain the title. We do a basic check for whether the title is present in the description early on, otherwise, display a title (LW only).

This PR also fixes a bug that caused wikitags with no description but erroneously stored wordcounts > 0 from then displaying complete hovers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209154734399668) by [Unito](https://www.unito.io)
