### PR TITLE
Refactor fragments

### DIFF
--- a/packages/lesswrong/components/admin/CurationNoticesItem.tsx
+++ b/packages/lesswrong/components/admin/CurationNoticesItem.tsx
@@ -13,7 +13,6 @@ import { postGetPageUrl } from '@/lib/collections/posts/helpers';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     border: theme.palette.border.commentBorder,

--- a/packages/lesswrong/components/admin/CurationNoticesItem.tsx
+++ b/packages/lesswrong/components/admin/CurationNoticesItem.tsx
@@ -12,7 +12,7 @@ import { Link } from '@/lib/reactRouterWrapper';
 import { postGetPageUrl } from '@/lib/collections/posts/helpers';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -161,8 +161,8 @@ export const CurationNoticesItem = ({curationNotice, classes}: {
           <WrappedSmartForm
             collectionName="CurationNotices"
             documentId={curationNotice._id}
-            mutationFragment={getFragment('CurationNoticesFragment')}
-            queryFragment={getFragment('CurationNoticesFragment')}
+            mutationFragmentName={'CurationNoticesFragment'}
+            queryFragmentName={'CurationNoticesFragment'}
             successCallback={() => setEdit(false)}
             prefilledProps={{userId: curationNotice.userId, postId: curationNotice.postId}}
           />

--- a/packages/lesswrong/components/admin/CurationPage.tsx
+++ b/packages/lesswrong/components/admin/CurationPage.tsx
@@ -6,7 +6,7 @@ import { userCanDo, userIsAdminOrMod } from '@/lib/vulcan-users/permissions.ts';
 import { filterNonnull, filterWhereFieldsNotNull } from '@/lib/utils/typeGuardUtils';
 import { unflattenComments } from '@/lib/utils/unflatten';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   curated: {
@@ -55,7 +55,7 @@ export const CurationPage = ({classes}: {
                 {post.title}
                 <WrappedSmartForm
                   collectionName="CurationNotices"
-                  mutationFragment={getFragment('CurationNoticesFragment')}
+                  mutationFragmentName={'CurationNoticesFragment'}
                   prefilledProps={{userId: currentUser._id, postId: post._id}}
                 />
               </BasicFormStyles>

--- a/packages/lesswrong/components/admin/CurationPage.tsx
+++ b/packages/lesswrong/components/admin/CurationPage.tsx
@@ -7,7 +7,6 @@ import { filterNonnull, filterWhereFieldsNotNull } from '@/lib/utils/typeGuardUt
 import { unflattenComments } from '@/lib/utils/unflatten';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   curated: {
     position: "absolute",

--- a/packages/lesswrong/components/comments/CommentsEditForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsEditForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const CommentsEditForm = ({ comment, successCallback, cancelCallback, className, formProps = {}, prefilledProps }: {
   comment: CommentsList | CommentsListWithParentMetadata,
@@ -20,8 +20,8 @@ const CommentsEditForm = ({ comment, successCallback, cancelCallback, className,
         successCallback={successCallback}
         cancelCallback={cancelCallback}
         showRemove={false}
-        queryFragment={getFragment('CommentEdit')}
-        mutationFragment={getFragment('CommentsList')}
+        queryFragmentName={'CommentEdit'}
+        mutationFragmentName={'CommentsList'}
         submitLabel="Save"
         formProps={formProps}
         prefilledProps={prefilledProps}

--- a/packages/lesswrong/components/comments/CommentsEditForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsEditForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const CommentsEditForm = ({ comment, successCallback, cancelCallback, className, formProps = {}, prefilledProps }: {
   comment: CommentsList | CommentsListWithParentMetadata,
   successCallback?: any,

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -21,7 +21,6 @@ import { useTracking } from "../../lib/analyticsEvents";
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 export type FormDisplayMode = "default" | "minimalist"
 
 export const COMMENTS_NEW_FORM_PADDING = isFriendlyUI ? 12 : 10;

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -20,7 +20,7 @@ import { isLWorAF } from '../../lib/instanceSettings';
 import { useTracking } from "../../lib/analyticsEvents";
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 export type FormDisplayMode = "default" | "minimalist"
 
@@ -499,7 +499,7 @@ const CommentsNewForm = ({
             <WrappedSmartForm
               id="new-comment-form"
               collectionName="Comments"
-              mutationFragment={getFragment(fragment)}
+              mutationFragmentName={fragment}
               successCallback={wrappedSuccessCallback}
               cancelCallback={wrappedCancelCallback}
               submitCallback={(data: unknown) => {

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -5,7 +5,6 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   formButton: {
     paddingBottom: "2px",

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -4,7 +4,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   formButton: {
@@ -56,8 +56,8 @@ const ModerationGuidelinesEditForm = ({ commentType = "post", documentId, onClos
           collectionName={isPost ? "Posts" : "Tags"}
           documentId={documentId}
           fields={['moderationGuidelines', ...(isPost ? ['moderationStyle'] : [])]}
-          queryFragment={getFragment(isPost ? "PostsEditQueryFragment" : "TagEditFragment")}
-          mutationFragment={getFragment(isPost ? "PostsPage" : "TagWithFlagsFragment")}
+          queryFragmentName={isPost ? "PostsEditQueryFragment" : "TagEditFragment"}
+          mutationFragmentName={isPost ? "PostsPage" : "TagWithFlagsFragment"}
           successCallback={onClose}
           formComponents={{
             FormSubmit: SubmitComponent,

--- a/packages/lesswrong/components/dropdowns/comments/withModerateComment.ts
+++ b/packages/lesswrong/components/dropdowns/comments/withModerateComment.ts
@@ -1,5 +1,6 @@
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 import { useMutation, gql } from '@apollo/client';
-import { getFragment } from '../../../lib/vulcan-lib/fragments';
+
 
 export const useModerateComment = ({fragmentName}: {
   fragmentName: FragmentName,
@@ -10,7 +11,7 @@ export const useModerateComment = ({fragmentName}: {
         ...${fragmentName}
       }
     }
-    ${getFragment(fragmentName)}
+    ${fragmentTextForQuery(fragmentName)}
   `);
   
   async function mutate(args: {commentId: string, deleted: boolean, deletedReason: string, deletedPublic?: boolean}) {

--- a/packages/lesswrong/components/dropdowns/comments/withModerateComment.ts
+++ b/packages/lesswrong/components/dropdowns/comments/withModerateComment.ts
@@ -1,7 +1,6 @@
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 import { useMutation, gql } from '@apollo/client';
 
-
 export const useModerateComment = ({fragmentName}: {
   fragmentName: FragmentName,
 }) => {

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -25,7 +25,6 @@ import { CKEditorPortalProvider } from './CKEditorPortalProvider';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const autosaveInterval = 3000; //milliseconds
 const remoteAutosaveInterval = 1000 * 60 * 5; // 5 minutes in milliseconds
 

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -23,7 +23,8 @@ import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE } from '@/lib/cookies/cookies';
 import { CKEditorPortalProvider } from './CKEditorPortalProvider';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const autosaveInterval = 3000; //milliseconds
 const remoteAutosaveInterval = 1000 * 60 * 5; // 5 minutes in milliseconds
@@ -250,7 +251,7 @@ export const EditorFormComponent = ({
         ...RevisionEdit
       }
     }
-    ${getFragment('RevisionEdit')}
+    ${fragmentTextForQuery('RevisionEdit')}
   `);
 
   // TODO: this currently clobbers the title if a new post had its contents edited before the title was edited

--- a/packages/lesswrong/components/form-components/PodcastEpisodeInput.tsx
+++ b/packages/lesswrong/components/form-components/PodcastEpisodeInput.tsx
@@ -117,7 +117,7 @@ const PodcastEpisodeInput = ({ value, path, document, classes, label, updateCurr
   const episodeTitleProps = episodeNotFound ? { value: episodeTitle } : { disabled: true, value: episodeTitle };
 
   const createNewEpisode = useCallback(async () => {
-    const episodeData: PodcastEpisodesDefaultFragment = {
+    const episodeData = {
       podcastId,
       externalEpisodeId,
       episodeLink,

--- a/packages/lesswrong/components/hooks/useCurrentFrontpageSurvey.ts
+++ b/packages/lesswrong/components/hooks/useCurrentFrontpageSurvey.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 import { gql, useQuery } from "@apollo/client";
-
-import { hasSurveys } from "@/lib/betas";
 import { fragmentTextForQuery } from "@/lib/vulcan-lib/fragments";
+import { hasSurveys } from "@/lib/betas";
+
 
 export const useCurrentFrontpageSurvey = (): {
   survey?: SurveyScheduleMinimumInfo,

--- a/packages/lesswrong/components/hooks/useCurrentFrontpageSurvey.ts
+++ b/packages/lesswrong/components/hooks/useCurrentFrontpageSurvey.ts
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { getFragment } from "@/lib/vulcan-lib/fragments.ts";
+
 import { hasSurveys } from "@/lib/betas";
+import { fragmentTextForQuery } from "@/lib/vulcan-lib/fragments";
 
 export const useCurrentFrontpageSurvey = (): {
   survey?: SurveyScheduleMinimumInfo,
@@ -14,7 +15,7 @@ export const useCurrentFrontpageSurvey = (): {
         ...SurveyScheduleMinimumInfo
       }
     }
-    ${getFragment("SurveyScheduleMinimumInfo")}
+    ${fragmentTextForQuery("SurveyScheduleMinimumInfo")}
   `, {
     skip: !hasSurveys,
     ssr: true,

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -12,7 +12,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import { useLocalStorageState } from '../hooks/useLocalStorageState';
 import { removeJargonDot } from './GlossarySidebar';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { fragmentTextForQuery, getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from "../../lib/vulcan-lib/fragments";
 
 // Integrity Alert! This is currently designed so if the model changes, users are informed
 // about what model is being used in the jargon generation process.
@@ -566,8 +566,8 @@ export const GlossaryEditForm = ({ classes, document, showTitle = true }: {
     {showNewJargonTermForm && <div className={classes.formStyles}>
       <WrappedSmartForm
         collectionName="JargonTerms"
-        mutationFragment={getFragment('JargonTerms')}
-        queryFragment={getFragment('JargonTerms')}
+        mutationFragmentName={'JargonTerms'}
+        queryFragmentName={'JargonTerms'}
         formComponents={{ FormSubmit: Components.JargonSubmitButton }}
         prefilledProps={{ postId: document._id }}
         cancelCallback={() => setShowNewJargonTermForm(false)}

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -6,7 +6,6 @@ import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 export const formStyles = {
   '& .form-section-default > div': {
     display: "flex",

--- a/packages/lesswrong/components/jargon/JargonEditorRow.tsx
+++ b/packages/lesswrong/components/jargon/JargonEditorRow.tsx
@@ -5,7 +5,7 @@ import { useUpdate } from '@/lib/crud/withUpdate';
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 export const formStyles = {
   '& .form-section-default > div': {
@@ -246,8 +246,8 @@ export const JargonEditorRow = ({classes, jargonTerm, instancesOfJargonCount, se
           <WrappedSmartForm
             collectionName="JargonTerms"
             documentId={jargonTerm._id}
-            mutationFragment={getFragment('JargonTerms')}
-            queryFragment={getFragment('JargonTerms')}
+            mutationFragmentName={'JargonTerms'}
+            queryFragmentName={'JargonTerms'}
             successCallback={() => setEdit(false)}
             cancelCallback={() => setEdit(false)}
             formComponents={{ FormSubmit: Components.JargonSubmitButton }}

--- a/packages/lesswrong/components/jargon/JargonTooltip.tsx
+++ b/packages/lesswrong/components/jargon/JargonTooltip.tsx
@@ -122,7 +122,7 @@ export const JargonTooltip = ({term, definitionHTML, approved, deleted, humansAn
   approved: boolean,
   deleted: boolean,
   altTerms: string[],
-  humansAndOrAIEdited: JargonTermsDefaultFragment['humansAndOrAIEdited'],
+  humansAndOrAIEdited: JargonTermsPost['humansAndOrAIEdited'],
   isFirstOccurrence?: boolean,
   placement?: PopperPlacementType
   children: React.ReactNode,

--- a/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
@@ -4,7 +4,7 @@ import { useCurrentUser } from '../common/withUser';
 import DialogContent from '@material-ui/core/DialogContent';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   localGroupForm: {
@@ -53,8 +53,8 @@ const GroupFormDialog =  ({ onClose, classes, documentId, isOnline }: {
       <WrappedSmartForm
         collectionName="Localgroups"
         documentId={documentId}
-        queryFragment={getFragment('localGroupsEdit')}
-        mutationFragment={getFragment('localGroupsHomeFragment')}
+        queryFragmentName={'localGroupsEdit'}
+        mutationFragmentName={'localGroupsHomeFragment'}
         formComponents={{
           FormSubmit: GroupFormSubmit
         }}

--- a/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
@@ -5,7 +5,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   localGroupForm: {
     "& div": {

--- a/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
+++ b/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
@@ -4,7 +4,6 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 /**
  * Form for editing the title of a private messages conversation and also for
  * adding additional participants.

--- a/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
+++ b/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
@@ -3,7 +3,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 /**
  * Form for editing the title of a private messages conversation and also for
@@ -19,9 +19,8 @@ const ConversationTitleEditForm = ({onClose, documentId}: {
         <Components.WrappedSmartForm
           collectionName="Conversations"
           documentId={documentId}
-          fragment={getFragment('ConversationsList')}
-          queryFragment={getFragment('ConversationsList')}
-          mutationFragment={getFragment('ConversationsList')}
+          queryFragmentName={'ConversationsList'}
+          mutationFragmentName={'ConversationsList'}
           successCallback={() => {
             if (onClose)
               onClose();

--- a/packages/lesswrong/components/messaging/MessagesNewForm.tsx
+++ b/packages/lesswrong/components/messaging/MessagesNewForm.tsx
@@ -8,7 +8,6 @@ import { FormDisplayMode } from "../comments/CommentsNewForm";
 import {isFriendlyUI} from '../../themes/forumTheme'
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/messaging/MessagesNewForm.tsx
+++ b/packages/lesswrong/components/messaging/MessagesNewForm.tsx
@@ -7,7 +7,7 @@ import classNames from "classnames";
 import { FormDisplayMode } from "../comments/CommentsNewForm";
 import {isFriendlyUI} from '../../themes/forumTheme'
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -163,7 +163,7 @@ export const MessagesNewForm = ({
             },
           },
         }}
-        mutationFragment={getFragment("messageListFragment")}
+        mutationFragmentName={'messageListFragment'}
         errorCallback={(message: any) => {
           setLoading(false);
           //eslint-disable-next-line no-console

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
@@ -4,7 +4,6 @@ import { useLocation } from '../../lib/routeUtil';
 import DeferRender from '../common/DeferRender';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     border: theme.palette.border.commentBorder,

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateItem.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useLocation } from '../../lib/routeUtil';
 import DeferRender from '../common/DeferRender';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -41,8 +41,8 @@ export const ModerationTemplateItem = ({classes, template}: {
           <WrappedSmartForm
             collectionName="ModerationTemplates"
             documentId={template._id}
-            mutationFragment={getFragment('ModerationTemplateFragment')}
-            queryFragment={getFragment('ModerationTemplateFragment')}
+            mutationFragmentName={'ModerationTemplateFragment'}
+            queryFragmentName={'ModerationTemplateFragment'}
             successCallback={() => setEdit(false)}
           /> 
         </BasicFormStyles>

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplatesPage.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplatesPage.tsx
@@ -6,7 +6,6 @@ import { ALLOWABLE_COLLECTIONS, TemplateType } from '../../lib/collections/moder
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   form: {
     border: theme.palette.border.commentBorder,

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplatesPage.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplatesPage.tsx
@@ -5,7 +5,7 @@ import {useMulti} from "../../lib/crud/withMulti";
 import { ALLOWABLE_COLLECTIONS, TemplateType } from '../../lib/collections/moderationTemplates/schema';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   form: {
@@ -85,7 +85,7 @@ export const ModerationTemplatesPage = ({classes}: {
         <BasicFormStyles>
           <WrappedSmartForm
             collectionName="ModerationTemplates"
-            mutationFragment={getFragment('ModerationTemplateFragment')}
+            mutationFragmentName={'ModerationTemplateFragment'}
           />
         </BasicFormStyles>
       </div>

--- a/packages/lesswrong/components/payments/EditPaymentInfoPage.tsx
+++ b/packages/lesswrong/components/payments/EditPaymentInfoPage.tsx
@@ -5,7 +5,6 @@ import { useCurrentUser } from '../common/withUser';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     maxWidth: 600,

--- a/packages/lesswrong/components/payments/EditPaymentInfoPage.tsx
+++ b/packages/lesswrong/components/payments/EditPaymentInfoPage.tsx
@@ -4,7 +4,7 @@ import { useMessages } from '../common/withMessages';
 import { useCurrentUser } from '../common/withUser';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -43,8 +43,8 @@ export const EditPaymentInfoPage = ({classes}: {
         }}
         // cancelCallback={cancelCallback}
         showRemove={false}
-        queryFragment={getFragment('UsersEdit')}
-        mutationFragment={getFragment('UsersEdit')}
+        queryFragmentName={'UsersEdit'}
+        mutationFragmentName={'UsersEdit'}
         submitLabel="Save"
       />
   </ContentStyles>;

--- a/packages/lesswrong/components/posts/ElicitBlock.tsx
+++ b/packages/lesswrong/components/posts/ElicitBlock.tsx
@@ -12,7 +12,8 @@ import sortBy from 'lodash/sortBy';
 import some from 'lodash/some';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const elicitDataFragment = `
   _id
@@ -189,7 +190,7 @@ const ElicitBlock = ({ classes, questionId = "IyWNjzc5P" }: {
        ${elicitDataFragment}
       }
     }
-    ${getFragment("UsersMinimumInfo")}
+    ${fragmentTextForQuery("UsersMinimumInfo")}
   `, { ssr: true, variables: { questionId } })
   const [makeElicitPrediction] = useMutation(gql`
     mutation ElicitPrediction($questionId:String, $prediction: Int) {
@@ -197,7 +198,7 @@ const ElicitBlock = ({ classes, questionId = "IyWNjzc5P" }: {
         ${elicitDataFragment}
       }
     }
-    ${getFragment("UsersMinimumInfo")}  
+    ${fragmentTextForQuery("UsersMinimumInfo")}  
   `);
   const allPredictions = data?.ElicitBlockData?.predictions || [];
   const nonCancelledPredictions = allPredictions.filter((p: AnyBecauseTodo) => p.prediction !== null);

--- a/packages/lesswrong/components/posts/ElicitBlock.tsx
+++ b/packages/lesswrong/components/posts/ElicitBlock.tsx
@@ -14,7 +14,6 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const elicitDataFragment = `
   _id
   title

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -18,7 +18,6 @@ import DeferRender from '../common/DeferRender';
 import { useSingleWithPreload } from '@/lib/crud/useSingleWithPreload';
 import { userCanCreateAndEditJargonTerms } from '@/lib/betas';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 
 const editor: Editor | null = null
@@ -162,8 +161,8 @@ const PostsEditForm = ({ documentId, version, classes }: {
             <WrappedSmartForm
               collectionName="Posts"
               documentId={documentId}
-              queryFragment={getFragment('PostsEditQueryFragment')}
-              mutationFragment={getFragment('PostsEditMutationFragment')}
+              queryFragmentName={'PostsEditQueryFragment'}
+              mutationFragmentName={'PostsEditMutationFragment'}
               successCallback={(post: any, options: any) => {
                 const alreadySubmittedToAF = post.suggestForAlignmentUserIds && post.suggestForAlignmentUserIds.includes(post.userId)
                 if (!post.draft && !alreadySubmittedToAF) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -17,7 +17,7 @@ import DeferRender from '../common/DeferRender';
 import { userCanCreateAndEditJargonTerms } from '@/lib/betas';
 import { tagGetUrl } from '@/lib/collections/tags/helpers';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 
@@ -381,7 +381,7 @@ const PostsNewForm = ({classes}: {
           <DeferRender ssr={false}>
               <WrappedSmartForm
                 collectionName="Posts"
-                mutationFragment={getFragment('PostsPage')}
+                mutationFragmentName={'PostsPage'}
                 prefilledProps={prefilledProps}
                 successCallback={(post: any, options: any) => {
                   if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -17,7 +17,6 @@ import DeferRender from '../common/DeferRender';
 import { userCanCreateAndEditJargonTerms } from '@/lib/betas';
 import { tagGetUrl } from '@/lib/collections/tags/helpers';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 

--- a/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const styles = (theme: ThemeType) => ({
   coauthorRequest: {
     border: theme.palette.border.grey400,

--- a/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostCoauthorRequest.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { gql, useMutation } from '@apollo/client';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (theme: ThemeType) => ({
   coauthorRequest: {
@@ -59,7 +60,7 @@ const PostCoauthorRequest = ({post, currentUser, classes}: {
           ...PostsDetails
         }
     }
-    ${getFragment('PostsDetails')}
+    ${fragmentTextForQuery('PostsDetails')}
   `)
 
   if (!isRequestedCoauthor(post, currentUser)) {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -8,11 +8,9 @@ import { useSubscribedLocation } from '../../../lib/routeUtil';
 import { isValidCommentView } from '../../../lib/commentViewOptions';
 import { postsCommentsThreadMultiOptions } from './PostsPage';
 import { useDisplayedPost } from '../usePost';
-import { useSingle } from '../../../lib/crud/withSingle';
 import { useApolloClient } from '@apollo/client';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { getFragment } from '@/lib/vulcan-lib/fragments';
-
 
 const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   sequenceId: string|null,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -11,7 +11,8 @@ import { useDisplayedPost } from '../usePost';
 import { useSingle } from '../../../lib/crud/withSingle';
 import { useApolloClient } from '@apollo/client';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+import { getFragment } from '@/lib/vulcan-lib/fragments';
+
 
 const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   sequenceId: string|null,

--- a/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from '../../../lib/routeUtil';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 export type RsvpResponse = "yes"|"maybe"|"no";
 export const responseToText: Record<RsvpResponse,string> = {
   yes: "Going",

--- a/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
@@ -10,7 +10,8 @@ import { useCurrentUser } from '../../common/withUser';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 import { useNavigate } from '../../../lib/routeUtil';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 export type RsvpResponse = "yes"|"maybe"|"no";
 export const responseToText: Record<RsvpResponse,string> = {
@@ -41,7 +42,7 @@ const RSVPForm = ({ post, onClose, initialResponse = "yes", classes }: {
         ...PostsDetails
         }
     }
-    ${getFragment("PostsDetails")}
+    ${fragmentTextForQuery("PostsDetails")}
   `)
   const navigate = useNavigate();
   const currentUser = useCurrentUser()

--- a/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
@@ -13,7 +13,8 @@ import { isFriendlyUI } from '../../../themes/forumTheme';
 import groupBy from "lodash/groupBy";
 import mapValues from "lodash/mapValues";
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (theme: ThemeType) => ({
   body: {
@@ -130,7 +131,7 @@ const RSVPs = ({post, classes}: {
         ...PostsDetails
         }
     }
-    ${getFragment("PostsDetails")}
+    ${fragmentTextForQuery("PostsDetails")}
   `)
   const cancelRSVP = async (rsvp: RSVPType) => await cancelMutation({variables: {postId: post._id, name: rsvp.name, userId: rsvp.userId}})
 

--- a/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
@@ -15,7 +15,6 @@ import mapValues from "lodash/mapValues";
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const styles = (theme: ThemeType) => ({
   body: {
     marginBottom: 48

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -23,9 +23,6 @@ import { useDialog } from '../common/withDialog';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
-const isAF = forumTypeSetting.get() === 'AlignmentForum'
-
 const styles = (theme: ThemeType) => ({
   root: {
     display: "flex",

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -21,7 +21,8 @@ import { sortingInfo } from './ReviewVotingPageMenu';
 import { useCommentBox } from '../hooks/useCommentBox';
 import { useDialog } from '../common/withDialog';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const isAF = forumTypeSetting.get() === 'AlignmentForum'
 
@@ -143,7 +144,7 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
         ...PostsReviewVotingList
       }
     }
-    ${getFragment("PostsReviewVotingList")} 
+    ${fragmentTextForQuery("PostsReviewVotingList")} 
   `);
 
   const [sortedPosts, setSortedPosts] = useState(postsResults)

--- a/packages/lesswrong/components/review/ReviewVotingPageMenu.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPageMenu.tsx
@@ -12,7 +12,7 @@ import { preferredHeadingCase } from '../../themes/forumTheme';
 import { isLW, isLWorAF } from '@/lib/instanceSettings';
 import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "@/lib/routeUtil";
 

--- a/packages/lesswrong/components/review/ReviewVotingPageMenu.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPageMenu.tsx
@@ -4,15 +4,13 @@ import classNames from 'classnames';
 import * as _ from "underscore"
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward'
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward'
-import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
+import { AnalyticsContext } from '../../lib/analyticsEvents'
 import { eligibleToNominate, ReviewPhase } from '../../lib/reviewUtils';
 import Select from '@material-ui/core/Select';
 import qs from 'qs';
 import { preferredHeadingCase } from '../../themes/forumTheme';
-import { isLW, isLWorAF } from '@/lib/instanceSettings';
 import { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "@/lib/routeUtil";
 

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -6,7 +6,8 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { ReviewOverviewTooltip } from './FrontpageReviewWidget';
 import { useCurrentUser } from '../common/withUser';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -34,7 +35,7 @@ const ReviewVotingWidget = ({classes, post, setNewVote, showTitle=true}: {classe
         ...PostsReviewVotingList
       }
     }
-    ${getFragment("PostsReviewVotingList")} 
+    ${fragmentTextForQuery("PostsReviewVotingList")} 
   `);
 
   const dispatchQualitativeVote = useCallback(async ({_id, postId, score}: {

--- a/packages/lesswrong/components/review/ReviewVotingWidget.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingWidget.tsx
@@ -8,7 +8,6 @@ import { useCurrentUser } from '../common/withUser';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     ...theme.typography.body2,

--- a/packages/lesswrong/components/rss/NewFeedButton.tsx
+++ b/packages/lesswrong/components/rss/NewFeedButton.tsx
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 import { useCurrentUser } from '../common/withUser';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -41,7 +41,7 @@ const NewFeedButton = ({classes, user, closeModal}: {
         </div>)}
         <Components.WrappedSmartForm
           collectionName="RSSFeeds"
-          mutationFragment={getFragment('newRSSFeedFragment')}
+          mutationFragmentName={'newRSSFeedFragment'}
           prefilledProps={{userId: user._id}}
           successCallback={() => {
             closeModal();

--- a/packages/lesswrong/components/rss/NewFeedButton.tsx
+++ b/packages/lesswrong/components/rss/NewFeedButton.tsx
@@ -4,7 +4,6 @@ import { useCurrentUser } from '../common/withUser';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     padding: 16

--- a/packages/lesswrong/components/seasonal/petrovDay/PetrovAdminConsole.tsx
+++ b/packages/lesswrong/components/seasonal/petrovDay/PetrovAdminConsole.tsx
@@ -56,7 +56,7 @@ export const PetrovAdminConsole = ({classes, currentUser}: {
     </div>
       {/* <WrappedSmartForm
         collectionName="PetrovDayActions"
-        mutationFragment={getFragment('PetrovDayActionInfo')}
+        mutationFragmentName={'PetrovDayActionInfo'}
       /> */}
   </PetrovWorldmapWrapper>
 }

--- a/packages/lesswrong/components/sequences/BooksEditForm.tsx
+++ b/packages/lesswrong/components/sequences/BooksEditForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const BooksEditForm = ({documentId, successCallback, cancelCallback, prefilledProps}: {
   documentId: string,
@@ -17,8 +17,8 @@ const BooksEditForm = ({documentId, successCallback, cancelCallback, prefilledPr
         cancelCallback={cancelCallback}
         prefilledProps={prefilledProps}
         showRemove={true}
-        queryFragment={getFragment('BookEdit')}
-        mutationFragment={getFragment('BookPageFragment')}
+        queryFragmentName={'BookEdit'}
+        mutationFragmentName={'BookPageFragment'}
       />
     </div>
   )

--- a/packages/lesswrong/components/sequences/BooksEditForm.tsx
+++ b/packages/lesswrong/components/sequences/BooksEditForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const BooksEditForm = ({documentId, successCallback, cancelCallback, prefilledProps}: {
   documentId: string,
   successCallback?: () => void,

--- a/packages/lesswrong/components/sequences/BooksNewForm.tsx
+++ b/packages/lesswrong/components/sequences/BooksNewForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const BooksNewForm = ({successCallback, cancelCallback, prefilledProps}: {
   successCallback?: () => void,
   cancelCallback?: () => void,

--- a/packages/lesswrong/components/sequences/BooksNewForm.tsx
+++ b/packages/lesswrong/components/sequences/BooksNewForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const BooksNewForm = ({successCallback, cancelCallback, prefilledProps}: {
   successCallback?: () => void,
@@ -14,9 +14,8 @@ const BooksNewForm = ({successCallback, cancelCallback, prefilledProps}: {
         successCallback={successCallback}
         cancelCallback={cancelCallback}
         prefilledProps={prefilledProps}
-        fragment={getFragment('BookPageFragment')}
-        queryFragment={getFragment('BookPageFragment')}
-        mutationFragment={getFragment('BookPageFragment')}
+        queryFragmentName={'BookPageFragment'}
+        mutationFragmentName={'BookPageFragment'}
       />
     </div>
   )

--- a/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
@@ -6,7 +6,6 @@ import { useMessages } from "../common/withMessages";
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     padding: theme.spacing.unit

--- a/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { useMessages } from "../common/withMessages";
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -67,8 +67,8 @@ const ChaptersEditForm = ({classes, documentId, postIds, successCallback, cancel
         cancelCallback={cancelCallback}
         changeCallback={changeCallback}
         showRemove={true}
-        queryFragment={getFragment('ChaptersEdit')}
-        mutationFragment={getFragment('ChaptersEdit')}
+        queryFragmentName={'ChaptersEdit'}
+        mutationFragmentName={'ChaptersEdit'}
       />
       <Button color="primary" className={classNames(
         classes.addDraftButton,

--- a/packages/lesswrong/components/sequences/ChaptersNewForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersNewForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { styles } from './CollectionsEditForm';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 //TODO: Manage chapter removal to remove the reference from all parent-sequences
 
@@ -20,9 +20,8 @@ const ChaptersNewForm = ({successCallback, cancelCallback, prefilledProps, class
         successCallback={successCallback}
         cancelCallback={cancelCallback}
         prefilledProps={prefilledProps}
-        fragment={getFragment('ChaptersFragment')}
-        queryFragment={getFragment('ChaptersFragment')}
-        mutationFragment={getFragment('ChaptersFragment')}
+        queryFragmentName={'ChaptersFragment'}
+        mutationFragmentName={'ChaptersFragment'}
       />
     </div>
   )

--- a/packages/lesswrong/components/sequences/ChaptersNewForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersNewForm.tsx
@@ -3,7 +3,6 @@ import { styles } from './CollectionsEditForm';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 //TODO: Manage chapter removal to remove the reference from all parent-sequences
 
 const ChaptersNewForm = ({successCallback, cancelCallback, prefilledProps, classes}: {

--- a/packages/lesswrong/components/sequences/CollectionsEditForm.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsEditForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 export const styles = (theme: ThemeType) => ({
   newOrEditForm: {
     maxWidth: 695,

--- a/packages/lesswrong/components/sequences/CollectionsEditForm.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsEditForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 export const styles = (theme: ThemeType) => ({
   newOrEditForm: {
@@ -57,8 +57,8 @@ const CollectionsEditForm = ({documentId, successCallback, cancelCallback, class
         successCallback={successCallback}
         cancelCallback={cancelCallback}
         showRemove={true}
-        queryFragment={getFragment('CollectionsEditFragment')}
-        mutationFragment={getFragment('CollectionsPageFragment')}
+        queryFragmentName={'CollectionsEditFragment'}
+        mutationFragmentName={'CollectionsPageFragment'}
       />
     </div>
   )

--- a/packages/lesswrong/components/sequences/SequencesEditForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesEditForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { styles } from './SequencesNewForm';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const SequencesEditForm = ({ documentId, successCallback, cancelCallback, removeSuccessCallback, classes }: {
   documentId: string,
   successCallback?: () => void,

--- a/packages/lesswrong/components/sequences/SequencesEditForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesEditForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styles } from './SequencesNewForm';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const SequencesEditForm = ({ documentId, successCallback, cancelCallback, removeSuccessCallback, classes }: {
   documentId: string,
@@ -19,8 +19,8 @@ const SequencesEditForm = ({ documentId, successCallback, cancelCallback, remove
         cancelCallback={cancelCallback}
         removeSuccessCallback={removeSuccessCallback}
         showRemove={true}
-        queryFragment={getFragment('SequencesEdit')}
-        mutationFragment={getFragment('SequencesEdit')}
+        queryFragmentName={'SequencesEdit'}
+        mutationFragmentName={'SequencesEdit'}
       />
     </div>
   )

--- a/packages/lesswrong/components/sequences/SequencesNewForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNewForm.tsx
@@ -5,7 +5,7 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 // Also used by SequencesEditForm
 export const styles = (theme: ThemeType) => ({
@@ -172,8 +172,8 @@ const SequencesNewForm = ({ redirect, cancelCallback, removeSuccessCallback, cla
           cancelCallback={cancelCallback}
           removeSuccessCallback={removeSuccessCallback}
           prefilledProps={{userId: currentUser._id}}
-          queryFragment={getFragment('SequencesEdit')}
-          mutationFragment={getFragment('SequencesPageFragment')}
+          queryFragmentName={'SequencesEdit'}
+          mutationFragmentName={'SequencesPageFragment'}
         />
       </div>
     )

--- a/packages/lesswrong/components/sequences/SequencesNewForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNewForm.tsx
@@ -1,11 +1,9 @@
 import { useMessages } from '../common/withMessages';
 import React from 'react';
 import { useCurrentUser } from '../common/withUser';
-import { legacyBreakpoints } from '../../lib/utils/theme';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useNavigate } from '../../lib/routeUtil';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 
 // Also used by SequencesEditForm
 export const styles = (theme: ThemeType) => ({

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -16,7 +16,7 @@ import { getSpotlightUrl } from '../../lib/collections/spotlights/helpers';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { usePublishAndDeDuplicateSpotlight } from './withPublishAndDeDuplicateSpotlight';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const TEXT_WIDTH = 350;
 
@@ -526,8 +526,8 @@ export const SpotlightItem = ({
                     collectionName="Spotlights"
                     fields={['description']}
                     documentId={spotlight._id}
-                    mutationFragment={getFragment('SpotlightEditQueryFragment')}
-                    queryFragment={getFragment('SpotlightEditQueryFragment')}
+                    mutationFragmentName={'SpotlightEditQueryFragment'}
+                    queryFragmentName={'SpotlightEditQueryFragment'}
                     successCallback={() => { setEditDescription(false); void handleUndraftSpotlight() }}
                   />
                 </div>
@@ -607,8 +607,8 @@ export const SpotlightItem = ({
             <WrappedSmartForm
               collectionName="Spotlights"
               documentId={spotlight._id}
-              mutationFragment={getFragment('SpotlightEditQueryFragment')}
-              queryFragment={getFragment('SpotlightEditQueryFragment')}
+              mutationFragmentName={'SpotlightEditQueryFragment'}
+              queryFragmentName={'SpotlightEditQueryFragment'}
               successCallback={onUpdate}
             />
             </SpotlightEditorStyles>

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -17,7 +17,6 @@ import { useUpdate } from '../../lib/crud/withUpdate';
 import { usePublishAndDeDuplicateSpotlight } from './withPublishAndDeDuplicateSpotlight';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const TEXT_WIDTH = 350;
 
 export const descriptionStyles = (theme: ThemeType) => ({

--- a/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
@@ -6,7 +6,6 @@ import { useLocation } from '../../lib/routeUtil';
 import { getSpotlightDisplayTitle } from './SpotlightItem';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   form: {
     padding: 16,

--- a/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightsPage.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil';
 import { getSpotlightDisplayTitle } from './SpotlightItem';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   form: {
@@ -99,7 +99,7 @@ export const SpotlightsPage = ({classes}: {
         <SpotlightEditorStyles>
           <WrappedSmartForm
             collectionName="Spotlights"
-            mutationFragment={getFragment('SpotlightEditQueryFragment')}
+            mutationFragmentName={'SpotlightEditQueryFragment'}
           />
         </SpotlightEditorStyles>
       </div>

--- a/packages/lesswrong/components/spotlights/withPublishAndDeDuplicateSpotlight.ts
+++ b/packages/lesswrong/components/spotlights/withPublishAndDeDuplicateSpotlight.ts
@@ -1,7 +1,6 @@
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 import { useMutation, gql } from '@apollo/client';
 
-
 export const usePublishAndDeDuplicateSpotlight = ({fragmentName}: {
   fragmentName: FragmentName,
 }) => {

--- a/packages/lesswrong/components/spotlights/withPublishAndDeDuplicateSpotlight.ts
+++ b/packages/lesswrong/components/spotlights/withPublishAndDeDuplicateSpotlight.ts
@@ -1,5 +1,6 @@
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 import { useMutation, gql } from '@apollo/client';
-import { getFragment } from '../../lib/vulcan-lib/fragments';
+
 
 export const usePublishAndDeDuplicateSpotlight = ({fragmentName}: {
   fragmentName: FragmentName,
@@ -10,7 +11,7 @@ export const usePublishAndDeDuplicateSpotlight = ({fragmentName}: {
         ...${fragmentName}
       }
     }
-    ${getFragment(fragmentName)}
+    ${fragmentTextForQuery(fragmentName)}
   `);
   
   async function mutate(args: {spotlightId: string}) {

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DialogContent from '@material-ui/core/DialogContent';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const ReportForm = ({ userId, postId, commentId, reportedUserId, onClose, onSubmit, title, link }: {
   userId: string,
@@ -28,7 +28,7 @@ const ReportForm = ({ userId, postId, commentId, reportedUserId, onClose, onSubm
       <DialogContent>
         <Components.WrappedSmartForm
           collectionName="Reports"
-          mutationFragment={getFragment('UnclaimedReportsList')}
+          mutationFragmentName={'UnclaimedReportsList'}
           prefilledProps={{
             userId: userId,
             postId: postId,

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import DialogContent from '@material-ui/core/DialogContent';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const ReportForm = ({ userId, postId, commentId, reportedUserId, onClose, onSubmit, title, link }: {
   userId: string,
   postId?: string,

--- a/packages/lesswrong/components/surveys/SurveyEditPage.tsx
+++ b/packages/lesswrong/components/surveys/SurveyEditPage.tsx
@@ -9,7 +9,6 @@ import type { SettingsOption } from "@/lib/collections/posts/dropdownOptions";
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from "@/lib/vulcan-lib/fragments";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     fontFamily: theme.palette.fonts.sansSerifStack,

--- a/packages/lesswrong/components/surveys/SurveyEditPage.tsx
+++ b/packages/lesswrong/components/surveys/SurveyEditPage.tsx
@@ -7,7 +7,8 @@ import { useSingle } from "@/lib/crud/withSingle";
 import { SurveyQuestionFormat, surveyQuestionFormats } from "@/lib/collections/surveyQuestions/schema";
 import type { SettingsOption } from "@/lib/collections/posts/dropdownOptions";
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from "@/lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -158,7 +159,7 @@ const SurveyForm = ({survey, refetch, classes}: {
         ...SurveyMinimumInfo
       }
     }
-    ${getFragment("SurveyMinimumInfo")}
+    ${fragmentTextForQuery("SurveyMinimumInfo")}
   `);
 
   const onSubmit = useCallback(async () => {

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -10,13 +10,11 @@ import { getSearchIndexName, getSearchClient } from '../../lib/search/searchUtil
 import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog';
 import CloseIcon from '@material-ui/icons/Close';
-
 import { formatFacetFilters } from '../search/SearchAutoComplete';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { Hits, InstantSearch } from '../../lib/utils/componentsWithChildren';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
-
 
 const styles = (theme: ThemeType) => ({
   root: {

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -15,7 +15,8 @@ import { formatFacetFilters } from '../search/SearchAutoComplete';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { Hits, InstantSearch } from '../../lib/utils/componentsWithChildren';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -112,7 +113,7 @@ const AddPostsToTag = ({classes, tag}: {
         ...TagRelCreationFragment
       }
     }
-    ${getFragment("TagRelCreationFragment")}
+    ${fragmentTextForQuery("TagRelCreationFragment")}
   `, {
     update(cache, { data: {addOrUpvoteTag: TagRel}  }) {
       updateEachQueryResultOfType({ func: handleUpdateMutation, store: cache, typeName: "Post",  document: TagRel.post })

--- a/packages/lesswrong/components/tagging/EditTagPage.tsx
+++ b/packages/lesswrong/components/tagging/EditTagPage.tsx
@@ -4,7 +4,6 @@ import { useTagBySlug } from './useTag';
 import { useApolloClient } from "@apollo/client";
 import { isLWorAF, taggingNameCapitalSetting } from '../../lib/instanceSettings';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 
 export const EditTagForm = ({tag, successCallback, cancelCallback, changeCallback, warnUnsavedChanges}: {

--- a/packages/lesswrong/components/tagging/EditTagPage.tsx
+++ b/packages/lesswrong/components/tagging/EditTagPage.tsx
@@ -4,7 +4,7 @@ import { useTagBySlug } from './useTag';
 import { useApolloClient } from "@apollo/client";
 import { isLWorAF, taggingNameCapitalSetting } from '../../lib/instanceSettings';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 
 export const EditTagForm = ({tag, successCallback, cancelCallback, changeCallback, warnUnsavedChanges}: {
@@ -20,8 +20,8 @@ export const EditTagForm = ({tag, successCallback, cancelCallback, changeCallbac
       key={`${tag?._id}_${tag?.description?.version}`}
       collectionName="Tags"
       documentId={tag._id}
-      queryFragment={getFragment('TagEditFragment')}
-      mutationFragment={getFragment('TagWithFlagsFragment')}
+      queryFragmentName={'TagEditFragment'}
+      mutationFragmentName={'TagWithFlagsFragment'}
       successCallback={successCallback}
       cancelCallback={cancelCallback}
       addFields={isLWorAF ? ['summaries'] : []}

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -19,7 +19,6 @@ import { stableSortTags } from '../../lib/collections/tags/helpers';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI ? {
     marginTop: 8,

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -17,7 +17,8 @@ import { FRIENDLY_HOVER_OVER_WIDTH } from '../common/FriendlyHoverOver';
 import { AnnualReviewMarketInfo, highlightMarket } from '../../lib/collections/posts/annualReviewMarkets';
 import { stableSortTags } from '../../lib/collections/tags/helpers';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (theme: ThemeType) => ({
   root: isFriendlyUI ? {
@@ -232,7 +233,7 @@ const FooterTagList = ({
         ...TagRelMinimumFragment
       }
     }
-    ${getFragment("TagRelMinimumFragment")}
+    ${fragmentTextForQuery("TagRelMinimumFragment")}
   `);
 
   const onTagSelected = useCallback(async ({tagId, tagName}: {tagId: string, tagName: string}) => {

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -6,7 +6,6 @@ import { useSingle } from '@/lib/crud/withSingle';
 import { useUpdate } from '@/lib/crud/withUpdate';
 import { slugify } from '@/lib/utils/slugify';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 import { useLocation, useNavigate } from "@/lib/routeUtil";
 
 export const styles = (_theme: ThemeType) => ({

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -6,7 +6,7 @@ import { useSingle } from '@/lib/crud/withSingle';
 import { useUpdate } from '@/lib/crud/withUpdate';
 import { slugify } from '@/lib/utils/slugify';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 import { useLocation, useNavigate } from "@/lib/routeUtil";
 
 export const styles = (_theme: ThemeType) => ({
@@ -82,8 +82,8 @@ const NewTagPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
       {!loadingExistingTag && <WrappedSmartForm
         collectionName="Tags"
         documentId={existingTag?._id}
-        queryFragment={getFragment('TagEditFragment')}
-        mutationFragment={getFragment('TagWithFlagsFragment')}
+        queryFragmentName={'TagEditFragment'}
+        mutationFragmentName={'TagWithFlagsFragment'}
         successCallback={async (tag: any) => {
           if (existingTag) {
             await updateTag({

--- a/packages/lesswrong/components/tagging/SummariesEditForm.tsx
+++ b/packages/lesswrong/components/tagging/SummariesEditForm.tsx
@@ -8,7 +8,6 @@ import { gql, useMutation } from "@apollo/client";
 import { SortableHandle as sortableHandle } from "react-sortable-hoc";
 import { Components, registerComponent } from "@/lib/vulcan-lib/components.tsx";
 
-
 const styles = defineStyles("SummariesEditForm", (theme: ThemeType) => ({
   root: {
     display: 'flex',

--- a/packages/lesswrong/components/tagging/SummariesEditForm.tsx
+++ b/packages/lesswrong/components/tagging/SummariesEditForm.tsx
@@ -7,7 +7,7 @@ import { makeSortableListComponent } from "../form-components/sortableList";
 import { gql, useMutation } from "@apollo/client";
 import { SortableHandle as sortableHandle } from "react-sortable-hoc";
 import { Components, registerComponent } from "@/lib/vulcan-lib/components.tsx";
-import { getFragment } from "@/lib/vulcan-lib/fragments.ts";
+
 
 const styles = defineStyles("SummariesEditForm", (theme: ThemeType) => ({
   root: {
@@ -222,8 +222,8 @@ const SummaryEditorRow = ({ summary, refetch }: {
         key={mountKey}
         collectionName="MultiDocuments"
         documentId={summary._id}
-        mutationFragment={getFragment('MultiDocumentContentDisplay')}
-        queryFragment={getFragment('MultiDocumentContentDisplay')}
+        mutationFragmentName={'MultiDocumentContentDisplay'}
+        queryFragmentName={'MultiDocumentContentDisplay'}
         prefetchedDocument={summary}
         successCallback={() => {
           setEdit(false);
@@ -263,8 +263,8 @@ const NewSummaryEditor = ({ parentDocument, refetchSummaries, setNewSummaryEdito
   return <div className={classes.summaryRowFormStyles}>
     <WrappedSmartForm
       collectionName="MultiDocuments"
-      mutationFragment={getFragment('MultiDocumentContentDisplay')}
-      queryFragment={getFragment('MultiDocumentContentDisplay')}
+      mutationFragmentName={'MultiDocumentContentDisplay'}
+      queryFragmentName={'MultiDocumentContentDisplay'}
       successCallback={wrappedSuccessCallback}
       cancelCallback={() => setNewSummaryEditorOpen(false)}
       formComponents={{ FormSubmit: SummarySubmitButtons }}

--- a/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
@@ -4,7 +4,6 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const TagFlagEditAndNewForm = ({ tagFlagId, onClose }: {
   tagFlagId?: string,
   onClose?: () => void,

--- a/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
@@ -3,7 +3,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const TagFlagEditAndNewForm = ({ tagFlagId, onClose }: {
   tagFlagId?: string,
@@ -24,8 +24,8 @@ const TagFlagEditAndNewForm = ({ tagFlagId, onClose }: {
         <Components.WrappedSmartForm
           collectionName="TagFlags"
           documentId={tagFlagId}
-          queryFragment={getFragment("TagFlagEditFragment")}
-          mutationFragment={getFragment("TagFlagFragment")}
+          queryFragmentName={'TagFlagEditFragment'}
+          mutationFragmentName={'TagFlagFragment'}
           successCallback={onClose}
         />
       </DialogContent>

--- a/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
@@ -7,7 +7,8 @@ import classNames from 'classnames';
 import { useTracking } from "../../../lib/analyticsEvents";
 import { gql, useMutation } from '@apollo/client';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
-import { getFragment } from "../../../lib/vulcan-lib/fragments";
+import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
+
 
 const styles = (_theme: ThemeType) => ({
   root: {
@@ -49,7 +50,7 @@ const SubforumSubscribeSection = ({
         ...UsersCurrent
       }
     }
-    ${getFragment("UsersCurrent")}
+    ${fragmentTextForQuery("UsersCurrent")}
   `, {refetchQueries: ['getCurrentUser']});
   const { LWTooltip } = Components
 

--- a/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
@@ -9,7 +9,6 @@ import { gql, useMutation } from '@apollo/client';
 import { Components, registerComponent } from "../../../lib/vulcan-lib/components";
 import { fragmentTextForQuery } from '@/lib/vulcan-lib/fragments';
 
-
 const styles = (_theme: ThemeType) => ({
   root: {
     display: "flex",

--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -8,7 +8,7 @@ import { userHasEagProfileImport } from '../../lib/betas';
 import moment from 'moment';
 import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 
@@ -181,8 +181,8 @@ const EditProfileForm = ({classes}: {
           FormGroupLayout: isFriendlyUI ? FormGroupFriendlyUserProfile : undefined,
         }}
         excludeHiddenFields={false}
-        queryFragment={getFragment('UsersProfileEdit')}
-        mutationFragment={getFragment('UsersProfileEdit')}
+        queryFragmentName={'UsersProfileEdit'}
+        mutationFragmentName={'UsersProfileEdit'}
         successCallback={async (user: AnyBecauseTodo) => {
           navigate(userGetProfileUrl(user))
         }}

--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -8,7 +8,6 @@ import { userHasEagProfileImport } from '../../lib/betas';
 import moment from 'moment';
 import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 

--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -11,7 +11,7 @@ import { configureDatadogRum } from '@/client/datadogRum';
 import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import { useNavigate } from '@/lib/routeUtil.tsx';
 import { Components, registerComponent } from "@/lib/vulcan-lib/components.tsx";
-import { getFragment } from "@/lib/vulcan-lib/fragments.ts";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -95,8 +95,8 @@ const UsersEditForm = ({terms, classes}: {
             navigate(userGetProfileUrl(user))
           }
         }}
-        queryFragment={getFragment('UsersEdit')}
-        mutationFragment={getFragment('UsersEdit')}
+        queryFragmentName={'UsersEdit'}
+        mutationFragmentName={'UsersEdit'}
         showRemove={false}
       />
     </div>

--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -12,7 +12,6 @@ import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import { useNavigate } from '@/lib/routeUtil.tsx';
 import { Components, registerComponent } from "@/lib/vulcan-lib/components.tsx";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     ...(isFriendlyUI && {

--- a/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
@@ -17,7 +17,6 @@ import { NavigationContext } from '@/lib/vulcan-core/appContext';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { getFragment } from '@/lib/vulcan-lib/fragments';
 
-
 const intlSuffix = '_intl';
 
 function convertFields(field: string) {

--- a/packages/lesswrong/components/vulcan-forms/propTypes.ts
+++ b/packages/lesswrong/components/vulcan-forms/propTypes.ts
@@ -87,8 +87,6 @@ export interface WrappedSmartFormProps<T extends CollectionNameString> extends S
   autoSubmit?: any
   formProps?: any
   
-  queryFragment?: any
-  mutationFragment?: any
   queryFragmentName?: FragmentName
   mutationFragmentName?: FragmentName
 
@@ -98,10 +96,7 @@ export interface WrappedSmartFormProps<T extends CollectionNameString> extends S
    * Warning - passing in a prefetched document into a wrapped smart form might cause unexpected issues for anything using ckEditor, if the loaded document comes back with different data than what was prefetched.
    */
   prefetchedDocument?: T extends keyof FragmentTypesByCollection ? FragmentTypes[FragmentTypesByCollection[T]] : never
-  
-  // fragment: Used externally, but may be erroneous; the internals of the forms seem to only use queryFragment and mutationFragment
-  fragment?: any
-  
+    
   // version: Passed from PostsEditForm, but may be erroneous; does not seem to be used inside the forms code
   version?: "draft"
   

--- a/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
@@ -8,7 +8,7 @@ import moment from 'moment';
 import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 export const gardenForm = (theme: ThemeType) => ({
   border: theme.palette.border.normal,
@@ -127,8 +127,8 @@ export const GardenCodeWidget = ({classes, type}: {classes: ClassesType<typeof s
           <Components.WrappedSmartForm
             collectionName="GardenCodes"
             fields={fields}
-            mutationFragment={getFragment("GardenCodeFragment")}
-            queryFragment={getFragment("GardenCodeFragment")}
+            mutationFragmentName={'GardenCodeFragment'}
+            queryFragmentName={'GardenCodeFragment'}
             formComponents={{
               FormSubmit: SubmitComponent,
               FormGroupLayout: Components.FormGroupNoStyling

--- a/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
@@ -9,7 +9,6 @@ import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import classNames from 'classnames';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 export const gardenForm = (theme: ThemeType) => ({
   border: theme.palette.border.normal,
   borderRadius: 3,

--- a/packages/lesswrong/components/walledGarden/GardenCodesEditForm.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesEditForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { gardenForm } from './GardenCodeWidget';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 
-
 const styles = (theme: ThemeType) => ({
   root: {
     ...gardenForm(theme)

--- a/packages/lesswrong/components/walledGarden/GardenCodesEditForm.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesEditForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { gardenForm } from './GardenCodeWidget';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
-import { getFragment } from "../../lib/vulcan-lib/fragments";
+
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -24,8 +24,8 @@ export const GardenCodesEditForm = ({classes, gardenCodeId, cancelCallback, succ
       successCallback={successCallback}
       cancelCallback={cancelCallback}
       showRemove={false}
-      queryFragment={getFragment('GardenCodeFragmentEdit')}
-      mutationFragment={getFragment('GardenCodeFragmentEdit')}
+      queryFragmentName={'GardenCodeFragmentEdit'}
+      mutationFragmentName={'GardenCodeFragmentEdit'}
       submitLabel="Save"
     />
   </ContentStyles>

--- a/packages/lesswrong/lib/alignment-forum/comments/fragments.ts
+++ b/packages/lesswrong/lib/alignment-forum/comments/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SuggestAlignmentComment = `
   fragment SuggestAlignmentComment on Comment {
     ...CommentsList
     post {
@@ -11,4 +9,4 @@ registerFragment(`
       _id
       displayName
     }
-  }`)
+  }`

--- a/packages/lesswrong/lib/alignment-forum/posts/fragments.ts
+++ b/packages/lesswrong/lib/alignment-forum/posts/fragments.ts
@@ -1,11 +1,8 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-
-registerFragment(`
+export const SuggestAlignmentPost = `
   fragment SuggestAlignmentPost on Post {
     ...PostsList
     suggestForAlignmentUsers {
       _id
       displayName
     }
-  }`)
+  }`

--- a/packages/lesswrong/lib/alignment-forum/users/fragments.ts
+++ b/packages/lesswrong/lib/alignment-forum/users/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SuggestAlignmentUser = `
   fragment SuggestAlignmentUser on User {
     ...UsersMinimumInfo
     afKarma
@@ -10,4 +8,4 @@ registerFragment(`
     groups
     afApplicationText
     afSubmittedApplication
-  }`)
+  }`

--- a/packages/lesswrong/lib/collections/advisorRequests/fragments.ts
+++ b/packages/lesswrong/lib/collections/advisorRequests/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const AdvisorRequestsMinimumInfo = `
   fragment AdvisorRequestsMinimumInfo on AdvisorRequest {
     _id
     userId
@@ -8,4 +6,4 @@ registerFragment(`
     interestedInMetaculus
     jobAds
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/bans/fragments.ts
+++ b/packages/lesswrong/lib/collections/bans/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const BansAdminPageFragment = `
   fragment BansAdminPageFragment on Ban {
     _id
     createdAt
@@ -14,4 +12,4 @@ registerFragment(`
     ip
     properties
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/books/fragments.ts
+++ b/packages/lesswrong/lib/collections/books/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const BookPageFragment = `
   fragment BookPageFragment on Book {
     _id
     createdAt
@@ -24,13 +22,13 @@ registerFragment(`
     hideProgressBar
     showChapters
   }
-`);
+`
 
-registerFragment(`
+export const BookEdit = `
   fragment BookEdit on Book {
     ...BookPageFragment
     contents {
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/chapters/fragments.ts
+++ b/packages/lesswrong/lib/collections/chapters/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ChaptersFragment = `
   fragment ChaptersFragment on Chapter {
     _id
     createdAt
@@ -16,13 +14,13 @@ registerFragment(`
       ...PostsListWithVotes
     }
   }
-`);
+`
 
-registerFragment(`
+export const ChaptersEdit = `
   fragment ChaptersEdit on Chapter {
     ...ChaptersFragment
     contents {
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/ckEditorUserSessions/fragments.ts
+++ b/packages/lesswrong/lib/collections/ckEditorUserSessions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const CkEditorUserSessionInfo = `
   fragment CkEditorUserSessionInfo on CkEditorUserSession {
     _id
     userId
@@ -8,4 +6,4 @@ registerFragment(`
     endedAt
     endedBy
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/clientIds/collection.ts
+++ b/packages/lesswrong/lib/collections/clientIds/collection.ts
@@ -1,6 +1,5 @@
 import schema from './schema';
 import { createCollection } from '../../vulcan-lib/collections';
-import { registerFragment } from '../../vulcan-lib/fragments';
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
 import { DatabaseIndexSet } from '@/lib/utils/databaseIndexSet';
@@ -27,20 +26,6 @@ addUniversalFields({
   collection: ClientIds,
   createdAtOptions: {canRead: ['admins']},
 });
-
-
-registerFragment(`
-  fragment ModeratorClientIDInfo on ClientId {
-    _id
-    clientId
-    createdAt
-    firstSeenReferrer
-    firstSeenLandingPage
-    users {
-      ...UsersMinimumInfo
-    }
-  }
-`);
 
 declare global {
   interface ClientIdsViewTerms extends ViewTermsBase {

--- a/packages/lesswrong/lib/collections/clientIds/fragments.ts
+++ b/packages/lesswrong/lib/collections/clientIds/fragments.ts
@@ -1,0 +1,12 @@
+export const ModeratorClientIDInfo = `
+  fragment ModeratorClientIDInfo on ClientId {
+    _id
+    clientId
+    createdAt
+    firstSeenReferrer
+    firstSeenLandingPage
+    users {
+      ...UsersMinimumInfo
+    }
+  }
+`;

--- a/packages/lesswrong/lib/collections/collections/fragments.ts
+++ b/packages/lesswrong/lib/collections/collections/fragments.ts
@@ -1,15 +1,13 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const CollectionContinueReadingFragment = `
   fragment CollectionContinueReadingFragment on Collection {
     _id
     title
     slug
     gridImageId
   }
-`);
+`
 
-registerFragment(`
+export const CollectionsPageFragment = `
   fragment CollectionsPageFragment on Collection {
     _id
     createdAt
@@ -30,18 +28,18 @@ registerFragment(`
     hideStartReadingButton
     noindex
   }
-`);
+`
 
-registerFragment(`
+export const CollectionsEditFragment = `
   fragment CollectionsEditFragment on Collection {
     ...CollectionsPageFragment
     contents {
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const CollectionsBestOfFragment = `
   fragment CollectionsBestOfFragment on Collection {
     _id
     createdAt
@@ -59,4 +57,4 @@ registerFragment(`
       ...RevisionDisplay
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/commentModeratorActions/fragments.ts
+++ b/packages/lesswrong/lib/collections/commentModeratorActions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const CommentModeratorActionDisplay = `
   fragment CommentModeratorActionDisplay on CommentModeratorAction {
     _id
     comment {
@@ -12,4 +10,4 @@ registerFragment(`
     createdAt
     endedAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const CommentsList = `
   fragment CommentsList on Comment {
     _id
     postId
@@ -77,18 +75,18 @@ registerFragment(`
     modGPTRecommendation
     originalDialogueId
   }
-`);
+`
 
-registerFragment(`
+export const CommentsListWithTopLevelComment = `
   fragment CommentsListWithTopLevelComment on Comment {
     ...CommentsList
     topLevelComment {
       ...CommentsList
     }
   }
-`);
+`
 
-registerFragment(`
+export const ShortformComments = `
   fragment ShortformComments on Comment {
     ...CommentsList
     post {
@@ -98,9 +96,9 @@ registerFragment(`
       ...TagPreviewFragment
     }
   }
-`)
+`
 
-registerFragment(`
+export const CommentWithRepliesFragment = `
   fragment CommentWithRepliesFragment on Comment {
     ...CommentsList
     lastSubthreadActivity
@@ -114,9 +112,9 @@ registerFragment(`
       ...PostsBase
     }
   }
-`);
+`
 
-registerFragment(`
+export const CommentEdit = `
   fragment CommentEdit on Comment {
     ...CommentsList
     relevantTagIds
@@ -124,9 +122,9 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const DeletedCommentsMetaData = `
   fragment DeletedCommentsMetaData on Comment {
     _id
     deleted
@@ -138,9 +136,9 @@ registerFragment(`
     deletedReason
     deletedPublic
   }
-`)
+`
 
-registerFragment(`
+export const DeletedCommentsModerationLog = `
   fragment DeletedCommentsModerationLog on Comment {
     ...DeletedCommentsMetaData
     user {
@@ -152,9 +150,9 @@ registerFragment(`
       _id
     }
   }
-`)
+`
 
-registerFragment(`
+export const CommentsListWithParentMetadata = `
   fragment CommentsListWithParentMetadata on Comment {
     ...CommentsList
     post {
@@ -165,20 +163,20 @@ registerFragment(`
       ...TagBasicInfo
     }
   }
-`);
+`
 
 // TODO: This is now the same as CommentWithRepliesFragment, now that said
 // fragment gets the tag field
-registerFragment(`
+export const StickySubforumCommentFragment = `
   fragment StickySubforumCommentFragment on Comment {
     ...CommentWithRepliesFragment
     tag {
       ...TagBasicInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const WithVoteComment = `
   fragment WithVoteComment on Comment {
     __typename
     _id
@@ -191,18 +189,18 @@ registerFragment(`
     afExtendedScore
     voteCount
   }
-`);
+`
 
-registerFragment(`
+export const CommentsListWithModerationMetadata = `
   fragment CommentsListWithModerationMetadata on Comment {
     ...CommentWithRepliesFragment
     allVotes {
       voteType
     }
   }
-`);
+`
 
-registerFragment(`
+export const CommentsListWithModGPTAnalysis = `
   fragment CommentsListWithModGPTAnalysis on Comment {
     ...CommentsList
     post {
@@ -210,9 +208,9 @@ registerFragment(`
     }
     modGPTAnalysis
   }
-`);
+`
 
-registerFragment(`
+export const CommentsForAutocomplete = `
   fragment CommentsForAutocomplete on Comment {
     _id
     postId
@@ -228,9 +226,9 @@ registerFragment(`
     post {
       ...PostsForAutocomplete
     }
-  }`)
+  }`
 
-registerFragment(`
+export const CommentsForAutocompleteWithParents = `
   fragment CommentsForAutocompleteWithParents on Comment {
     ...CommentsForAutocomplete
     ${/* We dynamically construct a fragment that gets the parentComment and its parentComment, etc. for up to 10 levels */ ''}
@@ -246,4 +244,4 @@ registerFragment(`
       }`.trim();
     })(10)}
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/conversations/fragments.ts
+++ b/packages/lesswrong/lib/collections/conversations/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "../../vulcan-lib/fragments";
-
-registerFragment(`
+export const ConversationsMinimumInfo = `
   fragment ConversationsMinimumInfo on Conversation {
     _id
     createdAt
@@ -11,9 +9,9 @@ registerFragment(`
     messageCount
     moderator
   }
-`);
+`
 
-registerFragment(`
+export const ConversationsList = `
   fragment ConversationsList on Conversation {
     ...ConversationsMinimumInfo
     participants {
@@ -23,11 +21,11 @@ registerFragment(`
       ...messageListFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const ConversationsListWithReadStatus = `
   fragment ConversationsListWithReadStatus on Conversation {
     ...ConversationsList
     hasUnreadMessages
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/curationNotices/fragments.ts
+++ b/packages/lesswrong/lib/collections/curationNotices/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const CurationNoticesFragment = `
   fragment CurationNoticesFragment on CurationNotice {
     _id
     createdAt
@@ -21,4 +19,4 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/dialogueChecks/fragments.ts
+++ b/packages/lesswrong/lib/collections/dialogueChecks/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const DialogueCheckInfo = `
   fragment DialogueCheckInfo on DialogueCheck {
     _id
     userId
@@ -15,4 +13,4 @@ registerFragment(`
       ...DialogueMatchPreferencesDefaultFragment
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/dialogueMatchPreferences/fragments.ts
+++ b/packages/lesswrong/lib/collections/dialogueMatchPreferences/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const DialogueMatchPreferenceInfo = `
   fragment DialogueMatchPreferenceInfo on DialogueMatchPreference {
     _id
     dialogueCheckId
@@ -12,4 +10,4 @@ registerFragment(`
     generatedDialogueId
     deleted
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/digestPosts/fragments.ts
+++ b/packages/lesswrong/lib/collections/digestPosts/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const DigestPostsMinimumInfo = `
   fragment DigestPostsMinimumInfo on DigestPost {
     _id
     digestId
@@ -8,4 +6,4 @@ registerFragment(`
     emailDigestStatus
     onsiteDigestStatus
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/digests/fragments.ts
+++ b/packages/lesswrong/lib/collections/digests/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const DigestsMinimumInfo = `
   fragment DigestsMinimumInfo on Digest {
     _id
     num
@@ -10,4 +8,4 @@ registerFragment(`
     onsiteImageId
     onsitePrimaryColor
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/electionCandidates/fragments.ts
+++ b/packages/lesswrong/lib/collections/electionCandidates/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "../../vulcan-lib/fragments";
-
-registerFragment(`
+export const ElectionCandidateBasicInfo = `
   fragment ElectionCandidateBasicInfo on ElectionCandidate {
     _id
     electionName
@@ -23,10 +21,10 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
 // For use in the "Other donation opportunities" section at the bottom of the Giving Portal
-registerFragment(`
+export const ElectionCandidateSimple = `
   fragment ElectionCandidateSimple on ElectionCandidate {
     _id
     name
@@ -35,11 +33,11 @@ registerFragment(`
     fundraiserLink
     description
   }
-`);
+`
 
 // This fragment has to be fully dereferenced, because the context of vote
 // fragments doesn't allow for spreading other fragments
-registerFragment(`
+export const WithVoteElectionCandidate = `
   fragment WithVoteElectionCandidate on ElectionCandidate {
     __typename
     _id
@@ -51,4 +49,4 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/electionVotes/fragments.ts
+++ b/packages/lesswrong/lib/collections/electionVotes/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "../../vulcan-lib/fragments";
-
-registerFragment(`
+export const ElectionVoteInfo = `
   fragment ElectionVoteInfo on ElectionVote {
     _id
     electionName
@@ -12,12 +10,12 @@ registerFragment(`
     userExplanation
     userOtherComments
   }
-`);
+`
 
-registerFragment(`
+export const ElectionVoteRecentDiscussion = `
   fragment ElectionVoteRecentDiscussion on ElectionVote {
     _id
     electionName
     submittedAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/elicitQuestions/collection.ts
+++ b/packages/lesswrong/lib/collections/elicitQuestions/collection.ts
@@ -1,7 +1,6 @@
 import schema from './schema';
 import { userIsAdminOrMod } from '@/lib/vulcan-users/permissions.ts';
 import { createCollection } from "../../vulcan-lib/collections";
-import { registerFragment } from "../../vulcan-lib/fragments";
 import { addUniversalFields } from "../../collectionUtils";
 import { getDefaultMutations } from "../../vulcan-core/default_mutations";
 import { getDefaultResolvers } from "../../vulcan-core/default_resolvers";
@@ -26,16 +25,6 @@ export const ElicitQuestions: ElicitQuestionsCollection = createCollection({
   }),
   logChanges: true,
 });
-
-registerFragment(`
-  fragment ElicitQuestionFragment on ElicitQuestion {
-    _id
-    title
-    notes
-    resolution
-    resolvesBy
-  }
-`);
 
 addUniversalFields({
   collection: ElicitQuestions

--- a/packages/lesswrong/lib/collections/elicitQuestions/fragments.ts
+++ b/packages/lesswrong/lib/collections/elicitQuestions/fragments.ts
@@ -1,0 +1,9 @@
+export const ElicitQuestionFragment = `
+  fragment ElicitQuestionFragment on ElicitQuestion {
+    _id
+    title
+    notes
+    resolution
+    resolvesBy
+  }
+`;

--- a/packages/lesswrong/lib/collections/featuredResources/fragments.ts
+++ b/packages/lesswrong/lib/collections/featuredResources/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const FeaturedResourcesFragment = `
   fragment FeaturedResourcesFragment on FeaturedResource {
     _id
     title
@@ -9,4 +7,4 @@ registerFragment(`
     ctaUrl
     expiresAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/forumEvents/fragments.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ForumEventsMinimumInfo = `
   fragment ForumEventsMinimumInfo on ForumEvent {
     _id
     title
@@ -19,9 +17,9 @@ registerFragment(`
 
     maxStickersPerUser
   }
-`);
+`
 
-registerFragment(`
+export const ForumEventsDisplay = `
   fragment ForumEventsDisplay on ForumEvent {
     ...ForumEventsMinimumInfo
     publicData
@@ -46,9 +44,9 @@ registerFragment(`
       html
     }
   }
-`);
+`
 
-registerFragment(`
+export const ForumEventsEdit = `
   fragment ForumEventsEdit on ForumEvent {
     ...ForumEventsMinimumInfo
     frontpageDescription {
@@ -61,4 +59,4 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/gardencodes/fragments.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const GardenCodeFragment = `
   fragment GardenCodeFragment on GardenCode {
     _id
     code
@@ -17,9 +15,9 @@ registerFragment(`
       ...RevisionDisplay
     }
   }
-`);
+`
 
-registerFragment(`
+export const GardenCodeFragmentEdit = `
   fragment GardenCodeFragmentEdit on GardenCode {
     _id
     code
@@ -36,5 +34,5 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`
 

--- a/packages/lesswrong/lib/collections/googleServiceAccountSessions/fragments.ts
+++ b/packages/lesswrong/lib/collections/googleServiceAccountSessions/fragments.ts
@@ -1,16 +1,14 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const GoogleServiceAccountSessionInfo = `
   fragment GoogleServiceAccountSessionInfo on GoogleServiceAccountSession {
     _id
     email
   }
-`);
+`
 
-registerFragment(`
+export const GoogleServiceAccountSessionAdminInfo = `
   fragment GoogleServiceAccountSessionAdminInfo on GoogleServiceAccountSession {
     _id
     email
     estimatedExpiry
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/jargonTerms/fragments.ts
+++ b/packages/lesswrong/lib/collections/jargonTerms/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const JargonTerms = `
   fragment JargonTerms on JargonTerm {
     _id
     postId
@@ -13,9 +11,9 @@ registerFragment(`
     deleted
     altTerms
   }
-`);
+`
 
-registerFragment(`
+export const JargonTermsPost = `
   fragment JargonTermsPost on JargonTerm {
     _id
     term
@@ -27,13 +25,13 @@ registerFragment(`
       ...RevisionDisplay
     }
   }
-`);
+`
 
-registerFragment(`
+export const JargonTermsWithPostInfo = `
   fragment JargonTermsWithPostInfo on JargonTerm {
     ...JargonTerms
     post {
       ...PostsMinimumInfo
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/llmConversations/fragments.ts
+++ b/packages/lesswrong/lib/collections/llmConversations/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const LlmConversationsFragment = `
   fragment LlmConversationsFragment on LlmConversation {
     _id
     userId
@@ -9,9 +7,9 @@ registerFragment(`
     lastUpdatedAt
     deleted
   }
-`);
+`
 
-registerFragment(`
+export const LlmConversationsViewingPageFragment = `
   fragment LlmConversationsViewingPageFragment on LlmConversation {
     ...LlmConversationsFragment
     totalCharacterCount
@@ -19,14 +17,14 @@ registerFragment(`
       ...UsersMinimumInfo
     }
   }
-`)
+`
 
 
-registerFragment(`
+export const LlmConversationsWithMessagesFragment = `
   fragment LlmConversationsWithMessagesFragment on LlmConversation {
     ...LlmConversationsFragment
     messages {
       ...LlmMessagesFragment
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/llmMessages/fragments.ts
+++ b/packages/lesswrong/lib/collections/llmMessages/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const LlmMessagesFragment = `
   fragment LlmMessagesFragment on LlmMessage {
     _id
     userId
@@ -9,4 +7,4 @@ registerFragment(`
     content
     createdAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/localgroups/fragments.ts
+++ b/packages/lesswrong/lib/collections/localgroups/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const localGroupsBase = `
   fragment localGroupsBase on Localgroup {
     _id
     createdAt
@@ -27,30 +25,30 @@ registerFragment(`
     inactive
     deleted
   }
-`);
+`
 
-registerFragment(`
+export const localGroupsHomeFragment = `
   fragment localGroupsHomeFragment on Localgroup {
     ...localGroupsBase
     contents {
       ...RevisionDisplay
     }
   }
-`);
+`
 
-registerFragment(`
+export const localGroupsEdit = `
   fragment localGroupsEdit on Localgroup {
     ...localGroupsBase
     contents {
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const localGroupsIsOnline = `
   fragment localGroupsIsOnline on Localgroup {
     _id
     name
     isOnline
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/lwevents/fragments.ts
+++ b/packages/lesswrong/lib/collections/lwevents/fragments.ts
@@ -1,7 +1,6 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
 import { addGraphQLSchema } from '../../vulcan-lib/graphql';
 
-registerFragment(`
+export const newEventFragment = `
   fragment newEventFragment on LWEvent {
     _id
     createdAt
@@ -11,9 +10,9 @@ registerFragment(`
     properties
     intercom
   }
-`);
+`
 
-registerFragment(`
+export const lastEventFragment = `
   fragment lastEventFragment on LWEvent {
     _id
     createdAt
@@ -24,9 +23,9 @@ registerFragment(`
     properties
     intercom
   }
-`);
+`
 
-registerFragment(`
+export const lwEventsAdminPageFragment = `
   fragment lwEventsAdminPageFragment on LWEvent {
     _id
     createdAt
@@ -40,9 +39,9 @@ registerFragment(`
     properties
     intercom
   }
-`);
+`
 
-registerFragment(`
+export const emailHistoryFragment = `
   fragment emailHistoryFragment on LWEvent {
     _id
     createdAt
@@ -50,7 +49,7 @@ registerFragment(`
     name
     properties
   }
-`);
+`
 
 addGraphQLSchema(`
   type FieldChange {
@@ -72,7 +71,7 @@ export type FieldChangeResult<N extends CollectionNameString> = {
   after: Partial<ObjectsByCollectionName[N]>
 }
 
-registerFragment(`
+export const FieldChangeFragment = `
   fragment FieldChangeFragment on FieldChange {
     _id
     createdAt
@@ -81,4 +80,4 @@ registerFragment(`
     before
     after
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/messages/fragments.ts
+++ b/packages/lesswrong/lib/collections/messages/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const messageListFragment = `
   fragment messageListFragment on Message {
     _id
     user {
@@ -14,4 +12,4 @@ registerFragment(`
     createdAt
     conversationId
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/moderationTemplates/fragments.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ModerationTemplateFragment = `
   fragment ModerationTemplateFragment on ModerationTemplate {
     _id
     name
@@ -11,4 +9,4 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/moderatorActions/fragments.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ModeratorActionDisplay = `
   fragment ModeratorActionDisplay on ModeratorAction {
     _id
     user {
@@ -12,4 +10,4 @@ registerFragment(`
     createdAt
     endedAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/multiDocuments/fragments.ts
+++ b/packages/lesswrong/lib/collections/multiDocuments/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const MultiDocumentMinimumInfo = `
   fragment MultiDocumentMinimumInfo on MultiDocument {
     _id
     parentDocumentId
@@ -27,9 +25,9 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentContentDisplay = `
   fragment MultiDocumentContentDisplay on MultiDocument {
     ...MultiDocumentMinimumInfo
     tableOfContents
@@ -37,9 +35,9 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentEdit = `
   fragment MultiDocumentEdit on MultiDocument {
     ...MultiDocumentContentDisplay
     arbitalLinkedPages {
@@ -49,18 +47,18 @@ registerFragment(`
       ...MultiDocumentContentDisplay
     }
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentParentDocument = `
   fragment MultiDocumentParentDocument on MultiDocument {
     ...MultiDocumentEdit
     parentTag {
       ...TagHistoryFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentWithContributors = `
   fragment MultiDocumentWithContributors on MultiDocument {
     ...MultiDocumentEdit
     contributors {
@@ -73,9 +71,9 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentRevision = `
   fragment MultiDocumentRevision on MultiDocument {
     ...MultiDocumentMinimumInfo
     contents(version: $version) {
@@ -83,9 +81,9 @@ registerFragment(`
     }
     tableOfContents(version: $version)
   }
-`);
+`
 
-registerFragment(`
+export const MultiDocumentWithContributorsRevision = `
   fragment MultiDocumentWithContributorsRevision on MultiDocument {
     ...MultiDocumentRevision
     contributors(version: $version) {
@@ -102,10 +100,10 @@ registerFragment(`
       ...ArbitalLinkedPagesFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const WithVoteMultiDocument = `
   fragment WithVoteMultiDocument on MultiDocument {
     ...MultiDocumentMinimumInfo
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/notifications/fragments.ts
+++ b/packages/lesswrong/lib/collections/notifications/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const NotificationsList = `
   fragment NotificationsList on Notification {
     _id
     documentId
@@ -14,4 +12,4 @@ registerFragment(`
     viewed
     extraData
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/petrovDayActions/fragments.ts
+++ b/packages/lesswrong/lib/collections/petrovDayActions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const PetrovDayActionInfo = `
   fragment PetrovDayActionInfo on PetrovDayAction {
     _id
     createdAt
@@ -8,4 +6,4 @@ registerFragment(`
     actionType
     data
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/petrovDayLaunchs/fragments.ts
+++ b/packages/lesswrong/lib/collections/petrovDayLaunchs/fragments.ts
@@ -1,10 +1,8 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const PetrovDayLaunchInfo = `
   fragment PetrovDayLaunchInfo on PetrovDayLaunch {
     _id
     createdAt
     launchCode
     userId
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/podcastEpisodes/fragments.ts
+++ b/packages/lesswrong/lib/collections/podcastEpisodes/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const PodcastEpisodeFull = `
   fragment PodcastEpisodeFull on PodcastEpisode {
     _id
     podcastId
@@ -8,4 +6,4 @@ registerFragment(`
     episodeLink
     externalEpisodeId
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/podcasts/fragments.ts
+++ b/packages/lesswrong/lib/collections/podcasts/fragments.ts
@@ -1,8 +1,6 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const PodcastSelect = `
   fragment PodcastSelect on Podcast {
     _id
     title
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -1,8 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-
-
-registerFragment(`
+export const PostsMinimumInfo = `
   fragment PostsMinimumInfo on Post {
     _id
     slug
@@ -23,11 +19,11 @@ registerFragment(`
     debate
     collabEditorDialogue
   }
-`);
+`
 
 // ...PostsAuthors
 
-registerFragment(`
+export const PostsTopItemInfo = `
   fragment PostsTopItemInfo on Post {
     ...PostsMinimumInfo
     ...PostsAuthors
@@ -56,9 +52,9 @@ registerFragment(`
     }
     finalReviewVoteScoreHighKarma
   }
-`);
+`
 
-registerFragment(`
+export const PostsBase = `
   fragment PostsBase on Post {
     ...PostsMinimumInfo
     
@@ -181,17 +177,17 @@ registerFragment(`
     
     disableRecommendation
   }
-`);
+`
 
-registerFragment(`
+export const PostsWithVotes = `
   fragment PostsWithVotes on Post {
     ...PostsBase
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
-registerFragment(`
+export const PostsListWithVotes = `
   fragment PostsListWithVotes on Post {
     ...PostsList
     currentUserVote
@@ -209,18 +205,18 @@ registerFragment(`
       externalEpisodeId
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsListWithVotesAndSequence = `
   fragment PostsListWithVotesAndSequence on Post {
     ...PostsListWithVotes
     canonicalSequence {
       ...SequencesPageFragment
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsReviewVotingList = `
   fragment PostsReviewVotingList on Post {
     ...PostsListWithVotes
     reviewVoteScoreAllKarma
@@ -230,9 +226,9 @@ registerFragment(`
     reviewVoteScoreAF
     reviewVotesAF
   }
-`)
+`
 
-registerFragment(`
+export const PostsModerationGuidelines = `
   fragment PostsModerationGuidelines on Post {
     ...PostsMinimumInfo
     frontpageDate
@@ -251,9 +247,9 @@ registerFragment(`
       }
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsAuthors = `
   fragment PostsAuthors on Post {
     user {
       ...UsersMinimumInfo
@@ -268,9 +264,9 @@ registerFragment(`
       ...UsersMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsListBase = `
   fragment PostsListBase on Post {
     ...PostsBase
     ...PostsAuthors
@@ -304,9 +300,9 @@ registerFragment(`
     dialogTooltipPreview
     disableSidenotes
   }
-`);
+`
 
-registerFragment(`
+export const PostsList = `
   fragment PostsList on Post {
     ...PostsListBase
     deletedDraft
@@ -319,36 +315,36 @@ registerFragment(`
     }
     fmCrosspost
   }
-`);
+`
 
-registerFragment(`
+export const SunshineCurationPostsList = `
   fragment SunshineCurationPostsList on Post {
     ...PostsList
     curationNotices {
       ...CurationNoticesFragment
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsListTag = `
   fragment PostsListTag on Post {
     ...PostsList
     tagRel(tagId: $tagId) {
       ...WithVoteTagRel
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsListTagWithVotes = `
   fragment PostsListTagWithVotes on Post {
     ...PostsListWithVotes
     tagRel(tagId: $tagId) {
       ...WithVoteTagRel
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsDetails = `
   fragment PostsDetails on Post {
     ...PostsListBase
 
@@ -449,9 +445,9 @@ registerFragment(`
       ...JargonTermsPost
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsExpandedHighlight = `
   fragment PostsExpandedHighlight on Post {
     _id
     contents {
@@ -459,9 +455,9 @@ registerFragment(`
       html
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsPlaintextDescription = `
   fragment PostsPlaintextDescription on Post {
     _id
     contents {
@@ -469,11 +465,11 @@ registerFragment(`
       plaintextDescription
     }
   }
-`);
+`
 
 // Same as PostsPage, with added just optional arguments to the content field
 // and a list of revisions
-registerFragment(`
+export const PostsRevision = `
   fragment PostsRevision on Post {
     ...PostsDetails
 
@@ -486,9 +482,9 @@ registerFragment(`
       ...RevisionMetadata
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsRevisionEdit = `
   fragment PostsRevisionEdit on Post {
     ...PostsDetails
 
@@ -501,9 +497,9 @@ registerFragment(`
       ...RevisionMetadata
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsWithNavigationAndRevision = `
   fragment PostsWithNavigationAndRevision on Post {
     ...PostsRevision
     ...PostSequenceNavigation
@@ -516,9 +512,9 @@ registerFragment(`
       ...ReviewWinnerAll
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsWithNavigation = `
   fragment PostsWithNavigation on Post {
     ...PostsPage
     ...PostSequenceNavigation
@@ -528,10 +524,10 @@ registerFragment(`
       ...ReviewWinnerAll
     }
   }
-`)
+`
 
 // This is a union of the fields needed by PostsTopNavigation and BottomNavigation.
-registerFragment(`
+export const PostSequenceNavigation = `
   fragment PostSequenceNavigation on Post {
     # Prev/next sequence navigation
     sequence(sequenceId: $sequenceId) {
@@ -550,9 +546,9 @@ registerFragment(`
       }
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsPage = `
   fragment PostsPage on Post {
     ...PostsDetails
     version
@@ -564,9 +560,9 @@ registerFragment(`
     }
     myEditorAccess
   }
-`)
+`
 
-registerFragment(`
+export const PostsEdit = `
   fragment PostsEdit on Post {
     ...PostsDetails
     ...PostSideComments
@@ -603,53 +599,53 @@ registerFragment(`
     }
     generateDraftJargon
   }
-`);
+`
 
-registerFragment(`
+export const PostsEditQueryFragment = `
   fragment PostsEditQueryFragment on Post {
     ...PostsEdit
     contents(version: $version) {
       ...RevisionEdit
     }
   }
-`);
-registerFragment(`
+`
+export const PostsEditMutationFragment = `
   fragment PostsEditMutationFragment on Post {
     ...PostsEdit
     contents {
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsRevisionsList = `
   fragment PostsRevisionsList on Post {
     _id
     revisions {
       ...RevisionMetadata
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsRecentDiscussion = `
   fragment PostsRecentDiscussion on Post {
     ...PostsListWithVotes
     recentComments(commentsLimit: $commentsLimit, maxAgeHours: $maxAgeHours, af: $af) {
       ...CommentsList
     }
   }
-`);
+`
 
-registerFragment(`
+export const ShortformRecentDiscussion = `
   fragment ShortformRecentDiscussion on Post {
     ...PostsListWithVotes
     recentComments(commentsLimit: $commentsLimit, maxAgeHours: $maxAgeHours, af: $af) {
       ...CommentsListWithTopLevelComment
     }
   }
-`);
+`
 
-registerFragment(`
+export const UsersBannedFromPostsModerationLog = `
   fragment UsersBannedFromPostsModerationLog on Post {
     user {
       ...UsersMinimumInfo
@@ -659,9 +655,9 @@ registerFragment(`
     _id
     bannedUserIds
   }
-`)
+`
 
-registerFragment(`
+export const SunshinePostsList = `
   fragment SunshinePostsList on Post {
     ...PostsListBase
 
@@ -707,9 +703,9 @@ registerFragment(`
       }
     }
   }
-`)
+`
 
-registerFragment(`
+export const WithVotePost = `
   fragment WithVotePost on Post {
     __typename
     _id
@@ -722,9 +718,9 @@ registerFragment(`
     afExtendedScore
     voteCount
   }
-`);
+`
 
-registerFragment(`
+export const HighlightWithHash = `
   fragment HighlightWithHash on Post {
     _id
     contents {
@@ -732,14 +728,14 @@ registerFragment(`
       htmlHighlightStartingAtHash(hash: $hash)
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostWithDialogueMessage = `
   fragment PostWithDialogueMessage on Post {
     _id
     dialogueMessageContents(dialogueMessageId: $dialogueMessageId)
   }
-`);
+`
 
 /**
  * Note that the side comments cache isn't actually used by the client. We
@@ -756,7 +752,7 @@ registerFragment(`
  * isn't the end of the word, but it is a _big_ field that we don't want to
  * waste bandwidth on).
  */
-registerFragment(`
+export const PostSideComments = `
   fragment PostSideComments on Post {
     _id
     sideComments
@@ -764,16 +760,16 @@ registerFragment(`
       ...SideCommentCacheMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostWithGeneratedSummary = `
   fragment PostWithGeneratedSummary on Post {
     _id
     languageModelSummary
   }
-`);
+`
 
-registerFragment(`
+export const PostsBestOfList = `
   fragment PostsBestOfList on Post {
     ...PostsListWithVotes
     podcastEpisode {
@@ -795,9 +791,9 @@ registerFragment(`
     }
     firstVideoAttribsForPreview
   }
-`);
+`
 
-registerFragment(`
+export const PostsRSSFeed = `
   fragment PostsRSSFeed on Post {
     ...PostsPage
     scoreExceeded2Date
@@ -808,9 +804,9 @@ registerFragment(`
     scoreExceeded200Date
     metaDate
   }
-`);
+`
 
-registerFragment(`
+export const PostsOriginalContents = `
   fragment PostsOriginalContents on Post {
     _id
     contents {
@@ -821,18 +817,18 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsHTML = `
   fragment PostsHTML on Post {
     _id
     contents {
       ...RevisionHTML
     }
   }
-`);
+`
 
-registerFragment(`
+export const PostsForAutocomplete = `
   fragment PostsForAutocomplete on Post {
     _id
     title
@@ -846,9 +842,9 @@ registerFragment(`
       markdown
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostForReviewWinnerItem = `
   fragment PostForReviewWinnerItem on Post {
     _id
     spotlight {
@@ -859,9 +855,9 @@ registerFragment(`
       category
     }
   }
-`)
+`
 
-registerFragment(`
+export const PostsTwitterAdmin = `
   fragment PostsTwitterAdmin on Post {
     ...PostsListWithVotes
     user {
@@ -871,4 +867,4 @@ registerFragment(`
       ...UsersSocialMediaInfo
     }
   }
-`)
+`

--- a/packages/lesswrong/lib/collections/reports/fragments.ts
+++ b/packages/lesswrong/lib/collections/reports/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UnclaimedReportsList = `
   fragment UnclaimedReportsList on Report {
     _id
     userId
@@ -38,4 +36,4 @@ registerFragment(`
     reportedAsSpam
     markedAsSpam
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/reviewVotes/fragments.ts
+++ b/packages/lesswrong/lib/collections/reviewVotes/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const reviewVoteFragment = `
   fragment reviewVoteFragment on ReviewVote {
     _id
     createdAt
@@ -13,10 +11,10 @@ registerFragment(`
     dummy
     reactions
   }
-`)
+`
 
 
-registerFragment(`
+export const reviewVoteWithUserAndPost = `
   fragment reviewVoteWithUserAndPost on ReviewVote {
     ...reviewVoteFragment
     user {
@@ -28,9 +26,9 @@ registerFragment(`
       ...PostsMinimumInfo
     }
   }
-`)
+`
 
-registerFragment(`
+export const reviewAdminDashboard = `
   fragment reviewAdminDashboard on ReviewVote {
     _id
     createdAt
@@ -41,6 +39,6 @@ registerFragment(`
       karma
     }
   }
-`)
+`
 
 

--- a/packages/lesswrong/lib/collections/reviewWinnerArts/fragments.ts
+++ b/packages/lesswrong/lib/collections/reviewWinnerArts/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ReviewWinnerArtImages = `
   fragment ReviewWinnerArtImages on ReviewWinnerArt {
     _id
     postId
@@ -10,4 +8,4 @@ registerFragment(`
       ...SplashArtCoordinates
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/reviewWinners/fragments.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const ReviewWinnerEditDisplay = `
   fragment ReviewWinnerEditDisplay on ReviewWinner {
     _id
     postId
@@ -8,9 +6,9 @@ registerFragment(`
     curatedOrder
     reviewRanking
   }
-`);
+`
 
-registerFragment(`
+export const ReviewWinnerTopPostsDisplay = `
   fragment ReviewWinnerTopPostsDisplay on ReviewWinner {
     _id
     postId
@@ -21,9 +19,9 @@ registerFragment(`
     curatedOrder
     reviewRanking
   }
-`);
+`
 
-registerFragment(`
+export const ReviewWinnerAll = `
   fragment ReviewWinnerAll on ReviewWinner {
     _id
     category
@@ -36,9 +34,9 @@ registerFragment(`
     }
     competitorCount
   }
-`);
+`
 
-registerFragment(`
+export const ReviewWinnerTopPostsPage = `
   fragment ReviewWinnerTopPostsPage on ReviewWinner {
     _id
     category
@@ -52,4 +50,4 @@ registerFragment(`
       }
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/revisions/fragments.ts
+++ b/packages/lesswrong/lib/collections/revisions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const RevisionDisplay = `
   fragment RevisionDisplay on Revision {
     _id
     version
@@ -13,16 +11,16 @@ registerFragment(`
     htmlHighlight
     plaintextDescription
   }
-`)
+`
 
-registerFragment(`
+export const RevisionHTML = `
   fragment RevisionHTML on Revision {
     _id
     html
   }
-`)
+`
 
-registerFragment(`
+export const RevisionEdit = `
   fragment RevisionEdit on Revision {
     _id
     version
@@ -41,9 +39,9 @@ registerFragment(`
     htmlHighlight
     plaintextDescription
   }
-`)
+`
 
-registerFragment(`
+export const RevisionMetadata = `
   fragment RevisionMetadata on Revision {
     _id
     version
@@ -58,9 +56,9 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
-registerFragment(`
+export const RevisionMetadataWithChangeMetrics = `
   fragment RevisionMetadataWithChangeMetrics on Revision {
     ...RevisionMetadata
     changeMetrics
@@ -68,9 +66,9 @@ registerFragment(`
       ...UsersMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const RevisionHistoryEntry = `
   fragment RevisionHistoryEntry on Revision {
     ...RevisionMetadata
     documentId
@@ -82,9 +80,9 @@ registerFragment(`
       ...UsersMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const RevisionHistorySummaryEdit = `
   fragment RevisionHistorySummaryEdit on Revision {
     ...RevisionHistoryEntry
     summary {
@@ -101,9 +99,9 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const RevisionTagFragment = `
   fragment RevisionTagFragment on Revision {
     ...RevisionHistoryEntry
     tag {
@@ -113,18 +111,18 @@ registerFragment(`
       ...MultiDocumentParentDocument
     }
   }
-`);
+`
 
-registerFragment(`
+export const RecentDiscussionRevisionTagFragment = `
   fragment RecentDiscussionRevisionTagFragment on Revision {
     ...RevisionHistoryEntry
     tag {
       ...TagRecentDiscussion
     }
   }
-`);
+`
 
-registerFragment(`
+export const WithVoteRevision = `
   fragment WithVoteRevision on Revision {
     __typename
     _id
@@ -135,4 +133,4 @@ registerFragment(`
     score
     voteCount
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/rssfeeds/fragments.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const RSSFeedMinimumInfo = `
   fragment RSSFeedMinimumInfo on RSSFeed {
     _id
     userId
@@ -14,9 +12,9 @@ registerFragment(`
     url
     importAsDraft
   }
-`);
+`
 
-registerFragment(`
+export const newRSSFeedFragment = `
   fragment newRSSFeedFragment on RSSFeed {
     _id
     userId
@@ -28,11 +26,11 @@ registerFragment(`
     status
     importAsDraft
   }
-`);
+`
 
 
 
-registerFragment(`
+export const RSSFeedMutationFragment = `
   fragment RSSFeedMutationFragment on RSSFeed {
     _id
     userId
@@ -42,4 +40,4 @@ registerFragment(`
     url
     importAsDraft
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SequencesPageTitleFragment = `
   fragment SequencesPageTitleFragment on Sequence {
     _id
     title
@@ -10,9 +8,9 @@ registerFragment(`
       title
     }
   }
-`);
+`
 
-registerFragment(`
+export const SequencesPageFragment = `
   fragment SequencesPageFragment on Sequence {
     ...SequencesPageTitleFragment
     createdAt
@@ -37,31 +35,31 @@ registerFragment(`
     postsCount
     readPostsCount
   }
-`);
+`
 
-registerFragment(`
+export const SequenceContinueReadingFragment = `
   fragment SequenceContinueReadingFragment on Sequence {
     _id
     title
     gridImageId
     canonicalCollectionSlug
   }
-`);
+`
 
-registerFragment(`
+export const SequencesPageWithChaptersFragment = `
   fragment SequencesPageWithChaptersFragment on Sequence {
     ...SequencesPageFragment
     chapters {
       ...ChaptersFragment
     }
   }
-`)
+`
 
-registerFragment(`
+export const SequencesEdit = `
   fragment SequencesEdit on Sequence {
     ...SequencesPageFragment
     contents { 
       ...RevisionEdit
     }
   }
-`)
+`

--- a/packages/lesswrong/lib/collections/sideCommentCaches/fragments.ts
+++ b/packages/lesswrong/lib/collections/sideCommentCaches/fragments.ts
@@ -1,11 +1,9 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
 // The raw side comment cache objects are not actually visible to the client
 // and are only used internally to generate the user facing `sideComments`
 // field on the posts object. This fragment is used by the SQL fragments
 // compiler to fetch the necessary fields for the resolver on the posts
 // collection.
-registerFragment(`
+export const SideCommentCacheMinimumInfo = `
   fragment SideCommentCacheMinimumInfo on SideCommentCache {
     _id
     postId
@@ -14,4 +12,4 @@ registerFragment(`
     version
     createdAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/splashArtCoordinates/fragments.ts
+++ b/packages/lesswrong/lib/collections/splashArtCoordinates/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SplashArtCoordinates = `
   fragment SplashArtCoordinates on SplashArtCoordinate {
     _id
     reviewWinnerArtId
@@ -20,4 +18,4 @@ registerFragment(`
     rightWidthPct
     rightFlipped
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/spotlights/fragments.ts
+++ b/packages/lesswrong/lib/collections/spotlights/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SpotlightMinimumInfo = `
   fragment SpotlightMinimumInfo on Spotlight {
     _id
     documentId
@@ -23,9 +21,9 @@ registerFragment(`
     imageFade
     imageFadeColor
   }
-`)
+`
 
-registerFragment(`
+export const SpotlightReviewWinner = `
   fragment SpotlightReviewWinner on Spotlight {
     ...SpotlightMinimumInfo
     description {
@@ -35,9 +33,9 @@ registerFragment(`
       ...ChaptersFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const SpotlightHeaderEventSubtitle = `
   fragment SpotlightHeaderEventSubtitle on Spotlight {
     ...SpotlightMinimumInfo
     post {
@@ -52,8 +50,8 @@ registerFragment(`
       slug
     }
   }
-`);
-registerFragment(`
+`
+export const SpotlightDisplay = `
   fragment SpotlightDisplay on Spotlight {
     ...SpotlightMinimumInfo
     post {
@@ -95,14 +93,14 @@ registerFragment(`
       html
     }
   }
-`);
+`
 
 
-registerFragment(`
+export const SpotlightEditQueryFragment = `
   fragment SpotlightEditQueryFragment on Spotlight {
     ...SpotlightMinimumInfo
     description {
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/subscriptions/fragments.ts
+++ b/packages/lesswrong/lib/collections/subscriptions/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const SubscriptionState = `
   fragment SubscriptionState on Subscription {
     _id
     userId
@@ -11,12 +9,12 @@ registerFragment(`
     deleted
     type
   }
-`);
+`
 
-registerFragment(`
+export const MembersOfGroupFragment = `
   fragment MembersOfGroupFragment on Subscription {
     user {
       ...UsersMinimumInfo
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/surveyQuestions/fragments.ts
+++ b/packages/lesswrong/lib/collections/surveyQuestions/fragments.ts
@@ -1,10 +1,8 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const SurveyQuestionMinimumInfo = `
   fragment SurveyQuestionMinimumInfo on SurveyQuestion {
     _id
     question
     format
     order
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/surveyResponses/fragments.ts
+++ b/packages/lesswrong/lib/collections/surveyResponses/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const SurveyResponseMinimumInfo = `
   fragment SurveyResponseMinimumInfo on SurveyResponse {
     _id
     surveyId
@@ -9,4 +7,4 @@ registerFragment(`
     clientId
     response
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/surveySchedules/fragments.ts
+++ b/packages/lesswrong/lib/collections/surveySchedules/fragments.ts
@@ -1,15 +1,13 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const SurveyScheduleMinimumInfo = `
   fragment SurveyScheduleMinimumInfo on SurveySchedule {
     _id
     survey {
       ...SurveyMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const SurveyScheduleEdit = `
   fragment SurveyScheduleEdit on SurveySchedule {
     ...SurveyScheduleMinimumInfo
     surveyId
@@ -24,4 +22,4 @@ registerFragment(`
     deactivated
     createdAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/surveys/fragments.ts
+++ b/packages/lesswrong/lib/collections/surveys/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
-registerFragment(`
+export const SurveyMinimumInfo = `
   fragment SurveyMinimumInfo on Survey {
     _id
     name
@@ -9,4 +7,4 @@ registerFragment(`
     }
     createdAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/tagFlags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const TagFlagFragment = `
   fragment TagFlagFragment on TagFlag {
     _id
     createdAt
@@ -14,13 +12,13 @@ registerFragment(`
       plaintextDescription
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagFlagEditFragment = `
   fragment TagFlagEditFragment on TagFlag {
     ...TagFlagFragment
     contents {
       ...RevisionEdit
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/tagRels/fragments.ts
+++ b/packages/lesswrong/lib/collections/tagRels/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const TagRelBasicInfo = `
   fragment TagRelBasicInfo on TagRel {
     _id
     score
@@ -12,10 +10,10 @@ registerFragment(`
     postId
     autoApplied
   }
-`);
+`
 
 
-registerFragment(`
+export const TagRelFragment = `
   fragment TagRelFragment on TagRel {
     ...TagRelBasicInfo
     tag {
@@ -28,9 +26,9 @@ registerFragment(`
     currentUserExtendedVote
     currentUserCanVote
   }
-`);
+`
 
-registerFragment(`
+export const TagRelHistoryFragment = `
   fragment TagRelHistoryFragment on TagRel {
     ...TagRelBasicInfo
     createdAt
@@ -41,9 +39,9 @@ registerFragment(`
       ...PostsList
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagRelCreationFragment = `
   fragment TagRelCreationFragment on TagRel {
     ...TagRelBasicInfo
     tag {
@@ -59,9 +57,9 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
-registerFragment(`
+export const TagRelMinimumFragment = `
   fragment TagRelMinimumFragment on TagRel {
     ...TagRelBasicInfo
     tag {
@@ -71,11 +69,11 @@ registerFragment(`
     currentUserExtendedVote
     currentUserCanVote
   }
-`);
+`
 
 
 // This fragment has to be fully dereferences, because the context of vote fragments doesn't allow for spreading other fragments
-registerFragment(`
+export const WithVoteTagRel = `
   fragment WithVoteTagRel on TagRel {
     __typename
     _id
@@ -87,4 +85,4 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const TagBasicInfo = `
   fragment TagBasicInfo on Tag {
     _id
     userId
@@ -31,9 +29,9 @@ registerFragment(`
     currentUserVote
     currentUserExtendedVote
   }
-`);
+`
 
-registerFragment(`
+export const TagDetailsFragment = `
   fragment TagDetailsFragment on Tag {
     ...TagBasicInfo
     subtitle
@@ -58,9 +56,9 @@ registerFragment(`
       ...SequencesPageFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagFragment = `
   fragment TagFragment on Tag {
     ...TagDetailsFragment
     parentTag {
@@ -79,9 +77,9 @@ registerFragment(`
     }
     canVoteOnRels
   }
-`);
+`
 
-registerFragment(`
+export const TagHistoryFragment = `
   fragment TagHistoryFragment on Tag {
     ...TagFragment
     tableOfContents
@@ -92,9 +90,9 @@ registerFragment(`
       ...MultiDocumentContentDisplay
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagCreationHistoryFragment = `
   fragment TagCreationHistoryFragment on Tag {
     ...TagFragment
     user {
@@ -104,9 +102,9 @@ registerFragment(`
       html
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagRevisionFragment = `
   fragment TagRevisionFragment on Tag {
     ...TagDetailsFragment
     parentTag {
@@ -129,9 +127,9 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagPreviewFragment = `
   fragment TagPreviewFragment on Tag {
     ...TagBasicInfo
     isRead
@@ -148,9 +146,9 @@ registerFragment(`
     canVoteOnRels
     isArbitalImport
   }
-`);
+`
 
-registerFragment(`
+export const TagSectionPreviewFragment = `
   fragment TagSectionPreviewFragment on Tag {
     ...TagBasicInfo
     isRead
@@ -166,9 +164,9 @@ registerFragment(`
     }
     canVoteOnRels
   }
-`);
+`
 
-registerFragment(`
+export const TagSubforumFragment = `
   fragment TagSubforumFragment on Tag {
     ...TagPreviewFragment
     subforumModeratorIds
@@ -178,10 +176,10 @@ registerFragment(`
       html
     }
   }
-`);
+`
 
 // TODO: would prefer to fetch subtags in fewer places
-registerFragment(`
+export const TagSubtagFragment = `
   fragment TagSubtagFragment on Tag {
     _id
     subforumModeratorIds
@@ -189,15 +187,15 @@ registerFragment(`
       ...TagPreviewFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagSubforumSidebarFragment = `
   fragment TagSubforumSidebarFragment on Tag {
     ...TagBasicInfo
   }
-`);
+`
 
-registerFragment(`
+export const TagDetailedPreviewFragment = `
   fragment TagDetailedPreviewFragment on Tag {
     ...TagDetailsFragment
     description {
@@ -205,9 +203,9 @@ registerFragment(`
       htmlHighlight
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagWithFlagsFragment = `
   fragment TagWithFlagsFragment on Tag {
     ...TagFragment
     tagFlagsIds
@@ -215,9 +213,9 @@ registerFragment(`
       ...TagFlagFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagWithFlagsAndRevisionFragment = `
   fragment TagWithFlagsAndRevisionFragment on Tag {
     ...TagRevisionFragment
     tagFlagsIds
@@ -225,10 +223,10 @@ registerFragment(`
       ...TagFlagFragment
     }
   }
-`);
+`
 
 // This matches custom graphql type in arbitalLinkedPagesField.ts that's a resolver field on Tags and MultiDocuments
-registerFragment(`
+export const ArbitalLinkedPagesFragment = `
   fragment ArbitalLinkedPagesFragment on ArbitalLinkedPages {
     faster {
       _id
@@ -271,9 +269,9 @@ registerFragment(`
       slug
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagPageArbitalContentFragment = `
   fragment TagPageArbitalContentFragment on Tag {
     lenses {
       ...MultiDocumentWithContributors
@@ -282,9 +280,9 @@ registerFragment(`
       ...ArbitalLinkedPagesFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagPageFragment = `
   fragment TagPageFragment on Tag {
     ...TagWithFlagsFragment
     tableOfContents
@@ -310,23 +308,23 @@ registerFragment(`
     }
     canVoteOnRels
   }
-`);
+`
 
-registerFragment(`
+export const TagPageWithArbitalContentFragment = `
   fragment TagPageWithArbitalContentFragment on Tag {
     ...TagPageFragment
     ...TagPageArbitalContentFragment
   }  
-`);
+`
 
-registerFragment(`
+export const AllTagsPageFragment = `
   fragment AllTagsPageFragment on Tag {
     ...TagWithFlagsFragment
     tableOfContents
   }
-`);
+`
 
-registerFragment(`
+export const TagPageWithRevisionFragment = `
   fragment TagPageWithRevisionFragment on Tag {
     ...TagWithFlagsAndRevisionFragment
     tableOfContents(version: $version)
@@ -352,16 +350,16 @@ registerFragment(`
     }
     canVoteOnRels
   }
-`);
+`
 
-registerFragment(`
+export const TagPageRevisionWithArbitalContentFragment = `
   fragment TagPageRevisionWithArbitalContentFragment on Tag {
     ...TagPageWithRevisionFragment
     ...TagPageArbitalContentFragment
   }  
-`);
+`
 
-registerFragment(`
+export const TagFullContributorsList = `
   fragment TagFullContributorsList on Tag {
     contributors {
       totalCount
@@ -376,9 +374,9 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagEditFragment = `
   fragment TagEditFragment on Tag {
     ...TagDetailsFragment
     isPostType
@@ -404,9 +402,9 @@ registerFragment(`
       ...RevisionEdit
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagRecentDiscussion = `
   fragment TagRecentDiscussion on Tag {
     ...TagFragment
     lastVisitedAt
@@ -414,18 +412,18 @@ registerFragment(`
       ...CommentsList
     }
   }
-`);
+`
 
-registerFragment(`
+export const SunshineTagFragment = `
   fragment SunshineTagFragment on Tag {
     ...TagFragment
     user {
       ...UsersMinimumInfo
     }
   }
-`);
+`
 
-registerFragment(`
+export const UserOnboardingTag = `
   fragment UserOnboardingTag on Tag {
     _id
     name
@@ -433,17 +431,17 @@ registerFragment(`
     bannerImageId
     squareImageId
   }
-`);
+`
 
-registerFragment(`
+export const TagName = `
   fragment TagName on Tag {
     _id
     name
     slug
   }
-`);
+`
 
-registerFragment(`
+export const ExplorePageTagFragment = `
   fragment ExplorePageTagFragment on Tag {
     ...TagFragment
     contributors(limit: $contributorsLimit) {
@@ -460,9 +458,9 @@ registerFragment(`
     }
     legacyData
   }
-`);
+`
 
-registerFragment(`
+export const ConceptItemFragment = `
   fragment ConceptItemFragment on Tag {
     _id
     core
@@ -484,9 +482,9 @@ registerFragment(`
       displayName
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagPageWithArbitalContentAndLensRevisionFragment = `
   fragment TagPageWithArbitalContentAndLensRevisionFragment on Tag {
     ...TagPageFragment
     arbitalLinkedPages {
@@ -496,10 +494,10 @@ registerFragment(`
       ...MultiDocumentWithContributorsRevision
     }
   }
-`);
+`
 
-registerFragment(`
+export const WithVoteTag = `
   fragment WithVoteTag on Tag {
     ...TagBasicInfo
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/typingIndicators/fragments.ts
+++ b/packages/lesswrong/lib/collections/typingIndicators/fragments.ts
@@ -1,10 +1,8 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const TypingIndicatorInfo = `
   fragment TypingIndicatorInfo on TypingIndicator {
     _id
     userId
     documentId
     lastUpdated
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/userEAGDetails/fragments.ts
+++ b/packages/lesswrong/lib/collections/userEAGDetails/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UserEAGDetailsMinimumInfo = `
   fragment UserEAGDetailsMinimumInfo on UserEAGDetail {
     _id
     userId
@@ -13,4 +11,4 @@ registerFragment(`
     experiencedIn
     interestedIn
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/userJobAds/fragments.ts
+++ b/packages/lesswrong/lib/collections/userJobAds/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UserJobAdsMinimumInfo = `
   fragment UserJobAdsMinimumInfo on UserJobAd {
     _id
     userId
@@ -10,4 +8,4 @@ registerFragment(`
     adState
     reminderSetAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/userMostValuablePosts/fragments.ts
+++ b/packages/lesswrong/lib/collections/userMostValuablePosts/fragments.ts
@@ -1,10 +1,8 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UserMostValuablePostInfo = `
   fragment UserMostValuablePostInfo on UserMostValuablePost {
     _id
     userId
     postId
     deleted
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/userRateLimits/fragments.ts
+++ b/packages/lesswrong/lib/collections/userRateLimits/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UserRateLimitDisplay = `
   fragment UserRateLimitDisplay on UserRateLimit {
     _id
     user {
@@ -14,4 +12,4 @@ registerFragment(`
     createdAt
     endedAt
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/userTagRels/fragments.ts
+++ b/packages/lesswrong/lib/collections/userTagRels/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "../../vulcan-lib/fragments";
-
-registerFragment(`
+export const UserTagRelDetails = `
   fragment UserTagRelDetails on UserTagRel {
     _id
     userId
@@ -9,4 +7,4 @@ registerFragment(`
     subforumEmailNotifications
     subforumHideIntroPost
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-registerFragment(`
+export const UsersMinimumInfo = `
   fragment UsersMinimumInfo on User {
     _id
     slug
@@ -26,9 +24,9 @@ registerFragment(`
     tagRevisionCount
     reviewedByUserId
   }
-`);
+`
 
-registerFragment(`
+export const UsersProfile = `
   fragment UsersProfile on User {
     ...UsersMinimumInfo
     oldSlugs
@@ -97,9 +95,9 @@ registerFragment(`
     commentingOnOtherUsersDisabled
     conversationsDisabled
   }
-`);
+`
 
-registerFragment(`
+export const UsersCurrent = `
   fragment UsersCurrent on User {
     ...UsersProfile
 
@@ -225,7 +223,7 @@ registerFragment(`
     generateJargonForDrafts
     generateJargonForPublishedPosts
   }
-`);
+`
 
 /**
  * Fragment containing rate-limit information (ie, whether the user is rate limited and when
@@ -233,30 +231,30 @@ registerFragment(`
  * involve some DB queries that we don't want to have to finish in serial before the rest of the
  * page can start loading.
  */
-registerFragment(`
+export const UsersCurrentCommentRateLimit = `
   fragment UsersCurrentCommentRateLimit on User {
     _id
     rateLimitNextAbleToComment(postId: $postId)
   }
-`);
+`
 
-registerFragment(`
+export const UsersCurrentPostRateLimit = `
   fragment UsersCurrentPostRateLimit on User {
     _id
     rateLimitNextAbleToPost(eventForm: $eventForm)
   }
-`);
+`
 
-registerFragment(`
+export const UserBookmarkedPosts = `
   fragment UserBookmarkedPosts on User {
     _id
     bookmarkedPosts {
       ...PostsList
     }
   }
-`);
+`
 
-registerFragment(`
+export const UserKarmaChanges = `
   fragment UserKarmaChanges on User {
     _id
     karmaChanges {
@@ -394,9 +392,9 @@ registerFragment(`
       }
     }
   }
-`);
+`
 
-registerFragment(`
+export const UsersBannedFromUsersModerationLog = `
   fragment UsersBannedFromUsersModerationLog on User {
     _id
     slug
@@ -404,9 +402,9 @@ registerFragment(`
     bannedUserIds
     bannedPersonalUserIds
   }
-`)
+`
 
-registerFragment(`
+export const SunshineUsersList = `
   fragment SunshineUsersList on User {
     ...UsersMinimumInfo
     karma
@@ -461,16 +459,16 @@ registerFragment(`
     recentKarmaInfo
     lastNotificationsCheck
   }
-`);
+`
 
-registerFragment(`
+export const UserAltAccountsFragment = `
   fragment UserAltAccountsFragment on User {
     ...SunshineUsersList
     IPs
   }
-`);
+`
 
-registerFragment(`
+export const SharedUserBooleans = `
   fragment SharedUserBooleans on User {
     walledGardenInvite
     hideWalledGardenUI
@@ -478,11 +476,11 @@ registerFragment(`
     taggingDashboardCollapsed
     usernameUnset
   }
-`)
+`
 
 // Fragment used for the map markers on /community. This is a much-larger-than-
 // usual number of users, so keep this fragment minimal.
-registerFragment(`
+export const UsersMapEntry = `
   fragment UsersMapEntry on User {
     _id
     displayName
@@ -496,10 +494,10 @@ registerFragment(`
     mapLocationSet
     htmlMapMarkerText
   }
-`);
+`
 
 
-registerFragment(`
+export const UsersEdit = `
   fragment UsersEdit on User {
     ...UsersCurrent
     biography {
@@ -609,9 +607,9 @@ registerFragment(`
 
     twitterProfileURLAdmin
   }
-`)
+`
 
-registerFragment(`
+export const UsersAdmin = `
   fragment UsersAdmin on User {
     _id
     username
@@ -624,17 +622,17 @@ registerFragment(`
     services
     karma
   }
-`);
+`
 
-registerFragment(`
+export const UsersWithReviewInfo = `
   fragment UsersWithReviewInfo on User {
     ...UsersMinimumInfo
     reviewVoteCount
     email
   }
-`)
+`
 
-registerFragment(`
+export const UsersProfileEdit = `
   fragment UsersProfileEdit on User {
     _id
     slug
@@ -666,25 +664,25 @@ registerFragment(`
     twitterProfileURL
     githubProfileURL
   }
-`)
+`
 
-registerFragment(`
+export const UsersCrosspostInfo = `
   fragment UsersCrosspostInfo on User {
     _id
     username
     slug
     fmCrosspostUserId
   }
-`)
+`
 
-registerFragment(`
+export const UsersOptedInToDialogueFacilitation = `
   fragment UsersOptedInToDialogueFacilitation on User {
     _id
     displayName
   }
-`);
+`
 
-registerFragment(`
+export const UserOnboardingAuthor = `
   fragment UserOnboardingAuthor on User {
     _id
     displayName
@@ -693,11 +691,11 @@ registerFragment(`
     jobTitle
     organization
   }
-`);
+`
 
-registerFragment(`
+export const UsersSocialMediaInfo = `
   fragment UsersSocialMediaInfo on User {
     ...UsersProfile
     twitterProfileURLAdmin
   }
-`);
+`

--- a/packages/lesswrong/lib/collections/votes/fragments.ts
+++ b/packages/lesswrong/lib/collections/votes/fragments.ts
@@ -1,7 +1,4 @@
-import { registerFragment } from '../../vulcan-lib/fragments';
-
-
-registerFragment(`
+export const TagRelVotes = `
   fragment TagRelVotes on Vote {
     _id
     userId
@@ -14,18 +11,18 @@ registerFragment(`
       ...WithVoteTagRel
     }
   }
-`);
+`
 
-registerFragment(`
+export const TagVotingActivity = `
   fragment TagVotingActivity on Vote {
     ...TagRelVotes
     tagRel {
       ...TagRelFragment
     }
   }
-`)
+`
 
-registerFragment(`
+export const UserVotes = `
   fragment UserVotes on Vote {
     _id
     userId
@@ -37,9 +34,9 @@ registerFragment(`
     isUnvote
     collectionName
   }
-`);
+`
 
-registerFragment(`
+export const UserVotesWithDocument = `
   fragment UserVotesWithDocument on Vote {
     ...UserVotes
     comment {
@@ -49,4 +46,4 @@ registerFragment(`
       ...PostsListWithVotes
     }
   }
-`);
+`

--- a/packages/lesswrong/lib/crud/withUpdate.tsx
+++ b/packages/lesswrong/lib/crud/withUpdate.tsx
@@ -82,22 +82,25 @@ export const useUpdate = <CollectionName extends CollectionNameString, F extends
     optimisticResponse?: FragmentTypes[F],
     extraVariables?: any,
   }) => {
-
-    const optimisticMutationResponse = {
-      [`update${typeName}`]: {
-        __typename: `update${typeName}`,
-        data: {
-          __typename: typeName,
-          ...optimisticResponse,  
+    const optimisticMutationResponse = optimisticResponse
+      ? {
+        optimisticResponse: {
+          [`update${typeName}`]: {
+            __typename: `update${typeName}`,
+            data: {
+              __typename: typeName,
+              ...optimisticResponse,  
+            }
+          }
         }
       }
-    };
+      : {};
 
     return mutate({
       variables: { selector, data, ...extraVariables },
       update: options.skipCacheUpdate ? undefined : updateCacheAfterUpdate(typeName),
-      optimisticResponse: optimisticMutationResponse
-    })
+      ...optimisticMutationResponse
+    });
   }, [mutate, typeName, options.skipCacheUpdate]);
   return {mutate: wrappedMutate, loading, error, called, data};
 }

--- a/packages/lesswrong/lib/fragments/allFragments.ts
+++ b/packages/lesswrong/lib/fragments/allFragments.ts
@@ -1,0 +1,186 @@
+// Alignment Forum imports
+import * as alignmentCommentsFragments from '../alignment-forum/comments/fragments';
+import * as alignmentPostsFragments from '../alignment-forum/posts/fragments';
+import * as alignmentUsersFragments from '../alignment-forum/users/fragments';
+
+// Collection imports
+import * as advisorRequestsFragments from '../collections/advisorRequests/fragments';
+import * as bansFragments from '../collections/bans/fragments';
+import * as booksFragments from '../collections/books/fragments';
+import * as chaptersFragments from '../collections/chapters/fragments';
+import * as ckEditorUserSessionsFragments from '../collections/ckEditorUserSessions/fragments';
+import * as clientIdsFragments from '../collections/clientIds/fragments';
+import * as collectionsFragments from '../collections/collections/fragments';
+import * as commentModeratorActionsFragments from '../collections/commentModeratorActions/fragments';
+import * as commentsFragments from '../collections/comments/fragments';
+import * as conversationsFragments from '../collections/conversations/fragments';
+import * as curationNoticesFragments from '../collections/curationNotices/fragments';
+import * as dialogueChecksFragments from '../collections/dialogueChecks/fragments';
+import * as dialogueMatchPreferencesFragments from '../collections/dialogueMatchPreferences/fragments';
+import * as digestPostsFragments from '../collections/digestPosts/fragments';
+import * as digestsFragments from '../collections/digests/fragments';
+import * as electionCandidatesFragments from '../collections/electionCandidates/fragments';
+import * as electionVotesFragments from '../collections/electionVotes/fragments';
+import * as elicitQuestionsFragments from '../collections/elicitQuestions/fragments';
+import * as featuredResourcesFragments from '../collections/featuredResources/fragments';
+import * as forumEventsFragments from '../collections/forumEvents/fragments';
+import * as gardencodesFragments from '../collections/gardencodes/fragments';
+import * as googleServiceAccountSessionsFragments from '../collections/googleServiceAccountSessions/fragments';
+import * as jargonTermsFragments from '../collections/jargonTerms/fragments';
+import * as llmConversationsFragments from '../collections/llmConversations/fragments';
+import * as llmMessagesFragments from '../collections/llmMessages/fragments';
+import * as localgroupsFragments from '../collections/localgroups/fragments';
+import * as lweventsFragments from '../collections/lwevents/fragments';
+import * as messagesFragments from '../collections/messages/fragments';
+import * as moderationTemplatesFragments from '../collections/moderationTemplates/fragments';
+import * as moderatorActionsFragments from '../collections/moderatorActions/fragments';
+import * as multiDocumentsFragments from '../collections/multiDocuments/fragments';
+import * as notificationsFragments from '../collections/notifications/fragments';
+import * as petrovDayActionsFragments from '../collections/petrovDayActions/fragments';
+import * as petrovDayLaunchsFragments from '../collections/petrovDayLaunchs/fragments';
+import * as podcastEpisodesFragments from '../collections/podcastEpisodes/fragments';
+import * as podcastsFragments from '../collections/podcasts/fragments';
+import * as postsFragments from '../collections/posts/fragments';
+import * as reportsFragments from '../collections/reports/fragments';
+import * as reviewVotesFragments from '../collections/reviewVotes/fragments';
+import * as reviewWinnerArtsFragments from '../collections/reviewWinnerArts/fragments';
+import * as reviewWinnersFragments from '../collections/reviewWinners/fragments';
+import * as revisionsFragments from '../collections/revisions/fragments';
+import * as rssfeedsFragments from '../collections/rssfeeds/fragments';
+import * as sequencesFragments from '../collections/sequences/fragments';
+import * as sideCommentCachesFragments from '../collections/sideCommentCaches/fragments';
+import * as splashArtCoordinatesFragments from '../collections/splashArtCoordinates/fragments';
+import * as spotlightsFragments from '../collections/spotlights/fragments';
+import * as subscriptionsFragments from '../collections/subscriptions/fragments';
+import * as surveyQuestionsFragments from '../collections/surveyQuestions/fragments';
+import * as surveyResponsesFragments from '../collections/surveyResponses/fragments';
+import * as surveySchedulesFragments from '../collections/surveySchedules/fragments';
+import * as surveysFragments from '../collections/surveys/fragments';
+import * as tagFlagsFragments from '../collections/tagFlags/fragments';
+import * as tagRelsFragments from '../collections/tagRels/fragments';
+import * as tagsFragments from '../collections/tags/fragments';
+import * as typingIndicatorsFragments from '../collections/typingIndicators/fragments';
+import * as userEAGDetailsFragments from '../collections/userEAGDetails/fragments';
+import * as userJobAdsFragments from '../collections/userJobAds/fragments';
+import * as userMostValuablePostsFragments from '../collections/userMostValuablePosts/fragments';
+import * as userRateLimitsFragments from '../collections/userRateLimits/fragments';
+import * as userTagRelsFragments from '../collections/userTagRels/fragments';
+import * as usersFragments from '../collections/users/fragments';
+import * as votesFragments from '../collections/votes/fragments';
+import * as subscribedUserFeedFragments from '../subscribedUsersFeed';
+import { getAllCollections } from '../vulcan-lib/getCollection';
+
+// Create default "dumb" gql fragment object for a given collection
+function getDefaultFragmentText<N extends CollectionNameString>(
+  collection: CollectionBase<N>,
+  schema: SchemaType<N>,
+  options = { onlyViewable: true },
+): string|null {
+  const fieldNames = Object.keys(schema).filter((fieldName: string) => {
+    /*
+
+    Exclude a field from the default fragment if
+    1. it has a resolver and addOriginalField is false
+    2. it has $ in its name
+    3. it's not viewable (if onlyViewable option is true)
+
+    */
+    const field: CollectionFieldSpecification<N> = schema[fieldName];
+    // OpenCRUD backwards compatibility
+
+    const isResolverField = field.resolveAs && !field.resolveAs.addOriginalField && field.resolveAs.type !== "ContentType";
+    return !(isResolverField || fieldName.includes('$') || fieldName.includes('.') || (options.onlyViewable && !field.canRead));
+  });
+
+  if (fieldNames.length) {
+    const fragmentText = `
+      fragment ${collection.collectionName}DefaultFragment on ${collection.typeName} {
+        ${fieldNames.map(fieldName => {
+          return fieldName+'\n';
+        }).join('')}
+      }
+    `;
+
+    return fragmentText;
+  } else {
+    return null;
+  }
+};
+
+const defaultFragments = Object.fromEntries(
+  getAllCollections()
+    .map(collection => [`${collection.collectionName}DefaultFragment`, getDefaultFragmentText(collection, collection._schemaFields)])
+    .filter(([_, fragment]) => fragment !== null)
+) as Record<Extract<keyof FragmentTypes, `${CollectionNameString}DefaultFragment`>, string>;
+
+export const allFragments = {
+  ...alignmentCommentsFragments,
+  ...alignmentPostsFragments,
+  ...alignmentUsersFragments,
+  
+  ...advisorRequestsFragments,
+  ...bansFragments,
+  ...booksFragments,
+  ...chaptersFragments,
+  ...ckEditorUserSessionsFragments,
+  ...clientIdsFragments,
+  ...collectionsFragments,
+  ...commentModeratorActionsFragments,
+  ...commentsFragments,
+  ...conversationsFragments,
+  ...curationNoticesFragments,
+  ...dialogueChecksFragments,
+  ...dialogueMatchPreferencesFragments,
+  ...digestPostsFragments,
+  ...digestsFragments,
+  ...electionCandidatesFragments,
+  ...electionVotesFragments,
+  ...elicitQuestionsFragments,
+  ...featuredResourcesFragments,
+  ...forumEventsFragments,
+  ...gardencodesFragments,
+  ...googleServiceAccountSessionsFragments,
+  ...jargonTermsFragments,
+  ...llmConversationsFragments,
+  ...llmMessagesFragments,
+  ...localgroupsFragments,
+  ...lweventsFragments,
+  ...messagesFragments,
+  ...moderationTemplatesFragments,
+  ...moderatorActionsFragments,
+  ...multiDocumentsFragments,
+  ...notificationsFragments,
+  ...petrovDayActionsFragments,
+  ...petrovDayLaunchsFragments,
+  ...podcastEpisodesFragments,
+  ...podcastsFragments,
+  ...postsFragments,
+  ...reportsFragments,
+  ...reviewVotesFragments,
+  ...reviewWinnerArtsFragments,
+  ...reviewWinnersFragments,
+  ...revisionsFragments,
+  ...rssfeedsFragments,
+  ...sequencesFragments,
+  ...sideCommentCachesFragments,
+  ...splashArtCoordinatesFragments,
+  ...spotlightsFragments,
+  ...subscriptionsFragments,
+  ...surveyQuestionsFragments,
+  ...surveyResponsesFragments,
+  ...surveySchedulesFragments,
+  ...surveysFragments,
+  ...tagFlagsFragments,
+  ...tagRelsFragments,
+  ...tagsFragments,
+  ...typingIndicatorsFragments,
+  ...userEAGDetailsFragments,
+  ...userJobAdsFragments,
+  ...userMostValuablePostsFragments,
+  ...userRateLimitsFragments,
+  ...userTagRelsFragments,
+  ...usersFragments,
+  ...votesFragments,
+  ...subscribedUserFeedFragments,
+  ...defaultFragments,
+};

--- a/packages/lesswrong/lib/fragments/allFragments.ts
+++ b/packages/lesswrong/lib/fragments/allFragments.ts
@@ -72,6 +72,7 @@ import { getAllCollections } from '../vulcan-lib/getCollection';
 import uniq from 'lodash/uniq';
 import SqlFragment from '@/server/sql/SqlFragment';
 import type { DocumentNode } from 'graphql';
+import { isAnyTest } from '../executionEnvironment';
 
 // Create default "dumb" gql fragment object for a given collection
 function getDefaultFragmentText<N extends CollectionNameString>(
@@ -123,6 +124,15 @@ const getDefaultFragments = (() => {
     return defaultFragments;
   }
 })();
+
+// Unfortunately the inversion with sql fragment compilation is a bit tricky to unroll, so for now we just dynamically load the test fragments if we're in a test environment.
+// We type this as Record<never, never> because we want to avoid it clobbering the rest of the fragment types.
+let testFragments: Record<never, never>;
+if (isAnyTest) {
+  testFragments = require('../../server/sql/tests/testFragments');
+} else {
+  testFragments = {};
+}
 
 const staticFragments = {
   ...alignmentCommentsFragments,
@@ -193,6 +203,7 @@ const staticFragments = {
   ...usersFragments,
   ...votesFragments,
   ...subscribedUserFeedFragments,
+  ...testFragments,
 };
 
 // This needs to have deferred execution because getDefaultFragments needs to be called after the collections are registered

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -11,6 +11,10 @@ interface AdvisorRequestsDefaultFragment { // fragment on AdvisorRequests
   readonly userId: string,
   readonly interestedInMetaculus: boolean,
   readonly jobAds: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface AdvisorRequestsMinimumInfo { // fragment on AdvisorRequests
@@ -23,6 +27,13 @@ interface AdvisorRequestsMinimumInfo { // fragment on AdvisorRequests
 
 interface AllTagsPageFragment extends TagWithFlagsFragment { // fragment on Tags
   readonly tableOfContents: any,
+}
+
+interface ArbitalCachesDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface ArbitalLinkedPagesFragment { // fragment on non-collection type
@@ -44,6 +55,10 @@ interface ArbitalTagContentRelsDefaultFragment { // fragment on ArbitalTagConten
   readonly type: "parent-taught-by-child" | "parent-is-requirement-of-child" | "parent-is-tag-of-child" | "parent-is-parent-of-child",
   readonly level: number,
   readonly isStrong: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface BansAdminPageFragment { // fragment on Bans
@@ -65,6 +80,10 @@ interface BansDefaultFragment { // fragment on Bans
   readonly reason: string,
   readonly comment: string,
   readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface BookEdit extends BookPageFragment { // fragment on Books
@@ -102,6 +121,10 @@ interface BooksDefaultFragment { // fragment on Books
   readonly displaySequencesAsGrid: boolean,
   readonly hideProgressBar: boolean,
   readonly showChapters: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ChaptersDefaultFragment { // fragment on Chapters
@@ -111,6 +134,10 @@ interface ChaptersDefaultFragment { // fragment on Chapters
   readonly number: number,
   readonly sequenceId: string,
   readonly postIds: Array<string>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
@@ -142,6 +169,10 @@ interface CkEditorUserSessionsDefaultFragment { // fragment on CkEditorUserSessi
   readonly userId: string,
   readonly endedAt: Date,
   readonly endedBy: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ClientIdsDefaultFragment { // fragment on ClientIds
@@ -152,6 +183,10 @@ interface ClientIdsDefaultFragment { // fragment on ClientIds
   readonly invalidated: boolean,
   readonly lastSeenAt: Date | null,
   readonly timesSeen: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CollectionContinueReadingFragment { // fragment on Collections
@@ -184,6 +219,10 @@ interface CollectionsDefaultFragment { // fragment on Collections
   readonly firstPageLink: string,
   readonly hideStartReadingButton: boolean,
   readonly noindex: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CollectionsEditFragment extends CollectionsPageFragment { // fragment on Collections
@@ -224,6 +263,10 @@ interface CommentModeratorActionsDefaultFragment { // fragment on CommentModerat
   readonly commentId: string,
   readonly type: "downvotedCommentAlert",
   readonly endedAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CommentWithRepliesFragment extends CommentsList { // fragment on Comments
@@ -308,6 +351,17 @@ interface CommentsDefaultFragment { // fragment on Comments
   readonly moveToAlignmentUserId: string,
   readonly agentFoundationsId: string,
   readonly originalDialogueId: string | null,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CommentsForAutocomplete { // fragment on Comments
@@ -495,6 +549,10 @@ interface ConversationsDefaultFragment { // fragment on Conversations
   readonly messageCount: number,
   readonly moderator: boolean | null,
   readonly archivedByIds: Array<string>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ConversationsList extends ConversationsMinimumInfo { // fragment on Conversations
@@ -529,6 +587,10 @@ interface CronHistoriesDefaultFragment { // fragment on CronHistories
 interface CurationEmailsDefaultFragment { // fragment on CurationEmails
   readonly userId: string,
   readonly postId: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CurationNoticesDefaultFragment { // fragment on CurationNotices
@@ -537,6 +599,10 @@ interface CurationNoticesDefaultFragment { // fragment on CurationNotices
   readonly commentId: string | null,
   readonly postId: string,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface CurationNoticesFragment { // fragment on CurationNotices
@@ -550,6 +616,20 @@ interface CurationNoticesFragment { // fragment on CurationNotices
   readonly post: PostsMinimumInfo|null,
   readonly deleted: boolean,
   readonly contents: RevisionEdit|null,
+}
+
+interface DatabaseMetadataDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
+}
+
+interface DebouncerEventsDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface DeletedCommentsMetaData { // fragment on Comments
@@ -594,6 +674,10 @@ interface DialogueChecksDefaultFragment { // fragment on DialogueChecks
   readonly checked: boolean,
   readonly checkedAt: Date,
   readonly hideInRecommendations: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface DialogueMatchPreferenceInfo { // fragment on DialogueMatchPreferences
@@ -626,6 +710,10 @@ interface DialogueMatchPreferencesDefaultFragment { // fragment on DialogueMatch
   readonly calendlyLink: string | null,
   readonly generatedDialogueId: string | null,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface DigestPostsDefaultFragment { // fragment on DigestPosts
@@ -633,6 +721,10 @@ interface DigestPostsDefaultFragment { // fragment on DigestPosts
   readonly postId: string,
   readonly emailDigestStatus: string | null,
   readonly onsiteDigestStatus: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface DigestPostsMinimumInfo { // fragment on DigestPosts
@@ -650,6 +742,10 @@ interface DigestsDefaultFragment { // fragment on Digests
   readonly publishedDate: Date | null,
   readonly onsiteImageId: string | null,
   readonly onsitePrimaryColor: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface DigestsMinimumInfo { // fragment on Digests
@@ -707,6 +803,17 @@ interface ElectionCandidatesDefaultFragment { // fragment on ElectionCandidates
   readonly isElectionFundraiser: boolean,
   readonly amountRaised: number | null,
   readonly targetAmount: number | null,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ElectionVoteInfo { // fragment on ElectionVotes
@@ -736,6 +843,10 @@ interface ElectionVotesDefaultFragment { // fragment on ElectionVotes
   readonly submissionComments: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly userExplanation: string | null,
   readonly userOtherComments: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ElicitQuestionFragment { // fragment on ElicitQuestions
@@ -769,6 +880,17 @@ interface ElicitQuestionsDefaultFragment { // fragment on ElicitQuestions
   readonly notes: string | null,
   readonly resolution: string | null,
   readonly resolvesBy: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface EmailTokensDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface ExplorePageTagFragment extends TagFragment { // fragment on Tags
@@ -782,6 +904,10 @@ interface FeaturedResourcesDefaultFragment { // fragment on FeaturedResources
   readonly ctaText: string,
   readonly ctaUrl: string,
   readonly expiresAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface FeaturedResourcesFragment { // fragment on FeaturedResources
@@ -822,6 +948,10 @@ interface ForumEventsDefaultFragment { // fragment on ForumEvents
   readonly customComponent: string | null,
   readonly commentPrompt: string | null,
   readonly publicData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ForumEventsDisplay extends ForumEventsMinimumInfo { // fragment on ForumEvents
@@ -916,6 +1046,11 @@ interface GardenCodesDefaultFragment { // fragment on GardenCodes
   readonly hidden: boolean,
   readonly deleted: boolean,
   readonly afOnly: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
 }
 
 interface GoogleServiceAccountSessionAdminInfo { // fragment on GoogleServiceAccountSessions
@@ -935,6 +1070,10 @@ interface GoogleServiceAccountSessionsDefaultFragment { // fragment on GoogleSer
   readonly estimatedExpiry: Date,
   readonly active: boolean,
   readonly revoked: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface HighlightWithHash { // fragment on Posts
@@ -945,6 +1084,13 @@ interface HighlightWithHash { // fragment on Posts
 interface HighlightWithHash_contents { // fragment on Revisions
   readonly _id: string,
   readonly htmlHighlightStartingAtHash: string,
+}
+
+interface ImagesDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface JargonTerms { // fragment on JargonTerms
@@ -962,10 +1108,13 @@ interface JargonTermsDefaultFragment { // fragment on JargonTerms
   readonly contents_latest: string,
   readonly postId: string,
   readonly term: string,
-  readonly humansAndOrAIEdited: "humans" | "AI" | "humansAndAI" | null,
   readonly approved: boolean,
   readonly deleted: boolean,
   readonly altTerms: Array<string>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface JargonTermsPost { // fragment on JargonTerms
@@ -989,6 +1138,17 @@ interface LWEventsDefaultFragment { // fragment on LWEvents
   readonly important: boolean,
   readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly intercom: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface LegacyDataDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface LlmConversationsDefaultFragment { // fragment on LlmConversations
@@ -996,8 +1156,11 @@ interface LlmConversationsDefaultFragment { // fragment on LlmConversations
   readonly title: string,
   readonly model: string,
   readonly systemPrompt: string | null,
-  readonly messages: Array<LlmMessage|null>,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface LlmConversationsFragment { // fragment on LlmConversations
@@ -1023,6 +1186,10 @@ interface LlmMessagesDefaultFragment { // fragment on LlmMessages
   readonly conversationId: string,
   readonly role: "user" | "assistant" | "user-context" | "assistant-context" | "lw-assistant",
   readonly content: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface LlmMessagesFragment { // fragment on LlmMessages
@@ -1055,6 +1222,10 @@ interface LocalgroupsDefaultFragment { // fragment on Localgroups
   readonly bannerImageId: string,
   readonly inactive: boolean,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ManifoldProbabilitiesCachesDefaultFragment { // fragment on ManifoldProbabilitiesCaches
@@ -1064,6 +1235,10 @@ interface ManifoldProbabilitiesCachesDefaultFragment { // fragment on ManifoldPr
   readonly year: number,
   readonly lastUpdated: Date,
   readonly url: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface MembersOfGroupFragment { // fragment on Subscriptions
@@ -1075,6 +1250,17 @@ interface MessagesDefaultFragment { // fragment on Messages
   readonly userId: string,
   readonly conversationId: string,
   readonly noEmail: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface MigrationsDefaultFragment { // fragment on Migrations
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ModerationTemplateFragment { // fragment on ModerationTemplates
@@ -1092,6 +1278,10 @@ interface ModerationTemplatesDefaultFragment { // fragment on ModerationTemplate
   readonly collectionName: "Messages" | "Comments" | "Rejections",
   readonly order: number,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ModeratorActionDisplay { // fragment on ModeratorActions
@@ -1108,6 +1298,10 @@ interface ModeratorActionsDefaultFragment { // fragment on ModeratorActions
   readonly userId: string,
   readonly type: "rateLimitOnePerDay" | "rateLimitOnePerThreeDays" | "rateLimitOnePerWeek" | "rateLimitOnePerFortnight" | "rateLimitOnePerMonth" | "rateLimitThreeCommentsPerPost" | "recentlyDownvotedContentAlert" | "lowAverageKarmaCommentAlert" | "lowAverageKarmaPostAlert" | "negativeUserKarmaAlert" | "movedPostToDraft" | "sentModeratorMessage" | "manualFlag" | "votingPatternWarningDelivered" | "flaggedForNDMs" | "autoBlockedFromSendingDMs" | "rejectedPost" | "rejectedComment" | "potentialTargetedDownvoting" | "exemptFromRateLimits" | "receivedSeniorDownvotesAlert",
   readonly endedAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ModeratorClientIDInfo { // fragment on ClientIds
@@ -1185,11 +1379,22 @@ interface MultiDocumentsDefaultFragment { // fragment on MultiDocuments
   readonly collectionName: "Tags" | "MultiDocuments",
   readonly fieldName: "description" | "summary",
   readonly index: number,
-  readonly tableOfContents: any /*{"definitions":[{}]}*/,
-  readonly contributors: any /*TagContributorsList*/,
   readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly htmlWithContributorAnnotations: string,
   readonly deleted: boolean,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
 }
 
 interface NotificationsDefaultFragment { // fragment on Notifications
@@ -1205,6 +1410,10 @@ interface NotificationsDefaultFragment { // fragment on Notifications
   readonly viewed: boolean,
   readonly emailed: boolean,
   readonly waitingForBatch: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface NotificationsList { // fragment on Notifications
@@ -1221,6 +1430,13 @@ interface NotificationsList { // fragment on Notifications
   readonly extraData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
+interface PageCacheDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
+}
+
 interface PetrovDayActionInfo { // fragment on PetrovDayActions
   readonly _id: string,
   readonly createdAt: Date,
@@ -1233,6 +1449,10 @@ interface PetrovDayActionsDefaultFragment { // fragment on PetrovDayActions
   readonly actionType: "optIn" | "hasRole" | "hasSide" | "nukeTheWest" | "nukeTheEast" | "eastPetrovAllClear" | "eastPetrovNukesIncoming" | "westPetrovAllClear" | "westPetrovNukesIncoming",
   readonly data: any /*{"definitions":[{}]}*/,
   readonly userId: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PetrovDayLaunchInfo { // fragment on PetrovDayLaunchs
@@ -1246,6 +1466,10 @@ interface PetrovDayLaunchsDefaultFragment { // fragment on PetrovDayLaunchs
   readonly launchCode: string,
   readonly hashedLaunchCode: string,
   readonly userId: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PodcastEpisodeFull { // fragment on PodcastEpisodes
@@ -1261,6 +1485,10 @@ interface PodcastEpisodesDefaultFragment { // fragment on PodcastEpisodes
   readonly title: string,
   readonly episodeLink: string,
   readonly externalEpisodeId: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PodcastSelect { // fragment on Podcasts
@@ -1272,6 +1500,10 @@ interface PodcastsDefaultFragment { // fragment on Podcasts
   readonly title: string,
   readonly applePodcastLink: string | null,
   readonly spotifyPodcastLink: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PostEmbeddingsDefaultFragment { // fragment on PostEmbeddings
@@ -1280,6 +1512,10 @@ interface PostEmbeddingsDefaultFragment { // fragment on PostEmbeddings
   readonly lastGeneratedAt: Date,
   readonly model: string,
   readonly embeddings: Array<number>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PostForReviewWinnerItem { // fragment on Posts
@@ -1306,6 +1542,10 @@ interface PostRecommendationsDefaultFragment { // fragment on PostRecommendation
   readonly recommendationCount: number,
   readonly lastRecommendedAt: Date,
   readonly clickedAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PostRelationsDefaultFragment { // fragment on PostRelations
@@ -1313,6 +1553,10 @@ interface PostRelationsDefaultFragment { // fragment on PostRelations
   readonly sourcePostId: string,
   readonly targetPostId: string,
   readonly order: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface PostSequenceNavigation { // fragment on Posts
@@ -1341,6 +1585,20 @@ interface PostSideComments { // fragment on Posts
   readonly _id: string,
   readonly sideComments: any,
   readonly sideCommentsCache: SideCommentCacheMinimumInfo|null,
+}
+
+interface PostViewTimesDefaultFragment { // fragment on PostViewTimes
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface PostViewsDefaultFragment { // fragment on non-collection type
+  readonly _id: any,
+  readonly schemaVersion: any,
+  readonly createdAt: any,
+  readonly legacyData: any,
 }
 
 interface PostWithDialogueMessage { // fragment on Posts
@@ -1526,9 +1784,6 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly reviewVoteCount: number,
   readonly positiveReviewVoteCount: number,
   readonly manifoldReviewMarketId: string | null,
-  readonly annualReviewMarketProbability: number|null,
-  readonly annualReviewMarketIsResolved: boolean|null,
-  readonly annualReviewMarketYear: number|null,
   readonly reviewVoteScoreAF: number,
   readonly reviewVotesAF: Array<number>,
   readonly reviewVoteScoreHighKarma: number,
@@ -1641,9 +1896,6 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly linkSharingKeyUsedBy: Array<string>,
   readonly commentSortOrder: string,
   readonly hideAuthor: boolean,
-  readonly tableOfContents: any,
-  readonly tableOfContentsRevision: any,
-  readonly sideComments: any,
   readonly sideCommentVisibility: string,
   readonly disableSidenotes: boolean,
   readonly moderationStyle: string,
@@ -1651,17 +1903,12 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly hideCommentKarma: boolean,
   readonly commentCount: number,
   readonly topLevelCommentCount: number,
-  readonly languageModelSummary: string,
   readonly debate: boolean,
   readonly collabEditorDialogue: boolean,
-  readonly totalDialogueResponseCount: number,
   readonly mostRecentPublishedDialogueResponseDate: Date | null,
-  readonly unreadDebateResponseCount: number,
   readonly rejected: boolean,
   readonly rejectedReason: string | null,
   readonly rejectedByUserId: string,
-  readonly dialogueMessageContents: string|null,
-  readonly firstVideoAttribsForPreview: any,
   readonly subforumTagId: string,
   readonly af: boolean,
   readonly afDate: Date,
@@ -1673,6 +1920,18 @@ interface PostsDefaultFragment { // fragment on Posts
   readonly agentFoundationsId: string,
   readonly swrCachingEnabled: boolean,
   readonly generateDraftJargon: boolean,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
 }
 
 interface PostsDetails extends PostsListBase { // fragment on Posts
@@ -2098,6 +2357,17 @@ interface RSSFeedsDefaultFragment { // fragment on RSSFeeds
   readonly rawFeed: any /*{"definitions":[{}]}*/,
   readonly setCanonicalUrl: boolean,
   readonly importAsDraft: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface ReadStatusesDefaultFragment { // fragment on ReadStatuses
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface RecentDiscussionRevisionTagFragment extends RevisionHistoryEntry { // fragment on Revisions
@@ -2111,6 +2381,10 @@ interface RecommendationsCachesDefaultFragment { // fragment on RecommendationsC
   readonly scenario: string,
   readonly attributionId: string,
   readonly ttlMs: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ReportsDefaultFragment { // fragment on Reports
@@ -2124,6 +2398,10 @@ interface ReportsDefaultFragment { // fragment on Reports
   readonly closedAt: Date | null,
   readonly markedAsSpam: boolean,
   readonly reportedAsSpam: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ReviewVotesDefaultFragment { // fragment on ReviewVotes
@@ -2135,6 +2413,10 @@ interface ReviewVotesDefaultFragment { // fragment on ReviewVotes
   readonly year: string,
   readonly dummy: boolean,
   readonly reactions: Array<string>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ReviewWinnerAll { // fragment on ReviewWinners
@@ -2160,6 +2442,10 @@ interface ReviewWinnerArtsDefaultFragment { // fragment on ReviewWinnerArts
   readonly postId: string,
   readonly splashArtImagePrompt: string,
   readonly splashArtImageUrl: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ReviewWinnerEditDisplay { // fragment on ReviewWinners
@@ -2200,6 +2486,10 @@ interface ReviewWinnersDefaultFragment { // fragment on ReviewWinners
   readonly curatedOrder: number | null,
   readonly reviewRanking: number,
   readonly isAI: boolean | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface RevisionDisplay { // fragment on Revisions
@@ -2302,18 +2592,21 @@ interface RevisionsDefaultFragment { // fragment on Revisions
   readonly draft: boolean,
   readonly originalContents: any /*ContentType*/,
   readonly html: string,
-  readonly markdown: string|null,
-  readonly draftJS: any /*JSON*/,
-  readonly ckEditorMarkup: string|null,
   readonly wordCount: number,
-  readonly htmlHighlight: string,
-  readonly htmlHighlightStartingAtHash: string,
-  readonly plaintextDescription: string,
-  readonly plaintextMainText: string,
-  readonly hasFootnotes: boolean|null,
   readonly changeMetrics: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly googleDocMetadata: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly skipAttributions: boolean,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SequenceContinueReadingFragment { // fragment on Sequences
@@ -2339,6 +2632,10 @@ interface SequencesDefaultFragment { // fragment on Sequences
   readonly hidden: boolean,
   readonly noindex: boolean,
   readonly af: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SequencesEdit extends SequencesPageFragment { // fragment on Sequences
@@ -2419,6 +2716,10 @@ interface SideCommentCachesDefaultFragment { // fragment on SideCommentCaches
   readonly annotatedHtml: string,
   readonly commentsByBlock: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly version: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SplashArtCoordinates { // fragment on SplashArtCoordinates
@@ -2458,6 +2759,10 @@ interface SplashArtCoordinatesDefaultFragment { // fragment on SplashArtCoordina
   readonly rightHeightPct: number,
   readonly rightWidthPct: number,
   readonly rightFlipped: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SpotlightDisplay extends SpotlightMinimumInfo { // fragment on Spotlights
@@ -2588,6 +2893,10 @@ interface SpotlightsDefaultFragment { // fragment on Spotlights
   readonly imageFadeColor: string | null,
   readonly spotlightImageId: string | null,
   readonly spotlightDarkImageId: string | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface StickySubforumCommentFragment extends CommentWithRepliesFragment { // fragment on Comments
@@ -2620,6 +2929,10 @@ interface SubscriptionsDefaultFragment { // fragment on Subscriptions
   readonly collectionName: string,
   readonly deleted: boolean,
   readonly type: "newComments" | "newUserComments" | "newShortform" | "newPosts" | "newRelatedQuestions" | "newEvents" | "newReplies" | "newTagPosts" | "newSequencePosts" | "newDebateComments" | "newDialogueMessages" | "newPublishedDialogueMessages" | "newActivityForFeed",
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SuggestAlignmentComment extends CommentsList { // fragment on Comments
@@ -2774,6 +3087,10 @@ interface SurveyQuestionsDefaultFragment { // fragment on SurveyQuestions
   readonly question: string,
   readonly format: "rank0To10" | "text" | "multilineText",
   readonly order: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SurveyResponseMinimumInfo { // fragment on SurveyResponses
@@ -2791,6 +3108,10 @@ interface SurveyResponsesDefaultFragment { // fragment on SurveyResponses
   readonly userId: string,
   readonly clientId: string,
   readonly response: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SurveyScheduleEdit extends SurveyScheduleMinimumInfo { // fragment on SurveySchedules
@@ -2824,10 +3145,18 @@ interface SurveySchedulesDefaultFragment { // fragment on SurveySchedules
   readonly endDate: Date | null,
   readonly deactivated: boolean,
   readonly clientIds: Array<string>,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface SurveysDefaultFragment { // fragment on Surveys
   readonly name: string,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface TagBasicInfo { // fragment on Tags
@@ -2940,6 +3269,11 @@ interface TagFlagsDefaultFragment { // fragment on TagFlags
   readonly name: string,
   readonly deleted: boolean,
   readonly order: number | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
 }
 
 interface TagFragment extends TagDetailsFragment { // fragment on Tags
@@ -3098,8 +3432,18 @@ interface TagRelsDefaultFragment { // fragment on TagRels
   readonly postId: string,
   readonly deleted: boolean,
   readonly userId: string | null,
-  readonly autoApplied: boolean,
   readonly backfilled: boolean,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface TagRevisionFragment extends TagDetailsFragment { // fragment on Tags
@@ -3198,9 +3542,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly lesswrongWikiImportRevision: string,
   readonly lesswrongWikiImportSlug: string,
   readonly lesswrongWikiImportCompleted: boolean,
-  readonly tableOfContents: any,
   readonly htmlWithContributorAnnotations: string,
-  readonly contributors: any /*TagContributorsList*/,
   readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly introSequenceId: string,
   readonly postsDefaultSortOrder: string,
@@ -3215,6 +3557,26 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly noindex: boolean,
   readonly isPlaceholderPage: boolean,
   readonly coreTagId: string | null,
+  readonly voteCount: number,
+  readonly baseScore: number,
+  readonly extendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly score: number,
+  readonly afBaseScore: number,
+  readonly afExtendedScore: any /*{"definitions":[{"type":"JSON"}]}*/,
+  readonly afVoteCount: number,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
+}
+
+interface TweetsDefaultFragment { // fragment on Tweets
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface TypingIndicatorInfo { // fragment on TypingIndicators
@@ -3228,6 +3590,10 @@ interface TypingIndicatorsDefaultFragment { // fragment on TypingIndicators
   readonly userId: string,
   readonly documentId: string,
   readonly lastUpdated: Date,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UnclaimedReportsList { // fragment on Reports
@@ -3261,6 +3627,13 @@ interface UnclaimedReportsList_claimedUser { // fragment on Users
   readonly slug: string,
 }
 
+interface UserActivitiesDefaultFragment { // fragment on UserActivities
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
 interface UserAltAccountsFragment extends SunshineUsersList { // fragment on Users
   readonly IPs: Array<string>,
 }
@@ -3279,6 +3652,10 @@ interface UserEAGDetailsDefaultFragment { // fragment on UserEAGDetails
   readonly experiencedIn: Array<string> | null,
   readonly interestedIn: Array<string> | null,
   readonly lastUpdated: Date,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UserEAGDetailsMinimumInfo { // fragment on UserEAGDetails
@@ -3300,6 +3677,10 @@ interface UserJobAdsDefaultFragment { // fragment on UserJobAds
   readonly adState: "seen" | "expanded" | "applied" | "reminderSet",
   readonly reminderSetAt: Date | null,
   readonly lastUpdated: Date,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UserJobAdsMinimumInfo { // fragment on UserJobAds
@@ -3328,6 +3709,10 @@ interface UserMostValuablePostsDefaultFragment { // fragment on UserMostValuable
   readonly userId: string,
   readonly postId: string,
   readonly deleted: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UserOnboardingAuthor { // fragment on Users
@@ -3366,6 +3751,10 @@ interface UserRateLimitsDefaultFragment { // fragment on UserRateLimits
   readonly intervalLength: number,
   readonly actionsPerInterval: number,
   readonly endedAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UserTagRelDetails { // fragment on UserTagRels
@@ -3383,6 +3772,10 @@ interface UserTagRelsDefaultFragment { // fragment on UserTagRels
   readonly subforumShowUnreadInSidebar: boolean,
   readonly subforumEmailNotifications: boolean,
   readonly subforumHideIntroPost: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface UserVotes { // fragment on Votes
@@ -3976,8 +4369,6 @@ interface UsersDefaultFragment { // fragment on Users
   readonly organization: string,
   readonly careerStage: Array<string>,
   readonly website: string,
-  readonly bio: string|null,
-  readonly htmlBio: string,
   readonly fmCrosspostUserId: string,
   readonly linkedinProfileURL: string,
   readonly facebookProfileURL: string,
@@ -4005,12 +4396,47 @@ interface UsersDefaultFragment { // fragment on Users
   readonly reviewForAlignmentForumUserId: string,
   readonly afApplicationText: string,
   readonly afSubmittedApplication: boolean,
-  readonly rateLimitNextAbleToComment: any,
-  readonly rateLimitNextAbleToPost: any,
-  readonly recentKarmaInfo: any,
   readonly hideSunshineSidebar: boolean,
   readonly inactiveSurveyEmailSentAt: Date | null,
   readonly userSurveyEmailSentAt: Date | null,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly slug: string,
+  readonly oldSlugs: Array<string>,
+  readonly recommendationSettings: {
+    frontpage: {
+      method: string,
+      count: number,
+      scoreOffset: number,
+      scoreExponent: number,
+      personalBlogpostModifier: number,
+      frontpageModifier: number,
+      curatedModifier: number,
+      onlyUnread: boolean,
+    },
+    frontpageEA: {
+      method: string,
+      count: number,
+      scoreOffset: number,
+      scoreExponent: number,
+      personalBlogpostModifier: number,
+      frontpageModifier: number,
+      curatedModifier: number,
+      onlyUnread: boolean,
+    },
+    recommendationspage: {
+      method: string,
+      count: number,
+      scoreOffset: number,
+      scoreExponent: number,
+      personalBlogpostModifier: number,
+      frontpageModifier: number,
+      curatedModifier: number,
+      onlyUnread: boolean,
+    },
+  },
 }
 
 interface UsersEdit extends UsersCurrent { // fragment on Users
@@ -4348,6 +4774,10 @@ interface VotesDefaultFragment { // fragment on Votes
   readonly votedAt: Date,
   readonly documentIsAf: boolean,
   readonly silenceNotification: boolean,
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface WithVoteComment { // fragment on Comments
@@ -4566,6 +4996,7 @@ interface FragmentTypes {
   AdvisorRequestsDefaultFragment: AdvisorRequestsDefaultFragment
   AdvisorRequestsMinimumInfo: AdvisorRequestsMinimumInfo
   AllTagsPageFragment: AllTagsPageFragment
+  ArbitalCachesDefaultFragment: ArbitalCachesDefaultFragment
   ArbitalLinkedPagesFragment: ArbitalLinkedPagesFragment
   ArbitalTagContentRelsDefaultFragment: ArbitalTagContentRelsDefaultFragment
   BansAdminPageFragment: BansAdminPageFragment
@@ -4605,6 +5036,8 @@ interface FragmentTypes {
   CurationEmailsDefaultFragment: CurationEmailsDefaultFragment
   CurationNoticesDefaultFragment: CurationNoticesDefaultFragment
   CurationNoticesFragment: CurationNoticesFragment
+  DatabaseMetadataDefaultFragment: DatabaseMetadataDefaultFragment
+  DebouncerEventsDefaultFragment: DebouncerEventsDefaultFragment
   DeletedCommentsMetaData: DeletedCommentsMetaData
   DeletedCommentsModerationLog: DeletedCommentsModerationLog
   DialogueCheckInfo: DialogueCheckInfo
@@ -4624,6 +5057,7 @@ interface FragmentTypes {
   ElicitQuestionFragment: ElicitQuestionFragment
   ElicitQuestionPredictionsDefaultFragment: ElicitQuestionPredictionsDefaultFragment
   ElicitQuestionsDefaultFragment: ElicitQuestionsDefaultFragment
+  EmailTokensDefaultFragment: EmailTokensDefaultFragment
   ExplorePageTagFragment: ExplorePageTagFragment
   FeaturedResourcesDefaultFragment: FeaturedResourcesDefaultFragment
   FeaturedResourcesFragment: FeaturedResourcesFragment
@@ -4639,11 +5073,13 @@ interface FragmentTypes {
   GoogleServiceAccountSessionInfo: GoogleServiceAccountSessionInfo
   GoogleServiceAccountSessionsDefaultFragment: GoogleServiceAccountSessionsDefaultFragment
   HighlightWithHash: HighlightWithHash
+  ImagesDefaultFragment: ImagesDefaultFragment
   JargonTerms: JargonTerms
   JargonTermsDefaultFragment: JargonTermsDefaultFragment
   JargonTermsPost: JargonTermsPost
   JargonTermsWithPostInfo: JargonTermsWithPostInfo
   LWEventsDefaultFragment: LWEventsDefaultFragment
+  LegacyDataDefaultFragment: LegacyDataDefaultFragment
   LlmConversationsDefaultFragment: LlmConversationsDefaultFragment
   LlmConversationsFragment: LlmConversationsFragment
   LlmConversationsViewingPageFragment: LlmConversationsViewingPageFragment
@@ -4654,6 +5090,7 @@ interface FragmentTypes {
   ManifoldProbabilitiesCachesDefaultFragment: ManifoldProbabilitiesCachesDefaultFragment
   MembersOfGroupFragment: MembersOfGroupFragment
   MessagesDefaultFragment: MessagesDefaultFragment
+  MigrationsDefaultFragment: MigrationsDefaultFragment
   ModerationTemplateFragment: ModerationTemplateFragment
   ModerationTemplatesDefaultFragment: ModerationTemplatesDefaultFragment
   ModeratorActionDisplay: ModeratorActionDisplay
@@ -4669,6 +5106,7 @@ interface FragmentTypes {
   MultiDocumentsDefaultFragment: MultiDocumentsDefaultFragment
   NotificationsDefaultFragment: NotificationsDefaultFragment
   NotificationsList: NotificationsList
+  PageCacheDefaultFragment: PageCacheDefaultFragment
   PetrovDayActionInfo: PetrovDayActionInfo
   PetrovDayActionsDefaultFragment: PetrovDayActionsDefaultFragment
   PetrovDayLaunchInfo: PetrovDayLaunchInfo
@@ -4683,6 +5121,8 @@ interface FragmentTypes {
   PostRelationsDefaultFragment: PostRelationsDefaultFragment
   PostSequenceNavigation: PostSequenceNavigation
   PostSideComments: PostSideComments
+  PostViewTimesDefaultFragment: PostViewTimesDefaultFragment
+  PostViewsDefaultFragment: PostViewsDefaultFragment
   PostWithDialogueMessage: PostWithDialogueMessage
   PostWithGeneratedSummary: PostWithGeneratedSummary
   PostsAuthors: PostsAuthors
@@ -4721,6 +5161,7 @@ interface FragmentTypes {
   RSSFeedMinimumInfo: RSSFeedMinimumInfo
   RSSFeedMutationFragment: RSSFeedMutationFragment
   RSSFeedsDefaultFragment: RSSFeedsDefaultFragment
+  ReadStatusesDefaultFragment: ReadStatusesDefaultFragment
   RecentDiscussionRevisionTagFragment: RecentDiscussionRevisionTagFragment
   RecommendationsCachesDefaultFragment: RecommendationsCachesDefaultFragment
   ReportsDefaultFragment: ReportsDefaultFragment
@@ -4817,9 +5258,11 @@ interface FragmentTypes {
   TagWithFlagsAndRevisionFragment: TagWithFlagsAndRevisionFragment
   TagWithFlagsFragment: TagWithFlagsFragment
   TagsDefaultFragment: TagsDefaultFragment
+  TweetsDefaultFragment: TweetsDefaultFragment
   TypingIndicatorInfo: TypingIndicatorInfo
   TypingIndicatorsDefaultFragment: TypingIndicatorsDefaultFragment
   UnclaimedReportsList: UnclaimedReportsList
+  UserActivitiesDefaultFragment: UserActivitiesDefaultFragment
   UserAltAccountsFragment: UserAltAccountsFragment
   UserBookmarkedPosts: UserBookmarkedPosts
   UserEAGDetailsDefaultFragment: UserEAGDetailsDefaultFragment
@@ -4878,6 +5321,7 @@ interface FragmentTypes {
 
 interface FragmentTypesByCollection {
   AdvisorRequests: "AdvisorRequestsDefaultFragment"|"AdvisorRequestsMinimumInfo"
+  ArbitalCacheses: "ArbitalCachesDefaultFragment"
   ArbitalLinkedPageses: "ArbitalLinkedPagesFragment"
   ArbitalTagContentRels: "ArbitalTagContentRelsDefaultFragment"
   Bans: "BansAdminPageFragment"|"BansDefaultFragment"
@@ -4892,6 +5336,8 @@ interface FragmentTypesByCollection {
   CronHistories: "CronHistoriesDefaultFragment"
   CurationEmails: "CurationEmailsDefaultFragment"
   CurationNotices: "CurationNoticesDefaultFragment"|"CurationNoticesFragment"
+  DatabaseMetadatas: "DatabaseMetadataDefaultFragment"
+  DebouncerEventses: "DebouncerEventsDefaultFragment"
   DialogueChecks: "DialogueCheckInfo"|"DialogueChecksDefaultFragment"
   DialogueMatchPreferences: "DialogueMatchPreferenceInfo"|"DialogueMatchPreferencesDefaultFragment"
   DigestPosts: "DigestPostsDefaultFragment"|"DigestPostsMinimumInfo"
@@ -4900,22 +5346,27 @@ interface FragmentTypesByCollection {
   ElectionVotes: "ElectionVoteInfo"|"ElectionVoteRecentDiscussion"|"ElectionVotesDefaultFragment"
   ElicitQuestionPredictions: "ElicitQuestionPredictionsDefaultFragment"
   ElicitQuestions: "ElicitQuestionFragment"|"ElicitQuestionsDefaultFragment"
+  EmailTokenses: "EmailTokensDefaultFragment"
   FeaturedResources: "FeaturedResourcesDefaultFragment"|"FeaturedResourcesFragment"
   FieldChanges: "FieldChangeFragment"
   ForumEvents: "ForumEventsDefaultFragment"|"ForumEventsDisplay"|"ForumEventsEdit"|"ForumEventsMinimumInfo"
   GardenCodes: "GardenCodeFragment"|"GardenCodeFragmentEdit"|"GardenCodesDefaultFragment"
   GoogleServiceAccountSessions: "GoogleServiceAccountSessionAdminInfo"|"GoogleServiceAccountSessionInfo"|"GoogleServiceAccountSessionsDefaultFragment"
+  Imageses: "ImagesDefaultFragment"
   JargonTerms: "JargonTerms"|"JargonTermsDefaultFragment"|"JargonTermsPost"|"JargonTermsWithPostInfo"
   LWEvents: "LWEventsDefaultFragment"|"emailHistoryFragment"|"lastEventFragment"|"lwEventsAdminPageFragment"|"newEventFragment"
+  LegacyDatas: "LegacyDataDefaultFragment"
   LlmConversations: "LlmConversationsDefaultFragment"|"LlmConversationsFragment"|"LlmConversationsViewingPageFragment"|"LlmConversationsWithMessagesFragment"
   LlmMessages: "LlmMessagesDefaultFragment"|"LlmMessagesFragment"
   Localgroups: "LocalgroupsDefaultFragment"|"localGroupsBase"|"localGroupsEdit"|"localGroupsHomeFragment"|"localGroupsIsOnline"
   ManifoldProbabilitiesCaches: "ManifoldProbabilitiesCachesDefaultFragment"
   Messages: "MessagesDefaultFragment"|"messageListFragment"
+  Migrations: "MigrationsDefaultFragment"
   ModerationTemplates: "ModerationTemplateFragment"|"ModerationTemplatesDefaultFragment"
   ModeratorActions: "ModeratorActionDisplay"|"ModeratorActionsDefaultFragment"
   MultiDocuments: "MultiDocumentContentDisplay"|"MultiDocumentEdit"|"MultiDocumentMinimumInfo"|"MultiDocumentParentDocument"|"MultiDocumentRevision"|"MultiDocumentWithContributors"|"MultiDocumentWithContributorsRevision"|"MultiDocumentsDefaultFragment"|"WithVoteMultiDocument"
   Notifications: "NotificationsDefaultFragment"|"NotificationsList"
+  PageCacheEntries: "PageCacheDefaultFragment"
   PetrovDayActions: "PetrovDayActionInfo"|"PetrovDayActionsDefaultFragment"
   PetrovDayLaunchs: "PetrovDayLaunchInfo"|"PetrovDayLaunchsDefaultFragment"
   PodcastEpisodes: "PodcastEpisodeFull"|"PodcastEpisodesDefaultFragment"
@@ -4923,8 +5374,11 @@ interface FragmentTypesByCollection {
   PostEmbeddings: "PostEmbeddingsDefaultFragment"
   PostRecommendations: "PostRecommendationsDefaultFragment"
   PostRelations: "PostRelationsDefaultFragment"
+  PostViewTimes: "PostViewTimesDefaultFragment"
+  PostViewses: "PostViewsDefaultFragment"
   Posts: "HighlightWithHash"|"PostForReviewWinnerItem"|"PostSequenceNavigation"|"PostSideComments"|"PostWithDialogueMessage"|"PostWithGeneratedSummary"|"PostsAuthors"|"PostsBase"|"PostsBestOfList"|"PostsDefaultFragment"|"PostsDetails"|"PostsEdit"|"PostsEditMutationFragment"|"PostsEditQueryFragment"|"PostsExpandedHighlight"|"PostsForAutocomplete"|"PostsHTML"|"PostsList"|"PostsListBase"|"PostsListTag"|"PostsListTagWithVotes"|"PostsListWithVotes"|"PostsListWithVotesAndSequence"|"PostsMinimumInfo"|"PostsModerationGuidelines"|"PostsOriginalContents"|"PostsPage"|"PostsPlaintextDescription"|"PostsRSSFeed"|"PostsRecentDiscussion"|"PostsReviewVotingList"|"PostsRevision"|"PostsRevisionEdit"|"PostsRevisionsList"|"PostsTopItemInfo"|"PostsTwitterAdmin"|"PostsWithNavigation"|"PostsWithNavigationAndRevision"|"PostsWithVotes"|"ShortformRecentDiscussion"|"SuggestAlignmentPost"|"SunshineCurationPostsList"|"SunshinePostsList"|"UsersBannedFromPostsModerationLog"|"WithVotePost"
   RSSFeeds: "RSSFeedMinimumInfo"|"RSSFeedMutationFragment"|"RSSFeedsDefaultFragment"|"newRSSFeedFragment"
+  ReadStatuses: "ReadStatusesDefaultFragment"
   RecommendationsCaches: "RecommendationsCachesDefaultFragment"
   Reports: "ReportsDefaultFragment"|"UnclaimedReportsList"
   ReviewVotes: "ReviewVotesDefaultFragment"|"reviewAdminDashboard"|"reviewVoteFragment"|"reviewVoteWithUserAndPost"
@@ -4945,7 +5399,9 @@ interface FragmentTypesByCollection {
   TagFlags: "TagFlagEditFragment"|"TagFlagFragment"|"TagFlagsDefaultFragment"
   TagRels: "TagRelBasicInfo"|"TagRelCreationFragment"|"TagRelFragment"|"TagRelHistoryFragment"|"TagRelMinimumFragment"|"TagRelsDefaultFragment"|"WithVoteTagRel"
   Tags: "AllTagsPageFragment"|"ConceptItemFragment"|"ExplorePageTagFragment"|"SunshineTagFragment"|"TagBasicInfo"|"TagCreationHistoryFragment"|"TagDetailedPreviewFragment"|"TagDetailsFragment"|"TagEditFragment"|"TagFragment"|"TagFullContributorsList"|"TagHistoryFragment"|"TagName"|"TagPageArbitalContentFragment"|"TagPageFragment"|"TagPageRevisionWithArbitalContentFragment"|"TagPageWithArbitalContentAndLensRevisionFragment"|"TagPageWithArbitalContentFragment"|"TagPageWithRevisionFragment"|"TagPreviewFragment"|"TagRecentDiscussion"|"TagRevisionFragment"|"TagSectionPreviewFragment"|"TagSubforumFragment"|"TagSubforumSidebarFragment"|"TagSubtagFragment"|"TagWithFlagsAndRevisionFragment"|"TagWithFlagsFragment"|"TagsDefaultFragment"|"UserOnboardingTag"|"WithVoteTag"
+  Tweets: "TweetsDefaultFragment"
   TypingIndicators: "TypingIndicatorInfo"|"TypingIndicatorsDefaultFragment"
+  UserActivities: "UserActivitiesDefaultFragment"
   UserEAGDetails: "UserEAGDetailsDefaultFragment"|"UserEAGDetailsMinimumInfo"
   UserJobAds: "UserJobAdsDefaultFragment"|"UserJobAdsMinimumInfo"
   UserMostValuablePosts: "UserMostValuablePostInfo"|"UserMostValuablePostsDefaultFragment"
@@ -4959,6 +5415,7 @@ interface CollectionNamesByFragmentName {
   AdvisorRequestsDefaultFragment: "AdvisorRequests"
   AdvisorRequestsMinimumInfo: "AdvisorRequests"
   AllTagsPageFragment: "Tags"
+  ArbitalCachesDefaultFragment: never
   ArbitalLinkedPagesFragment: never
   ArbitalTagContentRelsDefaultFragment: "ArbitalTagContentRels"
   BansAdminPageFragment: "Bans"
@@ -4998,6 +5455,8 @@ interface CollectionNamesByFragmentName {
   CurationEmailsDefaultFragment: "CurationEmails"
   CurationNoticesDefaultFragment: "CurationNotices"
   CurationNoticesFragment: "CurationNotices"
+  DatabaseMetadataDefaultFragment: never
+  DebouncerEventsDefaultFragment: never
   DeletedCommentsMetaData: "Comments"
   DeletedCommentsModerationLog: "Comments"
   DialogueCheckInfo: "DialogueChecks"
@@ -5017,6 +5476,7 @@ interface CollectionNamesByFragmentName {
   ElicitQuestionFragment: "ElicitQuestions"
   ElicitQuestionPredictionsDefaultFragment: "ElicitQuestionPredictions"
   ElicitQuestionsDefaultFragment: "ElicitQuestions"
+  EmailTokensDefaultFragment: never
   ExplorePageTagFragment: "Tags"
   FeaturedResourcesDefaultFragment: "FeaturedResources"
   FeaturedResourcesFragment: "FeaturedResources"
@@ -5032,11 +5492,13 @@ interface CollectionNamesByFragmentName {
   GoogleServiceAccountSessionInfo: "GoogleServiceAccountSessions"
   GoogleServiceAccountSessionsDefaultFragment: "GoogleServiceAccountSessions"
   HighlightWithHash: "Posts"
+  ImagesDefaultFragment: never
   JargonTerms: "JargonTerms"
   JargonTermsDefaultFragment: "JargonTerms"
   JargonTermsPost: "JargonTerms"
   JargonTermsWithPostInfo: "JargonTerms"
   LWEventsDefaultFragment: "LWEvents"
+  LegacyDataDefaultFragment: never
   LlmConversationsDefaultFragment: "LlmConversations"
   LlmConversationsFragment: "LlmConversations"
   LlmConversationsViewingPageFragment: "LlmConversations"
@@ -5047,6 +5509,7 @@ interface CollectionNamesByFragmentName {
   ManifoldProbabilitiesCachesDefaultFragment: "ManifoldProbabilitiesCaches"
   MembersOfGroupFragment: "Subscriptions"
   MessagesDefaultFragment: "Messages"
+  MigrationsDefaultFragment: "Migrations"
   ModerationTemplateFragment: "ModerationTemplates"
   ModerationTemplatesDefaultFragment: "ModerationTemplates"
   ModeratorActionDisplay: "ModeratorActions"
@@ -5062,6 +5525,7 @@ interface CollectionNamesByFragmentName {
   MultiDocumentsDefaultFragment: "MultiDocuments"
   NotificationsDefaultFragment: "Notifications"
   NotificationsList: "Notifications"
+  PageCacheDefaultFragment: never
   PetrovDayActionInfo: "PetrovDayActions"
   PetrovDayActionsDefaultFragment: "PetrovDayActions"
   PetrovDayLaunchInfo: "PetrovDayLaunchs"
@@ -5076,6 +5540,8 @@ interface CollectionNamesByFragmentName {
   PostRelationsDefaultFragment: "PostRelations"
   PostSequenceNavigation: "Posts"
   PostSideComments: "Posts"
+  PostViewTimesDefaultFragment: "PostViewTimes"
+  PostViewsDefaultFragment: never
   PostWithDialogueMessage: "Posts"
   PostWithGeneratedSummary: "Posts"
   PostsAuthors: "Posts"
@@ -5114,6 +5580,7 @@ interface CollectionNamesByFragmentName {
   RSSFeedMinimumInfo: "RSSFeeds"
   RSSFeedMutationFragment: "RSSFeeds"
   RSSFeedsDefaultFragment: "RSSFeeds"
+  ReadStatusesDefaultFragment: "ReadStatuses"
   RecentDiscussionRevisionTagFragment: "Revisions"
   RecommendationsCachesDefaultFragment: "RecommendationsCaches"
   ReportsDefaultFragment: "Reports"
@@ -5210,9 +5677,11 @@ interface CollectionNamesByFragmentName {
   TagWithFlagsAndRevisionFragment: "Tags"
   TagWithFlagsFragment: "Tags"
   TagsDefaultFragment: "Tags"
+  TweetsDefaultFragment: "Tweets"
   TypingIndicatorInfo: "TypingIndicators"
   TypingIndicatorsDefaultFragment: "TypingIndicators"
   UnclaimedReportsList: "Reports"
+  UserActivitiesDefaultFragment: "UserActivities"
   UserAltAccountsFragment: "Users"
   UserBookmarkedPosts: "Users"
   UserEAGDetailsDefaultFragment: "UserEAGDetails"

--- a/packages/lesswrong/lib/subscribedUsersFeed.ts
+++ b/packages/lesswrong/lib/subscribedUsersFeed.ts
@@ -1,6 +1,4 @@
-import { registerFragment } from "./vulcan-lib/fragments";
-
-registerFragment(`
+export const SubscribedPostAndCommentsFeed = `
   fragment SubscribedPostAndCommentsFeed on SubscribedPostAndComments {
     _id
     post {
@@ -12,4 +10,4 @@ registerFragment(`
     expandCommentIds
     postIsFromSubscribedUser
   }
-`);
+`

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -1,4 +1,3 @@
-import { getDefaultFragmentText, registerFragment } from './fragments';
 import { registerCollection } from './getCollection';
 import { pluralize } from './pluralize';
 import Collection from "@/server/sql/PgCollection"
@@ -13,9 +12,6 @@ export const createCollection = <N extends CollectionNameString>(
   options: CollectionOptions<N>,
 ): CollectionsByName[N] => {
   const collection: CollectionBase<N> = new Collection(options);
-
-  const defaultFragment = getDefaultFragmentText(collection, options.schema);
-  if (defaultFragment) registerFragment(defaultFragment);
 
   registerCollection(collection);
 

--- a/packages/lesswrong/server/fetchFragment.ts
+++ b/packages/lesswrong/server/fetchFragment.ts
@@ -3,6 +3,7 @@ import { getSqlClientOrThrow } from "./sql/sqlClient";
 import { accessFilterMultiple } from "../lib/utils/schemaUtils";
 import { computeContextFromUser } from "./vulcan-lib/apollo-server/context";
 import { getCollection } from "../lib/vulcan-lib/getCollection";
+import { getSqlFragment } from "@/lib/vulcan-lib/fragments";
 
 type FetchFragmentOptions<
   CollectionName extends CollectionNameString & keyof FragmentTypesByCollection,
@@ -70,8 +71,10 @@ export const fetchFragment = async <
     isSSR: false,
   });
 
+  const sqlFragment = getSqlFragment(fragmentName);
+
   const query = new SelectFragmentQuery(
-    fragmentName as FragmentName,
+    sqlFragment,
     currentUser ?? null,
     resolverArgs,
     selector,

--- a/packages/lesswrong/server/resolvers/defaultResolvers.ts
+++ b/packages/lesswrong/server/resolvers/defaultResolvers.ts
@@ -13,6 +13,7 @@ import isEqual from "lodash/isEqual";
 import { collectionNameToGraphQLType } from "@/lib/vulcan-lib/collections.ts";
 import { getAllCollections, getCollection } from "@/lib/vulcan-lib/getCollection.ts";
 import { convertDocumentIdToIdInSelector } from "@/lib/vulcan-lib/utils.ts";
+import { getSqlFragment } from "@/lib/vulcan-lib/fragments";
 
 const defaultOptions: DefaultResolverOptions = {
   cacheMaxAge: 300,
@@ -141,8 +142,9 @@ const addDefaultResolvers = <N extends CollectionNameString>(
 
       let fetchDocs: () => Promise<T[]>;
       if (fragmentName) {
+        const sqlFragment = getSqlFragment(fragmentName as FragmentName);
         const query = new SelectFragmentQuery(
-          fragmentName as FragmentName,
+          sqlFragment,
           currentUser,
           {...resolverArgs, ...terms},
           parameters.selector,
@@ -246,8 +248,9 @@ const addDefaultResolvers = <N extends CollectionNameString>(
 
       let doc: ObjectsByCollectionName[N] | null;
       if (fragmentName) {
+        const sqlFragment = getSqlFragment(fragmentName as FragmentName);
         const query = new SelectFragmentQuery(
-          fragmentName as FragmentName,
+          sqlFragment,
           currentUser,
           resolverArgs,
           selector,

--- a/packages/lesswrong/server/resolvers/jargonResolvers/jargonTermResolvers.ts
+++ b/packages/lesswrong/server/resolvers/jargonResolvers/jargonTermResolvers.ts
@@ -7,7 +7,7 @@ augmentFieldsDict(JargonTerms, {
   humansAndOrAIEdited: {
     resolveAs: {
       type: 'String',
-      resolver: async (document: DbJargonTerm, args: void, context: ResolverContext): Promise<JargonTermsDefaultFragment['humansAndOrAIEdited'] | null> => {
+      resolver: async (document: DbJargonTerm, args: void, context: ResolverContext): Promise<JargonTermsPost['humansAndOrAIEdited'] | null> => {
         const botAccountId = await getAdminTeamAccountId();
         if (!botAccountId) {
           return null;

--- a/packages/lesswrong/server/sql/SelectFragmentQuery.ts
+++ b/packages/lesswrong/server/sql/SelectFragmentQuery.ts
@@ -48,7 +48,6 @@ class SelectFragmentQuery<
      */
     prefixGenerator?: PrefixGenerator,
   ) {
-    // const fragment = getSqlFragment(fragmentName);
     const projection = sqlFragment.buildProjection<N>(
       currentUser,
       resolverArgs,

--- a/packages/lesswrong/server/sql/SelectFragmentQuery.ts
+++ b/packages/lesswrong/server/sql/SelectFragmentQuery.ts
@@ -1,6 +1,7 @@
 import SelectQuery from "./SelectQuery";
 import { getSqlFragment } from "../../lib/vulcan-lib/fragments";
 import type { CodeResolverMap, PrefixGenerator } from "./ProjectionContext";
+import type SqlFragment from "./SqlFragment";
 
 /**
  * `SelectFragmentQuery` is the main external interface for running select
@@ -23,8 +24,8 @@ class SelectFragmentQuery<
   private codeResolvers: CodeResolverMap = {};
 
   constructor(
-    /** The name of the fragment to use */
-    private fragmentName: FragmentName,
+    /** The SQL fragment to use */
+    private sqlFragment: SqlFragment,
     /** The current user, of null if logged out */
     currentUser: DbUser | null,
     /** Dictionary of arguments to pass to custom resolvers */
@@ -47,8 +48,8 @@ class SelectFragmentQuery<
      */
     prefixGenerator?: PrefixGenerator,
   ) {
-    const fragment = getSqlFragment(fragmentName);
-    const projection = fragment.buildProjection<N>(
+    // const fragment = getSqlFragment(fragmentName);
+    const projection = sqlFragment.buildProjection<N>(
       currentUser,
       resolverArgs,
       prefixGenerator,
@@ -85,7 +86,7 @@ class SelectFragmentQuery<
   }
 
   private getCommentLine() {
-    return `-- Fragment ${this.fragmentName}\n`;
+    return `-- Fragment ${this.sqlFragment.getName()}\n`;
   }
 
   compile() {

--- a/packages/lesswrong/server/sql/tests/testFragments.ts
+++ b/packages/lesswrong/server/sql/tests/testFragments.ts
@@ -1,0 +1,32 @@
+export const TestCollection2DefaultFragment = `
+  fragment TestCollection2DefaultFragment on TestCollection2 {
+    _id
+    data
+  }
+`
+
+export const TestCollection3DefaultFragment = `
+  fragment TestCollection3DefaultFragment on TestCollection3 {
+    _id
+    notNullData
+  }
+`
+
+export const TestCollection4DefaultFragment = `
+  fragment TestCollection4DefaultFragment on TestCollection4 {
+    _id
+    testCollection3Id
+    testCollection3 {
+      ...TestCollection3DefaultFragment
+    }
+  }
+`
+
+export const TestCollection4ArgFragment = `
+  fragment TestCollection4ArgFragment on TestCollection4 {
+    _id
+    testCollection2(testCollection2Id: $testCollection2Id) {
+      ...TestCollection2DefaultFragment
+    }
+  }
+`

--- a/packages/lesswrong/server/sql/tests/testHelpers.ts
+++ b/packages/lesswrong/server/sql/tests/testHelpers.ts
@@ -2,8 +2,6 @@ import { registerCollection } from "@/lib/vulcan-lib/getCollection";
 import Table from "../Table";
 import Query from "../Query";
 import { foreignKeyField, resolverOnlyField } from "@/lib/utils/schemaUtils";
-import { registerFragment } from "@/lib/vulcan-lib/fragments.ts";
-
 export type DbTestObject = {
   _id: string,
   a?: number,
@@ -72,12 +70,12 @@ export const TestCollection2 = {
   },
 } as unknown as CollectionBase<CollectionNameString>;
 
-registerFragment(`
+export const TestCollection2DefaultFragment = `
   fragment TestCollection2DefaultFragment on TestCollection2 {
     _id
     data
   }
-`);
+`
 
 export const testTable2 = Table.fromCollection<CollectionNameString, DbTestObject2>(TestCollection2);
 (TestCollection2 as any).getTable = () => testTable2;
@@ -110,12 +108,12 @@ export const testTable3 = Table.fromCollection<CollectionNameString, DbTestObjec
 (TestCollection3 as any).getTable = () => testTable3;
 registerCollection(TestCollection3);
 
-registerFragment(`
+export const TestCollection3DefaultFragment = `
   fragment TestCollection3DefaultFragment on TestCollection3 {
     _id
     notNullData
   }
-`);
+`
 
 export type DbTestObject4 = {
   _id: string,
@@ -164,7 +162,7 @@ export const testTable4 = Table.fromCollection<CollectionNameString, DbTestObjec
 (TestCollection4 as any).getTable = () => testTable4;
 registerCollection(TestCollection4);
 
-registerFragment(`
+export const TestCollection4DefaultFragment = `
   fragment TestCollection4DefaultFragment on TestCollection4 {
     _id
     testCollection3Id
@@ -172,16 +170,16 @@ registerFragment(`
       ...TestCollection3DefaultFragment
     }
   }
-`);
+`
 
-registerFragment(`
+export const TestCollection4ArgFragment = `
   fragment TestCollection4ArgFragment on TestCollection4 {
     _id
     testCollection2(testCollection2Id: $testCollection2Id) {
       ...TestCollection2DefaultFragment
     }
   }
-`);
+`
 
 export const normalizeWhitespace = (s: string) => s.trim().replace(/\s+/g, " ");
 

--- a/packages/lesswrong/server/sql/tests/testHelpers.ts
+++ b/packages/lesswrong/server/sql/tests/testHelpers.ts
@@ -70,13 +70,6 @@ export const TestCollection2 = {
   },
 } as unknown as CollectionBase<CollectionNameString>;
 
-export const TestCollection2DefaultFragment = `
-  fragment TestCollection2DefaultFragment on TestCollection2 {
-    _id
-    data
-  }
-`
-
 export const testTable2 = Table.fromCollection<CollectionNameString, DbTestObject2>(TestCollection2);
 (TestCollection2 as any).getTable = () => testTable2;
 registerCollection(TestCollection2);
@@ -107,13 +100,6 @@ export const TestCollection3 = {
 export const testTable3 = Table.fromCollection<CollectionNameString, DbTestObject3>(TestCollection3);
 (TestCollection3 as any).getTable = () => testTable3;
 registerCollection(TestCollection3);
-
-export const TestCollection3DefaultFragment = `
-  fragment TestCollection3DefaultFragment on TestCollection3 {
-    _id
-    notNullData
-  }
-`
 
 export type DbTestObject4 = {
   _id: string,
@@ -161,25 +147,6 @@ export const TestCollection4 = {
 export const testTable4 = Table.fromCollection<CollectionNameString, DbTestObject4>(TestCollection4);
 (TestCollection4 as any).getTable = () => testTable4;
 registerCollection(TestCollection4);
-
-export const TestCollection4DefaultFragment = `
-  fragment TestCollection4DefaultFragment on TestCollection4 {
-    _id
-    testCollection3Id
-    testCollection3 {
-      ...TestCollection3DefaultFragment
-    }
-  }
-`
-
-export const TestCollection4ArgFragment = `
-  fragment TestCollection4ArgFragment on TestCollection4 {
-    _id
-    testCollection2(testCollection2Id: $testCollection2Id) {
-      ...TestCollection2DefaultFragment
-    }
-  }
-`
 
 export const normalizeWhitespace = (s: string) => s.trim().replace(/\s+/g, " ");
 

--- a/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
@@ -9,7 +9,6 @@ describe("SelectFragmentQuery", () => {
     {
       name: "can build fragment queries with a where clause",
       getQuery: () => new SelectFragmentQuery(
-        // "TestCollection4DefaultFragment" as FragmentName,
         new SqlFragment(TestCollection4DefaultFragment, (fragmentName: FragmentName) => getMemoizedFragmentInfo(fragmentName).sqlFragment ?? null),
         {_id: "test-user-id"} as DbUser,
         null,
@@ -36,7 +35,6 @@ describe("SelectFragmentQuery", () => {
     {
       name: "can build fragment queries with resolver args",
       getQuery: () => new SelectFragmentQuery(
-        // "TestCollection4ArgFragment" as FragmentName,
         new SqlFragment(TestCollection4ArgFragment, (fragmentName: FragmentName) => getMemoizedFragmentInfo(fragmentName).sqlFragment ?? null),
         {_id: "test-user-id"} as DbUser,
         {testCollection2Id: "some-test-id"},

--- a/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
+++ b/packages/lesswrong/unitTests/sql/SelectFragmentQuery.tests.ts
@@ -1,12 +1,16 @@
+import { getMemoizedFragmentInfo } from "@/lib/fragments/allFragments";
 import SelectFragmentQuery from "@/server/sql/SelectFragmentQuery";
+import SqlFragment from "@/server/sql/SqlFragment";
 import { runTestCases } from "@/server/sql/tests/testHelpers";
+import { TestCollection4DefaultFragment, TestCollection4ArgFragment } from "@/server/sql/tests/testFragments";
 
 describe("SelectFragmentQuery", () => {
   runTestCases([
     {
       name: "can build fragment queries with a where clause",
       getQuery: () => new SelectFragmentQuery(
-        "TestCollection4DefaultFragment" as FragmentName,
+        // "TestCollection4DefaultFragment" as FragmentName,
+        new SqlFragment(TestCollection4DefaultFragment, (fragmentName: FragmentName) => getMemoizedFragmentInfo(fragmentName).sqlFragment ?? null),
         {_id: "test-user-id"} as DbUser,
         null,
         {_id: "test-document-id"},
@@ -32,7 +36,8 @@ describe("SelectFragmentQuery", () => {
     {
       name: "can build fragment queries with resolver args",
       getQuery: () => new SelectFragmentQuery(
-        "TestCollection4ArgFragment" as FragmentName,
+        // "TestCollection4ArgFragment" as FragmentName,
+        new SqlFragment(TestCollection4ArgFragment, (fragmentName: FragmentName) => getMemoizedFragmentInfo(fragmentName).sqlFragment ?? null),
         {_id: "test-user-id"} as DbUser,
         {testCollection2Id: "some-test-id"},
         {_id: "test-document-id"},


### PR DESCRIPTION
Refactors our fragment handling.  Several major changes:
1. Fragments are exported as string literals rather than being effectfully-registered to a global object
2. Almost all uses of `getFragment` are replaced with uses of `fragmentTextForQuery`
3. Given that, WrappedSmartForm loses some redundant props
4. We no longer register default fragments inside of `createCollection`. The changed execution order means we now also have all the universal fields added to collections inside of the default fragments, which seems good because we were previously missing _id fields and that can cause wonkiness.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209563990956062) by [Unito](https://www.unito.io)
