### PR TITLE
Fix ultrafeed analytics (and in general)

### DIFF
--- a/packages/lesswrong/components/books/Book2018Landing.tsx
+++ b/packages/lesswrong/components/books/Book2018Landing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
-import {captureEvent, useTracking} from "../../lib/analyticsEvents";
+import { useTracking } from "../../lib/analyticsEvents";
 import BookAnimation from "./BookAnimation";
 import BookCheckout from "../review/BookCheckout";
 import HeadTags from "../common/HeadTags";
@@ -362,6 +362,8 @@ const Interlude = ({classes, imageURL, coverImageUrl, spreadImageUrl, bigQuote, 
 const Book2018Landing = ({classes}: {
   classes: ClassesType<typeof styles>,
 }) => {
+  const { captureEvent } = useTracking();
+  
   return (
     <div>
       <HeadTags 

--- a/packages/lesswrong/components/books/Book2019Landing.tsx
+++ b/packages/lesswrong/components/books/Book2019Landing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
-import { captureEvent } from "../../lib/analyticsEvents";
+import { useTracking } from "../../lib/analyticsEvents";
 import Book2019Animation from "./Book2019Animation";
 import HeadTags from "../common/HeadTags";
 import LWTooltip from "../common/LWTooltip";
@@ -262,9 +262,9 @@ const HiddenQuote = ({classes}: {classes: ClassesType<typeof styles>}) => {
   )
 }
 
-const Book2019Landing = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
+const Book2019Landing = ({classes}: {classes: ClassesType<typeof styles>}) => {
+  const { captureEvent } = useTracking();
+
   return (
     <div>
       <HeadTags 

--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -20,7 +20,6 @@ import { captureException } from '@sentry/core';
 
 type PassedThroughContentItemBodyProps = Pick<ContentItemBodyProps, "description"|"noHoverPreviewPrefetch"|"nofollow"|"contentStyleType"|"replacedSubstrings"|"idInsertions"> & {
   bodyRef: React.RefObject<HTMLDivElement|null>,
-  captureEvent: (eventType: string, eventData: any) => void
 }
 
 type SubstitutionsAttr = Array<{substitutionIndex: number, isSplitContinuation: boolean}>;
@@ -55,7 +54,6 @@ type SubstitutionsAttr = Array<{substitutionIndex: number, isSplitContinuation: 
 export const ContentItemBody = (props: ContentItemBodyProps) => {
   const { onContentReady, nofollow, dangerouslySetInnerHTML, replacedSubstrings, className, ref } = props;
   const bodyRef = useRef<HTMLDivElement|null>(null);
-  const { captureEvent } = useTracking();
   const html = (nofollow
     ? addNofollowToHTML(dangerouslySetInnerHTML.__html)
     : dangerouslySetInnerHTML.__html
@@ -89,7 +87,6 @@ export const ContentItemBody = (props: ContentItemBodyProps) => {
   const passedThroughProps = {
     ...pick(props, ["description", "noHoverPreviewPrefetch", "nofollow", "contentStyleType", "replacedSubstrings", "idInsertions"]),
     bodyRef,
-    captureEvent,
   };
   
   return <div className={className} ref={bodyRef}>
@@ -107,7 +104,9 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
   passedThroughProps: PassedThroughContentItemBodyProps,
   root?: boolean,
 }) => {
-  const { replacedSubstrings } = passedThroughProps;;
+  const { replacedSubstrings } = passedThroughProps;
+  const { captureEvent } = useTracking();
+  
   switch (parsedHtml.type) {
     case htmlparser2.ElementType.CDATA:
     case htmlparser2.ElementType.Directive:
@@ -199,7 +198,7 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
         }
         const originalOnClick = attribs['onClick'];
         attribs['onClick'] = (ev: React.MouseEvent<HTMLAnchorElement>) => {
-          passedThroughProps.captureEvent("ctaButtonClicked", {href: attribs['data-href']});
+          captureEvent("ctaButtonClicked", {href: attribs['data-href']});
           originalOnClick?.(ev);
         }
       }

--- a/packages/lesswrong/components/hooks/useOnNavigate.tsx
+++ b/packages/lesswrong/components/hooks/useOnNavigate.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import type { RouterLocation } from '../../lib/vulcan-lib/routes';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { isClient } from '../../lib/executionEnvironment';
-import { captureEvent } from '../../lib/analyticsEvents';
+import { useTracking } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 
 let lastLocation: RouterLocation|null = null;
@@ -12,6 +12,7 @@ let onNavigateFunctions: Array<(locationChange: LocationChange) => void> = [];
 
 const NavigationEventSender = () => {
   const location = useSubscribedLocation();
+  const { captureEvent } = useTracking();
   
   useEffect(() => {
     // Only handle navigation events on the client (they don't apply to SSR)
@@ -32,7 +33,7 @@ const NavigationEventSender = () => {
         lastLocation = _.clone(location);
       }
     }
-  }, [location]);
+  }, [location, captureEvent]);
   
   return null;
 }

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -127,7 +127,6 @@ const EARecentDiscussionThread = ({
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: post._id,
     documentType: 'post',
-    wordCount: post.contents?.wordCount,
   });
 
   if (isSkippable) {

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -104,14 +104,12 @@ const EARecentDiscussionThread = ({
   comments,
   refetch,
   expandAllThreads: initialExpandAllThreads,
-  index,
   classes,
 }: {
   post: PostsRecentDiscussion,
   comments?: CommentsList[],
   refetch: () => void,
   expandAllThreads?: boolean,
-  index?: number,
   classes: ClassesType<typeof styles>,
 }) => {
   const {
@@ -129,7 +127,6 @@ const EARecentDiscussionThread = ({
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: post._id,
     documentType: 'post',
-    index,
     wordCount: post.contents?.wordCount,
   });
 
@@ -137,7 +134,6 @@ const EARecentDiscussionThread = ({
     return null;
   }
   return (
-    <AnalyticsContext recentDiscussionCardIndex={index}>
     <EARecentDiscussionItem {...getItemProps(post, comments)}>
       <div ref={viewTrackingRef} className={classes.header}>
         {!post.isEvent &&
@@ -184,7 +180,6 @@ const EARecentDiscussionThread = ({
         </div>
       )}
     </EARecentDiscussionItem>
-    </AnalyticsContext>
   );
 }
 

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -7,7 +7,7 @@ import withErrorBoundary from '../common/withErrorBoundary'
 
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
@@ -128,6 +128,7 @@ const FeedPostCommentsBranch = ({ comment, treeOptions, expandAllThreads, classe
   classes: ClassesType<typeof styles>
 }) => {
   const [expanded, setExpanded] = useState(expandAllThreads);
+  const { captureEvent } = useTracking();
 
   const flattenedCommentBranch = flattenCommentBranch(comment);
   let commentBranchWithGaps = flattenedCommentBranch.slice(1);

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -156,35 +156,38 @@ const RecentDiscussionFeed = ({
             renderers={{
               postCommented: {
                 render: (post: PostsRecentDiscussion, index: number) => (
+                  <AnalyticsContext pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={index}>
                   <ThreadComponent
                     post={post}
                     refetch={refetch}
                     comments={post.recentComments ?? undefined}
                     expandAllThreads={expandAll}
-                    index={index}
                   />
+                  </AnalyticsContext>
                 )
               },
               shortformCommented: {
                 render: (post: ShortformRecentDiscussion, index: number) => (
+                  <AnalyticsContext pageSubSectionContext='recentDiscussionShortform' recentDiscussionCardIndex={index}>
                   <ShortformComponent
                     post={post}
                     refetch={refetch}
                     comments={post.recentComments ?? undefined}
                     expandAllThreads={expandAll}
-                    index={index}
                   />
+                  </AnalyticsContext>
                 )
               },
               tagDiscussed: {
                 render: (tag: TagRecentDiscussion, index: number) => (
+                  <AnalyticsContext pageSubSectionContext='recentDiscussionTag' recentDiscussionCardIndex={index}>
                   <TagCommentedComponent
                     tag={tag}
                     refetch={refetch}
                     comments={tag.recentComments}
                     expandAllThreads={expandAll}
-                    index={index}
                   />
+                  </AnalyticsContext>
                 )
               },
               tagRevised: {

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -15,7 +15,7 @@ import CommentsNodeInner from "../comments/CommentsNode";
 import { ContentItemBody } from "../contents/ContentItemBody";
 import ContentStyles from "../common/ContentStyles";
 import { maybeDate } from '@/lib/utils/dateUtils';
-import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -83,6 +83,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
 }) => {
   const [truncated, setTruncated] = useState(true);
   const [expandAllThreads, setExpandAllThreads] = useState(false);
+  const { captureEvent } = useTracking();
   
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: tag._id,
@@ -102,7 +103,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
       tagName: tag.name,
       pageSectionContext: "recentDiscussion"
     });
-  }, [tag._id, tag.name]);
+  }, [tag._id, tag.name, captureEvent]);
 
   
   const descriptionHtml = tag.description?.html;

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -15,7 +15,7 @@ import CommentsNodeInner from "../comments/CommentsNode";
 import { ContentItemBody } from "../contents/ContentItemBody";
 import ContentStyles from "../common/ContentStyles";
 import { maybeDate } from '@/lib/utils/dateUtils';
-import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -72,13 +72,12 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThreads: initialExpandAllThreads, tagCommentType = "DISCUSSION", index, classes }: {
+const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThreads: initialExpandAllThreads, tagCommentType = "DISCUSSION", classes }: {
   tag: TagRecentDiscussion,
   refetch?: any,
   comments: Array<CommentsList>,
   expandAllThreads?: boolean
   tagCommentType?: TagCommentType,
-  index?: number,
   classes: ClassesType<typeof styles>
 }) => {
   const [truncated, setTruncated] = useState(true);
@@ -88,7 +87,6 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: tag._id,
     documentType: 'tag',
-    index,
   });
   
   const lastCommentId = comments && comments[0]?._id
@@ -123,7 +121,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
   
   const metadataWording = tag.wikiOnly ? "Wiki page" : `${taggingNameCapitalSetting.get()} page - ${tag.postCount} posts`;
   
-  return <AnalyticsContext pageSubSectionContext='recentDiscussionTag' recentDiscussionCardIndex={index}>
+  return (
     <div ref={viewTrackingRef} className={classes.root}>
       <div className={classes.tag}>
         <Link to={tagGetDiscussionUrl(tag)} className={classes.title}>
@@ -162,7 +160,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
         </div>
       </div> : null}
     </div>
-  </AnalyticsContext>
+  )
 }
 
 export default registerComponent(

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -194,7 +194,6 @@ const RecentDiscussionThread = ({
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: post._id,
     documentType: 'post',
-    wordCount: post.contents?.wordCount,
   });
 
   if (isSkippable) {

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -162,7 +162,6 @@ const RecentDiscussionThread = ({
   isSubforumIntroPost,
   commentTreeOptions = {},
   dismissCallback = () => {},
-  index,
   classes,
 }: {
   post: PostsRecentDiscussion,
@@ -174,7 +173,6 @@ const RecentDiscussionThread = ({
   isSubforumIntroPost?: boolean,
   commentTreeOptions?: CommentTreeOptions,
   dismissCallback?: () => void,
-  index?: number,
   classes: ClassesType<typeof styles>,
 }) => {
   const currentUser = useCurrentUser();
@@ -196,7 +194,6 @@ const RecentDiscussionThread = ({
   const viewTrackingRef = useRecentDiscussionViewTracking({
     documentId: post._id,
     documentType: 'post',
-    index,
     wordCount: post.contents?.wordCount,
   });
 
@@ -209,63 +206,61 @@ const RecentDiscussionThread = ({
     [classes.noComments]: post.commentCount === null
   });
   return (
-    <AnalyticsContext pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={index}>
-      <div ref={viewTrackingRef} className={classNames(
-        classes.root,
+    <div ref={viewTrackingRef} className={classNames(
+      classes.root,
+      {
+        [classes.plainBackground]: !isSubforumIntroPost,
+        [classes.primaryBackground]: isSubforumIntroPost
+      }
+    )}>
+      <div className={classNames(
+        classes.post,
         {
-          [classes.plainBackground]: !isSubforumIntroPost,
           [classes.primaryBackground]: isSubforumIntroPost
         }
       )}>
-        <div className={classNames(
-          classes.post,
-          {
-            [classes.primaryBackground]: isSubforumIntroPost
-          }
-        )}>
-          <div className={classes.postItem}>
-            {post.group && <PostsGroupDetails post={post} documentId={post.group._id} inRecentDiscussion={true} />}
-            <div className={classes.titleAndActions}>
-              <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})} eventProps={{intent: 'expandPost'}}>
-                {post.title}
-              </Link>
-              {isSubforumIntroPost && currentUser ? <Button
-                className={classes.closeButton}
-                onClick={dismissCallback}
-              >
-                <CloseIcon className={classes.closeIcon} />
-              </Button> : <div className={classes.actions}>
-                <PostActionsButton post={post} autoPlace vertical />
-              </div>}
-            </div>
-            <div className={classNames(classes.threadMeta, {[classes.smallerMeta]: smallerFonts})} onClick={showHighlight}>
-              <PostsItemMeta post={post} hideTags={!isFriendlyUI}/>
-            </div>
+        <div className={classes.postItem}>
+          {post.group && <PostsGroupDetails post={post} documentId={post.group._id} inRecentDiscussion={true} />}
+          <div className={classes.titleAndActions}>
+            <Link to={postGetPageUrl(post)} className={classNames(classes.title, {[classes.smallerTitle]: smallerFonts})} eventProps={{intent: 'expandPost'}}>
+              {post.title}
+            </Link>
+            {isSubforumIntroPost && currentUser ? <Button
+              className={classes.closeButton}
+              onClick={dismissCallback}
+            >
+              <CloseIcon className={classes.closeIcon} />
+            </Button> : <div className={classes.actions}>
+              <PostActionsButton post={post} autoPlace vertical />
+            </div>}
           </div>
-          <div className={highlightClasses}>
-            <PostsHighlight post={post} maxLengthWords={maxLengthWords ?? lastVisitedAt ? 50 : 170} smallerFonts={smallerFonts} />
+          <div className={classNames(classes.threadMeta, {[classes.smallerMeta]: smallerFonts})} onClick={showHighlight}>
+            <PostsItemMeta post={post} hideTags={!isFriendlyUI}/>
           </div>
         </div>
-        <div className={classes.content}>
-          <div className={classes.commentsList}>
-            {!!nestedComments.length && nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
-              <div key={comment.item._id}>
-                <CommentsNodeInner
-                  treeOptions={treeOptions}
-                  startThreadTruncated={true}
-                  expandAllThreads={expandAllThreads}
-                  expandNewComments={false}
-                  nestingLevel={1}
-                  comment={comment.item}
-                  childComments={comment.children}
-                  key={comment.item._id}
-                />
-              </div>
-            )}
-          </div>
+        <div className={highlightClasses}>
+          <PostsHighlight post={post} maxLengthWords={maxLengthWords ?? lastVisitedAt ? 50 : 170} smallerFonts={smallerFonts} />
         </div>
       </div>
-    </AnalyticsContext>
+      <div className={classes.content}>
+        <div className={classes.commentsList}>
+          {!!nestedComments.length && nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
+            <div key={comment.item._id}>
+              <CommentsNodeInner
+                treeOptions={treeOptions}
+                startThreadTruncated={true}
+                expandAllThreads={expandAllThreads}
+                expandNewComments={false}
+                nestingLevel={1}
+                comment={comment.item}
+                childComments={comment.children}
+                key={comment.item._id}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   )
 };
 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThreadsList.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThreadsList.tsx
@@ -15,6 +15,7 @@ import LoadMore from "../common/LoadMore";
 import { NetworkStatus } from "@apollo/client";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
 import { gql } from "@/lib/generated/gql-codegen";
+import { AnalyticsContext } from '../../lib/analyticsEvents';
 
 const PostsRecentDiscussionMultiQuery = gql(`
   query multiPostRecentDiscussionThreadsListQuery($selector: PostSelector, $limit: Int, $enableTotal: Boolean, $commentsLimit: Int, $maxAgeHours: Int, $af: Boolean) {
@@ -92,13 +93,14 @@ const RecentDiscussionThreadsList = ({
       <div>
         {results && <div>
           {results.map((post, i) =>
+            <AnalyticsContext key={post._id} pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={i}>
             <RecentDiscussionThread
-              key={post._id}
               post={post}
               refetch={refetch}
               comments={post.recentComments ?? undefined}
               expandAllThreads={expandAll}
             />
+            </AnalyticsContext>
           )}
         </div>}
         <AnalyticsInViewTracker eventProps={{inViewType: "loadMoreButton"}}>

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionThread.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useRecordPostView } from "../hooks/useRecordPostView";
 import { ThreadableCommentType, unflattenComments } from "../../lib/utils/unflatten";
 import type { CommentTreeOptions } from "../comments/commentTree";
-import { captureEvent } from "../../lib/analyticsEvents";
+import { useTracking } from "../../lib/analyticsEvents";
 
 export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   post,
@@ -21,6 +21,7 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
   const [markedAsVisitedAt, setMarkedAsVisitedAt] = useState<Date|null>(null);
   const [expandAllThreads, setExpandAllThreads] = useState(initialExpandAllThreads ?? false);
   const {recordPostView, recordPostCommentsView} = useRecordPostView(post);
+  const { captureEvent } = useTracking();
 
   const markAsRead = useCallback(
     () => {
@@ -43,7 +44,7 @@ export const useRecentDiscussionThread = <T extends ThreadableCommentType>({
       
       markAsRead();
     },
-    [setHighlightVisible, highlightVisible, markAsRead, post._id, post.contents?.wordCount],
+    [setHighlightVisible, highlightVisible, markAsRead, post._id, post.contents?.wordCount, captureEvent],
   );
 
   const markCommentsAsRead = useCallback(

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
@@ -4,7 +4,6 @@ import { useTracking } from '../../lib/analyticsEvents';
 interface ViewTrackingOptions {
   documentId: string;
   documentType: 'post' | 'comment' | 'tag';
-  wordCount?: number;
 }
 
 const VIEW_THRESHOLD_MS = 2000;
@@ -17,7 +16,6 @@ const LONG_VIEW_THRESHOLD_MS = 10000;
 export function useRecentDiscussionViewTracking({
   documentId,
   documentType,
-  wordCount,
 }: ViewTrackingOptions) {
   const elementRef = useRef<HTMLDivElement | null>(null);
   const viewTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -63,7 +61,7 @@ export function useRecentDiscussionViewTracking({
         longViewTimerRef.current = null;
       }
     }
-  }, [documentId, documentType, wordCount, captureEvent]);
+  }, [documentId, documentType, captureEvent]);
 
   useEffect(() => {
     const element = elementRef.current;

--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { captureEvent } from '../../lib/analyticsEvents';
+import { useTracking } from '../../lib/analyticsEvents';
 
 interface ViewTrackingOptions {
   documentId: string;
   documentType: 'post' | 'comment' | 'tag';
-  index?: number;
   wordCount?: number;
 }
 
@@ -18,7 +17,6 @@ const LONG_VIEW_THRESHOLD_MS = 10000;
 export function useRecentDiscussionViewTracking({
   documentId,
   documentType,
-  index,
   wordCount,
 }: ViewTrackingOptions) {
   const elementRef = useRef<HTMLDivElement | null>(null);
@@ -26,6 +24,7 @@ export function useRecentDiscussionViewTracking({
   const longViewTimerRef = useRef<NodeJS.Timeout | null>(null);
   const hasLoggedViewRef = useRef(false);
   const hasLoggedLongViewRef = useRef(false);
+  const { captureEvent } = useTracking();
 
   const handleIntersection = useCallback((entries: IntersectionObserverEntry[]) => {
     const entry = entries[0];
@@ -38,8 +37,6 @@ export function useRecentDiscussionViewTracking({
             documentId,
             documentType,
             durationMs: VIEW_THRESHOLD_MS,
-            index,
-            wordCount,
           });
           hasLoggedViewRef.current = true;
         }, VIEW_THRESHOLD_MS);
@@ -51,8 +48,6 @@ export function useRecentDiscussionViewTracking({
             documentId,
             documentType,
             durationMs: LONG_VIEW_THRESHOLD_MS,
-            index,
-            wordCount,
           });
           hasLoggedLongViewRef.current = true;
         }, LONG_VIEW_THRESHOLD_MS);
@@ -68,7 +63,7 @@ export function useRecentDiscussionViewTracking({
         longViewTimerRef.current = null;
       }
     }
-  }, [documentId, documentType, index, wordCount]);
+  }, [documentId, documentType, wordCount, captureEvent]);
 
   useEffect(() => {
     const element = elementRef.current;

--- a/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
+++ b/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useDismissRecommendation } from './withDismissRecommendation';
-import { captureEvent, AnalyticsContext } from '../../lib/analyticsEvents';
+import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 import PostsItem from "../posts/PostsItem";
 import PostsLoading from "../posts/PostsLoading";
@@ -17,6 +17,7 @@ const ContinueReadingList = ({ continueReading, continueReadingLoading, limit=3,
   const dismissRecommendation = useDismissRecommendation();
   const [dismissedRecommendations, setDismissedRecommendations] = useState<any>({});
   const [showAll, setShowAll] = useState(false);
+  const { captureEvent } = useTracking();
   
   const dismissAndHideRecommendation = (postId: string) => {
     void dismissRecommendation(postId);

--- a/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
+++ b/packages/lesswrong/components/seasonal/HomepageMap/HomepageMapFilter.tsx
@@ -8,7 +8,7 @@ import EmailIcon from '@/lib/vendor/@material-ui/icons/src/Email';
 import { useDialog } from '../../common/withDialog'
 import { useCurrentUser } from '../../common/withUser';
 import moment from 'moment';
-import { captureEvent } from '../../../lib/analyticsEvents';
+import { useTracking } from '../../../lib/analyticsEvents';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { HIDE_MAP_COOKIE } from '../../../lib/cookies/cookies';
@@ -70,6 +70,7 @@ const HomepageMapFilter = ({classes}: {classes: ClassesType<typeof styles>}) => 
   const currentUser = useCurrentUser()
   const { flash } = useMessages()
   const updateCurrentUser = useUpdateCurrentUser();
+  const { captureEvent } = useTracking();
   
   const [_, setCookie, removeCookie] = useCookiesWithConsent([HIDE_MAP_COOKIE]);
 

--- a/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumSubforumTab.tsx
@@ -22,6 +22,7 @@ import PostsListSortDropdown from "../../posts/PostsListSortDropdown";
 import PostsLayoutDropdown from "../../posts/PostsLayoutDropdown";
 import { gql } from "@/lib/generated/gql-codegen";
 import { SubforumFeedQueries } from '@/components/common/feeds/feedQueries';
+import { AnalyticsContext } from '../../../lib/analyticsEvents';
 
 const UserTagRelDetailsUpdateMutation = gql(`
   mutation updateUserTagRelSubforumSubforumTab($selector: SelectorInput!, $data: UpdateUserTagRelDataInput!) {
@@ -142,6 +143,7 @@ const SubforumSubforumTab = ({
   const cardLayoutComponent = <>
     {tag.subforumIntroPost && !hideIntroPost && (
       <div className={classes.feedPostWrapper}>
+        <AnalyticsContext pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={0}>
         <RecentDiscussionThread
           key={tag.subforumIntroPost._id}
           post={{ ...tag.subforumIntroPost, recentComments: [] }}
@@ -152,6 +154,7 @@ const SubforumSubforumTab = ({
           dismissCallback={dismissIntroPost}
           isSubforumIntroPost
         />
+        </AnalyticsContext>
       </div>
     )}
     <MixedTypeFeed
@@ -167,10 +170,11 @@ const SubforumSubforumTab = ({
       }}
       renderers={{
         tagSubforumPosts: {
-          render: (post: PostsRecentDiscussion) => {
+          render: (post: PostsRecentDiscussion, index: number) => {
             // Remove the intro post from the feed IFF it has not been dismissed from the top
             return !(post._id === tag.subforumIntroPost?._id && !hideIntroPost) && (
               <div className={classes.feedPostWrapper}>
+                <AnalyticsContext pageSubSectionContext='recentDiscussionThread' recentDiscussionCardIndex={index}>
                 <RecentDiscussionThread
                   key={post._id}
                   post={{ ...post }}
@@ -180,6 +184,7 @@ const SubforumSubforumTab = ({
                   refetch={refetch}
                   smallerFonts
                 />
+                </AnalyticsContext>
               </div>
             );
           },

--- a/packages/lesswrong/components/themes/usePrefersDarkMode.tsx
+++ b/packages/lesswrong/components/themes/usePrefersDarkMode.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import { isClient } from "../../lib/executionEnvironment";
-import { captureEvent } from "../../lib/analyticsEvents";
+import { useTracking } from "../../lib/analyticsEvents";
 
 const prefersDarkModeContext = createContext(false);
 
@@ -18,6 +18,7 @@ export const PrefersDarkModeProvider = ({children}: {
 }) => {
   const [query] = useState(() => buildQuery());
   const [prefersDarkMode, setPrefersDarkMode] = useState(query.matches);
+  const { captureEvent } = useTracking();
 
   useEffect(() => {
     const handler = ({matches}: MediaQueryListEvent) => {
@@ -32,7 +33,7 @@ export const PrefersDarkModeProvider = ({children}: {
       query.addEventListener("change", handler);
       return () => query.removeEventListener("change", handler);
     }
-  }, [query]);
+  }, [query, captureEvent]);
 
   return (
     <prefersDarkModeContext.Provider value={prefersDarkMode}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -213,7 +213,12 @@ export const UltraFeedCompressedCommentsItem = ({
   const { captureEvent } = useTracking();
   
   const handleClick = () => {
-    captureEvent("ultraFeedCompressedCommentsClicked", { numComments });
+    captureEvent("ultraFeedCompressedCommentsClicked", { 
+      numComments,
+      numExpanded: Math.min(3, numComments), // We always expand max 3 at a time
+      isFirstComment,
+      isLastComment,
+    });
     setExpanded();
   };
   

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -4,7 +4,7 @@ import { defineStyles, useStyles } from "../hooks/useStyles";
 import { nofollowKarmaThreshold } from "../../lib/publicSettings";
 import { UltraFeedSettingsType, DEFAULT_SETTINGS } from "./ultraFeedSettingsTypes";
 import { useUltraFeedObserver } from "./UltraFeedObserver";
-import { AnalyticsContext, captureEvent } from "@/lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "@/lib/analyticsEvents";
 import { FeedCommentMetaInfo, FeedItemDisplayStatus } from "./ultraFeedTypes";
 import { useOverflowNav } from "./OverflowNavObserverContext";
 import { useDialog } from "../common/withDialog";
@@ -179,6 +179,7 @@ const BranchNavigationButton = ({
   onBranchToggle?: () => void;
 }) => {
   const classes = useStyles(styles);
+  const { captureEvent } = useTracking();
   
   const handleClick = () => {
     captureEvent("ultraFeedBranchNavigationClicked", { 
@@ -209,6 +210,7 @@ export const UltraFeedCompressedCommentsItem = ({
   isLastComment?: boolean,
 }) => {
   const classes = useStyles(styles);
+  const { captureEvent } = useTracking();
   
   const handleClick = () => {
     captureEvent("ultraFeedCompressedCommentsClicked", { numComments });
@@ -289,6 +291,7 @@ export const UltraFeedCommentItem = ({
   const { openDialog } = useDialog();
   const overflowNav = useOverflowNav(elementRef);
   const currentUser = useCurrentUser();
+  const { captureEvent } = useTracking();
   
   const cannotReplyReason = customCannotReplyReason ?? (userOwns(currentUser, comment) ? "You cannot reply to your own comment from within the feed" : null);
 
@@ -383,7 +386,7 @@ export const UltraFeedCommentItem = ({
       onChangeDisplayStatus("expanded");
     }
 
-  }, [trackExpansion, comment._id, comment.postId, displayStatus, onChangeDisplayStatus, metaInfo.servedEventId]);
+  }, [trackExpansion, comment._id, comment.postId, displayStatus, onChangeDisplayStatus, metaInfo.servedEventId, captureEvent]);
 
   const handleContinueReadingClick = useCallback(() => {
     captureEvent("ultraFeedCommentItemContinueReadingClicked");
@@ -398,7 +401,7 @@ export const UltraFeedCommentItem = ({
         />
       )
     });
-  }, [openDialog, comment]);
+  }, [openDialog, comment, captureEvent]);
 
   const truncationParams = useMemo(() => {
     const { displaySettings } = settings;

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsItemMeta.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { AnalyticsContext, captureEvent } from "../../lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { useCurrentUser } from "../common/withUser";
 import { defineStyles, useStyles } from "../hooks/useStyles";
@@ -265,6 +265,7 @@ const UltraFeedCommentsItemMeta = ({
   const currentUser = useCurrentUser();
   const [postTitleHighlighted, setPostTitleHighlighted] = useState(false);
   const { post } = comment;
+  const { captureEvent } = useTracking();
 
   if (!post) {
     return null;

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -466,7 +466,7 @@ const UltraFeedPostDialog = ({
     e.stopPropagation();
     const action = showEmbeddedPlayer ? "close" : "open";
     const newCookieValue = showEmbeddedPlayer ? "false" : "true";
-    captureEvent("toggleAudioPlayer", { action });
+    captureEvent("toggleAudioPlayer", { action, pageModalContext: "ultraFeedPostModal" });
     setCookie(
       SHOW_PODCAST_PLAYER_COOKIE,
       newCookieValue, {

--- a/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedThreadItem.tsx
@@ -385,12 +385,6 @@ const UltraFeedThreadItem = ({thread, index, settings = DEFAULT_SETTINGS, startR
                   <UltraFeedCompressedCommentsItem
                     numComments={hiddenCount}
                     setExpanded={() => {
-                      captureEvent("ultraFeedThreadItemCompressedCommentsExpanded", { 
-                        ultraCardIndex: index, 
-                        ultraCardCount: compressedItems.length,
-                        numExpanded: Math.min(3, hiddenCount)
-                      });
-                      
                       // Always expand max 3 comments at a time
                       item.hiddenComments.slice(0, 3).forEach(h => {
                         setDisplayStatus(h._id, "expanded");

--- a/packages/lesswrong/components/ultraFeed/useSeeLess.ts
+++ b/packages/lesswrong/components/ultraFeed/useSeeLess.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useMutation } from '@apollo/client/react';
 import { gql } from '@/lib/generated/gql-codegen';
 import { useCurrentUser } from '../common/withUser';
-import { captureEvent } from '@/lib/analyticsEvents';
+import { useTracking } from '@/lib/analyticsEvents';
 import { recombeeApi } from '@/lib/recombee/client';
 import { FeedbackOptions } from './SeeLessFeedback';
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback';
@@ -29,6 +29,7 @@ export const useSeeLess = ({ documentId, documentType, recommId }: UseSeeLessOpt
   const [seeLessEventId, setSeeLessEventId] = useState<string | null>(null);
   const [pendingFeedback, setPendingFeedback] = useState<FeedbackOptions | null>(null);
   const [updateUltraFeedEvent] = useMutation(updateUltraFeedEventMutation);
+  const { captureEvent } = useTracking();
 
   const handleSeeLess = useCallback((eventId: string) => {
     setIsSeeLessMode(true);
@@ -69,7 +70,7 @@ export const useSeeLess = ({ documentId, documentType, recommId }: UseSeeLessOpt
     });
     
     setSeeLessEventId(null);
-  }, [currentUser, seeLessEventId, documentId, documentType, recommId, updateUltraFeedEvent]);
+  }, [currentUser, seeLessEventId, documentId, documentType, recommId, updateUltraFeedEvent, captureEvent]);
 
   const debouncedFeedbackUpdate = useDebouncedCallback(async (feedback: FeedbackOptions) => {
     if (!seeLessEventId || seeLessEventId === 'pending') return;

--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -7,7 +7,7 @@ import { useMutation, useApolloClient } from '@apollo/client/react';
 import { useQuery } from "@/lib/crud/useQuery"
 import { hasEventsSetting, isAF, isEAForum, isLW, isLWorAF, verifyEmailsSetting } from '@/lib/instanceSettings';
 import { useThemeOptions, useSetTheme } from '@/components/themes/useTheme';
-import { captureEvent } from '@/lib/analyticsEvents';
+
 import { configureDatadogRum } from '@/client/datadogRum';
 import { isBookUI, isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import { useLocation, useNavigate } from '@/lib/routeUtil.tsx';
@@ -46,6 +46,7 @@ import ErrorAccessDenied from "../../common/ErrorAccessDenied";
 import { withDateFields } from '@/lib/utils/dateUtils';
 import { gql } from "@/lib/generated/gql-codegen";
 import { useFormErrors } from '@/components/tanstack-form-components/BaseAppForm';
+import { useTracking } from '@/lib/analyticsEvents';
 
 const UsersEditUpdateMutation = gql(`
   mutation updateUserUsersEditForm($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -1343,6 +1344,7 @@ const UsersEditForm = ({ terms }: {
   `), { errorPolicy: 'all' })
   const currentThemeOptions = useThemeOptions();
   const setTheme = useSetTheme();
+  const { captureEvent } = useTracking();
 
   const userHasEditAccess = userCanEditUser(currentUser, terms);
 


### PR DESCRIPTION
Many places in the codebase were erroneously importing captureEvent directly and not using it via hook, meaning the events don't get context from surround <AnalyticsContext>

Separately there was some issue with callbacks using captureEvent getting defined outside of the AnalyticsContext wrappers, and the solution being to pull the wrappers up higher. This dovetailed with removing the additional index props that had been added and weren't doing anything but be in the wrappers

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210769464637667) by [Unito](https://www.unito.io)
