### PR TITLE
Fix flicker when focusing on QuickTakesEntry as logged out user

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -116,7 +116,24 @@ const QuickTakesEntry = ({
     void cancelCallback?.();
   }, [cancelCallback]);
 
+  // Desired behaviour here:
+  // 1. Always expand on focus
+  // 2. If the focus was triggered by a click and the user is logged out, show the login popup
+  //
+  // (2) requires tracking `isUnexpandedClickRef`, as the mouseup for the click will occur after the element has expanded
+  const isUnexpandedClickRef = useRef(false);
+  const onFocus = useCallback(() => {
+    if (!expanded) {
+      setExpanded(true);
+      isUnexpandedClickRef.current = true;
+    }
+  }, [currentUser, openDialog, onSignup, expanded]);
+
   const handleLoggedOut = useCallback(() => {
+    if (expanded && !isUnexpandedClickRef.current) return;
+
+    isUnexpandedClickRef.current = false;
+
     if (isFriendlyUI) {
       onSignup();
     } else {
@@ -125,7 +142,7 @@ const QuickTakesEntry = ({
         contents: ({onClose}) => <LoginPopup onClose={onClose} />
       });
     }
-  }, [currentUser, openDialog, onSignup]);
+  }, [currentUser, openDialog, onSignup, expanded]);
 
   useEffect(() => {
     setTimeout(() => {
@@ -154,7 +171,7 @@ const QuickTakesEntry = ({
     {expanded && showNewUserMessage && <div className={classes.userNotApprovedMessage}>Quick Takes is an excellent place for your first contribution!</div>}
     <div
       className={classNames(classes.commentEditor, {[classes.collapsed]: !expanded})}
-      onFocus={() => setExpanded(true)}
+      onFocus={onFocus}
       onClick={handleLoggedOut}
     >
       <CommentsNewForm

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -116,19 +116,14 @@ const QuickTakesEntry = ({
     void cancelCallback?.();
   }, [cancelCallback]);
 
-  const onFocus = useCallback(() => {
-    if (currentUser) {
-      setExpanded(true);
+  const handleLoggedOut = useCallback(() => {
+    if (isFriendlyUI) {
+      onSignup();
     } else {
-      if (isFriendlyUI) {
-        onSignup();
-      } else {
-        openDialog({
-          name: "LoginPopup",
-          contents: ({onClose}) => <LoginPopup onClose={onClose} />
-        });
-        setExpanded(true);
-      }
+      openDialog({
+        name: "LoginPopup",
+        contents: ({onClose}) => <LoginPopup onClose={onClose} />
+      });
     }
   }, [currentUser, openDialog, onSignup]);
 
@@ -159,7 +154,8 @@ const QuickTakesEntry = ({
     {expanded && showNewUserMessage && <div className={classes.userNotApprovedMessage}>Quick Takes is an excellent place for your first contribution!</div>}
     <div
       className={classNames(classes.commentEditor, {[classes.collapsed]: !expanded})}
-      onFocus={onFocus}
+      onFocus={() => setExpanded(true)}
+      onClick={handleLoggedOut}
     >
       <CommentsNewForm
         key={currentUser?._id ?? "logged-out"}


### PR DESCRIPTION
Previous behaviour:

https://github.com/user-attachments/assets/b8bdb469-3e27-43d5-9e71-9f3ce20bc6c6


https://github.com/user-attachments/assets/6cd30393-6d95-4e66-9ce4-6abbebc53e0e

