### PR TITLE
[EA] Post-release fixes for draft comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -179,7 +179,7 @@ const CommentSubmit = ({
   const currentUser = useCurrentUser();
   const { openDialog } = useDialog();
 
-  const abTestGroup = useABTest(draftCommentsABTest);
+  const abTestGroup = useABTest(draftCommentsABTest, !currentUser ? "treatment" : undefined);
   const allowDraftComments = hasDraftComments && (isAnyTest || abTestGroup === "treatment")
 
   const formButtonClass = isMinimalist ? classes.formButtonMinimalist : classes.formButton;

--- a/packages/lesswrong/components/comments/CommentsSubmitDropdown.tsx
+++ b/packages/lesswrong/components/comments/CommentsSubmitDropdown.tsx
@@ -9,6 +9,9 @@ import LWClickAwayListener from '../common/LWClickAwayListener';
 import DropdownMenu from '../dropdowns/DropdownMenu';
 import DropdownItem from '../dropdowns/DropdownItem';
 import { Paper } from '../widgets/Paper';
+import { useCurrentUser } from '../common/withUser';
+import { useDialog } from '../common/withDialog';
+import LoginPopup from '../users/LoginPopup';
 
 const styles = (theme: ThemeType) => ({
   buttonWrapper: {
@@ -46,7 +49,9 @@ export const CommentsSubmitDropdown = ({ handleSubmit, classes }: {
   handleSubmit: (meta: {draft: boolean}) => Promise<void>,
   classes: ClassesType<typeof styles>,
 }) => {
-  const { captureEvent } = useTracking()
+  const { captureEvent } = useTracking();
+  const currentUser = useCurrentUser();
+  const { openDialog } = useDialog();
 
   const [menuOpen, innerSetMenuOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null)
@@ -81,6 +86,14 @@ export const CommentsSubmitDropdown = ({ handleSubmit, classes }: {
               <DropdownItem
                 title={preferredHeadingCase("Save As Draft")}
                 onClick={() => {
+                  if (!currentUser) {
+                    openDialog({
+                      name: "LoginPopup",
+                      contents: ({onClose}) => <LoginPopup onClose={onClose}/>
+                    });
+                    return;
+                  }
+
                   void handleSubmit({ draft: true });
                   setMenuOpen(false);
                 }}

--- a/packages/lesswrong/lib/abTestImpl.ts
+++ b/packages/lesswrong/lib/abTestImpl.ts
@@ -138,12 +138,19 @@ export function weightedRandomPick<T extends string>(options: Record<T,number>, 
 
 
 // Returns the name of the A/B test group that the current user/client is in.
-export function useABTest<Groups extends string>(abtest: ABTest<Groups>): Groups {
+// `forceGroup` is a way to conveniently bypass this (for logged out users), to
+// make the page suitable for caching.
+export function useABTest<Group extends string>(abtest: ABTest<Group>, forceGroup?: string): Group {
   const currentUser = useCurrentUser();
   const clientId = useClientId();
   const abTestGroupsUsed = useContext(ABTestGroupsUsedContext);
+
+  if (forceGroup) {
+    return forceGroup as Group;
+  }
+
   const group = getUserABTestGroup(currentUser ? {user: currentUser} : {clientId}, abtest);
-  
+
   abTestGroupsUsed[abtest.name] = group;
   return group;
 }

--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -139,8 +139,12 @@ function defaultView(terms: CommentsViewTerms, _: ApolloClient<NormalizedCacheOb
     selector: {
       $and: [
         ...(shouldHideNewUnreviewedAuthorComments ? [hideNewUnreviewedAuthorComments] : []),
-        getDraftSelector({ drafts: terms.drafts, context }),
-        notDeletedOrDeletionIsPublic
+        // Note: This nested $and is a bug fix, without it some views don't return anything.
+        // This is probably a bug in mergeSelectors
+        { $and: [
+          getDraftSelector({ drafts: terms.drafts, context }),
+          notDeletedOrDeletionIsPublic
+        ] }
       ],
       hideAuthor: terms.userId ? false : undefined,
       ...(terms.commentIds && {_id: {$in: terms.commentIds}}),


### PR DESCRIPTION
1. Fix quick takes list not appearing for logged in users (due to a bug in mergeSelectors which I haven't been able to fix, but have worked around)
2. Fix A/B test technically (but not actually) breaking caching for logged out users. I have made it always show the dropdown for logged out, and show the login popup if someone tries to save a draft

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210402712081516) by [Unito](https://www.unito.io)
