### PR TITLE
Ultrafeed Address Duplicate Posts

### DIFF
--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -47,6 +47,9 @@ import { unflattenComments } from '../../lib/utils/unflatten';
 import PostsPageQuestionContent from "../questions/PostsPageQuestionContent";
 import { useSubscribedLocation } from "@/lib/routeUtil";
 import { randomId } from '@/lib/random';
+import { RecombeeRecommendationsContextWrapper } from '../recommendations/RecombeeRecommendationsContextWrapper';
+import AnalyticsInViewTracker from "../common/AnalyticsInViewTracker";
+import AttributionInViewTracker from "../common/AttributionInViewTracker";
 
 const styles = defineStyles("UltraFeedPostDialog", (theme: ThemeType) => ({
   dialogContent: {
@@ -435,7 +438,8 @@ const UltraFeedPostDialog = ({
   const showEmbeddedPlayerCookie = cookies[SHOW_PODCAST_PLAYER_COOKIE] === "true";
   const [showEmbeddedPlayer, setShowEmbeddedPlayer] = useState(showEmbeddedPlayerCookie);
   
-  const postId = partialPost?._id ?? post?._id;
+  const postId = (partialPost ?? post)._id;
+  const recommId = postMetaInfo.recommInfo?.recommId;
   
   // Fetch full post if needed
   const { loading: loadingPost, data: postData } = useQuery(ULTRA_FEED_POST_FRAGMENT_QUERY, {
@@ -701,7 +705,10 @@ const UltraFeedPostDialog = ({
       paperClassName={classes.dialogPaper}
       className={classes.modalWrapper}
     >
+      <RecombeeRecommendationsContextWrapper postId={postId} recommId={recommId}>
+      <AttributionInViewTracker eventProps={{ post: displayPost, portion: 1, recommId }}>
       <AnalyticsContext pageModalContext="ultraFeedPostModal" postId={postId}>
+      <AnalyticsInViewTracker eventProps={{ inViewType: "commentsSection" }}>
         <DialogContent className={classes.dialogContent}>
           <div ref={dialogInnerRef} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
             {/* Header */}
@@ -941,7 +948,10 @@ const UltraFeedPostDialog = ({
             footnoteHTML={footnoteDialogHTML}
           />
         )}
+      </AnalyticsInViewTracker>
       </AnalyticsContext>
+      </AttributionInViewTracker>
+      </RecombeeRecommendationsContextWrapper>
     </LWDialog>
   );
 };

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1174,7 +1174,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           AND "collectionName" = 'Posts'
           AND "eventType" = 'viewed'
           AND "createdAt" > NOW() - INTERVAL '$(maxAgeDays) days'
-        LIMIT 1000
+        LIMIT 2000
       ) ue ON p._id = ue."documentId"
       WHERE
         p."postedAt" > NOW() - INTERVAL '$(maxAgeDays) days'

--- a/packages/lesswrong/server/repos/UltraFeedEventsRepo.ts
+++ b/packages/lesswrong/server/repos/UltraFeedEventsRepo.ts
@@ -27,20 +27,27 @@ class UltraFeedEventsRepo extends AbstractRepo<'UltraFeedEvents'> {
   ): Promise<string[]> {
     const unviewedItems = await this.manyOrNone(`
       -- UltraFeedEventsRepo.getUnviewedRecombeePostIds
-      SELECT DISTINCT ON (uf_served."documentId")
-        uf_served."documentId"
-      FROM "UltraFeedEvents" uf_served
-      LEFT JOIN "UltraFeedEvents" uf_viewed
-        ON uf_served."documentId" = uf_viewed."documentId"
-        AND uf_served."userId" = uf_viewed."userId"
-        AND uf_viewed."eventType" = 'viewed'
-      WHERE uf_served."eventType" = 'served'
-        AND uf_served."userId" = $[userId]
-        AND uf_served."createdAt" > (NOW() - INTERVAL '1 day' * $[lookbackDays])
-        AND uf_served."collectionName" = 'Posts'
-        AND uf_served.event->'sources' ? $[scenarioId]
-        AND uf_viewed._id IS NULL
-      ORDER BY uf_served."documentId", uf_served."createdAt" DESC
+      SELECT
+        s."documentId"
+      FROM (
+        SELECT
+          "documentId",
+          SUM(CASE WHEN "eventType" = 'served' THEN 1 ELSE 0 END) as serve_count,
+          MAX(CASE WHEN "eventType" = 'served' THEN "createdAt" END) as last_served,
+          MAX(CASE WHEN "eventType" = 'viewed' THEN 1 ELSE 0 END) as was_viewed
+        FROM "UltraFeedEvents"
+        WHERE "userId" = $[userId]
+          AND "collectionName" = 'Posts'
+          AND "eventType" IN ('served', 'viewed')
+          AND "createdAt" > (NOW() - INTERVAL '1 day' * $[lookbackDays])
+          AND (
+            ("eventType" = 'served' AND event->'sources' ? $[scenarioId])
+            OR "eventType" = 'viewed'
+          )
+        GROUP BY "documentId"
+      ) s
+      WHERE s.serve_count < 4 AND s.was_viewed = 0
+      ORDER BY s.last_served
       LIMIT $[limit]
     `, {
       userId,

--- a/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
@@ -7,7 +7,7 @@ import keyBy from 'lodash/keyBy';
 
 // Configuration for unviewed items optimization
 const UNVIEWED_RECOMBEE_CONFIG = {
-  lookbackDays: 14,
+  lookbackDays: 14, // relevant for view events as we truncate served events sooner
   skipFetchThreshold: 0.5, // Skip if we have 70% of requested items
   reduceFetchThreshold: 0.3, // Reduce to 50% if we have 30% of requested items
 };

--- a/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
@@ -88,6 +88,8 @@ export async function getRecommendedPostsForUltraFeed(
     scenario: scenarioId,
     filterSettings: currentUser?.frontpageFilterSettings,
     skipTopOfListPosts: true,
+    rotationRate: 0.5,
+    rotationTime: 24 * 30, // 30 days (in hours)
     ...(exclusionFilterString && { filter: exclusionFilterString }),
   };
 


### PR DESCRIPTION
The UltraFeed post recommendations have been very repetitive, this PR is things that I did in the course of addressing that:

- providing rotation config (this is the one thing that likely really matters)
- not reserving unused recombee recs endlessly (instead capped at N viewings)
- providing more data back to Recombee about what's been viewed and interacted with