### PR TITLE
Improve some things about the `yarn repl` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "eslint": "eslint --max-warnings 0 --cache --ext .jsx,js,tsx,ts packages",
     "build": "ts-node --transpile-only ./build.ts",
     "migrate": "ts-node -r tsconfig-paths/register ./migrate.ts",
-    "repl": "NODE_OPTIONS=--inspect ts-node --swc -r tsconfig-paths/register --project tsconfig-repl.json scripts/repl.ts",
+    "repl": "NODE_OPTIONS='--inspect --no-deprecation' ts-node --swc -r tsconfig-paths/register --project tsconfig-repl.json scripts/repl.ts",
     "upload-ckeditor-bundle": "node -r tsconfig-paths/register deployCkEditorBundle",
     "branchdb": "ts-node -r tsconfig-paths/register scripts/branchDb.ts",
     "start": "yarn start-local-db",

--- a/packages/lesswrong/server/example.ts
+++ b/packages/lesswrong/server/example.ts
@@ -1,4 +1,0 @@
-
-export function throwException() {
-  throw new Error("Test")
-}

--- a/packages/lesswrong/server/example.ts
+++ b/packages/lesswrong/server/example.ts
@@ -1,0 +1,4 @@
+
+export function throwException() {
+  throw new Error("Test")
+}

--- a/packages/lesswrong/server/logging.ts
+++ b/packages/lesswrong/server/logging.ts
@@ -29,8 +29,6 @@ process.on("unhandledRejection", (r: any) => {
   }
 });
 
-captureEvent("serverStarted", {});
-
 
 export function serverInitSentry() {
   const sentryUrl = sentryUrlSetting.get()

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -18,6 +18,7 @@ import chokidar from 'chokidar';
 import fs from 'fs';
 import { basename, join } from 'path';
 import type { CommandLineArguments } from './commandLine';
+import { captureEvent } from '@/lib/analyticsEvents';
 
 /**
  * Entry point for the server, assuming it's a webserver (ie not cluster mode,
@@ -60,6 +61,7 @@ export async function runServerOnStartupFunctions() {
   initGraphQL();
 
   startSyncedCron();
+  captureEvent("serverStarted", {});
 }
 
 

--- a/scripts/repl.ts
+++ b/scripts/repl.ts
@@ -129,13 +129,19 @@ async function replMain() {
       repl.evalCode(`const {${Object.keys(importsExceptDefault).join(", ")}} = __repl_import;\n`);
     }
     if (commandLineOptions.command) {
-      const result = await repl.evalCode(commandLineOptions.command);
-      console.log(result);
-      process.exit(0);
+      try {
+        const result = await repl.evalCode(commandLineOptions.command);
+        console.log(result);
+      } finally {
+        process.exit(0);
+      }
     } else if (defaultExport && typeof defaultExport==='function') {
-      const result = await defaultExport();
-      console.log(result);
-      process.exit(0);
+      try {
+        const result = await defaultExport();
+        console.log(result);
+      } finally {
+        process.exit(0);
+      }
     }
   })();
 }


### PR DESCRIPTION
 * yarn repl [script] quits properly if the script fails
 * Don't send `serverStarted` event to analytics DB when creating a REPL
 * Suppress the nodejs warning about punycode

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209616339478360) by [Unito](https://www.unito.io)
