### PR TITLE
fix bayes guide custom html attribute handling in refactored ContentItemBody

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -265,6 +265,16 @@ function translateAttribs(attribs: Record<string,string>): Record<string,any> {
   if ('style' in attribsCopy) {
     attribsCopy.style = parseInlineStyle(attribs.style);
   }
+
+  if ('onclick' in attribsCopy) {
+    attribsCopy.onClick = new Function(attribsCopy.onclick);
+    delete attribsCopy.onclick;
+  }
+  if ('onchange' in attribsCopy) {
+    attribsCopy.onChange = new Function(attribsCopy.onchange);
+    delete attribsCopy.onchange;
+  }
+
   for (const attribKey of Object.keys(attribsCopy)) {
     if (attribKey in mapAttributeNames) {
       attribsCopy[mapAttributeNames[attribKey]] = attribsCopy[attribKey];
@@ -288,6 +298,7 @@ const mapAttributeNames: Record<string,string> = {
   "columnspan": "columnSpan",
   "rowspan": "rowSpan",
   "allowfullscreen": "allowFullScreen",
+  "for": "htmlFor",
 }
 
 function camelCaseCssAttribute(input: string) {

--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -267,6 +267,8 @@ function translateAttribs(attribs: Record<string,string>): Record<string,any> {
     attribsCopy.style = parseInlineStyle(attribs.style);
   }
 
+  // These two are used in the custom Bayes Rule Guide html.
+  // Using `new Function` seemed safer than `eval`.
   if ('onclick' in attribsCopy) {
     try {
       attribsCopy.onClick = new Function(attribsCopy.onclick);

--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -16,6 +16,7 @@ import { validateUrl } from '@/lib/vulcan-lib/utils';
 import { captureEvent } from '@/lib/analyticsEvents';
 import ForumEventPostPagePollSection from '../forumEvents/ForumEventPostPagePollSection';
 import repeat from 'lodash/repeat';
+import { captureException } from '@sentry/core';
 
 type PassedThroughContentItemBodyProps = Pick<ContentItemBodyProps, "description"|"noHoverPreviewPrefetch"|"nofollow"|"contentStyleType"|"replacedSubstrings"|"idInsertions"> & {
   bodyRef: React.RefObject<HTMLDivElement|null>
@@ -267,12 +268,24 @@ function translateAttribs(attribs: Record<string,string>): Record<string,any> {
   }
 
   if ('onclick' in attribsCopy) {
-    attribsCopy.onClick = new Function(attribsCopy.onclick);
-    delete attribsCopy.onclick;
+    try {
+      attribsCopy.onClick = new Function(attribsCopy.onclick);
+      delete attribsCopy.onclick;  
+    } catch (e) {
+      captureException(`Error parsing onclick attribute in ContentItemBody.  Original function string: ${attribsCopy.onclick}.  Error: ${e.message}`);
+      // eslint-disable-next-line no-console
+      console.error('Error parsing onclick attribute', e);
+    }
   }
   if ('onchange' in attribsCopy) {
-    attribsCopy.onChange = new Function(attribsCopy.onchange);
-    delete attribsCopy.onchange;
+    try {
+      attribsCopy.onChange = new Function(attribsCopy.onchange);
+      delete attribsCopy.onchange;  
+    } catch (e) {
+      captureException(`Error parsing onchange attribute in ContentItemBody.  Original function string: ${attribsCopy.onchange}.  Error: ${e.message}`);
+      // eslint-disable-next-line no-console
+      console.error('Error parsing onchange attribute', e);
+    }
   }
 
   for (const attribKey of Object.keys(attribsCopy)) {

--- a/packages/lesswrong/server/utils/arbital/resources/bayesGuideMultipleChoice.html
+++ b/packages/lesswrong/server/utils/arbital/resources/bayesGuideMultipleChoice.html
@@ -3,29 +3,29 @@
 
   <div class="options">
     <label class="option">
-      <input type="radio" name="preference" value="basic" data-not-wants="62d,62f" onchange="handleRadioChange(this)" checked />
-      <span>I want to have a basic theoretical and practical understanding of the Bayes' rule.</span>
+      <input id="bayes-guide-basic-radio" type="radio" name="preference" value="basic" data-not-wants="62d,62f" onchange="handleRadioChange(document.getElementById('bayes-guide-basic-radio'))" />
+      <span for="bayes-guide-basic-radio">I want to have a basic theoretical and practical understanding of the Bayes' rule.</span>
     </label>
 
     <label class="option">
-      <input type="radio" name="preference" value="quick" data-wants="62d" data-not-wants="62f" onchange="handleRadioChange(this)" />
-      <span
+      <input id="bayes-guide-quick-radio" type="radio" name="preference" value="quick" data-wants="62d" data-not-wants="62f" onchange="handleRadioChange(document.getElementById('bayes-guide-quick-radio'))" />
+      <span for="bayes-guide-quick-radio"
         >I can easily read algebra and don't mind the explanation moving at a fast pace. Just give me the basics,
         quick!</span
       >
     </label>
 
     <label class="option">
-      <input type="radio" name="preference" value="theoretical" data-wants="62f" data-not-wants="62d" onchange="handleRadioChange(this)" />
-      <span
+      <input id="bayes-guide-theoretical-radio" type="radio" name="preference" value="theoretical" data-wants="62f" data-not-wants="62d" onchange="handleRadioChange(document.getElementById('bayes-guide-theoretical-radio'))" />
+      <span for="bayes-guide-theoretical-radio"
         >I want the basics, but I'm also interested in reading more about the theoretical implications and the reasons
         why Bayes' rule is considered so important.</span
       >
     </label>
 
     <label class="option">
-      <input type="radio" name="preference" value="deep" data-wants="62d,62f" onchange="handleRadioChange(this)" />
-      <span
+      <input id="bayes-guide-deep-radio" type="radio" name="preference" value="deep" data-wants="62d,62f" onchange="handleRadioChange(document.getElementById('bayes-guide-deep-radio'))" />
+      <span for="bayes-guide-deep-radio"
         >I'd like to read everything! I want to have a <em>deep</em> theoretical and practical understanding of the
         Bayes' rule.</span
       >


### PR DESCRIPTION
The `ContentItemBody` refactor didn't play very nicely with the custom Bayes Rule Guide html (which is a pretty hacky one-off in our codebase).  Translate the necessary event handler attribute names to camelCase, parse the function strings, and set `for` on the input labels so that React knows what it's doing when you click on one of them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210433761276445) by [Unito](https://www.unito.io)
