### PR TITLE
fix overflow by wrapping

### DIFF
--- a/packages/lesswrong/components/tagging/lenses/LensTab.tsx
+++ b/packages/lesswrong/components/tagging/lenses/LensTab.tsx
@@ -12,6 +12,7 @@ const styles = defineStyles("LensTab", (theme: ThemeType) => ({
   },
   lensTabsContainer: {
     display: 'flex',
+    flexWrap: 'wrap-reverse',
     gap: '4px',
     [theme.breakpoints.up('md')]: {
       alignItems: 'flex-end',


### PR DESCRIPTION
<img width="515" alt="Logical decision theories - LessWrong 2025-02-26 13-20-26" src="https://github.com/user-attachments/assets/7f94cace-ae64-4c37-a3dd-252ae981868d" />

<img width="579" alt="A beginner's guide to explaining things - LessWrong 2025-02-26 13-20-43" src="https://github.com/user-attachments/assets/b5241bbc-23d4-4ff4-9419-629405816c6f" />

<img width="580" alt="Axiom of Choice - LessWrong 2025-02-26 13-20-54" src="https://github.com/user-attachments/assets/7c0ecbfb-fbc2-49e3-867d-63e5d3ee1cf9" />

BEFORE:
<img width="759" alt="A beginner's guide to explaining things - LessWrong 2025-02-26 13-21-22" src="https://github.com/user-attachments/assets/32af291d-3394-4962-a6f1-fb5d65f32917" />
<img width="762" alt="Axiom of Choice - LessWrong 2025-02-26 13-21-30" src="https://github.com/user-attachments/assets/7c836aa3-5845-4d67-90e9-9d16085cef1a" />

<img width="750" alt="Logical decision theories - LessWrong 2025-02-26 13-21-38" src="https://github.com/user-attachments/assets/ed425ba3-3d98-4e79-abf4-13738f1d7645" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209518108571421) by [Unito](https://www.unito.io)
