### PR TITLE
Remove lineHeight from sup

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -468,7 +468,8 @@ const baseBodyStyles = (theme: ThemeType) => ({
     verticalAlign: 'baseline',
     top: '-0.6em',
     fontSize: '65%',
-    position: 'relative'
+    position: 'relative',
+    lineHeight: 0,
   },
   '& sub': {
     fontSize: '70%',


### PR DESCRIPTION
footnotes right now change the line height in comments in ugly ways. This fixes this. I tested it on a few different pieces of content (both posts and comments), and I didn't see any issues, and saw it only improve things.

Before: 
<img width="668" alt="image" src="https://github.com/user-attachments/assets/8cffebec-62f9-454b-84d9-7cfb20324e0c" />

After:  
<img width="663" alt="image" src="https://github.com/user-attachments/assets/c856fd4e-54c0-4b48-a709-e67e9048babb" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209190549316065) by [Unito](https://www.unito.io)
