### PR TITLE
Fix broken event duplication

### DIFF
--- a/packages/lesswrong/lib/editor/make_editable.ts
+++ b/packages/lesswrong/lib/editor/make_editable.ts
@@ -214,10 +214,11 @@ export function getDenormalizedEditableResolver<N extends CollectionNameString>(
       documentId: doc._id,
       collectionName,
       editedAt: new Date(docField?.editedAt ?? Date.now()),
-      originalContents: getOriginalContents(
+      originalContents: await getOriginalContents(
         context.currentUser,
         doc,
         docField.originalContents,
+        context,
       ),
     } as DbRevision;
     // HACK: Pretend that this denormalized field is a DbRevision (even though


### PR DESCRIPTION
Fix two issues with duplicating events:
1. the change to autocreate posts led to an issue where we were passing in the entirety of editable fields back into a useCreate, which failed simpleSchema validation
2. non-admin group organizers (incorrectly) didn't have permissions to read the originalContents of posts

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209877567215397) by [Unito](https://www.unito.io)
