### PR TITLE
Register missing recommendations graphql resolvers

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-server/initGraphQL.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/initGraphQL.ts
@@ -38,7 +38,7 @@ import { graphqlTypeDefs as additionalPostsTypeDefs } from '@/lib/collections/po
 import { graphqlTypeDefs as additionalRevisionsTypeDefs } from '@/lib/collections/revisions/newSchema';
 import { graphqlTypeDefs as additionalTagsTypeDefs } from '@/lib/collections/tags/newSchema';
 import { graphqlTypeDefs as additionalUsersTypeDefs } from '@/lib/collections/users/newSchema';
-import { graphqlTypeDefs as additionalRecommendationsTypeDefs } from '@/server/recommendations';
+import { graphqlTypeDefs as recommendationsTypeDefs, graphqlQueries as recommendationsQueries } from '@/server/recommendations';
 import { graphqlTypeDefs as userResolversTypeDefs, graphqlMutations as userResolversMutations, graphqlQueries as userResolversQueries } from '@/server/resolvers/userResolvers';
 import { graphqlVoteTypeDefs as postVoteTypeDefs, graphqlVoteMutations as postVoteMutations } from '@/server/collections/posts/collection';
 import { graphqlVoteTypeDefs as commentVoteTypeDefs, graphqlVoteMutations as commentVoteMutations } from '@/server/collections/comments/collection';
@@ -113,7 +113,7 @@ export const typeDefs = gql`
   ${additionalRevisionsTypeDefs}
   ${additionalTagsTypeDefs}
   ${additionalUsersTypeDefs}
-  ${additionalRecommendationsTypeDefs}
+  ${recommendationsTypeDefs}
   ${userResolversTypeDefs}
   # # Vote typedefs
   ${postVoteTypeDefs}
@@ -185,6 +185,7 @@ export const typeDefs = gql`
 export const resolvers = {
   Query: {
     ...userResolversQueries,
+    ...recommendationsQueries,
     ...notificationQueries,
     ...commentQueries,
     ...analyticsGraphQLQueries,


### PR DESCRIPTION
All recommendations are currently broken because the graphql resolvers don't get registered anywhere. Weirdly, there's no console error says the resolver can't be found - it just silently fails.