### PR TITLE
Show curation sidebar when no curation drafts

### DIFF
--- a/packages/lesswrong/components/admin/CurationPage.tsx
+++ b/packages/lesswrong/components/admin/CurationPage.tsx
@@ -77,7 +77,7 @@ export const CurationPage = ({classes}: {
           </div>
     </SingleColumnSection>
     {<div className={classes.curated}>
-        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}} belowFold setCurationPost={setPost}/>
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}} atBottom setCurationPost={setPost}/>
     </div>}
   </div>;
 }

--- a/packages/lesswrong/components/recommendations/RecommendationsPageCuratedList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPageCuratedList.tsx
@@ -38,7 +38,7 @@ const RecommendationsPageCuratedList = ({classes}: {
           </AnalyticsContext>
         </SingleColumnSection>}
         {hasCuratedPostsSetting.get() && currentUser?.isAdmin && <div className={classes.curated}>
-          <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}} belowFold/>
+          <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}} atBottom/>
         </div>}
       </AnalyticsContext>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -31,10 +31,11 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost}: {
+const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost, timeForCuration}: {
   classes: ClassesType<typeof styles>,
   post: SunshineCurationPostsList,
   setCurationPost?: (post: SunshineCurationPostsList) => void,
+  timeForCuration?: boolean,
 }) => {
   const currentUser = useCurrentUser();
   const { CurationNoticesItem, SunshineListItem, SidebarHoverOver, Typography, PostsHighlight, SidebarInfo, SidebarAction, SidebarActionMenu, ForumIcon, FormatDate } = Components
@@ -142,9 +143,11 @@ const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost}: {
               <ForumIcon icon="Undo"/>
             </SidebarAction>
           }
-          <SidebarAction title="Curate Post" onClick={handleCurate}>
-            <ForumIcon icon="Star" />
-          </SidebarAction>
+          { timeForCuration &&
+            <SidebarAction title="Curate Post" onClick={handleCurate}>
+              <ForumIcon icon="Star" />
+            </SidebarAction>
+          }
           <SidebarAction title="Remove from Curation Suggestions" onClick={handleDisregardForCurated}>
             <ForumIcon icon="Clear"/>
           </SidebarAction>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -40,20 +40,26 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const shouldShow = (belowFold: boolean, curatedDate: Date, currentUser: UsersCurrent | null) => {
+const shouldShow = (atBottom: boolean, timeForCuration: boolean, currentUser: UsersCurrent | null, hasCurationDrafts: boolean) => {
   if (isEAForum) {
-    return !belowFold && currentUser?.isAdmin;
+    return !atBottom && currentUser?.isAdmin;
   } else {
-    const twoAndAHalfDaysAgo = new Date(new Date().getTime()-(2.5*24*60*60*1000));
-    return belowFold || (curatedDate <= twoAndAHalfDaysAgo);
+    return (atBottom === hasCurationDrafts) || timeForCuration;
   }
 }
 
-const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes, setCurationPost }: {
+const hasCurationDrafts = (results: SunshineCurationPostsList[] | undefined): boolean => {
+  if (!results || results.length === 0) return false;
+  
+  return results.some(post => post.curationNotices && post.curationNotices.length > 0);
+}
+
+const SunshineCuratedSuggestionsList = ({ terms, atBottom, classes, setCurationPost, setHasDrafts }: {
   terms: PostsViewTerms,
-  belowFold?: boolean,
+  atBottom?: boolean,
   classes: ClassesType<typeof styles>,
   setCurationPost?: (post: PostsList) => void,
+  setHasDrafts?: (hasDrafts: boolean) => void,
 }) => {
   const currentUser = useCurrentUser();
 
@@ -75,8 +81,16 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes, setCuration
     fragmentName: 'PostsList',
   });
   const curatedDate = curatedResults ? new Date(curatedResults[0]?.curatedDate) : new Date();
+  const twoAndAHalfDaysAgo = new Date(new Date().getTime()-(2.5*24*60*60*1000));
+  const timeForCuration = curatedDate <= twoAndAHalfDaysAgo;
 
