### PR TITLE
Remove incorrect padding for SuggestCuration list

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -7,9 +7,6 @@ import { isEAForum, isLWorAF } from '../../lib/instanceSettings';
 import { Link } from '@/lib/reactRouterWrapper';
 
 const styles = (theme: ThemeType) => ({
-  root: {
-    padding: 16,
-  },
   loadMorePadding: {
     paddingLeft: 16,
   },
@@ -114,7 +111,7 @@ const SunshineCuratedSuggestionsList = ({ terms, atBottom, classes, setCurationP
     LoadMore, LWTooltip, ForumIcon } = Components
 
   return (
-    <div className={classNames(classes.root, statusClass)}>
+    <div className={statusClass}>
       <SunshineListTitle>
         <Link to={`/admin/curation`}>Suggestions for Curated{needsDraftsText}</Link>
         <MetaInfo>


### PR DESCRIPTION
During the "make SuggestCuration more noticeable" PR, it got this padding which made it stop matching the spacing that the rest of the sidebar had (which had some side effects of being more squished and also making it harder to mouse over the hoverover)

This removes that padding:

Old:
<img width="192" alt="image" src="https://github.com/user-attachments/assets/e1615659-6f4f-44ce-8eb8-3db5b229a676" />

New:
<img width="457" alt="image" src="https://github.com/user-attachments/assets/a35127ac-1201-47b3-b742-0e136b131793" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209829755577684) by [Unito](https://www.unito.io)
