### PR TITLE
Fix a bug which, depending on the ordering of component renders and useEffects, sometimes caused the inline-react button to not appear

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -37,7 +37,6 @@ export const InlineReactSelectionWrapper = ({contentRef, voteProps, styling, chi
   const [disabledButton, setDisabledButton] = useState<boolean>(false);
 
   const { AddInlineReactionButton, LWPopper } = Components;
-  const contentRefCurrent = contentRef?.current;
   
   const detectSelection = useCallback((e: MouseEvent): void => {
     function clearAll() {

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -54,17 +54,17 @@ export const InlineReactSelectionWrapper = ({contentRef, voteProps, styling, chi
       return
     }
 
-    const selectionInCommentRef = contentRefCurrent?.containsNode(selectionAnchorNode);
+    const selectionInCommentRef = contentRef?.current?.containsNode(selectionAnchorNode);
     const selectionInPopupRef = popupRef && popupRef.current?.contains(selectionAnchorNode as Node);
 
     if (selectionInCommentRef && !selectionInPopupRef) {
-      const anchorEl = contentRefCurrent?.getAnchorEl();
+      const anchorEl = contentRef?.current?.getAnchorEl();
       
       if (anchorEl instanceof HTMLElement && selectedText.length > 1 ) {
         setAnchorEl(anchorEl);
         setQuote(selectedText);
         setYOffset(getYOffsetFromDocument(selection, commentTextRef));
-        const commentText = contentRefCurrent?.getText() ?? "";
+        const commentText = contentRef?.current?.getText() ?? "";
         // Count the number of occurrences of the quote in the raw text
         const count = countStringsInString(commentText, selectedText);
         setDisabledButton(count > 1)
@@ -75,7 +75,7 @@ export const InlineReactSelectionWrapper = ({contentRef, voteProps, styling, chi
     if (!selectionInCommentRef && !selectionInPopupRef) {
       clearAll()
     }
-  }, [contentRefCurrent, commentTextRef]);
+  }, [contentRef, commentTextRef]);
   
   useEffect(() => { 
     document.addEventListener('selectionchange', detectSelection);


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209347107481344) by [Unito](https://www.unito.io)
