### PR TITLE
Improve metrics for time spent on SSR

### DIFF
--- a/packages/lesswrong/server/sql/sqlClient.ts
+++ b/packages/lesswrong/server/sql/sqlClient.ts
@@ -1,6 +1,8 @@
 import type { DbTarget } from "./PgCollection";
+import { isProduction } from "@/lib/executionEnvironment";
 
 export const logAllQueries = false;
+export const measureSqlBytesDownloaded = !isProduction;
 
 /** Main sql client which is safe to use for all queries */
 let sql: SqlClient | null = null;


### PR DESCRIPTION
At the end of an SSR, there's an event "ssr" (sent to analytics db and also logged in the console) with a "timings" field. The timings in that field were prerenderTime, renderTime, and totalTime; but the prerender/render distinction doesn't actually make sense with our current setup, so this is really only provides a wall-time measurement. It'd be nice to have something more granular, particularly for when doing local development and optimizing.

Replace the timings with wallTime, cpuTime, and sqlBytesDownloaded. These represent the time from request start to completion, time spent not idle (ie, excluding database round trips), and size of (JSON stringified) database query result sets. Note that sqlBytesDownloaded does not account for compression and does not account for the actual wire format (which isn't JSON), but it should be directionally correct.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209616304669873) by [Unito](https://www.unito.io)
