### PR TITLE
Fix color of single-line comments after theme switch

### DIFF
--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -242,7 +242,7 @@ export const darkModeTheme: UserThemeSpecification = {
       commentNodeOdd: shadePalette.grey[25],
       commentNodeRoot: shadePalette.grey[0],
       commentModeratorHat: "#202719",
-      singleLineComment: 'none',
+      singleLineComment: 'unset',
       spoilerBlock: "#1b1b1b",
       cookieBanner: shadePalette.grey[900],
       tagLensTab: shadePalette.greyAlpha(.15),


### PR DESCRIPTION
The color in the dark theme was "none", but this is an invalid color value, so it fell through to a light-mode color

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210595712702575) by [Unito](https://www.unito.io)
