### PR TITLE
[EA] Track on-site notification hovers

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsPopoverNotification.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPopoverNotification.tsx
@@ -140,6 +140,9 @@ const NotificationsPopoverNotification = ({notification, refetch, classes}: {
     <PostsTooltip
       postId={post?._id ?? comment?.post?._id}
       commentId={comment?._id}
+      analyticsProps={{
+        notificationId: _id,
+      }}
       placement="left-start"
       clickable
     >

--- a/packages/lesswrong/components/posts/PostsItemTooltipWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsItemTooltipWrapper.tsx
@@ -27,7 +27,9 @@ const PostsItemTooltipWrapper = ({
       post={post}
       postsList
       placement={placement}
-      pageElementContext="postItemTooltip"
+      analyticsProps={{
+        pageElementContext: "postItemTooltip"
+      }}
       As={As}
       className={className}
       inlineBlock={false}

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/PostsTooltip.tsx
@@ -8,6 +8,7 @@ import {
   TaggedPostTooltipSingle,
 } from "./PostsPreviewTooltipSingle";
 import HoverOver from "../../common/HoverOver";
+import { AnalyticsProps } from "@/lib/analyticsEvents";
 
 const PostsTooltip = ({
   post,
@@ -24,9 +25,8 @@ const PostsTooltip = ({
   flip,
   placement,
   children,
-  pageElementContext,
-  pageElementSubContext,
   disabled,
+  analyticsProps,
   className,
 }: {
   post?: PostsList | SunshinePostsList | null,
@@ -43,10 +43,8 @@ const PostsTooltip = ({
   flip?: boolean,
   placement?: PopperPlacementType,
   children?: ReactNode,
-  pageElementContext?: string,
-  pageElementSubContext?: string,
-  //bypasses the component and just returns the children
   disabled?: boolean,
+  analyticsProps?: AnalyticsProps,
   className?: string,
 }) => {
   const renderTitle = useCallback(() => {
@@ -105,8 +103,7 @@ const PostsTooltip = ({
       clickable={clickable}
       flip={flip}
       analyticsProps={{
-        pageElementContext,
-        pageElementSubContext,
+        ...analyticsProps,
         postId: postId ?? post?._id,
       }}
       className={className}

--- a/packages/lesswrong/components/review/LatestReview.tsx
+++ b/packages/lesswrong/components/review/LatestReview.tsx
@@ -58,8 +58,10 @@ const LatestReview = ({classes}: { classes: ClassesType<typeof styles> }) => {
           commentId={comment._id}
           placement="bottom-start"
           clickable
-          pageElementContext="frontpageReviewWidget"
-          pageElementSubContext="latestReviews"
+          analyticsProps={{
+            pageElementContext: "frontpageReviewWidget",
+            pageElementSubContext: "latestReviews"
+          }}
         >
           <div className={classes.root}>
             <Link to={href} className={classes.lastReview}>

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -94,6 +94,7 @@ export type AnalyticsProps = {
   resourceUrl?: string,
   chapter?: string,
   documentSlug?: string,
+  notificationId?: string,
   postId?: string,
   forumEventId?: string,
   sequenceId?: string,


### PR DESCRIPTION
Adds `notificationId` to the `hoverEventTriggered` event for on-site notifications

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210869662594056) by [Unito](https://www.unito.io)
