### PR TITLE
Fix comments triple-dot menu positioning

### DIFF
--- a/packages/lesswrong/components/dropdowns/CombinedSubscriptionsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CombinedSubscriptionsDropdownItem.tsx
@@ -1,70 +1,60 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { isFriendlyUI } from "../../themes/forumTheme";
 import { Card } from "@/components/widgets/Paper";
-import NotifyMeDropdownItem, { NotifyMeDropdownItemProps } from "./NotifyMeDropdownItem";
+import { NotifyMeDropdownItem, type NotifyMeDropdownItemProps } from "./NotifyMeDropdownItem";
 import NotifyMeToggleDropdownItem, { NotifyMeToggleDropdownItemPropsExternal } from "./NotifyMeToggleDropdownItem";
 import LWTooltip from "../common/LWTooltip";
 import DropdownMenu from "./DropdownMenu";
 import DropdownItem from "./DropdownItem";
+import { defineStyles, useStyles } from "../hooks/useStyles";
 
-const styles = (_theme: ThemeType) => ({
+const styles = defineStyles("CombinedSubscriptionsDropdownItem", (_theme: ThemeType) => ({
   dropdownWrapper: {
     padding: "0 14px 0 10px",
     transform: "translateX(2px) translateY(-6px)",
   },
-});
+}));
 
 /**
  * On friendly sites, this is a single menu item that opens a submenu with subscription options.
  * On other sites, the subscription options are individual menu items.
  */
