### PR TITLE
allow tags and multidocs to be created without requiring them to have summaries immediately

### DIFF
--- a/packages/lesswrong/lib/collections/multiDocuments/newSchema.ts
+++ b/packages/lesswrong/lib/collections/multiDocuments/newSchema.ts
@@ -401,6 +401,7 @@ const schema = {
   summaries: {
     graphql: {
       outputType: "[MultiDocument!]!",
+      inputType: "[MultiDocument!]",
       canRead: ["guests"],
       resolver: getSummariesFieldResolver("MultiDocuments"),
       sqlResolver: getSummariesFieldSqlResolver("MultiDocuments"),

--- a/packages/lesswrong/lib/collections/tags/newSchema.ts
+++ b/packages/lesswrong/lib/collections/tags/newSchema.ts
@@ -1451,6 +1451,7 @@ const schema = {
   summaries: {
     graphql: {
       outputType: "[MultiDocument!]!",
+      inputType: "[MultiDocument!]",
       canRead: ["guests"],
       resolver: getSummariesFieldResolver("Tags"),
       sqlResolver: getSummariesFieldSqlResolver("Tags"),


### PR DESCRIPTION
One of the schema refactors involved using the new `outputType` as the default `inputType`.  Summaries previously had a required `graphQLtype` specified on their `resolverOnlyField` which got translated to that output type, but the initGraphQL logic wasn't treating that as an input type (in truth I'm not sure what the previous input type even was...).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209829771036858) by [Unito](https://www.unito.io)
