### PR TITLE
[EA] Remove tag notification subscription from onboarding

### DIFF
--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingTag.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingTag.tsx
@@ -4,6 +4,8 @@ import { useNotifyMe } from "../../hooks/useNotifyMe";
 import { useOptimisticToggle } from "../../hooks/useOptimisticToggle";
 import classNames from "classnames";
 import { useEAOnboarding } from "./useEAOnboarding";
+import { useSubscribeUserToTag } from "@/lib/filterSettings";
+import React from "react";
 
 const TAG_SIZE = 103;
 
@@ -73,21 +75,17 @@ export const EAOnboardingTag = ({tag, onSubscribed, classes}: {
 }) => {
   const {viewAsAdmin} = useEAOnboarding();
 
-  const {isSubscribed, onSubscribe} = useNotifyMe({
-    document: tag,
-    overrideSubscriptionType: "newTagPosts",
-    hideFlashes: true,
-  });
+  const { isSubscribed, subscribeUserToTag } = useSubscribeUserToTag(tag)
 
   // If viewAsAdmin is true, then this is an admin testing
   // and we don't want any real updates to happen
   const subscribedCallback = useCallback((
-    e: MouseEvent<HTMLDivElement>,
+    _e: MouseEvent<HTMLDivElement>,
     newValue: boolean,
   ) => {
-    !viewAsAdmin && void onSubscribe?.(e);
+    !viewAsAdmin && void subscribeUserToTag(tag, newValue ? "Subscribed" : "Default")
     onSubscribed?.(tag._id, newValue);
-  }, [onSubscribe, onSubscribed, tag._id, viewAsAdmin]);
+  }, [onSubscribed, subscribeUserToTag, tag, viewAsAdmin]);
 
   const [subscribed, toggleSubscribed] = useOptimisticToggle(
     viewAsAdmin ? false : (isSubscribed ?? false),

--- a/packages/lesswrong/lib/filterSettings.ts
+++ b/packages/lesswrong/lib/filterSettings.ts
@@ -172,13 +172,13 @@ export const filterModeIsSubscribed = (filterMode: FilterMode) =>
  * A simple wrapper on top of useFilterSettings focused on a single tag
  * subscription
  */
-export const useSubscribeUserToTag = (tag?: TagBasicInfo) => {
+export const useSubscribeUserToTag = (tag?: Pick<TagBasicInfo, "_id" | "name">) => {
   const { filterSettings, setTagFilter } = useFilterSettings()
   
   const tagFilterSetting = filterSettings.tags.find(ft => tag && ft.tagId === tag._id)
   const isSubscribed = !!(tagFilterSetting && (filterModeIsSubscribed(tagFilterSetting.filterMode)))
   
-  const subscribeUserToTag = useCallback((tag: TagBasicInfo, filterMode: FilterMode) => {
+  const subscribeUserToTag = useCallback((tag: Pick<TagBasicInfo, "_id" | "name">, filterMode: FilterMode) => {
     setTagFilter({
       tagId: tag._id,
       tagName: tag.name,


### PR DESCRIPTION
We discovered that newTagPosts notifications make up 96% of all notifications, and this increased a lot after we added this onboarding stage. This PR changes the behaviour to just upweight the tag on the frontpage, but not subscribe to notifications (which is actually closer to what the copy implies already):
![Screenshot 2025-03-04 at 14 13 20](https://github.com/user-attachments/assets/a91029b2-08a9-4f42-99d0-c1266e44c544)
