### PR TITLE
Fix background image positioning

### DIFF
--- a/packages/lesswrong/components/LWBackgroundImage.tsx
+++ b/packages/lesswrong/components/LWBackgroundImage.tsx
@@ -14,7 +14,7 @@ const styles = defineStyles("LWBackgroundImage", (theme: ThemeType) => ({
     position: 'absolute',
     width: '57vw',
     maxWidth: '1000px',
-    top: '-57px',
+    top: '-70px',
     right: '-334px',
     '-webkit-mask-image': `radial-gradient(ellipse at center top, ${theme.palette.text.alwaysBlack} 55%, transparent 70%)`,
     


### PR DESCRIPTION
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/6e6463e8-7b61-4d65-955b-c1a79946edb7" />

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/15f05a01-2763-490e-8606-86f082b3a317" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4c811cd8-366e-46e5-9a9f-761fe5eb5f0c" />

I'm not actually sure what the intended Widescreen version is supposed to look like

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209372921047855) by [Unito](https://www.unito.io)
