### PR TITLE
Fix ultrafeed back navigation AND improve post title modal behavior

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { useQuery, gql, ObservableQuery } from '@apollo/client';
+import { useQuery, gql, ObservableQuery, WatchQueryFetchPolicy } from '@apollo/client';
 import { useOnPageScroll } from './withOnPageScroll';
 import { isClient } from '../../lib/executionEnvironment';
 import { useOrderPreservingArray } from '../hooks/useOrderPreservingArray';
@@ -121,6 +121,9 @@ const MixedTypeFeed = (args: {
 
   // Distance from bottom of viewport to trigger loading more items
   loadMoreDistanceProp?: number,
+
+  // Apollo fetch policy
+  fetchPolicy?: WatchQueryFetchPolicy;
 }) => {
   const {
     resolverName,
@@ -138,6 +141,7 @@ const MixedTypeFeed = (args: {
     disableLoadMore,
     className,
     loadMoreDistanceProp = defaultLoadMoreDistance,
+    fetchPolicy = "cache-and-network",
   } = args;
 
   // Reference to a bottom-marker used for checking scroll position.
@@ -160,7 +164,7 @@ const MixedTypeFeed = (args: {
       offset: 0,
       limit: firstPageSize,
     },
-    fetchPolicy: "cache-and-network",
+    fetchPolicy,
     nextFetchPolicy: "cache-only",
     ssr: true,
   });

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -239,6 +239,7 @@ const UltraFeedContent = () => {
                 refetchRef={refetchSubscriptionContentRef}
                 resolverArgsValues={{ sessionId, settings: JSON.stringify(settings) }}
                 loadMoreDistanceProp={1000}
+                fetchPolicy="cache-first"
                 renderers={{
                   feedCommentThread: {
                     fragmentName: 'FeedCommentThreadFragment',

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -147,8 +147,6 @@ const UltraFeedPostItemHeader = ({
         {postTitlesAreModals ? (
           <a
             href={postGetPageUrl(post)}
-            target="_blank"
-            rel="noopener noreferrer"
             onClick={handleTitleClick}
             className={classnames(classes.title, { [classes.titleIsRead]: isRead })}
           >

--- a/packages/lesswrong/components/ultraFeed/UltraFeedSettings.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedSettings.tsx
@@ -159,7 +159,7 @@ type AlgorithmFieldValidationRules = Pick<UltraFeedSettingsType,
   'quickTakeBoost'
 >;
 
-type FormValuesState = Omit<UltraFeedSettingsType, 'lineClampNumberOfLines' | 'postTruncationBreakpoints' | 'commentTruncationBreakpoints' | 'sourceWeights' | 'commentDecayFactor' | 'commentDecayBiasHours' | 'ultraFeedSeenPenalty' | 'quickTakeBoost' | 'incognitoMode' | 'threadScoreAggregation' | 'threadScoreFirstN'> & {
+type FormValuesState = Omit<UltraFeedSettingsType, 'lineClampNumberOfLines' | 'postTruncationBreakpoints' | 'commentTruncationBreakpoints' | 'sourceWeights' | 'commentDecayFactor' | 'commentDecayBiasHours' | 'ultraFeedSeenPenalty' | 'quickTakeBoost' | 'incognitoMode' | 'threadScoreAggregation' | 'threadScoreFirstN' | 'postTitlesAreModals'> & {
   lineClampNumberOfLines: number | '';
   postTruncationBreakpoints: (number | '')[];
   commentTruncationBreakpoints: (number | '')[];
@@ -171,13 +171,14 @@ type FormValuesState = Omit<UltraFeedSettingsType, 'lineClampNumberOfLines' | 'p
   incognitoMode: boolean;
   threadScoreAggregation: 'sum' | 'max' | 'logSum' | 'avg';
   threadScoreFirstN: number | '';
+  postTitlesAreModals: boolean;
 };
 
 const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, onClose }: UltraFeedSettingsComponentProps) => {
   const { captureEvent } = useTracking();
   const classes = useStyles(styles);
   const [formValues, setFormValues] = useState<FormValuesState>(() => { 
-    const { lineClampNumberOfLines, postTruncationBreakpoints, commentTruncationBreakpoints, commentDecayFactor, commentDecayBiasHours, ultraFeedSeenPenalty, quickTakeBoost, incognitoMode, threadScoreAggregation, threadScoreFirstN } = settings;
+    const { lineClampNumberOfLines, postTruncationBreakpoints, commentTruncationBreakpoints, commentDecayFactor, commentDecayBiasHours, ultraFeedSeenPenalty, quickTakeBoost, incognitoMode, threadScoreAggregation, threadScoreFirstN, postTitlesAreModals } = settings;
 
     // Ensure arrays have length 3
     const ensureLength3 = (arr: (number | '')[]) => {
@@ -200,6 +201,7 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
       incognitoMode,
       threadScoreAggregation,
       threadScoreFirstN,
+      postTitlesAreModals,
     };
   });
 
@@ -230,6 +232,7 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
       incognitoMode: settings.incognitoMode,
       threadScoreAggregation: settings.threadScoreAggregation,
       threadScoreFirstN: settings.threadScoreFirstN,
+      postTitlesAreModals: settings.postTitlesAreModals,
     });
   }, [settings]);
 
@@ -250,6 +253,7 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
       incognitoMode: false,
       threadScoreAggregation: false,
       threadScoreFirstN: false,
+      postTitlesAreModals: false,
     }
   });
 
@@ -384,7 +388,7 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
     }
   }, []);
 
