### PR TITLE
Don't specify "NULLS FIRST"/"NULLS LAST" in PG sort on non-nullable fields

### DIFF
--- a/packages/lesswrong/server/sql/SelectQuery.ts
+++ b/packages/lesswrong/server/sql/SelectQuery.ts
@@ -1,6 +1,6 @@
 import Query, { Atom, sanitizeSqlComment } from "./Query";
 import Table from "./Table";
-import { IdType, UnknownType } from "./Type";
+import { DefaultValueType, IdType, NotNullType, Type, UnknownType } from "./Type";
 import { getCollectionByTableName } from "@/lib/vulcan-lib/getCollection";
 import { inspect } from "util";
 import { getCollationType } from "./collation";
@@ -343,9 +343,14 @@ class SelectQuery<T extends DbObject> extends Query<T> {
       this.atoms.push("ORDER BY");
       const sorts: string[] = [];
       for (const field in sort) {
-        const pgSorting = sort[field] === 1
-            ? "ASC NULLS FIRST"
-            : "DESC NULLS LAST"
+        const fieldType = this.table.getField(field)
+        const fieldIsNonnull =
+          (fieldType instanceof NotNullType)
+          || (fieldType instanceof DefaultValueType && fieldType.isNotNull());
+        const pgSorting =
+          (sort[field] === 1 ? "ASC" : "DESC")
+          + (fieldIsNonnull
+              ? "" : (sort[field] === 1 ? " NULLS FIRST" : " NULLS LAST"))
         sorts.push(`${this.resolveFieldName(field)} ${pgSorting}`);
       }
       this.atoms.push(sorts.join(", "));


### PR DESCRIPTION
This story starts with noticing that, in the PG performance analyzer on AWS, the following query is in the #1 spot, despite having only 0.08 calls/sec:

```
-- Comments.recentComments(limit)
SELECT "Comments".* FROM "Comments"
WHERE ( "debateResponse" IS NOT TRUE
   AND "rejected" IS NOT TRUE
   AND (
     ("authorIsUnreviewed" IS NOT TRUE OR "postedAt" < '2023-04-04T18:54:35.895+00:00')
       AND (("deleted" IS TRUE AND "deletedPublic" IS TRUE) OR "deleted" IS FALSE)
   )
   AND "score" > 0
   AND "deletedPublic" IS FALSE
)
ORDER BY "postedAt" DESC NULLS LAST
LIMIT ?
```

This corresponds to the recentComments view; it's used in /allComments and an RSS endpoint. Running EXPLAIN ANALYZE on this reveals that it is indeed a slow query, but performance gets drastically better if you replace `ORDER BY "postedAt" DESC NULLS LAST` with `ORDER BY "postedAt" DESC` (removing the "NULLS LAST"). Which is interesting because "postedAt" is not a nullable field. I checked that it is not nullable, in comments/schema.ts, schemas/accepted_schema.ts, introspecting on the production database, and finding the migration that made it not-nullable back in Dec 2023. It's as not-nullable as not-nullable can be. It looks like the query planner fails to take that into account, and uses a worse index, if the sort overrides the null-sorting.

This commit modifies the query planner to not put "NULLS FIRST" or "NULLS LAST" into the sort specification for fields that aren't nullable. This drastically improves the performance of /allComments, and probably improves the performance of some other queries as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209415897830141) by [Unito](https://www.unito.io)
