### PR TITLE
Fix light-mode header missing its drop shadow after navigation/theme-switch

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -116,7 +116,7 @@ export const styles = (theme: ThemeType) => ({
     color: theme.palette.text.bannerAdOverlay,
 
     ...(forumSelect({
-      LWAF: theme.themeOptions.name === 'dark'
+      LWAF: (theme.themeOptions.name === 'dark'
         ? {
           background: theme.palette.panelBackground.bannerAdTranslucent,
           backdropFilter: 'blur(4px) brightness(1.1)',
@@ -126,7 +126,13 @@ export const styles = (theme: ThemeType) => ({
           },
         } : {
           backgroundColor: theme.palette.header.background,
-        },
+          backdropFilter: 'unset',
+          "&$blackBackgroundAppBar": {
+            boxShadow: theme.palette.boxShadow.appBar,
+            background: theme.palette.header.background,
+          },
+        }
+      ) as any,
       default: {
         backgroundColor: theme.palette.header.background,
       },


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210605959182228) by [Unito](https://www.unito.io)
