### PR TITLE
introduce safe local storage api and apply everywhere

### DIFF
--- a/packages/lesswrong/components/common/CookieBanner/geolocation.ts
+++ b/packages/lesswrong/components/common/CookieBanner/geolocation.ts
@@ -1,6 +1,7 @@
 import { isServer } from "../../../lib/executionEnvironment";
 import { DatabasePublicSetting, hasCookieConsentSetting } from "../../../lib/publicSettings";
 import { getBrowserLocalStorage } from "../../editor/localStorageHandlers";
+import { safeLocalStorage } from "../../../lib/utils/safeLocalStorage";
 
 const ipApiKeySetting = new DatabasePublicSetting<string | null>('ipapi.apiKey', null);
 
@@ -36,10 +37,8 @@ const GDPR_COUNTRY_CODES: string[] = [
 ];
 
 function getCountryCodeFromLocalStorage(): string | null {
-  const ls = getBrowserLocalStorage();
-
-  const cachedCountryCode = ls?.getItem('countryCode');
-  const cachedTimestamp = ls?.getItem('countryCodeTimestamp');
+  const cachedCountryCode = safeLocalStorage.getItem('countryCode');
+  const cachedTimestamp = safeLocalStorage.getItem('countryCodeTimestamp');
 
   if (!cachedCountryCode || !cachedTimestamp) {
     return null;
@@ -51,8 +50,8 @@ function getCountryCodeFromLocalStorage(): string | null {
   // 48 hours
   const cacheTTL = 48 * 60 * 60 * 1000;
   if (timeDifference > cacheTTL) {
-    localStorage.removeItem('countryCode');
-    localStorage.removeItem('countryCodeTimestamp');
+    safeLocalStorage.removeItem('countryCode');
+    safeLocalStorage.removeItem('countryCodeTimestamp');
     return null;
   }
 
@@ -60,11 +59,9 @@ function getCountryCodeFromLocalStorage(): string | null {
 }
 
 function setCountryCodeToLocalStorage(countryCode: string) {
-  const ls = getBrowserLocalStorage();
-
   const timestamp = new Date().getTime();
-  ls?.setItem('countryCode', countryCode);
-  ls?.setItem('countryCodeTimestamp', timestamp.toString());
+  safeLocalStorage.setItem('countryCode', countryCode);
+  safeLocalStorage.setItem('countryCodeTimestamp', timestamp.toString());
 }
 
 export function getCachedUserCountryCode() {

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -30,6 +30,7 @@ import DistanceUnitToggle from "./modules/DistanceUnitToggle";
 import ForumIcon from "../common/ForumIcon";
 import { useMutation } from "@apollo/client/react";
 import { gql } from "@/lib/generated/gql-codegen";
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const UsersProfileUpdateMutation = gql(`
   mutation updateUserCommunity($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -281,9 +282,8 @@ const Community = ({classes}: {
       })
     } else {
       // save it in local storage
-      const ls = getBrowserLocalStorage()
       try {
-        ls?.setItem('userlocation', JSON.stringify({lat, lng, known: true, label: gmaps?.formatted_address}))
+        safeLocalStorage.setItem('userlocation', JSON.stringify({lat, lng, known: true, label: gmaps?.formatted_address}))
       } catch(e) {
         // eslint-disable-next-line no-console
         console.error(e);

--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -15,6 +15,7 @@ import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import { hasDigests } from '@/lib/betas';
 import { isEAForum } from '@/lib/instanceSettings';
 import { isServer } from '@/lib/executionEnvironment';
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const styles = defineStyles("StickyDigestAd", (theme: ThemeType) => ({
   '@keyframes digest-fade-in': {
@@ -214,11 +215,10 @@ export const MaybeStickyDigestAd = ({post}: {
   const [showDigestAd, setShowDigestAd] = useState(false)
 
   // postReadCount is currently only used by StickyDigestAd, to only show the ad after the client has visited multiple posts.
-  const ls = getBrowserLocalStorage()
   useEffect(() => {
-    if (ls && hasDigests) {
-      const postReadCount = ls.getItem('postReadCount') ?? '0'
-      ls.setItem('postReadCount', `${parseInt(postReadCount) + 1}`)
+    if (hasDigests) {
+      const postReadCount = safeLocalStorage.getItem('postReadCount') ?? '0'
+      safeLocalStorage.setItem('postReadCount', `${parseInt(postReadCount) + 1}`)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -31,6 +31,7 @@ import ForumIcon from "../common/ForumIcon";
 import { useMutation } from "@apollo/client/react";
 import { gql } from "@/lib/generated/gql-codegen";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const PostsListMultiQuery = gql(`
   query multiPostEventsHomeQuery($selector: PostSelector, $limit: Int, $enableTotal: Boolean) {
@@ -259,9 +260,8 @@ const EventsHome = ({classes}: {
       })
     } else {
       // save it in local storage
-      const ls = getBrowserLocalStorage()
       try {
-        ls?.setItem('userlocation', JSON.stringify({lat, lng, known: true, label: gmaps?.formatted_address}))
+        safeLocalStorage.setItem('userlocation', JSON.stringify({lat, lng, known: true, label: gmaps?.formatted_address}))
       } catch(e) {
         // eslint-disable-next-line no-console
         console.error(e);
@@ -341,9 +341,8 @@ const EventsHome = ({classes}: {
     setDistance(distance)
     
     // save it in local storage in km
-    const ls = getBrowserLocalStorage()
     const distanceKm = `${distanceUnit === 'mi' ? Math.round(distance / 0.621371) : distance}`
-    ls?.setItem('eventsDistanceFilter', distanceKm)
+    safeLocalStorage.setItem('eventsDistanceFilter', distanceKm)
   }
   
   const handleChangeDistanceUnit = (unit: 'km' | 'mi') => {

--- a/packages/lesswrong/components/hooks/useLocalStorageState.tsx
+++ b/packages/lesswrong/components/hooks/useLocalStorageState.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
-import { getBrowserLocalStorage } from "../editor/localStorageHandlers";
 import { capitalize } from "@/lib/vulcan-lib/utils";
+import { safeLocalStorage } from "@/lib/utils/safeLocalStorage";
 
 type LocalPromptExample<Suffix extends string> = {
   [K in Suffix]: string | undefined;
@@ -34,25 +34,24 @@ type LocalPromptExample<Suffix extends string> = {
  */
 
 export function useLocalStorageState<Suffix extends string>(key: Suffix, getStorageKey: (key: string) => string, defaultValue: string): LocalPromptExample<Suffix> {
-  const ls = getBrowserLocalStorage();
   const storageKey = getStorageKey(key);
   const [value, setValue] = useState<string | undefined>(defaultValue);
 
   const lsSetValue = useCallback((value: string) => {
     setValue(value);
     if (value === defaultValue) {
-      ls?.removeItem(storageKey);
+      safeLocalStorage.removeItem(storageKey);
     } else {
-      ls?.setItem(storageKey, value);
+      safeLocalStorage.setItem(storageKey, value);
     }
-  }, [ls, storageKey, defaultValue]);
+  }, [storageKey, defaultValue]);
 
   const capitalizedSuffix = capitalize(key);
 
   useEffect(() => {
-    const storedValue = ls?.getItem(storageKey);
+    const storedValue = safeLocalStorage.getItem(storageKey);
     if (storedValue) setValue(storedValue);
-  }, [storageKey, ls]);
+  }, [storageKey]);
 
   return {
     [key]: value,

--- a/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
+++ b/packages/lesswrong/components/hooks/useUnreadNotifications.tsx
@@ -10,6 +10,7 @@ import { NotificationsListMultiQuery } from '../notifications/NotificationsList'
 import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import type { ResultOf } from '@graphql-typed-document-node/core';
 import ErrorBoundary from '../common/ErrorBoundary';
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 export type NotificationCountsResult = {
   checkedAt: Date,
@@ -162,7 +163,7 @@ export const UnreadNotificationsContextProvider: FC<{
       lastNotificationsCheck: now,
     });
     await refetchBoth();
-    window.localStorage.setItem(notificationsCheckedAtLocalStorageKey, now.toISOString());
+    safeLocalStorage.setItem(notificationsCheckedAtLocalStorageKey, now.toISOString());
   }, [refetchBoth, updateCurrentUser]);
 
   const providedContext: UnreadNotificationsContext = useMemo(() => ({

--- a/packages/lesswrong/components/languageModels/AutocompleteModelSettings.tsx
+++ b/packages/lesswrong/components/languageModels/AutocompleteModelSettings.tsx
@@ -17,6 +17,7 @@ import LoadMore from "../common/LoadMore";
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const CommentsListMultiQuery = gql(`
   query multiCommentAutocompleteModelSettingsQuery($selector: CommentSelector, $limit: Int, $enableTotal: Boolean) {
@@ -381,15 +382,15 @@ const debouncedSaveSelection = debounce((selectedItems: Record<string, boolean>,
       ),
   );
 
-  localStorage.setItem("selectedTrainingPosts", JSON.stringify(selectedPosts));
-  localStorage.setItem("selectedTrainingComments", JSON.stringify(selectedComments));
+  safeLocalStorage.setItem("selectedTrainingPosts", JSON.stringify(selectedPosts));
+  safeLocalStorage.setItem("selectedTrainingComments", JSON.stringify(selectedComments));
 }, 200);
 
 const AutocompleteModelSettings = ({ classes }: { classes: ClassesType<typeof styles> }) => {
   const currentUser = useCurrentUser();
   const [selectedItems, setSelectedItems] = useState<Record<string, boolean>>(() => {
-    const savedPosts = JSON.parse(localStorage.getItem("selectedTrainingPosts") ?? "[]");
-    const savedComments = JSON.parse(localStorage.getItem("selectedTrainingComments") ?? "[]");
+    const savedPosts = JSON.parse(safeLocalStorage.getItem("selectedTrainingPosts") ?? "[]");
+    const savedComments = JSON.parse(safeLocalStorage.getItem("selectedTrainingComments") ?? "[]");
     const initialSelectedItems: Record<string, boolean> = {};
     [...savedPosts, ...savedComments].forEach((id) => {
       initialSelectedItems[id] = true;

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -31,16 +31,14 @@ import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import UltraFeedFeedback from './UltraFeedFeedback';
 import AnalyticsInViewTracker from '../common/AnalyticsInViewTracker';
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const ULTRAFEED_SESSION_ID_KEY = 'ultraFeedSessionId';
 
 const getStoredSettings = (): UltraFeedSettingsType => {
   if (!isClient) return DEFAULT_SETTINGS;
   
-  const ls = getBrowserLocalStorage();
-  if (!ls) return DEFAULT_SETTINGS;
-  
-  const storedSettings = ls.getItem(ULTRA_FEED_SETTINGS_KEY);
+  const storedSettings = safeLocalStorage.getItem(ULTRA_FEED_SETTINGS_KEY);
   if (!storedSettings) return DEFAULT_SETTINGS;
   
   try {
@@ -53,13 +51,12 @@ const getStoredSettings = (): UltraFeedSettingsType => {
 };
 
 const saveSettings = (settings: Partial<UltraFeedSettingsType>): UltraFeedSettingsType => {
-  const ls = getBrowserLocalStorage();
-  if (!ls) return DEFAULT_SETTINGS;
+  if (!isClient) return DEFAULT_SETTINGS;
   
   const currentSettings = getStoredSettings();
   const newSettings = { ...currentSettings, ...settings };
   
-  ls.setItem(ULTRA_FEED_SETTINGS_KEY, JSON.stringify(newSettings));
+  safeLocalStorage.setItem(ULTRA_FEED_SETTINGS_KEY, JSON.stringify(newSettings));
   return newSettings;
 };
 

--- a/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
+++ b/packages/lesswrong/components/users/FriendlyUsersProfile.tsx
@@ -60,6 +60,7 @@ import { useQueryWithLoadMore } from '@/components/hooks/useQueryWithLoadMore';
 import { gql } from "@/lib/generated/gql-codegen";
 import CommentsDraftList from '../comments/CommentsDraftList';
 import { StructuredData } from '../common/StructuredData';
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const PostsMinimumInfoMultiQuery = gql(`
   query multiPostFriendlyUsersProfileQuery($selector: PostSelector, $limit: Int, $enableTotal: Boolean) {
@@ -281,10 +282,9 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
 
   // track profile views in local storage
   useEffect(() => {
-    const ls = getBrowserLocalStorage()
-    if (currentUser && user && currentUser._id !== user._id && ls) {
+    if (currentUser && user && currentUser._id !== user._id) {
       let from = query.from
-      const storedLastViewedProfiles = ls.getItem('lastViewedProfiles')
+      const storedLastViewedProfiles = safeLocalStorage.getItem('lastViewedProfiles')
       let profiles: any[] = storedLastViewedProfiles ? JSON.parse(storedLastViewedProfiles) : []
       // if the profile user is already in the list, then remove them before re-adding them at the end
       const profileUserIndex = profiles?.findIndex(profile => profile.userId === user._id)
@@ -298,7 +298,7 @@ const FriendlyUsersProfile = ({terms, slug, classes}: {
       // we only bother to save the last 10 profiles
       if (profiles.length > 10) profiles.shift()
       // save it in local storage
-      ls.setItem('lastViewedProfiles', JSON.stringify(profiles))
+      safeLocalStorage.setItem('lastViewedProfiles', JSON.stringify(profiles))
     }
   }, [currentUser, user, query.from])
 

--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -12,6 +12,7 @@ import { DeferredForumSelect } from '@/lib/forumTypeUtils';
 import { TupleSet, UnionOf } from '@/lib/utils/typeGuardUtils';
 import type { ForumIconName } from '@/components/common/ForumIcon';
 import type { EditablePost } from '../posts/helpers';
+import { safeLocalStorage } from '@/lib/utils/safeLocalStorage';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -445,10 +446,9 @@ export const useUserLocation = (currentUser: UsersCurrent|DbUser|null, dontAsk?:
       return {lat: placeholderLat, lng: placeholderLng, loading: true, known: false, label: null}
     } else {
       // If we're on the browser, and the user isn't logged in, see if we saved it in local storage
-      const ls = getBrowserLocalStorage()
-      if (!currentUser && ls) {
+      if (!currentUser) {
         try {
-          const storedUserLocation = ls.getItem('userlocation')
+          const storedUserLocation = safeLocalStorage.getItem('userlocation')
           const lsLocation = storedUserLocation ? JSON.parse(storedUserLocation) : null
           if (lsLocation) {
             return {...lsLocation, loading: false}

--- a/packages/lesswrong/lib/utils/safeLocalStorage.ts
+++ b/packages/lesswrong/lib/utils/safeLocalStorage.ts
@@ -1,0 +1,75 @@
+import { getBrowserLocalStorage } from '../../components/editor/localStorageHandlers';
+
+/**
+ * Safe wrapper around localStorage operations that handles errors gracefully.
+ */
+export const safeLocalStorage = {
+  /**
+   * Safely get an item from localStorage
+   * @returns The stored value, or null if not found or an error occurs
+   */
+  getItem(key: string): string | null {
+    try {
+      const ls = getBrowserLocalStorage();
+      return ls?.getItem(key) ?? null;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to read from localStorage: ${key}`, e);
+      return null;
+    }
+  },
+
+  /**
+   * Safely set an item in localStorage
+   * @returns true if successful, false if an error occurs
+   */
+  setItem(key: string, value: string): boolean {
+    try {
+      const ls = getBrowserLocalStorage();
+      if (!ls) return false;
+      
+      ls.setItem(key, value);
+      return true;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to write to localStorage: ${key}`, e);
+      return false;
+    }
+  },
+
+  /**
+   * Safely remove an item from localStorage
+   * @returns true if successful, false if an error occurs
+   */
+  removeItem(key: string): boolean {
+    try {
+      const ls = getBrowserLocalStorage();
+      if (!ls) return false;
+      
+      ls.removeItem(key);
+      return true;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to remove from localStorage: ${key}`, e);
+      return false;
+    }
+  },
+
+  /**
+   * Check if localStorage is available and working
+   * @returns true if localStorage is available and we can write to it
+   */
+  isAvailable(): boolean {
+    try {
+      const ls = getBrowserLocalStorage();
+      if (!ls) return false;
+      
+      const testKey = '__localStorage_test__';
+      ls.setItem(testKey, 'test');
+      ls.removeItem(testKey);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}; 


### PR DESCRIPTION
Our existing usage of local storage is a little inconsistent and usually lacks error handling around actions that can throw and crash the app. This PR creates a small API wrapper and swaps it in where we were directly using ls.<soperation>