### PR TITLE
Add hotkey Ctrl+Shift+D to open the CkEditor Inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@aws-sdk/client-cloudfront": "^3.577.0",
     "@babel/runtime": "^7.26.10",
     "@centreforeffectivealtruism/umzug": "^3.2.1",
+    "@ckeditor/ckeditor5-inspector": "^4.1.0",
     "@ckeditor/ckeditor5-theme-lark": "^43.1.0",
     "@ckeditor/vite-plugin-ckeditor5": "^0.1.3",
     "@datadog/browser-rum": "^5.34.1",

--- a/packages/lesswrong/client/useCkEditorInspector.ts
+++ b/packages/lesswrong/client/useCkEditorInspector.ts
@@ -12,10 +12,6 @@ export function useCkEditorInspector(editorRef: RefObject<CKEditor<any>>) {
       //eslint-disable-next-line no-console
       console.log("Attaching CkEditor inspector");
       CKEditorInspector.attach(editorRef.current?.editor);
-    } else if (editorRef.current?.editor) {
-      console.log(`Not attaching to CkEditor: key=${ev.key}`);
-    } else {
-      console.log("Not attaching to CkEditor: Editor not ready");
     }
   });
 }

--- a/packages/lesswrong/client/useCkEditorInspector.ts
+++ b/packages/lesswrong/client/useCkEditorInspector.ts
@@ -1,0 +1,21 @@
+import { RefObject } from "react";
+import { useGlobalKeydown } from "@/components/common/withGlobalKeydown";
+import CKEditorInspector from "@ckeditor/ckeditor5-inspector";
+import type CKEditor from "@/lib/vendor/ckeditor5-react/ckeditor";
+
+export function useCkEditorInspector(editorRef: RefObject<CKEditor<any>>) {
+  useGlobalKeydown(ev => {
+    if (bundleIsProduction) {
+      return;
+    }
+    if (editorRef.current?.editor && ev.key === 'D' && ev.ctrlKey && ev.shiftKey) {
+      //eslint-disable-next-line no-console
+      console.log("Attaching CkEditor inspector");
+      CKEditorInspector.attach(editorRef.current?.editor);
+    } else if (editorRef.current?.editor) {
+      console.log(`Not attaching to CkEditor: key=${ev.key}`);
+    } else {
+      console.log("Not attaching to CkEditor: Editor not ready");
+    }
+  });
+}

--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -28,6 +28,9 @@ import type { ConditionalVisibilityPluginConfiguration  } from './conditionalVis
 import { CkEditorPortalContext } from './CKEditorPortalProvider';
 import { useDialog } from '../common/withDialog';
 import { claimsConfig } from './claims/claimsConfig';
+import { useGlobalKeydown } from '../common/withGlobalKeydown';
+import { isClient } from '@/lib/executionEnvironment';
+import { useCkEditorInspector } from '@/client/useCkEditorInspector';
 
 // Uncomment this line and the reference below to activate the CKEditor debugger
 // import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
@@ -568,6 +571,7 @@ const CKPostEditor = ({
   };
 
   useSyncCkEditorPlaceholder(editorObject, actualPlaceholder);
+  useCkEditorInspector(editorRef);
 
   return <div>
     {isBlockOwnershipMode && <>

--- a/packages/lesswrong/lib/types/moduleTypes.d.ts
+++ b/packages/lesswrong/lib/types/moduleTypes.d.ts
@@ -7,3 +7,4 @@ declare module 'draft-js-alignment-plugin';
 declare module 'draft-js-focus-plugin';
 declare module 'draft-js-richbuttons-plugin';
 declare module 'draft-js-block-breakout-plugin';
+declare module '@ckeditor/ckeditor5-inspector';

--- a/packages/lesswrong/stubs/client/useCkEditorInspector.ts
+++ b/packages/lesswrong/stubs/client/useCkEditorInspector.ts
@@ -1,0 +1,5 @@
+import { RefObject } from "react";
+import type CKEditor from "@/lib/vendor/ckeditor5-react/ckeditor";
+
+export function useCkEditorInspector(editorRef: RefObject<CKEditor<any>>) {
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,6 +2077,11 @@
     "@ckeditor/ckeditor5-utils" "43.3.1"
     lodash-es "4.17.21"
 
+"@ckeditor/ckeditor5-inspector@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-inspector/-/ckeditor5-inspector-4.1.0.tgz#ceb970f353ed6bd54ebf0c89a297f0f7fb4512f2"
+  integrity sha512-yKoIFpaSVQQIhgFEyoltwG40OSsWX5psYdYvNxW84nfxgrs90DJrbMQDtdchVZNMXBu6CkJfPiPG0WBLU9su3g==
+
 "@ckeditor/ckeditor5-theme-lark@^43.1.0":
   version "43.3.1"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.3.1.tgz#af79ad1929d6f5e3ea27b7a4b8ac590f62ae736e"


### PR DESCRIPTION
This integrates the CkEditor inspector, and opens it when you press Ctrl+Shift+D while on a post page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209804538724346) by [Unito](https://www.unito.io)