-export const CombinedSubscriptionsDropdownItem = ({notifyMeItems, classes}: {
+export const CombinedSubscriptionsDropdownItem = ({notifyMeItems}: {
   notifyMeItems: Array<NotifyMeDropdownItemProps & NotifyMeToggleDropdownItemPropsExternal>,
-  classes: ClassesType<typeof styles>,
 }) => {
-  return isFriendlyUI
-    ? (
-      <LWTooltip
-        title={
-          <div className={classes.dropdownWrapper}>
-            <Card>
-              <DropdownMenu>
-                {notifyMeItems.map((props) =>
-                  <NotifyMeToggleDropdownItem
-                    key={props.subscriptionType}
-                    {...props}
-                  />
-                )}
-              </DropdownMenu>
-            </Card>
-          </div>
-        }
-        clickable
-        tooltip={false}
-        inlineBlock={false}
-        placement="right-start"
-      >
-        <DropdownItem
-          title="Get notified"
-          icon="BellBorder"
-          afterIcon="ThickChevronRight"
-        />
-      </LWTooltip>
-    )
-    : (
-      <>
-        {notifyMeItems.map((props) =>
-          <NotifyMeDropdownItem {...props} key={props.subscriptionType} />
-        )}
-      </>
-    );
+  const classes = useStyles(styles);
+  if (isFriendlyUI) {
+    return <LWTooltip
+      title={
+        <div className={classes.dropdownWrapper}>
+          <Card>
+            <DropdownMenu>
+              {notifyMeItems.map((props) =>
+                <NotifyMeToggleDropdownItem
+                  key={props.subscriptionType}
+                  {...props}
+                />
+              )}
+            </DropdownMenu>
+          </Card>
+        </div>
+      }
+      clickable
+      tooltip={false}
+      inlineBlock={false}
+      placement="right-start"
+    >
+      <DropdownItem
+        title="Get notified"
+        icon="BellBorder"
+        afterIcon="ThickChevronRight"
+      />
+    </LWTooltip>
+  } else {
+    return <>
+      {notifyMeItems.map((props) =>
+        <NotifyMeDropdownItem {...props} key={props.subscriptionType} />
+      )}
+    </>
+  };
 }
-
-export default registerComponent(
-  "CombinedSubscriptionsDropdownItem",
-  CombinedSubscriptionsDropdownItem,
-  {styles},
-);
-
-

--- a/packages/lesswrong/components/dropdowns/DropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownItem.tsx
@@ -1,5 +1,4 @@
 import React, { FC, ReactElement, MouseEvent, PropsWithChildren, ReactNode } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import ForumIcon, { ForumIconName } from "../common/ForumIcon";
 import ListItemIcon from "@/lib/vendor/@material-ui/core/src/ListItemIcon";
 import { Link } from "../../lib/reactRouterWrapper";
@@ -9,8 +8,9 @@ import { isFriendlyUI } from "../../themes/forumTheme";
 import { MenuItem } from "../common/Menus";
 import Loading from "../vulcan-core/Loading";
 import LWTooltip from "../common/LWTooltip";
+import { defineStyles, useStyles } from "../hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("DropdownItem", (theme: ThemeType) => ({
   root: {
     ...(isFriendlyUI && {
       "&:hover": {
@@ -58,28 +58,7 @@ const styles = (theme: ThemeType) => ({
   tooltip: {
     display: "block",
   },
-});
-
-export type DropdownItemAction = {
-  onClick: (event: MouseEvent) => void | Promise<void>,
-  to?: never,
-} | {
-  onClick?: never,
-  to: HashLinkProps["to"],
-}
-
-export type DropdownItemProps = DropdownItemAction & {
-  title: ReactNode,
-  sideMessage?: string,
-  icon?: ForumIconName | (() => ReactElement),
-  iconClassName?: string,
-  menuItemClassName?: string,
-  afterIcon?: ForumIconName | (() => ReactElement),
-  tooltip?: string,
-  disabled?: boolean,
-  loading?: boolean,
-  rawLink?: boolean,
-}
+}));
 
 const DummyWrapper: FC<PropsWithChildren<{className?: string}>> = ({className, children}) =>
   <div className={className}>{children}</div>;
@@ -93,7 +72,7 @@ const RawLink: FC<PropsWithChildren<{
   </a>
 );
 
-const DropdownItem = ({
+export const DropdownItem = ({
   title,
   sideMessage,
   onClick,
@@ -106,10 +85,23 @@ const DropdownItem = ({
   disabled,
   loading,
   rawLink,
-  classes,
-}: DropdownItemProps & {classes: ClassesType<typeof styles>}) => {
+}: {
+  title: ReactNode,
+  sideMessage?: string,
+  icon?: ForumIconName | (() => ReactElement),
+  iconClassName?: string,
+  menuItemClassName?: string,
+  afterIcon?: ForumIconName | (() => ReactElement),
+  tooltip?: string,
+  disabled?: boolean,
+  loading?: boolean,
+  rawLink?: boolean,
+  onClick?: (event: MouseEvent) => void | Promise<void>,
+  to?: HashLinkProps["to"],
+}) => {
   const LinkWrapper = to ? rawLink ? RawLink : Link : DummyWrapper;
   const TooltipWrapper = tooltip ? LWTooltip : DummyWrapper;
+  const classes = useStyles(styles);
   return (
     <LinkWrapper to={to!} className={classes.root}>
       <TooltipWrapper title={tooltip!} className={classes.tooltip}>
@@ -147,10 +139,4 @@ const DropdownItem = ({
   );
 }
 
-export default registerComponent(
-  "DropdownItem",
-  DropdownItem,
-  {styles},
-);
-
-
+export default DropdownItem;

--- a/packages/lesswrong/components/dropdowns/DropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownItem.tsx
@@ -72,6 +72,12 @@ const RawLink: FC<PropsWithChildren<{
   </a>
 );
 
+/**
+ * Dropdown item, for use in menus such as the triple-dot menus on posts
+ * and comments. Note that menus are positioned based on size immediately
+ * after opening, so you should avoid loading states that make menu items
+ * significantly narrower than they will be when loaded.
+ */
 export const DropdownItem = ({
   title,
   sideMessage,
@@ -94,6 +100,12 @@ export const DropdownItem = ({
   afterIcon?: ForumIconName | (() => ReactElement),
   tooltip?: string,
   disabled?: boolean,
+  /**
+   * Replaces the menu item with a loading indicator. This should ONLY be used
+   * to indicate an action is in progress, that started after the menu has
+   * already opened; if the contents of a menu start out in a loading state,
+   * then its width will change and this may lead to it being awkwardly partly
+   * off-screen. */
   loading?: boolean,
   rawLink?: boolean,
   onClick?: (event: MouseEvent) => void | Promise<void>,

--- a/packages/lesswrong/components/dropdowns/NotifyMeDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/NotifyMeDropdownItem.tsx
@@ -37,7 +37,6 @@ const NotifyMeDropdownItemInternal: FC<NotifyMeDropdownItemInternalProps> = ({
       title={message}
       onClick={onSubscribe}
       icon={isSubscribed ? "Bell" : "BellBorder"}
-      loading={loading}
       tooltip={tooltip}
     />
   );

--- a/packages/lesswrong/components/dropdowns/NotifyMeDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/NotifyMeDropdownItem.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { NotifyMeDocument, useNotifyMe } from "../hooks/useNotifyMe";
 import type { SubscriptionType } from "../../lib/collections/subscriptions/helpers";
 import DropdownItem from "./DropdownItem";
@@ -44,16 +43,9 @@ const NotifyMeDropdownItemInternal: FC<NotifyMeDropdownItemInternalProps> = ({
   );
 }
 
-const NotifyMeDropdownItem = (props: NotifyMeDropdownItemProps) =>
+export const NotifyMeDropdownItem = (props: NotifyMeDropdownItemProps) =>
   props.document && (props.enabled ?? true)
     ? <NotifyMeDropdownItemInternal
       {...props as NotifyMeDropdownItemInternalProps}
     />
     : null;
-
-export default registerComponent(
-  "NotifyMeDropdownItem",
-  NotifyMeDropdownItem,
-);
-
-

--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -16,7 +16,7 @@ import ToggleIsModeratorCommentDropdownItem from "./ToggleIsModeratorCommentDrop
 import PinToProfileDropdownItem from "./PinToProfileDropdownItem";
 import DropdownMenu from "../DropdownMenu";
 import ShortformFrontpageDropdownItem from "./ShortformFrontpageDropdownItem";
-import CommentSubscriptionsDropdownItem from "./CommentSubscriptionsDropdownItem";
+import { CommentSubscriptionsDropdownItem } from "./CommentSubscriptionsDropdownItem";
 import BanUserFromPostDropdownItem from "./BanUserFromPostDropdownItem";
 import LockThreadDropdownItem from "./LockThreadDropdownItem";
 

--- a/packages/lesswrong/components/dropdowns/comments/CommentSubscriptionsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentSubscriptionsDropdownItem.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo } from "react";
-import { registerComponent } from "../../../lib/vulcan-lib/components";
 import { subscriptionTypes } from "../../../lib/collections/subscriptions/helpers";
 import { userGetDisplayName } from "../../../lib/collections/users/helpers";
 import { useCurrentUser } from "../../common/withUser";
 import { allowSubscribeToUserComments } from "../../../lib/betas";
-import CombinedSubscriptionsDropdownItem from "../CombinedSubscriptionsDropdownItem";
+import { CombinedSubscriptionsDropdownItem } from "../CombinedSubscriptionsDropdownItem";
 
 /**
  * A list of props that go into each subscription menu item,
@@ -75,10 +74,4 @@ export const CommentSubscriptionsDropdownItem = ({comment, post}: {
   }, [comment, post, currentUser, enableSubscribeToCommentUser]);
   return <CombinedSubscriptionsDropdownItem notifyMeItems={notifyMeItems} />
 }
-
-export default registerComponent(
-  "CommentSubscriptionsDropdownItem",
-  CommentSubscriptionsDropdownItem,
-);
-
 

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -24,7 +24,7 @@ import PostAnalyticsDropdownItem from "./PostAnalyticsDropdownItem";
 import ExcludeFromRecommendationsDropdownItem from "./ExcludeFromRecommendationsDropdownItem";
 import ApproveNewUserDropdownItem from "./ApproveNewUserDropdownItem";
 import SharePostSubmenu from "./SharePostSubmenu";
-import PostSubscriptionsDropdownItem from "./PostSubscriptionsDropdownItem";
+import { PostSubscriptionsDropdownItem } from "./PostSubscriptionsDropdownItem";
 import DislikeRecommendationDropdownItem from "./DislikeRecommendationDropdownItem";
 import HideFrontPageButton from './HideFrontpagePostDropdownItem';
 

--- a/packages/lesswrong/components/dropdowns/posts/PostSubscriptionsDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostSubscriptionsDropdownItem.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo } from "react";
-import { registerComponent } from "../../../lib/vulcan-lib/components";
 import { subscriptionTypes } from "../../../lib/collections/subscriptions/helpers";
 import { userGetDisplayName } from "../../../lib/collections/users/helpers";
 import { useCurrentUser } from "../../common/withUser";
 import { isDialogueParticipant } from "@/lib/collections/posts/helpers";
-import CombinedSubscriptionsDropdownItem from "../CombinedSubscriptionsDropdownItem";
+import { CombinedSubscriptionsDropdownItem } from "../CombinedSubscriptionsDropdownItem";
 
 /**
  * A list of props that go into each subscription menu item,
@@ -74,10 +73,3 @@ export const PostSubscriptionsDropdownItem = ({post}: {
   }, [post, currentUser, showSubscribeToDialogueButton]);
   return <CombinedSubscriptionsDropdownItem notifyMeItems={notifyMeItems} />
 }
-
-export default registerComponent(
-  "PostSubscriptionsDropdownItem",
-  PostSubscriptionsDropdownItem,
-);
-
-

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -68,7 +68,7 @@ import DebateBody from "../../comments/DebateBody";
 import PostsPageRecommendationsList from "../../recommendations/PostsPageRecommendationsList";
 import PostSideRecommendations from "../../recommendations/PostSideRecommendations";
 import PostBottomRecommendations from "../../recommendations/PostBottomRecommendations";
-import NotifyMeDropdownItem from "../../dropdowns/NotifyMeDropdownItem";
+import { NotifyMeDropdownItem } from "../../dropdowns/NotifyMeDropdownItem";
 import Row from "../../common/Row";
 import AnalyticsInViewTracker from "../../common/AnalyticsInViewTracker";
 import PostsPageQuestionContent from "../../questions/PostsPageQuestionContent";

--- a/packages/lesswrong/components/widgets/Menu.tsx
+++ b/packages/lesswrong/components/widgets/Menu.tsx
@@ -85,8 +85,11 @@ function getMenuPositionStyles(anchorEl: HTMLElement, element: HTMLElement, plac
   const anchorRect = anchorEl.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
   const placedRect = placeRectOverlapping(anchorRect, elementRect, placement);
-  const finalRect = pushRectInFromOffScreen(placedRect);
-  return rectToCSS(finalRect, placement);
+  const {rect: finalRect, anchorFromRight} = pushRectInFromOffScreen({
+    rect: placedRect,
+    anchorFromRight: ["bottom-end", "top-end"].includes(placement)
+  });
+  return rectToCSS(finalRect, anchorFromRight);
 }
 
 function getOffScreeStyles(): React.CSSProperties {
@@ -104,8 +107,7 @@ function placeRectOverlapping(anchorRect: DOMRect, elementRect: DOMRect, placeme
 /**
  * Make CSS that places a div at the given position, using `top` and either `left` or `right`.
  */
-function rectToCSS(rect: DOMRect, placement: PopperPlacementType): React.CSSProperties {
-  const anchorFromRight = ["bottom-end", "top-end"].includes(placement);
+function rectToCSS(rect: DOMRect, anchorFromRight: boolean): React.CSSProperties {
   if (anchorFromRight) {
     return {
       right: window.innerWidth - rect.right - window.scrollX,
@@ -123,8 +125,16 @@ function rectToCSS(rect: DOMRect, placement: PopperPlacementType): React.CSSProp
 
 /**
  * If the given rect is fully or partially off-screen, push it into the viewport.
+ * If it was pushed in from the right edge but not the left edge, then switch
+ * its anchoring to the right.
  */
-function pushRectInFromOffScreen(rect: DOMRect): DOMRect {
+function pushRectInFromOffScreen({rect, anchorFromRight}: {
+  rect: DOMRect
+  anchorFromRight: boolean
+}): {
+  rect: DOMRect,
+  anchorFromRight: boolean
+} {
   // Get viewport dimensions
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
@@ -140,6 +150,7 @@ function pushRectInFromOffScreen(rect: DOMRect): DOMRect {
   // Push in from the right edge
   if (newRect.right > viewportWidth) {
     newRect.x = viewportWidth - newRect.width;
+    anchorFromRight = true;
   }
   
   // Push in from the bottom edge
@@ -150,6 +161,7 @@ function pushRectInFromOffScreen(rect: DOMRect): DOMRect {
   // Push in from the left edge
   if (newRect.x < 0) {
     newRect.x = 0;
+    anchorFromRight = false;
   }
   
   // Push in from the top edge
@@ -168,5 +180,8 @@ function pushRectInFromOffScreen(rect: DOMRect): DOMRect {
     newRect.height = viewportHeight;
   }
   
-  return newRect;
+  return {
+    rect: newRect,
+    anchorFromRight
+  };
 }

--- a/packages/lesswrong/components/widgets/Menu.tsx
+++ b/packages/lesswrong/components/widgets/Menu.tsx
@@ -39,7 +39,7 @@ export function Menu({open, anchorEl, onClose, onClick, minWidth, className, chi
         <Paper>
           {children}
         </Paper>
-     ,</LWClickAwayListener>
+      </LWClickAwayListener>
     </div>
   </MenuPopper>
 }


### PR DESCRIPTION
The comment actions menu has some Subscribe options on it, which had a loading state while they figure out whether you're already subscribed. This was a problem because if those are the only wide items in the menu (ie, if you're logged in, not an admin, and the comment is on a post that isn't yours), then the menu width is significantly narrower in the loading state than it is when loaded, and the menu is positioned based on its initial size, not its loaded size.

Fixes this in two ways. First, gets rid of that loading state entirely, so the menu starts out the right size. Second, modifies `pushRectInFromOffScreen` so that if a menu was pushed in from the right, its anchoring is switched from left to right, so it will remain on-screen if its width changes.