### PR TITLE
Fix ability for users with custom moderation guidelines to create posts

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -379,7 +379,7 @@ const schema = {
       outputType: "Revision",
       canRead: ["guests"],
       canUpdate: ["members", "sunshineRegiment", "admins"],
-      canCreate: [userHasModerationGuidelines],
+      canCreate: ['members', 'sunshineRegiment', 'admins'],
       editableFieldOptions: { pingbacks: false, normalized: true },
       arguments: "version: String",
       resolver: getNormalizedEditableResolver("moderationGuidelines"),


### PR DESCRIPTION
This was fixed but the fix was accidentally reverted by the schema-refactoring PR.


