### PR TITLE
Add a ToC heuristic that if there are excessively many headings (>30)…

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -147,19 +147,17 @@ export function extractTableOfContents({
   }
   
   // If the number of headings is excessive (>30) and will not become small
-  // (<8) if the deepest heading level is dropped, drop the deepest heading
-  // level
-  while (headings.length > 30) {
+  // (<8) if the deepest heading level is dropped, and the deepest heading
+  // level comes from <b>/<strong>, drop the deepest heading level
+  if (headings.length > 30) {
     const deepestHeadingLevel = maxBy(headings, h => h.level)?.level ?? 0;
-    const headingsWithoutDeepestLevel = headings.filter(h => h.level < deepestHeadingLevel);
-    if (headingsWithoutDeepestLevel.length < headings.length) {
-      if (headingsWithoutDeepestLevel.length >= 8) {
-        headings = headingsWithoutDeepestLevel;
-      } else {
-        break;
+    if (deepestHeadingLevel >= 7) {
+      const headingsWithoutDeepestLevel = headings.filter(h => h.level < deepestHeadingLevel);
+      if (headingsWithoutDeepestLevel.length < headings.length) {
+        if (headingsWithoutDeepestLevel.length >= 8) {
+          headings = headingsWithoutDeepestLevel;
+        }
       }
-    } else {
-      break;
     }
   }
 


### PR DESCRIPTION
… and excluding the deepest level doesn't remove too much (still >=8 headings), we exclude the deepest level

This is motivated by https://www.lesswrong.com/posts/7im8at9PmhbT4JHsW/ngo-and-yudkowsky-on-alignment-difficulty where each message in a dialogue got a ToC entry, which was much too many

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210416522190625) by [Unito](https://www.unito.io)
