### PR TITLE
Fix error handling in useUnreadNotifications

### DIFF
--- a/packages/lesswrong/components/common/ErrorBoundary.tsx
+++ b/packages/lesswrong/components/common/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { configureScope, captureException }from '@sentry/core';
 import ErrorMessage from "./ErrorMessage";
 
 interface ErrorBoundaryProps {
+  hideMessage?: boolean
   children: React.ReactNode,
 }
 
@@ -46,7 +47,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 
   render() {
-    if (this.state.error) {
+    if (this.state.error && !this.props.hideMessage) {
       return <ErrorMessage message={this.state.error}/>
     }
     if (this.props.children)

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
@@ -9,6 +9,7 @@ import { type QueryRef, useBackgroundQuery, useReadQuery } from '@apollo/client/
 import { NotificationsListMultiQuery } from '../notifications/NotificationsList';
 import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import type { ResultOf } from '@graphql-typed-document-node/core';
+import ErrorBoundary from '../common/ErrorBoundary';
 
 export type NotificationCountsResult = {
   checkedAt: Date,
@@ -172,9 +173,11 @@ export const UnreadNotificationsContextProvider: FC<{
 
   return (
     <unreadNotificationsContext.Provider value={providedContext}>
-      {unreadNotificationCountsQueryRef && <SuspenseWrapper name="useUnreadNotifications">
-        <NotificationsEffects queryRef={unreadNotificationCountsQueryRef} refetchCounts={refetchCounts} refetchBoth={refetchBoth} />
-      </SuspenseWrapper>}
+      {unreadNotificationCountsQueryRef && <ErrorBoundary hideMessage>
+        <SuspenseWrapper name="useUnreadNotifications">
+          <NotificationsEffects queryRef={unreadNotificationCountsQueryRef} refetchCounts={refetchCounts} refetchBoth={refetchBoth} />
+        </SuspenseWrapper>
+      </ErrorBoundary>}
       {children}
     </unreadNotificationsContext.Provider>
   );


### PR DESCRIPTION
When you return to a defocused tab, it refetches notification counts. If this query failed (because your laptop is coming out of sleep, or you're in development and the server is restarting), this would reach an error boundary all the way outside the page, causing it to become blank. (This was introduced with the Suspense changes, which made this query use useReadQuery which throws rather than returning an error).

Add an error boundary to make this not blank the page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210654280228676) by [Unito](https://www.unito.io)
