### PR TITLE
Unhide the spotlight item on desktop

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -78,11 +78,9 @@ const LWHome = () => {
             </SingleColumnSection>}
           </>}
           {(!reviewIsActive() || getReviewPhase() === "RESULTS" || !showReviewOnFrontPageIfActive.get()) && !lightconeFundraiserActive.get() && <SingleColumnSection>
-            <div className={classes.hideOnDesktop}>
-              <SuspenseWrapper name="DismissibleSpotlightItem" fallback={<SpotlightItemFallback/>}>
-                <DismissibleSpotlightItem/> 
-              </SuspenseWrapper>
-            </div>
+            <SuspenseWrapper name="DismissibleSpotlightItem" fallback={<SpotlightItemFallback/>}>
+              <DismissibleSpotlightItem/> 
+            </SuspenseWrapper>
           </SingleColumnSection>}
           <SuspenseWrapper name="LWHomePosts" fallback={<div style={{height: 800}}/>}>
             <AnalyticsInViewTracker


### PR DESCRIPTION
We had a special case for the spotlight item that hides it on desktop, because it duplicates the right-hand sidebar of the IABIED special theme. Remove that, since the IABIED event is no longer active


