### PR TITLE
ensure we don't skip loading comments when a user changes the sorting

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageWrapper.tsx
@@ -59,15 +59,18 @@ const PostsPageWrapper = ({ sequenceId, version, documentId }: {
     ? {...(query as CommentsViewTerms), limit:1000}
     : {view: defaultView, limit: 1000, postId: documentId}
 
+  // Don't pass in the eagerPostComments if we skipped the query,
+  // otherwise PostsPage will skip the lazy query if the terms change
+  const skipEagerComments = !!postPreload;
   const commentQueryResult = useMulti({
     terms,
-    skip: !!postPreload,
+    skip: skipEagerComments,
     ...postsCommentsThreadMultiOptions,
   });
-  const eagerPostComments = {
-    terms,
-    queryResponse: commentQueryResult,
-  }
+  const eagerPostComments = skipEagerComments
+    ? undefined
+    : { terms, queryResponse: commentQueryResult };
+    
   // End of performance section
 
   const { Error404, Loading, PostsPageCrosspostWrapper, PostsPage } = Components;


### PR DESCRIPTION
A previous performance optimization accidentally caused us to not load comments in the case where we already had the post preloaded and the query view terms between PostsPageWrapper and PostsPage were the same.  (`eagerPostCommentTerms` had a `postId` in the terms passed down to `PostsPage`, while the terms defined in `PostsPage` didn't _until_ users switched comment sorting.)

Now we just don't pass through `eagerPostComment` if we've skipped loading them, so there's no way we'll try to "use" a skipped query result.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209876619464301) by [Unito](https://www.unito.io)
