### PR TITLE
[EA] Use best-of page title styles on the homepage

### DIFF
--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType } from "react";
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import SectionTitle, { SectionTitleProps } from "./SectionTitle";
+import { isFriendlyUI } from "@/themes/forumTheme";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Link } from "../../lib/reactRouterWrapper";
 import classNames from "classnames";
@@ -11,7 +12,7 @@ import ForumIcon from "./ForumIcon";
 const styles = (theme: ThemeType) => ({
   title: {
     display: "flex",
-    columnGap: 10
+    columnGap: isFriendlyUI ? 6 : 10,
   },
   afterContainer: {
     display: "flex",

--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -87,6 +87,7 @@ const ExpandableSection = ({
               </LWTooltip>
             </div>
           }
+          large
         >
           {expanded && (AfterTitleComponent || afterTitleTo) &&
             <div className={classes.afterContainer}>

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -164,7 +164,7 @@ const HomeLatestPosts = ({classes}: {classes: ClassesType<typeof styles>}) => {
   return (
     <AnalyticsContext pageSectionContext="latestPosts">
       <SingleColumnSection>
-        <SectionTitle title={latestPostsName} noTopMargin={isFriendlyUI} noBottomPadding>
+        <SectionTitle title={latestPostsName} noTopMargin={isFriendlyUI} noBottomPadding large>
           <div className={classes.postsListSettings}>
             <LWTooltip
               title={`Use these buttons to increase or decrease the visibility of posts based on ${taggingNameSetting.get()}. Use the "+" button at the end to add additional ${taggingNamePluralSetting.get()} to boost or reduce them.`}

--- a/packages/lesswrong/components/common/SectionTitle.tsx
+++ b/packages/lesswrong/components/common/SectionTitle.tsx
@@ -38,6 +38,18 @@ const styles = (theme: ThemeType) => ({
     paddingBottom: 0
   },
   title: sectionTitleStyle(theme),
+  largeTitle: isFriendlyUI
+    ? {
+      margin: 0,
+      fontFamily: theme.palette.fonts.sansSerifStack,
+      fontSize: 20,
+      fontWeight: 700,
+      color: theme.palette.grey[1000],
+      [theme.breakpoints.down("xs")]: {
+        fontSize: 16,
+      },
+    }
+    : sectionTitleStyle(theme),
   children: {
     ...theme.typography.commentStyle,
     [theme.breakpoints.down('sm')]: {
@@ -63,6 +75,7 @@ export type SectionTitleProps = {
   titleClassName?: string,
   rootClassName?: string,
   title: React.ReactNode,
+  large?: boolean,
   noTopMargin?: boolean,
   noBottomPadding?: boolean,
   centered?: boolean,
@@ -73,6 +86,7 @@ export type SectionTitleProps = {
 // This is meant to be used as the primary section title for the central page layout (normally used in conjunction with SingleColumnSection){}
 const SectionTitle = ({
   title,
+  large,
   noTopMargin,
   noBottomPadding,
   centered,
@@ -88,7 +102,10 @@ const SectionTitle = ({
       <Typography
         id={getAnchorId(anchor, title)}
         variant='display1'
-        className={classNames(classes.title, titleClassName)}
+        className={classNames(
+          large ? classes.largeTitle : classes.title,
+          titleClassName,
+        )}
       >
         {href
           ? <Link to={href}>{title}</Link>

--- a/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
+++ b/packages/lesswrong/components/ea-forum/EABestOfPage.tsx
@@ -15,6 +15,7 @@ import EACollectionCard from "./EACollectionCard";
 import EAPostsItem from "../posts/EAPostsItem";
 import PostsAudioCard from "../posts/PostsAudioCard";
 import PostsVideoCard from "../posts/PostsVideoCard";
+import SectionTitle from "../common/SectionTitle";
 
 const MAX_WIDTH = 1500;
 const MD_WIDTH = 1000;
@@ -74,11 +75,8 @@ const styles = (theme: ThemeType) => ({
     },
   },
   heading: {
-    fontFamily: theme.palette.fonts.sansSerifStack,
-    fontSize: 20,
-    fontWeight: 700,
     marginTop: 0,
-    marginBottom: 20,
+    marginBottom: 12,
   },
   gridSection: {
     display: "grid",
@@ -212,7 +210,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
             </div>
             <AnalyticsContext pageSectionContext="featuredCollections">
               <div>
-                <h2 className={classes.heading}>Featured collections</h2>
+                <SectionTitle title="Featured collections" large rootClassName={classes.heading} />
                 <div className={classes.gridSection}>
                   {featuredCollectionCollections.map((collection) => (
                     <EACollectionCard key={collection._id} collection={collection} />
@@ -228,7 +226,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
             </AnalyticsContext>
             <AnalyticsContext pageSectionContext="highlightsThisYear">
               <div>
-                <h2 className={classes.heading}>Highlights this year</h2>
+                <SectionTitle title="Highlights this year" large rootClassName={classes.heading} />
                 <div className={classes.listSection}>
                   {bestOfYearPosts.map((post) => (
                     <EAPostsItem
@@ -245,7 +243,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
             </AnalyticsContext>
             <AnalyticsContext pageSectionContext="exploreCauseAreas">
               <div>
-                <h2 className={classes.heading}>Explore cause areas</h2>
+                <SectionTitle title="Explore cause areas" large rootClassName={classes.heading} />
                 <div className={classes.gridSection}>
                   {introToCauseAreasSequences.map((sequence) => (
                     <EASequenceCard key={sequence._id} sequence={sequence} />
@@ -257,7 +255,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
           <div className={classNames(classes.column, classes.rightColumn)}>
             <AnalyticsContext pageSectionContext="highlightsThisMonth">
               <div>
-                <h2 className={classes.heading}>Highlights this month</h2>
+                <SectionTitle title="Highlights this month" large rootClassName={classes.heading} />
                 <div className={classes.listSection}>
                   {monthlyHighlights?.map((post, i) => (
                     <EAPostsItem
@@ -278,7 +276,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
             </AnalyticsContext>
             <AnalyticsContext pageSectionContext="featuredVideo">
               <div>
-                <h2 className={classes.heading}>Featured videos</h2>
+                <SectionTitle title="Featured videos" large rootClassName={classes.heading} />
                 <div className={classNames(classes.listSection, classes.listGap)}>
                   {featuredVideoPosts.map((post) => (
                     <PostsVideoCard key={post._id} post={post} />
@@ -291,7 +289,7 @@ const EABestOfPage = ({ classes }: { classes: ClassesType<typeof styles> }) => {
             </AnalyticsContext>
             {/* <AnalyticsContext pageSectionContext="featuredAudio">
               <div>
-                <h2 className={classes.heading}>Featured audio</h2>
+                <SectionTitle title="Featured audio" large rootClassName={classes.heading} />
                 <div className={classNames(classes.listSection, classes.listGap)}>
                   {featuredAudioPosts.map((post) => (
                     <PostsAudioCard key={post._id} post={post} />

--- a/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeMainContent.tsx
@@ -101,7 +101,7 @@ const EAHomeMainContent = ({FrontpageNode, classes}: {
             spotlight={spotlight}
             className={classes.spotlightMargin}
           />} */}
-          <SectionTitle title="New & upvoted" noTopMargin>
+          <SectionTitle title="New & upvoted" noTopMargin large>
             <div className={classes.postsListSettings}>
               <Link to={`/topics/${activeTab.slug}`} className={classes.learnMoreLink}>
                 View more

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -88,7 +88,7 @@ const RecentDiscussionFeed = ({
     <AnalyticsContext pageSectionContext="recentDiscussion">
       <AnalyticsInViewTracker eventProps={{inViewType: "recentDiscussion"}}>
         <SingleColumnSection>
-          <SectionTitle title={title} />
+          <SectionTitle title={title} large />
           <MixedTypeFeed
             firstPageSize={10}
             pageSize={20}


### PR DESCRIPTION
Prio candidate. Adds a `large` prop to `SectionTitle` that uses the same styles as the titles on the /best-of page and uses these styles on the home page. Also migrates the titles on the /best-of page to use `SectionTitle` with this new option.

<img width="897" alt="Screenshot 2025-07-03 at 19 46 30" src="https://github.com/user-attachments/assets/e4a683c9-8686-4f38-b1f6-a6f21ed91576" />
<img width="881" alt="Screenshot 2025-07-03 at 19 46 38" src="https://github.com/user-attachments/assets/5afab337-2489-48bb-bb41-c876502ad155" />
<img width="920" alt="Screenshot 2025-07-03 at 19 46 43" src="https://github.com/user-attachments/assets/97afb9ee-9a8b-4cc2-866b-ca9ae72c75e7" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210710567533297) by [Unito](https://www.unito.io)
