### PR TITLE
validate that selections in fragments include _id fields

### DIFF
--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -6,6 +6,7 @@ registerFragment(`
     postId
     tagId
     tag {
+      _id
       slug
     }
     relevantTagIds
@@ -196,6 +197,7 @@ registerFragment(`
   fragment CommentsListWithModerationMetadata on Comment {
     ...CommentWithRepliesFragment
     allVotes {
+      _id
       voteType
     }
   }
@@ -222,6 +224,7 @@ registerFragment(`
       ...UsersMinimumInfo
     }
     contents {
+      _id
       markdown
     }
     post {

--- a/packages/lesswrong/lib/collections/messages/fragments.ts
+++ b/packages/lesswrong/lib/collections/messages/fragments.ts
@@ -8,6 +8,7 @@ registerFragment(`
       profileImageId
     }
     contents {
+      _id
       html
       plaintextMainText
     }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -842,6 +842,7 @@ registerFragment(`
       ...UsersMinimumInfo
     }
     contents {
+      _id
       markdown
     }
   }

--- a/packages/lesswrong/lib/collections/reviewWinners/fragments.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/fragments.ts
@@ -49,6 +49,7 @@ registerFragment(`
     reviewYear
     reviewRanking
     reviewWinnerArt {
+      _id
       splashArtImageUrl
       activeSplashArtCoordinates {
         ...SplashArtCoordinates

--- a/packages/lesswrong/lib/collections/spotlights/fragments.ts
+++ b/packages/lesswrong/lib/collections/spotlights/fragments.ts
@@ -29,6 +29,7 @@ registerFragment(`
   fragment SpotlightReviewWinner on Spotlight {
     ...SpotlightMinimumInfo
     description {
+      _id
       html
     }
     sequenceChapters {
@@ -66,6 +67,7 @@ registerFragment(`
       ...ChaptersFragment
     }
     description {
+      _id
       html
     }
   }

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -101,6 +101,7 @@ registerFragment(`
       ...UsersMinimumInfo
     }
     description {
+      _id
       html
     }
   }

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -444,6 +444,7 @@ registerFragment(`
     }
     usersContactedBeforeReview
     associatedClientIds {
+      _id
       clientId
       firstSeenReferrer
       firstSeenLandingPage

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1761,6 +1761,7 @@ interface PostsForAutocomplete { // fragment on Posts
 }
 
 interface PostsForAutocomplete_contents { // fragment on Revisions
+  readonly _id: string,
   readonly markdown: string|null,
 }
 
@@ -1848,6 +1849,7 @@ interface CommentsList { // fragment on Comments
 }
 
 interface CommentsList_tag { // fragment on Tags
+  readonly _id: string,
   readonly slug: string,
 }
 
@@ -1935,6 +1937,7 @@ interface CommentsListWithModerationMetadata extends CommentWithRepliesFragment 
 }
 
 interface CommentsListWithModerationMetadata_allVotes { // fragment on Votes
+  readonly _id: string,
   readonly voteType: "bigDownvote" | "bigUpvote" | "neutral" | "smallDownvote" | "smallUpvote",
 }
 
@@ -1955,6 +1958,7 @@ interface CommentsForAutocomplete { // fragment on Comments
 }
 
 interface CommentsForAutocomplete_contents { // fragment on Revisions
+  readonly _id: string,
   readonly markdown: string|null,
 }
 
@@ -2112,6 +2116,7 @@ interface messageListFragment_user extends UsersMinimumInfo { // fragment on Use
 }
 
 interface messageListFragment_contents { // fragment on Revisions
+  readonly _id: string,
   readonly html: string,
   readonly plaintextMainText: string,
 }
@@ -2700,6 +2705,7 @@ interface TagCreationHistoryFragment extends TagFragment { // fragment on Tags
 }
 
 interface TagCreationHistoryFragment_description { // fragment on Revisions
+  readonly _id: string,
   readonly html: string,
 }
 
@@ -3442,6 +3448,7 @@ interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
 }
 
 interface SunshineUsersList_associatedClientIds { // fragment on ClientIds
+  readonly _id: string,
   readonly clientId: string,
   readonly firstSeenReferrer: string | null,
   readonly firstSeenLandingPage: string,
@@ -3855,6 +3862,7 @@ interface SpotlightReviewWinner extends SpotlightMinimumInfo { // fragment on Sp
 }
 
 interface SpotlightReviewWinner_description { // fragment on Revisions
+  readonly _id: string,
   readonly html: string,
 }
 
@@ -3888,6 +3896,7 @@ interface SpotlightDisplay_document_user { // fragment on Users
 }
 
 interface SpotlightDisplay_description { // fragment on Revisions
+  readonly _id: string,
   readonly html: string,
 }
 
@@ -4278,6 +4287,7 @@ interface ReviewWinnerTopPostsPage { // fragment on ReviewWinners
 }
 
 interface ReviewWinnerTopPostsPage_reviewWinnerArt { // fragment on ReviewWinnerArts
+  readonly _id: string,
   readonly splashArtImageUrl: string,
   readonly activeSplashArtCoordinates: SplashArtCoordinates|null,
 }

--- a/packages/lesswrong/lib/vulcan-lib/fragments.ts
+++ b/packages/lesswrong/lib/vulcan-lib/fragments.ts
@@ -1,8 +1,9 @@
-import type { DocumentNode } from 'graphql';
+import type { DocumentNode, FragmentDefinitionNode, FieldNode, GraphQLScalarType } from 'graphql';
 import gql from 'graphql-tag';
 import * as _ from 'underscore';
 // This has a stub for the client bundle
 import SqlFragment from '@/server/sql/SqlFragment';
+import { getCollectionByTypeName } from './getCollection';
 
 interface FragmentDefinition {
   fragmentText: string
@@ -51,6 +52,10 @@ export const registerFragment = (fragmentTextSource: string): void => {
   if(subFragments && subFragments.length) {
     Fragments[fragmentName].subFragments = subFragments as Array<FragmentName>;
   }
+
+  // Validate that the fragment isn't missing any _id fields nested in collection-type fields
+  const fragmentDef = parseGraphQLFragment(fragmentText);
+  validateFragmentSelections(fragmentDef, fragmentDef.typeCondition.name.value);
 };
 
 // Create gql fragment object from text and subfragments
@@ -124,6 +129,7 @@ export const getFragment = (fragmentName: FragmentName): DocumentNode => {
     // return fragment object created by gql
     return initializeFragment(fragmentName);
   }
+
   return fragmentObject;
 };
 
@@ -150,6 +156,169 @@ const getFragmentText = (fragmentName: FragmentName): string => {
   // return fragment object created by gql
   return Fragments[fragmentName].fragmentText;  
 };
+
+const parseGraphQLFragment = (fragmentText: string) => {
+  const parsed = gql`${fragmentText}`;
+  if (!parsed.definitions[0] || parsed.definitions[0].kind !== 'FragmentDefinition') {
+    throw new Error("Invalid fragment definition");
+  }
+  return parsed.definitions[0];
+}
+
+// get GraphQL type for a given schema and field name
+export const getGraphQLType = <N extends CollectionNameString>(
+  schema: SchemaType<N>,
+  fieldName: string,
+  isInput = false,
+): string|null => {
+  const field = schema[fieldName];
+  const type = field.type.singleType;
+  const typeName =
+    typeof type === 'object' ? 'Object' : typeof type === 'function' ? type.name : type;
+
+  // LESSWRONG: Add optional property to override default input type generation
+  if (isInput && field.inputType) {
+    return field.inputType
+  }
+
+  switch (typeName) {
+    case 'String':
+      return 'String';
+
+    case 'Boolean':
+      return 'Boolean';
+
+    case 'Number':
+      return 'Float';
+
+    case 'SimpleSchema.Integer':
+      return 'Int';
+
+    // for arrays, look for type of associated schema field or default to [String]
+    case 'Array':
+      const arrayItemFieldName = `${fieldName}.$`;
+      // note: make sure field has an associated array
+      if (schema[arrayItemFieldName]) {
+        // try to get array type from associated array
+        const arrayItemType = getGraphQLType(schema, arrayItemFieldName);
+        return arrayItemType ? `[${arrayItemType}]` : null;
+      }
+      return null;
+
+    case 'Object':
+      return 'JSON';
+
+    case 'Date':
+      return 'Date';
+
+    default:
+      return null;
+  }
+};
+
+interface SelectionFieldInfo {
+  fieldName: string;
+  fieldType: string | GraphQLScalarType | null;
+  selection: FieldNode;
+}
+
+interface MaybeCollectionFieldInfo extends SelectionFieldInfo {
+  fieldType: string;
+}
+
+const isMaybeCollectionFieldInfo = (fieldInfo: SelectionFieldInfo): fieldInfo is MaybeCollectionFieldInfo => {
+  return typeof fieldInfo.fieldType === 'string';
+};
+
+const resolveFragmentFieldNode = (fragmentDef: FragmentDefinitionNode | FieldNode, resolveSchemaFieldMap: Record<string, string>, schema: SchemaType<CollectionNameString>) => {
+  const fieldName = resolveSchemaFieldMap[fragmentDef.name.value] ?? fragmentDef.name.value;
+  const field = schema[fieldName];
+  return { fieldName, field };
+};
+
+const isValidCollectionName = (fieldType: string) => {
+  // Array and/or non-nullable collection types still need to be checked, so strip out the brackets and exclamation marks
+  const maybeCollectionName = fieldType.replace(/[![\]]+/g, "");
+  try {
+    getCollectionByTypeName(maybeCollectionName);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * We need to validate that the fragment isn't missing any _id fields nested in collection-type fields
+ * If that happens, it can cause weird client-side bugs where the apollo cache doesn't know how to resolve stuff
+ * Sometimes stuff blows up, sometimes weirder and more annoying things happen.
+ * Anyways, there's not really a reason to want to omit the field.
+ * 
+ * This isn't perfect because it doesn't check non-collection-based fragments, since we don't have
+ * a good way of checking the "intended" type of any given field inside one of those fragments.
+ */
+const validateFragmentSelections = (fragmentDef: FragmentDefinitionNode | FieldNode, typeName: string) => {
+  const selectionSet = fragmentDef.selectionSet;
+  
+  // Get the collection for this type if it exists
+  let collection: CollectionBase<CollectionNameString>|null = null;
+  try {
+    collection = getCollectionByTypeName(typeName.replace(/[![\]]+/g, ""));
+  } catch (e) {
+    // Not a collection type, skip validation
+    return;
+  }
+
+  if (!selectionSet) return;
+
+  const schema = collection._schemaFields;
+
+  // For fragments on collections, we only need to check fields that have a resolver
+  // Other fields won't have _id fields nested in them (with the exception of normalized editable fields, which get treated as resolver fields anyways)
+  const resolverFields = Object.keys(schema).filter(fieldName => schema[fieldName].resolveAs);
+
+  // However, since we'll be mapping over the selection set, which will contain field names that don't actually exist in the schema,
+  // we need to map the "resolver field" names referenced in the fragment to the actual schema field names that generated them
+  const resolverFieldToOriginalFieldMap = Object.fromEntries(
+    resolverFields.map(fieldName => [schema[fieldName].resolveAs?.fieldName ?? fieldName, fieldName])
+  );
+
+  const selectionResolverFieldMetadata = selectionSet.selections
+    .filter(selection => selection.kind === 'Field')
+    .map(selection => {
+      const { field, fieldName } = resolveFragmentFieldNode(selection, resolverFieldToOriginalFieldMap, schema);
+      return { field, fieldName, selection };
+    })
+    // Filter out fields that don't have a resolver
+    .filter(({ field }) => !!field?.resolveAs)
+    .map(({ fieldName, field, selection }) => {
+      const fieldType = field.resolveAs?.type ?? getGraphQLType(schema, fieldName);
+      return { fieldName, fieldType, selection };
+    })
+    // Filter out fields that aren't even possibly collection types
+    .filter(isMaybeCollectionFieldInfo);
+
+  for (const { selection, fieldName, fieldType } of selectionResolverFieldMetadata) {
+    const validCollectionName = isValidCollectionName(fieldType);
+    
+    if (validCollectionName && selection.selectionSet) {
+      const { selections } = selection.selectionSet;
+
+      // Check if there's a fragment spread - if so, we don't need to check for _id
+      // since we'll check the nested fragment at some point, and if that doesn't have _id,
+      // we'll fail validation anyway.
+      const hasSpread = selections.some(s => s.kind === 'FragmentSpread');
+      const hasId = selections.some(s => s.kind === 'Field' && s.name.value === '_id');
+
+      // If there's no fragment spread and no _id field on a field that's resolved to a collection type, throw an error
+      if (!hasSpread && !hasId) {
+        throw new Error(`Fragment "${fragmentDef.name.value}" is missing _id field for collection type "${fieldType}" in field "${fieldName}"`);
+      }
+      
+      // Recursively validate nested selections
+      validateFragmentSelections(selection, fieldType);
+    }
+  }
+}
 
 export const initializeFragment = (fragmentName: FragmentName): DocumentNode => {
   const fragment = Fragments[fragmentName];


### PR DESCRIPTION
It's (as far as I can tell) always a mistake to forgo the _id field when selecting a set of fields from field that's resolved with a collection type, since it can mess up the Apollo cache and cause horrible things to happen.

This solution isn't comprehensive since it doesn't validate fragments that aren't based on collections (i.e. `SubscribedPostAndCommentsFeed`), and to get the "canonical" field type for each field in those fragments we'd probably need do something annoying like dig them out of the `executableSchema`, since we don't have a collection schema that we can inspect.  That seems like a pretty minor issue, all things considered.