### PR TITLE
[EA] Make whenConfirmationEmailSent types forumType-agnostic

### DIFF
--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -670,10 +670,8 @@ const schema = {
     graphql: {
       outputType: "Date",
       canRead: ["members"],
-      // Editing this triggers a verification email, so don't allow editing on instances (like EAF) that don't use email verification
-      canUpdate: verifyEmailsSetting.get()
-        ? [userOwns, 'sunshineRegiment', 'admins']
-        : [],
+      // Setting this will trigger a verification email to be sent (unless `verifyEmailsSetting` is false, in which case it does nothing)
+      canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
       canCreate: ["members"],
       validation: {
         optional: true,

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3698,6 +3698,14 @@ CREATE INDEX IF NOT EXISTS "idx_Votes_collectionName_userId_voteType_cancelled_i
   "votedAt"
 );
 
+-- Index "idx_Votes_userId_collectionName_cancelled_votedAt"
+CREATE INDEX IF NOT EXISTS "idx_Votes_userId_collectionName_cancelled_votedAt" ON "Votes" USING btree (
+  "userId",
+  "collectionName",
+  "cancelled",
+  "votedAt"
+);
+
 -- Index "idx_Votes_documentId"
 CREATE INDEX IF NOT EXISTS "idx_Votes_documentId" ON "Votes" USING btree ("documentId");
 


### PR DESCRIPTION
Running `yarn generate` on EAF was causing `whenConfirmationEmailSent` to be removed from the input type. This was because `canUpdate` depended on `verifyEmailsSetting`.

We already check `verifyEmailsSetting` before sending an email, so removing this doesn't have any effect apart from fixing the type errors.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210262994451425) by [Unito](https://www.unito.io)
