### PR TITLE
Assorted small changes

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,5 +1,6 @@
 --ignore-dir=.git
---ignore-dir=build
+--ignore-dir=match:build[0-9]*
+--ignore-dir=generated
 --ignore-dir=obj
 --ignore-dir=build4000
 --ignore-dir=.circleci
@@ -14,4 +15,6 @@
 --ignore-dir=express/src
 --ignore-file=is:client_stats.html
 --ignore-file=is:client_meta.json
+--ignore-file=is:queryLog.txt
+--ignore-file=is:.component-cache.json
 --ignore-dir=packages/lesswrong/lib/generated/gql-codegen

--- a/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
+++ b/packages/lesswrong/components/form-components/TagFlagToggleList.tsx
@@ -56,7 +56,7 @@ const TagFlagToggleList = ({ value, path, updateCurrentValues }: {
     {results?.map(({_id}) => {
       const selected = value && value.includes(_id);
       return <a key={_id} onClick={() => handleClick(_id)}>
-        <TagFlagItem documentId={_id} style={selected ? "grey" : "white"} showNumber={false} />
+        <TagFlagItem documentId={_id} style={selected ? "grey" : "white"} />
       </a>
     })}
   </div></DeferRender>

--- a/packages/lesswrong/components/tagging/TagFlagItem.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagItem.tsx
@@ -59,10 +59,9 @@ const styles = (theme: ThemeType) => ({
 
 type ItemTypeName = "tagFlagId"|"allPages"|"userPages"
 
-const TagFlagItem = ({documentId, itemType = "tagFlagId", showNumber = true, style = "grey", classes }: {
+const TagFlagItem = ({documentId, itemType = "tagFlagId", style = "grey", classes }: {
   documentId?: string,
   itemType?: ItemTypeName,
-  showNumber?: boolean,
   style?: "white"|"grey"|"black",
   classes: ClassesType<typeof styles>,
 }) => {
@@ -70,6 +69,7 @@ const TagFlagItem = ({documentId, itemType = "tagFlagId", showNumber = true, sty
   const currentUser = useCurrentUser();
   const { data } = useQuery(TagFlagFragmentQuery, {
     variables: { documentId: documentId },
+    skip: !documentId,
     fetchPolicy: "cache-first",
   });
   const tagFlag = data?.tagFlag?.result;
@@ -82,16 +82,6 @@ const TagFlagItem = ({documentId, itemType = "tagFlagId", showNumber = true, sty
   }
   
   const { view, limit, ...selectorTerms } = TagFlagItemTerms[itemType];
-  const { data: dataTagWithFlags, loading } = useQuery(TagWithFlagsFragmentMultiQuery, {
-    variables: {
-      selector: { [view]: selectorTerms },
-      limit: 0,
-      enableTotal: true,
-    },
-    skip: !showNumber,
-    notifyOnNetworkStatusChange: true,
-  });
-  const totalCount = dataTagWithFlags?.tags?.totalCount;
   
   const rootStyles = classNames(classes.root, {[classes.black]: style === "black", [classes.white]: style === "white"});
   
@@ -130,7 +120,7 @@ const TagFlagItem = ({documentId, itemType = "tagFlagId", showNumber = true, sty
           </Card>
         </AnalyticsContext>}
     </LWPopper>
-    {tagFlagText[itemType]}{(!loading && showNumber)? `: ${totalCount}` : ``}
+    {tagFlagText[itemType]}
   </span>
 }
 

--- a/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
@@ -184,7 +184,6 @@ const TagsDetailsItem = ({ tag, classes, showFlags = false, flagId, collapse = f
         <QueryLink query={query.focus === tagFlag?._id ? {} : { focus: tagFlag?._id }}>
           <TagFlagItem
             documentId={tagFlag._id}
-            showNumber={false}
             style={query.focus === tagFlag?._id ? "black" : "grey"}
           />
         </QueryLink>

--- a/packages/lesswrong/lib/crud/useQuery.ts
+++ b/packages/lesswrong/lib/crud/useQuery.ts
@@ -14,6 +14,16 @@ type UseQueryOptions = {
   skip?: boolean,
 };
 
+/**
+ * Wrapper around apollo-client's useQuery, which uses Suspense
+ * (useSuspenseQuery) for SSR, then switches to to regular useQuery afterwards.
+ * We do this because handling non-first-time loading states (ie Load More
+ * buttons) is generally easier with useQuery returning `loading: true` rather
+ * than suspending the component that used it, and we have a lot of preexisting
+ * code with loading states built around this idiom that should keep working.
+ * Wrapping useQuery this way also gives us better options for working around
+ * apollo-client bugs than if we were using apollo directly.
+ */
 export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryOptions) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   if (bundleIsServer && useContext(EnableSuspenseContext)) {

--- a/packages/lesswrong/server/resolvers/defaultResolvers.ts
+++ b/packages/lesswrong/server/resolvers/defaultResolvers.ts
@@ -268,11 +268,22 @@ export const getDefaultResolvers = <N extends CollectionNameString>(
     const { currentUser } = context;
 
     // useSingle allows passing in `_id` as `documentId`
-    if (usedSelector.documentId) {
+    if ('documentId' in usedSelector) {
       usedSelector._id = usedSelector.documentId;
       delete usedSelector.documentId;
     }
     const documentId = usedSelector._id;
+    
+    if (!documentId) {
+      if (allowNull) {
+        return { result: null };
+      } else {
+        throwError({
+          id: 'app.missing_document',
+          data: { documentId, selector, collectionName: collection.collectionName },
+        });
+      }
+    }
 
     // get fragment from GraphQL AST
     const fragmentInfo = getFragmentInfo(info, "result", typeName);


### PR DESCRIPTION
 * Improve error handling of default single resolver

We used to use the single resolver exclusively through `useSingle`, which will skip the query if the provided documentId is null. In most places where we converted this to `useQuery`, we either have a type-system guarantee that it isn't null or have a corresponding skip, but there were a few places where this wasn't the case. This led to a very-opaque exception from deep in the internals of the postgres query-generation code. Either allow a missing documentId, returning null, if the resolver was called with `allowNull: true`, or throw a better exception if not.

 * Remove showNumber option from TagFlagItem

TagFlagItem had an option to show the number of tags with a given flag. It did this by downloading all of those tags, which was so slow that the one page that used this feature (the tagging dashboard) would simply crash.

 * Add a block comment to our useQuery wrapper
 * Add some ignore paths to .ackrc

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210664998070707) by [Unito](https://www.unito.io)
