### PR TITLE
[FriendlyUI only] cleanup some rate limit messaging

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -486,7 +486,11 @@ const CommentsNewForm = ({
           })
           : undefined
         }>
-          {formDisabledDueToRateLimit && <RateLimitWarning lastRateLimitExpiry={lastRateLimitExpiry} rateLimitMessage={rateLimitMessage} />}
+          {formDisabledDueToRateLimit && <RateLimitWarning
+            contentType="comment"
+            lastRateLimitExpiry={lastRateLimitExpiry}
+            rateLimitMessage={rateLimitMessage}
+          />}
           <div onFocus={(ev) => {
             afNonMemberDisplayInitialPopup(currentUser, openDialog)
             ev.preventDefault()

--- a/packages/lesswrong/components/common/WarningBanner.tsx
+++ b/packages/lesswrong/components/common/WarningBanner.tsx
@@ -9,7 +9,7 @@ const styles = (theme: ThemeType) => ({
     fontFamily: theme.typography.commentStyle.fontFamily,
     color: theme.palette.text.warning,
     fontSize: 14,
-    lineHeight: '18px',
+    lineHeight: '20px',
     fontWeight: '500',
     padding: '10px 8px',
     borderRadius: 4,
@@ -17,12 +17,15 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 8,
   },
   icon: {
-    transform: "translateY(1px)",
+    transform: "translateY(3px)",
     fontSize: 16,
   },
   message: {
-    flexGrow: 1
-  }
+    flexGrow: 1,
+    '& a': {
+      textDecoration: 'underline',
+    }
+  },
 });
 
 const WarningBanner = ({message, classes}: {
@@ -32,9 +35,7 @@ const WarningBanner = ({message, classes}: {
   
   return <div className={classes.root}>
     <Components.ForumIcon icon="Warning" className={classes.icon} />
-    <div className={classes.message}>
-      {message}
-    </div>
+    <div className={classes.message} dangerouslySetInnerHTML={{__html: message}} />
   </div>
 }
 

--- a/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeCommunityPosts.tsx
@@ -27,7 +27,7 @@ const EAHomeCommunityPosts = ({classes}: {classes: ClassesType<typeof styles>}) 
     section: "community",
     onExpandEvent: "communityPostsSectionExpanded",
     onCollapseEvent: "communityPostsSectionCollapsed",
-    defaultExpanded: "loggedIn",
+    defaultExpanded: "all",
     cookieName: SHOW_COMMUNITY_POSTS_SECTION_COOKIE,
   });
   const now = useCurrentTime();

--- a/packages/lesswrong/components/editor/RateLimitWarning.tsx
+++ b/packages/lesswrong/components/editor/RateLimitWarning.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import moment from 'moment';
-import { isEAForum } from '../../lib/instanceSettings';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import { isFriendlyUI } from '../../themes/forumTheme';
 
@@ -24,7 +23,8 @@ const styles = (theme: ThemeType) => ({
 });
 
 // Tells the user when they can next comment or post if they're rate limited, and a brief explanation
-const RateLimitWarning = ({lastRateLimitExpiry, rateLimitMessage, classes}: {
+const RateLimitWarning = ({contentType, lastRateLimitExpiry, rateLimitMessage, classes}: {
+  contentType: 'comment' | 'post',
   lastRateLimitExpiry: Date,
   rateLimitMessage?: string,
   classes: ClassesType<typeof styles>
@@ -55,8 +55,8 @@ const RateLimitWarning = ({lastRateLimitExpiry, rateLimitMessage, classes}: {
   }
 
   let message = `<p>You can submit again in ${getTimeUntilNextPost()}.</p> ${rateLimitMessage ?? ''}`
-  if (isEAForum) {
-    message = `You've written more than 3 comments in the last 30 minutes. Please wait ${getTimeUntilNextPost()} before commenting again. ${rateLimitMessage ?? ''}`
+  if (isFriendlyUI) {
+    message = `Please wait ${getTimeUntilNextPost()} before ${contentType === 'comment' ? 'commenting' : 'posting'} again. ${rateLimitMessage ?? ''}`
   }
 
   if (isFriendlyUI) {

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -152,7 +152,11 @@ const PostsEditForm = ({ documentId, version, classes }: {
       <div className={classes.postForm}>
         <HeadTags title={document.title} />
         {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
-        {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
+        {rateLimitNextAbleToPost && <RateLimitWarning
+          contentType="post"
+          lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible}
+          rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}
+        />}
         <DeferRender ssr={false}>
           <EditorContext.Provider value={[editorState, setEditorState]}>
             <WrappedSmartForm

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -371,7 +371,11 @@ const PostsNewForm = ({classes}: {
         <RecaptchaWarning currentUser={currentUser}>
           <PostsAcceptTos currentUser={currentUser} />
           {postWillBeHidden && <NewPostModerationWarning />}
-          {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
+          {rateLimitNextAbleToPost && <RateLimitWarning
+            contentType="post"
+            lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible}
+            rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}
+          />}
           <DeferRender ssr={false}>
               <WrappedSmartForm
                 collectionName="Posts"

--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -21,6 +21,8 @@ const timeframe = <A extends AutoRateLimit['actionType']>(timeframeString: Timef
   }
 };
 
+const eaDefaultMessage = `<a href="https://forum.effectivealtruism.org/posts/yND9aGJgobm5dEXqF/guide-to-norms-on-the-forum">Click here</a> to read more about EA Forum norms.`
+
 const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
   POSTS: [
   ],
@@ -29,13 +31,13 @@ const EA: {POSTS: PostAutoRateLimit[], COMMENTS: CommentAutoRateLimit[]} = {
       ...timeframe('4 Comments per 30 minutes'),
       isActive: (user) => (user.karma < 30),
       rateLimitType: "lowKarma",
-      rateLimitMessage: "You'll be able to post more comments as your karma increases.",
+      rateLimitMessage: `You'll be able to post more comments as your karma increases. ${eaDefaultMessage}`,
       appliesToOwnPosts: true
     }, {
       ...timeframe('4 Comments per 30 minutes'),
       isActive: (user, features) => features.downvoteRatio >= 0.3,
       rateLimitType: "downvoteRatio",
-      rateLimitMessage: "",
+      rateLimitMessage: `You've written more than 3 comments in the last 30 minutes. ${eaDefaultMessage}`,
       appliesToOwnPosts: true
     },
   ]

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -354,13 +354,13 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToEAForumAudien
 const welcomeMessageDelayer = new EventDebouncer({
   name: "welcomeMessageDelay",
   
-  // Delay is by default 60 minutes between when you create an account, and
+  // Delay is by default 5 minutes between when you create an account, and
   // when we send the welcome email. The theory is that users creating new
   // accounts are often doing so because they're about to write a comment or
   // something, and derailing them with a bunch of stuff to read at that
   // particular moment could be bad.
   // LW wants people to see site intro before posting
-  defaultTiming: isLW ? {type: "none"} : {type: "delayed", delayMinutes: 60},
+  defaultTiming: isLW ? {type: "none"} : {type: "delayed", delayMinutes: 5},
   
   callback: (userId: string) => {
     void sendWelcomeMessageTo(userId);


### PR DESCRIPTION
I noticed when playing around with rate limits that our banner sometimes has incorrect messaging. So I've made it work more like LW's messaging (and added a link to the guide to Forum norms), and slightly cleaned up the UI.

<img width="667" alt="Screenshot 2025-01-21 at 3 00 43 PM" src="https://github.com/user-attachments/assets/43188ade-61dd-441e-b125-2f0584889aeb" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209207223660098) by [Unito](https://www.unito.io)
