### PR TITLE
Refactor mutation-callbacks

### DIFF
--- a/packages/lesswrong/lib/collectionUtils.ts
+++ b/packages/lesswrong/lib/collectionUtils.ts
@@ -42,7 +42,7 @@ export function addUniversalFields<N extends CollectionNameString>({
       nullable: false,
       hidden: true,
       canRead: ['guests'],
-      onInsert: () => new Date(),
+      onCreate: () => new Date(),
       ...createdAtOptions,
     },
     legacyData: {

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -8,7 +8,7 @@ const schema: SchemaType<"Books"> = {
     type: Date,
     optional: true,
     canRead: ['guests'],
-    onInsert: () => new Date(),
+    onCreate: () => new Date(),
   },
 
   // Custom Properties

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -76,7 +76,7 @@ const schema: SchemaType<"Comments"> = {
         return await userGetDisplayNameById(document.userId)
       }
     },
-    onEdit: async (modifier, document, currentUser) => {
+    onUpdate: async ({modifier, document, currentUser}) => {
       // if userId is changing, change the author name too
       if (modifier.$set && modifier.$set.userId) {
         return await userGetDisplayNameById(modifier.$set.userId)
@@ -546,7 +546,7 @@ const schema: SchemaType<"Comments"> = {
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['sunshineRegiment', 'admins'],
-    onEdit: (modifier, document, currentUser) => {
+    onUpdate: ({modifier}) => {
       if (modifier.$set && (modifier.$set.deletedPublic || modifier.$set.deleted)) {
         return new Date()
       }
@@ -567,7 +567,7 @@ const schema: SchemaType<"Comments"> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['members'],
     hidden: true,
-    onEdit: (modifier, document, currentUser) => {
+    onUpdate: ({modifier, document, currentUser}) => {
       if (modifier.$set && (modifier.$set.deletedPublic || modifier.$set.deleted) && currentUser) {
         return modifier.$set.deletedByUserId || currentUser._id
       }
@@ -780,7 +780,7 @@ const schema: SchemaType<"Comments"> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     hidden: true,
-    onEdit: (modifier, document, currentUser) => {
+    onUpdate: ({modifier, document, currentUser}) => {
       if (modifier.$set?.rejected && currentUser) {
         return modifier.$set.rejectedByUserId || currentUser._id
       }

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -62,7 +62,7 @@ const schema: SchemaType<"Comments"> = {
     type: Date,
     optional: true,
     canRead: ['guests'],
-    onInsert: (document, currentUser) => new Date(),
+    onCreate: () => new Date(),
     nullable: false
   },
   // The comment author's name
@@ -70,13 +70,13 @@ const schema: SchemaType<"Comments"> = {
     type: String,
     optional: true,
     canRead: [documentIsNotDeleted],
-    onInsert: async (document, currentUser) => {
+    onCreate: async ({document}) => {
       // if userId is changing, change the author name too
       if (document.userId) {
         return await userGetDisplayNameById(document.userId)
       }
     },
-    onUpdate: async ({modifier, document, currentUser}) => {
+    onUpdate: async ({modifier}) => {
       // if userId is changing, change the author name too
       if (modifier.$set && modifier.$set.userId) {
         return await userGetDisplayNameById(modifier.$set.userId)
@@ -331,7 +331,7 @@ const schema: SchemaType<"Comments"> = {
     denormalized: true,
     optional: true,
     canRead: ['guests'],
-    onInsert: (document, currentUser) => new Date(),
+    onCreate: () => new Date(),
   },
 
   // The semver-style version of the post that this comment was made against

--- a/packages/lesswrong/lib/collections/conversations/schema.ts
+++ b/packages/lesswrong/lib/collections/conversations/schema.ts
@@ -36,7 +36,7 @@ const schema: SchemaType<"Conversations"> = {
     type: Date,
     denormalized: true,
     canRead: ['members'],
-    onInsert: (document) => {
+    onCreate: () => {
       return new Date(); // if this is an insert, set latestActivity to current timestamp
     },
     optional: true,

--- a/packages/lesswrong/lib/collections/elicitQuestionPredictions/schema.ts
+++ b/packages/lesswrong/lib/collections/elicitQuestionPredictions/schema.ts
@@ -32,7 +32,7 @@ const schema: SchemaType<"ElicitQuestionPredictions"> = {
   },
   createdAt: {
     type: Date,
-    onInsert: (prediction) => prediction.createdAt ?? new Date(),
+    onCreate: ({document: prediction}) => prediction.createdAt ?? new Date(),
     ...commonFields(false)
   },
   notes: {

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -36,7 +36,7 @@ const schema: SchemaType<"GardenCodes"> = {
     optional: true,
     canRead: ['guests'],
     nullable: false,
-    onInsert: (gardenCode) => {
+    onCreate: () => {
       return generateCode(4)
     },
   },
@@ -75,7 +75,7 @@ const schema: SchemaType<"GardenCodes"> = {
     optional: true,
     canRead: ['guests'],
     nullable: false,
-    onInsert: async (gardenCode) => {
+    onCreate: async ({document: gardenCode}) => {
       return await getUnusedSlugByCollectionName("GardenCodes", slugify(gardenCode.title))
     },
   },
@@ -87,7 +87,7 @@ const schema: SchemaType<"GardenCodes"> = {
     control: 'datetime',
     label: "Start Time",
     optional: true,
-    onInsert: () => new Date(),
+    onCreate: () => new Date(),
     order: 20
   },
   endTime: {
@@ -100,7 +100,7 @@ const schema: SchemaType<"GardenCodes"> = {
     optional: true,
     nullable: false,
     order: 25,
-    onInsert: (gardenCode) => {
+    onCreate: ({document: gardenCode}) => {
       return moment(gardenCode.startTime).add(12, 'hours').toDate()
     }
   },

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -76,7 +76,7 @@ const schema: SchemaType<"Localgroups"> = {
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: ['members'],
-    onInsert: () => new Date(),
+    onCreate: () => new Date(),
     hidden: true,
   },
 

--- a/packages/lesswrong/lib/collections/moderatorActions/schema.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/schema.ts
@@ -78,7 +78,7 @@ export const MAX_ALLOWED_CONTACTS_BEFORE_BLOCK = forumSelect({EAForum: 4, defaul
 /**
  * If the action hasn't ended yet (either no endedAt, or endedAt in the future), it's active.
  */
-export const isActionActive = (moderatorAction: DbModeratorAction) => {
+export const isActionActive = (moderatorAction: Pick<DbModeratorAction, "endedAt">) => {
   return !moderatorAction.endedAt || moderatorAction.endedAt > new Date();
 }
 

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -178,7 +178,7 @@ const schema: SchemaType<"Posts"> = {
     canUpdate: ['admins'],
     control: 'datetime',
     group: formGroups.adminOptions,
-    onInsert: (post, currentUser) => {
+    onCreate: ({document: post, currentUser}) => {
       // Set the post's postedAt if it's going to be approved
       if (!post.postedAt && postGetDefaultStatus(currentUser!) === postStatuses.STATUS_APPROVED) {
         return new Date();
@@ -256,7 +256,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: false,
     canRead: ['guests'],
-    onInsert: async (post) => {
+    onCreate: async ({document: post}) => {
       return await getUnusedSlugByCollectionName("Posts", slugify(post.title))
     },
     onUpdate: async ({modifier, newDocument: post}) => {
@@ -280,7 +280,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     canRead: ['guests'],
     hidden: true,
-    onInsert: (post: DbPost) => post.postedAt || new Date(),
+    onCreate: ({document: post}) => post.postedAt || new Date(),
   },
   // Count of how many times the post's link was clicked
   clickCount: {
@@ -315,7 +315,7 @@ const schema: SchemaType<"Posts"> = {
     canCreate: ['admins'],
     canUpdate: ['admins', 'sunshineRegiment'],
     control: 'select',
-    onInsert: (document, currentUser) => {
+    onCreate: ({document, currentUser}) => {
       if (!document.status) {
         return postGetDefaultStatus(currentUser!);
       }
@@ -335,7 +335,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: false,
     canRead: ['guests'],
-    onInsert: (post) => {
+    onCreate: ({document: post}) => {
       // Set the post's isFuture to true if necessary
       if (post.postedAt) {
         const postTime = new Date(post.postedAt).getTime();
@@ -371,7 +371,7 @@ const schema: SchemaType<"Posts"> = {
     control: 'checkbox',
     order: 10,
     group: formGroups.adminOptions,
-    onInsert: (post) => {
+    onCreate: ({document: post}) => {
       if(!post.sticky) {
         return false;
       }
@@ -1533,7 +1533,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     hidden: true,
     ...(!requireReviewToFrontpagePostsSetting.get() && {
-      onInsert: ({isEvent, submitToFrontpage, draft}) => eaFrontpageDateDefault(
+      onCreate: ({document: {isEvent, submitToFrontpage, draft}}) => eaFrontpageDateDefault(
         isEvent,
         submitToFrontpage,
         draft,
@@ -2066,7 +2066,7 @@ const schema: SchemaType<"Posts"> = {
     nullable: false,
     canRead: ['guests'],
     hidden: true,
-    onInsert: (document) => document.baseScore ?? 0,
+    onCreate: ({document}) => document.baseScore ?? 0,
   },
   // The timestamp when the post's maxBaseScore first exceeded 2
   scoreExceeded2Date: {
@@ -2074,7 +2074,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 2 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 2 ? new Date() : null
   },
   // The timestamp when the post's maxBaseScore first exceeded 30
   scoreExceeded30Date: {
@@ -2082,7 +2082,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 30 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 30 ? new Date() : null
   },
   // The timestamp when the post's maxBaseScore first exceeded 45
   scoreExceeded45Date: {
@@ -2090,7 +2090,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 45 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 45 ? new Date() : null
   },
   // The timestamp when the post's maxBaseScore first exceeded 75
   scoreExceeded75Date: {
@@ -2098,7 +2098,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 75 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 75 ? new Date() : null
   },
   // The timestamp when the post's maxBaseScore first exceeded 125
   scoreExceeded125Date: {
@@ -2106,7 +2106,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 125 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 125 ? new Date() : null
   },
   // The timestamp when the post's maxBaseScore first exceeded 200
   scoreExceeded200Date: {
@@ -2114,7 +2114,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     nullable: true,
     canRead: ['guests'],
-    onInsert: document => document.baseScore >= 200 ? new Date() : null
+    onCreate: ({document}) => document.baseScore >= 200 ? new Date() : null
   },
   bannedUserIds: {
     type: Array,
@@ -2489,7 +2489,7 @@ const schema: SchemaType<"Posts"> = {
     canUpdate: ['admins'],
     canCreate: ['admins'],
     control: 'checkbox',
-    onInsert: (post) => {
+    onCreate: ({document: post}) => {
       if(!post.metaSticky) {
         return false;
       }
@@ -3032,7 +3032,7 @@ const schema: SchemaType<"Posts"> = {
     optional: true,
     hidden: true,
     canRead: ['guests'],
-    onInsert: () => new Date(),
+    onCreate: () => new Date(),
   },
 
   afSticky: {
@@ -3047,7 +3047,7 @@ const schema: SchemaType<"Posts"> = {
     canUpdate: ['alignmentForumAdmins', 'admins'],
     canCreate: ['alignmentForumAdmins', 'admins'],
     control: 'checkbox',
-    onInsert: (post: DbPost) => {
+    onCreate: ({document: post}) => {
       if(!post.afSticky) {
         return false;
       }

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -184,7 +184,7 @@ const schema: SchemaType<"Posts"> = {
         return new Date();
       }
     },
-    onEdit: (modifier, post) => {
+    onUpdate: ({modifier, newDocument: post}) => {
       // Set the post's postedAt if it's going to be approved
       if (!post.postedAt && modifier.$set.status === postStatuses.STATUS_APPROVED) {
         return new Date();
@@ -259,7 +259,7 @@ const schema: SchemaType<"Posts"> = {
     onInsert: async (post) => {
       return await getUnusedSlugByCollectionName("Posts", slugify(post.title))
     },
-    onEdit: async (modifier, post) => {
+    onUpdate: async ({modifier, newDocument: post}) => {
       if (modifier.$set.title) {
         return await getUnusedSlugByCollectionName("Posts", slugify(modifier.$set.title), false, post._id)
       }
@@ -320,7 +320,7 @@ const schema: SchemaType<"Posts"> = {
         return postGetDefaultStatus(currentUser!);
       }
     },
-    onEdit: (modifier, document, currentUser) => {
+    onUpdate: ({modifier, document, currentUser}) => {
       // if for some reason post status has been removed, give it default status
       if (modifier.$unset && modifier.$unset.status) {
         return postGetDefaultStatus(currentUser!);
@@ -345,7 +345,7 @@ const schema: SchemaType<"Posts"> = {
         return false;
       }
     },
-    onEdit: (modifier, post) => {
+    onUpdate: ({modifier, newDocument: post}) => {
       // Set the post's isFuture to true if necessary
       if (modifier.$set.postedAt) {
         const postTime = new Date(modifier.$set.postedAt).getTime();
@@ -376,7 +376,7 @@ const schema: SchemaType<"Posts"> = {
         return false;
       }
     },
-    onEdit: (modifier, post) => {
+    onUpdate: ({modifier}) => {
       if (!modifier.$set.sticky) {
         return false;
       }
@@ -421,7 +421,7 @@ const schema: SchemaType<"Posts"> = {
     denormalized: true,
     optional: true,
     canRead: [documentIsNotDeleted],
-    onEdit: async (modifier, document, currentUser) => {
+    onUpdate: async ({modifier, document, currentUser}) => {
       // if userId is changing, change the author name too
       if (modifier.$set && modifier.$set.userId) {
         return await userGetDisplayNameById(modifier.$set.userId)
@@ -2494,7 +2494,7 @@ const schema: SchemaType<"Posts"> = {
         return false;
       }
     },
-    onEdit: (modifier, post) => {
+    onUpdate: ({modifier}) => {
       if (!modifier.$set.metaSticky) {
         return false;
       }
@@ -2923,7 +2923,7 @@ const schema: SchemaType<"Posts"> = {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
     hidden: true,
-    onEdit: (modifier, document, currentUser) => {
+    onUpdate: ({modifier, document, currentUser}) => {
       if (modifier.$set?.rejected && currentUser) {
         return modifier.$set.rejectedByUserId || currentUser._id
       }
@@ -3052,7 +3052,7 @@ const schema: SchemaType<"Posts"> = {
         return false;
       }
     },
-    onEdit: (modifier: MongoModifier<DbPost>, post: DbPost) => {
+    onUpdate: ({modifier}) => {
       if (!(modifier.$set && modifier.$set.afSticky)) {
         return false;
       }

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -32,7 +32,7 @@ const schema: SchemaType<"TagFlags"> = {
     optional: true,
     nullable: false,
     canRead: ['guests'],
-    onInsert: async (tagFlag) => {
+    onCreate: async ({document: tagFlag}) => {
       return await getUnusedSlugByCollectionName("TagFlags", slugify(tagFlag.name))
     },
     onUpdate: async ({modifier, newDocument: tagFlag}) => {

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -35,7 +35,7 @@ const schema: SchemaType<"TagFlags"> = {
     onInsert: async (tagFlag) => {
       return await getUnusedSlugByCollectionName("TagFlags", slugify(tagFlag.name))
     },
-    onEdit: async (modifier, tagFlag) => {
+    onUpdate: async ({modifier, newDocument: tagFlag}) => {
       if (modifier.$set.name) {
         return await getUnusedSlugByCollectionName("TagFlags", slugify(modifier.$set.name), false, tagFlag._id)
       }

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -68,7 +68,7 @@ const schema: SchemaType<"Tags"> = {
     canCreate: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.advancedOptions,
-    onInsert: async (tag) => {
+    onCreate: async ({document: tag}) => {
       const basicSlug = slugify(tag.name);
       return await getUnusedSlugByCollectionName('Tags', basicSlug, true);
     },

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -339,7 +339,7 @@ const schema: SchemaType<"Users"> = {
     canUpdate: ['admins'],
     canCreate: ['members'],
     hidden: true,
-    onInsert: user => {
+    onCreate: ({document: user}) => {
       if (!user.username && user.services?.twitter?.screenName) {
         return user.services.twitter.screenName;
       }
@@ -1775,8 +1775,7 @@ const schema: SchemaType<"Users"> = {
     type: Number,
     denormalized: true,
     optional: true,
-    onInsert: (document, currentUser) => 0,
-
+    onCreate: () => 0,
 
     ...denormalizedCountOfReferences({
       fieldName: "frontpagePostCount",
@@ -2589,7 +2588,7 @@ const schema: SchemaType<"Users"> = {
     canRead: ["guests"],
     canUpdate: [userOwns, "admins"],
     hidden: true,
-    onInsert: (user) => user.createdAt,
+    onCreate: ({document: user}) => user.createdAt,
     ...schemaDefaultValue(new Date(0)),
   },
 

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -161,7 +161,7 @@ interface MergedViewQueryAndOptions<T extends DbObject> {
 
 export type MongoSelector<T extends DbObject> = any; //TODO
 type MongoProjection<T extends DbObject> = Partial<Record<keyof T, 0 | 1 | boolean>> | Record<string, any>;
-type MongoModifier<T extends DbObject> = {$inc?: any, $min?: any, $max?: any, $mul?: any, $rename?: any, $set?: any, $setOnInsert?: any, $unset?: any, $addToSet?: any, $pop?: any, $pull?: any, $push?: any, $pullAll?: any, $bit?: any}; //TODO
+type MongoModifier<T extends DbObject|DbInsertion<DbObject>> = {$inc?: any, $min?: any, $max?: any, $mul?: any, $rename?: any, $set?: any, $setOnInsert?: any, $unset?: any, $addToSet?: any, $pop?: any, $pull?: any, $push?: any, $pullAll?: any, $bit?: any}; //TODO
 
 type MongoFindOptions<T extends DbObject> = Partial<{
   sort: MongoSort<T>,
@@ -355,7 +355,10 @@ type EditableCollectionNames = {
 
 type CollectionNameOfObject<T extends DbObject> = Exclude<T['__collectionName'], undefined>;
 
-type DbInsertion<T extends DbObject> = ReplaceFieldsOfType<T, EditableFieldContents, EditableFieldInsertion>
+type DbInsertion<T extends DbObject> = Omit<
+  ReplaceFieldsOfType<T, EditableFieldContents, EditableFieldInsertion>,
+  "_id"
+>
 
 type SpotlightDocumentType = 'Post' | 'Sequence';
 interface SpotlightFirstPost {

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -180,20 +180,23 @@ interface CollectionFieldSpecification<N extends CollectionNameString> extends C
   inputType?: any,
   
   // Field mutation callbacks, invoked from Vulcan mutators. Notes:
-  //  * onInsert is deprecated (but still used) because of Vulcan's
-  //    mass-renaming and switch to named arguments
   //  * The "document" field in onUpdate is deprecated due to an earlier mixup
   //    (breaking change) affecting whether it means oldDocument or newDocument
   //  * Return type of these callbacks is not enforced because we don't have the
-  //    field's type in a usable format here. onInsert, onCreate, and onUpdate
-  //    should all return a new value for the field, EXCEPT that if
-  //    they return undefined the field value is left unchanged.
+  //    field's type in a usable format here. onCreate and onUpdate should all
+  //    return a new value for the field, EXCEPT that if they return undefined
+  //    the field value is left unchanged.
   //
-  /**
-   * @deprecated
-   */
-  onInsert?: (doc: DbInsertion<ObjectsByCollectionName[N]>, currentUser: DbUser|null) => any,
-  onCreate?: (args: {data: DbInsertion<ObjectsByCollectionName[N]>, currentUser: DbUser|null, collection: CollectionBase<N>, context: ResolverContext, document: ObjectsByCollectionName[N], newDocument: ObjectsByCollectionName[N], schema: SchemaType<N>, fieldName: string}) => any,
+  onCreate?: (args: {
+    data: DbInsertion<ObjectsByCollectionName[N]>,
+    currentUser: DbUser|null,
+    collection: CollectionBase<N>,
+    context: ResolverContext,
+    document: ObjectsByCollectionName[N],
+    newDocument: ObjectsByCollectionName[N],
+    schema: SchemaType<N>,
+    fieldName: string
+  }) => any,
   onUpdate?: (args: {
     data: Partial<ObjectsByCollectionName[N]>,
     oldDocument: ObjectsByCollectionName[N],

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -180,13 +180,13 @@ interface CollectionFieldSpecification<N extends CollectionNameString> extends C
   inputType?: any,
   
   // Field mutation callbacks, invoked from Vulcan mutators. Notes:
-  //  * onInsert and onEdit are deprecated (but still used) because
-  //    of Vulcan's mass-renaming and switch to named arguments
+  //  * onInsert is deprecated (but still used) because of Vulcan's
+  //    mass-renaming and switch to named arguments
   //  * The "document" field in onUpdate is deprecated due to an earlier mixup
   //    (breaking change) affecting whether it means oldDocument or newDocument
   //  * Return type of these callbacks is not enforced because we don't have the
-  //    field's type in a usable format here. onInsert, onCreate, onEdit, and
-  //    onUpdate should all return a new value for the field, EXCEPT that if
+  //    field's type in a usable format here. onInsert, onCreate, and onUpdate
+  //    should all return a new value for the field, EXCEPT that if
   //    they return undefined the field value is left unchanged.
   //
   /**
@@ -194,11 +194,18 @@ interface CollectionFieldSpecification<N extends CollectionNameString> extends C
    */
   onInsert?: (doc: DbInsertion<ObjectsByCollectionName[N]>, currentUser: DbUser|null) => any,
   onCreate?: (args: {data: DbInsertion<ObjectsByCollectionName[N]>, currentUser: DbUser|null, collection: CollectionBase<N>, context: ResolverContext, document: ObjectsByCollectionName[N], newDocument: ObjectsByCollectionName[N], schema: SchemaType<N>, fieldName: string}) => any,
-  /**
-   * @deprecated
-   */
-  onEdit?: (modifier: any, oldDocument: ObjectsByCollectionName[N], currentUser: DbUser|null, newDocument: ObjectsByCollectionName[N]) => any,
-  onUpdate?: (args: {data: Partial<ObjectsByCollectionName[N]>, oldDocument: ObjectsByCollectionName[N], newDocument: ObjectsByCollectionName[N], document: ObjectsByCollectionName[N], currentUser: DbUser|null, collection: CollectionBase<N>, context: ResolverContext, schema: SchemaType<N>, fieldName: string}) => any,
+  onUpdate?: (args: {
+    data: Partial<ObjectsByCollectionName[N]>,
+    oldDocument: ObjectsByCollectionName[N],
+    newDocument: ObjectsByCollectionName[N],
+    document: ObjectsByCollectionName[N],
+    currentUser: DbUser|null,
+    collection: CollectionBase<N>,
+    context: ResolverContext,
+    schema: SchemaType<N>,
+    fieldName: string
+    modifier: MongoModifier<ObjectsByCollectionName[N]>
+  }) => any,
   onDelete?: (args: {document: ObjectsByCollectionName[N], currentUser: DbUser|null, collection: CollectionBase<N>, context: ResolverContext, schema: SchemaType<N>}) => Promise<void>,
   
   countOfReferences?: {

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -184,7 +184,6 @@ export const schemaProperties = [
   'onCreate', // field insert callback
   'onUpdate', // field edit callback
   'onDelete', // field remove callback
-  'onInsert', // OpenCRUD backwards compatibility
   'canRead',
   'canCreate',
   'canUpdate',

--- a/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
+++ b/packages/lesswrong/lib/vulcan-forms/schema_utils.ts
@@ -185,7 +185,6 @@ export const schemaProperties = [
   'onUpdate', // field edit callback
   'onDelete', // field remove callback
   'onInsert', // OpenCRUD backwards compatibility
-  'onEdit', // OpenCRUD backwards compatibility
   'canRead',
   'canCreate',
   'canUpdate',

--- a/packages/lesswrong/lib/vulcan-lib/config.ts
+++ b/packages/lesswrong/lib/vulcan-lib/config.ts
@@ -27,10 +27,7 @@ SimpleSchema.extendOptions([
   'group', // form fieldset group
 
   'onCreate', // field insert callback
-  'onInsert', // field insert callback (OpenCRUD backwards compatibility)
-
   'onUpdate', // field edit callback
-
   'onDelete', // field remove callback
 
   'canRead', // who can view the field

--- a/packages/lesswrong/lib/vulcan-lib/config.ts
+++ b/packages/lesswrong/lib/vulcan-lib/config.ts
@@ -30,7 +30,6 @@ SimpleSchema.extendOptions([
   'onInsert', // field insert callback (OpenCRUD backwards compatibility)
 
   'onUpdate', // field edit callback
-  'onEdit', // field edit callback (OpenCRUD backwards compatibility)
 
   'onDelete', // field remove callback
 

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -140,7 +140,7 @@ getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations 
 // comments.remove.async                            //
 //////////////////////////////////////////////////////
 
-getCollectionHooks("Comments").removeAsync.add(async function CommentsRemovePostCommenters (comment: DbComment, currentUser: DbUser) {
+getCollectionHooks("Comments").deleteAsync.add(async function CommentsRemovePostCommenters ({document: comment}) {
   const { postId } = comment;
 
   if (postId) {
@@ -154,7 +154,7 @@ getCollectionHooks("Comments").removeAsync.add(async function CommentsRemovePost
   }
 });
 
-getCollectionHooks("Comments").removeAsync.add(async function CommentsRemoveChildrenComments (comment: DbComment, currentUser: DbUser) {
+getCollectionHooks("Comments").deleteAsync.add(async function CommentsRemoveChildrenComments ({document: comment, currentUser}) {
 
   const childrenComments = await Comments.find({parentCommentId: comment._id}).fetch();
 

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -51,7 +51,10 @@ export const getAdminTeamAccount = async () => {
  */
 export const noDeletionPmReason = 'Requested account deletion';
 
-getCollectionHooks("Comments").newValidate.add(async function createShortformPost (comment: DbComment, currentUser: DbUser) {
+getCollectionHooks("Comments").createBefore.add(async function createShortformPost (comment, {currentUser}) {
+  if (!currentUser) {
+    throw new Error("Must be logged in");
+  }
   if (comment.shortform && !comment.postId) {
     if (currentUser.shortformFeedId) {
       return ({
@@ -86,7 +89,8 @@ getCollectionHooks("Comments").newValidate.add(async function createShortformPos
       postId: post.data._id
     })
   }
-  return comment
+  
+  return comment;
 });
 
 getCollectionHooks("Comments").newSync.add(async function CommentsNewOperations (comment: DbComment, _, context: ResolverContext) {
@@ -230,12 +234,11 @@ export async function moderateCommentsPostUpdate (comment: DbComment, currentUse
   }
 }
 
-getCollectionHooks("Comments").newValidate.add(function NewCommentsEmptyCheck (comment: DbComment) {
+getCollectionHooks("Comments").createValidate.add(function NewCommentsEmptyCheck (validationErrors, {document: comment}) {
   const { data } = (comment.contents && comment.contents.originalContents) || {}
   if (!data) {
     throw new Error("You cannot submit an empty comment");
   }
-  return comment;
 });
 
 interface SendModerationPMParams {

--- a/packages/lesswrong/server/callbacks/jargonTermCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/jargonTermCallbacks.ts
@@ -2,20 +2,24 @@ import { sanitize } from "@/lib/vulcan-lib/utils";
 import { getCollectionHooks } from "../mutationCallbacks";
 
 // TODO: test that this works correctly in both the case where it's called before make_editable and after make_editable callback that creates the normalized contents
-export function sanitizeJargonTerm<T extends Partial<DbJargonTerm>>(jargonTerm: T) {
+export function sanitizeJargonTerm<T extends DbJargonTerm|DbInsertion<DbJargonTerm>>(jargonTerm: T) {
   const sanitizedJargonTerm = { ...jargonTerm };
 
   if (sanitizedJargonTerm.term) {
     sanitizedJargonTerm.term = sanitize(sanitizedJargonTerm.term);
   }
 
-  if (sanitizedJargonTerm.contents?.html) {
+  if (sanitizedJargonTerm.contents && ('html' in sanitizedJargonTerm.contents) && sanitizedJargonTerm.contents?.html) {
     sanitizedJargonTerm.contents.html = sanitize(sanitizedJargonTerm.contents.html);
   }
 
   return sanitizedJargonTerm;
 }
 
-getCollectionHooks("JargonTerms").createBefore.add(sanitizeJargonTerm);
+getCollectionHooks("JargonTerms").createBefore.add((jargonTerm) => {
+  return sanitizeJargonTerm(jargonTerm)
+});
 
-getCollectionHooks("JargonTerms").updateBefore.add(sanitizeJargonTerm);
+getCollectionHooks("JargonTerms").updateBefore.add((_, {newDocument: jargonTerm}) => {
+  return sanitizeJargonTerm(jargonTerm)
+});

--- a/packages/lesswrong/server/callbacks/localgroupCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/localgroupCallbacks.ts
@@ -4,7 +4,7 @@ import { createNotifications } from '../notificationCallbacksHelpers';
 import Users from '../../lib/vulcan-users';
 
 
-getCollectionHooks("Localgroups").createValidate.add((validationErrors: Array<any>, {document: group}: {document: DbLocalgroup}) => {
+getCollectionHooks("Localgroups").createValidate.add((validationErrors: Array<any>, {document: group}) => {
   if (!group.isOnline && !group.location)
     throw new Error("Location is required for local groups");
   
@@ -18,7 +18,7 @@ getCollectionHooks("Localgroups").updateValidate.add((validationErrors: Array<an
   return validationErrors;
 });
 
-getCollectionHooks("Localgroups").createAsync.add(async ({document}: {document: DbLocalgroup}) => {
+getCollectionHooks("Localgroups").createAsync.add(async ({document}) => {
   await createNotifications({userIds: document.organizerIds, notificationType: "newGroupOrganizer", documentType: "localgroup", documentId: document._id})
 })
 

--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -5,12 +5,11 @@ import { loadByIds } from '../../lib/loaders';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { createMutator, updateMutator } from '../vulcan-lib';
 
-getCollectionHooks("Messages").newValidate.add(function NewMessageEmptyCheck (message: DbMessage) {
+getCollectionHooks("Messages").createValidate.add(function NewMessageEmptyCheck (validationErrors, {document: message}) {
   const { data } = (message.contents && message.contents.originalContents) || {}
   if (!data) {
     throw new Error("You cannot send an empty message");
   }
-  return message;
 });
 
 getCollectionHooks("Messages").createAsync.add(function unArchiveConversations({document}) {

--- a/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
@@ -103,7 +103,7 @@ async function enforcePostRateLimit (user: DbUser) {
 
 async function enforceCommentRateLimit({user, comment, context}: {
   user: DbUser,
-  comment: DbComment,
+  comment: DbInsertion<DbComment>,
   context: ResolverContext,
 }) {
   const rateLimit = await rateLimitDateWhenUserNextAbleToComment(user, comment.postId, context);

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -29,7 +29,7 @@ interface AfterCreateRevisionCallbackContext {
 }
 export const afterCreateRevisionCallback = new CallbackHook<[AfterCreateRevisionCallbackContext]>("revisions.afterRevisionCreated");
 
-export function getInitialVersion(document: DbPost|DbObject) {
+export function getInitialVersion(document: DbInsertion<DbPost|DbObject>) {
   if ((document as DbPost).draft) {
     return '0.1.0'
   } else {
@@ -108,7 +108,7 @@ function addEditableCallbacks<N extends CollectionNameString>({collection, optio
   const collectionName = collection.collectionName;
 
   getCollectionHooks(collectionName).createBefore.add(
-    async function editorSerializationBeforeCreate (doc: DbType, {currentUser, context}) {
+    async function editorSerializationBeforeCreate (doc: DbInsertion<DbType>, {currentUser, context}) {
     const editableField = (doc as AnyBecauseHard)[fieldName] as EditableFieldInsertion | undefined;
     if (editableField?.originalContents) {
       if (!currentUser) { throw Error("Can't create document without current user") }

--- a/packages/lesswrong/server/mutationCallbacks.ts
+++ b/packages/lesswrong/server/mutationCallbacks.ts
@@ -29,40 +29,36 @@ export interface DeleteCallbackProperties<N extends CollectionNameString> extend
 export class CollectionMutationCallbacks<N extends CollectionNameString> {
   createValidate: CallbackChainHook<CallbackValidationErrors,[CreateCallbackProperties<N>]>
   newValidate: CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>
+  
   createBefore: CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>
-  newBefore: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
+  
   newSync: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null,ResolverContext]>
+
   createAfter: CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>
   newAfter: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
+
   createAsync: CallbackHook<[CreateCallbackProperties<N>]>
   newAsync: CallbackHook<[ObjectsByCollectionName[N],DbUser|null,any]>
 
   updateValidate: CallbackChainHook<CallbackValidationErrors,[UpdateCallbackProperties<N>]>
-  editValidate: CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,CallbackValidationErrors]>
+
   updateBefore: CallbackChainHook<Partial<ObjectsByCollectionName[N]>,[UpdateCallbackProperties<N>]>
-  /**
-   * @deprecated use updateBefore
-   */
-  editBefore: CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,ObjectsByCollectionName[N]]>
+
   editSync: CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,ObjectsByCollectionName[N]]>
+
   updateAfter: CallbackChainHook<ObjectsByCollectionName[N],[UpdateCallbackProperties<N>]>
-  editAfter: CallbackChainHook<ObjectsByCollectionName[N],[ObjectsByCollectionName[N],DbUser|null]>
+
   updateAsync: CallbackHook<[UpdateCallbackProperties<N>]>
   editAsync: CallbackHook<[ObjectsByCollectionName[N],ObjectsByCollectionName[N],DbUser|null,CollectionBase<N>]>
 
   deleteValidate: CallbackChainHook<CallbackValidationErrors,[DeleteCallbackProperties<N>]>
-  removeValidate: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
   deleteBefore: CallbackChainHook<ObjectsByCollectionName[N],[DeleteCallbackProperties<N>]>
-  removeBefore: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
-  removeSync: CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>
   deleteAsync: CallbackHook<[DeleteCallbackProperties<N>]>
-  removeAsync: CallbackHook<[ObjectsByCollectionName[N],DbUser|null,CollectionBase<N>]>
 
   constructor(collectionName: N) {
     this.createValidate = new CallbackChainHook<CallbackValidationErrors,[CreateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.create.validate`);
     this.newValidate = new CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>(`${collectionName.toLowerCase()}.new.validate`);
     this.createBefore = new CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.create.before`);
-    this.newBefore = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.new.before`);
     this.newSync = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null,ResolverContext]>(`${collectionName.toLowerCase()}.new.sync`);
     this.createAfter = new CallbackChainHook<ObjectsByCollectionName[N],[CreateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.create.after`);
     this.newAfter = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.new.after`);
@@ -70,22 +66,15 @@ export class CollectionMutationCallbacks<N extends CollectionNameString> {
     this.newAsync = new CallbackHook<[ObjectsByCollectionName[N],DbUser|null,any]>(`${collectionName.toLowerCase()}.new.async`);
 
     this.updateValidate = new CallbackChainHook<CallbackValidationErrors,[UpdateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.update.validate`);
-    this.editValidate = new CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,CallbackValidationErrors]>(`${collectionName.toLowerCase()}.edit.validate`)
     this.updateBefore = new CallbackChainHook<Partial<ObjectsByCollectionName[N]>,[UpdateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.update.before`);
-    this.editBefore = new CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,ObjectsByCollectionName[N]]>(`${collectionName.toLowerCase()}.edit.before`);
     this.editSync = new CallbackChainHook<MongoModifier<ObjectsByCollectionName[N]>,[ObjectsByCollectionName[N],DbUser|null,ObjectsByCollectionName[N]]>(`${collectionName.toLowerCase()}.edit.sync`);
     this.updateAfter = new CallbackChainHook<ObjectsByCollectionName[N],[UpdateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.update.after`);
-    this.editAfter = new CallbackChainHook<ObjectsByCollectionName[N],[ObjectsByCollectionName[N],DbUser|null]>(`${collectionName.toLowerCase()}.edit.after`)
     this.updateAsync = new CallbackHook<[UpdateCallbackProperties<N>]>(`${collectionName.toLowerCase()}.update.async`);
     this.editAsync = new CallbackHook<[ObjectsByCollectionName[N],ObjectsByCollectionName[N],DbUser|null,CollectionBase<N>]>(`${collectionName.toLowerCase()}.edit.async`)
 
     this.deleteValidate = new CallbackChainHook<CallbackValidationErrors,[DeleteCallbackProperties<N>]>(`${collectionName.toLowerCase()}.delete.validate`);
-    this.removeValidate = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.remove.validate`);
     this.deleteBefore = new CallbackChainHook<ObjectsByCollectionName[N],[DeleteCallbackProperties<N>]>(`${collectionName.toLowerCase()}.delete.before`);
-    this.removeBefore = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.remove.before`);
-    this.removeSync = new CallbackChainHook<ObjectsByCollectionName[N],[DbUser|null]>(`${collectionName.toLowerCase()}.remove.sync`);
     this.deleteAsync = new CallbackHook<[DeleteCallbackProperties<N>]>(`${collectionName.toLowerCase()}.delete.async`);
-    this.removeAsync = new CallbackHook<[ObjectsByCollectionName[N],DbUser|null,CollectionBase<N>]>(`${collectionName.toLowerCase()}.remove.async`);
   }
 }
 

--- a/packages/lesswrong/server/mutationCallbacks.ts
+++ b/packages/lesswrong/server/mutationCallbacks.ts
@@ -1,6 +1,6 @@
 import { CallbackHook, CallbackChainHook } from './utils/callbackHooks';
 
-type CallbackValidationErrors = Array<any>;
+export type CallbackValidationErrors = Array<any>;
 
 interface CallbackPropertiesBase<N extends CollectionNameString> {
   // TODO: Many of these are empirically optional, but setting them to optional
@@ -42,7 +42,6 @@ export interface DeleteCallbackProperties<N extends CollectionNameString> extend
 
 export class CollectionMutationCallbacks<N extends CollectionNameString> {
   createValidate: CallbackChainHook<CallbackValidationErrors,[CreateCallbackProperties<N>]>
-  newValidate: CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>
   
   createBefore: CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[CreateCallbackProperties<N>]>
   newSync: CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,ResolverContext]>
@@ -71,7 +70,6 @@ export class CollectionMutationCallbacks<N extends CollectionNameString> {
   constructor(collectionName: N) {
     const namePrefix = collectionName.toLowerCase();
     this.createValidate = new CallbackChainHook<CallbackValidationErrors,[CreateCallbackProperties<N>]>(`${namePrefix}.create.validate`);
-    this.newValidate = new CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,CallbackValidationErrors]>(`${collectionName.toLowerCase()}.new.validate`);
     this.createBefore = new CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[CreateCallbackProperties<N>]>(`${namePrefix}.create.before`);
     this.newSync = new CallbackChainHook<DbInsertion<ObjectsByCollectionName[N]>,[DbUser|null,ResolverContext]>(`${namePrefix}.new.sync`);
     this.createAfter = new CallbackChainHook<ObjectsByCollectionName[N],[AfterCreateCallbackProperties<N>]>(`${namePrefix}.create.after`);

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -23,7 +23,7 @@ function normalizeTagName(name: string) {
     return name;
 }
 
-getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any>, {document: tag}: {document: DbTag}) => {
+getCollectionHooks("Tags").createValidate.add(async (validationErrors: Array<any>, {document: tag}) => {
   if (!tag.name || !tag.name.length)
     throw new Error("Name is required");
   if (!isValidTagName(tag.name))

--- a/packages/lesswrong/server/utils/callbackHooks.ts
+++ b/packages/lesswrong/server/utils/callbackHooks.ts
@@ -80,7 +80,7 @@ export class CallbackChainHook<IteratorType,ArgumentsType extends any[]> {
     let result = item;
     try {
       for (const callback of this._callbacks) {
-        result = await runCallback(item, callback);
+        result = await runCallback(result, callback);
       }
       
     } finally {

--- a/packages/lesswrong/server/utils/callbackHooks.ts
+++ b/packages/lesswrong/server/utils/callbackHooks.ts
@@ -1,6 +1,8 @@
-import { isServer } from '@/lib/executionEnvironment';
 import { isPromise } from '@/lib/vulcan-lib/utils';
 import { loggerConstructor } from '@/lib/utils/logging'
+import { sleep } from '@/lib/utils/asyncUtils';
+
+type MaybePromise<T> = T|Promise<T>
 
 export interface CallbackPropertiesBase<N extends CollectionNameString> {
   // TODO: Many of these are empirically optional, but setting them to optional
@@ -11,30 +13,89 @@ export interface CallbackPropertiesBase<N extends CollectionNameString> {
   schema: SchemaType<N>
 }
 
+type CallbackChainFn<IteratorType,ArgumentsType extends any[]> = (doc: IteratorType, ...args: ArgumentsType) => (MaybePromise<IteratorType> | undefined | void)
+
+/**
+ * A set of callbacks which run in a chain, each modifying a value and passing
+ * it to the next. Each callback in the chain receives a current-version of the
+ * object (of type IteratorType) plus additional arguments (of type
+ * ArgumentsType), and either returns a new value which replaces the one it was
+ * passed, or undefined (in which case it leaves it unchanged). The return
+ * value of the last step in the chain is returned as the overall result.
+ *
+ * If `ignoreExceptions: false` is passed to `runCallbacks`, any exception will
+ * stop later functions from running, and bubble out of the call to
+ * `runCallbacks`. Otherwise, exceptions will be `console.log`'ed but otherwise
+ * have no effect.
+ */
 export class CallbackChainHook<IteratorType,ArgumentsType extends any[]> {
   private _name: string
-  private _callbacks: Array<AnyBecauseTodo> = []
+  private _callbacks: Array<CallbackChainFn<IteratorType,ArgumentsType>> = []
   
   constructor(name: string) {
     this._name = name;
   }
   
-  add = (fn: (doc: IteratorType, ...args: ArgumentsType) =>
-    (Promise<IteratorType|Partial<IteratorType>> | IteratorType | undefined | void)
-  ) => {
+  add = (fn: CallbackChainFn<IteratorType,ArgumentsType>) => {
     this._callbacks.push(fn);
     if (this._callbacks.length > 20) {
       // eslint-disable-next-line no-console
       console.log(`Warning: Excessively many callbacks (${this._callbacks.length}) on hook ${this._name}.`);
     }
   }
-  
-  runCallbacks = async ({iterator, properties, ignoreExceptions}: {iterator: IteratorType, properties: ArgumentsType, ignoreExceptions?: boolean}): Promise<IteratorType> => {
-    const start = Date.now();
 
-    const result = await this._runCallbacks({
-      iterator, properties, ignoreExceptions
-    });
+  runCallbacks = async (options: {
+    iterator: IteratorType,
+    properties: ArgumentsType,
+    ignoreExceptions?: boolean,
+  }): Promise<IteratorType> => {
+    const start = Date.now();
+    const logger = loggerConstructor(`callbacks-${options.properties[0]?.collection?.collectionName.toLowerCase()}`)
+    const hook = this._name;
+    const item = options.iterator;
+    const args = options.properties;
+    const ignoreExceptions = ("ignoreExceptions" in options) ? options.ignoreExceptions : true;
+    
+    let inProgressCallbackKey = markCallbackStarted(hook);
+    
+    // Wrapper around a single callback that fills in the return value if the
+    // callback function returns undefined, and eats exceptions (with a
+    // console.log) if ignoreExceptions is true.
+    const runCallback = (accumulator: IteratorType, callback: CallbackChainFn<IteratorType,ArgumentsType>) => {
+      logger(`\x1b[32m[${hook}] [${callback.name || 'noname callback'}]\x1b[0m`); //]]
+      try {
+        const result = callback.apply(this, [accumulator, ...args]);
+
+        if (typeof result === 'undefined') {
+          // if result of current iteration is undefined, don't pass it on
+          // logger(`// Warning: Sync callback [${callback.name}] in hook [${hook}] didn't return a result!`)
+          return accumulator;
+        } else {
+          return result;
+        }
+
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log(`\x1b[31m// error at callback [${callback.name}] in hook [${hook}]\x1b[0m`); //]]
+        // eslint-disable-next-line no-console
+        console.log(error);
+        if (error.break || (error.data && error.data.break) || !ignoreExceptions) {
+          throw error;
+        }
+        // pass the unchanged accumulator to the next iteration of the loop
+        return accumulator;
+      }
+    };
+
+    let result = item;
+    try {
+      for (const callback of this._callbacks) {
+        result = await runCallback(item, callback);
+      }
+      
+    } finally {
+      markCallbackFinished(inProgressCallbackKey, hook);
+    }
 
     const timeElapsed = Date.now() - start;
     // Need to use this from Globals to avoid import cycles
@@ -45,110 +106,20 @@ export class CallbackChainHook<IteratorType,ArgumentsType extends any[]> {
     // }, true);
 
     return result;
-  }
-
-  /**
-   * @summary Successively run all of a hook's callbacks on an item
-   * @param {String} hook - First argument: the name of the hook, or an array
-   * @param {Object} item - Second argument: the post, comment, modifier, etc. on which to run the callbacks
-   * @param {Any} args - Other arguments will be passed to each successive iteration
-   * @param {Array} callbacks - Optionally, pass an array of callback functions instead of passing a hook name
-   * @param {Boolean} ignoreExceptions - Only available as a named argument, default true. If true, exceptions
-   *   thrown from callbacks will be logged but otherwise ignored. If false, exceptions thrown from callbacks
-   *   will be rethrown.
-   * @returns {Object} Returns the item after it's been through all the callbacks for this hook
-   */
-  _runCallbacks = <N extends CollectionNameString> (options: {
-    iterator?: any,
-    // A bit of a mess. If you stick to non-deprecated hooks, you'll get the typed version
-    properties: [CallbackPropertiesBase<N>]|any[],
-    ignoreExceptions?: boolean,
-  }) => {
-    const logger = loggerConstructor(`callbacks-${options.properties[0]?.collection?.collectionName.toLowerCase()}`)
-    const hook = this._name;
-    const item = options.iterator;
-    const args = options.properties;
-    let ignoreExceptions: boolean;
-    if ("ignoreExceptions" in options)
-      ignoreExceptions = !!options.ignoreExceptions;
-    else
-      ignoreExceptions = true;
-    const callbacks = this._callbacks;
-  
-    // flag used to detect the callback that initiated the async context
-    let asyncContext = false;
-    
-    let inProgressCallbackKey = markCallbackStarted(hook);
-    
-    try {
-      if (typeof callbacks !== 'undefined' && !!callbacks.length) { // if the hook exists, and contains callbacks to run
-        const runCallback = (accumulator: AnyBecauseTodo, callback: AnyBecauseTodo) => {
-          logger(`\x1b[32m[${hook}] [${callback.name || 'noname callback'}]\x1b[0m`); //]]
-          try {
-            const result = callback.apply(this, [accumulator].concat(args));
-    
-            if (typeof result === 'undefined') {
-              // if result of current iteration is undefined, don't pass it on
-              // logger(`// Warning: Sync callback [${callback.name}] in hook [${hook}] didn't return a result!`)
-              return accumulator;
-            } else {
-              return result;
-            }
-    
-          } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log(`\x1b[31m// error at callback [${callback.name}] in hook [${hook}]\x1b[0m`); //]]
-            // eslint-disable-next-line no-console
-            console.log(error);
-            if (error.break || (error.data && error.data.break) || !ignoreExceptions) {
-              throw error;
-            }
-            // pass the unchanged accumulator to the next iteration of the loop
-            return accumulator;
-          }
-        };
-    
-        const result = callbacks.reduce(function (accumulator: AnyBecauseTodo, callback: AnyBecauseTodo, index: AnyBecauseTodo) {
-          if (isPromise(accumulator)) {
-            if (!asyncContext) {
-              logger(`\x1b[32m[${hook}] Started async context for [${callbacks[index-1] && callbacks[index-1].name}]\x1b[0m`); //]]
-              asyncContext = true;
-            }
-            return new Promise((resolve, reject) => {
-              accumulator
-                .then(result => {
-                  if (result === undefined) {
-                    // eslint-disable-next-line no-console
-                    console.error('Async before callbacks should not return undefined. Please return the document/data instead')
-                  }
-                  try {
-                    // run this callback once we have the previous value
-                    resolve(runCallback(result, callback));
-                  } catch (error) {
-                    // error will be thrown only for breaking errors, so throw it up in the promise chain
-                    reject(error);
-                  }
-                })
-                .catch(reject);
-            });
-          } else {
-            return runCallback(accumulator, callback);
-          }
-        }, item);
-        
-        return result;
-      } else { // else, just return the item unchanged
-        return item;
-      }
-    } finally {
-      markCallbackFinished(inProgressCallbackKey, hook);
-    }
   };
 }
 
+type CallbackHookFn<ArgumentsType extends any[]> = (...args: ArgumentsType) => void|Promise<void>
+
+/**
+ * A set of callbacks, which are run independently/concurrently and which
+ * return nothing. Running the callbacks returned immediately (they are
+ * deferred to run in the background); any exceptions bubble out to a top-level
+ * context, rather than to the function that called them.
+ */
 export class CallbackHook<ArgumentsType extends any[]> {
   private _name: string
-  private _callbacks: Array<AnyBecauseTodo> = []
+  private _callbacks: Array<CallbackHookFn<ArgumentsType>> = []
   
   constructor(name: string) {
     this._name = name;
@@ -161,73 +132,43 @@ export class CallbackHook<ArgumentsType extends any[]> {
       console.log(`Warning: Excessively many callbacks (${this._callbacks.length}) on hook ${this._name}.`);
     }
   }
-  
-  runCallbacksAsync = async (properties: ArgumentsType): Promise<void> => {
+
+  runCallbacksAsync = async (args: ArgumentsType) => {
     const start = Date.now();
+    const logger = loggerConstructor(`callbacks-${this._name}`)
+    let pendingDeferredCallbackStart = markCallbackStarted(this._name);
 
-    await this._runCallbacksAsync({ properties });
-
-    const timeElapsed = Date.now() - start;
-    // Need to use this from Globals to avoid import cycles
-    // Temporarily disabled to investigate performance issues 
-    // Globals.captureEvent('callbacksCompleted', {
-    //   callbackHookName: this.name,
-    //   timeElapsed
-    // }, true);
-  }
-
-  /**
-   * @summary Successively run all of a hook's callbacks on an item, in async mode (only works on server)
-   * @param {String} hook - First argument: the name of the hook
-   * @param {Any} args - Other arguments will be passed to each successive iteration
-   */
-  _runCallbacksAsync = <N extends CollectionNameString> (options: {
-    // A bit of a mess. If you stick to non-deprecated hooks, you'll get the typed version
-    properties: [CallbackPropertiesBase<N>]|any[]
-  }) => {
-    const logger = loggerConstructor(`callbacks-${options.properties[0]?.collection?.collectionName.toLowerCase()}`)
-    const hook = this._name;
-    const args = options.properties;
+    void (async () => {
+      // defer to avoid holding up client
+      await sleep(0);
   
-    const callbacks = this._callbacks
+      await Promise.all(this._callbacks.map(async (callback) => {
+        logger(`\x1b[32m[${this._name}]: [${callback.name || 'noname callback'}]\x1b[0m`); //]]
+        let pendingAsyncCallback = markCallbackStarted(this._name);
   
-    if (isServer && typeof callbacks !== 'undefined' && !!callbacks.length) {
-      let pendingDeferredCallbackStart = markCallbackStarted(hook);
+        try {
+          await callback.apply(null, args);
+        } catch(e) {
+          // eslint-disable-next-line no-console
+          console.log(`Error running async callback [${callback.name}] on hook [${this._name}]`);
+          // eslint-disable-next-line no-console
+          console.log(e);
+          throw e;
+        } finally {
+          markCallbackFinished(pendingAsyncCallback, this._name);
+        }
+      }));
+      
+      markCallbackFinished(pendingDeferredCallbackStart, this._name);
   
-      // use defer to avoid holding up client
-      setTimeout(function () {
-        // run all post submit server callbacks on post object successively
-        callbacks.forEach(function (this: any, callback: AnyBecauseTodo) {
-          logger(`\x1b[32m[${hook}]: [${callback.name || 'noname callback'}]\x1b[0m`); //]]
-          
-          let pendingAsyncCallback = markCallbackStarted(hook);
-          try {
-            let callbackResult = callback.apply(this, args);
-            if (isPromise(callbackResult)) {
-              callbackResult
-                .then(
-                  result => markCallbackFinished(pendingAsyncCallback, hook),
-                  exception => {
-                    markCallbackFinished(pendingAsyncCallback, hook)
-                    // eslint-disable-next-line no-console
-                    console.log(`Error running async callback [${callback.name}] on hook [${hook}]`);
-                    // eslint-disable-next-line no-console
-                    console.log(exception);
-                    throw exception;
-                  }
-                )
-            } else {
-              markCallbackFinished(pendingAsyncCallback, hook);
-            }
-          } finally {
-            markCallbackFinished(pendingAsyncCallback, hook);
-          }
-        });
-        
-        markCallbackFinished(pendingDeferredCallbackStart, hook);
-      }, 0);
-  
-    }
+      const timeElapsed = Date.now() - start;
+      // Need to use this from Globals to avoid import cycles
+      // Temporarily disabled to investigate performance issues 
+      // Globals.captureEvent('callbacksCompleted', {
+      //   callbackHookName: this.name,
+      //   timeElapsed
+      // }, true);
+    })();
   }
 }
 

--- a/packages/lesswrong/server/utils/callbackHooks.ts
+++ b/packages/lesswrong/server/utils/callbackHooks.ts
@@ -1,17 +1,7 @@
-import { isPromise } from '@/lib/vulcan-lib/utils';
 import { loggerConstructor } from '@/lib/utils/logging'
 import { sleep } from '@/lib/utils/asyncUtils';
 
 type MaybePromise<T> = T|Promise<T>
-
-export interface CallbackPropertiesBase<N extends CollectionNameString> {
-  // TODO: Many of these are empirically optional, but setting them to optional
-  // causes a bajillion type errors, so we will not be fixing today
-  currentUser: DbUser|null
-  collection: CollectionBase<N>
-  context: ResolverContext
-  schema: SchemaType<N>
-}
 
 type CallbackChainFn<IteratorType,ArgumentsType extends any[]> = (doc: IteratorType, ...args: ArgumentsType) => (MaybePromise<IteratorType> | undefined | void)
 

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -376,20 +376,13 @@ export const updateMutator: UpdateMutator = async <N extends CollectionNameStrin
   onUpdate
 
   */
-  logger('field onUpdate/onEdit callbacks')
+  logger('field onUpdate callbacks')
+  const dataAsModifier = dataToModifier(clone(data));
   for (let fieldName of Object.keys(schema)) {
     let autoValue;
     const schemaField = schema[fieldName];
     if (schemaField.onUpdate) {
-      autoValue = await schemaField.onUpdate({...properties, fieldName});
-    } else if (schemaField.onEdit) {
-      // OpenCRUD backwards compatibility
-      autoValue = await schemaField.onEdit(
-        dataToModifier(clone(data)),
-        oldDocument,
-        currentUser,
-        document
-      );
+      autoValue = await schemaField.onUpdate({...properties, fieldName, modifier: dataAsModifier});
     }
     if (typeof autoValue !== 'undefined') {
       logger(`onUpdate returned a value to update for ${fieldName}: ${autoValue}`)

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -166,7 +166,7 @@ export const createMutator: CreateMutator = async <N extends CollectionNameStrin
   note: clone arguments in case callbacks modify them
 
   */
-  logger('field onCreate/onInsert callbacks')
+  logger('field onCreate callbacks')
   const start = Date.now();
   for (let fieldName of Object.keys(schema)) {
     let autoValue;
@@ -175,9 +175,6 @@ export const createMutator: CreateMutator = async <N extends CollectionNameStrin
       // OpenCRUD backwards compatibility: keep both newDocument and data for now, but phase out newDocument eventually
       // eslint-disable-next-line no-await-in-loop
       autoValue = await schemaField.onCreate({...properties, fieldName} as any); // eslint-disable-line no-await-in-loop
-    } else if (schemaField.onInsert) {
-      // OpenCRUD backwards compatibility
-      autoValue = await schemaField.onInsert(clone(document) as any, currentUser); // eslint-disable-line no-await-in-loop
     }
     if (typeof autoValue !== 'undefined') {
       logger(`onCreate returned a value to insert for field ${fieldName}: ${autoValue}`)

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -215,14 +215,6 @@ export const createMutator: CreateMutator = async <N extends CollectionNameStrin
     iterator: document as ObjectsByCollectionName[N], // Pretend this isn't Partial
     properties: [properties],
   }) as Partial<DbInsertion<ObjectsByCollectionName[N]>>;
-  logger('newBefore')
-  // OpenCRUD backwards compatibility
-  document = await hooks.newBefore.runCallbacks({
-    iterator: document as ObjectsByCollectionName[N], // Pretend this isn't Partial
-    properties: [
-      currentUser
-    ]
-  }) as Partial<DbInsertion<ObjectsByCollectionName[N]>>;
   logger('newSync')
   document = await hooks.newSync.runCallbacks({
     iterator: document as ObjectsByCollectionName[N], // Pretend this isn't Partial
@@ -371,14 +363,6 @@ export const updateMutator: UpdateMutator = async <N extends CollectionNameStrin
       properties: [properties],
       ignoreExceptions: false,
     });
-    // OpenCRUD backwards compatibility
-    data = modifierToData(
-      await hooks.editValidate.runCallbacks({
-        iterator: dataToModifier(data),
-        properties: [document, currentUser, validationErrors],
-        ignoreExceptions: false,
-      })
-    );
 
     // LESSWRONG - added custom message (showing all validation errors instead of a generic message)
     if (validationErrors.length) {
@@ -428,18 +412,6 @@ export const updateMutator: UpdateMutator = async <N extends CollectionNameStrin
     iterator: data,
     properties: [properties],
   });
-  logger('editBefore')
-  // OpenCRUD backwards compatibility
-  data = modifierToData(
-    await hooks.editBefore.runCallbacks({
-      iterator: dataToModifier(data),
-      properties: [
-        oldDocument,
-        currentUser,
-        document
-      ]
-    })
-  );
   logger('editSync')
   data = modifierToData(
     await hooks.editSync.runCallbacks({
@@ -497,15 +469,6 @@ export const updateMutator: UpdateMutator = async <N extends CollectionNameStrin
   document = await hooks.updateAfter.runCallbacks({
     iterator: document,
     properties: [properties],
-  });
-  logger('editAfter')
-  // OpenCRUD backwards compatibility
-  document = await hooks.editAfter.runCallbacks({
-    iterator: document,
-    properties: [
-      oldDocument,
-      currentUser
-    ]
   });
 
   /*
@@ -587,12 +550,6 @@ export const deleteMutator: DeleteMutator = async <N extends CollectionNameStrin
       properties: [properties],
       ignoreExceptions: false,
     });
-    // OpenCRUD backwards compatibility
-    document = await hooks.removeValidate.runCallbacks({
-      iterator: document,
-      properties: [currentUser],
-      ignoreExceptions: false,
-    });
 
     if (validationErrors.length) {
       console.log(validationErrors); // eslint-disable-line no-console
@@ -621,15 +578,6 @@ export const deleteMutator: DeleteMutator = async <N extends CollectionNameStrin
     iterator: document,
     properties: [properties],
   });
-  // OpenCRUD backwards compatibility
-  await hooks.removeBefore.runCallbacks({
-    iterator: document,
-    properties: [currentUser]
-  });
-  await hooks.removeSync.runCallbacks({
-    iterator: document,
-    properties: [currentUser]
-  });
 
   /*
 
@@ -650,12 +598,6 @@ export const deleteMutator: DeleteMutator = async <N extends CollectionNameStrin
 
   */
   await hooks.deleteAsync.runCallbacksAsync([properties]);
-  // OpenCRUD backwards compatibility
-  await hooks.removeAsync.runCallbacksAsync([
-    document,
-    currentUser,
-    collection
-  ]);
 
   return { data: document };
 };

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -73,7 +73,7 @@ export const validateCreateMutation = async <N extends CollectionNameString>(
 ) => {
   let { document } = mutatorParams;
   const callbackProperties = mutatorParamsToCallbackProps(mutatorParams);
-  const { collection, context, currentUser } = callbackProperties;
+  const { collection, context } = callbackProperties;
 
   const hooks = getCollectionHooks(collection.collectionName);
   
@@ -83,12 +83,6 @@ export const validateCreateMutation = async <N extends CollectionNameString>(
   validationErrors = await hooks.createValidate.runCallbacks({
     iterator: validationErrors,
     properties: [callbackProperties],
-    ignoreExceptions: false,
-  });
-  // OpenCRUD backwards compatibility
-  document = await hooks.newValidate.runCallbacks({
-    iterator: document as DbInsertion<ObjectsByCollectionName[N]>, // Pretend this isn't Partial
-    properties: [currentUser, validationErrors],
     ignoreExceptions: false,
   });
   if (validationErrors.length) {


### PR DESCRIPTION
Clean up (some) of the technical debt inherited via Vulcan's callbacks system. Removes the global callbacks-namespace (callback names are now limited to only being used in console.logs rather than being semantically meaningful). Merges onEdit with onUpdate, onInsert with onCreate, and newValidate with createValidate. Makes the type signatures of creation callbacks accurately reflect the fact that an _id might not be assigned yet. Rewrites the comments in `callbackHooks.ts` to not be lies.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209210599157677) by [Unito](https://www.unito.io)
