### PR TITLE
Fix missing numbering of footnote side-items when post is Markdown and uses [^N] syntax

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -351,7 +351,8 @@ function getFootnoteIndex(href: string, html: string): string|null {
   // This prevents using the version of the footnote from within quick-switch edit form that has a div parent instead of an ol
   const footnoteWithOlParent = allMatchingElements.find(el => 
     el.parentElement?.tagName === 'OL' &&
-    el.parentElement.classList.contains('footnotes')
+    (el.parentElement.classList.contains('footnotes')
+      || el.parentElement.classList.contains('footnotes-list'))
   );
   
   if (footnoteWithOlParent) {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210212055377332) by [Unito](https://www.unito.io)
