### PR TITLE
Export comments 'draft' field to elastic

### DIFF
--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -178,6 +178,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
         c."userId",
         COALESCE(c."baseScore", 0) AS "baseScore",
         COALESCE(c."deleted", FALSE) AS "deleted",
+        COALESCE(c."draft", FALSE) AS "draft",
         COALESCE(c."rejected", FALSE) AS "rejected",
         COALESCE(c."authorIsUnreviewed", FALSE) AS "authorIsUnreviewed",
         COALESCE(c."retracted", FALSE) AS "retracted",

--- a/packages/lesswrong/server/search/searchDocuments.d.ts
+++ b/packages/lesswrong/server/search/searchDocuments.d.ts
@@ -11,6 +11,7 @@ interface SearchComment extends SearchBase {
   isDeleted: boolean,
   retracted: boolean,
   deleted: boolean,
+  draft: boolean,
   spam: boolean,
   legacy: boolean,
   userIP: string | null,


### PR DESCRIPTION
Search for comments is currently broken because the `draft` field is missing in elastic. We need to merge this then, after deploying, run `yarn repl prod packages/lesswrong/server/search/elastic/ElasticExporter.ts 'new ElasticExporter().configureIndexes()'`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210439244261294) by [Unito](https://www.unito.io)
