### PR TITLE
Fix unsetting validated strings

### DIFF
--- a/packages/lesswrong/server/collections/comments/mutations.ts
+++ b/packages/lesswrong/server/collections/comments/mutations.ts
@@ -154,7 +154,7 @@ export async function updateComment({ selector, data }: UpdateCommentInput, cont
     props: updateCallbackProperties,
   });
 
-  let modifier = dataToModifier(data);
+  let modifier = dataToModifier(data, schema);
   modifier = await moveToAnswers(modifier, oldDocument, context);
   modifier = await handleForumEventMetadataEdit(modifier, oldDocument, context);
 

--- a/packages/lesswrong/server/collections/posts/mutations.ts
+++ b/packages/lesswrong/server/collections/posts/mutations.ts
@@ -194,7 +194,7 @@ export async function updatePost({ selector, data }: { data: UpdatePostDataInput
   // This has to be done _after_ the new revision is created
   data = await handleCrosspostUpdate(context, data, updateCallbackProperties);
 
-  let modifier = dataToModifier(data);
+  let modifier = dataToModifier(data, schema);
   modifier = clearCourseEndTime(modifier, oldDocument);
   modifier = removeFrontpageDate(modifier, oldDocument);
   modifier = resetPostApprovedDate(modifier, oldDocument);

--- a/packages/lesswrong/server/collections/users/mutations.ts
+++ b/packages/lesswrong/server/collections/users/mutations.ts
@@ -117,7 +117,7 @@ export async function updateUser({ selector, data }: { data: UpdateUserDataInput
     props: updateCallbackProperties,
   });
 
-  let modifier = dataToModifier(data);
+  let modifier = dataToModifier(data, schema);
 
   maybeSendVerificationEmail(modifier, oldDocument);
   modifier = clearKarmaChangeBatchOnSettingsChange(modifier, oldDocument);

--- a/packages/lesswrong/server/vulcan-lib/mutators.ts
+++ b/packages/lesswrong/server/vulcan-lib/mutators.ts
@@ -1,6 +1,7 @@
 import { convertDocumentIdToIdInSelector, UpdateSelector } from '../../lib/vulcan-lib/utils';
 import { dataToModifier } from './validation';
 import { throwError } from './errors';
+import { getSchema } from '@/lib/schema/allSchemas';
 import type { CreateCallbackProperties, UpdateCallbackProperties, AfterCreateCallbackProperties } from '../mutationCallbacks';
 import isEmpty from 'lodash/isEmpty';
 import pickBy from 'lodash/pickBy';
@@ -45,7 +46,7 @@ export async function runFieldOnUpdateCallbacks<
   data: D,
   properties: UpdateCallbackProperties<CollectionName, D>
 ): Promise<D> {
-  const dataAsModifier = dataToModifier(clone(data));
+  const dataAsModifier = dataToModifier(clone(data), schema);
   for (let fieldName in schema) {
     let autoValue;
     const { graphql } = schema[fieldName];
@@ -212,7 +213,7 @@ export async function updateAndReturnDocument<N extends CollectionNameString>(
   selector: { _id: string },
   context: ResolverContext
 ): Promise<ObjectsByCollectionName[N]> {
-  const modifier = dataToModifier(data);
+  const modifier = dataToModifier(data, getSchema(collection.collectionName));
 
   // remove empty modifiers
   if (isEmpty(modifier.$set)) {


### PR DESCRIPTION
If you try to unset a string with a regex validator (for instance, the website for a local group) we currently throw an exception as we're trying to assign an empty-string which doesn't pass the validator. Instead, we should actually nullify the field.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210621881374771) by [Unito](https://www.unito.io)
