### PR TITLE
Rewrite Snackbar animation/timers to avoid spurious rerenders

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
@@ -7,6 +7,7 @@ import { DialogTitle } from "@/components/widgets/DialogTitle";
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import TextField from '@/lib/vendor/@material-ui/core/src/TextField';
 import { DialogActions } from '../widgets/DialogActions';
+import { WithMessagesFunctions } from '../common/FlashMessages';
 
 const styles = (theme: ThemeType) => ({
   modalTextField: {
@@ -18,7 +19,7 @@ interface ExternalProps {
   onClose: any,
 }
 
-interface AFApplicationFormProps extends ExternalProps, WithMessagesProps, WithStylesProps, WithUpdateCurrentUserProps {
+interface AFApplicationFormProps extends ExternalProps, WithMessagesFunctions, WithStylesProps, WithUpdateCurrentUserProps {
 }
 interface AFApplicationFormState {
   applicationText: string,

--- a/packages/lesswrong/components/common/FlashMessages.tsx
+++ b/packages/lesswrong/components/common/FlashMessages.tsx
@@ -1,105 +1,188 @@
-import React, { useState, useCallback, ReactNode, useMemo } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
-import { MessageContext, useMessages } from './withMessages';
+import React, { useState, useCallback, ReactNode, useMemo, useContext, type ReactElement, useEffect } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import { MessageFunctionsContext } from './withMessages';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { Snackbar } from '../widgets/Snackbar';
-import { SnackbarContent } from '../widgets/SnackbarContent';
+import { defineStyles, useStyles } from '../hooks/useStyles';
+import { Paper } from '../widgets/Paper';
+import { isFriendlyUI } from '@/themes/forumTheme';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("FlashMessages", (theme) => ({
   root: {
   },
-});
+  paper: {
+    backgroundColor: theme.palette.panelBackground.default,
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    padding: '6px 24px',
+    [theme.breakpoints.up('md')]: {
+      minWidth: 288,
+      maxWidth: 568,
+      borderRadius: 4,
+    },
+    [theme.breakpoints.down('sm')]: {
+      flexGrow: 1,
+    },
+  },
+  message: {
+    padding: '8px 0',
+    color: theme.palette.text.maxIntensity,
+    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+  },
+  action: {
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: 'auto',
+    paddingLeft: 24,
+    marginRight: -8,
+  },
+}));
+
+const messageExpirationTime = 6000
+const closeAnimationDelay = 500;
+
+export type WithMessagesMessage = string|{
+  messageString?: string|ReactElement,
+  type?: "success"|"error"|"failure",
+  action?: () => void
+  actionName?: string
+};
+
+export interface WithMessagesFunctions {
+  flash: (message: WithMessagesMessage) => void,
+  clear: () => void,
+  tick: () => void,
+}
+
+type MessagesState = {
+  messages: WithMessagesMessage[]
+  expiryTimer: ReturnType<typeof setTimeout>|null
+  animationState: "opening"|"open"|"closing"|"closed"
+};
+
+const MessagesStateContext = React.createContext<MessagesState|null>(null);
 
 export const MessageContextProvider = ({children}: {
   children: ReactNode
 }) => {
-  const [messages,setMessages] = useState<AnyBecauseTodo[]>([]);
+  const [messages,setMessages] = useState<MessagesState>(() => ({
+    messages: [],
+    expiryTimer: null,
+    animationState: "closed",
+  }));
+  
+  const clear = useCallback(() => {
+    setMessages(messages => {
+      if (messages.expiryTimer) {
+        clearTimeout(messages.expiryTimer);
+      }
+      if (messages.animationState === "closing") {
+        return {
+          messages: [],
+          expiryTimer: null,
+          animationState: "closed",
+        };
+      } else {
+        return {
+          messages: messages.messages,
+          expiryTimer: setTimeout(clear, closeAnimationDelay),
+          animationState: "closing",
+        }
+      }
+    });
+  }, []);
   
   const flash = useCallback((message: WithMessagesMessage) => {
-    if (!messages.length) {
-      setMessages([message])
-    } else {
-      // Show the transition for clearing the old message, then pop up the new one
-      setMessages(messages.map((message: AnyBecauseTodo) => ({...message, hide:true})));
-      setTimeout(() => {
-        setMessages([message]);
-      }, 500);
-    }
-  }, [messages]);
+    setMessages(messages => {
+      if (messages.expiryTimer) {
+        clearTimeout(messages.expiryTimer);
+      }
+      return {
+        messages: [
+          ...messages.messages,
+          message
+        ],
+        expiryTimer: setTimeout(clear, messageExpirationTime),
+        animationState: messages.animationState === "closed" ? "opening" : "open",
+      };
+    });
+  }, [clear]);
 
-  const clear = useCallback(() => {
-    setMessages(messages.map((message: AnyBecauseTodo) => ({...message, hide:true})));
-    setTimeout(() => {
-      setMessages([]);
-    }, 500);
-  }, [messages]);
+  const tick = useCallback(() => {
+    setMessages(messages => {
+      if (messages.animationState === "opening") {
+        return {
+          ...messages,
+          animationState: "open",
+        };
+      } else {
+        return messages;
+      }
+    });
+  }, []);
 
   const messagesContext = useMemo(
-    () => ({ messages, flash, clear }),
-    [messages, flash, clear]
+    () => ({ flash, clear, tick }),
+    [flash, clear, tick]
   );
 
-  // FIXME: While this is mostly referentially stable, MessageContext will change
-  // when flash-messages are added or removed. This means that when a flash-message
-  // is added, every component on the page that called useMessages() will rerender,
-  // even if it was intended to be send-only. That includes a lot of components
-  // including vote buttons, so on a page with a lot of comments, this can be
-  // very slow.
-  
-  return <MessageContext.Provider value={messagesContext}>
-    {children}
-  </MessageContext.Provider>
+  return <MessageFunctionsContext.Provider value={messagesContext}>
+    <MessagesStateContext.Provider value={messages}>
+      {children}
+    </MessagesStateContext.Provider>
+  </MessageFunctionsContext.Provider>
 }
 
-const FlashMessages = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
-  const getProperties = (message: WithMessagesMessage) => {
-    if (typeof message === 'string') {
-      // if error is a string, use it as message
-      return {
-        message: message,
-        type: 'error'
-      }
-    } else {
-      // else return full error object after internationalizing message
-      const { messageString } = message;
-      return {
-        ...message,
-        message: messageString,
-      };
+const FlashMessages = () => {
+  const messagesState = useContext(MessagesStateContext);
+  const messagesFunctions = useContext(MessageFunctionsContext);
+  const clear = messagesFunctions?.clear;
+  const tick = messagesFunctions?.tick;
+  const classes = useStyles(styles);
+  const { Typography } = Components;
+
+  useEffect(() => {
+    if (messagesState?.animationState === "opening") {
+      setTimeout(() => tick?.(), 0);
     }
+  }, [messagesState?.animationState, tick]);
+
+  if (!messagesState || messagesState.animationState === "closed") {
+    return null;
   }
 
-  const { messages, clear } = useMessages();
-  let messageObject = messages.length > 0 ? getProperties(messages[0]) : undefined;
   return (
     <div className={classes.root}>
-      <Snackbar
-        // @ts-ignore there is no hide property on the message props!
-        open={!!messageObject && !messageObject.hide}
-        autoHideDuration={6000}
-        onClose={clear}
-      >
-        <SnackbarContent
-          message={messageObject && messageObject.message}
-          action={
-            messageObject?.action &&
-            <Button
-              onClick={messageObject?.action}
-              color="primary"
-            >
-              {/* @ts-ignore there is no actionName property on the message props! */}
-              {messageObject?.actionName || "UNDO"}
-            </Button>
-          }
-        />
+      <Snackbar open={messagesState.animationState==="open"}>
+        <Paper
+          square
+          elevation={6}
+          className={classes.paper}
+        >
+          <Typography variant="body1">
+            {messagesState.messages.map((message,i) => {
+              if(typeof message === 'string') {
+                return message;
+              } else {
+                return <div key={i}>
+                  {message.messageString}
+                  {message.action && <div className={classes.action}>
+                    <Button onClick={message.action}>
+                      {message.actionName ?? "UNDO"}
+                    </Button>
+                  </div>}
+                </div>
+              }
+            })}
+          </Typography>
+        </Paper>
       </Snackbar>
     </div>
   );
 }
 
-const FlashMessagesComponent = registerComponent('FlashMessages', FlashMessages, {styles});
+const FlashMessagesComponent = registerComponent('FlashMessages', FlashMessages);
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/common/hocTypes.ts
+++ b/packages/lesswrong/components/common/hocTypes.ts
@@ -1,6 +1,5 @@
 import type { FetchResult } from '@apollo/client';
 import { RouterLocation } from '../../lib/vulcan-lib/routes';
-import { ReactElement } from 'react';
 import type { JssStylesCallback } from '@/lib/jssStyles';
 
 declare global {
@@ -14,14 +13,6 @@ type ClassesType<
 
 interface WithStylesProps {
   classes: ClassesType<AnyStyles>,
-}
-
-type WithMessagesMessage = string|{id?: string, properties?: any, messageString?: string|ReactElement, type?: string, action?: any};
-
-interface WithMessagesProps {
-  messages: Array<WithMessagesMessage>,
-  flash: (message: WithMessagesMessage) => void,
-  clear: () => void,
 }
 
 interface WithUserProps {

--- a/packages/lesswrong/components/common/withMessages.ts
+++ b/packages/lesswrong/components/common/withMessages.ts
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react';
 import { hookToHoc } from '../../lib/hocUtils';
+import { WithMessagesFunctions } from './FlashMessages';
 
-export const MessageContext = React.createContext<WithMessagesProps|null>(null);
+export const MessageFunctionsContext = React.createContext<WithMessagesFunctions|null>(null);
 
 // Hook/HoC that provides access to flash messages stored in context
-export const useMessages = (): WithMessagesProps => useContext(MessageContext)!;
+export const useMessages = (): WithMessagesFunctions => useContext(MessageFunctionsContext)!;
 export const withMessages = hookToHoc(useMessages);
 export default withMessages;

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -12,6 +12,7 @@ import LibraryAddIcon from '@/lib/vendor/@material-ui/icons/src/LibraryAdd';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { pickBestReverseGeocodingResult } from '../../lib/geocoding';
 import { useGoogleMaps } from '../form-components/LocationFormComponent';
+import { WithMessagesFunctions } from '../common/FlashMessages';
 
 const styles = (theme: ThemeType) => ({
   link: {
@@ -30,7 +31,7 @@ const styles = (theme: ThemeType) => ({
 
 interface ExternalProps {
 }
-interface CommunityHomeProps extends ExternalProps, WithMessagesProps, WithLocationProps, WithDialogProps {
+interface CommunityHomeProps extends ExternalProps, WithMessagesFunctions, WithLocationProps, WithDialogProps {
 }
 interface CommunityHomeState {
   currentUserLocation: any,

--- a/packages/lesswrong/components/widgets/Snackbar.tsx
+++ b/packages/lesswrong/components/widgets/Snackbar.tsx
@@ -12,25 +12,26 @@ export const styles = defineStyles("MuiSnackbar", theme => ({
     right: 0,
     justifyContent: 'center',
     alignItems: 'center',
-    transition: 'transform 0.4s ease-in-out, opacity 0.4s ease-in-out',
-
+    bottom: 0,
+  },
+  snackbar: {
+    transition: 'transform .4s ease-in-out',
     bottom: 0,
     [theme.breakpoints.up('md')]: {
       left: '50%',
       right: 'auto',
-      transform: 'translateX(-50%)',
     },
   },
   enter: {
     transform: 'translateY(0)',
     [theme.breakpoints.up('md')]: {
-      transform: 'translateX(-50%) translateY(0)',
+      transform: 'translateY(0)',
     },
   },
   exit: {
-    transform: 'translateY(100%)',
+    transform: 'translateY(50px)',
     [theme.breakpoints.up('md')]: {
-      transform: 'translateX(-50%) translateY(100%)',
+      transform: 'translateY(50px)',
     },
   },
 }));
@@ -38,103 +39,28 @@ export const styles = defineStyles("MuiSnackbar", theme => ({
 // Derived from material-UI Snackbar
 
 export const Snackbar = (props: {
-  autoHideDuration: number,
   className?: string,
-  onClose: () => void,
   open: boolean,
-  resumeHideDuration?: number,
   children: React.ReactNode,
 }) => {
   const classes = useStyles(styles);
   const {
-    autoHideDuration,
     children,
     className,
-    onClose,
     open,
-    resumeHideDuration,
   } = props;
 
-  const autoHideTimer = useRef<ReturnType<typeof setTimeout>|null>(null);
-
-  // Timer that controls delay before snackbar auto hides
-  const setAutoHideTimer = useCallback((autoHideDuration?: number) => {
-    const autoHideDurationBefore = autoHideDuration ?? props.autoHideDuration;
-
-    if (!onClose || autoHideDurationBefore == null) {
-      return -1;
-    }
-
-    if (autoHideTimer.current) {
-      clearTimeout(autoHideTimer.current);
-    }
-    autoHideTimer.current = setTimeout(() => {
-      const autoHideDurationAfter = autoHideDuration ?? props.autoHideDuration;
-      if (!onClose || autoHideDurationAfter == null) {
-        return;
-      }
-
-      onClose();
-    }, autoHideDurationBefore);
-  }, [onClose, props.autoHideDuration]);
-
-  const handleMouseEnter = (event: React.MouseEvent) => {
-    handlePause();
-  };
-
-  const handleMouseLeave = (event: React.MouseEvent) => {
-    handleResume();
-  };
-
-  // Pause the timer when the user is interacting with the Snackbar
-  // or when the user hide the window.
-  const handlePause = useCallback(() => {
-    if (autoHideTimer.current) {
-      clearTimeout(autoHideTimer.current);
-      autoHideTimer.current = null;
-    }
-  }, []);
-
-  // Restart the timer when the user is no longer interacting with the Snackbar
-  // or when the window is shown back.
-  const handleResume = useCallback(() => {
-    if (autoHideDuration != null) {
-      if (resumeHideDuration != null) {
-        setAutoHideTimer(resumeHideDuration);
-        return;
-      }
-      setAutoHideTimer(autoHideDuration * 0.5);
-    }
-  }, [autoHideDuration, resumeHideDuration, setAutoHideTimer]);
-
-  useEffect(() => {
-    setAutoHideTimer();
-    return () => {
-      handlePause();
-    };
-  }, [open, setAutoHideTimer, handlePause]);
-
-  useEffect(() => {
-    window.addEventListener("focus", handleResume);
-    window.addEventListener("blur", handlePause);
-  }, [handlePause, handleResume]);
-
-  // So we only render active snackbars.
-  if (!open) {
-    return null;
-  }
-  
   return (
     <div
-      className={classNames(
-        classes.root,
-        open ? classes.enter : classes.exit,
-        className,
-      )}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      className={classes.root}
     >
-      {children}
+      <div className={classNames(
+        classes.snackbar,
+        open ? classes.enter : classes.exit,
+        className
+      )}>
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes an issue introduced by material-UI refactoring, where the timer that closes the messages snackbar causes rerendering of the page, even when the snackbar isn't open.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210095012052351) by [Unito](https://www.unito.io)
