### PR TITLE
Improve UltraFeed Analytics

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionQuickTake.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionQuickTake.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import CommentsItem from "../comments/CommentsItem/CommentsItem";
 import CommentsNodeInner from "../comments/CommentsNode";
 import { maybeDate } from "@/lib/utils/dateUtils";
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const styles = (_theme: ThemeType) => ({
   quickTakeBody: {
@@ -84,12 +85,14 @@ const EARecentDiscussionQuickTake = ({
   comments,
   refetch,
   expandAllThreads: initialExpandAllThreads,
+  index,
   classes,
 }: {
   post: ShortformRecentDiscussion,
   comments?: CommentsListWithTopLevelComment[],
   refetch: () => void,
   expandAllThreads?: boolean,
+  index?: number,
   classes: ClassesType<typeof styles>,
 }) => {
   const {
@@ -111,7 +114,7 @@ const EARecentDiscussionQuickTake = ({
   const splitComments = splitByTopLevelComment(nestedComments);
   return (
     <>
-      {splitComments.map((comments) => {
+      {splitComments.map((comments, splitIndex) => {
         if (!comments.length) {
           return null;
         }
@@ -123,8 +126,8 @@ const EARecentDiscussionQuickTake = ({
           return null;
         }
         return (
+          <AnalyticsContext key={quickTake._id} recentDiscussionCardIndex={index}>
           <EARecentDiscussionItem
-            key={quickTake._id}
             {...getItemProps(post, comments[0])}
           >
             <CommentsItem
@@ -153,6 +156,7 @@ const EARecentDiscussionQuickTake = ({
               />
             ))}
           </EARecentDiscussionItem>
+          </AnalyticsContext>
         );
       })}
     </>

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { Link } from "../../lib/reactRouterWrapper";
 import { useRecentDiscussionThread } from "./useRecentDiscussionThread";
+import { useRecentDiscussionViewTracking } from "./useRecentDiscussionViewTracking";
 import { postGetCommentsUrl } from "../../lib/collections/posts/helpers";
 import type { CommentTreeNode } from "../../lib/utils/unflatten";
 import EARecentDiscussionItem, { EARecentDiscussionItemProps } from "./EARecentDiscussionItem";
@@ -14,6 +15,7 @@ import LinkPostMessage from "../posts/LinkPostMessage";
 import EAKarmaDisplay from "../common/EAKarmaDisplay";
 import PostsTitle from "../posts/PostsTitle";
 import { maybeDate } from "@/lib/utils/dateUtils";
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType) => ({
   header: {
@@ -102,12 +104,14 @@ const EARecentDiscussionThread = ({
   comments,
   refetch,
   expandAllThreads: initialExpandAllThreads,
+  index,
   classes,
 }: {
   post: PostsRecentDiscussion,
   comments?: CommentsList[],
   refetch: () => void,
   expandAllThreads?: boolean,
+  index?: number,
   classes: ClassesType<typeof styles>,
 }) => {
   const {
@@ -122,12 +126,21 @@ const EARecentDiscussionThread = ({
     initialExpandAllThreads,
   });
 
+  // Track view duration
+  const viewTrackingRef = useRecentDiscussionViewTracking({
+    documentId: post._id,
+    documentType: 'post',
+    index,
+    wordCount: post.contents?.wordCount,
+  });
+
   if (isSkippable) {
     return null;
   }
   return (
+    <AnalyticsContext recentDiscussionCardIndex={index}>
     <EARecentDiscussionItem {...getItemProps(post, comments)}>
-      <div className={classes.header}>
+      <div ref={viewTrackingRef} className={classes.header}>
         {!post.isEvent &&
           <EAKarmaDisplay post={post} className={classes.karmaDisplay} />
         }
@@ -172,6 +185,7 @@ const EARecentDiscussionThread = ({
         </div>
       )}
     </EARecentDiscussionItem>
+    </AnalyticsContext>
   );
 }
 

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -7,7 +7,7 @@ import withErrorBoundary from '../common/withErrorBoundary'
 
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
@@ -145,7 +145,16 @@ const FeedPostCommentsBranch = ({ comment, treeOptions, expandAllThreads, classe
 
   const showExtraChildrenButton =
     extraChildrenCount > 0 ? (
-      <a className={classes.showChildren} onClick={() => setExpanded(true)}>
+      <a className={classes.showChildren} onClick={() => {
+        captureEvent("showMoreCommentsClicked", {
+          parentCommentId: comment.item._id,
+          postId: comment.item.postId,
+          shownCount: commentBranchWithGaps.length,
+          totalCount: flattenedCommentBranch.length - 1,
+          hiddenCount: extraChildrenCount,
+        });
+        setExpanded(true);
+      }}>
         Showing {commentBranchWithGaps.length} of {flattenedCommentBranch.length - 1} replies (Click to show all)
       </a>
     ) : null;

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -25,6 +25,7 @@ import { RecentDiscussionFeedQuery } from '../common/feeds/feedQueries';
 import FeedSelectorDropdown from '../common/FeedSelectorCheckbox';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { isBookUI } from '@/themes/forumTheme';
+import { randomId } from '../../lib/random';
 
 const styles = defineStyles("RecentDiscussionFeed", (theme: ThemeType) => ({
   titleRow: {
@@ -92,6 +93,15 @@ const RecentDiscussionFeed = ({
   const refetchRef = useRef<null|ObservableQuery['refetch']>(null);
   const currentUser = useCurrentUser();
   const expandAll = currentUser?.noCollapseCommentsFrontpage || expandAllThreads
+  
+  // Session tracking similar to UltraFeed
+  const [sessionId] = useState<string>(() => {
+    if (typeof window === 'undefined') return randomId();
+    const storage = window.sessionStorage;
+    const currentId = storage ? storage.getItem('recentDiscussionSessionId') ?? randomId() : randomId();
+    storage.setItem('recentDiscussionSessionId', currentId);
+    return currentId;
+  });
 
   useGlobalKeydown(event => {
     const F_Key = 70
@@ -125,7 +135,7 @@ const RecentDiscussionFeed = ({
     : undefined;
 
   return (
-    <AnalyticsContext pageSectionContext="recentDiscussion">
+    <AnalyticsContext pageSectionContext="recentDiscussion" recentDiscussionContext={{ sessionId }}>
       <AnalyticsInViewTracker eventProps={{inViewType: "recentDiscussion"}}>
         <SingleColumnSection>
           <SectionTitle title={title} titleClassName={classes.titleText}>
@@ -149,43 +159,50 @@ const RecentDiscussionFeed = ({
             refetchRef={refetchRef}
             renderers={{
               postCommented: {
-                render: (post: PostsRecentDiscussion) => (
+                render: (post: PostsRecentDiscussion, index: number) => (
                   <ThreadComponent
                     post={post}
                     refetch={refetch}
                     comments={post.recentComments ?? undefined}
                     expandAllThreads={expandAll}
+                    index={index}
                   />
                 )
               },
               shortformCommented: {
-                render: (post: ShortformRecentDiscussion) => (
+                render: (post: ShortformRecentDiscussion, index: number) => (
                   <ShortformComponent
                     post={post}
                     refetch={refetch}
                     comments={post.recentComments ?? undefined}
                     expandAllThreads={expandAll}
+                    index={index}
                   />
                 )
               },
               tagDiscussed: {
-                render: (tag: TagRecentDiscussion) => (
+                render: (tag: TagRecentDiscussion, index: number) => (
                   <TagCommentedComponent
                     tag={tag}
                     refetch={refetch}
                     comments={tag.recentComments}
                     expandAllThreads={expandAll}
+                    index={index}
                   />
                 )
               },
               tagRevised: {
-                render: (revision: RecentDiscussionRevisionTagFragment) => <div>
-                  {revision.tag && revision.documentId && <TagRevisionComponent
-                    tag={revision.tag}
-                    revision={revision}
-                    headingStyle="full"
-                    documentId={revision.documentId}
-                  />}
+                render: (revision: RecentDiscussionRevisionTagFragment, index: number) => <div>
+                  {revision.tag && revision.documentId && (
+                    <AnalyticsContext recentDiscussionCardIndex={index}>
+                      <TagRevisionComponent
+                        tag={revision.tag}
+                        revision={revision}
+                        headingStyle="full"
+                        documentId={revision.documentId}
+                      />
+                    </AnalyticsContext>
+                  )}
                 </div>,
               },
 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -15,7 +15,7 @@ import CommentsNodeInner from "../comments/CommentsNode";
 import { ContentItemBody } from "../contents/ContentItemBody";
 import ContentStyles from "../common/ContentStyles";
 import { maybeDate } from '@/lib/utils/dateUtils';
-import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -97,7 +97,14 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   const clickExpandDescription = useCallback(() => {
     setTruncated(false);
     setExpandAllThreads(true);
-  }, []);
+    
+    captureEvent("readMoreClicked", {
+      tagId: tag._id,
+      tagName: tag.name,
+      pageSectionContext: "recentDiscussion"
+    });
+  }, [tag._id, tag.name]);
+
   
   const descriptionHtml = tag.description?.html;
   const readMore = `<a>(${preferredHeadingCase("Read More")})</a>`;
@@ -119,7 +126,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   return <AnalyticsContext pageSubSectionContext='recentDiscussionTag' recentDiscussionCardIndex={index}>
     <div ref={viewTrackingRef} className={classes.root}>
       <div className={classes.tag}>
-        <Link to={tagGetDiscussionUrl(tag)} className={classes.title}>
+        <Link to={tagGetDiscussionUrl(tag)} className={classes.title} onClick={handleTagClick}>
           {tag.name}
         </Link>
         

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -14,6 +14,7 @@ import type { CommentTreeOptions } from '../comments/commentTree';
 import { useCurrentUser } from '../common/withUser';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
+import { useRecentDiscussionViewTracking } from './useRecentDiscussionViewTracking';
 import PostsGroupDetails from "../posts/PostsGroupDetails";
 import PostsItemMeta from "../posts/PostsItemMeta";
 import CommentsNodeInner from "../comments/CommentsNode";
@@ -161,6 +162,7 @@ const RecentDiscussionThread = ({
   isSubforumIntroPost,
   commentTreeOptions = {},
   dismissCallback = () => {},
+  index,
   classes,
 }: {
   post: PostsRecentDiscussion,
@@ -172,6 +174,7 @@ const RecentDiscussionThread = ({
   isSubforumIntroPost?: boolean,
   commentTreeOptions?: CommentTreeOptions,
   dismissCallback?: () => void,
+  index?: number,
   classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser();
@@ -190,6 +193,13 @@ const RecentDiscussionThread = ({
     initialExpandAllThreads,
   });
 
+  const viewTrackingRef = useRecentDiscussionViewTracking({
+    documentId: post._id,
+    documentType: 'post',
+    index,
+    wordCount: post.contents?.wordCount,
+  });
+
   if (isSkippable) {
     return null
   }
@@ -199,8 +209,8 @@ const RecentDiscussionThread = ({
     [classes.noComments]: post.commentCount === null
   });
   return (
-    <AnalyticsContext pageSubSectionContext='recentDiscussionThread'>
-      <div className={classNames(
+    <AnalyticsContext pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={index}>
+      <div ref={viewTrackingRef} className={classNames(
         classes.root,
         {
           [classes.plainBackground]: !isSubforumIntroPost,

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { useRecordPostView } from "../hooks/useRecordPostView";
 import { ThreadableCommentType, unflattenComments } from "../../lib/utils/unflatten";
 import type { CommentTreeOptions } from "../comments/commentTree";
+import { captureEvent } from "../../lib/analyticsEvents";
 
 export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   post,
@@ -31,10 +32,18 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   );
   const showHighlight = useCallback(
     () => {
-      setHighlightVisible(!highlightVisible);
+      const newHighlightVisible = !highlightVisible;
+      setHighlightVisible(newHighlightVisible);
+      
+      captureEvent("recentDiscussionPostHighlightToggled", {
+        postId: post._id,
+        expanded: newHighlightVisible,
+        wordCount: post.contents?.wordCount,
+      });
+      
       markAsRead();
     },
-    [setHighlightVisible, highlightVisible, markAsRead],
+    [setHighlightVisible, highlightVisible, markAsRead, post._id, post.contents?.wordCount],
   );
 
   const markCommentsAsRead = useCallback(

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { captureEvent } from '../../lib/analyticsEvents';
+
+interface ViewTrackingOptions {
+  documentId: string;
+  documentType: 'post' | 'comment' | 'tag';
+  index?: number;
+  wordCount?: number;
+}
+
+const VIEW_THRESHOLD_MS = 2000;
+const LONG_VIEW_THRESHOLD_MS = 10000;
+
+/**
+ * Hook to track view duration for Recent Discussion items.
+ * Captures analytics events when items are viewed for 2s and 10s.
+ */
+export function useRecentDiscussionViewTracking({
+  documentId,
+  documentType,
+  index,
+  wordCount,
+}: ViewTrackingOptions) {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const viewTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const longViewTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const hasLoggedViewRef = useRef(false);
+  const hasLoggedLongViewRef = useRef(false);
+
+  const handleIntersection = useCallback((entries: IntersectionObserverEntry[]) => {
+    const entry = entries[0];
+    
+    if (entry.isIntersecting) {
+      // Start timers when element becomes visible
+      if (!hasLoggedViewRef.current) {
+        viewTimerRef.current = setTimeout(() => {
+          captureEvent('recentDiscussionItemViewed', {
+            documentId,
+            documentType,
+            durationMs: VIEW_THRESHOLD_MS,
+            index,
+            wordCount,
+          });
+          hasLoggedViewRef.current = true;
+        }, VIEW_THRESHOLD_MS);
+      }
+      
+      if (!hasLoggedLongViewRef.current) {
+        longViewTimerRef.current = setTimeout(() => {
+          captureEvent('recentDiscussionItemLongViewed', {
+            documentId,
+            documentType,
+            durationMs: LONG_VIEW_THRESHOLD_MS,
+            index,
+            wordCount,
+          });
+          hasLoggedLongViewRef.current = true;
+        }, LONG_VIEW_THRESHOLD_MS);
+      }
+    } else {
+      // Clear timers when element leaves viewport
+      if (viewTimerRef.current) {
+        clearTimeout(viewTimerRef.current);
+        viewTimerRef.current = null;
+      }
+      if (longViewTimerRef.current) {
+        clearTimeout(longViewTimerRef.current);
+        longViewTimerRef.current = null;
+      }
+    }
+  }, [documentId, documentType, index, wordCount]);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    // Create observer with same margins as UltraFeed (250px threshold)
+    const observer = new IntersectionObserver(handleIntersection, {
+      rootMargin: '-250px 0px -250px 0px',
+      threshold: 0,
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+      if (viewTimerRef.current) clearTimeout(viewTimerRef.current);
+      if (longViewTimerRef.current) clearTimeout(longViewTimerRef.current);
+    };
+  }, [handleIntersection]);
+
+  return elementRef;
+} 

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -433,6 +433,7 @@ const UltraFeedItemFooterCore = ({
             other: false,
             text: '',
           },
+          sources: metaInfo?.sources,
           cancelled: false,
         }
       }

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -534,7 +534,7 @@ const UltraFeedPostItem = ({
   }), [isReplying, handleReplyClick, handleReplySubmit, handleReplyCancel]);
 
   const handleOpenDialog = useCallback((location: "title" | "content") => {
-    captureEvent("ultraFeedPostItemTitleClicked", { location });
+    captureEvent("ultraFeedPostDialogOpened", { location });
     trackExpansion({
       documentId: post._id,
       documentType: 'post',

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -127,6 +127,8 @@ export type AnalyticsProps = {
   ultraFeedElementType?: FeedItemType,
   ultraFeedCardId?: string,
   ultraFeedCardIndex?: number,
+  recentDiscussionContext?: { sessionId: string },
+  recentDiscussionCardIndex?: number,
   /** @deprecated Use `pageSectionContext` instead */
   listContext?: string,
   /** @deprecated Use `pageSectionContext` instead */


### PR DESCRIPTION
Focused on improving ability to compare between feeds

----
notes written by LLM:

# Analytics Comparison: UltraFeed vs RecentDiscussion

This document compares the analytics tracking between UltraFeed and RecentDiscussion feeds for A/B testing purposes.

## Summary of Changes Made

### Session Tracking ✅
- Added `sessionId` generation to RecentDiscussionFeed
- Stored in sessionStorage as 'recentDiscussionSessionId'
- Passed through `AnalyticsContext` via `recentDiscussionContext`

### Position/Index Tracking ✅
- Added `index` prop to all RecentDiscussion item components
- Passed through `AnalyticsContext` as `recentDiscussionCardIndex`
- Tracks position of items in the feed for optimization analysis

### View Duration Tracking ✅
- Created `useRecentDiscussionViewTracking` hook
- Tracks 2-second and 10-second view thresholds
- Events: `recentDiscussionItemViewed` and `recentDiscussionItemLongViewed`
- Uses same 250px viewport margin as UltraFeed

### Analytics Context Integration ✅
- All RecentDiscussion components are wrapped with `AnalyticsContext`
- Standard events (e.g., `commentExpanded`, `readMoreClicked`) automatically include:
  - `pageSubSectionContext`: 'recentDiscussionThread' or 'recentDiscussionTag'
  - `recentDiscussionCardIndex`: position in feed
- No need for RecentDiscussion-specific events - context distinguishes the source

## Detailed Event Comparison

### UltraFeed Exclusive Events

#### Client-side events (via captureEvent):
- `ultraFeedPostItemExpanded` - Post content expansion
- `ultraFeedCommentItemExpanded` - Comment expansion
- `ultraFeedPostDialogOpened` - Full post modal opened
- `ultraFeedCommentIconClicked` - Reply button interactions
- `ultraFeedSeeLessClicked` - Negative feedback
- `ultraFeedCompressedCommentsClicked` - Show hidden comments
- `ultraFeedThreadItemCompressedCommentsExpanded` - Thread expansion
- `ultraFeedSettingsToggled` - Settings panel open/close
- `ultraFeedSettingsUpdated` - Settings changed
- `ultraFeedBranchNavigationClicked` - Navigate between comment branches
- `ultraFeedPostDialogScrollToComments` - Scroll to comments in modal
- `ultraFeedComposerQuickTakeDialogOpened` - Quick take composer opened

#### Server-side events (via UltraFeedEvents table):
- `viewed` - 2-second view threshold
- `longViewed` - 10-second view threshold  
- `expanded` - Content expansion with metadata
- `interacted` - Bookmarks, comments clicks
- `seeLess` - Negative feedback with reasons
- `served` - Items shown to user

### RecentDiscussion Events

#### New events added:
- `recentDiscussionPostHighlightToggled` - Post preview expansion
- `recentDiscussionItemViewed` - 2-second view threshold
- `recentDiscussionItemLongViewed` - 10-second view threshold
- `showMoreCommentsClicked` - Show hidden replies (generic event)

#### Existing events enhanced with context:
- `commentExpanded` - Includes RecentDiscussion context via AnalyticsContext
- `readMoreClicked` - Tag description expansion with pageSectionContext
- `recordPostView` - Post views with type: "recentDiscussionClick"
- `recordTagView` - Tag views with type: "recentDiscussionClick"
- `recordPostCommentsView` - Comment view tracking
- `subscribeReminderButtonClicked` - Subscribe reminder interactions

### Shared Analytics

Both feeds share these through common components:
- `tripleDotClick` - Post actions menu
- Post mount tracking
- Link click tracking
- Bookmark interactions
- Voting events
- Comment submission

## Key Differences

1. **Persistence**: UltraFeed uses server-side UltraFeedEvents table for durable tracking
2. **Granularity**: UltraFeed tracks more granular interactions (settings, navigation, feedback)
3. **Context**: UltraFeed includes source tracking and recommendation metadata
4. **Feedback**: UltraFeed has "see less" system with detailed feedback reasons

## Implementation Notes

- Rather than creating RecentDiscussion-specific events for common interactions, we leverage `AnalyticsContext` to provide context
- Standard events fired within RecentDiscussion components automatically include:
  - Feed type context (`pageSubSectionContext`)
  - Position information (`recentDiscussionCardIndex`)
- This approach reduces code duplication and ensures consistent tracking across the application

## Usage in A/B Testing

For fair comparison between feeds:
- Filter standard events by `pageSubSectionContext` to isolate RecentDiscussion interactions
- Compare view duration metrics (2s and 10s thresholds)
- Compare expansion/engagement rates for both posts and comments
- Use session IDs to track per-session behavior
- Use position data to analyze scroll depth and item effectiveness
- Track tag engagement separately from post engagement
- Account for different UI patterns when comparing interaction rates 