### PR TITLE
Fix jank in the animation when the notifications sidebar slides in

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -79,9 +79,6 @@ const NotificationsMenuInner = ({open, setIsOpen, hasOpened}: {
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
-  const {unreadNotificationCountsQueryRef} = useUnreadNotifications();
-  const {data} = useReadQuery(unreadNotificationCountsQueryRef!);
-  const unreadPrivateMessages = data?.unreadNotificationCounts?.unreadPrivateMessages ?? 0;
   const [tab,setTab] = useState(0);
 
   if (!currentUser) {
@@ -109,7 +106,9 @@ const NotificationsMenuInner = ({open, setIsOpen, hasOpened}: {
         <Badge
           className={classes.badgeContainer}
           badgeClassName={classes.badge}
-          badgeContent={unreadPrivateMessages>0 ? `${unreadPrivateMessages}` : ""}
+          badgeContent={<SuspenseWrapper name="UnreadPrivateMessagesCountBadge">
+            <UnreadPrivateMessagesCountBadge/>
+          </SuspenseWrapper>}
         >
           <MailIcon className={classes.icon} />
         </Badge>
@@ -170,6 +169,13 @@ const NotificationsMenuInner = ({open, setIsOpen, hasOpened}: {
     </div>
   )
 };
+
+const UnreadPrivateMessagesCountBadge = () => {
+  const {unreadNotificationCountsQueryRef} = useUnreadNotifications();
+  const {data} = useReadQuery(unreadNotificationCountsQueryRef!);
+  const unreadPrivateMessages = data?.unreadNotificationCounts?.unreadPrivateMessages ?? 0;
+  return unreadPrivateMessages>0 ? `${unreadPrivateMessages}` : ""
+}
 
 const NotificationsMenu = ({open, setIsOpen, hasOpened}: {
   open: boolean,


### PR DESCRIPTION
After some refactoring in `useUnreadNotifications` and `NotificationsMenu` driven by suspense, when you opened the notification sidebar, the badge on the Messages tab would trigger a refetch of the notification-counts query, which would cause the whole sidebar to suspend while it loaded, which would make the slide-in animation very janky. Fix by putting the badge on the Messages tab into its own suspense boundary.

(Most client-side things don't use suspense like this; `useUnreadNotifications` gets suspense because it uses `useBackgroundQuery`/`useReadQuery` rather than `useQuery`, which was necessary because it's a context provider.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210653110119877) by [Unito](https://www.unito.io)
