### PR TITLE
Small tweak to debate week banner

### DIFF
--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -39,9 +39,9 @@ const styles = (theme: ThemeType) => ({
   },
   question: {
     fontSize: 32,
-    lineHeight: '110%',
+    lineHeight: '100%',
     fontWeight: 700,
-    maxWidth: 700,
+    maxWidth: 730,
     marginBottom: 13,
     marginLeft: "auto",
     marginRight: "auto"


### PR DESCRIPTION
To avoid one lonely word on the last line I increased the max-width slightly. Also slightly decreased the line-height.

**Before**
![Screenshot 2025-03-18 at 12 33 06](https://github.com/user-attachments/assets/c8862734-a527-438b-9794-58595f220382)

**After**
![Screenshot 2025-03-18 at 12 33 46](https://github.com/user-attachments/assets/0f61d52c-183c-4d8e-97e9-7f8118848330)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209712146042625) by [Unito](https://www.unito.io)