-  const handleBooleanChange = useCallback((key: 'incognitoMode', checked: boolean) => {
+  const handleBooleanChange = useCallback((key: 'incognitoMode' | 'postTitlesAreModals', checked: boolean) => {
     setFormValues(prev => ({ ...prev, [key]: checked }));
   }, []);
 
@@ -411,7 +415,8 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
            errors.commentDecayBiasHours ||
            errors.ultraFeedSeenPenalty ||
            errors.quickTakeBoost ||
-           errors.threadScoreFirstN;
+           errors.threadScoreFirstN ||
+           errors.postTitlesAreModals;
   }, [errors, formValues.sourceWeights]);
 
   const handleSave = useCallback(() => {
@@ -537,6 +542,7 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
     validatedValues.threadScoreAggregation = formValues.threadScoreAggregation;
 
     validatedValues.incognitoMode = formValues.incognitoMode;
+    validatedValues.postTitlesAreModals = formValues.postTitlesAreModals;
 
     if (hasValidationErrors) {
       return; 
@@ -575,6 +581,9 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
     }
     if (validatedValues.threadScoreFirstN !== undefined) {
       finalSettingsToUpdate.threadScoreFirstN = validatedValues.threadScoreFirstN;
+    }
+    if (validatedValues.postTitlesAreModals !== undefined) {
+      finalSettingsToUpdate.postTitlesAreModals = validatedValues.postTitlesAreModals;
     }
 
     if (Object.keys(finalSettingsToUpdate).length > 0) {
@@ -840,6 +849,25 @@ const UltraFeedSettings = ({ settings, updateSettings, resetSettingsToDefault, o
         </div>
         <p className={classes.inputDescription} style={{paddingLeft: 0}}>
           When enabled, no history (servings, views, expansions, etc.) is recorded for your account.
+        </p>
+      </div>
+      
+      <div className={classes.settingGroup}>
+        <h3 className={classes.groupTitle}>UI Preferences</h3>
+        <div className={classes.inputContainer} style={{flexWrap: 'nowrap'}}> 
+          <input 
+            type="checkbox" 
+            id="postTitlesAreModalsCheckbox" 
+            checked={formValues.postTitlesAreModals}
+            onChange={(e) => handleBooleanChange('postTitlesAreModals', e.target.checked)}
+            style={{marginRight: '8px'}}
+          />
+          <label htmlFor="postTitlesAreModalsCheckbox" className={classes.inputLabel} style={{flex: '1 1 auto', cursor: 'pointer'}}>
+            Open post titles in modal on click
+          </label>
+        </div>
+        <p className={classes.inputDescription} style={{paddingLeft: 0}}>
+          If checked, clicking a post title opens it in a modal. If unchecked, it navigates directly to the post page like a normal link. Right-click/Cmd-click behavior is unaffected.
         </p>
       </div>
       

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -16,6 +16,7 @@ export interface UltraFeedSettingsType {
   incognitoMode: boolean;
   threadScoreAggregation: 'sum' | 'max' | 'logSum' | 'avg';
   threadScoreFirstN: number;
+  postTitlesAreModals: boolean;
 }
 
 export const DEFAULT_SOURCE_WEIGHTS: Record<FeedItemSourceType, number> = {
@@ -38,6 +39,7 @@ export const DEFAULT_SETTINGS: UltraFeedSettingsType = {
   incognitoMode: false,
   threadScoreAggregation: 'logSum',
   threadScoreFirstN: 0,
+  postTitlesAreModals: true,
 };
 
 export const ULTRA_FEED_SETTINGS_KEY = 'ultraFeedSettings'; 

--- a/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
+++ b/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
@@ -7025,6 +7025,7 @@ input UpdateUserDataInput {
   groups: [String!]
   theme: JSON
   lastUsedTimezone: String
+  whenConfirmationEmailSent: Date
   legacy: Boolean
   commentSorting: String
   sortDraftsBy: String

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -4140,6 +4140,7 @@ interface UpdateUserDataInput {
   groups?: Array<string> | null;
   theme?: any;
   lastUsedTimezone?: string | null;
+  whenConfirmationEmailSent?: Date | null;
   legacy?: boolean | null;
   commentSorting?: string | null;
   sortDraftsBy?: string | null;


### PR DESCRIPTION
- change network policy to avoid refreshing ultrafeed on navigate and back
- post titles can still be right- and middle-clicked even when being buttons for opening modals
- post titles opening modals now has a setting

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210087018151869) by [Unito](https://www.unito.io)
