### PR TITLE
Ultrafeed Better Analytics 20250714

### DIFF
--- a/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
+++ b/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
@@ -115,6 +115,14 @@ const AnalyticsPageInitializer = () => {
     const { setTimerIsActive } = useCountUpTimer([10, 30], 60)
     const { updateLastActivity } = useSessionManagement()
 
+    const userIsIdleRef = useRef(userIsIdle);
+    const pageIsVisibleRef = useRef(pageIsVisible);
+
+    useEffect(() => {
+      userIsIdleRef.current = userIsIdle;
+      pageIsVisibleRef.current = pageIsVisible;
+    }, [userIsIdle, pageIsVisible]);
+
     useEffect(() => {
       setTimerIsActive(pageIsVisible && !userIsIdle); //disable timer whenever tab hidden or user inactive
     }, [pageIsVisible, userIsIdle, setTimerIsActive])
@@ -126,14 +134,14 @@ const AnalyticsPageInitializer = () => {
     }, [userIsIdle, pageIsVisible, updateLastActivity])
 
     useEffect(() => {
-      if (!userIsIdle && pageIsVisible) {
-        const interval = setInterval(() => {
+      const interval = setInterval(() => {
+        if (!userIsIdleRef.current && pageIsVisibleRef.current) {
           updateLastActivity();
-        }, 120 * 1000); // 120 seconds
+        }
+      }, 120 * 1000);
 
-        return () => clearInterval(interval);
-      }
-    }, [userIsIdle, pageIsVisible, updateLastActivity])
+      return () => clearInterval(interval);
+    }, [updateLastActivity])
 
   return <></>
 };

--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -92,29 +92,24 @@ const LWHome = () => {
             </SuspenseWrapper>
           </SingleColumnSection>}
           <SuspenseWrapper name="LWHomePosts" fallback={<div style={{height: 800}}/>}>
-            <AnalyticsInViewTracker
-              eventProps={{inViewType: "homePosts"}}
-              observerProps={{threshold:[0, 0.5, 1]}}
-            >
-              <LWHomePosts>
-                <QuickTakesSection />
-                <SuspenseWrapper name="EAPopularCommentsSection">
-                  <EAPopularCommentsSection />
-                </SuspenseWrapper>
-                
+            <LWHomePosts>
+              <QuickTakesSection />
+              <SuspenseWrapper name="EAPopularCommentsSection">
+                <EAPopularCommentsSection />
+              </SuspenseWrapper>
+              
+              <AnalyticsInViewTracker eventProps={{inViewType: "feedSection"}} observerProps={{threshold:[0, 0.5, 1]}}>
                 <SuspenseWrapper name="UltraFeed">
-                  {shouldShowUltraFeed ? (
-                    <UltraFeed />
-                  ) : (
-                    <RecentDiscussionFeed
+                  {shouldShowUltraFeed && <UltraFeed />}
+                  {!shouldShowUltraFeed && <RecentDiscussionFeed
                       af={false}
                       commentsLimit={4}
                       maxAgeHours={18}
-                    />
-                  )}
+                    />}
                 </SuspenseWrapper>
-              </LWHomePosts>
-            </AnalyticsInViewTracker>
+              </AnalyticsInViewTracker>
+
+            </LWHomePosts>
           </SuspenseWrapper>
         </React.Fragment>
       </AnalyticsContext>

