### PR TITLE
Prevent apollo-client from double-fetching queries that are in the preloaded cache after SSR

### DIFF
--- a/packages/lesswrong/client/apolloClient.ts
+++ b/packages/lesswrong/client/apolloClient.ts
@@ -10,5 +10,6 @@ export const createApolloClient = (baseUrl = '/'): ApolloClient<NormalizedCacheO
   return new ApolloClient({
     link: ApolloLink.from([headerLink, createErrorLink(), createHttpLink(baseUrl)]),
     cache,
+    ssrForceFetchDelay: 1,
   });
 };

--- a/packages/lesswrong/client/start.tsx
+++ b/packages/lesswrong/client/start.tsx
@@ -11,9 +11,7 @@ export function hydrateClient() {
   populateComponentsAppDebug();
   initServerSentEvents();
   const apolloClient = createApolloClient();
-  apolloClient.disableNetworkFetches = true;
   const foreignApolloClient = createApolloClient(fmCrosspostBaseUrlSetting.get() ?? "/");
-  foreignApolloClient.disableNetworkFetches = true;
 
   // Create the root element, if it doesn't already exist.
   if (!document.getElementById('react-app')) {
@@ -41,8 +39,6 @@ export function hydrateClient() {
     <Main />,
   );
   setTimeout(() => {
-    apolloClient.disableNetworkFetches = false;
-    foreignApolloClient.disableNetworkFetches = false;
     // Remove the SSR interaction disable styles (which are only added in E2E
     // tests) - see `apolloServer.ts`
     document.getElementById("ssr-interaction-disable")?.remove();


### PR DESCRIPTION
When you load an SSRed page, there's an apollo-client cache included at the end, containing the results of all queries used in that page, which is used during hydration. We want queries that are in the cache to not then make network requests, even if they have a fetch mode of `cache-and-network` (cache-and-network is a fetch mode that would follow up with a network request, but which is intended for client-side navigation, not for SSR).

In order to prevent unnecessary extra network requests, we set the `disableNetworkFetches` option on apollo-client, and then unset it after hydration. At some point, this stopped working--most likely with the React 19 upgrade, but it might have been earlier. This doesn't slow down the time until the page is displayed, but does waste some bandwidth and server CPU afterwards. This is probably because "being done with hydration" isn't a sharp concept anymore with React being more asynchronous (since React 18).

Fix this by using apollo-client's `ssrForceFetchDelay` option instead, which does approximately the same thing but leaves the details of when to reenable fetching to apollo-client, and which seems to work.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210222089381884) by [Unito](https://www.unito.io)
