### PR TITLE
Add a graphql field resolver for "profile"

### DIFF
--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -868,7 +868,9 @@ const schema = {
       canRead: ["guests"],
       // GraphQL resolver is provided for API back-compat (issarice's reader
       // has it in its user fragment), but only returns an empty object.
-      resolver: (user, args, context) => ({}),
+      resolver: (user, args, context) => ({
+        fieldNoLongerSupported: true
+      }),
     },
     form: {
       hidden: true,

--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -856,9 +856,19 @@ const schema = {
       group: () => adminGroup,
     },
   },
+  // A mostly-legacy field. For OAuth users, includes information that was
+  // submitted with the OAuth login; for users imported from old LW, includes
+  // a link.
   profile: {
     database: {
       type: "JSONB",
+    },
+    graphql: {
+      outputType: "JSON",
+      canRead: ["guests"],
+      // GraphQL resolver is provided for API back-compat (issarice's reader
+      // has it in its user fragment), but only returns an empty object.
+      resolver: (user, args, context) => ({}),
     },
     form: {
       hidden: true,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -2209,7 +2209,7 @@ interface DbUser extends DbObject {
   postGlossariesPinned: boolean
   postingDisabled: boolean | null
   previousDisplayName: string | null
-  profile: any
+  profile: any /*{"definitions":[{}]}*/
   profileImageId: string | null
   profileTagIds: Array<string>
   profileUpdatedAt: Date

--- a/packages/lesswrong/lib/generated/defaultFragments.ts
+++ b/packages/lesswrong/lib/generated/defaultFragments.ts
@@ -1568,6 +1568,7 @@ export const UsersDefaultFragment = `
     username
     emails
     isAdmin
+    profile
     services
     displayName
     previousDisplayName

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -4156,6 +4156,7 @@ interface UsersDefaultFragment { // fragment on Users
     verified: boolean,
   }>,
   readonly isAdmin: boolean,
+  readonly profile: any,
   readonly services: any /*{"definitions":[{"blackbox":true}]}*/,
   readonly displayName: string,
   readonly previousDisplayName: string,

--- a/packages/lesswrong/lib/generated/fragments.gql
+++ b/packages/lesswrong/lib/generated/fragments.gql
@@ -4605,6 +4605,7 @@ fragment UsersDefaultFragment on User {
   username
   emails
   isAdmin
+  profile
   services
   displayName
   previousDisplayName

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -9428,6 +9428,7 @@ type User {
   username: String
   emails: [JSON]
   isAdmin: Boolean
+  profile: JSON
   services: JSON
   hasAuth0Id: Boolean
   displayName: String
@@ -9900,6 +9901,7 @@ input UpdateUserDataInput {
   groups: [String]
   theme: JSON
   lastUsedTimezone: String
+  whenConfirmationEmailSent: Date
   legacy: Boolean
   commentSorting: String
   sortDraftsBy: String


### PR DESCRIPTION
Adds a graphql resolver for the "profile" field, mainly so that issarice's reader doesn't clutter Sentry by making lots of requests involving a field it can no longer read.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209956389209329) by [Unito](https://www.unito.io)
