### PR TITLE
adjust toc height based on presence of comment count

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/LWCommentCount.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/LWCommentCount.tsx
@@ -1,6 +1,6 @@
 import React, { FC, MouseEvent } from 'react';
 import classNames from 'classnames';
-import { FIXED_TOC_COMMENT_COUNT_HEIGHT, HOVER_CLASSNAME } from './MultiToCLayout';
+import { HOVER_CLASSNAME } from './MultiToCLayout';
 import { CommentsLink } from '../PostsPage/PostsPagePostHeader';
 import { Components, registerComponent } from "@/lib/vulcan-lib/components";
 

--- a/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/MultiToCLayout.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { MAX_COLUMN_WIDTH } from '../PostsPage/PostsPage';
 import { fullHeightToCEnabled } from '../../../lib/betas';
@@ -175,7 +175,6 @@ const MultiToCLayout = ({segments, classes, tocRowMap = [], showSplashPageHeader
   showSplashPageHeader?: boolean,
   answerCount?: number,
   commentCount?: number,
-  fixedTocCommentCountHeight?: number,
   tocContext?: 'tag' | 'post'
 }) => {
   const { LWCommentCount } = Components;
@@ -191,15 +190,16 @@ const MultiToCLayout = ({segments, classes, tocRowMap = [], showSplashPageHeader
   const showCommentCount = commentCount !== undefined || answerCount !== undefined;
 
   // Create a ref for the root element to set CSS variable
-  const rootRef = React.useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
-  // Set the CSS variable when the component mounts or when fixedTocCommentCountHeight changes
-  React.useEffect(() => {
+  // Set the CSS variable when the component mounts
+  useEffect(() => {
     if (rootRef.current) {
       const fixedTocCommentCountHeight = tocContext === 'tag' ? 20 : DEFAULT_FIXED_TOC_COMMENT_COUNT_HEIGHT;
       rootRef.current.style.setProperty('--fixed-toc-comment-count-height', `${fixedTocCommentCountHeight}px`);
     }
-  }, [tocContext]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <div className={classes.root} ref={rootRef}>
     <div className={classNames(classes.tableOfContents)} style={{ gridTemplateAreas, gridTemplateRows }}>

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -893,6 +893,7 @@ const LWTagPage = () => {
         },
       ]}
       tocRowMap={[0, 1, 1, 1]}
+      tocContext='tag'
     />
   );
   


### PR DESCRIPTION
Tag pages don't have a comment count in the bottom left, making the ToC seem like it doesn't take up the full height. This PR makes this adjustable with a prop into MultiToc

Because the value gets used in a number of places, trying out an approach using css variables.

BEFORE:
<img width="1728" alt="Bayes' rule - LessWrong 2025-02-26 17-50-09" src="https://github.com/user-attachments/assets/127af27f-d6f3-4a7f-90cf-f236a3981dcc" />


AFTER
<img width="1728" alt="Bayes' rule - LessWrong 2025-02-26 17-42-56" src="https://github.com/user-attachments/assets/19ef37f5-f4d1-42d9-acf0-3691e21dd32d" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209519921348054) by [Unito](https://www.unito.io)
