### PR TITLE
Refactor email components

### DIFF
--- a/packages/lesswrong/components/hooks/FMJssProvider.tsx
+++ b/packages/lesswrong/components/hooks/FMJssProvider.tsx
@@ -1,21 +1,14 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { useTheme } from "../themes/useTheme";
-import type { StyleDefinition } from "@/server/styleGeneration";
-import { setClientMountedStyles, StylesContext, StylesContextType } from "./useStyles";
+import { createStylesContext, setClientMountedStyles, StylesContext, StylesContextType } from "./useStyles";
 import { isClient } from "@/lib/executionEnvironment";
 
-export const FMJssProvider = ({children}: {
+export const FMJssProvider = ({stylesContext, children}: {
+  stylesContext?: StylesContextType
   children: React.ReactNode
 }) => {
   const theme = useTheme();
-  const [mountedStyles] = useState(() => new Map<string, {
-    refcount: number
-    styleDefinition: StyleDefinition,
-    styleNode: HTMLStyleElement
-  }>());
-  const jssState = useMemo<StylesContextType>(() => ({
-    theme, mountedStyles: mountedStyles
-  }), [theme, mountedStyles]);
+  const [jssState] = useState(() => stylesContext ?? createStylesContext(theme));
   
   if (isClient) {
     setClientMountedStyles(jssState);

--- a/packages/lesswrong/components/hooks/useStyles.tsx
+++ b/packages/lesswrong/components/hooks/useStyles.tsx
@@ -10,11 +10,23 @@ export type StylesContextType = {
   mountedStyles: Map<string, {
     refcount: number
     styleDefinition: StyleDefinition<any>
-    styleNode: HTMLStyleElement
+    styleNode?: HTMLStyleElement
   }>
 }
 
 export const StylesContext = createContext<StylesContextType|null>(null);
+
+
+export function createStylesContext(theme: ThemeType): StylesContextType {
+  return {
+    theme,
+    mountedStyles: new Map<string, {
+      refcount: number
+      styleDefinition: StyleDefinition<any>
+      styleNode?: HTMLStyleElement
+    }>()
+  };
+}
 
 /**
  * _clientMountedStyles: Client-side-only global variable that contains the
@@ -48,7 +60,7 @@ export const defineStyles = <T extends string, N extends string>(
   if (isClient && _clientMountedStyles) {
     const mountedStyles = _clientMountedStyles.mountedStyles.get(name);
     if (mountedStyles) {
-      mountedStyles.styleNode.remove();
+      mountedStyles.styleNode?.remove();
       mountedStyles.styleNode = createAndInsertStyleNode(_clientMountedStyles.theme, definition);
     }
   }
@@ -72,7 +84,7 @@ function addStyleUsage<T extends string>(context: StylesContextType, styleDefini
     if (mountedStyleNode.styleDefinition !== styleDefinition) {
       // Style is mounted by that name, but it doesn't match? Replace it, keeping
       // the ref count
-      mountedStyleNode.styleNode.remove();
+      mountedStyleNode.styleNode?.remove();
       mountedStyleNode.styleNode = createAndInsertStyleNode(theme, styleDefinition);
       context.mountedStyles.get(name)!.refcount++;
     } else {
@@ -88,7 +100,7 @@ function removeStyleUsage<T extends string>(context: StylesContextType, styleDef
     const mountedStyle = context.mountedStyles.get(name)!
     const newRefcount = --mountedStyle.refcount;
     if (!newRefcount) {
-      mountedStyle.styleNode.remove();
+      mountedStyle.styleNode?.remove();
       context.mountedStyles.delete(name);
     }
   }
@@ -98,9 +110,18 @@ export const useStyles = <T extends string>(styles: StyleDefinition<T>): JssStyl
   const stylesContext = useContext(StylesContext);
 
   if (bundleIsServer) {
-    // If we're rendering server-side, we just return a classes object and
-    // don't need to mount any style nodes/etc, because the SSR will use the
-    // static stylesheet.
+    // If we're rendering server-side, we might or might not have
+    // StylesContext. If we do, use it to record which styles were used during
+    // the render. This is used when rendering emails, or if you want to server
+    // an SSR with styles inlined rather than in a static stlyesheet.
+    if (stylesContext) {
+      if (!stylesContext.mountedStyles.has(styles.name)) {
+        stylesContext.mountedStyles.set(styles.name, {
+          refcount: 1,
+          styleDefinition: styles,
+        });
+      }
+    }
   } else {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useLayoutEffect(() => {

--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -33,6 +33,7 @@ import _ from "underscore";
 import moment from "moment";
 import isEqual from "lodash/isEqual";
 import uniq from "lodash/uniq";
+import { EmailComment } from "../emailComponents/EmailComment";
 
 interface SendModerationPMParams {
   action: 'deleted' | 'rejected',
@@ -160,7 +161,7 @@ const utils = {
         user: user,
         to: email,
         subject: `New comment on ${post.title}`,
-        body: <Components.EmailComment commentId={comment._id}/>,
+        body: <EmailComment commentId={comment._id}/>,
       });
     }
   },

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -43,6 +43,8 @@ import { captureException } from "@sentry/core";
 import moment from "moment";
 import _ from "underscore";
 import { getRejectionMessage } from "./commentCallbackFunctions";
+import { EmailCuratedAuthors } from "../emailComponents/EmailCuratedAuthors";
+import { EventUpdatedEmail } from "../emailComponents/EventUpdatedEmail";
 
 /** Create notifications for a new post being published */
 export async function sendNewPostNotifications(post: DbPost) {
@@ -893,7 +895,7 @@ export async function eventUpdatedNotifications({document: newPost, oldDocument:
         user: user,
         to: email,
         subject: `Event updated: ${newPost.title}`,
-        body: <Components.EventUpdatedEmail postId={newPost._id} />
+        body: <EventUpdatedEmail postId={newPost._id} />
       });
     }
     
@@ -1120,7 +1122,7 @@ export async function sendEAFCuratedAuthorsNotification(post: DbPost, oldPost: D
     void Promise.all(authors.map(author => wrapAndSendEmail({
         user: author,
         subject: "We’ve curated your post",
-        body: <Components.EmailCuratedAuthors user={author} post={post} />
+        body: <EmailCuratedAuthors user={author} post={post} />
       })
     ))
   }

--- a/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
@@ -7,7 +7,6 @@ import { getUserEmail, userGetLocation, userShortformPostTitle } from "@/lib/col
 import { isAnyTest } from "@/lib/executionEnvironment";
 import { isEAForum, isLW, isLWorAF, verifyEmailsSetting } from "@/lib/instanceSettings";
 import { mailchimpEAForumListIdSetting, mailchimpForumDigestListIdSetting, recombeeEnabledSetting } from "@/lib/publicSettings";
-import { Components } from "@/lib/vulcan-lib/components";
 import { encodeIntlError } from "@/lib/vulcan-lib/utils";
 import { userIsAdminOrMod, userOwns } from "@/lib/vulcan-users/permissions";
 import { captureException } from "@sentry/core";
@@ -38,6 +37,7 @@ import isEqual from "lodash/isEqual";
 import md5 from "md5";
 import { FieldChanges } from "@/server/collections/fieldChanges/collection";
 import { createAnonymousContext } from "../vulcan-lib/createContexts";
+import { EmailContentItemBody } from "../emailComponents/EmailContentItemBody";
 
 
 async function sendWelcomeMessageTo(userId: string) {
@@ -112,7 +112,7 @@ async function sendWelcomeMessageTo(userId: string) {
     await wrapAndSendEmail({
       user,
       subject: subjectLine,
-      body: <Components.EmailContentItemBody dangerouslySetInnerHTML={{ __html: welcomeMessageBody }}/>
+      body: <EmailContentItemBody dangerouslySetInnerHTML={{ __html: welcomeMessageBody }}/>
     })
   }
 }

--- a/packages/lesswrong/server/curationEmails/cron.tsx
+++ b/packages/lesswrong/server/curationEmails/cron.tsx
@@ -5,7 +5,6 @@ import { Posts } from "../../server/collections/posts/collection";
 import Users from "../../server/collections/users/collection";
 import { isEAForum, testServerSetting } from "../../lib/instanceSettings";
 import { randomId } from "../../lib/random";
-import { Components } from "../../lib/vulcan-lib/components";
 import { addCronJob } from "../cron/cronUtil";
 import { wrapAndSendEmail } from "../emails/renderEmail";
 import CurationEmailsRepo from "../repos/CurationEmailsRepo";
@@ -13,6 +12,7 @@ import UsersRepo from "../repos/UsersRepo";
 
 import chunk from "lodash/chunk";
 import moment from "moment";
+import { PostsEmail } from "../emailComponents/PostsEmail";
 
 export async function findUsersToEmail(filter: MongoSelector<DbUser>) {
   let usersMatchingFilter = await Users.find(filter).fetch();
@@ -54,7 +54,7 @@ export async function sendCurationEmail({users, postId, reason, subject}: {
     await wrapAndSendEmail({
       user,
       subject: subject ?? post.title,
-      body: <Components.PostsEmail postIds={[post._id]} reason={reason}/>
+      body: <PostsEmail postIds={[post._id]} reason={reason}/>
     });
   }
 }

--- a/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
+import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailAnnualForumUserSurvey", (theme: ThemeType) => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontSize: 15,
@@ -13,15 +14,12 @@ const styles = (theme: ThemeType) => ({
   hr: {
     marginTop: 30,
   }
-});
+}));
 
-const EmailAnnualForumUserSurvey = ({
-  user,
-  classes,
-}: {
+const EmailAnnualForumUserSurvey = ({ user }: {
   user: DbUser;
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
   const surveyLink = 'https://forms.cea.community/forum-survey-2024?utm_source=ea_forum&utm_medium=email&utm_campaign=survey_reminder'
 
   return (
@@ -54,11 +52,7 @@ const EmailAnnualForumUserSurvey = ({
   );
 };
 
-const EmailAnnualForumUserSurveyComponent = registerComponent(
-  "EmailAnnualForumUserSurvey",
-  EmailAnnualForumUserSurvey,
-  { styles }
-);
+const EmailAnnualForumUserSurveyComponent = registerComponent("EmailAnnualForumUserSurvey", EmailAnnualForumUserSurvey);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
 const styles = defineStyles("EmailAnnualForumUserSurvey", (theme: ThemeType) => ({
@@ -16,7 +15,7 @@ const styles = defineStyles("EmailAnnualForumUserSurvey", (theme: ThemeType) => 
   }
 }));
 
-const EmailAnnualForumUserSurvey = ({ user }: {
+export const EmailAnnualForumUserSurvey = ({ user }: {
   user: DbUser;
 }) => {
   const classes = useStyles(styles);
@@ -51,11 +50,3 @@ const EmailAnnualForumUserSurvey = ({ user }: {
     </div>
   );
 };
-
-const EmailAnnualForumUserSurveyComponent = registerComponent("EmailAnnualForumUserSurvey", EmailAnnualForumUserSurvey);
-
-declare global {
-  interface ComponentTypes {
-    EmailAnnualForumUserSurvey: typeof EmailAnnualForumUserSurveyComponent;
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import groupBy from 'lodash/groupBy';
-import './EmailFormatDate';
-import './EmailPostAuthors';
-import './EmailContentItemBody';
 import filter from 'lodash/filter';
 import { tagGetSubforumUrl, tagGetDiscussionUrl } from '../../lib/collections/tags/helpers';
 import { commentGetPageUrl } from '../../lib/collections/comments/helpers';
 import startCase from 'lodash/startCase';
 import { isFriendlyUI } from '@/themes/forumTheme';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import { EmailFormatDate } from './EmailFormatDate';
+import { EmailUsername } from './EmailUsername';
+import { EmailContentItemBody } from './EmailContentItemBody';
 
 const styles = defineStyles("EmailComment", (theme: ThemeType) => ({
   headingLink: {
@@ -32,11 +31,10 @@ const styles = defineStyles("EmailComment", (theme: ThemeType) => ({
   },
 }));
 
-const EmailCommentBatch = ({comments}: {
+export const EmailCommentBatch = ({comments}: {
   comments: Partial<DbComment>[],
 }) => {
   const classes = useStyles(styles);
-  const { EmailComment } = Components;
   const commentsOnPosts = filter(comments, comment => !!comment.postId)
   const commentsByPostId = groupBy(commentsOnPosts, (comment: DbComment)=>comment.postId);
   const commentsOnTags = filter(comments, comment => !!comment.tagId && comment.tagCommentType === "DISCUSSION")
@@ -80,8 +78,6 @@ const EmailCommentBatch = ({comments}: {
   </div>;
 }
 
-const EmailCommentBatchComponent = registerComponent("EmailCommentBatch", EmailCommentBatch);
-
 const HeadingLink = ({ text, href }: { text: string; href: string; }) => {
   const classes = useStyles(styles);
   return (
@@ -121,11 +117,10 @@ const EmailCommentsOnTagHeader = ({tagId, isSubforum}: {tagId: string, isSubforu
   return <HeadingLink {...props}/>
 }
 
-const EmailComment = ({commentId, hideTitle}: {
+export const EmailComment = ({commentId, hideTitle}: {
   commentId: string,
   hideTitle?: boolean,
 }) => {
-  const { EmailUsername, EmailFormatDate, EmailContentItemBody } = Components;
   const { document: comment, loading, error } = useSingle({
     documentId: commentId,
     collectionName: "Comments",
@@ -153,13 +148,4 @@ const EmailComment = ({commentId, hideTitle}: {
     </div>
     <EmailContentItemBody dangerouslySetInnerHTML={{ __html: comment.contents?.html }}/>
   </div>;
-}
-
-const EmailCommentComponent = registerComponent("EmailComment", EmailComment);
-
-declare global {
-  interface ComponentTypes {
-    EmailCommentBatch: typeof EmailCommentBatchComponent,
-    EmailComment: typeof EmailCommentComponent,
-  }
 }

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -11,8 +11,9 @@ import { tagGetSubforumUrl, tagGetDiscussionUrl } from '../../lib/collections/ta
 import { commentGetPageUrl } from '../../lib/collections/comments/helpers';
 import startCase from 'lodash/startCase';
 import { isFriendlyUI } from '@/themes/forumTheme';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailComment", (theme: ThemeType) => ({
   headingLink: {
     color: theme.palette.text.maxIntensity,
     textDecoration: "none",
@@ -29,12 +30,12 @@ const styles = (theme: ThemeType) => ({
     marginRight: 5,
     marginBottom: 10
   },
-});
+}));
 
-const EmailCommentBatch = ({comments, classes}: {
+const EmailCommentBatch = ({comments}: {
   comments: Partial<DbComment>[],
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const { EmailComment } = Components;
   const commentsOnPosts = filter(comments, comment => !!comment.postId)
   const commentsByPostId = groupBy(commentsOnPosts, (comment: DbComment)=>comment.postId);
@@ -63,25 +64,26 @@ const EmailCommentBatch = ({comments, classes}: {
 
       return (
         <div key={postId}>
-          <EmailCommentsOnPostHeader postId={postId} classes={classes} allShortform={allShortform} />
+          <EmailCommentsOnPostHeader postId={postId} allShortform={allShortform} />
           {commentsListComponent(comments, true)}
         </div>
       );
     })}
     {Object.keys(commentsByTagId).map(tagId => <div key={tagId}>
-      <EmailCommentsOnTagHeader tagId={tagId} isSubforum={false}  classes={classes}/>
+      <EmailCommentsOnTagHeader tagId={tagId} isSubforum={false}/>
       {commentsListComponent(commentsByTagId[tagId])}
     </div>)}
     {Object.keys(commentsBySubforumTagId).map(tagId => <div key={tagId}>
-      <EmailCommentsOnTagHeader tagId={tagId} isSubforum={true}  classes={classes}/>
+      <EmailCommentsOnTagHeader tagId={tagId} isSubforum={true}/>
       {commentsListComponent(commentsBySubforumTagId[tagId])}
     </div>)}
   </div>;
 }
 
-const EmailCommentBatchComponent = registerComponent("EmailCommentBatch", EmailCommentBatch, {styles});
+const EmailCommentBatchComponent = registerComponent("EmailCommentBatch", EmailCommentBatch);
 
-const HeadingLink = ({ text, href, classes }: { text: string; href: string; classes: ClassesType<typeof styles> }) => {
+const HeadingLink = ({ text, href }: { text: string; href: string; }) => {
+  const classes = useStyles(styles);
   return (
     <h1>
       <a href={href} className={classes.headingLink}>
@@ -91,7 +93,7 @@ const HeadingLink = ({ text, href, classes }: { text: string; href: string; clas
   );
 };
 
-const EmailCommentsOnPostHeader = ({postId, classes, allShortform}: {postId: string, classes: ClassesType<typeof styles>, allShortform: boolean}) => {
+const EmailCommentsOnPostHeader = ({postId, allShortform}: {postId: string, allShortform: boolean}) => {
   const { document: post } = useSingle({
     documentId: postId,
     collectionName: "Posts",
@@ -101,10 +103,10 @@ const EmailCommentsOnPostHeader = ({postId, classes, allShortform}: {postId: str
 
   const title = allShortform ? post.title : `New comments on ${post.title}`
 
-  return <HeadingLink text={title} href={postGetPageUrl(post, true)} classes={classes}/>
+  return <HeadingLink text={title} href={postGetPageUrl(post, true)}/>
 }
 
-const EmailCommentsOnTagHeader = ({tagId, isSubforum, classes}: {tagId: string, isSubforum: boolean, classes: ClassesType<typeof styles>}) => {
+const EmailCommentsOnTagHeader = ({tagId, isSubforum}: {tagId: string, isSubforum: boolean}) => {
   const { document: tag } = useSingle({
     documentId: tagId,
     collectionName: "Tags",
@@ -116,7 +118,7 @@ const EmailCommentsOnTagHeader = ({tagId, isSubforum, classes}: {tagId: string, 
   const props = isSubforum
     ? { text: `New comments in the ${startCase(tag.name)} subforum`, href: tagGetSubforumUrl(tag, true) }
     : { text: `New discussion comments on ${tag.name}`, href: tagGetDiscussionUrl(tag) };
-  return <HeadingLink {...props} classes={classes}/>
+  return <HeadingLink {...props}/>
 }
 
 const EmailComment = ({commentId, hideTitle}: {

--- a/packages/lesswrong/server/emailComponents/EmailContentItemBody.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailContentItemBody.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 
 // The body of a content-item (post, comment etc), starting from HTML and
 // rendered with whatever enhancements we can apply to emails. (In a browser,
 // this would include things like link hover-preview. In a email, we can't do
 // that, so this doesn't currently have any enhancements, but it might in the
 // future.)
-const EmailContentItemBody = ({className, dangerouslySetInnerHTML}: {
+export const EmailContentItemBody = ({className, dangerouslySetInnerHTML}: {
   className?: string,
   dangerouslySetInnerHTML: any
 }) => {
   return <div className={className} dangerouslySetInnerHTML={dangerouslySetInnerHTML}/>
-}
-
-const EmailContentItemBodyComponent = registerComponent("EmailContentItemBody", EmailContentItemBody);
-
-declare global {
-  interface ComponentTypes {
-    EmailContentItemBody: typeof EmailContentItemBodyComponent
-  }
 }

--- a/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
@@ -17,7 +16,7 @@ const styles = defineStyles("EmailCuratedAuthors", (theme: ThemeType) => ({
   }
 }));
 
-const EmailCuratedAuthors = ({ user, post }: {
+export const EmailCuratedAuthors = ({ user, post }: {
   user: DbUser;
   post: DbPost;
 }) => {
@@ -51,11 +50,3 @@ const EmailCuratedAuthors = ({ user, post }: {
     </div>
   );
 };
-
-const EmailCuratedAuthorsComponent = registerComponent("EmailCuratedAuthors", EmailCuratedAuthors);
-
-declare global {
-  interface ComponentTypes {
-    EmailCuratedAuthors: typeof EmailCuratedAuthorsComponent;
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailCuratedAuthors.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
+import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailCuratedAuthors", (theme: ThemeType) => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontSize: 15,
@@ -14,17 +15,13 @@ const styles = (theme: ThemeType) => ({
   hr: {
     marginTop: 30,
   }
-});
+}));
 
-const EmailCuratedAuthors = ({
-  user,
-  post,
-  classes,
-}: {
+const EmailCuratedAuthors = ({ user, post }: {
   user: DbUser;
   post: DbPost;
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
 
   return (
     <div className={classes.root}>
@@ -55,11 +52,7 @@ const EmailCuratedAuthors = ({
   );
 };
 
-const EmailCuratedAuthorsComponent = registerComponent(
-  "EmailCuratedAuthors",
-  EmailCuratedAuthors,
-  { styles }
-);
+const EmailCuratedAuthorsComponent = registerComponent("EmailCuratedAuthors", EmailCuratedAuthors);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { registerComponent } from '../../lib/vulcan-lib/components';
-import './EmailFormatDate';
-import './EmailPostAuthors';
-import './EmailContentItemBody';
-import './EmailPostDate';
 import { useRecommendations } from '../../components/recommendations/withRecommendations';
 import { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
@@ -15,7 +10,7 @@ const styles = defineStyles("EmailFooterRecommendations", (theme: ThemeType) => 
   }
 }));
 
-const EmailFooterRecommendations = () => {
+export const EmailFooterRecommendations = () => {
   const classes = useStyles(styles);
   const algorithm: RecommendationsAlgorithm = {
     method: "sample",
@@ -40,10 +35,3 @@ const EmailFooterRecommendations = () => {
   </>
 }
 
-const EmailFooterRecommendationsComponent = registerComponent("EmailFooterRecommendations", EmailFooterRecommendations);
-
-declare global {
-  interface ComponentTypes {
-    EmailFooterRecommendations: typeof EmailFooterRecommendationsComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
@@ -7,16 +7,16 @@ import './EmailContentItemBody';
 import './EmailPostDate';
 import { useRecommendations } from '../../components/recommendations/withRecommendations';
 import { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailFooterRecommendations", (theme: ThemeType) => ({
   recommendedPostsHeader: {
     fontSize: '1rem'
   }
-});
+}));
 
-const EmailFooterRecommendations = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
+const EmailFooterRecommendations = () => {
+  const classes = useStyles(styles);
   const algorithm: RecommendationsAlgorithm = {
     method: "sample",
     count: 5,
@@ -40,7 +40,7 @@ const EmailFooterRecommendations = ({classes}: {
   </>
 }
 
-const EmailFooterRecommendationsComponent = registerComponent("EmailFooterRecommendations", EmailFooterRecommendations, {styles});
+const EmailFooterRecommendationsComponent = registerComponent("EmailFooterRecommendations", EmailFooterRecommendations);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailFormatDate.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFormatDate.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import moment from '../../lib/moment-timezone';
 
 /// A date, formatted for an email. Unlike FormatDate (which is used on regular
 /// pages), this doesn't have a tooltip (because that won't work in emails),
 /// and also, it never uses relative dates (because they would be relative to
 /// when the email was sent, which may be far from when the email is read.)
-const EmailFormatDate = ({date, format}: {
+export const EmailFormatDate = ({date, format}: {
   date: Date,
   format?: string
 }) => {
@@ -16,10 +15,3 @@ const EmailFormatDate = ({date, format}: {
     return <span>{moment(new Date(date)).format("LLL z").trim()}</span>
 }
 
-const EmailFormatDateComponent = registerComponent('EmailFormatDate', EmailFormatDate);
-
-declare global {
-  interface ComponentTypes {
-    EmailFormatDate: typeof EmailFormatDateComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSurvey.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSurvey.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
 const styles = defineStyles("EmailInactiveUserSurvey", (theme: ThemeType) => ({
@@ -16,7 +15,7 @@ const styles = defineStyles("EmailInactiveUserSurvey", (theme: ThemeType) => ({
   }
 }));
 
-const EmailInactiveUserSurvey = ({ user }: {
+export const EmailInactiveUserSurvey = ({ user }: {
   user: DbUser;
 }) => {
   const classes = useStyles(styles);
@@ -48,10 +47,3 @@ const EmailInactiveUserSurvey = ({ user }: {
   );
 };
 
-const EmailInactiveUserSurveyComponent = registerComponent("EmailInactiveUserSurvey", EmailInactiveUserSurvey);
-
-declare global {
-  interface ComponentTypes {
-    EmailInactiveUserSurvey: typeof EmailInactiveUserSurveyComponent;
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSurvey.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSurvey.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
+import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailInactiveUserSurvey", (theme: ThemeType) => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontSize: 15,
@@ -13,15 +14,12 @@ const styles = (theme: ThemeType) => ({
   hr: {
     marginTop: 30,
   }
-});
+}));
 
-const EmailInactiveUserSurvey = ({
-  user,
-  classes,
-}: {
+const EmailInactiveUserSurvey = ({ user }: {
   user: DbUser;
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
   const surveyLink = 'https://docs.google.com/forms/d/e/1FAIpQLSevnR0viER-xSUbcL0AsQpQ8Zn7X5iuvUgMcs3XEqk55SngLw/viewform'
 
   return (
@@ -50,11 +48,7 @@ const EmailInactiveUserSurvey = ({
   );
 };
 
-const EmailInactiveUserSurveyComponent = registerComponent(
-  "EmailInactiveUserSurvey",
-  EmailInactiveUserSurvey,
-  { styles }
-);
+const EmailInactiveUserSurveyComponent = registerComponent("EmailInactiveUserSurvey", EmailInactiveUserSurvey);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailJobAdReminder.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailJobAdReminder.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { JOB_AD_DATA } from "../../components/ea-forum/TargetedJobAd";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
@@ -20,7 +19,7 @@ const styles = defineStyles("EmailJobAdReminder", (theme: ThemeType) => ({
   }
 }));
 
-const EmailJobAdReminder = ({ jobName }: {
+export const EmailJobAdReminder = ({ jobName }: {
   jobName: string;
 }) => {
   const classes = useStyles(styles);
@@ -37,10 +36,3 @@ const EmailJobAdReminder = ({ jobName }: {
   );
 };
 
-const EmailJobAdReminderComponent = registerComponent("EmailJobAdReminder", EmailJobAdReminder);
-
-declare global {
-  interface ComponentTypes {
-    EmailJobAdReminder: typeof EmailJobAdReminderComponent;
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailJobAdReminder.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailJobAdReminder.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { JOB_AD_DATA } from "../../components/ea-forum/TargetedJobAd";
+import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailJobAdReminder", (theme: ThemeType) => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontSize: 16,
@@ -17,15 +18,12 @@ const styles = (theme: ThemeType) => ({
   hr: {
     marginTop: 20,
   }
-});
+}));
 
-const EmailJobAdReminder = ({
-  jobName,
-  classes,
-}: {
+const EmailJobAdReminder = ({ jobName }: {
   jobName: string;
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
   const jobData = JOB_AD_DATA[jobName];
   const link = jobData.bitlyLink;
 
@@ -39,11 +37,7 @@ const EmailJobAdReminder = ({
   );
 };
 
-const EmailJobAdReminderComponent = registerComponent(
-  "EmailJobAdReminder",
-  EmailJobAdReminder,
-  { styles }
-);
+const EmailJobAdReminderComponent = registerComponent("EmailJobAdReminder", EmailJobAdReminder);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailPostAuthors.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailPostAuthors.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import './EmailUsername';
-import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { getSiteUrl } from "../../lib/vulcan-lib/utils";
+import { EmailUsername } from './EmailUsername';
 
-const EmailPostAuthors = ({post}: {
+export const EmailPostAuthors = ({post}: {
   post: PostsRevision
 }) => {
-  const { EmailUsername } = Components;
-  
   const groupName = post.group ?
     <span>Posted in <a href={`${getSiteUrl().slice(0,-1)}/groups/${post.group._id}`}>{post.group.name}</a> </span> :
     null;
@@ -22,10 +19,3 @@ const EmailPostAuthors = ({post}: {
   </>
 }
 
-const EmailPostAuthorsComponent = registerComponent("EmailPostAuthors", EmailPostAuthors);
-
-declare global {
-  interface ComponentTypes {
-    EmailPostAuthors: typeof EmailPostAuthorsComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailPostDate.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailPostDate.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import { Components } from '../../lib/vulcan-lib/components';
 import { useTimezone } from '../../components/common/withTimezone';
+import { EmailFormatDate } from './EmailFormatDate';
 
-const EmailPostDate = ({post}: {
+export const EmailPostDate = ({post}: {
   post: PostsBase
 }) => {
   const { timezone, timezoneIsKnown } = useTimezone()
   
-  const { EmailFormatDate, PrettyEventDateTime } = Components;
+  const { PrettyEventDateTime } = Components;
   
   if (post.isEvent) {
     return <span><PrettyEventDateTime post={post} timezone={timezoneIsKnown ? timezone : undefined} /></span>
@@ -15,13 +16,5 @@ const EmailPostDate = ({post}: {
     return <EmailFormatDate date={post.curatedDate}/>
   } else {
     return <EmailFormatDate date={post.postedAt}/>
-  }
-}
-
-const EmailPostDateComponent = registerComponent("EmailPostDate", EmailPostDate);
-
-declare global {
-  interface ComponentTypes {
-    EmailPostDate: typeof EmailPostDateComponent
   }
 }

--- a/packages/lesswrong/server/emailComponents/EmailUsername.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailUsername.tsx
@@ -1,18 +1,10 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { userGetProfileUrl } from '../../lib/collections/users/helpers';
 
-const EmailUsername = ({user}: {
+export const EmailUsername = ({user}: {
   user: UsersMinimumInfo|DbUser|null|undefined
 }) => {
   if (!user) return <span>[deleted]</span>
   return <a href={userGetProfileUrl(user, true)}>{user.displayName}</a>
 }
 
-const EmailUsernameComponent = registerComponent("EmailUsername", EmailUsername);
-
-declare global {
-  interface ComponentTypes {
-    EmailUsername: typeof EmailUsernameComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailUsernameByID.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailUsernameByID.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
+import { EmailUsername } from './EmailUsername';
 
-const EmailUsernameByID = ({userID}: {
+export const EmailUsernameByID = ({userID}: {
   userID: string
 }) => {
   const { document, loading } = useSingle({
@@ -10,13 +10,6 @@ const EmailUsernameByID = ({userID}: {
     collectionName: "Users",
     fragmentName: 'UsersMinimumInfo',
   });
-  return <Components.EmailUsername user={document}/>
+  return <EmailUsername user={document}/>
 }
 
-const EmailUsernameByIDComponent = registerComponent("EmailUsernameByID", EmailUsernameByID);
-
-declare global {
-  interface ComponentTypes {
-    EmailUsernameByID: typeof EmailUsernameByIDComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -3,24 +3,25 @@ import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import { isFriendlyUI } from '@/themes/forumTheme';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
   root: {
     ...(isFriendlyUI ? {...theme.typography.smallText} : {}),
     "& img": {
       maxWidth: "100%",
     }
   },
-})
+}))
 
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-const EmailWrapper = ({unsubscribeAllLink, children, classes}: {
+const EmailWrapper = ({unsubscribeAllLink, children}: {
   unsubscribeAllLink: string | null,
   children: React.ReactNode,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const accountLink = `${getSiteUrl()}account`
   const siteNameWithArticle = siteNameWithArticleSetting.get()
   
@@ -99,7 +100,7 @@ const EmailWrapper = ({unsubscribeAllLink, children, classes}: {
   );
 }
 
-const EmailWrapperComponent = registerComponent("EmailWrapper", EmailWrapper, {styles});
+const EmailWrapperComponent = registerComponent("EmailWrapper", EmailWrapper);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import { isFriendlyUI } from '@/themes/forumTheme';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
@@ -17,7 +16,7 @@ const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-const EmailWrapper = ({unsubscribeAllLink, children}: {
+export const EmailWrapper = ({unsubscribeAllLink, children}: {
   unsubscribeAllLink: string | null,
   children: React.ReactNode,
 }) => {
@@ -100,10 +99,3 @@ const EmailWrapper = ({unsubscribeAllLink, children}: {
   );
 }
 
-const EmailWrapperComponent = registerComponent("EmailWrapper", EmailWrapper);
-
-declare global {
-  interface ComponentTypes {
-    EmailWrapper: typeof EmailWrapperComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EventTomorrowReminder.tsx
+++ b/packages/lesswrong/server/emailComponents/EventTomorrowReminder.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import type { RSVPType } from '../../lib/collections/posts/newSchema';
 
-const styles = (theme: ThemeType) => ({
-});
-
 const EventTomorrowReminder = ({postId, rsvp}: {
   postId: string,
   rsvp: RSVPType,
@@ -16,7 +13,7 @@ const EventTomorrowReminder = ({postId, rsvp}: {
   />
 }
 
-const EventTomorrowReminderComponent = registerComponent("EventTomorrowReminder", EventTomorrowReminder, {styles});
+const EventTomorrowReminderComponent = registerComponent("EventTomorrowReminder", EventTomorrowReminder);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EventTomorrowReminder.tsx
+++ b/packages/lesswrong/server/emailComponents/EventTomorrowReminder.tsx
@@ -1,22 +1,15 @@
 import React from 'react';
-import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import type { RSVPType } from '../../lib/collections/posts/newSchema';
+import { PostsEmail } from './PostsEmail';
 
-const EventTomorrowReminder = ({postId, rsvp}: {
+export const EventTomorrowReminder = ({postId, rsvp}: {
   postId: string,
   rsvp: RSVPType,
 }) => {
-  return <Components.PostsEmail
+  return <PostsEmail
     postIds={[postId]}
     hideRecommendations
     reason={`you RSVPed ${rsvp.response} to this event`}
   />
 }
 
-const EventTomorrowReminderComponent = registerComponent("EventTomorrowReminder", EventTomorrowReminder);
-
-declare global {
-  interface ComponentTypes {
-    EventTomorrowReminder: typeof EventTomorrowReminderComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
@@ -4,8 +4,9 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useTimezone } from '../../components/common/withTimezone';
 import { Components, registerComponent } from "../../lib/vulcan-lib/components";
 import { getSiteUrl } from "../../lib/vulcan-lib/utils";
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EventUpdatedEmail", (theme: ThemeType) => ({
   root: {
     marginBottom: 40
   },
@@ -35,13 +36,14 @@ const styles = (theme: ThemeType) => ({
   },
   data: {
     fontSize: 18,
-  }
-});
+  },
+  onlineEventLocation: {},
+}));
 
-const EventUpdatedEmail = ({postId, classes}: {
+const EventUpdatedEmail = ({postId}: {
   postId: string,
-  classes: any,
 }) => {
+  const classes = useStyles(styles);
   const { document: post, loading } = useSingle({
     documentId: postId,
     collectionName: "Posts",
@@ -86,7 +88,7 @@ const EventUpdatedEmail = ({postId, classes}: {
   </div>
 }
 
-const EventUpdatedEmailComponent = registerComponent("EventUpdatedEmail", EventUpdatedEmail, {styles});
+const EventUpdatedEmailComponent = registerComponent("EventUpdatedEmail", EventUpdatedEmail);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventUpdatedEmail.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSingle } from '../../lib/crud/withSingle';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useTimezone } from '../../components/common/withTimezone';
-import { Components, registerComponent } from "../../lib/vulcan-lib/components";
+import { Components } from "../../lib/vulcan-lib/components";
 import { getSiteUrl } from "../../lib/vulcan-lib/utils";
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
@@ -40,7 +40,7 @@ const styles = defineStyles("EventUpdatedEmail", (theme: ThemeType) => ({
   onlineEventLocation: {},
 }));
 
-const EventUpdatedEmail = ({postId}: {
+export const EventUpdatedEmail = ({postId}: {
   postId: string,
 }) => {
   const classes = useStyles(styles);
@@ -86,12 +86,4 @@ const EventUpdatedEmail = ({postId}: {
       <div className={classes.data}>{eventLocation}</div>
     </p>
   </div>
-}
-
-const EventUpdatedEmailComponent = registerComponent("EventUpdatedEmail", EventUpdatedEmail);
-
-declare global {
-  interface ComponentTypes {
-    EventUpdatedEmail: typeof EventUpdatedEmailComponent
-  }
 }

--- a/packages/lesswrong/server/emailComponents/NewDialogueMessagesEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewDialogueMessagesEmail.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import { getConfirmedCoauthorIds, postGetEditUrl, postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
 import { userGetDisplayName } from '../../lib/collections/users/helpers';
+import { EmailContentItemBody } from './EmailContentItemBody';
 
 export interface DialogueMessageEmailInfo {
   messageContents: string,
   messageAuthorId: string,
 }
 
-const NewDialogueMessagesEmail = ({documentId, userId, dialogueMessageEmailInfo}: {
+export const NewDialogueMessagesEmail = ({documentId, userId, dialogueMessageEmailInfo}: {
   documentId: string,
   userId: string,
   dialogueMessageEmailInfo?: DialogueMessageEmailInfo
 }) => {
-
-  const { EmailContentItemBody } = Components;
-
   const { document: post } = useSingle({
     documentId,
     collectionName: "Posts",
@@ -61,13 +58,5 @@ const NewDialogueMessagesEmail = ({documentId, userId, dialogueMessageEmailInfo}
       <p>There are new responses in the dialogue you are subscribed to, <a href={postGetPageUrl(post)}>{post.title}</a>.
       </p>
     </>;
-  }
-}
-
-const NewDialogueMessagesEmailComponent = registerComponent("NewDialogueMessagesEmail", NewDialogueMessagesEmail);
-
-declare global {
-  interface ComponentTypes {
-    NewDialogueMessagesEmail: typeof NewDialogueMessagesEmailComponent
   }
 }

--- a/packages/lesswrong/server/emailComponents/PostNominatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PostNominatedEmail.tsx
@@ -15,7 +15,6 @@ import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 const PostNominatedEmail = ({documentId, reason}: {
   documentId: string,
   reason?: string,
-  classes: any,
 }) => {
   const { document: post } = useSingle({
     documentId,

--- a/packages/lesswrong/server/emailComponents/PostNominatedEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PostNominatedEmail.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
-import './EmailFormatDate';
-import './EmailPostAuthors';
-import './EmailContentItemBody';
-import './EmailPostDate';
-import './EmailFooterRecommendations';
 import { getNominationPhaseEnd, REVIEW_NAME_IN_SITU, REVIEW_YEAR } from '../../lib/reviewUtils';
-import moment from 'moment';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 
 
-const PostNominatedEmail = ({documentId, reason}: {
+export const PostNominatedEmail = ({documentId, reason}: {
   documentId: string,
   reason?: string,
 }) => {
@@ -39,10 +32,3 @@ const PostNominatedEmail = ({documentId, reason}: {
   </React.Fragment>);
 }
 
-const PostNominatedEmailComponent = registerComponent("PostNominatedEmail", PostNominatedEmail);
-
-declare global {
-  interface ComponentTypes {
-    PostNominatedEmail: typeof PostNominatedEmailComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/PostsEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PostsEmail.tsx
@@ -6,6 +6,7 @@ import { postGetPageUrl, postGetLink, postGetLinkTarget } from '../../lib/collec
 import { truncatise } from '@/lib/truncatise';
 import { SMALL_TRUNCATION_CHAR_COUNT } from '@/lib/editor/ellipsize';
 import { LocationContext, NavigationContext } from '@/lib/vulcan-core/appContext';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
 const getPodcastInfoElement = (podcastEpisode: PostsDetails_podcastEpisode) => {
   const { podcast: { applePodcastLink, spotifyPodcastLink }, episodeLink, externalEpisodeId } = podcastEpisode;
@@ -67,7 +68,7 @@ const getTruncatedHtml = (html: string) => {
   }
 };
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("PostsEmail", (theme: ThemeType) => ({
   heading: {
     textAlign: "center",
     color: theme.palette.primary.main,
@@ -104,19 +105,18 @@ const styles = (theme: ThemeType) => ({
     marginTop: 30,
     marginBottom: 30,
   },
-});
+}));
 
 function PostsEmailInner({
   postIds,
   reason,
   hideRecommendations,
-  classes,
 }: {
   postIds: string[];
   reason?: string;
   hideRecommendations?: boolean;
-  classes: ClassesType<typeof styles>;
 }) {
+  const classes = useStyles(styles);
   const { results: posts } = useMulti({
     collectionName: "Posts",
     fragmentName: "PostsRevision",
@@ -214,12 +214,12 @@ function PostsEmailInner({
   );
 }
 
-const PostsEmail = ({ postIds, reason, hideRecommendations, classes }: {
+const PostsEmail = ({ postIds, reason, hideRecommendations}: {
   postIds: string[];
   reason?: string;
   hideRecommendations?: boolean;
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
   return (
     // Providers are required for useMulti
     <LocationContext.Provider
@@ -256,14 +256,13 @@ const PostsEmail = ({ postIds, reason, hideRecommendations, classes }: {
           postIds={postIds}
           reason={reason}
           hideRecommendations={hideRecommendations}
-          classes={classes}
         />
       </NavigationContext.Provider>
     </LocationContext.Provider>
   );
 };
 
-const PostsEmailComponent = registerComponent("PostsEmail", PostsEmail, { styles });
+const PostsEmailComponent = registerComponent("PostsEmail", PostsEmail);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/PostsEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PostsEmail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import { Components } from '../../lib/vulcan-lib/components';
 import { useMulti } from '@/lib/crud/withMulti';
 import { isFriendlyUI } from '@/themes/forumTheme';
 import { postGetPageUrl, postGetLink, postGetLinkTarget } from '../../lib/collections/posts/helpers';
@@ -7,6 +7,10 @@ import { truncatise } from '@/lib/truncatise';
 import { SMALL_TRUNCATION_CHAR_COUNT } from '@/lib/editor/ellipsize';
 import { LocationContext, NavigationContext } from '@/lib/vulcan-core/appContext';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import { EmailPostAuthors } from './EmailPostAuthors';
+import { EmailContentItemBody } from './EmailContentItemBody';
+import { EmailFooterRecommendations } from './EmailFooterRecommendations';
+import { EmailPostDate } from './EmailPostDate';
 
 const getPodcastInfoElement = (podcastEpisode: PostsDetails_podcastEpisode) => {
   const { podcast: { applePodcastLink, spotifyPodcastLink }, episodeLink, externalEpisodeId } = podcastEpisode;
@@ -123,7 +127,7 @@ function PostsEmailInner({
     terms: { postIds },
   });
 
-  const { EmailPostAuthors, EmailContentItemBody, EmailPostDate, ContentStyles, EmailFooterRecommendations } = Components;
+  const { ContentStyles } = Components;
 
   if (!posts || posts.length === 0) {
     return null;
@@ -214,7 +218,7 @@ function PostsEmailInner({
   );
 }
 
-const PostsEmail = ({ postIds, reason, hideRecommendations}: {
+export const PostsEmail = ({ postIds, reason, hideRecommendations}: {
   postIds: string[];
   reason?: string;
   hideRecommendations?: boolean;
@@ -261,13 +265,3 @@ const PostsEmail = ({ postIds, reason, hideRecommendations}: {
     </LocationContext.Provider>
   );
 };
-
-const PostsEmailComponent = registerComponent("PostsEmail", PostsEmail);
-
-declare global {
-  interface ComponentTypes {
-    PostsEmail: typeof PostsEmailComponent;
-  }
-}
-
-export default PostsEmailComponent;

--- a/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
-import { registerComponent, Components } from '../../lib/vulcan-lib/components';
 import { conversationGetPageUrl } from '../../lib/collections/conversations/helpers';
 import { useCurrentUser } from '../../components/common/withUser';
 import * as _ from 'underscore';
-import './EmailUsername';
-import './EmailFormatDate';
-import './EmailContentItemBody';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import { EmailUsername } from './EmailUsername';
+import { EmailFormatDate } from './EmailFormatDate';
+import { EmailContentItemBody } from './EmailContentItemBody';
 
 const styles = defineStyles("PriveMessagesEmail", (theme: ThemeType) => ({
   message: {
   },
 }));
 
-const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
+export const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
   conversations: Array<DbConversation>,
   messages: Array<DbMessage>,
   participantsById: Record<string,DbUser>,
@@ -25,7 +24,7 @@ const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
       <p>
         You received {messages.length>1 ? "private messages" : "a private message"}.
       </p>
-      <Components.PrivateMessagesEmailConversation
+      <PrivateMessagesEmailConversation
         conversation={conversations[0]}
         messages={messages}
         participantsById={participantsById}
@@ -36,7 +35,7 @@ const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
       <p>
         You received {messages.length} private messages in {conversations.length} conversations.
       </p>
-      {conversations.map(conv => <Components.PrivateMessagesEmailConversation
+      {conversations.map(conv => <PrivateMessagesEmailConversation
         conversation={conv}
         key={conv._id}
         messages={_.filter(messages, message=>message.conversationId===conv._id)}
@@ -45,15 +44,12 @@ const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
     </React.Fragment>
   }
 }
-const PrivateMessagesEmailComponent = registerComponent("PrivateMessagesEmail", PrivateMessagesEmail);
 
 /// A list of users, nicely rendered with links, comma separators and an "and"
 /// conjunction between the last two (if there are at least two).
-const EmailListOfUsers = ({users}: {
+export const EmailListOfUsers = ({users}: {
   users: Array<DbUser>
 }) => {
-  const { EmailUsername } = Components;
-  
   if (users.length === 0) {
     return <span>nobody</span>;
   } else if(users.length === 1) {
@@ -68,16 +64,14 @@ const EmailListOfUsers = ({users}: {
     return <span>{result}</span>;
   }
 }
-const EmailListOfUsersComponent = registerComponent("EmailListOfUsers", EmailListOfUsers);
 
-const PrivateMessagesEmailConversation = ({conversation, messages, participantsById}: {
+export const PrivateMessagesEmailConversation = ({conversation, messages, participantsById}: {
   conversation: ConversationsList|DbConversation,
   messages: Array<DbMessage>,
   participantsById: Partial<Record<string,DbUser>>,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
-  const { EmailUsername, EmailListOfUsers, EmailFormatDate, EmailContentItemBody } = Components;
   const sitename = siteNameWithArticleSetting.get()
   const conversationLink = conversationGetPageUrl(conversation, true);
   
@@ -100,14 +94,4 @@ const PrivateMessagesEmailConversation = ({conversation, messages, participantsB
       }}/>
     </div>)}
   </React.Fragment>);
-}
-
-const PrivateMessagesEmailConversationComponent = registerComponent("PrivateMessagesEmailConversation", PrivateMessagesEmailConversation);
-
-declare global {
-  interface ComponentTypes {
-    PrivateMessagesEmail: typeof PrivateMessagesEmailComponent,
-    EmailListOfUsers: typeof EmailListOfUsersComponent,
-    PrivateMessagesEmailConversation: typeof PrivateMessagesEmailConversationComponent,
-  }
 }

--- a/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
@@ -7,18 +7,19 @@ import './EmailUsername';
 import './EmailFormatDate';
 import './EmailContentItemBody';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("PriveMessagesEmail", (theme: ThemeType) => ({
   message: {
   },
-});
+}));
 
-const PrivateMessagesEmail = ({conversations, messages, participantsById, classes}: {
+const PrivateMessagesEmail = ({conversations, messages, participantsById}: {
   conversations: Array<DbConversation>,
   messages: Array<DbMessage>,
   participantsById: Record<string,DbUser>,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   if (conversations.length === 1) {
     return <React.Fragment>
       <p>
@@ -69,12 +70,12 @@ const EmailListOfUsers = ({users}: {
 }
 const EmailListOfUsersComponent = registerComponent("EmailListOfUsers", EmailListOfUsers);
 
-const PrivateMessagesEmailConversation = ({conversation, messages, participantsById, classes}: {
+const PrivateMessagesEmailConversation = ({conversation, messages, participantsById}: {
   conversation: ConversationsList|DbConversation,
   messages: Array<DbMessage>,
   participantsById: Partial<Record<string,DbUser>>,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const { EmailUsername, EmailListOfUsers, EmailFormatDate, EmailContentItemBody } = Components;
   const sitename = siteNameWithArticleSetting.get()
@@ -101,7 +102,7 @@ const PrivateMessagesEmailConversation = ({conversation, messages, participantsB
   </React.Fragment>);
 }
 
-const PrivateMessagesEmailConversationComponent = registerComponent("PrivateMessagesEmailConversation", PrivateMessagesEmailConversation, {styles});
+const PrivateMessagesEmailConversationComponent = registerComponent("PrivateMessagesEmailConversation", PrivateMessagesEmailConversation);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emailComponents/SequenceNewPostsEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/SequenceNewPostsEmail.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { makeCloudinaryImageUrl } from '../../components/common/CloudinaryImage2';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
@@ -19,7 +18,7 @@ const styles = defineStyles("SequenceNewPostsEmail", (theme: ThemeType) => ({
   },
 }));
 
-const SequenceNewPostsEmail = ({sequence, posts}: {
+export const SequenceNewPostsEmail = ({sequence, posts}: {
   sequence: DbSequence,
   posts: DbPost[],
 }) => {
@@ -48,10 +47,3 @@ const SequenceNewPostsEmail = ({sequence, posts}: {
   </div>
 }
 
-const SequenceNewPostsEmailComponent = registerComponent("SequenceNewPostsEmail", SequenceNewPostsEmail);
-
-declare global {
-  interface ComponentTypes {
-    SequenceNewPostsEmail: typeof SequenceNewPostsEmailComponent
-  }
-}

--- a/packages/lesswrong/server/emailComponents/SequenceNewPostsEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/SequenceNewPostsEmail.tsx
@@ -3,8 +3,9 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { makeCloudinaryImageUrl } from '../../components/common/CloudinaryImage2';
 import { sequenceGetPageUrl } from '../../lib/collections/sequences/helpers';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("SequenceNewPostsEmail", (theme: ThemeType) => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontSize: 16,
@@ -16,13 +17,13 @@ const styles = (theme: ThemeType) => ({
     maxHeight: 250,
     margin: '0 auto 25px',
   },
-});
+}));
 
-const SequenceNewPostsEmail = ({sequence, posts, classes}: {
+const SequenceNewPostsEmail = ({sequence, posts}: {
   sequence: DbSequence,
   posts: DbPost[],
-  classes: any,
 }) => {
+  const classes = useStyles(styles);
   const img = sequence.gridImageId || sequence.bannerImageId;
     const imgUrl = img ? makeCloudinaryImageUrl(img, {
       c: "fill",
@@ -47,7 +48,7 @@ const SequenceNewPostsEmail = ({sequence, posts, classes}: {
   </div>
 }
 
-const SequenceNewPostsEmailComponent = registerComponent("SequenceNewPostsEmail", SequenceNewPostsEmail, {styles});
+const SequenceNewPostsEmailComponent = registerComponent("SequenceNewPostsEmail", SequenceNewPostsEmail);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -15,7 +15,7 @@ import { getUserEmail, userEmailAddressIsVerified} from '../../lib/collections/u
 import { forumTitleSetting, isLWorAF } from '../../lib/instanceSettings';
 import { getForumTheme } from '../../themes/forumTheme';
 import { DatabaseServerSetting } from '../databaseSettings';
-import { Components, EmailRenderContext } from '../../lib/vulcan-lib/components';
+import { EmailRenderContext } from '../../lib/vulcan-lib/components';
 import { computeContextFromUser } from '../vulcan-lib/apollo-server/context';
 import { createMutator } from '../vulcan-lib/mutators';
 import { UnsubscribeAllToken } from '../emails/emailTokens';
@@ -28,6 +28,7 @@ import { createStylesContext } from '@/components/hooks/useStyles';
 import { generateEmailStylesheet } from '../styleGeneration';
 import { ThemeContextProvider } from '@/components/themes/useTheme';
 import { ThemeOptions } from '@/themes/themeNames';
+import { EmailWrapper } from '../emailComponents/EmailWrapper';
 
 export interface RenderedEmail {
   user: DbUser | null,
@@ -238,11 +239,11 @@ export const wrapAndRenderEmail = async ({user, to, from, subject, body}: {user:
     to,
     from,
     subject: subject,
-    bodyComponent: <Components.EmailWrapper
+    bodyComponent: <EmailWrapper
       unsubscribeAllLink={unsubscribeAllLink}
     >
       {body}
-    </Components.EmailWrapper>
+    </EmailWrapper>
   });
 }
 

--- a/packages/lesswrong/server/eventReminders.tsx
+++ b/packages/lesswrong/server/eventReminders.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Components } from '../lib/vulcan-lib/components';
 import { testServerSetting } from '../lib/instanceSettings';
 import { Posts } from '../server/collections/posts/collection';
 import { postStatuses } from '../lib/collections/posts/constants';
@@ -8,8 +7,8 @@ import { getUsersToNotifyAboutEvent } from './notificationCallbacks';
 import { addCronJob } from './cron/cronUtil';
 import { updateMutator } from './vulcan-lib/mutators';
 import { wrapAndSendEmail } from './emails/renderEmail';
-import './emailComponents/EventTomorrowReminder';
 import moment from '../lib/moment-timezone';
+import { EventTomorrowReminder } from './emailComponents/EventTomorrowReminder';
 
 async function checkAndSendUpcomingEventEmails() {
   const in24hours = moment(new Date()).add(24, 'hours').toDate();
@@ -56,7 +55,7 @@ async function checkAndSendUpcomingEventEmails() {
       await wrapAndSendEmail({
         user, to: email,
         subject: `Event reminder: ${upcomingEvent.title}`,
-        body: <Components.EventTomorrowReminder rsvp={rsvp} postId={upcomingEvent._id}/>
+        body: <EventTomorrowReminder rsvp={rsvp} postId={upcomingEvent._id}/>
       });
     }
   }

--- a/packages/lesswrong/server/inactiveUserSurveyCron.tsx
+++ b/packages/lesswrong/server/inactiveUserSurveyCron.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { addCronJob } from './cron/cronUtil';
 import { wrapAndSendEmail } from './emails/renderEmail';
-import './emailComponents/EmailInactiveUserSurvey';
 import { loggerConstructor } from '../lib/utils/logging';
 import UsersRepo from './repos/UsersRepo';
 import Users from '@/server/collections/users/collection';
 import { isEAForum } from '../lib/instanceSettings';
-import { Components } from "../lib/vulcan-lib/components";
+import { EmailInactiveUserSurvey } from './emailComponents/EmailInactiveUserSurvey';
 
 /**
  * Sends emails to inactive users with a link to a feedback survey
@@ -31,7 +30,7 @@ export const sendInactiveUserSurveyEmails = async () => {
         user,
         from: 'EA Forum Team <eaforum@centreforeffectivealtruism.org>',
         subject: `Help us improve the site`,
-        body: <Components.EmailInactiveUserSurvey user={user} />,
+        body: <EmailInactiveUserSurvey user={user} />,
       })
       await Users.rawUpdateOne(
         {_id: user._id},

--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -6,11 +6,11 @@ import { EventDebouncer } from './debouncer';
 import toDictionary from '../lib/utils/toDictionary';
 import { userIsAdmin } from '../lib/vulcan-users/permissions';
 import { Posts } from '../server/collections/posts/collection';
-import { Components } from '../lib/vulcan-lib/components';
 import { getUserEmail } from "../lib/collections/users/helpers";
 import Users from '@/server/collections/users/collection';
 import { computeContextFromUser } from './vulcan-lib/apollo-server/context';
 import gql from 'graphql-tag';
+import { PostsEmail } from './emailComponents/PostsEmail';
 
 // string (notification type name) => Debouncer
 export const notificationDebouncers = toDictionary(getNotificationTypes(),
@@ -133,7 +133,7 @@ export const graphqlQueries = {
         emails = [{
           user: currentUser,
           subject: post.title,
-          body: <Components.PostsEmail postIds={[post._id]} reason='you have the "Email me new posts in Curated" option enabled' />
+          body: <PostsEmail postIds={[post._id]} reason='you have the "Email me new posts in Curated" option enabled' />
         }]
       }
     }

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -2,11 +2,6 @@ import Notifications from '../server/collections/notifications/collection';
 import Users from '../server/collections/users/collection';
 import { Posts } from '../server/collections/posts/collection';
 import { getConfirmedCoauthorIds } from '../lib/collections/posts/helpers';
-import './emailComponents/EmailWrapper';
-import './emailComponents/PostsEmail';
-import './emailComponents/PostNominatedEmail';
-import './emailComponents/PrivateMessagesEmail';
-import './emailComponents/EmailCuratedAuthors';
 import * as _ from 'underscore';
 import { getCollectionHooks } from './mutationCallbacks';
 

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Components } from '../lib/vulcan-lib/components';
 import { makeAbsolute, getSiteUrl, combineUrls } from '../lib/vulcan-lib/utils';
 import { Posts } from '../server/collections/posts/collection';
 import { postGetPageUrl, postGetAuthorName, postGetEditUrl } from '../lib/collections/posts/helpers';
@@ -13,11 +12,6 @@ import keyBy from 'lodash/keyBy';
 import Users from '../server/collections/users/collection';
 import { userGetDisplayName, userGetProfileUrl } from '../lib/collections/users/helpers';
 import * as _ from 'underscore';
-import './emailComponents/EmailComment';
-import './emailComponents/PrivateMessagesEmail';
-import './emailComponents/EventUpdatedEmail';
-import './emailComponents/EmailUsernameByID';
-import './emailComponents/SequenceNewPostsEmail';
 import {getDocumentSummary, taggedPostMessage, NotificationDocument, getDocument} from '../lib/notificationTypes'
 import { commentGetPageUrlFromIds } from "../lib/collections/comments/helpers";
 import { getReviewTitle, REVIEW_YEAR } from '../lib/reviewUtils';
@@ -27,8 +21,15 @@ import Tags from '../server/collections/tags/collection';
 import { tagGetSubforumUrl } from '../lib/collections/tags/helpers';
 import uniq from 'lodash/uniq';
 import startCase from 'lodash/startCase';
-import { DialogueMessageEmailInfo } from './emailComponents/NewDialogueMessagesEmail';
+import { DialogueMessageEmailInfo, NewDialogueMessagesEmail } from './emailComponents/NewDialogueMessagesEmail';
 import Sequences from '../server/collections/sequences/collection';
+import { PostsEmail } from './emailComponents/PostsEmail';
+import { EmailCommentBatch } from './emailComponents/EmailComment';
+import { PostNominatedEmail } from './emailComponents/PostNominatedEmail';
+import { SequenceNewPostsEmail } from './emailComponents/SequenceNewPostsEmail';
+import { PrivateMessagesEmail } from './emailComponents/PrivateMessagesEmail';
+import { EventUpdatedEmail } from './emailComponents/EventUpdatedEmail';
+import { EmailUsernameByID } from './emailComponents/EmailUsernameByID';
 
 interface ServerNotificationType {
   name: string,
@@ -82,7 +83,7 @@ export const NewPostNotification = serverRegisterNotificationType({
       return true;
     }))) as string[];
 
-    return <Components.PostsEmail postIds={postIds}/>
+    return <PostsEmail postIds={postIds}/>
   },
 });
 
@@ -106,7 +107,7 @@ export const NewEventNotification = serverRegisterNotificationType({
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find event post to generate body for: ${postId}`)
-    return <Components.PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to this group"/>
+    return <PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to this group"/>
   },
 });
 
@@ -121,7 +122,7 @@ export const NewGroupPostNotification = serverRegisterNotificationType({
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find group post to generate body for: ${postId}`)
-    return <Components.PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to this group"/>
+    return <PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to this group"/>
   },
 });
 
@@ -134,7 +135,7 @@ export const NominatedPostNotification = serverRegisterNotificationType({
   emailBody: async ({user, notifications}: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find nominated post to generate body for: ${postId}`)
-    return <Components.PostNominatedEmail documentId={postId} />
+    return <PostNominatedEmail documentId={postId} />
   }
 })
 
@@ -161,7 +162,7 @@ export const NewShortformNotification = serverRegisterNotificationType({
     const comments = await Comments.find({_id: {$in: commentIds}}).fetch();
     if (!comments.length) throw Error(`Can't find comments for comment email notification: ${notifications}`);
 
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   }
 })
 
@@ -176,7 +177,7 @@ export const NewTagPostsNotification = serverRegisterNotificationType({
     const {documentId, documentType} = notifications[0]
     const tagRel = await TagRels.findOne({_id: documentId})
     if (tagRel) {
-      return <Components.PostsEmail postIds={ [tagRel.postId] }/>
+      return <PostsEmail postIds={ [tagRel.postId] }/>
     }
   }
 })
@@ -203,7 +204,7 @@ export const NewSequencePostsNotification = serverRegisterNotificationType({
     
     if (!posts.length) throw Error(`No valid new posts for notification: ${notifications[0]}`)
     
-    return <Components.SequenceNewPostsEmail sequence={sequence} posts={posts} />;
+    return <SequenceNewPostsEmail sequence={sequence} posts={posts} />;
   }
 })
 
@@ -226,7 +227,7 @@ export const NewCommentNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -249,7 +250,7 @@ export const NewUserCommentNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -283,7 +284,7 @@ export const NewSubforumCommentNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -305,7 +306,7 @@ export const NewDialogueMessageNotification = serverRegisterNotificationType({
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId!; // We skip notifications without a documentId in the skip function
     const dialogueMessageEmailInfo = getDialogueMessageEmailInfo(notifications[0].extraData)
-    return <Components.NewDialogueMessagesEmail documentId={postId} userId={user._id} dialogueMessageEmailInfo={dialogueMessageEmailInfo}/>;
+    return <NewDialogueMessagesEmail documentId={postId} userId={user._id} dialogueMessageEmailInfo={dialogueMessageEmailInfo}/>;
   },
   skip: async ({ notifications }: {notifications: DbNotification[]}) => {
     return !notifications[0].documentId
@@ -331,7 +332,7 @@ export const NewDialogueMessageBatchNotification = serverRegisterNotificationTyp
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find dialogue to generate body for: ${postId}`)
-    return <Components.NewDialogueMessagesEmail documentId={postId} userId={user._id}/>;
+    return <NewDialogueMessagesEmail documentId={postId} userId={user._id}/>;
   },
 });
 
@@ -347,7 +348,7 @@ export const NewPublishedDialogueMessageNotification = serverRegisterNotificatio
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find dialogue to generate body for: ${postId}`)
-    return <Components.NewDialogueMessagesEmail documentId={postId} userId={user._id}/>;
+    return <NewDialogueMessagesEmail documentId={postId} userId={user._id}/>;
   },
 });
 
@@ -370,7 +371,7 @@ export const NewDebateCommentNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -393,7 +394,7 @@ export const NewDebateReplyNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -416,7 +417,7 @@ export const NewReplyNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -441,7 +442,7 @@ export const NewReplyToYouNotification = serverRegisterNotificationType({
     const commentsRaw = await Comments.find({_id: {$in: commentIds}}).fetch();
     const comments = await accessFilterMultiple(user, 'Comments', commentsRaw, context);
     
-    return <Components.EmailCommentBatch comments={comments}/>;
+    return <EmailCommentBatch comments={comments}/>;
   },
 });
 
@@ -494,7 +495,7 @@ export const NewMessageNotification = serverRegisterNotificationType({
   emailBody: async function({ user, notifications, context }: {user: DbUser, notifications: DbNotification[], context: ResolverContext}) {
     const { conversations, messages, participantsById } = await this.loadData!({ user, notifications, context });
     
-    return <Components.PrivateMessagesEmail
+    return <PrivateMessagesEmail
       conversations={conversations}
       messages={messages}
       participantsById={participantsById}
@@ -627,7 +628,7 @@ export const NewEventInRadiusNotification = serverRegisterNotificationType({
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId = notifications[0].documentId;
     if (!postId) throw Error(`Can't find event to generate body for: ${postId}`)
-    return <Components.PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to nearby events notifications"/>
+    return <PostsEmail postIds={[postId]} hideRecommendations={true} reason="you are subscribed to nearby events notifications"/>
   },
 });
 
@@ -642,7 +643,7 @@ export const EditedEventInRadiusNotification = serverRegisterNotificationType({
   emailBody: async ({ user, notifications }: {user: DbUser, notifications: DbNotification[]}) => {
     const postId= notifications[0].documentId
     if (!postId) throw Error(`Can't find event to generate body for: ${postId}`)
-    return <Components.EventUpdatedEmail postId={postId} />
+    return <EventUpdatedEmail postId={postId} />
   },
 });
 
@@ -737,7 +738,6 @@ export const NewCommentOnDraftNotification = serverRegisterNotificationType({
     const post = await Posts.findOne({_id: firstNotification.documentId});
     const postTitle = post?.title;
     const postLink = postGetEditUrl(firstNotification.documentId, true, firstNotification.extraData?.linkSharingKey);
-    const { EmailUsernameByID } = Components;
     
     return <div>
       {notifications.map((notification,i) => <div key={i}>

--- a/packages/lesswrong/server/scripts/sendAnnualForumUserSurveyEmails.tsx
+++ b/packages/lesswrong/server/scripts/sendAnnualForumUserSurveyEmails.tsx
@@ -3,9 +3,8 @@ import { isEAForum } from "@/lib/instanceSettings";
 import { loggerConstructor } from "@/lib/utils/logging";
 import UsersRepo from "../repos/UsersRepo";
 import { wrapAndSendEmail } from "../emails/renderEmail";
-import './../emailComponents/EmailAnnualForumUserSurvey';
 import Users from '@/server/collections/users/collection';
-import { Components } from "@/lib/vulcan-lib/components.tsx";
+import { EmailAnnualForumUserSurvey } from './../emailComponents/EmailAnnualForumUserSurvey';
 
 /**
  * Used by the EA Forum to send an email to a subset of users
@@ -39,7 +38,7 @@ export const sendUserSurveyEmails = async (limit=10) => {
         user,
         from: 'EA Forum Team <eaforum@centreforeffectivealtruism.org>',
         subject: `We’d love to hear from you! Fill out the 2024 EA Forum user survey`,
-        body: <Components.EmailAnnualForumUserSurvey user={user} />,
+        body: <EmailAnnualForumUserSurvey user={user} />,
       })
       await Users.rawUpdateOne(
         {_id: user._id},

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -154,8 +154,6 @@ export function generateEmailStylesheet({muiSheetsRegistry, stylesContext, theme
   const usedStyleDefinitions = [...mountedStyles.values()].map(s => s.styleDefinition)
   const usedStylesByName = keyBy(usedStyleDefinitions, s=>s.name);
   const css = stylesToStylesheet(usedStylesByName, theme, themeOptions);
-  //console.log(css);
-  console.log(`Email used styles: ${Object.keys(mountedStyles).join(",")}`);
 
   return muiSheet + css;
 }

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -47,7 +47,7 @@ const generateMergedStylesheet = (themeOptions: ThemeOptions): Buffer => {
   
   const theme = getForumTheme(themeOptions);
   const cssVars = requestedCssVarsToString(theme);
-  const jssStylesheet = stylesToStylesheet(allStyles, theme, themeOptions);
+  const jssStylesheet = stylesToStylesheet(allStyles, theme, themeOptions, true);
   
   const mergedCSS = [
     draftjsStyles(),
@@ -83,14 +83,14 @@ function getAllStylesByName() {
   };
 }
 
-function stylesToStylesheet(allStyles: Record<string,StyleDefinition>, theme: ThemeType, themeOptions: ThemeOptions): string {
+function stylesToStylesheet(allStyles: Record<string,StyleDefinition>, theme: ThemeType, themeOptions: ThemeOptions, addPotentiallUnusedMuiStyles: boolean): string {
   const context: any = {};
   const stylesByName = sortBy(Object.keys(allStyles), n=>n);
   const stylesByNameAndPriority = sortBy(stylesByName, n=>allStyles[n].options?.stylePriority ?? 0);
   
   const DummyComponent = (props: any) => <div/>
   const DummyTree = <div>
-    {Object.keys(usedMuiStyles).map((componentName: string) => {
+    {addPotentiallUnusedMuiStyles && Object.keys(usedMuiStyles).map((componentName: string) => {
       const StyledComponent = withStyles(usedMuiStyles[componentName], {name: componentName})(DummyComponent)
       return <StyledComponent key={componentName}/>
     })}
@@ -153,7 +153,7 @@ export function generateEmailStylesheet({muiSheetsRegistry, stylesContext, theme
   const mountedStyles = stylesContext.mountedStyles;
   const usedStyleDefinitions = [...mountedStyles.values()].map(s => s.styleDefinition)
   const usedStylesByName = keyBy(usedStyleDefinitions, s=>s.name);
-  const css = stylesToStylesheet(usedStylesByName, theme, themeOptions);
+  const css = stylesToStylesheet(usedStylesByName, theme, themeOptions, false);
 
   return muiSheet + css;
 }

--- a/packages/lesswrong/server/userJobAdCron.tsx
+++ b/packages/lesswrong/server/userJobAdCron.tsx
@@ -6,10 +6,9 @@ import UserJobAds from '../server/collections/userJobAds/collection';
 import { Users } from '../server/collections/users/collection';
 import uniq from 'lodash/fp/uniq';
 import { wrapAndSendEmail } from './emails/renderEmail';
-import './emailComponents/EmailJobAdReminder';
 import { loggerConstructor } from '../lib/utils/logging';
 import { isEAForum } from '../lib/instanceSettings';
-import { Components } from "../lib/vulcan-lib/components";
+import { EmailJobAdReminder } from './emailComponents/EmailJobAdReminder';
 
 // Exported to allow running with "yarn repl"
 export const sendJobAdReminderEmails = async () => {
@@ -56,7 +55,7 @@ export const sendJobAdReminderEmails = async () => {
       void wrapAndSendEmail({
         user: recipient,
         subject: `Reminder: ${jobAdData.role} role at${jobAdData.insertThe ? ' the ' : ' '}${jobAdData.org}`,
-        body: <Components.EmailJobAdReminder jobName={userJobAd.jobName} />,
+        body: <EmailJobAdReminder jobName={userJobAd.jobName} />,
         force: true  // ignore the "unsubscribe to all" in this case, since the user initiated it
       })
     }


### PR DESCRIPTION
Email components use regular imports, rather than `Components`, and hook styles, rather than HoC styles.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209931094386004) by [Unito](https://www.unito.io)
