### PR TITLE
[EA] Disable custom datadog metrics

### DIFF
--- a/packages/lesswrong/server/datadog/tracer.ts
+++ b/packages/lesswrong/server/datadog/tracer.ts
@@ -19,7 +19,8 @@ if (isDatadogEnabled) {
   })
 }
 
-export const dogstatsd = isDatadogEnabled
+const CUSTOM_METRICS_ENABLED = false;
+export const dogstatsd = isDatadogEnabled && CUSTOM_METRICS_ENABLED
   ? new StatsD({
       host: process.env.IS_DOCKER ? "172.17.0.1" : undefined,
       prefix: 'forummagnum.',


### PR DESCRIPTION
Last month we had a big jump in the cost of custom metrics. This is resolved now, but given that we don't use custom metrics that much I think it's best to disable them until we have better cost alerting set up

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210696272047833) by [Unito](https://www.unito.io)
