### PR TITLE
Distinguish between direct and indirect replies to threads

### DIFF
--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -624,16 +624,23 @@ export const NewReplyNotification = registerNotificationType({
 export const NewReplyToYouNotification = registerNotificationType({
   name: "newReplyToYou",
   userSettingField: "notificationRepliesToMyComments",
-  async getMessage({documentType, documentId, context}: GetMessageProps) {
+  async getMessage({documentType, documentId, context, extraData}: GetMessageProps) {
     let document = await getDocument(documentType, documentId, context) as DbComment;
-    return await commentGetAuthorName(document, context) + ' replied to your comment on "' + await getCommentParentTitle(document, context) + '"';
+    if (extraData?.direct === false) {
+      return await commentGetAuthorName(document, context) + ' replied to a thread you\'re in on "' + await getCommentParentTitle(document, context) + '"';
+    } else {
+      return await commentGetAuthorName(document, context) + ' replied to your comment on "' + await getCommentParentTitle(document, context) + '"';
+    }
   },
   getIcon() {
     return <CommentsIcon style={iconStyles}/>
   },
-  Display: ({User, Comment, Post}) => <>
-    <User /> replied to your <Comment /> on <Post />
-  </>,
+  Display: ({notification, User, Comment, Post}) => {
+    const isDirect = notification.extraData?.direct !== false;
+    return <>
+      <User /> replied to {isDirect ? 'your comment' : 'a thread you\'re in'} on <Post />
+    </>;
+  },
 });
 
 // Vulcan notification that we don't really use

--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -190,14 +190,15 @@ const utils = {
       });
   
       let newReplyUserIds: string[] = [];
-      let newReplyToYouUserIds: string[] = [];
+      let newReplyToYouDirectUserIds: string[] = [];
+      let newReplyToYouIndirectUserIds: string[] = [];
   
-      for (const {commentId, userId} of parentComments) {
+      for (const {commentId: currentParentCommentId, userId: currentParentCommentAuthorId} of parentComments) {
         const subscribedUsers = await getSubscribedUsers({
-          documentId: commentId,
+          documentId: currentParentCommentId,
           collectionName: "Comments",
           type: subscriptionTypes.newReplies,
-          potentiallyDefaultSubscribedUserIds: [userId],
+          potentiallyDefaultSubscribedUserIds: [currentParentCommentAuthorId],
           userIsDefaultSubscribed: u => u.auto_subscribe_to_my_comments
         })
         const subscribedUserIds = _.map(subscribedUsers, u=>u._id);
@@ -205,24 +206,30 @@ const utils = {
         // Don't notify the author of their own comment, and filter out the author
         // of the parent-comment to be treated specially (with a newReplyToYou
         // notification instead of a newReply notification).
-        newReplyUserIds = [...newReplyUserIds, ..._.difference(subscribedUserIds, [comment.userId, commentId])]
+        newReplyUserIds = [...newReplyUserIds, ..._.difference(subscribedUserIds, [comment.userId, currentParentCommentAuthorId])]
   
         // Separately notify authors of replies to their own comments
-        if (subscribedUserIds.includes(userId) && userId !== comment.userId) {
-          newReplyToYouUserIds = [...newReplyToYouUserIds, ...subscribedUserIds]
+        if (subscribedUserIds.includes(currentParentCommentAuthorId) && currentParentCommentAuthorId !== comment.userId) {
+          if (currentParentCommentId === comment.parentCommentId) {
+            newReplyToYouDirectUserIds = [...newReplyToYouDirectUserIds, currentParentCommentAuthorId]
+          } else {
+            newReplyToYouIndirectUserIds = [...newReplyToYouIndirectUserIds, currentParentCommentAuthorId]
+          }
         }
       }
-  
-      // Take the difference as a precaution to prevent double-notifying
-      newReplyUserIds = uniq(_.difference(newReplyUserIds, newReplyToYouUserIds));
-      newReplyToYouUserIds = uniq(newReplyToYouUserIds);
+
+      // Take the difference to prevent double-notifying
+      newReplyUserIds = uniq(_.difference(newReplyUserIds, [...newReplyToYouDirectUserIds, ...newReplyToYouIndirectUserIds]));
+      newReplyToYouIndirectUserIds = uniq(_.difference(newReplyToYouIndirectUserIds, newReplyToYouDirectUserIds)); // Direct replies take precedence over indirect replies
+      newReplyToYouDirectUserIds = uniq(newReplyToYouDirectUserIds);
   
       await Promise.all([
         createNotifications({userIds: newReplyUserIds, notificationType: 'newReply', documentType: 'comment', documentId: comment._id}),
-        createNotifications({userIds: newReplyToYouUserIds, notificationType: 'newReplyToYou', documentType: 'comment', documentId: comment._id})
+        createNotifications({userIds: newReplyToYouDirectUserIds, notificationType: 'newReplyToYou', documentType: 'comment', documentId: comment._id, extraData: {direct: true}}),
+        createNotifications({userIds: newReplyToYouIndirectUserIds, notificationType: 'newReplyToYou', documentType: 'comment', documentId: comment._id, extraData: {direct: false}})
       ]);
   
-      notifiedUsers = [...notifiedUsers, ...newReplyUserIds, ...newReplyToYouUserIds];
+      notifiedUsers = [...notifiedUsers, ...newReplyUserIds, ...newReplyToYouDirectUserIds];
     }
   
     // 2. If this comment is a debate comment, notify users who are subscribed to the post as a debate (`newDebateComments`)

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -424,14 +424,16 @@ export const NewReplyToYouNotification = serverRegisterNotificationType({
   name: "newReplyToYou",
   canCombineEmails: true,
   emailSubject: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
+    const anyIndirect = notifications.some(n => n.extraData?.direct === false);
+
     if (notifications.length > 1) {
-      return `${notifications.length} replies to your comments`;
+      return anyIndirect ? `${notifications.length} replies to threads you participated in` : `${notifications.length} replies to your comments`;
     } else {
       const comment = await Comments.findOne(notifications[0].documentId);
       if (!comment) throw Error(`Can't find comment for notification: ${notifications[0]}`)
       const author = await Users.findOne(comment.userId);
       if (!author) throw Error(`Can't find author for new comment notification: ${notifications[0]}`)
-      return `${userGetDisplayName(author)} replied to your comment`;
+      return anyIndirect ? `${userGetDisplayName(author)} replied to a thread you participated in` : `${userGetDisplayName(author)} replied to your comment`;
     }
   },
   emailBody: async ({ user, notifications, context }: {user: DbUser, notifications: DbNotification[], context: ResolverContext}) => {


### PR DESCRIPTION
We received some complaints from users who were confused about indirect replies using the wording "replied to you", this changes the wording to "replied to a thread you're in..." in those cases.

Note that I haven't tested actually sending the emails, because I have only changed the subject line.

## Screenshots

Notification popover:
![Screenshot 2025-04-02 at 16 12 13](https://github.com/user-attachments/assets/f7a3ee96-ac99-4c6b-8ecb-c91621e9e68f)

Emails (note only the subject line has changed):
![Screenshot 2025-04-02 at 16 10 28](https://github.com/user-attachments/assets/14de3628-811b-4da3-80b3-64771d35b1bb)
![Screenshot 2025-04-02 at 16 11 20](https://github.com/user-attachments/assets/05859a67-6204-445c-b647-c0adf3f74e66)

Notifications page (there was a separate bug in this before, where it said `your <a>comment</a>` in the blurb but actually linked to the reply):
![Screenshot 2025-04-02 at 16 14 54](https://github.com/user-attachments/assets/7c31c4ea-b124-49e2-9d24-a514eb0b90d6)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209872896122292) by [Unito](https://www.unito.io)
