### PR TITLE
[EA] Allow setting the question on polls

### DIFF
--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -15,6 +15,7 @@ import type { ForumEventVoteDisplay } from "./ForumEventResultIcon";
 import { Link } from "@/lib/reactRouterWrapper";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { commentGetPageUrlFromIds } from "@/lib/collections/comments/helpers";
+import { parseDocumentFromString, ServerSafeNode } from "@/lib/domParser";
 
 export const POLL_MAX_WIDTH = 800;
 const SLIDER_MAX_WIDTH = 1120;
@@ -378,27 +379,100 @@ const clusterForumEventVotes = ({
   return clusters;
 };
 
-const PollQuestion = ({
+function footnotesToTooltips({
+  html,
+  event,
+  classes,
+}: {
+  html: string;
+  event: ForumEventsDisplay;
+  classes: ClassesType<typeof styles>;
+}): React.ReactNode[] {
+  const { LWTooltip } = Components;
+
+  const { document } = parseDocumentFromString(html);
+
+  const footnotes = Array.from(document.querySelectorAll(".footnote-item"));
+  const footnotesMap: Record<string, string> = {};
+  for (const li of footnotes) {
+    const footnoteId = li.getAttribute("data-footnote-id");
+    if (!footnoteId) continue;
+    const footnoteHtml = li.querySelector(".footnote-content")?.innerHTML ?? "";
+    footnotesMap[footnoteId] = footnoteHtml;
+  }
+
+  // Remove the footnotes block from the DOM so we don't flatten it
+  const footnotesList = document.querySelector(".footnotes");
+  footnotesList?.remove();
+
+  const resultArray: React.ReactNode[] = [];
+
+  function walkNode(node: ChildNode) {
+    // If TEXT_NODE, just push its text, dropping the specific html tag etc
+    if (node.nodeType === ServerSafeNode.TEXT_NODE) {
+      const text = node.textContent || "";
+      if (text.trim() !== "") {
+        resultArray.push(text);
+      }
+      return;
+    }
+
+    if (node.nodeType === ServerSafeNode.ELEMENT_NODE) {
+      const el = node as Element;
+
+      // If it's a .footnote-reference, produce a <LWTooltip>
+      if (el.classList.contains("footnote-reference")) {
+        const footnoteId = el.getAttribute("data-footnote-id") || "";
+        const content = footnotesMap[footnoteId] || "";
+
+        // Extract just digits from e.g. "[1]" → "1"
+        const footnoteNumberRaw = el.textContent?.trim() || "";
+        const footnoteNumber = footnoteNumberRaw.replace(/[^\d]+/g, "") || "?";
+
+        const tooltipNode = (
+          <LWTooltip
+            key={footnoteNumber}
+            title={<div dangerouslySetInnerHTML={{ __html: content }} />}
+          >
+            <span
+              className={classes.questionFootnote}
+              style={{ color: event.contrastColor ?? event.darkColor }}
+            >
+              {footnoteNumber}
+            </span>
+          </LWTooltip>
+        );
+        resultArray.push(tooltipNode);
+      } else {
+        Array.from(el.childNodes).forEach(walkNode);
+      }
+    }
+  }
+
+  // Walk all top level nodes, recursing into child nodes
+  Array.from(document.body.childNodes).forEach(walkNode);
+
+  return resultArray;
+}
+
+function PollQuestion({
   event,
   classes,
 }: {
   event: ForumEventsDisplay;
   classes: ClassesType<typeof styles>;
-}) => {
-  const { LWTooltip } = Components;
+}) {
+  const { pollQuestion } = event;
 
-  return (
-    <div className={classes.question}>
-      “It would be better to spend an extra $100m
-      <LWTooltip title="In total. You can imagine this is a trust that could be spent down today, or over any time period.">
-        <span className={classes.questionFootnote} style={{ color: event.contrastColor ?? event.darkColor }}>
-          1
-        </span>
-      </LWTooltip>{" "}
-      on animal welfare than on global health”
-    </div>
+  const displayHtml = useMemo(
+    () => (pollQuestion?.html ? footnotesToTooltips({ html: pollQuestion.html, event, classes }) : null),
+    [pollQuestion?.html, event, classes]
   );
-};
+
+  if (!displayHtml) return null;
+
+  return <div className={classes.question}>{displayHtml}</div>;
+}
 
 /**
  * This component is for forum events that have a poll.

--- a/packages/lesswrong/lib/collections/forumEvents/fragments.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/fragments.ts
@@ -43,6 +43,10 @@ export const ForumEventsDisplay = `
       _id
       html
     }
+    pollQuestion {
+      _id
+      html
+    }
   }
 `
 
@@ -56,6 +60,9 @@ export const ForumEventsEdit = `
       ...RevisionEdit
     }
     postPageDescription {
+      ...RevisionEdit
+    }
+    pollQuestion {
       ...RevisionEdit
     }
   }

--- a/packages/lesswrong/lib/collections/forumEvents/schema.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/schema.ts
@@ -69,7 +69,7 @@ const schema: SchemaType<"ForumEvents"> = {
     },
     ...defaultEditableProps,
   }),
-  
+
   title: {
     ...defaultProps(),
     type: String,
@@ -180,6 +180,19 @@ const schema: SchemaType<"ForumEvents"> = {
     type: String,
     options: () => EVENT_FORMATS.map(ef => ({value: ef, label: ef}))
   },
+  ...editableFields("ForumEvents", {
+    fieldName: "pollQuestion",
+    label: "Poll question",
+    hintText: 'Write the poll question as plain text (no headings), footnotes will appear as tooltips on the frontpage',
+    getLocalStorageId: (forumEvent) => {
+      return {
+        id: `forumEvent:pollQuestion:${forumEvent?._id ?? "create"}`,
+        verify: true,
+      };
+    },
+    normalized: true,
+    ...defaultEditableProps,
+  }),
   maxStickersPerUser: {
     ...defaultProps(),
     ...schemaDefaultValue(1),

--- a/packages/lesswrong/lib/domParser.ts
+++ b/packages/lesswrong/lib/domParser.ts
@@ -22,3 +22,43 @@ export function parseDocumentFromString(html: string): {
     return { document, window };
   }
 }
+
+// Vendored from typescript/lib/lib.dom.d.ts, as Node is only available as a global on the client
+export const ServerSafeNode = {
+  /** node is an element. */
+  ELEMENT_NODE: 1 as const,
+  /** node is an attribute. */
+  ATTRIBUTE_NODE: 2 as const,
+  /** node is a Text node. */
+  TEXT_NODE: 3 as const,
+  /** node is a CDATASection node. */
+  CDATA_SECTION_NODE: 4 as const,
+  /** node is an entity reference. */
+  ENTITY_REFERENCE_NODE: 5 as const,
+  /** node is an entity. */
+  ENTITY_NODE: 6 as const,
+  /** node is a ProcessingInstruction node. */
+  PROCESSING_INSTRUCTION_NODE: 7 as const,
+  /** node is a Comment node. */
+  COMMENT_NODE: 8 as const,
+  /** node is a document. */
+  DOCUMENT_NODE: 9 as const,
+  /** node is a doctype. */
+  DOCUMENT_TYPE_NODE: 10 as const,
+  /** node is a DocumentFragment node. */
+  DOCUMENT_FRAGMENT_NODE: 11 as const,
+  /** node is a notation. */
+  NOTATION_NODE: 12 as const,
+  /** Set when node and other are not in the same tree. */
+  DOCUMENT_POSITION_DISCONNECTED: 0x01 as const,
+  /** Set when other is preceding node. */
+  DOCUMENT_POSITION_PRECEDING: 0x02 as const,
+  /** Set when other is following node. */
+  DOCUMENT_POSITION_FOLLOWING: 0x04 as const,
+  /** Set when other is an ancestor of node. */
+  DOCUMENT_POSITION_CONTAINS: 0x08 as const,
+  /** Set when other is a descendant of node. */
+  DOCUMENT_POSITION_CONTAINED_BY: 0x10 as const,
+  /** Set when the position is implementation-specific. */
+  DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: 0x20 as const,
+};

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -516,6 +516,7 @@ interface DbForumEvent extends DbObject {
   legacyData: any /*{"definitions":[{"blackbox":true}]}*/
   lightColor: string
   maxStickersPerUser: number
+  pollQuestion_latest: string | null
   postId: string | null
   postPageDescription: EditableFieldContents | null
   postPageDescription_latest: string | null

--- a/packages/lesswrong/lib/generated/defaultFragments.ts
+++ b/packages/lesswrong/lib/generated/defaultFragments.ts
@@ -454,7 +454,7 @@ export const FeaturedResourcesDefaultFragment = `
 `;
 
 export const FieldChangesDefaultFragment = `
-  fragment FieldChangesDefaultFragment on undefined {
+  fragment FieldChangesDefaultFragment on FieldChange {
     _id
     schemaVersion
     createdAt
@@ -477,6 +477,7 @@ export const ForumEventsDefaultFragment = `
     frontpageDescription_latest
     frontpageDescriptionMobile_latest
     postPageDescription_latest
+    pollQuestion_latest
     title
     startDate
     endDate

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -930,17 +930,17 @@ interface FieldChangeFragment { // fragment on FieldChanges
   readonly newValue: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
-interface FieldChangesDefaultFragment { // fragment on non-collection type
-  readonly _id: any,
-  readonly schemaVersion: any,
-  readonly createdAt: any,
-  readonly legacyData: any,
-  readonly userId: any,
-  readonly changeGroup: any,
-  readonly documentId: any,
-  readonly fieldName: any,
-  readonly oldValue: any,
-  readonly newValue: any,
+interface FieldChangesDefaultFragment { // fragment on FieldChanges
+  readonly _id: string,
+  readonly schemaVersion: number,
+  readonly createdAt: Date,
+  readonly legacyData: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly userId: string,
+  readonly changeGroup: string,
+  readonly documentId: string,
+  readonly fieldName: string,
+  readonly oldValue: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly newValue: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface ForumEventsDefaultFragment { // fragment on ForumEvents
@@ -951,6 +951,7 @@ interface ForumEventsDefaultFragment { // fragment on ForumEvents
   readonly frontpageDescription_latest: string,
   readonly frontpageDescriptionMobile_latest: string,
   readonly postPageDescription_latest: string,
+  readonly pollQuestion_latest: string,
   readonly title: string,
   readonly startDate: Date,
   readonly endDate: Date,
@@ -977,6 +978,7 @@ interface ForumEventsDisplay extends ForumEventsMinimumInfo { // fragment on For
   readonly frontpageDescription: ForumEventsDisplay_frontpageDescription|null,
   readonly frontpageDescriptionMobile: ForumEventsDisplay_frontpageDescriptionMobile|null,
   readonly postPageDescription: ForumEventsDisplay_postPageDescription|null,
+  readonly pollQuestion: ForumEventsDisplay_pollQuestion|null,
 }
 
 interface ForumEventsDisplay_frontpageDescription { // fragment on Revisions
@@ -994,10 +996,16 @@ interface ForumEventsDisplay_postPageDescription { // fragment on Revisions
   readonly html: string,
 }
 
+interface ForumEventsDisplay_pollQuestion { // fragment on Revisions
+  readonly _id: string,
+  readonly html: string,
+}
+
 interface ForumEventsEdit extends ForumEventsMinimumInfo { // fragment on ForumEvents
   readonly frontpageDescription: RevisionEdit|null,
   readonly frontpageDescriptionMobile: RevisionEdit|null,
   readonly postPageDescription: RevisionEdit|null,
+  readonly pollQuestion: RevisionEdit|null,
 }
 
 interface ForumEventsMinimumInfo { // fragment on ForumEvents
@@ -5357,7 +5365,7 @@ interface FragmentTypesByCollection {
   ElicitQuestions: "ElicitQuestionFragment"|"ElicitQuestionsDefaultFragment"
   EmailTokenses: "EmailTokensDefaultFragment"
   FeaturedResources: "FeaturedResourcesDefaultFragment"|"FeaturedResourcesFragment"
-  FieldChanges: "FieldChangeFragment"
+  FieldChanges: "FieldChangeFragment"|"FieldChangesDefaultFragment"
   ForumEvents: "ForumEventsDefaultFragment"|"ForumEventsDisplay"|"ForumEventsEdit"|"ForumEventsMinimumInfo"
   GardenCodes: "GardenCodeFragment"|"GardenCodeFragmentEdit"|"GardenCodesDefaultFragment"
   GoogleServiceAccountSessions: "GoogleServiceAccountSessionAdminInfo"|"GoogleServiceAccountSessionInfo"|"GoogleServiceAccountSessionsDefaultFragment"
@@ -5418,7 +5426,6 @@ interface FragmentTypesByCollection {
   UserTagRels: "UserTagRelDetails"|"UserTagRelsDefaultFragment"
   Users: "SharedUserBooleans"|"SuggestAlignmentUser"|"SunshineUsersList"|"UserAltAccountsFragment"|"UserBookmarkedPosts"|"UserKarmaChanges"|"UserOnboardingAuthor"|"UsersAdmin"|"UsersBannedFromUsersModerationLog"|"UsersCrosspostInfo"|"UsersCurrent"|"UsersCurrentCommentRateLimit"|"UsersCurrentPostRateLimit"|"UsersDefaultFragment"|"UsersEdit"|"UsersMapEntry"|"UsersMinimumInfo"|"UsersOptedInToDialogueFacilitation"|"UsersProfile"|"UsersProfileEdit"|"UsersSocialMediaInfo"|"UsersWithReviewInfo"
   Votes: "TagRelVotes"|"TagVotingActivity"|"UserVotes"|"UserVotesWithDocument"|"VotesDefaultFragment"
-  undefineds: "FieldChangesDefaultFragment"
 }
 
 interface CollectionNamesByFragmentName {
@@ -5491,7 +5498,7 @@ interface CollectionNamesByFragmentName {
   FeaturedResourcesDefaultFragment: "FeaturedResources"
   FeaturedResourcesFragment: "FeaturedResources"
   FieldChangeFragment: "FieldChanges"
-  FieldChangesDefaultFragment: never
+  FieldChangesDefaultFragment: "FieldChanges"
   ForumEventsDefaultFragment: "ForumEvents"
   ForumEventsDisplay: "ForumEvents"
   ForumEventsEdit: "ForumEvents"

--- a/packages/lesswrong/server/migrations/20250312T131725.add_pollQuestion.ts
+++ b/packages/lesswrong/server/migrations/20250312T131725.add_pollQuestion.ts
@@ -1,0 +1,10 @@
+import ForumEvents from "../collections/forumEvents/collection";
+import { addField, dropField } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  await addField(db, ForumEvents, "pollQuestion_latest");
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await dropField(db, ForumEvents, "pollQuestion_latest");
+}

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -949,6 +949,7 @@ CREATE TABLE "ForumEvents" (
   "frontpageDescriptionMobile_latest" TEXT,
   "postPageDescription" JSONB,
   "postPageDescription_latest" TEXT,
+  "pollQuestion_latest" TEXT,
   "title" TEXT NOT NULL,
   "startDate" TIMESTAMPTZ NOT NULL,
   "endDate" TIMESTAMPTZ NOT NULL,


### PR DESCRIPTION
This allows admins to set the question with an editable field, where footnotes are then parsed into tooltips when rendering. The color used is "Accent color" in the form

![Screenshot 2025-03-12 at 14 39 45](https://github.com/user-attachments/assets/3fa58373-d42f-454f-9586-43b96136fa9c)
![Screenshot 2025-03-12 at 14 38 35](https://github.com/user-attachments/assets/40efe587-181c-45b6-9b8e-54583f2c2750)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209655227498811) by [Unito](https://www.unito.io)
