### PR TITLE
Block '/api/notificationEvents' url from datadog

### DIFF
--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -11,7 +11,11 @@ if (isDatadogEnabled) {
     // logInjection: true
   });
   tracer.use('express', {
-    service: 'forummagnum'
+    service: 'forummagnum',
+    blocklist: [
+      // This stays open for a long time and skews the average request duration
+      '/api/notificationEvents'
+    ]
   })
 }
 

--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -14,7 +14,7 @@ if (isDatadogEnabled) {
     service: 'forummagnum',
     blocklist: [
       // This stays open for a long time and skews the average request duration
-      '/api/notificationEvents'
+      /notificationEvents/
     ]
   })
 }


### PR DESCRIPTION
With [this upgrade](https://github.com/ForumMagnum/ForumMagnum/pull/10446) we lost the ability to filter out specific urls from the request duration metric, so `/api/notificationEvents` is now pulling up the average

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209455294596160) by [Unito](https://www.unito.io)
