### PR TITLE
Ultrafeed fix ckeditor interactions closing modal

### DIFF
--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -48,6 +48,7 @@ import { SuspenseWrapper } from './SuspenseWrapper';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import PostsLoading from '../posts/PostsLoading';
 import { registerComponent } from '@/lib/vulcan-lib/components';
+import AnalyticsInViewTracker from './AnalyticsInViewTracker';
 
 const SubscriptionStateMultiQuery = gql(`
   query multiSubscriptionLWHomePostsQuery($selector: SubscriptionSelector, $limit: Int, $enableTotal: Boolean) {
@@ -636,6 +637,10 @@ const LWHomePosts = ({ children, }: {
 
   return (
     // TODO: do we need capturePostItemOnMount here?
+    <AnalyticsInViewTracker
+      eventProps={{inViewType: "postsFeed"}}
+      observerProps={{threshold:[0, 0.5, 1]}}
+    >
     <AnalyticsContext pageSectionContext="postsFeed">
       <SingleColumnSection>
         <div className={classes.settingsVisibilityControls}>
@@ -731,6 +736,7 @@ const LWHomePosts = ({ children, }: {
         </>}
       </SingleColumnSection>
     </AnalyticsContext>
+    </AnalyticsInViewTracker>
   )
 }
 

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentsDialog.tsx
@@ -255,6 +255,7 @@ const UltraFeedCommentsDialog = ({
       open={true}
       onClose={handleClose}
       fullWidth
+      disableBackdropClick
       paperClassName={classes.dialogPaper}
     >
       <AnalyticsContext pageModalContext="ultraFeedCommentsModal" postId={postId} commentId={targetCommentId}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -572,6 +572,7 @@ const UltraFeedPostDialog = ({
       open={true}
       onClose={handleClose}
       fullWidth
+      disableBackdropClick
       paperClassName={classes.dialogPaper}
       className={classes.modalWrapper}
     >


### PR DESCRIPTION
- ckEditor toolbar interactions closed the ultrafeed modals, fixed by disabling outside clicks (they're full sceen anyway)
- failed to commit an AnalyticsInViewTracker in the last PR