### PR TITLE
[EA] Add source field to mailchimp signups

### DIFF
--- a/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
@@ -382,6 +382,7 @@ export async function updateMailchimpSubscription(data: UpdateUserDataInput, {ol
           longitude,
         }}),
         merge_fields: {
+          SOURCE: 'EAForum',
           FNAME: data.displayName,
         },
         status: update.status,


### PR DESCRIPTION
We're about to start recording the source of signups on effectivealtruism.org and centreforeffectivealtruism.org, so we should probably do the same on the forum as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210238164152619) by [Unito](https://www.unito.io)
