### PR TITLE
[EA Forum only] mods can see posts that are suggested for curation

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -20,6 +20,7 @@ import SidebarAction from "./SidebarAction";
 import SidebarActionMenu from "./SidebarActionMenu";
 import ForumIcon from "../common/ForumIcon";
 import FormatDate from "../common/FormatDate";
+import { isEAForum } from '@/lib/instanceSettings';
 
 const styles = (theme: ThemeType) => ({
   audioIcon: {
@@ -95,7 +96,8 @@ const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost, timeFor
     })
   }
 
-  const hasCurationNotice = post.curationNotices && post.curationNotices.length > 0
+  // On the EA Forum, only admins can curate and remove from curation suggestions
+  const canCurate = isEAForum ? currentUser?.isAdmin : true;
 
   return (
     <span {...eventHandlers}>
@@ -151,14 +153,15 @@ const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost, timeFor
               <ForumIcon icon="Undo"/>
             </SidebarAction>
           }
-          { timeForCuration &&
+          { timeForCuration && canCurate &&
             <SidebarAction title="Curate Post" onClick={handleCurate}>
               <ForumIcon icon="Star" />
             </SidebarAction>
           }
-          <SidebarAction title="Remove from Curation Suggestions" onClick={handleDisregardForCurated}>
-            <ForumIcon icon="Clear"/>
-          </SidebarAction>
+          { canCurate && <SidebarAction title="Remove from Curation Suggestions" onClick={handleDisregardForCurated}>
+              <ForumIcon icon="Clear"/>
+            </SidebarAction>
+          }
         </SidebarActionMenu>}
       </SunshineListItem>
     </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -12,6 +12,7 @@ import FormatDate from "../common/FormatDate";
 import LoadMore from "../common/LoadMore";
 import LWTooltip from "../common/LWTooltip";
 import ForumIcon from "../common/ForumIcon";
+import { userIsMemberOf } from '@/lib/vulcan-users/permissions';
 
 const styles = (theme: ThemeType) => ({
   loadMorePadding: {
@@ -46,7 +47,7 @@ const styles = (theme: ThemeType) => ({
 
 const shouldShow = (atBottom: boolean, timeForCuration: boolean, currentUser: UsersCurrent | null, hasCurationDrafts: boolean) => {
   if (isEAForum) {
-    return !atBottom && currentUser?.isAdmin;
+    return !atBottom && (currentUser?.isAdmin || userIsMemberOf(currentUser, 'canSuggestCuration'));
   } else {
     return (atBottom === hasCurationDrafts) || timeForCuration;
   }


### PR DESCRIPTION
Currently, EA Forum mods can see the sunshine sidebar, and they can suggest individual posts for curation, but they don't see the list of "Suggested for Curated" posts. This PR just adds this list to their sidebar, to make it easier for them to +1 a suggestion.

Currently curation is only done by people on the Forum Team, so I've hidden the options to curate and remove a post from the list from non-admins on the EA Forum.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210427173769308) by [Unito](https://www.unito.io)
