### PR TITLE
Fix event emails

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -63,6 +63,8 @@ declare global {
     curatedAfter?: Date|string|null,
     timeField?: keyof DbPost,
     postIds?: Array<string>,
+    /** Fetch exactly these postIds and apply no other filters (apart from permissions checks) */
+    exactPostIds?: Array<string>,
     notPostIds?: Array<string>,
     reviewYear?: number,
     reviewPhase?: ReviewPhase,
@@ -221,7 +223,13 @@ function defaultView(terms: PostsViewTerms, _: ApolloClient<NormalizedCacheObjec
   if (terms.curatedAfter) {
     params.selector.curatedDate = {$gte: moment(terms.curatedAfter).toDate()}
   }
-  
+
+  // If we want only the exact postIds, remove all other selector fields. Access
+  // filtering will still be applied by defaultResolvers.ts
+  if (terms.exactPostIds) {
+    params.selector = { _id: { $in: terms.exactPostIds } };
+  }
+
   return params;
 }
 

--- a/packages/lesswrong/server/emailComponents/PostsEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PostsEmail.tsx
@@ -124,7 +124,7 @@ function PostsEmailInner({
   const { results: posts } = useMulti({
     collectionName: "Posts",
     fragmentName: "PostsRevision",
-    terms: { postIds },
+    terms: { exactPostIds: postIds },
   });
 
   const { ContentStyles } = Components;


### PR DESCRIPTION
Event emails were broken by #10515, because that PR switched the email from using a `useSingle` to a `useMulti`, and the default view for posts filters out events.

This PR adds a term `exactPostIds`, when given this removes all other selectors from the default view so that the result is the same as if several `useSingle`s had been used (i.e. only filtering based on access checks)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209989444903009) by [Unito](https://www.unito.io)
