### PR TITLE
Ultrafeed Fix Back Navigation & Constants Adjustment

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
+++ b/packages/lesswrong/components/recentDiscussion/useRecentDiscussionViewTracking.ts
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useTracking } from '../../lib/analyticsEvents';
+import { MIN_VISIBLE_PX } from '../ultraFeed/UltraFeedObserver';
 
 interface ViewTrackingOptions {
   documentId: string;
   documentType: 'post' | 'comment' | 'tag';
 }
 
-const VIEW_THRESHOLD_MS = 2000;
+const VIEW_THRESHOLD_MS = 1000;
 const LONG_VIEW_THRESHOLD_MS = 10000;
 
 /**
@@ -67,9 +68,9 @@ export function useRecentDiscussionViewTracking({
     const element = elementRef.current;
     if (!element) return;
 
-    // Create observer with same margins as UltraFeed (250px threshold)
+    // Create observer with same margins as UltraFeed
     const observer = new IntersectionObserver(handleIntersection, {
-      rootMargin: '-250px 0px -250px 0px',
+      rootMargin: `-${MIN_VISIBLE_PX}px 0px -${MIN_VISIBLE_PX}px 0px`,
       threshold: 0,
     });
 

--- a/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
@@ -93,9 +93,9 @@ const UltraFeedObserverContext = createContext<UltraFeedObserverContextType | nu
 
 // Minimum amount of the element (in pixels) that must be inside the viewport to
 // count as "visible enough" to register a view event.
-const MIN_VISIBLE_PX = 250;
+export const MIN_VISIBLE_PX = 100;
 
-const VIEW_THRESHOLD_MS = 2000;
+const VIEW_THRESHOLD_MS = 1000;
 const LONG_VIEW_THRESHOLD_MS = 10000;
 
 const documentTypeToCollectionName = {

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -532,10 +532,10 @@ const UltraFeedPostDialog = ({
   }, [scrollableContentRef]);
 
   
-  const handleClose = () => {
-    captureEvent("ultraFeedDialogClosed", { collectionName: "Posts", postId: postId ?? post?._id });
+  const handleClose = useCallback(() => {
+    captureEvent("ultraFeedDialogClosed", { collectionName: "Posts", postId });
     onClose();
-  };
+  }, [captureEvent, onClose, postId]);
   
   // Dialog navigation and scroll behavior
   const postUrl = displayPost ? `${postGetPageUrl(displayPost)}?${qs.stringify({ from: 'feedModal' })}` : undefined;

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -28,12 +28,12 @@ export interface UltraFeedSettingsType {
 }
 
 const DEFAULT_DISPLAY_SETTINGS: UltraFeedDisplaySettings = {
-  postInitialWords: 100,
-  postMaxWords: 250,
   lineClampNumberOfLines: 0,
-  commentCollapsedInitialWords: 50,
-  commentExpandedInitialWords: 100,
-  commentMaxWords: 250,
+  commentCollapsedInitialWords: 75,
+  commentExpandedInitialWords: 150,
+  commentMaxWords: 350,
+  postInitialWords: 100,
+  postMaxWords: 300,
 };
 
 export const truncationLevels = ['Very Short', 'Short', 'Medium', 'Long', 'Full'] as const;
@@ -41,9 +41,9 @@ export type TruncationLevel = typeof truncationLevels[number];
 export const SHOW_ALL_BREAKPOINT_VALUE = 100_000;
 
 export const levelToWordCountMap: Record<TruncationLevel, number> = {
-  'Very Short': 50,
-  'Short': 100,
-  'Medium': 250,
+  'Very Short': 75,
+  'Short': 150,
+  'Medium': 350,
   'Long': 1000,
   'Full': SHOW_ALL_BREAKPOINT_VALUE,
 };
@@ -51,7 +51,7 @@ export const levelToWordCountMap: Record<TruncationLevel, number> = {
 export const levelToPostWordCountMap: Record<TruncationLevel, number> = {
   'Very Short': 50,
   'Short': 100,
-  'Medium': 250,
+  'Medium': 300,
   'Long': 2000,
   'Full': SHOW_ALL_BREAKPOINT_VALUE,
 };
@@ -59,7 +59,7 @@ export const levelToPostWordCountMap: Record<TruncationLevel, number> = {
 
 export const DEFAULT_SOURCE_WEIGHTS: Record<FeedItemSourceType, number> = {
   'recentComments': 20,
-  'quicktakes': 20,
+  'quicktakes': 15,
   'subscriptionsComments': 15,
   'recombee-lesswrong-custom': 30,
   'hacker-news': 30,


### PR DESCRIPTION
- fix a bug in the back navigation of ultrafeed modals introduced by unnecessary rerenders because a callback that wasn't stable
- adjust some values in the default settings and thresholds for triggering view events

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210838548771707) by [Unito](https://www.unito.io)
