### PR TITLE
Fix n plus one review comment query

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -3130,7 +3130,12 @@ const schema: SchemaType<"Posts"> = {
     canRead: ['guests'],
     resolver: async (post: DbPost, args: {}, context: ResolverContext) => {
       const { currentUser, Comments } = context;
-      const reviews = await context.Comments.find({postId: post._id, baseScore: {$gte: 10}, reviewingForReview: {$ne: null}}, {sort: {baseScore: -1}, limit: 2}).fetch();
+      const reviews = await getWithCustomLoader(
+        context,
+        'postReviews',
+        post._id,
+        (postIds: string[]) => context.repos.comments.getPostReviews(postIds, 2, 10),
+      );
       return await accessFilterMultiple(currentUser, Comments, reviews, context);
     }
   }),

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -9,7 +9,7 @@ import { EA_FORUM_COMMUNITY_TOPIC_ID } from "../../lib/collections/tags/collecti
 import { recordPerfMetrics } from "./perfMetricWrapper";
 import { forumSelect } from "../../lib/forumTypeUtils";
 import { isAF } from "../../lib/instanceSettings";
-import { getViewablePostsSelector } from "./helpers";
+import { getViewableCommentsSelector, getViewablePostsSelector } from "./helpers";
 
 type ExtendedCommentWithReactions = DbComment & {
   yourVote?: string,
@@ -428,6 +428,29 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     `,
       [commentId, limit]
     );
+  }
+
+  async getPostReviews(postIds: string[], reviewsPerPost: number, minScore: number): Promise<DbComment[][]> {
+    const comments = await this.manyOrNone(`
+      -- CommentsRepo.getPostReviews
+      WITH cte AS (
+        SELECT
+          comment_with_rownumber.*,
+          ROW_NUMBER() OVER (PARTITION BY comment_with_rownumber."postId" ORDER BY comment_with_rownumber."baseScore" DESC) as rn
+        FROM "Comments" comment_with_rownumber
+        WHERE comment_with_rownumber."postId" IN ($1:csv)
+        AND comment_with_rownumber."reviewingForReview" IS NOT NULL
+        AND comment_with_rownumber."baseScore" >= $3
+        AND ${getViewableCommentsSelector('comment_with_rownumber')}
+      )
+      SELECT *
+      FROM cte
+      WHERE rn <= $2
+      ORDER BY "baseScore" DESC
+    `, [postIds, reviewsPerPost, minScore]);
+    
+    const commentsByPost = groupBy(comments, c=>c.postId);
+    return postIds.map(postId => commentsByPost[postId] ?? []);
   }
 }
 

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -39,3 +39,12 @@ export const getViewableTagsSelector = (tagsTableAlias?: string) => {
     ${aliasPrefix}"adminOnly" = FALSE
   `;
 }
+
+export const getViewableCommentsSelector = (commentsTableAlias?: string) => {
+  const aliasPrefix = commentsTableAlias ? `${commentsTableAlias}.` : "";
+  return `
+    ${aliasPrefix}"rejected" IS NOT TRUE AND
+    ${aliasPrefix}"debateResponse" IS NOT TRUE AND
+    ${aliasPrefix}"authorIsUnreviewed" IS NOT TRUE
+  `;
+};

--- a/packages/lesswrong/server/sql/sqlClient.ts
+++ b/packages/lesswrong/server/sql/sqlClient.ts
@@ -1,6 +1,6 @@
 import type { DbTarget } from "./PgCollection";
 
-export const logAllQueries = false;
+export const logAllQueries = true;
 
 /** Main sql client which is safe to use for all queries */
 let sql: SqlClient | null = null;


### PR DESCRIPTION
The `reviews` resolver field was an n+1 query, which was particularly bad on the top posts page which was fetching hundreds of posts at the same time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209418670993021) by [Unito](https://www.unito.io)
