### PR TITLE
Ultrafeed improved checkbox

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { getReviewPhase, reviewIsActive, REVIEW_YEAR } from '../../lib/reviewUtils';
 import { showReviewOnFrontPageIfActive, lightconeFundraiserThermometerGoalAmount, lightconeFundraiserActive } from '../../lib/publicSettings';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
-import { LAST_VISITED_FRONTPAGE_COOKIE, ULTRA_FEED_ENABLED_COOKIE } from '../../lib/cookies/cookies';
+import { LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
 import moment from 'moment';
 import { userHasUltraFeed,visitorGetsDynamicFrontpage } from '../../lib/betas';
 import { isLW, isAF } from '@/lib/instanceSettings';
@@ -51,9 +51,7 @@ const getStructuredData = () => ({
 })
 
 const LWHome = () => {
-  const currentUser = useCurrentUser();
-  const [ultraFeedCookie] = useCookiesWithConsent([ULTRA_FEED_ENABLED_COOKIE]);
-  const ultraFeedEnabled = !!currentUser && (ultraFeedCookie[ULTRA_FEED_ENABLED_COOKIE] === "true");
+  const [isUltraFeedShowing, setIsUltraFeedShowing] = useState(false);
 
   return (
       <AnalyticsContext pageContext="homePage">
@@ -75,8 +73,8 @@ const LWHome = () => {
             <LWHomePosts>
               <QuickTakesSection />
               <EAPopularCommentsSection />
-              <UltraFeed />
-              {!ultraFeedEnabled && ( 
+              <UltraFeed onShowingChange={setIsUltraFeedShowing} />
+              {!isUltraFeedShowing && (
                 <RecentDiscussionFeed
                   af={false}
                   commentsLimit={4}

--- a/packages/lesswrong/components/pages/UltraFeedPage.tsx
+++ b/packages/lesswrong/components/pages/UltraFeedPage.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { useStyles, defineStyles } from '../hooks/useStyles';
 import { useCurrentUser } from '../common/withUser';
 import UltraFeed from "../ultraFeed/UltraFeed";
+import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
+import { ULTRA_FEED_ENABLED_COOKIE, ULTRA_FEED_PAGE_VISITED_COOKIE } from '../../lib/cookies/cookies';
+import { useEffect } from 'react';
 
 const styles = defineStyles("UltraFeedPage", (theme: ThemeType) => ({
   loginMessage: {
@@ -13,6 +16,18 @@ const styles = defineStyles("UltraFeedPage", (theme: ThemeType) => ({
 const UltraFeedPage = () => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
+  const [_, setCookie] = useCookiesWithConsent([ULTRA_FEED_PAGE_VISITED_COOKIE]);
+
+  useEffect(() => {
+    setCookie(ULTRA_FEED_PAGE_VISITED_COOKIE, 'true', { 
+      path: "/", 
+    });
+
+    setCookie(ULTRA_FEED_ENABLED_COOKIE, 'true', { 
+      path: "/", 
+    });
+
+  }, [setCookie]);
 
   if (!currentUser) {
     return (

--- a/packages/lesswrong/components/pages/UltraFeedPage.tsx
+++ b/packages/lesswrong/components/pages/UltraFeedPage.tsx
@@ -16,17 +16,22 @@ const styles = defineStyles("UltraFeedPage", (theme: ThemeType) => ({
 const UltraFeedPage = () => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
-  const [_, setCookie] = useCookiesWithConsent([ULTRA_FEED_PAGE_VISITED_COOKIE]);
+  const [cookies, setCookie] = useCookiesWithConsent([ULTRA_FEED_PAGE_VISITED_COOKIE]);
+
+  const isFirstVisit = cookies[ULTRA_FEED_PAGE_VISITED_COOKIE] !== 'true';
 
   useEffect(() => {
+    if (isFirstVisit) {
+      setCookie(ULTRA_FEED_ENABLED_COOKIE, 'true', { 
+        path: "/", 
+      });
+    }
+
     setCookie(ULTRA_FEED_PAGE_VISITED_COOKIE, 'true', { 
       path: "/", 
     });
 
-    setCookie(ULTRA_FEED_ENABLED_COOKIE, 'true', { 
-      path: "/", 
-    });
-
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setCookie]);
 
   if (!currentUser) {

--- a/packages/lesswrong/components/pages/UltraFeedPage.tsx
+++ b/packages/lesswrong/components/pages/UltraFeedPage.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useStyles, defineStyles } from '../hooks/useStyles';
 import { useCurrentUser } from '../common/withUser';
 import UltraFeed from "../ultraFeed/UltraFeed";
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { ULTRA_FEED_ENABLED_COOKIE, ULTRA_FEED_PAGE_VISITED_COOKIE } from '../../lib/cookies/cookies';
-import { useEffect } from 'react';
 
 const styles = defineStyles("UltraFeedPage", (theme: ThemeType) => ({
   loginMessage: {

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useCurrentUser } from '../common/withUser';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
-import { ULTRA_FEED_ENABLED_COOKIE } from '../../lib/cookies/cookies';
+import { ULTRA_FEED_ENABLED_COOKIE, ULTRA_FEED_PAGE_VISITED_COOKIE } from '../../lib/cookies/cookies';
 import type { ObservableQuery } from '@apollo/client';
 import { randomId } from '../../lib/random';
 import DeferRender from '../common/DeferRender';
@@ -163,12 +163,8 @@ const UltraFeedContent = ({alwaysShow = false}: {
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
-  const [ultraFeedCookie, setUltraFeedCookie] = useCookiesWithConsent([ULTRA_FEED_ENABLED_COOKIE]);
-  const ultraFeedEnabledCookie = ultraFeedCookie[ULTRA_FEED_ENABLED_COOKIE] === "true";
-  const ultraFeedEnabled = !!currentUser && (ultraFeedEnabledCookie || alwaysShow);
-  
-  const [settings, setSettings] = useState<UltraFeedSettingsType>(getStoredSettings);
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [settings, setSettings] = useState<UltraFeedSettingsType>(getStoredSettings);
   const [sessionId] = useState<string>(() => {
     if (typeof window === 'undefined') return randomId();
     const storage = window.sessionStorage;
@@ -176,16 +172,12 @@ const UltraFeedContent = ({alwaysShow = false}: {
     storage.setItem(ULTRAFEED_SESSION_ID_KEY, currentId);
     return currentId;
   });
-  
   const refetchSubscriptionContentRef = useRef<null | ObservableQuery['refetch']>(null);
 
-  if (!(userIsAdminOrMod(currentUser) || ultraFeedEnabled || alwaysShow)) {
+
+  if (!currentUser) {
     return null;
   }
-
-  const toggleUltraFeed = () => {
-    setUltraFeedCookie(ULTRA_FEED_ENABLED_COOKIE, String(!ultraFeedEnabledCookie), { path: "/" });
-  };
 
   const toggleSettings = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -219,23 +211,9 @@ const UltraFeedContent = ({alwaysShow = false}: {
     </div>
   </>;
 
-  const checkBoxLabel = alwaysShow ? "Use New Feed on the frontpage (in place of Recent Discussion)" : "Use New Feed";
-
   return (
     <AnalyticsContext pageSectionContext="ultraFeed" ultraFeedContext={{ sessionId }}>
-    <div className={classes.root}>
-      <SingleColumnSection>
-        <div className={classes.toggleContainer}>
-          <SectionFooterCheckbox 
-            value={ultraFeedEnabledCookie} 
-            onClick={toggleUltraFeed} 
-            label={checkBoxLabel}
-            labelClassName={alwaysShow ? classes.checkboxLabelAlwaysShow : classes.checkboxLabel}
-          />
-        </div>
-      </SingleColumnSection>
-      
-      {ultraFeedEnabled && <>
+      <div className={classes.root}>
         <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode}>
         <OverflowNavObserverProvider>
           <SingleColumnSection>
@@ -334,19 +312,60 @@ const UltraFeedContent = ({alwaysShow = false}: {
           </SingleColumnSection>
         </OverflowNavObserverProvider>
         </UltraFeedObserverProvider>
-      </>}
-    </div>
+      </div>
     </AnalyticsContext>
   );
 };
 
-const UltraFeed = ({alwaysShow = false}: {
+const UltraFeed = ({alwaysShow = false, onShowingChange}: {
   alwaysShow?: boolean
+  onShowingChange?: (isShowing: boolean) => void
 }) => {
+  const classes = useStyles(styles);
+  const currentUser = useCurrentUser();
+  const [ultraFeedCookie, setUltraFeedCookie] = useCookiesWithConsent([ULTRA_FEED_ENABLED_COOKIE]);
+  const [ultraFeedPageVisitedCookie] = useCookiesWithConsent([ULTRA_FEED_PAGE_VISITED_COOKIE]);
+
+  
+  const hasVisitedFeedPage = ultraFeedPageVisitedCookie[ULTRA_FEED_PAGE_VISITED_COOKIE] === "true";
+  const checkboxChecked = ultraFeedCookie[ULTRA_FEED_ENABLED_COOKIE] === "true";
+
+  const showFeed = (alwaysShow || checkboxChecked || userIsAdminOrMod(currentUser)) && !!currentUser;
+  const showCheckbox = (checkboxChecked || hasVisitedFeedPage || alwaysShow || userIsAdminOrMod(currentUser)) && !!currentUser;
+
+  useEffect(() => {
+    onShowingChange?.(showFeed);
+  }, [showFeed, onShowingChange]);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const toggleUltraFeed = () => {
+    setUltraFeedCookie(ULTRA_FEED_ENABLED_COOKIE, String(!checkboxChecked), { path: "/" });
+  };
+
+  const checkBoxLabel = alwaysShow ? "Use New Feed on the frontpage (in place of Recent Discussion)" : "Use New Feed";
+  const labelClassName = alwaysShow ? classes.checkboxLabelAlwaysShow : classes.checkboxLabel;
+
   return (
-    <DeferRender ssr={false}>
-      <UltraFeedContent alwaysShow={alwaysShow} />
-    </DeferRender>
+    <>
+      {showCheckbox && <SingleColumnSection>
+          <div className={classes.toggleContainer}>
+            <SectionFooterCheckbox 
+            value={checkboxChecked} 
+            onClick={toggleUltraFeed} 
+            label={checkBoxLabel}
+            labelClassName={labelClassName}
+          />
+        </div>
+      </SingleColumnSection>}
+      {showFeed && (
+        <DeferRender ssr={false}>
+          <UltraFeedContent alwaysShow={alwaysShow} />
+        </DeferRender>
+      )}
+    </>
   );
 };
 

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -212,6 +212,12 @@ export const ULTRA_FEED_ENABLED_COOKIE = registerCookie({
   description: "Whether the ultra feed mode is enabled, which hides QuickTakes and Popular Comments",
 })
 
+export const ULTRA_FEED_PAGE_VISITED_COOKIE = registerCookie({
+  name: 'ultra_feed_page_visited',
+  type: "functional",
+  description: "Whether the user has ever visited the ultra feed page",
+})
+
 
 // Third party cookies
 


### PR DESCRIPTION
Makes it so that if you have visited the /feed page
- you always see the checkbox for enabling ultrafeed on the frontpage even if unchecked
- the ultrafeed is enabled on the frontpage for you automatically when you first visit (subsequent visits won't reenable it though)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210467483056631) by [Unito](https://www.unito.io)
