### PR TITLE
Vote icon positioning tweak

### DIFF
--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -10,6 +10,73 @@ import type { OverallVoteButtonProps } from './OverallVoteButton';
 import classNames from 'classnames';
 import { isFriendlyUI } from '../../themes/forumTheme';
 
+/* -- Helper Tooltip Components -- */
+function TooltipIfDisabled({
+  canVote,
+  children,
+  LWTooltip,
+  classes,
+  whyYouCantVote,
+  karmaTooltipTitle,
+  tooltipPlacement = 'top',
+}: {
+  canVote: boolean;
+  children: React.ReactNode;
+  classes: ClassesType<typeof styles>;
+  LWTooltip: React.ComponentType<any>;
+  whyYouCantVote: string | undefined;
+  karmaTooltipTitle: React.ReactNode;
+  tooltipPlacement?: string;
+}) {
+  if (canVote) {
+    // If they can vote, we just return the children
+    return <>{children}</>;
+  }
+  // Otherwise, wrap them in a tooltip explaining why
+  return (
+    <LWTooltip
+      placement={tooltipPlacement}
+      popperClassName={classes.tooltip}
+      title={
+        <>
+          <div>{whyYouCantVote}</div>
+          <div>{karmaTooltipTitle}</div>
+        </>
+      }
+    >
+      {children}
+    </LWTooltip>
+  );
+}
+
+function TooltipIfEnabled({
+  canVote,
+  children,
+  LWTooltip,
+  classes,
+  tooltipPlacement = 'top',
+  ...restProps
+}: {
+  canVote: boolean;
+  children: React.ReactNode;
+  classes: ClassesType<typeof styles>;
+  LWTooltip: React.ComponentType<any>;
+  tooltipPlacement?: string;
+  [key: string]: any; // for e.g. "title", "popperClassName", etc.
+}) {
+  if (canVote) {
+    // Only wrap in LWTooltip if they can vote
+    return (
+      <LWTooltip placement={tooltipPlacement} popperClassName={classes.tooltip} {...restProps}>
+        {children}
+      </LWTooltip>
+    );
+  }
+  // If they can't vote, we just return children unwrapped
+  return <>{children}</>;
+}
+
+/* -- JSS Styles -- */
 const styles = (theme: ThemeType) => ({
   overallSection: {
     display: 'inline-block',
@@ -56,20 +123,20 @@ const styles = (theme: ThemeType) => ({
     transform: "translateY(-3px)",
   },
   verticalArrows: {
-    "& .LWTooltip-root": {
-    },
+    "& .LWTooltip-root": {},
     "& $voteScore": {
       display: "block",
     },
   },
-})
+});
 
