### PR TITLE
Fix a lib-to-client import

### DIFF
--- a/packages/lesswrong/lib/cookies/callbacks.ts
+++ b/packages/lesswrong/lib/cookies/callbacks.ts
@@ -1,7 +1,7 @@
 import Cookies from "universal-cookie";
-import { initDatadog } from "../../client/datadogRum";
+import { initDatadog } from "@/client/datadogRum";
 import { ALL_COOKIES, CookieType, isCookieAllowed } from "./utils";
-import { initReCaptcha } from "../../client/reCaptcha";
+import { initReCaptcha } from "@/client/reCaptcha";
 
 type CookiePreferencesChangedCallbackProps = {
   cookiePreferences: CookieType[];

--- a/packages/lesswrong/stubs/client/datadogRum.ts
+++ b/packages/lesswrong/stubs/client/datadogRum.ts
@@ -1,4 +1,7 @@
 
+export function initDatadog() {
+}
+
 export function configureDatadogRum() {
 }
 

--- a/packages/lesswrong/stubs/client/reCaptcha.ts
+++ b/packages/lesswrong/stubs/client/reCaptcha.ts
@@ -1,0 +1,3 @@
+
+export function initReCaptcha() {
+}


### PR DESCRIPTION
During unit tests this warning appears:

```
  Datadog Browser SDK: SDK is loaded more than once. This is unsupported and might have unexpected behavior.
```

This happens because lib/cookies/callbacks.ts imports "../../client/datadogRum", using a relative path (rather than @/client), and client/datadogRum imports @datadog/browser-rum, which is a side-effectful import. Fix by converting the ../client imports to @/client, so they get redirected to stubs.

Assigning to CEA to review because, while I don't think this breaks dataog (the file is also imported from `client/clientStartup`), that's maybe be worth testing.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210245009459391) by [Unito](https://www.unito.io)
