### PR TITLE
mods can hide the sunshine sidebar

### DIFF
--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -4189,7 +4189,7 @@ const schema = {
     graphql: {
       outputType: "Boolean",
       canRead: [userOwns, "admins"],
-      canUpdate: ["admins"],
+      canUpdate: [userOwns, "admins"],
       canCreate: ["admins"],
       validation: {
         optional: true,


### PR DESCRIPTION
Our mods are not all admins, so this is just to enable the option for them to update their own `hideSunshineSidebar`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210514945069027) by [Unito](https://www.unito.io)
