### PR TITLE
[EA] Mod slack forwarding fixes

### DIFF
--- a/packages/lesswrong/lib/collections/reports/newSchema.ts
+++ b/packages/lesswrong/lib/collections/reports/newSchema.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_CREATED_AT_FIELD, DEFAULT_ID_FIELD, DEFAULT_LEGACY_DATA_FIELD, DEFAULT_SCHEMA_VERSION_FIELD } from "@/lib/collections/helpers/sharedFieldConstants";
-import { generateIdResolverSingle } from "../../utils/schemaUtils";
+import { generateIdResolverSingle, getForeignKeySqlResolver } from "../../utils/schemaUtils";
 
 const schema = {
   _id: DEFAULT_ID_FIELD,
@@ -33,6 +33,11 @@ const schema = {
       outputType: "User",
       canRead: ["guests"],
       resolver: generateIdResolverSingle({ foreignCollectionName: "Users", fieldName: "userId" }),
+      sqlResolver: getForeignKeySqlResolver({
+        collectionName: "Users",
+        nullable: true,
+        idFieldName: "userId",
+      }),
     },
   },
   reportedUserId: {
@@ -54,6 +59,11 @@ const schema = {
       outputType: "User",
       canRead: ["guests"],
       resolver: generateIdResolverSingle({ foreignCollectionName: "Users", fieldName: "reportedUserId" }),
+      sqlResolver: getForeignKeySqlResolver({
+        collectionName: "Users",
+        nullable: true,
+        idFieldName: "reportedUserId",
+      }),
     },
   },
   commentId: {
@@ -75,6 +85,11 @@ const schema = {
       outputType: "Comment",
       canRead: ["guests"],
       resolver: generateIdResolverSingle({ foreignCollectionName: "Comments", fieldName: "commentId" }),
+      sqlResolver: getForeignKeySqlResolver({
+        collectionName: "Comments",
+        nullable: true,
+        idFieldName: "commentId",
+      }),
     },
   },
   postId: {
@@ -96,6 +111,11 @@ const schema = {
       outputType: "Post",
       canRead: ["guests"],
       resolver: generateIdResolverSingle({ foreignCollectionName: "Posts", fieldName: "postId" }),
+      sqlResolver: getForeignKeySqlResolver({
+        collectionName: "Posts",
+        nullable: true,
+        idFieldName: "postId",
+      }),
     },
   },
   link: {
@@ -129,6 +149,11 @@ const schema = {
       outputType: "User",
       canRead: ["guests"],
       resolver: generateIdResolverSingle({ foreignCollectionName: "Users", fieldName: "claimedUserId" }),
+      sqlResolver: getForeignKeySqlResolver({
+        collectionName: "Users",
+        nullable: true,
+        idFieldName: "claimedUserId",
+      }),
     },
   },
   description: {

--- a/packages/lesswrong/server/slack.ts
+++ b/packages/lesswrong/server/slack.ts
@@ -97,7 +97,6 @@ export const forwardReportToModSlack = async (
                 text: `View ${contentType} on the EA Forum`,
                 emoji: true,
               },
-              value: `view_${contentType}_on_ea_forum`,
               url,
             },
           ]


### PR DESCRIPTION
- Fix comment reports not being sent to Slack.
  - This was caused by a code resolver not running - I'm not sure why this wasn't happening but it is already known to be a bit "temperamental". The easy fix here is to just bypass them by adding sql resolvers, which seems like a good thing to do anyway even it it just kicks the _actual_ bug down the road.
- Remove the `value` field from the button to stop Slack trying (and failing) to run a custom action which breaks the link.
- Add a `dryRun` option to `forwardReportToModSlack` to make debugging easier without spamming Slack.