### PR TITLE
Send inactive user summary email

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsSamplePage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsSamplePage.tsx
@@ -70,6 +70,8 @@ const getDefaultFeatures = (): Record<RecommendationFeatureName, string> => ({
   tagSimilarity: "1.5",
   collabFilter: "1",
   textSimilarity: "1",
+  subscribedAuthorPosts: "0",
+  subscribedTagPosts: "0",
 });
 
 const featureInputToFeatures = (

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -25,6 +25,8 @@ export const recommendationFeatureNames = new TupleSet([
   "tagSimilarity",
   "collabFilter",
   "textSimilarity",
+  "subscribedAuthorPosts",
+  "subscribedTagPosts",
 ] as const);
 
 export const isRecommendationFeatureName =

--- a/packages/lesswrong/lib/voting/eaEmojiPalette.ts
+++ b/packages/lesswrong/lib/voting/eaEmojiPalette.ts
@@ -62,6 +62,9 @@ export const getEAAnonymousEmojiByName = (targetName: string) =>
 export const getEAPublicEmojiByName = (targetName: string) =>
   eaEmojiPalette.find(({name}) => name === targetName)
 
+export const getEAEmojiByName = (targetName: string) =>
+  getEAAnonymousEmojiByName(targetName) ?? getEAPublicEmojiByName(targetName);
+
 export const getEAEmojisForKarmaChanges = (showNegative: boolean) => ({
   publicEmojis: eaEmojiPalette
     .filter(({isNegative}) => showNegative || !isNegative)

--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -31,7 +31,6 @@ import './server/manualMigrations/migrationsDashboardGraphql';
 import './server/legacy-redirects/routes';
 import './server/editor/utils';
 import './server/mapsUtils';
-import './server/emails/index';
 import './server/posts/index';
 
 import './server/analytics/serverAnalyticsWriter';

--- a/packages/lesswrong/server/cron/allCronJobs.ts
+++ b/packages/lesswrong/server/cron/allCronJobs.ts
@@ -7,6 +7,7 @@ import { cronDebouncedEventHandler } from "@/server/debouncer";
 import { cronUpdateMissingEmbeddings } from "@/server/embeddings";
 import { cronCheckAndSendUpcomingEventEmails } from "@/server/eventReminders";
 import { sendInactiveUserSurveyEmailsCron } from "@/server/inactiveUserSurveyCron";
+import { sendInactiveUserSummaryEmailsCron } from "@/server/emails/inactiveUserSummaryCron";
 import { refreshKarmaInflationCron } from "@/server/karmaInflation/cron";
 import { checkScheduledPostsCron } from "@/server/posts/cron";
 import { prunePerfMetricsCron } from "@/server/prunePerfMetricsCron";
@@ -33,6 +34,7 @@ export const allCronJobs: (CronJobSpec|null)[] = [
   cronUpdateMissingEmbeddings,
   cronCheckAndSendUpcomingEventEmails,
   sendInactiveUserSurveyEmailsCron,
+  sendInactiveUserSummaryEmailsCron,
   refreshKarmaInflationCron,
   checkScheduledPostsCron,
   prunePerfMetricsCron,

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -1,8 +1,8 @@
 import React, { Fragment } from "react";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
+import { getEAEmojiByName } from "@/lib/voting/eaEmojiPalette";
 import { getSiteUrl } from "@/lib/vulcan-lib/utils";
-import { truncate } from "@/lib/editor/ellipsize";
 import { EmailUsername } from "./EmailUsername";
 
 export type BestReaction = {name: string, count: number};
@@ -12,8 +12,9 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     background: theme.palette.text.alwaysWhite,
     color: theme.palette.text.alwaysBlack,
     fontFamily: theme.palette.fonts.sansSerifStack,
-    fontSize: 12,
+    fontSize: 14,
     fontWeight: 400,
+    lineHeight: "22px",
     width: 522,
     maxWidth: "100%",
     margin: "24px auto",
@@ -22,7 +23,7 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     marginBottom: 48,
   },
   heading: {
-    fontSize: 16,
+    fontSize: 20,
     fontWeight: 700,
   },
   mostCommentedPost: {
@@ -30,18 +31,20 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     color: "inherit",
   },
   notifications: {
-    fontSize: 11,
-    fontStyle: "italic",
+    fontSize: 12,
     textDecoration: "underline",
-    color: "inherit",
   },
   post: {
-    marginBottom: 40,
+    marginBottom: 20,
+    padding: "12px 24px",
+    background: theme.palette.grey[100],
+    borderRadius: theme.borderRadius.default,
   },
   postTitle: {
-    fontSize: 30,
+    fontSize: 32,
     fontWeight: 700,
     lineHeight: "36px",
+    textDecoration: "none",
     marginBottom: 0,
     color: "inherit",
   },
@@ -54,15 +57,18 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     textDecoration: "none",
   },
   postBody: {
-    fontFamily: theme.palette.fonts.serifStack,
-    fontSize: 12,
-    fontWeight: 400,
+    fontWeight: 500,
   },
   hr: {
     border: "none",
     borderBottom: `1px solid ${theme.palette.text.alwaysBlack}`,
   },
 }));
