### PR TITLE
[EA Forum only] default sort tag page posts by top instead of relevance

### DIFF
--- a/packages/lesswrong/components/tagging/EATagPage.tsx
+++ b/packages/lesswrong/components/tagging/EATagPage.tsx
@@ -193,7 +193,7 @@ const PostsListHeading: FC<{
       <>
         <SectionTitle title={`Posts tagged ${tag.name}`} />
         <div className={classes.postListMeta}>
-          <PostsListSortDropdown value={query.sortedBy || "relevance"} />
+          <PostsListSortDropdown value={query.sortedBy || "top"} />
           <div className={classes.relevance}>
             <RelevanceLabel />
           </div>
@@ -204,7 +204,7 @@ const PostsListHeading: FC<{
   return (
     <div className={classes.tagHeader}>
       <div className={classes.postsTaggedTitle}>Posts tagged <em>{tag.name}</em></div>
-      <PostsListSortDropdown value={query.sortedBy || "relevance"}/>
+      <PostsListSortDropdown value={query.sortedBy || "top"}/>
     </div>
   );
 }
@@ -333,7 +333,7 @@ const EATagPage = ({classes}: {
     : htmlWithAnchors
   }
 
-  const headTagDescription = tag.description?.plaintextDescription || `All posts related to ${tag.name}, sorted by relevance`
+  const headTagDescription = tag.description?.plaintextDescription || `All posts related to ${tag.name}`
   
   const tagFlagItemType: AnyBecauseTodo = {
     allPages: "allPages",
@@ -355,7 +355,7 @@ const EATagPage = ({classes}: {
     pageContext='tagPage'
     tagName={tag.name}
     tagId={tag._id}
-    sortedBy={query.sortedBy || "relevance"}
+    sortedBy={query.sortedBy || "top"}
     limit={terms.limit}
   >
     <HeadTags

--- a/packages/lesswrong/components/tagging/TagPageUtils.tsx
+++ b/packages/lesswrong/components/tagging/TagPageUtils.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import LWTooltip from "../common/LWTooltip";
-import { isEAForum } from "@/lib/instanceSettings";
+import { isFriendlyUI } from "@/themes/forumTheme";
 
 export const tagPageHeaderStyles = (theme: ThemeType) => ({
   postListMeta: {
@@ -21,9 +21,9 @@ export const tagPageHeaderStyles = (theme: ThemeType) => ({
 export const tagPostTerms = (tag: Pick<TagBasicInfo, "_id" | "name"> | null, query: any) => {
   if (!tag) return
   
-  // EA Forum defaults to top sort order for tag pages
+  // friendly ui defaults to top sort order for tag pages
   return ({
-    ...(isEAForum && {sortedBy: "top"}),
+    ...(isFriendlyUI && {sortedBy: "top"}),
     ...query,
     filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
     view: "tagRelevance",

--- a/packages/lesswrong/components/tagging/TagPageUtils.tsx
+++ b/packages/lesswrong/components/tagging/TagPageUtils.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import LWTooltip from "../common/LWTooltip";
+import { isEAForum } from "@/lib/instanceSettings";
 
 export const tagPageHeaderStyles = (theme: ThemeType) => ({
   postListMeta: {
@@ -19,7 +20,10 @@ export const tagPageHeaderStyles = (theme: ThemeType) => ({
 
 export const tagPostTerms = (tag: Pick<TagBasicInfo, "_id" | "name"> | null, query: any) => {
   if (!tag) return
+  
+  // EA Forum defaults to top sort order for tag pages
   return ({
+    ...(isEAForum && {sortedBy: "top"}),
     ...query,
     filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
     view: "tagRelevance",

--- a/packages/lesswrong/components/tagging/subforums/SubforumWikiTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumWikiTab.tsx
@@ -137,7 +137,7 @@ const SubforumWikiTab = ({tag, revision, truncated, setTruncated, classes}: {
           <AnalyticsContext pageSectionContext="tagsSection">
             <SectionTitle title={`Posts tagged ${tag.name}`} />
             <div className={classes.postListMeta}>
-              <PostsListSortDropdown value={query.sortedBy || "relevance"} />
+              <PostsListSortDropdown value={query.sortedBy || "top"} />
               <div className={classes.relevance}>
                 <RelevanceLabel />
               </div>

--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -4188,7 +4188,7 @@ const schema = {
     graphql: {
       outputType: "Boolean",
       canRead: [userOwns, "admins"],
-      canUpdate: ["admins"],
+      canUpdate: [userOwns, "admins"],
       canCreate: ["admins"],
       validation: {
         optional: true,


### PR DESCRIPTION
@Will-Howard and I agreed that the default "relevance" sort is not useful (people rarely vote on relevance), so we're changing it to "top" (which is much more likely to be useful for new users).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210536206924354) by [Unito](https://www.unito.io)
