### PR TITLE
Fix CkEditor side-comment highlight covering up adjacent lines in dialogues

### DIFF
--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -546,7 +546,12 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
   editor: {
     commentPanelBackground: "#ffffff",
     sideCommentEditorBackground: "#f3f7fb",
-    commentMarker: "#fef7a9",
+    // Color used for background highlighting of CEditor side-comments. In some
+    // contexts with short line height (in particular, dialogues), this
+    // highlight bleeds over adjacent lines and covers up descenders. Partially
+    // mitigate this by making it a high-intensity color at 50% transparency
+    // rather than a low-intensity color at full opacity.
+    commentMarker: "rgba(255,241,82,.5)",
     commentMarkerActive: "#fdf05d",
   },
   blockquoteHighlight: {

--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -100,6 +100,15 @@ const globalStyle = (theme: ThemeType) => ({
     "--ck-color-list-button-on-background": theme.palette.buttons.mentions.selected,
     "--ck-color-list-button-on-background-focus": theme.palette.buttons.mentions.selectedHover,
   },
+  
+  // CkEditor's inline comments have a yellow background highlight. In some
+  // contexts with short line height (dialogue), this highlight bleeds over
+  // adjacent lines. Partially mitigate this by removing the default top and
+  // bottom border, which added 3px of overlap.
+  ".ck-comment-marker": {
+    borderTop: "none !important",
+    borderBottom: "none !important",
+  },
 
   // Starting in v38, CkEditor puts a "powered by CkEditor" badge in the corner
   // when focused. This is removed by putting a `licenseKey` in the ckeditor


### PR DESCRIPTION
In CkEditor dialogues, the font is such that the space reserved for ascenders/descenders is large relative to the line height. This interacts badly with CkEditor side-comments, which add a yellow background highlight to text ranges; the background highlight of each line covers part of the line above it.

The ideal fix would be to create a stacking context and use z-indexes to put all of the text on top of all of the background, as in this stackoverflow thread: https://stackoverflow.com/a/76044890/274472 . However, in order to do this we would need an extra wrapper span inside the .ck-comment-marker span, and that's coming from a part of CkEditor that we don't control, so we have to make do with a less-clean solution. So instead we shrink the highlight vertically by 3px on the top and 3px on the bottom, which reduces the overlap to only cutting off the bottoms of descenders rather than cutting off more of the character, and we make the highlight a higher-intensity color with transparency rather than a lower-intensity color at full opacity, so that the descenders can show through when they're in the overlap region.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209229174617943) by [Unito](https://www.unito.io)
