### PR TITLE
Refetch documents after editing on subforum wiki page

### DIFF
--- a/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
@@ -150,7 +150,11 @@ const TagSubforumPage2 = ({classes}: {
   const revision = queryVersion ?? queryRevision ?? undefined;
   
   const contributorsLimit = 7;
-  const { tag, loading: loadingTag } = useTagBySlug(slug, revision ? "TagPageWithRevisionFragment" : "TagPageFragment", {
+  const {
+    tag,
+    loading: loadingTag,
+    refetch: refetchTag,
+  } = useTagBySlug(slug, revision ? "TagPageWithRevisionFragment" : "TagPageFragment", {
     extraVariables: revision ? {
       version: 'String',
       contributorsLimit: 'Int',
@@ -346,7 +350,15 @@ const TagSubforumPage2 = ({classes}: {
         setNewShortformOpen={setNewShortformOpen}
       />
     ),
-    wiki: <SubforumWikiTab tag={tag} revision={revision} truncated={truncated} setTruncated={setTruncated} />,
+    wiki: (
+      <SubforumWikiTab
+        tag={tag}
+        refetchTag={refetchTag}
+        revision={revision}
+        truncated={truncated}
+        setTruncated={setTruncated}
+      />
+    ),
   };
 
   return (


### PR DESCRIPTION
After editing a tag on a subforum wiki page we then display the old unedited version without refetching which makes it look like the edit didn't save even though it did.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210809169752198) by [Unito](https://www.unito.io)
