### PR TITLE
[EA] Log detailed sentry exception when error occurs during signup

### DIFF
--- a/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
+++ b/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
@@ -9,6 +9,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { useRefetchCurrentUser } from "../../common/withUser";
 import {forumTitleSetting, siteNameWithArticleSetting} from '../../../lib/instanceSettings'
 import { LoginAction, useLoginPopoverContext } from "../../hooks/useLoginPopoverContext";
+import { captureException } from '@sentry/core';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -265,10 +266,21 @@ export const EALoginPopover = ({action: action_, setAction: setAction_, facebook
     } catch(e) {
       // eslint-disable-next-line no-console
       console.error(e);
+      captureException(e, {
+        tags: {
+          component: "EALoginPopover",
+          action: action || "unknown",
+        },
+        extra: {
+          email,
+          isSignup,
+          isResettingPassword,
+        },
+      });
       setError(e.description || e.message || String(e) || "An error occurred");
     }
     setLoading(false);
-  }, [client, email]);
+  }, [client, email, action, isSignup, isResettingPassword]);
 
   const onSubmit = useCallback(async (ev: FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
@@ -297,6 +309,17 @@ export const EALoginPopover = ({action: action_, setAction: setAction_, facebook
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);
+      captureException(e, {
+        tags: {
+          component: "EALoginPopover",
+          action: action || "unknown",
+        },
+        extra: {
+          email,
+          isSignup,
+          isResettingPassword,
+        },
+      });
       setError(e.description || e.message || String(e) || "An error occurred");
       setPolicy(e.policy ?? null);
     } finally {
@@ -304,7 +327,7 @@ export const EALoginPopover = ({action: action_, setAction: setAction_, facebook
     }
   }, [
     client, email, password, isSignup, isResettingPassword,
-    onSendPasswordReset, refetchCurrentUser,
+    onSendPasswordReset, refetchCurrentUser, action,
   ]);
 
   const onClickGoogle = useCallback(async () => {


### PR DESCRIPTION
This is to monitor for new errors that occur as a result of:
- Cutting Mongo
- Cutting Facebook login

I have created an [alert](https://centre-for-effective-altruism.sentry.io/alerts/rules/ea-forum/15843318/details/) in Sentry to forward errors to the #forum-auth-errors Slack channel