-  if (!shouldShow(!!belowFold, curatedDate, currentUser)) {
+  const hasDrafts = hasCurationDrafts(results);
+  
+  if (setHasDrafts) {
+    setHasDrafts(hasDrafts);
+  }
+
+  if (!shouldShow(!!atBottom, timeForCuration, currentUser, hasDrafts)) {
     return null
   }
 
@@ -114,7 +128,7 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold, classes, setCuration
       </SunshineListTitle>
       {results?.map(post =>
         <div key={post._id} >
-          <SunshineCuratedSuggestionsItem post={post} setCurationPost={setCurationPost}/>
+          <SunshineCuratedSuggestionsItem post={post} setCurationPost={setCurationPost} timeForCuration={timeForCuration}/>
         </div>
       )}
       {showLoadMore && <div className={classes.loadMorePadding}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -108,13 +108,15 @@ const SunshineCuratedSuggestionsList = ({ terms, atBottom, classes, setCurationP
     }
   }
 
+  const needsDraftsText = !timeForCuration && !hasDrafts ? " (No drafts!)" : "";
+
   const { SunshineListTitle, SunshineCuratedSuggestionsItem, MetaInfo, FormatDate,
     LoadMore, LWTooltip, ForumIcon } = Components
 
   return (
     <div className={classNames(classes.root, statusClass)}>
       <SunshineListTitle>
-        <Link to={`/admin/curation`}>Suggestions for Curated</Link>
+        <Link to={`/admin/curation`}>Suggestions for Curated{needsDraftsText}</Link>
         <MetaInfo>
           <FormatDate date={curatedDate}/>
         </MetaInfo>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -41,7 +41,6 @@ const styles = (theme: ThemeType) => ({
 })
 
 const SunshineSidebar = ({classes}: {classes: ClassesType<typeof styles>}) => {
-  const [showSidebar, setShowSidebar] = useState(false)
   const [showUnderbelly, setShowUnderbelly] = useState(false)
   const currentUser = useCurrentUser();
 
@@ -67,9 +66,9 @@ const SunshineSidebar = ({classes}: {classes: ClassesType<typeof styles>}) => {
     <div className={classes.root}>
       {showInitialSidebar && <div className={classes.background}>
         <SunshineGoogleServiceAccount />
-        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
         <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 10}} currentUser={currentUser}/>
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         <SunshineReportedContentList currentUser={currentUser}/>
         <SunshineNewTagsList />
         
@@ -79,34 +78,11 @@ const SunshineSidebar = ({classes}: {classes: ClassesType<typeof styles>}) => {
           <AFSuggestCommentsList />
           <AFSuggestUsersList />
         </div>}
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}} atBottom/>
       </div>}
 
-      {userCanDo(currentUser, 'posts.moderate.all') && <div>
-        { showSidebar ? <div className={classes.toggle} onClick={() => setShowSidebar(false)}>
-          Hide Full Sidebar
-            <KeyboardArrowDownIcon />
-          </div>
-          :
-          <div className={classes.toggle} onClick={() => setShowSidebar(true)}>
-            Show Full Sidebar
-            <KeyboardArrowRightIcon />
-          </div>}
-      </div>}
-
-
-      { showSidebar && userCanDo(currentUser, 'posts.moderate.all') && <div>
-        {!!currentUser!.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}        
-        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}} belowFold/>
-
-        {/* regular admins (but not sunshines) see AF content below the fold */}
-        { userIsAdmin(currentUser) && <div>
-          <AFSuggestUsersList />
-          <AFSuggestPostsList />
-          <AFSuggestCommentsList />
-        </div>}
-      </div>}
-
-      { showSidebar && <div>
+      { userCanDo(currentUser, 'posts.moderate.all') && <div>
+        {!!currentUser!.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
         { showUnderbelly ? <div className={classes.toggle} onClick={() => setShowUnderbelly(false)}>
           Hide {underbellyName}
           <KeyboardArrowDownIcon/>


### PR DESCRIPTION
Thought I'd experiment with keeping the curation list a bit more visible when a curation isn't urgent, but we don't have any curation notice drafts

Also removes the curation button if it's not needed, in order to avoid people getting confused

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209683391690680) by [Unito](https://www.unito.io)
