### PR TITLE
fix lack of overflow truncation on tag page right sidebar

### DIFF
--- a/packages/lesswrong/components/tagging/ArbitalLinkedPagesRightSidebar.tsx
+++ b/packages/lesswrong/components/tagging/ArbitalLinkedPagesRightSidebar.tsx
@@ -27,11 +27,6 @@ const styles = defineStyles("ArbitalLinkedPages", (theme: ThemeType) => ({
     zIndex: 2,
     height: 140,
     width: "100%",
-    // background: `linear-gradient(0deg, 
-    //   ${theme.palette.background.pageActiveAreaBackground} 30%,
-    //   ${theme.palette.panelBackground.translucent} 70%,
-    //   transparent 100%
-    // )`,
     opacity: 1,
   },
 
@@ -40,8 +35,6 @@ const styles = defineStyles("ArbitalLinkedPages", (theme: ThemeType) => ({
     fontSize: '1.0rem',
     marginBottom: 4,
     color: theme.palette.grey[600],
-    minWidth: 'fit-content',
-    // whiteSpace: 'nowrap',
     display: 'block',
     cursor: 'pointer',
     '&:hover': {


### PR DESCRIPTION
Long children in linked pages weren't getting truncated due to a 'fit-content' css property. Now removed. Unclear why it was there (probably I wrote that code though).

Before:
![image](https://github.com/user-attachments/assets/ff5dd13d-1861-46dd-b3ae-738b0640c4ac)


After:

<img width="874" alt="Orthogonality Thesis - LessWrong 2025-02-25 19-50-01" src="https://github.com/user-attachments/assets/1373418e-24e4-477f-a923-00b6ef6a846b" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209505297912685) by [Unito](https://www.unito.io)
