### PR TITLE
Always show load more for bookmarks

### DIFF
--- a/packages/lesswrong/components/bookmarks/BookmarksList.tsx
+++ b/packages/lesswrong/components/bookmarks/BookmarksList.tsx
@@ -38,6 +38,7 @@ const BookmarksList = ({showMessageIfEmpty=false, limit=20, hideLoadMore=false, 
     fragmentName: "PostsListWithVotes",
     fetchPolicy: "cache-and-network",
     skip: !currentUser?._id,
+    alwaysShowLoadMore: true,
   });
   
   if (!currentUser) return null


### PR DESCRIPTION
Right now when a user has more than 2 pages of bookmarks, they cannot load them all because the way we manually handle limits prevents the loadMore from displaying after being pressed once. This circumvents this issue by just always showing the loadMore, which is a bit sad, but the alternative fixed seemed harder.