### PR TITLE
Clear `add` param on keyword page after adding

### DIFF
--- a/packages/lesswrong/components/keywords/KeywordsPage.tsx
+++ b/packages/lesswrong/components/keywords/KeywordsPage.tsx
@@ -3,9 +3,10 @@ import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useUpdateCurrentUser } from "../hooks/useUpdateCurrentUser";
 import { useCurrentUser } from "../common/withUser";
 import { useMessages } from "../common/withMessages";
-import { useLocation } from "@/lib/routeUtil";
+import { useLocation, useNavigate } from "@/lib/routeUtil";
 import { Link } from "@/lib/reactRouterWrapper";
 import { AnalyticsContext } from "@/lib/analyticsEvents";
+import qs from "qs";
 import uniq from "lodash/uniq";
 import classNames from "classnames";
 import SingleColumnSection from "../common/SingleColumnSection";
@@ -125,13 +126,18 @@ const KeywordsPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
   }, [flash, updateCurrentUser, keywordAlerts]);
 
   // Automatically add a keyword from the ?add= query param (used on search page)
-  const {query} = useLocation();
-  const keywordToAdd = query.add;
+  const navigate = useNavigate();
+  const location = useLocation();
   useEffect(() => {
+    const {add: keywordToAdd, ...restOfQuery} = location.query;
     if (keywordToAdd) {
       void saveKeyword(keywordToAdd);
+      navigate(
+        {...location, search: qs.stringify(restOfQuery)},
+        {replace: true},
+      );
     }
-  }, [keywordToAdd, saveKeyword]);
+  }, [navigate, location, saveKeyword]);
 
   if (!currentUser) {
     return (


### PR DESCRIPTION
We have an `?add=` query parameter on the keyword page to automatically add a keyword when navigating to the page (this is used by the "notify me" button on the search page). Currently, we don't clear this parameter after adding the keyword which means it's impossible to then _remove_ that keyword unless you renavigate to the page without the query parameter, otherwise it just adds it again. This PR changes the logic to automatically remove the query parameter once we've consumed it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210808920631713) by [Unito](https://www.unito.io)
