### PR TITLE
Fix ToC Et Al Contributor Hover Highlighting

### DIFF
--- a/packages/lesswrong/components/tagging/ContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/ContributorsList.tsx
@@ -88,10 +88,10 @@ function ToCContributorsList({
       ))}
       {hiddenContributors.length > 0 && (
         <LWTooltip
-          title={hiddenContributors.map((c, i) => (
-            <span key={c.user._id}>
-              <UsersNameDisplay user={c.user} className={classes.contributorName} />
-              {i < hiddenContributors.length - 1 ? ', ' : ''}
+          title={hiddenContributors.map(( {user}, idx) => (
+            <span key={user._id} onMouseOver={() => onHoverContributor(user._id)} onMouseOut={() => onHoverContributor(null)}>
+              <UsersNameDisplay user={user} className={classes.contributorName}/>
+              {idx < hiddenContributors.length - 1 ? ', ' : ''}
             </span>
           ))}
           clickable


### PR DESCRIPTION
Unlike in the header, the contributor et al's users in the hover tooltip were not highlighting contributors when mousing over. 

The relevant spans were missing the handlers.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209492886770668) by [Unito](https://www.unito.io)
