### PR TITLE
[EA] Fix messages form styling

### DIFF
--- a/packages/lesswrong/components/messaging/MessagesNewForm.tsx
+++ b/packages/lesswrong/components/messaging/MessagesNewForm.tsx
@@ -32,17 +32,18 @@ const styles = (theme: ThemeType) => ({
     borderRadius: theme.borderRadius.default,
     backgroundColor: theme.palette.grey[100],
     width: "100%",
-    '& .form-section-default': {
-      width: "100%"
-    },
-    '& .form-input': {
-      width: "100%",
-      margin: '2.5px 0 0 0'
-    },
     '& form': {
       display: "flex",
       flexDirection: "row",
-    }
+      alignItems: "flex-end",
+    },
+    '& form > div': {
+      marginTop: '2.5px',
+      marginBottom: '2.5px',
+    },
+    '& form > .form-component-EditorFormComponent': {
+      flexGrow: 1,
+    },
   },
 });
 


### PR DESCRIPTION
Before/after, this was broken at some point in [this](https://github.com/ForumMagnum/ForumMagnum/pull/10845) set of changes:
![Screenshot 2025-05-15 at 13 34 17](https://github.com/user-attachments/assets/fd48d053-3216-4293-b443-50e2fd2b7a98)

![Screenshot 2025-05-15 at 13 40 38](https://github.com/user-attachments/assets/262634de-bf92-495f-a5df-d87149c0e8fd)