### PR TITLE
don't strip out the af property if the comment is being submitted while on the alignment forum

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -277,7 +277,7 @@ export const CommentForm = ({
 
         if (formType === 'new') {
           const { af, ...rest } = formApi.state.values;
-          const submitData = showAfCheckbox ? { ...rest, af } : rest;
+          const submitData = (showAfCheckbox || isAF) ? { ...rest, af } : rest;
 
           const { data } = await create({ data: submitData });
           result = data?.createComment.data;


### PR DESCRIPTION
Oops.  I'd previously been stripping out the `af` property from being submitted based on whether we were showing the `af` checkbox on LessWrong, as a proxy for whether users had permission to create/modify that field, but that obviously omitted the case where the comment was being submitted on the AF directly.