### PR TITLE
[EA] fix onboarding horizontal scroll

### DIFF
--- a/packages/lesswrong/components/common/BlurredBackgroundModal.tsx
+++ b/packages/lesswrong/components/common/BlurredBackgroundModal.tsx
@@ -4,6 +4,9 @@ import classNames from "classnames";
 import LWDialog from "./LWDialog";
 
 const styles = (theme: ThemeType) => ({
+  paper: {
+    maxWidth: "unset !important",
+  },
   root: {
     background: theme.palette.panelBackground.modalBackground,
     borderRadius: theme.borderRadius.default,
@@ -47,11 +50,18 @@ export const BlurredBackgroundModal = ({
   className?: string,
   classes: ClassesType<typeof styles>,
 }) => {
-  return <LWDialog open={open} onClose={onClose} backdrop="blur">
-    <div className={classNames(classes.root, className)}>
-      {children}
-    </div>
-  </LWDialog>
+  return (
+    <LWDialog
+      open={open}
+      onClose={onClose}
+      backdrop="blur"
+      paperClassName={classes.paper}
+    >
+      <div className={classNames(classes.root, className)}>
+        {children}
+      </div>
+    </LWDialog>
+  );
 }
 
 export default registerComponent(


### PR DESCRIPTION
You can currently horizontally scroll the onboarding dialog, which shouldn't be possible. This was probably broken when MUI was vendored and `LWDialog` was created.

<img width="754" alt="Screenshot 2025-06-25 at 13 17 21" src="https://github.com/user-attachments/assets/dcf0b043-a042-411a-9b84-3499384af0da" />
