### PR TITLE
Remove user-link from review pill

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/ReviewPillContainer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/BestOfLessWrong/ReviewPillContainer.tsx
@@ -125,7 +125,7 @@ const ReviewPillContainer = ({postId}: {postId: string}) => {
             <div className={classes.review}>
               Review by
               <div className={classes.reviewerName}>
-                <UsersNameDisplay noTooltip user={review.user} />
+                <UsersNameDisplay noTooltip user={review.user} simple />
               </div>
             </div>
           </HashLink>


### PR DESCRIPTION
Previously, the username in a ReviewPill on a best of lesswrong post was a click target for the user's profile link, which was confusing for some people. Now the whole pill just links to the review.