### PR TITLE
Make an idiom for type-safe cross-file classname references

### DIFF
--- a/packages/lesswrong/components/hooks/useStyles.tsx
+++ b/packages/lesswrong/components/hooks/useStyles.tsx
@@ -32,12 +32,12 @@ export function setClientMountedStyles(styles: StylesContextType) {
 
 export const topLevelStyleDefinitions: Record<string,StyleDefinition<string>> = {};
 
-export const defineStyles = <T extends string>(
-  name: string,
+export const defineStyles = <T extends string, N extends string>(
+  name: N,
   styles: (theme: ThemeType) => JssStyles<T>,
   options?: StyleOptions
-): StyleDefinition<T> => {
-  const definition: StyleDefinition<T> = {
+): StyleDefinition<T,N> => {
+  const definition: StyleDefinition<T,N> = {
     name,
     styles,
     options,
@@ -115,6 +115,13 @@ export const useStyles = <T extends string>(styles: StyleDefinition<T>): JssStyl
     styles.nameProxy = classNameProxy(styles.name+"-");
   }
   return styles.nameProxy;
+}
+
+export function getClassName<T extends StyleDefinition>(
+  stylesName: T["name"],
+  className: keyof ReturnType<T["styles"]> & string
+) {
+  return `${stylesName}-${className}`;
 }
 
 export const withAddClasses = (

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -19,7 +19,7 @@ import { isLWorAF } from '@/lib/instanceSettings';
 import { useLocation, useNavigate } from "../../../lib/routeUtil";
 import { getClassName } from '@/components/hooks/useStyles';
 import type { TableOfContentsRowStyles } from './TableOfContentsRow';
-import { TableOfContentsDividerStyles } from './TableOfContentsDivider';
+import type { TableOfContentsDividerStyles } from './TableOfContentsDivider';
 
 function normalizeToCScale({containerPosition, sections}: {
   sections: ToCSection[]

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -17,6 +17,9 @@ import { getOffsetChainTop } from '@/lib/utils/domUtil';
 import { scrollFocusOnElement, ScrollHighlightLandmark } from '@/lib/scrollUtils';
 import { isLWorAF } from '@/lib/instanceSettings';
 import { useLocation, useNavigate } from "../../../lib/routeUtil";
+import { getClassName } from '@/components/hooks/useStyles';
+import type { TableOfContentsRowStyles } from './TableOfContentsRow';
+import { TableOfContentsDividerStyles } from './TableOfContentsDivider';
 
 function normalizeToCScale({containerPosition, sections}: {
   sections: ToCSection[]
@@ -128,7 +131,7 @@ const styles = (theme: ThemeType) => ({
     flexDirection: 'column',
     paddingTop: 22,
     //Override bottom border of title row for FixedToC but not in other uses of TableOfContentsRow
-    '& .TableOfContentsRow-title': {
+    [`& .${getClassName<TableOfContentsRowStyles>("TableOfContentsRow", "title")}`]: {
       borderBottom: "none",
     },
     wordBreak: 'break-word',
@@ -226,7 +229,7 @@ const styles = (theme: ThemeType) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
-    '& .TableOfContentsDivider-divider': {
+    [`& .${getClassName<TableOfContentsDividerStyles>("TableOfContentsDivider", "divider")}`]: {
       marginLeft: 4,
     },
   },

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsDivider.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsDivider.tsx
@@ -1,7 +1,8 @@
 import React, { CSSProperties } from 'react';
 import { registerComponent } from "../../../lib/vulcan-lib/components";
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("TableOfContentsDivider", (theme: ThemeType) => ({
   divider: {
     width: 80,
     marginBottom:theme.spacing.unit,
@@ -10,16 +11,17 @@ const styles = (theme: ThemeType) => ({
     paddingBottom: theme.spacing.unit,
     display:"block",
   }
-})
+}))
+export type TableOfContentsDividerStyles = typeof styles;
 
-const TableOfContentsDivider = ({ scaleStyling, classes }: {
+const TableOfContentsDivider = ({ scaleStyling }: {
   scaleStyling?: CSSProperties
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   return <div className={classes.divider} style={scaleStyling}/>
 }
 
-const TableOfContentsDividerComponent = registerComponent('TableOfContentsDivider', TableOfContentsDivider, {styles});
+const TableOfContentsDividerComponent = registerComponent('TableOfContentsDivider', TableOfContentsDivider);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -3,13 +3,14 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib/component
 import classNames from 'classnames';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import { fullHeightToCEnabled } from '../../../lib/betas';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
 const sectionOffsetStyling = (fullHeightToCEnabled ? {
   display: 'flex',
   flexDirection: 'column-reverse',
 } : {});
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("TableOfContentsRow", (theme: ThemeType) => ({
   root: {
     position: "relative",
     ...theme.typography.body2,
@@ -105,27 +106,17 @@ const styles = (theme: ThemeType) => ({
     flexDirection: 'column-reverse',
     transition: 'opacity 0.4s ease-in-out, height 0.4s ease-in-out, max-height 0.4s ease-in-out, margin-top 0.4s ease-in-out',
   }
-});
-
-const levelToClassName = (level: number, classes: ClassesType<typeof styles>) => {
-  switch(level) {
-    case 0: return classes.level0;
-    case 1: return classes.level1;
-    case 2: return classes.level2;
-    case 3: return classes.level3;
-    default: return classes.level4;
-  }
-}
+}));
+export type TableOfContentsRowStyles = typeof styles;
 
 const TableOfContentsRow = ({
-  indentLevel=0, highlighted=false, href, onClick, children, classes, title, divider, answer, dense, scale, fullHeight, commentToC
+  indentLevel=0, highlighted=false, href, onClick, children, title, divider, answer, dense, scale, fullHeight, commentToC
 }: {
   indentLevel?: number,
   highlighted?: boolean,
   href: string,
   onClick?: (ev: any) => void,
   children?: React.ReactNode,
-  classes: ClassesType<typeof styles>,
   title?: boolean,
   divider?: boolean,
   answer?: boolean,
@@ -135,6 +126,7 @@ const TableOfContentsRow = ({
   fullHeight?: boolean,
   commentToC?: boolean
 }) => {
+  const classes = useStyles(styles);
   const fullHeightTitle = !!(title && fullHeight);
 
   const scaleStyling = scale !== undefined ? { flex: scale } : undefined;
@@ -143,10 +135,20 @@ const TableOfContentsRow = ({
     return <Components.TableOfContentsDivider scaleStyling={scaleStyling} />
   }
   
+  const levelToClassName = (level: number) => {
+    switch(level) {
+      case 0: return classes.level0;
+      case 1: return classes.level1;
+      case 2: return classes.level2;
+      case 3: return classes.level3;
+      default: return classes.level4;
+    }
+  }
+
   return <div
     className={classNames(
       classes.root,
-      levelToClassName(indentLevel, classes),
+      levelToClassName(indentLevel),
       { [classes.titleContainer]: fullHeightTitle },
       { [classes.highlighted]: highlighted },
     )}
@@ -162,7 +164,7 @@ const TableOfContentsRow = ({
   </div>
 }
 
-const TableOfContentsRowComponent = registerComponent("TableOfContentsRow", TableOfContentsRow, {styles});
+const TableOfContentsRowComponent = registerComponent("TableOfContentsRow", TableOfContentsRow);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -22,13 +22,12 @@ import keyBy from 'lodash/keyBy';
 import type { JssStyles } from '@/lib/jssStyles';
 
 export type ClassNameProxy<T extends string = string> = Record<T,string>
-export type StyleDefinition<T extends string = string> = {
-  name: string
+export type StyleDefinition<T extends string = string, N extends string = string> = {
+  name: N
   styles: (theme: ThemeType) => JssStyles<T>
   options?: StyleOptions
   nameProxy: ClassNameProxy<T>|null
 }
-
 export type StyleOptions = {
   // Whether to ignore the presence of colors that don't come from the theme in
   // the component's stylesheet. Use for things that don't change color with


### PR DESCRIPTION
One of the obstacles to refactoring is that, when moving components around, there's a possibility of sneaky references to their stylesheet that weren't covered by the type system, in the form of styles that refer to `& .ComponentName-className`. This is particularly an issue with material-UI components, but also happens elsewhere.

This commit introduces an idiom for doing this in a type-safe way, with a type-only import. You define styles with `defineStyles` (it must be the hook version, not the HoC version), export the type of the styles, then in a stylesheet use

    `.getClassName<StyleType>("ComponentName", "ClassName")`

This typechecks iff the mentioned styles have the right name and have a class by that name.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209916037808395) by [Unito](https://www.unito.io)
