### PR TITLE
Various Minor Wikitag Fixes

### DIFF
--- a/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { registerComponent, Components, fragmentTextForQuery } from '../../lib/vulcan-lib';
-import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { useLocation } from '../../lib/routeUtil';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import SearchIcon from '@material-ui/icons/Search';
@@ -200,6 +200,7 @@ const uncategorizedRootTag = {
   coreTagId: null,
   parentTagId: null,
   isArbitalImport: false,
+  wikiOnly: true,
 };
 
 // TODO: we really need to figure out a better way to handle this than slugs, especially with the merged rationality page
@@ -239,6 +240,7 @@ const ArbitalRedirectNotice = ({ onDismiss }: {
 
 const AllWikiTagsPage = () => {
   const classes = useStyles(styles);
+  const { captureEvent } = useTracking();
 
   const { WikiTagGroup, Loading, NewWikiTagButton } = Components;
 
@@ -274,6 +276,7 @@ const AllWikiTagsPage = () => {
   // Function to handle search state changes
   const handleSearchStateChange = (searchState: any) => {
     setCurrentQuery(searchState.query || '');
+    captureEvent('searchQueryUpdated', { query: searchState.query });
   };
 
   const CustomStateResults = connectStateResults(({ searchResults, isSearchStalled }) => {
@@ -287,6 +290,7 @@ const AllWikiTagsPage = () => {
     }
 
     return (
+      <AnalyticsContext searchQuery={currentQuery}>
       <div className={classes.mainContent}>
         {priorityTags.map((tag: ConceptItemFragment) => (
           tag && <WikiTagGroup
@@ -300,9 +304,10 @@ const AllWikiTagsPage = () => {
           coreTag={uncategorizedRootTag}
           searchTagIds={currentQuery ? tagIds : null}
           showArbitalIcons={isArbitalRedirect}
-          noLinkOrHoverOnTitle
-        />
-      </div>
+            noLinkOrHoverOnTitle
+          />
+        </div>
+      </AnalyticsContext>
     );
   });
 

--- a/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllWikiTagsPage.tsx
@@ -304,9 +304,9 @@ const AllWikiTagsPage = () => {
           coreTag={uncategorizedRootTag}
           searchTagIds={currentQuery ? tagIds : null}
           showArbitalIcons={isArbitalRedirect}
-            noLinkOrHoverOnTitle
-          />
-        </div>
+          noLinkOrHoverOnTitle
+        />
+      </div>
       </AnalyticsContext>
     );
   });

--- a/packages/lesswrong/components/tagging/ConceptItem.tsx
+++ b/packages/lesswrong/components/tagging/ConceptItem.tsx
@@ -171,7 +171,7 @@ const ConceptItem = ({
           : <TagsTooltip
               tagSlug={wikitag.slug}
               noPrefetch
-              previewPostCount={0}
+              previewPostCount={3}
               placement='right-start'
           >
             <Link to={tagGetUrl({ slug: wikitag.slug })}>
@@ -236,7 +236,7 @@ const ConceptItem = ({
             <ArbitalLogo className={classes.arbitalIcon} strokeWidth={0.7} />
           </LWTooltip>
         )}
-        {wikitag.postCount > 0 && (
+        {(wikitag.postCount > 0 && !wikitag.wikiOnly) && (
           <span className={classes.postCount}>
             <TagsTooltip
               tagSlug={wikitag.slug}

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -186,7 +186,7 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
     </div>
     <br />
     </>}
-    {!!numFlags && isLWorAF && <>
+    {!!numFlags && !isLWorAF && <>
       <div>
         This article has the following flag{tag.tagFlagsIds?.length > 1 ? "s" : ""}:{' '}
         {tag.tagFlags.map((flag, i) => <span key={flag._id}>{flag.name}{(i + 1) < tag.tagFlags?.length && ", "}</span>)}

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -172,7 +172,7 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
     && (undeletedLensCount < 5)
     && isLWorAF;
 
-  const editTooltipHasContent = noEditNotAuthor || noEditKarmaTooLow || numFlags || beginnersGuideContentTag
+  const editTooltipHasContent = noEditNotAuthor || noEditKarmaTooLow || (numFlags && !isLWorAF) || beginnersGuideContentTag
   const editTooltip = editTooltipHasContent && <>
     {noEditNotAuthor && <>
       <div>
@@ -186,7 +186,7 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
     </div>
     <br />
     </>}
-    {!!numFlags && <>
+    {!!numFlags && isLWorAF && <>
       <div>
         This article has the following flag{tag.tagFlagsIds?.length > 1 ? "s" : ""}:{' '}
         {tag.tagFlags.map((flag, i) => <span key={flag._id}>{flag.name}{(i + 1) < tag.tagFlags?.length && ", "}</span>)}

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -147,6 +147,7 @@ export type AnalyticsProps = {
   onsite?: boolean,
   terms?: PostsViewTerms,
   viewType?: string,
+  searchQuery?: string,
   componentName?: string,
   /** @deprecated Use `pageSectionContext` instead */
   listContext?: string,

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -475,6 +475,7 @@ registerFragment(`
       _id
       wordCount
     }
+    wikiOnly
     isArbitalImport
     coreTagId
     maxScore

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2930,6 +2930,7 @@ interface ConceptItemFragment { // fragment on Tags
   readonly postCount: number,
   readonly baseScore: number,
   readonly description: ConceptItemFragment_description|null,
+  readonly wikiOnly: boolean,
   readonly isArbitalImport: boolean|null,
   readonly coreTagId: string | null,
   readonly maxScore: number|null,


### PR DESCRIPTION
- fix concept item blank posts tooltip when tag is wikionly but still has some tagrels
- remove tagflags from edit tooltip for LW
- display some tags in the hover preview of core tags
- track search query and clicking on results when searching on Concepts page

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209414416707824) by [Unito](https://www.unito.io)
