### PR TITLE
LLM-checking on post-publish

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -8,7 +8,7 @@ import { getConfirmedCoauthorIds, isRecombeeRecommendablePost, postIsApproved, p
 import { getLatestContentsRevision } from "@/server/collections/revisions/helpers";
 import { subscriptionTypes } from "@/lib/collections/subscriptions/helpers";
 import { isAnyTest, isE2E } from "@/lib/executionEnvironment";
-import { eaFrontpageDateDefault, isEAForum, requireReviewToFrontpagePostsSetting } from "@/lib/instanceSettings";
+import { eaFrontpageDateDefault, isEAForum, requireReviewToFrontpagePostsSetting, isLW } from "@/lib/instanceSettings";
 import { recombeeEnabledSetting, vertexEnabledSetting } from "@/lib/publicSettings";
 import { asyncForeachSequential } from "@/lib/utils/asyncUtils";
 import { isWeekend } from "@/lib/utils/timeUtil";
@@ -52,6 +52,7 @@ import { updateNotification } from "../collections/notifications/mutations";
 import { EmailCuratedAuthors } from "../emailComponents/EmailCuratedAuthors";
 import { EventUpdatedEmail } from "../emailComponents/EventUpdatedEmail";
 import { PostsHTML } from "@/lib/collections/posts/fragments";
+import { createAutomatedContentEvaluation } from "../collections/revisions/mutations";
 
 /** Create notifications for a new post being published */
 export async function sendNewPostNotifications(post: DbPost) {
@@ -143,6 +144,15 @@ export async function onPostPublished(post: DbPost, context: ResolverContext) {
   const { updateScoreOnPostPublish } = require("./votingCallbacks");
   await updateScoreOnPostPublish(post, context);
   await onPublishUtils.ensureNonzeroRevisionVersionsAfterUndraft(post, context);
+  
+  // Trigger automated content evaluation for posts being published
+  // This handles the case where a post was created as a draft and is now being published
+  if (isLW) {
+    const latestRevision = await getLatestContentsRevision(post, context);
+    if (latestRevision && latestRevision.collectionName === "Posts" && latestRevision.fieldName === "contents") {
+      void createAutomatedContentEvaluation(latestRevision, context);
+    }
+  }
 }
 
 const utils = {
@@ -1053,7 +1063,7 @@ export async function sendEAFCuratedAuthorsNotification(post: DbPost, oldPost: D
     
     void Promise.all(authors.map(author => wrapAndSendEmail({
         user: author,
-        subject: "We’ve curated your post",
+        subject: "We've curated your post",
         body: <EmailCuratedAuthors user={author} post={post} />
       })
     ))

--- a/packages/lesswrong/server/collections/revisions/mutations.ts
+++ b/packages/lesswrong/server/collections/revisions/mutations.ts
@@ -286,7 +286,15 @@ ${output_text}`,
   };
 };
 
-async function createAutomatedContentEvaluation(revision: DbRevision, context: ResolverContext) {
+export async function createAutomatedContentEvaluation(revision: DbRevision, context: ResolverContext) {
+  // Check if evaluation already exists for this revision
+  const existingEvaluation = await AutomatedContentEvaluations.findOne({ revisionId: revision._id });
+  if (existingEvaluation) {
+    // eslint-disable-next-line no-console
+    console.log(`Automated content evaluation already exists for revision ${revision._id}`);
+    return;
+  }
+
   const [validatedEvaluation, llmEvaluation] = await Promise.all([
     getSaplingEvaluation(revision),
     getLlmEvaluation(revision, context),


### PR DESCRIPTION
I *think* this should fix an issue where sometimes posts from new users didn't get checked-for-LLM-ness, although I'm not sure I understand the intended setup.