### PR TITLE
Switch from "source-map-support" to node builtin --enable-source-maps

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -449,7 +449,7 @@ async function main() {
   let serverCli: string[] = [
     "node",
     ...(!isProduction ? ["--inspect"] : []),
-    "-r", "source-map-support/register",
+    "--enable-source-maps",
     "--", `${getOutputDir()}/server/js/serverBundle.js`,
     "--settings", settingsFile,
     ...(opts.shell ? ["--shell"] : []),
@@ -502,7 +502,8 @@ async function main() {
       "bcrypt", "node-pre-gyp", "intercom-client", "node:*",
       "fsevents", "chokidar", "auth0", "dd-trace", "pg-formatter",
       "gpt-3-encoder", "@elastic/elasticsearch", "zod", "node-abort-controller",
-      "cheerio", "vite", "@vitejs/plugin-react",
+      "cheerio", "vite", "@vitejs/plugin-react", "@google-cloud", "@aws-sdk",
+      "@anthropic-ai/sdk", "openai", "@googlemaps",
     ],
   })
   

--- a/package.json
+++ b/package.json
@@ -302,7 +302,6 @@
     "setimmediate": "^1.0.5",
     "shallowequal": "^1.1.0",
     "simpl-schema": "^1.5.0",
-    "source-map-support": "^0.5.19",
     "speakingurl": "^9.0.0",
     "stripe": "^17.4.0",
     "tlds": "^1.203.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17563,7 +17563,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.19, source-map-support@^0.5.6:
+source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
Switch from using the `source-map-support` library to nodejs's built-in source maps with `--enable-source-maps`, because the built-in source maps use less RAM. This change was attempted before when we were on node 18, but crashed on staging/test servers because, although node 18's builtin source map support uses less RAM in steady-state, during startup it bursts to extremely high memory usage (enough that VM processes ran out and hung in a loop of garbage collecting forever.) I believe node 22 no longer has that problem (watching memory usage in a debugger, I'm able to see the memory usage spike under node 18, and don't see a similar spike in node 22.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209268071031797) by [Unito](https://www.unito.io)
