### PR TITLE
[EA] Use 'exact' fields for keyword alert search

### DIFF
--- a/packages/lesswrong/server/keywordAlerts/keywordSearch.ts
+++ b/packages/lesswrong/server/keywordAlerts/keywordSearch.ts
@@ -27,7 +27,7 @@ export const fetchPostIdsForKeyword = async (
             {
               multi_match: {
                 query: keyword,
-                fields: [ "title", "body" ],
+                fields: [ "title.exact", "body.exact" ],
                 type: "phrase",
               },
             }


### PR DESCRIPTION
In the last tweaks PR I switched to a phrase query, but forgot to change the fields to use the `.exact` version.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210727138676907) by [Unito](https://www.unito.io)
