### PR TITLE
Fix nullability errors on digest edit page

### DIFF
--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -136,7 +136,7 @@ const styles = (theme: ThemeType) => ({
 
 type DigestPlannerPostData = {
   post: PostsListWithVotes,
-  digestPost: DigestPost
+  digestPost: DigestPost | null
   rating: number
 }
 export type PostWithRating = PostsListWithVotes & {rating: number}
@@ -198,7 +198,7 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
   // save the list of all eligible posts, along with their ratings
   const [posts, setPosts] = useState<Array<PostWithRating>>()
   // track the digest status of each post (i.e. whether or not it's in the email and on-site digests)
-  const [postStatuses, setPostStatuses] = useState<Record<string, DigestPost>>({})
+  const [postStatuses, setPostStatuses] = useState<Record<string, Partial<DigestPost>>>({})
   // disable all status icons while processing the previous click
   const [statusIconsDisabled, setStatusIconsDisabled] = useState<boolean>(false)
   // by default, the current user's votes are hidden, but they can click the column header to reveal them
@@ -210,13 +210,13 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     if (!eligiblePosts) return
     
     const newPosts: Array<PostWithRating> = []
-    const newPostStatuses: Record<string,DigestPost> = {}
+    const newPostStatuses: Record<string, Partial<DigestPost>> = {}
     eligiblePosts.forEach(postData => {
       newPosts.push({...postData.post, rating: postData.rating})
       newPostStatuses[postData.post._id] = {
-        _id: postData.digestPost._id,
-        emailDigestStatus: postData.digestPost.emailDigestStatus ?? 'pending',
-        onsiteDigestStatus: postData.digestPost.onsiteDigestStatus ?? 'pending'
+        _id: postData.digestPost?._id,
+        emailDigestStatus: postData.digestPost?.emailDigestStatus ?? 'pending',
+        onsiteDigestStatus: postData.digestPost?.onsiteDigestStatus ?? 'pending'
       }
     })
     // sort the list by curated, then suggested for curation, then rating, then karma
@@ -257,7 +257,8 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     }
     setEmailDigestFilter(newFilter)
   }
