### PR TITLE
Fix issue that sometimes (unclear when) causes errors when loading users for the community-page map

### DIFF
--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -489,7 +489,10 @@ registerFragment(`
     username
     fullName
     slug
-    mapLocationLatLng { lat lng }
+    mapLocationLatLng {
+      lat
+      lng
+    }
     mapLocationSet
     htmlMapMarkerText
   }


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209506386803222) by [Unito](https://www.unito.io)
