### PR TITLE
Fix an N+1 select in JargonTerms

### DIFF
--- a/packages/lesswrong/server/repos/JargonTermsRepo.ts
+++ b/packages/lesswrong/server/repos/JargonTermsRepo.ts
@@ -1,6 +1,8 @@
 import AbstractRepo from "./AbstractRepo";
 import JargonTerms from "@/server/collections/jargonTerms/collection";
 import { recordPerfMetrics } from "./perfMetricWrapper";
+import keyBy from "lodash/keyBy";
+
 class JargonTermsRepo extends AbstractRepo<"JargonTerms"> {
   constructor() {
     super(JargonTerms);
@@ -23,6 +25,48 @@ class JargonTermsRepo extends AbstractRepo<"JargonTerms"> {
       AND jt."postId" != $2
       ORDER BY jt.term, jtr."editedAt" DESC
     `, [userId, postId]);
+  }
+  
+  async getHumansAndOrAIEdited(botAccountId: string, documentIds: string[]): Promise<Array<"humans"|"AI"|"humansAndAI">> {
+    const oldestAndNewestRevisionIds = await this.getRawDb().any(`
+      -- JargonTermsRepo.getHumansAndOrAIEdited
+      WITH newest_revisions AS (
+        SELECT
+          DISTINCT ON ("documentId")
+          _id, "documentId", "userId"
+        FROM "Revisions"
+        WHERE "documentId" IN ($1:csv)
+        ORDER BY "documentId", "createdAt" DESC
+      ),
+      oldest_revisions AS (
+        SELECT
+          DISTINCT ON ("documentId")
+          _id, "documentId", "userId"
+        FROM "Revisions"
+        WHERE "documentId" IN ($1:csv)
+        ORDER BY "documentId", "createdAt" ASC
+      )
+      SELECT
+        n."documentId",
+        n."userId" AS newest_revision_user_id,
+        o."userId" AS oldest_revision_user_id
+      FROM newest_revisions n
+      JOIN oldest_revisions o ON n."documentId" = o."documentId"
+      ORDER BY n."documentId";
+    `, [documentIds]);
+    const rowsById = keyBy(oldestAndNewestRevisionIds, r=>r.documentId);
+    return documentIds.map((documentId: string) => {
+      const { oldest_revision_user_id, newest_revision_user_id } = rowsById[documentId];
+      const madeByAI = oldest_revision_user_id === botAccountId;
+      const editedByHumans = newest_revision_user_id !== botAccountId;
+      if (madeByAI && editedByHumans) {
+        return "humansAndAI";
+      } else if (!madeByAI && editedByHumans) {
+        return "humans";
+      } else {
+        return "AI";
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Fix an N+1 select in `JargonTerms. humansAndOrAIEdited`. You wouldn't think this would come up in practice, but actually it does a bunch of queries on the critical path of post-pages where the glossary is hidden (because none of the jargon terms are approved). Optimize it to one query.