### PR TITLE
Make openDialog no longer rely on components-by-name

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
@@ -14,8 +14,11 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-interface AFApplicationFormProps extends WithMessagesProps, WithStylesProps, WithUpdateCurrentUserProps {
+interface ExternalProps {
   onClose: any,
+}
+
+interface AFApplicationFormProps extends ExternalProps, WithMessagesProps, WithStylesProps, WithUpdateCurrentUserProps {
 }
 interface AFApplicationFormState {
   applicationText: string,
@@ -80,7 +83,7 @@ class AFApplicationForm extends PureComponent<AFApplicationFormProps,AFApplicati
   }
 }
 
-const AFApplicationFormComponent = registerComponent(
+const AFApplicationFormComponent = registerComponent<ExternalProps>(
   'AFApplicationForm', AFApplicationForm, { styles, hocs: [
     withMessages,
     withUpdateCurrentUser,

--- a/packages/lesswrong/components/analytics/AnalyticsGraph.tsx
+++ b/packages/lesswrong/components/analytics/AnalyticsGraph.tsx
@@ -292,12 +292,13 @@ export const AnalyticsGraph = ({
       updateDisplayDates(startDate, endDate);
     } else {
       openDialog({
-        componentName: 'DateRangeModal',
-        componentProps: {
-          startDate: displayStartDate,
-          endDate: displayEndDate,
-          updateDisplayDates
-        },
+        name: 'DateRangeModal',
+        contents: ({onClose}) => <Components.DateRangeModal
+          onClose={onClose}
+          startDate={displayStartDate}
+          endDate={displayEndDate}
+          updateDisplayDates={updateDisplayDates}
+        />,
       });
     }
   }, [displayEndDate, displayStartDate, openDialog, updateDisplayDates]);

--- a/packages/lesswrong/components/books/Book2019FrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/Book2019FrontpageWidget.tsx
@@ -138,8 +138,8 @@ const Book2019FrontpageWidget = ({ classes }: {
       })
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     }
   }

--- a/packages/lesswrong/components/books/Book2020FrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/Book2020FrontpageWidget.tsx
@@ -123,8 +123,8 @@ const Book2020FrontpageWidget = ({ classes }: {
       })
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     }
   }

