### PR TITLE
[EA] Change from 9 to 10 buckets per side on polls to make agree % more readable

### DIFF
--- a/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
+++ b/packages/lesswrong/components/forumEvents/ForumEventPoll.tsx
@@ -25,7 +25,7 @@ const SLIDER_MAX_WIDTH = 1120;
 const RESULT_ICON_MAX_HEIGHT = 27;
 const USER_IMAGE_SIZE = 30;
 const DEFAULT_STACK_IMAGES = 20;
-const NUM_TICKS = 19;
+const NUM_TICKS = 21;
 const GAP = "calc(0.6% + 4px)" // Accounts for 2px outline
 
 const styles = (theme: ThemeType) => ({


### PR DESCRIPTION
Based on the suggestion from Will A [here](https://forum.effectivealtruism.org/posts/pAYSK7voaNeDRDFCs/diy-debate-week-april-28-may-4th?commentId=G7C2AgpCFNEvhRMrv)