### PR TITLE
Some Arbital fixes

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -152,13 +152,13 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
       this.addCTAButtonEventListeners(element);
 
       this.markScrollableBlocks(element);
-      this.markConditionallyVisibleBlocks(element);
       this.collapseFootnotes(element);
       this.markHoverableLinks(element);
       this.markElicitBlocks(element);
       this.wrapStrawPoll(element);
       this.applyIdInsertions(element);
       this.exposeInternalIds(element);
+      this.markConditionallyVisibleBlocks(element);
     } catch(e) {
       // Don't let exceptions escape from here. This ensures that, if client-side
       // modifications crash, the post/comment text still remains visible.

--- a/packages/lesswrong/components/editor/conditionalVisibilityBlock/ConditionalVisibilityBlockDisplay.tsx
+++ b/packages/lesswrong/components/editor/conditionalVisibilityBlock/ConditionalVisibilityBlockDisplay.tsx
@@ -1,6 +1,15 @@
 import React, { createContext, useContext } from 'react';
 import { Components, registerComponent } from '@/lib/vulcan-lib/components';
 import { ConditionalVisibilitySettings } from './conditionalVisibility';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+
+const styles = defineStyles("ConditionalVisibilityBlockDisplay", (theme) => ({
+  revealHiddenBlocks: {
+    "& .conditionallyVisibleBlock.defaultHidden": {
+      display: "block",
+    },
+  },
+}));
 
 export const RevealHiddenBlocksContext = createContext(false);
 
@@ -49,6 +58,17 @@ const ConditionalVisibilityBlockDisplay = ({options, children}: {
   } else {
     return null;
   }
+}
+
+export const RevealHiddenBlocks = ({children}: {
+  children: React.ReactNode
+}) => {
+  const classes = useStyles(styles);
+  return <RevealHiddenBlocksContext.Provider value={true}>
+    <div className={classes.revealHiddenBlocks}>
+      {children}
+    </div>
+  </RevealHiddenBlocksContext.Provider>
 }
 
 const ConditionalVisibilityBlockDisplayComponent = registerComponent('ConditionalVisibilityBlockDisplay', ConditionalVisibilityBlockDisplay);

--- a/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
+++ b/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
@@ -5,7 +5,7 @@ import { useLocation } from '../../../lib/routeUtil';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 import { addDefaultLensToLenses, TagLens } from '@/lib/arbital/useTagLenses';
 import keyBy from 'lodash/keyBy';
-import { RevealHiddenBlocksContext } from '@/components/editor/conditionalVisibilityBlock/ConditionalVisibilityBlockDisplay';
+import { RevealHiddenBlocks, RevealHiddenBlocksContext } from '@/components/editor/conditionalVisibilityBlock/ConditionalVisibilityBlockDisplay';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import Checkbox from '@material-ui/core/Checkbox';
 import Select from '@material-ui/core/Select';
@@ -104,7 +104,7 @@ const TagHistoryPage = () => {
     />
 
     <div className={classes.feed}>
-    <RevealHiddenBlocksContext.Provider value={true}>
+    <RevealHiddenBlocks>
     <MixedTypeFeed
       pageSize={25}
       resolverName="TagHistoryFeed"
@@ -228,7 +228,7 @@ const TagHistoryPage = () => {
         },
       }}
     />
-    </RevealHiddenBlocksContext.Provider>
+    </RevealHiddenBlocks>
     </div>
   </SingleColumnSection>
 }

--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -401,6 +401,8 @@ export const sanitize = function(s: string): string {
         'detailsBlockContent',
         'calendly-preview',
         'conditionallyVisibleBlock',
+        'defaultVisible',
+        'defaultHidden',
         /arb-custom-script-[a-zA-Z0-9]*/,
       ],
       iframe: [ 'thoughtSaverFrame' ],

--- a/packages/lesswrong/server/resolvers/htmlDiff.ts
+++ b/packages/lesswrong/server/resolvers/htmlDiff.ts
@@ -32,7 +32,15 @@ export const trimHtmlDiff = (html: string): string => {
   
   rootElement.children().each(function(i, elem) {
     const e = $(elem)
-    if (!e.find('ins').length && !e.find('del').length) {
+    let isInsDel = false;
+    for (const node of e) {
+      if (node.type === 'tag') {
+        if (node.tagName === 'ins' || node.tagName === 'del') {
+          isInsDel = true;
+        }
+      }
+    }
+    if (!isInsDel && !e.find('ins').length && !e.find('del').length) {
       e.remove()
     }
   })

--- a/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
+++ b/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
@@ -419,8 +419,8 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
         return '<div arb-hidden-text button-text=\'' + buttonText + '\'>' + html + '\n\n</div>';*/
         
         return `<details class="detailsBlock">
-          <summary class="detailsBlockTitle">${buttonText}</summary>
-          <div class="detailsBlockContent">${blockText}</div>
+          <summary class="detailsBlockTitle">\n${buttonText}\n</summary>
+          <div class="detailsBlockContent">\n${blockText}\n</div>
         </details>`;
       });
     });
@@ -1052,7 +1052,7 @@ function conditionallyVisibleBlockToHTML(settings: ConditionalVisibilitySettings
     "defaultVisible": isDefaultVisible,
     "defaultHidden": !isDefaultVisible,
   })
