### PR TITLE
give older clients some time to cycle out before removing enableCache from the server-side input schemas

### DIFF
--- a/packages/lesswrong/server/collections/advisorRequests/queries.ts
+++ b/packages/lesswrong/server/collections/advisorRequests/queries.ts
@@ -23,6 +23,7 @@ export const graphqlAdvisorRequestQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiAdvisorRequestOutput {

--- a/packages/lesswrong/server/collections/arbitalTagContentRels/queries.ts
+++ b/packages/lesswrong/server/collections/arbitalTagContentRels/queries.ts
@@ -23,6 +23,7 @@ export const graphqlArbitalTagContentRelQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiArbitalTagContentRelOutput {

--- a/packages/lesswrong/server/collections/bans/queries.ts
+++ b/packages/lesswrong/server/collections/bans/queries.ts
@@ -23,6 +23,7 @@ export const graphqlBanQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiBanOutput {

--- a/packages/lesswrong/server/collections/books/queries.ts
+++ b/packages/lesswrong/server/collections/books/queries.ts
@@ -23,6 +23,7 @@ export const graphqlBookQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiBookOutput {

--- a/packages/lesswrong/server/collections/chapters/queries.ts
+++ b/packages/lesswrong/server/collections/chapters/queries.ts
@@ -23,6 +23,7 @@ export const graphqlChapterQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiChapterOutput {

--- a/packages/lesswrong/server/collections/ckEditorUserSessions/queries.ts
+++ b/packages/lesswrong/server/collections/ckEditorUserSessions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlCkEditorUserSessionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiCkEditorUserSessionOutput {

--- a/packages/lesswrong/server/collections/clientIds/queries.ts
+++ b/packages/lesswrong/server/collections/clientIds/queries.ts
@@ -23,6 +23,7 @@ export const graphqlClientIdQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiClientIdOutput {

--- a/packages/lesswrong/server/collections/collections/queries.ts
+++ b/packages/lesswrong/server/collections/collections/queries.ts
@@ -23,6 +23,7 @@ export const graphqlCollectionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiCollectionOutput {

--- a/packages/lesswrong/server/collections/commentModeratorActions/queries.ts
+++ b/packages/lesswrong/server/collections/commentModeratorActions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlCommentModeratorActionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiCommentModeratorActionOutput {

--- a/packages/lesswrong/server/collections/comments/queries.ts
+++ b/packages/lesswrong/server/collections/comments/queries.ts
@@ -23,6 +23,7 @@ export const graphqlCommentQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiCommentOutput {

--- a/packages/lesswrong/server/collections/conversations/queries.ts
+++ b/packages/lesswrong/server/collections/conversations/queries.ts
@@ -23,6 +23,7 @@ export const graphqlConversationQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiConversationOutput {

--- a/packages/lesswrong/server/collections/curationNotices/queries.ts
+++ b/packages/lesswrong/server/collections/curationNotices/queries.ts
@@ -23,6 +23,7 @@ export const graphqlCurationNoticeQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiCurationNoticeOutput {

--- a/packages/lesswrong/server/collections/dialogueChecks/queries.ts
+++ b/packages/lesswrong/server/collections/dialogueChecks/queries.ts
@@ -23,6 +23,7 @@ export const graphqlDialogueCheckQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiDialogueCheckOutput {

--- a/packages/lesswrong/server/collections/dialogueMatchPreferences/queries.ts
+++ b/packages/lesswrong/server/collections/dialogueMatchPreferences/queries.ts
@@ -23,6 +23,7 @@ export const graphqlDialogueMatchPreferenceQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiDialogueMatchPreferenceOutput {

--- a/packages/lesswrong/server/collections/digestPosts/queries.ts
+++ b/packages/lesswrong/server/collections/digestPosts/queries.ts
@@ -23,6 +23,7 @@ export const graphqlDigestPostQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiDigestPostOutput {

--- a/packages/lesswrong/server/collections/digests/queries.ts
+++ b/packages/lesswrong/server/collections/digests/queries.ts
@@ -23,6 +23,7 @@ export const graphqlDigestQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiDigestOutput {

--- a/packages/lesswrong/server/collections/electionCandidates/queries.ts
+++ b/packages/lesswrong/server/collections/electionCandidates/queries.ts
@@ -23,6 +23,7 @@ export const graphqlElectionCandidateQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiElectionCandidateOutput {

--- a/packages/lesswrong/server/collections/electionVotes/queries.ts
+++ b/packages/lesswrong/server/collections/electionVotes/queries.ts
@@ -23,6 +23,7 @@ export const graphqlElectionVoteQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiElectionVoteOutput {

--- a/packages/lesswrong/server/collections/elicitQuestionPredictions/queries.ts
+++ b/packages/lesswrong/server/collections/elicitQuestionPredictions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlElicitQuestionPredictionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiElicitQuestionPredictionOutput {

--- a/packages/lesswrong/server/collections/elicitQuestions/queries.ts
+++ b/packages/lesswrong/server/collections/elicitQuestions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlElicitQuestionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiElicitQuestionOutput {

--- a/packages/lesswrong/server/collections/featuredResources/queries.ts
+++ b/packages/lesswrong/server/collections/featuredResources/queries.ts
@@ -23,6 +23,7 @@ export const graphqlFeaturedResourceQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiFeaturedResourceOutput {

--- a/packages/lesswrong/server/collections/forumEvents/queries.ts
+++ b/packages/lesswrong/server/collections/forumEvents/queries.ts
@@ -23,6 +23,7 @@ export const graphqlForumEventQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiForumEventOutput {

--- a/packages/lesswrong/server/collections/gardencodes/queries.ts
+++ b/packages/lesswrong/server/collections/gardencodes/queries.ts
@@ -23,6 +23,7 @@ export const graphqlGardenCodeQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiGardenCodeOutput {

--- a/packages/lesswrong/server/collections/googleServiceAccountSessions/queries.ts
+++ b/packages/lesswrong/server/collections/googleServiceAccountSessions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlGoogleServiceAccountSessionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiGoogleServiceAccountSessionOutput {

--- a/packages/lesswrong/server/collections/jargonTerms/queries.ts
+++ b/packages/lesswrong/server/collections/jargonTerms/queries.ts
@@ -23,6 +23,7 @@ export const graphqlJargonTermQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiJargonTermOutput {

--- a/packages/lesswrong/server/collections/llmConversations/queries.ts
+++ b/packages/lesswrong/server/collections/llmConversations/queries.ts
@@ -23,6 +23,7 @@ export const graphqlLlmConversationQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiLlmConversationOutput {

--- a/packages/lesswrong/server/collections/localgroups/queries.ts
+++ b/packages/lesswrong/server/collections/localgroups/queries.ts
@@ -23,6 +23,7 @@ export const graphqlLocalgroupQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiLocalgroupOutput {

--- a/packages/lesswrong/server/collections/lwevents/queries.ts
+++ b/packages/lesswrong/server/collections/lwevents/queries.ts
@@ -23,6 +23,7 @@ export const graphqlLWEventQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiLWEventOutput {

--- a/packages/lesswrong/server/collections/messages/queries.ts
+++ b/packages/lesswrong/server/collections/messages/queries.ts
@@ -23,6 +23,7 @@ export const graphqlMessageQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiMessageOutput {

--- a/packages/lesswrong/server/collections/moderationTemplates/queries.ts
+++ b/packages/lesswrong/server/collections/moderationTemplates/queries.ts
@@ -23,6 +23,7 @@ export const graphqlModerationTemplateQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiModerationTemplateOutput {

--- a/packages/lesswrong/server/collections/moderatorActions/queries.ts
+++ b/packages/lesswrong/server/collections/moderatorActions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlModeratorActionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiModeratorActionOutput {

--- a/packages/lesswrong/server/collections/multiDocuments/queries.ts
+++ b/packages/lesswrong/server/collections/multiDocuments/queries.ts
@@ -23,6 +23,7 @@ export const graphqlMultiDocumentQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiMultiDocumentOutput {

--- a/packages/lesswrong/server/collections/notifications/queries.ts
+++ b/packages/lesswrong/server/collections/notifications/queries.ts
@@ -23,6 +23,7 @@ export const graphqlNotificationQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiNotificationOutput {

--- a/packages/lesswrong/server/collections/petrovDayActions/queries.ts
+++ b/packages/lesswrong/server/collections/petrovDayActions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlPetrovDayActionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiPetrovDayActionOutput {

--- a/packages/lesswrong/server/collections/podcastEpisodes/queries.ts
+++ b/packages/lesswrong/server/collections/podcastEpisodes/queries.ts
@@ -23,6 +23,7 @@ export const graphqlPodcastEpisodeQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiPodcastEpisodeOutput {

--- a/packages/lesswrong/server/collections/podcasts/queries.ts
+++ b/packages/lesswrong/server/collections/podcasts/queries.ts
@@ -23,6 +23,7 @@ export const graphqlPodcastQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiPodcastOutput {

--- a/packages/lesswrong/server/collections/postRelations/queries.ts
+++ b/packages/lesswrong/server/collections/postRelations/queries.ts
@@ -23,6 +23,7 @@ export const graphqlPostRelationQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiPostRelationOutput {

--- a/packages/lesswrong/server/collections/posts/queries.ts
+++ b/packages/lesswrong/server/collections/posts/queries.ts
@@ -23,6 +23,7 @@ export const graphqlPostQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiPostOutput {

--- a/packages/lesswrong/server/collections/reports/queries.ts
+++ b/packages/lesswrong/server/collections/reports/queries.ts
@@ -23,6 +23,7 @@ export const graphqlReportQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiReportOutput {

--- a/packages/lesswrong/server/collections/reviewVotes/queries.ts
+++ b/packages/lesswrong/server/collections/reviewVotes/queries.ts
@@ -23,6 +23,7 @@ export const graphqlReviewVoteQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiReviewVoteOutput {

--- a/packages/lesswrong/server/collections/reviewWinnerArts/queries.ts
+++ b/packages/lesswrong/server/collections/reviewWinnerArts/queries.ts
@@ -23,6 +23,7 @@ export const graphqlReviewWinnerArtQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiReviewWinnerArtOutput {

--- a/packages/lesswrong/server/collections/reviewWinners/queries.ts
+++ b/packages/lesswrong/server/collections/reviewWinners/queries.ts
@@ -23,6 +23,7 @@ export const graphqlReviewWinnerQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiReviewWinnerOutput {

--- a/packages/lesswrong/server/collections/revisions/queries.ts
+++ b/packages/lesswrong/server/collections/revisions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlRevisionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiRevisionOutput {

--- a/packages/lesswrong/server/collections/rssfeeds/queries.ts
+++ b/packages/lesswrong/server/collections/rssfeeds/queries.ts
@@ -23,6 +23,7 @@ export const graphqlRSSFeedQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiRSSFeedOutput {

--- a/packages/lesswrong/server/collections/sequences/queries.ts
+++ b/packages/lesswrong/server/collections/sequences/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSequenceQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSequenceOutput {

--- a/packages/lesswrong/server/collections/splashArtCoordinates/queries.ts
+++ b/packages/lesswrong/server/collections/splashArtCoordinates/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSplashArtCoordinateQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSplashArtCoordinateOutput {

--- a/packages/lesswrong/server/collections/spotlights/queries.ts
+++ b/packages/lesswrong/server/collections/spotlights/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSpotlightQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSpotlightOutput {

--- a/packages/lesswrong/server/collections/subscriptions/queries.ts
+++ b/packages/lesswrong/server/collections/subscriptions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSubscriptionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSubscriptionOutput {

--- a/packages/lesswrong/server/collections/surveyQuestions/queries.ts
+++ b/packages/lesswrong/server/collections/surveyQuestions/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSurveyQuestionQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSurveyQuestionOutput {

--- a/packages/lesswrong/server/collections/surveyResponses/queries.ts
+++ b/packages/lesswrong/server/collections/surveyResponses/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSurveyResponseQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSurveyResponseOutput {

--- a/packages/lesswrong/server/collections/surveySchedules/queries.ts
+++ b/packages/lesswrong/server/collections/surveySchedules/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSurveyScheduleQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSurveyScheduleOutput {

--- a/packages/lesswrong/server/collections/surveys/queries.ts
+++ b/packages/lesswrong/server/collections/surveys/queries.ts
@@ -23,6 +23,7 @@ export const graphqlSurveyQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiSurveyOutput {

--- a/packages/lesswrong/server/collections/tagFlags/queries.ts
+++ b/packages/lesswrong/server/collections/tagFlags/queries.ts
@@ -23,6 +23,7 @@ export const graphqlTagFlagQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiTagFlagOutput {

--- a/packages/lesswrong/server/collections/tagRels/queries.ts
+++ b/packages/lesswrong/server/collections/tagRels/queries.ts
@@ -23,6 +23,7 @@ export const graphqlTagRelQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiTagRelOutput {

--- a/packages/lesswrong/server/collections/tags/queries.ts
+++ b/packages/lesswrong/server/collections/tags/queries.ts
@@ -23,6 +23,7 @@ export const graphqlTagQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiTagOutput {

--- a/packages/lesswrong/server/collections/typingIndicators/queries.ts
+++ b/packages/lesswrong/server/collections/typingIndicators/queries.ts
@@ -23,6 +23,7 @@ export const graphqlTypingIndicatorQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiTypingIndicatorOutput {

--- a/packages/lesswrong/server/collections/userEAGDetails/queries.ts
+++ b/packages/lesswrong/server/collections/userEAGDetails/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserEAGDetailQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserEAGDetailOutput {

--- a/packages/lesswrong/server/collections/userJobAds/queries.ts
+++ b/packages/lesswrong/server/collections/userJobAds/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserJobAdQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserJobAdOutput {

--- a/packages/lesswrong/server/collections/userMostValuablePosts/queries.ts
+++ b/packages/lesswrong/server/collections/userMostValuablePosts/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserMostValuablePostQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserMostValuablePostOutput {

--- a/packages/lesswrong/server/collections/userRateLimits/queries.ts
+++ b/packages/lesswrong/server/collections/userRateLimits/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserRateLimitQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserRateLimitOutput {

--- a/packages/lesswrong/server/collections/userTagRels/queries.ts
+++ b/packages/lesswrong/server/collections/userTagRels/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserTagRelQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserTagRelOutput {

--- a/packages/lesswrong/server/collections/users/queries.ts
+++ b/packages/lesswrong/server/collections/users/queries.ts
@@ -23,6 +23,7 @@ export const graphqlUserQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiUserOutput {

--- a/packages/lesswrong/server/collections/votes/queries.ts
+++ b/packages/lesswrong/server/collections/votes/queries.ts
@@ -23,6 +23,7 @@ export const graphqlVoteQueryTypeDefs = gql`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type MultiVoteOutput {

--- a/packages/lesswrong/server/scripts/moveMutations.ts
+++ b/packages/lesswrong/server/scripts/moveMutations.ts
@@ -615,6 +615,7 @@ export const ${typeDefsVariableName} = gql\`
     terms: JSON
     resolverArgs: JSON
     enableTotal: Boolean
+    enableCache: Boolean
   }
   
   type ${multiOutputTypeName} {


### PR DESCRIPTION
Should've done a two-stage deploy initially, but alas.

