### PR TITLE
Pin node version to fix ERR_REQUIRE_ESM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
     "@types/react": "^19.0.0"
   },
   "engines": {
-    "node": "22.x"
+    "node": "22.15.0"
   },
   "knip": {
     "entry": [

--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
     "@types/react": "^19.0.0"
   },
   "engines": {
-    "node": "22.15.0"
+    "node": ">=22.12.0"
   },
   "knip": {
     "entry": [


### PR DESCRIPTION
On node v22.9.0 I was getting this error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/wh/Documents/code/ForumMagnum-vite/node_modules/@stylistic/eslint-plugin-ts/dist/index.js from /Users/wh/Documents/code/ForumMagnum-vite/node_modules/@eslint/eslintrc/dist/eslintrc.cjs not supported.
Instead change the require of index.js in /Users/wh/Documents/code/ForumMagnum-vite/node_modules/@eslint/eslintrc/dist/eslintrc.cjs to a dynamic import() which is available in all CommonJS modules.
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at ConfigArrayFactory._loadPlugin (/Users/wh/Documents/code/ForumMagnum-vite/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3433:42)
    at /Users/wh/Documents/code/ForumMagnum-vite/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3304:33
    at Array.reduce (<anonymous>)
```

This is fixed by upgrading to 22.15.0, and Ollie says 22.12.0 also works, so pinning to that or above

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210252091960014) by [Unito](https://www.unito.io)
