### PR TITLE
Add lessonline splash back

### DIFF
--- a/packages/lesswrong/components/LWBackgroundImage.tsx
+++ b/packages/lesswrong/components/LWBackgroundImage.tsx
@@ -140,7 +140,7 @@ export const LWBackgroundImage = ({standaloneNavigation}: {
   if (getReviewPhase() === 'RESULTS') homePageImage = reviewCompleteImage
 
   // TODO: comment this out after we're done with LessOnline banner
-  const priceIncreaseDate = new Date('2025-04-02T08:00:00Z')
+  const priceIncreaseDate = new Date('2025-05-25T08:00:00Z')
   if (new Date() < priceIncreaseDate) {
     homePageImage = <LessOnline2025Banner priceIncreaseDate={priceIncreaseDate} />
   }


### PR DESCRIPTION
Add LessOnline guy back to frontpage for a week:

I'm actually not 100% sure what we want to say in terms of when the price-increase is.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/239765d0-4b32-48c5-b848-71de39cc9da3" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210324333823536) by [Unito](https://www.unito.io)
