### PR TITLE
Remove function checkForMemoryLeaks which was using lots of CPU time in prod

### DIFF
--- a/packages/lesswrong/server/logging.ts
+++ b/packages/lesswrong/server/logging.ts
@@ -2,7 +2,7 @@ import { captureException } from '@sentry/core';
 import { captureEvent } from '../lib/analyticsEvents';
 import { isAnyTest } from '../lib/executionEnvironment';
 import { DatabaseServerSetting } from './databaseSettings';
-import { printInFlightRequests, checkForMemoryLeaks } from './vulcan-lib/apollo-ssr/pageCache';
+import { printInFlightRequests } from './vulcan-lib/apollo-ssr/pageCache';
 
 import * as Sentry from '@sentry/node';
 import * as SentryIntegrations from '@sentry/integrations';
@@ -65,7 +65,7 @@ export const addSentryMiddlewares = (addConnectHandler: AddMiddlewareType) => {
 const gigabytes = 1024*1024*1024;
 const consoleLogMemoryUsageThreshold = new DatabaseServerSetting<number>("consoleLogMemoryUsage", 1.5*gigabytes);
 const sentryErrorMemoryUsageThreshold = new DatabaseServerSetting<number>("sentryErrorMemoryUsage", 2.1*gigabytes);
-const memoryUsageCheckInterval = new DatabaseServerSetting<number>("memoryUsageCheckInterval", 2000);
+const memoryUsageCheckInterval = new DatabaseServerSetting<number>("memoryUsageCheckInterval", 10000);
 
 export function startMemoryUsageMonitor() {
   if (!isAnyTest) {
@@ -74,8 +74,6 @@ export function startMemoryUsageMonitor() {
       if (memoryUsage > consoleLogMemoryUsageThreshold.get()) {
         // eslint-disable-next-line no-console
         console.log(`Memory usage is high: ${memoryUsage} bytes (warning threshold: ${consoleLogMemoryUsageThreshold.get()})`);
-        checkForMemoryLeaks();
-        
         logInFlightStuff();
       }
       if (memoryUsage > sentryErrorMemoryUsageThreshold.get()) {

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -368,35 +368,6 @@ export function printCacheState(options: any={}) {
 }
 
 
-export function checkForMemoryLeaks() {
-  if (Object.keys(cachedABtestsIndex).length > 5000) {
-    // eslint-disable-next-line no-console
-    console.log(`Possible memory leak: cachedABtestsIndex has ${Object.keys(cachedABtestsIndex).length} entries`);
-  }
-  if (keysToCheckForExpiredEntries.length > 5000) {
-    // eslint-disable-next-line no-console
-    console.log(`Possible memory leak: keysToCheckForExpiredEntries has ${keysToCheckForExpiredEntries} entries`);
-  }
-  
-  const cachedABtestsIndexArrayElements = sumBy(Object.keys(cachedABtestsIndex), key=>cachedABtestsIndex[key]?.length||0);
-  if (cachedABtestsIndexArrayElements > 5000) {
-    // eslint-disable-next-line no-console
-    console.log(`Possible memory leak: cachedABtestsIndexArrayElements=${cachedABtestsIndexArrayElements}`);
-  }
-  
-  const inProgressRenderCount = sumBy(Object.keys(inProgressRenders), key=>inProgressRenders[key]?.length||0);
-  if (inProgressRenderCount > 100) {
-    // eslint-disable-next-line no-console
-    console.log(`Possible memory leak: inProgressRenderCount=${inProgressRenderCount}`);
-  }
-  
-  const pageCacheContentsBytes = sumBy(pageCache.values(), v=>JSON.stringify(v).length);
-  if (pageCacheContentsBytes > 2*maxPageCacheSizeBytes) {
-    // eslint-disable-next-line no-console
-    console.log(`Possible memory leak: pageCacheContentsBytes=${pageCacheContentsBytes}`);
-  }
-}
-
 export function printInFlightRequests() {
   let inProgressRenderKeys: string[] = [];
   for (let cacheKey of Object.keys(inProgressRenders)) {


### PR DESCRIPTION
We had a check that, every 2s, checks the server-process's memory usage, and if it's over a threshold, logs a warning and calls a function `checkForMemoryLeaks`, which checks some global variables for signs of them having grown larger than they're supposed to. It turns out that checking those globals was itself a slow operation, and, since it's all in one uninterruptiple block of CPU time, it noticeably affected P75 latency. And it wasn't actually finding anything to warn about anyways.

Slow the interval from 2s to 10s, and remove the slow part.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209528638185965) by [Unito](https://www.unito.io)
