### PR TITLE
fetch only one spotlight from the database, instead of all of them, when getting the current spotlight

### DIFF
--- a/packages/lesswrong/server/resolvers/spotlightResolvers.ts
+++ b/packages/lesswrong/server/resolvers/spotlightResolvers.ts
@@ -30,13 +30,13 @@ export const spotlightGqlMutations = {
 
 export const spotlightGqlQueries = {
   async currentSpotlight(root: void, args: {}, context: ResolverContext, info: AnyBecauseTodo) {
-    const mostRecentlyPromoted = await Spotlights.find(
+    const mostRecentlyPromoted = await Spotlights.findOne(
       { draft: false, deletedDraft: false, lastPromotedAt: {$lt: new Date()} },
       {
         sort: {lastPromotedAt: -1, position: 1}
       }
-    ).fetch();
-    return mostRecentlyPromoted?.[0] ?? null;
+    );
+    return mostRecentlyPromoted;
   }
 };
 


### PR DESCRIPTION
If the DB cache isn't warm this is an extra 600ms (though I guess that should rarely happen), and I don't know what the extra overhead is on actually grabbing 300+ spotlights from the DB.  I don't think there's actually any reason to get all of them since we're sorting them in the DB anyways.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210749466332782) by [Unito](https://www.unito.io)
