### PR TITLE
Make default inbox exclude moderator messages

### DIFF
--- a/packages/lesswrong/lib/collections/conversations/views.ts
+++ b/packages/lesswrong/lib/collections/conversations/views.ts
@@ -37,7 +37,7 @@ function moderatorConversations(terms: ConversationsViewTerms) {
 function userConversations(terms: ConversationsViewTerms) {
   const showArchivedFilter = terms.showArchive ? {} : {archivedByIds: {$ne: terms.userId}}
   return {
-    selector: {participantIds: terms.userId, messageCount: {$gt: 0}, ...showArchivedFilter},
+    selector: {moderator: {$ne: true}, participantIds: terms.userId, messageCount: {$gt: 0}, ...showArchivedFilter},
     options: {sort: {latestActivity: -1}}
   };
 }

--- a/packages/lesswrong/lib/collections/conversations/views.ts
+++ b/packages/lesswrong/lib/collections/conversations/views.ts
@@ -1,4 +1,4 @@
-import { isAF } from '../../instanceSettings';
+import { isAF, isLW } from '../../instanceSettings';
 import { viewFieldNullOrMissing } from '@/lib/utils/viewConstants';
 import { CollectionViewSet } from '../../../lib/views/collectionViewSet';
 
@@ -36,8 +36,9 @@ function moderatorConversations(terms: ConversationsViewTerms) {
 // notifications for a specific user (what you see in the notifications menu)
 function userConversations(terms: ConversationsViewTerms) {
   const showArchivedFilter = terms.showArchive ? {} : {archivedByIds: {$ne: terms.userId}}
+  const moderatorSelector = isLW ? {moderator: {$ne: true}} : {}
   return {
-    selector: {moderator: {$ne: true}, participantIds: terms.userId, messageCount: {$gt: 0}, ...showArchivedFilter},
+    selector: {participantIds: terms.userId, messageCount: {$gt: 0}, ...showArchivedFilter, ...moderatorSelector},
     options: {sort: {latestActivity: -1}}
   };
 }


### PR DESCRIPTION
It's pretty annoying to have my LW inbox filled with moderator messages (from rejection DMs). This PR removes those (you can still get them in the `/moderatorInbox`. 

I'm not 100% sure if this affects EA Forum or not.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209706283062564) by [Unito](https://www.unito.io)
