### PR TITLE
Fix colors and essays for BestOfLessWrongAnnouncement

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
@@ -29,7 +29,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     fontSize: '1.1rem',
     ...theme.typography.commentStyle,
     textTransform: 'uppercase',
-    color: theme.palette.grey[700],
+    color: "#616161",
     position: 'relative',
     top: 2,
     [theme.breakpoints.down('sm')]: {
@@ -54,7 +54,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     '&:hover $winnerItem': {
       [theme.breakpoints.up('md')]: {
         opacity: 1,
-        borderBottom: theme.palette.border.grey200,
+        borderBottom: `1px solid #eee`,
       },
     },
     '&:hover $winnerItem:last-child': {
@@ -125,7 +125,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     color: theme.palette.text.alwaysWhite,
     whiteSpace: 'nowrap',
     backdropFilter: 'blur(1px)',
-    textShadow: `0 0 4px ${theme.palette.greyAlpha(.8)}, 0 0 8px ${theme.palette.greyAlpha(.2)}`,
+    textShadow: `0 0 4px rgba(0,0,0,0.8), 0 0 8px rgba(0,0,0,0.2)`,
   },
   winnersContainer: {
     display: "flex",
@@ -153,10 +153,10 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
       filter: "brightness(1) saturate(1)",
     },
     '&:hover $winnerCategoryRank': {
-      color: theme.palette.grey[300],
+      color: "#e0e0e0",
     },
     '&:hover $winnerTitle': {
-      color: theme.palette.grey[100],
+      color: "#f5f5f5",
     },
     '&:hover $winnerImageBackground': {
       opacity: .2,
@@ -185,7 +185,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     ...theme.typography.body2,
     transition: "opacity 0.2s ease-in-out",
     fontSize: 13,
-    color: theme.palette.grey[300],
+    color: "#e0e0e0",
     lineHeight: '1.2',
     position: "absolute",
     textShadow: `0px 0px 3px ${theme.palette.text.alwaysBlack}, 0 0 5px ${theme.palette.text.alwaysBlack}`,
@@ -198,13 +198,13 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     ...theme.typography.body2,
     transition: "opacity 0.1s ease-in-out",
     fontSize: '.9rem',
-    color: theme.palette.grey[500],
+    color: "#9e9e9e",
     lineHeight: '1.2',
     position: "absolute",
     bottom: 8,
     left: 8,
     opacity: 0,
-    textShadow: `0 0 4px ${theme.palette.greyAlpha(.8)}`,
+    textShadow: `0 0 4px rgba(0,0,0,0.8)`,
     [theme.breakpoints.down('sm')]: {
       display: 'none',
     },
@@ -230,7 +230,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
       display: "none"
     }
   },
-}));
+}), { allowNonThemeColors: true });
 
 const BestOfLessWrongAnnouncement = () => {
   const classes = useStyles(styles);

--- a/packages/lesswrong/lib/collections/reviewWinners/views.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/views.ts
@@ -28,7 +28,7 @@ function bestOfLessWrongAnnouncement() {
       _id: {
         // the top 3 winners of each category, for the most recent year
         $in: [
-          'J8NJ2P3BZ7kFipJRq', 'ZLDe6fkJujBi82uni', '2ZjiwMBKbwnLugpkt', 'xmaEheyR38b4uvukZ', 'WF4K3gfSSQvnHos7v', 'pwZwZ9MKS9GbhAYT7', '4Z4nA4zcc782nx3A8', 'ZLjciCktgoqGiNB29', 'xnKryiM7ZCpvdvniL', 'S8pM7Abj3MzdSjFE4', '3G52nqBHmbgqTsS5M', 'tcPKsGv5W3FNbmHAi', 'aXkdhqNe97P54tqaw', 'KTcyhwZXrDjwrHno6', 'jQbrebZtMvBueLaDQ', 'cccL2hK8zbJJdPc4b', '4gQcQ4uJ2chZRADiZ', 'sD4mr92qrmckK9hE8'
+          'J8NJ2P3BZ7kFipJRq', 'ZLDe6fkJujBi82uni', '2ZjiwMBKbwnLugpkt', 'xmaEheyR38b4uvukZ', 'sg764fMCcucPALosr', '4Z4nA4zcc782nx3A8', 'ZLjciCktgoqGiNB29', 'xnKryiM7ZCpvdvniL', 'S8pM7Abj3MzdSjFE4', '3G52nqBHmbgqTsS5M', 'tcPKsGv5W3FNbmHAi', 'aXkdhqNe97P54tqaw', 'KTcyhwZXrDjwrHno6', 'jQbrebZtMvBueLaDQ', 'cccL2hK8zbJJdPc4b', '4gQcQ4uJ2chZRADiZ', 'sD4mr92qrmckK9hE8', 'pwZwZ9MKS9GbhAYT7'
         ]
       }
     },

--- a/packages/lesswrong/unitTests/themePalette.tests.ts
+++ b/packages/lesswrong/unitTests/themePalette.tests.ts
@@ -59,7 +59,7 @@ describe('JSS', () => {
     for (const name in topLevelStyleDefinitions) {
       const styleGetter = topLevelStyleDefinitions[name].styles;
       const styles = styleGetter(fakeTheme);
-      if (styles && !ComponentsTable[name]?.options?.allowNonThemeColors) {
+      if (styles && !topLevelStyleDefinitions[name].options?.allowNonThemeColors) {
         assertNoNonPaletteColors(name, styles, nonPaletteColors);
       }
     }


### PR DESCRIPTION
BestOfLessWrongAnnouncement had some colors that (incorrectly) changed in darkmode. This hardcodes them to always be the same.

Also, fixes some of the essays that were incorrectly listed as top-3 winners in their category.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209943739603874) by [Unito](https://www.unito.io)
