### PR TITLE
Make the LW background image visible at medium breakpoint

### DIFF
--- a/packages/lesswrong/components/LWBackgroundImage.tsx
+++ b/packages/lesswrong/components/LWBackgroundImage.tsx
@@ -10,6 +10,7 @@ import CloudinaryImage2 from "./common/CloudinaryImage2";
 const styles = defineStyles("LWBackgroundImage", (theme: ThemeType) => ({
   root: {
     position: 'absolute',
+    top: 0,
     right: 0,
   },
   backgroundImage: {
@@ -38,7 +39,7 @@ const styles = defineStyles("LWBackgroundImage", (theme: ThemeType) => ({
     right: 0,
     height: "100vh",
     width: '57vw',
-    ['@media(max-width: 1000px)']: {
+    [theme.breakpoints.down('sm')]: {
       display: 'none'
     },
   },


### PR DESCRIPTION
The LW background image ("science orbs"), at medium breakpoint, was winding up in the post footer below the bottom of the infinite scroll, where it isn't visible.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210766444960627) by [Unito](https://www.unito.io)