-  
+
+  /*
   const handleUpdateOnsiteDigestFilter = (val: InDigestStatusOption) => {
     let newFilter = [...onsiteDigestFilter]
     if (newFilter.includes(val)) {
@@ -267,7 +268,8 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     }
     setOnsiteDigestFilter(newFilter)
   }
-  
+  */
+
   const resetFilters = () => {
     setEmailDigestFilter([...DIGEST_STATUS_OPTIONS])
     setOnsiteDigestFilter([...DIGEST_STATUS_OPTIONS])
@@ -339,7 +341,7 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
   const copyDigestToClipboard = async () => {
     if (!posts) return
     
-    const digestPosts = posts.filter(p => ['yes','maybe'].includes(postStatuses[p._id].emailDigestStatus))
+    const digestPosts = posts.filter(p => ['yes','maybe'].includes(postStatuses[p._id].emailDigestStatus ?? ""))
     // sort the "yes" posts to be listed before the "maybe" posts
     digestPosts.sort((a, b) => {
       const aYes = postStatuses[a._id].emailDigestStatus === 'yes'
@@ -391,8 +393,11 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
 
     // filter by selected digest statuses (i.e. whether or not the post is in the email or on-site digest)
     let visiblePosts = posts.filter(post => {
-      return emailDigestFilter.includes(postStatuses[post._id].emailDigestStatus) &&
-        onsiteDigestFilter.includes(postStatuses[post._id].onsiteDigestStatus)
+      const {emailDigestStatus, onsiteDigestStatus} = postStatuses[post._id];
+      return emailDigestStatus &&
+        onsiteDigestStatus &&
+        emailDigestFilter.includes(emailDigestStatus) &&
+        onsiteDigestFilter.includes(onsiteDigestStatus)
     })
     // then filter by the selected tag
     if (tagFilter) {
@@ -407,7 +412,8 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     if (!posts) return null
     // build a set of all eligible posts filtered by tag and on-site digest status
     let postSet = posts.filter(post => {
-      return onsiteDigestFilter.includes(postStatuses[post._id].onsiteDigestStatus)
+      const {onsiteDigestStatus} = postStatuses[post._id];
+      return onsiteDigestStatus && onsiteDigestFilter.includes(onsiteDigestStatus)
     })
     if (tagFilter) {
       postSet = postSet.filter(post => post.tags.find(tag => tag._id === tagFilter))
@@ -419,7 +425,8 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     if (!posts) return null
     // build a set of all eligible posts filtered by tag and email digest status
     let postSet = posts.filter(post => {
-      return emailDigestFilter.includes(postStatuses[post._id].emailDigestStatus)
+      const {emailDigestStatus} = postStatuses[post._id];
+      return emailDigestStatus && emailDigestFilter.includes(emailDigestStatus)
     })
     if (tagFilter) {
       postSet = postSet.filter(post => post.tags.find(tag => tag._id === tagFilter))
@@ -431,8 +438,11 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
     if (!coreAndPopularTags || !posts) return null
     // build a set of all elible posts filtered by status
     const postSet = posts.filter(post => {
-      return emailDigestFilter.includes(postStatuses[post._id].emailDigestStatus) &&
-        onsiteDigestFilter.includes(postStatuses[post._id].onsiteDigestStatus)
+      const {emailDigestStatus, onsiteDigestStatus} = postStatuses[post._id];
+      return emailDigestStatus &&
+        emailDigestFilter.includes(emailDigestStatus) &&
+        onsiteDigestStatus &&
+        onsiteDigestFilter.includes(onsiteDigestStatus);
     })
     return coreAndPopularTags.reduce((prev: Record<string, SettingsOption>, next) => {
       prev[next._id] = {label: `${next.name} (${postSet.filter(p => p.tags.some(t => t._id === next._id)).length})`}

--- a/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigest.tsx
@@ -305,6 +305,8 @@ const EditDigest = ({classes}: {classes: ClassesType<typeof styles>}) => {
       case 'pending':
         newStatus = 'yes'
         break
+      default:
+        break;
     }
     newPostStatuses[postId][statusField] = newStatus
     

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
@@ -189,7 +189,7 @@ const EditDigestTableRow = ({post, postStatus, statusIconsDisabled, handleClickS
       case 'no':
         iconNode = <CloseIcon />
         break
-      case 'pending':
+      default:
         iconNode = <CheckIcon /> // this has opacity: 0, it's just here to appear on hover
         break
     }

--- a/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
+++ b/packages/lesswrong/components/ea-forum/digest/EditDigestTableRow.tsx
@@ -161,7 +161,7 @@ const voteToIcon = (post: PostsListWithVotes): React.ReactNode => {
 
 const EditDigestTableRow = ({post, postStatus, statusIconsDisabled, handleClickStatusIcon, visibleTagIds, setTagFilter, votesVisible, classes}: {
   post: PostWithRating,
-  postStatus: DigestPost,
+  postStatus: Partial<DigestPost>,
   statusIconsDisabled: boolean,
   handleClickStatusIcon: (postId: string, statusField: StatusField) => void,
   visibleTagIds: string[],
@@ -176,7 +176,7 @@ const EditDigestTableRow = ({post, postStatus, statusIconsDisabled, handleClickS
   /**
    * Build the cell with the given status icon
    */
-  const getStatusIconCell = (postId: string, statusField: StatusField, postStatus: DigestPost) => {
+  const getStatusIconCell = (postId: string, statusField: StatusField, postStatus: Partial<DigestPost>) => {
     const status = postStatus[statusField]
     let iconNode = null
     switch (status) {

--- a/packages/lesswrong/lib/collections/digests/helpers.ts
+++ b/packages/lesswrong/lib/collections/digests/helpers.ts
@@ -82,14 +82,19 @@ export const getEmailDigestPostListData = (posts: PostsListWithVotes[]) => {
  */
 export const getStatusFilterOptions = ({posts, postStatuses, statusFieldName}: {
   posts: PostsListBase[],
-  postStatuses: Record<string, DigestPost>,
+  postStatuses: Record<string, Partial<DigestPost>>,
   statusFieldName: StatusField
 }) => {
   // count how many posts have each status, to be displayed in the labels
   const counts: Record<string, number> = {}
   DIGEST_STATUS_OPTIONS.forEach(option => counts[option] = 0)
-  posts.forEach(p => counts[postStatuses[p._id][statusFieldName]]++)
-  
+  posts.forEach(p => {
+    const status = postStatuses[p._id][statusFieldName];
+    if (status) {
+      counts[status]++
+    }
+  })
+
   const options: Record<string, SettingsOption> = {}
   DIGEST_STATUS_OPTIONS.forEach((option: InDigestStatusOption) => {
     options[option] = {label: `${capitalize(option)} (${counts[option]})`}

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -292,11 +292,13 @@ export const postGqlQueries = {
 
       return {
         post,
-        digestPost: {
-          _id: post.digestPostId,
-          emailDigestStatus: post.emailDigestStatus,
-          onsiteDigestStatus: post.onsiteDigestStatus
-        },
+        digestPost: post.digestPostId
+          ? {
+            _id: post.digestPostId,
+            emailDigestStatus: post.emailDigestStatus,
+            onsiteDigestStatus: post.onsiteDigestStatus
+          }
+          : null,
         rating: 0
       }
     })


### PR DESCRIPTION
The backend can return null for digest post ids, but the frontend assumed they were always defined. The recent refactors turned this into a graphql error, and fixing this led to an avalanche of type errors that needed to be fixed as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210055564821419) by [Unito](https://www.unito.io)
