### PR TITLE
Fix side-items when footnotes contain themselves, internal link previews containing footnotes

### DIFF
--- a/packages/lesswrong/components/contents/SideItems.tsx
+++ b/packages/lesswrong/components/contents/SideItems.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { useHover } from '@/components/common/withHover';
 import { registerComponent } from '@/lib/vulcan-lib/components';
 import { getOffsetChainTop } from '@/lib/utils/domUtil';
+import { defineStyles, useStyles } from '../hooks/useStyles';
 
 export type SideItemOptions = {
   format: "block"|"icon",
@@ -45,7 +46,7 @@ export type SideItemContentContextType = {
 };
 export const SideItemContentContext = createContext<SideItemContentContextType|null>(null);
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("SideItems", (theme: ThemeType) => ({
   sideItem: {
     position: "absolute",
     width: "100%",
@@ -54,7 +55,7 @@ export const styles = (theme: ThemeType) => ({
     position: "relative",
     height: "100%",
   },
-});
+}));
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -63,10 +64,10 @@ function useForceRerender() {
   return {renderCount, rerender};
 }
 
-const SideItemsContainerInner = ({classes, children}: {
-  classes: ClassesType<typeof styles>,
+export const SideItemsContainer = ({children}: {
   children: React.ReactNode
 }) => {
+  const classes = useStyles(styles);
   const state = useRef<SideItemsState>({sideItems: [], maxId: -1});
   const contentsRef = useRef<HTMLDivElement|null>(null);
   const {renderCount, rerender} = useForceRerender();
@@ -147,9 +148,8 @@ const SideItemsContainerInner = ({classes, children}: {
   );
 }
 
-const SideItemsSidebarInner = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
+export const SideItemsSidebar = () => {
+  const classes = useStyles(styles);
   const placementContext = useContext(SideItemsPlacementContext);
   const displayContext = useContext(SideItemsDisplayContext);
   const sideItemColumnRef = useRef<HTMLDivElement>(null);
@@ -261,7 +261,13 @@ export const useHasSideItemsSidebar = (): boolean => {
   return !!useContext(SideItemsPlacementContext);
 }
 
-export const SideItemsContainer = registerComponent('SideItemsContainer', SideItemsContainerInner, {styles});
-export const SideItemsSidebar = registerComponent('SideItemsSidebar', SideItemsSidebarInner, {styles});
-
+export const NoSideItems = ({children}: {
+  children: React.ReactNode
+}) => {
+  return <SideItemsPlacementContext.Provider value={null}>
+    <SideItemsDisplayContext.Provider value={null}>
+      {children}
+    </SideItemsDisplayContext.Provider>
+  </SideItemsPlacementContext.Provider>
+}
 

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Card } from "@/components/widgets/Paper";
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useHover } from '../common/withHover';
@@ -161,7 +161,8 @@ const FootnotePreview = ({classes, href, id, rel, contentStyleType="postHighligh
   const { eventHandlers: sidenoteEventHandlers, hover: sidenoteHovered } = useHover();
   const eitherHovered = anchorHovered || sidenoteHovered;
   const [footnoteHTML,setFootnoteHTML] = useState<string|null>(null);
-  const footnoteAncestors = useContext(FootnoteAncestorsContext) ?? [];
+  const memoizedEmptyArray = useMemo(() => [], []);
+  const footnoteAncestors = useContext(FootnoteAncestorsContext) ?? memoizedEmptyArray;
   
   useEffect(() => {
     const extractedFootnoteHTML = footnoteAncestors.includes(href)

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -11,6 +11,7 @@ import { getUrlClass } from '@/server/utils/getUrlClass';
 import type { ContentStyleType } from '../common/ContentStyles';
 import { DefaultPreview, MetaculusPreview, ManifoldPreview, FatebookPreview, NeuronpediaPreview, MetaforecastPreview, OWIDPreview, ArbitalPreview, EstimakerPreview, ViewpointsPreview } from './PostLinkPreview';
 import FootnotePreview from "./FootnotePreview";
+import { NoSideItems } from '../contents/SideItems';
 
 export const parseRouteWithErrors = (onsiteUrl: string, contentSourceDescription?: string) => {
   return parseRoute({
@@ -97,9 +98,11 @@ const HoverPreviewLink = ({ href, contentSourceDescription, id, rel, noPrefetch,
 
         if (PreviewComponent) {
           return <AnalyticsContext pageElementContext="linkPreview" href={destinationUrl} hoverPreviewType={previewComponentName} onsite>
-            <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} id={id} noPrefetch={noPrefetch}>
-              {children}
-            </PreviewComponent>
+            <NoSideItems>
+              <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} id={id} noPrefetch={noPrefetch}>
+                {children}
+              </PreviewComponent>
+            </NoSideItems>
           </AnalyticsContext>
         } else {
           return <DefaultPreview href={href} id={id} rel={rel}>


### PR DESCRIPTION
[This post](https://www.lesswrong.com/posts/Fg8dtE8HHkDoiGcwt/new-feature-support-for-footnotes) exercises corner cases of footnotes: Footnotes containing each other, footnotes containing themselves, and an internal links where the preview shows the post's footnotes. This caused problems with side-item footnote previews, which this PR fixes.