### PR TITLE
Don't show unreviewed comments in all posts page tag history blocks, various feeds

### DIFF
--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -45,6 +45,10 @@ export function getDefaultViewSelector<N extends CollectionNameString>(collectio
   return replaceSpecialFieldSelectors(viewQuery.selector);
 }
 
+export function mergeWithDefaultViewSelector<N extends CollectionNameString>(collectionName: N, selector: MongoSelector<ObjectsByCollectionName[N]>) {
+  return mergeSelectors(getDefaultViewSelector(collectionName), selector);
+}
+
 /**
  * Given a set of terms describing a view, translate them into a mongodb selector
  * and options, which is ready to execute (but don't execute it yet).

--- a/packages/lesswrong/server/resolvers/allTagsActivityFeed.ts
+++ b/packages/lesswrong/server/resolvers/allTagsActivityFeed.ts
@@ -39,6 +39,7 @@ export const allTagsActivityFeedGraphQLQueries = {
           collection: Tags,
           sortField: "createdAt",
           context,
+          includeDefaultSelector: false,
           selector: {}
         }),
         // Tag revisions
@@ -47,6 +48,7 @@ export const allTagsActivityFeedGraphQLQueries = {
           collection: Revisions,
           sortField: "editedAt",
           context,
+          includeDefaultSelector: false,
           selector: {
             collectionName: "Tags",
             fieldName: "description",
@@ -66,6 +68,7 @@ export const allTagsActivityFeedGraphQLQueries = {
           collection: Comments,
           sortField: "postedAt",
           context,
+          includeDefaultSelector: false,
           selector: {
             tagId: {$ne: null},
           },

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -71,7 +71,7 @@ export const recentDiscussionFeedGraphQLQueries = {
       {[`tagRelevance.${EA_FORUM_TRANSLATION_TOPIC_ID}`]: {$exists: false}},
     ]};
 
-    const postSelector = {
+    const postSelector: MongoSelector<DbPost> = {
       baseScore: {$gt:0},
       hideFrontpageComments: false,
       lastCommentedAt: {$exists: true},
@@ -97,6 +97,7 @@ export const recentDiscussionFeedGraphQLQueries = {
           collection: Posts,
           sortField: "lastCommentedAt",
           context,
+          includeDefaultSelector: false,
           selector: {
             ...postSelector,
             $or: [
@@ -111,6 +112,7 @@ export const recentDiscussionFeedGraphQLQueries = {
           collection: Posts,
           sortField: "lastCommentedAt",
           context,
+          includeDefaultSelector: false,
           selector: {
             ...postSelector,
             shortform: {$eq: true},
@@ -122,7 +124,9 @@ export const recentDiscussionFeedGraphQLQueries = {
           collection: Tags,
           sortField: "lastCommentedAt",
           context,
+          includeDefaultSelector: true,
           selector: {
+            wikiOnly: viewFieldAllowAny,
             lastCommentedAt: {$exists: true},
             ...(af ? {af: true} : undefined),
           },
@@ -133,6 +137,7 @@ export const recentDiscussionFeedGraphQLQueries = {
           collection: Revisions,
           sortField: "editedAt",
           context,
+          includeDefaultSelector: true,
           selector: {
             collectionName: "Tags",
             fieldName: "description",

--- a/packages/lesswrong/server/resolvers/tagHistoryFeed.ts
+++ b/packages/lesswrong/server/resolvers/tagHistoryFeed.ts
@@ -84,6 +84,7 @@ export const tagHistoryFeedGraphQLQueries = {
           collection: TagRels,
           sortField: "createdAt",
           context,
+          includeDefaultSelector: false,
           selector: {tagId},
         }) : null),
         // Tag revisions
@@ -92,6 +93,7 @@ export const tagHistoryFeedGraphQLQueries = {
           collection: Revisions,
           sortField: "editedAt",
           context,
+          includeDefaultSelector: false,
           selector: {
             documentId: tagId,
             collectionName: "Tags",
@@ -112,6 +114,7 @@ export const tagHistoryFeedGraphQLQueries = {
           collection: Comments,
           sortField: "postedAt",
           context,
+          includeDefaultSelector: true,
           selector: {
             parentCommentId: null,
             tagId,


### PR DESCRIPTION
This applies the default selector to tag edit blocks on the All Posts page, as well as some other places where it was missing, preventing comments from unreviewed users (which might be spam) from appearing there.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210383463652184) by [Unito](https://www.unito.io)
