### PR TITLE
[EA] Remove Facebook option from signup form

### DIFF
--- a/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
+++ b/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
@@ -444,7 +444,7 @@ export const EALoginPopover = ({action: action_, setAction: setAction_, facebook
             >
               <img src={links.googleLogo} /> Continue with Google
             </EAButton>}
-            {facebookEnabled && <EAButton
+            {facebookEnabled && !isSignup && <EAButton
               style="grey"
               variant="outlined"
               onClick={onClickFacebook}


### PR DESCRIPTION
We are deprecating facebook login soon. Disabling new signups means we can export a list of users who are affected without needing to deal with stragglers later.

Note that this doesn't actually disable new signups, if you click the button from the login section it will still sign you up. But the rate of Facebook signups is about 3 a month so I'm hoping this will deter people until we cut it entirely (around ~1st April). I will re-check before removing the connection entirely that there aren't any new signups

![Screenshot 2025-03-06 at 14 13 48](https://github.com/user-attachments/assets/0dd08167-c7d9-4670-a347-039edf21d6a4)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209596547100068) by [Unito](https://www.unito.io)
