### PR TITLE
Fix mis-named default imports of CommentsNode

### DIFF
--- a/packages/lesswrong/components/bookmarks/VoteHistoryTab.tsx
+++ b/packages/lesswrong/components/bookmarks/VoteHistoryTab.tsx
@@ -6,7 +6,7 @@ import { commentsNodeRootMarginBottom, maxSmallish, maxTiny } from '../../themes
 import Loading from "../vulcan-core/Loading";
 import SectionTitle from "../common/SectionTitle";
 import PostsItem from "../posts/PostsItem";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import LoadMore from "../common/LoadMore";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
 import { gql } from "@/lib/generated/gql-codegen";
@@ -76,7 +76,7 @@ const VoteHistoryTab = ({classes}: {classes: ClassesType<typeof styles>}) => {
       );
     } else if (vote.comment) {
       const item = vote.comment;
-      return <CommentsNodeInner
+      return <CommentsNode
         key={item._id}
         comment={item}
         treeOptions={{showPostTitle: true, forceNotSingleLine: true, post: item.post || undefined}}

--- a/packages/lesswrong/components/comments/CommentById.tsx
+++ b/packages/lesswrong/components/comments/CommentById.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import type { CommentTreeOptions } from './commentTree';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 
 const CommentsListQuery = gql(`
   query CommentById($documentId: String) {
@@ -28,7 +28,7 @@ const CommentById = ({commentId, nestingLevel=0, isChild=false, treeOptions, loa
   const comment = data?.comment?.result;
   if (!comment) return null;
   
-  return <CommentsNodeInner
+  return <CommentsNode
     comment={comment}
     nestingLevel={nestingLevel}
     isChild={isChild}

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { unflattenComments, addGapIndicators } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import withErrorBoundary from '../common/withErrorBoundary';
-import CommentsNodeInner, { CommentsNodeProps } from './CommentsNode';
+import CommentsNode, { CommentsNodeProps } from './CommentsNode';
 
 const styles = (theme: ThemeType) => ({
   showChildren: {
@@ -68,7 +68,7 @@ const CommentWithReplies = ({
     ) : null;
 
   return (
-    <CommentsNodeInner
+    <CommentsNode
       startThreadTruncated={true}
       nestingLevel={1}
       comment={comment}

--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -9,7 +9,7 @@ import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import classNames from 'classnames';
 import ErrorBoundary from "../common/ErrorBoundary";
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 import SettingsButton from "../icons/SettingsButton";
 import LoginPopupButton from "../users/LoginPopupButton";
 import LWTooltip from "../common/LWTooltip";
@@ -81,7 +81,7 @@ const CommentsListFn = ({treeOptions, comments, totalComments=0, startThreadTrun
         sorting view, so that the scroll position doesn't move. */}
     <div className={classNames({[classes.commentsListLoadingSpacer]: loading})}>
       {comments.map(comment =>
-        <CommentsNodeInner
+        <CommentsNode
           treeOptions={treeOptions}
           startThreadTruncated={startThreadTruncated || totalComments >= POST_COMMENT_COUNT_TRUNCATE_THRESHOLD}
           expandAllThreads={expandAllThreads}

--- a/packages/lesswrong/components/comments/ModeratorComments.tsx
+++ b/packages/lesswrong/components/comments/ModeratorComments.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { sectionTitleStyle } from '../common/SectionTitle';
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 import Loading from "../vulcan-core/Loading";
 import LoadMore from "../common/LoadMore";
 import SingleColumnSection from "../common/SingleColumnSection";
@@ -65,7 +65,7 @@ const ModeratorComments = ({classes, terms={view: "moderatorComments"}, truncate
       <div className={classes.root}>
         {results.map(comment =>
           <div key={comment._id}>
-            <CommentsNodeInner
+            <CommentsNode
               treeOptions={{
                 condensed: false,
                 post: comment.post || undefined,

--- a/packages/lesswrong/components/comments/RecentComments.tsx
+++ b/packages/lesswrong/components/comments/RecentComments.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { Typography } from "../common/Typography";
 import Loading from "../vulcan-core/Loading";
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 import LoadMore from "../common/LoadMore";
 import { NetworkStatus } from "@apollo/client";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
@@ -65,7 +65,7 @@ const RecentComments = ({classes, selector, limit, truncated=false, showPinnedOn
   return <div className={classes.root}>
     {validResults.map(comment =>
       <div key={comment._id}>
-        <CommentsNodeInner
+        <CommentsNode
           treeOptions={{
             condensed: false,
             post: comment.post || undefined,

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -16,7 +16,7 @@ import CommentShortformIcon from "./CommentsItem/CommentShortformIcon";
 import PostsItemComments from "../posts/PostsItemComments";
 import ContentStyles from "../common/ContentStyles";
 import LWPopper from "../common/LWPopper";
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 import { defineStyles, useStyles } from '../hooks/useStyles';
 
 export const SINGLE_LINE_PADDING_TOP = 5
@@ -245,7 +245,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
         clickable={false}
       >
           <div className={classes.preview}>
-            <CommentsNodeInner
+            <CommentsNode
               truncated
               nestingLevel={1}
               comment={comment}

--- a/packages/lesswrong/components/comments/UserCommentsReplies.tsx
+++ b/packages/lesswrong/components/comments/UserCommentsReplies.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useLocation } from '../../lib/routeUtil';
 import { getUserFromResults } from '../users/UsersProfile';
 import { slugify } from '@/lib/utils/slugify';
-import CommentsNodeInner from "./CommentsNode";
+import CommentsNode from "./CommentsNode";
 import LoadMore from "../common/LoadMore";
 import SingleColumnSection from "../common/SingleColumnSection";
 import SectionTitle from "../common/SectionTitle";
@@ -82,7 +82,7 @@ const UserCommentsReplies = ({ classes }: { classes: ClassesType<typeof styles> 
       <div className={classes.root}>
         {results.map(comment =>
           <div key={comment._id}>
-            <CommentsNodeInner
+            <CommentsNode
               treeOptions={{
                 condensed: false,
                 post: comment.post || undefined,

--- a/packages/lesswrong/components/languageModels/AutocompleteModelSettings.tsx
+++ b/packages/lesswrong/components/languageModels/AutocompleteModelSettings.tsx
@@ -9,7 +9,7 @@ import LinearProgress from "@/lib/vendor/@material-ui/core/src/LinearProgress";
 import { CommentTreeOptions } from "../comments/commentTree";
 import debounce from "lodash/debounce";
 import PostsItem from "../posts/PostsItem";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import ForumIcon from "../common/ForumIcon";
 import SingleColumnSection from "../common/SingleColumnSection";
 import Loading from "../vulcan-core/Loading";
@@ -348,7 +348,7 @@ const AuthorSection = ({
             onToggle={onToggle}
             onSelectAll={onSelectAll}
             ItemComponent={({ item }) => (
-              <CommentsNodeInner
+              <CommentsNode
                 treeOptions={{ forceSingleLine: true } as CommentTreeOptions}
                 comment={item as CommentsList}
               />
@@ -500,7 +500,7 @@ const AutocompleteModelSettings = ({ classes }: { classes: ClassesType<typeof st
               onToggle={setSelectedItems}
               onSelectAll={handleSelectAll}
               ItemComponent={({ item }) => (
-                <CommentsNodeInner
+                <CommentsNode
                   treeOptions={{ forceSingleLine: true } as CommentTreeOptions}
                   comment={item as CommentsList}
                 />

--- a/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPage/NotificationsPageItem.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import LWTooltip from "../../common/LWTooltip";
-import CommentsNodeInner from "../../comments/CommentsNode";
+import CommentsNode from "../../comments/CommentsNode";
 import Loading from "../../vulcan-core/Loading";
 
 const CommentsListWithParentMetadataQuery = gql(`
@@ -180,7 +180,7 @@ export const NotificationsPageItem = ({
             <div className={classes.preview}>
               {previewCommentLoading && <Loading />}
               {previewComment &&
-                <CommentsNodeInner
+                <CommentsNode
                   treeOptions={{
                     scrollOnExpand: false,
                     condensed: true,

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/EAPostsPreviewTooltip.tsx
@@ -6,7 +6,7 @@ import type { PostsPreviewTooltipProps } from "./PostsPreviewTooltip";
 import PostExcerpt from "../../common/excerpts/PostExcerpt";
 import EAPostMeta from "../../ea-forum/EAPostMeta";
 import TruncatedTagsList from "../../tagging/TruncatedTagsList";
-import CommentsNodeInner from "../../comments/CommentsNode";
+import CommentsNode from "../../comments/CommentsNode";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -96,7 +96,7 @@ const EAPostsPreviewTooltip = ({
           </div>
           {comment
             ? (
-              <CommentsNodeInner
+              <CommentsNode
                 treeOptions={{
                   post,
                   hideReply: true,

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
@@ -13,7 +13,7 @@ import { gql } from "@/lib/generated/gql-codegen";
 import PostsUserAndCoauthors from "../PostsUserAndCoauthors";
 import PostsTitle from "../PostsTitle";
 import { ContentItemBody } from "../../contents/ContentItemBody";
-import CommentsNodeInner from "../../comments/CommentsNode";
+import CommentsNode from "../../comments/CommentsNode";
 import BookmarkButton from "../BookmarkButton";
 import FormatDate from "../../common/FormatDate";
 import Loading from "../../vulcan-core/Loading";
@@ -253,7 +253,7 @@ const LWPostsPreviewTooltip = ({
         </div>
         {renderedComment
           ? <div className={classes.comment}>
-              <CommentsNodeInner
+              <CommentsNode
                 treeOptions={{
                   post,
                   hideReply: true,

--- a/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
@@ -7,7 +7,7 @@ import classNames from "classnames";
 import { commentBodyStyles } from "../../themes/stylePiping";
 import ForumIcon from "../common/ForumIcon";
 import LWPopper from "../common/LWPopper";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import CommentsItemMeta from "../comments/CommentsItem/CommentsItemMeta";
 import CommentBottomCaveats from "../comments/CommentsItem/CommentBottomCaveats";
 
@@ -140,7 +140,7 @@ const LWQuickTakesCollapsedListItem = ({ quickTake, setExpanded, classes }: {
       clickable={false}
     >
       <div className={classes.hoverOver}>
-        <CommentsNodeInner
+        <CommentsNode
           truncated
           nestingLevel={1}
           comment={quickTake}

--- a/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesCollapsedListItem.tsx
@@ -16,7 +16,7 @@ import LWTooltip from "../common/LWTooltip";
 import FooterTag from "../tagging/FooterTag";
 import CommentsMenu from "../dropdowns/comments/CommentsMenu";
 import LWPopper from "../common/LWPopper";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -210,7 +210,7 @@ const QuickTakesCollapsedListItem = ({quickTake, setExpanded, classes}: {
         clickable={false}
       >
         <div className={classes.hoverOver}>
-          <CommentsNodeInner
+          <CommentsNode
             truncated
             nestingLevel={1}
             comment={quickTake}

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -5,7 +5,7 @@ import { isFriendlyUI } from "../../themes/forumTheme";
 import { isLWorAF } from "../../lib/instanceSettings";
 import classNames from "classnames";
 import DeferRender from "../common/DeferRender";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import QuickTakesCollapsedListItem from "./QuickTakesCollapsedListItem";
 import LWQuickTakesCollapsedListItem from "./LWQuickTakesCollapsedListItem";
 
@@ -46,7 +46,7 @@ const QuickTakesListItem = ({quickTake, classes}: {
   const expandedComment = (
     <DeferRender ssr={false}>
       <div className={classNames(classes.expandedRoot, { [classes.hidden]: !expanded })}>
-        <CommentsNodeInner
+        <CommentsNode
           treeOptions={{
             post: quickTake.post ?? undefined,
             showCollapseButtons: isFriendlyUI,

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionQuickTake.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionQuickTake.tsx
@@ -6,7 +6,7 @@ import type { CommentTreeNode } from "../../lib/utils/unflatten";
 import EARecentDiscussionItem, { EARecentDiscussionItemProps } from "./EARecentDiscussionItem";
 import classNames from "classnames";
 import CommentsItem from "../comments/CommentsItem/CommentsItem";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { maybeDate } from "@/lib/utils/dateUtils";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
@@ -141,7 +141,7 @@ const EARecentDiscussionQuickTake = ({
               })}
             />
             {hasComments && comments.map((comment) => (
-              <CommentsNodeInner
+              <CommentsNode
                 key={comment.item._id}
                 treeOptions={{
                   ...treeOptions,

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionTagCommented.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionTagCommented.tsx
@@ -8,7 +8,7 @@ import type { TagCommentType } from "../../lib/collections/comments/types";
 import type { CommentTreeOptions } from "../comments/commentTree";
 import EARecentDiscussionItem from "./EARecentDiscussionItem";
 import TagExcerpt from "../common/excerpts/TagExcerpt";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { maybeDate } from "@/lib/utils/dateUtils";
 
 const styles = (theme: ThemeType) => ({
@@ -82,7 +82,7 @@ const EARecentDiscussionTagCommented = ({
       <TagExcerpt tag={tag} className={classes.excerpt} />
       {nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
         <div key={comment.item._id}>
-          <CommentsNodeInner
+          <CommentsNode
             treeOptions={treeOptions}
             startThreadTruncated={true}
             expandAllThreads={expandAllThreads}

--- a/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/EARecentDiscussionThread.tsx
@@ -9,7 +9,7 @@ import EARecentDiscussionItem, { EARecentDiscussionItemProps } from "./EARecentD
 import classNames from "classnames";
 import EAPostMeta from "../ea-forum/EAPostMeta";
 import ForumIcon from "../common/ForumIcon";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import PostExcerpt from "../common/excerpts/PostExcerpt";
 import LinkPostMessage from "../posts/LinkPostMessage";
 import EAKarmaDisplay from "../common/EAKarmaDisplay";
@@ -167,7 +167,7 @@ const EARecentDiscussionThread = ({
       />
       {nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
         <div key={comment.item._id}>
-          <CommentsNodeInner
+          <CommentsNode
             treeOptions={treeOptions}
             startThreadTruncated={true}
             expandAllThreads={expandAllThreads}

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -11,7 +11,7 @@ import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import FeedPostsHighlight from "../posts/FeedPostsHighlight";
 import PostActionsButton from "../dropdowns/posts/PostActionsButton";
 import FeedPostCardMeta from "../posts/FeedPostCardMeta";
@@ -161,7 +161,7 @@ const FeedPostCommentsBranch = ({ comment, treeOptions, expandAllThreads, classe
     ) : null;
 
   return <div key={comment.item._id}>
-    <CommentsNodeInner
+    <CommentsNode
       treeOptions={treeOptions}
       startThreadTruncated={true}
       showExtraChildrenButton={showExtraChildrenButton}

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -11,7 +11,7 @@ import { TagCommentType } from '../../lib/collections/comments/types';
 import { useOrderPreservingArray } from '../hooks/useOrderPreservingArray';
 import { preferredHeadingCase } from '../../themes/forumTheme';
 import { useRecentDiscussionViewTracking } from './useRecentDiscussionViewTracking';
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { ContentItemBody } from "../contents/ContentItemBody";
 import ContentStyles from "../common/ContentStyles";
 import { maybeDate } from '@/lib/utils/dateUtils';
@@ -146,7 +146,7 @@ const RecentDiscussionTag = ({ tag, refetch = () => {}, comments, expandAllThrea
         <div className={classes.commentsList}>
           {nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
             <div key={comment.item._id}>
-              <CommentsNodeInner
+              <CommentsNode
                 treeOptions={commentTreeOptions}
                 startThreadTruncated={true}
                 expandAllThreads={initialExpandAllThreads || expandAllThreads}

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -17,7 +17,7 @@ import { useRecentDiscussionThread } from './useRecentDiscussionThread';
 import { useRecentDiscussionViewTracking } from './useRecentDiscussionViewTracking';
 import PostsGroupDetails from "../posts/PostsGroupDetails";
 import PostsItemMeta from "../posts/PostsItemMeta";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import PostsHighlight from "../posts/PostsHighlight";
 import PostActionsButton from "../dropdowns/posts/PostActionsButton";
 
@@ -245,7 +245,7 @@ const RecentDiscussionThread = ({
         <div className={classes.commentsList}>
           {!!nestedComments.length && nestedComments.map((comment: CommentTreeNode<CommentsList>) =>
             <div key={comment.item._id}>
-              <CommentsNodeInner
+              <CommentsNode
                 treeOptions={treeOptions}
                 startThreadTruncated={true}
                 expandAllThreads={expandAllThreads}

--- a/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
+++ b/packages/lesswrong/components/review/ReviewsLeaderboard.tsx
@@ -10,7 +10,7 @@ import UsersNameDisplay from "../users/UsersNameDisplay";
 import Row from "../common/Row";
 import MetaInfo from "../common/MetaInfo";
 import LWTooltip from "../common/LWTooltip";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -108,7 +108,7 @@ export const ReviewsLeaderboard = ({classes, reviews, reviewYear}: {
         </div>
         <div className={classes.reviews}>{reviewUser.reviews.map(review => {
           return <LWTooltip placement="bottom-start" title={<div className={classes.card}>
-            <CommentsNodeInner treeOptions={{showPostTitle: true}} comment={review}/></div>} tooltip={false} key={review._id}>
+            <CommentsNode treeOptions={{showPostTitle: true}} comment={review}/></div>} tooltip={false} key={review._id}>
             <a href={`/reviews/${reviewYear ?? "all"}#${review._id}`} onClick={() => setTruncated(true)}>
               <MetaInfo>{(review.baseScore ?? 0) - getSelfUpvotePower(review.user)}</MetaInfo>
             </a>

--- a/packages/lesswrong/components/review/ReviewsList.tsx
+++ b/packages/lesswrong/components/review/ReviewsList.tsx
@@ -5,7 +5,7 @@ import { ReviewYear } from '../../lib/reviewUtils';
 import { TupleSet, UnionOf } from '../../lib/utils/typeGuardUtils';
 import sortBy from 'lodash/sortBy';
 import { Typography } from "../common/Typography";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import SectionTitle from "../common/SectionTitle";
 import ReviewsLeaderboard from "./ReviewsLeaderboard";
 import Loading from "../vulcan-core/Loading";
@@ -77,7 +77,7 @@ export const ReviewsList = ({classes, title, defaultSort, reviewYear}: {
       {(loading) && <Loading />}
       {sortedReviews.map(comment =>
         <div key={comment._id} id={comment._id}>
-          <CommentsNodeInner
+          <CommentsNode
             treeOptions={{
               condensed: false,
               post: comment.post ?? undefined,

--- a/packages/lesswrong/components/review/SingleLineReviewsList.tsx
+++ b/packages/lesswrong/components/review/SingleLineReviewsList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { REVIEW_YEAR } from '../../lib/reviewUtils';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 
@@ -30,7 +30,7 @@ const SingleLineReviewsList = () => {
   return <div>
     {results?.map(comment =>
         <div key={comment._id}>
-          <CommentsNodeInner
+          <CommentsNode
             treeOptions={{
               condensed: true,
               singleLineCollapse: true,

--- a/packages/lesswrong/components/shortform/ShortformListItem.tsx
+++ b/packages/lesswrong/components/shortform/ShortformListItem.tsx
@@ -13,7 +13,7 @@ import LWTooltip from "../common/LWTooltip";
 import ForumIcon from "../common/ForumIcon";
 import UsersName from "../users/UsersName";
 import FooterTag from "../tagging/FooterTag";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -112,7 +112,7 @@ const ShortformListItem = ({comment, hideTag, classes}: {
   if (expanded) {
     return (
       <div className={classes.expandedRoot}>
-        <CommentsNodeInner
+        <CommentsNode
           treeOptions={treeOptions}
           comment={comment}
           loadChildrenSeparately
@@ -173,7 +173,7 @@ const ShortformListItem = ({comment, hideTag, classes}: {
         clickable={false}
       >
         <div className={classes.hoverOver}>
-          <CommentsNodeInner
+          <CommentsNode
             truncated
             nestingLevel={1}
             comment={comment}

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
 import QuickTakesListItem from "../quickTakes/QuickTakesListItem";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import LoadMore from "../common/LoadMore";
 import ContentType from "../posts/PostsPage/ContentType";
 import { useQueryWithLoadMore } from "@/components/hooks/useQueryWithLoadMore";
@@ -42,7 +42,7 @@ const ShortformItem: FC<{comment: ShortformComments}> = ({comment}) => {
     );
   }
   return (
-    <CommentsNodeInner
+    <CommentsNode
       treeOptions={{
         post: comment.post || undefined,
         forceSingleLine: true

--- a/packages/lesswrong/components/sunshineDashboard/AllReactedCommentsPage.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AllReactedCommentsPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import SingleColumnSection from "../common/SingleColumnSection";
 import SectionTitle from "../common/SectionTitle";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import LoadMore from "../common/LoadMore";
 import { gql } from '@/lib/generated/gql-codegen';
 import { useQueryWithLoadMore } from '../hooks/useQueryWithLoadMore';
@@ -41,7 +41,7 @@ export const AllReactedCommentsPage = ({classes}: {
       <div className={classes.root}>
         {results && results.map((comment: CommentsListWithParentMetadata) =>
           <div key={comment._id}>
-            <CommentsNodeInner
+            <CommentsNode
               treeOptions={{
                 condensed: false,
                 post: comment.post || undefined,

--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { commentGetPageUrlFromIds } from '../../lib/collections/comments/helpers';
 import classNames from 'classnames';
 import LWPopper from "../common/LWPopper";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import FormatDate from "../common/FormatDate";
 
 const styles = (theme: ThemeType) => ({
@@ -68,7 +68,7 @@ const CommentKarmaWithPreview = ({ comment, classes, displayTitle, reviewedAt }:
         placement={displayTitle ? "right-start" : "bottom-start"}
       >
       <div className={classes.commentPreview}>
-        <CommentsNodeInner treeOptions={{showPostTitle: true}} comment={comment} forceUnTruncated forceUnCollapsed/>
+        <CommentsNode treeOptions={{showPostTitle: true}} comment={comment} forceUnTruncated forceUnCollapsed/>
       </div>
     </LWPopper>
   </span>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { RejectedContentControls } from "./RejectedContentControls";
 import ForumIcon from "../common/ForumIcon";
 import { defineStyles, useStyles } from '../hooks/useStyles';
@@ -37,7 +37,7 @@ export const SunshineNewUserCommentItem = ({comment}: {
       <ForumIcon className={classes?.expandCollapseButton} icon={isCollapsed ? "ThickChevronRight" : "ThickChevronDown"} onClick={() => setIsCollapsed(!isCollapsed)} />
       <RejectedContentControls contentWrapper={{collectionName:"Comments", content:comment}}/>
     </div>
-    {!isCollapsed && <CommentsNodeInner 
+    {!isCollapsed && <CommentsNode 
       treeOptions={{
         condensed: false,
         post: comment.post || undefined,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -16,7 +16,7 @@ import PostsHighlight from "../posts/PostsHighlight";
 import SidebarActionMenu from "./SidebarActionMenu";
 import SidebarAction from "./SidebarAction";
 import FormatDate from "../common/FormatDate";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import { Typography } from "../common/Typography";
 import SunshineCommentsItemOverview from "./SunshineCommentsItemOverview";
 import SunshineNewUsersInfo from "./SunshineNewUsersInfo";
@@ -135,7 +135,7 @@ const SunshineReportedItem = ({report, classes, currentUser, refetch}: {
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl} >
           <Typography variant="body2">
-            {comment && <CommentsNodeInner
+            {comment && <CommentsNode
               treeOptions={{
                 condensed: false,
                 post: comment.post || undefined,

--- a/packages/lesswrong/components/tagging/TagActivityFeed.tsx
+++ b/packages/lesswrong/components/tagging/TagActivityFeed.tsx
@@ -4,7 +4,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import SingleColumnSection from "../common/SingleColumnSection";
 import { MixedTypeFeed } from "../common/MixedTypeFeed";
 import TagRevisionItem from "./TagRevisionItem";
-import CommentsNodeInner from "../comments/CommentsNode";
+import CommentsNode from "../comments/CommentsNode";
 import NewTagItem from "./NewTagItem";
 import SectionTitle from "../common/SectionTitle";
 import { AllTagsActivityFeedQuery } from '../common/feeds/feedQueries';
@@ -35,7 +35,7 @@ const TagActivityFeed = ({pageSize = 50}: {
         },
         tagDiscussionComment: {
           render: (comment: CommentsListWithParentMetadata) => <div>
-            <CommentsNodeInner
+            <CommentsNode
               treeOptions={{
                 showPostTitle: true,
                 tag: comment.tag || undefined,

--- a/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
+++ b/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
@@ -23,7 +23,7 @@ import TagRevisionItem from "../TagRevisionItem";
 import LensRevisionItem from "./LensRevisionItem";
 import SummaryRevisionItem from "./SummaryRevisionItem";
 import FormatDate from "../../common/FormatDate";
-import CommentsNodeInner from "../../comments/CommentsNode";
+import CommentsNode from "../../comments/CommentsNode";
 import Loading from "../../vulcan-core/Loading";
 import LinkToPost from "../../linkPreview/LinkToPost";
 import SingleLineFeedEvent from "../../common/SingleLineFeedEvent";
@@ -208,7 +208,7 @@ const TagHistoryPage = () => {
               return null;
             return <div>
               <SingleLineFeedEvent icon={<ForumIcon className={classNames(classes.feedIcon, classes.commentIcon)} icon="Comment"/>}>
-                <CommentsNodeInner
+                <CommentsNode
                   treeOptions={{ tag, forceSingleLine: collapseAll }}
                   comment={comment}
                   loadChildrenSeparately={true}


### PR DESCRIPTION
Due to a codemod or find-replace accident, imports of CommentsNode thought they were importing CommentsNodeInner (which they correctly were not).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210883099975567) by [Unito](https://www.unito.io)
