### PR TITLE
Wikitag styling fixes 20250218

### DIFF
--- a/packages/lesswrong/components/tagging/ContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/ContributorsList.tsx
@@ -124,7 +124,7 @@ const HeadingContributorsList = ({topContributors, smallContributors, onHoverCon
       clickable
       placement="top"
     >
-      et al.&nbsp;
+      et al.
     </LWTooltip>}
   </div>
 }

--- a/packages/lesswrong/components/tagging/ContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/ContributorsList.tsx
@@ -6,7 +6,6 @@ import { DocumentContributorWithStats, DocumentContributorsInfo } from '@/lib/ar
 
 const styles = defineStyles("ContributorsList", (theme: ThemeType) => ({
   contributorNameWrapper: {
-    flex: 1,
     [theme.breakpoints.down('sm')]: {
       fontSize: '15px',
     },
@@ -16,14 +15,15 @@ const styles = defineStyles("ContributorsList", (theme: ThemeType) => ({
   },
   tocContributors: {
     display: 'flex',
-    flexDirection: 'column',
+    flexDirection: 'row',
     gap: '4px',
-    marginBottom: 12
+    marginBottom: 12,
+    marginLeft: 16,
   },
   tocContributor: {
-    marginLeft: 16,
     fontFamily: theme.palette.fonts.sansSerifStack,
     color: theme.palette.greyAlpha(0.5),
+    fontWeight: 550,
   },
 }))
 
@@ -65,20 +65,43 @@ const ContributorsList = ({ contributors, onHoverContributor, endWithComma }: {
   </span>))}</>;
 }
 
-const ToCContributorsList = ({topContributors, onHoverContributor}: {
-  topContributors: NonnullDocumentContributorWithStats[]
-  onHoverContributor: (userId: string|null) => void
-}) => {
-  const { UsersNameDisplay } = Components;
+function ToCContributorsList({
+  contributors,
+  onHoverContributor,
+}: {
+  contributors: NonnullDocumentContributorWithStats[]
+  onHoverContributor: (userId: string | null) => void
+}) {
+  const { LWTooltip, UsersNameDisplay } = Components;
   const classes = useStyles(styles);
 
-  return <div className={classes.tocContributors}>
-    {topContributors.map(({ user }: { user: UsersMinimumInfo }, idx: number) => (
-      <span className={classes.tocContributor} key={user._id} onMouseOver={() => onHoverContributor(user._id)} onMouseOut={() => onHoverContributor(null)}>
-        <UsersNameDisplay key={user._id} user={user} className={classes.contributorName} />
-      </span>
-    ))}
-  </div>;
+  const displayedContributors = contributors.slice(0, 2);
+  const hiddenContributors = contributors.slice(2);
+
+  return (
+    <div className={classes.tocContributors}>
+      {displayedContributors.map(({ user }, idx) => (
+        <span key={user._id} className={classes.tocContributor} onMouseOver={() => onHoverContributor(user._id)} onMouseOut={() => onHoverContributor(null)}>
+          <UsersNameDisplay user={user} className={classes.contributorName} />
+          {(idx < displayedContributors.length - 1) || (idx === displayedContributors.length - 1 && hiddenContributors.length > 0) ? ', ' : ''}
+        </span>
+      ))}
+      {hiddenContributors.length > 0 && (
+        <LWTooltip
+          title={hiddenContributors.map((c, i) => (
+            <span key={c.user._id}>
+              <UsersNameDisplay user={c.user} className={classes.contributorName} />
+              {i < hiddenContributors.length - 1 ? ', ' : ''}
+            </span>
+          ))}
+          clickable
+          placement="top"
+        >
+          <span className={classes.tocContributor}>et al.</span>
+        </LWTooltip>
+      )}
+    </div>
+  );
 }
 
 const HeadingContributorsList = ({topContributors, smallContributors, onHoverContributor}: {
@@ -101,7 +124,7 @@ const HeadingContributorsList = ({topContributors, smallContributors, onHoverCon
       clickable
       placement="top"
     >
-      et al.
+      et al.&nbsp;
     </LWTooltip>}
   </div>
 }

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -99,7 +99,7 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     ...theme.typography[isFriendlyUI ? "headerStyle" : "commentStyle"],
     marginTop: 0,
     fontWeight: isFriendlyUI ? 700 : 600,
-    ...theme.typography.smallCaps,
+    lineHeight: 1.05,
     [theme.breakpoints.down('sm')]: {
       fontSize: '27px',
     },

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -7,7 +7,7 @@ import { subscriptionTypes } from '../../lib/collections/subscriptions/schema';
 import { tagGetUrl, tagMinimumKarmaPermissions, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
 import { useMulti, UseMultiOptions } from '../../lib/crud/withMulti';
 import { truncate } from '../../lib/editor/ellipsize';
-import { Link, Redirect } from '../../lib/reactRouterWrapper';
+import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { useGlobalKeydown, useOnSearchHotkey } from '../common/withGlobalKeydown';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
@@ -211,7 +211,6 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     display: 'flex',
     justifyContent: 'flex-start',
     columnGap: 4,
-    // flexDirection: 'column',
     fontSize: '17px',
     lineHeight: 'inherit',
     marginBottom: 8,
@@ -648,9 +647,6 @@ const LWTagPage = () => {
     const baseTagUrl = tagGetUrl(tag);
     const queryString = !isEmpty(query) ? `?${qs.stringify(query)}` : '';
     return <PermanentRedirect url={`${baseTagUrl}${queryString}`} />
-  }
-  if (editing && !currentUser) {
-    return <Redirect to={`/login?redirect=${window.location.href}`} />
   }
   if (editing && !tagUserHasSufficientKarma(currentUser, "edit")) {
     throw new Error(`Sorry, you cannot edit ${taggingNamePluralSetting.get()} without ${tagMinimumKarmaPermissions.edit} or more karma.`)

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -7,7 +7,7 @@ import { subscriptionTypes } from '../../lib/collections/subscriptions/schema';
 import { tagGetUrl, tagMinimumKarmaPermissions, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
 import { useMulti, UseMultiOptions } from '../../lib/crud/withMulti';
 import { truncate } from '../../lib/editor/ellipsize';
-import { Link } from '../../lib/reactRouterWrapper';
+import { Link, Redirect } from '../../lib/reactRouterWrapper';
 import { useLocation } from '../../lib/routeUtil';
 import { useGlobalKeydown, useOnSearchHotkey } from '../common/withGlobalKeydown';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
@@ -97,7 +97,8 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
   title: {
     ...theme.typography[isFriendlyUI ? "display2" : "display3"],
     ...theme.typography[isFriendlyUI ? "headerStyle" : "commentStyle"],
-    marginTop: 0,
+    marginTop: 4,
+    marginBottom: 12,
     fontWeight: isFriendlyUI ? 700 : 600,
     lineHeight: 1.05,
     [theme.breakpoints.down('sm')]: {
@@ -208,15 +209,13 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     ...theme.typography.body1,
     color: theme.palette.grey[600],
     display: 'flex',
-    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    // flexDirection: 'column',
     fontSize: '17px',
     lineHeight: 'inherit',
     marginBottom: 8,
   },
   lastUpdated: {
-    ...theme.typography.body2,
-    color: theme.palette.grey[600],
-    fontWeight: 550,
   },
   alternativeArrowIcon: {
     width: 16,
@@ -649,6 +648,9 @@ const LWTagPage = () => {
     const queryString = !isEmpty(query) ? `?${qs.stringify(query)}` : '';
     return <PermanentRedirect url={`${baseTagUrl}${queryString}`} />
   }
+  if (editing && !currentUser) {
+    return <Redirect to={`/login?redirect=${window.location.href}`} />
+  }
   if (editing && !tagUserHasSufficientKarma(currentUser, "edit")) {
     throw new Error(`Sorry, you cannot edit ${taggingNamePluralSetting.get()} without ${tagMinimumKarmaPermissions.edit} or more karma.`)
   }
@@ -807,7 +809,7 @@ const LWTagPage = () => {
     <TableOfContents
       sectionData={selectedLens?.tableOfContents ?? tag.tableOfContents}
       title={tag.name}
-      heading={<Components.ToCContributorsList topContributors={topContributors} onHoverContributor={onHoverContributor} />}
+      heading={<Components.ToCContributorsList contributors={topContributors.concat(smallContributors)} onHoverContributor={onHoverContributor} />}
       onClickSection={expandAll}
       fixedPositionToc
       hover

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -210,6 +210,7 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     color: theme.palette.grey[600],
     display: 'flex',
     justifyContent: 'flex-start',
+    columnGap: 4,
     // flexDirection: 'column',
     fontSize: '17px',
     lineHeight: 'inherit',

--- a/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
@@ -42,14 +42,18 @@ const styles = (theme: ThemeType) => ({
   },
   hideLabel: {
     display: "none",
+  },
+  text: {
+    marginRight: 2,
   }
 });
 
 
-const TagDiscussionButton = ({tag, text = "Discussion", hideLabel = false, hideLabelOnMobile = false, classes}: {
+const TagDiscussionButton = ({tag, text = "Discussion", hideLabel = false, hideParens = false, hideLabelOnMobile = false, classes}: {
   tag: TagFragment | TagBasicInfo | TagCreationHistoryFragment,
   text?: string,
   hideLabel?: boolean,
+  hideParens?: boolean,
   hideLabelOnMobile?: boolean,
   classes: ClassesType<typeof styles>,
 }) => {
@@ -67,8 +71,8 @@ const TagDiscussionButton = ({tag, text = "Discussion", hideLabel = false, hideL
     enableTotal: true,
   });
 
-  const hideLabelClass = hideLabel ? classes.hideLabel : undefined;
-  const hideLabelOnMobileClass = hideLabelOnMobile ? classes.hideOnMobile : undefined;
+  const labelClass = hideLabel ? classes.hideLabel : classes.text;
+  const labelOnMobileClass = hideLabelOnMobile ? classes.hideOnMobile : classes.text;
 
   const discussionCountClass = hideLabel ? classes.discussionCountWithoutLabel : classes.discussionCount;
 
@@ -81,8 +85,8 @@ const TagDiscussionButton = ({tag, text = "Discussion", hideLabel = false, hideL
     {...eventHandlers}
   >
     <CommentOutlinedIcon className={classes.discussionButtonIcon} />
-    <span className={classNames(hideLabelClass, hideLabelOnMobileClass)}>{text}</span>
-    {!loading && <span className={discussionCountClass}>&nbsp;{`(${totalCount || 0})`}</span>}
+    <span className={classNames(labelClass, labelOnMobileClass)}>{text}</span>
+    {!loading && <span className={discussionCountClass}>{hideParens ? (totalCount ?? 0) : `(${totalCount ?? 0})`}</span>}
     <PopperCard open={showDiscussionPopper} anchorEl={anchorEl} placement="bottom-start" >
       <TagDiscussion tag={tag}/>
     </PopperCard>

--- a/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
+++ b/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
@@ -14,12 +14,13 @@ import HistoryIcon from '@material-ui/icons/History';
 
 const styles = defineStyles("TagPageActionsMenu", (theme: ThemeType) => ({
   tagPageTripleDotMenu: {
-    marginLeft: -4,
+    marginLeft: -8,
     alignItems: "end",
     fontSize: "30px",
   },
   tripleDotIcon: {
     marginTop: 1,
+    rotate: "90deg",
   },
   menuIcon: {
     color: theme.palette.grey[600],
@@ -28,7 +29,6 @@ const styles = defineStyles("TagPageActionsMenu", (theme: ThemeType) => ({
   },
   historyIcon: {
     color: theme.palette.grey[600],
-    // marginRight: 12,
     "--icon-size": "16px",
   },
   menu: {},
@@ -39,10 +39,10 @@ const styles = defineStyles("TagPageActionsMenu", (theme: ThemeType) => ({
   },
 }))
 
-const TagPageActionsMenuButton = ({tagOrLens, createLens, setEditing}: {
+const TagPageActionsMenuButton = ({tagOrLens, createLens, handleEditClick}: {
   tagOrLens: TagLens|undefined
   createLens: (() => void)|null,
-  setEditing: ((editing: boolean) => void)|null,
+  handleEditClick: ((reactEvent: React.MouseEvent<HTMLSpanElement>) => void)|null,
 }) => {
   const classes = useStyles(styles);
   const [anchorEl, setAnchorEl] = useState<any>(null);
@@ -76,16 +76,16 @@ const TagPageActionsMenuButton = ({tagOrLens, createLens, setEditing}: {
       {everOpened && <TagPageActionsMenu
         tagOrLens={tagOrLens}
         createLens={createLens}
-        setEditing={setEditing}
+        handleEditClick={handleEditClick}
       />}
     </Menu>
   </>
 }
 
-const TagPageActionsMenu = ({tagOrLens, createLens, setEditing}: {
+const TagPageActionsMenu = ({tagOrLens, handleEditClick, createLens}: {
   tagOrLens: TagLens
+  handleEditClick: ((reactEvent: React.MouseEvent<HTMLSpanElement>) => void)|null,
   createLens: (() => void)|null,
-  setEditing: ((editing: boolean) => void)|null,
 }) => {
   const { DropdownMenu, DropdownItem, MenuItem, ForumIcon, LWTooltip, AnalyticsTracker } = Components;
   const currentUser = useCurrentUser();
@@ -115,7 +115,7 @@ const TagPageActionsMenu = ({tagOrLens, createLens, setEditing}: {
   }
 
   //check if any of the buttons will render, else don't show the menu
-  const willRender = !!setEditing || !!createLens || (userIsAdminOrMod(currentUser) && isLensPage);
+  const willRender = !!handleEditClick || !!createLens || (userIsAdminOrMod(currentUser) && isLensPage);
 
   if (!willRender) {
     return null;
@@ -123,7 +123,7 @@ const TagPageActionsMenu = ({tagOrLens, createLens, setEditing}: {
 
   return <AnalyticsTracker eventType="tagPageTripleDotClicked" captureOnClick>
     <DropdownMenu>
-      {!!setEditing && <MenuItem onClick={() => setEditing(true)}>
+      {!!handleEditClick && <MenuItem onClick={handleEditClick}>
         <ForumIcon icon="Edit" className={classes.menuIcon}/>
         Edit
       </MenuItem>}

--- a/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
+++ b/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
@@ -142,11 +142,6 @@ const TagPageActionsMenu = ({tagOrLens, handleEditClick, createLens}: {
         <ForumIcon className={classes.infoCircle} icon="InfoCircle"/>
         </LWTooltip>
       </MenuItem>}
-      {/* <DropdownItem
-        to={tagGetHistoryUrl(tagOrLens)}
-        icon={() => <HistoryIcon fontSize="inherit"/>}
-        title="History"
-      /> */}
     </DropdownMenu>
   </AnalyticsTracker>
 }

--- a/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
+++ b/packages/lesswrong/components/tagging/TagPageActionsMenu.tsx
@@ -9,10 +9,28 @@ import { useCurrentUser } from '../common/withUser';
 import { userIsAdminOrMod } from '@/lib/vulcan-users';
 import { useMessages } from '../common/withMessages';
 import { captureException } from '@sentry/core';
+import { tagGetHistoryUrl, tagUserHasSufficientKarma } from '@/lib/collections/tags/helpers';
+import HistoryIcon from '@material-ui/icons/History';
 
 const styles = defineStyles("TagPageActionsMenu", (theme: ThemeType) => ({
-  tagPageTripleDotMenu: {},
-  icon: {},
+  tagPageTripleDotMenu: {
+    marginLeft: -4,
+    alignItems: "end",
+    fontSize: "30px",
+  },
+  tripleDotIcon: {
+    marginTop: 1,
+  },
+  menuIcon: {
+    color: theme.palette.grey[600],
+    marginRight: 12,
+    "--icon-size": "16px",
+  },
+  historyIcon: {
+    color: theme.palette.grey[600],
+    // marginRight: 12,
+    "--icon-size": "16px",
+  },
   menu: {},
   infoCircle: {
     color: theme.palette.greyAlpha(0.5),
@@ -21,16 +39,17 @@ const styles = defineStyles("TagPageActionsMenu", (theme: ThemeType) => ({
   },
 }))
 
-const TagPageActionsMenuButton = ({tagOrLens, createLens}: {
+const TagPageActionsMenuButton = ({tagOrLens, createLens, setEditing}: {
   tagOrLens: TagLens|undefined
   createLens: (() => void)|null,
+  setEditing: ((editing: boolean) => void)|null,
 }) => {
   const classes = useStyles(styles);
   const [anchorEl, setAnchorEl] = useState<any>(null);
   const [everOpened, setEverOpened] = useState(false);
   const { captureEvent } = useTracking({eventType: "tagPageMenuClicked", eventProps: {tagOrLensId: tagOrLens?._id, itemType: "tag"}});
   const { ForumIcon } = Components;
-  
+
   if (!tagOrLens) {
     return null;
   }
@@ -43,7 +62,7 @@ const TagPageActionsMenuButton = ({tagOrLens, createLens}: {
         setEverOpened(true);
       }}
     >
-      <ForumIcon icon="EllipsisVertical" className={classes.icon}/>
+      <ForumIcon icon="EllipsisVertical" className={classes.tripleDotIcon}/>
     </span>
     <Menu
       onClick={() => {
@@ -57,16 +76,18 @@ const TagPageActionsMenuButton = ({tagOrLens, createLens}: {
       {everOpened && <TagPageActionsMenu
         tagOrLens={tagOrLens}
         createLens={createLens}
+        setEditing={setEditing}
       />}
     </Menu>
   </>
 }
 
-const TagPageActionsMenu = ({tagOrLens, createLens}: {
+const TagPageActionsMenu = ({tagOrLens, createLens, setEditing}: {
   tagOrLens: TagLens
   createLens: (() => void)|null,
+  setEditing: ((editing: boolean) => void)|null,
 }) => {
-  const { DropdownMenu, MenuItem, ForumIcon, LWTooltip, AnalyticsTracker } = Components;
+  const { DropdownMenu, DropdownItem, MenuItem, ForumIcon, LWTooltip, AnalyticsTracker } = Components;
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
   const apolloClient = useApolloClient();
@@ -93,9 +114,21 @@ const TagPageActionsMenu = ({tagOrLens, createLens}: {
     }
   }
 
+  //check if any of the buttons will render, else don't show the menu
+  const willRender = !!setEditing || !!createLens || (userIsAdminOrMod(currentUser) && isLensPage);
+
+  if (!willRender) {
+    return null;
+  }
+
   return <AnalyticsTracker eventType="tagPageTripleDotClicked" captureOnClick>
     <DropdownMenu>
+      {!!setEditing && <MenuItem onClick={() => setEditing(true)}>
+        <ForumIcon icon="Edit" className={classes.menuIcon}/>
+        Edit
+      </MenuItem>}
       {!!createLens && <MenuItem onClick={createLens}>
+        <ForumIcon icon="Plus" className={classes.menuIcon}/>
         New Lens
       </MenuItem>}
     {userIsAdminOrMod(currentUser) && isLensPage && <MenuItem onClick={promoteLens}>
@@ -109,6 +142,11 @@ const TagPageActionsMenu = ({tagOrLens, createLens}: {
         <ForumIcon className={classes.infoCircle} icon="InfoCircle"/>
         </LWTooltip>
       </MenuItem>}
+      {/* <DropdownItem
+        to={tagGetHistoryUrl(tagOrLens)}
+        icon={() => <HistoryIcon fontSize="inherit"/>}
+        title="History"
+      /> */}
     </DropdownMenu>
   </AnalyticsTracker>
 }

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -24,13 +24,14 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[700],
     display: "flex",
     flexWrap: "wrap",
+    columnGap: 16,
     [theme.breakpoints.down('xs')]: {
       marginTop: isFriendlyUI ? 8 : undefined,
     },
     '& svg': {
       height: 20,
       width: 20,
-      marginRight: 4,
+      // marginRight: 4,
       marginBottom: 1, // JP it's fine, stop adjusting single pixels
       cursor: "pointer",
       color: theme.palette.grey[700]
@@ -48,7 +49,7 @@ const styles = (theme: ThemeType) => ({
     },
   },
   likeButtonWrapper: {
-    marginRight: 20,
+    // marginRight: 16,
     fontSize: 12,
   },
   buttonTooltip: {
@@ -58,7 +59,7 @@ const styles = (theme: ThemeType) => ({
   button: {
     display: "flex",
     alignItems: "center",
-    marginRight: 16,
+    // marginRight: 16,
   },
   buttonLabel: {
     [theme.breakpoints.down('sm')]: {
@@ -68,7 +69,7 @@ const styles = (theme: ThemeType) => ({
   lockIcon: {
     display: "flex",
     alignItems: "center",
-    marginRight: 16,
+    // marginRight: 16,
     '&:hover': {
       opacity: 1
     },
@@ -80,7 +81,7 @@ const styles = (theme: ThemeType) => ({
     display: "flex !important",
   },
   subscribeTo: {
-    marginRight: 16
+    // marginRight: 16
   },
   helpImprove: {
     [theme.breakpoints.down('sm')]: {
@@ -108,22 +109,39 @@ export function useTagEditingRestricted(tag: TagPageWithRevisionFragment | TagPa
 
   return { canEdit, noEditNotAuthor, noEditKarmaTooLow };
 }
-
-const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels = false, className, refetchTag, updateSelectedLens, classes }: {
-  tag: TagPageWithRevisionFragment | TagPageFragment | TagPageWithArbitalContentFragment,
-  selectedLens?: TagLens
-  editing: boolean,
-  setEditing: (editing: boolean) => void,
-  hideLabels?: boolean,
-  className?: string,
-  refetchTag?: () => Promise<void>,
-  updateSelectedLens?: (lensId: string) => void,
-  classes: ClassesType<typeof styles>
+const TagPageButtonRow = ({
+  tag,
+  selectedLens,
+  editing,
+  setEditing,
+  hideLabels = false,
+  className,
+  refetchTag,
+  updateSelectedLens,
+  classes
+}: {
+  tag: TagPageWithRevisionFragment | TagPageFragment | TagPageWithArbitalContentFragment;
+  selectedLens?: TagLens;
+  editing: boolean;
+  setEditing: (editing: boolean) => void;
+  hideLabels?: boolean;
+  className?: string;
+  refetchTag?: () => Promise<void>;
+  updateSelectedLens?: (lensId: string) => void;
+  classes: ClassesType<typeof styles>;
 }) => {
   const { openDialog } = useDialog();
   const currentUser = useCurrentUser();
-  const { LWTooltip, NotifyMeButton, TagDiscussionButton, ContentItemBody, ForumIcon, TagOrLensLikeButton, TagPageActionsMenuButton } = Components;
-  const { tag: beginnersGuideContentTag } = useTagBySlug("tag-cta-popup", "TagFragment")
+  const {
+    LWTooltip,
+    NotifyMeButton,
+    TagDiscussionButton,
+    ContentItemBody,
+    ForumIcon,
+    TagOrLensLikeButton,
+    TagPageActionsMenuButton
+  } = Components;
+  const { tag: beginnersGuideContentTag } = useTagBySlug("tag-cta-popup", "TagFragment");
 
   const { captureEvent } = useTracking();
 
@@ -199,6 +217,8 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
     />
   </>;
 
+  console.log("canEdit", {canEdit, editing, setEditing})
+
   return <AnalyticsContext pageSectionContext="tagPageButtonRow">
     <div className={classNames(classes.buttonsRow, className)}>
       {!editing && <LWTooltip
@@ -252,6 +272,7 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
       {isLWorAF && <TagPageActionsMenuButton
         tagOrLens={selectedLens}
         createLens={canCreateLens ? handleNewLensClick : null}
+        setEditing={!editing && canEdit ? setEditing : null}
       />}
     </div>
   </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -217,8 +217,6 @@ const TagPageButtonRow = ({
     />
   </>;
 
-  console.log("canEdit", {canEdit, editing, setEditing})
-
   return <AnalyticsContext pageSectionContext="tagPageButtonRow">
     <div className={classNames(classes.buttonsRow, className)}>
       {!editing && <LWTooltip
@@ -272,7 +270,7 @@ const TagPageButtonRow = ({
       {isLWorAF && <TagPageActionsMenuButton
         tagOrLens={selectedLens}
         createLens={canCreateLens ? handleNewLensClick : null}
-        setEditing={!editing && canEdit ? setEditing : null}
+        handleEditClick={!editing && canEdit ? handleEditClick : null}
       />}
     </div>
   </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -31,7 +31,6 @@ const styles = (theme: ThemeType) => ({
     '& svg': {
       height: 20,
       width: 20,
-      // marginRight: 4,
       marginBottom: 1, // JP it's fine, stop adjusting single pixels
       cursor: "pointer",
       color: theme.palette.grey[700]
@@ -49,7 +48,6 @@ const styles = (theme: ThemeType) => ({
     },
   },
   likeButtonWrapper: {
-    // marginRight: 16,
     fontSize: 12,
   },
   buttonTooltip: {
@@ -59,7 +57,6 @@ const styles = (theme: ThemeType) => ({
   button: {
     display: "flex",
     alignItems: "center",
-    // marginRight: 16,
   },
   buttonLabel: {
     [theme.breakpoints.down('sm')]: {
@@ -69,7 +66,6 @@ const styles = (theme: ThemeType) => ({
   lockIcon: {
     display: "flex",
     alignItems: "center",
-    // marginRight: 16,
     '&:hover': {
       opacity: 1
     },
@@ -81,7 +77,6 @@ const styles = (theme: ThemeType) => ({
     display: "flex !important",
   },
   subscribeTo: {
-    // marginRight: 16
   },
   helpImprove: {
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -236,7 +236,7 @@ const TagPageButtonRow = ({ tag, selectedLens, editing, setEditing, hideLabels =
           subscriptionType={subscriptionTypes.newTagPosts}
         />
       </LWTooltip>}
-      {<div className={classes.button}><TagDiscussionButton tag={tag} hideLabel={hideLabels} hideLabelOnMobile /></div>}
+      {<div className={classes.button}><TagDiscussionButton tag={tag} hideLabel={hideLabels} hideLabelOnMobile hideParens /></div>}
       {selectedLens && <div className={classes.likeButtonWrapper}>
         <TagOrLensLikeButton lens={selectedLens} isSelected={true} stylingVariant="buttonRow" />
       </div>}

--- a/packages/lesswrong/components/users/LoginPage.tsx
+++ b/packages/lesswrong/components/users/LoginPage.tsx
@@ -2,8 +2,19 @@ import React, { useEffect } from 'react';
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
 import { useNavigate } from '../../lib/reactRouterWrapper';
+import { defineStyles, useStyles } from '../hooks/useStyles';
+
+const styles = defineStyles("LoginPage", (theme: ThemeType) => ({
+  root: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "flex-start",
+    height: "100vh",
+  },
+}));
 
 const LoginPage = () => {
+  const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const navigate = useNavigate();
 
@@ -20,7 +31,9 @@ const LoginPage = () => {
     // `componentWillMount`.
     return <div />;
   } else {
-    return <Components.LoginForm />;
+    return <div className={classes.root}>
+      <Components.LoginForm />
+    </div>;
   }
 }
 

--- a/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
@@ -41,6 +41,7 @@ const styles = defineStyles("ReactionsAndLikesVote", (theme) => ({
     paddingBottom: 2,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontWeight: 500,
+    marginLeft: 1,
   },
   likeCountButtonRow: {
     ...theme.typography.commentStyle,
@@ -127,7 +128,7 @@ const ReactionsAndLikesVote  = ({
   </div>
   
   const likeCountElement = stylingVariant === "buttonRow"
-    ? <span className={classes.likeCountButtonRow}>{`(${likeCount})`}</span>
+    ? <span className={classes.likeCountButtonRow}>{`${likeCount}`}</span>
     : <span className={classes.likeCount}>{likeCount}</span>;
   
 

--- a/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
@@ -13,14 +13,12 @@ import { isMobile } from '@/lib/utils/isMobile';
 const styles = defineStyles("ReactionsAndLikesVote", (theme) => ({
   unselectedLikeButton: {
     cursor: "pointer",
-    marginRight: 4,
     display: "flex",
     alignItems: "center",
     color: theme.palette.grey[800],
   },
   selectedLikeButton: {
     cursor: "pointer",
-    marginRight: 4,
     display: "flex",
     alignItems: "center",
     color: theme.palette.grey[600],

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -529,7 +529,7 @@ addRoute(
   {
     name: 'tagsAll',
     path: getAllTagsPath(),
-    componentName: isEAForum ? 'EAAllTagsPage' : 'AllTagsPage',
+    componentName: isEAForum ? 'EAAllTagsPage' : 'AllWikiTagsPage',
     title: isEAForum ? `${taggingNamePluralCapitalSetting.get()} — Main Page` : "Concepts Portal",
     description: isEAForum ? `Browse the core ${taggingNamePluralSetting.get()} discussed on the EA Forum and an organised wiki of key ${taggingNameSetting.get()} pages` : undefined,
     hasLeftNavigationColumn: false,


### PR DESCRIPTION
Went through Oli's list:

- Tag page title line-height is too high
- Parens around numbers in the top-right corner is bad
- Icons in the top-right corner have bad spacing
- The triple-dot menu should always be populated (instead hide it if completely empty)
- The last-updated date should be on the same line as the authors (when it fits), and the same font
- The ToC author list should be limited to at most two, with an “et al” or something

<img width="220" alt="Bayes' rule - LessWrong 2025-02-18 18-28-02" src="https://github.com/user-attachments/assets/bf32bf47-4fbc-48e6-9cc7-c3a22a811e43" />

<img width="592" alt="Bayes' rule - LessWrong 2025-02-18 18-43-17" src="https://github.com/user-attachments/assets/7fa89f53-c051-4e50-a795-b457d2a0b7d6" />

<img width="774" alt="Bayes' rule - LessWrong 2025-02-18 18-43-50" src="https://github.com/user-attachments/assets/41a3684f-8855-4314-a802-25464727dd79" />

<img width="774" alt="Bayes' rule - LessWrong 2025-02-18 18-43-50" src="https://github.com/user-attachments/assets/36ebe3db-495d-41bc-9cf7-03a8d715fbef" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209439178672681) by [Unito](https://www.unito.io)
