### PR TITLE
UI tweaks

### DIFF
--- a/packages/lesswrong/components/jargon/GlossarySidebar.tsx
+++ b/packages/lesswrong/components/jargon/GlossarySidebar.tsx
@@ -215,11 +215,7 @@ const GlossarySidebar = ({post, showAllTerms, setShowAllTerms, approvedTermsCoun
     return null;
   }
 
-  if (!userCanViewJargonTerms(currentUser)) {
-    return null;
-  }
-
-  if (approvedTermsCount === 0 && unapprovedTermsCount === 0) {
+  if (approvedTermsCount === 0) {
     return null;
   }
 

--- a/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/ReviewPillContainer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/ReviewPillContainer.tsx
@@ -108,7 +108,7 @@ const ReviewPillContainer = ({postId}: {postId: string}) => {
             <div className={classes.review}>
               Review by
               <div className={classes.reviewerName}>
-                <UsersNameDisplay user={review.user} />
+                <UsersNameDisplay noTooltip user={review.user} />
               </div>
             </div>
           </HashLink>


### PR DESCRIPTION
Two small UI tweaks: 
* Hide the glossary unless the author has approved at least one term
* Don't have a Usersname tooltip on review pills, since the parent already has a tooltip for the review itself

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209966735807987) by [Unito](https://www.unito.io)
