### PR TITLE
NoSSR link previews and side-comments

### DIFF
--- a/packages/lesswrong/components/comments/SideCommentIcon.tsx
+++ b/packages/lesswrong/components/comments/SideCommentIcon.tsx
@@ -273,6 +273,7 @@ const SideCommentSingle = ({commentId, post, dontTruncateRoot=false, closeDialog
     fragmentName: 'CommentWithRepliesFragment',
     preloadFragmentName: 'CommentsList',
     documentId: commentId,
+    ssr: false,
   });
 
   const optimisticComment: CommentWithRepliesFragment | null = comment

--- a/packages/lesswrong/components/comments/useComment.ts
+++ b/packages/lesswrong/components/comments/useComment.ts
@@ -1,7 +1,7 @@
 import { useMulti } from '../../lib/crud/withMulti';
 import { isValidBase36Id } from '../../lib/utils/base36id';
 
-export const useCommentByLegacyId = ({ legacyId }: { legacyId: string }): {
+export const useCommentByLegacyId = ({ legacyId, ssr=true }: { legacyId: string, ssr?: boolean }): {
   comment: CommentsList|null,
   loading: boolean,
   error: any,
@@ -19,6 +19,7 @@ export const useCommentByLegacyId = ({ legacyId }: { legacyId: string }): {
     fragmentName: 'CommentsList',
     limit: 1,
     enableTotal: false,
+    ssr,
   });
   
   if (!isValidId) {

--- a/packages/lesswrong/components/linkPreview/LinkToPost.tsx
+++ b/packages/lesswrong/components/linkPreview/LinkToPost.tsx
@@ -1,37 +1,39 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { linkStyle } from './PostLinkPreview';
+import { linkStyles } from './PostLinkPreview';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
+import { defineStyles, useStyles } from '../hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
-  ...linkStyle(theme),
+const styles = defineStyles("LinkToPost", (theme: ThemeType) => ({
   linkColor: {
     color: theme.palette.primary.main,
   },
-});
+}));
 
 // A link to a post. Differs from the stuff in PostLinkPreview in that it's a
 // provided post object, rather than integrating with user-provided markup.
