### PR TITLE
Don't import all components

### DIFF
--- a/packages/lesswrong/client/start.tsx
+++ b/packages/lesswrong/client/start.tsx
@@ -3,12 +3,10 @@ import AppGenerator from './AppGenerator';
 
 import { createApolloClient } from './apolloClient';
 import { fmCrosspostBaseUrlSetting } from "../lib/instanceSettings";
-import { populateComponentsAppDebug } from '../lib/vulcan-lib/components';
 import { initServerSentEvents } from "./serverSentEventsClient";
 import { hydrateRoot } from 'react-dom/client';
 
 export function hydrateClient() {
-  populateComponentsAppDebug();
   initServerSentEvents();
   const apolloClient = createApolloClient();
   apolloClient.prioritizeCacheValues = true;

--- a/packages/lesswrong/lib/index.ts
+++ b/packages/lesswrong/lib/index.ts
@@ -17,9 +17,6 @@ import '../components/momentjs';
 import './helpers'
 import './routes';
 
-import '@/allComponents';
-import '@/lib/generated/nonRegisteredComponents';
-
 // Alignment Forum
 import './alignment-forum/users/helpers';
 

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -96,16 +96,6 @@ export function registerComponent<PropType>(
   return composeComponent({ name, rawComponent, hocs, options });
 }
 
-// If true, `importComponent` imports immediately (rather than deferring until
-// first use) and checks that the file registered the components named, with a
-// lot of log-spam.
-const debugComponentImports = false;
-
-
-export function importAllComponents() {
-  require('@/lib/generated/allComponents');
-}
-
 const composeComponent = (componentMeta: ComponentsTableEntry) => {
   const componentWithMemo = componentMeta.options?.areEqual
     ? memoizeComponent(componentMeta.options.areEqual, componentMeta.rawComponent, componentMeta.name, !!componentMeta.options.debugRerenders)
@@ -200,14 +190,3 @@ const memoizeComponent = (areEqual: AreEqualOption, component: any, name: string
     });
   }
 }
-
-/**
- * Called once on app startup
- *
- * See debugComponentImports for intended use
- */
-export const populateComponentsAppDebug = (): void => {
-  if (debugComponentImports) {
-    importAllComponents();
-  }
-};

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { importAllComponents } from '../lib/vulcan-lib/components';
 import { addStaticRoute } from './vulcan-lib/staticRoutes';
 import sortBy from 'lodash/sortBy';
 import miscStyles from '../themes/globalStyles/miscStyles';
@@ -53,7 +52,7 @@ const generateMergedStylesheet = (themeOptions: ThemeOptions): Buffer => {
 }
 
 function getAllStylesByName() {
-  importAllComponents();
+  require("@/lib/generated/allComponents");
   require("@/lib/generated/nonRegisteredComponents");
   
   return {

--- a/packages/lesswrong/unitTests/components.tests.ts
+++ b/packages/lesswrong/unitTests/components.tests.ts
@@ -1,7 +1,0 @@
-import { importAllComponents } from '../lib/vulcan-lib/components';
-
-describe("Components", function () {
-  it("doesn't crash when importing every component file", () => {
-    importAllComponents();
-  })
-});

--- a/packages/lesswrong/unitTests/themePalette.tests.ts
+++ b/packages/lesswrong/unitTests/themePalette.tests.ts
@@ -1,16 +1,9 @@
-import { importAllComponents } from '../lib/vulcan-lib/components';
 import { getForumTheme } from '../themes/forumTheme';
 import * as _ from 'underscore';
 import { topLevelStyleDefinitions } from '@/components/hooks/useStyles';
 import type { JssStyles } from '@/lib/jssStyles';
-
-/*
- * We call `importAllComponents` in the test to actually call `require` on all
- * the components that are registed in the deferred components table, but we
- * need this import to actually get the components _into_ the deferred
- * components table in the first place.
- */
 import '../lib/generated/allComponents';
+import '../lib/generated/nonRegisteredComponents';
 
 describe('JSS', () => {
   /**
@@ -24,7 +17,6 @@ describe('JSS', () => {
    * dark mode and accidentally make something black-on-black.
    */
   it('uses only colors that come from the theme palette or change in dark mode', () => {
-    importAllComponents();
     const lightTheme = getForumTheme({name: "default", siteThemeOverride: {}}) as unknown as ThemeType;
     const darkTheme = getForumTheme({name: "dark", siteThemeOverride: {}}) as unknown as ThemeType;
     const stubbedLightTheme = replacePaletteWithStubs(lightTheme);


### PR DESCRIPTION
We refactored away the `Components` table idiom, making `registerComponent` just a way of applying HoCs, and eliminating the need to import all components lest they be identified by string-name and used. But we didn't actually remove the import statement that imported all of them.

Remove the all-components import from `lib/index.ts`, so that the client no longer needs to import all components. (`styleGeneration.ts` on the server still uses it, to generate a merged stylesheet with every compnent's styles.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210712763737476) by [Unito](https://www.unito.io)
