### PR TITLE
Fix AllPosts Tag Page username styles

### DIFF
--- a/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
+++ b/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
@@ -101,8 +101,9 @@ const styles = (theme: ThemeType) => ({
   usernames: {
     marginRight: 16,
     maxWidth: 310,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
     textOverflow: "ellipsis",
-    overflowX: "hidden",
     textAlign: "right",
     [theme.breakpoints.down('xs')]: {
       maxWidth: 160


### PR DESCRIPTION
Before:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/c0cc0172-53f7-4fd9-aef1-fea3c3caa7f6" />

After:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/66771a47-d57e-4773-b124-835689e1c32f" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210738476020886) by [Unito](https://www.unito.io)
