### PR TITLE
fix stale comments on edit

### DIFF
--- a/packages/lesswrong/components/comments/CommentsEditForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsEditForm.tsx
@@ -17,6 +17,7 @@ const CommentsEditForm = ({ comment, successCallback, cancelCallback, className,
     collectionName: 'Comments',
     fragmentName: 'CommentEdit',
     documentId: comment._id,
+    fetchPolicy: 'network-only',
   });
 
   if (loading) {


### PR DESCRIPTION
The recent form refactor forgot to include `fetchPolicy: 'network-only'` in at least one place where users might actually edit the same form more than once without refreshing the page (comments).  This might also be good to include for some other forms, but this is the most critical one (it's already set properly for posts).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210255846236910) by [Unito](https://www.unito.io)
