### PR TITLE
Speed up jargon-term resolver's check whether terms were bot-generated

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -47,6 +47,18 @@ export const getAdminTeamAccount = async () => {
   return account;
 }
 
+export const getAdminTeamAccountId = (() => {
+  let teamAccountId: string|null = null;
+  return async () => {
+    if (!teamAccountId) {
+      const teamAccount = await getAdminTeamAccount()
+      if (!teamAccount) return null;
+      teamAccountId = teamAccount._id;
+    }
+    return teamAccountId;
+  };
+})();
+
 /**
  * Don't send a PM to users if their comments are deleted with this reason.  Used for account deletion requests.
  */

--- a/packages/lesswrong/server/resolvers/jargonResolvers/jargonTermResolvers.ts
+++ b/packages/lesswrong/server/resolvers/jargonResolvers/jargonTermResolvers.ts
@@ -1,6 +1,6 @@
 import JargonTerms from "@/lib/collections/jargonTerms/collection";
 import { augmentFieldsDict } from "@/lib/utils/schemaUtils";
-import { getAdminTeamAccount } from "@/server/callbacks/commentCallbacks";
+import { getAdminTeamAccountId } from "@/server/callbacks/commentCallbacks";
 import Revisions from "@/lib/collections/revisions/collection";
 
 augmentFieldsDict(JargonTerms, {
@@ -8,8 +8,8 @@ augmentFieldsDict(JargonTerms, {
     resolveAs: {
       type: 'String',
       resolver: async (document: DbJargonTerm, args: void, context: ResolverContext): Promise<JargonTermsDefaultFragment['humansAndOrAIEdited'] | null> => {
-        const botAccount = await getAdminTeamAccount();
-        if (!botAccount) {
+        const botAccountId = await getAdminTeamAccountId();
+        if (!botAccountId) {
           return null;
         }
 
@@ -24,8 +24,8 @@ augmentFieldsDict(JargonTerms, {
           return null;
         }
         
-        const madeByAI = earliestRevision.userId === botAccount._id;
-        const editedByHumans = latestRevision.userId !== botAccount._id;
+        const madeByAI = earliestRevision.userId === botAccountId;
+        const editedByHumans = latestRevision.userId !== botAccountId;
 
         if (madeByAI && editedByHumans) {
           return 'humansAndAI';


### PR DESCRIPTION
Fetching the site admin account was on the postgres slow query leaderboard, which was dumb. Cache it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209415992376607) by [Unito](https://www.unito.io)
