### PR TITLE
No throw on unknown view

### DIFF
--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -80,7 +80,7 @@ function getParameters<N extends CollectionNameString>(
 
   // handle view option
   if (terms.view && collectionViewSet.getView(terms.view)) {
-    const viewFn = collectionViewSet.getView(terms.view);
+    const viewFn = collectionViewSet.getView(terms.view)!;
     const view = viewFn(terms, apolloClient, context);
     let mergedParameters = mergeSelectors(parameters, view);
 

--- a/packages/lesswrong/lib/views/collectionViewSet.ts
+++ b/packages/lesswrong/lib/views/collectionViewSet.ts
@@ -13,9 +13,11 @@ export class CollectionViewSet<N extends CollectionNameString, Views extends Rec
     return this.defaultView;
   }
 
-  getView<T extends keyof Views & string>(viewName: T): Views[T] {
+  getView<T extends keyof Views & string>(viewName: T): Views[T] | undefined {
     if (!this.views[viewName]) {
-      throw new Error(`View ${viewName} not found in collection ${this.collectionName}`);
+      // eslint-disable-next-line no-console
+      console.warn(`View ${viewName} not found in collection ${this.collectionName}`);
+      return undefined;
     }
     return this.views[viewName];
   }


### PR DESCRIPTION
Previously, requests with view names that we didn't have registered were just treated like requests that weren't specifying a view.  Some friendly 3rd party clients were using those.  Un-break that.