### PR TITLE
Reduce excessive HoCs

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -84,7 +84,7 @@ export type ContentReplacedSubstringComponentInfo = {
   props: AnyBecauseHard
 };
 
-interface ContentItemBodyProps extends ExternalProps, WithStylesProps, WithUserProps, WithLocationProps, WithTrackingProps {}
+interface ContentItemBodyProps extends ExternalProps, WithTrackingProps {}
 interface ContentItemBodyState {
   updatedElements: boolean,
   renderIndex: number
@@ -632,7 +632,8 @@ const addNofollowToHTML = (html: string): string => {
 
 const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
   hocs: [withTracking],
-  
+  allowRef: true,
+
   // Memoization options. If this spuriously rerenders, then voting on a comment
   // that contains a YouTube embed causes that embed to visually flash and lose
   // its place.

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -632,6 +632,8 @@ const addNofollowToHTML = (html: string): string => {
 
 const ContentItemBodyComponent = registerComponent<ExternalProps>("ContentItemBody", ContentItemBody, {
   hocs: [withTracking],
+  
+  // NOTE: Because this takes a ref, it can only use HoCs that will forward that ref.
   allowRef: true,
 
   // Memoization options. If this spuriously rerenders, then voting on a comment

--- a/packages/lesswrong/components/common/withErrorBoundary.tsx
+++ b/packages/lesswrong/components/common/withErrorBoundary.tsx
@@ -9,13 +9,11 @@ import { Components } from '../../lib/vulcan-lib/components';
 /// In order to catch errors that occur in other higher-order components on
 /// the same component, put this _first_.
 const withErrorBoundary = (WrappedComponent: React.FunctionComponent<unknown & { ref: React.ForwardedRef<unknown> }>) => {
-  return forwardRef((props, ref) => {
-    return (
-      <Components.ErrorBoundary>
-        <WrappedComponent ref={ref} {...props} />
-      </Components.ErrorBoundary>
-    );
-  })
+  return function WrapWithErrorBoundary(props: AnyBecauseHard) {
+    return <Components.ErrorBoundary>
+      <WrappedComponent {...props} />
+    </Components.ErrorBoundary>
+  }
 }
 
 export default withErrorBoundary

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -816,7 +816,9 @@ export class Editor extends Component<EditorProps,EditorComponentState> {
 // can call its methods, which means it can't have any HoCs. In particular, it
 // can't have 'styles' (since that would add a HoC); instead, it exports its
 // styles, and has classes provided by whatever wraps it.
-export const EditorComponent = registerComponent('Editor', Editor);
+export const EditorComponent = registerComponent('Editor', Editor, {
+  allowRef: true,
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/forumEvents/ForumEventSticker.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventSticker.tsx
@@ -59,7 +59,7 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-type ForumEventStickerProps = {
+const ForumEventSticker = ({ x, y, theta, user, comment, emoji, icon = "AddEmoji", tooltipDisabled, onClear, saveDraftSticker, setUserVoteRef, classes }: {
   x: number;
   y: number;
   theta: number;
@@ -70,11 +70,9 @@ type ForumEventStickerProps = {
   tooltipDisabled?: boolean;
   onClear?: () => void;
   saveDraftSticker?: (event: React.MouseEvent) => void;
-};
-const ForumEventSticker = React.forwardRef<
-  HTMLDivElement,
-  ForumEventStickerProps & { classes: ClassesType<typeof styles> }
->(({ x, y, theta, user, comment, emoji, icon = "AddEmoji", tooltipDisabled, onClear, saveDraftSticker, classes }, ref) => {
+  setUserVoteRef?: any
+  classes: ClassesType<typeof styles>
+}) => {
   const { ForumIcon, ForumEventResultPopper, LWTooltip, UsersNameDisplay } = Components;
 
   const isHoverSticker = !!saveDraftSticker;
@@ -92,7 +90,7 @@ const ForumEventSticker = React.forwardRef<
     <InteractionWrapper>
       <div
         className={classNames(classes.sticker, {[classes.hoverSticker]: isHoverSticker})}
-        ref={ref}
+        ref={setUserVoteRef}
         style={{
           left: `${x * 100}%`,
           top: `${y * 100}%`,
@@ -127,7 +125,7 @@ const ForumEventSticker = React.forwardRef<
       </div>
     </InteractionWrapper>
   );
-});
+}
 
 
 const ForumEventStickerComponent = registerComponent( 'ForumEventSticker', ForumEventSticker, {styles});

--- a/packages/lesswrong/components/forumEvents/ForumEventStickers.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventStickers.tsx
@@ -261,7 +261,7 @@ const ForumEventStickers: FC<{
           <ForumEventSticker
             {...draftSticker}
             tooltipDisabled={commentFormOpen}
-            ref={setUserVoteRef}
+            setUserVoteRef={setUserVoteRef}
             onClear={() => clearSticker(null)}
           />
         )}

--- a/packages/lesswrong/components/peopleDirectory/peopleDirectoryColumns.ts
+++ b/packages/lesswrong/components/peopleDirectory/peopleDirectoryColumns.ts
@@ -34,9 +34,9 @@ export type PeopleDirectoryColumn<
   defaultSort?: "asc" | "desc",
   columnWidth?: string,
   componentName: T,
-  props?: Omit<ComponentProps<ComponentTypes[T]>, "user">,
+  props?: Omit<ComponentProps<ComponentTypes[T]>, "user"|"ref">,
   skeletonComponentName?: S,
-  skeletonProps?: Omit<ComponentProps<ComponentTypes[S]>, "user">,
+  skeletonProps?: Omit<ComponentProps<ComponentTypes[S]>, "user"|"ref">,
 } & PeopleDirectoryColumnState;
 
 export const peopleDirectoryColumns: PeopleDirectoryColumn<CellComponentName>[] = [

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -183,9 +183,9 @@ will likely have to add tracking manually with a captureEvent call. (Search code
 The best way to ensure you are tracking correctly with is to look at the logs
 in the client or server (ensure getShowAnalyticsDebug is returning true).
 */
-export const AnalyticsContext = ({children, ...props}: AnalyticsProps & {
+export function AnalyticsContext({children, ...props}: AnalyticsProps & {
   children: ReactNode,
-}) => {
+}) {
   const existingContextData = useContext(ReactTrackingContext)
 
   // Create a child context, which is the parent context plus the provided props

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -87,7 +87,7 @@ const addClassnames = (componentName: string, styles: any, hasForwardRef: boolea
   const classesProxy = classNameProxy(componentName+'-');
   
   if (hasForwardRef) {
-    return (WrappedComponent: any) => forwardRef((props, ref) => {
+    return (WrappedComponent: any) => forwardRef(function addClassnames(props, ref) {
       const emailRenderContext = React.useContext(EmailRenderContext);
       if (emailRenderContext?.isEmailRender) {
         const withStylesHoc = withStyles(styles, {name: componentName})
@@ -97,7 +97,7 @@ const addClassnames = (componentName: string, styles: any, hasForwardRef: boolea
       return <WrappedComponent ref={ref} {...props} classes={classesProxy}/>
     })
   } else {
-    return (WrappedComponent: any) => (props: AnyBecauseHard) => {
+    return (WrappedComponent: any) => function addClassnames(props: AnyBecauseHard) {
       const emailRenderContext = React.useContext(EmailRenderContext);
       if (emailRenderContext?.isEmailRender) {
         const withStylesHoc = withStyles(styles, {name: componentName})

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -87,7 +87,7 @@ const addClassnames = (componentName: string, styles: any, hasForwardRef: boolea
   const classesProxy = classNameProxy(componentName+'-');
   
   if (hasForwardRef) {
-    return (WrappedComponent: any) => forwardRef(function addClassnames(props, ref) {
+    return (WrappedComponent: any) => forwardRef(function AddClassnames(props, ref) {
       const emailRenderContext = React.useContext(EmailRenderContext);
       if (emailRenderContext?.isEmailRender) {
         const withStylesHoc = withStyles(styles, {name: componentName})
@@ -97,7 +97,7 @@ const addClassnames = (componentName: string, styles: any, hasForwardRef: boolea
       return <WrappedComponent ref={ref} {...props} classes={classesProxy}/>
     })
   } else {
-    return (WrappedComponent: any) => function addClassnames(props: AnyBecauseHard) {
+    return (WrappedComponent: any) => function AddClassnames(props: AnyBecauseHard) {
       const emailRenderContext = React.useContext(EmailRenderContext);
       if (emailRenderContext?.isEmailRender) {
         const withStylesHoc = withStyles(styles, {name: componentName})


### PR DESCRIPTION
This PR attempts to make the React component debugger more usable (and maybe improve performance a bit) by reducing the number of unnecessary and anonymous HoCs in our component tree. In particular, there are many copies of `forwardRef` (outnumbering all other components combined), despite the fact that we only have two components (`ContentItemBody` and `Editor`) that can take a ref.

Remove `forwardRef` from most places where it isn't needed. Also give some anonymous HoCs names.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209632756591460) by [Unito](https://www.unito.io)
