### PR TITLE
Remove DeferredForumSelect

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -11,7 +11,7 @@ import { postStatuses } from '../posts/constants';
 import GraphQLJSON from 'graphql-type-json';
 import { REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../reviewUtils';
 import uniqBy from 'lodash/uniqBy'
-import { userThemeSettings, defaultThemeOptions } from "../../../themes/themeNames";
+import { userThemeSettings, getDefaultThemeOptions } from "../../../themes/themeNames";
 import { postsLayouts } from '../posts/dropdownOptions';
 import type { ForumIconName } from '../../../components/common/ForumIcon';
 import { getCommentViewOptions } from '../../commentViewOptions';
@@ -579,7 +579,7 @@ const schema: SchemaType<"Users"> = {
     type: userTheme,
     optional: true,
     nullable: true,
-    ...schemaDefaultValue(defaultThemeOptions),
+    ...schemaDefaultValue(getDefaultThemeOptions(), "deferred"),
     canCreate: ['members'],
     canUpdate: ownsOrIsAdmin,
     canRead: ownsOrIsAdmin,

--- a/packages/lesswrong/lib/forumTypeUtils.ts
+++ b/packages/lesswrong/lib/forumTypeUtils.ts
@@ -21,15 +21,3 @@ export function forumSelect<T>(forumOptions: ForumOptions<T>, forumType?: ForumT
   // @ts-ignore - if we get here, our type definition guarantees that there's a default set
   return forumOptions.default
 }
-
-export class DeferredForumSelect<T> {
-  constructor(private forumOptions: ForumOptions<T>) {}
-
-  getDefault() {
-    return "default" in this.forumOptions ? this.forumOptions.default : undefined;
-  }
-
-  get(forumType?: ForumTypeString): NonUndefined<T> {
-    return forumSelect(this.forumOptions, forumType);
-  }
-}

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -7,7 +7,6 @@ import { asyncFilter } from './asyncUtils';
 import type { GraphQLScalarType } from 'graphql';
 import DataLoader from 'dataloader';
 import * as _ from 'underscore';
-import { DeferredForumSelect } from '../forumTypeUtils';
 import { addSlugCallbacks, getUnusedSlugByCollectionName } from '@/server/utils/slugUtil';
 import { slugify } from './slugify';
 
@@ -414,16 +413,15 @@ export function googleLocationToMongoLocation(gmaps: AnyBecauseTodo) {
 }
 export function schemaDefaultValue<N extends CollectionNameString>(
   defaultValue: any,
+  initTiming: "build-time" | "deferred" = "build-time"
 ): Partial<CollectionFieldSpecification<N>> {
-  const isForumSpecific = defaultValue instanceof DeferredForumSelect;
-
   // Used for both onCreate and onUpdate
   const fillIfMissing = ({ newDocument, fieldName }: {
     newDocument: ObjectsByCollectionName[N];
     fieldName: string;
   }) => {
     if (newDocument[fieldName as keyof ObjectsByCollectionName[N]] === undefined) {
-      return isForumSpecific ? defaultValue.get() : defaultValue;
+      return defaultValue;
     } else {
       return undefined;
     }
@@ -442,7 +440,7 @@ export function schemaDefaultValue<N extends CollectionNameString>(
   };
 
   return {
-    defaultValue: isForumSpecific ? defaultValue.getDefault() : defaultValue,
+    defaultValue: initTiming === "build-time" ? defaultValue : undefined,
     onCreate: fillIfMissing,
     onUpdate: throwIfSetToNull,
     canAutofillDefault: true,

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -419,13 +419,8 @@ export function schemaDefaultValue<N extends CollectionNameString>(
   const fillIfMissing = ({ newDocument, fieldName }: {
     newDocument: ObjectsByCollectionName[N];
     fieldName: string;
-  }) => {
-    if (newDocument[fieldName as keyof ObjectsByCollectionName[N]] === undefined) {
-      return defaultValue;
-    } else {
-      return undefined;
-    }
-  };
+  }) => newDocument[fieldName as keyof ObjectsByCollectionName[N]] ?? defaultValue;
+
   const throwIfSetToNull = ({ oldDocument, document, fieldName }: {
     oldDocument: ObjectsByCollectionName[N];
     document: ObjectsByCollectionName[N];

--- a/packages/lesswrong/server/migrations/20250213T121131.defer_defaults.ts
+++ b/packages/lesswrong/server/migrations/20250213T121131.defer_defaults.ts
@@ -1,0 +1,12 @@
+import Users from "@/lib/vulcan-users"
+import { dropDefaultValue } from "./meta/utils"
+
+export const up = async ({db}: MigrationContext) => {
+  await dropDefaultValue(db, Users, "theme");
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await db.none(`
+    ALTER TABLE "Users" ALTER COLUMN theme SET DEFAULT '{"name":"default"}'::JSONB;
+  `);
+}

--- a/packages/lesswrong/server/sql/Type.ts
+++ b/packages/lesswrong/server/sql/Type.ts
@@ -2,7 +2,6 @@ import { getCollection } from "@/lib/vulcan-lib/getCollection";
 import GraphQLJSON from 'graphql-type-json';
 import SimpleSchema from "simpl-schema";
 import { ID_LENGTH } from "@/lib/random";
-import { DeferredForumSelect } from "@/lib/forumTypeUtils";
 import { ForumTypeString } from "@/lib/instanceSettings";
 import { editableFieldIsNormalized } from "@/lib/editor/makeEditableOptions";
 
@@ -81,12 +80,9 @@ export abstract class Type {
 
     if (schema.defaultValue !== undefined && schema.defaultValue !== null) {
       const {defaultValue, ...rest} = schema;
-      const value = defaultValue instanceof DeferredForumSelect
-        ? defaultValue.get(forumType)
-        : defaultValue;
       return new DefaultValueType(
         Type.fromSchema(collection, fieldName, rest, indexSchema, forumType),
-        value,
+        defaultValue,
       );
     }
 

--- a/packages/lesswrong/themes/themeNames.ts
+++ b/packages/lesswrong/themes/themeNames.ts
@@ -1,4 +1,4 @@
-import { DeferredForumSelect } from '../lib/forumTypeUtils';
+import { forumSelect } from '../lib/forumTypeUtils';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { TupleSet } from '../lib/utils/typeGuardUtils';
 
@@ -29,8 +29,8 @@ export type ThemeMetadata = {
   label: string
 }
 
-export const themeMetadata: Array<ThemeMetadata> = forumTypeSetting.get() === "EAForum"
-  ? [
+export const themeMetadata: Array<ThemeMetadata> = forumSelect({
+  EAForum: [
     {
       name: "auto",
       label: "Auto",
@@ -43,8 +43,8 @@ export const themeMetadata: Array<ThemeMetadata> = forumTypeSetting.get() === "E
       name: "dark",
       label: "Dark",
     },
-  ]
-  : [
+  ],
+  default: [
     {
       name: "default",
       label: "Default",
@@ -57,7 +57,8 @@ export const themeMetadata: Array<ThemeMetadata> = forumTypeSetting.get() === "E
       name: "auto",
       label: "Auto",
     },
-  ];
+  ],
+});
 
 export function isValidSerializedThemeOptions(options: string|object): options is string | AbstractThemeOptions {
   try {
@@ -99,13 +100,11 @@ export function getForumType(themeOptions: AbstractThemeOptions) {
   return (themeOptions?.siteThemeOverride && themeOptions.siteThemeOverride[actualForumType]) || actualForumType;
 }
 
-export const defaultThemeOptions = new DeferredForumSelect({
-  EAForum: {name: "auto"},
-  default: {name: "default"},
-} as const);
-
 export const getDefaultThemeOptions = (): AbstractThemeOptions =>
-  defaultThemeOptions.get();
+  forumSelect({
+    EAForum: {name: "auto"},
+    default: {name: "default"},
+  } as const)
 
 const deserializeThemeOptions = (themeOptions: object | string): AbstractThemeOptions => {
   if (typeof themeOptions === "string") {

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3206,7 +3206,7 @@ CREATE TABLE "Users" (
   "noindex" BOOL NOT NULL DEFAULT FALSE,
   "groups" TEXT[],
   "lwWikiImport" BOOL,
-  "theme" JSONB NOT NULL DEFAULT '{"name":"default"}'::JSONB,
+  "theme" JSONB NOT NULL,
   "lastUsedTimezone" TEXT,
   "whenConfirmationEmailSent" TIMESTAMPTZ,
   "legacy" BOOL NOT NULL DEFAULT FALSE,


### PR DESCRIPTION
I'm in the process of adding another case like this (where the default value depends on the forumType), and I think it's simpler to make this a manual flag rather than relying on an `instanceof` check. Reasoning:
- You still have to remember to use DeferredForumSelect (which is currently only used in one place), so the current version doesn't really catch errors for you
- There might be other reasons a default value would need to be deferred
- Applying the default at the schema level is a bit misleading for people reading the schema

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209397802520627) by [Unito](https://www.unito.io)
