### PR TITLE
fix wrapping behavior of contributor list and last updated

### DIFF
--- a/packages/lesswrong/components/tagging/ContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/ContributorsList.tsx
@@ -6,6 +6,7 @@ import { DocumentContributorWithStats, DocumentContributorsInfo } from '@/lib/ar
 
 const styles = defineStyles("ContributorsList", (theme: ThemeType) => ({
   contributorNameWrapper: {
+    display: 'inline',
     [theme.breakpoints.down('sm')]: {
       fontSize: '15px',
     },
@@ -112,7 +113,7 @@ const HeadingContributorsList = ({topContributors, smallContributors, onHoverCon
   const classes = useStyles(styles);
   const { LWTooltip } = Components;
 
-  return <div className={classes.contributorNameWrapper}>
+  return <span className={classes.contributorNameWrapper}>
     <span>Written by </span>
     <ContributorsList
       contributors={topContributors}
@@ -126,7 +127,7 @@ const HeadingContributorsList = ({topContributors, smallContributors, onHoverCon
     >
       et al.
     </LWTooltip>}
-  </div>
+  </span>
 }
 
 const ContributorsListComponent = registerComponent('ContributorsList', ContributorsList);

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -213,6 +213,9 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     lineHeight: 'inherit',
     marginBottom: 8,
   },
+  contributorRowContent: {
+    display: 'inline',
+  },
   lastUpdated: {
   },
   alternativeArrowIcon: {
@@ -862,7 +865,7 @@ const LWTagPage = () => {
         }
       </div>
       {(topContributors.length > 0 || smallContributors.length > 0) && <div className={classes.contributorRow}>
-        <span style={{ display: 'inline' }}>
+        <span className={classes.contributorRowContent}>
           <Components.HeadingContributorsList topContributors={topContributors} smallContributors={smallContributors} onHoverContributor={onHoverContributor} />
           {selectedLens?.contents?.editedAt && <>
             {' '}{'last updated '}

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -208,9 +208,7 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
   contributorRow: {
     ...theme.typography.body1,
     color: theme.palette.grey[600],
-    display: 'flex',
-    justifyContent: 'flex-start',
-    columnGap: 4,
+    display: 'block',
     fontSize: '17px',
     lineHeight: 'inherit',
     marginBottom: 8,
@@ -864,11 +862,13 @@ const LWTagPage = () => {
         }
       </div>
       {(topContributors.length > 0 || smallContributors.length > 0) && <div className={classes.contributorRow}>
-        <Components.HeadingContributorsList topContributors={topContributors} smallContributors={smallContributors} onHoverContributor={onHoverContributor} />
-        {selectedLens?.contents?.editedAt && <div className={classes.lastUpdated}>
-          {'last updated '}
-          {selectedLens?.contents?.editedAt && <FormatDate date={selectedLens.contents.editedAt} format="Do MMM YYYY" tooltip={false} />}
-        </div>}
+        <span style={{ display: 'inline' }}>
+          <Components.HeadingContributorsList topContributors={topContributors} smallContributors={smallContributors} onHoverContributor={onHoverContributor} />
+          {selectedLens?.contents?.editedAt && <>
+            {' '}{'last updated '}
+            <FormatDate date={selectedLens.contents.editedAt} format="Do MMM YYYY" tooltip={false} />
+          </>}
+        </span>
       </div>}
       <ArbitalRelationshipsSmallScreen arbitalLinkedPages={selectedLens?.arbitalLinkedPages ?? undefined} tag={tag} selectedLens={selectedLens} />
     </div>


### PR DESCRIPTION
previously:
![image](https://github.com/user-attachments/assets/74d96aa2-a94f-4356-99cd-1eca8a5f4e86)

now:
<img width="563" alt="Waterfall diagram - LessWrong 2025-02-26 15-03-34" src="https://github.com/user-attachments/assets/477ecb96-a878-4a6e-abbb-f14c49c58336" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209518898236710) by [Unito](https://www.unito.io)
