### PR TITLE
Fix the color of the dismiss button on spotlight items, while in dark mode

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -66,8 +66,15 @@ const styles = (theme: ThemeType) => ({
       opacity: .2
     },
     '&:hover $closeButton': {
-      color: theme.palette.grey[100],
-      background: theme.palette.panelBackground.default,
+      ...(isFriendlyUI ? {
+        color: theme.palette.grey[100],
+        background: theme.palette.panelBackground.default,
+      } : {
+        // This button is on top of an image that doesn't invert in dark mode, so
+        // we can't use palette-colors that invert
+        color: theme.palette.type==="dark" ? "rgba(0,0,0,.7)" : theme.palette.grey[400],
+        background: theme.palette.type==="dark" ? "white" : theme.palette.panelBackground.default,
+      }),
     }
   },
   contentContainer: {

--- a/packages/lesswrong/unitTests/themePalette.tests.ts
+++ b/packages/lesswrong/unitTests/themePalette.tests.ts
@@ -24,6 +24,14 @@ jest.mock("../components/editor/DraftJSEditor", () => {
 import "../server";
 
 describe('JSS', () => {
+  /**
+   * Check that component styles use only colors from the theme, when
+   * instantiated with the default theme. It is okay to use non-palette colors
+   * conditionally, eg with
+   *    `theme.palette.type==="dark" ? "#123456" : theme.palette.panelBackground.default`
+   * since the main purpose of this test is to make sure you don't forget about
+   * dark mode and accidentally make something black-on-black.
+   */
   it('uses only colors from the theme palette', () => {
     importAllComponents();
     const realTheme = getForumTheme({name: "default", siteThemeOverride: {}}) as unknown as ThemeType;


### PR DESCRIPTION
This was using palette colors which invert in dark mode (normally correct), but overlayed on top of an image (which doesn't invert). The result wasn't illegible or anything, but looked kind of ugly.

I forum-gated this change because there was already some forum-gating on the `color` prop for `closeButton`, and I wasn't testing the interaction.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209346058503481) by [Unito](https://www.unito.io)
