### PR TITLE
Add migration to update `fm_get_user_profile_updated_at`

### DIFF
--- a/packages/lesswrong/server/migrations/20250314T160703.update_fm_get_user_profile_updated_at.ts
+++ b/packages/lesswrong/server/migrations/20250314T160703.update_fm_get_user_profile_updated_at.ts
@@ -1,0 +1,9 @@
+import { updateFunctions } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  await updateFunctions(db);
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await updateFunctions(db);
+}


### PR DESCRIPTION
Missing migration from PR #10522 which updated the function source

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209682108438930) by [Unito](https://www.unito.io)
