### PR TITLE
Improve the deveoper ergonomics of dark-mode colors

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -117,7 +117,7 @@ export const styles = (theme: ThemeType) => ({
     color: theme.palette.text.bannerAdOverlay,
 
     ...(forumSelect({
-      LWAF: (theme.themeOptions.name === 'dark'
+      LWAF: (theme.dark
         ? {
           background: theme.palette.panelBackground.bannerAdTranslucent,
           backdropFilter: 'blur(4px) brightness(1.1)',

--- a/packages/lesswrong/components/common/HomeTagBar.tsx
+++ b/packages/lesswrong/components/common/HomeTagBar.tsx
@@ -150,10 +150,10 @@ const styles = (theme: ThemeType) => ({
     },
   },
   eventTab: {
-    ...eventTabStyles(theme.themeOptions.name === "dark"),
+    ...eventTabStyles(theme.dark),
   },
   activeEventTab: {
-    ...eventTabStyles(theme.themeOptions.name !== "dark"),
+    ...eventTabStyles(theme.dark),
   },
   placeholderTab: {
     flex: 'none',

--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -16,7 +16,7 @@ const styles = defineStyles("LoadMore", (theme: ThemeType) => ({
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
     color: theme.palette.lwTertiary.main,
-    ...(isBookUI && theme.themeOptions.name === 'dark' && {
+    ...(isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     display: "inline-block",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -98,7 +98,7 @@ const styles = (theme: ThemeType) => ({
   navText: {
     ...theme.typography.body2,
     color: "inherit",
-    ...(isBookUI && theme.themeOptions.name==='dark' && {
+    ...(isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     textTransform: "none !important",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -41,7 +41,7 @@ const styles = (theme: ThemeType) => {
     divider: {
       width: 50,
       borderBottom: theme.palette.border.normal,
-      ...(isBookUI && theme.themeOptions.name==='dark' && {
+      ...(isBookUI && theme.dark && {
         color: theme.palette.text.bannerAdOverlay,
         background: theme.palette.text.bannerAdOverlay,
       }),

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -16,7 +16,7 @@ const styles = (theme: ThemeType) => ({
     // padding reflects how large an icon+padding is
     paddingLeft: (theme.spacing.unit*2) + iconPadding(theme),
     color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.grey[700],
-    ...(isBookUI && theme.themeOptions.name==='dark' && {
+    ...(isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     width:

--- a/packages/lesswrong/components/common/TabPicker.tsx
+++ b/packages/lesswrong/components/common/TabPicker.tsx
@@ -118,7 +118,7 @@ const styles = (theme: ThemeType) => ({
     }
   },
   inactiveTab: {
-    ...(theme.themeOptions.name === 'dark' ? {
+    ...(theme.dark ? {
       backgroundColor: theme.palette.tab.inactive.bannerAdBackground,
       backdropFilter: theme.palette.filters.bannerAdBlurMedium,
       color: theme.palette.text.bannerAdOverlay,

--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -16,7 +16,7 @@ const styles = defineStyles("DatePicker", (theme: ThemeType) => {
   const datepicker__holidaysColor = theme.palette.invertIfDarkMode("#ff6803");
   const datepicker__mutedColor = theme.palette.invertIfDarkMode("#ccc");
   const datepicker__selectedColor = theme.palette.invertIfDarkMode("#216ba5");
-  const datepicker__selectedColorDisabled = theme.themeOptions.name === 'dark'
+  const datepicker__selectedColorDisabled = theme.dark
     ? "rgba(222, 148, 90, .5)"
     : "rgba(33, 107, 165, .5)";
   const datepicker__textColor = theme.palette.text.maxIntensity;

--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -80,7 +80,7 @@ export const styles = (theme: ThemeType) => ({
   background: {
     width: "100%",
     background: theme.palette.panelBackground.default,
-    ...(isBookUI && theme.themeOptions.name === 'dark' && {
+    ...(isBookUI && theme.dark && {
       background: theme.palette.panelBackground.bannerAdTranslucent,
       backdropFilter: theme.palette.filters.bannerAdBlur,
       ...isIfAnyoneBuildsItFrontPage({
@@ -113,7 +113,7 @@ export const styles = (theme: ThemeType) => ({
   withGrayHover: {
     '&:hover': {
       backgroundColor: theme.palette.panelBackground.postsItemHover,
-      ...(isBookUI && theme.themeOptions.name === 'dark' && {
+      ...(isBookUI && theme.dark && {
         backgroundColor: theme.palette.panelBackground.bannerAdTranslucentHeavy,
       }),
     },

--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -16,7 +16,7 @@ import { isBookUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
   onGrayBackground: {
-    ...(isBookUI && theme.themeOptions.name === 'dark' && {
+    ...(isBookUI && theme.dark && {
       color: theme.palette.greyAlpha(1),
     }),
   },

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -43,7 +43,7 @@ const styles = (theme: ThemeType) => ({
       color: theme.palette.greyAlpha(0.7),
       fontWeight: 500,
     }),
-    ...(isFriendlyUI && theme.themeOptions.name === 'dark' && {
+    ...(isFriendlyUI && theme.dark && {
       color: theme.palette.icon.dim,
     }),
   },

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -41,7 +41,7 @@ const styles = (theme: ThemeType) => ({
     marginRight: theme.spacing.unit,
   },
   onGrayBackground: {
-    ...(isBookUI && theme.themeOptions.name === 'dark' && {
+    ...(isBookUI && theme.dark && {
       color: theme.palette.greyAlpha(1),
     }),
   },
@@ -128,10 +128,10 @@ const styles = (theme: ThemeType) => ({
     padding: "0 6px",
     height: 20,
     border: "none",
-    backgroundColor: theme.themeOptions.name === "dark"
+    backgroundColor: theme.dark
       ? "var(--post-title-tag-foreground)"
       : "var(--post-title-tag-background)",
-    color: theme.themeOptions.name === "dark"
+    color: theme.dark
       ? "var(--post-title-tag-background)"
       : "var(--post-title-tag-foreground)",
   },

--- a/packages/lesswrong/components/widgets/Paper.tsx
+++ b/packages/lesswrong/components/widgets/Paper.tsx
@@ -9,7 +9,7 @@ const styles = defineStyles("MuiPaper", (theme: ThemeType) => {
     elevations[`elevation${index}`] = {
       boxShadow: shadow,
       
-      ...(theme.themeOptions.name === "dark" && {
+      ...(theme.dark && {
         boxShadow: "none",
       }),
     };

--- a/packages/lesswrong/lib/vendor/@material-ui/core/src/Button/Button.tsx
+++ b/packages/lesswrong/lib/vendor/@material-ui/core/src/Button/Button.tsx
@@ -143,7 +143,7 @@ export const styles = defineStyles("MuiButton", theme => ({
   },
   /* Styles applied to the root element if `variant="[contained | fab]"`. */
   contained: {
-    color: theme.themeOptions.name === 'dark' ? theme.palette.greyAlpha(1.0) : theme.palette.greyAlpha(0.87),
+    color: theme.dark ? theme.palette.greyAlpha(1.0) : theme.palette.greyAlpha(0.87),
     backgroundColor: theme.palette.grey[300],
     boxShadow: theme.shadows[2],
     '&$focusVisible': {

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -23,6 +23,7 @@ export const baseTheme: BaseThemeSpecification = {
     const spacingUnit = 8
   
     return {
+      dark: false,
       baseFontSize: 13,
       breakpoints: {
         values: {

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -141,6 +141,7 @@ export const defaultShadePalette = (): ThemeShadePalette => {
   const greyAlpha = (alpha: number) => `rgba(0,0,0,${alpha})`;
   const inverseGreyAlpha = (alpha: number) => `rgba(255,255,255,${alpha})`;
   return {
+    dark: false,
     grey,
     greyAlpha,
     inverseGreyAlpha,

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -68,6 +68,7 @@ declare global {
     710: ColorString,
   }
   type ThemeShadePalette = {
+    dark: boolean,
     grey: ThemeGreyscale,
     greyAlpha: (alpha: number) => ColorString,
     inverseGreyAlpha: (alpha: number) => ColorString,
@@ -634,6 +635,7 @@ declare global {
   type ThemeType = {
     forumType: ForumTypeString,
     themeOptions: ThemeOptions,
+    dark: boolean,
 
     baseFontSize: number,
     

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -196,6 +196,7 @@ const forumOverrides = (palette: ThemePalette): PartialDeep<ThemeType['overrides
 
 export const darkModeTheme: UserThemeSpecification = {
   shadePalette: {
+    dark: true,
     grey: invertedGreyscale,
     greyAlpha,
     inverseGreyAlpha,
@@ -347,6 +348,7 @@ export const darkModeTheme: UserThemeSpecification = {
     }
   }, forumComponentPalette(shadePalette)),
   make: (palette: ThemePalette): PartialDeep<NativeThemeType> => ({
+    dark: true,
     postImageStyles: {
       // Override image background color to white (so that transparent isn't
       // black). Necessary because there are a handful of posts with images that

--- a/packages/lesswrong/unitTests/themePalette.tests.ts
+++ b/packages/lesswrong/unitTests/themePalette.tests.ts
@@ -58,7 +58,7 @@ function assertNoNonPaletteColorsRec(componentName: string, path: string, lightM
   if (typeof lightModeStyleFragment === "string") {
     const mentionedColor = stringMentionsAnyColor(lightModeStyleFragment);
     if (mentionedColor && lightModeStyleFragment === darkModeStyleFragment) {
-      outNonPaletteColors.push(`Non-palette color in styles for ${componentName} at ${path} - ${mentionedColor}`);
+      outNonPaletteColors.push(`Color for ${componentName} at ${path} (${mentionedColor}) is the same in light mode and dark mode. To prevent black-on-black text, use either a theme palette color, or check for dark mode with theme.dark ? colorOne : colorTwo. Or disable the warning for this component by passing {allowNonThemeColors: true} in the stylesheet options.`);
     }
   } else if (typeof lightModeStyleFragment === "object") {
     for (let key of Object.keys(lightModeStyleFragment)) {


### PR DESCRIPTION
We have a unit test to prevent black-on-black text on dark mode, which checks styles to make sure that when they contain colors, those colors differ between light mode and dark mode. This was originally framed as "colors can only come from the theme's palette". This was later generalized to allow non-palette colors if they're different between light and dark mode, ie if you used
```
theme.themeOptions.name === "dark" ? "colorOne" : "colorTwo"
```
but this option wasn't mentioned in the unit-test error message, and is kind of awkward.

Add `theme.dark`, as a shorter substitute for `theme.themeOptions.name`. Also modify the unit-test's error message to mention the option of branching on `theme.dark`, and to mention the option of passing the `{allowNonThemeColors: true}` option.


