### PR TITLE
Allow coauthors to update social preview and don't require an image id

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -90,7 +90,7 @@ export const graphqlTypeDefs = gql`
   }
 
   input SocialPreviewInput {
-    imageId: String!
+    imageId: String
     text: String
   }
 
@@ -2373,7 +2373,7 @@ const schema = {
       inputType: "SocialPreviewInput",
       validation: { blackbox: true },
       canRead: ["guests"],
-      canUpdate: [userOwns, "sunshineRegiment", "admins"],
+      canUpdate: ["members", "sunshineRegiment", "admins"],
       canCreate: ["members", "sunshineRegiment", "admins"],
     },
   },

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -10162,7 +10162,7 @@ export type Site = {
 };
 
 export type SocialPreviewInput = {
-  imageId: Scalars['String']['input'];
+  imageId?: InputMaybe<Scalars['String']['input']>;
   text?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -59,7 +59,7 @@ input CoauthorStatusInput {
 }
 
 input SocialPreviewInput {
-  imageId: String!
+  imageId: String
   text: String
 }
 

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -10159,7 +10159,7 @@ type Site = {
 };
 
 type SocialPreviewInput = {
-  imageId: Scalars['String']['input'];
+  imageId?: InputMaybe<Scalars['String']['input']>;
   text?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -420,7 +420,7 @@ interface CoauthorStatusInput {
 }
 
 interface SocialPreviewInput {
-  imageId: string;
+  imageId?: string | null;
   text?: string | null;
 }
 


### PR DESCRIPTION
There might still be an outstanding bug where the `socialPreview` field being rendered in the form automatically marks it as dirty (and causes it to be unnecessarily included in the update payload).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210538211526278) by [Unito](https://www.unito.io)
