### PR TITLE
Add analytics db SSL setting back in

### DIFF
--- a/packages/lesswrong/server/analytics/postgresConnection.ts
+++ b/packages/lesswrong/server/analytics/postgresConnection.ts
@@ -68,20 +68,20 @@ function getAnalyticsConnectionFromString(connectionString: string | null): Anal
   }
 
   if (!analyticsConnectionPools.get(connectionString)) {
-    // let ssl = sslSetting.get()
-    // if (ssl) {
-    //   const caFilePath = getFullCAFilePath()
-    //   const ca = caFilePath ? fs.readFileSync(caFilePath).toString() : undefined
+    let ssl = sslSetting.get();
+    if (ssl) {
+      const caFilePath = getFullCAFilePath();
+      const ca = caFilePath ? fs.readFileSync(caFilePath).toString() : undefined;
 
-    //   ssl = {
-    //     ...ssl,
-    //     ...(ca && {ca})
-    //   }
-    // }
+      ssl = {
+        ...ssl,
+        ...(ca && { ca })
+      };
+    }
 
     const connectionOptions = {
       connectionString: connectionString,
-      // ...(ssl && {ssl})
+      ...(ssl && { ssl })
     };
 
     analyticsConnectionPools.set(connectionString, pgPromiseLib(connectionOptions));


### PR DESCRIPTION
Unclear why this was removed, but this results in a `no pg_hba.conf entry for host` error for the EA Forum

cc @b0b3rt 