### PR TITLE
add resolvers for now-required revision fields which might be missing values in denormalized revisions

### DIFF
--- a/packages/lesswrong/lib/collections/revisions/newSchema.ts
+++ b/packages/lesswrong/lib/collections/revisions/newSchema.ts
@@ -141,6 +141,7 @@ const schema = {
       outputType: "String!",
       inputType: "String",
       canRead: ["guests"],
+      resolver: ({ version }) => version ?? '1.0.0',
       validation: {
         optional: true,
       },
@@ -275,6 +276,7 @@ const schema = {
       outputType: "Float!",
       inputType: "Float",
       canRead: ["guests"],
+      resolver: ({ wordCount }) => wordCount ?? 0,
       validation: {
         optional: true,
       },
@@ -399,6 +401,7 @@ const schema = {
       outputType: "Boolean!",
       inputType: "Boolean",
       canRead: ["guests"],
+      resolver: ({ skipAttributions }) => skipAttributions ?? false,
       canUpdate: ["sunshineRegiment", "admins"],
       validation: {
         optional: true,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1209994903350058) by [Unito](https://www.unito.io)
