### PR TITLE
Fix a bug that would cause the New Tag page (on LW) to get stuck in a loading state if SSR'ed

### DIFF
--- a/packages/lesswrong/lib/crud/withMulti.ts
+++ b/packages/lesswrong/lib/crud/withMulti.ts
@@ -256,7 +256,7 @@ export function useMulti<
   }
   
   return {
-    loading: loading || networkStatus === NetworkStatus.fetchMore,
+    loading: (loading || networkStatus === NetworkStatus.fetchMore) && !skip,
     loadingInitial: networkStatus === NetworkStatus.loading,
     loadingMore: networkStatus === NetworkStatus.fetchMore,
     results,


### PR DESCRIPTION
Due to a bug in older apollo-client versions (up to 3.6.3), when `skip: true` is passed to `useSingle` or `useMulti`, it returns `loading: true` forever if it was present during SSR. Work around this by enforcing that `loading` is false if `skip: true` is passed. (I will look at upgrading apollo-client separately)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209287157105712) by [Unito](https://www.unito.io)
