### PR TITLE
Exclude draft sequences from `getViewableSequencesSelector`

### DIFF
--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -6,7 +6,8 @@ import { postStatuses } from "../../lib/collections/posts/constants";
 export const getViewableSequencesSelector = (sequencesTableAlias?: string) => {
   const aliasPrefix = sequencesTableAlias ? `${sequencesTableAlias}.` : "";
   return `
-    ${aliasPrefix}"hidden" = FALSE
+    ${aliasPrefix}"hidden" IS NOT TRUE AND
+    ${aliasPrefix}"draft" IS NOT TRUE
   `;
 }
 


### PR DESCRIPTION
This selector is used in two places in `SequencesRepo`, both of which are currently a bug:
- `sequenceRouteWillDefinitelyReturn200`
- `getSitemapSequences`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210848348250168) by [Unito](https://www.unito.io)