--- a/packages/lesswrong/components/books/BookFrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/BookFrontpageWidget.tsx
@@ -143,8 +143,8 @@ const BookFrontpageWidget = ({ classes }: {
       })
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     }
   }

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -240,8 +240,8 @@ const CommentSubmit = ({
         onClick={(ev) => {
           if (!currentUser) {
             openDialog({
-              componentName: "LoginPopup",
-              componentProps: {},
+              name: "LoginPopup",
+              contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>,
             });
             ev.preventDefault();
           }
@@ -355,8 +355,11 @@ const CommentsNewForm = ({
       const dialogProps = { user: currentUser, post };
       if (shouldOpenNewUserGuidelinesDialog(dialogProps)) {
         openDialog({
-          componentName: 'NewUserGuidelinesDialog',
-          componentProps: dialogProps,
+          name: 'NewUserGuidelinesDialog',
+          contents: ({onClose}) => <Components.NewUserGuidelinesDialog
+            onClose={onClose}
+            {...dialogProps}
+          />
         });
       }
       if (isLWorAF) {

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -154,11 +154,12 @@ const ModerationGuidelinesBox = ({classes, commentType = "post", documentId}: {
     e.stopPropagation()
 
     openDialog({
-      componentName: "ModerationGuidelinesEditForm",
-      componentProps: {
-        commentType,
-        documentId,
-      }
+      name: "ModerationGuidelinesEditForm",
+      contents: ({onClose}) => <Components.ModerationGuidelinesEditForm
+        onClose={onClose}
+        commentType={commentType}
+        documentId={documentId}
+      />
     });
   }
   

--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -136,8 +136,12 @@ const SideCommentIconMobile = ({commentIds, post, classes}: {
 
   const openModal = () => {
     openDialog({
-      componentName: 'SideCommentDialog',
-      componentProps: { commentIds, post }
+      name: 'SideCommentDialog',
+      contents: ({onClose}) => <Components.SideCommentDialog
+        onClose={onClose}
+        commentIds={commentIds}
+        post={post}
+      />
     });
   };
     

--- a/packages/lesswrong/components/common/CookieBanner/CookieBanner.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookieBanner.tsx
@@ -89,7 +89,10 @@ const CookieBanner = ({ classes }: { classes: ClassesType<typeof styles> }) => {
         By clicking "Accept all" you agree to their use. Customise your{" "}
         <a
           onClick={() => {
-            openDialog({ componentName: "CookieDialog", componentProps: {} });
+            openDialog({
+              name: "CookieDialog",
+              contents: ({onClose}) => <Components.CookieDialog onClose={onClose} />
+            });
           }}
         >
           cookie settings

--- a/packages/lesswrong/components/common/CookieBanner/CookiePolicy.tsx
+++ b/packages/lesswrong/components/common/CookieBanner/CookiePolicy.tsx
@@ -116,7 +116,10 @@ const CookiePolicy = ({ classes }: { classes: ClassesType<typeof styles> }) => {
         {/* TODO possibly make this generic for all CEA websites once all the cookie banners are done */}
         We use cookies on the EA Forum. This cookie notice applies only to the EA Forum. You may access and change your
         cookie preferences at any time by clicking{" "}
-        <a onClick={() => openDialog({ componentName: "CookieDialog", componentProps: {} })}>here</a>.
+        <a onClick={() => openDialog({
+          name: "CookieDialog",
+          contents: ({onClose}) => <Components.CookieDialog onClose={onClose} />
+        })}>here</a>.
       </Typography>
       <Typography variant="body1">
         If you choose to reject cookies you are ultimately responsible for removing any that have already been set (such as if you

--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -1,15 +1,14 @@
 import React, { useMemo, useCallback, useState } from 'react';
-import { Components } from '../../lib/vulcan-lib/components';
 import { hookToHoc } from '../../lib/hocUtils';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useOnNavigate } from '../hooks/useOnNavigate';
 
-export type CloseableComponent = ComponentWithProps<{ onClose?: any }>
+export type DialogContentsFn = (args: {onClose: () => void}) => React.ReactNode
 
 export interface OpenDialogContextType {
-  openDialog: <T extends CloseableComponent>({componentName, componentProps}: {
-    componentName: T,
-    componentProps?: Omit<React.ComponentProps<typeof Components[T]>,"onClose"|"classes">,
+  openDialog: ({name, contents, closeOnNavigate}: {
+    name: string
+    contents: DialogContentsFn
     closeOnNavigate?: boolean,
   }) => void,
   closeDialog: () => void,
@@ -20,22 +19,22 @@ export const OpenDialogContext = React.createContext<OpenDialogContextType|null>
 export const DialogManager = ({children}: {
   children: React.ReactNode,
 }) => {
-  const [componentNameWithProps, setComponentNameWithProps] = useState<{componentName: CloseableComponent, componentProps: any} | null>(null);
+  const [dialogName, setDialogName] = useState<string|null>(null);
+  const [dialogContents, setDialogContents] = useState<DialogContentsFn|null>(null);
   const [closeOnNavigate, setCloseOnNavigate] = useState<boolean>(false);
   const {captureEvent} = useTracking();
-  const isOpen = !!componentNameWithProps?.componentName;
   
   const closeDialog = useCallback(() => {
-    captureEvent("dialogBox", {open: false, dialogName: componentNameWithProps?.componentName})
-    setComponentNameWithProps(null);
-  }, [captureEvent, componentNameWithProps?.componentName]);
-
-  const ModalComponent = isOpen ? (Components[componentNameWithProps?.componentName]) : null;
+    captureEvent("dialogBox", {open: false, dialogName})
+    setDialogName(null);
+    setDialogContents(null);
+  }, [captureEvent, dialogName]);
   
   const providedContext = useMemo((): OpenDialogContextType => ({
-    openDialog: ({componentName, componentProps, closeOnNavigate}) => {
-      captureEvent("dialogBox", {open: true, dialogName: componentName})
-      setComponentNameWithProps({componentName, componentProps});
+    openDialog: ({name, contents, closeOnNavigate}) => {
+      captureEvent("dialogBox", {open: true, dialogName: name})
+      setDialogName(name);
+      setDialogContents(() => contents);
       setCloseOnNavigate(closeOnNavigate || false)
     },
     closeDialog: closeDialog
@@ -45,11 +44,12 @@ export const DialogManager = ({children}: {
     if (closeOnNavigate) closeDialog()
   })
 
-  const modal = (ModalComponent && isOpen) && <ModalComponent {...componentNameWithProps?.componentProps} onClose={closeDialog} />
   return (
     <OpenDialogContext.Provider value={providedContext}>
       {children}
-      {isOpen && <span>{modal}</span>}
+      {dialogContents && <span>
+        {dialogContents({onClose: closeDialog})}
+      </span>}
     </OpenDialogContext.Provider>
   );
 }

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -327,15 +327,31 @@ const Community = ({classes}: {
   const keywordSearchTimer = useRef<any>(null)
 
   const openEventNotificationsForm = () => {
-    openDialog({
-      componentName: currentUser ? "EventNotificationsDialog" : "LoginPopup",
-    });
+    if (currentUser) {
+      openDialog({
+        name: "EventNotificationsDialog",
+        contents: ({onClose}) => <Components.EventNotificationsDialog onClose={onClose} />
+      });
+    } else {
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
+    }
   }
   
   const openSetPersonalLocationForm = () => {
-    openDialog({
-      componentName: currentUser ? "SetPersonalMapLocationDialog" : "LoginPopup",
-    });
+    if (currentUser) {
+      openDialog({
+        name: "SetPersonalMapLocationDialog",
+        contents: ({onClose}) => <Components.SetPersonalMapLocationDialog onClose={onClose} />
+      });
+    } else {
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
+    }
   }
   
   const { CommunityBanner, LocalGroups, OnlineGroups, CommunityMembers, GroupFormLink,

--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
@@ -23,10 +23,11 @@ const DeleteCommentDropdownItem = ({comment, post, tag}: {
 
   const showDeleteDialog = () => {
     openDialog({
-      componentName: "DeleteCommentDialog",
-      componentProps: {
-        comment: comment,
-      },
+      name: "DeleteCommentDialog",
+      contents: ({onClose}) => <Components.DeleteCommentDialog
+        onClose={onClose}
+        comment={comment}
+      />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/comments/LockThreadDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/LockThreadDropdownItem.tsx
@@ -23,8 +23,11 @@ const LockThreadDropdownItem = ({comment}: {comment: CommentsList}) => {
 
   const handleLockThread = () => {
     openDialog({
-      componentName: "LockThreadDialog",
-      componentProps: {commentId: comment._id},
+      name: "LockThreadDialog",
+      contents: ({onClose}) => <Components.LockThreadDialog
+        onClose={onClose}
+        commentId={comment._id}
+      />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/comments/ReportCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/ReportCommentDropdownItem.tsx
@@ -21,13 +21,14 @@ const ReportCommentDropdownItem = ({comment, post}: {
     }
 
     openDialog({
-      componentName: "ReportForm",
-      componentProps: {
-        commentId: comment._id,
-        postId: comment.postId,
-        link: "/posts/" + comment.postId + "/a/" + comment._id,
-        userId: currentUser._id,
-      }
+      name: "ReportForm",
+      contents: ({onClose}) => <Components.ReportForm
+        onClose={onClose}
+        commentId={comment._id}
+        postId={comment.postId}
+        link={"/posts/" + comment.postId + "/a/" + comment._id}
+        userId={currentUser._id}
+      />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/posts/DislikeRecommendationDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/DislikeRecommendationDropdownItem.tsx
@@ -34,8 +34,8 @@ const DislikeRecommendationDropdownItem = ({post}: {post: PostsBase}) => {
   const dislikeRecommendation = () => {
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       return;
     }

--- a/packages/lesswrong/components/dropdowns/posts/EditTagsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/EditTagsDropdownItem.tsx
@@ -14,8 +14,8 @@ const EditTagsDropdownItem = ({post, closeMenu}: {
   const handleOpenTagDialog = async () => {
     closeMenu?.();
     openDialog({
-      componentName: "EditTagsDialog",
-      componentProps: {post},
+      name: "EditTagsDialog",
+      contents: ({onClose}) => <Components.EditTagsDialog onClose={onClose} post={post} />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/posts/HideFrontpagePostDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/HideFrontpagePostDropdownItem.tsx
@@ -34,8 +34,8 @@ const HideFrontpagePostDropdownItem = ({post}: {post: PostsBase}) => {
   const toggleShown = () => {
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       return;
     }

--- a/packages/lesswrong/components/dropdowns/posts/ReportPostDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/ReportPostDropdownItem.tsx
@@ -17,12 +17,13 @@ const ReportPostDropdownItem = ({post}: {post: PostsBase}) => {
       return;
     }
     openDialog({
-      componentName: "ReportForm",
-      componentProps: {
-        postId: post._id,
-        link: "/posts/" + post._id,
-        userId: currentUser._id,
-      },
+      name: "ReportForm",
+      contents: ({onClose}) => <Components.ReportForm
+        onClose={onClose}
+        postId={post._id}
+        link={"/posts/" + post._id}
+        userId={currentUser._id}
+      />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/posts/ResyncRssDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/ResyncRssDropdownItem.tsx
@@ -54,8 +54,8 @@ const ResyncRssDropdownItem = ({post, closeMenu, classes}: {
   function onClick() {
     closeMenu();
     openDialog({
-      componentName: "ResyncRssDialog",
-      componentProps: { post },
+      name: "ResyncRssDialog",
+      contents: ({onClose}) => <Components.ResyncRssDialog onClose={onClose} post={post} />
     });
   }
 

--- a/packages/lesswrong/components/dropdowns/posts/SummarizeDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/SummarizeDropdownItem.tsx
@@ -17,8 +17,11 @@ const SummarizeDropdownItem = ({post, closeMenu}: {
   const showPostSummary = () => {
     closeMenu?.();
     openDialog({
-      componentName: "PostSummaryDialog",
-      componentProps: {post},
+      name: "PostSummaryDialog",
+      contents: ({onClose}) => <Components.PostSummaryDialog
+        onClose={onClose}
+        post={post}
+      />
     });
   }
 

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestActionButtons.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestActionButtons.tsx
@@ -56,8 +56,8 @@ const EditDigestActionButtons = ({digest, classes}: {
       })
     } else {
       openDialog({
-        componentName: 'ConfirmPublishDialog',
-        componentProps: {digest}
+        name: 'ConfirmPublishDialog',
+        contents: ({onClose}) => <Components.ConfirmPublishDialog onClose={onClose} digest={digest} />
       })
     }
   }

--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -132,12 +132,13 @@ const PostSharingSettings = ({document, formType, value, updateCurrentValues, su
     }
     
     openDialog({
-      componentName: "PostSharingSettingsDialog",
-      componentProps: {
-        post: document,
-        linkSharingKey: document.linkSharingKey ?? undefined,
-        initialSharingSettings,
-        onConfirm: async (newSharingSettings: SharingSettings, newSharedUsers: string[], isChanged: boolean) => {
+      name: "PostSharingSettingsDialog",
+      contents: ({onClose}) => <Components.PostSharingSettingsDialog
+        onClose={onClose}
+        post={document}
+        linkSharingKey={document.linkSharingKey ?? undefined}
+        initialSharingSettings={initialSharingSettings}
+        onConfirm={async (newSharingSettings: SharingSettings, newSharedUsers: string[], isChanged: boolean) => {
           if (isChanged || formType==="new") {
             await updateCurrentValues({
               sharingSettings: newSharingSettings,
@@ -157,9 +158,9 @@ const PostSharingSettings = ({document, formType, value, updateCurrentValues, su
             }
           }
           closeDialog();
-        },
-        initialShareWithUsers: document.shareWithUsers || [],
-      },
+        }}
+        initialShareWithUsers={document.shareWithUsers || []}
+      />
     });
   }, [openDialog, closeDialog, formType, document, updateCurrentValues, initialSharingSettings, flash, submitForm]);
 

--- a/packages/lesswrong/components/editor/PostVersionHistory.tsx
+++ b/packages/lesswrong/components/editor/PostVersionHistory.tsx
@@ -110,8 +110,12 @@ const PostVersionHistoryButton = ({post, postId, classes}: {
     onClick={() => {
       captureEvent("versionHistoryButtonClicked", {postId})
       openDialog({
-        componentName: "PostVersionHistory",
-        componentProps: {post, postId},
+        name: "PostVersionHistory",
+        contents: ({onClose}) => <Components.PostVersionHistory
+          onClose={onClose}
+          post={post}
+          postId={postId}
+        />
       })
     }}
     variant={"outlined"}

--- a/packages/lesswrong/components/editor/TagVersionHistory.tsx
+++ b/packages/lesswrong/components/editor/TagVersionHistory.tsx
@@ -70,10 +70,11 @@ const TagVersionHistoryButton = ({tagId, classes}: {
     onClick={() => {
       captureEvent("tagVersionHistoryButtonClicked", {tagId})
       openDialog({
-        componentName: "TagVersionHistory",
-        componentProps: {
-          tagId
-        },
+        name: "TagVersionHistory",
+        contents: ({onClose}) => <Components.TagVersionHistory
+          onClose={onClose}
+          tagId={tagId}
+        />
       })
     }}
   >

--- a/packages/lesswrong/components/editor/claims/claimsConfig.tsx
+++ b/packages/lesswrong/components/editor/claims/claimsConfig.tsx
@@ -8,8 +8,11 @@ import type { ClaimsPluginConfiguration, CreateClaimDialogProps } from './claims
 export const claimsConfig = (portalContext: CkEditorPortalContextType|null, openDialog: OpenDialogContextType['openDialog']): ClaimsPluginConfiguration => ({
   openNewClaimDialog: (props: CreateClaimDialogProps) => {
     openDialog({
-      componentName: "CreateClaimDialog",
-      componentProps: props,
+      name: "CreateClaimDialog",
+      contents: ({onClose}) => <Components.CreateClaimDialog
+        onClose={onClose}
+        {...props}
+      />
     });
   },
   renderClaimPreviewInto: (element: HTMLElement, claimId: string) => {

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -294,9 +294,17 @@ const EventsHome = ({classes}: {
   }, [userLocation])
 
   const openEventNotificationsForm = () => {
-    openDialog({
-      componentName: currentUser ? "EventNotificationsDialog" : "LoginPopup",
-    });
+    if (currentUser) {
+      openDialog({
+        name: "EventNotificationsDialog",
+        contents: ({onClose}) => <Components.EventNotificationsDialog onClose={onClose} />
+      });
+    } else {
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
+    }
   }
   
   const handleChangeDistance = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -282,8 +282,8 @@ const ImageUpload = ({
         {(name === 'eventImageId') && <Button
           variant="outlined"
           onClick={() => openDialog({
-            componentName: "ImageUploadDefaultsDialog",
-            componentProps: {onSelect: chooseDefaultImg}
+            name: "ImageUploadDefaultsDialog",
+            contents: ({onClose}) => <Components.ImageUploadDefaultsDialog onClose={onClose} onSelect={chooseDefaultImg} />
           })}
         >
           Choose from ours
@@ -292,10 +292,12 @@ const ImageUpload = ({
           <Button
             variant="outlined"
             onClick={() => openDialog({
-              componentName: "ImageUploadDefaultsDialog",
-              componentProps: {
-                onSelect: chooseDefaultImg,
-                type: "Profile"}
+              name: "ImageUploadDefaultsDialog",
+              contents: ({onClose}) => <Components.ImageUploadDefaultsDialog
+                onClose={onClose}
+                onSelect={chooseDefaultImg}
+                type={"Profile"}
+              />
             })}
           >
             Choose from ours

--- a/packages/lesswrong/components/hooks/useBookmarkPost.tsx
+++ b/packages/lesswrong/components/hooks/useBookmarkPost.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from "react";
+import React, { MouseEvent, useState } from "react";
 import { useDialog } from "../common/withDialog";
 import { useCurrentUser } from "../common/withUser";
 import { pluck } from "underscore";
@@ -7,6 +7,7 @@ import { gql, useMutation } from "@apollo/client";
 import { fragmentTextForQuery } from "../../lib/vulcan-lib/fragments";
 import type { ForumIconName } from "../common/ForumIcon";
 import { isFriendlyUI } from "../../themes/forumTheme";
+import { Components } from "@/lib/vulcan-lib/components";
 
 export type BookmarkPost = {
   icon: ForumIconName,
@@ -54,8 +55,8 @@ export const useBookmarkPost = (post: PostsBase): BookmarkPost => {
   const toggleBookmark = (event: MouseEvent) => {
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       event.preventDefault();
       return;

--- a/packages/lesswrong/components/hooks/useCommentBox.tsx
+++ b/packages/lesswrong/components/hooks/useCommentBox.tsx
@@ -1,10 +1,9 @@
-import React, { ComponentProps, useCallback, useMemo, useState } from 'react';
-import { Components } from '../../lib/vulcan-lib/components';
+import React, { useCallback, useMemo, useState } from 'react';
 import { hookToHoc } from '../../lib/hocUtils';
-import type { CloseableComponent } from '../common/withDialog';
 
+type CommentBoxFn = (args: {onClose: () => void}) => React.ReactNode
 interface CommentBoxContextType {
-  openCommentBox: <T extends CloseableComponent>({componentName, componentProps}: {componentName: T, componentProps: Omit<ComponentProps<ComponentTypes[T]>, 'onClose' | 'classes'>}) => void,
+  openCommentBox: ({commentBox}: {commentBox: CommentBoxFn}) => void,
   close: () => void,
 }
 export const CommentBoxContext = React.createContext<CommentBoxContextType|null>(null);
@@ -12,21 +11,15 @@ export const CommentBoxContext = React.createContext<CommentBoxContextType|null>
 export const CommentBoxManager = ({ children }: {
   children: React.ReactNode
 }) => {
-  const [ componentName, setComponentName] = useState<CloseableComponent|null>(null)
-  const [ componentProps, setComponentProps] = useState<Record<string,any>|null>(null)
-
-  const CommentBoxComponent = componentName ? Components[componentName] : null;
+  const [ commentBox, setCommentBox] = useState<CommentBoxFn|null>(null)
 
   const close = useCallback(() => {
-    setComponentName(null)
-    setComponentProps(null)
+    setCommentBox(null);
   }, []);
-  const openCommentBox = useCallback(({componentName, componentProps}: {
-    componentName: CloseableComponent,
-    componentProps: AnyBecauseHard,
+  const openCommentBox = useCallback(({commentBox}: {
+    commentBox: CommentBoxFn
   }) => {
-    setComponentName(componentName)
-    setComponentProps(componentProps)
+    setCommentBox(() => commentBox);
   }, []);
   const commentBoxContext = useMemo(
     () => ({ openCommentBox, close }),
@@ -36,12 +29,9 @@ export const CommentBoxManager = ({ children }: {
   return (
     <CommentBoxContext.Provider value={commentBoxContext}>
       {children}
-      {CommentBoxComponent && componentName &&
-        <CommentBoxComponent
-          {...componentProps as AnyBecauseHard}
-          onClose={close}
-        />
-      }
+      {commentBox && <span>
+        {commentBox({onClose: close})}
+      </span>}
     </CommentBoxContext.Provider>
   );
 }

--- a/packages/lesswrong/components/hooks/useNotifyMe.tsx
+++ b/packages/lesswrong/components/hooks/useNotifyMe.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback } from "react";
+import React, { MouseEvent, useCallback } from "react";
 import { useTracking } from "../../lib/analyticsEvents";
 import { useCreate } from "../../lib/crud/withCreate";
 import { graphqlTypeToCollectionName } from "../../lib/vulcan-lib/collections";
@@ -13,6 +13,7 @@ import type { SubscriptionType } from "../../lib/collections/subscriptions/helpe
 import { useMulti } from "../../lib/crud/withMulti";
 import { max } from "underscore";
 import { userIsDefaultSubscribed, userSubscriptionStateIsFixed } from "../../lib/subscriptionUtil";
+import { Components } from "@/lib/vulcan-lib/components";
 
 export type NotifyMeDocument =
   UsersProfile |
@@ -128,7 +129,10 @@ export const useNotifyMe = ({
 
   const onSubscribe = useCallback(async (e: MouseEvent) => {
     if (!currentUser) {
-      openDialog({componentName: "LoginPopup"});
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
       return;
     }
 

--- a/packages/lesswrong/components/languageModels/LanguageModelLauncherButton.tsx
+++ b/packages/lesswrong/components/languageModels/LanguageModelLauncherButton.tsx
@@ -51,7 +51,8 @@ export const LanguageModelLauncherButton = ({classes}: {
   const openLlmChat = useCallback(() => {
     captureEvent("languageModelLauncherButtonClicked");
     openDialog({
-      componentName:"PopupLanguageModelChat",
+      name: "PopupLanguageModelChat",
+      contents: ({onClose}) => <Components.PopupLanguageModelChat onClose={onClose}/>,
     })
     setCookie(SHOW_LLM_CHAT_COOKIE, "true", { path: "/" });
   },[openDialog, captureEvent, setCookie]);

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -170,10 +170,11 @@ const FootnotePreview = ({classes, href, id, rel, contentStyleType="postHighligh
     if (isRegularClick(ev) && isMobile() && footnoteHTML !== null) {
       setDisableHover(true);
       openDialog({
-        componentName: "FootnoteDialog",
-        componentProps: {
-          footnoteHTML: footnoteHTML,
-        },
+        name: "FootnoteDialog",
+        contents: ({onClose}) => <Components.FootnoteDialog
+          onClose={onClose}
+          footnoteHTML={footnoteHTML}
+        />
       });
       ev.preventDefault();
     } else {

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -95,15 +95,31 @@ const CommunityHome = ({classes}: {
   }, [isEAForum, currentUser, currentUserLocation, updateUserLocation])
 
   const openSetPersonalLocationForm = () => {
-    openDialog({
-      componentName: currentUser ? "SetPersonalMapLocationDialog" : "LoginPopup",
-    });
+    if (currentUser) {
+      openDialog({
+        name: "SetPersonalMapLocationDialog",
+        contents: ({onClose}) => <Components.SetPersonalMapLocationDialog onClose={onClose} />
+      });
+    } else {
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
+    }
   }
 
   const openEventNotificationsForm = () => {
-    openDialog({
-      componentName: currentUser ? "EventNotificationsDialog" : "LoginPopup",
-    });
+    if (currentUser) {
+      openDialog({
+        name: "EventNotificationsDialog",
+        contents: ({onClose}) => <Components.EventNotificationsDialog onClose={onClose} />
+      });
+    } else {
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      });
+    }
   }
 
   const isAdmin = userIsAdmin(currentUser);

--- a/packages/lesswrong/components/localGroups/GroupFormLink.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormLink.tsx
@@ -15,8 +15,12 @@ const GroupFormLink = ({documentId, isOnline}: {
 
   const handleOpenGroupForm = () => {
     openDialog({
-      componentName: "GroupFormDialog",
-      componentProps: {documentId: documentId, isOnline: isOnline}
+      name: "GroupFormDialog",
+      contents: ({onClose}) => <Components.GroupFormDialog
+        onClose={onClose}
+        documentId={documentId}
+        isOnline={isOnline}
+      />
     })
   }
 

--- a/packages/lesswrong/components/messaging/ConversationDetails.tsx
+++ b/packages/lesswrong/components/messaging/ConversationDetails.tsx
@@ -26,10 +26,11 @@ const ConversationDetails = ({conversation, hideOptions = false, classes}: {
 
   const openConversationOptions = () => {
     openDialog({
-      componentName: "ConversationTitleEditForm",
-      componentProps: {
-        documentId: conversation._id
-      }
+      name: "ConversationTitleEditForm",
+      contents: ({onClose}) => <Components.ConversationTitleEditForm
+        onClose={onClose}
+        documentId={conversation._id}
+      />
     });
   }
 

--- a/packages/lesswrong/components/messaging/FriendlyInbox.tsx
+++ b/packages/lesswrong/components/messaging/FriendlyInbox.tsx
@@ -202,10 +202,11 @@ const FriendlyInbox = ({
 
   const openNewConversationDialog = useCallback(() => {
     openDialog({
-      componentName: "NewConversationDialog",
-      componentProps: {
-        isModInbox,
-      },
+      name: "NewConversationDialog",
+      contents: ({onClose}) => <Components.NewConversationDialog
+        onClose={onClose}
+        isModInbox={isModInbox}
+      />
     });
   }, [isModInbox, openDialog]);
 
@@ -251,10 +252,11 @@ const FriendlyInbox = ({
     if (!conversationId) return;
 
     openDialog({
-      componentName: "ConversationTitleEditForm",
-      componentProps: {
-        documentId: conversationId,
-      },
+      name: "ConversationTitleEditForm",
+      contents: ({onClose}) => <Components.ConversationTitleEditForm
+        onClose={onClose}
+        documentId={conversationId}
+      />
     });
   };
 

--- a/packages/lesswrong/components/messaging/NewConversationButton.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationButton.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent, ReactNode, useCallback, useEffect } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import qs from 'qs';
 import { useDialog } from '../common/withDialog';
 import { useNavigate } from '../../lib/routeUtil';
@@ -64,10 +64,13 @@ const NewConversationButton = ({
 
   const handleClick = currentUser
     ? (e: MouseEvent) => {
-      initiateConversation([user._id])
-      e.stopPropagation()
-    }
-    : () => openDialog({componentName: "LoginPopup"})
+        initiateConversation([user._id])
+        e.stopPropagation()
+      }
+    : () => openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
+      })
 
   if (currentUser && !userCanStartConversations(currentUser)) return null
 

--- a/packages/lesswrong/components/posts/ElicitBlock.tsx
+++ b/packages/lesswrong/components/posts/ElicitBlock.tsx
@@ -255,8 +255,8 @@ const ElicitBlock = ({ classes, questionId = "IyWNjzc5P" }: {
                 })
               } else {
                 openDialog({
-                  componentName: "LoginPopup",
-                  componentProps: {}
+                  name: "LoginPopup",
+                  contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
                 });
               }
             }}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -518,10 +518,11 @@ const PostsPage = ({fullPost, postPreload, eagerPostComments, refetch, classes}:
 
     if (fullPost) {
       openDialog({
-        componentName: "SharePostPopup",
-        componentProps: {
-          post: fullPost,
-        },
+        name: "SharePostPopup",
+        contents: ({onClose}) => <Components.SharePostPopup
+          onClose={onClose}
+          post={fullPost}
+        />,
         closeOnNavigate: true,
       });
     }
@@ -678,10 +679,12 @@ const { HeadTags, CitationTags, PostsPagePostHeader, LWPostsPageHeader, PostsPag
 
   const onClickCommentOnSelection = useCallback((html: string) => {
     openDialog({
-      componentName: "ReplyCommentDialog",
-      componentProps: {
-        post, initialHtml: html
-      },
+      name: "ReplyCommentDialog",
+      contents: ({onClose}) => <Components.ReplyCommentDialog
+        onClose={onClose}
+        post={post}
+        initialHtml={html}
+      />
     })
   }, [openDialog, post]);
 

--- a/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
@@ -115,8 +115,12 @@ const RSVPs = ({post, classes}: {
   const currentUser = useCurrentUser()
   const openRSVPForm = useCallback((initialResponse: string) => {
     openDialog({
-      componentName: "RSVPForm",
-      componentProps: { post, initialResponse }
+      name: "RSVPForm",
+      contents: ({onClose}) => <Components.RSVPForm
+        onClose={onClose}
+        post={post}
+        initialResponse={initialResponse}
+      />
     })
   }, [post, openDialog])
   useEffect(() => {

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -124,8 +124,8 @@ const QuickTakesEntry = ({
         onSignup();
       } else {
         openDialog({
-          componentName: "LoginPopup",
-          componentProps: {}
+          name: "LoginPopup",
+          contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
         });
         setExpanded(true);
       }

--- a/packages/lesswrong/components/review/ReviewPostButton.tsx
+++ b/packages/lesswrong/components/review/ReviewPostButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
-import { registerComponent } from '../../lib/vulcan-lib/components';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { useCommentBox } from '../hooks/useCommentBox';
 import { useDialog } from '../common/withDialog';
 import { useCurrentUser } from '../common/withUser';
@@ -33,15 +33,15 @@ const ReviewPostButton = ({classes, post, reviewMessage="Review", year}: {
   const handleClick = () => {
     if (currentUser) {
       openCommentBox({
-        componentName: "ReviewPostForm",
-        componentProps: {
-          post: post
-        }
+        commentBox: ({onClose}) => <Components.ReviewPostForm
+          onClose={onClose}
+          post={post}
+        />
       });
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
     }
   }

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -358,10 +358,10 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
       close();
       // this component requires a currentUser so we don't need to do a login check
       openCommentBox({
-        componentName: "ReviewPostForm",
-        componentProps: {
-          post: post
-        }
+        commentBox: ({onClose}) => <Components.ReviewPostForm
+          onClose={onClose}
+          post={post}
+        />
       });
       setExpandedPost(post)
     }

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
@@ -6,13 +6,14 @@ import { useMessages } from '../../common/withMessages';
 import classNames from 'classnames'
 import Divider from '@/lib/vendor/@material-ui/core/src/Divider';
 import EmailIcon from '@/lib/vendor/@material-ui/icons/src/Email';
-import { CloseableComponent, OpenDialogContextType, useDialog } from '../../common/withDialog'
+import { useDialog } from '../../common/withDialog'
 import { useCurrentUser } from '../../common/withUser';
 import moment from 'moment';
 import { captureEvent } from '../../../lib/analyticsEvents';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { HIDE_MAP_COOKIE } from '../../../lib/cookies/cookies';
+import { createFallBackDialogHandler } from '@/components/localGroups/CommunityMapFilter';
 
 const styles = (theme: ThemeType) => ({
   section: {
@@ -62,16 +63,6 @@ const styles = (theme: ThemeType) => ({
   }
 });
 
-const createFallBackDialogHandler = (
-  openDialog: OpenDialogContextType['openDialog'],
-  dialogName: CloseableComponent,
-  currentUser: UsersCurrent | null
-) => {
-  return () => openDialog({
-    componentName: currentUser ? dialogName : "LoginPopup",
-  });
-}
-
 const HomepageMapFilter = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const { openDialog } = useDialog()
   const currentUser = useCurrentUser()
@@ -116,7 +107,11 @@ const HomepageMapFilter = ({classes}: {classes: ClassesType<typeof styles>}) => 
     <LWTooltip title="Get notified when events are in your area" placement="left">
       <div
           className={classNames(classes.section, classes.subscribeSection)}
-          onClick={createFallBackDialogHandler(openDialog, "EventNotificationsDialog", currentUser)}
+          onClick={createFallBackDialogHandler(
+            openDialog, "EventNotificationsDialog",
+            ({onClose}) => <Components.EventNotificationsDialog onClose={onClose} />,
+            currentUser
+          )}
         >
         <EmailIcon className={classNames(classes.actionIcon, classes.subscribeIcon)} /> 
         <span className={classes.buttonText}> Subscribe to events</span>

--- a/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
@@ -45,11 +45,12 @@ const ChaptersEditForm = ({classes, documentId, postIds, successCallback, cancel
   const showAddDraftPostDialog = () => {
     if (saved) {
       openDialog({
-        componentName: "AddDraftPostDialog",
-        componentProps: {
-          documentId: documentId,
-          postIds: postIds,
-        }
+        name: "AddDraftPostDialog",
+        contents: ({onClose}) => <Components.AddDraftPostDialog
+          onClose={onClose}
+          documentId={documentId}
+          postIds={postIds}
+        />
       });
     } else {
       flash("Save your changes before adding draft posts.")

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -340,9 +340,12 @@ export const ModeratorActions = ({classes, user, currentUser, refetch, comments,
     </LWTooltip>
     <LWTooltip title="Create a new moderator action for this user">
       <ReportProblemIcon className={classes.modButton} onClick={() => openDialog({
-        componentName: 'NewModeratorActionDialog',
-        componentProps: {userId: user._id}})}
-      />
+        name: 'NewModeratorActionDialog',
+        contents: ({onClose}) => <Components.NewModeratorActionDialog
+          onClose={onClose}
+          userId={user._id}
+        />
+      })}/>
     </LWTooltip>
   </div>
 

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -121,8 +121,8 @@ const AddPostsToTag = ({classes, tag}: {
   const onPostSelected = useCallback(async (postId: string) => {
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       return
     }

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -107,8 +107,8 @@ const AllTagsPage = ({classes}: {
                   </Link>}
                   {!currentUser && <a onClick={(ev) => {
                     openDialog({
-                      componentName: "LoginPopup",
-                      componentProps: {}
+                      name: "LoginPopup",
+                      contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
                     });
                     ev.preventDefault();
                   }}>

--- a/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
@@ -81,8 +81,8 @@ const EAAllTagsPage = ({classes}: {
               </Link>}
               {!currentUser && <a onClick={(ev) => {
                 openDialog({
-                  componentName: "LoginPopup",
-                  componentProps: {}
+                  name: "LoginPopup",
+                  contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
                 });
                 ev.preventDefault();
               }}>

--- a/packages/lesswrong/components/tagging/EAPostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/EAPostsItemTagRelevance.tsx
@@ -71,8 +71,8 @@ const EAPostsItemTagRelevance = ({tagRel, classes}: {
       flash(whyYouCantVote ?? "You can't vote on this");
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
     }
   }

--- a/packages/lesswrong/components/tagging/NewWikiTagButton.tsx
+++ b/packages/lesswrong/components/tagging/NewWikiTagButton.tsx
@@ -47,8 +47,8 @@ const NewWikiTagButton = ({ hideLabel=false, className }: {
     event.preventDefault();
     event.stopPropagation();
     openDialog({
-      componentName: "LoginPopup",
-      componentProps: {},
+      name: "LoginPopup",
+      contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
     });
   };
 

--- a/packages/lesswrong/components/tagging/SubscribeButton.tsx
+++ b/packages/lesswrong/components/tagging/SubscribeButton.tsx
@@ -182,8 +182,8 @@ const SubscribeButton = ({
         flash({messageString: isSubscribed ? "Unsubscribed" : "Subscribed"});
       } else {
         openDialog({
-          componentName: "LoginPopup",
-          componentProps: {}
+          name: "LoginPopup",
+          contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
         });
       }
     } catch(error) {

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -177,20 +177,21 @@ const TagPageButtonRow = ({
     captureEvent('tagPageButtonRowNewLensClick');
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       return;
     }
 
     if (!refetchTag || !updateSelectedLens) return;
     openDialog({
-      componentName: "NewLensDialog",
-      componentProps: {
-        tag,
-        refetchTag,
-        updateSelectedLens,
-      }
+      name: "NewLensDialog",
+      contents: ({onClose}) => <Components.NewLensDialog
+        onClose={onClose}
+        tag={tag}
+        refetchTag={refetchTag}
+        updateSelectedLens={updateSelectedLens}
+      />
     });
   }
 
@@ -200,8 +201,8 @@ const TagPageButtonRow = ({
       setEditing(true)
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
       e.preventDefault();
     }

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -98,8 +98,8 @@ const TagProgressBar = ({ classes }: {
       })
     } else {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
     }
   }

--- a/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
+++ b/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
@@ -1,4 +1,4 @@
-import { registerComponent } from '../../lib/vulcan-lib/components';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -39,8 +39,8 @@ const TagRelevanceButton = ({document, voteType, vote, label, classes, cancelVot
   const wrappedVote = (voteType: string) => {
     if(!currentUser){
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
       });
     } else {
       vote({document, voteType: null, collectionName: "TagRels", currentUser});

--- a/packages/lesswrong/components/tagging/TagRevisionItemShortMetadata.tsx
+++ b/packages/lesswrong/components/tagging/TagRevisionItemShortMetadata.tsx
@@ -40,10 +40,11 @@ const TagRevisionItemShortMetadata = ({tag, url, itemDescription, revision, clas
   
   function showArbitalImportDetails() {
     openDialog({
-      componentName: "ArbitalImportRevisionDetails",
-      componentProps: {
-        revision,
-      },
+      name: "ArbitalImportRevisionDetails",
+      contents: ({onClose}) => <Components.ArbitalImportRevisionDetails
+        onClose={onClose}
+        revision={revision}
+      />
     });
   }
   

--- a/packages/lesswrong/components/tagging/TaggingDashboard.tsx
+++ b/packages/lesswrong/components/tagging/TaggingDashboard.tsx
@@ -127,14 +127,18 @@ const TaggingDashboard = ({classes}: {
           <SectionButton>
             {query.focus && <QueryLink query={{}}> Reset Filter </QueryLink>}
             {currentUser?.isAdmin &&
-                <span className={classes.editButton} onClick={() => openDialog({
-                  componentName: "TagFlagEditAndNewForm",
-                  componentProps: query.focus ? {tagFlagId: query.focus} : {}
-                })}>
-                  {query.focus ?
-                    `Edit ${taggingNameCapitalSetting.get()} Flag` :
-                    `New ${taggingNameCapitalSetting.get()} Flag`}
-                </span>
+              <span className={classes.editButton} onClick={() => openDialog({
+                name: "TagFlagEditAndNewForm",
+                contents: ({onClose}) => <Components.TagFlagEditAndNewForm
+                  onClose={onClose}
+                  {...(query.focus ? {tagFlagId: query.focus} : {})}
+                />
+              })}>
+                {query.focus
+                  ? `Edit ${taggingNameCapitalSetting.get()} Flag`
+                  : `New ${taggingNameCapitalSetting.get()} Flag`
+                }
+              </span>
             }
             <a
               className={classes.collapseButton}
@@ -162,12 +166,12 @@ const TaggingDashboard = ({classes}: {
           </QueryLink>)}
         </div>
         {!loading && tagsFiltered?.map(tag => <TagsDetailsItem
-              key={tag._id}
-              tag={tag}
-              showFlags
-              flagId={query.focus}
-              collapse={collapsed}
-            />)}
+          key={tag._id}
+          tag={tag}
+          showFlags
+          flagId={query.focus}
+          collapse={collapsed}
+        />)}
         <div className={classes.loadMore}>
           <LoadMore {...loadMoreProps}/>
         </div>

--- a/packages/lesswrong/components/tagging/WriteNewButton.tsx
+++ b/packages/lesswrong/components/tagging/WriteNewButton.tsx
@@ -101,8 +101,8 @@ const WriteNewButton = ({
           captureEvent('writeNewClicked', {tagId: tag._id, newState: open ? "closed" : "open"});
           if (!currentUser) {
             openDialog({
-              componentName: "LoginPopup",
-              componentProps: {},
+              name: "LoginPopup",
+              contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
             });
             return
           }

--- a/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubscribeSection.tsx
@@ -64,8 +64,8 @@ const SubforumSubscribeSection = ({
         await subforumMembershipMutation({variables: {tagId: tag._id, member: true}});
       } else {
         openDialog({
-          componentName: "LoginPopup",
-          componentProps: {}
+          name: "LoginPopup",
+          contents: ({onClose}) => <Components.LoginPopup onClose={onClose} />
         });
       }
     } catch(error) {

--- a/packages/lesswrong/components/users/LoginPopupButton.tsx
+++ b/packages/lesswrong/components/users/LoginPopupButton.tsx
@@ -30,8 +30,8 @@ const LoginPopupButton = ({classes, children, title, className}: {
       <a className={className ? className : classes.root} onClick={(ev) => {
           if (!currentUser) {
             openDialog({
-              componentName: "LoginPopup",
-              componentProps: {}
+              name: "LoginPopup",
+              contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
             });
             ev.preventDefault();
           }

--- a/packages/lesswrong/components/users/ReportUserButton.tsx
+++ b/packages/lesswrong/components/users/ReportUserButton.tsx
@@ -34,15 +34,16 @@ const ReportUserButton = ({user, classes}: {
     if (!user) return
   
     openDialog({
-      componentName: "ReportForm",
-      componentProps: {
-        reportedUserId: user._id,
-        link: `/users/${user.slug}`,
-        userId: currentUser._id,
-        onSubmit: () => {
+      name: "ReportForm",
+      contents: ({onClose}) => <Components.ReportForm
+        onClose={onClose}
+        reportedUserId={user._id}
+        link={`/users/${user.slug}`}
+        userId={currentUser._id}
+        onSubmit={() => {
           flash({messageString: "Your report has been sent to the moderators"})
-        }
-      }
+        }}
+      />,
     })
   }
   

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -215,7 +215,10 @@ const UsersMenu = ({classes}: {
       ? (
         <DropdownItem
           title={styleSelect({friendly: "Dialogue", default: preferredHeadingCase("New Dialogue")})}
-          onClick={() => openDialog({componentName:"NewDialogueDialog"})}
+          onClick={() => openDialog({
+            name:"NewDialogueDialog",
+            contents: ({onClose}) => <Components.NewDialogueDialog onClose={onClose}/>
+          })}
         />
       )
     : null,
@@ -229,7 +232,10 @@ const UsersMenu = ({classes}: {
         ? (
           <DropdownItem
             title={styleSelect({friendly: "Quick take", default: preferredHeadingCase("New Quick Take")})}
-            onClick={() => openDialog({componentName:"NewShortformDialog"})}
+            onClick={() => openDialog({
+              name:"NewShortformDialog",
+              contents: ({onClose}) => <Components.NewShortformDialog onClose={onClose}/>
+            })}
           />
         )
       : null,
@@ -334,7 +340,10 @@ const UsersMenu = ({classes}: {
               {isAF && !isAfMember &&
                 <DropdownItem
                   title={preferredHeadingCase("Apply for Membership")}
-                  onClick={() => openDialog({componentName: "AFApplicationForm"})}
+                  onClick={() => openDialog({
+                    name: "AFApplicationForm",
+                    contents: ({onClose}) => <Components.AFApplicationForm onClose={onClose}/>
+                  })}
                 />
               }
               {currentUser.noKibitz &&

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -333,8 +333,11 @@ const UsersProfileFn = ({terms, slug, classes}: {
                 <div
                   className={classes.subscribeButton}
                   onClick={() => openDialog({ 
-                    componentName: "NewDialogueDialog", 
-                    componentProps: { initialParticipantIds: [user._id] } 
+                    name: "NewDialogueDialog", 
+                    contents: ({onClose}) => <Components.NewDialogueDialog
+                      onClose={onClose}
+                      initialParticipantIds={[user._id]}
+                    />
                   })}
                 >
                   <a>Dialogue</a>

--- a/packages/lesswrong/components/users/account/DeleteAccountSection.tsx
+++ b/packages/lesswrong/components/users/account/DeleteAccountSection.tsx
@@ -78,10 +78,11 @@ const DeleteAccountSection = ({
       void confirmAction()
     } else {
       openDialog({
-        componentName: 'DeleteAccountConfirmationModal',
-        componentProps: {
-          confirmAction
-        }
+        name: 'DeleteAccountConfirmationModal',
+        contents: ({onClose}) => <Components.DeleteAccountConfirmationModal
+          onClose={onClose}
+          confirmAction={confirmAction}
+        />
       })
     }
   }, [openDialog, updateUser, user._id, user.deleted, user.permanentDeletionRequestedAt]);

--- a/packages/lesswrong/components/votes/AxisVoteButton.tsx
+++ b/packages/lesswrong/components/votes/AxisVoteButton.tsx
@@ -20,8 +20,8 @@ const AxisVoteButton = <T extends VoteableTypeClient>({VoteIconComponent, vote, 
   const wrappedVote = (strength: "big"|"small"|"neutral") => {
     if(!currentUser){
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     } else {
       vote({

--- a/packages/lesswrong/components/votes/EAReactsSection.tsx
+++ b/packages/lesswrong/components/votes/EAReactsSection.tsx
@@ -253,8 +253,8 @@ const EAReactsSection: FC<{
     
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
       return;
     }

--- a/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/EmojiReactionVoteOnComment.tsx
@@ -96,9 +96,9 @@ const BallotEmojiReaction = ({reaction, voteProps, classes}: {
   return <div className={classNames(classes.voteButton, {[classes.voteButtonSelected]: isSelected})} onClick={async () => {
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
-      })
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
+      });
     } else {
       await voteProps.vote({
         document: voteProps.document,

--- a/packages/lesswrong/components/votes/OverallVoteButton.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteButton.tsx
@@ -42,8 +42,8 @@ const OverallVoteButton = <T extends VoteableTypeClient>({
     
     if(!currentUser){
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     } else {
       vote?.({document, voteType: voteType, extendedVote: document?.currentUserExtendedVote, currentUser});

--- a/packages/lesswrong/components/votes/ReactBallotVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/ReactBallotVoteOnComment.tsx
@@ -188,8 +188,8 @@ const BallotStandaloneReaction = ({reaction, voteProps, classes}: {
   return <div className={classNames(classes.voteButton, classes.standaloneReaction, {[classes.voteButtonSelected]: isSelected})} onClick={async ev => {
     if(!currentUser){
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {}
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     } else {
       await voteProps.vote({

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -175,9 +175,9 @@ export const useNamesAttachedReactionsVoting = (voteProps: VotingProps<VoteableT
 
   function openLoginDialog() {
     openDialog({
-      componentName: "LoginPopup",
-      componentProps: {}
-    })
+      name: "LoginPopup",
+      contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
+    });
   }
 
   async function toggleReaction(name: string, quote: QuoteLocator|null) {

--- a/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/ReactionsAndLikesVote.tsx
@@ -95,8 +95,8 @@ const ReactionsAndLikesVote  = ({
 
     if (!currentUser) {
       openDialog({
-        componentName: "LoginPopup",
-        componentProps: {},
+        name: "LoginPopup",
+        contents: ({onClose}) => <Components.LoginPopup onClose={onClose}/>
       });
     } else if (currentUserLikesIt) {
       await voteProps.vote({

--- a/packages/lesswrong/components/votes/withVote.tsx
+++ b/packages/lesswrong/components/votes/withVote.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useMessages } from '../common/withMessages';
 import { useDialog } from '../common/withDialog';
 import { useMutation, gql } from '@apollo/client';
@@ -10,6 +10,7 @@ import * as _ from 'underscore';
 import { VotingProps } from './votingProps';
 import { fragmentTextForQuery } from "../../lib/vulcan-lib/fragments";
 import { collectionNameToTypeName } from '@/lib/generated/collectionTypeNames';
+import { Components } from '@/lib/vulcan-lib/components';
 
 const getVoteMutationQuery = (typeName: string) => {
   const mutationName = `performVote${typeName}`;
@@ -38,8 +39,8 @@ export const useVote = <T extends VoteableTypeClient>(document: T, collectionNam
   
   const showVotingPatternWarningPopup= useCallback(() => {
     openDialog({
-      componentName: "VotingPatternsWarningPopup",
-      componentProps: {},
+      name: "VotingPatternsWarningPopup",
+      contents: ({onClose}) => <Components.VotingPatternsWarningPopup onClose={onClose}/>,
       closeOnNavigate: true,
     });
   }, [openDialog]);

--- a/packages/lesswrong/lib/alignment-forum/displayAFNonMemberPopups.tsx
+++ b/packages/lesswrong/lib/alignment-forum/displayAFNonMemberPopups.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import {userNeedsAFNonMemberWarning} from "./users/helpers";
 import {commentSuggestForAlignment} from "./comments/helpers";
 import {postSuggestForAlignment} from "./posts/helpers";
 import {OpenDialogContextType} from "../../components/common/withDialog";
+import { Components } from "../vulcan-lib/components";
 
 
 const isComment = (document: PostsBase | CommentsList): document is CommentsList => {
@@ -11,7 +13,10 @@ const isComment = (document: PostsBase | CommentsList): document is CommentsList
 
 export const afNonMemberDisplayInitialPopup = (currentUser: UsersCurrent|null, openDialog: OpenDialogContextType["openDialog"]): boolean => {
   if (userNeedsAFNonMemberWarning(currentUser)) { //only fires on AF for non-members
-    openDialog({componentName: "AFNonMemberInitialPopup"})
+    openDialog({
+      name: "AFNonMemberInitialPopup",
+      contents: ({onClose}) => <Components.AFNonMemberInitialPopup onClose={onClose}/>
+    })
     return true;
   }
   return false;
@@ -29,14 +34,21 @@ export const afNonMemberSuccessHandling = ({currentUser, document, openDialog, u
     if (isComment(document)) {
       void commentSuggestForAlignment({currentUser, comment: document, updateComment: updateDocument})
       openDialog({
-        componentName: "AFNonMemberSuccessPopup",
-        componentProps: {_id: document._id, postId: document.postId}
+        name: "AFNonMemberSuccessPopup",
+        contents: ({onClose}) => <Components.AFNonMemberSuccessPopup
+          _id={document._id}
+          postId={document.postId}
+          onClose={onClose}
+        />,
       })
     } else {
       void postSuggestForAlignment({currentUser, post: document, updatePost: updateDocument})
       openDialog({
-        componentName: "AFNonMemberSuccessPopup",
-        componentProps: {_id: document._id}
+        name: "AFNonMemberSuccessPopup",
+        contents: ({onClose}) => <Components.AFNonMemberSuccessPopup
+          onClose={onClose}
+          _id={document._id}
+        />,
       })
     }
   }


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209877423111028) by [Unito](https://www.unito.io)
