### PR TITLE
Fix crash when editing some posts

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -107,7 +107,7 @@ export const graphqlTypeDefs = gql`
   }
 
   type SocialPreviewOutput {
-    imageId: String!
+    imageId: String
     text: String
   }
 

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -10175,7 +10175,7 @@ export type SocialPreviewInput = {
 
 export type SocialPreviewOutput = {
   __typename?: 'SocialPreviewOutput';
-  imageId: Scalars['String']['output'];
+  imageId: Maybe<Scalars['String']['output']>;
   text: Maybe<Scalars['String']['output']>;
 };
 
@@ -20422,7 +20422,7 @@ export type PostsEdit = (
   ) | null, customHighlight: (
     { __typename?: 'Revision' }
     & RevisionEdit
-  ) | null, socialPreview: { __typename?: 'SocialPreviewOutput', imageId: string, text: string | null } | null, socialPreviewData: { __typename?: 'SocialPreviewType', _id: string, imageId: string | null, text: string | null }, user: (
+  ) | null, socialPreview: { __typename?: 'SocialPreviewOutput', imageId: string | null, text: string | null } | null, socialPreviewData: { __typename?: 'SocialPreviewType', _id: string, imageId: string | null, text: string | null }, user: (
     { __typename?: 'User', moderationStyle: string | null, bannedUserIds: Array<string> | null, moderatorAssistance: boolean | null }
     & UsersMinimumInfo
   ) | null, usersSharedWith: Array<(

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -76,7 +76,7 @@ type CoauthorStatusOutput {
 }
 
 type SocialPreviewOutput {
-  imageId: String!
+  imageId: String
   text: String
 }
 

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -10172,7 +10172,7 @@ type SocialPreviewInput = {
 
 type SocialPreviewOutput = {
   __typename?: 'SocialPreviewOutput';
-  imageId: Scalars['String']['output'];
+  imageId?: Maybe<Scalars['String']['output']>;
   text?: Maybe<Scalars['String']['output']>;
 };
 
@@ -25011,7 +25011,7 @@ type PostsEdit_Post_customHighlight_Revision = (
   & RevisionEdit
 );
 
-type PostsEdit_Post_socialPreview_SocialPreviewOutput = { __typename?: 'SocialPreviewOutput', imageId: string, text: string | null };
+type PostsEdit_Post_socialPreview_SocialPreviewOutput = { __typename?: 'SocialPreviewOutput', imageId: string | null, text: string | null };
 
 type PostsEdit_Post_socialPreviewData_SocialPreviewType = { __typename?: 'SocialPreviewType', _id: string, imageId: string | null, text: string | null };
 

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -438,7 +438,7 @@ interface CoauthorStatusOutput {
 }
 
 interface SocialPreviewOutput {
-  imageId: string;
+  imageId: string | null;
   text: string | null;
 }
 


### PR DESCRIPTION
This was previously fixed, and accidentally reverted. See: https://lworg.slack.com/archives/CJUN2UAFN/p1750351999979259 ;  https://lworg.slack.com/archives/CJUN2UAFN/p1749581682746829?thread_ts=1749580409.934209&cid=CJUN2UAFN

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210596336715249) by [Unito](https://www.unito.io)
