### PR TITLE
Some fixes to wiki-adjacent pages

### DIFF
--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -6,6 +6,7 @@ registerFragment(`
     postId
     tagId
     tag {
+      _id
       slug
     }
     relevantTagIds

--- a/packages/lesswrong/server/editor/utils.ts
+++ b/packages/lesswrong/server/editor/utils.ts
@@ -5,6 +5,7 @@ import { diff } from "../vendor/node-htmldiff/htmldiff";
 import { cheerioParse } from '../utils/htmlUtil'
 import cheerio from 'cheerio'
 import { extractVersionsFromSemver } from '../../lib/editor/utils';
+import { normalizeHtmlForDiff } from '../resolvers/htmlDiff';
 
 export const trimLatexAndAddCSS = (dom: any, css: string) => {
   // Remove empty paragraphs
@@ -114,7 +115,7 @@ const countCharsInTag = (parsedHtml: cheerio.Root, tagName: string): number => {
 }
 
 export const htmlToChangeMetrics = (oldHtml: string, newHtml: string): ChangeMetrics => {
-  const htmlDiff = diff(oldHtml, newHtml);
+  const htmlDiff = diff(normalizeHtmlForDiff(oldHtml), normalizeHtmlForDiff(newHtml));
   const parsedHtml = cheerioParse(htmlDiff);
 
   /// Given an HTML diff, where added sections are marked with <ins> and <del>

--- a/packages/lesswrong/server/resolvers/htmlDiff.ts
+++ b/packages/lesswrong/server/resolvers/htmlDiff.ts
@@ -1,10 +1,16 @@
 import { diff } from '../vendor/node-htmldiff/htmldiff';
-import { cheerioParse } from '../utils/htmlUtil';
+import { cheerioParse, tokenizeHtml } from '../utils/htmlUtil';
 import { sanitize } from '../../lib/vulcan-lib/utils';
+import { Globals } from '../vulcan-lib';
 
 export const diffHtml = (before: string, after: string, trim: boolean): string => {
+  // Normalize unicode and &entities; so that smart quotes changing form won't
+  // produce spurious differences
+  const normalizedBefore = normalizeHtmlForDiff(before);
+  const normalizedAfter = normalizeHtmlForDiff(after);
+
   // Diff the revisions
-  const diffHtmlUnsafe = diff(before, after);
+  const diffHtmlUnsafe = diff(normalizedBefore, normalizedAfter);
   
   let trimmed = trim ? trimHtmlDiff(diffHtmlUnsafe) : diffHtmlUnsafe;
   
@@ -33,3 +39,45 @@ export const trimHtmlDiff = (html: string): string => {
   
   return $.html();
 }
+
+/**
+ * Several common characters (quotes, smart-quotes) can be represented as
+ * either regular characters (maybe unicode), or as HTML entities. In some
+ * historical imported wiki content they're represented as HTML entities, but
+ * opening a wiki page in CkEditor and re-saving it converts them to their
+ * regular-character form, creating spurious changes in the history page and
+ * in chars-edited metrics.
+ *
+ * This function normalizes these differences away so that we can get a diff
+ * that excludes these.
+ *
+ * Note that while this is used for change-metrics, it's not currently used
+ * for attributing edits of particular chars to users, because the
+ * normalization changes the string length and the attribution code is
+ * sensitive to that.
+ */
+export function normalizeHtmlForDiff(html: string): string {
+  const tokens = tokenizeHtml(html);
+  function normalizeEntity(entityStr: string): string {
+    switch (entityStr) {
+      case "&quot;":
+        return "\"";
+      case "&#x201C;":
+        return "“";
+      case "&#x201D;":
+        return "”";
+      default:
+        console.log(entityStr);
+        return entityStr;
+    }
+  }
+  return tokens.map(([tokenType, tokenString]) => {
+    if (tokenType==="charRefNamed" || tokenType==="charRefHex") {
+      return normalizeEntity(tokenString);
+    } else {
+      return tokenString;
+    }
+  }).join("");
+}
+
+Globals.normalizeHtmlForDiff = normalizeHtmlForDiff;


### PR DESCRIPTION
 * Fix crash in TagActivityFeed caused by a subfragment not having an _id
 * Exclude spurious edits to quotes/smart-quotes from diffs in wiki history