### PR TITLE
Remove the last remnants of React legacy context

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -7,7 +7,6 @@ import { Editor, EditorChangeEvent, getUserDefaultEditor, getInitialEditorConten
   getBlankEditorContents, EditorContents, isBlank, serializeEditorContents,
   EditorTypeString, styles, FormProps, shouldSubmitContents } from './Editor';
 import withErrorBoundary from '../common/withErrorBoundary';
-import PropTypes from 'prop-types';
 import * as _ from 'underscore';
 import { gql, useLazyQuery, useMutation } from '@apollo/client';
 import { isEAForum, isLWorAF } from '../../lib/instanceSettings';
@@ -81,6 +80,9 @@ export const EditorFormComponent = ({
   formVariant,
   commentStyles,
   updateCurrentValues,
+  submitForm,
+  addToSubmitForm,
+  addToSuccessForm,
   classes,
 }: FormComponentProps<any> & {
   form: any,
@@ -91,10 +93,9 @@ export const EditorFormComponent = ({
   formVariant?: "default" | "grey",
   commentStyles: boolean,
   classes: ClassesType<typeof styles>,
-}, context: any) => {
+}) => {
   const { commentEditor, collectionName, hideControls } = (form || {});
   const { editorHintText, maxHeight } = (formProps || {});
-  const { submitForm } = context;
   const { flash } = useMessages()
   const currentUser = useCurrentUser();
   const editorRef = useRef<Editor|null>(null);
@@ -388,7 +389,7 @@ export const EditorFormComponent = ({
   
   useEffect(() => {
     if (editorRef.current) {
-      const cleanupSubmitForm = context.addToSubmitForm(async (submission: any) => {
+      const cleanupSubmitForm = addToSubmitForm(async (submission: any) => {
         if (editorRef.current && shouldSubmitContents(editorRef.current))
           return {
             ...submission,
@@ -397,7 +398,7 @@ export const EditorFormComponent = ({
         else
           return submission;
       });
-      const cleanupSuccessForm = context.addToSuccessForm((result: any, form: any, submitOptions: any) => {
+      const cleanupSuccessForm = addToSuccessForm((result: any, form: any, submitOptions: any) => {
         getLocalStorageHandlers(currentEditorType).reset();
         // If we're autosaving (noReload: true), don't clear the editor!  Also no point in clearing it if we're getting redirected anyways
         if (editorRef.current && (!submitOptions?.redirectToEditor && !submitOptions?.noReload) && !isCollabEditor) {
@@ -442,7 +443,7 @@ export const EditorFormComponent = ({
       };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!!editorRef.current, fieldName, initialEditorType, context.addToSuccessForm, context.addToSubmitForm]);
+  }, [!!editorRef.current, fieldName, initialEditorType, addToSuccessForm, addToSubmitForm]);
   
   const fieldHasCommitMessages = getEditableFieldInCollection(collectionName as CollectionNameString, fieldName)?.editableFieldOptions.clientOptions.revisionsHaveCommitMessages;
   const hasCommitMessages = fieldHasCommitMessages
@@ -536,12 +537,6 @@ export const EditorFormComponent = ({
 export const EditorFormComponentComponent = registerComponent('EditorFormComponent', EditorFormComponent, {
   hocs: [withErrorBoundary], styles
 });
-
-(EditorFormComponent as any).contextTypes = {
-  addToSubmitForm: PropTypes.func,
-  addToSuccessForm: PropTypes.func,
-  submitForm: PropTypes.func,
-};
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -98,11 +98,10 @@ const noSharePermissionTooltip = isFriendlyUI
   ? "You need at least 1 karma or to be approved by a moderator to share this post"
   : "You need at least 1 karma or to be approved by a mod to share";
 
-const PostSharingSettings = ({document, formType, value, updateCurrentValues, classes}: FormComponentProps<SharingSettings> & {
+const PostSharingSettings = ({document, formType, value, updateCurrentValues, submitForm, classes}: FormComponentProps<SharingSettings> & {
   document: PostsEditQueryFragment,
   classes: ClassesType<typeof styles>
-}, context: any) => {
-  const {submitForm} = context;
+}) => {
   const {openDialog, closeDialog} = useDialog();
   const currentUser = useCurrentUser();
   const initialSharingSettings = value || defaultSharingSettings;
@@ -179,11 +178,6 @@ const PostSharingSettings = ({document, formType, value, updateCurrentValues, cl
       </EAButton>
     </LWTooltip>
 }
-
-(PostSharingSettings as any).contextTypes = {
-  submitForm: PropTypes.func,
-};
-
 
 const PostSharingSettingsDialog = ({post, linkSharingKey, initialSharingSettings, initialShareWithUsers, onClose, onConfirm, classes}: {
   // postId: string,

--- a/packages/lesswrong/components/form-components/FormSubmit.tsx
+++ b/packages/lesswrong/components/form-components/FormSubmit.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 import Button from '@material-ui/core/Button';
@@ -52,11 +51,9 @@ const FormSubmit = ({
   document,
   collectionName,
   updateCurrentValues,
+  addToDeletedValues,
   classes,
-}: FormButtonProps & {classes: ClassesType<typeof styles>},
-{
-  addToDeletedValues
-}: FormComponentContext<any>) => {
+}: FormButtonProps & {classes: ClassesType<typeof styles>}) => {
   const currentUser = useCurrentUser();
 
   // NOTE: collectionName was previously annotated with type Lowercase<CollectionNameString>
@@ -137,12 +134,6 @@ const FormSubmit = ({
   </div>
 };
 
-(FormSubmit as any).contextTypes = {
-  addToDeletedValues: PropTypes.func,
-}
-
-
-// Replaces FormSubmit from vulcan-forms.
 const FormSubmitComponent = registerComponent('FormSubmit', FormSubmit, {styles});
 
 declare global {

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -68,8 +68,10 @@ const PostSubmit = ({
   feedbackLabel = "Request Feedback",
   cancelCallback, document, collectionName,
   updateCurrentValues,
+  submitForm,
+  addToSuccessForm,
   classes
-}: PostSubmitProps, { addToSuccessForm, submitForm }: any) => {
+}: PostSubmitProps) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking();
   if (!currentUser) throw Error("must be logged in to post")
@@ -155,23 +157,7 @@ const PostSubmit = ({
   );
 }
 
-PostSubmit.propTypes = {
-  submitLabel: PropTypes.string,
-  cancelLabel: PropTypes.string,
-  cancelCallback: PropTypes.func,
-  document: PropTypes.object,
-  collectionName: PropTypes.string,
-  classes: PropTypes.object,
-};
-
-PostSubmit.contextTypes = {
-  addToSuccessForm: PropTypes.func,
-  submitForm: PropTypes.func
-}
-
-
-// HACK: Cast PostSubmit to hide the legacy context arguments, to make the type checking work
-const PostSubmitComponent = registerComponent('PostSubmit', (PostSubmit as React.ComponentType<PostSubmitProps>), {styles});
+const PostSubmitComponent = registerComponent('PostSubmit', PostSubmit, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/vulcan-forms/FieldErrors.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FieldErrors.tsx
@@ -8,14 +8,15 @@ const styles = (theme: ThemeType) => ({
   }
 })
 
-const FieldErrors = ({ errors, classes }: {
+const FieldErrors = ({ errors, getLabel, classes }: {
   errors: any[]
+  getLabel: (fieldName: string, fieldLocale?: any) => string,
   classes: ClassesType<typeof styles>
 }) => (
   <ul className={classNames(classes.root, "form-input-errors")}>
     {errors.map((error, index) => (
       <li key={index}>
-        <Components.FormError error={error} errorContext="field" />
+        <Components.FormError error={error} errorContext="field" getLabel={getLabel} />
       </li>
     ))}
   </ul>

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -561,31 +561,6 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
     this.setState(fn);
   };
 
-  // pass on context to all child components
-  getChildContext = () => {
-    return {
-      throwError: this.throwError,
-      clearForm: this.clearForm,
-      refetchForm: this.refetchForm,
-      isChanged: this.isChanged,
-      submitForm: this.submitForm, //Change in name because we already have a function
-      // called submitForm, but no reason for the user to know
-      // about that
-      addToDeletedValues: this.addToDeletedValues,
-      updateCurrentValues: this.updateCurrentValues,
-      getDocument: this.getDocument,
-      getLabel: this.getLabel,
-      initialDocument: this.state.initialDocument,
-      setFormState: this.setFormState,
-      addToSubmitForm: this.addToSubmitForm,
-      addToSuccessForm: this.addToSuccessForm,
-      addToFailureForm: this.addToFailureForm,
-      errors: this.state.errors,
-      currentValues: this.state.currentValues,
-      deletedValues: this.state.deletedValues
-    };
-  };
-
   // --------------------------------------------------------------------- //
   // ------------------------------ Lifecycle ---------------------------- //
   // --------------------------------------------------------------------- //
@@ -1030,6 +1005,7 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
       >
         <Components.FormErrors
           errors={this.state.errors}
+          getLabel={this.getLabel}
         />
 
         {this.getFieldGroups().map((group, i) => (
@@ -1047,12 +1023,18 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
             disabled={this.state.disabled}
             formComponents={this.props.formComponents}
             formProps={this.props.formProps}
+            submitForm={this.submitForm}
+            addToSubmitForm={this.addToSubmitForm}
+            addToSuccessForm={this.addToSuccessForm}
+            getLabel={this.getLabel}
+            getDocument={this.getDocument}
             key={`${i}-${group.name}`}
           />
         ))}
 
         {this.props.repeatErrors && <Components.FormErrors
           errors={this.state.errors}
+          getLabel={this.getLabel}
         />}
 
         {!this.props.autoSubmit && <FormSubmit
@@ -1075,6 +1057,9 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
           currentValues={this.state.currentValues}
           deletedValues={this.state.deletedValues}
           errors={this.state.errors}
+          addToSubmitForm={this.addToSubmitForm}
+          addToSuccessForm={this.addToSuccessForm}
+          addToDeletedValues={this.addToDeletedValues}
         />}
       </form>
     );
@@ -1111,24 +1096,4 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
   ...callbackProps,
 
   currentUser: PropTypes.object,
-};
-
-(Form as any).childContextTypes = {
-  addToDeletedValues: PropTypes.func,
-  deletedValues: PropTypes.array,
-  addToSubmitForm: PropTypes.func,
-  addToFailureForm: PropTypes.func,
-  addToSuccessForm: PropTypes.func,
-  updateCurrentValues: PropTypes.func,
-  setFormState: PropTypes.func,
-  throwError: PropTypes.func,
-  clearForm: PropTypes.func,
-  refetchForm: PropTypes.func,
-  isChanged: PropTypes.func,
-  initialDocument: PropTypes.object,
-  getDocument: PropTypes.func,
-  getLabel: PropTypes.func,
-  submitForm: PropTypes.func,
-  errors: PropTypes.array,
-  currentValues: PropTypes.object
 };

--- a/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormComponent.tsx
@@ -7,7 +7,6 @@ import SimpleSchema from 'simpl-schema';
 import { isEmptyValue, getNullValue } from '../../lib/vulcan-forms/utils';
 
 class FormComponent<T extends DbObject> extends Component<FormComponentWrapperProps<T>> {
-  declare context: AnyBecauseTodo
 
   constructor(props: FormComponentWrapperProps<T>) {
     super(props);
@@ -84,12 +83,11 @@ class FormComponent<T extends DbObject> extends Component<FormComponentWrapperPr
   };
 
   // Get value from Form state through document and currentValues props
-  getValue = (props?: any, context?: any) => {
+  getValue = (props?: any) => {
     const p = props || this.props;
-    const c = context || this.context;
     const { locale, defaultValue, deletedValues, formType, datatype } = p;
     const path = locale ? `${this.getPath(p)}.value` : this.getPath(p);
-    const currentDocument = c.getDocument();
+    const currentDocument = p.getDocument();
     let value = get(currentDocument, path);
     // note: force intl fields to be treated like strings
     const nullValue = locale ? '' : getNullValue(datatype);
@@ -224,7 +222,7 @@ class FormComponent<T extends DbObject> extends Component<FormComponentWrapperPr
         {...this.props}
         value={this.getValue()}
         errors={this.getErrors()}
-        document={this.context.getDocument()}
+        document={this.props.getDocument()}
         onChange={this.handleChange}
         clearField={this.clearField}
         formInput={this.getFormInput()}
@@ -242,10 +240,6 @@ class FormComponent<T extends DbObject> extends Component<FormComponentWrapperPr
     }
   }
 }
-
-(FormComponent as any).contextTypes = {
-  getDocument: PropTypes.func.isRequired
-};
 
 const FormComponentComponent = registerComponent('FormComponent', FormComponent);
 

--- a/packages/lesswrong/components/vulcan-forms/FormComponentInner.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormComponentInner.tsx
@@ -41,6 +41,7 @@ const FormComponentInner = (props: FormComponentInnerWrapperProps<any>) => {
     input,
     beforeComponent,
     afterComponent,
+    getLabel,
     errors,
   } = props;
 
@@ -93,7 +94,7 @@ const FormComponentInner = (props: FormComponentInnerWrapperProps<any>) => {
     <div className={classNames(inputClass, {[classes.highlightAnimation]: highlight})} ref={scrollRef}>
       {instantiateComponent(beforeComponent, properties)}
       <FormInput {...properties}/>
-      {hasErrors ? <Components.FieldErrors errors={errors} /> : null}
+      {hasErrors ? <Components.FieldErrors errors={errors} getLabel={getLabel} /> : null}
       {renderClear()}
       {instantiateComponent(afterComponent, properties)}
     </div>

--- a/packages/lesswrong/components/vulcan-forms/FormError.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormError.tsx
@@ -3,15 +3,11 @@ import PropTypes from 'prop-types';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import FormattedMessage from '../../lib/vulcan-i18n/message';
 
-const FormError = (
-  { error, errorContext="" }: {
-    error: any,
-    errorContext: any,
-  },
-  { getLabel=(name)=>name }: {
-    getLabel?: (name: string, local: string) => string,
-  }
-) => {
+const FormError = ({ error, errorContext="", getLabel }: {
+  error: any,
+  errorContext: any,
+  getLabel: (fieldName: string, fieldLocale?: any) => string,
+}) => {
   if (error.message) { // A normal string error
     return error.message;
   } else if (error.id) { // An internationalized error
@@ -34,10 +30,6 @@ const FormError = (
   } else {
     return 'Error submitting form';
   }
-};
-
-(FormError as any).contextTypes = {
-  getLabel: PropTypes.func,
 };
 
 

--- a/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
@@ -8,8 +8,9 @@ const styles = (theme: ThemeType) => ({
   }
 })
 
-const FormErrors = ({ errors, classes }: {
+const FormErrors = ({ errors, getLabel, classes }: {
   errors: any[]
+  getLabel: (fieldName: string, fieldLocale?: any) => string,
   classes: ClassesType<typeof styles>
 }) => (
   <div className={classNames(classes.root, "form-errors")}>
@@ -18,7 +19,7 @@ const FormErrors = ({ errors, classes }: {
         <ul>
           {errors.map((error, index) => (
             <li key={index}>
-              <Components.FormError error={error} errorContext="form" />
+              <Components.FormError error={error} errorContext="form" getLabel={getLabel} />
             </li>
           ))}
         </ul>

--- a/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
@@ -52,7 +52,7 @@ const FormGroupHeaderComponent = registerComponent('FormGroupHeader', FormGroupH
   styles: headerStyles
 });
 
-interface FormControlProps {
+interface PassedThroughFormGroupProps {
   disabled: boolean;
   errors: any[];
   throwError: any;
@@ -64,9 +64,14 @@ interface FormControlProps {
   formType: "new" | "edit";
   formProps: any;
   formComponents?: FormComponentOverridesType;
+  submitForm: any
+  addToSubmitForm: any
+  addToSuccessForm: any
+  getLabel: (fieldName: string, fieldLocale?: any) => string,
+  getDocument: any,
 }
 
-interface FormGroupProps<N extends CollectionNameString> extends FormControlProps {
+interface FormGroupProps<N extends CollectionNameString> extends PassedThroughFormGroupProps {
   group: FormGroupType<N>
   fields: FormField<N>[]
 }
@@ -84,7 +89,12 @@ const FormGroup = ({
   addToDeletedValues,
   clearFieldErrors,
   formType,
-  formProps
+  formProps,
+  submitForm,
+  addToSubmitForm,
+  addToSuccessForm,
+  getLabel,
+  getDocument,
 }: FormGroupProps<CollectionNameString>) => {
   const { query } = useLocation();
   const { name, label, startCollapsed, helpText, hideHeader, layoutComponent, layoutComponentProps } = group;
@@ -128,7 +138,7 @@ const FormGroup = ({
     || formComponents?.FormGroupLayout
     || Components.FormGroupLayout;
 
-  const formControlProps: FormControlProps = {
+  const formControlProps: PassedThroughFormGroupProps = {
     disabled,
     errors,
     throwError,
@@ -140,6 +150,11 @@ const FormGroup = ({
     formType,
     formProps,
     formComponents,
+    submitForm,
+    addToSubmitForm,
+    addToSuccessForm,
+    getLabel,
+    getDocument,
   };
 
   return (

--- a/packages/lesswrong/components/vulcan-forms/FormNestedArray.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormNestedArray.tsx
@@ -110,6 +110,7 @@ class FormNestedArray extends PureComponent<FormNestedArrayProps<any>> {
             <Components.FieldErrors
               key="form-nested-errors"
               errors={nestedArrayErrors}
+              getLabel={this.props.getLabel}
             />
           ) : null
         ]}

--- a/packages/lesswrong/components/vulcan-forms/FormNestedItem.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormNestedItem.tsx
@@ -30,8 +30,6 @@ const FormNestedItem = ({ nestedFields, name, path, removeItem, itemIndex, formC
   itemIndex: number
   formComponents: FormComponentOverridesType
   hideRemove: boolean
-}, { errors }: {
-  errors: any[]
 }) => {
   const isArray = typeof itemIndex !== 'undefined';
   return (
@@ -71,10 +69,6 @@ const FormNestedItem = ({ nestedFields, name, path, removeItem, itemIndex, formC
       }
     />
   );
-};
-
-FormNestedItem.contextTypes = {
-  errors: PropTypes.array
 };
 
 const FormNestedItemComponent = registerComponent('FormNestedItem', FormNestedItem);

--- a/packages/lesswrong/components/vulcan-forms/FormNestedObject.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormNestedObject.tsx
@@ -32,7 +32,7 @@ class FormNestedObject extends PureComponent<FormNestedObjectProps> {
       'inputProperties',
       'nestedInput'
     );
-    const { errors } = this.props;
+    const { errors, getLabel } = this.props;
     // only keep errors specific to the nested array (and not its subfields)
     const nestedObjectErrors = errors.filter(
       error => error.path && error.path === this.props.path
@@ -51,6 +51,7 @@ class FormNestedObject extends PureComponent<FormNestedObjectProps> {
           hasErrors ? (
             <Components.FieldErrors
               key="form-nested-errors"
+              getLabel={getLabel}
               errors={nestedObjectErrors}
             />
           ) : null

--- a/packages/lesswrong/components/vulcan-forms/propTypes.ts
+++ b/packages/lesswrong/components/vulcan-forms/propTypes.ts
@@ -132,6 +132,7 @@ declare global {
 
   interface FormComponentWrapperProps<T> {
     document: any
+    getDocument: any
     name: string
     label?: string
     placeholder?: string
@@ -149,6 +150,7 @@ declare global {
     clearFieldErrors: any
     tooltip?: string
     formComponents?: FormComponentOverridesType
+    getLabel: (fieldName: string, fieldLocale?: any) => string,
     locale?: string
     max?: number
     nestedInput: any
@@ -156,6 +158,9 @@ declare global {
     formType: "new"|"edit"
     setFooterContent?: any
     hideClear?: boolean
+    submitForm: any
+    addToSubmitForm: any
+    addToSuccessForm: any
   }
   interface FormComponentInnerWrapperProps<T> extends FormComponentWrapperProps<T> {
     beforeComponent?: any
@@ -182,9 +187,8 @@ declare global {
     deletedValues?: any
     errors?: any[]
     formType: "edit"|"new"
-  }
-  interface FormComponentContext<T> {
-    updateCurrentValues: UpdateCurrentValues
-    addToDeletedValues: any
+    addToSubmitForm: any
+    addToSuccessForm: any;
+    addToDeletedValues: any;
   }
 }


### PR DESCRIPTION
This removes the last remaining usages of React legacy context, which were in vulcan-forms, by replacing context vars with normal props. (This is one of the prerequisites to upgrading to React 19.)