-const LinkToPost = ({post, classes}: {
+const LinkToPost = ({post}: {
   post: PostsList|null,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
+  const linkClasses = useStyles(linkStyles);
+
   if (!post) {
     return <span>[Deleted]</span>
   }
   const visited = post?.isRead;
   return (
     <PostsTooltip post={post} placement="bottom-start" clickable>
-      <Link className={classNames(classes.link, classes.linkColor, visited && "visited")} to={postGetPageUrl(post)}>
+      <Link className={classNames(linkClasses.link, classes.linkColor, visited && "visited")} to={postGetPageUrl(post)}>
         {post.title}
       </Link>
     </PostsTooltip>
   );
 }
 
-export default registerComponent("LinkToPost", LinkToPost, {styles});
+export default registerComponent("LinkToPost", LinkToPost);
 
 

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -30,8 +30,7 @@ let missingLinkPreviewsLogged = new Set<string>();
 // on it which contain links to LessWrong posts that only exist in the prod DB,
 // not the dev DB, and the error-logging that used to produce was extremely
 // voluminous.
-function logMissingLinkPreview(message: string)
-{
+function logMissingLinkPreview(message: string) {
   if (isClient) {
     if(!missingLinkPreviewsLogged.has(message)) {
       missingLinkPreviewsLogged.add(message);
@@ -210,10 +209,11 @@ const PostLinkPreviewVariantCheck = ({ href, post, targetLocation, comment, comm
   </PostLinkPreviewWithPost>
 }
 
-export const linkStyle = (theme: ThemeType) => (
-  visitedLinksHaveFilledInCircle
-    ? {
-      link: {
+
+export const linkStyles = defineStyles("LinkStyles", (theme: ThemeType) => ({
+  link: {
+    ...(visitedLinksHaveFilledInCircle
+      ? {
         '&:after': {
           content: '""',
           top: -7,
@@ -255,30 +255,85 @@ export const linkStyle = (theme: ThemeType) => (
           background: theme.palette.link.visited ?? theme.palette.primary.main,
           border: `1.2px solid ${theme.palette.link.visited ?? theme.palette.primary.main}`,
         },
-      },
-      redLink: {
-        color: `${theme.palette.error.main} !important`,
-        '&:after': {
-          border: `1.2px solid ${theme.palette.error.main}`,
-        },
-        '&:visited:after, &.visited:after': {
-          border: `1.2px solid ${theme.palette.error.main}`,
-        },
-      },
-    } : {
-      link: {
+      } : {
         '&:after': {
           content: '"°"',
           marginLeft: 1,
         },
+      }
+    )
+  },
+  redLink: {
+    ...(visitedLinksHaveFilledInCircle ? {
+      color: `${theme.palette.error.main} !important`,
+      '&:after': {
+        border: `1.2px solid ${theme.palette.error.main}`,
       },
-      redLink: undefined,
-    }
-);
-
-const styles = (theme: ThemeType) => ({
-  ...linkStyle(theme)
-})
+      '&:visited:after, &.visited:after': {
+        border: `1.2px solid ${theme.palette.error.main}`,
+      },
+    } : {})
+  },
+  
+  owidIframe: {
+    width: 600,
+    height: 375,
+    border: "none",
+    maxWidth: "100vw",
+  },
+  owidBackground: {
+  },
+  metaculusIframe: {
+    width: 400,
+    height: 250,
+    border: "none",
+    maxWidth: "100vw"
+  },
+  metaculusBackground: {
+    backgroundColor: theme.palette.panelBackground.metaculusBackground,
+  },
+  fatebookIframe: {
+    width: 560,
+    height: 200,
+    border: "none",
+    maxWidth: "100vw",
+    backgroundColor: theme.palette.panelBackground.default,
+    borderRadius: 3,
+    boxShadow: theme.palette.boxShadow.eaCard,
+  },
+  manifoldIframe: {
+    width: 560,
+    height: 405,
+    border: "none",
+    maxWidth: "100vw",
+  },
+  neuronpediaIframe: {
+    width: "100%",
+    height: 360,
+    border: "1px solid",
+    borderColor: theme.palette.grey[300],
+    borderRadius: 6,
+    maxWidth: 639,
+  },
+  metaforecastIframe: {
+    width: 560,
+    height: 405,
+    border: "none",
+    maxWidth: "100vw",
+  },
+  estimakerIframe: {
+    width: 560,
+    height: 405,
+    border: "none",
+    maxWidth: "100vw",
+  },
+  viewpointsIframe: {
+    width: 560,
+    height: 300,
+    border: "none",
+    maxWidth: "100vw",
+  },
+}));
 
 const PostLinkCommentPreview = ({href, commentId, post, id, children}: {
   href: string,
@@ -310,8 +365,6 @@ const PostLinkCommentPreview = ({href, commentId, post, id, children}: {
   </PostLinkPreviewWithPost>
 }
 
-const postLinkPreviewWithPostStyles = defineStyles('PostLinkPreviewWithPost', styles);
-
 const PostLinkPreviewWithPost = ({href, post, id, children}: {
   href: string,
   post: PostsList|null,
@@ -319,7 +372,7 @@ const PostLinkPreviewWithPost = ({href, post, id, children}: {
   error: any,
   children: ReactNode,
 }) => {
-  const classes = useStyles(postLinkPreviewWithPostStyles);
+  const classes = useStyles(linkStyles);
 
   if (!post) {
     return <Link to={href} className={classes.link}>
@@ -344,8 +397,6 @@ const PostLinkPreviewWithPost = ({href, post, id, children}: {
   );
 }
 
-const commentLinkPreviewWithCommentStyles = defineStyles('CommentLinkPreviewWithComment', styles);
-
 const CommentLinkPreviewWithComment = ({href, comment, post, id, children}: {
   href: string,
   comment: any,
@@ -354,7 +405,7 @@ const CommentLinkPreviewWithComment = ({href, comment, post, id, children}: {
   error: any,
   children: ReactNode,
 }) => {
-  const classes = useStyles(commentLinkPreviewWithCommentStyles);
+  const classes = useStyles(linkStyles);
 
   if (!comment) {
     return <Link to={href} className={classes.link}>
@@ -376,14 +427,12 @@ const CommentLinkPreviewWithComment = ({href, comment, post, id, children}: {
   );
 }
 
-const sequencePreviewStyles = defineStyles('SequencePreview', styles);
-
 export const SequencePreview = ({targetLocation, href, children}: {
   targetLocation: any,
   href: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(sequencePreviewStyles);
+  const classes = useStyles(linkStyles);
   
   const sequenceId = targetLocation.params._id;
 
@@ -467,23 +516,12 @@ export const DefaultPreview = ({href, onsite=false, id, rel, children}: {
   );
 }
 
-const owidStyles = defineStyles('OWIDPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 600,
-    height: 375,
-    border: "none",
-    maxWidth: "100vw",
-  },
-  background: {},
-  ...linkStyle(theme)
-}));
-
 export const OWIDPreview = ({href, id, children}: {
   href: string,
   id?: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(owidStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
   const [match] = href.match(/^http(?:s?):\/\/ourworldindata\.org\/grapher\/.*/) || []
 
@@ -500,33 +538,20 @@ export const OWIDPreview = ({href, id, children}: {
       </a>
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-        <div className={classes.background}>
-          <iframe className={classes.iframeStyling} src={match} />
+        <div className={classes.owidBackground}>
+          <iframe className={classes.owidIframe} src={match} />
         </div>
       </LWPopper>
     </span>
   </AnalyticsTracker>
 }
 
-const metaculusStyles = defineStyles('MetaculusPreview', (theme: ThemeType) => ({
-  background: {
-    backgroundColor: theme.palette.panelBackground.metaculusBackground,
-  },
-  iframeStyling: {
-    width: 400,
-    height: 250, 
-    border: "none",
-    maxWidth: "100vw"
-  },
-  ...linkStyle(theme)
-}));
-
 export const MetaculusPreview = ({href, id, children}: {
   href: string,
   id?: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(metaculusStyles);
+  const classes = useStyles(linkStyles);
 
   const { anchorEl, hover, eventHandlers } = useHover();
   const [match, www, questionNumber] = href.match(/^http(?:s?):\/\/(www\.)?metaculus\.com\/questions\/([a-zA-Z0-9]{1,6})?/) || []
@@ -544,33 +569,20 @@ export const MetaculusPreview = ({href, id, children}: {
       </a>
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-        <div className={classes.background}>
-          <iframe className={classes.iframeStyling} src={`https://d3s0w6fek99l5b.cloudfront.net/s/1/questions/embed/${questionNumber}/?plot=pdf`} />
+        <div className={classes.metaculusBackground}>
+          <iframe className={classes.metaculusIframe} src={`https://d3s0w6fek99l5b.cloudfront.net/s/1/questions/embed/${questionNumber}/?plot=pdf`} />
         </div>
       </LWPopper>
     </span>
   </AnalyticsTracker>
 }
 
-const fatebookStyles = defineStyles('FatebookPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 560,
-    height: 200,
-    border: "none",
-    maxWidth: "100vw",
-    backgroundColor: theme.palette.panelBackground.default,
-    borderRadius: 3,
-    boxShadow: theme.palette.boxShadow.eaCard,
-  },
-  link: linkStyle(theme),
-}));
-
 export const FatebookPreview = ({href, id, children}: {
   href: string,
   id?: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(fatebookStyles);
+  const classes = useStyles(linkStyles);
   
   const { anchorEl, hover, eventHandlers } = useHover();
 
@@ -596,29 +608,19 @@ export const FatebookPreview = ({href, id, children}: {
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={url} />
+          <iframe className={classes.fatebookIframe} src={url} />
         </LWPopper>
       </span>
     </AnalyticsTracker>
   );
 };
 
-const manifoldStyles = defineStyles('ManifoldPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 560,
-    height: 405,
-    border: "none",
-    maxWidth: "100vw",
-  },
-  ...linkStyle(theme),
-}));
-
 export const ManifoldPreview = ({href, id, children}: {
   href: string;
   id?: string;
   children: ReactNode,
 }) => {
-  const classes = useStyles(manifoldStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
 
   // test if fits https://manifold.markets/embed/[...]
@@ -645,31 +647,19 @@ export const ManifoldPreview = ({href, id, children}: {
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={url} />
+          <iframe className={classes.manifoldIframe} src={url} />
         </LWPopper>
       </span>
     </AnalyticsTracker>
   );
 };
 
-const neuronpediaStyles = defineStyles('NeuronpediaPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: "100%",
-    height: 360,
-    border: "1px solid",
-    borderColor: theme.palette.grey[300],
-    borderRadius: 6,
-    maxWidth: 639,
-  },
-  ...linkStyle(theme),
-}));
-
 export const NeuronpediaPreview = ({href, id, children}: {
   href: string;
   id?: string;
   children: ReactNode,
 }) => {
-  const classes = useStyles(neuronpediaStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
 
   // test if it's already an embed url https://[www.]neuronpedia.org/[model]/[layer]/[index]?embed=true[...]
@@ -697,29 +687,19 @@ export const NeuronpediaPreview = ({href, id, children}: {
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={url} />
+          <iframe className={classes.neuronpediaIframe} src={url} />
         </LWPopper>
       </span>
     </AnalyticsTracker>
   );
 };
 
-const metaforecastStyles = defineStyles('MetaforecastPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 560,
-    height: 405,
-    border: "none",
-    maxWidth: "100vw",
-  },
-  ...linkStyle(theme),
-}));
-
 export const MetaforecastPreview = ({href, id, children}: {
   href: string;
   id?: string;
   children: ReactNode,
 }) => {
-  const classes = useStyles(metaforecastStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
 
   // test if fits https://metaforecast.org/questions/embed/[...]
@@ -746,7 +726,7 @@ export const MetaforecastPreview = ({href, id, children}: {
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={url} />
+          <iframe className={classes.metaforecastIframe} src={url} />
         </LWPopper>
       </span>
     </AnalyticsTracker>
@@ -778,7 +758,6 @@ const arbitalStyles = defineStyles('ArbitalPreview', (theme: ThemeType) => ({
     fill: theme.palette.icon.dim2,
     marginTop: -5
   },
-  ...linkStyle(theme)
 }));
 
 export const ArbitalPreview = ({href, id, children}: {
@@ -787,6 +766,8 @@ export const ArbitalPreview = ({href, id, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(arbitalStyles);
+  const linkClasses = useStyles(linkStyles);
+
   const { anchorEl, hover, eventHandlers } = useHover();
   const [match, www, arbitalSlug] = href.match(/^http(?:s?):\/\/(www\.)?arbital\.com\/p\/([a-zA-Z0-9_]+)+/) || []
 
@@ -810,7 +791,7 @@ export const ArbitalPreview = ({href, id, children}: {
 
   return <AnalyticsTracker eventType="link" eventProps={{to: href}}>
     <span {...eventHandlers}>
-      <a className={classes.link} href={href} id={id}>
+      <a className={linkClasses.link} href={href} id={id}>
         {children}
       </a>
       
@@ -829,22 +810,12 @@ export const ArbitalPreview = ({href, id, children}: {
   </AnalyticsTracker>
 }
 
-const estimakerStyles = defineStyles('EstimakerPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 560,
-    height: 405,
-    border: "none",
-    maxWidth: "100vw",
-  },
-  ...linkStyle(theme),
-}));
-
 export const EstimakerPreview = ({href, id, children}: {
   href: string,
   id?: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(estimakerStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
 
   // test if fits https://estimaker.app/_/$user/$slug
@@ -865,29 +836,19 @@ export const EstimakerPreview = ({href, id, children}: {
           {children}
         </a>
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={href} />
+          <iframe className={classes.estimakerIframe} src={href} />
         </LWPopper>
       </span>
     </AnalyticsTracker>
   );
 };
 
-const viewpointsStyles = defineStyles('ViewpointsPreview', (theme: ThemeType) => ({
-  iframeStyling: {
-    width: 560,
-    height: 300,
-    border: "none",
-    maxWidth: "100vw",
-  },
-  ...linkStyle(theme),
-}));
-
 export const ViewpointsPreview = ({href, id, children}: {
   href: string,
   id?: string,
   children: ReactNode,
 }) => {
-  const classes = useStyles(viewpointsStyles);
+  const classes = useStyles(linkStyles);
   const { anchorEl, hover, eventHandlers } = useHover();
 
   // test if fits https://viewpoints.xyz/embed/polls/$slug
@@ -913,7 +874,7 @@ export const ViewpointsPreview = ({href, id, children}: {
           {children}
         </a>
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <iframe className={classes.iframeStyling} src={url} />
+          <iframe className={classes.viewpointsIframe} src={url} />
         </LWPopper>
       </span>
     </AnalyticsTracker>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -1,11 +1,9 @@
 import React, { ReactNode } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { Card } from "@/components/widgets/Paper";
-import SupervisorAccountIcon from '@/lib/vendor/@material-ui/icons/src/SupervisorAccount';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Link } from '../../lib/reactRouterWrapper';
 import { looksLikeDbIdString } from '../../lib/routeUtil';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useCommentByLegacyId } from '../comments/useComment';
 import { useHover } from '../common/withHover';
 import { usePostByLegacyId, usePostBySlug } from '../posts/usePost';
@@ -54,8 +52,8 @@ export const PostLinkPreview = ({href, targetLocation, id, children}: {
   const { document: post, loading, error } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as any, //TODO
-
+    fetchPolicy: 'cache-first',
+    ssr: false,
     documentId: postID,
     allowNull: true,
   });
@@ -85,7 +83,8 @@ export const PostLinkPreviewSequencePost = ({href, targetLocation, id, children}
   const { document: post, loading, error } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as any, //TODO
+    fetchPolicy: 'cache-first',
+    ssr: false,
     documentId: postID,
     allowNull: true,
   });
@@ -106,7 +105,7 @@ export const PostLinkPreviewSlug = ({href, targetLocation, id, children}: {
   children: ReactNode,
 }) => {
   const slug = targetLocation.params.slug;
-  const { post, error } = usePostBySlug({ slug });
+  const { post, error } = usePostBySlug({ slug, ssr: false });
 
   return <PostLinkPreviewVariantCheck href={href} post={post} targetLocation={targetLocation} error={error} id={id}>
     {children}
@@ -120,7 +119,7 @@ export const PostLinkPreviewLegacy = ({href, targetLocation, id, children}: {
   children: ReactNode,
 }) => {
   const legacyId = targetLocation.params.id;
-  const { post, error } = usePostByLegacyId({ legacyId });
+  const { post, error } = usePostByLegacyId({ legacyId, ssr: false });
 
   return <PostLinkPreviewVariantCheck href={href} post={post} targetLocation={targetLocation} error={error} id={id}>
     {children}
@@ -136,8 +135,8 @@ export const CommentLinkPreviewLegacy = ({href, targetLocation, id, children}: {
   const legacyPostId = targetLocation.params.id;
   const legacyCommentId = targetLocation.params.commentId;
 
-  const { post, error: postError } = usePostByLegacyId({ legacyId: legacyPostId });
-  const { comment, error: commentError } = useCommentByLegacyId({ legacyId: legacyCommentId });
+  const { post, error: postError } = usePostByLegacyId({ legacyId: legacyPostId, ssr: false });
+  const { comment, error: commentError } = useCommentByLegacyId({ legacyId: legacyCommentId, ssr: false });
   const error = postError || commentError;
 
   if (comment) {
@@ -162,8 +161,8 @@ export const PostCommentLinkPreviewGreaterWrong = ({href, targetLocation, id, ch
   const { document: post, loading } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as any, //TODO
-
+    fetchPolicy: 'cache-first',
+    ssr: false,
     documentId: postId,
     allowNull: true,
   });
@@ -292,7 +291,8 @@ const PostLinkCommentPreview = ({href, commentId, post, id, children}: {
   const { document: comment, loading, error } = useSingle({
     collectionName: "Comments",
     fragmentName: 'CommentsList',
-    fetchPolicy: 'cache-then-network' as any, //TODO
+    fetchPolicy: 'cache-first',
+    ssr: false,
     documentId: commentId,
     allowNull: true,
   });
@@ -322,11 +322,9 @@ const PostLinkPreviewWithPost = ({href, post, id, children}: {
   const classes = useStyles(postLinkPreviewWithPostStyles);
 
   if (!post) {
-    return <span>
-      <Link to={href}>
-        {children}
-      </Link>
-    </span>
+    return <Link to={href} className={classes.link}>
+      {children}
+    </Link>
   }
 
   const hash = (href.indexOf("#") >= 0) ? (href.split("#")[1]) : undefined;
@@ -359,11 +357,9 @@ const CommentLinkPreviewWithComment = ({href, comment, post, id, children}: {
   const classes = useStyles(commentLinkPreviewWithCommentStyles);
 
   if (!comment) {
-    return <span>
-      <Link to={href}>
-        {children}
-      </Link>
-    </span>
+    return <Link to={href} className={classes.link}>
+      {children}
+    </Link>
   }
   return (
     <PostsTooltip
@@ -395,7 +391,8 @@ export const SequencePreview = ({targetLocation, href, children}: {
     documentId: sequenceId,
     collectionName: "Sequences",
     fragmentName: 'SequencesPageFragment',
-    fetchPolicy: 'cache-then-network' as any,
+    fetchPolicy: 'cache-first',
+    ssr: false,
     allowNull: true,
   });
 

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsPreviewTooltipSingle.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsPreviewTooltipSingle.tsx
@@ -10,7 +10,7 @@ export const PostsPreviewTooltipSingle = ({postId, postsList=false}: {
   const { document: post, loading: postLoading } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as AnyBecauseTodo,
+    fetchPolicy: 'cache-first',
     documentId: postId,
   });
   if (postLoading) {
@@ -30,7 +30,7 @@ export const DialogueMessagePreviewTooltip = ({postId, postsList=false, dialogue
   const { document: post, loading: postLoading } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as AnyBecauseTodo,
+    fetchPolicy: 'cache-first',
     documentId: postId,
   });
   if (postLoading) {
@@ -49,14 +49,14 @@ export const PostsPreviewTooltipSingleWithComment = ({postId, commentId}: {
   const { document: post, loading: postLoading } = useSingle({
     collectionName: "Posts",
     fragmentName: 'PostsList',
-    fetchPolicy: 'cache-then-network' as AnyBecauseTodo,
+    fetchPolicy: 'cache-first',
     documentId: postId,
   });
 
   const { document: comment, loading: commentLoading } = useSingle({
     collectionName: "Comments",
     fragmentName: 'CommentsList',
-    fetchPolicy: 'cache-then-network' as AnyBecauseTodo,
+    fetchPolicy: 'cache-first',
     documentId: commentId,
   });
   if (postLoading || commentLoading) {
@@ -77,7 +77,7 @@ export const TaggedPostTooltipSingle = ({tagRelId}: {tagRelId: string}) => {
   const { document: tagRel, loading: tagRelLoading } = useSingle({
     collectionName: "TagRels",
     fragmentName: 'TagRelFragment',
-    fetchPolicy: 'cache-then-network' as AnyBecauseTodo,
+    fetchPolicy: 'cache-first',
     documentId: tagRelId,
   });
   if (tagRelLoading) {

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback } from "react";
-import { registerComponent } from "../../../lib/vulcan-lib/components";
 import type { Placement as PopperPlacementType } from "popper.js"
 import { DialogueMessageInfo, PostsPreviewTooltip } from "./PostsPreviewTooltip";
 import {
@@ -117,9 +116,4 @@ const PostsTooltip = ({
   );
 }
 
-export default registerComponent(
-  "PostsTooltip",
-  PostsTooltip,
-);
-
-
+export default PostsTooltip;

--- a/packages/lesswrong/components/posts/usePost.ts
+++ b/packages/lesswrong/components/posts/usePost.ts
@@ -2,7 +2,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { ApolloError } from '@apollo/client';
 import { useSingle, UseSingleProps } from '../../lib/crud/withSingle';
 
-export const usePostBySlug = ({slug}: {slug: string}):
+export const usePostBySlug = ({slug, ssr=true}: {slug: string, ssr?: boolean}):
   {
     post: PostsPage,
     loading: false,
@@ -22,6 +22,7 @@ export const usePostBySlug = ({slug}: {slug: string}):
     fragmentName: 'PostsPage',
     limit: 1,
     enableTotal: false,
+    ssr,
   });
   
   if (results && results.length>0 && results[0]._id) {
@@ -39,7 +40,10 @@ export const usePostBySlug = ({slug}: {slug: string}):
   }
 }
 
-export const usePostByLegacyId = ({ legacyId }: {legacyId: string}):
+export const usePostByLegacyId = ({ legacyId, ssr=true }: {
+  legacyId: string
+  ssr?: boolean
+}):
   {
     post: PostsPage,
     loading: false,
@@ -59,6 +63,7 @@ export const usePostByLegacyId = ({ legacyId }: {legacyId: string}):
     fragmentName: 'PostsPage',
     limit: 1,
     enableTotal: false,
+    ssr,
   });
   
   if (results && results.length>0 && results[0]._id) {

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useTagPreview } from './useTag';
-import { linkStyle } from '../linkPreview/PostLinkPreview';
+import { linkStyles } from '../linkPreview/PostLinkPreview';
 import { removeUrlParameters } from '../../lib/routeUtil';
 import classNames from 'classnames';
 import { hasWikiLenses } from '@/lib/betas';
@@ -10,7 +10,6 @@ import { defineStyles, useStyles } from '../hooks/useStyles';
 import TagsTooltip from "./TagsTooltip";
 
 const styles = defineStyles('TagHoverPreview', (theme: ThemeType) => ({
-  ...linkStyle(theme),
   count: {
     color: theme.palette.secondary.main, // grey[500],
     fontSize: ".9em",
@@ -38,6 +37,7 @@ export const TagHoverPreview = ({
   children: React.ReactNode,
 }) => {
   const classes = useStyles(styles);
+  const linkClasses = useStyles(linkStyles);
   
   const { params: {slug}, hash } = targetLocation;
   // Slice the hash to remove the leading # (which won't be a part of the
@@ -66,9 +66,9 @@ export const TagHoverPreview = ({
     >
       <Link
         className={classNames(
-          !showPostCount && classes.link,
+          !showPostCount && linkClasses.link,
           isRead && "visited",
-          isRedLink && classes.redLink,
+          isRedLink && linkClasses.redLink,
         )}
         to={linkTarget}
       >

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -46,7 +46,7 @@ const TagSearchHit = ({hit, onClick, hidePostCount=false, isVotingContext, class
     documentId: hit._id,
     collectionName: "Tags",
     fragmentName: "TagPreviewFragment",
-    fetchPolicy: 'cache-then-network' as any, //TODO
+    fetchPolicy: 'cache-first',
   });
   const {eventHandlers, hover, anchorEl} = useHover();
   const currentUser = useCurrentUser();

--- a/packages/lesswrong/lib/crud/useSingleWithPreload.ts
+++ b/packages/lesswrong/lib/crud/useSingleWithPreload.ts
@@ -12,11 +12,13 @@ export function useSingleWithPreload<
   fragmentName,
   preloadFragmentName,
   documentId,
+  ssr=true,
 }: {
   collectionName: CollectionName;
   fragmentName: FragmentName;
   preloadFragmentName: PreloadFragmentName;
   documentId: string;
+  ssr?: boolean,
 }) {
   const apolloClient = useApolloClient();
 
@@ -32,6 +34,7 @@ export function useSingleWithPreload<
     documentId,
     collectionName,
     fragmentName,
+    ssr,
   });
 
   return {


### PR DESCRIPTION
With the recent ContentItemBody rework, links embedded in posts SSR with their link-preview indicator circle present. However, a cost of this was that the server would fetch a preview of the post, in order to get it ready for hover and to get the user's read-status to decide whether to fill in the circle or not. This was a change from the previous behavior, where the post preview would be fetched by the client post-load.

This restores the earlier timing: the post preview is downloaded by the client after SSR is complete. However, the link-circle will be present immediately (but always unfilled), so that the SSR is visually consistent.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210426958049913) by [Unito](https://www.unito.io)
