### PR TITLE
Don't show a (false, maybe zero) words-left cout when ContentItemTruncated is limited by height instead of wordcount

### DIFF
--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -20,8 +20,12 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
   graceWords?: number,
   expanded?: boolean,
   rawWordCount: number,
-  // Suffix, shown only if truncated
-  getTruncatedSuffix?: (props: {wordsLeft: number}) => React.ReactNode,
+  /**
+   * Suffix, shown only if truncated. If the truncation was due to the word
+   * count limit, includes the number of words left; if it was due to the height
+   * limit instead of the word-count limit, wordsLeft is null.
+   */
+  getTruncatedSuffix?: (props: {wordsLeft: number|null}) => React.ReactNode,
   // Alternate suffix, shown if truncated didn't happen (because it wasn't long
   // enough to need it)
   nonTruncatedSuffix?: React.ReactNode
@@ -68,7 +72,7 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
         nofollow={nofollow}
       />
     </div>
-    {showSuffix && getTruncatedSuffix && getTruncatedSuffix({wordsLeft})}
+    {showSuffix && getTruncatedSuffix && getTruncatedSuffix({wordsLeft: hasHeightLimit ? null : wordsLeft})}
     {!showSuffix && nonTruncatedSuffix}
   </>
 }

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -34,17 +34,18 @@ const styles = (theme: ThemeType) => ({
 const TruncatedSuffix: FC<{
   post: PostsList,
   forceSeeMore?: boolean,
-  wordsLeft: number,
+  wordsLeft: number|null,
   clickExpand: (ev: MouseEvent) => void,
 }> = ({post, forceSeeMore, wordsLeft, clickExpand}) => {
-  if (forceSeeMore || wordsLeft < 1000) {
+  if (forceSeeMore || (wordsLeft && wordsLeft < 1000)) {
     return (
       <Link
         to={postGetPageUrl(post)}
         onClick={clickExpand}
         eventProps={{intent: 'expandPost'}}
       >
-        ({preferredHeadingCase("See More")} – {wordsLeft} more words)
+        {"("}{preferredHeadingCase("See More")}
+        {wordsLeft && <>{" – "}{wordsLeft} more words</>}{")"}
       </Link>
     );
   }

--- a/packages/lesswrong/components/revisions/CompareRevisions.tsx
+++ b/packages/lesswrong/components/revisions/CompareRevisions.tsx
@@ -77,9 +77,10 @@ const CompareRevisions = ({
         rawWordCount={wordCount}
         graceWords={20}
         expanded={expanded}
-        getTruncatedSuffix={({wordsLeft}: {wordsLeft: number}) =>
+        getTruncatedSuffix={({wordsLeft}: {wordsLeft: number|null}) =>
           <div className={classes.expand} onClick={() => setExpanded(true)}>
-            Read More ({wordsLeft} more words)
+            {wordsLeft && <>Read More ({wordsLeft} more words)</>}
+            {!wordsLeft && <>Read More</>}
           </div>
         }
         dangerouslySetInnerHTML={{__html: diffResultHtml}}


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209354283862163) by [Unito](https://www.unito.io)
