### PR TITLE
Fix LW Review end date

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewWidget.tsx
@@ -7,7 +7,7 @@ import type { RecommendationsAlgorithm } from '../../lib/collections/users/recom
 import classNames from 'classnames';
 import { forumTitleSetting } from '../../lib/instanceSettings';
 import moment from 'moment';
-import { eligibleToNominate, getReviewPhase, getReviewTitle, ReviewYear, REVIEW_YEAR, getResultsPhaseEnd, getNominationPhaseEnd, getReviewPhaseEnd, getReviewStart, reviewPostPath, longformReviewTagId } from '../../lib/reviewUtils';
+import { eligibleToNominate, getReviewPhase, getReviewTitle, ReviewYear, REVIEW_YEAR, getResultsPhaseEnd, getNominationPhaseEnd, getReviewPhaseEnd, getReviewStart, reviewPostPath, longformReviewTagId, getVotingPhaseEnd } from '../../lib/reviewUtils';
 import { allPostsParams } from './NominationsPage';
 import qs from 'qs';
 
@@ -227,7 +227,7 @@ const FrontpageReviewWidget = ({classes, showFrontpageItems=true, reviewYear, cl
   const nominationStartDate = getReviewStart(reviewYear)
   const nominationEndDate = getNominationPhaseEnd(reviewYear)
   const reviewEndDate = getReviewPhaseEnd(reviewYear)
-  const voteEndDate = getResultsPhaseEnd(reviewYear)
+  const voteEndDate = getVotingPhaseEnd(reviewYear)
 
   // These should be calculated at render
   const currentDate = moment.utc()

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -64,8 +64,8 @@ export function getReviewPeriodEnd(reviewYear: ReviewYear = REVIEW_YEAR) {
 export const getReviewStart = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-02`).add(TIMEZONE_OFFSET, 'hours')
 export const getNominationPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-16`).add(TIMEZONE_OFFSET, 'hours')
 export const getReviewPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-01-16`).add(TIMEZONE_OFFSET, 'hours')
-export const getVotingPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-01`).add(TIMEZONE_OFFSET, 'hours')
-export const getResultsPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-06`).add(TIMEZONE_OFFSET, 'hours')
+export const getVotingPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-05`).add(TIMEZONE_OFFSET, 'hours')
+export const getResultsPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-10`).add(TIMEZONE_OFFSET, 'hours')
 
 function recomputeReviewPhase(reviewYear?: ReviewYear): ReviewPhase {
   if (reviewYear && reviewYear !== REVIEW_YEAR) {


### PR DESCRIPTION
The Voting Phase was supposed to end on Feb 1st, with the Results phase ending on Feb 6th, but I accidentally had made the Frontpage widget say the vote ended on the 6th. I'm going to extend it since we didn't do the Final Push yet.

Since I think it was actually kinda crazy to have the review end 6 days into February I'm slightly splitting the difference and setting the end of the voting phase to be the 5th, and will make sure the Voting Wizard goes live tomorrow (Saturday) so there's a reasonable amount of time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209296388903107) by [Unito](https://www.unito.io)
