### PR TITLE
Fix the Share button in the post triple-dot menu doing nothing

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/SharePostSubmenu.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/SharePostSubmenu.tsx
@@ -19,7 +19,7 @@ const SharePostSubmenu = ({post, closeMenu, classes}: {
   function shareClicked() {
     // navigator.canShare will be present on mobile devices with sharing-intents,
     // absent on desktop.
-    if (isMobile() && !!navigator.canShare) {
+    if (isMobile() && !!navigator.canShare?.()) {
       const sharingOptions = {
         title: post.title,
         text: post.title,
@@ -33,7 +33,7 @@ const SharePostSubmenu = ({post, closeMenu, classes}: {
     }
   }
   
-  const hasSubmenu = isServer || !navigator.canShare;
+  const hasSubmenu = isServer || !navigator.canShare?.();
   const MaybeWrapWithSubmenu = hasSubmenu
     ? ({children}: {children: React.ReactNode}) => <LWTooltip
         title={<SharePostActions post={post} onClick={closeMenu} />}


### PR DESCRIPTION
The post triple-dot menu uses `navigator.canShare` to determine whether it has sharing Intents (ie, whether this is a phone where non-browser apps have registered intent handlers for sharing URLs). The intended behavior is that on a phone, clicking the Share button in the post triple-dot menu sends an intent, while on desktop, it opens a submenu with Copy Link and other options. However, `navigator.canShare` is a function, not a boolean, so this tried to use the mobile case on desktop (which didn't work).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209779066189669) by [Unito](https://www.unito.io)
