### PR TITLE
make imageId field in SocialPreview gql types optional to match actual data in database

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -105,7 +105,7 @@ export const graphqlTypeDefs = gql`
   }
 
   type SocialPreviewOutput {
-    imageId: String!
+    imageId: String
     text: String
   }
 

--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -88,7 +88,7 @@ export const graphqlTypeDefs = gql`
   }
 
   input SocialPreviewInput {
-    imageId: String!
+    imageId: String
     text: String
   }
 

--- a/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
+++ b/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
@@ -72,7 +72,7 @@ type CoauthorStatusOutput {
 }
 
 type SocialPreviewOutput {
-  imageId: String!
+  imageId: String
   text: String
 }
 

--- a/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
+++ b/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
@@ -55,7 +55,7 @@ input CoauthorStatusInput {
 }
 
 input SocialPreviewInput {
-  imageId: String!
+  imageId: String
   text: String
 }
 

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -58,7 +58,7 @@ interface CoauthorStatusOutput {
 }
 
 interface SocialPreviewOutput {
-  imageId: string;
+  imageId: string | null;
   text: string | null;
 }
 

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -41,7 +41,7 @@ interface CoauthorStatusInput {
 }
 
 interface SocialPreviewInput {
-  imageId: string;
+  imageId?: string | null;
   text?: string | null;
 }
 

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3698,6 +3698,14 @@ CREATE INDEX IF NOT EXISTS "idx_Votes_collectionName_userId_voteType_cancelled_i
   "votedAt"
 );
 
+-- Index "idx_Votes_userId_collectionName_cancelled_votedAt"
+CREATE INDEX IF NOT EXISTS "idx_Votes_userId_collectionName_cancelled_votedAt" ON "Votes" USING btree (
+  "userId",
+  "collectionName",
+  "cancelled",
+  "votedAt"
+);
+
 -- Index "idx_Votes_documentId"
 CREATE INDEX IF NOT EXISTS "idx_Votes_documentId" ON "Votes" USING btree ("documentId");
 


### PR DESCRIPTION
At least one user reported being unable to edit a post because they were getting a 404 (caused by an error thrown in our graphql layer when it tried to return a null value for a required field).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210268894060158) by [Unito](https://www.unito.io)
