### PR TITLE
Fix UsersWhoReacted hiding users who anti-reacted due to incorrect layout

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/UsersWhoReacted.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/UsersWhoReacted.tsx
@@ -46,26 +46,25 @@ const UsersWhoReacted = ({reactions, wrap=false, showTooltip=true, classes}: {
   </div>
 
   const component = <div className={classes.usersWhoReactedRoot}>
-    {usersWhoProReacted.length > 0 &&
-      <div className={classNames(classes.usersWhoReacted, {[classes.usersWhoReactedWrap]: wrap})}>
+    <div className={classNames(classes.usersWhoReacted, {[classes.usersWhoReactedWrap]: wrap})}>
+      {usersWhoProReacted.length > 0 && <>
         {usersWhoProReacted.map((userReactInfo,i) =>
           <span key={userReactInfo.userId}>
-            {(i>0) && <span>{", "}</span>}
+            {(i>0) && ", "}
             {userReactInfo.displayName}
           </span>
         )}
-      </div>
-    }
-    {usersWhoAntiReacted.length > 0 &&
-      <div className={classNames(classes.usersWhoReacted, {[classes.usersWhoReactedWrap]: wrap})}>
+      </>}
+      {usersWhoProReacted.length > 0 && usersWhoAntiReacted.length > 0 && ", "}
+      {usersWhoAntiReacted.length > 0 && <>
         {usersWhoAntiReacted.map((userReactInfo,i) =>
           <span key={userReactInfo.userId} className={classes.userWhoAntiReacted}>
-            {(i>0) && <span>{", "}</span>}
+            {(i>0) && ", "}
             {userReactInfo.displayName}
           </span>
         )}
-      </div>
-    }
+      </>}
+    </div>
   </div>
 
   if (showTooltip) {


### PR DESCRIPTION
Introduced in: https://github.com/ForumMagnum/ForumMagnum/pull/10301/files#diff-67a0ce2a609f1b8291f0880505b1e7e1c5f499b0bf4601b3cbd855b7d4617c68R9

Previous commit made `UsersWhoReacted-usersWhoReactedRoot` a flexbox, which was incorrect because it had two children and didn't actually want those children to flex-size themselves. Fixed by merging them into one child, which is not quite the original behavior but at least avoids fully hiding any data. (The original behavior was that there would be a guaranteed line-break between reacters and anti-reacters. The flexbox behavior tried to put reacters and anti-reacters into two columns, and additionally one of the columns could be near-zero-size. The new behavior just wraps the all together in one long comma-separated list.)

Before:
![Screenshot 2025-02-20 at 16 40 48](https://github.com/user-attachments/assets/276aa410-a8a7-4c44-9704-0a6c63d994ef)

After:
![Screenshot 2025-02-20 at 16 40 20](https://github.com/user-attachments/assets/59a47dde-0405-47f3-844c-212757e70810)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209460981616601) by [Unito](https://www.unito.io)
