### PR TITLE
Fix filtering for topics from the search UI

### DIFF
--- a/packages/lesswrong/components/search/SearchFilters.tsx
+++ b/packages/lesswrong/components/search/SearchFilters.tsx
@@ -141,7 +141,7 @@ const SearchFilters = ({classes, tab, tagsFilter, handleUpdateTagsFilter, onSort
       />
     </>}
     {['Posts', 'Comments', 'Users'].includes(tab) && <CustomTagsRefinementList
-      attribute="tags"
+      attribute="tags._id"
       defaultRefinement={tagsFilter}
       tagsFilter={tagsFilter}
       setTagsFilter={handleUpdateTagsFilter}


### PR DESCRIPTION
In #9879 we changed the schema of post tags in elasticsearch from an array of tag ids to an array or objects with tag `_id`, `slug` and `name` fields to enable searching for topics using a search string. However, we forgot to update the UI facet for selecting tags which is still trying to match the target tag id directly against items in the tag array, instead of checking the `_id` field so all searches return 0 results.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209295391217427) by [Unito](https://www.unito.io)
