### PR TITLE
switch to using wasEverUndrafted field in mod views for performance reasons

### DIFF
--- a/packages/lesswrong/components/hooks/usePublishedPosts.ts
+++ b/packages/lesswrong/components/hooks/usePublishedPosts.ts
@@ -3,13 +3,10 @@ import { useMulti } from "../../lib/crud/withMulti";
 /**
  * Used to fetch a list of posts for moderation contexts.
  * To preserve user privacy, don't return drafts which have never been published.
- * 
- * We're doing this with a batch query against LWEvents instead of a resolver field on each post for performance reasons.
- * It's still a bit slow, probably because the LWEvents index goes name_userId_documentId,
- * and we aren't providing userId because we don't want to hide posts moved back to draft by someone else (i.e. an admin).
+ * This used to be implemented with LWEvents, but now we're just using the `wasEverUndrafted` field.
  */
 export function usePublishedPosts(userId: string, contentLimit = 20) {
-  const { results: posts = [], loading: postsLoading } = useMulti({
+  const { results: posts = [], loading } = useMulti({
     terms:{ view:"sunshineNewUsersPosts", userId },
     collectionName: "Posts",
     fragmentName: 'SunshinePostsList',
@@ -17,28 +14,8 @@ export function usePublishedPosts(userId: string, contentLimit = 20) {
     limit: contentLimit
   });
 
-  const draftPostIds = posts.filter(p => p.draft).map(p => p._id);
-
-  const skipEvents = draftPostIds.length === 0;
-
-  const { results: moveToDraftEvents, loading: lwEventsLoading } = useMulti({
-    terms: { view: 'postEverPublished', postIds: draftPostIds },
-    collectionName: "LWEvents",
-    fragmentName: 'LWEventsDefaultFragment',
-    skip: draftPostIds.length === 0,
-    // Add a bit of padding in case someone's drafted and republished a post more than once
-    limit: draftPostIds.length + 5
-  });
-
-  const everPublishedPostIds = new Set((moveToDraftEvents ?? []).map(event => event.documentId));
-
-  const postsToDisplay = posts.filter((post) => !post.draft || everPublishedPostIds.has(post._id));
-
-  // lwEventsLoading will be true if we're skipping it, which leads to incorrectly showing the spinner
-  const loading = postsLoading || (lwEventsLoading && !skipEvents);
-
   return {
-    posts: loading ? undefined : postsToDisplay,
+    posts: loading ? undefined : posts,
     loading
   };
 }

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1266,7 +1266,8 @@ Posts.addView("sunshineNewUsersPosts", (terms: PostsViewTerms) => {
       authorIsUnreviewed: null,
       groupId: null,
       draft: viewFieldAllowAny,
-      rejected: null
+      rejected: null,
+      wasEverUndrafted: true,
     },
     options: {
       sort: {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1265,9 +1265,11 @@ Posts.addView("sunshineNewUsersPosts", (terms: PostsViewTerms) => {
       userId: terms.userId,
       authorIsUnreviewed: null,
       groupId: null,
-      draft: viewFieldAllowAny,
       rejected: null,
-      wasEverUndrafted: true,
+      $or: [
+        { wasEverUndrafted: true },
+        { draft: false }
+      ]
     },
     options: {
       sort: {


### PR DESCRIPTION
Before the `wasEverUndrafted` field, we were querying LWEvents to check if a post was ever undrafted (and filtering it out if not) when showing mods which posts a user had, for privacy reasons.  This has scaled poorly (and/or there may have been some recent change which caused that query to behave much worse).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209468247509723) by [Unito](https://www.unito.io)