--- a/packages/lesswrong/components/hooks/useSessionManagement.ts
+++ b/packages/lesswrong/components/hooks/useSessionManagement.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
+import { randomId } from '../../lib/random';
+import { clientContextVars, useTracking } from '../../lib/analyticsEvents';
+import { isClient } from '../../lib/executionEnvironment';
+
+const SESSION_STORAGE_KEY = 'lwSessionTracker';
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+interface SessionData {
+  sessionId: string;
+  lastActivityTimestamp: number;
+}
+
+export function useSessionManagement() {
+  const [sessionData, setSessionData] = useState<SessionData | null>(null);
+  const sessionDataRef = useRef<SessionData | null>(null);
+  const { captureEvent } = useTracking();
+
+  useEffect(() => {
+    sessionDataRef.current = sessionData;
+  }, [sessionData]);
+
+  const getOrCreateSession = useCallback((): SessionData => {
+    const ls = getBrowserLocalStorage();
+    if (!ls) {
+      return { sessionId: randomId(), lastActivityTimestamp: Date.now() };
+    }
+
+    const storedData = ls.getItem(SESSION_STORAGE_KEY);
+    if (storedData) {
+      try {
+        const parsed = JSON.parse(storedData) as SessionData;
+        if (Date.now() - parsed.lastActivityTimestamp < SESSION_TIMEOUT_MS) {
+          return parsed;
+        }
+        const newSession: SessionData = {
+          sessionId: randomId(),
+          lastActivityTimestamp: Date.now()
+        };
+        ls.setItem(SESSION_STORAGE_KEY, JSON.stringify(newSession));
+        captureEvent('sessionStarted', { previousSessionId: parsed.sessionId, previousSessionLastActivity: parsed.lastActivityTimestamp });
+        
+        return newSession;
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to parse session data", e);
+      }
+    }
+
+    const newSession: SessionData = {
+      sessionId: randomId(),
+      lastActivityTimestamp: Date.now()
+    };
+    ls.setItem(SESSION_STORAGE_KEY, JSON.stringify(newSession));
+    captureEvent('sessionStarted');
+    
+    return newSession;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateLastActivity = useCallback(() => {
+    const ls = getBrowserLocalStorage();
+    if (!ls || !sessionDataRef.current) return;
+
+    const updatedSession = { ...sessionDataRef.current, lastActivityTimestamp: Date.now() };
+    ls.setItem(SESSION_STORAGE_KEY, JSON.stringify(updatedSession));
+    setSessionData(updatedSession);
+  }, []);
+
+  useEffect(() => {
+    const session = getOrCreateSession();
+    setSessionData(session);
+    
+    if (isClient) {
+      clientContextVars.sessionId = session.sessionId;
+    }
+
+    // Listen for cross-tab session updates
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === SESSION_STORAGE_KEY && e.newValue) {
+        try {
+          const newSession = JSON.parse(e.newValue) as SessionData;
+          setSessionData(newSession);
+          if (isClient) {
+            clientContextVars.sessionId = newSession.sessionId;
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("Failed to parse session data from storage event", err);
+        }
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, [getOrCreateSession]);
+
+  return { sessionData, updateLastActivity };
+} 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -131,7 +131,7 @@ const RecentDiscussionFeed = ({
     : undefined;
 
   return (
-    <AnalyticsContext pageSectionContext="recentDiscussion" recentDiscussionContext={{ sessionId }}>
+    <AnalyticsContext pageSectionContext="recentDiscussion" recentDiscussionContext={{ feedSessionId: sessionId }}>
       <AnalyticsInViewTracker eventProps={{inViewType: "recentDiscussion"}}>
         <SingleColumnSection>
           <SectionTitle title={title} titleClassName={classes.titleText}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -30,6 +30,7 @@ import { ultraFeedEnabledSetting } from '../../lib/publicSettings';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import UltraFeedFeedback from './UltraFeedFeedback';
+import AnalyticsInViewTracker from '../common/AnalyticsInViewTracker';
 
 const ULTRAFEED_SESSION_ID_KEY = 'ultraFeedSessionId';
 
@@ -244,6 +245,7 @@ const UltraFeedContent = ({alwaysShow = false}: {
 
   return (
     <AnalyticsContext pageSectionContext="ultraFeed" ultraFeedContext={{ feedSessionId: sessionId }}>
+      <AnalyticsInViewTracker eventProps={{inViewType: "ultraFeed"}}>
       <div className={classes.root}>
         <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode}>
         <OverflowNavObserverProvider>
@@ -357,6 +359,7 @@ const UltraFeedContent = ({alwaysShow = false}: {
           </div>
         )}
       </div>
+      </AnalyticsInViewTracker>
     </AnalyticsContext>
   );
 };

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -243,7 +243,7 @@ const UltraFeedContent = ({alwaysShow = false}: {
   </>;
 
   return (
-    <AnalyticsContext pageSectionContext="ultraFeed" ultraFeedContext={{ sessionId }}>
+    <AnalyticsContext pageSectionContext="ultraFeed" ultraFeedContext={{ feedSessionId: sessionId }}>
       <div className={classes.root}>
         <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode}>
         <OverflowNavObserverProvider>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
@@ -16,7 +16,7 @@ import { useModalHashLinkScroll, scrollToElementInContainer } from "../hooks/use
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
 import { NetworkStatus } from "@apollo/client";
 import FootnoteDialog from '../linkPreview/FootnoteDialog';
-import { AnalyticsContext } from "@/lib/analyticsEvents";
+import { AnalyticsContext, useTracking } from "@/lib/analyticsEvents";
 
 const CommentsListMultiQuery = gql(`
   query multiCommentUltraFeedCommentsDialogQuery($selector: CommentSelector, $limit: Int, $enableTotal: Boolean) {
@@ -151,6 +151,7 @@ const UltraFeedCommentsDialog = ({
   onClose: () => void,
 }) => {
   const classes = useStyles(styles);
+  const { captureEvent } = useTracking();
   const scrollableContentRef = useRef<HTMLDivElement>(null);
   const [footnoteDialogHTML, setFootnoteDialogHTML] = useState<string | null>(null);
 
@@ -200,7 +201,12 @@ const UltraFeedCommentsDialog = ({
   const isLoading = loadingPost || (loadingComments && networkStatus !== NetworkStatus.fetchMore);
   const loadingMoreComments = (networkStatus === NetworkStatus.fetchMore);
 
-  useDialogNavigation(onClose);
+  const handleClose = () => {
+    captureEvent("ultraFeedDialogClosed", { collectionName: "Comments", postId, commentId: targetCommentId, });
+    onClose();
+  };
+
+  useDialogNavigation(handleClose);
   useDisableBodyScroll();
   
   // Necessary because other changes to comments can trigger the scroll useEffect to run again
@@ -247,7 +253,7 @@ const UltraFeedCommentsDialog = ({
   return (
     <LWDialog
       open={true}
-      onClose={onClose}
+      onClose={handleClose}
       fullWidth
       paperClassName={classes.dialogPaper}
     >
@@ -256,7 +262,7 @@ const UltraFeedCommentsDialog = ({
         <div className={classes.stickyHeader}>
           <ForumIcon 
             icon="Close"
-            onClick={onClose}
+            onClick={handleClose}
             className={classes.closeButton}
           />
           {postDataForTree
@@ -265,7 +271,7 @@ const UltraFeedCommentsDialog = ({
                 className={classes.title}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onClose();
+                  handleClose();
                 }}
               >
                 {postTitle}

--- a/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedItemFooter.tsx
@@ -377,7 +377,7 @@ const UltraFeedItemFooterCore = ({
         userId: currentUser._id,
         eventType: 'interacted' as const,
         documentId: voteProps.document._id,
-        collectionName: voteProps.collectionName as "Posts" | "Comments" | "Spotlights",
+        collectionName: voteProps.collectionName,
         feedItemId: metaInfo?.servedEventId,
         event: { interactionType },
       }

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -486,11 +486,16 @@ const UltraFeedPostDialog = ({
   });
   const hasTocData = !!tocData && (tocData.sections ?? []).length > 0;
 
+  const handleClose = () => {
+    captureEvent("ultraFeedDialogClosed", { collectionName: "Posts", postId: postId ?? post?._id });
+    onClose();
+  };
+
   // Handle dialog navigation (browser back button / swipe back navigation  + replacing url)
   const postUrl = displayPost 
     ? `${postGetPageUrl(displayPost)}?${qs.stringify({ from: 'feedModal' })}`
     : undefined;
-  useDialogNavigation(onClose, postUrl);
+  useDialogNavigation(handleClose, postUrl);
   useDisableBodyScroll();
   
   // Handle clicks on hash links (like footnotes) within the modal. If we don't do this, clicking on hash links can close the modal, fail to scroll, etc.
@@ -565,7 +570,7 @@ const UltraFeedPostDialog = ({
   return (
     <LWDialog
       open={true}
-      onClose={onClose}
+      onClose={handleClose}
       fullWidth
       paperClassName={classes.dialogPaper}
       className={classes.modalWrapper}
@@ -584,7 +589,7 @@ const UltraFeedPostDialog = ({
               <div className={classes.stickyHeader}>
                 <ForumIcon 
                   icon="Close"
-                  onClick={onClose}
+                  onClick={handleClose}
                   className={classes.closeButton}
                 />
                 {tocButton}
@@ -638,7 +643,7 @@ const UltraFeedPostDialog = ({
                             className={classes.title}
                             onClick={(e) => {
                               e.stopPropagation();
-                              onClose();
+                              handleClose();
                             }
                           }>
                             {displayPost.title}

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -155,7 +155,7 @@ export interface LinearCommentThreadStatistics {
 }
 
 export interface UltraFeedAnalyticsContext {
-  sessionId: string;
+  feedSessionId: string;
 }
 export interface ThreadEngagementStats {
   threadTopLevelId: string;

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -21,7 +21,8 @@ export const clientContextVars: {
   userId?: string | undefined;
   clientId?: string;
   tabId?: string | null;
-  abTestGroupsUsed?: RelevantTestGroupAllocation
+  abTestGroupsUsed?: RelevantTestGroupAllocation;
+  sessionId?: string;
 } = {};
 
 function getShowAnalyticsDebug() {
@@ -127,7 +128,7 @@ export type AnalyticsProps = {
   ultraFeedElementType?: FeedItemType,
   ultraFeedCardId?: string,
   ultraFeedCardIndex?: number,
-  recentDiscussionContext?: { sessionId: string },
+  recentDiscussionContext?: { feedSessionId: string },
   recentDiscussionCardIndex?: number,
   /** @deprecated Use `pageSectionContext` instead */
   listContext?: string,


### PR DESCRIPTION
- ultrafeed view events also logged to server
- sessionId for all tabs and events going on on a device at once
- inView tracking around the feeds
- track when dialogs close

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210805413907560) by [Unito](https://www.unito.io)
