### PR TITLE
Add a migration that updates SQL functions

### DIFF
--- a/packages/lesswrong/server/migrations/20250314T190647.updateSqlFunctions.ts
+++ b/packages/lesswrong/server/migrations/20250314T190647.updateSqlFunctions.ts
@@ -1,0 +1,8 @@
+import { updateFunctions } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  updateFunctions(db);
+}
+
+export const down = async ({db}: MigrationContext) => {
+}

--- a/packages/lesswrong/server/migrations/20250314T190647.updateSqlFunctions.ts
+++ b/packages/lesswrong/server/migrations/20250314T190647.updateSqlFunctions.ts
@@ -1,7 +1,7 @@
 import { updateFunctions } from "./meta/utils";
 
 export const up = async ({db}: MigrationContext) => {
-  updateFunctions(db);
+  await updateFunctions(db);
 }
 
 export const down = async ({db}: MigrationContext) => {


### PR DESCRIPTION
Fixes breakage in https://github.com/ForumMagnum/ForumMagnum/pull/10522/files#diff-bc5842cb5e475c1a328750d4d17c1201eb3156b26307a1d64b213fc105f7239d, (field-changes table) which updated a SQL function but didn't call `updateFunctions`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209683777697274) by [Unito](https://www.unito.io)
