### PR TITLE
Fix the "offset" option on views using compiled fragments

### DIFF
--- a/packages/lesswrong/server/resolvers/defaultResolvers.ts
+++ b/packages/lesswrong/server/resolvers/defaultResolvers.ts
@@ -166,7 +166,10 @@ export const getDefaultResolvers = <N extends CollectionNameString>(
         {...resolverArgs, ...terms},
         parameters.selector,
         parameters.syntheticFields,
-        parameters.options,
+        {
+          ...parameters.options,
+          skip: terms.offset,
+        }
       );
       const compiledQuery = query.compile();
       const db = getSqlClientOrThrow();


### PR DESCRIPTION
Views take an "offset" fragment for pagination, which skips the first N results. This is handled in performQueryFromViewParameters, but was not handled on the other branch in the default multi resolver. This isn't used in our own client code, but it is used by GreaterWrong, which uses it when fetching comments on posts after the first 500.

The symptom of this not working was that GW would fetch the first 500 comments on a post with more comments than that, ask for the next 500 comments and get the same 500 comments back, conclude that getting 500 meant there must also be a third page, and repeat until it eventually runs into an "Exceeded maximum value for skip" error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209956460638780) by [Unito](https://www.unito.io)
