### PR TITLE
Pass through the logged-in user's context when adding a new user to a conversation after they send a message

### DIFF
--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -76,7 +76,7 @@ export async function addParticipantIfNew({ document, currentUser, context }: Af
     await updateConversation({
       data: { participantIds: [...conversation.participantIds, currentUser._id] },
       selector: { _id: conversationId }
-    }, createAnonymousContext());
+    }, context);
   }
 }
 

--- a/playwright/crossposts.spec.ts
+++ b/playwright/crossposts.spec.ts
@@ -59,6 +59,10 @@ test("connect crossposting account and create post", async ({browser}) => {
   const newTitle = `Edited test crosspost title ${Math.random()}`;
   const newBody = `Edited test crosspost body ${Math.random()}`;
   await setPostContent(pages[0], {title: newTitle, body: newBody});
+  // There might be some kind of race condition with the title component updating the title value
+  // causing failures like https://github.com/ForumMagnum/ForumMagnum/actions/runs/14984250935/job/42095023479?pr=10840
+  // but we didn't actually figure out exactly what the problem was or if it was at all related.
+  await pages[0].waitForTimeout(1000);
   await pages[0].getByText("Publish changes").click();
 
   // Check the edits were saved locally


### PR DESCRIPTION
Previously, this worked either because we were passing in `currentUser` to the `updateMutator` that updated the conversation, or because we were skipping validation and `flagOrBlockUserOnManyDMs` (which threw an error for me when I sent a message to a conversation I wasn't a participant in) was a validation callback.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210231941863632) by [Unito](https://www.unito.io)
