### PR TITLE
Fit rejection reasons onto screen

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
@@ -58,7 +58,7 @@ export const RejectContentButton = ({contentWrapper, classes}: {
       anchorEl={anchorEl}
       clickable={true}
       allowOverflow={true}
-      placement={"right"}
+      placement={"right-start"}
     >
       <LWClickAwayListener onClickAway={() => setShowRejectionDialog(false)}>
         <RejectContentDialog rejectContent={handleRejectContent}/>

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -40,8 +40,8 @@ const styles = (theme: ThemeType) => ({
     flexDirection: 'column'
   },
   checkbox: {
-    paddingTop: 6,
-    paddingBottom: 6
+    paddingTop: 2,
+    paddingBottom: 2
   },
   modalTextField: {
     marginTop: 10,

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -124,7 +124,7 @@ const RejectContentDialog = ({classes, rejectContent}: {
   const { data, loading, loadMoreProps } = useQueryWithLoadMore(ModerationTemplateFragmentMultiQuery, {
     variables: {
       selector: { moderationTemplatesList: { collectionName: "Rejections" } },
-      limit: 25,
+      limit: 50,
       enableTotal: true,
     },
   });


### PR DESCRIPTION
Rejections were taking up more than a vertical-page-height, this PR makes them denser, and appear in a more predictable place.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/612c18e7-95e6-4c68-a37a-f4f10a01c98a" />
