### PR TITLE
change fragment so tag hover previews from FootTag.tsx display summaries

### DIFF
--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -42,9 +42,6 @@ registerFragment(`
       _id
       html
     }
-    tags {
-      ...TagPreviewFragment
-    }
     reviewWinner {
       ...ReviewWinnerTopPostsPage
     }

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -145,6 +145,9 @@ registerFragment(`
       _id
       htmlHighlight
     }
+    summaries {
+      ...MultiDocumentContentDisplay
+    }
     canVoteOnRels
     isArbitalImport
   }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -2005,7 +2005,6 @@ interface PostsTopItemInfo extends PostsMinimumInfo, PostsAuthors { // fragment 
   readonly isRead: boolean|null,
   readonly contents: PostsTopItemInfo_contents|null,
   readonly customHighlight: PostsTopItemInfo_customHighlight|null,
-  readonly tags: Array<TagPreviewFragment>,
   readonly reviewWinner: ReviewWinnerTopPostsPage|null,
   readonly spotlight: SpotlightReviewWinner|null,
   readonly reviews: Array<CommentsList>,
@@ -2999,6 +2998,7 @@ interface TagPreviewFragment extends TagBasicInfo { // fragment on Tags
   readonly parentTag: TagBasicInfo|null,
   readonly subTags: Array<TagBasicInfo>,
   readonly description: TagPreviewFragment_description|null,
+  readonly summaries: Array<MultiDocumentContentDisplay>,
   readonly canVoteOnRels: Array<"userOwns" | "userOwnsOnlyUpvote" | "guests" | "members" | "admins" | "sunshineRegiment" | "alignmentForumAdmins" | "alignmentForum" | "alignmentVoters" | "podcasters" | "canBypassPostRateLimit" | "trustLevel1" | "canModeratePersonal" | "canSuggestCuration" | "debaters" | "realAdmins">,
   readonly isArbitalImport: boolean|null,
 }


### PR DESCRIPTION
Tags showing at the top of post pages (FooterTag elements) weren't showing summaries for tags when they're present because they weren't being passed the summaries (but some type coercion/casting was hiding this. Fixed by modifying the fragments.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209502388334198) by [Unito](https://www.unito.io)
