### PR TITLE
Fix ckeditor bundle deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "migrate": "ts-node -r tsconfig-paths/register --project tsconfig-repl.json ./migrate.ts",
     "gfrepl": "NODE_OPTIONS='--inspect --no-deprecation' SETTINGS_FILE=settings-local-dev-devdb-ea.json ts-node --swc -r tsconfig-paths/register --project tsconfig-repl.json scripts/repl.ts",
     "repl": "NODE_OPTIONS='--inspect --no-deprecation' ts-node --swc -r tsconfig-paths/register --project tsconfig-repl.json scripts/repl.ts",
-    "upload-ckeditor-bundle": "node -r tsconfig-paths/register deployCkEditorBundle",
+    "upload-ckeditor-bundle": "ts-node --swc -r tsconfig-paths/register --project tsconfig-repl.json ./deployCkEditorBundle.ts",
     "branchdb": "ts-node -r tsconfig-paths/register scripts/branchDb.ts",
     "start": "yarn start-local-db",
     "start-local-db": "ts-node --transpile-only ./build.ts -run --watch --lint --settings settings-dev.json --db ../LessWrong-Credentials/connectionConfigs/local.json",

--- a/packages/lesswrong/components/common/ReCaptcha.tsx
+++ b/packages/lesswrong/components/common/ReCaptcha.tsx
@@ -5,8 +5,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components'
 import { reCaptchaSiteKeySetting } from '../../lib/publicSettings'
 import { isClient } from '../../lib/executionEnvironment';
 
-const reCaptchaSiteKey = reCaptchaSiteKeySetting.get()
-
 const propTypes = {
   elementID: PropTypes.string,
   verifyCallbackName: PropTypes.string,
@@ -18,7 +16,6 @@ const propTypes = {
 const defaultProps = {
   elementID: 'g-recaptcha',
   verifyCallbackName: 'verifyCallback',
-  sitekey: reCaptchaSiteKey
 }
 
 const isReady = () =>
@@ -71,7 +68,7 @@ class ReCaptchaInner extends Component<ReCaptchaProps,ReCaptchaState> {
 
   execute () {
     const {
-      sitekey,
+      sitekey = reCaptchaSiteKeySetting.get(),
       verifyCallback,
       action,
     } = this.props

--- a/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
+++ b/packages/lesswrong/components/ea-forum/auth/EALoginPopover.tsx
@@ -238,9 +238,7 @@ const links = {
   privacy: "/privacyPolicy",
 } as const;
 
-const FACEBOOK_DEFAULT_ENABLED = auth0FacebookLoginEnabled.get()
-
-export const EALoginPopover = ({action: action_, setAction: setAction_, facebookEnabled = FACEBOOK_DEFAULT_ENABLED, googleEnabled = true, classes}: {
+export const EALoginPopover = ({action: action_, setAction: setAction_, facebookEnabled = auth0FacebookLoginEnabled.get(), googleEnabled = true, classes}: {
   action?: LoginAction | null,
   setAction?: (action: LoginAction | null) => void,
   facebookEnabled?: boolean,


### PR DESCRIPTION
What was probably the recent components refactor broke the ckeditor bundle deployment script, because that script was doing a dynamic require of `ckEditorApi`, which probably now has a bunch of components in its import tree.  Some of those components were performing top-level access of database settings.  Generally that's a bit of an anti-pattern, but at least one of them (`postsListViewTypeSetting`, in `usePostsListView.ts`) looked non-trivial to fix, so I fixed the script to start a server before doing the dynamic import instead.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210266277309661) by [Unito](https://www.unito.io)