-  return `<div class="${classes}" data-visibility="${visibilityAttrEscaped}">${contentsHtml}</div>`
+  return `<div class="${classes}" data-visibility="${visibilityAttrEscaped}">\n${contentsHtml}\n</div>`
 }
 
 type PathType = {
@@ -1085,4 +1085,3 @@ function pathToCtaButton(path: PathType, conversionContext: ArbitalConversionCon
   
   return `<a class="ck-cta-button" href="${url}">Start Reading</a>`;
 }
-

--- a/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
+++ b/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
@@ -593,7 +593,7 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
         /*var cachedValue = stateService.getMathjaxCacheValue(key);
         var style = cachedValue ? ('style=\'' + cachedValue.style + ';display:inline-block;\' ') : '';
         return prefix + '<span ' + style + 'arb-math-compiler="' + key + '">&nbsp;</span>';*/
-        return prefix + latexSourceToCkEditorEmbeddedLatexTag(mathjaxText, true);
+        return prefix + latexSourceToCkEditorEmbeddedLatexTag(mathjaxText, false);
       });
     });
     // Process $$mathjax$$ spans.
@@ -605,7 +605,7 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
         /*var key = '$$' + encodedText + '$$';
         var style = cachedValue ? ('style=\'' + cachedValue.style + '\' ') : '';
         return prefix + '<span ' + style + 'class=\'mathjax-div\' arb-math-compiler="' + key + '">&nbsp;</span>';*/
-        return prefix + latexSourceToCkEditorEmbeddedLatexTag(mathjaxText, true);
+        return prefix + latexSourceToCkEditorEmbeddedLatexTag(mathjaxText, false);
       });
     });
     // Process $mathjax$ spans.

--- a/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
+++ b/packages/lesswrong/server/scripts/arbitalImport/markdownService.tsx
@@ -631,12 +631,11 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
         return prefix + '<span class=\'markdown-note\' arb-text-popover-anchor>' + markdown + '</span>';*/
 
         const footnoteId = randomId();
-        const footnoteIndex = footnotes.length+1;
         footnotes.push({
           footnoteId,
           contentsMarkdown: markdown,
         });
-        const numberedFootnoteText = encodeToPreventFurtherMarkdownProcessing(`[${footnoteIndex}]`);
+        const numberedFootnoteText = encodeToPreventFurtherMarkdownProcessing(`[${footnoteId}]`);
         return `<span class="footnote-reference" data-footnote-id="${footnoteId}" data-footnote-reference id="fnref${footnoteId}"><sup><a href="#fn${footnoteId}" id="fnref=${footnoteId}">${numberedFootnoteText}</a></sup></span>`;
       });
     });
@@ -993,9 +992,16 @@ export async function arbitalMarkdownToCkEditorMarkup({markdown: pageMarkdown, p
   let html = converter.makeHtml(pageMarkdown);
   
   if (footnotes.length > 0) {
+    // Number footnotes in the order their IDs first appear in the generated HTML
+    const sortedFootnotes = orderBy(footnotes, f=>html.indexOf(f.footnoteId));
+    for (let i=0; i<sortedFootnotes.length; i++) {
+      //html = html.replace(`[${sortedFootnotes[i].footnoteId}]`, i+1);
+      html = html.replace(`[${sortedFootnotes[i].footnoteId}]`, `[${i+1}]`);
+    }
+
     html += `<ol class="footnote-section footnotes" data-footnote-section role="doc-endnotes">`;
-    for (let i=0; i<footnotes.length; i++) {
-      const footnote = footnotes[i];
+    for (let i=0; i<sortedFootnotes.length; i++) {
+      const footnote = sortedFootnotes[i];
       const returnLinkHtml = `<span class="footnote-back-link" data-footnote-back-link data-footnote-id="${footnote.footnoteId}"><sup><strong><a href="#fnref${footnote.footnoteId}">^︎</a></strong></sup></span>`;
       const contentsHtml = converter.makeHtml(footnote.contentsMarkdown);
       html += `<li id="fn${footnote.footnoteId}" class="footnote-item" data-footnote-item data-footnote-index="${i+1}" data-footnote-id="${footnote.footnoteId}" role="doc-endnote">${returnLinkHtml}<div class="footnote-content" data-footnote-content>${contentsHtml}</div></li>`;

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -353,6 +353,9 @@ const conditionallyVisibleBlockStyles = (theme: ThemeType) => ({
     border: theme.palette.border.normal,
     borderRadius: 4,
     padding: 8,
+    "&.defaultHidden": {
+      display: "none",
+    },
   },
 });
 


### PR DESCRIPTION
 * Fix a bug that caused untranslated markdown adjacent to (not necessarily inside) conditionally visible sections
 * Fixed an issue that caused Arbital imported LaTeX to be inline (uncentered) when it should be block
 * Fix conditionally-visible blocks (such as Todo/Comment blocks in imported Arbital content) being incorrectly visible during SSR
 * trimHtmlDiff doesn't omit sections that have an <ins>/<del> as the root instead of being wrapped in a <p>
 * Link hover previews work inside conditionally-visible sections
 * Fix out-of-order footnote numbering on Arbital-imported pages that use certain formatting