### PR TITLE
Ultrafeed Improvements 20250623

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -42,7 +42,6 @@ import Footer from "./common/Footer";
 import FlashMessages from "./common/FlashMessages";
 import AnalyticsClient from "./common/AnalyticsClient";
 import AnalyticsPageInitializer from "./common/AnalyticsPageInitializer";
-import NavigationEventSender from "./hooks/useOnNavigate";
 import EAOnboardingFlow from "./ea-forum/onboarding/EAOnboardingFlow";
 import BasicOnboardingFlow from "./onboarding/BasicOnboardingFlow";
 import { CommentOnSelectionPageWrapper } from "./comments/CommentOnSelection";
@@ -413,7 +412,6 @@ const Layout = ({currentUser, children}: {
 
               <AnalyticsClient/>
               <AnalyticsPageInitializer/>
-              <NavigationEventSender/>
               <GlobalHotkeys/>
               {/* Only show intercom after they have accepted cookies */}
               <DeferRender ssr={false}>

--- a/packages/lesswrong/components/bookmarks/BookmarksFeed.tsx
+++ b/packages/lesswrong/components/bookmarks/BookmarksFeed.tsx
@@ -100,7 +100,7 @@ const BookmarksFeed = () => {
                 lastViewed: null, 
                 lastInteracted: null,
                 postedAt: commentData.postedAt,
-                directDescendentCount: commentData.directChildrenCount,
+                descendentCount: commentData.descendentCount,
               }
             };
             const threadData: DisplayFeedCommentThread = {

--- a/packages/lesswrong/components/bookmarks/BookmarksFeed.tsx
+++ b/packages/lesswrong/components/bookmarks/BookmarksFeed.tsx
@@ -101,6 +101,7 @@ const BookmarksFeed = () => {
                 lastInteracted: null,
                 postedAt: commentData.postedAt,
                 descendentCount: commentData.descendentCount,
+                directDescendentCount: commentData.directChildrenCount,
               }
             };
             const threadData: DisplayFeedCommentThread = {

--- a/packages/lesswrong/components/comments/CantCommentExplanation.tsx
+++ b/packages/lesswrong/components/comments/CantCommentExplanation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useCurrentUser } from '../common/withUser';
-import { userIsBannedFromAllPersonalPosts, userIsBannedFromAllPosts, userIsBannedFromPost } from '../../lib/collections/users/helpers';
+import { userIsBannedFromAllPersonalPosts, userIsBannedFromAllPosts, userIsBannedFromPost, userIsNotShortformOwner } from '../../lib/collections/users/helpers';
 import classNames from 'classnames';
 import { moderationEmail } from '../../lib/publicSettings';
 import { isFriendlyUI } from '../../themes/forumTheme';
@@ -43,6 +43,10 @@ const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post: Posts
 
   if (post?.commentsLockedToAccountsCreatedAfter) {
     return <>Comments on this post are disabled to accounts created after <CalendarDate date={post.commentsLockedToAccountsCreatedAfter}/></>
+  }
+
+  if (post?.shortform && userIsNotShortformOwner(user, post)) {
+    return <>Only the owner of a Quick Take's container can leave top-level comments on it.</>
   }
 
   return <>You cannot comment at this time</>

--- a/packages/lesswrong/components/hooks/useDialogNavigation.ts
+++ b/packages/lesswrong/components/hooks/useDialogNavigation.ts
@@ -1,14 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-interface UseDialogNavigationOptions {
-  /**
-   * Whether to track if the dialog is closing via the back button.
-   * When true, returns an isClosingViaBackRef that can be used to determine
-   * if the dialog is closing via browser navigation.
-   */
-  trackClosingViaBack?: boolean;
-}
-
 /**
  * Manages browser navigation for dialogs by:
  * 1. Adding a history entry when the dialog opens
@@ -19,24 +10,16 @@ interface UseDialogNavigationOptions {
  * navigating away from the page.
  * 
  * @param onClose - Function to call when the dialog should close
- * @param options - Optional configuration
- * @returns Object with isClosingViaBackRef if trackClosingViaBack is true
  */
-export const useDialogNavigation = (
-  onClose: () => void,
-  options?: UseDialogNavigationOptions
-) => {
+export const useDialogNavigation = (onClose: () => void) => {
   const isClosingViaBackRef = useRef(false);
-  const { trackClosingViaBack = false } = options || {};
 
   useEffect(() => {
     window.history.pushState({ dialogOpen: true }, '');
 
     const handlePopState = (event: PopStateEvent) => {
       if (!event.state?.dialogOpen) {
-        if (trackClosingViaBack) {
-          isClosingViaBackRef.current = true;
-        }
+        isClosingViaBackRef.current = true;
         onClose();
       }
     };
@@ -46,14 +29,9 @@ export const useDialogNavigation = (
     return () => {
       window.removeEventListener('popstate', handlePopState);
       // If dialog is closing normally (not via back), remove the history entry
-      if (
-        (!trackClosingViaBack || !isClosingViaBackRef.current) && 
-        window.history.state?.dialogOpen
-      ) {
+      if (!isClosingViaBackRef.current && window.history.state?.dialogOpen) {
         window.history.back();
       }
     };
-  }, [onClose, trackClosingViaBack]);
-
-  return trackClosingViaBack ? { isClosingViaBackRef } : {};
+  }, [onClose]);
 }; 

--- a/packages/lesswrong/components/hooks/useDialogNavigation.ts
+++ b/packages/lesswrong/components/hooks/useDialogNavigation.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+interface UseDialogNavigationOptions {
+  /**
+   * Whether to track if the dialog is closing via the back button.
+   * When true, returns an isClosingViaBackRef that can be used to determine
+   * if the dialog is closing via browser navigation.
+   */
+  trackClosingViaBack?: boolean;
+}
+
+/**
+ * Manages browser navigation for dialogs by:
+ * 1. Adding a history entry when the dialog opens
+ * 2. Handling browser back button/swipe to close the dialog
+ * 3. Cleaning up the history entry when the dialog closes normally
+ * 
+ * This ensures that the back button closes the dialog instead of
+ * navigating away from the page.
+ * 
+ * @param onClose - Function to call when the dialog should close
+ * @param options - Optional configuration
+ * @returns Object with isClosingViaBackRef if trackClosingViaBack is true
+ */
+export const useDialogNavigation = (
+  onClose: () => void,
+  options?: UseDialogNavigationOptions
+) => {
+  const isClosingViaBackRef = useRef(false);
+  const { trackClosingViaBack = false } = options || {};
+
+  useEffect(() => {
+    window.history.pushState({ dialogOpen: true }, '');
+
+    const handlePopState = (event: PopStateEvent) => {
+      if (!event.state?.dialogOpen) {
+        if (trackClosingViaBack) {
+          isClosingViaBackRef.current = true;
+        }
+        onClose();
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      // If dialog is closing normally (not via back), remove the history entry
+      if (
+        (!trackClosingViaBack || !isClosingViaBackRef.current) && 
+        window.history.state?.dialogOpen
+      ) {
+        window.history.back();
+      }
+    };
+  }, [onClose, trackClosingViaBack]);
+
+  return trackClosingViaBack ? { isClosingViaBackRef } : {};
+}; 

--- a/packages/lesswrong/components/hooks/useDisableBodyScroll.ts
+++ b/packages/lesswrong/components/hooks/useDisableBodyScroll.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+/**
+ * Disables scrolling on the document body when the component mounts,
+ * and restores the original overflow setting when the component unmounts.
+ * 
+ * This is useful for modals, dialogs, and other overlays that should
+ * prevent the background content from scrolling while they are open.
+ */
+export const useDisableBodyScroll = () => {
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+}; 

--- a/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
+++ b/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
@@ -77,9 +77,9 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
     },
   },
   reactsAndCount: {
+    top: 1,
     display: 'flex',
     alignItems: 'center',
-    marginLeft: '8px',
     cursor: 'pointer',
     fontSize: theme.typography.body2.fontSize,
     color: theme.palette.ultraFeed.dim,
@@ -115,7 +115,7 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
   addReactionButton: {
     opacity: 0.4,
     position: "relative",
-    top: 2,
+    top: 1,
     color: theme.palette.ultraFeed.dim,
     display: 'flex',
     alignItems: 'center',

--- a/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
+++ b/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
@@ -115,7 +115,7 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
   addReactionButton: {
     opacity: 0.4,
     position: "relative",
-    top: 0,
+    top: 2,
     color: theme.palette.ultraFeed.dim,
     display: 'flex',
     alignItems: 'center',
@@ -131,7 +131,7 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
       width: 20,
     },
     [theme.breakpoints.down('sm')]: {
-      top: 3,
+      top: 1,
       opacity: 1,
     },
   },

--- a/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
+++ b/packages/lesswrong/components/ultraFeed/CondensedFooterReactions.tsx
@@ -16,6 +16,9 @@ import { Card } from "@/components/widgets/Paper";
 import { AddReactionIcon } from '../icons/AddReactionIcon';
 import HoverOver from "../common/HoverOver";
 
+const ICON_BUTTON_SIZE = 24;
+const ICON_BUTTON_SIZE_MOBILE = 26;
+
 const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
   root: {
     display: 'flex',
@@ -25,6 +28,53 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
     marginRight: '4px',
     display: 'flex',
     alignItems: 'center',
+  },
+  reactionIconContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+  },
+  reactionIconWrapper: {
+    width: ICON_BUTTON_SIZE,
+    height: ICON_BUTTON_SIZE,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.grey[200],
+    border: `2px solid ${theme.palette.background.paper}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    zIndex: 2,
+    '& > *': {
+      transform: 'scale(0.9)',
+      [theme.breakpoints.down('sm')]: {
+        transform: 'scale(0.9)',
+      },
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: ICON_BUTTON_SIZE_MOBILE,
+      height: ICON_BUTTON_SIZE_MOBILE,
+    },
+  },
+  ellipsisIconWrapper: {
+    width: ICON_BUTTON_SIZE,
+    height: ICON_BUTTON_SIZE,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.grey[200],
+    border: `2px solid ${theme.palette.background.paper}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    marginLeft: -8, // Overlap with the previous icon
+    zIndex: 1,
+    fontSize: 8,
+    color: theme.palette.ultraFeed.dim,
+    fontWeight: 600,
+    [theme.breakpoints.down('sm')]: {
+      width: ICON_BUTTON_SIZE_MOBILE,
+      height: ICON_BUTTON_SIZE_MOBILE,
+    },
   },
   reactsAndCount: {
     display: 'flex',
@@ -43,9 +93,6 @@ const styles = defineStyles("CondensedFooterReactions", (theme: ThemeType) => ({
   },
   reactsAndCountActive: {
     backgroundColor: theme.palette.grey[200],
-  },
-  reactionIcon: {
-    marginRight: 4,
   },
   overviewPopperCard: {
     padding: 0,
@@ -379,8 +426,15 @@ const CondensedFooterReactions = ({
   const totalReactionCount = sortedReactions.reduce((sum, reaction) => sum + reaction.numberShown, 0);
 
   const topIconElement: React.ReactNode | null = sortedReactions.length > 0 && totalReactionCount > 0 ? (
-    <div className={classes.reactionIcon}>
-      <ReactionIcon react={sortedReactions[0]?.react as EmojiReactName} />
+    <div className={classes.reactionIconContainer}>
+      <div className={classes.reactionIconWrapper}>
+        <ReactionIcon react={sortedReactions[0]?.react as EmojiReactName} />
+      </div>
+      {sortedReactions.length > 1 && (
+        <div className={classes.ellipsisIconWrapper}>
+          •••
+        </div>
+      )}
     </div>
   ) : null;
   

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
@@ -222,7 +222,6 @@ const UltraFeedCommentsDialog = ({
     // Handle popstate (back button/swipe)
     const handlePopState = (event: PopStateEvent) => {
       if (!event.state?.dialogOpen) {
-        isClosingViaBackRef.current = true;
         onClose();
       }
     };
@@ -232,7 +231,7 @@ const UltraFeedCommentsDialog = ({
     return () => {
       window.removeEventListener('popstate', handlePopState);
       // If dialog is closing normally (not via back), remove the history entry
-      if (!isClosingViaBackRef.current && window.history.state?.dialogOpen) {
+      if (window.history.state?.dialogOpen) {
         window.history.back();
       }
     };

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
@@ -217,7 +217,7 @@ const UltraFeedCommentsDialog = ({
   const comments = isPost ? postComments : threadComments;
   const totalCount = isPost ? postCommentsTotalCount : threadCommentsTotalCount;
 
-  useDialogNavigation(onClose, { trackClosingViaBack: true });
+  useDialogNavigation(onClose);
   useDisableBodyScroll();
 
   // TODO: Do this more elegantly, combine within existing functionality in CommentsNode?

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
@@ -10,6 +10,8 @@ import Loading from "../vulcan-core/Loading";
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import ForumIcon from '../common/ForumIcon';
+import { useDialogNavigation } from "../hooks/useDialogNavigation";
+import { useDisableBodyScroll } from "../hooks/useDisableBodyScroll";
 
 const CommentsListMultiQuery = gql(`
   query multiCommentUltraFeedCommentsDialogQuery($selector: CommentSelector, $limit: Int, $enableTotal: Boolean) {
@@ -215,36 +217,8 @@ const UltraFeedCommentsDialog = ({
   const comments = isPost ? postComments : threadComments;
   const totalCount = isPost ? postCommentsTotalCount : threadCommentsTotalCount;
 
-  // Handle browser back button / swipe back navigation
-  useEffect(() => {
-    window.history.pushState({ dialogOpen: true }, '');
-
-    // Handle popstate (back button/swipe)
-    const handlePopState = (event: PopStateEvent) => {
-      if (!event.state?.dialogOpen) {
-        onClose();
-      }
-    };
-
-    window.addEventListener('popstate', handlePopState);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-      // If dialog is closing normally (not via back), remove the history entry
-      if (window.history.state?.dialogOpen) {
-        window.history.back();
-      }
-    };
-  }, [onClose]);
-
-  // Disable background scroll while dialog open
-  useEffect(() => {
-    const originalOverflow = window.document.body.style.overflow;
-    window.document.body.style.overflow = 'hidden';
-    return () => {
-      window.document.body.style.overflow = originalOverflow;
-    };
-  }, []);
+  useDialogNavigation(onClose, { trackClosingViaBack: true });
+  useDisableBodyScroll();
 
   // TODO: Do this more elegantly, combine within existing functionality in CommentsNode?
   // scroll to comment clicked on when dialog opens

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -461,7 +461,7 @@ const UltraFeedItemFooterCore = ({
   );
 
   const showAllCommentsButton = (commentCount ?? 0) > 0 
-    ? <LWTooltip title={`Show all comments (${commentCount} direct child${commentCount === 1 ? '' : 'ren'})`}>
+    ? <LWTooltip title={`Show all ${commentCount} descendant${commentCount === 1 ? '' : 's'}`}>
       <div
         onClick={onClickComments}
         className={classes.showAllComments}
@@ -611,7 +611,7 @@ const UltraFeedCommentFooter = ({ comment, metaInfo, className, onSeeLess, isSee
   const voteProps = useVote(comment, "Comments", votingSystem);
   const hideKarma = !!parentPost?.hideCommentKarma;
   const showVoteButtons = votingSystem.name === "namesAttachedReactions" && !hideKarma;
-  const commentCount = metaInfo.directDescendentCount;
+  const commentCount = metaInfo.descendentCount;
   const bookmarkProps: BookmarkProps = {documentId: comment._id, highlighted: metaInfo.sources?.includes("bookmarks")};
   
   const onClickComments = () => {

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -56,8 +56,6 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
       color: `${theme.palette.linkHover.dim} !important`,
     },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: 8,
-      paddingRight: 8,
       justifyContent: "space-between",
       ...theme.typography.ultraFeedMobileStyle,
       "& > *:not(:last-child)": {
@@ -76,12 +74,19 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
       height: 18,
       top: 2,
       [theme.breakpoints.down('sm')]: {
+        top: 3,
         height: 20,
         width: 20,
       },
     },
     [theme.breakpoints.down('sm')]: {
-      top: 2,
+      bottom: 1
+    }
+  },
+  showAllCommentsWrapper: {
+    display: 'inline-flex',
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
     }
   },
   showAllComments: {
@@ -156,8 +161,10 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     bottom: 2,
   },
   condensedFooterReactions: {
-    [theme.breakpoints.up('md')]: {
-      marginLeft: 'auto',
+    marginLeft: 'auto',
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: 'unset',
+      
     },
   },
   bookmarkButton: {
@@ -172,7 +179,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
       },
     },
     [theme.breakpoints.down('sm')]: {
-      top: 5,
+      top: 2,
       opacity: 1,
     },
   },
@@ -205,7 +212,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
       opacity: 1,
     },
     [theme.breakpoints.down('sm')]: {
-      top: 4,
+      top: 0,
       opacity: 1,
     },
   },
@@ -238,7 +245,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     "& .VoteArrowIconSolid-root": {
     },
     [theme.breakpoints.down('sm')]: {
-      top: 3,
+      top: 0,
     }
   },
   agreementButtons: {
@@ -248,7 +255,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     bottom: 0,
     marginLeft: -8,
     [theme.breakpoints.down('sm')]: {
-      top: 3,
+      top: 0,
     }
   },
   footerVoteScoreOverride: {
@@ -468,7 +475,8 @@ const UltraFeedItemFooterCore = ({
     : `Show all ${commentCount} descendant${commentCount === 1 ? '' : 's'}`;
 
   const showAllCommentsButton = (commentCount ?? 0) > 0 
-    ? <LWTooltip title={showAllCommentsTooltip}>
+    ? <div className={classes.showAllCommentsWrapper}>
+      <LWTooltip title={showAllCommentsTooltip}>
       <div
         onClick={onClickComments}
         className={classes.showAllComments}
@@ -476,7 +484,8 @@ const UltraFeedItemFooterCore = ({
         <DebateIconOutline />
         <span className={classes.showAllCommentsCount}>{commentCount}</span>
       </div>
-    </LWTooltip>
+      </LWTooltip>
+    </div>
    : null;
 
   const votingSystem = voteProps.document.votingSystem || getDefaultVotingSystem();

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -46,6 +46,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     opacity: `1 !important`,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: theme.typography.body2.fontSize,
+    lineHeight: 1,
     // every child except last has margin right applied
     "& > *:not(:last-child)": {
       marginRight: 16,
@@ -73,7 +74,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     "& svg": {
       position: "relative",
       height: 18,
-      top: 1,
+      top: 2,
       [theme.breakpoints.down('sm')]: {
         height: 20,
         width: 20,
@@ -85,7 +86,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
   },
   showAllComments: {
     position: 'relative',
-    top: 0,
+    bottom: 0,
     padding: 2,
     opacity: 0.6,
     display: "inline-flex",
@@ -96,7 +97,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     "& svg": {
       position: "relative",
       height: 14,
-      top: 0,
+      top: 2,
     },
     "&:hover": {
       opacity: 1,
@@ -231,7 +232,8 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
   },
   overallVoteButtons: {
     position: 'relative',
-    top: 1,
+    top: 0,
+    bottom: 1,
     color: `${theme.palette.ultraFeed.dim} !important`,
     "& .VoteArrowIconSolid-root": {
     },
@@ -242,7 +244,8 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
   agreementButtons: {
     position: 'relative',
     color: `${theme.palette.ultraFeed.dim} !important`,
-    top: 1,
+    top: 0,
+    bottom: 0,
     marginLeft: -8,
     [theme.breakpoints.down('sm')]: {
       top: 3,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -132,7 +132,7 @@ const styles = defineStyles("UltraFeedItemFooter", (theme: ThemeType) => ({
     display: 'inline-flex',
     alignItems: 'center',
     borderRadius: 4,
-    padding: 2,
+    padding: "2px 4px",
     transition: 'background-color 0.2s ease',
     "&:hover": {
       backgroundColor: theme.palette.panelBackground.hoverHighlightGrey,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -460,8 +460,12 @@ const UltraFeedItemFooterCore = ({
     </div>
   );
 
+  const showAllCommentsTooltip = (collectionName==='Posts')
+    ? `Show all comments`
+    : `Show all ${commentCount} descendant${commentCount === 1 ? '' : 's'}`;
+
   const showAllCommentsButton = (commentCount ?? 0) > 0 
-    ? <LWTooltip title={`Show all ${commentCount} descendant${commentCount === 1 ? '' : 's'}`}>
+    ? <LWTooltip title={showAllCommentsTooltip}>
       <div
         onClick={onClickComments}
         className={classes.showAllComments}

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -243,7 +243,16 @@ const styles = defineStyles("UltraFeedPostDialog", (theme: ThemeType) => ({
   },
   dialogInnerWrapper: {
     display: 'grid',
-    gridTemplateColumns: 'minmax(200px, 270px) 1fr',
+    // replicating PostsPage.tsx grid layout even though we haven't yet implemented side comments, reacts, and notes
+    gridTemplateColumns: `
+      0px
+      minmax(200px, 270px)
+      minmax(35px, 0.25fr)
+      minmax(min-content, 720px)
+      minmax(10px,30px)
+      50px
+      minmax(0px, 0.5fr)
+    `,
     height: '100%',
     overflowY: 'auto',
     position: 'relative',
@@ -366,8 +375,6 @@ const UltraFeedPostDialog = ({
   const [cookies, setCookie] = useCookiesWithConsent([SHOW_PODCAST_PLAYER_COOKIE]);
   const showEmbeddedPlayerCookie = cookies[SHOW_PODCAST_PLAYER_COOKIE] === "true";
   const [showEmbeddedPlayer, setShowEmbeddedPlayer] = useState(showEmbeddedPlayerCookie);
-  const authorListRef = useRef<HTMLDivElement>(null);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollableContentRef = useRef<HTMLDivElement>(null);
   const dialogInnerRef = useRef<HTMLDivElement>(null);
   const isClosingViaBackRef = useRef(false);
@@ -568,16 +575,21 @@ const UltraFeedPostDialog = ({
               </div>
               <div className={shouldShowToc ? classes.dialogInnerWrapper : undefined} ref={shouldShowToc ? scrollableContentRef : undefined}>
                 {shouldShowToc && (
-                  <div className={classes.tocColumnWrapper}>
-                    {hasTocData && tocData && (
-                      <FixedPositionToC
-                        tocSections={tocData.sections}
-                        title={displayPost.title}
-                        heading={<PostFixedPositionToCHeading post={displayPost as PostsListWithVotes}/>}
-                        scrollContainerRef={scrollableContentRef as React.RefObject<HTMLElement>}
-                      />
-                    )}
-                  </div>
+                  <>
+                    {/* placeholders for side comments, reacts, and notes */}
+                    <div />
+                    <div className={classes.tocColumnWrapper}>
+                      {hasTocData && tocData && (
+                        <FixedPositionToC
+                          tocSections={tocData.sections}
+                          title={displayPost.title}
+                          heading={<PostFixedPositionToCHeading post={displayPost as PostsListWithVotes}/>}
+                          scrollContainerRef={scrollableContentRef as React.RefObject<HTMLElement>}
+                        />
+                      )}
+                    </div>
+                    <div />
+                  </>
                 )}
                 <div 
                   className={classes.scrollableContent} 
@@ -661,6 +673,10 @@ const UltraFeedPostDialog = ({
                     />
                   )}
                 </div>
+                {/* placeholders for side comments, reacts, and notes */}
+                <div />
+                <div />
+                <div />
               </div>
               {shouldShowToc && (
                 <div className={classes.commentCount} onClick={scrollToComments} style={{ cursor: 'pointer' }}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -433,7 +433,7 @@ const UltraFeedPostDialog = ({
   const hasTocData = !!tocData && (tocData.sections ?? []).length > 0;
 
   // Handle browser back button / swipe back navigation
-  useDialogNavigation(onClose, { trackClosingViaBack: true });
+  useDialogNavigation(onClose);
   useDisableBodyScroll();
 
   // Bridge scroll events from internal container to window so hooks relying on window scroll keep working
@@ -549,7 +549,7 @@ const UltraFeedPostDialog = ({
               <div className={shouldShowToc ? classes.dialogInnerWrapper : undefined} ref={shouldShowToc ? scrollableContentRef : undefined}>
                 {shouldShowToc && (
                   <>
-                    {/* placeholders for side comments, reacts, and notes */}
+                    {/* placeholders for side comments, reacts, and notes with grid layout (helps get centering right) */}
                     <div />
                     <div className={classes.tocColumnWrapper}>
                       {hasTocData && tocData && (
@@ -646,7 +646,7 @@ const UltraFeedPostDialog = ({
                     />
                   )}
                 </div>
-                {/* placeholders for side comments, reacts, and notes */}
+                {/* placeholders for side comments, reacts, and notes with grid layout (helps get centering right) */}
                 <div />
                 <div />
                 <div />

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -414,6 +414,7 @@ const UltraFeedPostItem = ({
       displayStatus: 'expanded',
       sources: [],
       descendentCount: 0,
+      directDescendentCount: 0,
       highlight: false,
       lastServed: new Date(),
       lastViewed: null,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -413,7 +413,7 @@ const UltraFeedPostItem = ({
     const defaultMetaInfo: FeedCommentMetaInfo = {
       displayStatus: 'expanded',
       sources: [],
-      directDescendentCount: 0,
+      descendentCount: 0,
       highlight: false,
       lastServed: new Date(),
       lastViewed: null,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedQuickTakeDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedQuickTakeDialog.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import LWDialog from '../common/LWDialog';
 import { DialogContent } from '../widgets/DialogContent';
 import ForumIcon from '../common/ForumIcon';
 import QuickTakesEntry from '../quickTakes/QuickTakesEntry';
+import { useDisableBodyScroll } from '../hooks/useDisableBodyScroll';
 
 const styles = defineStyles("UltraFeedQuickTakeDialog", (theme: ThemeType) => ({
   dialogContent: {
@@ -78,14 +79,7 @@ type UltraFeedQuickTakeDialogProps = {
 const UltraFeedQuickTakeDialog = ({ onClose, currentUser }: UltraFeedQuickTakeDialogProps) => {
   const classes = useStyles(styles);
 
-  // Disable background scroll while dialog open
-  useEffect(() => {
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, []);
+  useDisableBodyScroll();
 
   return (
     <LWDialog

--- a/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
@@ -282,6 +282,7 @@ const UltraFeedThreadItem = ({thread, index, settings = DEFAULT_SETTINGS}: {
       displayStatus: 'expanded',
       sources: [],
       descendentCount: 0,
+      directDescendentCount: 0,
       highlight: false,
       lastServed: new Date(),
       lastViewed: null,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
@@ -281,7 +281,7 @@ const UltraFeedThreadItem = ({thread, index, settings = DEFAULT_SETTINGS}: {
     const defaultMetaInfo: FeedCommentMetaInfo = {
       displayStatus: 'expanded',
       sources: [],
-      directDescendentCount: 0,
+      descendentCount: 0,
       highlight: false,
       lastServed: new Date(),
       lastViewed: null,

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -40,6 +40,8 @@ export interface FeedPostMetaInfo {
 export interface FeedCommentMetaInfo {
   sources: FeedItemSourceType[];
   descendentCount: number;
+  /** @deprecated Use descendentCount instead. This field previously had a typo and only counted direct children. */
+  directDescendentCount?: number;
   lastServed?: Date | null;
   lastViewed?: Date | null;
   lastInteracted?: Date | null;
@@ -62,6 +64,7 @@ export interface FeedCommentFromDb {
   lastViewed: Date | null;
   lastInteracted: Date | null;
   postedAt: Date | null;
+  descendentCount?: number;
 }
 
 export interface FeedPostFromDb extends DbPost {

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -39,7 +39,7 @@ export interface FeedPostMetaInfo {
 }
 export interface FeedCommentMetaInfo {
   sources: FeedItemSourceType[];
-  directDescendentCount: number;
+  descendentCount: number;
   lastServed?: Date | null;
   lastViewed?: Date | null;
   lastInteracted?: Date | null;

--- a/packages/lesswrong/components/votes/ReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/ReactionsPalette.tsx
@@ -17,6 +17,7 @@ import ReactionDescription from "./lwReactions/ReactionDescription";
 import MetaInfo from "../common/MetaInfo";
 import { useMutation } from "@apollo/client";
 import { gql } from "@/lib/generated/gql-codegen";
+import { getCuratedActiveReactions } from '../../lib/voting/curatedReactionsList';
 
 const UsersCurrentUpdateMutation = gql(`
   mutation updateUserReactionsPalette($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -173,8 +174,7 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote}: {
   const [displayStyle, setDisplayStyle] = useState<ReactPaletteStyle>(reactPaletteStyle);
   const debouncedCaptureEvent = useRef(debounce(captureEvent, 500))
   
-  const activeReacts = namesAttachedReactions.filter(r=>!r.deprecated);
-  const reactionsToShow = reactionsSearch(activeReacts, searchText);
+  const reactionsToShow = getCuratedActiveReactions(searchText);
 
   const [updateUser] = useMutation(UsersCurrentUpdateMutation);
 
@@ -365,19 +365,6 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote}: {
       </a>}
     </div>
   </div>
-}
-
-export function reactionsSearch(candidates: NamesAttachedReactionType[], searchText: string): NamesAttachedReactionType[] {
-  if (!searchText || !searchText.length)
-    return candidates;
-  
-  searchText = searchText.toLowerCase();
-
-  return candidates.filter(
-    reaction => reaction.name.toLowerCase().startsWith(searchText)
-      || reaction.label.toLowerCase().startsWith(searchText)
-      || reaction.searchTerms?.some(searchTerm => searchTerm.toLowerCase().startsWith(searchText))
-  );
 }
 
 export default registerComponent('ReactionsPalette', ReactionsPalette);

--- a/packages/lesswrong/components/votes/ReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/ReactionsPalette.tsx
@@ -17,7 +17,19 @@ import ReactionDescription from "./lwReactions/ReactionDescription";
 import MetaInfo from "../common/MetaInfo";
 import { useMutation } from "@apollo/client";
 import { gql } from "@/lib/generated/gql-codegen";
-import { getCuratedActiveReactions } from '../../lib/voting/curatedReactionsList';
+import { 
+  getCuratedActiveReactions,
+  listPrimary as listPrimaryNames,
+  listEmotions as listEmotionNames,
+  gridPrimary as gridPrimaryNames,
+  gridEmotions as gridEmotionNames,
+  gridSectionB as gridSectionBNames,
+  gridSectionC as gridSectionCNames,
+  likelihoods as likelihoodNames,
+  listViewSectionB as listViewSectionBNames,
+  listViewSectionC as listViewSectionCNames,
+  listViewSectionD as listViewSectionDNames
+} from '../../lib/voting/curatedReactionsList';
 
 const UsersCurrentUpdateMutation = gql(`
   mutation updateUserReactionsPalette($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -206,58 +218,16 @@ const ReactionsPalette = ({getCurrentUserReactionVote, toggleReaction, quote}: {
 
   const getReactionFromName = (name: string) => namesAttachedReactions.find(r => r.name === name && reactionsToShow.includes(r));
 
-  const listPrimary = [
-    'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'seen', 'thanks', 
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const listEmotions = [
-    'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'paperclip', 
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const gridPrimary = [
-    'agree', 'disagree', 'important', 'dontUnderstand', 'changemind', 'shrug', 'thinking', 'surprise', 'seen',  
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const gridEmotions = [
-    'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'thanks', 
-  ].map(r => getReactionFromName(r)).filter(r => r);
-  
-  const gridSectionB = [
-    'crux',       'hitsTheMark', 'locallyValid',   'scout',     'facilitation',             'concrete',  'yeswhatimean', 'clear', 'betTrue',
-    'notacrux',   'miss',        'locallyInvalid', 'soldier',   'unnecessarily-combative','examples',  'strawman',     'muddled', 'betFalse',
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const gridSectionC = [
-    'heart', 'insightful', 'taboo',  'offtopic',  'elaborate',  'timecost',  'typo', 'scholarship', 'why'
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const likelihoods = [
-    '1percent', '10percent', '25percent', '40percent', '50percent', '60percent', '75percent', '90percent', '99percent',
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const listViewSectionB = [
-    'changemind',   'insightful',
-    'thanks',       'heart',
-    'typo',         'why', 
-    'offtopic',     'elaborate',
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const listViewSectionC = [
-    'hitsTheMark',  'miss',
-    'crux',         'notacrux',
-    'locallyValid', 'locallyInvalid',
-    'facilitation', 'unnecessarily-combative',
-    'yeswhatimean', 'strawman',
-    'concrete',     'examples',
-    'clear',        'muddled',
-    'betTrue',     'betFalse',
-    'scout',        'soldier',
-  ].map(r => getReactionFromName(r)).filter(r => r);
-
-  const listViewSectionD = [
-    'scholarship',  'taboo',             
-    'coveredAlready','timecost',
-  ].map(r => getReactionFromName(r)).filter(r => r );
+  const listPrimary = listPrimaryNames.map(r => getReactionFromName(r)).filter(r => r);
+  const listEmotions = listEmotionNames.map(r => getReactionFromName(r)).filter(r => r);
+  const gridPrimary = gridPrimaryNames.map(r => getReactionFromName(r)).filter(r => r);
+  const gridEmotions = gridEmotionNames.map(r => getReactionFromName(r)).filter(r => r);
+  const gridSectionB = gridSectionBNames.map(r => getReactionFromName(r)).filter(r => r);
+  const gridSectionC = gridSectionCNames.map(r => getReactionFromName(r)).filter(r => r);
+  const likelihoods = likelihoodNames.map(r => getReactionFromName(r)).filter(r => r);
+  const listViewSectionB = listViewSectionBNames.map(r => getReactionFromName(r)).filter(r => r);
+  const listViewSectionC = listViewSectionCNames.map(r => getReactionFromName(r)).filter(r => r);
+  const listViewSectionD = listViewSectionDNames.map(r => getReactionFromName(r)).filter(r => r);
 
   const gridReactButton = (reaction: NamesAttachedReactionType, size=24) => {
     const currentUserVote = getCurrentUserReactionVote(reaction.name, quote);

--- a/packages/lesswrong/components/votes/UltraFeedReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/UltraFeedReactionsPalette.tsx
@@ -2,8 +2,6 @@ import React, {useRef, useState} from 'react';
 import { EmojiReactName, QuoteLocator, VoteOnReactionType } from '../../lib/voting/namesAttachedReactions';
 import { NamesAttachedReactionType } from '../../lib/voting/reactions';
 import classNames from 'classnames';
-import { useTracking } from "../../lib/analyticsEvents";
-import debounce from "lodash/debounce";
 import type { Placement as PopperPlacementType } from "popper.js"
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import ReactionIcon from "./ReactionIcon";

--- a/packages/lesswrong/components/votes/UltraFeedReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/UltraFeedReactionsPalette.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, useState} from 'react';
 import { EmojiReactName, QuoteLocator, VoteOnReactionType } from '../../lib/voting/namesAttachedReactions';
-import { namesAttachedReactions, NamesAttachedReactionType } from '../../lib/voting/reactions';
+import { NamesAttachedReactionType } from '../../lib/voting/reactions';
 import classNames from 'classnames';
 import { useTracking } from "../../lib/analyticsEvents";
 import debounce from "lodash/debounce";
@@ -9,7 +9,7 @@ import { defineStyles, useStyles } from '../hooks/useStyles';
 import ReactionIcon from "./ReactionIcon";
 import LWTooltip from "../common/LWTooltip";
 import ReactionDescription from "./lwReactions/ReactionDescription";
-import { reactionsSearch } from './ReactionsPalette';
+import { getCuratedActiveReactions } from '../../lib/voting/curatedReactionsList';
 
 const styles = defineStyles('UltraFeedReactionsPalette', (theme: ThemeType) => ({
   moreReactions: {
@@ -175,8 +175,7 @@ const UltraFeedReactionsPalette = ({
   const classes = useStyles(styles);
   const [searchText,setSearchText] = useState("");
   
-  const activeReacts = namesAttachedReactions.filter(r=>!r.deprecated);
-  const reactionsToShow = reactionsSearch(activeReacts, searchText);
+  const reactionsToShow = getCuratedActiveReactions(searchText);
 
   return <div className={classes.moreReactions}>
     <input

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -24,6 +24,7 @@ import Loading from "./Loading";
 import HeadTags from "../common/HeadTags";
 import ScrollToTop from "./ScrollToTop";
 import Layout from "../Layout";
+import NavigationEventSender from "../hooks/useOnNavigate";
 
 interface ExternalProps {
   apolloClient: AnyBecauseTodo,
@@ -112,6 +113,8 @@ const App = ({serverRequestStatus}: ExternalProps) => {
         <Layout currentUser={currentUser}>
           <location.RouteComponent />
         </Layout>
+        {/* keep at bottom so its effect runs after DialogManager registers its close-on-navigate callback */}
+        <NavigationEventSender /> 
       </MessageContextProvider>
     </RefetchCurrentUserContext.Provider>
     </ServerRequestStatusContext.Provider>

--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -211,6 +211,14 @@ export const userIsBannedFromPost = (user: UsersMinimumInfo|DbUser, post: PostsD
   )
 }
 
+export const userIsNotShortformOwner = (user: UsersCurrent|DbUser, post: PostsDetails|DbPost): boolean => {
+  return !!(
+    post.shortform &&
+    post.userId &&
+    post.userId !== user._id
+  )
+}
+
 export const userIsBannedFromAllPosts = (user: UsersCurrent|DbUser, post: PostsDetails|DbPost, postAuthor: PermissionableUser|DbUser|null): boolean => {
   return !!(
     // @ts-ignore FIXME: Not enforcing that the fragment includes bannedUserIds

--- a/packages/lesswrong/lib/voting/curatedReactionsList.ts
+++ b/packages/lesswrong/lib/voting/curatedReactionsList.ts
@@ -1,33 +1,73 @@
 import { namesAttachedReactions, NamesAttachedReactionType } from './reactions';
 
-export const primaryReactionNames = [
-  'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'seen', 'thanks'
+// List View Sections
+export const listPrimary = [
+  'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'seen', 'thanks', 
 ];
 
-export const emotionReactionNames = [
-  'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'paperclip'
+export const listEmotions = [
+  'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'paperclip', 
 ];
 
-export const extendedReactionNames = [
-  'changemind', 'insightful', 'heart', 'typo', 'why', 'offtopic', 'elaborate',
-  'hitsTheMark', 'miss', 'crux', 'notacrux', 'locallyValid', 'locallyInvalid',
-  'facilitation', 'unnecessarily-combative', 'yeswhatimean', 'strawman',
-  'concrete', 'examples', 'clear', 'muddled', 'betTrue', 'betFalse',
-  'scout', 'soldier', 'scholarship', 'taboo', 'coveredAlready', 'timecost'
+export const listViewSectionB = [
+  'changemind',   'insightful',
+  'thanks',       'heart',
+  'typo',         'why', 
+  'offtopic',     'elaborate',
 ];
 
-export const likelihoodReactionNames = [
-  '1percent', '10percent', '25percent', '40percent', '50percent', 
-  '60percent', '75percent', '90percent', '99percent'
+export const listViewSectionC = [
+  'hitsTheMark',  'miss',
+  'crux',         'notacrux',
+  'locallyValid', 'locallyInvalid',
+  'facilitation', 'unnecessarily-combative',
+  'yeswhatimean', 'strawman',
+  'concrete',     'examples',
+  'clear',        'muddled',
+  'betTrue',      'betFalse',
+  'scout',        'soldier',
+];
+
+export const listViewSectionD = [
+  'scholarship',  'taboo',             
+  'coveredAlready','timecost',
+];
+
+// Grid View Sections
+export const gridPrimary = [
+  'agree', 'disagree', 'important', 'dontUnderstand', 'changemind', 'shrug', 'thinking', 'surprise', 'seen',  
+];
+
+export const gridEmotions = [
+  'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'thanks', 
+];
+
+export const gridSectionB = [
+  'crux',       'hitsTheMark', 'locallyValid',   'scout',     'facilitation',             'concrete',  'yeswhatimean', 'clear', 'betTrue',
+  'notacrux',   'miss',        'locallyInvalid', 'soldier',   'unnecessarily-combative','examples',  'strawman',     'muddled', 'betFalse',
+];
+
+export const gridSectionC = [
+  'heart', 'insightful', 'taboo',  'offtopic',  'elaborate',  'timecost',  'typo', 'scholarship', 'why'
+];
+
+export const likelihoods = [
+  '1percent', '10percent', '25percent', '40percent', '50percent', '60percent', '75percent', '90percent', '99percent',
 ];
 
 export const getAllCuratedReactionNames = (): string[] => {
   return [
-    ...primaryReactionNames,
-    ...emotionReactionNames,
-    ...extendedReactionNames,
-    ...likelihoodReactionNames
-  ];
+    ...listPrimary,
+    ...listEmotions,
+    ...listViewSectionB,
+    ...listViewSectionC,
+    ...listViewSectionD,
+    ...gridPrimary,
+    ...gridEmotions,
+    ...gridSectionB,
+    ...gridSectionC,
+    ...likelihoods
+  ].filter((name, index, self) => self.indexOf(name) === index);
 };
 
 // Filter reactions to only include curated and non-deprecated ones

--- a/packages/lesswrong/lib/voting/curatedReactionsList.ts
+++ b/packages/lesswrong/lib/voting/curatedReactionsList.ts
@@ -1,4 +1,5 @@
 import { namesAttachedReactions, NamesAttachedReactionType } from './reactions';
+import uniq from 'lodash/uniq';
 
 // List View Sections
 export const listPrimary = [
@@ -56,7 +57,7 @@ export const likelihoods = [
 ];
 
 export const getAllCuratedReactionNames = (): string[] => {
-  return [
+  return uniq([
     ...listPrimary,
     ...listEmotions,
     ...listViewSectionB,
@@ -67,7 +68,7 @@ export const getAllCuratedReactionNames = (): string[] => {
     ...gridSectionB,
     ...gridSectionC,
     ...likelihoods
-  ].filter((name, index, self) => self.indexOf(name) === index);
+  ]);
 };
 
 // Filter reactions to only include curated and non-deprecated ones

--- a/packages/lesswrong/lib/voting/curatedReactionsList.ts
+++ b/packages/lesswrong/lib/voting/curatedReactionsList.ts
@@ -1,0 +1,50 @@
+import { namesAttachedReactions, NamesAttachedReactionType } from './reactions';
+
+export const primaryReactionNames = [
+  'agree', 'disagree', 'important', 'dontUnderstand', 'shrug', 'thinking', 'surprise', 'seen', 'thanks'
+];
+
+export const emotionReactionNames = [
+  'smile', 'laugh', 'disappointed', 'confused', 'roll', 'excitement', 'thumbs-up', 'thumbs-down', 'paperclip'
+];
+
+export const extendedReactionNames = [
+  'changemind', 'insightful', 'heart', 'typo', 'why', 'offtopic', 'elaborate',
+  'hitsTheMark', 'miss', 'crux', 'notacrux', 'locallyValid', 'locallyInvalid',
+  'facilitation', 'unnecessarily-combative', 'yeswhatimean', 'strawman',
+  'concrete', 'examples', 'clear', 'muddled', 'betTrue', 'betFalse',
+  'scout', 'soldier', 'scholarship', 'taboo', 'coveredAlready', 'timecost'
+];
+
+export const likelihoodReactionNames = [
+  '1percent', '10percent', '25percent', '40percent', '50percent', 
+  '60percent', '75percent', '90percent', '99percent'
+];
+
+export const getAllCuratedReactionNames = (): string[] => {
+  return [
+    ...primaryReactionNames,
+    ...emotionReactionNames,
+    ...extendedReactionNames,
+    ...likelihoodReactionNames
+  ];
+};
+
+// Filter reactions to only include curated and non-deprecated ones
+export const getCuratedActiveReactions = (searchText: string = ''): NamesAttachedReactionType[] => {
+  const curatedNames = getAllCuratedReactionNames();
+  const activeReacts = namesAttachedReactions.filter(r => 
+    !r.deprecated && curatedNames.includes(r.name)
+  );
+  
+  if (!searchText || !searchText.length) {
+    return activeReacts;
+  }
+  
+  const searchLower = searchText.toLowerCase();
+  return activeReacts.filter(
+    reaction => reaction.name.toLowerCase().startsWith(searchLower)
+      || reaction.label.toLowerCase().startsWith(searchLower)
+      || reaction.searchTerms?.some(searchTerm => searchTerm.toLowerCase().startsWith(searchLower))
+  );
+}; 

--- a/packages/lesswrong/server/repos/BookmarksRepo.ts
+++ b/packages/lesswrong/server/repos/BookmarksRepo.ts
@@ -8,6 +8,7 @@ interface UltraFeedBookmark {
   collectionName: string;
   postId: string | null;
   descendentCount: number | null;
+  directDescendentCount: number | null;
 }
 
 class BookmarksRepo extends AbstractRepo<"Bookmarks"> {
@@ -49,7 +50,8 @@ class BookmarksRepo extends AbstractRepo<"Bookmarks"> {
         b."documentId",
         b."collectionName",
         c."postId",
-        c."descendentCount"
+        c."descendentCount",
+        c."directDescendentCount"
       FROM "Bookmarks" b
       LEFT JOIN "Comments" c ON b."documentId" = c."_id"
       WHERE b."userId" = $(userId)

--- a/packages/lesswrong/server/repos/BookmarksRepo.ts
+++ b/packages/lesswrong/server/repos/BookmarksRepo.ts
@@ -7,7 +7,7 @@ interface UltraFeedBookmark {
   documentId: string;
   collectionName: string;
   postId: string | null;
-  directChildrenCount: number | null;
+  descendentCount: number | null;
 }
 
 class BookmarksRepo extends AbstractRepo<"Bookmarks"> {
@@ -49,7 +49,7 @@ class BookmarksRepo extends AbstractRepo<"Bookmarks"> {
         b."documentId",
         b."collectionName",
         c."postId",
-        c."directChildrenCount"
+        c."descendentCount"
       FROM "Bookmarks" b
       LEFT JOIN "Comments" c ON b."documentId" = c."_id"
       WHERE b."userId" = $(userId)

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -518,7 +518,8 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
             c."topLevelCommentId",
             c."parentCommentId",
             c.shortform,
-            c."postedAt"
+            c."postedAt",
+            c."descendentCount"
           FROM "Comments" c
           JOIN "CandidateThreadTopLevelIds" ct
               ON c."topLevelCommentId" = ct."threadTopLevelId"
@@ -580,6 +581,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           c."parentCommentId",
           c.shortform,
           c."postedAt",
+          c."descendentCount",
           ce."lastServed",
           ce."lastViewed",
           ce."lastInteracted"
@@ -604,6 +606,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
       baseScore: comment.baseScore,
       shortform: comment.shortform ?? null,
       postedAt: comment.postedAt,
+      descendentCount: comment.descendentCount,
       sources: ['recentComments'],
       lastServed: null, 
       lastViewed: comment.lastViewed ?? null,

--- a/packages/lesswrong/server/ultraFeed/ultraFeedBookmarkHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedBookmarkHelpers.ts
@@ -28,6 +28,7 @@ function prepareBookmarksForUltraFeed(bookmarks: UltraFeedBookmark[]): PreparedB
           lastInteracted: null,
           postedAt: null,
           descendentCount: b.descendentCount ?? 0,
+          directDescendentCount: b.descendentCount ?? 0,
         };
         const comment: PreDisplayFeedComment = {
           commentId: b.documentId, postId: b.postId, baseScore: 0, metaInfo,

--- a/packages/lesswrong/server/ultraFeed/ultraFeedBookmarkHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedBookmarkHelpers.ts
@@ -27,7 +27,7 @@ function prepareBookmarksForUltraFeed(bookmarks: UltraFeedBookmark[]): PreparedB
           lastViewed: null,
           lastInteracted: null,
           postedAt: null,
-          directDescendentCount: b.directChildrenCount ?? 0,
+          descendentCount: b.descendentCount ?? 0,
         };
         const comment: PreDisplayFeedComment = {
           commentId: b.documentId, postId: b.postId, baseScore: 0, metaInfo,

--- a/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
@@ -21,29 +21,6 @@ import {
 import * as crypto from 'crypto';
 
 /**
- * Recursively calculates the total number of descendants for a given comment ID.
- * It uses memoization to avoid re-calculating counts for the same sub-threads.
- */
-const getDescendantCount = (
-  id: string,
-  children: Record<string, string[]>,
-  cache: Record<string, number>
-): number => {
-  if (cache[id] !== undefined) {
-    return cache[id];
-  }
-
-  const childIds = children[id] ?? [];
-  const count = childIds.reduce(
-    (acc, childId) => acc + 1 + getDescendantCount(childId, children, cache),
-    0
-  );
-
-  cache[id] = count;
-  return count;
-};
-
-/**
  * Generates a stable hash ID for a comment thread based on its comment IDs (sensitive to sort order).
  * This MUST match the hash generation logic used in the resolver when checking against served threads.
  */
@@ -76,19 +53,20 @@ export function buildDistinctLinearThreads(
     children[parent].push(c.commentId);
   }
 
-  const descendantCountCache: Record<string, number> = {};
-
   const enhancedCandidates: PreDisplayFeedComment[] = candidates.map(candidate => {
-    const descendentCount = getDescendantCount(candidate.commentId, children, descendantCountCache);
+    const descendentCount = candidate.descendentCount ?? 0;
+    const directDescendentCount = children[candidate.commentId] ? children[candidate.commentId].length : 0;
 
     return {
       commentId: candidate.commentId,
       postId: candidate.postId,
       baseScore: candidate.baseScore,
+      parentCommentId: candidate.parentCommentId ?? undefined,
       topLevelCommentId: candidate.topLevelCommentId,
       metaInfo: {
         sources: candidate.sources as FeedItemSourceType[],
         descendentCount,
+        directDescendentCount,
         lastServed: candidate.lastServed,
         lastViewed: candidate.lastViewed,
         lastInteracted: candidate.lastInteracted,
@@ -454,6 +432,7 @@ function prepareThreadForDisplay(
     const newMetaInfo: FeedCommentMetaInfo = {
       sources: comment.sources as FeedItemSourceType[],
       descendentCount: comment.metaInfo?.descendentCount ?? 0, 
+      directDescendentCount: comment.metaInfo?.directDescendentCount ?? 0,
       lastServed: comment.lastServed, 
       lastViewed: comment.lastViewed,
       lastInteracted: comment.lastInteracted,


### PR DESCRIPTION
- Comments Modal is fullscreen. Properly closes on all navigate events
- UltraFeedItems now show "total descendent" count for comment count instead just immediate descendent
- Text in Post Modal is centered (via replicating the grid layout of PostsPage)

- We indicate when there are multiple react types on an item:
<img width="810" alt="LessWrong Feed — LessWrong 2025-06-24 12-56-45" src="https://github.com/user-attachments/assets/85bef0bd-060f-4059-bf91-58989025858d" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210632128623126) by [Unito](https://www.unito.io)
