### PR TITLE
[EA Forum only] fix post title hoverovers

### DIFF
--- a/packages/lesswrong/components/tagging/TruncatedTagsList.tsx
+++ b/packages/lesswrong/components/tagging/TruncatedTagsList.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useEffect, RefObject } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { recalculateTruncation } from "../../lib/truncateUtils";
 import classNames from "classnames";
-import { useMulti } from "@/lib/crud/withMulti";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -48,26 +47,7 @@ const TruncatedTagsList = ({post, expandContainer, className, classes}: {
   classes: ClassesType<typeof styles>,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
-
-  // The post passed in as an argument might have a post fragment that contains
-  // tags with preview text included, or it might not. In the latter case,
-  // start a request to fetch the tags, so that we can display them if they're
-  // hovered.
-  const { results, loading } = useMulti({
-    terms: {
-      view: "tagsOnPost",
-      postId: post._id,
-    },
-    collectionName: "TagRels",
-    fragmentName: "TagRelMinimumFragment",
-    limit: 100,
-    skip: !post.tags.length || ('description' in post.tags[0]),
-    ssr: false,
-  });
-  
-  const tags = results
-    ? results.map(tagRel => tagRel.tag)
-    : post.tags;
+  const tags = post.tags;
 
   useEffect(() => {
     if (!tags?.length) {
@@ -95,7 +75,7 @@ const TruncatedTagsList = ({post, expandContainer, className, classes}: {
       <div className={classes.scratch} aria-hidden="true">
         {tags.map((tag) => tag &&
           <span key={tag._id} className={classes.item}>
-            <FooterTag tag={tag} smallText hoverable="ifDescriptionPresent" />
+            <FooterTag tag={tag} smallText hoverable={false} />
           </span>
         )}
         <span className={classes.more}>


### PR DESCRIPTION
I noticed this error when hovering over a post title on staging:
<img width="735" alt="Screenshot 2025-02-06 at 4 14 02 PM" src="https://github.com/user-attachments/assets/95e67baa-55b3-4bbb-8b0d-a032ee87f91b" />

Seems like it was caused by https://github.com/ForumMagnum/ForumMagnum/pull/10324? We don't need tags in our post hoverover to be hoverable, because our post hoverover is not clickable. So I reverted the changes in this file and it fixed the issue.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209346435231720) by [Unito](https://www.unito.io)
