### PR TITLE
Fix read time minutes SQL resolver

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -857,9 +857,9 @@ const schema = {
             _id: field("contents_latest"),
           },
           resolver: (revisionsField) => `GREATEST(1, ROUND(COALESCE(
-        ${field("readTimeMinutesOverride")},
-        ${revisionsField("wordCount")}
-      ) / ${READ_WORDS_PER_MINUTE}))`,
+            ${field("readTimeMinutesOverride")},
+            ${revisionsField("wordCount")} / ${READ_WORDS_PER_MINUTE}
+          )))`,
         }),
     },
   },


### PR DESCRIPTION
For posts, `readTimeMinutes` is calculated by first trying to use `readTimeMinutesOverride` and if that's not set then defaulting to taking the word count and diving by 250. The SQL resolver is currently returning incorrect results when `readTimeMinutesOverride` is set, as it's trying to also divide _this_ by 250, as if it were a word count instead of a read time.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210573117788090) by [Unito](https://www.unito.io)
