### PR TITLE
[EA] Fix EA QuickTakesEntry styling

### DIFF
--- a/packages/lesswrong/components/form-components/FormGroupQuickTakes.tsx
+++ b/packages/lesswrong/components/form-components/FormGroupQuickTakes.tsx
@@ -5,7 +5,7 @@ import { FormGroupLayoutProps } from './FormGroupLayout';
 const styles = (_theme: ThemeType) => ({
   root: {
     display: 'contents',
-    '& .form-component-FormComponentQuickTakesTags': {
+    '& .input-relevantTagIds': {
       order: 100,
     },
   },


### PR DESCRIPTION
We were relying on a hack to show the submit buttons in the right place, and this was broken in #10755

Before/After:
![Screenshot 2025-05-21 at 12 01 07](https://github.com/user-attachments/assets/ea86e9c8-98c0-43a7-9ccb-45b208d7d462)

![Screenshot 2025-05-21 at 12 00 30](https://github.com/user-attachments/assets/13965528-ca99-4c89-978c-6606caed99be)
