### PR TITLE
Fix an infinite loop crash when glossary contains empty-string as a jargon term

### DIFF
--- a/packages/lesswrong/components/jargon/utils.ts
+++ b/packages/lesswrong/components/jargon/utils.ts
@@ -12,6 +12,7 @@ export function countInstancesOfJargon(
   const isWordChar = (char: string) => /[\p{L}\p{N}'-]/u.test(char);
   
   const countMatches = (term: string): number => {
+    if (!term) return 0;
     let count = 0;
     let index = postText.indexOf(term);
     


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209973642393712) by [Unito](https://www.unito.io)
