### PR TITLE
Migrate notification settings to new format, and update EAF defaults

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1712,7 +1712,7 @@ const schema: SchemaType<"Users"> = {
     hidden: !hasEventsSetting.get(),
     ...notificationTypeSettingsField(mergeNotificationSettings({ email: { enabled: true } })),
   },
-  notificationKarmaPowersGained: { // TODO fix in prev PR
+  notificationKarmaPowersGained: {
     label: "Karma powers gained",
     hidden: true,
     ...notificationTypeSettingsField(new DeferredForumSelect<NotificationTypeSettings>({

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1652,7 +1652,10 @@ const schema: SchemaType<"Users"> = {
     label: isEAForum
       ? "Quick takes by users I'm subscribed to"
       : "Shortform by users I'm subscribed to",
-    ...notificationTypeSettingsField(),
+    ...notificationTypeSettingsField(new DeferredForumSelect<NotificationTypeSettings>({
+      EAForum: mergeNotificationSettings({email: { enabled: true, batchingFrequency: "daily" }}),
+      default: defaultNotificationTypeSettings,
+    } as const)),
   },
   notificationRepliesToMyComments: {
     label: "Replies to my comments",
@@ -1671,13 +1674,16 @@ const schema: SchemaType<"Users"> = {
   notificationSubscribedUserPost: {
     label: "Posts by users I'm subscribed to",
     ...notificationTypeSettingsField(new DeferredForumSelect<NotificationTypeSettings>({
-      EAForum: mergeNotificationSettings({email: { enabled: true }}),
+      EAForum: mergeNotificationSettings({email: { enabled: true, batchingFrequency: "daily" }}),
       default: defaultNotificationTypeSettings,
     } as const)),
   },
   notificationSubscribedUserComment: {
     label: "Comments by users I'm subscribed to",
-    ...notificationTypeSettingsField(),
+    ...notificationTypeSettingsField(new DeferredForumSelect<NotificationTypeSettings>({
+      EAForum: mergeNotificationSettings({email: { enabled: true, batchingFrequency: "daily" }}),
+      default: defaultNotificationTypeSettings,
+    } as const)),
     hidden: !allowSubscribeToUserComments
   },
   notificationPostsInGroups: {
@@ -1746,7 +1752,10 @@ const schema: SchemaType<"Users"> = {
   },
   notificationNewMention: {
     label: "Someone has mentioned me in a post or a comment",
-    ...notificationTypeSettingsField(),
+    ...notificationTypeSettingsField(new DeferredForumSelect<NotificationTypeSettings>({
+      EAForum: mergeNotificationSettings({email: { enabled: true }}),
+      default: defaultNotificationTypeSettings,
+    } as const)),
   },
   notificationDialogueMessages: {
     label: "New dialogue content in a dialogue I'm participating in",

--- a/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
+++ b/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
@@ -1,0 +1,126 @@
+import Users from "@/lib/collections/users/collection";
+import usersSchema, { LegacyNotificationTypeSettings, legacyToNewNotificationTypeSettings, newToLegacyNotificationTypeSettings, NotificationTypeSettings } from "@/lib/collections/users/schema";
+
+const notificationTypes = [
+  "notificationCommentsOnSubscribedPost",
+  "notificationShortformContent",
+  "notificationRepliesToMyComments",
+  "notificationRepliesToSubscribedComments",
+  "notificationSubscribedUserPost",
+  "notificationSubscribedUserComment",
+  "notificationPostsInGroups",
+  "notificationSubscribedTagPost",
+  "notificationSubscribedSequencePost",
+  "notificationPrivateMessage",
+  "notificationSharedWithMe",
+  "notificationAlignmentSubmissionApproved",
+  "notificationEventInRadius",
+  "notificationKarmaPowersGained",
+  "notificationRSVPs",
+  "notificationGroupAdministration",
+  "notificationCommentsOnDraft",
+  "notificationPostsNominatedReview",
+  "notificationSubforumUnread",
+  "notificationNewMention",
+  "notificationDialogueMessages",
+  "notificationPublishedDialogueMessages",
+  "notificationAddedAsCoauthor",
+  "notificationDebateCommentsOnSubscribedPost",
+  "notificationDebateReplies",
+  "notificationDialogueMatch",
+  "notificationNewDialogueChecks",
+  "notificationYourTurnMatchForm"
+] as const;
+
+const fetchEverChangedSettingUsers = async ({
+  db,
+  fieldName,
+}: {
+  db: SqlClient;
+  fieldName: (typeof notificationTypes)[number];
+}) => {
+  return (
+    await db.any<{ userId: string }>(
+      `
+    SELECT DISTINCT "documentId" AS "userId"
+    FROM "LWEvents"
+    WHERE "name" = 'fieldChanges'
+      AND properties -> 'before' ->> $1 IS NOT NULL
+      AND properties -> 'after' ->> $1 IS NOT NULL
+      AND properties -> 'before' ->> $1 <> properties -> 'after' ->> $1;
+  `,
+      [fieldName]
+    )
+  ).map((u) => u.userId);
+};
+
+const migrateFormat = async ({
+  db,
+  toNew,
+  dryRun
+}: {
+  db: SqlClient;
+  toNew: boolean;
+  dryRun?: boolean; // for debugging
+}) => {
+  const convertFormat = toNew ? legacyToNewNotificationTypeSettings : newToLegacyNotificationTypeSettings;
+
+  console.time("fetchEverChangedSettingUsers");
+
+  const userChangesPromises = notificationTypes.map((fieldName) =>
+    fetchEverChangedSettingUsers({ db, fieldName })
+  );
+
+  const usersWithChangesByNotificationSetting = await Promise.all(userChangesPromises);
+
+  console.timeEnd("fetchEverChangedSettingUsers");
+
+  for (let i = 0; i < usersWithChangesByNotificationSetting.length; i++) {
+    const fieldName = notificationTypes[i];
+    const usersEverChangedSetting = usersWithChangesByNotificationSetting[i];
+    console.log(`Field: ${fieldName}, Number of users who have ever changed setting: ${usersEverChangedSetting.length}`);
+
+    // @ts-ignore we know none of the `onCreate`s require the additional fields
+    const newDefault = convertFormat(usersSchema[fieldName].onCreate?.({ newDocument: {} as DbUser, fieldName }));
+
+    console.log("Updating setting for users who have never changed from the default...");
+    if (!dryRun) {
+      await Users.rawUpdateMany(
+        { _id: { $nin: usersEverChangedSetting } },
+        { $set: { [fieldName]: newDefault } }
+      );
+    } else {
+      console.log("Would have run rawUpdateMany with args:", { _id: { $nin: usersEverChangedSetting } }, { $set: { [fieldName]: newDefault } });
+    }
+
+    console.log("Migrating setting for users who *have* changed from the default...");
+
+    const usersToUpdate = await Users.find(
+      { _id: { $in: usersEverChangedSetting } },
+      {},
+      { _id: 1, [fieldName]: 1 }
+    ).fetch();
+
+    // TODO maybe batch these
+    for (const user of usersToUpdate) {
+      const oldValue = user[fieldName] as NotificationTypeSettings | LegacyNotificationTypeSettings;
+      const newValue = convertFormat(oldValue);
+
+      if (!dryRun) {
+        await Users.rawUpdateOne({ _id: user._id }, { $set: { [fieldName]: newValue } })
+      } else {
+        console.log("Would have run rawUpdateOne with args:", { _id: user._id }, { $set: { [fieldName]: newValue } });
+      }
+    }
+
+    console.log(`${!dryRun ? usersToUpdate.length : 0} users migrated`);
+  }
+};
+
+export const up = async ({ db }: MigrationContext) => {
+  await migrateFormat({ db, toNew: true });
+};
+
+export const down = async ({ db }: MigrationContext) => {
+  await migrateFormat({ db, toNew: false });
+};

--- a/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
+++ b/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
-import Users from "@/lib/collections/users/collection";
 import usersSchema, { LegacyNotificationTypeSettings, legacyToNewNotificationTypeSettings, newToLegacyNotificationTypeSettings, NotificationTypeSettings } from "@/lib/collections/users/schema";
 import { updateDefaultValue } from "./meta/utils";
 import { executePromiseQueue } from "@/lib/utils/asyncUtils";
+import Users from "../collections/users/collection";
 
 const notificationTypes = [
   "notificationCommentsOnSubscribedPost",

--- a/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
+++ b/packages/lesswrong/server/migrations/20250225T125732.migrate_notification_format.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import Users from "@/lib/collections/users/collection";
 import usersSchema, { LegacyNotificationTypeSettings, legacyToNewNotificationTypeSettings, newToLegacyNotificationTypeSettings, NotificationTypeSettings } from "@/lib/collections/users/schema";
 import { updateDefaultValue } from "./meta/utils";

--- a/packages/lesswrong/server/sql/PgCollection.ts
+++ b/packages/lesswrong/server/sql/PgCollection.ts
@@ -102,7 +102,6 @@ class PgCollection<
     const quiet = data?.options?.quiet ?? false;
     try {
       const {sql, args} = query.compile();
-      console.log({sql, args});
       const client = getSqlClientOrThrow(target);
 
       result = await client.any(sql, args, () => `${sql}: ${JSON.stringify(args)}`, quiet);

--- a/packages/lesswrong/server/sql/PgCollection.ts
+++ b/packages/lesswrong/server/sql/PgCollection.ts
@@ -102,6 +102,7 @@ class PgCollection<
     const quiet = data?.options?.quiet ?? false;
     try {
       const {sql, args} = query.compile();
+      console.log({sql, args});
       const client = getSqlClientOrThrow(target);
 
       result = await client.any(sql, args, () => `${sql}: ${JSON.stringify(args)}`, quiet);

--- a/packages/lesswrong/server/sql/Query.ts
+++ b/packages/lesswrong/server/sql/Query.ts
@@ -420,6 +420,12 @@ abstract class Query<T extends DbObject> {
           return ["NOT (", ...this.compileComparison(fieldName, value[comparer]), ")"];
 
         case "$nin":
+          const expression = value[comparer];
+
+          if (Array.isArray(expression) && expression.length === 0) {
+            return ["1=1"];
+          }
+
           return this.compileComparison(fieldName, {$not: {$in: value[comparer]}});
 
         case "$in":

--- a/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectQuery.tests.ts
@@ -171,6 +171,12 @@ describe("SelectQuery", () => {
       expectedArgs: [1, 2, 3],
     },
     {
+      name: "can build select query with not-in comparison to an empty array [regression test]",
+      getQuery: () => new SelectQuery(testTable, {a: {$nin: []}}),
+      expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE 1=1',
+      expectedArgs: [],
+    },
+    {
       name: "can build select query with all comparison",
       getQuery: () => new SelectQuery(testTable, {a: {$all: [10, 20]}}),
       expectedSql: 'SELECT "TestCollection".* FROM "TestCollection" WHERE "a" @> ARRAY[ $1 ::DOUBLE PRECISION , $2 ::DOUBLE PRECISION ]',


### PR DESCRIPTION
This will be against master once #10466 is merged

Notifications defaults changed for EAF:
- `notificationCommentsOnSubscribedPost` (newComment): realtime onsite, no email -> realtime onsite, daily by email
- `notificationRepliesToMyComments` (newReplyToYou): realtime onsite, no email -> realtime onsite, realtime by email
- `notificationRepliesToSubscribedComments` (newReply): realtime onsite, no email -> realtime onsite, daily by email
- `notificationKarmaPowersGained` (karmaPowersGained): realtime onsite, no email -> realtime onsite, realtime by email

@darkruby501 @Discordius lmk if you want to adopt any of these so I can remove the forum gating in those cases

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209498853393689) by [Unito](https://www.unito.io)
