### PR TITLE
Fix tag button row spacing

### DIFF
--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -75,12 +75,14 @@ const styles = (theme: ThemeType) => ({
   },
   subscribeToWrapper: {
     display: "flex !important",
-    marginLeft: -2,
-    marginRight: -5,
-
+    ...(isFriendlyUI ? {
+    } : {
+      marginLeft: -2,
+      marginRight: -5,
     '& .MuiListItemIcon-root': {
       marginRight: "unset !important",
     },
+    }),
   },
   subscribeTo: {
   },

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -79,9 +79,9 @@ const styles = (theme: ThemeType) => ({
     } : {
       marginLeft: -2,
       marginRight: -5,
-    '& .MuiListItemIcon-root': {
-      marginRight: "unset !important",
-    },
+      '& .MuiListItemIcon-root': {
+        marginRight: "unset !important",
+      },
     }),
   },
   subscribeTo: {

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -75,6 +75,12 @@ const styles = (theme: ThemeType) => ({
   },
   subscribeToWrapper: {
     display: "flex !important",
+    marginLeft: -2,
+    marginRight: -5,
+
+    '& .MuiListItemIcon-root': {
+      marginRight: "unset !important",
+    },
   },
   subscribeTo: {
   },


### PR DESCRIPTION
Spacing around the notification button (that only appears on tag pages) was messed up due to extra marginRight coming from MUI styling. Overriden here.

<img width="243" alt="Absurdity Heuristic - LessWrong 2025-02-26 12-30-31" src="https://github.com/user-attachments/assets/9c18a3d8-d8a1-4329-8fe9-a2015a4c45f1" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209517647007946) by [Unito](https://www.unito.io)
