### PR TITLE
fix disappearing footnote number issue on tag pages

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -319,44 +319,57 @@ function getFootnoteId(href: string, html: string): string|null {
  * Because of different versions of the CkEditor footnote plugin, imported
  * posts, etc, we have several different strategies for doing this:
  *  - Find the footnote reference, and use the data-footnote-index prop
- *  - Find the footnote in the post footer, and if it's inside an <ol> tag, use
+ *  - Find the footnote in the page footer, and if it's inside an <ol> tag, use
  *    its position within that tag's list of children
  */
 function getFootnoteIndex(href: string, html: string): string|null {
-  // Parse the footnote for its data-footnote-id, use that to find the footnote
-  // reference (which is a span that wraps around the part of the footnote that
-  // got hover-preview-ified), and take the data-footnote-index from that to
-  // display.
   const footnoteId = getFootnoteId(href, html);
   if (!footnoteId) return null;
 
-  const fromFootnoteIndexAttribute = document.getElementById("fnref"+footnoteId)
-    ?.getAttribute("data-footnote-index");
-  if (fromFootnoteIndexAttribute)
-    return fromFootnoteIndexAttribute;
+  const footnoteRef = document.getElementById("fnref"+footnoteId);
+  const fromFootnoteIndexAttribute = footnoteRef?.getAttribute("data-footnote-index");
   
-  const footnoteElement = document.getElementById("fn"+footnoteId);
-  if (footnoteElement) {
-    const parentElement = footnoteElement.parentElement;
-    if (parentElement && parentElement.tagName === 'OL') {
-      const olStartAttr = parentElement.getAttribute("start");
-      const olStart = olStartAttr ? parseInt(olStartAttr) : 1;
+  if (fromFootnoteIndexAttribute) {
+    return fromFootnoteIndexAttribute;
+  }
+  
+  const allMatchingElements = Array.from(document.querySelectorAll(`#fn${footnoteId}`));
+  
+  // First try to find element with an OL parent with the "footnotes" class
+  // This is the most reliable way to get the correct footnote
+  // This prevents using the version of the footnote from within quick-switch edit form that has a div parent instead of an ol
+  const footnoteWithOlParent = allMatchingElements.find(el => 
+    el.parentElement?.tagName === 'OL' &&
+    el.parentElement.classList.contains('footnotes')
+  );
+  
+  if (footnoteWithOlParent) {
+    const parentElement = footnoteWithOlParent.parentElement;
+    
+    const olStartAttr = parentElement?.getAttribute("start");
+    const olStart = olStartAttr ? parseInt(olStartAttr) : 1;
 
-      let numPrecedingLiElements = 0;
-      for (let i=0; i<parentElement.children.length; i++) {
-        const elem = parentElement.children.item(i);
-        if (elem === footnoteElement) {
-          break;
-        }
-        if (elem?.tagName === 'LI') {
-          numPrecedingLiElements++;
-        }
+    let numPrecedingLiElements = 0;
+    for (let i=0; i<(parentElement?.children.length ?? 0); i++) {
+      const elem = parentElement?.children.item(i);
+      if (elem === footnoteWithOlParent) {
+        break;
       }
-      return ""+(numPrecedingLiElements+olStart);
+      if (elem?.tagName === 'LI') {
+        numPrecedingLiElements++;
+      }
+    }
+    
+    return (olStart + numPrecedingLiElements).toString();
+  }
+  
+  for (const element of allMatchingElements) {
+    const indexAttr = element.getAttribute('data-footnote-index');
+    if (indexAttr) {
+      return indexAttr;
     }
   }
   
-
   return null;
 }
 

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -321,8 +321,15 @@ function getFootnoteId(href: string, html: string): string|null {
  *  - Find the footnote reference, and use the data-footnote-index prop
  *  - Find the footnote in the page footer, and if it's inside an <ol> tag, use
  *    its position within that tag's list of children
+ * 
+ * We specifically look for footnotes with an OL parent that has the "footnotes" class
+ * to avoid using versions of the footnote that's present from the ckEditor edit form (present for quick-switching).
  */
 function getFootnoteIndex(href: string, html: string): string|null {
+  // Parse the footnote for its data-footnote-id, use that to find the footnote
+  // reference (which is a span that wraps around the part of the footnote that
+  // got hover-preview-ified), and take the data-footnote-index from that to
+  // display.
   const footnoteId = getFootnoteId(href, html);
   if (!footnoteId) return null;
 
@@ -335,8 +342,7 @@ function getFootnoteIndex(href: string, html: string): string|null {
   
   const allMatchingElements = Array.from(document.querySelectorAll(`#fn${footnoteId}`));
   
-  // First try to find element with an OL parent with the "footnotes" class
-  // This is the most reliable way to get the correct footnote
+  // Try to find element with an OL parent with the "footnotes" class
   // This prevents using the version of the footnote from within quick-switch edit form that has a div parent instead of an ol
   const footnoteWithOlParent = allMatchingElements.find(el => 
     el.parentElement?.tagName === 'OL' &&
@@ -361,13 +367,6 @@ function getFootnoteIndex(href: string, html: string): string|null {
     }
     
     return (olStart + numPrecedingLiElements).toString();
-  }
-  
-  for (const element of allMatchingElements) {
-    const indexAttr = element.getAttribute('data-footnote-index');
-    if (indexAttr) {
-      return indexAttr;
-    }
   }
   
   return null;


### PR DESCRIPTION
From Slack:

I have the following bug: Sidenotes on tag pages initially show the footnote number, but after a rerender (when you hover over them, or resize the page), the number disappears

The reason is because getFootnoteIndex uses document.getElementById to find the footnote definition at the bottom of the page, but instead of finding the <li> inside an <ol> that it expects, it finds... an <li> with the same id inside the hidden CkEditor instance that's created to enable quickly switching to the editor, which has a few unexpected extra elements in between that getFootnoteIndex doesn't know how to handle.

---
This solution checks for the correct parent type OL and not DIV

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209504930524397) by [Unito](https://www.unito.io)