+
+const truncateDescription = (description: string = "") => {
+  const truncated = description.slice(0, 260);
+  return truncated.length < description.length ? truncated + "..." : truncated;
+}
 
 export const EmailInactiveUserSummary = ({
   user,
@@ -79,8 +85,9 @@ export const EmailInactiveUserSummary = ({
   unreadNotifications: number,
   recommendedPosts: PostsList[],
 }) => {
+  const bestEmoji = bestReaction ? getEAEmojiByName(bestReaction.name) : null;
   const showKarmaChange = karmaChange > 0;
-  const showBestReaction = bestReaction && bestReaction.count > 0;
+  const showBestReaction = bestReaction && bestReaction.count > 0 && bestEmoji;
   const showMostCommentedPost = mostCommentedPost && mostCommentedPost.commentCount > 0;
   const showUnreadNotifications = unreadNotifications > 0 && unreadNotifications < 5;
 
@@ -113,8 +120,9 @@ export const EmailInactiveUserSummary = ({
           }
           {showBestReaction &&
             <p>
-              You received {bestReaction.count} :{bestReaction.name}:{" "}
-              react{bestReaction.count > 1 ? 's' : ''}.
+              You received {bestReaction.count}{" "}
+              &quot;{bestEmoji.label.toLowerCase()}&quot;{" "}
+              react{bestReaction.count > 1 ? 's' : ''}
             </p>
           }
           {showMostCommentedPost &&
@@ -127,7 +135,7 @@ export const EmailInactiveUserSummary = ({
                 className={classes.mostCommentedPost}
               >
                 {mostCommentedPost.post.title}
-              </a>.
+              </a>
             </p>
           }
           <p>
@@ -159,19 +167,10 @@ export const EmailInactiveUserSummary = ({
               </Fragment>
             ))}
           </p>
-          {post.contents?.htmlHighlight &&
-            <div
-              dangerouslySetInnerHTML={{
-                __html: truncate(
-                  post.contents?.htmlHighlight,
-                  80,
-                  "words",
-                  "...",
-                  false,
-                ),
-              }}
-              className={classes.postBody}
-            />
+          {post.contents?.plaintextDescription &&
+            <div className={classes.postBody}>
+              {truncateDescription(post.contents.plaintextDescription)}
+            </div>
           }
         </div>
       ))}

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -75,6 +75,17 @@ export const EmailInactiveUserSummary = ({
   unreadNotifications: number,
   recommendedPosts: PostsList[],
 }) => {
+  const showKarmaChange = karmaChange > 0;
+  const showBestReaction = bestReaction && bestReaction.count > 0;
+  const showMostCommentedPost = mostCommentedPost && mostCommentedPost.commentCount > 0;
+  const showUnreadNotifications = unreadNotifications > 0;
+
+  const showNotificationsSection =
+    showKarmaChange ||
+    showBestReaction ||
+    showMostCommentedPost ||
+    showUnreadNotifications;
+
   const classes = useStyles(styles);
   return (
     <div className={classes.root}>
@@ -86,39 +97,44 @@ export const EmailInactiveUserSummary = ({
         things you’ve missed.
       </p>
       <div className={classes.spacing} />
-      <h2 className={classes.heading}>
-        Your notifications
-      </h2>
-      {karmaChange > 0 &&
-        <p>
-          You earned {karmaChange} karma.
-        </p>
+      {showNotificationsSection &&
+        <>
+          <h2 className={classes.heading}>
+            Your notifications
+          </h2>
+          {showKarmaChange &&
+            <p>
+              You earned {karmaChange} karma.
+            </p>
+          }
+          {showBestReaction &&
+            <p>
+              You received {bestReaction.count} :{bestReaction.name}:{" "}
+              react{bestReaction.count > 1 ? 's' : ''}.
+            </p>
+          }
+          {showMostCommentedPost &&
+            <p>
+              You got {mostCommentedPost.commentCount} new{" "}
+              {mostCommentedPost.commentCount === 1 ? "reply" : "replies"}{" "}
+              on your post{" "}
+              <a
+                href={postGetPageUrl(mostCommentedPost.post, true)}
+                className={classes.mostCommentedPost}
+              >
+                {mostCommentedPost.post.title}
+              </a>.
+            </p>
+          }
+          <p>
+            <a href={getSiteUrl()} className={classes.notifications}>
+              See all your notifications on the EA Forum
+              {showUnreadNotifications && ` (${unreadNotifications} unread)`}
+            </a>
+          </p>
+          <div className={classes.spacing} />
+        </>
       }
-      {bestReaction && bestReaction.count > 0 &&
-        <p>
-          You received {bestReaction.count} :{bestReaction.name}: react{bestReaction.count > 1 ? 's' : ''}.
-        </p>
-      }
-      {mostCommentedPost && mostCommentedPost.commentCount > 0 &&
-        <p>
-          You got {mostCommentedPost.commentCount} new{" "}
-          {mostCommentedPost.commentCount === 1 ? "reply" : "replies"}{" "}
-          on your post{" "}
-          <a
-            href={postGetPageUrl(mostCommentedPost.post, true)}
-            className={classes.mostCommentedPost}
-          >
-            {mostCommentedPost.post.title}
-          </a>.
-        </p>
-      }
-      <p>
-        <a href={getSiteUrl()} className={classes.notifications}>
-          See all your notifications on the EA Forum
-          {unreadNotifications > 0 && ` (${unreadNotifications} unread)`}
-        </a>
-      </p>
-      <div className={classes.spacing} />
       {recommendedPosts.length > 0 &&
         <h2 className={classes.heading}>
           Posts you might like

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -82,7 +82,7 @@ export const EmailInactiveUserSummary = ({
   const showKarmaChange = karmaChange > 0;
   const showBestReaction = bestReaction && bestReaction.count > 0;
   const showMostCommentedPost = mostCommentedPost && mostCommentedPost.commentCount > 0;
-  const showUnreadNotifications = unreadNotifications > 0;
+  const showUnreadNotifications = unreadNotifications > 0 && unreadNotifications < 5;
 
   const showNotificationsSection =
     showKarmaChange ||

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -75,27 +75,23 @@ export const EmailInactiveUserSummary = ({
   karmaChange,
   bestReaction,
   mostCommentedPost,
-  unreadNotifications,
   recommendedPosts,
 }: {
   user: DbUser,
   karmaChange: number,
   bestReaction?: BestReaction,
   mostCommentedPost?: {post: DbPost, commentCount: number},
-  unreadNotifications: number,
   recommendedPosts: PostsList[],
 }) => {
   const bestEmoji = bestReaction ? getEAEmojiByName(bestReaction.name) : null;
   const showKarmaChange = karmaChange > 0;
   const showBestReaction = bestReaction && bestReaction.count > 0 && bestEmoji;
   const showMostCommentedPost = mostCommentedPost && mostCommentedPost.commentCount > 0;
-  const showUnreadNotifications = unreadNotifications > 0 && unreadNotifications < 5;
 
   const showNotificationsSection =
     showKarmaChange ||
     showBestReaction ||
-    showMostCommentedPost ||
-    showUnreadNotifications;
+    showMostCommentedPost;
 
   const classes = useStyles(styles);
   return (
@@ -141,7 +137,6 @@ export const EmailInactiveUserSummary = ({
           <p>
             <a href={getSiteUrl()} className={classes.notifications}>
               See all your notifications on the EA Forum
-              {showUnreadNotifications && ` (${unreadNotifications} unread)`}
             </a>
           </p>
           <div className={classes.spacing} />

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -108,7 +108,7 @@ export const EmailInactiveUserSummary = ({
           </h2>
           {showKarmaChange &&
             <p>
-              You earned {karmaChange} karma.
+              You earned {karmaChange} karma 🎉
             </p>
           }
           {showBestReaction &&

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -101,7 +101,7 @@ export const EmailInactiveUserSummary = ({
   return (
     <div className={classes.root}>
       <p>
-        Hi <EmailUsername user={user} />,
+        Hi {user.displayName},
       </p>
       <p>
         We noticed you haven’t been on the EA Forum in a while. Here are some

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -36,9 +36,12 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
   },
   post: {
     marginBottom: 20,
-    padding: "12px 24px",
+    padding: "18px 24px",
     background: theme.palette.grey[100],
     borderRadius: theme.borderRadius.default,
+  },
+  postTitleWrapper: {
+    marginTop: 0,
   },
   postTitle: {
     fontSize: 32,
@@ -149,7 +152,7 @@ export const EmailInactiveUserSummary = ({
       }
       {recommendedPosts.map((post) => (
         <div className={classes.post} key={post._id}>
-          <h3>
+          <h3 className={classes.postTitleWrapper}>
             <a href={postGetPageUrl(post, true)} className={classes.postTitle}>
               {post.title}
             </a>

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -96,7 +96,7 @@ export const EmailInactiveUserSummary = ({
       }
       {bestReaction && bestReaction.count > 0 &&
         <p>
-          You received {bestReaction.count} :{bestReaction.name}:.
+          You received {bestReaction.count} :{bestReaction.name}: react{bestReaction.count > 1 ? 's' : ''}.
         </p>
       }
       {mostCommentedPost && mostCommentedPost.commentCount > 0 &&

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -17,7 +17,6 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     lineHeight: "22px",
     width: 522,
     maxWidth: "100%",
-    margin: "24px auto",
   },
   spacing: {
     marginBottom: 48,

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -60,7 +60,7 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     textDecoration: "none",
   },
   postBody: {
-    fontWeight: 500,
+    fontWeight: 400,
   },
   hr: {
     border: "none",

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { defineStyles, useStyles } from "@/components/hooks/useStyles";
+import { postGetPageUrl } from "@/lib/collections/posts/helpers";
+import { getSiteUrl } from "@/lib/vulcan-lib/utils";
+import { truncate } from "@/lib/editor/ellipsize";
+import { EmailUsername } from "./EmailUsername";
+
+export type BestReaction = {name: string, count: number};
+
+const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
+  root: {
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    fontSize: 12,
+    fontWeight: 400,
+    width: 522,
+    maxWidth: "100%",
+    margin: "24px auto",
+  },
+  spacing: {
+    marginBottom: 48,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: 700,
+  },
+  mostCommentedPost: {
+    textDecoration: "underline",
+    color: "inherit",
+  },
+  notifications: {
+    fontSize: 11,
+  },
+  notificationsLink: {
+    fontStyle: "italic",
+    textDecoration: "underline",
+    color: "inherit",
+  },
+  post: {
+    marginBottom: 40,
+  },
+  postTitle: {
+    fontSize: 30,
+    fontWeight: 700,
+    marginBottom: 0,
+    color: "inherit",
+  },
+  postAuthors: {
+    marginBottom: 16,
+  },
+  postBody: {
+    fontFamily: theme.palette.fonts.serifStack,
+    fontSize: 12,
+    fontWeight: 400,
+  },
+}));
+
+export const EmailInactiveUserSummary = ({
+  user,
+  karmaChange,
+  bestReaction,
+  mostCommentedPost,
+  unreadNotifications,
+  recommendedPosts,
+}: {
+  user: DbUser,
+  karmaChange: number,
+  bestReaction?: BestReaction,
+  mostCommentedPost?: {post: DbPost, commentCount: number},
+  unreadNotifications: number,
+  recommendedPosts: PostsList[],
+}) => {
+  const classes = useStyles(styles);
+  return (
+    <div className={classes.root}>
+      <p>
+        Hi <EmailUsername user={user} />,
+      </p>
+      <p>
+        We noticed you haven’t been on the EA Forum in a while. Here are some
+        things you’ve missed.
+      </p>
+      <div className={classes.spacing} />
+      <h2 className={classes.heading}>
+        Your notifications
+      </h2>
+      {karmaChange > 0 &&
+        <p>
+          You earned {karmaChange} karma.
+        </p>
+      }
+      {bestReaction && bestReaction.count > 0 &&
+        <p>
+          You received {bestReaction.count} :{bestReaction.name}:.
+        </p>
+      }
+      {mostCommentedPost && mostCommentedPost.commentCount > 0 &&
+        <p>
+          You got {mostCommentedPost.commentCount} new{" "}
+          {mostCommentedPost.commentCount === 1 ? "reply" : "replies"}{" "}
+          on your post{" "}
+          <a
+            href={postGetPageUrl(mostCommentedPost.post, true)}
+            className={classes.mostCommentedPost}
+          >
+            {mostCommentedPost.post.title}
+          </a>.
+        </p>
+      }
+      <p className={classes.notifications}>
+        {unreadNotifications > 0
+          ? (
+            <>
+              You have {unreadNotifications} unread notifications -{" "}
+              <a href={getSiteUrl()} className={classes.notificationsLink}>
+                View on the EA Forum
+              </a>
+            </>
+          )
+          : (
+            <a href={getSiteUrl()} className={classes.notificationsLink}>
+              See all your notifications on the EA Forum
+            </a>
+          )
+        }
+      </p>
+      <div className={classes.spacing} />
+      {recommendedPosts.length > 0 &&
+        <h2 className={classes.heading}>
+          Posts you might like
+        </h2>
+      }
+      {recommendedPosts.map((post) => (
+        <div className={classes.post} key={post._id}>
+          <h3>
+            <a href={postGetPageUrl(post, true)} className={classes.postTitle}>
+              {post.title}
+            </a>
+          </h3>
+          <p className={classes.postAuthors}>
+            by {post.user?.displayName}
+          </p>
+          {post.contents?.htmlHighlight &&
+            <div
+              dangerouslySetInnerHTML={{
+                __html: truncate(
+                  post.contents?.htmlHighlight,
+                  80,
+                  "words",
+                  "...",
+                  false,
+                ),
+              }}
+              className={classes.postBody}
+            />
+          }
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -9,6 +9,8 @@ export type BestReaction = {name: string, count: number};
 
 const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
   root: {
+    background: theme.palette.text.alwaysWhite,
+    color: theme.palette.text.alwaysBlack,
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: 12,
     fontWeight: 400,
@@ -51,6 +53,10 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     fontFamily: theme.palette.fonts.serifStack,
     fontSize: 12,
     fontWeight: 400,
+  },
+  hr: {
+    border: "none",
+    borderBottom: `1px solid ${theme.palette.text.alwaysBlack}`,
   },
 }));
 
@@ -155,6 +161,7 @@ export const EmailInactiveUserSummary = ({
           }
         </div>
       ))}
+      <hr className={classes.hr} />
     </div>
   );
 };

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -43,10 +43,12 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
   postTitle: {
     fontSize: 30,
     fontWeight: 700,
+    lineHeight: "36px",
     marginBottom: 0,
     color: "inherit",
   },
   postAuthors: {
+    fontWeight: 500,
     marginBottom: 16,
   },
   postBody: {

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { getSiteUrl } from "@/lib/vulcan-lib/utils";
@@ -46,8 +46,12 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
     color: "inherit",
   },
   postAuthors: {
-    fontWeight: 500,
     marginBottom: 16,
+  },
+  postAuthor: {
+    fontWeight: 500,
+    color: theme.palette.text.alwaysBlack,
+    textDecoration: "none",
   },
   postBody: {
     fontFamily: theme.palette.fonts.serifStack,
@@ -148,7 +152,12 @@ export const EmailInactiveUserSummary = ({
             </a>
           </h3>
           <p className={classes.postAuthors}>
-            by {post.user?.displayName}
+            by <EmailUsername user={post.user} className={classes.postAuthor} />
+            {post.coauthors.map((coauthor) => (
+              <Fragment key={coauthor._id}>
+                {", "}<EmailUsername user={coauthor} className={classes.postAuthor} />
+              </Fragment>
+            ))}
           </p>
           {post.contents?.htmlHighlight &&
             <div

--- a/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailInactiveUserSummary.tsx
@@ -31,8 +31,6 @@ const styles = defineStyles("EmailInactiveUserSummary", (theme: ThemeType) => ({
   },
   notifications: {
     fontSize: 11,
-  },
-  notificationsLink: {
     fontStyle: "italic",
     textDecoration: "underline",
     color: "inherit",
@@ -114,22 +112,11 @@ export const EmailInactiveUserSummary = ({
           </a>.
         </p>
       }
-      <p className={classes.notifications}>
-        {unreadNotifications > 0
-          ? (
-            <>
-              You have {unreadNotifications} unread notifications -{" "}
-              <a href={getSiteUrl()} className={classes.notificationsLink}>
-                View on the EA Forum
-              </a>
-            </>
-          )
-          : (
-            <a href={getSiteUrl()} className={classes.notificationsLink}>
-              See all your notifications on the EA Forum
-            </a>
-          )
-        }
+      <p>
+        <a href={getSiteUrl()} className={classes.notifications}>
+          See all your notifications on the EA Forum
+          {unreadNotifications > 0 && ` (${unreadNotifications} unread)`}
+        </a>
       </p>
       <div className={classes.spacing} />
       {recommendedPosts.length > 0 &&

--- a/packages/lesswrong/server/emailComponents/EmailUsername.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailUsername.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { userGetProfileUrl } from '../../lib/collections/users/helpers';
 
-export const EmailUsername = ({user}: {
+export const EmailUsername = ({user, className}: {
   user: UsersMinimumInfo|DbUser|null|undefined
+  className?: string,
 }) => {
-  if (!user) return <span>[deleted]</span>
-  return <a href={userGetProfileUrl(user, true)}>{user.displayName}</a>
+  if (!user) {
+    return <span className={className}>[deleted]</span>;
+  }
+  return (
+    <a href={userGetProfileUrl(user, true)} className={className}>
+      {user.displayName}
+    </a>
+  );
 }
 

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -16,8 +16,9 @@ const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-export const EmailWrapper = ({unsubscribeAllLink, children}: {
+export const EmailWrapper = ({unsubscribeAllLink, centerFooter, children}: {
   unsubscribeAllLink: string | null,
+  centerFooter?: boolean,
   children: React.ReactNode,
 }) => {
   const classes = useStyles(styles);
@@ -57,6 +58,9 @@ export const EmailWrapper = ({unsubscribeAllLink, children}: {
   const innerTdProps: any = {
     bgcolor: "#ffffff",
   };
+  const footerProps: any = {
+    align: centerFooter ? "center" : undefined,
+  };
   
   return (
     <body {...bodyProps}>
@@ -78,7 +82,7 @@ export const EmailWrapper = ({unsubscribeAllLink, children}: {
                         {children}
                       </td>
                     </tr>
-                    <tr><td className="container-padding">
+                    <tr><td className="container-padding" {...footerProps}>
                       <br/>
                       {unsubscribeAllLink && <>
                         <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -16,9 +16,8 @@ const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-export const EmailWrapper = ({unsubscribeAllLink, centerFooter, children}: {
+export const EmailWrapper = ({unsubscribeAllLink, children}: {
   unsubscribeAllLink: string | null,
-  centerFooter?: boolean,
   children: React.ReactNode,
 }) => {
   const classes = useStyles(styles);
@@ -58,10 +57,6 @@ export const EmailWrapper = ({unsubscribeAllLink, centerFooter, children}: {
   const innerTdProps: any = {
     bgcolor: "#ffffff",
   };
-  const footerProps: any = {
-    align: centerFooter ? "center" : undefined,
-  };
-  
   return (
     <body {...bodyProps}>
       <br/>
@@ -82,7 +77,7 @@ export const EmailWrapper = ({unsubscribeAllLink, centerFooter, children}: {
                         {children}
                       </td>
                     </tr>
-                    <tr><td className="container-padding" {...footerProps}>
+                    <tr><td className="container-padding">
                       <br/>
                       {unsubscribeAllLink && <>
                         <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -3,6 +3,7 @@ import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import { isFriendlyUI } from '@/themes/forumTheme';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import classNames from 'classnames';
 
 const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
   root: {
@@ -10,6 +11,9 @@ const styles = defineStyles("EmailWrapper", (theme: ThemeType) => ({
     "& img": {
       maxWidth: "100%",
     }
+  },
+  unsubscribe: {
+    fontWeight: isFriendlyUI ? 400 : undefined,
   },
 }))
 
@@ -77,15 +81,17 @@ export const EmailWrapper = ({unsubscribeAllLink, children}: {
                         {children}
                       </td>
                     </tr>
-                    <tr><td className="container-padding">
-                      <br/>
-                      {unsubscribeAllLink && <>
-                        <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}
-                        (from all emails from {siteNameWithArticle})
-                        or <a href={accountLink}>Change your notifications settings</a>
-                      </>}
-                      <br/>
-                    </td></tr>
+                    <tr>
+                      <td className={classNames("container-padding", classes.unsubscribe)}>
+                        <br/>
+                        {unsubscribeAllLink && <>
+                          <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}
+                          (from all emails from {siteNameWithArticle})
+                          or <a href={accountLink}>Change your notifications settings</a>
+                        </>}
+                        <br/>
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </td>

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { hasInactiveSummaryEmail } from "@/lib/betas"
+import { generateEmail, wrapAndSendEmail } from "./renderEmail";
+import { fetchFragment } from "../fetchFragment";
+import {
+  BestReaction,
+  EmailInactiveUserSummary,
+} from "../emailComponents/EmailInactiveUserSummary";
+import FeatureStrategy from "../recommendations/FeatureStrategy";
+import Notifications from "../collections/notifications/collection";
+import Users from "../collections/users/collection";
+import UsersRepo from "../repos/UsersRepo";
+import VotesRepo from "../repos/VotesRepo";
+import PostsRepo from "../repos/PostsRepo";
+import sum from "lodash/sum";
+
+const chooseBestReaction = (
+  reactions: Record<string, number>,
+): BestReaction | undefined => {
+  const entries = Object.entries(reactions);
+  const maxEntry = entries.reduce(
+    (max, entry) => entry[1] > max[1] ? entry : max,
+    entries[0],
+  );
+  return maxEntry ? {name: maxEntry[0], count: maxEntry[1]} : undefined;
+}
+
+const sendInactiveUserSummaryEmail = async (
+  {fetchActivitySince, ...user}: DbUser & {fetchActivitySince: Date},
+  dryRun = false,
+) => {
+  if (!hasInactiveSummaryEmail || !user.email) {
+    return;
+  }
+
+  const now = new Date();
+  const votesRepo = new VotesRepo();
+  const postsRepo = new PostsRepo();
+  const [
+    karmaChanges,
+    reacts,
+    agreements,
+    mostCommentedPost,
+    unreadNotifications,
+    recommendations,
+  ] = await Promise.all([
+    votesRepo.getEAKarmaChanges({
+      userId: user._id,
+      startDate: fetchActivitySince,
+      endDate: now,
+      showNegative: true,
+    }),
+    votesRepo.getEAWrappedReactsReceived(user._id, fetchActivitySince, now),
+    votesRepo.getEAWrappedAgreements(user._id, fetchActivitySince, now),
+    postsRepo.getUsersMostCommentedPostSince(user._id, fetchActivitySince),
+    Notifications.find({
+      userId: user._id,
+      createdAt: {$gt: fetchActivitySince},
+      viewed: false,
+      emailed: false,
+      deleted: false,
+    }).count(),
+    new FeatureStrategy().recommend(user, 5, {
+      name: "feature",
+      postId: "",
+      features: [
+        {feature: "curated", weight: 1},
+        {feature: "karma", weight: 0.1},
+      ],
+    }, {
+      publishedAfter: fetchActivitySince,
+    }),
+  ]);
+
+  const karmaChange = sum(karmaChanges.map(({scoreChange}) => scoreChange));
+  const reactions = {...reacts, ...agreements};
+  const bestReaction = chooseBestReaction(reactions);
+
+  const recommendedPosts = await fetchFragment({
+    collectionName: "Posts",
+    fragmentName: "PostsList",
+    currentUser: user,
+    selector: {
+      _id: { $in: recommendations.posts.map((post) => post._id) },
+    },
+  });
+
+  const from = "EA Forum Team <eaforum@centreforeffectivealtruism.org>";
+  const subject = "See what you’ve missed on the Forum";
+  const tag = "inactive-user-summary";
+  const utmParams = {
+    utm_source: "inactive_user_summary",
+    utm_user_id: user._id,
+  };
+  const body = (
+    <EmailInactiveUserSummary
+      user={user}
+      karmaChange={karmaChange}
+      bestReaction={bestReaction}
+      mostCommentedPost={mostCommentedPost ?? undefined}
+      unreadNotifications={unreadNotifications}
+      recommendedPosts={recommendedPosts}
+    />
+  );
+
+  if (dryRun) {
+    const email = await generateEmail({
+      user,
+      from,
+      to: user.email,
+      subject,
+      bodyComponent: body,
+      utmParams,
+      tag,
+    });
+    // eslint-disable-next-line no-console
+    console.log("Generated dry-run email HTML:", email.html);
+  } else {
+    await wrapAndSendEmail({user, from, subject, body, utmParams, tag});
+    await Users.rawUpdateOne(
+      {_id: user._id},
+      {$set: {inactiveSummaryEmailSentAt: now}},
+    );
+  }
+}
+
+export const sendInactiveUserSummaryEmails = async (
+  limit = 10,
+  dryRun = false,
+) => {
+  if (!hasInactiveSummaryEmail) {
+    return;
+  }
+
+  const promises: Promise<void>[] = [];
+  const users = await new UsersRepo().getUsersForInactiveSummaryEmail(limit);
+  for (const user of users) {
+    try {
+      promises.push(sendInactiveUserSummaryEmail(user, dryRun));
+    } catch (err) {
+      console.error(
+        `Error sending inactive user summary email to ${user._id}`,
+        err,
+      );
+    }
+  }
+  await Promise.all(promises);
+}

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -14,6 +14,7 @@ import UsersRepo from "../repos/UsersRepo";
 import VotesRepo from "../repos/VotesRepo";
 import PostsRepo from "../repos/PostsRepo";
 import sum from "lodash/sum";
+import { addCronJob } from "../cron/cronUtil";
 
 const chooseBestReaction = (
   reactions: Record<string, number>,
@@ -144,7 +145,7 @@ const sendInactiveUserSummaryEmail = async (
 }
 
 export const sendInactiveUserSummaryEmails = async (
-  limit = 10,
+  limit = 20,
   dryRun = false,
 ) => {
   if (!hasInactiveSummaryEmail) {
@@ -165,3 +166,10 @@ export const sendInactiveUserSummaryEmails = async (
     }
   }
 }
+
+export const sendInactiveUserSummaryEmailsCron = addCronJob({
+  name: "sendInactiveUserSummaryEmails",
+  interval: "every 1 day",
+  disabled: !hasInactiveSummaryEmail,
+  job: sendInactiveUserSummaryEmails,
+});

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -23,7 +23,7 @@ const chooseBestReaction = (
     (max, entry) => entry[1] > max[1] ? entry : max,
     entries[0],
   );
-  return maxEntry ? {name: maxEntry[0], count: maxEntry[1]} : undefined;
+  return maxEntry?.[1] ? {name: maxEntry[0], count: maxEntry[1]} : undefined;
 }
 
 const sendInactiveUserSummaryEmail = async (
@@ -119,6 +119,7 @@ const sendInactiveUserSummaryEmail = async (
           {body}
         </EmailWrapper>
       ),
+      includeCustomFonts: true,
       utmParams,
       tag,
     });
@@ -131,6 +132,7 @@ const sendInactiveUserSummaryEmail = async (
       subject,
       body,
       utmParams,
+      includeCustomFonts: true,
       tag,
       centerFooter: true,
     });

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -8,7 +8,6 @@ import {
 } from "../emailComponents/EmailInactiveUserSummary";
 import { EmailWrapper } from "../emailComponents/EmailWrapper";
 import FeatureStrategy from "../recommendations/FeatureStrategy";
-import Notifications from "../collections/notifications/collection";
 import Users from "../collections/users/collection";
 import UsersRepo from "../repos/UsersRepo";
 import VotesRepo from "../repos/VotesRepo";
@@ -45,7 +44,6 @@ const sendInactiveUserSummaryEmail = async (
     reacts,
     agreements,
     mostCommentedPost,
-    unreadNotifications,
     recommendations,
   ] = await Promise.all([
     votesRepo.getEAKarmaChanges({
@@ -57,13 +55,6 @@ const sendInactiveUserSummaryEmail = async (
     votesRepo.getEAReactsReceived(user._id, fetchActivitySince, now),
     votesRepo.getEAAgreements(user._id, fetchActivitySince, now),
     postsRepo.getUsersMostCommentedPostSince(user._id, fetchActivitySince),
-    Notifications.find({
-      userId: user._id,
-      createdAt: {$gt: fetchActivitySince},
-      viewed: false,
-      emailed: false,
-      deleted: false,
-    }).count(),
     featureStrategy.recommend(user, 5, {
       name: "feature",
       postId: "",
@@ -105,7 +96,6 @@ const sendInactiveUserSummaryEmail = async (
       karmaChange={karmaChange}
       bestReaction={bestReaction}
       mostCommentedPost={mostCommentedPost ?? undefined}
-      unreadNotifications={unreadNotifications}
       recommendedPosts={recommendedPosts}
     />
   );

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -111,7 +111,7 @@ const sendInactiveUserSummaryEmail = async (
       to: user.email,
       subject,
       bodyComponent: (
-        <EmailWrapper unsubscribeAllLink="#">
+        <EmailWrapper unsubscribeAllLink="#" centerFooter>
           {body}
         </EmailWrapper>
       ),
@@ -121,7 +121,15 @@ const sendInactiveUserSummaryEmail = async (
     // eslint-disable-next-line no-console
     console.log("Generated dry-run email HTML:", email.html);
   } else {
-    await wrapAndSendEmail({user, from, subject, body, utmParams, tag});
+    await wrapAndSendEmail({
+      user,
+      from,
+      subject,
+      body,
+      utmParams,
+      tag,
+      centerFooter: true,
+    });
     await Users.rawUpdateOne(
       {_id: user._id},
       {$set: {inactiveSummaryEmailSentAt: now}},

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -50,7 +50,6 @@ const sendInactiveUserSummaryEmail = async (
       userId: user._id,
       startDate: fetchActivitySince,
       endDate: now,
-      showNegative: true,
     }),
     votesRepo.getEAReactsReceived(user._id, fetchActivitySince, now),
     votesRepo.getEAAgreements(user._id, fetchActivitySince, now),

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -96,6 +96,7 @@ const sendInactiveUserSummaryEmail = async (
   const tag = "inactive-user-summary";
   const utmParams = {
     utm_source: "inactive_user_summary",
+    utm_medium: "email",
     utm_user_id: user._id,
   };
   const body = (

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -117,7 +117,7 @@ const sendInactiveUserSummaryEmail = async (
       to: user.email,
       subject,
       bodyComponent: (
-        <EmailWrapper unsubscribeAllLink="#" centerFooter>
+        <EmailWrapper unsubscribeAllLink="#">
           {body}
         </EmailWrapper>
       ),
@@ -136,7 +136,6 @@ const sendInactiveUserSummaryEmail = async (
       utmParams,
       includeCustomFonts: true,
       tag,
-      centerFooter: true,
     });
     await Users.rawUpdateOne(
       {_id: user._id},

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -67,8 +67,10 @@ const sendInactiveUserSummaryEmail = async (
       name: "feature",
       postId: "",
       features: [
-        {feature: "curated", weight: 1},
-        {feature: "karma", weight: 0.1},
+        {feature: "subscribedAuthorPosts", weight: 1},
+        {feature: "subscribedTagPosts", weight: 0.9},
+        {feature: "curated", weight: 0.75},
+        {feature: "karma", weight: 0.4},
       ],
     }, {
       publishedAfter: fetchActivitySince,

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -243,6 +243,7 @@ export const wrapAndRenderEmail = async ({
   from,
   subject,
   body,
+  centerFooter,
   utmParams,
   tag,
 }: {
@@ -251,6 +252,7 @@ export const wrapAndRenderEmail = async ({
   from?: string;
   subject: string;
   body: React.ReactNode;
+  centerFooter?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
 }): Promise<RenderedEmail> => {
@@ -260,11 +262,14 @@ export const wrapAndRenderEmail = async ({
     to,
     from,
     subject: subject,
-    bodyComponent: <EmailWrapper
-      unsubscribeAllLink={unsubscribeAllLink}
-    >
-      {body}
-    </EmailWrapper>,
+    bodyComponent: (
+      <EmailWrapper
+        unsubscribeAllLink={unsubscribeAllLink}
+        centerFooter={centerFooter}
+      >
+        {body}
+      </EmailWrapper>
+    ),
     utmParams,
     tag,
   });
@@ -277,6 +282,7 @@ export const wrapAndSendEmail = async ({
   from,
   subject,
   body,
+  centerFooter,
   utmParams,
   tag,
 }: {
@@ -286,6 +292,7 @@ export const wrapAndSendEmail = async ({
   from?: string;
   subject: string;
   body: React.ReactNode;
+  centerFooter?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
 }): Promise<boolean> => {
@@ -312,6 +319,7 @@ export const wrapAndSendEmail = async ({
       body,
       utmParams,
       tag,
+      centerFooter,
     });
     const succeeded = await sendEmail(email);
     void logSentEmail(email, user, {succeeded});

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -89,12 +89,32 @@ const emailGlobalCss = () => `
   }
 `;
 
-function addEmailBoilerplate({ css, title, body }: {
+const getEmailCustomFontLinks = () => {
+  const theme = getForumTheme({name: "default"});
+  const {fontDownloads} = theme.typography;
+  if (!fontDownloads?.length) {
+    return "";
+  }
+  const links = fontDownloads.map((href) => (
+    `<link href='${href}' rel='stylesheet' type='text/css'>`
+  ));
+  // Desktop outlook chokes on external font references
+  return `\n<!--[if !mso]><!-->\n${links.join("\n")}\n<!--<![endif]-->`;
+}
+
+type BoilerplateGenerator = (options: {
   css: string,
   title: string,
-  body: string
-}): string
-{
+  body: string,
+  includeCustomFonts?: boolean,
+}) => string;
+
+const addEmailBoilerplate: BoilerplateGenerator = ({
+  css,
+  title,
+  body,
+  includeCustomFonts,
+}) => {
   return `
     <html lang="en">
     <head>
@@ -103,8 +123,8 @@ function addEmailBoilerplate({ css, title, body }: {
       <meta name="viewport" content="initial-scale=1.0"/>
       <!-- disable auto telephone linking in iOS -->
       <meta name="format-detection" content="telephone=no"/>
-   
       <title>${title}</title>
+      ${includeCustomFonts ? getEmailCustomFontLinks() : ""}
       <style>
         ${emailGlobalCss()}
         ${css}
@@ -142,7 +162,8 @@ export async function generateEmail({
   from,
   subject,
   bodyComponent,
-  boilerplateGenerator=addEmailBoilerplate,
+  boilerplateGenerator = addEmailBoilerplate,
+  includeCustomFonts,
   utmParams,
   tag,
 }: {
@@ -151,7 +172,8 @@ export async function generateEmail({
   from?: string,
   subject: string,
   bodyComponent: React.ReactNode,
-  boilerplateGenerator?: (props: {css: string, title: string, body: string}) => string,
+  boilerplateGenerator?: BoilerplateGenerator,
+  includeCustomFonts?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
 }): Promise<RenderedEmail>
@@ -201,8 +223,13 @@ export async function generateEmail({
   // Get JSS styles, which were added to sheetsRegistry as a byproduct of
   // renderToString.
   const css = generateEmailStylesheet({ stylesContext, theme, themeOptions });
-  const html = boilerplateGenerator({ css, body, title:subject })
-  
+  const html = boilerplateGenerator({
+    css,
+    body,
+    title: subject,
+    includeCustomFonts,
+  });
+
   // Find any relative links, and convert them to absolute
   const htmlWithAbsoluteUrls = makeAllUrlsAbsolute(html, getSiteUrl());
   const htmlWithUtmParams = utmifyForumBacklinks({ html: htmlWithAbsoluteUrls, utmParams, siteUrl: getSiteUrl() });
@@ -244,6 +271,7 @@ export const wrapAndRenderEmail = async ({
   subject,
   body,
   centerFooter,
+  includeCustomFonts,
   utmParams,
   tag,
 }: {
@@ -253,6 +281,7 @@ export const wrapAndRenderEmail = async ({
   subject: string;
   body: React.ReactNode;
   centerFooter?: boolean,
+  includeCustomFonts?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
 }): Promise<RenderedEmail> => {
@@ -271,6 +300,7 @@ export const wrapAndRenderEmail = async ({
       </EmailWrapper>
     ),
     utmParams,
+    includeCustomFonts,
     tag,
   });
 }
@@ -283,6 +313,7 @@ export const wrapAndSendEmail = async ({
   subject,
   body,
   centerFooter,
+  includeCustomFonts,
   utmParams,
   tag,
 }: {
@@ -293,6 +324,7 @@ export const wrapAndSendEmail = async ({
   subject: string;
   body: React.ReactNode;
   centerFooter?: boolean,
+  includeCustomFonts?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
 }): Promise<boolean> => {
@@ -318,6 +350,7 @@ export const wrapAndSendEmail = async ({
       subject,
       body,
       utmParams,
+      includeCustomFonts,
       tag,
       centerFooter,
     });

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -270,7 +270,6 @@ export const wrapAndRenderEmail = async ({
   from,
   subject,
   body,
-  centerFooter,
   includeCustomFonts,
   utmParams,
   tag,
@@ -280,7 +279,6 @@ export const wrapAndRenderEmail = async ({
   from?: string;
   subject: string;
   body: React.ReactNode;
-  centerFooter?: boolean,
   includeCustomFonts?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
@@ -292,10 +290,7 @@ export const wrapAndRenderEmail = async ({
     from,
     subject: subject,
     bodyComponent: (
-      <EmailWrapper
-        unsubscribeAllLink={unsubscribeAllLink}
-        centerFooter={centerFooter}
-      >
+      <EmailWrapper unsubscribeAllLink={unsubscribeAllLink}>
         {body}
       </EmailWrapper>
     ),
@@ -312,7 +307,6 @@ export const wrapAndSendEmail = async ({
   from,
   subject,
   body,
-  centerFooter,
   includeCustomFonts,
   utmParams,
   tag,
@@ -323,7 +317,6 @@ export const wrapAndSendEmail = async ({
   from?: string;
   subject: string;
   body: React.ReactNode;
-  centerFooter?: boolean,
   includeCustomFonts?: boolean,
   utmParams?: Partial<Record<UtmParam, string>>;
   tag: string,
@@ -352,7 +345,6 @@ export const wrapAndSendEmail = async ({
       utmParams,
       includeCustomFonts,
       tag,
-      centerFooter,
     });
     const succeeded = await sendEmail(email);
     void logSentEmail(email, user, {succeeded});

--- a/packages/lesswrong/server/recommendations/Feature.ts
+++ b/packages/lesswrong/server/recommendations/Feature.ts
@@ -98,6 +98,42 @@ class TextSimilarityFeature extends Feature {
   }
 }
 
+class SubscribedAuthorPostsFeature extends Feature {
+  getJoin() {
+    return `
+      LEFT JOIN "Subscriptions" author_subs ON
+        author_subs."collectionName" = 'Users' AND
+        author_subs."state" = 'subscribed' AND
+        author_subs."deleted" IS NOT TRUE AND
+        author_subs."type" = 'newPosts' AND
+        author_subs."userId" = $(userId) AND
+        author_subs."documentId" = p."userId"
+    `;
+  }
+
+  getScore() {
+    return `(CASE WHEN author_subs."_id" IS NULL THEN 0 ELSE 1 END)`;
+  }
+}
+
+class SubscribedTagPostsFeature extends Feature {
+  getJoin() {
+    return `
+      LEFT JOIN "Subscriptions" tag_subs ON
+        tag_subs."collectionName" = 'Tags' AND
+        tag_subs."state" = 'subscribed' AND
+        tag_subs."deleted" IS NOT TRUE AND
+        tag_subs."type" = 'newTagPosts' AND
+        tag_subs."userId" = $(userId) AND
+        (p."tagRelevance"->tag_subs."documentId")::INTEGER >= 1
+    `;
+  }
+
+  getScore() {
+    return `(CASE WHEN tag_subs."_id" IS NULL THEN 0 ELSE 1 END)`;
+  }
+}
+
 export const featureRegistry: Record<
   RecommendationFeatureName,
   ConstructableFeature
@@ -107,4 +143,6 @@ export const featureRegistry: Record<
   tagSimilarity: TagSimilarityFeature,
   collabFilter: CollabFilterFeature,
   textSimilarity: TextSimilarityFeature,
+  subscribedAuthorPosts: SubscribedAuthorPostsFeature,
+  subscribedTagPosts: SubscribedTagPostsFeature,
 };

--- a/packages/lesswrong/server/recommendations/FeatureStrategy.ts
+++ b/packages/lesswrong/server/recommendations/FeatureStrategy.ts
@@ -38,10 +38,10 @@ class FeatureStrategy extends RecommendationStrategy {
     let args = {};
 
     if (options?.publishedAfter) {
-      filters += `p."createdAt" > $(publishedAfter) AND `;
+      filters += `p."postedAt" > $(publishedAfter) AND `;
     }
     if (options?.publishedBefore) {
-      filters += `p."createdAt" < $(publishedBefore) AND `;
+      filters += `p."postedAt" < $(publishedBefore) AND `;
     }
 
     for (const {feature: featureName, weight} of features) {

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1290,7 +1290,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         SELECT "_id", UNNEST("coauthorStatuses")->>'userId' "coauthorId"
         FROM "Posts"
       ) q ON p."_id" = q."_id"
-      JOIN "Comments" c ON p."_id" = c."postId"
+      JOIN "Comments" c ON p."_id" = c."postId" AND NOT c."draft" AND NOT c."deleted"
       WHERE
         (p."userId" = $1 OR q."coauthorId" = $1)
         AND ${getViewablePostsSelector("p")}

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1291,7 +1291,8 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       ) q ON p."_id" = q."_id"
       JOIN "Comments" c ON p."_id" = c."postId"
       WHERE
-        p."userId" = $1 OR q."coauthorId" = $1
+        (p."userId" = $1 OR q."coauthorId" = $1)
+        AND ${getViewablePostsSelector("p")}
       GROUP BY p."_id"
       ORDER BY "commentCount" DESC
       LIMIT 1

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1281,20 +1281,20 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   } | null> {
     return this.getRawDb().oneOrNone(`
       -- PostsRepo.getUsersMostCommentedPostSince
-        SELECT
-          ROW_TO_JSON(p.*) "post",
-          COUNT(c.*) FILTER (WHERE c."postedAt" > $2) "commentCount"
-        FROM "Posts" p
-        LEFT JOIN (
-          SELECT "_id", UNNEST("coauthorStatuses")->>'userId' "coauthorId"
-          FROM "Posts"
-        ) q ON p."_id" = q."_id"
-        JOIN "Comments" c ON p."_id" = c."postId"
-        WHERE
-          p."userId" = $1 OR q."coauthorId" = $1
-        GROUP BY p."_id"
-        ORDER BY "commentCount" DESC
-        LIMIT 1
+      SELECT
+        ROW_TO_JSON(p.*) "post",
+        COUNT(c.*) FILTER (WHERE c."postedAt" > $2) "commentCount"
+      FROM "Posts" p
+      LEFT JOIN (
+        SELECT "_id", UNNEST("coauthorStatuses")->>'userId' "coauthorId"
+        FROM "Posts"
+      ) q ON p."_id" = q."_id"
+      JOIN "Comments" c ON p."_id" = c."postId"
+      WHERE
+        p."userId" = $1 OR q."coauthorId" = $1
+      GROUP BY p."_id"
+      ORDER BY "commentCount" DESC
+      LIMIT 1
     `, [userId, since]);
   }
 

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -565,18 +565,23 @@ class UsersRepo extends AbstractRepo<"Users"> {
       WHERE
         (
           (
-            -- Exactly 21 days since last active and no email in that time
-            rs."max_last_updated"::DATE = (CURRENT_DATE - INTERVAL '21 days')::DATE
-            AND (
+            -- User has never received a summary email, or they read a post since the last summary email:
+            -- Send a summary email if it's been 21+ days since they last visited
+            (
               u."inactiveSummaryEmailSentAt" IS NULL
               OR u."inactiveSummaryEmailSentAt" < rs."max_last_updated"
             )
-          ) OR (
-            -- 50+ days since last email (or never sent) and no site visits since
-            (
-              u."inactiveSummaryEmailSentAt" IS NULL
-              OR u."inactiveSummaryEmailSentAt" <= CURRENT_DATE - INTERVAL '50 days'
+            AND (
+              rs."max_last_updated" <= CURRENT_DATE - INTERVAL '21 days'
+              OR (
+                rs."max_last_updated" IS NULL
+                AND u."createdAt" <= CURRENT_DATE - INTERVAL '21 days'
+              )
             )
+          ) OR (
+            -- User hasn't read a post since their last summary email:
+            -- Send a summary email if it's been 50+ days since the last summary email
+            u."inactiveSummaryEmailSentAt" <= CURRENT_DATE - INTERVAL '50 days'
             AND (
               rs."max_last_updated" IS NULL
               OR rs."max_last_updated" < u."inactiveSummaryEmailSentAt"

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -558,6 +558,7 @@ class UsersRepo extends AbstractRepo<"Users"> {
       LEFT JOIN (
         SELECT "userId", MAX("lastUpdated") AS max_last_updated
         FROM "ReadStatuses"
+        WHERE "isRead" IS TRUE
         GROUP BY "userId"
       ) AS rs ON u._id = rs."userId"
       WHERE

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -580,7 +580,7 @@ class UsersRepo extends AbstractRepo<"Users"> {
           OR u."sunshineNotes" IS NULL
           OR u."sunshineNotes" = ''
         )
-        AND u."karma" >= -10
+        AND u."karma" >= 0
       ORDER BY rs."max_last_updated" DESC
       LIMIT $1
     `, [limit])

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -558,7 +558,6 @@ class UsersRepo extends AbstractRepo<"Users"> {
       LEFT JOIN (
         SELECT "userId", MAX("lastUpdated") AS max_last_updated
         FROM "ReadStatuses"
-        WHERE "isRead" IS TRUE
         GROUP BY "userId"
       ) AS rs ON u._id = rs."userId"
       WHERE

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -552,7 +552,8 @@ class UsersRepo extends AbstractRepo<"Users"> {
         u.*,
         GREATEST(
           u."inactiveSummaryEmailSentAt",
-          rs."max_last_updated"
+          rs."max_last_updated",
+          u."createdAt"
         ) "fetchActivitySince"
       FROM public."Users" AS u
       LEFT JOIN (

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -596,6 +596,7 @@ class UsersRepo extends AbstractRepo<"Users"> {
           OR u."sunshineNotes" = ''
         )
         AND u."karma" >= 0
+        AND u."email" IS NOT NULL
       ORDER BY rs."max_last_updated" DESC
       LIMIT $1
     `, [limit])

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -667,7 +667,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     `, [userId]);
   }
 
-  async getEAWrappedReactsReceived(
+  async getEAReactsReceived(
     userId: string,
     start: Date,
     end: Date,
@@ -676,7 +676,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
       `COUNT(*) FILTER (WHERE ("extendedVoteType"->'${name}')::BOOLEAN) AS "${name}"`,
     );
     const result = await this.getRawDb().oneOrNone(`
-      -- VotesRepo.getEAWrappedReactsReceived
+      -- VotesRepo.getEAReactsReceived
       SELECT ${fields.join(", ")}
       FROM "Votes"
       WHERE
@@ -696,7 +696,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     return result;
   }
 
-  async getEAWrappedReactsGiven(
+  async getEAReactsGiven(
     userId: string,
     start: Date,
     end: Date,
@@ -705,7 +705,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
       `COUNT(*) FILTER (WHERE ("extendedVoteType"->'${name}')::BOOLEAN) AS "${name}"`,
     );
     const result = await this.getRawDb().oneOrNone(`
-      -- VotesRepo.getEAWrappedReactsGiven
+      -- VotesRepo.getEAReactsGiven
       SELECT ${fields.join(", ")}
       FROM "Votes"
       WHERE
@@ -725,13 +725,13 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     return result;
   }
 
-  async getEAWrappedAgreements(
+  async getEAAgreements(
     userId: string,
     start: Date,
     end: Date,
   ): Promise<Record<"agree" | "disagree", number>> {
     const result = await this.getRawDb().oneOrNone(`
-      -- VotesRepo.getEAWrappedAgreements
+      -- VotesRepo.getEAAgreements
       SELECT
         COUNT(*) FILTER
           (WHERE ("extendedVoteType"->'agree')::BOOLEAN IS TRUE) AS "agree",
@@ -754,6 +754,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
     }
     return result;
   }
+
   async getNetKarmaChangesForAuthorsOverPeriod(days: number, limit: number): Promise<Array<{ userId: string; netKarma: number }>> {
     return this.getRawDb().any(`
       -- VotesRepo.getNetKarmaChangesForAuthorsOverPeriod

--- a/packages/lesswrong/server/wrapped/wrappedDataByYear.ts
+++ b/packages/lesswrong/server/wrapped/wrappedDataByYear.ts
@@ -190,9 +190,9 @@ export const getWrappedDataByYear = async (
     repos.comments.getAuthorshipStats({ userId: user._id, year, shortform: true }),
     readAuthorStatsPromise,
     repos.posts.getReadCoreTagStats({ userId: user._id, year }),
-    repos.votes.getEAWrappedReactsReceived(userId, start, end),
-    repos.votes.getEAWrappedReactsGiven(userId, start, end),
-    repos.votes.getEAWrappedAgreements(userId, start, end),
+    repos.votes.getEAReactsReceived(userId, start, end),
+    repos.votes.getEAReactsGiven(userId, start, end),
+    repos.votes.getEAAgreements(userId, start, end),
     repos.comments.getEAWrappedDiscussionsStarted(userId, start, end),
   ]);
 


### PR DESCRIPTION
[Figma](https://www.figma.com/design/vt5B6OD5AEcmzhjn9S0ps7/2024-Q4?node-id=244-9&m=dev)

You can generate some test emails (without actually sending them) with:
```
yarn repl prod "packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx" "sendInactiveUserSummaryEmails(10, true)"
```
Then you can copy the HTML from the console output and paste it into [https://app.postdrop.io/](https://app.postdrop.io/) for a preview.

This PR also includes logic to load Inter and Merriwether, but very few email clients actually support this so most users will actually end up with Helvetica and Georgia which are the highest precedence web-safe fonts in our stack.

Below is an example email (this was generated with real data, so I've redacted the username and post title for the sake of the publicly posted screenshots):

<img width="741" height="839" alt="Screenshot 2025-07-17 at 14 39 04" src="https://github.com/user-attachments/assets/2ec8e235-295a-4b82-8b4c-930ffc1551e6" />
<img width="741" height="839" alt="Screenshot 2025-07-17 at 11 55 33" src="https://github.com/user-attachments/assets/98c7eeae-ec03-4a0a-a138-d78b0ced16b8" />
<img width="740" height="563" alt="Screenshot 2025-07-17 at 11 55 42" src="https://github.com/user-attachments/assets/8e8ad094-4a9e-41e9-8cfc-0b8ad0995d01" />


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210799768106931) by [Unito](https://www.unito.io)
