### PR TITLE
Core-tag-assignments file marks some Arbital pages as excluded from import

### DIFF
--- a/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
+++ b/packages/lesswrong/server/scripts/arbitalImport/arbitalImport.ts
@@ -2211,7 +2211,7 @@ async function importCoreTagAssignments(coreTagAssignmentsFile: string) {
         deleted: true
       }}
     );
-  }));
+  }), 10);
 
   // Update each tag's coreTagId field
   await executePromiseQueue(filteredTagAssignments.map(ta => async () => {


### PR DESCRIPTION
...In which case we still import them into the DB as normal, but mark them as deleted, so that in the future when we make it so you can see the history of deleted wiki pages, they will be visible that way.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209404172268839) by [Unito](https://www.unito.io)
