### PR TITLE
[EA] Hotfix for broken subforum pages

### DIFF
--- a/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
@@ -108,7 +108,7 @@ const SubforumSubforumTab = ({
   // if no sort order was selected, try to use the tag page's default sort order for posts
   const sortBy: CommentSortingMode = (
     (sortByOptions.includes(query.sortedBy) && query.sortedBy)
-    || (tag.postsDefaultSortOrder && sortByOptions.includes(tag.postsDefaultSortOrder))
+    || (sortByOptions.includes(tag.postsDefaultSortOrder ?? '') && tag.postsDefaultSortOrder)
     || defaultSubforumSorting
   ) as CommentSortingMode;
   


### PR DESCRIPTION
Introduced here: https://github.com/ForumMagnum/ForumMagnum/commit/3814cb88219c20caf7bb90ec8f7a811016ced4f6#diff-60330ed47a029f73ab3e90855b949280e3686de0b3452282953e7465c980d35f

Subforums on the EA Forum now means the pages for the core topics, which are more focused on new posts than on the wiki article.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210102340130666) by [Unito](https://www.unito.io)
