### PR TITLE
Fix crash due to empty $and in sunshineNewCommentsList

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -372,7 +372,6 @@ function sunshineNewCommentsList(terms: CommentsViewTerms) {
     selector: {
       ...dontHideDeletedAndUnreviewed,
       $or: [
-        {$and: []},
         {needsReview: true},
         {baseScore: {$lte:0}}
       ],


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209759253794939) by [Unito](https://www.unito.io)
