### PR TITLE
Improve the notifications button

### DIFF
--- a/packages/lesswrong/client/clientStartup.ts
+++ b/packages/lesswrong/client/clientStartup.ts
@@ -53,6 +53,9 @@ async function clientStartup() {
   initLegacyRoutes();
   hydrateClient();
   
+  // See comment in server/rendering/eventCapture.ts
+  window.__replayEvents?.();
+  
   if (enableVite) {
     setTimeout(removeStaticStylesheet, 1000);
     viteHandleReload();

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -46,15 +46,19 @@ const styles = defineStyles("NotificationsMenu", (theme: ThemeType) => ({
       color: theme.palette.greyAlpha(1.0),
     },
   },
-  cancel: {
+  cancelWrapper: {
     position: "absolute",
     top: 0,
-    right: 5,
-    margin: "10px",
+    height: 48,
+    right: 0,
+    paddingRight: 5,
     cursor: "pointer",
+  },
+  cancel: {
+    margin: "10px",
 
     color: theme.palette.icon.dim5,
-    "&:hover": {
+    "$cancelWrapper:hover &": {
       color: theme.palette.icon.normal,
     },
   },
@@ -161,7 +165,9 @@ const NotificationsMenuInner = ({open, setIsOpen, hasOpened}: {
                 */}
               <Tab className={classes.hiddenTab} />
             </Tabs>
-            <ClearIcon className={classes.cancel} onClick={() => setIsOpen(false)} />
+            <div className={classes.cancelWrapper} onClick={() => setIsOpen(false)}>
+              <ClearIcon className={classes.cancel} />
+            </div>
             <NotificationsList terms={{...notificationTerms, userId: currentUser._id}} currentUser={currentUser}/>
           </div>}
         </Drawer>}

--- a/packages/lesswrong/lib/types/windowObjectExtensions.ts
+++ b/packages/lesswrong/lib/types/windowObjectExtensions.ts
@@ -16,6 +16,7 @@ declare global {
     __APOLLO_STATE__: any,
     __APOLLO_FOREIGN_STATE__: any,
     missingMainStylesheet?: boolean,
+    __replayEvents?: () => void,
     
     googleMapsFinishedLoading?: () => void,
     killPreloadScroll?: () => void,

--- a/packages/lesswrong/server/rendering/eventCapture.ts
+++ b/packages/lesswrong/server/rendering/eventCapture.ts
@@ -1,0 +1,19 @@
+
+/**
+ * During pageload, there's a window of time in which we've streamed SSR'ed
+ * components to the client, but not yet downloaded and run the javascript
+ * bundle. By default, any events (ie clicks) during this time would be lost.
+ * For clicks that are on <a> tags, this has an acceptable fallback (they have
+ * an href, so the click is handled by following the link). But for clicks that
+ * are supposed to do things other than navigate, this doesn't work.
+ *
+ * To address this, we inject a small script which captures and stores events.
+ * After calling `hydrateClient`, we replay them. This makes it so that clicks
+ * may be delayed until the page is done downloading, but they aren't lost.
+ *
+ * This hack is particularly motivated by the notifications icon, which users
+ * are relatively likely to click on immediately. This also works for front
+ * page tabs (Recent/Enriched/Recommended/Susbcribed/etc) and for anything else
+ * that's clickable but not a link.
+ */
+export const eventCaptureScript = `<script>(function(){ const q=[]; const types=['click']; const cap=e=>q.push(e); types.forEach(t=>document.addEventListener(t,cap,true)); window.__replayEvents=()=>{ types.forEach(t=>document.removeEventListener(t,cap,true)); q.forEach(e=>{ const evt=new e.constructor(e.type,e); e.target.dispatchEvent(evt)})}})()</script>`;

--- a/packages/lesswrong/server/rendering/renderPage.tsx
+++ b/packages/lesswrong/server/rendering/renderPage.tsx
@@ -49,6 +49,7 @@ import { HelmetServerState } from 'react-helmet-async';
 import every from 'lodash/every';
 import { prefilterHandleRequest } from '../apolloServer';
 import { HIDE_IF_ANYONE_BUILDS_IT_SPOTLIGHT } from '@/components/themes/useTheme';
+import { eventCaptureScript } from './eventCapture';
 
 export interface RenderSuccessResult {
   ssrBody: string
@@ -215,6 +216,7 @@ export async function handleRequest(request: Request, response: Response) {
     // relative to any scripts that come later than this is undetermined and
     // varies based on timings and the browser cache.
     + clientScript
+    + eventCaptureScript
     + themeOptionsHeader
   );
 


### PR DESCRIPTION
This PR solves the problem of clicks getting lost if they occur during pageload before `hydrateRoot` is called, particularly focused on the notifications bell icon but also fixing lost clicks for other things such as the home posts list tabs. It works by injecting a small script that captures click events, and replaying them after `hydrateRoot` is called.

This is kind of a hack, but there doesn't seem to be an idiomatic way to do this without delaying first contentful paint until `hydrateRoot` is called, which is much too long to delay without bundle splitting and is probably still too long to delay even _with_ bundle splitting. While there is documentation and references referring to React having an event-replay system aimed at a scenario that sounds kind of like this one, this is in fact only for later parts of the loading process, after the React library has been downloaded and called.

Also expands the click target of the notifications menu's close button, after it's open.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210664966095002) by [Unito](https://www.unito.io)
