### PR TITLE
Improve in-context comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -210,9 +210,10 @@ const CommentsNodeInner = ({
       setTruncated(false);
       setSingleLine(false);
       setTruncatedStateSet(true);
-      if (scroll) {
-        scrollIntoView(scrollBehaviour);
-      }
+    }
+
+    if (scroll) {
+      scrollIntoView(scrollBehaviour);
     }
   };
 


### PR DESCRIPTION
In-context comment links are currently quite unreliable on navigation (they do seem to work on page load). I believe the change here was essentially a bug before (in the [original PR to use in-context comments](https://github.com/ForumMagnum/ForumMagnum/pull/9699)), as I intended it to always scroll to the comment at this point regardless of whether it was collapsed. Changing this seems to make it a lot more reliable (as far as I can tell it now works every time).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210342833116260) by [Unito](https://www.unito.io)
