### PR TITLE
[EA] Fix missing MUI padding

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -54,7 +54,7 @@ const styles = (theme: ThemeType) => ({
         paddingLeft: 16,
         paddingRight: 16,
       } : {
-        padding: 16,
+        padding: "10px 16px",
       }
     ),
     display: "flex",

--- a/packages/lesswrong/components/dropdowns/DropdownDivider.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownDivider.tsx
@@ -5,7 +5,7 @@ import { isFriendlyUI } from "../../themes/forumTheme";
 
 const styles = (_theme: ThemeType) => ({
   root: {
-    margin: isFriendlyUI ? `6px 0` : undefined,
+    margin: isFriendlyUI ? `6px 0 !important` : undefined,
   },
 });
 


### PR DESCRIPTION
Fixes several places where padding has been broken by recent MUI refactors:

<img width="273" alt="Screenshot 2025-04-23 at 11 41 54 2" src="https://github.com/user-attachments/assets/1c0a0b3a-2c63-4dc3-8314-4f8c938f3001" />
<img width="321" alt="Screenshot 2025-04-23 at 11 42 22" src="https://github.com/user-attachments/assets/cb740e43-a6ff-426e-b40f-80b3c1d5a5a3" />
<img width="244" alt="Screenshot 2025-04-23 at 11 41 54" src="https://github.com/user-attachments/assets/7b2c6965-8b18-48ae-92d6-16dc5eb64deb" />


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210055828618358) by [Unito](https://www.unito.io)
