### PR TITLE
Fix double-fetch of comments when navigating to a post page

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -20,6 +20,9 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   const currentUser = useCurrentUser();
   const { query } = useSubscribedLocation();
 
+  // Check the cache for a copy of the post with the PostsListWithVotes fragment, so that when you click through
+  // a PostsItem, you can see the start of the post (the part of the text that was in the hover-preview) while
+  // it loads the rest.
   const apolloClient = useApolloClient();
   const postPreload = apolloClient.cache.readFragment<PostsListWithVotes>({
     fragment: getFragment("PostsListWithVotes"),
@@ -41,7 +44,9 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
   const { document: post, refetch, loading, error, fetchProps } = useDisplayedPost(documentId, sequenceId, version);
 
   // This section is a performance optimisation to make comment fetching start as soon as possible rather than waiting for
-  // the post to be fetched first. This is mainly beneficial in SSR
+  // the post to be fetched first. This is mainly beneficial in SSR. We don't preload comments if the post was preloaded
+  // (which happens on the client when navigating through a PostsItem), because the preloaded post already takes care of
+  // the waterfalling queries and the preload would be a duplicate query.
 
   // Note: in principle defaultView can depend on the post (via post.commentSortOrder). In practice this is almost never set,
   // less than 1/1000 posts have it set. If it is set the consequences are that the comments will be fetched twice. This shouldn't
@@ -56,6 +61,7 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
 
   const commentQueryResult = useMulti({
     terms,
+    skip: !!postPreload,
     ...postsCommentsThreadMultiOptions,
   });
   const eagerPostComments = {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209706586376040) by [Unito](https://www.unito.io)
