### PR TITLE
Fix Apollo error when updating cache entry or a query that is in an initial loading state

### DIFF
--- a/packages/lesswrong/lib/crud/cacheUpdates.ts
+++ b/packages/lesswrong/lib/crud/cacheUpdates.ts
@@ -40,6 +40,7 @@ export const updateEachQueryResultOfType = ({ store, typeName, func, document }:
   watchesToUpdate.forEach(({query, variables}: {query: any, variables: any}) => {
     const { input: { terms } } = variables
     const data: any = store.readQuery({query, variables})
+    if (!data) return;
     const multiResolverName = getMultiResolverName(typeName);
     const collectionName = typeNameToCollectionName[typeName];
     const parameters = viewTermsToQuery(collectionName, terms);


### PR DESCRIPTION
When you perform an update mutation, we have some code that attempts to find and update queries that would be affected by the change. However, if there is a query that would be affected by the change and it's still in an initial loading state, this crashes with a null-reference exception.

In practice this doesn't come up often, but one repro is that if you're logged in as a moderator and you open the notification tray while the Sunshine Sidebar new users list is loading, it will console-log an error and fail to clear your notification count.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209956367210344) by [Unito](https://www.unito.io)
