### PR TITLE
Fix an occasional crash in build script when auto-refresh connection closes while waiting for server to start

### DIFF
--- a/scripts/startup/autoRefreshServer.ts
+++ b/scripts/startup/autoRefreshServer.ts
@@ -113,7 +113,13 @@ export function startAutoRefreshServer({serverPort, websocketPort}: {
     });
     
     await waitForServerReady(serverPort);
-    ws.send(`{"latestBuildTimestamp": "${getEitherBundleTimestamp()}"}`);
+    try {
+      ws.send(`{"latestBuildTimestamp": "${getEitherBundleTimestamp()}"}`);
+    } catch(e) {
+      // Sending can fail if a connection disconnected during the window while
+      // we're waiting for server startup
+      ws.close();
+    }
   });
 }
 


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209821086254315) by [Unito](https://www.unito.io)
