### PR TITLE
Fix conversion from collection name to notification document type

### DIFF
--- a/packages/lesswrong/lib/notificationTypes.tsx
+++ b/packages/lesswrong/lib/notificationTypes.tsx
@@ -91,7 +91,7 @@ export type NotificationDisplay =
     tagRelId?: string,
   };
 
-export const notificationDocumentTypes = new TupleSet(['post', 'comment', 'user', 'message', 'tagRel', 'sequence', 'localgroup', 'dialogueCheck', 'dialogueMatchPreference'] as const)
+const notificationDocumentTypes = new TupleSet(['post', 'comment', 'user', 'message', 'tagRel', 'sequence', 'localgroup', 'dialogueCheck', 'dialogueMatchPreference'] as const)
 export type NotificationDocument = UnionOf<typeof notificationDocumentTypes>
 
 interface GetMessageProps {


### PR DESCRIPTION
Mention notifications are currently broken because we're incorrectly converting collection names to notification document types (wrong pluralisation) which means we early-exit before creating the notifications.

This PR is targeted at ea-deploy, but the commit should also probably be cherry-picked into master.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210569020640689) by [Unito](https://www.unito.io)
