### PR TITLE
[EA] Move author hoverovers to `bottom-start` in post items

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAPostMeta.tsx
+++ b/packages/lesswrong/components/ea-forum/EAPostMeta.tsx
@@ -74,7 +74,12 @@ const EAPostMeta = ({post, useEventStyles, useCuratedDate=true, className, class
         <span className={classes.eventOrganizer}>
           <span className={classes.dot}>·</span>
           <InteractionWrapper className={classes.interactionWrapper}>
-            <TruncatedAuthorsList post={post} expandContainer={authorExpandContainer} className={classes.authorsList} />
+            <TruncatedAuthorsList
+              post={post}
+              expandContainer={authorExpandContainer}
+              tooltipPlacement="bottom-start"
+              className={classes.authorsList}
+            />
           </InteractionWrapper>
         </span>
       </div>
@@ -90,6 +95,7 @@ const EAPostMeta = ({post, useEventStyles, useCuratedDate=true, className, class
         <TruncatedAuthorsList
           post={post}
           expandContainer={authorExpandContainer}
+          tooltipPlacement="bottom-start"
         />
       </InteractionWrapper>
       <div>

--- a/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
+++ b/packages/lesswrong/components/posts/TruncatedAuthorsList.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, RefObject, useState, useCallback } from "reac
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { usePostsUserAndCoauthors } from "./usePostsUserAndCoauthors";
 import { recalculateTruncation } from "../../lib/truncateUtils";
+import type { Placement as PopperPlacementType } from "popper.js"
 import classNames from "classnames";
 import UsersNameDisplay from "../users/UsersNameDisplay";
 import UserNameDeleted from "../users/UserNameDeleted";
@@ -58,12 +59,14 @@ const reformatAuthorPlaceholder = (
 const TruncatedAuthorsList = ({
   post,
   expandContainer,
+  tooltipPlacement,
   className,
   classes,
   useMoreSuffix = true
 }: {
   post: PostsList | SunshinePostsList | PostsBestOfList,
   expandContainer: RefObject<HTMLDivElement|null>,
+  tooltipPlacement?: PopperPlacementType,
   className?: string,
   classes: ClassesType<typeof styles>,
   useMoreSuffix?: boolean,
@@ -96,13 +99,13 @@ const TruncatedAuthorsList = ({
     : (
       <div className={classNames(classes.root, className)} ref={ref}>
         <span className={classNames(classes.item, classes.placeholder)}>
-          <UsersNameDisplay user={authors[0]} />
+          <UsersNameDisplay user={authors[0]} tooltipPlacement={tooltipPlacement} />
         </span>
         <div className={classes.scratch} aria-hidden="true">
           {authors.map((author, i) =>
             <span key={author._id} className={classes.item}>
               {i > 0 ? ", " : ""}
-              <UsersNameDisplay user={author} />
+              <UsersNameDisplay user={author} tooltipPlacement={tooltipPlacement} />
             </span>
           )}
           {authors.length > 1 && (
@@ -110,7 +113,11 @@ const TruncatedAuthorsList = ({
               title={
                 <div className={classes.tooltip}>
                   {authors.slice(1).map((author: UsersMinimumInfo) => (
-                    <UsersNameDisplay key={author._id} user={author} />
+                    <UsersNameDisplay
+                      key={author._id}
+                      user={author}
+                      tooltipPlacement={tooltipPlacement}
+                    />
                   ))}
                 </div>
               }


### PR DESCRIPTION
It's always annoyed me that, in post items, the tooltip for the post title is below the text but the tooltips for the author names are to the left of the text. This means that when you move your mouse over the post items all the tooltips quickly flick about in both directions. This PR is a quick change to move the author tooltips under the text as well, and I think it makes moving your mouse over the post items a lot tidier and less hectic.

![output](https://github.com/user-attachments/assets/4bcf1037-ee92-436c-9793-8677c74ecc08)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210684488286564) by [Unito](https://www.unito.io)
