### PR TITLE
[EA] Attempt fix for sticky notification star

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -182,19 +182,28 @@ const FriendlyNotificationsMenuButton = ({
 
   const onOpenNotificationsPopover = useCallback(() => {
     const now = new Date();
-    void updateCurrentUser({
-      karmaChangeLastOpened: now,
-      karmaChangeBatchStart: now,
-    });
+
+    if (karmaChanges?.karmaChanges) {
+      void updateCurrentUser({
+        karmaChangeLastOpened: karmaChanges.karmaChanges.endDate,
+        karmaChangeBatchStart: now,
+      })
+    }
+
     void notificationsOpened();
-  }, [updateCurrentUser, notificationsOpened]);
+  }, [updateCurrentUser, notificationsOpened, karmaChanges?.karmaChanges.endDate]);
 
   const closePopover = useCallback(() => setOpen(false), []);
 
   const onClick = useCallback(() => {
+    if (!open) {
+      onOpenNotificationsPopover();
+    }
+
     setOpen((open) => !open);
     toggle();
-  }, [toggle]);
+  }, [toggle, open, onOpenNotificationsPopover]);
+
   return (
     <div ref={anchorEl}>
       <Badge

--- a/packages/lesswrong/components/notifications/NotificationsPopover.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPopover.tsx
@@ -171,12 +171,6 @@ const NotificationsPopover = ({
     previousData?.NotificationDisplays?.results ??
     [];
 
-  useEffect(() => {
-    if (!notificationsLoading && notifs.length <= defaultLimit) {
-      onOpenNotificationsPopover?.();
-    }
-  }, [notificationsLoading, onOpenNotificationsPopover, notifs.length]);
-
   const hasNewKarmaChanges = useMemo(() => cachedKarmaChanges &&
     (
       cachedKarmaChanges.posts?.length ||


### PR DESCRIPTION
Previously it waited until the notifications had loaded before updating `karmaChangeLastOpened`. The karma changes were visible before the notifications load, so @oetherington and I think this could be sufficient to explain the sticky notifications star, as people could check their karma and close the popover before all the notifications loaded.