### PR TITLE
Within-page links to post sections have link previews

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -7,7 +7,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { isServer } from '../../lib/executionEnvironment';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { isMobile } from '../../lib/utils/isMobile'
-import { locationHashIsFootnote } from '../posts/PostsPage/CollapsedFootnotes';
+import { locationHashIsFootnote, locationHashIsFootnoteBackreference } from '../posts/PostsPage/CollapsedFootnotes';
 import {useCurrentUser} from '../common/withUser'
 import { getUrlClass } from '@/server/utils/getUrlClass';
 
@@ -73,10 +73,11 @@ const HoverPreviewLink = ({ href, contentSourceDescription, id, rel, noPrefetch,
       return <Components.FootnotePreview href={href} id={id} rel={rel}>
         {children}
       </Components.FootnotePreview>
+    } else if (locationHashIsFootnoteBackreference(href)) {
+      return <a href={href} id={id} rel={rel}>
+        {children}
+      </a>
     }
-    return <a href={href} id={id} rel={rel}>
-      {children}
-    </a>
   }
 
   try {

--- a/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/CollapsedFootnotes.tsx
@@ -12,6 +12,8 @@ export const EXPAND_FOOTNOTES_EVENT = "expand-footnotes";
 
 export const locationHashIsFootnote = (hash: string) =>
   hash.startsWith("#fn") && !hash.startsWith("#fnref");
+export const locationHashIsFootnoteBackreference = (hash: string) =>
+  hash.startsWith("#fnref");
 
 const styles = (theme: ThemeType) => ({
   collapse: {


### PR DESCRIPTION
A post can link to other sections within the same post with `#section_title`, eg the "(more)" links in https://www.lesswrong.com/posts/hnJSm9AmA3dPEzPaC/what-is-malevolence-on-the-nature-measurement-and#Important_caveats_when_thinking_about_malevolence . Add a link hover preview to them (the same preview as when another post linked to the section; it already has support for starting the highlight excerpt at the right section.).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209354409124577) by [Unito](https://www.unito.io)
