### PR TITLE
Edit Delete Reason

### DIFF
--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -6,6 +6,7 @@ import { gql } from "@/lib/generated/gql-codegen";
 import EditCommentDropdownItem from "./EditCommentDropdownItem";
 import ReportCommentDropdownItem from "./ReportCommentDropdownItem";
 import DeleteCommentDropdownItem from "./DeleteCommentDropdownItem";
+import EditDeleteReasonDropdownItem from "./EditDeleteReasonDropdownItem";
 import RetractCommentDropdownItem from "./RetractCommentDropdownItem";
 import BanUserFromAllPostsDropdownItem from "./BanUserFromAllPostsDropdownItem";
 import DropdownDivider from "../DropdownDivider";
@@ -74,6 +75,7 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       <MoveToAnswersDropdownItem comment={comment} post={postDetails} />
       <ShortformFrontpageDropdownItem comment={comment} />
       <DeleteCommentDropdownItem comment={comment} post={postDetails} tag={tag} />
+      <EditDeleteReasonDropdownItem comment={comment} post={postDetails} tag={tag} />
       <RetractCommentDropdownItem comment={comment} />
       <LockThreadDropdownItem comment={comment} />
       <BanUserFromPostDropdownItem comment={comment} post={postDetails} />

--- a/packages/lesswrong/components/dropdowns/comments/EditDeleteReasonDialog.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/EditDeleteReasonDialog.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { registerComponent } from '../../../lib/vulcan-lib/components';
+import { useMessages } from '../../common/withMessages';
+import { useModerateComment } from './withModerateComment';
+import { DialogActions } from '@/components/widgets/DialogActions';
+import { DialogContent } from '../../widgets/DialogContent';
+import { DialogTitle } from '../../widgets/DialogTitle';
+import Button from '@/lib/vendor/@material-ui/core/src/Button';
+import TextField from '@/lib/vendor/@material-ui/core/src/TextField';
+import { isFriendlyUI } from '../../../themes/forumTheme';
+import LWDialog from "../../common/LWDialog";
+
+const styles = (theme: ThemeType) => ({
+  subtitle: {
+    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+  },
+  modalTextField: {
+    marginTop: 10,
+  },
+})
+
+const EditDeleteReasonDialog = ({comment, onClose, classes}: {
+  comment: CommentsList,
+  onClose?: () => void,
+  classes: ClassesType<typeof styles>,
+}) => {
+  const [deletedReason, setDeletedReason] = useState(comment.deletedReason || "");
+  const {moderateCommentMutation} = useModerateComment();
+  const { flash } = useMessages();
+
+  const handleSave = async (event: React.MouseEvent) => {
+    event.preventDefault();
+    try {
+      await moderateCommentMutation({
+        commentId: comment._id,
+        deleted: true,
+        deletedPublic: comment.deletedPublic,
+        deletedReason: deletedReason,
+      });
+      flash({messageString: "Successfully updated delete reason", type: "success"});
+      if (onClose) {
+        onClose();
+      }
+    } catch(e) {
+      flash({messageString: e.message, type: "error"});
+    }
+  }
+
+  return (
+    <LWDialog open={true} onClose={onClose}>
+      <DialogTitle>
+        Edit Delete Reason
+      </DialogTitle>
+      <DialogContent>
+        <p className={classes.subtitle}><em>
+          {comment.deletedPublic 
+            ? "This reason is publicly displayed below the comment."
+            : "This reason is sent privately to the comment author."
+          }
+        </em></p>
+        <br/>
+        <TextField
+          id="edit-delete-reason"
+          label="Reason for deletion"
+          className={classes.modalTextField}
+          value={deletedReason}
+          onChange={(event) => setDeletedReason(event.target.value)}
+          fullWidth
+          multiline
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>
+          Cancel
+        </Button>
+        <Button color="primary" onClick={handleSave}>
+          Save
+        </Button>
+      </DialogActions>
+    </LWDialog>
+  );
+}
+
+export default registerComponent(
+  'EditDeleteReasonDialog', EditDeleteReasonDialog, {styles}
+); 

--- a/packages/lesswrong/components/dropdowns/comments/EditDeleteReasonDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/EditDeleteReasonDropdownItem.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { registerComponent } from '../../../lib/vulcan-lib/components';
+import { userCanModerateComment } from '../../../lib/collections/users/helpers';
+import { useDialog } from '../../common/withDialog';
+import { useCurrentUser } from '../../common/withUser';
+import { userIsAdminOrMod } from '../../../lib/vulcan-users/permissions';
+import EditDeleteReasonDialog from "./EditDeleteReasonDialog";
+import DropdownItem from "../DropdownItem";
+
+const EditDeleteReasonDropdownItem = ({comment, post, tag}: {
+  comment: CommentsList,
+  post?: PostsBase,
+  tag?: TagBasicInfo,
+}) => {
+  const currentUser = useCurrentUser();
+  const {openDialog} = useDialog();
+
+  const showEditReasonDialog = () => {
+    openDialog({
+      name: "EditDeleteReasonDialog",
+      contents: ({onClose}) => <EditDeleteReasonDialog
+        onClose={onClose}
+        comment={comment}
+      />
+    });
+  }
+
+  // Only show this option if:
+  // 1. User has permission to moderate this comment
+  // 2. The comment is already deleted
+  // 3. User is either admin/mod or the person who deleted it
+  if (
+    !currentUser
+    || (!post && !tag)
+    || !userCanModerateComment(currentUser, post ?? null, tag ?? null, comment)
+    || !comment.deleted
+    || !(userIsAdminOrMod(currentUser) || comment.deletedByUserId === currentUser._id)
+  ) {
+    return null;
+  }
+
+  return (
+    <DropdownItem
+      title="Edit Delete Reason"
+      onClick={showEditReasonDialog}
+    />
+  );
+}
+
+export default registerComponent(
+  'EditDeleteReasonDropdownItem', EditDeleteReasonDropdownItem,
+); 


### PR DESCRIPTION
This was a quick test of Opus 4 handling an Intercom feature request. I think it did it approximately right. I don't know that we actually want this feature.

From Nate: 

> feature request: the ability to edit "delete reasons" without undeleting and redeleting

https://app.intercom.com/a/inbox/wtb8z7sj/inbox/shared/unassigned/conversation/215469653254821?view=List