### PR TITLE
[EA] Fix standalone navigation slide

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -72,9 +72,10 @@ const NavigationStandalone = ({
   </>
 }
 
-const slideStyles = defineStyles("Slide", (theme: ThemeType) => ({
+const slideStyles = defineStyles("Slide", () => ({
   wrapper: {
     position: "relative",
+    minWidth: "fit-content",
   },
   slider: {
     transition: "left 0.3s ease-in-out",
@@ -106,5 +107,3 @@ const Slide = ({slidIn, children}: {
 export default registerComponent(
   'NavigationStandalone', NavigationStandalone, {styles}
 );
-
-


### PR DESCRIPTION
There's currently a bug where trying to hide the sidebar on pages with standalone navigation enabled only shifts it left by 100px instead of completely off-screen.

![Screenshot 2025-07-03 at 17 18 28](https://github.com/user-attachments/assets/db717d82-742f-4a87-beca-d71c30ea3ec7)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210727380305819) by [Unito](https://www.unito.io)
