### PR TITLE
Fix type errors related to refs under React 19

### DIFF
--- a/packages/lesswrong/components/admin/TwitterAdmin.tsx
+++ b/packages/lesswrong/components/admin/TwitterAdmin.tsx
@@ -114,7 +114,7 @@ const TwitterAdmin = ({ classes }: { classes: ClassesType<typeof styles> }) => {
     itemsPerPage: 20,
   });
 
-  const authorExpandContainer = useRef(null);
+  const authorExpandContainer = useRef<HTMLDivElement|null>(null);
 
   if (!userIsAdmin(currentUser)) {
     return <Error404 />;

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -48,7 +48,7 @@ const CommentBody = ({
   classes,
 }: {
   comment: CommentsList,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null,
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null,
   collapsed?: boolean,
   truncated?: boolean,
   postPage?: boolean,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -36,7 +36,7 @@ const CommentBottom = ({comment, treeOptions, votingSystem, voteProps, commentBo
   treeOptions: CommentTreeOptions,
   votingSystem: VotingSystem
   voteProps: VotingProps<VoteableTypeClient>,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null,
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null,
   replyButton: React.ReactNode,
   classes: ClassesType<typeof styles>,
 }) => {

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -24,7 +24,7 @@ interface ExternalProps {
    * methods. (Doing so is handled by React, not by anything inside of this
    * using the ref prop)
    */
-  ref?: React.RefObject<ContentItemBody>
+  ref?: React.RefObject<ContentItemBody|null>
 
   // className: Name of an additional CSS class to apply to this element.
   className?: string;
@@ -103,7 +103,7 @@ interface ContentItemBodyState {
 //      dangerouslySetInnerHTML on a div, ie, you set the HTML content of this
 //      by passing dangerouslySetInnerHTML={{__html: "<p>foo</p>"}}.
 export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyState> {
-  private bodyRef: React.RefObject<HTMLDivElement>
+  private bodyRef: React.RefObject<HTMLDivElement|null>
 
   private replacedElements: Array<{
     replacementElement: React.ReactNode
@@ -112,7 +112,7 @@ export class ContentItemBody extends Component<ContentItemBodyProps,ContentItemB
   
   constructor(props: ContentItemBodyProps) {
     super(props);
-    this.bodyRef = React.createRef<HTMLDivElement>();
+    this.bodyRef = React.createRef<HTMLDivElement|null>();
     this.replacedElements = [];
     this.state = {
       updatedElements:false,

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -284,7 +284,7 @@ const Header = ({
   sidebarHidden: boolean,
   toggleStandaloneNavigation: () => void,
   stayAtTop?: boolean,
-  searchResultsArea: React.RefObject<HTMLDivElement>,
+  searchResultsArea: React.RefObject<HTMLDivElement|null>,
   // CSS var corresponding to the background color you want to apply (see also appBarDarkBackground above)
   backgroundColor?: string,
   classes: ClassesType<typeof styles>,

--- a/packages/lesswrong/components/common/useCheckMeritsCollapse.ts
+++ b/packages/lesswrong/components/common/useCheckMeritsCollapse.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect, useRef, useState } from 'react';
 
 export function useCheckMeritsCollapse<T extends HTMLElement>(
   {ref, height, deps}:
-  {ref: RefObject<T>, height: number, deps?: any[]}
+  {ref: RefObject<T|null>, height: number, deps?: any[]}
 ) {
   // this tracks whether the contents of the tab actually overflow
   const [meritsCollapse, setMeritsCollapse] = useState(false)

--- a/packages/lesswrong/components/contents/SideItems.tsx
+++ b/packages/lesswrong/components/contents/SideItems.tsx
@@ -9,7 +9,7 @@ import { getOffsetChainTop } from '@/lib/utils/domUtil';
 export type SideItemOptions = {
   format: "block"|"icon",
   offsetTop: number,
-  measuredElement?: React.RefObject<HTMLElement>,
+  measuredElement?: React.RefObject<HTMLElement|null>,
 }
 const defaultSideItemOptions: SideItemOptions = {
   format: "block",

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingInput.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingInput.tsx
@@ -39,7 +39,7 @@ const EAOnboardingInput = ({
   placeholder: string,
   As?: "input" | "textarea",
   rows?: number,
-  inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>,
+  inputRef?: RefObject<HTMLInputElement|null> | RefObject<HTMLTextAreaElement|null>,
   disabled?: boolean,
   className?: string,
   classes: ClassesType<typeof styles>,

--- a/packages/lesswrong/components/ea-forum/wrapped/WrappedShareButton.tsx
+++ b/packages/lesswrong/components/ea-forum/wrapped/WrappedShareButton.tsx
@@ -31,7 +31,7 @@ const styles = (theme: ThemeType) => ({
 
 const WrappedShareButton = ({name, screenshotRef, onRendered, className, classes}: {
   name: string,
-  screenshotRef: RefObject<HTMLElement>,
+  screenshotRef: RefObject<HTMLElement|null>,
   onRendered?: (canvas: HTMLCanvasElement) => void,
   className?: string,
   classes: ClassesType<typeof styles>,

--- a/packages/lesswrong/components/ea-forum/wrapped/hooks.tsx
+++ b/packages/lesswrong/components/ea-forum/wrapped/hooks.tsx
@@ -285,8 +285,8 @@ type ForumWrappedContext = {
   mostValuablePosts: PostsListWithVotes[],
   mostValuablePostsLoading: boolean,
   mostValuablePostsLoadMoreProps: LoadMoreProps,
-  thinkingVideoRef: RefObject<HTMLVideoElement>,
-  personalityVideoRef: RefObject<HTMLVideoElement>,
+  thinkingVideoRef: RefObject<HTMLVideoElement|null>,
+  personalityVideoRef: RefObject<HTMLVideoElement|null>,
 }
 
 const forumWrappedContext = createContext<ForumWrappedContext | null>(null);

--- a/packages/lesswrong/components/editor/EditLinkpostUrl.tsx
+++ b/packages/lesswrong/components/editor/EditLinkpostUrl.tsx
@@ -45,7 +45,7 @@ const EditLinkpostUrl = ({
   placeholder?: string;
   updateCurrentValues<T extends {}>(values: T): void;
 }) => {
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const { postCategory } = document;
   if (postCategory !== "linkpost") return null;

--- a/packages/lesswrong/components/editor/EditUrl.tsx
+++ b/packages/lesswrong/components/editor/EditUrl.tsx
@@ -64,7 +64,7 @@ const EditUrl = ({ value, path, classes, document, defaultValue, label, hintText
   tooltip?: string,
 }) => {
   const [active, setActive] = useState(!!value);
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
   let HintTextComponent: React.ComponentClass | React.FC;
   if (hintText && (hintText in ComponentsTable || hintText in DeferredComponentsTable)) {
     HintTextComponent = Components[hintText as keyof ComponentTypes]

--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -815,7 +815,7 @@ export const ForumEventPoll = ({
                 {ticks.map((tickIndex) => (
                   <div
                     key={tickIndex}
-                    ref={(el) => (tickRefs.current[tickIndex] = el)}
+                    ref={(el) => {tickRefs.current[tickIndex] = el}}
                     className={classNames(
                       classes.tick,
                       isDragging.current && classes.tickDragging,

--- a/packages/lesswrong/components/hooks/useObserver.ts
+++ b/packages/lesswrong/components/hooks/useObserver.ts
@@ -35,10 +35,10 @@ export const useObserver = <T extends Element>({
   onExit,
   threshold = 0.8,
   maxTriggers = -1,
-}: UseObserverProps): RefObject<T> => {
+}: UseObserverProps): RefObject<T|null> => {
   const enterTriggerCount = useRef(0);
   const exitTriggerCount = useRef(0);
-  const ref = useRef<T>(null);
+  const ref = useRef<T|null>(null);
   useEffect(() => {
     const target = ref.current;
     if (target) {

--- a/packages/lesswrong/components/hooks/useReplaceTextContent.ts
+++ b/packages/lesswrong/components/hooks/useReplaceTextContent.ts
@@ -108,7 +108,7 @@ function replaceText(node: Node, replacements: ReplacementTuple[]) {
 
 export function useReplaceTextContent() {
   const replacements: ReplacementTuple[] = Object.entries(textReplacementsSetting.get());
-  const observerRef = useRef<MutationObserver | null>();
+  const observerRef = useRef<MutationObserver | null>(null);
 
   return () => {
     for (let node of textNodesUnder(document.body)) {

--- a/packages/lesswrong/components/messaging/ConversationContents.tsx
+++ b/packages/lesswrong/components/messaging/ConversationContents.tsx
@@ -46,7 +46,7 @@ const ConversationContents = ({
 }: {
   conversation: ConversationsList;
   currentUser: UsersCurrent;
-  scrollRef?: React.RefObject<HTMLDivElement>;
+  scrollRef?: React.RefObject<HTMLDivElement|null>;
   classes: ClassesType<typeof styles>;
 }) => {
   // Count messages sent, and use it to set a distinct value for `key` on `MessagesNewForm`

--- a/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
+++ b/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
@@ -39,7 +39,7 @@ const NotificationTypeSettingsWidget = ({ path, value, label, updateCurrentValue
     });
   }
   
-  const channelOptions: Record<NotificationChannelOption, React.ReactChild> = {
+  const channelOptions: Record<NotificationChannelOption, React.ReactNode> = {
     none: <MenuItem value="none" key="none">Don't notify</MenuItem>,
     onsite: <MenuItem value="onsite" key="onsite">Notify me on-site</MenuItem>,
     email: <MenuItem value="email" key="email">Notify me by email</MenuItem>,

--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPage.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPage.tsx
@@ -38,7 +38,7 @@ export const NotificationsPage = ({classes}: {
 
   // Save the initial karma changes to display, as they'll be marked as read
   // once the user visits the page and they'll dissapear
-  const karmaChanges = useRef<KarmaChanges>();
+  const karmaChanges = useRef<KarmaChanges>(null);
   if (fetchedKarmaChanges && !karmaChanges.current) {
     karmaChanges.current = fetchedKarmaChanges.karmaChanges;
   }
@@ -68,7 +68,7 @@ export const NotificationsPage = ({classes}: {
     <div className={classes.root}>
       <div className={classes.title}>Notifications</div>
       <NotificationsPageTabContextProvider>
-        <NotificationsPageFeed karmaChanges={karmaChanges.current} />
+        <NotificationsPageFeed karmaChanges={karmaChanges.current ?? undefined} />
       </NotificationsPageTabContextProvider>
     </div>
   );

--- a/packages/lesswrong/components/posts/EALargePostsItem.tsx
+++ b/packages/lesswrong/components/posts/EALargePostsItem.tsx
@@ -111,7 +111,7 @@ const EALargePostsItem = ({
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
-  const authorExpandContainer = useRef(null);
+  const authorExpandContainer = useRef<HTMLDivElement|null>(null);
 
   const postLink = postGetPageUrl(post);
   const {onClick} = useClickableCell({href: postLink});

--- a/packages/lesswrong/components/posts/FeedPostCardMeta.tsx
+++ b/packages/lesswrong/components/posts/FeedPostCardMeta.tsx
@@ -75,7 +75,7 @@ const FeedPostCardMeta = ({post, className, classes}: {
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
-  const authorExpandContainer = useRef(null);
+  const authorExpandContainer = useRef<HTMLDivElement|null>(null);
 
   const {
     TruncatedAuthorsList, ForumIcon, LWTooltip, FormatDate

--- a/packages/lesswrong/components/posts/PostsPage/ImageCropPreview.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ImageCropPreview.tsx
@@ -218,7 +218,7 @@ const SaveAllBar = ({showSaveAllButton, loading, saveAllCoordinates}: {showSaveA
 }
 
 const ImageCropPreview = ({ imgRef, setCropPreview, classes, flipped }: {
-  imgRef: RefObject<HTMLImageElement>,
+  imgRef: RefObject<HTMLImageElement|null>,
   setCropPreview: (coordinates?: Coordinates) => void,
   classes: ClassesType<typeof styles>,
   flipped: boolean

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
@@ -61,7 +61,7 @@ const EAPostsPreviewTooltip = ({
   comment,
   classes,
 }: EAPostsPreviewTooltipProps) => {
-  const tagsRef = useRef(null);
+  const tagsRef = useRef<HTMLDivElement|null>(null);
 
   if (!post) {
     return null;

--- a/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
+++ b/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
@@ -44,12 +44,12 @@ const reformatAuthorPlaceholder = (
 
 const TruncatedAuthorsList = ({post, expandContainer, className, classes}: {
   post: PostsList | SunshinePostsList | PostsBestOfList,
-  expandContainer: RefObject<HTMLDivElement>,
+  expandContainer: RefObject<HTMLDivElement|null>,
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
   const {isAnon, authors, topCommentAuthor} = usePostsUserAndCoauthors(post);
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement|null>(null);
 
   useEffect(() => {
     if (isAnon || authors.length === 0) {

--- a/packages/lesswrong/components/tagging/AddTagOrWikiPage.tsx
+++ b/packages/lesswrong/components/tagging/AddTagOrWikiPage.tsx
@@ -50,7 +50,7 @@ const AddTagOrWikiPage = ({onTagSelected, isVotingContext, onlyTags, numSuggesti
   const searchStateChanged = React.useCallback((searchState: SearchState) => {
     setSearchOpen((searchState.query?.length ?? 0) > 0);
   }, []);
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // When this appears, yield to the event loop once, use getElementsByTagName
   // to find the search input text box, then focus it.

--- a/packages/lesswrong/components/tagging/TruncatedTagsList.tsx
+++ b/packages/lesswrong/components/tagging/TruncatedTagsList.tsx
@@ -42,11 +42,11 @@ const reformatTagPlaceholder = (
 
 const TruncatedTagsList = ({post, expandContainer, className, classes}: {
   post: PostsList | SunshinePostsList | PostsBestOfList,
-  expandContainer: RefObject<HTMLDivElement>,
+  expandContainer: RefObject<HTMLDivElement|null>,
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement|null>(null);
   const tags = post.tags;
 
   useEffect(() => {

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType) => ({
 });
 
 export const InlineReactSelectionWrapper = ({contentRef, voteProps, styling, children, classes}: {
-  contentRef?: React.RefObject<ContentItemBody>|null, // we need this to check if the mouse is still over the comment, and it needs to be passed down from CommentsItem instead of declared here because it needs extra padding in order to behave intuively (without losing the selection)
+  contentRef?: React.RefObject<ContentItemBody|null>|null, // we need this to check if the mouse is still over the comment, and it needs to be passed down from CommentsItem instead of declared here because it needs extra padding in order to behave intuively (without losing the selection)
   voteProps: VotingProps<VoteableTypeClient>
   styling: "comment"|"post"|"tag",
   children: React.ReactNode,
@@ -106,7 +106,7 @@ export const InlineReactSelectionWrapper = ({contentRef, voteProps, styling, chi
   );
 }
 
-function getYOffsetFromDocument (selection: Selection, commentTextRef: React.RefObject<HTMLDivElement>) {
+function getYOffsetFromDocument (selection: Selection, commentTextRef: React.RefObject<HTMLDivElement|null>) {
   const commentTextRect = commentTextRef.current?.getBoundingClientRect();
   if (!commentTextRect) return 0;
 

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -354,7 +354,7 @@ const HoverableReactionIcon = ({reactionRowRef, react, numberShown, voteProps, q
   numberShown: number,
   voteProps: VotingProps<VoteableTypeClient>,
   quote: QuoteLocator|null,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null,
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null,
   classes: ClassesType<typeof styles>,
 }) => {
   const { hover, eventHandlers: {onMouseOver, onMouseLeave} } = useHover();
@@ -479,7 +479,7 @@ const NamesAttachedReactionsHoverSingleReaction = ({react, voteProps, classes, c
   react: EmojiReactName,
   voteProps: VotingProps<VoteableTypeClient>,
   classes: ClassesType<typeof styles>,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null
 }) => {
   const { ReactionHoverTopRow, ReactionQuotesHoverInfo } = Components;
   const normalizedReactions = getNormalizedReactionsListFromVoteProps(voteProps);

--- a/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionQuotesHoverInfo.tsx
@@ -65,7 +65,7 @@ const ReactionQuotesHoverInfo = ({react, quote, voteProps, commentBodyRef, class
   react: EmojiReactName,
   quote: QuoteLocator,
   voteProps: VotingProps<VoteableTypeClient>,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null,
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null,
   classes: ClassesType<typeof styles>
 }) => {
   const { ReactOrAntireactVote, UsersWhoReacted } = Components;

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -34,7 +34,7 @@ const App = ({serverRequestStatus, history}: ExternalProps & {
   const reactDomLocation = useLocation();
   const locationContext = useRef<RouterLocation | null>(null);
   const subscribeLocationContext = useRef<RouterLocation | null>(null);
-  const navigationContext = useRef<{ history: History<unknown> } | null>();
+  const navigationContext = useRef<{ history: History<unknown> } | null>(null);
 
   const locale = localeSetting.get();
 

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -130,13 +130,13 @@ export class Form<N extends CollectionNameString> extends Component<SmartFormPro
   constructor(props: SmartFormProps<N>) {
     super(props);
 
-    this.formRef = React.createRef<HTMLFormElement>();
+    this.formRef = React.createRef<HTMLFormElement|null>();
     this.state = {
       ...getInitialStateFromProps(props)
     };
   }
 
-  formRef: React.RefObject<HTMLFormElement>
+  formRef: React.RefObject<HTMLFormElement|null>
   unblock: any
   
   defaultValues: any = {};

--- a/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
@@ -15,7 +15,7 @@ const styles = (theme: ThemeType) => ({
 
 
 const GatherTownIframeWrapper = ({iframeRef, classes}: {
-  iframeRef: React.RefObject<HTMLIFrameElement>,
+  iframeRef: React.RefObject<HTMLIFrameElement|null>,
   classes: ClassesType<typeof styles>,
 }) => {
   useEffect(() => {

--- a/packages/lesswrong/lib/hocUtils.tsx
+++ b/packages/lesswrong/lib/hocUtils.tsx
@@ -19,6 +19,6 @@ export function hookToHoc<P, HP, HR>(
       const hookProps = hookParams !== undefined ? hookFn(hookParams) : hookFn();
       return <Component ref={ref} {...props} {...hookProps} />;
     };
-    return React.forwardRef(WithHook);
+    return React.forwardRef(WithHook as any);
   }
 }

--- a/packages/lesswrong/lib/postSideRecommendations.tsx
+++ b/packages/lesswrong/lib/postSideRecommendations.tsx
@@ -139,7 +139,7 @@ const useGenerator = (
   post: RecommendablePost,
 ): RecommendationsGenerator => {
   const [cookies] = useCookiesWithConsent();
-  const generator = useRef<RecommendationsGenerator>();
+  const generator = useRef<RecommendationsGenerator>(null);
   if (!generator.current) {
     const generators = getAvailableGenerators(user, post, cookies);
     const index = Math.floor(seed) % generators.length;

--- a/packages/lesswrong/lib/truncateUtils.ts
+++ b/packages/lesswrong/lib/truncateUtils.ts
@@ -32,8 +32,8 @@ type TruncationClasses = "more" | "scratch" | "placeholder" | "item";
  * example, '+ n more' where n is the number of excluded items.
  */
 export const recalculateTruncation = (
-  ref: RefObject<HTMLDivElement>,
-  expandContainer: RefObject<HTMLDivElement>,
+  ref: RefObject<HTMLDivElement|null>,
+  expandContainer: RefObject<HTMLDivElement|null>,
   classes: ClassesType<JssStylesCallback<TruncationClasses>>,
   reformatPlaceholder: (
     moreCount: number,

--- a/packages/lesswrong/lib/voting/votingSystems.tsx
+++ b/packages/lesswrong/lib/voting/votingSystems.tsx
@@ -21,7 +21,7 @@ export type CommentVotingComponentProps<T extends VotingPropsDocument = VotingPr
   hideKarma?: boolean,
   collectionName: VoteableCollectionName,
   votingSystem: VotingSystem,
-  commentBodyRef?: React.RefObject<ContentItemBody>|null,
+  commentBodyRef?: React.RefObject<ContentItemBody|null>|null,
   voteProps?: VotingProps<VoteableTypeClient>,
   post?: PostsWithNavigation | PostsWithNavigationAndRevision,
 }


### PR DESCRIPTION
React 19 changes the type signature of useRef and some related types. Modify our usages of refs so they will typecheck after upgrading to React 19.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209709855405806) by [Unito](https://www.unito.io)
