### PR TITLE
Fix infinite redirect when user `oldSlugs` contains `slug`

### DIFF
--- a/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
+++ b/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
@@ -280,7 +280,7 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
     return <Error404/>
   }
 
-  if (user.oldSlugs?.includes(slug) && !user.deleted) {
+  if (slug !== user.slug && user.oldSlugs?.includes(slug) && !user.deleted) {
     return <PermanentRedirect url={userGetProfileUrlFromSlug(user.slug)} />
   }
 

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -232,7 +232,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
       return <Error404/>
     }
 
-    if (user.oldSlugs?.includes(slug) && !user.deleted) {
+    if (slug !== user.slug && user.oldSlugs?.includes(slug) && !user.deleted) {
       return <PermanentRedirect url={userGetProfileUrlFromSlug(user.slug)} />
     }
 


### PR DESCRIPTION
If a user's `oldSlugs` contains their current `slug` then their profile page enters an infinite redirect loop. This is the symptom but not the cause of #10448.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209537275207472) by [Unito](https://www.unito.io)
