### PR TITLE
Fix ReviewWinner filtering

### DIFF
--- a/packages/lesswrong/lib/collections/reviewWinners/cache.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/cache.ts
@@ -1,4 +1,4 @@
-import { BEST_OF_LESSWRONG_PUBLISH_YEAR, REVIEW_YEAR } from "@/lib/reviewUtils";
+import { BEST_OF_LESSWRONG_PUBLISH_YEAR } from "@/lib/reviewUtils";
 import keyBy from "lodash/keyBy";
 import mapValues from "lodash/mapValues";
 import moment from "moment";

--- a/packages/lesswrong/lib/collections/reviewWinners/cache.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/cache.ts
@@ -35,6 +35,6 @@ export async function getPostReviewWinnerInfo(postId: string, context: ResolverC
 
   return (
     REVIEW_WINNER_CACHE.reviewWinnersByPostId[postId] ??
-    await context.ReviewWinners.findOne({ postId, createdAt: {$lt: moment(`${BEST_OF_LESSWRONG_PUBLISH_YEAR}-01-01`).toDate()} })
+    await context.ReviewWinners.findOne({ postId, reviewYear: {$lte: BEST_OF_LESSWRONG_PUBLISH_YEAR} })
   );
 }

--- a/packages/lesswrong/lib/collections/reviewWinners/cache.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/cache.ts
@@ -1,3 +1,4 @@
+import { BEST_OF_LESSWRONG_PUBLISH_YEAR, REVIEW_YEAR } from "@/lib/reviewUtils";
 import keyBy from "lodash/keyBy";
 import mapValues from "lodash/mapValues";
 import moment from "moment";
@@ -34,6 +35,6 @@ export async function getPostReviewWinnerInfo(postId: string, context: ResolverC
 
   return (
     REVIEW_WINNER_CACHE.reviewWinnersByPostId[postId] ??
-    await context.ReviewWinners.findOne({ postId })
+    await context.ReviewWinners.findOne({ postId, createdAt: {$lt: moment(`${BEST_OF_LESSWRONG_PUBLISH_YEAR}-01-01`).toDate()} })
   );
 }


### PR DESCRIPTION
Our previous attempt at filtering review winners didn't actually prevent them from appearing styled fancily on Post Pages. This fixes that filter.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209372047186650) by [Unito](https://www.unito.io)
