### PR TITLE
Fix up the tag-page contributors list

### DIFF
--- a/packages/lesswrong/components/tagging/ContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/ContributorsList.tsx
@@ -16,13 +16,11 @@ const styles = defineStyles("ContributorsList", (theme: ThemeType) => ({
     fontWeight: 550,
   },
   tocContributors: {
-    display: 'flex',
-    flexDirection: 'row',
-    gap: '4px',
     marginBottom: 12,
     marginLeft: 16,
   },
   tocContributor: {
+    cursor: "pointer",
     fontFamily: theme.palette.fonts.sansSerifStack,
     color: theme.palette.greyAlpha(0.5),
     fontWeight: 550,
@@ -111,7 +109,7 @@ export const HeadingContributorsList = ({topContributors, smallContributors, onH
 }) => {
   const classes = useStyles(styles);
   return <span className={classes.contributorNameWrapper}>
-    <span>Written by </span>
+    <span>Edited by </span>
     <ContributorsList
       contributors={topContributors}
       onHoverContributor={onHoverContributor}

--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -26,9 +26,10 @@ export const userGetDisplayName = (user: UserDisplayNameInfo | null): string => 
   if (!user) {
     return "";
   } else {
-    return forumTypeSetting.get() === 'AlignmentForum' ? 
-      (user.fullName || user.displayName) ?? "" :
-      (user.displayName || getUserName(user)) ?? ""
+    return (forumTypeSetting.get() === 'AlignmentForum'
+      ? (user.fullName || user.displayName) ?? ""
+      : (user.displayName || getUserName(user)) ?? ""
+    ).trim();
   }
 };
 


### PR DESCRIPTION
 * Fix broken formatting caused by using a flexbox in the ToC version of the contributors list, which breaks when user display names have spaces in them
 * Change "Written by" to "Edited by" in central column contributors list
 * Trim trailing whitespace on user display names (affects Miranda Dixon-Luinenburg who has a trailing space in her displayName for some reason)
 * "Et al" gets cursor:pointer


