### PR TITLE
Fix occasional mispositioned side-items when the end of an inline reaction and the start of another inline reaction touch

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -508,7 +508,9 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
           );
           // Do surgery on the DOM
           if (range) {
-            const subRanges = splitRangeIntoReplaceableSubRanges(range);
+            const reduced = reduceRangeToText(range);
+            if (!reduced) continue;
+            const subRanges = splitRangeIntoReplaceableSubRanges(reduced);
             let first=true;
             for (let subRange of subRanges) {
               const reducedRange = reduceRangeToText(subRange);

--- a/packages/lesswrong/lib/utils/rawDom.tsx
+++ b/packages/lesswrong/lib/utils/rawDom.tsx
@@ -216,7 +216,7 @@ export function reduceRangeToText(range: Range): Range|null {
       // Inside a text node, buf after all of the actual text. Find the next
       // text node in the tree, and set the position to be the start of that
       // one rather than the end of this one.
-      const nextTextNode = nextTextNodeAfter(startContainer as Text);
+      const nextTextNode = nextNonemptyTextNodeAfter(startContainer as Text);
       if (!nextTextNode) return null;
       result.setStart(nextTextNode, 0);
     }
@@ -234,7 +234,7 @@ export function reduceRangeToText(range: Range): Range|null {
     if (pos.nodeType === Node.TEXT_NODE) {
       result.setStart(pos, 0);
     } else {
-      const nextTextNode = nextTextNodeAfter(pos);
+      const nextTextNode = nextNonemptyTextNodeAfter(pos);
       if (!nextTextNode) return null;
       result.setStart(nextTextNode, 0);
     }
@@ -277,6 +277,14 @@ function nextTextNodeAfter(node: Node): Text|null {
   do {
     pos = nextLeafNodeAfter(pos);
   } while (pos && pos.nodeType !== Node.TEXT_NODE);
+  return pos as Text|null;
+}
+
+function nextNonemptyTextNodeAfter(node: Node): Text|null {
+  let pos: Node|null = node;
+  do {
+    pos = nextLeafNodeAfter(pos);
+  } while (pos && (pos.nodeType !== Node.TEXT_NODE || pos.textContent===null || !pos.textContent.length));
   return pos as Text|null;
 }
 


### PR DESCRIPTION
`toRange` can return a DOM range that, in addition to including the intended text, also includes empty nodes that are adjacent to it. In some cases (eg inline reactions on [this post](http://localhost:3000/posts/8wBN8cdNAv3c7vt6p/the-case-against-ai-control-research)), where two inline reactions touch (the start of one is the end of the next), this can result in the second inline reaction being mispositioned.

Fix by trimming earlier, and fixing a limitation of `reduceRangeToText` that it would only trim by one text element at a time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209209654759531) by [Unito](https://www.unito.io)
