### PR TITLE
Fix some non-fatal crashes in SSR that happen during unit tests

### DIFF
--- a/packages/lesswrong/components/common/LWDialog.tsx
+++ b/packages/lesswrong/components/common/LWDialog.tsx
@@ -91,7 +91,7 @@ const LWDialog = ({open, fullScreen, title, maxWidth='sm', fullWidth, disableBac
   
   return <>
     {backdrop!=="none" && openRecently && <Backdrop visible={open} style={backdrop}/>}
-    {(open || (everOpened && keepMounted)) && createPortal(
+    {everOpened && (open || keepMounted) && createPortal(
       <div>
         <ClickAwayListener onClickAway={() => {
           if (!disableBackdropClick)


### PR DESCRIPTION
`runCrosspostsTests` had this error in its output (without actually failing the test):
```
[WebServer] ReferenceError: document is not defined
    at Component (/home/runner/work/ForumMagnum/ForumMagnum/packages/lesswrong/components/common/LWDialog.tsx:119:7)
```
This is because LWDialog uses a portal in such a way that it only works client-sided, and EALoginPopover tries to use it in an SSR context. Fix by making LWDialog not crash if SSRed (though it will wait til after it's hydrated to actually display anything).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210322768759340) by [Unito](https://www.unito.io)
