### PR TITLE
Only show tag/lens card Revision Icons on the tag history page

### DIFF
--- a/packages/lesswrong/components/common/SingleLineFeedEvent.tsx
+++ b/packages/lesswrong/components/common/SingleLineFeedEvent.tsx
@@ -8,7 +8,8 @@ const styles = defineStyles("SingleLineFeedEvent", (theme: ThemeType) => ({
   root: {
     display: "flex",
     ...theme.typography.body2,
-    margin: 8,
+    marginTop: 8,
+    marginBottom: 8,
     width: "100%",
   },
   tooltipWrapper: {
@@ -62,7 +63,7 @@ const SingleLineFeedEvent = ({expands=false, expanded=false, setExpanded, frame,
   expanded?: boolean,
   setExpanded?: (expanded: boolean) => void,
   frame?: boolean,
-  icon: React.ReactNode,
+  icon?: React.ReactNode,
   tooltip?: React.ReactNode,
   children: React.ReactNode,
 }) => {
@@ -76,7 +77,7 @@ const SingleLineFeedEvent = ({expands=false, expanded=false, setExpanded, frame,
   }
 
   const contents = <div className={classNames(classes.root, expands && !expanded && classes.expandable)} onClick={handleClick}>
-    <div className={classNames(classes.icon, frame && classes.iconNextToFrame)}>{icon}</div>
+    {icon && <div className={classNames(classes.icon, frame && classes.iconNextToFrame)}>{icon}</div>}
     <div className={classNames(classes.contents, frame && classes.frame)}>
       {children}
     </div>

--- a/packages/lesswrong/components/tagging/TagRevisionItem.tsx
+++ b/packages/lesswrong/components/tagging/TagRevisionItem.tsx
@@ -25,6 +25,7 @@ const TagRevisionItem = ({
   documentId,
   showDiscussionLink=true,
   noContainer=false,
+  showIcon=false
 }: {
   tag: TagBasicInfo,
   collapsed?: boolean,
@@ -34,6 +35,7 @@ const TagRevisionItem = ({
   documentId: string,
   showDiscussionLink?: boolean,
   noContainer?: boolean,
+  showIcon?: boolean
 }) => {
   const classes = useStyles(styles);
   const tagHistoryClasses = useStyles(tagHistoryStyles);
@@ -70,7 +72,7 @@ const TagRevisionItem = ({
   return noContainer
     ? contents
     : <Components.SingleLineFeedEvent
-        icon={<ForumIcon className={tagHistoryClasses.feedIcon} icon="Edit"/>}
+        icon={showIcon ? <ForumIcon className={tagHistoryClasses.feedIcon} icon="Edit"/> : undefined}
         frame expands expanded={expanded || !collapsed} setExpanded={setExpanded}
         tooltip={!(expanded || !collapsed) && diffBody}
       >

--- a/packages/lesswrong/components/tagging/history/LensRevisionItem.tsx
+++ b/packages/lesswrong/components/tagging/history/LensRevisionItem.tsx
@@ -13,12 +13,13 @@ const styles = defineStyles("LensRevisionItem", (theme: ThemeType) => ({
   },
 }));
 
-const LensRevisionItem = ({tag, collapsed, lens, revision, noContainer = false}: {
+const LensRevisionItem = ({tag, collapsed, lens, revision, noContainer = false, showIcon = false}: {
   tag: TagBasicInfo,
   collapsed?: boolean,
   lens: MultiDocumentContentDisplay | TagLens,
   revision: RevisionHistoryEntry,
   noContainer?: boolean,
+  showIcon?: boolean
 }) => {
   const classes = useStyles(styles);
   const tagHistoryClasses = useStyles(tagHistoryStyles);
@@ -54,7 +55,7 @@ const LensRevisionItem = ({tag, collapsed, lens, revision, noContainer = false}:
   return (noContainer
     ? contents
     : <Components.SingleLineFeedEvent
-        icon={<ForumIcon className={tagHistoryClasses.feedIcon} icon="Edit"/>}
+        icon={showIcon ? <ForumIcon className={tagHistoryClasses.feedIcon} icon="Edit"/> : undefined}
         frame expands expanded={expanded || !collapsed} setExpanded={setExpanded}
         tooltip={!(expanded || !collapsed) && diffBody}
       >

--- a/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
+++ b/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
@@ -144,6 +144,7 @@ const TagHistoryPage = () => {
                 headingStyle={"abridged"}
                 documentId={tag._id}
                 showDiscussionLink={false}
+                showIcon={true}
               />
             </div>
           }
@@ -160,6 +161,7 @@ const TagHistoryPage = () => {
                 collapsed={collapseAll && focusedUser!==revision.user?.slug}
                 lens={lens}
                 revision={revision}
+                showIcon={true}
               />
             </div>
           }


### PR DESCRIPTION
The icons Jim added to cards are helpful on Tag History page in distinguishing history event types, but cause misalignment when those items appear in recent discussion and maybe elsewhere.

This PR makes it so the icons only show on the TagHistoryPage and are "opt in"

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209504166101150) by [Unito](https://www.unito.io)
