### PR TITLE
Fix reaction icons being white-on-white after navigating from theme-overridden front page to a light-mode post page

### DIFF
--- a/packages/lesswrong/components/votes/ReactionIcon.tsx
+++ b/packages/lesswrong/components/votes/ReactionIcon.tsx
@@ -9,10 +9,10 @@ const styles = (theme: ThemeType) => ({
     marginTop: 1
   },
   invertIfDarkMode: {
-    filter: (theme.palette.type==="dark") ? "invert(1)" : undefined,
+    filter: (theme.palette.type==="dark") ? "invert(1)" : "unset",
   },
   invertUnlessDarkMode: {
-    filter: (theme.palette.type==="dark") ? undefined : "invert(1)"
+    filter: (theme.palette.type==="dark") ? "unset" : "invert(1)"
   }
 })
 

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -493,6 +493,9 @@ export const defaultComponentPalette = (shades: ThemeShadePalette): ThemeCompone
       hoverBackground: shades.grey[800],
     },
   },
+  intercom: {
+    buttonBackground: "unset",
+  },
   sideItemIndicator: {
     sideComment: '#5f9b65',
     inlineReaction: 'lch(68 34.48 85.39 / 76%)',


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210588829800038) by [Unito](https://www.unito.io)
