### PR TITLE
Remove line truncation

### DIFF
--- a/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
+++ b/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
@@ -167,7 +167,7 @@ const FeedContentBody = ({
   }, [resetSignal]);
 
   const currentWordLimit = isExpanded ? maxWordCount : initialWordCount;
-  const applyLineClamp = clampOverride && clampOverride > 0 && !isExpanded;
+  const applyLineClamp = false //clampOverride && clampOverride > 0 && !isExpanded; //to-do fix and reenable
 
   const handleExpand = useCallback(() => {
     if (isExpanded) return;

--- a/packages/lesswrong/components/ultraFeed/settingsComponents/UltraFeedSettingsComponents.tsx
+++ b/packages/lesswrong/components/ultraFeed/settingsComponents/UltraFeedSettingsComponents.tsx
@@ -430,7 +430,8 @@ const checkForNonstandardValues = (originalSettings: UltraFeedSettingsType) => {
 
   const { displaySettings } = originalSettings;
 
-  if (displaySettings.lineClampNumberOfLines !== 0) return true;
+  // Temporarily commenting out lineclamp check while broken
+  // if (displaySettings.lineClampNumberOfLines !== 0) return true;
 
   // Check if the current word count settings match standard truncation levels
   if (!allowedCommentValues.has(displaySettings.commentCollapsedInitialWords)) return true;
@@ -580,6 +581,7 @@ export const AdvancedTruncationSettings: React.FC<AdvancedTruncationSettingsProp
 
       <div className={classes.truncationSection}>
         <h4 className={classes.truncationSectionTitle}>Comments</h4>
+        {/* Temporarily commenting out lineclamp settings while broken
         <TruncationInput
           field="lineClampNumberOfLines"
           value={values.lineClampNumberOfLines}
@@ -595,6 +597,7 @@ export const AdvancedTruncationSettings: React.FC<AdvancedTruncationSettingsProp
             When line clamp is non-zero, deemphasized comments are truncated based on number of lines instead of word count.
           </p>
         )}
+        */}
         <p className={classes.groupDescription}>
           Some comments are deemphasized and will be truncated to a shorter length.
         </p>
@@ -604,7 +607,6 @@ export const AdvancedTruncationSettings: React.FC<AdvancedTruncationSettingsProp
           onChange={onWordCountChange}
           label="Initial (deemphasized)"
           error={errors.commentCollapsedInitialWords}
-          disabled={values.lineClampNumberOfLines !== 0 && values.lineClampNumberOfLines !== ''}
         />
         <TruncationInput
           field="commentExpandedInitialWords"


### PR DESCRIPTION
Changes in expansion require a "read more" button that lineclamp doesn't currently have, so it breaks. This disables lineclamp until properly fixed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210506976422667) by [Unito](https://www.unito.io)
