### PR TITLE
move clientId middleware logic inside of the render queue for SSR requests

### DIFF
--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -255,7 +255,7 @@ export function startWebserver() {
 
   app.use('/graphql', express.json({ limit: '50mb' }));
   app.use('/graphql', express.text({ type: 'application/graphql' }));
-  app.use('/graphql', perfMetricMiddleware, clientIdMiddleware);
+  app.use('/graphql', clientIdMiddleware, perfMetricMiddleware);
   apolloServer.applyMiddleware({ app })
 
   addStaticRoute("/js/bundle.js", ({query}, req, res, context) => {

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -25,7 +25,7 @@ import { embedAsGlobalVar } from './vulcan-lib/apollo-ssr/renderUtil';
 import { addAuthMiddlewares, expressSessionSecretSetting } from './authenticationMiddlewares';
 import { addForumSpecificMiddleware } from './forumSpecificMiddleware';
 import { addSentryMiddlewares, logGraphqlQueryStarted, logGraphqlQueryFinished } from './logging';
-import { addClientIdMiddleware } from './clientIdMiddleware';
+import { clientIdMiddleware } from './clientIdMiddleware';
 import { classesForAbTestGroups } from '../lib/abTestImpl';
 import expressSession from 'express-session';
 import MongoStore from './vendor/ConnectMongo/MongoStore';
@@ -87,7 +87,7 @@ const ssrInteractionDisable = isE2E
 /**
  * If allowed, write the prefetchPrefix to the response so the client can start downloading resources
  */
-const maybePrefetchResources = async ({
+const maybePrefetchResources = ({
   request,
   response,
   parsedRoute,
@@ -99,18 +99,22 @@ const maybePrefetchResources = async ({
   prefetchPrefix: string;
 }) => {
 
-  const enableResourcePrefetch = parsedRoute.currentRoute?.enableResourcePrefetch;
-  const prefetchResources =
-    typeof enableResourcePrefetch === "function"
-      ? await enableResourcePrefetch(request, response, parsedRoute, createAnonymousContext())
-      : enableResourcePrefetch;
+  const maybeWritePrefetchedResourcesToResponse = async () => {
+    const enableResourcePrefetch = parsedRoute.currentRoute?.enableResourcePrefetch;
+    const prefetchResources =
+      typeof enableResourcePrefetch === "function"
+        ? await enableResourcePrefetch(request, response, parsedRoute, createAnonymousContext())
+        : enableResourcePrefetch;
 
-  if (prefetchResources) {
-    response.setHeader("X-Accel-Buffering", "no"); // force nginx to send start of response immediately
-    trySetResponseStatus({ response, status: 200 });
-    response.write(prefetchPrefix);
-  }
-  return prefetchResources;
+    if (prefetchResources) {
+      response.setHeader("X-Accel-Buffering", "no"); // force nginx to send start of response immediately
+      trySetResponseStatus({ response, status: 200 });
+      response.write(prefetchPrefix);
+    }
+    return prefetchResources;
+  };
+
+  return maybeWritePrefetchedResourcesToResponse;
 };
 
 class ApolloServerLogging implements ApolloServerPlugin<ResolverContext> {
@@ -198,7 +202,7 @@ export function startWebserver() {
   }
 
   app.use(express.urlencoded({ extended: true })); // We send passwords + username via urlencoded form parameters
-  app.use('/analyticsEvent', express.json({ limit: '50mb' }));
+  app.use('/analyticsEvent', express.json({ limit: '50mb' }), clientIdMiddleware);
   app.use('/ckeditor-webhook', express.json({ limit: '50mb' }));
 
   if (isElasticEnabled) {
@@ -214,7 +218,6 @@ export function startWebserver() {
   addForumSpecificMiddleware(addMiddleware);
   addSentryMiddlewares(addMiddleware);
   addCacheControlMiddleware(addMiddleware);
-  addClientIdMiddleware(addMiddleware);
   if (isDatadogEnabled) {
     app.use(datadogMiddleware);
   }
@@ -252,7 +255,7 @@ export function startWebserver() {
 
   app.use('/graphql', express.json({ limit: '50mb' }));
   app.use('/graphql', express.text({ type: 'application/graphql' }));
-  app.use('/graphql', perfMetricMiddleware);
+  app.use('/graphql', perfMetricMiddleware, clientIdMiddleware);
   apolloServer.applyMiddleware({ app })
 
   addStaticRoute("/js/bundle.js", ({query}, req, res, context) => {
@@ -292,7 +295,7 @@ export function startWebserver() {
     }
   });
   // Setup CKEditor Token
-  app.use("/ckeditor-token", ckEditorTokenHandler)
+  app.use("/ckeditor-token", clientIdMiddleware, ckEditorTokenHandler)
   
   // Static files folder
   app.use(express.static(path.join(__dirname, '../../client')))
@@ -437,16 +440,18 @@ export function startWebserver() {
     const prefetchResourcesPromise = maybePrefetchResources({ request, response, parsedRoute, prefetchPrefix });
 
     const renderResultPromise = performanceMetricLoggingEnabled.get()
-      ? asyncLocalStorage.run({}, () => renderWithCache(request, response, user, tabId))
-      : renderWithCache(request, response, user, tabId);
+      ? asyncLocalStorage.run({}, () => renderWithCache(request, response, user, tabId, prefetchResourcesPromise))
+      : renderWithCache(request, response, user, tabId, prefetchResourcesPromise);
 
-    const [prefetchingResources, renderResult] = await Promise.all([prefetchResourcesPromise, renderResultPromise]);
+    const renderResult = await renderResultPromise;
 
     if (renderResult.aborted) {
       trySetResponseStatus({ response, status: 499 });
       response.end();
       return;
     }
+
+    const prefetchingResources = await renderResult.prefetchedResources;
 
     const {
       ssrBody,

--- a/packages/lesswrong/server/autocompleteEndpoint.ts
+++ b/packages/lesswrong/server/autocompleteEndpoint.ts
@@ -10,6 +10,7 @@ import { pipeline } from 'stream/promises'
 import { hyperbolicApiKey } from "@/lib/instanceSettings";
 import { runFragmentMultiQuery } from "./vulcan-lib/query";
 import Users from "@/lib/vulcan-users";
+import { clientIdMiddleware } from "./clientIdMiddleware";
 
 
 
@@ -262,7 +263,7 @@ ${finalSection}`.trim();
 
 
 export function addAutocompleteEndpoint(app: Express) {
-  app.use("/api/autocomplete", express.json());
+  app.use("/api/autocomplete", express.json(), clientIdMiddleware);
   app.post("/api/autocomplete", async (req, res) => {
     const context = await getContextFromReqAndRes({req, res, isSSR: false});
     const currentUser = context.currentUser

--- a/packages/lesswrong/server/clientIdMiddleware.ts
+++ b/packages/lesswrong/server/clientIdMiddleware.ts
@@ -1,6 +1,5 @@
 import { isNotRandomId, randomId } from '../lib/random';
 import { getCookieFromReq, setCookieOnResponse } from './utils/httpUtil';
-import type { AddMiddlewareType } from './apolloServer';
 import express from 'express';
 import { responseIsCacheable } from './cacheControlMiddleware';
 import { ClientIdsRepo } from './repos';
@@ -24,85 +23,89 @@ const isApplicableUrl = (url: string) =>
 const CLIENT_ID_COOKIE_EXPIRATION_SECONDS = 10 * 365 * 24 * 60 * 60;
 
 /**
+ * This is used in three contexts:
+ * 1. In the middleware, where we want to conditionally await the promise depending on the route
+ * 2. In both cachedPageRender and renderPage, where we want to ensure the clientId is set before prefetching resources (but don't want to block the render)
+ */
+export async function ensureClientId(req: express.Request, res: express.Response) {
+  const existingClientId = getCookieFromReq(req, "clientId")
+  const referrer = req.headers?.["referer"] ?? null;
+  const url = req.url;
+
+  const clientIdsRepo = new ClientIdsRepo()
+
+  // 1. If there is no client id, and this page won't be cached, create a clientId and add it to the response
+  let newClientId: string | null = null
+  if (!existingClientId && !responseIsCacheable(res)) {
+    newClientId = randomId();
+    setCookieOnResponse({
+      req, res,
+      cookieName: "clientId",
+      cookieValue: newClientId,
+      maxAge: CLIENT_ID_COOKIE_EXPIRATION_SECONDS
+    });
+  }
+
+  // 2. If there is a client id, ensure (asynchronously) that it is stored in the DB
+  const clientId = existingClientId ?? newClientId;
+  const userId = getUserFromReq(req)?._id;
+
+  const shouldEnsureClientId = clientId && isApplicableUrl(req.url) && !isNotRandomId(clientId) && !hasSeen({ clientId, userId });
+  if (!shouldEnsureClientId) {
+    return () => Promise.resolve();
+  }
+
+  try {
+    const { invalidated } = await clientIdsRepo.ensureClientId({
+      clientId,
+      userId,
+      referrer,
+      landingPage: url,
+    });
+
+    if (invalidated) {
+      const refreshedClientId = randomId();
+
+      await clientIdsRepo.ensureClientId({
+        clientId: refreshedClientId,
+        userId,
+        referrer,
+        landingPage: url,
+      });
+
+      // Cookies are returned with the headers
+      if (!res.headersSent) {
+        setCookieOnResponse({
+          req, res,
+          cookieName: "clientId",
+          cookieValue: refreshedClientId,
+          maxAge: CLIENT_ID_COOKIE_EXPIRATION_SECONDS
+        });
+      }
+
+      setHasSeen({ clientId: refreshedClientId, userId });
+    } else {
+      setHasSeen({ clientId, userId });
+    }
+  } catch (e) {
+    //eslint-disable-next-line no-console
+    console.error(e);
+  }
+}
+
+/**
  * - Assign a client id if there isn't one currently assigned
  * - Ensure the client id is stored in our DB (it may have been generated externally)
  * - Ensure the clientId and userId are associated
  */
-export const addClientIdMiddleware = (addMiddleware: AddMiddlewareType) => {
-  addMiddleware(async function addClientId(req: express.Request, res: express.Response, next: express.NextFunction) {
 
-    const existingClientId = getCookieFromReq(req, "clientId")
-    const referrer = req.headers?.["referer"] ?? null;
-    const url = req.url;
+export async function clientIdMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
+  // TODO: don't execute this call in the middleware on requests that might trigger renders?
+  if (req.url === '/analyticsEvent') {
+    await ensureClientId(req, res);
+  } else {
+    void ensureClientId(req, res);
+  }
 
-    const clientIdsRepo = new ClientIdsRepo()
-
-    // 1. If there is no client id, and this page won't be cached, create a clientId and add it to the response
-    let newClientId: string | null = null
-    if (!existingClientId && !responseIsCacheable(res)) {
-      newClientId = randomId();
-      setCookieOnResponse({
-        req, res,
-        cookieName: "clientId",
-        cookieValue: newClientId,
-        maxAge: CLIENT_ID_COOKIE_EXPIRATION_SECONDS
-      });
-    }
-
-    // 2. If there is a client id, ensure (asynchronously) that it is stored in the DB
-    const clientId = existingClientId ?? newClientId;
-    const userId = getUserFromReq(req)?._id;
-    if (clientId && isApplicableUrl(req.url) && !isNotRandomId(clientId) && !hasSeen({ clientId, userId })) {
-      try {
-        // This is a wrapped promise because we don't want to hold up the rest of the request with the round trip
-        // However, if we get a request with a clientId that we've invalidated (i.e. because we had an oopsie and wrote too many userIds to it),
-        // we want to return a new clientId to the requester.
-        // We do this in a blocking way when the request is for /analyticsEvent, since clients don't care about response times on that route.
-        const ensureClientIdPromise = (async () => {
-          const { invalidated } = await clientIdsRepo.ensureClientId({
-            clientId,
-            userId,
-            referrer,
-            landingPage: url,
-          });
-
-          if (invalidated) {
-            const refreshedClientId = randomId();
-
-            await clientIdsRepo.ensureClientId({
-              clientId: refreshedClientId,
-              userId,
-              referrer,
-              landingPage: url,
-            });
-
-            // Cookies are returned with the headers
-            if (!res.headersSent) {
-              setCookieOnResponse({
-                req, res,
-                cookieName: "clientId",
-                cookieValue: refreshedClientId,
-                maxAge: CLIENT_ID_COOKIE_EXPIRATION_SECONDS
-              });
-            }
-
-            setHasSeen({ clientId: refreshedClientId, userId });
-          } else {
-            setHasSeen({ clientId, userId });
-          }
-        });
-
-        if (url === '/analyticsEvent') {
-          await ensureClientIdPromise();
-        } else {
-          void ensureClientIdPromise();
-        }
-      } catch(e) {
-        //eslint-disable-next-line no-console
-        console.error(e);
-      }
-    }
-
-    next();
-  });
+  next();
 }

--- a/packages/lesswrong/server/resolvers/anthropicResolvers.ts
+++ b/packages/lesswrong/server/resolvers/anthropicResolvers.ts
@@ -16,6 +16,7 @@ import { markdownToHtml, htmlToMarkdown } from "../editor/conversionUtils";
 import { getOpenAI } from "../languageModels/languageModelIntegration";
 import express, { Express } from "express";
 import { captureException } from "@sentry/core";
+import { clientIdMiddleware } from "../clientIdMiddleware";
 
 interface InitializeConversationArgs {
   newMessage: ClientMessage;
@@ -532,7 +533,7 @@ async function prepareMessagesForConversation({ newMessage, conversationId, cont
 
 
 export function addLlmChatEndpoint(app: Express) {
-  app.use("/api/sendLlmChat", express.json());
+  app.use("/api/sendLlmChat", express.json(), clientIdMiddleware);
   app.post("/api/sendLlmChat", async (req, res) => {
     const context = await getContextFromReqAndRes({req, res, isSSR: false});
     const currentUser = context.currentUser;

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -145,7 +145,7 @@ function openRenderRequestPerfMetric(renderParams: AttemptCachedRenderParams | A
   setAsyncStoreValue('requestPerfMetric', perfMetric);
 }
 
-function closeRenderRequstPerfMetric(rendered: RenderResult & { cached?: boolean }) {
+function closeRenderRequestPerfMetric(rendered: RenderResult & { cached?: boolean }) {
   if (!performanceMetricLoggingEnabled.get()) return;
 
   setAsyncStoreValue('requestPerfMetric', (incompletePerfMetric) => {
@@ -288,7 +288,7 @@ export const renderWithCache = async (req: Request, res: Response, user: DbUser|
     rendered = await queueRenderRequest({ req, res, userAgent, startTime, user, cacheAttempt, maybePrefetchResources });
   }
 
-  closeRenderRequstPerfMetric(rendered);
+  closeRenderRequestPerfMetric(rendered);
 
   if (rendered.aborted) {
     return rendered;

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -26,7 +26,7 @@ import { DatabaseServerSetting } from '../../databaseSettings';
 import type { Request, Response } from 'express';
 import { DEFAULT_TIMEZONE } from '../../../lib/utils/timeUtil';
 import { getIpFromRequest } from '../../datadog/datadogMiddleware';
-import { addStartRenderTimeToPerfMetric, asyncLocalStorage, closePerfMetric, closeRequestPerfMetric, openPerfMetric, setAsyncStoreValue } from '../../perfMetrics';
+import { addStartRenderTimeToPerfMetric, closeRequestPerfMetric, openPerfMetric, setAsyncStoreValue } from '../../perfMetrics';
 import { maxRenderQueueSize, queuedRequestTimeoutSecondsSetting, commentPermalinkStyleSetting } from '../../../lib/publicSettings';
 import { performanceMetricLoggingEnabled } from '../../../lib/instanceSettings';
 import { getClientIP } from '@/server/utils/getClientIP';
@@ -37,6 +37,7 @@ import { visitorGetsDynamicFrontpage } from '../../../lib/betas';
 import { responseIsCacheable } from '../../cacheControlMiddleware';
 import moment from 'moment';
 import { preloadScrollToCommentScript } from '@/lib/scrollUtils';
+import { ensureClientId } from '@/server/clientIdMiddleware';
 
 const slowSSRWarnThresholdSetting = new DatabaseServerSetting<number>("slowSSRWarnThreshold", 3000);
 
@@ -46,7 +47,7 @@ type RenderTimings = {
   renderTime: number
 }
 
-export type RenderResult = {
+export interface RenderSuccessResult {
   ssrBody: string
   headers: Array<string>
   serializedApolloState: string
@@ -62,164 +63,243 @@ export type RenderResult = {
   timezone: string,
   timings: RenderTimings,
   aborted: false,
-} | {
-  aborted: true
+  prefetchedResources: Promise<boolean | undefined>,
 }
 
-interface RenderRequestParams {
+interface RenderAbortResult {
+  aborted: true;
+}
+
+export type RenderResult = RenderSuccessResult | RenderAbortResult;
+
+interface CacheMissParams {
+  cacheAttempt: true;
+  prefetchedResources: Promise<boolean | undefined>;
+}
+
+interface CacheSkipParams {
+  cacheAttempt: false;
+  maybePrefetchResources: () => Promise<boolean | undefined>;
+}
+
+interface BaseRenderRequestParams {
   req: Request,
   user: DbUser|null,
   startTime: Date,
   res: Response,
-  clientId?: string,
   userAgent?: string,
 }
+
+type RenderRequestParams = BaseRenderRequestParams & (CacheMissParams | CacheSkipParams);
 
 interface RenderPriorityQueueSlot extends RequestData {
   callback: () => Promise<void>;
   renderRequestParams: RenderRequestParams;
 }
 
-export const renderWithCache = async (req: Request, res: Response, user: DbUser|null, tabId: string | null) => {
-  const startTime = new Date();
+interface AttemptCachedRenderParams {
+  req: Request;
+  res: Response;
+  startTime: Date;
+  userAgent?: string;
+  url: string;
+  tabId: string|null;
+  ip: string;
+  cacheAttempt: true;
+}
+
+interface AttemptNonCachedRenderParams {
+  req: Request;
+  res: Response;
+  startTime: Date;
+  userAgent?: string;
+  url: string;
+  tabId: string|null;
+  ip: string;
+  cacheAttempt: false;
+  user: DbUser|null;
+}
+
+function openRenderRequestPerfMetric(renderParams: AttemptCachedRenderParams | AttemptNonCachedRenderParams) {
+  if (!performanceMetricLoggingEnabled.get()) return;
+
+  const { req, startTime, userAgent } = renderParams;
   
+  const userIdField = !renderParams.cacheAttempt
+    ? { user_id: renderParams.user?._id }
+    : {};
+
+  const opName = renderParams.cacheAttempt
+    ? "unknown"
+    : "skipCache";
+
+  const perfMetric = openPerfMetric({
+    op_type: "ssr",
+    op_name: opName,
+    client_path: req.originalUrl,
+    ip: getClientIP(req),
+    user_agent: userAgent,
+    ...userIdField,
+  }, startTime);
+
+  setAsyncStoreValue('requestPerfMetric', perfMetric);
+}
+
+function closeRenderRequstPerfMetric(rendered: RenderResult & { cached?: boolean }) {
+  if (!performanceMetricLoggingEnabled.get()) return;
+
+  setAsyncStoreValue('requestPerfMetric', (incompletePerfMetric) => {
+    if (!incompletePerfMetric) return;
+
+    if (incompletePerfMetric.op_name !== "unknown") {
+      return incompletePerfMetric;
+    }
+
+    // If we're closing a request that was eligible for caching, we would have initially set the op_name to "unknown"
+    // We need to set the op_name to "cacheHit" or "cacheMiss" here, after we've determined which it was
+    const opName = rendered.cached ? "cacheHit" : "cacheMiss";
+    return {
+      ...incompletePerfMetric,
+      op_name: opName
+    }
+  });
+
+  closeRequestPerfMetric();
+}
+
+function recordSsrAnalytics(
+  params: AttemptCachedRenderParams | AttemptNonCachedRenderParams,
+  rendered: Exclude<RenderResult, { aborted: true }> & { cached?: boolean }
+) {
+  const { req, startTime, userAgent, url, tabId, ip } = params;
+
+  if (!shouldRecordSsrAnalytics(userAgent)) return;
+
+  const clientId = getCookieFromReq(req, "clientId");
+
+  const userId = params.cacheAttempt
+    ? null
+    : params.user?._id;
+
+  const timings = params.cacheAttempt
+    ? { totalTime: new Date().valueOf() - startTime.valueOf() }
+    : rendered.timings;
+
+  const cached = params.cacheAttempt
+    ? rendered.cached
+    : false;
+
+  const abTestGroups = rendered.allAbTestGroups;
+
+  Vulcan.captureEvent("ssr", {
+    url,
+    tabId,
+    clientId,
+    ip,
+    userAgent,
+    userId,
+    timings,
+    abTestGroups,
+    cached,
+  });
+}
+
+function getRequestMetadata(req: Request) {
   const ip = getIpFromRequest(req)
   const userAgent = req.headers["user-agent"];
-  
   const url = getPathFromReq(req);
-  
-  const clientId = getCookieFromReq(req, "clientId");
-  
-  const ssrEventParams = {
-    url: url,
-    clientId, tabId,
-    userAgent: userAgent,
-  };
+
+  return { ip, userAgent, url };
+}
+function shouldSkipCache(req: Request, user: DbUser|null) {
+  const { userAgent, url } = getRequestMetadata(req);
 
   const isHealthCheck = userAgent === healthCheckUserAgentSetting.get();
-  const abTestGroups = getAllUserABTestGroups(user ? {user} : {clientId});
-  
+
   // Skip the page-cache if the user-agent is Slackbot's link-preview fetcher
   // because we need to render that page with a different value for the
   // twitter:card meta tag (see also: HeadTags.tsx, Head.tsx).
   const isSlackBot = userAgent && userAgent.startsWith("Slackbot-LinkExpanding");
-  
-  const userDescription = user?.username ?? `logged out ${ip} (${userAgent})`;
-  
+
   const lastVisitedFrontpage = getCookieFromReq(req, LAST_VISITED_FRONTPAGE_COOKIE);
   // For LW, skip the cache on users who have visited the frontpage before, including logged out. 
   // Doing this so we can show dynamic latest posts list with varying HN decay parameters based on visit frequency (see useractivities/cron.ts).
   const showDynamicFrontpage = !!lastVisitedFrontpage && visitorGetsDynamicFrontpage(user) && url === "/";
-  
-  if ((!isHealthCheck && (user || isExcludedFromPageCache(url))) || isSlackBot || showDynamicFrontpage) {
-    // When logged in, don't use the page cache (logged-in pages have notifications and stuff)
-    recordCacheBypass({path: getPathFromReq(req), userAgent: userAgent ?? ''});
-    
-    if (performanceMetricLoggingEnabled.get()) {
-      const perfMetric = openPerfMetric({
-        op_type: "ssr",
-        op_name: "skipCache",
-        client_path: req.originalUrl,
-        //we compute ip via two different methods in the codebase, using this one to be consistent with other perf_metrics
-        ip: getClientIP(req),
-        user_agent: userAgent,
-        user_id: user?._id
-      }, startTime);
 
-      setAsyncStoreValue('requestPerfMetric', perfMetric);
-    }
+  return (
+    (!isHealthCheck && (user || isExcludedFromPageCache(url))) ||
+    isSlackBot ||
+    showDynamicFrontpage
+  );
+}
 
-    const rendered = await queueRenderRequest({
-      req, user, startTime, res, clientId, userAgent,
-    });
+function logRequestToConsole(
+  req: Request,
+  user: DbUser | null,
+  tabId: string | null,
+  rendered: Exclude<RenderResult, { aborted: true }> & { cached?: boolean }
+) {
+  const { ip, userAgent, url } = getRequestMetadata(req);
 
-    if (performanceMetricLoggingEnabled.get()) {
-      closeRequestPerfMetric();
-    }
-    
-    if (rendered.aborted) {
-      return rendered;
-    }
+  const userDescription = user?.username ?? `logged out ${ip} (${userAgent})`;
 
-    if (shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
-      // Capture an analytics event at the conclusion of the render
-      Vulcan.captureEvent("ssr", {
-        ...ssrEventParams,
-        userId: user?._id,
-        timings: rendered.timings,
-        cached: false,
-        abTestGroups: rendered.allAbTestGroups,
-        ip
-      });
-    }
-
+  if (rendered.cached) {
     // eslint-disable-next-line no-console
-    console.log(`Finished SSR of ${url} for ${userDescription} (${formatTimings(rendered.timings)}, tab ${tabId})`);
-    
-    return {
-      ...rendered,
-      headers: [...rendered.headers],
-    };
+    console.log(`Served ${url} from cache for ${userDescription}`);
   } else {
-    if (performanceMetricLoggingEnabled.get()) {
-      const perfMetric = openPerfMetric({
-        op_type: "ssr",
-        op_name: "unknown",
-        client_path: req.originalUrl,
-        //we compute ip via two different methods in the codebase, using this one to be consistent with other perf_metrics
-        ip: getClientIP(req),
-        user_agent: userAgent
-      }, startTime);
-
-      setAsyncStoreValue('requestPerfMetric', perfMetric);
-    }
-
-    const rendered = await cachedPageRender(req, abTestGroups, userAgent, (req: Request) => queueRenderRequest({
-      req, user: null, startTime, res, clientId, userAgent
-    }));
-    
-    if (rendered.aborted) {
-      return rendered;
-    }
-
-    if (rendered.cached) {
-      // eslint-disable-next-line no-console
-      console.log(`Served ${url} from cache for ${userDescription}`);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log(`Finished SSR of ${url} for ${userDescription}: (${formatTimings(rendered.timings)}, tab ${tabId})`);
-    }
-
-    if (performanceMetricLoggingEnabled.get()) {
-      setAsyncStoreValue('requestPerfMetric', (incompletePerfMetric) => {
-        if (!incompletePerfMetric) return;
-        return {
-          ...incompletePerfMetric,
-          op_name: rendered.cached ? "cacheHit" : "cacheMiss"
-        }
-      });
-
-      closeRequestPerfMetric();
-    }
-
-    if (shouldRecordSsrAnalytics(ssrEventParams.userAgent)) {
-      Vulcan.captureEvent("ssr", {
-        ...ssrEventParams,
-        userId: null,
-        timings: {
-          totalTime: new Date().valueOf()-startTime.valueOf(),
-        },
-        abTestGroups: rendered.allAbTestGroups,
-        cached: rendered.cached,
-        ip
-      });
-    }
-    
-    return {
-      ...rendered,
-      headers: [...rendered.headers],
-    };
+    // eslint-disable-next-line no-console
+    console.log(`Finished SSR of ${url} for ${userDescription}: (${formatTimings(rendered.timings)}, tab ${tabId})`);
   }
+}
+
+export const renderWithCache = async (req: Request, res: Response, user: DbUser|null, tabId: string | null, maybePrefetchResources: () => Promise<boolean | undefined>) => {
+  const startTime = new Date();
+  
+  const { ip, userAgent, url } = getRequestMetadata(req);
+
+  const cacheAttempt = !shouldSkipCache(req, user);
+
+  const baseRenderParams = { req, res, startTime, userAgent, url, tabId, ip };
+  const cacheSensitiveParams = cacheAttempt
+    ? { cacheAttempt }
+    : { cacheAttempt: false, user } as const;
+
+  const renderParams: AttemptCachedRenderParams | AttemptNonCachedRenderParams = { ...baseRenderParams, ...cacheSensitiveParams };
+
+  // If the request isn't eligible to hit the page cache, we record a cache bypass
+  if (!cacheAttempt) {
+    recordCacheBypass({ path: getPathFromReq(req), userAgent: userAgent ?? '' });
+  }
+
+  openRenderRequestPerfMetric(renderParams);
+
+  let rendered: RenderResult & { cached?: boolean };
+  if (cacheAttempt) {
+    rendered = await cachedPageRender(
+      req, res, userAgent, maybePrefetchResources,
+      // We need the result of `maybePrefetchResources` in both `cachedPageRender` and `queueRenderRequest`
+      // In the case where the page is cached, we need to return the result of the promise from `cachedPageRender`
+      // In the case where the page is not cached, we need to return the result of the promise from `queueRenderRequest`
+      // But we don't want to call `maybePrefetchResources` twice, so we pipe through the promise we get from calling `maybePrefetchResources` in `cachedPageRender`
+      (req, prefetchedResources) => queueRenderRequest({ req, res, userAgent, startTime, user: null, cacheAttempt, prefetchedResources })
+    );
+  } else {
+    rendered = await queueRenderRequest({ req, res, userAgent, startTime, user, cacheAttempt, maybePrefetchResources });
+  }
+
+  closeRenderRequstPerfMetric(rendered);
+
+  if (rendered.aborted) {
+    return rendered;
+  }
+
+  logRequestToConsole(req, user, tabId, rendered);
+  recordSsrAnalytics(renderParams, rendered);
+
+  return {
+    ...rendered,
+    headers: [...rendered.headers],
+  };
 };
 
 let inFlightRenderCount = 0;
@@ -351,7 +431,23 @@ const buildSSRBody = (htmlContent: string, userAgent?: string) => {
   return `${prefix}<div id="react-app">${htmlContent}</div>${suffix}`;
 }
 
-const renderRequest = async ({req, user, startTime, res, clientId, userAgent}: RenderRequestParams): Promise<RenderResult> => {
+const renderRequest = async ({req, user, startTime, res, userAgent, ...cacheAttemptParams}: RenderRequestParams): Promise<RenderResult> => {
+  let prefetchedResources: Promise<boolean | undefined>;
+  if (!cacheAttemptParams.cacheAttempt) {
+    // If this is rendering a request for a page that is not cache-eligible,
+    // we would not yet have called either ensureClientId or maybePrefetchResources
+    // We need to call ensureClientId before:
+    // 1. prefetching resources (because that might write to the response, and we need to set the headers before that)
+    // 2. computing context (to ensure the clientId is set on the request)
+    void ensureClientId(req, res);
+    prefetchedResources = cacheAttemptParams.maybePrefetchResources();
+  } else {
+    // If this is rendering a request for a cache-eligible page that was a cache miss,
+    // we would have called ensureClientId and maybePrefetchResources already in `cachedPageRender`
+    // We can just use the prefetchedResources that were passed in from `cachedPageRender`, and don't need to call ensureClientId again
+    prefetchedResources = cacheAttemptParams.prefetchedResources;
+  }
+
   const cacheFriendly = responseIsCacheable(res);
   const timezone = getCookieFromReq(req, "timezone") ?? DEFAULT_TIMEZONE;
 
@@ -455,6 +551,8 @@ const renderRequest = async ({req, user, startTime, res, clientId, userAgent}: R
     }
   }
 
+  const clientId = getCookieFromReq(req, "clientId");
+
   return {
     ssrBody,
     headers: [head],
@@ -470,6 +568,7 @@ const renderRequest = async ({req, user, startTime, res, clientId, userAgent}: R
     cacheFriendly,
     timezone,
     timings,
+    prefetchedResources,
     aborted: false,
   };
 }

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -211,6 +211,7 @@ function getRequestMetadata(req: Request) {
 
   return { ip, userAgent, url };
 }
+
 function shouldSkipCache(req: Request, user: DbUser|null) {
   const { userAgent, url } = getRequestMetadata(req);
 


### PR DESCRIPTION
We've had a lot of trouble with bots lately, and one unfortunate pattern is our site going down because some bot makes a lot of SSR-eligible requests, which make their way into our internal render queue, but not before the clientIdMiddleware has fired off an insert for each one (or attempted to do so).  With a sufficiently high volume of requests, this results in:
1. our database not being able to keep up with the write load
2. all of our server instances not having any available database connections to serve other traffic, since the overwhelming majority of requests in Node's stack will be bot-driven clientId requests

This PR aims to solve (or at least mitigate) the issue by removing the all-route clientIdMiddleware, and manually applying it to those routes where we actually need it (primarily `/analyticsEvent`, `/graphql`, and other places where we compute a context).

For the SSR route (`'*'`), we move the clientId check/upsert inside of the render queue, in order to prevent out-of-band, unthrottled requests to the database.  This does sadly require also moving the prefetching logic as well, since we need to set the `clientId` on the response header before writing the prefix in cases where we can do that.

Along the way, I also refactored/cleaned up the `renderWithCache` function, which should now be easier to read and understand.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209438983727964) by [Unito](https://www.unito.io)
