### PR TITLE
Re-apply lost theme overrides from MUI migration

### DIFF
--- a/packages/lesswrong/components/widgets/Paper.tsx
+++ b/packages/lesswrong/components/widgets/Paper.tsx
@@ -1,6 +1,7 @@
 import React, { type CSSProperties } from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import classNames from 'classnames';
+import { isLW } from '@/lib/instanceSettings';
 
 const styles = defineStyles("MuiPaper", (theme: ThemeType) => {
   const elevations: Record<string,AnyBecauseHard> = {};
@@ -51,6 +52,10 @@ export const Paper = ({elevation=2, square=false, className, style, children}: {
 const cardStyles = defineStyles("Card", (theme) => ({
   root: {
     overflow: "hidden",
+    ...(isLW && {
+      borderRadius: 1,
+      boxShadow: theme.palette.boxShadow.lwCard,
+    })
   },
 }));
 

--- a/packages/lesswrong/components/widgets/TableCell.tsx
+++ b/packages/lesswrong/components/widgets/TableCell.tsx
@@ -32,8 +32,16 @@ export const styles = defineStyles("TableCell", theme => ({
   /* Styles applied to the root element if `variant="body"` or `context.table.body`. */
   body: {
     color: theme.palette.text.primary,
-    fontSize: "0.8125rem",
     fontWeight: 400,
+    fontSize: 14.3,
+    lineHeight: "19.5px",
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+    marginTop: 0,
+    marginBottom: 0,
+    wordBreak: "normal",
   },
   /* Styles applied to the root element if `variant="footer"` or `context.table.footer`. */
   footer: {

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -243,11 +243,6 @@ export const baseTheme: BaseThemeSpecification = {
         `0px 11px 15px -7px ${palette.boxShadowColor(0.2)},0px 24px 38px 3px ${palette.boxShadowColor(0.14)},0px 9px 46px 8px ${palette.boxShadowColor(0.12)}`,
       ],
       overrides: {
-        MuiButton: {
-          contained: {
-            // TODO: Override color, for which material-UI uses getContrastText() which produces a non-theme color
-          },
-        },
         MuiSelect: {
           selectMenu: {
             paddingLeft: spacingUnit
@@ -261,19 +256,6 @@ export const baseTheme: BaseThemeSpecification = {
             lineHeight: "19.5px",
           }
         },
-        MuiTableCell: {
-          body: {
-            fontSize: 14.3,
-            lineHeight: "19.5px",
-            paddingLeft: 16,
-            paddingRight: 16,
-            paddingTop: 12,
-            paddingBottom: 12,
-            marginTop: 0,
-            marginBottom: 0,
-            wordBreak: "normal",
-          }
-        }
       },
       rawCSS: [
         `@property --top-posts-page-scrim-opacity {

--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -127,12 +127,6 @@ export const lessWrongTheme: SiteThemeSpecification = {
           paddingBottom: 8
         }
       },
-      MuiCard: {
-        root: {
-          borderRadius: 1,
-          boxShadow: palette.boxShadow.lwCard,
-        }
-      }
     }
   }),
 };


### PR DESCRIPTION
Fixes bug introduced in #10694. The symptom I found was the tables in the post analytics page looking off. Before/after of that:
![Screenshot 2025-04-17 at 14 01 04](https://github.com/user-attachments/assets/f4540815-1aa0-4b39-9ffe-182620578715)
![Screenshot 2025-04-17 at 14 02 27](https://github.com/user-attachments/assets/7168e239-6340-47a8-aa46-c1977c7b4436)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210013117918732) by [Unito](https://www.unito.io)
