### PR TITLE
Refactor makeEditable away from using global state.

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect, useContext } from 'react';
-import { debateEditorPlaceholder, defaultEditorPlaceholder, linkpostEditorPlaceholder, questionEditorPlaceholder } from '../../lib/editor/make_editable';
+import { debateEditorPlaceholder, defaultEditorPlaceholder, getEditableFieldInCollection, linkpostEditorPlaceholder, questionEditorPlaceholder } from '../../lib/editor/make_editable';
 import { getLSHandlers, getLSKeyPrefix } from './localStorageHandlers'
 import { userCanCreateCommitMessages, userHasPostAutosave } from '../../lib/betas';
 import { useCurrentUser } from '../common/withUser';
@@ -18,7 +18,6 @@ import { DynamicTableOfContentsContext } from '../posts/TableOfContents/DynamicT
 import isEqual from 'lodash/isEqual';
 import { useDebouncedCallback, useStabilizedCallback } from '../hooks/useDebouncedCallback';
 import { useMessages } from '../common/withMessages';
-import { editableCollectionsFieldOptions } from '@/lib/editor/makeEditableOptions';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE } from '@/lib/cookies/cookies';
@@ -102,14 +101,14 @@ export const EditorFormComponent = ({
   const hasUnsavedDataRef = useRef({hasUnsavedData: false});
   const isCollabEditor = collectionName === 'Posts' && isCollaborative(document, fieldName);
   const { captureEvent } = useTracking()
-  const editableFieldOptions = editableCollectionsFieldOptions[collectionName as CollectionNameString][fieldName];
+  const { editableFieldOptions } = getEditableFieldInCollection(collectionName, fieldName)!;
 
   const getLocalStorageHandlers = useCallback((editorType: EditorTypeString) => {
-    const getLocalStorageId = editableFieldOptions.getLocalStorageId;
+    const getLocalStorageId = editableFieldOptions.clientOptions.getLocalStorageId;
     return getLSHandlers(getLocalStorageId, document, name,
       getLSKeyPrefix(editorType)
     );
-  }, [document, name, editableFieldOptions.getLocalStorageId]);
+  }, [document, name, editableFieldOptions.clientOptions.getLocalStorageId]);
   
   const [contents,setContents] = useState(() => getInitialEditorContents(
     value, document, fieldName, currentUser
@@ -314,7 +313,7 @@ export const EditorFormComponent = ({
   
   const wrappedSetContents = useStabilizedCallback((change: EditorChangeEvent) => {
     const {contents: newContents, autosave} = change;
-    if (dynamicTableOfContents && editableFieldOptions.hasToc) {
+    if (dynamicTableOfContents && editableFieldOptions.clientOptions.hasToc) {
       dynamicTableOfContents.setToc(change.contents);
     }
     setContents(newContents);
@@ -356,11 +355,11 @@ export const EditorFormComponent = ({
   
   const hasGeneratedFirstToC = useRef({generated: false});
   useEffect(() => {
-    if (dynamicTableOfContents && contents && !hasGeneratedFirstToC.current.generated && editableFieldOptions.hasToc) {
+    if (dynamicTableOfContents && contents && !hasGeneratedFirstToC.current.generated && editableFieldOptions.clientOptions.hasToc) {
       dynamicTableOfContents.setToc(contents);
       hasGeneratedFirstToC.current.generated = true;
     }
-  }, [contents, dynamicTableOfContents, editableFieldOptions.hasToc]);
+  }, [contents, dynamicTableOfContents, editableFieldOptions.clientOptions.hasToc]);
 
   useEffect(() => {
     const unloadEventListener = (ev: BeforeUnloadEvent) => {
@@ -445,7 +444,7 @@ export const EditorFormComponent = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!editorRef.current, fieldName, initialEditorType, context.addToSuccessForm, context.addToSubmitForm]);
   
-  const fieldHasCommitMessages = editableCollectionsFieldOptions[collectionName as CollectionNameString][fieldName].revisionsHaveCommitMessages;
+  const fieldHasCommitMessages = getEditableFieldInCollection(collectionName as CollectionNameString, fieldName)?.editableFieldOptions.clientOptions.revisionsHaveCommitMessages;
   const hasCommitMessages = fieldHasCommitMessages
     && currentUser && userCanCreateCommitMessages(currentUser)
     && (collectionName!=="Tags" || updatedFormType==="edit");

--- a/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
+++ b/packages/lesswrong/components/form-components/WrappedSmartForm.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib/components';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable'
 import type { WrappedSmartFormProps } from '../vulcan-forms/propTypes';
 import * as _ from 'underscore';
 
@@ -18,14 +18,14 @@ import * as _ from 'underscore';
 function WrappedSmartForm<T extends CollectionNameString>(props: WrappedSmartFormProps<T>) {
   const { collectionName } = props
 
-  if (editableCollections.has(collectionName)) {
+  if (getEditableCollectionNames().includes(collectionName)) {
     return <Components.FormWrapper
       {...props}
       submitCallback={(data: AnyBecauseTodo) => {
         if (props.submitCallback) {data = props.submitCallback(data)}
         
         // For all editable fields, ensure that we actually have data, and make sure we submit the response in the correct shape
-        const editableFields = _.object(editableCollectionsFields[collectionName].map(fieldName => {
+        const editableFields = _.object(getEditableFieldNamesForCollection(collectionName).map(fieldName => {
           const { originalContents, updateType, commitMessage, dataWithDiscardedSuggestions } = (data && data[fieldName]) || {}
           return [
             fieldName, // _.object takes array of tuples, with first value being fieldName and second being value

--- a/packages/lesswrong/lib/collections/books/collection.ts
+++ b/packages/lesswrong/lib/collections/books/collection.ts
@@ -1,6 +1,5 @@
 import { createCollection } from '../../vulcan-lib/collections';
 import schema from './schema';
-import { makeEditable } from '../../editor/make_editable';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
@@ -20,16 +19,6 @@ export const Books: BooksCollection = createCollection({
   logChanges: true,
 });
 
-makeEditable({
-  collection: Books,
-  options: {
-    order: 20,
-    getLocalStorageId: (book, name) => {
-      if (book._id) { return {id: `${book._id}_${name}`, verify: true} }
-      return {id: `collection: ${book.collectionId}_${name}`, verify: false}
-    },
-  }
-})
 addUniversalFields({collection: Books})
 
 export default Books;

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -1,6 +1,14 @@
+import { editableFields } from '@/lib/editor/make_editable';
 import { arrayOfForeignKeysField } from '../../utils/schemaUtils'
 
 const schema: SchemaType<"Books"> = {
+  ...editableFields("Books", {
+    order: 20,
+    getLocalStorageId: (book, name) => {
+      if (book._id) { return {id: `${book._id}_${name}`, verify: true} }
+      return {id: `collection: ${book.collectionId}_${name}`, verify: false}
+    },
+  }),
 
   // default properties
 

--- a/packages/lesswrong/lib/collections/chapters/collection.ts
+++ b/packages/lesswrong/lib/collections/chapters/collection.ts
@@ -2,7 +2,6 @@ import { createCollection } from '../../vulcan-lib/collections';
 import schema from './schema';
 import { userOwns, userCanDo } from '../../vulcan-users/permissions';
 import Sequences from '../sequences/collection';
-import { makeEditable } from '../../editor/make_editable';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -45,16 +44,6 @@ export const Chapters: ChaptersCollection = createCollection({
   logChanges: true,
 })
 
-makeEditable({
-  collection: Chapters,
-  options: {
-    order: 30,
-    getLocalStorageId: (chapter, name) => {
-      if (chapter._id) { return {id: `${chapter._id}_${name}`, verify: true} }
-      return {id: `sequence: ${chapter.sequenceId}_${name}`, verify: false}
-    },
-  }
-})
 addUniversalFields({collection: Chapters})
 
 Chapters.checkAccess = async (user: DbUser|null, document: DbChapter, context: ResolverContext|null): Promise<boolean> => {

--- a/packages/lesswrong/lib/collections/chapters/schema.ts
+++ b/packages/lesswrong/lib/collections/chapters/schema.ts
@@ -1,3 +1,4 @@
+import { editableFields } from '@/lib/editor/make_editable'
 import { foreignKeyField, arrayOfForeignKeysField } from '../../utils/schemaUtils'
 
 export const formGroups: Partial<Record<string, FormGroupType<"Chapters">>> = {
@@ -10,8 +11,14 @@ export const formGroups: Partial<Record<string, FormGroupType<"Chapters">>> = {
 }
 
 const schema: SchemaType<"Chapters"> = {
-  // Custom Properties
-
+  ...editableFields("Chapters", {
+    order: 30,
+    getLocalStorageId: (chapter, name) => {
+      if (chapter._id) { return {id: `${chapter._id}_${name}`, verify: true} }
+      return {id: `sequence: ${chapter.sequenceId}_${name}`, verify: false}
+    },
+  }),
+  
   title: {
     type: String,
     optional: true,

--- a/packages/lesswrong/lib/collections/collections/collection.ts
+++ b/packages/lesswrong/lib/collections/collections/collection.ts
@@ -1,6 +1,5 @@
 import { createCollection } from '../../vulcan-lib/collections';
 import schema from './schema';
-import { makeEditable } from '../../editor/make_editable';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
@@ -20,13 +19,6 @@ export const Collections: CollectionsCollection = createCollection({
   mutations: getDefaultMutations('Collections'),
   logChanges: true,
 });
-
-makeEditable({
-  collection: Collections,
-  options: {
-    order: 20
-  }
-})
 
 addUniversalFields({
   collection: Collections,

--- a/packages/lesswrong/lib/collections/collections/schema.ts
+++ b/packages/lesswrong/lib/collections/collections/schema.ts
@@ -1,7 +1,11 @@
 import { getWithCustomLoader } from '../../loaders';
 import { foreignKeyField, resolverOnlyField, accessFilterMultiple, schemaDefaultValue } from '../../utils/schemaUtils'
+import { editableFields } from '@/lib/editor/make_editable'
 
 const schema: SchemaType<"Collections"> = {
+  ...editableFields("Collections", {
+    order: 20,
+  }),
 
   // default properties
   userId: {

--- a/packages/lesswrong/lib/collections/comments/collection.ts
+++ b/packages/lesswrong/lib/collections/comments/collection.ts
@@ -4,8 +4,6 @@ import { userCanDo, userOwns } from '../../vulcan-users/permissions';
 import { userIsAllowedToComment } from '../users/helpers';
 import { mongoFindOne } from '../../mongoQueries';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
-import { makeEditable } from '../../editor/make_editable';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { commentVotingOptions } from './voting';
@@ -55,24 +53,5 @@ addUniversalFields({
   collection: Comments,
   createdAtOptions: {canRead: ['admins']},
 });
-
-makeEditable({
-  collection: Comments,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    // Sets the algorithm for determing what storage ids to use for local storage management
-    getLocalStorageId: (comment, name) => {
-      if (comment._id) { return {id: comment._id, verify: true} }
-      if (comment.parentCommentId) { return {id: ('parent:' + comment.parentCommentId), verify: false}}
-      return {id: ('post:' + comment.postId), verify: false}
-    },
-    hintText: isFriendlyUI ? 'Write a new comment...' : undefined,
-    order: 25,
-    pingbacks: true,
-  }
-})
 
 export default Comments;

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -11,6 +11,8 @@ import { viewTermsToQuery } from '../../utils/viewUtils';
 import GraphQLJSON from 'graphql-type-json';
 import {quickTakesTagsEnabledSetting} from '../../publicSettings'
 import { ForumEventCommentMetadataSchema } from '../forumEvents/types';
+import { editableFields } from '@/lib/editor/make_editable';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
 export const moderationOptionsGroup: FormGroupType<"Comments"> = {
   order: 50,
@@ -27,6 +29,19 @@ export const alignmentOptionsGroup = {
 };
 
 const schema: SchemaType<"Comments"> = {
+  ...editableFields("Comments", {
+    commentEditor: true,
+    commentStyles: true,
+    getLocalStorageId: (comment, name) => {
+      if (comment._id) { return {id: comment._id, verify: true} }
+      if (comment.parentCommentId) { return {id: ('parent:' + comment.parentCommentId), verify: false}}
+      return {id: ('post:' + comment.postId), verify: false}
+    },
+    hintText: isFriendlyUI ? 'Write a new comment...' : undefined,
+    order: 25,
+    pingbacks: true,
+  }),
+  
   // The `_id` of the parent comment, if there is one
   parentCommentId: {
     ...foreignKeyField({

--- a/packages/lesswrong/lib/collections/curationNotices/collection.ts
+++ b/packages/lesswrong/lib/collections/curationNotices/collection.ts
@@ -1,7 +1,6 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
 import { getDefaultMutations } from '../../vulcan-core/default_mutations';
-import { makeEditable } from "../../editor/make_editable";
 import { userIsAdminOrMod } from '@/lib/vulcan-users/permissions.ts';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -26,16 +25,6 @@ export const CurationNotices: CurationNoticesCollection = createCollection({
 });
 
 addUniversalFields({collection: CurationNotices});
-
-makeEditable({
-  collection: CurationNotices,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    order: 20
-  }
-})
 
 CurationNotices.checkAccess = async (user) => {
   return userIsAdminOrMod(user);

--- a/packages/lesswrong/lib/collections/curationNotices/schema.ts
+++ b/packages/lesswrong/lib/collections/curationNotices/schema.ts
@@ -1,6 +1,13 @@
+import { editableFields } from '@/lib/editor/make_editable';
 import { foreignKeyField, schemaDefaultValue } from '../../utils/schemaUtils';
 
 const schema: SchemaType<"CurationNotices"> = {
+  ...editableFields("CurationNotices", {
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    order: 20
+  }),
   userId: {
     ...foreignKeyField({
       idFieldName: "userId",

--- a/packages/lesswrong/lib/collections/forumEvents/collection.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/collection.ts
@@ -1,7 +1,6 @@
 import schema from "./schema";
 import { createCollection } from "../../vulcan-lib/collections";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
-import { makeEditable } from "../../editor/make_editable";
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { DatabaseIndexSet } from "@/lib/utils/databaseIndexSet";
@@ -21,71 +20,5 @@ export const ForumEvents: ForumEventsCollection = createCollection({
 });
 
 addUniversalFields({collection: ForumEvents});
-
-makeEditable({
-  collection: ForumEvents,
-  options: {
-    fieldName: "frontpageDescription",
-    label: "Frontpage description",
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    getLocalStorageId: (forumEvent) => {
-      return {
-        id: `forumEvent:frontpageDescription:${forumEvent?._id ?? "create"}`,
-        verify: true,
-      };
-    },
-    permissions: {
-      canRead: ["guests"],
-      canUpdate: ["admins"],
-      canCreate: ["admins"],
-    },
-  },
-});
-
-makeEditable({
-  collection: ForumEvents,
-  options: {
-    fieldName: "frontpageDescriptionMobile",
-    label: "Frontpage description (mobile)",
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    getLocalStorageId: (forumEvent) => {
-      return {
-        id: `forumEvent:frontpageDescriptionMobile:${forumEvent?._id ?? "create"}`,
-        verify: true,
-      };
-    },
-    permissions: {
-      canRead: ["guests"],
-      canUpdate: ["admins"],
-      canCreate: ["admins"],
-    },
-  },
-});
-
-makeEditable({
-  collection: ForumEvents,
-  options: {
-    fieldName: "postPageDescription",
-    label: "Post page description",
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    getLocalStorageId: (forumEvent) => {
-      return {
-        id: `forumEvent:postPageDescription:${forumEvent?._id ?? "create"}`,
-        verify: true,
-      };
-    },
-    permissions: {
-      canRead: ["guests"],
-      canUpdate: ["admins"],
-      canCreate: ["admins"],
-    },
-  },
-});
 
 export default ForumEvents;

--- a/packages/lesswrong/lib/collections/forumEvents/schema.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/schema.ts
@@ -1,5 +1,7 @@
+import { editableFields } from "@/lib/editor/make_editable";
 import { foreignKeyField, resolverOnlyField, schemaDefaultValue } from "../../utils/schemaUtils";
 import { EVENT_FORMATS } from "./types";
+import type { MakeEditableOptions } from "@/lib/editor/makeEditableOptions";
 
 const formGroups: Partial<Record<string, FormGroupType<"ForumEvents">>> = {
   stickerEventOptions: {
@@ -18,7 +20,54 @@ const defaultProps = (nullable = false): CollectionFieldSpecification<"ForumEven
   canCreate: ["admins"],
 });
 
+const defaultEditableProps: Pick<MakeEditableOptions<'ForumEvents'>, "commentEditor" | "commentStyles" | "hideControls" | "permissions"> = {
+  commentEditor: true,
+  commentStyles: true,
+  hideControls: true,
+  permissions: {
+    canRead: ["guests"],
+    canUpdate: ["admins"],
+    canCreate: ["admins"],
+  },
+};
+
 const schema: SchemaType<"ForumEvents"> = {
+  ...editableFields("ForumEvents", {
+    fieldName: "frontpageDescription",
+    label: "Frontpage description",
+    getLocalStorageId: (forumEvent) => {
+      return {
+        id: `forumEvent:frontpageDescription:${forumEvent?._id ?? "create"}`,
+        verify: true,
+      };
+    },
+    ...defaultEditableProps,
+  }),
+
+  ...editableFields("ForumEvents", {
+    fieldName: "frontpageDescriptionMobile",
+    label: "Frontpage description (mobile)",
+    getLocalStorageId: (forumEvent) => {
+      return {
+        id: `forumEvent:frontpageDescriptionMobile:${forumEvent?._id ?? "create"}`,
+        verify: true,
+      };
+    },
+    ...defaultEditableProps,
+  }),
+
+  ...editableFields("ForumEvents", {
+    fieldName: "postPageDescription",
+    label: "Post page description",
+    getLocalStorageId: (forumEvent) => {
+      return {
+        id: `forumEvent:postPageDescription:${forumEvent?._id ?? "create"}`,
+        verify: true,
+      };
+    },
+    ...defaultEditableProps,
+  }),
+  
   title: {
     ...defaultProps(),
     type: String,

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -3,7 +3,7 @@ import { addSlugFields, foreignKeyField, schemaDefaultValue } from '../../utils/
 import './fragments';
 import { userOwns } from '../../vulcan-users/permissions';
 import moment from 'moment'
-import { makeEditable } from '../../editor/make_editable';
+import { editableFields } from '../../editor/make_editable';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
@@ -31,6 +31,14 @@ export const eventTypes = [
 ]
 
 const schema: SchemaType<"GardenCodes"> = {
+  ...editableFields("GardenCodes", {
+    pingbacks: true,
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    order: 20
+  }),
+  
   code: {
     type: String,
     optional: true,
@@ -201,16 +209,5 @@ addSlugFields({
   getTitle: (gc) => gc.title,
   includesOldSlugs: false,
 });
-
-makeEditable({
-  collection: GardenCodes,
-  options: {
-    pingbacks: true,
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    order: 20
-  }
-})
 
 export default GardenCodes;

--- a/packages/lesswrong/lib/collections/helpers/arbitalLinkedPagesField.ts
+++ b/packages/lesswrong/lib/collections/helpers/arbitalLinkedPagesField.ts
@@ -3,8 +3,8 @@ import { resolverOnlyField } from '../../utils/schemaUtils';
 import { getWithCustomLoader } from '@/lib/loaders';
 import range from 'lodash/range';
 
-interface ArbitalLinkedPagesFieldOptions {
-  collectionName: string;
+interface ArbitalLinkedPagesFieldOptions<N extends CollectionNameString> {
+  collectionName: N;
 }
 
 addGraphQLSchema(`
@@ -25,10 +25,10 @@ addGraphQLSchema(`
   }
 `);
 
-export function arbitalLinkedPagesField(options: ArbitalLinkedPagesFieldOptions) {
+export function arbitalLinkedPagesField<N extends CollectionNameString>(options: ArbitalLinkedPagesFieldOptions<N>) {
   const { collectionName } = options;
 
-  return resolverOnlyField({
+  return resolverOnlyField<N>({
     type: 'ArbitalLinkedPages',
     graphQLtype: 'ArbitalLinkedPages',
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/jargonTerms/collection.ts
+++ b/packages/lesswrong/lib/collections/jargonTerms/collection.ts
@@ -1,7 +1,6 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
-import { makeEditable } from "../../editor/make_editable";
 import { userIsAdmin, userOwns } from '@/lib/vulcan-users/permissions';
 import { Posts } from '../posts/collection';
 import { userCanCreateAndEditJargonTerms } from '@/lib/betas';
@@ -60,22 +59,6 @@ export const JargonTerms: JargonTermsCollection = createCollection({
 });
 
 addUniversalFields({collection: JargonTerms});
-
-makeEditable({
-  collection: JargonTerms,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    order: 10,
-    hintText: 'If you want to add a custom term, use this form.  The description goes here.  The term, as well as any alt terms, must appear in your post.',
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['members'],
-      canCreate: ['members'],
-    }
-  },
-});
 
 JargonTerms.checkAccess = async (user: DbUser | null, jargonTerm: DbJargonTerm, context: ResolverContext | null) => {
   const post = context

--- a/packages/lesswrong/lib/collections/jargonTerms/schema.ts
+++ b/packages/lesswrong/lib/collections/jargonTerms/schema.ts
@@ -1,6 +1,19 @@
+import { editableFields } from '@/lib/editor/make_editable';
 import { foreignKeyField, schemaDefaultValue } from '../../utils/schemaUtils';
 
 const schema: SchemaType<"JargonTerms"> = {
+  ...editableFields("JargonTerms", {
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    order: 10,
+    hintText: 'If you want to add a custom term, use this form.  The description goes here.  The term, as well as any alt terms, must appear in your post.',
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['members'],
+      canCreate: ['members'],
+    }
+  }),
   postId: {
     canRead: ['guests'],
     canCreate: ['members'],

--- a/packages/lesswrong/lib/collections/localgroups/collection.ts
+++ b/packages/lesswrong/lib/collections/localgroups/collection.ts
@@ -1,7 +1,6 @@
 import { userCanDo } from '../../vulcan-users/permissions';
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
-import { makeEditable } from '../../editor/make_editable'
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -45,23 +44,6 @@ export const Localgroups: LocalgroupsCollection = createCollection({
   mutations: getDefaultMutations('Localgroups', options),
   logChanges: true,
 });
-
-makeEditable({
-  collection: Localgroups,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    order: 25,
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['members'],
-      canCreate: ['members']
-    },
-    hintText: "Short description"
-  }
-})
 
 addUniversalFields({collection: Localgroups})
 

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -3,6 +3,7 @@ import { schemaDefaultValue, arrayOfForeignKeysField, denormalizedField, googleL
 import { localGroupTypeFormOptions } from './groupTypes';
 import { isEAForum, isLW } from '../../instanceSettings';
 import { isFriendlyUI, preferredHeadingCase } from '../../../themes/forumTheme';
+import { editableFields } from '@/lib/editor/make_editable';
 
 export const GROUP_CATEGORIES = [
   {value: 'national', label: 'National'},
@@ -26,6 +27,18 @@ const formGroups: Partial<Record<string, FormGroupType<"Localgroups">>> = {
 };
 
 const schema: SchemaType<"Localgroups"> = {
+  ...editableFields("Localgroups", {
+    commentEditor: true,
+    commentStyles: true,
+    order: 25,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['members'],
+      canCreate: ['members']
+    },
+    hintText: "Short description"
+  }),
+  
   name: {
     type: String,
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/messages/collection.ts
+++ b/packages/lesswrong/lib/collections/messages/collection.ts
@@ -2,7 +2,6 @@ import { userCanDo, userOwns } from '../../vulcan-users/permissions';
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
 import Conversations from '../conversations/collection'
-import { makeEditable } from '../../editor/make_editable'
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -46,22 +45,6 @@ export const Messages: MessagesCollection = createCollection({
   // free of confidential stuff that admins shouldn't look at.
   logChanges: false,
 });
-
-makeEditable({
-  collection: Messages,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    permissions: {
-      canRead: ['members'],
-      canCreate: ['members'],
-      canUpdate: userOwns,
-    },
-    order: 2,
-  }
-})
 
 addUniversalFields({
   collection: Messages,

--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -1,6 +1,18 @@
+import { editableFields } from '@/lib/editor/make_editable';
 import { foreignKeyField, schemaDefaultValue } from '../../utils/schemaUtils'
+import { userOwns } from '@/lib/vulcan-users/permissions';
 
 const schema: SchemaType<"Messages"> = {
+  ...editableFields("Messages", {
+    commentEditor: true,
+    commentStyles: true,
+    permissions: {
+      canRead: ['members'],
+      canCreate: ['members'],
+      canUpdate: userOwns,
+    },
+    order: 2,
+  }),
   userId: {
     ...foreignKeyField({
       idFieldName: "userId",

--- a/packages/lesswrong/lib/collections/moderationTemplates/collection.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/collection.ts
@@ -1,7 +1,6 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
 import { getDefaultMutations } from '../../vulcan-core/default_mutations';
-import { makeEditable } from "../../editor/make_editable";
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { DatabaseIndexSet } from '@/lib/utils/databaseIndexSet';
@@ -22,15 +21,5 @@ export const ModerationTemplates: ModerationTemplatesCollection = createCollecti
 });
 
 addUniversalFields({collection: ModerationTemplates});
-
-makeEditable({
-  collection: ModerationTemplates,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    order: 20
-  }
-})
 
 export default ModerationTemplates;

--- a/packages/lesswrong/lib/collections/moderationTemplates/schema.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/schema.ts
@@ -1,3 +1,4 @@
+import { editableFields } from '@/lib/editor/make_editable';
 import { schemaDefaultValue } from '../../utils/schemaUtils';
 
 export const ALLOWABLE_COLLECTIONS: TemplateType[] = ['Messages', 'Comments', 'Rejections'];
@@ -5,6 +6,12 @@ export const ALLOWABLE_COLLECTIONS: TemplateType[] = ['Messages', 'Comments', 'R
 export type TemplateType = 'Messages' | 'Comments' | 'Rejections';
 
 const schema: SchemaType<"ModerationTemplates"> = {
+  ...editableFields("ModerationTemplates", {
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    order: 20
+  }),
   name: {
     type: String,
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/multiDocuments/collection.ts
+++ b/packages/lesswrong/lib/collections/multiDocuments/collection.ts
@@ -1,4 +1,3 @@
-import { makeEditable } from "@/lib/editor/make_editable";
 import schema from "./schema";
 import { userIsAdmin, userOwns } from "@/lib/vulcan-users/permissions";
 import { canMutateParentDocument, getRootDocument } from "./helpers";
@@ -52,27 +51,6 @@ addSlugFields({
   getTitle: (md) => md.title ?? md.tabTitle,
   onCollision: "rejectNewDocument",
   includesOldSlugs: true,
-});
-
-makeEditable({
-  collection: MultiDocuments,
-  options: {
-    fieldName: "contents",
-    order: 30,
-    commentStyles: true,
-    normalized: true,
-    revisionsHaveCommitMessages: true,
-    pingbacks: true,
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['members'],
-      canCreate: ['members']
-    },
-    getLocalStorageId: (multiDocument: DbMultiDocument, name: string) => {
-      const { _id, parentDocumentId, collectionName } = multiDocument;
-      return { id: `multiDocument:${collectionName}:${parentDocumentId}:${_id}`, verify: false };
-    },
-  },
 });
 
 MultiDocuments.checkAccess = async (user: DbUser | null, multiDocument: DbMultiDocument, context: ResolverContext | null, outReasonDenied) => {

--- a/packages/lesswrong/lib/collections/multiDocuments/schema.ts
+++ b/packages/lesswrong/lib/collections/multiDocuments/schema.ts
@@ -3,6 +3,7 @@ import { arbitalLinkedPagesField } from '../helpers/arbitalLinkedPagesField';
 import { summariesField } from "../helpers/summariesField";
 import { formGroups } from "./formGroups";
 import { userIsAdminOrMod, userOwns } from "@/lib/vulcan-users/permissions";
+import { editableFields } from "@/lib/editor/make_editable";
 
 const MULTI_DOCUMENT_DELETION_WINDOW = 1000 * 60 * 60 * 24 * 7;
 
@@ -18,6 +19,23 @@ export function userCanDeleteMultiDocument(user: DbUser | UsersCurrent | null, d
 }
 
 const schema: SchemaType<"MultiDocuments"> = {
+  ...editableFields("MultiDocuments", {
+    fieldName: "contents",
+    order: 30,
+    commentStyles: true,
+    normalized: true,
+    revisionsHaveCommitMessages: true,
+    pingbacks: true,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['members'],
+      canCreate: ['members']
+    },
+    getLocalStorageId: (multiDocument: DbMultiDocument, name: string) => {
+      const { _id, parentDocumentId, collectionName } = multiDocument;
+      return { id: `multiDocument:${collectionName}:${parentDocumentId}:${_id}`, verify: false };
+    },
+  }),
   // In the case of tag lenses, this is the title displayed in the body of the tag page when the lens is selected.
   // In the case of summaries, we don't have a title that needs to be in the "body"; we just use the tab title in the summary tab.
   title: {

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -3,10 +3,6 @@ import { createCollection } from '../../vulcan-lib/collections';
 import { userOwns, userCanDo, userIsMemberOf, userIsPodcaster } from '../../vulcan-users/permissions';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
 import { canUserEditPostMetadata, userIsPostGroupOrganizer } from './helpers';
-import { makeEditable } from '../../editor/make_editable';
-import { formGroups } from './formGroups';
-import { isFriendlyUI } from '../../../themes/forumTheme';
-import { hasAuthorModeration } from '../../betas';
 import { addSlugFields } from '@/lib/utils/schemaUtils';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -58,13 +54,6 @@ export const Posts = createCollection({
   ],
 });
 
-const userHasModerationGuidelines = (currentUser: DbUser|null): boolean => {
-  if (!hasAuthorModeration) {
-    return false;
-  }
-  return !!(currentUser && ((currentUser.moderationGuidelines && currentUser.moderationGuidelines.html) || currentUser.moderationStyle))
-}
-
 addUniversalFields({
   collection: Posts,
   createdAtOptions: {canRead: ['admins']},
@@ -78,56 +67,6 @@ addSlugFields({
   oldSlugsOptions: {
   },
 });
-
-makeEditable({
-  collection: Posts,
-  options: {
-    formGroup: formGroups.content,
-    order: 25,
-    pingbacks: true,
-    permissions: {
-      canRead: ['guests'],
-      // TODO: we also need to cover userIsPostGroupOrganizer somehow, but we can't right now since it's async
-      canUpdate: ['members', 'sunshineRegiment', 'admins'],
-      canCreate: ['members']
-    },
-    hasToc: true,
-    normalized: true,
-  }
-})
-
-makeEditable({
-  collection: Posts,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    formGroup: formGroups.moderationGroup,
-    hidden: isFriendlyUI,
-    order: 50,
-    fieldName: "moderationGuidelines",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['members', 'sunshineRegiment', 'admins'],
-      canCreate: [userHasModerationGuidelines]
-    },
-    normalized: true,
-  }
-})
-
-makeEditable({
-  collection: Posts,
-  options: {
-    formGroup: formGroups.highlight,
-    fieldName: "customHighlight",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['sunshineRegiment', 'admins'],
-      canCreate: ['sunshineRegiment', 'admins'],
-    },
-  }
-})
 
 Posts.checkAccess = postCheckAccess;
 

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -33,7 +33,7 @@ import { getDefaultViewSelector } from '../../utils/viewUtils';
 import GraphQLJSON from 'graphql-type-json';
 import { addGraphQLSchema } from '../../vulcan-lib/graphql';
 import SideCommentCaches from '../sideCommentCaches/collection';
-import { hasSideComments, hasSidenotes, userCanCreateAndEditJargonTerms, userCanViewJargonTerms, userCanViewUnapprovedJargonTerms } from '../../betas';
+import { hasAuthorModeration, hasSideComments, hasSidenotes, userCanCreateAndEditJargonTerms, userCanViewJargonTerms } from '../../betas';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 import { getPostReviewWinnerInfo } from '@/server/review/reviewWinnersCache';
 import { stableSortTags } from '../tags/helpers';
@@ -42,6 +42,7 @@ import { marketInfoLoader } from './annualReviewMarkets';
 import mapValues from 'lodash/mapValues';
 import groupBy from 'lodash/groupBy';
 import { documentIsNotDeleted, userOverNKarmaFunc, userOverNKarmaOrApproved, userOwns } from "../../vulcan-users/permissions";
+import { editableFields } from '@/lib/editor/make_editable';
 
 // TODO: This disagrees with the value used for the book progress bar
 export const READ_WORDS_PER_MINUTE = 250;
@@ -165,7 +166,53 @@ const schemaDefaultValueFmCrosspost = schemaDefaultValue({
   isCrosspost: false,
 })
 
+const userHasModerationGuidelines = (currentUser: DbUser|null): boolean => {
+  if (!hasAuthorModeration) {
+    return false;
+  }
+  return !!(currentUser && ((currentUser.moderationGuidelines && currentUser.moderationGuidelines.html) || currentUser.moderationStyle))
+}
+
 const schema: SchemaType<"Posts"> = {
+  ...editableFields("Posts", {
+    formGroup: formGroups.content,
+    order: 25,
+    pingbacks: true,
+    permissions: {
+      canRead: ['guests'],
+      // TODO: we also need to cover userIsPostGroupOrganizer somehow, but we can't right now since it's async
+      canUpdate: ['members', 'sunshineRegiment', 'admins'],
+      canCreate: ['members']
+    },
+    hasToc: true,
+    normalized: true,
+  }),
+
+  ...editableFields("Posts", {
+    fieldName: "moderationGuidelines",
+    commentEditor: true,
+    commentStyles: true,
+    formGroup: formGroups.moderationGroup,
+    hidden: isFriendlyUI,
+    order: 50,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['members', 'sunshineRegiment', 'admins'],
+      canCreate: [userHasModerationGuidelines]
+    },
+    normalized: true,
+  }),
+
+  ...editableFields("Posts", {
+    fieldName: "customHighlight",
+    formGroup: formGroups.highlight,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['sunshineRegiment', 'admins'],
+      canCreate: ['sunshineRegiment', 'admins'],
+    },
+  }),
+  
   // Timestamp of post first appearing on the site (i.e. being approved)
   postedAt: {
     type: Date,

--- a/packages/lesswrong/lib/collections/sequences/collection.ts
+++ b/packages/lesswrong/lib/collections/sequences/collection.ts
@@ -1,7 +1,6 @@
 import { createCollection } from '../../vulcan-lib/collections';
 import { userCanDo, userOwns } from '../../vulcan-users/permissions';
 import schema from './schema';
-import { makeEditable } from '../../editor/make_editable';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -48,12 +47,6 @@ export const Sequences = createCollection({
   logChanges: true,
 })
 
-makeEditable({
-  collection: Sequences,
-  options: {
-    order: 20,
-  }
-})
 addUniversalFields({collection: Sequences})
 
 Sequences.checkAccess = async (user, document) => {

--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -2,6 +2,7 @@ import { schemaDefaultValue, foreignKeyField, accessFilterSingle, accessFilterMu
 import { getWithCustomLoader } from '../../loaders';
 import { preferredHeadingCase } from '../../../themes/forumTheme';
 import { userOwns } from '../../vulcan-users/permissions';
+import { editableFields } from '@/lib/editor/make_editable';
 
 const formGroups: Partial<Record<string, FormGroupType<"Sequences">>> = {
   adminOptions: {
@@ -19,6 +20,10 @@ const formGroups: Partial<Record<string, FormGroupType<"Sequences">>> = {
 };
 
 const schema: SchemaType<"Sequences"> = {
+  ...editableFields("Sequences", {
+    order: 20,
+  }),
+  
   lastUpdated: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/spotlights/collection.ts
+++ b/packages/lesswrong/lib/collections/spotlights/collection.ts
@@ -1,6 +1,5 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
-import { makeEditable } from '../../editor/make_editable';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -21,25 +20,5 @@ export const Spotlights: SpotlightsCollection = createCollection({
 });
 
 addUniversalFields({ collection: Spotlights });
-
-makeEditable({
-  collection: Spotlights,
-  options: {
-    fieldName: "description",
-    commentEditor: true,
-    commentStyles: true,
-    hideControls: true,
-    getLocalStorageId: (spotlight) => {
-      if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
-      return {id: `spotlight:create`, verify:true}
-    },
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['admins', 'sunshineRegiment'],
-      canCreate: ['admins', 'sunshineRegiment']
-    },
-    order: 100
-  }
-});
 
 export default Spotlights;

--- a/packages/lesswrong/lib/collections/spotlights/schema.ts
+++ b/packages/lesswrong/lib/collections/spotlights/schema.ts
@@ -1,6 +1,7 @@
 import range from "lodash/range";
 import { schemaDefaultValue, resolverOnlyField, accessFilterSingle, accessFilterMultiple } from "../../utils/schemaUtils";
 import { isLWorAF } from "../../instanceSettings";
+import { editableFields } from "@/lib/editor/make_editable";
 
 const SPOTLIGHT_DOCUMENT_TYPES = ['Sequence', 'Post', 'Tag'] as const;
 
@@ -30,6 +31,23 @@ const shiftSpotlightItems = async ({ startBound, endBound, offset, context }: Sh
 };
 
 const schema: SchemaType<"Spotlights"> = {
+  ...editableFields("Spotlights", {
+    fieldName: "description",
+    commentEditor: true,
+    commentStyles: true,
+    hideControls: true,
+    getLocalStorageId: (spotlight) => {
+      if (spotlight._id) { return {id: `spotlight:${spotlight._id}`, verify:true} }
+      return {id: `spotlight:create`, verify:true}
+    },
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['admins', 'sunshineRegiment'],
+      canCreate: ['admins', 'sunshineRegiment']
+    },
+    order: 100
+  }),
+  
   documentId: {
     type: String,
     nullable: false,

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -1,7 +1,7 @@
 import { createCollection } from '../../vulcan-lib/collections';
 import { addSlugFields, schemaDefaultValue } from '../../utils/schemaUtils';
 import { getDefaultMutations, MutationOptions } from '../../vulcan-core/default_mutations';
-import { makeEditable } from '../../editor/make_editable';
+import { editableFields } from '../../editor/make_editable';
 import './fragments'
 import { userCanDo } from '../../vulcan-users/permissions';
 import { addUniversalFields } from "../../collectionUtils";
@@ -9,6 +9,13 @@ import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { DatabaseIndexSet } from '@/lib/utils/databaseIndexSet';
 
 const schema: SchemaType<"TagFlags"> = {
+  ...editableFields("TagFlags", {
+    order: 30,
+    getLocalStorageId: (tagFlag, name) => {
+      if (tagFlag._id) { return {id: `${tagFlag._id}_${name}`, verify: true} }
+      return {id: `tagFlag: ${name}`, verify: false}
+    },
+  }),
   name: {
     type: String,
     nullable: false,
@@ -78,15 +85,5 @@ addSlugFields({
   includesOldSlugs: false,
 });
 
-makeEditable({
-  collection: TagFlags,
-  options: {
-    order: 30,
-    getLocalStorageId: (tagFlag, name) => {
-      if (tagFlag._id) { return {id: `${tagFlag._id}_${name}`, verify: true} }
-      return {id: `tagFlag: ${name}`, verify: false}
-    },
-  }
-})
 export default TagFlags;
 

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -1,9 +1,8 @@
 import { createCollection } from '../../vulcan-lib/collections';
-import { makeEditable } from '../../editor/make_editable'
 import { userCanCreateTags } from '../../betas';
 import { userIsAdmin } from '../../vulcan-users/permissions';
 import schema from './schema';
-import { tagUserHasSufficientKarma, userIsSubforumModerator } from './helpers';
+import { tagUserHasSufficientKarma } from './helpers';
 import { formGroups } from './formGroups';
 import { addSlugFields } from '@/lib/utils/schemaUtils';
 import { addUniversalFields } from "../../collectionUtils";
@@ -72,57 +71,5 @@ addSlugFields({
   },
   includesOldSlugs: true,
 });
-
-makeEditable({
-  collection: Tags,
-  options: {
-    commentStyles: true,
-    fieldName: "description",
-    pingbacks: true,
-    getLocalStorageId: (tag, name) => {
-      if (tag._id) { return {id: `tag:${tag._id}`, verify:true} }
-      return {id: `tag:create`, verify:true}
-    },
-    revisionsHaveCommitMessages: true,
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: ['members'],
-      canCreate: ['members']
-    },
-    order: 10
-  }
-});
-
-makeEditable({
-  collection: Tags,
-  options: {
-    formGroup: formGroups.subforumWelcomeMessage,
-    fieldName: "subforumWelcomeText",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
-      canCreate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
-    },
-  }
-});
-
-makeEditable({
-  collection: Tags,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    formGroup: formGroups.subforumModerationGuidelines,
-    hidden: true,
-    order: 50,
-    fieldName: "moderationGuidelines",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
-      canCreate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
-    },
-  }
-})
 
 export default Tags;

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -16,6 +16,8 @@ import { arbitalLinkedPagesField } from '../helpers/arbitalLinkedPagesField';
 import { summariesField } from '../helpers/summariesField';
 import uniqBy from 'lodash/uniqBy';
 import { LikesList } from '@/lib/voting/reactionsAndLikes';
+import { editableFields } from '@/lib/editor/make_editable';
+import { userIsSubforumModerator } from './helpers';
 
 addGraphQLSchema(`
   type TagContributor {
@@ -57,6 +59,47 @@ async function getTagMultiDocuments(
 }
 
 const schema: SchemaType<"Tags"> = {
+  ...editableFields("Tags", {
+    fieldName: "description",
+    commentStyles: true,
+    pingbacks: true,
+    getLocalStorageId: (tag, name) => {
+      if (tag._id) { return {id: `tag:${tag._id}`, verify:true} }
+      return {id: `tag:create`, verify:true}
+    },
+    revisionsHaveCommitMessages: true,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: ['members'],
+      canCreate: ['members']
+    },
+    order: 10
+  }),
+
+  ...editableFields("Tags", {
+    fieldName: "subforumWelcomeText",
+    formGroup: formGroups.subforumWelcomeMessage,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
+      canCreate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
+    },
+  }),
+
+  ...editableFields("Tags", {
+    fieldName: "moderationGuidelines",
+    commentEditor: true,
+    commentStyles: true,
+    formGroup: formGroups.subforumModerationGuidelines,
+    hidden: true,
+    order: 50,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
+      canCreate: [userIsSubforumModerator, 'sunshineRegiment', 'admins'],
+    },
+  }),
+  
   name: {
     type: String,
     nullable: false,

--- a/packages/lesswrong/lib/collections/users/collection.ts
+++ b/packages/lesswrong/lib/collections/users/collection.ts
@@ -1,9 +1,6 @@
 import schema, { createDisplayName } from './schema';
 import { userOwns, userCanDo } from '../../vulcan-users/permissions';
-import { makeEditable } from '../../editor/make_editable';
 import { formGroups } from './formGroups';
-import { isEAForum } from '../../instanceSettings';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { addSlugFields } from '@/lib/utils/schemaUtils';
 import { createCollection } from "../../vulcan-lib/collections";
 import { addGraphQLQuery, addGraphQLResolvers } from "../../vulcan-lib/graphql";
@@ -72,90 +69,6 @@ addSlugFields({
     order: 40,
     group: formGroups.adminOptions,
   },
-});
-
-makeEditable({
-  collection: Users,
-  options: {
-    // Determines whether to use the comment editor configuration (e.g. Toolbars)
-    commentEditor: true,
-    // Determines whether to use the comment editor styles (e.g. Fonts)
-    commentStyles: true,
-    formGroup: formGroups.moderationGroup,
-    hidden: isFriendlyUI,
-    order: 50,
-    fieldName: "moderationGuidelines",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-      canCreate: [userOwns, 'sunshineRegiment', 'admins']
-    }
-  }
-})
-
-makeEditable({
-  collection: Users,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    formGroup: formGroups.aboutMe,
-    hidden: true,
-    order: 7,
-    fieldName: 'howOthersCanHelpMe',
-    label: "How others can help me",
-    formVariant: isFriendlyUI ? "grey" : undefined,
-    hintText: "Ex: I am looking for opportunities to do...",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-      canCreate: [userOwns, 'sunshineRegiment', 'admins']
-    },
-  }
-})
-
-makeEditable({
-  collection: Users,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    formGroup: formGroups.aboutMe,
-    hidden: true,
-    order: 8,
-    fieldName: 'howICanHelpOthers',
-    label: "How I can help others",
-    formVariant: isFriendlyUI ? "grey" : undefined,
-    hintText: "Ex: Reach out to me if you have questions about...",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-      canCreate: [userOwns, 'sunshineRegiment', 'admins']
-    },
-  }
-})
-
-// biography: Some text the user provides for their profile page and to display
-// when people hover over their name.
-//
-// Replaces the old "bio" and "htmlBio" fields, which were markdown only, and
-// which now exist as resolver-only fields for back-compatibility.
-makeEditable({
-  collection: Users,
-  options: {
-    commentEditor: true,
-    commentStyles: true,
-    hidden: isEAForum,
-    order: isEAForum ? 6 : 40,
-    formGroup: isEAForum ? formGroups.aboutMe : formGroups.default,
-    fieldName: "biography",
-    label: "Bio",
-    formVariant: isFriendlyUI ? "grey" : undefined,
-    hintText: "Tell us about yourself",
-    permissions: {
-      canRead: ['guests'],
-      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-      canCreate: [userOwns, 'sunshineRegiment', 'admins']
-    },
-  }
 });
 
 Users.checkAccess = async (user: DbUser|null, document: DbUser, context: ResolverContext|null): Promise<boolean> => {

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -22,6 +22,7 @@ import { isFriendlyUI } from '../../../themes/forumTheme';
 import { DeferredForumSelect } from '../../forumTypeUtils';
 import { getNestedProperty } from "../../vulcan-lib/utils";
 import { addGraphQLSchema } from "../../vulcan-lib/graphql";
+import { editableFields } from '@/lib/editor/make_editable';
 
 ///////////////////////////////////////
 // Order for the Schema is as follows. Change as you see fit:
@@ -334,6 +335,76 @@ addGraphQLSchema(`
  * @type {Object}
  */
 const schema: SchemaType<"Users"> = {
+  ...editableFields("Users", {
+    fieldName: "moderationGuidelines",
+    commentEditor: true,
+    commentStyles: true,
+    formGroup: formGroups.moderationGroup,
+    hidden: isFriendlyUI,
+    order: 50,
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+      canCreate: [userOwns, 'sunshineRegiment', 'admins']
+    }
+  }),
+
+  ...editableFields("Users", {
+    fieldName: 'howOthersCanHelpMe',
+    commentEditor: true,
+    commentStyles: true,
+    formGroup: formGroups.aboutMe,
+    hidden: true,
+    order: 7,
+    label: "How others can help me",
+    formVariant: isFriendlyUI ? "grey" : undefined,
+    hintText: "Ex: I am looking for opportunities to do...",
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+      canCreate: [userOwns, 'sunshineRegiment', 'admins']
+    },
+  }),
+
+  ...editableFields("Users", {
+    fieldName: 'howICanHelpOthers',
+    commentEditor: true,
+    commentStyles: true,
+    formGroup: formGroups.aboutMe,
+    hidden: true,
+    order: 8,
+    label: "How I can help others",
+    formVariant: isFriendlyUI ? "grey" : undefined,
+    hintText: "Ex: Reach out to me if you have questions about...",
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+      canCreate: [userOwns, 'sunshineRegiment', 'admins']
+    },
+  }),
+
+  // biography: Some text the user provides for their profile page and to display
+  // when people hover over their name.
+  //
+  // Replaces the old "bio" and "htmlBio" fields, which were markdown only, and
+  // which now exist as resolver-only fields for back-compatibility.
+  ...editableFields("Users", {
+    fieldName: "biography",
+    commentEditor: true,
+    commentStyles: true,
+    hidden: isEAForum,
+    order: isEAForum ? 6 : 40,
+    formGroup: isEAForum ? formGroups.aboutMe : formGroups.default,
+    label: "Bio",
+    formVariant: isFriendlyUI ? "grey" : undefined,
+    hintText: "Tell us about yourself",
+    permissions: {
+      canRead: ['guests'],
+      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+      canCreate: [userOwns, 'sunshineRegiment', 'admins']
+    },
+  }),
+  
   username: {
     type: String,
     optional: true,

--- a/packages/lesswrong/lib/editor/makeEditableOptions.ts
+++ b/packages/lesswrong/lib/editor/makeEditableOptions.ts
@@ -9,6 +9,23 @@ export type MakeEditableOptionsFieldName<N extends CollectionNameString> = {
   normalized: true,
 };
 
+
+export interface EditableFieldCallbackOptions {
+  pingbacks: boolean;
+  normalized: boolean;
+}
+
+export interface EditableFieldClientOptions {
+  hasToc?: boolean,
+  getLocalStorageId?: null | ((doc: any, name: string) => {id: string, verify: boolean}),
+  revisionsHaveCommitMessages?: boolean,
+}
+
+export interface EditableFieldOptions {
+  callbackOptions: EditableFieldCallbackOptions;
+  clientOptions: EditableFieldClientOptions;
+}
+
 export type MakeEditableOptions<N extends CollectionNameString> = {
   commentEditor?: boolean,
   commentStyles?: boolean,
@@ -31,10 +48,3 @@ export type MakeEditableOptions<N extends CollectionNameString> = {
   hidden?: boolean,
   hasToc?: boolean,
 } & MakeEditableOptionsFieldName<N>;
-
-export const editableCollectionsFieldOptions: Record<CollectionNameString, Record<string, MakeEditableOptions<CollectionNameString>>> = {} as any;
-
-export const editableFieldIsNormalized = (
-  collectionName: CollectionNameString,
-  fieldName: string,
-) => !!editableCollectionsFieldOptions[collectionName]?.[fieldName]?.normalized;

--- a/packages/lesswrong/lib/editor/make_editable.ts
+++ b/packages/lesswrong/lib/editor/make_editable.ts
@@ -1,11 +1,12 @@
 import { documentIsNotDeleted, userOwns } from '../vulcan-users/permissions';
 import { camelCaseify } from '../vulcan-lib/utils';
 import { ContentType, getOriginalContents } from '../collections/revisions/schema'
-import { accessFilterMultiple, addFieldsDict } from '../utils/schemaUtils';
+import { accessFilterMultiple } from '../utils/schemaUtils';
 import SimpleSchema from 'simpl-schema'
 import { getWithLoader } from '../loaders';
 import { isFriendlyUI } from '../../themes/forumTheme';
-import { EditableFieldName, MakeEditableOptions, editableCollectionsFieldOptions } from './makeEditableOptions';
+import { getAllCollections } from '../vulcan-lib/getCollection';
+import type { EditableFieldCallbackOptions, EditableFieldClientOptions, EditableFieldName, EditableFieldOptions, MakeEditableOptions } from './makeEditableOptions';
 
 export const RevisionStorageType = new SimpleSchema({
   originalContents: {type: ContentType, optional: true},
@@ -70,13 +71,39 @@ const defaultOptions: MakeEditableOptions<CollectionNameString> = {
   revisionsHaveCommitMessages: false,
 }
 
-export const editableCollections = new Set<CollectionNameString>()
-export const editableCollectionsFields: Record<CollectionNameString,Array<string>> = {} as any;
-let editableFieldsSealed = false;
-export function sealEditableFields() { editableFieldsSealed=true }
+interface EditableField<N extends CollectionNameString> extends CollectionFieldSpecification<N> {
+  editableFieldOptions: EditableFieldOptions;
+};
+
+export function isEditableField<N extends CollectionNameString>(field: [string, CollectionFieldSpecification<N>]): field is [string, EditableField<N>] {
+  return !!field[1].editableFieldOptions;
+}
+
+export const getEditableFieldsByCollection = (() => {
+  let editableFieldsByCollection: Partial<Record<CollectionNameString, Record<string, EditableField<CollectionNameString>>>>;
+  return () => {
+    if (!editableFieldsByCollection) {
+      const allCollections = getAllCollections();
+      editableFieldsByCollection = allCollections.reduce<Partial<Record<CollectionNameString, Record<string, EditableField<CollectionNameString>>>>>((acc, collection) => {
+        const editableFields = Object.entries(collection._schemaFields).filter(isEditableField);
+        if (editableFields.length > 0) {
+          acc[collection.collectionName] = Object.fromEntries(editableFields);
+        }
+        return acc;
+      }, {});
+    }
+
+    return editableFieldsByCollection;
+  }
+})();
+
+export const getEditableCollectionNames = () => Object.keys(getEditableFieldsByCollection()) as CollectionNameString[];
+export const getEditableFieldNamesForCollection = (collectionName: CollectionNameString) => Object.keys(getEditableFieldsByCollection()[collectionName] ?? {});
+export const getEditableFieldInCollection = <N extends CollectionNameString>(collectionName: N, fieldName: string) => getEditableFieldsByCollection()[collectionName]?.[fieldName];
+export const editableFieldIsNormalized = (collectionName: CollectionNameString, fieldName: string) => !!getEditableFieldInCollection(collectionName, fieldName)?.editableFieldOptions.callbackOptions.normalized;
 
 const buildEditableResolver = <N extends CollectionNameString>(
-  collection: CollectionBase<N>,
+  collectionName: N,
   fieldName: string,
   normalized: boolean,
 ): CollectionFieldResolveAs<N> => {
@@ -185,7 +212,7 @@ const buildEditableResolver = <N extends CollectionNameString>(
         // resolvers, and those resolvers depend on these fields existing.
         _id: `${doc._id}_${fieldName}`, //HACK
         documentId: doc._id,
-        collectionName: collection.collectionName,
+        collectionName,
         editedAt: new Date(docField?.editedAt ?? Date.now()),
         originalContents: getOriginalContents(
           context.currentUser,
@@ -200,33 +227,44 @@ const buildEditableResolver = <N extends CollectionNameString>(
   };
 }
 
-export const makeEditable = <N extends CollectionNameString>({
-  collection,
-  options = {},
-}: {
-  collection: CollectionBase<N>,
-  options: MakeEditableOptions<N>,
-}) => {
-  if (editableFieldsSealed)
-    throw new Error("Called makeEditable after addAllEditableCallbacks already ran; this indicates a problem with import order");
-  
-  options = {...defaultOptions, ...options}
+
+const defaultPingbackFields = {
+  // Dictionary from collection name to array of distinct referenced
+  // document IDs in that collection, in order of appearance
+  pingbacks: {
+    type: Object,
+    canRead: 'guests',
+    optional: true,
+    hidden: true,
+    denormalized: true,
+  },
+  "pingbacks.$": {
+    type: Array,
+  },
+  "pingbacks.$.$": {
+    type: String,
+  },
+} as const;
+
+export function editableFields<N extends CollectionNameString>(collectionName: N, options: MakeEditableOptions<N> = {}): Record<string, CollectionFieldSpecification<N>> {  
+  const optionsWithDefaults = { ...defaultOptions, ...options };
   const {
     commentEditor,
     commentStyles,
-    formGroup,
-    permissions,
-    fieldName = "contents" as EditableFieldName<N>,
     label,
     formVariant,
     hintText,
     order,
-    hidden = false,
     hideControls = false,
+    formGroup,
+    permissions,
+    fieldName = "contents" as EditableFieldName<N>,
+    hidden = false,
     pingbacks = false,
     normalized = false,
-    //revisionsHaveCommitMessages, //unused in this function (but used elsewhere)
-  } = options
+    revisionsHaveCommitMessages,
+    hasToc,
+  } = optionsWithDefaults;
 
   // We don't want to allow random stuff like escape characters in editable field names, since:
   // 1. why would you do that
@@ -235,7 +273,6 @@ export const makeEditable = <N extends CollectionNameString>({
     throw new Error(`Invalid characters in ${fieldName}; only a-z & A-Z are allowed.`);
   }
 
-  const collectionName = collection.collectionName;
   const getLocalStorageId = options.getLocalStorageId || ((doc: any, name: string): {id: string, verify: boolean} => {
     const { _id, conversationId } = doc
     if (_id && name) { return {id: `${_id}${name}`, verify: true}}
@@ -246,109 +283,113 @@ export const makeEditable = <N extends CollectionNameString>({
       throw Error(`Can't get storage ID for this document: ${doc}`)
     }
   });
-  
-  editableCollections.add(collectionName)
-  editableCollectionsFields[collectionName] = [
-    ...(editableCollectionsFields[collectionName] || []),
-    fieldName
-  ]
-  editableCollectionsFieldOptions[collectionName] = {
-    ...editableCollectionsFieldOptions[collectionName],
-    [fieldName]: {
-      ...options,
-      fieldName,
-      getLocalStorageId
+
+  const callbackOptions: EditableFieldCallbackOptions = {
+    pingbacks,
+    normalized,
+  };
+
+  const clientOptions: EditableFieldClientOptions = {
+    getLocalStorageId,
+    hasToc,
+    revisionsHaveCommitMessages
+  };
+
+  const editableFieldOptions: EditableFieldOptions = {
+    callbackOptions,
+    clientOptions,
+  };
+
+  const formOptions = {
+    label,
+    formVariant,
+    hintText,
+    fieldName,
+    collectionName,
+    commentEditor,
+    commentStyles,
+    hideControls,
+  };
+
+  const editableField: CollectionFieldSpecification<N> = {
+    type: RevisionStorageType,
+    editableFieldOptions,
+    optional: true,
+    logChanges: false, //Logged via Revisions rather than LWEvents
+    typescriptType: "EditableFieldContents",
+    group: formGroup,
+    ...permissions,
+    order,
+    hidden,
+    control: 'EditorFormComponent',
+    resolveAs: buildEditableResolver(collectionName, fieldName, normalized),
+    form: formOptions,
+  };
+
+  const latestRevisionIdFieldName = `${fieldName}_latest`;
+  const latestRevisionIdField: CollectionFieldSpecification<N> = {
+    type: String,
+    canRead: ['guests'],
+    optional: true,
+  };
+
+  const revisionsResolverFieldName = fieldName === "contents"
+    ? "revisions"
+    : camelCaseify(`${fieldName}Revisions`);
+
+  const revisionsResolverField: CollectionFieldSpecification<N> = {
+    type: Object,
+    canRead: ['guests'],
+    optional: true,
+    resolveAs: {
+      type: '[Revision]',
+      arguments: 'limit: Int = 5',
+      resolver: async (post: ObjectsByCollectionName[N], args: { limit: number }, context: ResolverContext) => {
+        const { limit } = args;
+        const { currentUser, Revisions } = context;
+
+        // getWithLoader is used here to fix a performance bug for a particularly nasty bot which resolves `revisions` for thousands of comments.
+        // Previously, this would cause a query for every comment whereas now it only causes one (admittedly quite slow) query
+        const loaderResults = await getWithLoader(
+          context,
+          Revisions,
+          `revisionsByDocumentId_${fieldName}_${limit}`,
+          {fieldName},
+          "documentId",
+          post._id,
+          {sort: {editedAt: -1}, limit},
+        );
+
+        return await accessFilterMultiple(currentUser, Revisions, loaderResults, context);
+      }
     },
   };
 
-  addFieldsDict(collection, {
-    [fieldName]: {
-      type: RevisionStorageType,
-      optional: true,
-      logChanges: false, //Logged via Revisions rather than LWEvents
-      typescriptType: "EditableFieldContents",
-      group: formGroup,
-      ...permissions,
-      order,
-      hidden,
-      control: 'EditorFormComponent',
-      resolveAs: buildEditableResolver(collection, fieldName, normalized),
-      form: {
-        label,
-        formVariant,
-        hintText,
-        fieldName,
-        collectionName,
-        commentEditor,
-        commentStyles,
-        hideControls,
-      },
-    },
+  const versionResolverFieldName = fieldName === "contents"
+    ? "version"
+    : camelCaseify(`${fieldName}Version`);
 
-    [`${fieldName}_latest`]: {
-      type: String,
-      canRead: ['guests'],
-      optional: true,
-    },
-
-    [fieldName === "contents" ? "revisions" : camelCaseify(`${fieldName}Revisions`)]: {
-      type: Object,
-      canRead: ['guests'],
-      optional: true,
-      resolveAs: {
-        type: '[Revision]',
-        arguments: 'limit: Int = 5',
-        resolver: async (post: ObjectsByCollectionName[N], args: { limit: number }, context: ResolverContext) => {
-          const { limit } = args;
-          const { currentUser, Revisions } = context;
-
-          // getWithLoader is used here to fix a performance bug for a particularly nasty bot which resolves `revisions` for thousands of comments.
-          // Previously, this would cause a query for every comment whereas now it only causes one (admittedly quite slow) query
-          const loaderResults = await getWithLoader(
-            context,
-            Revisions,
-            `revisionsByDocumentId_${fieldName}_${limit}`,
-            {fieldName},
-            "documentId",
-            post._id,
-            {sort: {editedAt: -1}, limit},
-          );
-
-          return await accessFilterMultiple(currentUser, Revisions, loaderResults, context);
-        }
+  const versionResolverField: CollectionFieldSpecification<N> = {
+    type: String,
+    canRead: ['guests'],
+    optional: true,
+    resolveAs: {
+      type: 'String',
+      resolver: (doc: ObjectsByCollectionName[N]): string => {
+        return (doc as AnyBecauseTodo)[fieldName]?.version
       }
     },
-    
-    [fieldName === "contents" ? "version" : camelCaseify(`${fieldName}Version`)]: {
-      type: String,
-      canRead: ['guests'],
-      optional: true,
-      resolveAs: {
-        type: 'String',
-        resolver: (post: ObjectsByCollectionName[N]): string => {
-          return (post as AnyBecauseTodo)[fieldName]?.version
-        }
-      }
-    }
-  });
-  
-  if (pingbacks) {
-    addFieldsDict(collection, {
-      // Dictionary from collection name to array of distinct referenced
-      // document IDs in that collection, in order of appearance
-      pingbacks: {
-        type: Object,
-        canRead: 'guests',
-        optional: true,
-        hidden: true,
-        denormalized: true,
-      },
-      "pingbacks.$": {
-        type: Array,
-      },
-      "pingbacks.$.$": {
-        type: String,
-      },
-    });
-  }
+  };
+
+  const pingbackFields: Partial<typeof defaultPingbackFields> = pingbacks
+    ? defaultPingbackFields
+    : {};
+
+  return {
+    [fieldName]: editableField,
+    [latestRevisionIdFieldName]: latestRevisionIdField,
+    [revisionsResolverFieldName]: revisionsResolverField,
+    [versionResolverFieldName]: versionResolverField,
+    ...pingbackFields,
+  };
 }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -90,6 +90,7 @@ interface BookPageFragment { // fragment on Books
 }
 
 interface BooksDefaultFragment { // fragment on Books
+  readonly contents_latest: string,
   readonly postedAt: Date,
   readonly title: string,
   readonly subtitle: string,
@@ -104,6 +105,7 @@ interface BooksDefaultFragment { // fragment on Books
 }
 
 interface ChaptersDefaultFragment { // fragment on Chapters
+  readonly contents_latest: string,
   readonly title: string,
   readonly subtitle: string,
   readonly number: number,
@@ -174,6 +176,7 @@ interface CollectionsBestOfFragment { // fragment on Collections
 }
 
 interface CollectionsDefaultFragment { // fragment on Collections
+  readonly contents_latest: string,
   readonly userId: string,
   readonly title: string,
   readonly slug: string,
@@ -231,6 +234,8 @@ interface CommentWithRepliesFragment extends CommentsList { // fragment on Comme
 }
 
 interface CommentsDefaultFragment { // fragment on Comments
+  readonly contents_latest: string,
+  readonly pingbacks: any /*{"definitions":[{}]}*/,
   readonly parentCommentId: string,
   readonly topLevelCommentId: string,
   readonly postedAt: Date,
@@ -527,6 +532,7 @@ interface CurationEmailsDefaultFragment { // fragment on CurationEmails
 }
 
 interface CurationNoticesDefaultFragment { // fragment on CurationNotices
+  readonly contents_latest: string,
   readonly userId: string,
   readonly commentId: string | null,
   readonly postId: string,
@@ -797,6 +803,9 @@ interface FieldChangeFragment { // fragment on non-collection type
 }
 
 interface ForumEventsDefaultFragment { // fragment on ForumEvents
+  readonly frontpageDescription_latest: string,
+  readonly frontpageDescriptionMobile_latest: string,
+  readonly postPageDescription_latest: string,
   readonly title: string,
   readonly startDate: Date,
   readonly endDate: Date,
@@ -895,6 +904,8 @@ interface GardenCodeFragmentEdit { // fragment on GardenCodes
 }
 
 interface GardenCodesDefaultFragment { // fragment on GardenCodes
+  readonly contents_latest: string,
+  readonly pingbacks: any /*{"definitions":[{}]}*/,
   readonly code: string,
   readonly title: string,
   readonly userId: string,
@@ -948,6 +959,7 @@ interface JargonTerms { // fragment on JargonTerms
 }
 
 interface JargonTermsDefaultFragment { // fragment on JargonTerms
+  readonly contents_latest: string,
   readonly postId: string,
   readonly term: string,
   readonly humansAndOrAIEdited: "humans" | "AI" | "humansAndAI" | null,
@@ -1023,6 +1035,7 @@ interface LlmMessagesFragment { // fragment on LlmMessages
 }
 
 interface LocalgroupsDefaultFragment { // fragment on Localgroups
+  readonly contents_latest: string,
   readonly name: string,
   readonly nameInAnotherLanguage: string,
   readonly organizerIds: Array<string>,
@@ -1058,6 +1071,7 @@ interface MembersOfGroupFragment { // fragment on Subscriptions
 }
 
 interface MessagesDefaultFragment { // fragment on Messages
+  readonly contents_latest: string,
   readonly userId: string,
   readonly conversationId: string,
   readonly noEmail: boolean,
@@ -1073,6 +1087,7 @@ interface ModerationTemplateFragment { // fragment on ModerationTemplates
 }
 
 interface ModerationTemplatesDefaultFragment { // fragment on ModerationTemplates
+  readonly contents_latest: string,
   readonly name: string,
   readonly collectionName: "Messages" | "Comments" | "Rejections",
   readonly order: number,
@@ -1159,6 +1174,8 @@ interface MultiDocumentWithContributorsRevision extends MultiDocumentRevision { 
 }
 
 interface MultiDocumentsDefaultFragment { // fragment on MultiDocuments
+  readonly contents_latest: string,
+  readonly pingbacks: any /*{"definitions":[{}]}*/,
   readonly title: string | null,
   readonly preview: string | null,
   readonly tabTitle: string,
@@ -1471,6 +1488,10 @@ interface PostsBestOfList_podcastEpisode_podcast { // fragment on Podcasts
 }
 
 interface PostsDefaultFragment { // fragment on Posts
+  readonly contents_latest: string,
+  readonly pingbacks: any /*{"definitions":[{}]}*/,
+  readonly moderationGuidelines_latest: string,
+  readonly customHighlight_latest: string,
   readonly postedAt: Date,
   readonly modifiedAt: Date,
   readonly url: string,
@@ -2303,6 +2324,7 @@ interface SequenceContinueReadingFragment { // fragment on Sequences
 }
 
 interface SequencesDefaultFragment { // fragment on Sequences
+  readonly contents_latest: string,
   readonly lastUpdated: Date,
   readonly userId: string,
   readonly title: string,
@@ -2546,6 +2568,7 @@ interface SpotlightReviewWinner_description { // fragment on Revisions
 }
 
 interface SpotlightsDefaultFragment { // fragment on Spotlights
+  readonly description_latest: string,
   readonly documentId: string,
   readonly documentType: "Sequence" | "Post" | "Tag",
   readonly position: number,
@@ -2913,6 +2936,7 @@ interface TagFlagFragment_contents { // fragment on Revisions
 }
 
 interface TagFlagsDefaultFragment { // fragment on TagFlags
+  readonly contents_latest: string,
   readonly name: string,
   readonly deleted: boolean,
   readonly order: number | null,
@@ -3143,6 +3167,10 @@ interface TagWithFlagsFragment extends TagFragment { // fragment on Tags
 }
 
 interface TagsDefaultFragment { // fragment on Tags
+  readonly description_latest: string,
+  readonly pingbacks: any /*{"definitions":[{}]}*/,
+  readonly subforumWelcomeText_latest: string,
+  readonly moderationGuidelines_latest: string,
   readonly name: string,
   readonly shortName: string | null,
   readonly subtitle: string | null,
@@ -3593,6 +3621,10 @@ interface UsersCurrentPostRateLimit { // fragment on Users
 }
 
 interface UsersDefaultFragment { // fragment on Users
+  readonly moderationGuidelines_latest: string,
+  readonly howOthersCanHelpMe_latest: string,
+  readonly howICanHelpOthers_latest: string,
+  readonly biography_latest: string,
   readonly username: string,
   readonly emails: Array<any /*{"definitions":[{}]}*/>,
   readonly isAdmin: boolean,

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -1,9 +1,10 @@
 import type { GraphQLScalarType } from 'graphql';
 import type { SimpleSchema } from 'simpl-schema';
-import { formProperties } from '../vulcan-forms/schema_utils';
+import type { formProperties } from '../vulcan-forms/schema_utils';
 import type { SmartFormProps } from '../../components/vulcan-forms/propTypes';
-import { permissionGroups } from "../permissions";
+import type { permissionGroups } from "../permissions";
 import type { FormGroupLayoutProps } from '../../components/form-components/FormGroupLayout';
+import type { EditableFieldOptions } from '../editor/makeEditableOptions';
 
 /// This file is wrapped in 'declare global' because it's an ambient declaration
 /// file (meaning types in this file can be used without being imported).
@@ -214,7 +215,8 @@ interface CollectionFieldSpecification<N extends CollectionNameString> extends C
   }) => any,
   onDelete?: (args: {document: ObjectsByCollectionName[N], currentUser: DbUser|null, collection: CollectionBase<N>, context: ResolverContext}) => Promise<void>,
 
-  countOfReferences?: CountOfReferenceOptions
+  countOfReferences?: CountOfReferenceOptions;
+  editableFieldOptions?: EditableFieldOptions;
 }
 
 /** Field specification for a Form field, created from the collection schema */

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -313,6 +313,9 @@ SimpleSchema.extendOptions(['logChanges'])
 // addCountOfReferenceCallbacks).
 SimpleSchema.extendOptions(['countOfReferences']);
 
+// For fields that are editable, this option allows you to specify the editable field options
+SimpleSchema.extendOptions(['editableFieldOptions']);
+
 
 // Helper function to add all the correct callbacks and metadata for a field
 // which is denormalized, where its denormalized value is a function only of

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -1,12 +1,12 @@
 import { isEAForum, isLWorAF } from '../../lib/instanceSettings';
 import { swrInvalidatePostRoute } from '../cache/swr';
-import { EditableCallbackProperties } from '../editor/make_editable_callbacks';
 import { HAS_EMBEDDINGS_FOR_RECOMMENDATIONS } from '../embeddings';
 import { handleCrosspostUpdate, performCrosspost } from "../fmCrosspost/crosspost";
 import { AfterCreateCallbackProperties, CallbackValidationErrors, CreateCallbackProperties, getCollectionHooks, UpdateCallbackProperties } from '../mutationCallbacks';
+import { rehostPostMetaImages } from '../scripts/convertImagesToCloudinary';
 import { elasticSyncDocument } from '../search/elastic/elasticCallbacks';
 import { moveToAFUpdatesUserAFKarma } from './alignment-forum/callbacks';
-import { addLinkSharingKey, addReferrerToPost, applyNewPostTags, assertPostTitleHasNoEmojis, autoTagNewPost, autoTagUndraftedPost, checkRecentRepost, checkTosAccepted, clearCourseEndTime, createNewJargonTermsCallback, debateMustHaveCoauthor, eventUpdatedNotifications, extractSocialPreviewImage, fixEventStartAndEndTimes, lwPostsNewUpvoteOwnPost, notifyUsersAddedAsCoauthors, notifyUsersAddedAsPostCoauthors, oldPostsLastCommentedAt, onEditAddLinkSharingKey, onPostPublished, postsNewDefaultLocation, postsNewDefaultTypes, postsNewPostRelation, postsNewRateLimit, postsNewUserApprovedStatus, postsUndraftRateLimit, removeFrontpageDate, removeRedraftNotifications, resetDialogueMatches, resetPostApprovedDate, scheduleCoauthoredPostWhenUndrafted, scheduleCoauthoredPostWithUnconfirmedCoauthors, sendAlignmentSubmissionApprovalNotifications, sendCoauthorRequestNotifications, sendEAFCuratedAuthorsNotification, sendLWAFPostCurationEmails, sendNewPublishedDialogueMessageNotifications, sendPostApprovalNotifications, sendPostSharedWithUserNotifications, sendRejectionPM, sendUsersSharedOnPostNotifications, setPostUndraftedFields, syncTagRelevance, triggerReviewForNewPostIfNeeded, updateCommentHideKarma, updatedPostMaybeTriggerReview, updatePostEmbeddingsOnChange, updatePostShortform, updateRecombeePost, updateUserNotesOnPostDraft, updateUserNotesOnPostRejection } from './postCallbackFunctions';
+import { addLinkSharingKey, addReferrerToPost, applyNewPostTags, assertPostTitleHasNoEmojis, autoTagNewPost, autoTagUndraftedPost, checkRecentRepost, checkTosAccepted, clearCourseEndTime, createNewJargonTermsCallback, debateMustHaveCoauthor, eventUpdatedNotifications, extractSocialPreviewImage, fixEventStartAndEndTimes, lwPostsNewUpvoteOwnPost, notifyUsersAddedAsCoauthors, notifyUsersAddedAsPostCoauthors, oldPostsLastCommentedAt, onEditAddLinkSharingKey, onPostPublished, postsNewDefaultLocation, postsNewDefaultTypes, postsNewPostRelation, postsNewRateLimit, postsNewUserApprovedStatus, postsUndraftRateLimit, removeFrontpageDate, removeRedraftNotifications, resetDialogueMatches, resetPostApprovedDate, scheduleCoauthoredPostWhenUndrafted, scheduleCoauthoredPostWithUnconfirmedCoauthors, sendAlignmentSubmissionApprovalNotifications, sendCoauthorRequestNotifications, sendEAFCuratedAuthorsNotification, sendLWAFPostCurationEmails, sendNewPublishedDialogueMessageNotifications, sendPostApprovalNotifications, sendPostSharedWithUserNotifications, sendRejectionPM, sendUsersSharedOnPostNotifications, setPostUndraftedFields, syncTagRelevance, triggerReviewForNewPostIfNeeded, updateCommentHideKarma, updatedPostMaybeTriggerReview, updateFirstDebateCommentPostId, updatePostEmbeddingsOnChange, updatePostShortform, updateRecombeePost, updateUserNotesOnPostDraft, updateUserNotesOnPostRejection } from './postCallbackFunctions';
 
 
 // TODO: refactor these in some way similar to countOfReferences callbacks?
@@ -82,20 +82,6 @@ async function postNewSync(post: DbPost, currentUser: DbUser | null, context: Re
   return post;
 }
 
-// async function postCreateAfterEditableCallbacks(
-//   post: DbPost,
-//   props: AfterCreateCallbackProperties<'Posts'>,
-//   editableCallbackOptions: EditableCallbackProperties<'Posts'>
-// ): Promise<DbPost> {
-//   post = await editorSerializationAfterCreate(post, props, editableCallbackOptions);
-//   post = await notifyUsersAboutPingbackMentionsInCreate(post, props, editableCallbackOptions);
-//   if (editableCallbackOptions.fieldName === 'contents') {
-//     post = await updateFirstDebateCommentPostId(post, props);
-//   }
-
-//   return post;
-// }
-
 async function postCreateAfter(post: DbPost, props: AfterCreateCallbackProperties<'Posts'>): Promise<DbPost> {
   await swrInvalidatePostRoute(post._id);
   if (!post.authorIsUnreviewed && !post.draft) {
@@ -103,11 +89,7 @@ async function postCreateAfter(post: DbPost, props: AfterCreateCallbackPropertie
   }
   post = await applyNewPostTags(post, props);
   post = await createNewJargonTermsCallback(post, props);
-
-  // post editable fields callbacks
-  // post = await postCreateAfterEditableCallbacks(post, props, postContentsEditableCallbackOptions);
-  // post = await postCreateAfterEditableCallbacks(post, props, postModerationGuidelinesEditableCallbackOptions);
-  // post = await postCreateAfterEditableCallbacks(post, props, postCustomHighlightEditableCallbackOptions);
+  post = await updateFirstDebateCommentPostId(post, props);
 
   return post;
 }
@@ -136,13 +118,8 @@ async function postNewAsync(post: DbPost) {
     await updatePostEmbeddingsOnChange(post, undefined);
   }
 
-  // post editable fields callbacks
-  // await reuploadImagesInNew(post, postContentsEditableCallbackOptions);
-  // await reuploadImagesInNew(post, postModerationGuidelinesEditableCallbackOptions);
-  // await reuploadImagesInNew(post, postCustomHighlightEditableCallbackOptions);
-
-  // This editable callback only needs to run once, not once per field, since it's not field-specific
-  // await rehostPostMetaImagesInNew(post);
+  // This used to be an editable callback, but it only needs to run once, rather than once per field
+  await rehostPostMetaImages(post);
 }
 
 async function postUpdateValidate(validationErrors: CallbackValidationErrors, props: UpdateCallbackProperties<'Posts'>): Promise<CallbackValidationErrors> {
@@ -166,11 +143,6 @@ async function postUpdateBefore(post: Partial<DbPost>, props: UpdateCallbackProp
   post = await handleCrosspostUpdate(post, props);
   post = onEditAddLinkSharingKey(post, props);
 
-  // post editable fields callbacks
-  // post = await editorSerializationEdit(post, props, postContentsEditableCallbackOptions);
-  // post = await editorSerializationEdit(post, props, postModerationGuidelinesEditableCallbackOptions);
-  // post = await editorSerializationEdit(post, props, postCustomHighlightEditableCallbackOptions);
-
   return post;
 }
 
@@ -188,12 +160,7 @@ async function postUpdateAfter(post: DbPost, props: UpdateCallbackProperties<'Po
   post = await resetDialogueMatches(post, props);
   post = await createNewJargonTermsCallback(post, props);
   
-  // post editable fields callbacks
-  // post = await notifyUsersAboutPingbackMentionsInUpdate(post, props, postContentsEditableCallbackOptions);
-  // post = await notifyUsersAboutPingbackMentionsInUpdate(post, props, postModerationGuidelinesEditableCallbackOptions);
-  // post = await notifyUsersAboutPingbackMentionsInUpdate(post, props, postCustomHighlightEditableCallbackOptions);
-
-  // countOfReference callbacks run after this
+  // countOfReference callbacks run after this (and after post editable fields callbacks)
 
   return post;
 }
@@ -234,10 +201,6 @@ async function postEditAsync(post: DbPost, oldPost: DbPost, currentUser: DbUser 
   await extractSocialPreviewImage(post, props);
   await oldPostsLastCommentedAt(post, context);
 
-  // post editable fields callbacks
-  // await reuploadImagesInEdit(post, oldPost, postContentsEditableCallbackOptions);
-  // await reuploadImagesInEdit(post, oldPost, postModerationGuidelinesEditableCallbackOptions);
-  // await reuploadImagesInEdit(post, oldPost, postCustomHighlightEditableCallbackOptions);
 
   // elastic callbacks
   await elasticSyncDocument('Posts', post._id);

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -1,24 +1,61 @@
-import {AfterCreateCallbackProperties, CreateCallbackProperties, getCollectionHooks, UpdateCallbackProperties} from '../mutationCallbacks'
-import {Revisions} from '../../lib/collections/revisions/collection'
 import {extractVersionsFromSemver} from '../../lib/editor/utils'
 import {htmlToPingbacks} from '../pingbacks'
-import {
-  editableCollections,
-  editableCollectionsFields,
-  sealEditableFields,
-} from '../../lib/editor/make_editable'
-import {collectionNameToTypeName, getCollection} from '../../lib/vulcan-lib/getCollection'
+import { isEditableField } from '../../lib/editor/make_editable'
+import { collectionNameToTypeName } from '../../lib/vulcan-lib/getCollection'
 import { CallbackHook } from '../utils/callbackHooks'
 import {createMutator, validateCreateMutation} from '../vulcan-lib/mutators'
 import {dataToHTML, dataToWordCount} from './conversionUtils'
 import {notifyUsersAboutMentions, PingbackDocumentPartial} from './mentions-notify'
 import {getLatestRev, getNextVersion, htmlToChangeMetrics, isBeingUndrafted, MaybeDrafteable} from './utils'
-import { Comments } from '../../lib/collections/comments/collection'
 import isEqual from 'lodash/isEqual'
 import { fetchFragmentSingle } from '../fetchFragment'
-import { getLatestContentsRevision } from '@/lib/collections/revisions/helpers'
-import { MakeEditableOptions, editableCollectionsFieldOptions } from '@/lib/editor/makeEditableOptions'
-import { convertImagesInObject, rehostPostMetaImages } from '../scripts/convertImagesToCloudinary'
+import { convertImagesInObject } from '../scripts/convertImagesToCloudinary'
+import type { AfterCreateCallbackProperties, CreateCallbackProperties, UpdateCallbackProperties } from '../mutationCallbacks'
+import type { MakeEditableOptions } from '@/lib/editor/makeEditableOptions'
+
+interface CreateBeforeEditableCallbackProperties<N extends CollectionNameString> {
+  doc: Partial<DbInsertion<ObjectsByCollectionName[N]>>;
+  props: CreateCallbackProperties<N>;
+}
+
+interface UpdateBeforeEditableCallbackProperties<N extends CollectionNameString> {
+  docData: Partial<ObjectsByCollectionName[N]>;
+  props: UpdateCallbackProperties<N>;
+}
+
+interface CreateAfterEditableCallbackProperties<N extends CollectionNameString> {
+  newDoc: ObjectsByCollectionName[N];
+  props: AfterCreateCallbackProperties<N>;
+}
+
+interface UpdateAfterEditableCallbackProperties<N extends CollectionNameString> {
+  newDoc: ObjectsByCollectionName[N];
+  props: UpdateCallbackProperties<N>;
+}
+
+interface NewAsyncEditableCallbackProperties<N extends CollectionNameString> {
+  newDoc: ObjectsByCollectionName[N];
+  props: AfterCreateCallbackProperties<N>;
+}
+
+interface EditAsyncEditableCallbackProperties<N extends CollectionNameString> {
+  newDoc: ObjectsByCollectionName[N];
+  props: UpdateCallbackProperties<N>;
+}
+
+function getEditableFieldsCallbackProps<N extends CollectionNameString>({ schema, collection }: { schema: SchemaType<N>, collection: CollectionBase<N> }) {
+  const editableFields = Object.entries(schema).filter(isEditableField);
+  return editableFields.map(([fieldName, fieldSpec]) => {
+    const { collectionName } = collection;
+    const { pingbacks, normalized } = fieldSpec.editableFieldOptions.callbackOptions;
+    return {
+      fieldName,
+      pingbacks,
+      normalized,
+      collectionName,
+    };
+  });
+}
 
 // TODO: Now that the make_editable callbacks use createMutator to create
 // revisions, we can now add these to the regular ${collection}.create.after
@@ -29,7 +66,7 @@ interface AfterCreateRevisionCallbackContext {
 }
 export const afterCreateRevisionCallback = new CallbackHook<[AfterCreateRevisionCallbackContext]>("revisions.afterRevisionCreated");
 
-export function getInitialVersion(document: DbInsertion<DbPost|DbObject>) {
+export function getInitialVersion(document: Partial<DbInsertion<DbPost|DbObject>>) {
   if ((document as DbPost).draft) {
     return '0.1.0'
   } else {
@@ -86,13 +123,9 @@ export const revisionIsChange = async (doc: AnyBecauseTodo, fieldName: string): 
 
 export type EditableCallbackProperties<N extends CollectionNameString> = Pick<MakeEditableOptions<N>, 'fieldName' | 'normalized' | 'pingbacks'> & { collectionName: N };
 
-/**************************************************************************************/
-/* TODO: these shouldn't be used until we refactor or get rid of addEditableCallbacks */
-/**************************************************************************************/
-
 // createBefore
-export async function editorSerializationBeforeCreate<N extends CollectionNameString>(
-  doc: DbInsertion<ObjectsByCollectionName[N]>,
+async function createInitialRevision<N extends CollectionNameString>(
+  doc: Partial<DbInsertion<ObjectsByCollectionName[N]>>,
   {currentUser, context}: CreateCallbackProperties<N>,
   options: EditableCallbackProperties<N>,
 ) {
@@ -178,9 +211,8 @@ export async function editorSerializationBeforeCreate<N extends CollectionNameSt
   return doc
 }
 
-
 // updateBefore
-export async function editorSerializationEdit<N extends CollectionNameString>(
+async function createUpdateRevision<N extends CollectionNameString>(
   docData: Partial<ObjectsByCollectionName[N]>,
   { oldDocument: document, newDocument, currentUser, context }: UpdateCallbackProperties<N>,
   options: EditableCallbackProperties<N>,
@@ -282,7 +314,7 @@ export async function editorSerializationEdit<N extends CollectionNameString>(
 
 
 // createAfter
-export async function editorSerializationAfterCreate<N extends CollectionNameString>(newDoc: ObjectsByCollectionName[N], { context }: AfterCreateCallbackProperties<N>, options: EditableCallbackProperties<N>) {
+async function updateRevisionDocumentId<N extends CollectionNameString>(newDoc: ObjectsByCollectionName[N], { context }: AfterCreateCallbackProperties<N>, options: EditableCallbackProperties<N>) {
   const { fieldName = "contents" } = options;
 
   const { Revisions } = context;
@@ -299,7 +331,8 @@ export async function editorSerializationAfterCreate<N extends CollectionNameStr
   return newDoc;
 }
 
-export async function notifyUsersAboutPingbackMentionsInCreate<N extends CollectionNameString>(
+// createAfter
+async function notifyUsersAboutPingbackMentionsInCreate<N extends CollectionNameString>(
   newDocument: ObjectsByCollectionName[N],
   { currentUser }: AfterCreateCallbackProperties<N>,
   options: EditableCallbackProperties<N>,
@@ -315,34 +348,8 @@ export async function notifyUsersAboutPingbackMentionsInCreate<N extends Collect
   return newDocument
 }
 
-export async function updateFirstDebateCommentPostId(newDoc: DbPost, { context, currentUser }: AfterCreateCallbackProperties<'Posts'>) {
-  const { Comments } = context;
-
-  const isFirstDebatePostComment = 'debate' in newDoc
-      ? !!newDoc.debate
-      : false;
-  if (currentUser && isFirstDebatePostComment) {
-    const revision = await getLatestContentsRevision(newDoc, context);
-    if (!revision?.html) {
-      return newDoc;
-    }
-    await createMutator({
-      collection: Comments,
-      document: {
-        userId: currentUser._id,
-        postId: newDoc._id,
-        contents: revision as EditableFieldInsertion,
-        debateResponse: true,
-      },
-      context,
-      currentUser,
-    });
-  }
-  return newDoc;
-}
-
 // updateAfter
-export async function notifyUsersAboutPingbackMentionsInUpdate<N extends CollectionNameString>(
+async function notifyUsersAboutPingbackMentionsInUpdate<N extends CollectionNameString>(
   newDocument: ObjectsByCollectionName[N],
   { oldDocument, currentUser, context }: UpdateCallbackProperties<N>,
   options: EditableCallbackProperties<N>,
@@ -356,6 +363,13 @@ export async function notifyUsersAboutPingbackMentionsInUpdate<N extends Collect
   return newDocument
 }
 
+// newAsync
+async function reuploadImagesInNew(doc: DbObject, options: EditableCallbackProperties<CollectionNameString>) {
+  const { fieldName = "contents", collectionName } = options;
+
+  await convertImagesInObject(collectionName, doc._id, fieldName)
+}
+
 // editAsync
 /**
  * Reupload images to cloudinary. This is mainly for images pasted from google docs, because
@@ -366,7 +380,7 @@ export async function notifyUsersAboutPingbackMentionsInUpdate<N extends Collect
  * See: https://app.asana.com/0/628521446211730/1203311932993130/f
  * It's fine to leave it here just in case though
  */
-export async function reuploadImagesInEdit(doc: DbObject, oldDoc: DbObject, options: EditableCallbackProperties<CollectionNameString>) {
+async function reuploadImagesInEdit(doc: DbObject, oldDoc: DbObject, options: EditableCallbackProperties<CollectionNameString>) {
   const { fieldName = "contents", collectionName } = options;
 
   const latestField = `${fieldName}_latest`;
@@ -377,297 +391,72 @@ export async function reuploadImagesInEdit(doc: DbObject, oldDoc: DbObject, opti
   await convertImagesInObject(collectionName, doc._id, fieldName);
 }
 
-// newAsync
-export async function reuploadImagesInNew(doc: DbObject, options: EditableCallbackProperties<CollectionNameString>) {
-  const { fieldName = "contents", collectionName } = options;
+export async function runCreateBeforeEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: CreateBeforeEditableCallbackProperties<N>) {
+  let { props, doc: mutableDoc } = runCallbackStageProperties;
 
-  await convertImagesInObject(collectionName, doc._id, fieldName)
-}
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
 
-export async function rehostPostMetaImagesInNew(doc: DbPost) {
-  await rehostPostMetaImages(doc);
-}
-
-
-function addEditableCallbacks<N extends CollectionNameString>({collection, options = {}}: {
-  collection: CollectionBase<N>,
-  options: MakeEditableOptions<N>,
-}) {
-  // The type of the DbObject containing this field
-  type DbType = ObjectsByCollectionName[N];
-
-  // The type of the mutation object that is used to update this db object.
-  // TODO: This should also include a list of the editable resolver-only fields
-  // but we don't currently have a way to do that - it probably needs some
-  // additions to the type generation script.
-  type UpdateData = Partial<DbType>;
-
-  const {
-    fieldName = "contents",
-    pingbacks = false,
-    normalized,
-  } = options
-
-  const collectionName = collection.collectionName;
-
-  getCollectionHooks(collectionName).createBefore.add(
-    async function editorSerializationBeforeCreate (doc: DbInsertion<DbType>, {currentUser, context}) {
-    const editableField = (doc as AnyBecauseHard)[fieldName] as EditableFieldInsertion | undefined;
-    if (editableField?.originalContents) {
-      if (!currentUser) { throw Error("Can't create document without current user") }
-      const originalContents: DbRevision["originalContents"] = editableField.originalContents
-      const commitMessage = editableField.commitMessage ?? null;
-      const googleDocMetadata = editableField.googleDocMetadata;
-      const revision = await buildRevision({
-        originalContents,
-        currentUser,
-      });
-      const { html, wordCount } = revision;
-      const version = getInitialVersion(doc)
-      const userId = currentUser._id
-      const editedAt = new Date()
-      const changeMetrics = htmlToChangeMetrics("", html);
-      const isFirstDebatePostComment = (collectionName === 'Posts' && 'debate' in doc)
-        ? (!!doc.debate && fieldName === 'contents')
-        : false;
-
-      if (isFirstDebatePostComment) {
-        const createFirstCommentParams: CreateMutatorParams<"Comments"> = {
-          collection: Comments,
-          document: {
-            userId,
-            contents: editableField,
-            debateResponse: true,
-          },
-          context,
-          currentUser,
-        };
-
-        // We need to validate that we'll be able to successfully create the comment in the updateFirstDebateCommentPostId callback
-        // If we can't, we'll be stuck with a malformed debate post with no comments
-        await validateCreateMutation(createFirstCommentParams);
-      }
-
-      const newRevision: Omit<DbRevision, "documentId" | "schemaVersion" | "_id" | "voteCount" | "baseScore" | "extendedScore" | "score" | "inactive" | "autosaveTimeoutStart" | "afBaseScore" | "afExtendedScore" | "afVoteCount" | "legacyData"> = {
-        ...revision,
-        fieldName,
-        collectionName,
-        version,
-        draft: versionIsDraft(version, collectionName),
-        updateType: 'initial',
-        commitMessage,
-        googleDocMetadata,
-        skipAttributions: false,
-        changeMetrics,
-        createdAt: editedAt,
-      };
-      const firstRevision = await createMutator({
-        collection: Revisions,
-        document: newRevision,
-        validate: false
-      });
-
-      return {
-        ...doc,
-        ...(!normalized && {
-          [fieldName]: {
-            ...editableField,
-            html, version, userId, editedAt, wordCount,
-            updateType: 'initial'
-          },
-        }),
-        [`${fieldName}_latest`]: firstRevision.data._id,
-        ...(pingbacks ? {
-          pingbacks: await htmlToPingbacks(html, null),
-        } : null),
-      }
-    }
-    return doc
-  });
-
-  getCollectionHooks(collectionName).updateBefore.add(
-    async function editorSerializationEdit (
-      docData: UpdateData,
-      {oldDocument: document, newDocument, currentUser},
-    ) {
-    const editableField = (docData as AnyBecauseHard)[fieldName] as EditableFieldUpdate | undefined;
-    if (editableField?.originalContents) {
-      if (!currentUser) { throw Error("Can't create document without current user") }
-
-      const commitMessage = editableField.commitMessage ?? null;
-      const dataWithDiscardedSuggestions = editableField.dataWithDiscardedSuggestions
-      delete editableField.dataWithDiscardedSuggestions
-
-      const oldRevisionId = (document as AnyBecauseHard)?.[`${fieldName}_latest`];
-      const oldRevision = oldRevisionId
-        ? await fetchFragmentSingle({
-          collectionName: "Revisions",
-          fragmentName: "RevisionMetadata",
-          selector: {_id: oldRevisionId},
-          currentUser: null,
-          skipFiltering: true,
-        })
-        : null;
-
-      const revision = await buildRevision({
-        originalContents: (newDocument as AnyBecauseHard)[fieldName].originalContents,
-        dataWithDiscardedSuggestions,
-        currentUser,
-      });
-      const { html, wordCount } = revision;
-
-      const defaultUpdateType = editableField.updateType ||
-        (!oldRevision && 'initial') ||
-        'minor';
-      // When a document is undrafted for the first time, we ensure that this constitutes a major update
-      const { major } = extractVersionsFromSemver(oldRevision?.version ?? null);
-      const beingUndrafted = isBeingUndrafted(document as MaybeDrafteable, newDocument as MaybeDrafteable)
-      const updateType = (beingUndrafted && (major < 1)) ? 'major' : defaultUpdateType
-      const userId = currentUser._id
-      const editedAt = new Date()
-      const previousRev = await getLatestRev(newDocument._id, fieldName);
-      const version = getNextVersion(previousRev, updateType, (newDocument as DbPost).draft)
-      const changeMetrics = htmlToChangeMetrics(previousRev?.html || "", html);
-
-      const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "extendedScore"| "score" | "inactive" | "autosaveTimeoutStart" | "afBaseScore" | "afExtendedScore" | "afVoteCount" | "legacyData" | "googleDocMetadata"> = {
-        documentId: document._id,
-        ...revision,
-        fieldName,
-        collectionName,
-        version,
-        draft: versionIsDraft(version, collectionName),
-        updateType,
-        commitMessage,
-        changeMetrics,
-        createdAt: editedAt,
-        skipAttributions: false,
-      };
-      
-      const newRevisionDoc = await createMutator({
-        collection: Revisions,
-        document: newRevision,
-        validate: false
-      });
-
-      const newRevisionId = newRevisionDoc.data._id;
-
-      if (newRevisionId) {
-        await afterCreateRevisionCallback.runCallbacksAsync([{ revisionID: newRevisionId }]);
-      }
-
-      return {
-        ...docData,
-        ...(!normalized && {
-          [fieldName]: {
-            ...editableField,
-            html, version, userId, editedAt, wordCount
-          },
-        }),
-        [`${fieldName}_latest`]: newRevisionId,
-        ...(pingbacks ? {
-          pingbacks: await htmlToPingbacks(html, [{
-              collectionName: collection.collectionName,
-              documentId: document._id,
-            }]
-          ),
-        } : null),
-      }
-    }
-    return docData
-  });
-
-  getCollectionHooks(collectionName).createAfter.add(
-    async function editorSerializationAfterCreate(newDoc) {
-    // Update revision to point to the document that owns it.
-    const revisionID = (newDoc as AnyBecauseHard)[`${fieldName}_latest`];
-    if (revisionID) {
-      await Revisions.rawUpdateOne(
-        { _id: revisionID },
-        { $set: { documentId: newDoc._id } }
-      );
-      await afterCreateRevisionCallback.runCallbacksAsync([{ revisionID: revisionID }]);
-    }
-    return newDoc;
-  });
-
-  getCollectionHooks(collectionName).createAfter.add(async (newDocument, {currentUser}) => {
-    if (currentUser && pingbacks && 'pingbacks' in newDocument) {
-      await notifyUsersAboutMentions(currentUser, collection.typeName, newDocument)
-    }
-
-    return newDocument
-  })
-
-  if (collectionName === 'Posts' && fieldName === 'contents') {
-    getCollectionHooks("Posts").createAfter.add(
-      async function updateFirstDebateCommentPostId(newDoc, { context, currentUser })
-    {
-      const isFirstDebatePostComment = 'debate' in newDoc
-          ? !!newDoc.debate
-          : false;
-      if (currentUser && isFirstDebatePostComment) {
-        const revision = await getLatestContentsRevision(newDoc, context);
-        if (!revision?.html) {
-          return newDoc;
-        }
-        await createMutator({
-          collection: Comments,
-          document: {
-            userId: currentUser._id,
-            postId: newDoc._id,
-            contents: revision as EditableFieldInsertion,
-            debateResponse: true,
-          },
-          context,
-          currentUser,
-        });
-      }
-      return newDoc;
-    });
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    mutableDoc = await createInitialRevision<N>(mutableDoc, props, editableFieldCallbackProps);
   }
 
-  getCollectionHooks(collectionName).updateAfter.add(async (newDocument, {oldDocument, currentUser}) => {
-    if (currentUser && pingbacks && 'pingbacks' in newDocument) {
-      await notifyUsersAboutMentions(currentUser, collection.typeName, newDocument, oldDocument as PingbackDocumentPartial)
-    }
+  return mutableDoc;
+}
 
-    return newDocument
-  })
+export async function runCreateAfterEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: CreateAfterEditableCallbackProperties<N>) {
+  let { props, newDoc: mutableDoc } = runCallbackStageProperties;
 
-  /**
-   * Reupload images to cloudinary. This is mainly for images pasted from google docs, because
-   * they have fairly strict rate limits that often result in them failing to load.
-   *
-   * NOTE: This is still necessary even if CkEditor is configured to reupload
-   * images, because images have URLs that come from Markdown or RSS sync.
-   * See: https://app.asana.com/0/628521446211730/1203311932993130/f
-   * It's fine to leave it here just in case though
-   */
-  getCollectionHooks(collectionName).editAsync.add(async (doc: DbObject, oldDoc: DbObject) => {
-    const latestField = `${fieldName}_latest`;
-    const hasChanged = (oldDoc as AnyBecauseHard)?.[latestField] !== (doc as AnyBecauseHard)?.[latestField];
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
 
-    if (!hasChanged) return;
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    mutableDoc = await updateRevisionDocumentId<N>(mutableDoc, props, editableFieldCallbackProps);
+    mutableDoc = await notifyUsersAboutPingbackMentionsInCreate<N>(mutableDoc, props, editableFieldCallbackProps);
 
-    await convertImagesInObject(collectionName, doc._id, fieldName);
-  })
-  getCollectionHooks(collectionName).newAsync.add(async (doc: DbObject) => {
-    await convertImagesInObject(collectionName, doc._id, fieldName)
-  })
-  if (collectionName === 'Posts') {
-    getCollectionHooks("Posts").newAsync.add(async (doc: DbPost) => {
-      await rehostPostMetaImages(doc);
-    })
+  }
+
+  return mutableDoc;
+}
+
+export async function runNewAsyncEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: NewAsyncEditableCallbackProperties<N>) {
+  let { props, newDoc } = runCallbackStageProperties;
+
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
+
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    await reuploadImagesInNew(newDoc, editableFieldCallbackProps);
   }
 }
 
-export function addAllEditableCallbacks() {
-  sealEditableFields();
-  for (let collectionName of editableCollections) {
-    for (let fieldName of editableCollectionsFields[collectionName]) {
-      const collection = getCollection(collectionName);
-      const options = editableCollectionsFieldOptions[collectionName][fieldName];
-      addEditableCallbacks({collection, options});
-    }
+export async function runUpdateBeforeEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: UpdateBeforeEditableCallbackProperties<N>) {
+  let { props, docData } = runCallbackStageProperties;
+
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
+
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    docData = await createUpdateRevision<N>(docData, props, editableFieldCallbackProps);
+  }
+
+  return docData;
+}
+
+export async function runUpdateAfterEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: UpdateAfterEditableCallbackProperties<N>) {
+  let { props, newDoc } = runCallbackStageProperties;
+
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
+
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    newDoc = await notifyUsersAboutPingbackMentionsInUpdate<N>(newDoc, props, editableFieldCallbackProps);
+  }
+
+  return newDoc;
+}
+
+export async function runEditAsyncEditableCallbacks<N extends CollectionNameString>(runCallbackStageProperties: EditAsyncEditableCallbackProperties<N>) {
+  let { props, newDoc } = runCallbackStageProperties;
+
+  const editableFieldsCallbackProps = getEditableFieldsCallbackProps(props);
+
+  for (const editableFieldCallbackProps of editableFieldsCallbackProps) {
+    await reuploadImagesInEdit(newDoc, props.oldDocument, editableFieldCallbackProps);
   }
 }

--- a/packages/lesswrong/server/manualMigrations/2019-01-30-migrateEditableFields.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-01-30-migrateEditableFields.ts
@@ -1,5 +1,5 @@
 import { registerMigration, migrateDocuments } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable'
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import { Revisions } from '../../lib/collections/revisions/collection';
 
@@ -42,7 +42,7 @@ export default registerMigration({
   dateWritten: "2019-01-30",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
+    for (let collectionName of getEditableCollectionNames()) {
       const collection = getCollection(collectionName)
       await migrateDocuments({
         description: `Migrate ${collectionName} to new content fields`,
@@ -55,7 +55,7 @@ export default registerMigration({
           let collectionUpdates: Array<any> = []
           let newRevisions: Array<any> = []
           documents.forEach(doc => {
-            editableCollectionsFields[collectionName]!.forEach((fieldName) => {
+            getEditableFieldNamesForCollection(collectionName).forEach((fieldName) => {
               let contentFields
               let newFieldName
               if (["Sequences", "Books", "Chapters", "Collections"].includes(collectionName)) { // Special case for sequences, books, collections and chapters

--- a/packages/lesswrong/server/manualMigrations/2019-02-04-replaceObjectIdsInEditableFields.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-02-04-replaceObjectIdsInEditableFields.ts
@@ -1,5 +1,5 @@
 import { registerMigration, migrateDocuments } from './migrationUtils';
-import { editableCollections } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames } from '../../lib/editor/make_editable'
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import * as _ from 'underscore';
 
@@ -8,7 +8,7 @@ export default registerMigration({
   dateWritten: "2019-02-04",
   idempotent: true,
   action: async () => {
-    const collectionNames: Array<CollectionNameString> = [...editableCollections, "Revisions", "Votes"]
+    const collectionNames: Array<CollectionNameString> = [...getEditableCollectionNames(), "Revisions", "Votes"]
     for (let collectionName of collectionNames) {
       const collection = getCollection(collectionName)
       await migrateDocuments({

--- a/packages/lesswrong/server/manualMigrations/2019-02-14-computeWordCounts.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-02-14-computeWordCounts.ts
@@ -1,5 +1,5 @@
 import { registerMigration, migrateDocuments } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable'
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import { dataToWordCount } from '../editor/conversionUtils';
 import { Revisions } from '../../lib/collections/revisions/collection';
@@ -43,8 +43,8 @@ export default registerMigration({
     });
     
     // Fill in wordCount in the denormalized latest revs on posts/comments/etc
-    for (let collectionName of editableCollections) {
-      for (let fieldName of editableCollectionsFields[collectionName]!) {
+    for (let collectionName of getEditableCollectionNames()) {
+      for (let fieldName of getEditableFieldNamesForCollection(collectionName)) {
         const collection: CollectionBase<any> = getCollection(collectionName)
         await migrateDocuments({
           description: `Compute word counts for ${collectionName}.${fieldName}`,

--- a/packages/lesswrong/server/manualMigrations/2019-04-12-dropDenormalizedContents.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-04-12-dropDenormalizedContents.ts
@@ -1,5 +1,5 @@
 import { registerMigration, dropUnusedField } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable'
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 
 export default registerMigration({
@@ -7,8 +7,8 @@ export default registerMigration({
   dateWritten: "2019-04-12",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
-      for (let editableField of editableCollectionsFields[collectionName]!) {
+    for (let collectionName of getEditableCollectionNames()) {
+      for (let editableField of getEditableFieldNamesForCollection(collectionName)) {
         // eslint-disable-next-line no-console
         console.log(`Dropping denormalized part of ${collectionName}.${editableField}...`);
         

--- a/packages/lesswrong/server/manualMigrations/2019-10-10-generatePingbacks.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-10-10-generatePingbacks.ts
@@ -1,8 +1,7 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable';
+import { getEditableFieldsByCollection } from '../../lib/editor/make_editable';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import { htmlToPingbacks } from '../pingbacks';
-import { editableCollectionsFieldOptions } from '@/lib/editor/makeEditableOptions';
 import Revisions from '@/lib/collections/revisions/collection';
 
 export default registerMigration({
@@ -10,10 +9,10 @@ export default registerMigration({
   dateWritten: "2019-10-10",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
-      for (let editableField of editableCollectionsFields[collectionName]!) {
-        if (editableCollectionsFieldOptions[collectionName][editableField].pingbacks) {
-          await updatePingbacks(collectionName, editableField);
+    for (let [collectionName, editableFields] of Object.entries(getEditableFieldsByCollection())) {
+      for (let [fieldName, editableField] of Object.entries(editableFields)) {
+        if (editableField.editableFieldOptions.callbackOptions.pingbacks) {
+          await updatePingbacks(collectionName as CollectionNameString, fieldName);
         }
       }
     }

--- a/packages/lesswrong/server/manualMigrations/2019-11-24-editableLatestRevision1.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-11-24-editableLatestRevision1.ts
@@ -1,6 +1,6 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable';
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable';
 import { Revisions } from '../../lib/collections/revisions/collection';
 
 // The upgrade procedure here is:
@@ -20,8 +20,8 @@ export default registerMigration({
   dateWritten: "2019-11-24",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections)
-    for (let fieldName of editableCollectionsFields[collectionName]!)
+    for (let collectionName of getEditableCollectionNames())
+    for (let fieldName of getEditableFieldNamesForCollection(collectionName))
     {
       const collection = getCollection(collectionName);
       // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/manualMigrations/2019-12-05-generatePingbacksAgain.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-12-05-generatePingbacksAgain.ts
@@ -1,8 +1,7 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable';
+import { getEditableFieldsByCollection } from '../../lib/editor/make_editable';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import { htmlToPingbacks } from '../pingbacks';
-import { editableCollectionsFieldOptions } from '@/lib/editor/makeEditableOptions';
 import Revisions from '@/lib/collections/revisions/collection';
 
 export default registerMigration({
@@ -10,10 +9,10 @@ export default registerMigration({
   dateWritten: "2019-12-05",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
-      for (let editableField of editableCollectionsFields[collectionName]!) {
-        if (editableCollectionsFieldOptions[collectionName][editableField].pingbacks) {
-          await updatePingbacks(collectionName, editableField);
+    for (let [collectionName, editableFields] of Object.entries(getEditableFieldsByCollection())) {
+      for (let [fieldName, editableField] of Object.entries(editableFields)) {
+        if (editableField.editableFieldOptions.callbackOptions.pingbacks) {
+          await updatePingbacks(collectionName as CollectionNameString, fieldName);
         }
       }
     }

--- a/packages/lesswrong/server/manualMigrations/2020-01-02-fillMissingRevisionFieldNames.ts
+++ b/packages/lesswrong/server/manualMigrations/2020-01-02-fillMissingRevisionFieldNames.ts
@@ -1,5 +1,5 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable';
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from '../../lib/editor/make_editable';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import Revisions from '../../lib/collections/revisions/collection'
 
@@ -29,11 +29,11 @@ export default registerMigration({
 function collectionsWithExactlyOneEditableField(): Array<{collectionName: CollectionNameString, fieldName: string}>
 {
   let result: Array<{collectionName: CollectionNameString, fieldName: string}> = [];
-  for (let collectionName of editableCollections) {
-    if (editableCollectionsFields[collectionName]!.length === 1) {
+  for (let collectionName of getEditableCollectionNames()) {
+    if (getEditableFieldNamesForCollection(collectionName).length === 1) {
       result.push({
         collectionName,
-        fieldName: editableCollectionsFields[collectionName]![0],
+        fieldName: getEditableFieldNamesForCollection(collectionName)[0],
       });
     }
   }

--- a/packages/lesswrong/server/manualMigrations/2020-05-05-addRevisionCollectionName.ts
+++ b/packages/lesswrong/server/manualMigrations/2020-05-05-addRevisionCollectionName.ts
@@ -1,5 +1,5 @@
 import { registerMigration, forEachDocumentBatchInCollection } from './migrationUtils';
-import { editableCollections } from '../../lib/editor/make_editable';
+import { getEditableCollectionNames } from '../../lib/editor/make_editable';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import Revisions from '../../lib/collections/revisions/collection'
 
@@ -8,7 +8,7 @@ export default registerMigration({
   dateWritten: "2020-05-05",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
+    for (let collectionName of getEditableCollectionNames()) {
       // eslint-disable-next-line no-console
       console.log(`Migrating revisions for collection ${collectionName}`);
       await forEachDocumentBatchInCollection({

--- a/packages/lesswrong/server/manualMigrations/2022-08-31-recomputeWordCounts.ts
+++ b/packages/lesswrong/server/manualMigrations/2022-08-31-recomputeWordCounts.ts
@@ -1,5 +1,5 @@
 import { registerMigration, forEachDocumentBatchInCollection } from "./migrationUtils";
-import { editableCollections, editableCollectionsFields } from "../../lib/editor/make_editable"
+import { getEditableCollectionNames, getEditableFieldNamesForCollection } from "../../lib/editor/make_editable"
 import { getCollection } from "../../lib/vulcan-lib/getCollection";
 import { dataToWordCount } from "../editor/conversionUtils";
 import { Revisions } from "../../lib/collections/revisions/collection";
@@ -43,8 +43,8 @@ export default registerMigration({
         }
       },
     });
-    for (const collectionName of editableCollections) {
-      for (const fieldName of editableCollectionsFields[collectionName]!) {
+    for (const collectionName of getEditableCollectionNames()) {
+      for (const fieldName of getEditableFieldNamesForCollection(collectionName)) {
         const collection: CollectionBase<any> = getCollection(collectionName)
         await forEachDocumentBatchInCollection({
           collection,

--- a/packages/lesswrong/server/resolvers/diffResolvers.ts
+++ b/packages/lesswrong/server/resolvers/diffResolvers.ts
@@ -1,7 +1,7 @@
 import { addGraphQLResolvers, addGraphQLQuery } from '../../lib/vulcan-lib/graphql';
 import { isValidCollectionName } from '../../lib/vulcan-lib/getCollection';
 import { Revisions } from '../../lib/collections/revisions/collection';
-import { editableCollections, editableCollectionsFields, } from '../../lib/editor/make_editable';
+import { getEditableCollectionNames, getEditableFieldNamesForCollection, } from '../../lib/editor/make_editable';
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
 import { diffHtml } from './htmlDiff';
 import { getPrecedingRev } from '../editor/utils';
@@ -18,10 +18,10 @@ addGraphQLResolvers({
       if (!isValidCollectionName(collectionName)) {
         throw new Error(`Invalid collection for RevisionsDiff: ${collectionName}`);
       }
-      if (!editableCollections.has(collectionName)) {
+      if (!getEditableCollectionNames().includes(collectionName)) {
         throw new Error(`Invalid collection for RevisionsDiff: ${collectionName}`);
       }
-      if (!editableCollectionsFields[collectionName]!.find(f=>f===fieldName)) {
+      if (!getEditableFieldNamesForCollection(collectionName).find(f=>f===fieldName)) {
         throw new Error(`Invalid field for RevisionsDiff: ${collectionName}.${fieldName}`);
       }
       

--- a/packages/lesswrong/server/scripts/arbitalImport/reconvertMarkdown.ts
+++ b/packages/lesswrong/server/scripts/arbitalImport/reconvertMarkdown.ts
@@ -9,7 +9,6 @@ import { Comments } from "@/lib/collections/comments/collection.ts";
 import Tags from "@/lib/collections/tags/collection";
 import { getRootDocument } from "@/lib/collections/multiDocuments/helpers";
 import { MultiDocuments } from "@/lib/collections/multiDocuments/collection";
-import { editableCollectionsFieldOptions } from "@/lib/editor/makeEditableOptions";
 import { getLatestRev } from "@/server/editor/utils";
 import pick from "lodash/pick";
 import { updateDenormalizedHtmlAttributions } from "@/server/tagging/updateDenormalizedHtmlAttributions";
@@ -17,6 +16,7 @@ import { updateDenormalizedContributorsList } from "@/server/utils/contributorsU
 import { buildRevision } from "@/server/editor/make_editable_callbacks";
 import { Users } from "@/lib/collections/users/collection";
 import { getCollection } from "@/lib/vulcan-lib/getCollection.ts";
+import { getEditableFieldInCollection } from "@/lib/editor/make_editable";
 
 export const reconvertArbitalMarkdown  = async (mysqlConnectionString: string, options: ArbitalImportOptions) => {
   const optionsWithDefaults: ArbitalImportOptions = {...defaultArbitalImportOptions, ...options};
@@ -123,9 +123,9 @@ export const reconvertArbitalMarkdown  = async (mysqlConnectionString: string, o
 }
 
 
-async function updateDenormalizedEditable(documentId: string, collectionName: CollectionNameString, fieldName: string) {
+async function updateDenormalizedEditable<N extends CollectionNameString>(documentId: string, collectionName: N, fieldName: string) {
   const collection = getCollection(collectionName);
-  if (!editableCollectionsFieldOptions[collectionName][fieldName].normalized) {
+  if (!getEditableFieldInCollection(collectionName, fieldName)?.editableFieldOptions.callbackOptions.normalized) {
     const latestRev = await getLatestRev(documentId, fieldName);
     if (!latestRev) throw new Error(`Could not get latest rev for ${collectionName}["${documentId}"].${fieldName}`);
     await collection.rawUpdateOne(

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -1,6 +1,6 @@
 import Users from '../../lib/collections/users/collection';
 import { Revisions } from '../../lib/collections/revisions/collection';
-import { editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableFieldNamesForCollection, editableFieldIsNormalized } from '../../lib/editor/make_editable'
 import ReadStatuses from '../../lib/collections/readStatus/collection';
 import { Votes } from '../../lib/collections/votes/collection';
 import { Conversations } from '../../lib/collections/conversations/collection'
@@ -12,7 +12,6 @@ import PostsRepo from '../repos/PostsRepo';
 import VotesRepo from '../repos/VotesRepo';
 import { collectionsThatAffectKarma } from '../callbacks/votingCallbacks';
 import { filterNonnull, filterWhereFieldsNotNull } from '../../lib/utils/typeGuardUtils';
-import { editableFieldIsNormalized } from '@/lib/editor/makeEditableOptions';
 import { getUnusedSlugByCollectionName } from '@/server/utils/slugUtil';
 import { updateMutator } from "../vulcan-lib/mutators";
 import { getCollection } from "../../lib/vulcan-lib/getCollection";
@@ -61,8 +60,8 @@ const transferCollection = async ({sourceUserId, targetUserId, collectionName, f
         try {
           await transferOwnership({documentId: doc._id, targetUserId, collection, fieldName})
           // Transfer ownership of all revisions and denormalized references for editable fields
-          const editableFieldNames = editableCollectionsFields[collectionName]
-          if (editableFieldNames?.length) {
+          const editableFieldNames = getEditableFieldNamesForCollection(collectionName)
+          if (editableFieldNames.length) {
             await asyncForeachSequential(editableFieldNames, async (editableFieldName) => {
               await transferEditableField({documentId: doc._id, sourceUserId, targetUserId, collection, fieldName: editableFieldName})
             })

--- a/packages/lesswrong/server/scripts/validateMakeEditableDenormalization.ts
+++ b/packages/lesswrong/server/scripts/validateMakeEditableDenormalization.ts
@@ -1,7 +1,6 @@
-import { editableCollections, editableCollectionsFields } from '../../lib/editor/make_editable'
+import { getEditableCollectionNames, getEditableFieldNamesForCollection, editableFieldIsNormalized } from '../../lib/editor/make_editable'
 import { Revisions } from '../../lib/collections/revisions/collection';
 import { forEachDocumentBatchInCollection } from '../manualMigrations/migrationUtils';
-import { editableFieldIsNormalized } from '@/lib/editor/makeEditableOptions';
 import * as _ from 'underscore';
 import { getCollection } from "../../lib/vulcan-lib/getCollection";
 
@@ -16,8 +15,8 @@ export const validateMakeEditableDenormalization = async () => {
     console.error("    "+err);
   }
   
-  for (let collectionName of editableCollections) {
-    for (let editableField of editableCollectionsFields[collectionName]!) {
+  for (let collectionName of getEditableCollectionNames()) {
+    for (let editableField of getEditableFieldNamesForCollection(collectionName)) {
       if (editableFieldIsNormalized(collectionName, editableField)) {
         continue;
       }

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -6,7 +6,6 @@ import { initRenderQueueLogging } from './vulcan-lib/apollo-ssr/renderPage';
 import { serverInitSentry, startMemoryUsageMonitor } from './logging';
 import { initLegacyRoutes } from '@/lib/routes';
 import { startupSanityChecks } from './startupSanityChecks';
-import { addAllEditableCallbacks } from './editor/make_editable_callbacks';
 import { refreshKarmaInflationCache } from './karmaInflation/cron';
 import { initGoogleVertex } from './google-vertex/client';
 import { addElicitResolvers } from './resolvers/elicitPredictions';
@@ -52,7 +51,6 @@ export async function runServerOnStartupFunctions() {
   startMemoryUsageMonitor();
   initLegacyRoutes();
   await startupSanityChecks();
-  addAllEditableCallbacks();
   await refreshKarmaInflationCache();
   initGoogleVertex();
   addElicitResolvers();

--- a/packages/lesswrong/server/sql/Type.ts
+++ b/packages/lesswrong/server/sql/Type.ts
@@ -4,7 +4,7 @@ import SimpleSchema from "simpl-schema";
 import { ID_LENGTH } from "@/lib/random";
 import { DeferredForumSelect } from "@/lib/forumTypeUtils";
 import { ForumTypeString } from "@/lib/instanceSettings";
-import { editableFieldIsNormalized } from "@/lib/editor/makeEditableOptions";
+import { editableFieldIsNormalized } from "@/lib/editor/make_editable";
 
 const forceNonResolverFields = [
   "contents",

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -12,7 +12,7 @@ import { parseDocumentFromString } from '../lib/domParser';
 import { FetchedFragment } from './fetchFragment';
 import { getLatestContentsRevision } from '../lib/collections/revisions/helpers';
 import { applyCustomArbitalScripts } from './utils/arbital/arbitalCustomScripts';
-import { editableCollectionsFields } from '@/lib/editor/make_editable';
+import { getEditableFieldNamesForCollection } from '@/lib/editor/make_editable';
 async function getTocAnswersServer (document: DbPost) {
   if (!document.question) return []
 
@@ -52,7 +52,7 @@ async function getHtmlWithContributorAnnotations({
   version: string | null,
   context: ResolverContext,
 }) {
-  if (!editableCollectionsFields[collectionName].includes(fieldName)) {
+  if (!getEditableFieldNamesForCollection(collectionName).includes(fieldName)) {
     // eslint-disable-next-line no-console
     console.log(`Author annotation failed: Field ${fieldName} not in editableCollectionsFields[${collectionName}]`);
     return null;

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -96,6 +96,8 @@ CREATE INDEX IF NOT EXISTS "idx_Bans_ip" ON "Bans" USING btree ("ip");
 -- Table "Books"
 CREATE TABLE "Books" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "postedAt" TIMESTAMPTZ,
   "title" TEXT,
   "subtitle" TEXT,
@@ -107,8 +109,6 @@ CREATE TABLE "Books" (
   "displaySequencesAsGrid" BOOL,
   "hideProgressBar" BOOL,
   "showChapters" BOOL,
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -123,13 +123,13 @@ CREATE INDEX IF NOT EXISTS "idx_Books_collectionId" ON "Books" USING btree ("col
 -- Table "Chapters"
 CREATE TABLE "Chapters" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "title" TEXT,
   "subtitle" TEXT,
   "number" DOUBLE PRECISION,
   "sequenceId" VARCHAR(27),
   "postIds" VARCHAR(27) [] NOT NULL DEFAULT '{}',
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -186,6 +186,8 @@ CREATE INDEX IF NOT EXISTS "idx_ClientIds_userIds" ON "ClientIds" USING gin ("us
 -- Table "Collections"
 CREATE TABLE "Collections" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "userId" VARCHAR(27) NOT NULL,
   "title" TEXT NOT NULL,
   "slug" TEXT NOT NULL,
@@ -193,8 +195,6 @@ CREATE TABLE "Collections" (
   "firstPageLink" TEXT NOT NULL,
   "hideStartReadingButton" BOOL,
   "noindex" BOOL NOT NULL DEFAULT FALSE,
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -226,6 +226,9 @@ CREATE INDEX IF NOT EXISTS "idx_CommentModeratorActions_commentId_createdAt" ON 
 -- Table "Comments"
 CREATE TABLE "Comments" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
+  "pingbacks" JSONB,
   "parentCommentId" VARCHAR(27),
   "topLevelCommentId" VARCHAR(27),
   "postedAt" TIMESTAMPTZ NOT NULL,
@@ -299,10 +302,7 @@ CREATE TABLE "Comments" (
   "afVoteCount" DOUBLE PRECISION,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "contents" JSONB,
-  "contents_latest" TEXT,
-  "pingbacks" JSONB
+  "legacyData" JSONB
 );
 
 -- Index "idx_Comments_postId"
@@ -657,15 +657,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS "idx_CurationEmails_userId" ON "CurationEmails
 -- Table "CurationNotices"
 CREATE TABLE "CurationNotices" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "userId" VARCHAR(27) NOT NULL,
   "commentId" VARCHAR(27),
   "postId" VARCHAR(27),
   "deleted" BOOL NOT NULL DEFAULT FALSE,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "contents" JSONB,
-  "contents_latest" TEXT
+  "legacyData" JSONB
 );
 
 -- Index "idx_CurationNotices_schemaVersion"
@@ -917,6 +917,12 @@ CREATE INDEX IF NOT EXISTS "idx_FeaturedResources_schemaVersion" ON "FeaturedRes
 -- Table "ForumEvents"
 CREATE TABLE "ForumEvents" (
   _id VARCHAR(27) PRIMARY KEY,
+  "frontpageDescription" JSONB,
+  "frontpageDescription_latest" TEXT,
+  "frontpageDescriptionMobile" JSONB,
+  "frontpageDescriptionMobile_latest" TEXT,
+  "postPageDescription" JSONB,
+  "postPageDescription_latest" TEXT,
   "title" TEXT NOT NULL,
   "startDate" TIMESTAMPTZ NOT NULL,
   "endDate" TIMESTAMPTZ NOT NULL,
@@ -935,13 +941,7 @@ CREATE TABLE "ForumEvents" (
   "publicData" JSONB,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "frontpageDescription" JSONB,
-  "frontpageDescription_latest" TEXT,
-  "frontpageDescriptionMobile" JSONB,
-  "frontpageDescriptionMobile_latest" TEXT,
-  "postPageDescription" JSONB,
-  "postPageDescription_latest" TEXT
+  "legacyData" JSONB
 );
 
 -- Index "idx_ForumEvents_schemaVersion"
@@ -953,6 +953,9 @@ CREATE INDEX IF NOT EXISTS "idx_ForumEvents_endDate" ON "ForumEvents" USING btre
 -- Table "GardenCodes"
 CREATE TABLE "GardenCodes" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
+  "pingbacks" JSONB,
   "code" TEXT NOT NULL,
   "title" TEXT NOT NULL DEFAULT 'Guest Day Pass',
   "userId" VARCHAR(27) NOT NULL,
@@ -966,10 +969,7 @@ CREATE TABLE "GardenCodes" (
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
-  "slug" TEXT NOT NULL,
-  "contents" JSONB,
-  "contents_latest" TEXT,
-  "pingbacks" JSONB
+  "slug" TEXT NOT NULL
 );
 
 -- Index "idx_GardenCodes_schemaVersion"
@@ -1024,6 +1024,8 @@ CREATE INDEX IF NOT EXISTS "idx_Images_cdnHostedUrl" ON "Images" USING btree ("c
 -- Table "JargonTerms"
 CREATE TABLE "JargonTerms" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "postId" VARCHAR(27) NOT NULL,
   "term" TEXT NOT NULL,
   "approved" BOOL NOT NULL DEFAULT FALSE,
@@ -1031,9 +1033,7 @@ CREATE TABLE "JargonTerms" (
   "altTerms" TEXT[] NOT NULL DEFAULT '{}',
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "contents" JSONB,
-  "contents_latest" TEXT
+  "legacyData" JSONB
 );
 
 -- Index "idx_JargonTerms_schemaVersion"
@@ -1124,6 +1124,8 @@ CREATE INDEX IF NOT EXISTS "idx_LlmMessages_conversationId_createdAt" ON "LlmMes
 -- Table "Localgroups"
 CREATE TABLE "Localgroups" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "name" TEXT,
   "nameInAnotherLanguage" TEXT,
   "organizerIds" VARCHAR(27) [] NOT NULL DEFAULT '{}',
@@ -1144,8 +1146,6 @@ CREATE TABLE "Localgroups" (
   "inactive" BOOL NOT NULL DEFAULT FALSE,
   "deleted" BOOL NOT NULL DEFAULT FALSE,
   "salesforceId" TEXT,
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -1200,11 +1200,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS "idx_ManifoldProbabilitiesCaches_marketId" ON 
 -- Table "Messages"
 CREATE TABLE "Messages" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "userId" VARCHAR(27) NOT NULL,
   "conversationId" VARCHAR(27) NOT NULL,
   "noEmail" BOOL NOT NULL DEFAULT FALSE,
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -1234,15 +1234,15 @@ CREATE INDEX IF NOT EXISTS "idx_Migrations_schemaVersion" ON "Migrations" USING 
 -- Table "ModerationTemplates"
 CREATE TABLE "ModerationTemplates" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "name" TEXT NOT NULL,
   "collectionName" TEXT NOT NULL,
   "order" DOUBLE PRECISION NOT NULL DEFAULT 10,
   "deleted" BOOL NOT NULL DEFAULT FALSE,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "contents" JSONB,
-  "contents_latest" TEXT
+  "legacyData" JSONB
 );
 
 -- Index "idx_ModerationTemplates_schemaVersion"
@@ -1277,6 +1277,8 @@ CREATE INDEX IF NOT EXISTS "idx_ModeratorActions_type_createdAt_endedAt" ON "Mod
 -- Table "MultiDocuments"
 CREATE TABLE "MultiDocuments" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents_latest" TEXT,
+  "pingbacks" JSONB,
   "title" TEXT,
   "preview" TEXT,
   "tabTitle" TEXT NOT NULL,
@@ -1301,9 +1303,7 @@ CREATE TABLE "MultiDocuments" (
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
   "slug" TEXT NOT NULL,
-  "oldSlugs" TEXT[] NOT NULL DEFAULT '{}',
-  "contents_latest" TEXT,
-  "pingbacks" JSONB
+  "oldSlugs" TEXT[] NOT NULL DEFAULT '{}'
 );
 
 -- Index "idx_MultiDocuments_schemaVersion"
@@ -1567,6 +1567,11 @@ CREATE INDEX IF NOT EXISTS "idx_PostViews_windowStart" ON "PostViews" USING btre
 -- Table "Posts"
 CREATE TABLE "Posts" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents_latest" TEXT,
+  "pingbacks" JSONB,
+  "moderationGuidelines_latest" TEXT,
+  "customHighlight" JSONB,
+  "customHighlight_latest" TEXT,
   "postedAt" TIMESTAMPTZ NOT NULL,
   "modifiedAt" TIMESTAMPTZ,
   "url" VARCHAR(500),
@@ -1730,12 +1735,7 @@ CREATE TABLE "Posts" (
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
-  "slug" TEXT NOT NULL,
-  "contents_latest" TEXT,
-  "pingbacks" JSONB,
-  "moderationGuidelines_latest" TEXT,
-  "customHighlight" JSONB,
-  "customHighlight_latest" TEXT
+  "slug" TEXT NOT NULL
 );
 
 -- Index "idx_posts_coauthorStatuses_postedAt"
@@ -2590,6 +2590,8 @@ CREATE INDEX IF NOT EXISTS "idx_Revisions_schemaVersion" ON "Revisions" USING bt
 -- Table "Sequences"
 CREATE TABLE "Sequences" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "lastUpdated" TIMESTAMPTZ NOT NULL,
   "userId" VARCHAR(27) NOT NULL,
   "title" TEXT NOT NULL,
@@ -2604,8 +2606,6 @@ CREATE TABLE "Sequences" (
   "hidden" BOOL NOT NULL DEFAULT FALSE,
   "noindex" BOOL NOT NULL DEFAULT FALSE,
   "af" BOOL NOT NULL DEFAULT FALSE,
-  "contents" JSONB,
-  "contents_latest" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB
@@ -2705,6 +2705,8 @@ CREATE INDEX IF NOT EXISTS "idx_SplashArtCoordinates_reviewWinnerArtId_createdAt
 -- Table "Spotlights"
 CREATE TABLE "Spotlights" (
   _id VARCHAR(27) PRIMARY KEY,
+  "description" JSONB,
+  "description_latest" TEXT,
   "documentId" TEXT NOT NULL,
   "documentType" TEXT NOT NULL DEFAULT 'Sequence',
   "position" DOUBLE PRECISION NOT NULL,
@@ -2726,9 +2728,7 @@ CREATE TABLE "Spotlights" (
   "spotlightDarkImageId" TEXT,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "legacyData" JSONB,
-  "description" JSONB,
-  "description_latest" TEXT
+  "legacyData" JSONB
 );
 
 -- Index "idx_Spotlights_schemaVersion"
@@ -2855,15 +2855,15 @@ CREATE INDEX IF NOT EXISTS "idx_Surveys_schemaVersion" ON "Surveys" USING btree 
 -- Table "TagFlags"
 CREATE TABLE "TagFlags" (
   _id VARCHAR(27) PRIMARY KEY,
+  "contents" JSONB,
+  "contents_latest" TEXT,
   "name" TEXT NOT NULL,
   "deleted" BOOL NOT NULL DEFAULT FALSE,
   "order" DOUBLE PRECISION,
   "schemaVersion" DOUBLE PRECISION NOT NULL DEFAULT 1,
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
-  "slug" TEXT NOT NULL,
-  "contents" JSONB,
-  "contents_latest" TEXT
+  "slug" TEXT NOT NULL
 );
 
 -- Index "idx_TagFlags_schemaVersion"
@@ -2905,6 +2905,13 @@ CREATE INDEX IF NOT EXISTS "idx_TagRels_tagId" ON "TagRels" USING btree ("tagId"
 -- Table "Tags"
 CREATE TABLE "Tags" (
   _id VARCHAR(27) PRIMARY KEY,
+  "description" JSONB,
+  "description_latest" TEXT,
+  "pingbacks" JSONB,
+  "subforumWelcomeText" JSONB,
+  "subforumWelcomeText_latest" TEXT,
+  "moderationGuidelines" JSONB,
+  "moderationGuidelines_latest" TEXT,
   "name" TEXT NOT NULL,
   "shortName" TEXT,
   "subtitle" TEXT,
@@ -2959,14 +2966,7 @@ CREATE TABLE "Tags" (
   "createdAt" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "legacyData" JSONB,
   "slug" TEXT NOT NULL,
-  "oldSlugs" TEXT[] NOT NULL DEFAULT '{}',
-  "description" JSONB,
-  "description_latest" TEXT,
-  "pingbacks" JSONB,
-  "subforumWelcomeText" JSONB,
-  "subforumWelcomeText_latest" TEXT,
-  "moderationGuidelines" JSONB,
-  "moderationGuidelines_latest" TEXT
+  "oldSlugs" TEXT[] NOT NULL DEFAULT '{}'
 );
 
 -- Index "idx_Tags_deleted_adminOnly"
@@ -3199,6 +3199,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS "idx_UserTagRels_tagId_userId" ON "UserTagRels
 -- Table "Users"
 CREATE TABLE "Users" (
   _id VARCHAR(27) PRIMARY KEY,
+  "moderationGuidelines" JSONB,
+  "moderationGuidelines_latest" TEXT,
+  "howOthersCanHelpMe" JSONB,
+  "howOthersCanHelpMe_latest" TEXT,
+  "howICanHelpOthers" JSONB,
+  "howICanHelpOthers_latest" TEXT,
+  "biography" JSONB,
+  "biography_latest" TEXT,
   "username" TEXT,
   "emails" JSONB[],
   "isAdmin" BOOL NOT NULL DEFAULT FALSE,
@@ -3425,14 +3433,6 @@ CREATE TABLE "Users" (
   "legacyData" JSONB,
   "slug" TEXT NOT NULL,
   "oldSlugs" TEXT[] NOT NULL DEFAULT '{}',
-  "moderationGuidelines" JSONB,
-  "moderationGuidelines_latest" TEXT,
-  "howOthersCanHelpMe" JSONB,
-  "howOthersCanHelpMe_latest" TEXT,
-  "howICanHelpOthers" JSONB,
-  "howICanHelpOthers_latest" TEXT,
-  "biography" JSONB,
-  "biography_latest" TEXT,
   "recommendationSettings" JSONB
 );
 
@@ -3991,26 +3991,6 @@ REPLACE FUNCTION fm_get_user_profile_updated_at (userid TEXT) RETURNS TIMESTAMPT
           )
       $$;
 
--- View "UniquePostUpvoters"
-CREATE MATERIALIZED VIEW IF NOT EXISTS "UniquePostUpvoters" AS
-SELECT
-  p."_id" AS "postId",
-  ARRAY_AGG(
-    DISTINCT ('x' || SUBSTR(MD5(v."userId"), 1, 8))::BIT(32)::INTEGER
-  ) AS "voters"
-FROM
-  "Posts" p
-  INNER JOIN "Votes" v ON p."_id" = v."documentId" AND
-  v."collectionName" = 'Posts' AND
-  v."cancelled" IS NOT TRUE AND
-  v."isUnvote" IS NOT TRUE AND
-  v."voteType" IN ('smallUpvote', 'bigUpvote')
-GROUP BY
-  p."_id";
-
--- CustomIndex "idx_UniquePostUpvoters_postId"
-CREATE UNIQUE INDEX IF NOT EXISTS "idx_UniquePostUpvoters_postId" ON "UniquePostUpvoters" ("postId");
-
 -- View "ConversationUnreadMessages"
 CREATE OR REPLACE VIEW "ConversationUnreadMessages" AS
 SELECT
@@ -4041,3 +4021,23 @@ FROM
 
 -- CustomIndex "idx_user_login_tokens_hashed_token"
 CREATE UNIQUE INDEX IF NOT EXISTS idx_user_login_tokens_hashed_token ON "UserLoginTokens" USING BTREE ("hashedToken");
+
+-- View "UniquePostUpvoters"
+CREATE MATERIALIZED VIEW IF NOT EXISTS "UniquePostUpvoters" AS
+SELECT
+  p."_id" AS "postId",
+  ARRAY_AGG(
+    DISTINCT ('x' || SUBSTR(MD5(v."userId"), 1, 8))::BIT(32)::INTEGER
+  ) AS "voters"
+FROM
+  "Posts" p
+  INNER JOIN "Votes" v ON p."_id" = v."documentId" AND
+  v."collectionName" = 'Posts' AND
+  v."cancelled" IS NOT TRUE AND
+  v."isUnvote" IS NOT TRUE AND
+  v."voteType" IN ('smallUpvote', 'bigUpvote')
+GROUP BY
+  p."_id";
+
+-- CustomIndex "idx_UniquePostUpvoters_postId"
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_UniquePostUpvoters_postId" ON "UniquePostUpvoters" ("postId");


### PR DESCRIPTION
In particular, we now do two things instead of calling makeEditable on a collection:
1. we manually add editable fields to that collection's schema (using the same set of options previously passed to makeEditable) using a new helper function `editableFields`
2. we manually invoke the (refactored) editable callbacks at each necessary stage inside of `createMutator` and `updateMutator`

We also remove all the effectful tracking of what collections have editable fields, what their options are, etc, and replace those with helper functions which get the necessary information on demand.  Currently those rely on `getAllCollections`; hopefully soon that'll be `getAllSchemas` (or something) so that we can avoid pulling collections into the client.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209544869851585) by [Unito](https://www.unito.io)
