### PR TITLE
Explicitly call elastic sync in create and update mutator

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -4,7 +4,6 @@ import { HAS_EMBEDDINGS_FOR_RECOMMENDATIONS } from '../embeddings';
 import { handleCrosspostUpdate, performCrosspost } from "../fmCrosspost/crosspost";
 import { AfterCreateCallbackProperties, CallbackValidationErrors, CreateCallbackProperties, getCollectionHooks, UpdateCallbackProperties } from '../mutationCallbacks';
 import { rehostPostMetaImages } from '../scripts/convertImagesToCloudinary';
-import { elasticSyncDocument } from '../search/elastic/elasticCallbacks';
 import { moveToAFUpdatesUserAFKarma } from './alignment-forum/callbacks';
 import { addLinkSharingKey, addReferrerToPost, applyNewPostTags, assertPostTitleHasNoEmojis, autoTagNewPost, autoTagUndraftedPost, checkRecentRepost, checkTosAccepted, clearCourseEndTime, createNewJargonTermsCallback, debateMustHaveCoauthor, eventUpdatedNotifications, extractSocialPreviewImage, fixEventStartAndEndTimes, lwPostsNewUpvoteOwnPost, notifyUsersAddedAsCoauthors, notifyUsersAddedAsPostCoauthors, oldPostsLastCommentedAt, onEditAddLinkSharingKey, onPostPublished, postsNewDefaultLocation, postsNewDefaultTypes, postsNewPostRelation, postsNewRateLimit, postsNewUserApprovedStatus, postsUndraftRateLimit, removeFrontpageDate, removeRedraftNotifications, resetDialogueMatches, resetPostApprovedDate, scheduleCoauthoredPostWhenUndrafted, scheduleCoauthoredPostWithUnconfirmedCoauthors, sendAlignmentSubmissionApprovalNotifications, sendCoauthorRequestNotifications, sendEAFCuratedAuthorsNotification, sendLWAFPostCurationEmails, sendNewPublishedDialogueMessageNotifications, sendPostApprovalNotifications, sendPostSharedWithUserNotifications, sendRejectionPM, sendUsersSharedOnPostNotifications, setPostUndraftedFields, syncTagRelevance, triggerReviewForNewPostIfNeeded, updateCommentHideKarma, updatedPostMaybeTriggerReview, updateFirstDebateCommentPostId, updatePostEmbeddingsOnChange, updatePostShortform, updateRecombeePost, updateUserNotesOnPostDraft, updateUserNotesOnPostRejection } from './postCallbackFunctions';
 
@@ -107,9 +106,6 @@ async function postCreateAsync(props: AfterCreateCallbackProperties<'Posts'>) {
   await notifyUsersAddedAsPostCoauthors(props);
   await triggerReviewForNewPostIfNeeded(props);
   await autoTagNewPost(props);
-
-  // elastic callback
-  await elasticSyncDocument('Posts', props.document._id);
 }
 
 async function postNewAsync(post: DbPost) {
@@ -200,10 +196,6 @@ async function postEditAsync(post: DbPost, oldPost: DbPost, currentUser: DbUser 
   await updateCommentHideKarma(post, oldPost, context);
   await extractSocialPreviewImage(post, props);
   await oldPostsLastCommentedAt(post, context);
-
-
-  // elastic callbacks
-  await elasticSyncDocument('Posts', post._id);
 }
 
 getCollectionHooks('Posts').createValidate.add(postCreateValidate);

--- a/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
+++ b/packages/lesswrong/server/search/elastic/elasticCallbacks.ts
@@ -1,16 +1,11 @@
-import {
-  SearchIndexCollectionName,
-  searchIndexedCollectionNames,
-} from "../../../lib/search/searchUtil";
-import { getCollectionHooks } from "../../mutationCallbacks";
+import { SearchIndexCollectionName } from "../../../lib/search/searchUtil";
 import ElasticClient from "./ElasticClient";
 import ElasticExporter from "./ElasticExporter";
-import { isElasticEnabled } from "../../../lib/instanceSettings";
 
-export const elasticSyncDocument = async (
+export async function elasticSyncDocument(
   collectionName: SearchIndexCollectionName,
   documentId: string,
-) => {
+) {
   try {
     const client = new ElasticClient();
     const exporter = new ElasticExporter(client);
@@ -18,17 +13,5 @@ export const elasticSyncDocument = async (
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(`[${collectionName}] Failed to index Elasticsearch document:`, e);
-  }
-}
-
-export const registerElasticCallbacks = () => {
-  if (!isElasticEnabled) {
-    return;
-  }
-
-  for (const collectionName of searchIndexedCollectionNames) {
-    const callback = ({_id}: DbObject) => elasticSyncDocument(collectionName, _id);
-    getCollectionHooks(collectionName).createAsync.add(({ document }) => callback(document));
-    getCollectionHooks(collectionName).editAsync.add(callback);
   }
 }

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -17,7 +17,6 @@ import { isAnyTest, isMigrations } from '@/lib/executionEnvironment';
 import chokidar from 'chokidar';
 import fs from 'fs';
 import { basename, join } from 'path';
-import { registerElasticCallbacks } from './search/elastic/elasticCallbacks';
 import type { CommandLineArguments } from './commandLine';
 
 /**
@@ -59,7 +58,6 @@ export async function runServerOnStartupFunctions() {
   // define executableSchema
   createVoteableUnionType();
   initGraphQL();
-  registerElasticCallbacks();
 
   startSyncedCron();
 }

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -193,6 +193,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
 
     await onVoteCancel(newDocument, vote, collection, user);
   }
+  // TODO: it seems possible we could do an early return here if we have zero vote cancellations, but I want to test it more thoroughly before doing that
   const newScores = await recalculateDocumentScores(document, collection.collectionName, context);
   await collection.rawUpdateOne(
     {_id: document._id},


### PR DESCRIPTION
Just getting rid of some more callbacks.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209564715177881) by [Unito](https://www.unito.io)
