### PR TITLE
Fix link to draft comments bug

### DIFF
--- a/packages/lesswrong/components/comments/CommentsDraftList.tsx
+++ b/packages/lesswrong/components/comments/CommentsDraftList.tsx
@@ -60,7 +60,7 @@ const CommentsDraftList = ({userId, postId, initialLimit, itemsPerPage, showTota
 
   // Move the linked comment up to the top if given
   const results = ([linkedComment, ...(rawResults ?? [])]
-    .filter(v => v) as DraftComments[])
+    .filter(v => v?.draft) as DraftComments[])
     .reduce((acc, comment) => {
       if (!acc.some(existingComment => existingComment._id === comment._id)) {
         acc.push(comment);


### PR DESCRIPTION
Linking to any comment would make it appear in the draft comments section, because I forgot to filter to only drafts for the linked comment in that list:
![image](https://github.com/user-attachments/assets/fc95aba3-7125-49cb-9c7d-fa9aac913381)
