### PR TITLE
BestOfLessWrongAnnouncement style + link update

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
@@ -16,6 +16,7 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
   },
   title: {
     ...theme.typography.title,
+    color: theme.palette.grey[800],
     textWrap: 'balance',
     fontSize: 40,
     marginTop: 12,

--- a/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/BestOfLessWrongAnnouncement.tsx
@@ -24,6 +24,11 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
     [theme.breakpoints.down('sm')]: {
       fontSize: 40,
     },
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 32,
+      marginTop: 8,
+      marginBottom: 10,
+    },
   },
   viewAllLink: {
     ...theme.typography.body1,
@@ -72,6 +77,9 @@ const styles = defineStyles("BestOfLessWrongAnnouncement", (theme: ThemeType) =>
       [theme.breakpoints.up('md')]: {
         opacity: 1,
       },
+    },
+    [theme.breakpoints.down('xs')]: {
+      marginBottom: -16
     },
   },
   category: {
@@ -280,7 +288,7 @@ const BestOfLessWrongAnnouncement = () => {
     <AnalyticsContext pageSectionContext="bestOfLessWrongAnnouncement">
       <SingleColumnSection>
         <div className={classes.titleContainer}>
-          <Link to={`/bestoflesswrong#year-category-section`} className={classes.title}>
+          <Link to={`/posts/sHvByGZRCsFuxtTKr/voting-results-for-the-2023-review`} className={classes.title}>
             Best of LessWrong {REVIEW_YEAR}
           </Link>
           <Link to={`/bestoflesswrong`} className={classes.viewAllLink}> 

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -130,7 +130,6 @@ export const baseTheme: BaseThemeSpecification = {
           color: palette.grey[800],
         },
         title: {
-          color: palette.grey[800],
           fontSize: 18,
           fontWeight: 400,
           marginBottom: 3,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -130,6 +130,7 @@ export const baseTheme: BaseThemeSpecification = {
           color: palette.grey[800],
         },
         title: {
+          color: palette.grey[800],
           fontSize: 18,
           fontWeight: 400,
           marginBottom: 3,


### PR DESCRIPTION
This 
– adds a couple small improvements to the mobile styling
– adds a link to the Voting Results post
– updates the title to use a grey color that will properly invert in darkmode. (I think typography.title should have this across-the-board, but was scared to update it without doing more comprehensive testing than I have time for)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209952896029469) by [Unito](https://www.unito.io)
