### PR TITLE
Fix a subtle memory leak caused by putting a resolverContext into async storage

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -245,7 +245,6 @@ export function startWebserver() {
     context: async ({ req, res }: { req: express.Request, res: express.Response }) => {
       const context = await getContextFromReqAndRes({req, res, isSSR: false});
       configureSentryScope(context);
-      setAsyncStoreValue('resolverContext', context);
       return context;
     },
     plugins: [new ApolloServerLogging()],

--- a/packages/lesswrong/server/perfMetrics.ts
+++ b/packages/lesswrong/server/perfMetrics.ts
@@ -10,7 +10,6 @@ import { getClientIP } from './utils/getClientIP';
 type IncompletePerfMetricProps = Pick<PerfMetric, 'op_type' | 'op_name' | 'parent_trace_id' | 'extra_data' | 'client_path' | 'gql_string' | 'sql_string' | 'ip' | 'user_agent' | 'user_id'>;
 
 interface AsyncLocalStorageContext {
-  resolverContext?: ResolverContext;
   requestPerfMetric?: IncompletePerfMetric;
   inDbRepoMethod?: boolean;
 }

--- a/packages/lesswrong/server/repos/perfMetricWrapper.ts
+++ b/packages/lesswrong/server/repos/perfMetricWrapper.ts
@@ -1,5 +1,5 @@
 import { performanceMetricLoggingEnabled } from "../../lib/instanceSettings";
-import { asyncLocalStorage, closePerfMetric, openPerfMetric } from "../perfMetrics";
+import { asyncLocalStorage, closePerfMetric, getParentTraceId, openPerfMetric } from "../perfMetrics";
 
 type Constructor<TResult, TParams extends any[] = any[]> = new (
   ...params: TParams
@@ -22,13 +22,7 @@ function wrapWithPerfMetrics(method: Function, repoName: string, methodName: str
     }
 
     const asyncContext = asyncLocalStorage.getStore();
-
-    let parentTraceIdField;
-    if (asyncContext) {
-      parentTraceIdField = { parent_trace_id: asyncContext.resolverContext?.perfMetric?.trace_id }
-    } else {
-      parentTraceIdField = {};
-    }
+    const parentTraceIdField = getParentTraceId();
 
     const opName = `${repoName}.${methodName}`;
 

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -364,9 +364,6 @@ const renderRequest = async ({req, user, startTime, res, clientId, userAgent}: R
     };
   }
   configureSentryScope(requestContext);
-  if (performanceMetricLoggingEnabled.get()) {
-    setAsyncStoreValue('resolverContext', requestContext);
-  }
   
   // according to the Apollo doc, client needs to be recreated on every request
   // this avoids caching server side


### PR DESCRIPTION
Poking around in memory dumps, I found that a bounded (but significant) number of `resolverContext` instances were being leaked on startup, which is a problem because `resolverContext` includes a loader-cache which is meant to be ephemeral, and contains a signficant amount of data. The issue is that the internals of the `dataloader` library hold onto a resolved promise, which captures the `Context` that the `DataLoader` class was constructed in, which captures all associated async local storage.

The only thing the `resolverContext` in `AsyncLocalStorageContext` was being used for was as a source of a `trace_id`, put the same `trace_id` is also available via a different, smaller async local storage variable. I checked that the values from these two sources matched, then removed `resolverContext` from AsyncLocalStorageContext.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209268037695467) by [Unito](https://www.unito.io)
