### PR TITLE
[EA] Fix sticky being unset when a non-admin edits the post

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -409,12 +409,15 @@ const schema: SchemaType<"Posts"> = {
     order: 10,
     group: formGroups.adminOptions,
     onCreate: ({document: post}) => {
-      if(!post.sticky) {
+      if(!isEAForum && !post.sticky) {
         return false;
       }
     },
     onUpdate: ({modifier}) => {
-      if (!modifier.$set.sticky) {
+      // WH 2025-03-17: I think this is a bug in general, as a non-admin editing this post will cause
+      // sticky to be set to false. Forum-gating to EAF to speed up fixing this live bug for us, but
+      // I believe this function and `onCreate`
+      if (!isEAForum && !modifier.$set.sticky) {
         return false;
       }
     }


### PR DESCRIPTION
[This post](https://forum.effectivealtruism.org/posts/bpqurdjZvyYmHoHiA/existential-choices-symposium-with-will-macaskill-and-other) keeps being accidentally un-stickied, presumably because there is some kind of update being triggered by a non-admin