+/* -- Main Component -- */
 const OverallVoteAxis = ({
   document,
-  hideKarma=false,
+  hideKarma = false,
   voteProps,
   classes,
-  showBox=false,
+  showBox = false,
   verticalArrows,
   largeArrows,
   className,
@@ -85,23 +152,23 @@ const OverallVoteAxis = ({
 }) => {
   const currentUser = useCurrentUser();
 
-
-  const { OverallVoteButton, LWTooltip } = Components
+  const { OverallVoteButton, LWTooltip } = Components;
 
   const collectionName = voteProps.collectionName;
-  const extendedScore = voteProps.document?.extendedScore
+  const extendedScore = voteProps.document?.extendedScore;
   const voteCount = extendedScore && ("approvalVoteCount" in extendedScore)
     ? extendedScore.approvalVoteCount
     : (voteProps.voteCount || 0);
   const karma = voteProps.baseScore;
-  const {fail, reason: whyYouCantVote} = voteButtonsDisabledForUser(currentUser);
+
+  const { fail, reason: whyYouCantVote } = voteButtonsDisabledForUser(currentUser);
   const canVote = !fail;
 
-  let moveToAlignnmentUserId = ""
+  let moveToAlignnmentUserId = "";
   let documentTypeName = "comment";
   if (collectionName === "Comments") {
-    const comment = document as CommentsList
-    moveToAlignnmentUserId = comment.moveToAlignmentUserId
+    const comment = document as CommentsList;
+    moveToAlignnmentUserId = comment.moveToAlignmentUserId;
   }
   if (collectionName === "Posts") {
     documentTypeName = "post";
@@ -116,128 +183,160 @@ const OverallVoteAxis = ({
 
   const moveToAfInfo = userIsAdmin(currentUser) && !!moveToAlignnmentUserId && (
     <div className={classes.tooltipHelp}>
-      <span>Moved to AF by <Components.UsersName documentId={moveToAlignnmentUserId }/> on { afDate && moment(new Date(afDate)).format('YYYY-MM-DD') }</span>
+      <span>
+        Moved to AF by <Components.UsersName documentId={moveToAlignnmentUserId} /> on{' '}
+        {afDate && moment(new Date(afDate)).format('YYYY-MM-DD')}
+      </span>
     </div>
-  )
+  );
 
-  const karmaTooltipTitle = React.useMemo(() =>  hideKarma
+  const karmaTooltipTitle = hideKarma
     ? 'This post has disabled karma visibility'
-    : <div>This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount === 1 ? "Vote" : "Votes"})</div>
-  , [hideKarma, documentTypeName, karma, voteCount])
+    : (
+      <div>
+        This {documentTypeName} has {karma} <b>overall</b> karma ({voteCount} {voteCount === 1 ? "Vote" : "Votes"})
+      </div>
+    );
 
-  const TooltipIfDisabled = React.useMemo(() => canVote
-    ? ({children}: {children: React.ReactNode}) => <>{children}</>
-    : ({children}: {children: React.ReactNode}) => <LWTooltip
-      placement="top"
-      popperClassName={classes.tooltip}
-      title={<>
-        <div>{whyYouCantVote}</div>
-        <div>{karmaTooltipTitle}</div>
-      </>}
-    >
-      {children}
-    </LWTooltip>
-  , [canVote, karmaTooltipTitle, whyYouCantVote, classes.tooltip, LWTooltip])
-  
-  const TooltipIfEnabled = React.useMemo(() => canVote
-    ? ({children, ...props}: React.ComponentProps<typeof LWTooltip>) =>
-      <LWTooltip {...props} popperClassName={classes.tooltip}>
-        {children}
-      </LWTooltip>
-    : ({children}: {children: React.ReactNode}) => <>{children}</>
-  , [canVote, LWTooltip, classes.tooltip])
+  // Moved these tooltip gates to separate components above, removing inline creation.
+  const tooltipPlacement = "top";
 
-
-  // Moved down here to allow for useMemo hooks
+  // Return null if no document
   if (!document) return null;
 
-  const tooltipPlacement = "top"
-
-  const buttonProps: Partial<OverallVoteButtonProps<VoteableTypeClient>> = {largeArrow: largeArrows};
+  const buttonProps: Partial<OverallVoteButtonProps<VoteableTypeClient>> = { largeArrow: largeArrows };
   if (verticalArrows) {
     buttonProps.solidArrow = true;
   }
 
-  return <TooltipIfDisabled>
-    <span className={classes.vote}>
-      {!!af && !isAF &&
-        <LWTooltip
-          placement={tooltipPlacement}
-          popperClassName={classes.tooltip}
-          title={
-            <div>
-              <p>AI Alignment Forum Karma</p>
-              { moveToAfInfo }
-            </div>
-          }
-        >
-          <span className={classes.secondaryScore}>
-            <span className={classes.secondarySymbol}>Ω</span>
-            <span className={classes.secondaryScoreNumber}>{afBaseScore || 0}</span>
-          </span>
-        </LWTooltip>
-      }
-      {!af && isAF &&
-        <LWTooltip
-          title="LessWrong Karma"
-          placement={tooltipPlacement}
-          className={classes.lwTooltip}
-        >
-          <span className={classes.secondaryScore}>
-            <span className={classes.secondarySymbol}>LW</span>
-            <span className={classes.secondaryScoreNumber}>{document.baseScore || 0}</span>
-          </span>
-        </LWTooltip>
-      }
-      {(!isAF || !!af) &&
-        <span className={classNames(classes.overallSection, className, {
-          [classes.overallSectionBox]: showBox,
-          [classes.verticalArrows]: verticalArrows,
-        })}>
-          <TooltipIfEnabled
-            title={<div><b>Overall Karma: Downvote</b><br />How much do you like this overall?<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
+  return (
+    <TooltipIfDisabled
+      canVote={canVote}
+      LWTooltip={LWTooltip}
+      classes={classes}
+      whyYouCantVote={whyYouCantVote}
+      karmaTooltipTitle={karmaTooltipTitle}
+      tooltipPlacement={tooltipPlacement}
+    >
+      <span className={classes.vote}>
+        {!!af && !isAF && (
+          <LWTooltip
             placement={tooltipPlacement}
-          >
-            <OverallVoteButton
-              orientation={verticalArrows ? "down" : "left"}
-              color="error"
-              upOrDown="Downvote"
-              enabled={canVote}
-              {...voteProps}
-              {...buttonProps}
-            />
-          </TooltipIfEnabled>
-          <TooltipIfEnabled title={karmaTooltipTitle} placement={tooltipPlacement}>
-            {hideKarma
-              ? <span>{' '}</span>
-              : <span className={classes.voteScore}>
-                  {karma}
-                </span>
+            popperClassName={classes.tooltip}
+            title={
+              <div>
+                <p>AI Alignment Forum Karma</p>
+                {moveToAfInfo}
+              </div>
             }
-          </TooltipIfEnabled>
-          <TooltipIfEnabled
-            title={<div><b>Overall Karma: Upvote</b><br />How much do you like this overall?<br /><em>For strong upvote, click-and-hold<br />(Click twice on mobile)</em></div>}
-            placement={tooltipPlacement}
           >
-            <OverallVoteButton
-              orientation={verticalArrows ? "up" : "right"}
-              color="secondary"
-              upOrDown="Upvote"
-              enabled={canVote}
-              {...voteProps}
-              {...buttonProps}
-            />
-          </TooltipIfEnabled>
-        </span>
-      }
-    </span>
-  </TooltipIfDisabled>
-}
+            <span className={classes.secondaryScore}>
+              <span className={classes.secondarySymbol}>Ω</span>
+              <span className={classes.secondaryScoreNumber}>{afBaseScore || 0}</span>
+            </span>
+          </LWTooltip>
+        )}
 
-const OverallVoteAxisComponent = registerComponent('OverallVoteAxis', OverallVoteAxis, {styles});
+        {!af && isAF && (
+          <LWTooltip
+            title="LessWrong Karma"
+            placement={tooltipPlacement}
+            className={classes.lwTooltip}
+          >
+            <span className={classes.secondaryScore}>
+              <span className={classes.secondarySymbol}>LW</span>
+              <span className={classes.secondaryScoreNumber}>{document.baseScore || 0}</span>
+            </span>
+          </LWTooltip>
+        )}
+
+        {(!isAF || !!af) && (
+          <span
+            className={classNames(classes.overallSection, className, {
+              [classes.overallSectionBox]: showBox,
+              [classes.verticalArrows]: verticalArrows,
+            })}
+          >
+            <TooltipIfEnabled
+              canVote={canVote}
+              LWTooltip={LWTooltip}
+              classes={classes}
+              tooltipPlacement={tooltipPlacement}
+              title={
+                <div>
+                  <b>Overall Karma: Downvote</b>
+                  <br />
+                  How much do you like this overall?
+                  <br />
+                  <em>For strong downvote, click-and-hold
+                  <br />
+                  (Click twice on mobile)</em>
+                </div>
+              }
+            >
+              <OverallVoteButton
+                orientation={verticalArrows ? "down" : "left"}
+                color="error"
+                upOrDown="Downvote"
+                enabled={canVote}
+                {...voteProps}
+                {...buttonProps}
+              />
+            </TooltipIfEnabled>
+
+            <TooltipIfEnabled
+              canVote={canVote}
+              LWTooltip={LWTooltip}
+              classes={classes}
+              tooltipPlacement={tooltipPlacement}
+              title={karmaTooltipTitle}
+            >
+              {hideKarma ? (
+                <span> </span>
+              ) : (
+                <span className={classes.voteScore}>{karma}</span>
+              )}
+            </TooltipIfEnabled>
+
+            <TooltipIfEnabled
+              canVote={canVote}
+              LWTooltip={LWTooltip}
+              classes={classes}
+              tooltipPlacement={tooltipPlacement}
+              title={
+                <div>
+                  <b>Overall Karma: Upvote</b>
+                  <br />
+                  How much do you like this overall?
+                  <br />
+                  <em>For strong upvote, click-and-hold
+                  <br />
+                  (Click twice on mobile)</em>
+                </div>
+              }
+            >
+              <OverallVoteButton
+                orientation={verticalArrows ? "up" : "right"}
+                color="secondary"
+                upOrDown="Upvote"
+                enabled={canVote}
+                {...voteProps}
+                {...buttonProps}
+              />
+            </TooltipIfEnabled>
+          </span>
+        )}
+      </span>
+    </TooltipIfDisabled>
+  );
+};
+
+const OverallVoteAxisComponent = registerComponent('OverallVoteAxis', OverallVoteAxis, { styles });
 
 declare global {
   interface ComponentTypes {
-    OverallVoteAxis: typeof OverallVoteAxisComponent
+    OverallVoteAxis: typeof OverallVoteAxisComponent;
   }
 }
+
+export default OverallVoteAxisComponent;

--- a/packages/lesswrong/components/votes/VoteArrowIconSolid.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIconSolid.tsx
@@ -19,6 +19,12 @@ const styles = (theme: ThemeType) => ({
     '&:hover': {
       backgroundColor: 'transparent',
     },
+    marginLeft: 1,
+    marginRight: 1,
+    transition: 'margin-top 0.2s ease-in-out',
+  },
+  rootAnimationCompleted: {
+    marginTop: 4,
   },
   disabled: {
     cursor: 'not-allowed',
@@ -150,7 +156,8 @@ const VoteArrowIconSolid = ({
         classes.root,
         classes[orientation],
         largeArrow && classes[`${orientation}Large`],
-        !enabled && classes.disabled
+        !enabled && classes.disabled,
+        bigVoted && classes.rootAnimationCompleted
       )}
       onMouseDown={handlers.handleMouseDown}
       onMouseUp={handlers.handleMouseUp}


### PR DESCRIPTION
This makes it so that after you strong-voted, the vote icon moves a tiny bit in the opposite direction, keeping the center of mass of the small vote and strong vote constant. This looks a lot better in comment items. 

I also added a small margin left and margin right to vote arrows, so improve spacing in the comment items.

This annoyingly required a refactoring of OverallVoteAxis, which created lots of inline components which then messed up the react reconciliation and so prevented all animations from working when triggered by props changes. This fixes that (and more broadly, I think we should just add a lint against creating components within render functions).