### PR TITLE
When adding a random ID to resolve slug collisions, don't use uppercase chars

### DIFF
--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -1,6 +1,6 @@
 import { getCollection } from '@/lib/vulcan-lib';
 import moment from 'moment';
-import { randomId } from '@/lib/random';
+import { randomLowercaseId } from '@/lib/random';
 import { isServer } from '@/lib/executionEnvironment';
 
 // Get relative link to conversation (used only in session)
@@ -72,7 +72,7 @@ export const getUnusedSlug = async function <N extends CollectionNameWithSlug>(
     if (index <= 10) {
       suffix = '-'+index;
     } else {
-      const randomIndex = randomId(index<20 ? 4 : 8);
+      const randomIndex = randomLowercaseId(index<20 ? 4 : 8);
       suffix = '-'+randomIndex;
     }
   }


### PR DESCRIPTION
This fixes a bug where if a user changes their displayName to something unicode-only, resulting in a slug unicode-[ID], their profile page becomes unreachable (because their account's slug has an uppercase character in it, but while the route converts to lowercase).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209258273634202) by [Unito](https://www.unito.io)
