### PR TITLE
Exclude headings in footnotes from TOC

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -126,6 +126,9 @@ export function extractTableOfContents({
     if (tagIsHeadingIfWholeParagraph(tagName) && !tagIsWholeParagraph({ element, window })) {
       continue;
     }
+    if (element.closest(".footnotes")) {
+      break;
+    }
 
     // Get title from element text
     let title = elementToToCTitle(element);

--- a/packages/lesswrong/unitTests/tableOfContents.tests.ts
+++ b/packages/lesswrong/unitTests/tableOfContents.tests.ts
@@ -134,4 +134,36 @@ describe("extractTableOfContents", () => {
       ],
     });
   });
+  it("excludes headings inside footnotes", () => {
+    const html = normalizeHtml(`
+      <h1>Title</h1>
+      <p>Some content here</p>
+      <div class="footnotes">
+      <ol>
+      <li>
+      <h2>A heading inside a footnote</h2>
+      </li>
+      </ol>
+      </div>
+    `);
+    const { document, window } = parseDocumentFromString(html);
+    const tocData = extractTableOfContents({ document, window });
+    expect(tocData).toEqual({
+      html: normalizeHtml(`
+        <h1 id="Title">Title</h1>
+        <p>Some content here</p>
+        <div class="footnotes">
+        <ol>
+        <li>
+        <h2>A heading inside a footnote</h2>
+        </li>
+        </ol>
+        </div>
+      `),
+      sections: [
+        { title: "Title", anchor: "Title", level: 1 },
+        { anchor: "postHeadingsDivider", divider: true, level: 0 },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
We got a bug report that bold sections in footnotes were showing in the table of contents. I figure we should probably just exclude all headings in footnotes from the TOC.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210531421110531) by [Unito](https://www.unito.io)
