### PR TITLE
[EA] Make posts always fill full width

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -275,7 +275,7 @@ export const styles = (theme: ThemeType) => ({
   },
   postBody: {
     ...(isFriendlyUI && {
-      width: "max-content",
+      width: "100%",
     }),
   },
   audioPlayerHidden: {


### PR DESCRIPTION
Before/after:
![Screenshot 2025-04-23 at 16 03 56](https://github.com/user-attachments/assets/12a931ed-058c-40f2-9105-02e16d59be98)
![Screenshot 2025-04-23 at 16 03 39](https://github.com/user-attachments/assets/e6b5193b-363d-4314-afad-8b6f43ae1add)

The acute motivation for this is that I expect some people will create posts containing only polls, in which case we want them to fill out the full space

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210058520720442) by [Unito](https://www.unito.io)
