### PR TITLE
Ultrafeed more obvious comment relationships and icons for content sources/types

### DIFF
--- a/packages/lesswrong/components/spotlights/SpotlightFeedItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightFeedItem.tsx
@@ -13,6 +13,8 @@ import { AnalyticsContext } from '@/lib/analyticsEvents';
 import { ContentItemBody } from "../contents/ContentItemBody";
 import CloudinaryImage2 from "../common/CloudinaryImage2";
 import { Typography } from "../common/Typography";
+import StarIcon from "@/lib/vendor/@material-ui/icons/src/Star";
+import LWTooltip from "../common/LWTooltip";
 
 const buildVerticalFadeMask = (breakpoints: string[]) => {
   const mask = `linear-gradient(to bottom, ${breakpoints.join(",")})`;
@@ -93,6 +95,16 @@ const useSpotlightFeedItemStyles = defineStyles(
       display: "flex",
       alignItems: "center",
       marginBottom: 8,
+      textWrap: 'balance',
+    },
+    starIcon: {
+      width: 20,
+      height: 20,
+      marginRight: 8,
+      color: theme.palette.grey[800],
+      opacity: 1,
+      position: 'relative',
+      top: 3,
     },
     subtitle: {
       ...theme.typography.postStyle,
@@ -255,6 +267,9 @@ const SpotlightFeedItem = ({
           <div className={classes.content}>
             <div className={classes.titleArea}>
               <div className={classes.title}>
+                <LWTooltip title="This is a featured item" placement="top">
+                  <StarIcon className={classes.starIcon} />
+                </LWTooltip>
                 <Link to={url}>
                   {getSpotlightDisplayTitle(spotlight)}
                 </Link>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -24,7 +24,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     position: 'relative',
     paddingTop: commentHeaderPaddingDesktop,
     backgroundColor: 'transparent',
-    transition: 'background-color 0.75s ease-out',
+    transition: 'background-color 1.0s ease-out',
   },
   rootWithAnimation: {
     backgroundColor: `${theme.palette.primary.main}3b`,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -23,6 +23,12 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
   root: {
     position: 'relative',
     paddingTop: commentHeaderPaddingDesktop,
+    backgroundColor: 'transparent',
+    transition: 'background-color 0.75s ease-out',
+  },
+  rootWithAnimation: {
+    backgroundColor: `${theme.palette.primary.main}3b`,
+    transition: 'none',
   },
   mainContent: {
     display: 'flex',
@@ -168,6 +174,9 @@ export interface UltraFeedCommentItemProps {
   isLastComment?: boolean;
   onPostTitleClick?: () => void;
   settings?: UltraFeedSettingsType;
+  parentAuthorName?: string | null;
+  onReplyIconClick?: () => void;
+  isHighlightAnimating?: boolean;
 }
 
 export const UltraFeedCommentItem = ({
@@ -180,6 +189,9 @@ export const UltraFeedCommentItem = ({
   isLastComment = false,
   onPostTitleClick,
   settings = DEFAULT_SETTINGS,
+  parentAuthorName,
+  onReplyIconClick,
+  isHighlightAnimating = false,
 }: UltraFeedCommentItemProps) => {
   const classes = useStyles(styles);
   const { observe, unobserve, trackExpansion, hasBeenLongViewed, subscribeToLongView, unsubscribeFromLongView } = useUltraFeedObserver();
@@ -283,7 +295,9 @@ export const UltraFeedCommentItem = ({
 
   return (
     <AnalyticsContext ultraFeedElementType="feedComment" ultraFeedCardId={comment._id}>
-    <div className={classes.root}>
+    <div className={classNames(classes.root, {
+      [classes.rootWithAnimation]: isHighlightAnimating
+    })}>
       <div className={classes.mainContent}>
         <div className={classes.verticalLineContainer}>
           <div className={classNames(
@@ -302,7 +316,10 @@ export const UltraFeedCommentItem = ({
               comment={comment}
               setShowEdit={() => {}}
               showPostTitle={showPostTitle}
-              onPostTitleClick={onPostTitleClick} />
+              onPostTitleClick={onPostTitleClick}
+              parentAuthorName={parentAuthorName}
+              onReplyIconClick={onReplyIconClick}
+            />
           </div>
           <div className={classes.contentWrapper}>
             <FeedContentBody

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { AnalyticsContext } from "../../lib/analyticsEvents";
+import React, { useState } from "react";
+import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { useCurrentUser } from "../common/withUser";
 import { defineStyles, useStyles } from "../hooks/useStyles";
@@ -9,10 +9,10 @@ import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import CommentsMenu from "../dropdowns/comments/CommentsMenu";
 import CommentsItemDate from "../comments/CommentsItem/CommentsItemDate";
 import CommentUserName from "../comments/CommentsItem/CommentUserName";
-import CommentShortformIcon from "../comments/CommentsItem/CommentShortformIcon";
 import UltraFeedCommentActions from "./UltraFeedCommentActions";
 import SubdirectoryArrowLeft from "@/lib/vendor/@material-ui/icons/src/SubdirectoryArrowLeft";
 import LWTooltip from "../common/LWTooltip";
+import ForumIcon from "../common/ForumIcon";
 
 const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => ({
   root: {
@@ -57,12 +57,23 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
   commentShortformIconContainer: {
     position: 'relative',
     bottom: 0,
+    cursor: 'pointer',
+    "&:hover": {
+      opacity: 0.7,
+    },
   },
   commentShortformIcon: {
-    position: 'relative',
     [theme.breakpoints.down('sm')]: {
       bottom: 10
     },
+    cursor: "pointer",
+    color: theme.palette.grey[600],
+    width: 13,
+    height: 13,
+    marginLeft: -2,
+    marginRight: theme.spacing.unit,
+    position: "relative",
+    top: 2
   },
   username: {
     marginRight: 8,
@@ -88,17 +99,25 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
     maxWidth: '70%',
     position: 'relative',
     marginLeft: 'auto',
-    marginRight: 16,
+    marginRight: 8,
     cursor: 'pointer',
     overflow: "hidden",
     wordBreak: 'break-all',
     display: "-webkit-box",
     "-webkit-box-orient": "vertical",
     "-webkit-line-clamp": 1,
+    backgroundColor: 'transparent',
+    transition: 'background-color 1.5s ease-out',
+    padding: '2px 8px',
+    borderRadius: 4,
+  },
+  sameRowPostTitleHighlighted: {
+    backgroundColor: `${theme.palette.primary.main}3b`,
+    transition: 'none',
   },
   belowPostTitle: {
-    marginTop: 8,
-    marginRight: 12,
+    marginTop: 4,
+    marginRight: 4,
     color: theme.palette.link.dim,
     fontSize: theme.typography.body2.fontSize,
     lineHeight: theme.typography.body2.lineHeight,
@@ -112,6 +131,14 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
     [theme.breakpoints.down('sm')]: {
       fontSize: theme.typography.ultraFeedMobileStyle.fontSize,
     },
+    backgroundColor: 'transparent',
+    transition: 'background-color 1.5s ease-out',
+    padding: '4px 8px',
+    borderRadius: 4,
+  },
+  belowPostTitleHighlighted: {
+    backgroundColor: `${theme.palette.primary.main}3b`,
+    transition: 'none',
   },
   postTitleReplyTo: {
     marginRight: 4,
@@ -143,11 +170,12 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
   },
 }));
 
-const ReplyingToTitle = ({comment, position, enabled, onPostTitleClick}: {
+const ReplyingToTitle = ({comment, position, enabled, onPostTitleClick, highlighted}: {
   comment: UltraFeedComment,
   position: 'metarow' | 'below',
   enabled?: boolean,
   onPostTitleClick?: () => void,
+  highlighted?: boolean,
 }) => {
   const classes = useStyles(styles);
   const { post } = comment;
@@ -168,8 +196,10 @@ const ReplyingToTitle = ({comment, position, enabled, onPostTitleClick}: {
     <div 
       className={classNames({
         [classes.sameRowPostTitle]: position === 'metarow',
+        [classes.sameRowPostTitleHighlighted]: position === 'metarow' && highlighted,
         [classes.hideOnMobile]: position === 'metarow' && !post.shortform,
         [classes.belowPostTitle]: position === 'below',
+        [classes.belowPostTitleHighlighted]: position === 'below' && highlighted,
         [classes.hideOnDesktop]: position === 'below',
       })}
     >
@@ -208,6 +238,7 @@ const UltraFeedCommentsItemMeta = ({
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
+  const [postTitleHighlighted, setPostTitleHighlighted] = useState(false);
   const { post } = comment;
 
   if (!post) {
@@ -234,6 +265,22 @@ const UltraFeedCommentsItemMeta = ({
     }
   };
 
+  const handleShortformIconClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setPostTitleHighlighted(true);
+    
+    // Track the click event
+    captureEvent("ultraFeedShortformIconClicked", {
+      commentId: comment._id,
+      postId: post._id,
+    });
+    
+    // Remove highlight after a short delay
+    setTimeout(() => {
+      setPostTitleHighlighted(false);
+    }, 100);
+  };
+
   return (
     <div className={classes.root}>
       <div className={classes.tripleDotMenu}>
@@ -257,9 +304,16 @@ const UltraFeedCommentsItemMeta = ({
             />
           </LWTooltip>
         )}
-        {comment.shortform && post && <div className={classes.commentShortformIconContainer}>
-          <CommentShortformIcon comment={comment} post={post} iconClassName={classes.commentShortformIcon}/>
-        </div>}
+        {comment.shortform && !comment.topLevelCommentId && post && (
+          <LWTooltip
+            title={post.title}
+            placement="top"
+          >
+            <div className={classes.commentShortformIconContainer} onClick={handleShortformIconClick}>
+              <ForumIcon icon="Shortform" className={classes.commentShortformIcon} />
+            </div>
+          </LWTooltip>
+        )}
         <CommentUserName
           comment={comment}
           className={classes.username}
@@ -272,9 +326,9 @@ const UltraFeedCommentsItemMeta = ({
             {moderatorCommentAnnotation}
           </span>
         }
-        <ReplyingToTitle enabled={showPostTitle} position="metarow" comment={comment} onPostTitleClick={onPostTitleClick} />
+        <ReplyingToTitle enabled={showPostTitle} position="metarow" comment={comment} onPostTitleClick={onPostTitleClick} highlighted={postTitleHighlighted} />
       </div>
-      <ReplyingToTitle enabled={showPostTitle && !post?.shortform} position="below" comment={comment} onPostTitleClick={onPostTitleClick} />
+      <ReplyingToTitle enabled={showPostTitle && !post?.shortform} position="below" comment={comment} onPostTitleClick={onPostTitleClick} highlighted={postTitleHighlighted} />
     </div>
   );
 };

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
@@ -12,6 +12,8 @@ import CommentsItemDate from "../comments/CommentsItem/CommentsItemDate";
 import CommentUserName from "../comments/CommentsItem/CommentUserName";
 import CommentShortformIcon from "../comments/CommentsItem/CommentShortformIcon";
 import UltraFeedCommentActions from "./UltraFeedCommentActions";
+import SubdirectoryArrowLeft from "@/lib/vendor/@material-ui/icons/src/SubdirectoryArrowLeft";
+import LWTooltip from "../common/LWTooltip";
 
 const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => ({
   root: {
@@ -129,6 +131,17 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
       display: 'none',
     },
   },
+  replyingToIcon: {
+    fontSize: 14,
+    transform: "rotate(90deg)",
+    marginRight: 4,
+  },
+  replyingToIconClickable: {
+    cursor: "pointer",
+    "&:hover": {
+      opacity: 0.7,
+    },
+  },
 }));
 
 const ReplyingToTitle = ({comment, position, enabled, onPostTitleClick}: {
@@ -182,6 +195,8 @@ const UltraFeedCommentsItemMeta = ({
   hideActionsMenu,
   showPostTitle,
   onPostTitleClick,
+  parentAuthorName,
+  onReplyIconClick,
 }: {
   comment: UltraFeedComment,
   setShowEdit?: () => void,
@@ -189,6 +204,8 @@ const UltraFeedCommentsItemMeta = ({
   hideActionsMenu?: boolean,
   showPostTitle?: boolean,
   onPostTitleClick?: () => void,
+  parentAuthorName?: string | null,
+  onReplyIconClick?: () => void,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
@@ -209,6 +226,14 @@ const UltraFeedCommentsItemMeta = ({
   );
 
   const isNewContent = comment.postedAt && (new Date(comment.postedAt) > new Date(Date.now() - (7 * 24 * 60 * 60 * 1000)));
+  const isTopLevelComment = !comment.parentCommentId;
+
+  const handleReplyIconClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (onReplyIconClick) {
+      onReplyIconClick();
+    }
+  };
 
   return (
     <div className={classes.root}>
@@ -220,33 +245,42 @@ const UltraFeedCommentsItemMeta = ({
         }
       </div>
       <div className={classes.metaRow}>
-          {comment.shortform && post && <div className={classes.commentShortformIconContainer}>
-            <CommentShortformIcon comment={comment} post={post} iconClassName={classes.commentShortformIcon}/>
-          </div>}
-          <CommentUserName
-            comment={comment}
-            className={classes.username}
-          />
-          {!hideDate && post && <span className={classNames({[classes.newContentDateStyling]: isNewContent})}>
-            <CommentsItemDate comment={comment} post={post} className={classes.date}/>
-          </span>}
-          {showModeratorCommentAnnotation &&
-            <span className={classes.moderatorHat}>
-              {moderatorCommentAnnotation}
-            </span>
-          }
-          <ReplyingToTitle enabled={showPostTitle} position="metarow" comment={comment} onPostTitleClick={onPostTitleClick} />
+        {!isTopLevelComment && (
+          <LWTooltip 
+            title={parentAuthorName ? `Replying to ${parentAuthorName}` : "Replying to parent comment"}
+            placement="top"
+          >
+            <SubdirectoryArrowLeft 
+              className={classNames(classes.replyingToIcon, {
+                [classes.replyingToIconClickable]: !!onReplyIconClick
+              })}
+              onClick={handleReplyIconClick}
+            />
+          </LWTooltip>
+        )}
+        {comment.shortform && post && <div className={classes.commentShortformIconContainer}>
+          <CommentShortformIcon comment={comment} post={post} iconClassName={classes.commentShortformIcon}/>
+        </div>}
+        <CommentUserName
+          comment={comment}
+          className={classes.username}
+        />
+        {!hideDate && post && <span className={classNames({[classes.newContentDateStyling]: isNewContent})}>
+          <CommentsItemDate comment={comment} post={post} className={classes.date}/>
+        </span>}
+        {showModeratorCommentAnnotation &&
+          <span className={classes.moderatorHat}>
+            {moderatorCommentAnnotation}
+          </span>
+        }
+        <ReplyingToTitle enabled={showPostTitle} position="metarow" comment={comment} onPostTitleClick={onPostTitleClick} />
       </div>
       <ReplyingToTitle enabled={showPostTitle && !post?.shortform} position="below" comment={comment} onPostTitleClick={onPostTitleClick} />
     </div>
   );
 };
 
-export default registerComponent(
-  "UltraFeedCommentsItemMeta",
-  UltraFeedCommentsItemMeta
-);
-
+export default UltraFeedCommentsItemMeta;
 
 
  

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
@@ -13,6 +13,7 @@ import UltraFeedCommentActions from "./UltraFeedCommentActions";
 import SubdirectoryArrowLeft from "@/lib/vendor/@material-ui/icons/src/SubdirectoryArrowLeft";
 import LWTooltip from "../common/LWTooltip";
 import ForumIcon from "../common/ForumIcon";
+import DebateIcon from "@/lib/vendor/@material-ui/icons/src/Forum";
 
 const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => ({
   root: {
@@ -74,6 +75,26 @@ const styles = defineStyles("UltraFeedCommentsItemMeta", (theme: ThemeType) => (
     marginRight: theme.spacing.unit,
     position: "relative",
     top: 2
+  },
+  debateIconContainer: {
+    position: 'relative',
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    "&:hover": {
+      opacity: 0.7,
+    },
+  },
+  debateIcon: {
+    cursor: "pointer",
+    color: theme.palette.grey[500],
+    width: 16,
+    height: 16,
+    marginLeft: -2,
+    marginRight: 6,
+    position: "relative",
+    top: 2,
   },
   username: {
     marginRight: 8,
@@ -265,12 +286,12 @@ const UltraFeedCommentsItemMeta = ({
     }
   };
 
-  const handleShortformIconClick = (event: React.MouseEvent) => {
+  const handlePostTitleHighlight = (event: React.MouseEvent, iconType: 'shortform' | 'debate') => {
     event.stopPropagation();
     setPostTitleHighlighted(true);
     
     // Track the click event
-    captureEvent("ultraFeedShortformIconClicked", {
+    captureEvent(iconType === 'shortform' ? "ultraFeedShortformIconClicked" : "ultraFeedDebateIconClicked", {
       commentId: comment._id,
       postId: post._id,
     });
@@ -309,8 +330,18 @@ const UltraFeedCommentsItemMeta = ({
             title={post.title}
             placement="top"
           >
-            <div className={classes.commentShortformIconContainer} onClick={handleShortformIconClick}>
+            <div className={classes.commentShortformIconContainer} onClick={(event) => handlePostTitleHighlight(event, 'shortform')}>
               <ForumIcon icon="Shortform" className={classes.commentShortformIcon} />
+            </div>
+          </LWTooltip>
+        )}
+        {!comment.shortform && isTopLevelComment && post && (
+          <LWTooltip
+            title={`Replying to ${post.title}`}
+            placement="top"
+          >
+            <div className={classes.debateIconContainer} onClick={(event) => handlePostTitleHighlight(event, 'debate')}>
+              <DebateIcon className={classes.debateIcon} />
             </div>
           </LWTooltip>
         )}

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { useCurrentUser } from "../common/withUser";

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -111,11 +111,11 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   sourceIcon: {
     width: 16,
     height: 16,
-    marginRight: 8,
+    marginRight: 6,
     color: theme.palette.grey[600],
     opacity: 0.7,
     position: 'relative',
-    top: 2,
+    top: 3,
     flexShrink: 0,
   },
   metaDateContainer: {
@@ -150,6 +150,13 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   },
 }));
 
+const sourceIconMap: Array<{ source: FeedItemSourceType, icon: any, tooltip: string }> = [
+  { source: 'bookmarks' as FeedItemSourceType, icon: BookmarksIcon, tooltip: "From your bookmarks" },
+  { source: 'subscriptions' as FeedItemSourceType, icon: SubscriptionsIcon, tooltip: "From users you follow" },
+  { source: 'recombee-lesswrong-custom' as FeedItemSourceType, icon: SparkleIcon, tooltip: "Recommended for you" },
+  { source: 'hacker-news' as FeedItemSourceType, icon: ClockIcon, tooltip: "Latest posts" },
+];
+
 interface UltraFeedPostItemHeaderProps {
   post: PostsListWithVotes;
   isRead: boolean;
@@ -175,35 +182,13 @@ const UltraFeedPostItemHeader = ({
     }
   };
 
-  const getSourceIcon = () => {
-    if (sources.includes('bookmarks')) {
-      return { icon: BookmarksIcon, tooltip: "From your bookmarks" };
-    }
-    if (sources.includes('subscriptions')) {
-      return { icon: SubscriptionsIcon, tooltip: "From users you follow" };
-    }
-    if (sources.includes('recombee-lesswrong-custom')) {
-      return { icon: SparkleIcon, tooltip: "Recommended for you" };
-    }
-    if (sources.includes('hacker-news')) {
-      return { icon: ClockIcon, tooltip: "Latest posts" };
-    }
-    return null;
-  };
-
-  const sourceIconInfo = getSourceIcon();
+  const sourceIcons = sourceIconMap
+    .filter(({ source }) => sources.includes(source))
+    .map(({ source, icon, tooltip }) => ({ icon, tooltip, key: source }));
 
   return (
     <div className={classes.header}>
       <div className={classes.titleContainer}>
-        {sourceIconInfo && (
-          <LWTooltip title={sourceIconInfo.tooltip} placement="top">
-            <span>
-              <sourceIconInfo.icon className={classes.sourceIcon} />
-            </span>
-          </LWTooltip>
-        )}
-        {/* Mobile version: Respects postTitlesAreModals */}
         <div className={classes.hideOnDesktop}>
           {postTitlesAreModals ? (
             <a
@@ -233,6 +218,13 @@ const UltraFeedPostItemHeader = ({
         </div>
       </div>
       <div className={classes.metaRow}>
+        {sourceIcons.map((iconInfo) => (
+          <LWTooltip key={iconInfo.key} title={iconInfo.tooltip} placement="top">
+            <span>
+              <iconInfo.icon className={classes.sourceIcon} />
+            </span>
+          </LWTooltip>
+        ))}
         <TruncatedAuthorsList post={post} useMoreSuffix={false} expandContainer={authorListRef} className={classes.authorsList} />
         {post.postedAt && (
           <span className={classes.metaDateContainer}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -111,7 +111,7 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   sourceIcon: {
     width: 16,
     height: 16,
-    marginRight: 6,
+    marginRight: 8,
     color: theme.palette.grey[600],
     opacity: 0.7,
     position: 'relative',

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from "../../lib/vulcan-lib/components";
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { defineStyles, useStyles } from "../hooks/useStyles";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
-import { FeedPostMetaInfo } from "./ultraFeedTypes";
+import { FeedPostMetaInfo, FeedItemSourceType } from "./ultraFeedTypes";
 import { nofollowKarmaThreshold } from "../../lib/publicSettings";
 import { UltraFeedSettingsType, DEFAULT_SETTINGS } from "./ultraFeedSettingsTypes";
 import { useUltraFeedObserver } from "./UltraFeedObserver";
@@ -25,6 +25,11 @@ import UltraFeedItemFooter from "./UltraFeedItemFooter";
 import Loading from "../vulcan-core/Loading";
 import OverflowNavButtons from "./OverflowNavButtons";
 import UltraFeedPostActions from "./UltraFeedPostActions";
+import BookmarksIcon from "@/lib/vendor/@material-ui/icons/src/Bookmarks";
+import ClockIcon from "@/lib/vendor/@material-ui/icons/src/AccessTime";
+import SubscriptionsIcon from "@/lib/vendor/@material-ui/icons/src/NotificationsNone";
+import LWTooltip from "../common/LWTooltip";
+import { SparkleIcon } from "../icons/sparkleIcon";
 
 const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   root: {
@@ -60,8 +65,8 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   },
   titleContainer: {
     display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
     width: '100%',
     [theme.breakpoints.down('sm')]: {
     },
@@ -103,6 +108,16 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
       fontSize: "1.3rem",
     },
   },
+  sourceIcon: {
+    width: 16,
+    height: 16,
+    marginRight: 8,
+    color: theme.palette.grey[600],
+    opacity: 0.7,
+    position: 'relative',
+    top: 2,
+    flexShrink: 0,
+  },
   metaDateContainer: {
     marginRight: 8,
   },
@@ -140,6 +155,7 @@ interface UltraFeedPostItemHeaderProps {
   isRead: boolean;
   handleOpenDialog: (params?: { textFragment?: string }) => void;
   postTitlesAreModals: boolean;
+  sources: FeedItemSourceType[];
 }
 
 const UltraFeedPostItemHeader = ({
@@ -147,6 +163,7 @@ const UltraFeedPostItemHeader = ({
   isRead,
   handleOpenDialog,
   postTitlesAreModals,
+  sources,
 }: UltraFeedPostItemHeaderProps) => {
   const classes = useStyles(styles);
   const authorListRef = useRef<HTMLDivElement>(null);
@@ -158,9 +175,34 @@ const UltraFeedPostItemHeader = ({
     }
   };
 
+  const getSourceIcon = () => {
+    if (sources.includes('bookmarks')) {
+      return { icon: BookmarksIcon, tooltip: "From your bookmarks" };
+    }
+    if (sources.includes('subscriptions')) {
+      return { icon: SubscriptionsIcon, tooltip: "From users you follow" };
+    }
+    if (sources.includes('recombee-lesswrong-custom')) {
+      return { icon: SparkleIcon, tooltip: "Recommended for you" };
+    }
+    if (sources.includes('hacker-news')) {
+      return { icon: ClockIcon, tooltip: "Latest posts" };
+    }
+    return null;
+  };
+
+  const sourceIconInfo = getSourceIcon();
+
   return (
     <div className={classes.header}>
       <div className={classes.titleContainer}>
+        {sourceIconInfo && (
+          <LWTooltip title={sourceIconInfo.tooltip} placement="top">
+            <span>
+              <sourceIconInfo.icon className={classes.sourceIcon} />
+            </span>
+          </LWTooltip>
+        )}
         {/* Mobile version: Respects postTitlesAreModals */}
         <div className={classes.hideOnDesktop}>
           {postTitlesAreModals ? (
@@ -353,6 +395,7 @@ const UltraFeedPostItem = ({
           isRead={isRead}
           handleOpenDialog={handleOpenDialog}
           postTitlesAreModals={displaySettings.postTitlesAreModals}
+          sources={postMetaInfo.sources}
         />
 
         {shouldShowLoading && loadingFullPost ? (

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -39,7 +39,7 @@ export const DEFAULT_SOURCE_WEIGHTS: Record<FeedItemSourceType, number> = {
   'recombee-lesswrong-custom': 30,
   'hacker-news': 30,
   'spotlights': 5,
-  'bookmarks': 5,
+  'bookmarks': 1,
   'subscriptions': 20,
 };
 export interface CommentScoringSettings {

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -38,7 +38,7 @@ export const DEFAULT_SOURCE_WEIGHTS: Record<FeedItemSourceType, number> = {
   'recentComments': 80,
   'recombee-lesswrong-custom': 30,
   'hacker-news': 30,
-  'spotlights': 5,
+  'spotlights': 2,
   'bookmarks': 1,
   'subscriptions': 20,
 };


### PR DESCRIPTION
When you click the "replying to" icon, it pulses the parent to indicate what it's a reply to
<img width="362" alt="LessWrong Feed — LessWrong 2025-06-05 16-20-56" src="https://github.com/user-attachments/assets/9242c467-510a-448a-b77e-058b09ce5ecd" />
clicking the "top level comment" icon (reusing dialog icon) or shortform comment briefly highlights the title 

Post items now have an icon indicating their source. And spotlight feed items have a star (indicating "curated")
<img width="390" alt="LessWrong Feed — LessWrong 2025-06-05 16-23-21" src="https://github.com/user-attachments/assets/81a6cdf8-8e55-44bb-ba05-091aee3de809" />

