### PR TITLE
Declutter LW Tag Editing View

### DIFF
--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -765,10 +765,11 @@ const LWTagPage = () => {
 
   const tagPostsAndCommentsSection = (
     <div className={classes.centralColumn}>
-      {editing && <TagDiscussionSection
+      {/* disabling this for now as it clutters the page and isn't getting much use, but leaving here for future consideration of somehow restoring it */}
+      {/* {editing && <TagDiscussionSection
         key={tag._id}
         tag={tag}
-      />}
+      />} */}
       {tag.sequence && <TagIntroSequence tag={tag} />}
       {!tag.wikiOnly && <>
         <AnalyticsContext pageSectionContext="tagsSection">

--- a/packages/lesswrong/lib/collections/tags/formGroups.ts
+++ b/packages/lesswrong/lib/collections/tags/formGroups.ts
@@ -21,6 +21,6 @@ export const formGroups: Partial<Record<string, FormGroupType<"Tags">>> = {
     order: 50,
     name: "summaries",
     label: "Summaries",
-    startCollapsed: false,
+    startCollapsed: true,
   }
 };

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -340,6 +340,7 @@ const schema: SchemaType<"Tags"> = {
     label: "Flags: ",
     order: 30,
     optional: true,
+    hidden: true,
     canRead: ['guests'],
     canUpdate: ['members', 'sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins']


### PR DESCRIPTION
Following the recent changes, the tag edit page had gotten unwieldy. This PR cleans it up by:

- hiding the Tag Flag pills since they're not actually in use by any one
- getting rid of the discussion section since also not really in use and clutters it up
- collapsing the summaries section by default – most pages will not have summaries and I don't think we're really encouraging people to write them

<img width="768" alt="Absurdity Heuristic - LessWrong 2025-02-11 16-05-48" src="https://github.com/user-attachments/assets/d17b821f-26f8-4163-a764-fb42daf540f4" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209381996981152) by [Unito](https://www.unito.io)
