### PR TITLE
Background tasks (voided promises) use the `backgroundTask` utility function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,12 +178,17 @@ module.exports = {
       ]
     }],
 
-    // Warn on missing await
+    // Warn on missing await. We use ignoreVoid: true by default but change it
+    // to false for lib/ and server/ because you should use the
+    // `backgroundTask()` function rather than void, except in the `components`
+    // folder in which void is allowed (specified in the `overrides` section
+    // below).
     // The ignoreVoid option makes it so that
     //   void someAwaitableFunction()
     // can be used as a way of marking a function as deliberately not-awaited.
     "@typescript-eslint/no-floating-promises": [1, {
-      ignoreVoid: true
+      ignoreVoid: true,
+      ignoreIIFE: true,
     }],
 
     // Like no-implicit-any, but specifically for things that are exported. Turn
@@ -320,6 +325,20 @@ module.exports = {
           ...clientRestrictedImportPaths
         ]}],
       }
+    },
+    {
+      "files": [
+        "packages/lesswrong/lib/**/*.ts",
+        "packages/lesswrong/lib/**/*.tsx",
+        "packages/lesswrong/server/**/*.ts",
+        "packages/lesswrong/server/**/*.tsx",
+      ],
+      "rules": {
+        "@typescript-eslint/no-floating-promises": [1, {
+          ignoreVoid: false,
+          ignoreIIFE: true,
+        }],
+      },
     }
   ],
   "env": {

--- a/packages/lesswrong/lib/alignment-forum/displayAFNonMemberPopups.tsx
+++ b/packages/lesswrong/lib/alignment-forum/displayAFNonMemberPopups.tsx
@@ -54,6 +54,7 @@ export const useAfNonMemberSuccessHandling = () => {
   return useCallback((document: PostsBase | CommentsList) => {
     if (!!currentUser && userNeedsAFNonMemberWarning(currentUser, false)) {
       if (isComment(document)) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         void updateComment({
           variables: {
             selector: { _id: document._id},
@@ -69,6 +70,7 @@ export const useAfNonMemberSuccessHandling = () => {
           />,
         })
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         void updatePost({
           variables: {
             selector: { _id: document._id },

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -432,6 +432,7 @@ export function flushClientEvents(force: boolean = false) {
 
   const eventsToWrite = pendingAnalyticsEvents;
   pendingAnalyticsEvents = [];
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   void clientWriteEvents(eventsToWrite.map(event => ({
     ...event,
     props: {

--- a/packages/lesswrong/lib/collections/posts/annualReviewMarkets.ts
+++ b/packages/lesswrong/lib/collections/posts/annualReviewMarkets.ts
@@ -1,3 +1,4 @@
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { manifoldAPIKeySetting, highlightReviewWinnerThresholdSetting } from "../../instanceSettings";
 import { getWithCustomLoader, loadByIds } from "../../loaders";
 import { filterNonnull } from "../../utils/typeGuardUtils";
@@ -160,14 +161,14 @@ export const getPostMarketInfo = async (post: DbPost, context: ResolverContext):
   });
 
   if (!cacheItem) {
-    void refreshMarketInfoInCache(post, context)
+    backgroundTask(refreshMarketInfoInCache(post, context))
     return undefined;
   }
 
   const timeDifference = new Date().getTime() - cacheItem.lastUpdated.getTime();
 
   if (timeDifference >= 10_000) {
-    void refreshMarketInfoInCache(post, context);
+    backgroundTask(refreshMarketInfoInCache(post, context));
   }
 
   return { probability: cacheItem.probability, isResolved: cacheItem.isResolved, year: cacheItem.year, url: cacheItem.url ?? '' };

--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -75,6 +75,7 @@ import { filterNonnull } from "@/lib/utils/typeGuardUtils";
 import gql from "graphql-tag";
 import { CommentsViews } from "../comments/views";
 import { commentIncludedInCounts } from "../comments/helpers";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 export const graphqlTypeDefs = gql`
   type SocialPreviewType {
@@ -3608,11 +3609,11 @@ const schema = {
             })),
           });
 
-          void context.repos.sideComments.saveSideCommentCache(
+          backgroundTask(context.repos.sideComments.saveSideCommentCache(
             post._id,
             sideCommentMatches.html,
             sideCommentMatches.sideCommentsByBlock
-          );
+          ));
 
           unfilteredResult = {
             annotatedHtml: sideCommentMatches.html,

--- a/packages/lesswrong/lib/cookies/callbacks.ts
+++ b/packages/lesswrong/lib/cookies/callbacks.ts
@@ -2,6 +2,7 @@ import Cookies from "universal-cookie";
 import { initDatadog } from "@/client/datadogRum";
 import { ALL_COOKIES, CookieType, isCookieAllowed } from "./utils";
 import { initReCaptcha } from "@/client/reCaptcha";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 type CookiePreferencesChangedCallbackProps = {
   cookiePreferences: CookieType[];
@@ -14,8 +15,8 @@ type CookiePreferencesChangedCallbackProps = {
  * There is no way to turn it off without reloading currently (see https://github.com/DataDog/browser-sdk/issues/1008)
  */
 export function cookiePreferencesChanged({cookiePreferences, explicitlyChanged}: CookiePreferencesChangedCallbackProps) {
-  void initDatadog();
-  void initReCaptcha();
+  backgroundTask(initDatadog());
+  backgroundTask(initReCaptcha());
 
   // Send a cookie_preferences_changed event to Google Tag Manager, which triggers google analytics and hotjar to start
   //

--- a/packages/lesswrong/lib/events/withNewEvents.ts
+++ b/packages/lesswrong/lib/events/withNewEvents.ts
@@ -4,6 +4,7 @@ import { hookToHoc } from '../../lib/hocUtils';
 import * as _ from 'underscore';
 import { useMutationNoCache } from '../crud/useMutationNoCache';
 import { gql } from "@/lib/generated/gql-codegen";
+import { backgroundTask } from '@/server/utils/backgroundTask';
 
 const newEventFragmentMutation = gql(`
   mutation createLWEventwithNewEvents($data: CreateLWEventDataInput!) {
@@ -38,7 +39,7 @@ export const useNewEvents = () => {
       setEvents({ ...events, eventId: event });
     }
     
-    void createLWEvent({ variables: { data: event } });
+    backgroundTask(createLWEvent({ variables: { data: event } }));
     return eventId;
   }, [events, createLWEvent]);
   
@@ -46,7 +47,7 @@ export const useNewEvents = () => {
     let event = events[eventId];
     let currentTime = new Date();
     
-    void createLWEvent({
+    backgroundTask(createLWEvent({
       variables: {
         data: {
           ...event,
@@ -58,8 +59,8 @@ export const useNewEvents = () => {
           },
         }
       }
-});
-    
+    }));
+
     setEvents(_.omit(events, eventId));
     return eventId;
   }, [events, createLWEvent]);

--- a/packages/lesswrong/lib/filterSettings.ts
+++ b/packages/lesswrong/lib/filterSettings.ts
@@ -5,10 +5,10 @@ import { defaultVisibilityTags } from './publicSettings';
 import filter from 'lodash/filter';
 import findIndex from 'lodash/findIndex'
 import { useTracking } from './analyticsEvents';
-import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import { type QueryRef, useBackgroundQuery, useReadQuery } from '@apollo/client/react';
 import { type ResultOf } from '@graphql-typed-document-node/core';
+import { backgroundTask } from '@/server/utils/backgroundTask';
 
 export const TagBasicInfoMultiQuery = gql(`
   query multiTagfilterSettingsQuery($selector: TagSelector, $limit: Int, $enableTotal: Boolean) {
@@ -105,13 +105,12 @@ export const useFilterSettings = () => {
     },
   });
 
-  
   /** Set the whole mess */
   const setFilterSettings = useCallback((newSettings: FilterSettings) => {
     setFilterSettingsLocally(newSettings)
-    void updateCurrentUser({
+    backgroundTask(updateCurrentUser({
       frontpageFilterSettings: newSettings,
-    })
+    }))
   }, [updateCurrentUser])
   
   const setPersonalBlogFilter = useCallback((mode: FilterMode) => {

--- a/packages/lesswrong/lib/utils/swrCache.ts
+++ b/packages/lesswrong/lib/utils/swrCache.ts
@@ -1,3 +1,4 @@
+import { backgroundTask } from "@/server/utils/backgroundTask"
 
 export class SwrCache<T, Args extends any[]> {
   private value: T|null
@@ -19,7 +20,7 @@ export class SwrCache<T, Args extends any[]> {
       await this.recompute(...args);
       return this.value!;
     } else if (this.lastUpdatedAt < new Date().getTime() - this.expiryMs) {
-      void this.recompute(...args);
+      backgroundTask(this.recompute(...args));
       return this.value;
     } else {
       return this.value;

--- a/packages/lesswrong/lib/vendor/ckeditor5-watchdog/contextwatchdog.ts
+++ b/packages/lesswrong/lib/vendor/ckeditor5-watchdog/contextwatchdog.ts
@@ -302,6 +302,7 @@ export default class ContextWatchdog<TContext extends Context = Context> extends
 							return;
 						}
 
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
 						void this._actionQueues.enqueue( item.id, () => new Promise<void>( res => {
 							const rethrowRestartEventOnce = () => {
 								watchdog.off( 'restart', rethrowRestartEventOnce );

--- a/packages/lesswrong/lib/vendor/ckeditor5-watchdog/watchdog.ts
+++ b/packages/lesswrong/lib/vendor/ckeditor5-watchdog/watchdog.ts
@@ -234,6 +234,7 @@ export default abstract class Watchdog {
 			this._fire( 'error', { error, causesRestart } );
 
 			if ( causesRestart ) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
 				void this._restart();
 			} else {
 				this.state = 'crashedPermanently';

--- a/packages/lesswrong/server/analytics/analyticsViews.ts
+++ b/packages/lesswrong/server/analytics/analyticsViews.ts
@@ -1,6 +1,7 @@
 import { forumSelect } from "@/lib/forumTypeUtils";
 import { getAnalyticsConnection } from "./postgresConnection";
 import { addCronJob } from "../cron/cronUtil";
+import { backgroundTask } from "../utils/backgroundTask";
 
 const maintenanceQueries = forumSelect({
   EAForum: [
@@ -22,7 +23,7 @@ export const cronMaintainAnalyticsViews = addCronJob({
 
     for (const query of maintenanceQueries) {
       // Run these concurrently and don't wait, as they can take ~hours
-      void db.none(query)
+      backgroundTask(db.none(query))
     }
   },
 });

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -28,6 +28,7 @@ import { isE2E } from '../lib/executionEnvironment';
 import { getUnusedSlugByCollectionName } from './utils/slugUtil';
 import { slugify } from '@/lib/utils/slugify';
 import { prepareClientId } from './clientIdMiddleware';
+import { backgroundTask } from './utils/backgroundTask';
 
 /**
  * Passport declares an empty interface User in the Express namespace. We modify
@@ -185,7 +186,7 @@ function createAccessTokenStrategy(auth0Strategy: AnyBecauseTodo) {
     } else {
       auth0Strategy.userProfile(accessToken, (_err: AnyBecauseTodo, profile: AnyBecauseTodo) => {
         if (profile) {
-          void accessTokenUserHandler(accessToken, resumeToken, profile, done)
+          backgroundTask(accessTokenUserHandler(accessToken, resumeToken, profile, done))
         } else {
           return done("Invalid token")
         }

--- a/packages/lesswrong/server/callbacks/countOfReferenceCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/countOfReferenceCallbacks.ts
@@ -4,6 +4,7 @@ import { getCollection } from "@/server/collections/allCollections";
 import { searchIndexedCollectionNamesSet } from "@/lib/search/searchUtil";
 import { collectionNameToTypeName } from "@/lib/generated/collectionTypeNames";
 import { allSchemas } from "@/lib/schema/allSchemas";
+import { backgroundTask } from "../utils/backgroundTask";
 
 interface InvertedCountOfReferenceOptions {
   sourceCollectionName: CollectionNameString,
@@ -186,7 +187,7 @@ function getSharedCountOfReferenceFunctionOptions<N extends CollectionNameString
   const resync = (documentId: string) => {
     if (resyncElastic && searchIndexedCollectionNamesSet.has(sourceCollectionName)) {
       const { elasticSyncDocument } = require("../search/elastic/elasticCallbacks"); //cycle-breaking
-      void elasticSyncDocument(sourceCollectionName, documentId);
+      backgroundTask(elasticSyncDocument(sourceCollectionName, documentId));
     }
   }
 

--- a/packages/lesswrong/server/callbacks/digestCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/digestCallbacks.tsx
@@ -1,4 +1,5 @@
 import { UpdateCallbackProperties } from '../mutationCallbacks';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export async function createNextDigestOnPublish({newDocument, oldDocument, context}: UpdateCallbackProperties<"Digests">) {
   const { Digests } = context;
@@ -10,12 +11,12 @@ export async function createNextDigestOnPublish({newDocument, oldDocument, conte
 
   const { createDigest }: typeof import('../collections/digests/mutations') = await require('../collections/digests/mutations');
 
-  void createDigest({
+  backgroundTask(createDigest({
     data: {
       num: (newDocument.num ?? 0) + 1,
       startDate: newDocument.endDate ?? new Date()
     }
-  }, context);
+  }, context));
 }
 
 export async function backdatePreviousDigest({newDocument, oldDocument, context}: UpdateCallbackProperties<"Digests">) {

--- a/packages/lesswrong/server/callbacks/localgroupCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/localgroupCallbacks.ts
@@ -1,6 +1,7 @@
 import type { AfterCreateCallbackProperties, UpdateCallbackProperties } from '../mutationCallbacks';
 import difference from 'lodash/difference';
 import { createNotifications } from '../notificationCallbacksHelpers';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export function validateGroupIsOnlineOrHasLocation(group: CreateLocalgroupDataInput | DbLocalgroup) {
   if (!group.isOnline && !group.location)
@@ -31,10 +32,10 @@ export async function handleOrganizerUpdates({ newDocument, oldDocument, context
 
     const newOrganizerOfGroupIds = difference(organizer.organizerOfGroupIds, [newDocument._id])
     if (organizer.organizerOfGroupIds.length > newOrganizerOfGroupIds.length) {
-      void Users.rawUpdateOne(
+      backgroundTask(Users.rawUpdateOne(
         {_id: organizer._id},
         {$set: {organizerOfGroupIds: newOrganizerOfGroupIds}}
-      )
+      ))
     }
   })
 }

--- a/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/moderatorActionCallbacks.ts
@@ -4,6 +4,7 @@ import { appendToSunshineNotes } from '../../lib/collections/users/helpers';
 import { loggerConstructor } from '../../lib/utils/logging';
 import { AfterCreateCallbackProperties } from '../mutationCallbacks';
 import { triggerReview } from './helpers';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export async function triggerReviewAfterModeration({ newDocument, currentUser, context }: AfterCreateCallbackProperties<'ModeratorActions'>) {
   const moderatorAction = newDocument;
@@ -12,7 +13,7 @@ export async function triggerReviewAfterModeration({ newDocument, currentUser, c
   logger('ModeratorAction created, triggering review if necessary')
   if (isActionActive(moderatorAction) || moderatorAction.type === RECEIVED_SENIOR_DOWNVOTES_ALERT) {
     logger('isActionActive truthy')
-    void triggerReview(moderatedUserId, context);
+    backgroundTask(triggerReview(moderatedUserId, context));
   }
 
   // In the case where there isn't a currentUser, that means that the moderator action was created using automod (via callback) rather than being manually applied

--- a/packages/lesswrong/server/callbacks/multiDocumentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/multiDocumentCallbacks.ts
@@ -1,7 +1,8 @@
 import { elasticSyncDocument } from '../search/elastic/elasticCallbacks';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export function reindexParentTagIfNeeded(multiDoc: DbMultiDocument) {
   if (multiDoc.collectionName === 'Tags' && multiDoc.fieldName === 'description') {
-    void elasticSyncDocument('Tags', multiDoc.parentDocumentId);
+    backgroundTask(elasticSyncDocument('Tags', multiDoc.parentDocumentId));
   }
 }

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -52,6 +52,7 @@ import { updateNotification } from "../collections/notifications/mutations";
 import { EmailCuratedAuthors } from "../emailComponents/EmailCuratedAuthors";
 import { EventUpdatedEmail } from "../emailComponents/EventUpdatedEmail";
 import { PostsHTML } from "@/lib/collections/posts/fragments";
+import { backgroundTask } from "../utils/backgroundTask";
 
 /** Create notifications for a new post being published */
 export async function sendNewPostNotifications(post: DbPost) {
@@ -113,15 +114,17 @@ const onPublishUtils = {
     if (!isRecombeeRecommendablePost(post)) return;
   
     if (recombeeEnabledSetting.get()) {
-      void recombeeApi.upsertPost(post, context)
+      backgroundTask(recombeeApi.upsertPost(post, context)
         // eslint-disable-next-line no-console
-        .catch(e => console.log('Error when sending published post to recombee', { e }));
+        .catch(e => console.log('Error when sending published post to recombee', { e }))
+      );
     }
   
     if (vertexEnabledSetting.get()) {
-      void googleVertexApi.upsertPost({ post }, context)
+      backgroundTask(googleVertexApi.upsertPost({ post }, context)
         // eslint-disable-next-line no-console
-        .catch(e => console.log('Error when sending published post to google vertex', { e }));
+        .catch(e => console.log('Error when sending published post to google vertex', { e }))
+      );
     }
   },
 
@@ -578,7 +581,7 @@ export async function createNewJargonTermsCallback<T extends Pick<DbPost, '_id' 
   // TODO: do we want different behavior for new vs updated posts?
   if (changeMetrics.added > 1000 || !existingJargon.length) {
     // TODO: do we want to exclude existing jargon terms from being added again for posts which had a large diff but already had some jargon terms?
-    void createNewJargonTerms({ postId: post._id, currentUser, context });
+    backgroundTask(createNewJargonTerms({ postId: post._id, currentUser, context }));
   }
 
   return post;
@@ -624,13 +627,13 @@ export async function lwPostsNewUpvoteOwnPost(post: DbPost, callbackProperties: 
 
 export function postsNewPostRelation(post: DbPost, { context }: AfterCreateCallbackProperties<'Posts'>) {
   if (post.originalPostRelationSourceId) {
-    void createPostRelation({
+    backgroundTask(createPostRelation({
       data: {
         type: "subQuestion",
         sourcePostId: post.originalPostRelationSourceId,
         targetPostId: post._id,
       }
-    }, context);
+    }, context));
   }
   return post
 }
@@ -687,7 +690,7 @@ export async function triggerReviewForNewPostIfNeeded({ document, context }: Aft
 export async function autoTagNewPost({ document, context }: AfterCreateCallbackProperties<"Posts">) {
   if (!document.draft) {
     // Post created (and is not a draft)
-    void utils.applyAutoTags(document, context);
+    backgroundTask(utils.applyAutoTags(document, context));
   }
 }
 
@@ -870,7 +873,7 @@ export async function notifyUsersAddedAsCoauthors({ oldDocument: oldPost, newDoc
 export async function autoTagUndraftedPost({oldDocument, newDocument, context}: UpdateCallbackProperties<'Posts'>) {
   if (oldDocument.draft && !newDocument.draft) {
     // Post was undrafted
-    void utils.applyAutoTags(newDocument, context);
+    backgroundTask(utils.applyAutoTags(newDocument, context));
   }
 }
 
@@ -944,25 +947,25 @@ export async function sendRejectionPM({ newDocument: post, oldDocument: oldPost,
  */
 export async function updateUserNotesOnPostDraft({ newDocument, oldDocument, currentUser, context }: UpdateCallbackProperties<"Posts">) {
   if (!oldDocument.draft && newDocument.draft && userIsAdmin(currentUser)) {
-    void createModeratorAction({
+    backgroundTask(createModeratorAction({
       data: {
         userId: newDocument.userId,
         type: MOVED_POST_TO_DRAFT,
         endedAt: new Date()
       },
-    }, context);
+    }, context));
   }
 }
 
 export async function updateUserNotesOnPostRejection({ newDocument, oldDocument, currentUser, context }: UpdateCallbackProperties<"Posts">) {
   if (!oldDocument.rejected && newDocument.rejected) {
-    void createModeratorAction({
+    backgroundTask(createModeratorAction({
       data: {
         userId: newDocument.userId,
         type: REJECTED_POST,
         endedAt: new Date()
       },
-    }, context);
+    }, context));
   }
 }
 
@@ -974,22 +977,24 @@ export async function updateRecombeePost({ newDocument, oldDocument, context }: 
   if ((post.draft && !redrafted) || !isRecombeeRecommendablePost(post)) return;
 
   if (recombeeEnabledSetting.get()) {
-    void recombeeApi.upsertPost(post, context)
-    // eslint-disable-next-line no-console
-    .catch(e => console.log('Error when sending updated post to recombee', { e }));
+    backgroundTask(recombeeApi.upsertPost(post, context)
+      // eslint-disable-next-line no-console
+      .catch(e => console.log('Error when sending updated post to recombee', { e }))
+    )
   }
 
   if (vertexEnabledSetting.get()) {
-    void googleVertexApi.upsertPost({ post }, context)
+    backgroundTask(googleVertexApi.upsertPost({ post }, context)
       // eslint-disable-next-line no-console
-      .catch(e => console.log('Error when sending updated post to google vertex', { e }));
+      .catch(e => console.log('Error when sending updated post to google vertex', { e }))
+    );
   }
 }
 
 /* EDIT ASYNC */
 export function sendPostApprovalNotifications(post: Pick<DbPost, '_id' | 'userId' | 'status'>, oldPost: DbPost) {
   if (postIsApproved(post) && !postIsApproved(oldPost)) {
-    void createNotifications({userIds: [post.userId], notificationType: 'postApproved', documentType: 'post', documentId: post._id});
+    backgroundTask(createNotifications({userIds: [post.userId], notificationType: 'postApproved', documentType: 'post', documentId: post._id}));
   }
 }
 
@@ -1030,13 +1035,17 @@ export async function removeRedraftNotifications(newPost: Pick<DbPost, '_id' | '
 
     // delete post notifications
     const postNotifications = await Notifications.find({documentId: newPost._id}).fetch()
-    postNotifications.forEach(notification => void updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context));
+    postNotifications.forEach(notification =>
+      backgroundTask(updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context))
+    );
 
     // delete tagRel notifications (note this deletes them even if the TagRel itself has `deleted: true`)
     const tagRels = await TagRels.find({postId:newPost._id}).fetch()
     await asyncForeachSequential(tagRels, async (tagRel) => {
       const tagRelNotifications = await Notifications.find({documentId: tagRel._id}).fetch()
-      tagRelNotifications.forEach(notification => void updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context));
+      tagRelNotifications.forEach(notification =>
+        backgroundTask(updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context))
+      );
     });
   }
 }
@@ -1051,12 +1060,13 @@ export async function sendEAFCuratedAuthorsNotification(post: DbPost, oldPost: D
       _id: {$in: authorIds}
     }).fetch()
     
-    void Promise.all(authors.map(author => wrapAndSendEmail({
+    backgroundTask(Promise.all(
+      authors.map(author => wrapAndSendEmail({
         user: author,
         subject: "We’ve curated your post",
         body: <EmailCuratedAuthors user={author} post={post} />
       })
-    ))
+    )))
   }
 }
 

--- a/packages/lesswrong/server/callbacks/sequenceCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/sequenceCallbacks.ts
@@ -1,6 +1,8 @@
+import { backgroundTask } from "../utils/backgroundTask";
+
 export function createFirstChapter(sequence: DbSequence, context: ResolverContext) {
   const { Chapters } = context;
   if (sequence._id) {
-    void Chapters.rawInsert({sequenceId:sequence._id, postIds: []})
+    backgroundTask(Chapters.rawInsert({sequenceId:sequence._id, postIds: []}))
   }
 }

--- a/packages/lesswrong/server/callbacks/tagCallbackFunctions.ts
+++ b/packages/lesswrong/server/callbacks/tagCallbackFunctions.ts
@@ -10,6 +10,7 @@ import { postIsPublic } from "@/lib/collections/posts/helpers";
 import { subscriptionTypes } from "@/lib/collections/subscriptions/helpers";
 import _ from "underscore";
 import { updateTag } from "../collections/tags/mutations";
+import { backgroundTask } from "../utils/backgroundTask";
 
 const utils = {
   isValidTagName: (name: string) => {
@@ -129,7 +130,7 @@ export async function reexportProfileTagUsersToElastic(newDocument: DbTag, { old
       projection: {_id: 1},
     }).fetch();
     for (const user of users) {
-      void elasticSyncDocument("Users", user._id);
+      backgroundTask(elasticSyncDocument("Users", user._id));
     }
   }
   return newDocument;

--- a/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
@@ -43,6 +43,7 @@ import { updateComment } from "../collections/comments/mutations";
 import { createUser, updateUser } from "../collections/users/mutations";
 import { EmailContentItemBody } from "../emailComponents/EmailContentItemBody";
 import { PostsHTML } from "@/lib/collections/posts/fragments";
+import { backgroundTask } from "../utils/backgroundTask";
 
 
 async function sendWelcomeMessageTo(userId: string) {
@@ -127,7 +128,7 @@ const welcomeMessageDelayer = new EventDebouncer({
   defaultTiming: isLW ? {type: "none"} : {type: "delayed", delayMinutes: 5},
   
   callback: (userId: string) => {
-    void sendWelcomeMessageTo(userId);
+    backgroundTask(sendWelcomeMessageTo(userId));
   },
 });
 
@@ -194,7 +195,7 @@ const utils = {
 
   sendVerificationEmailConditional: async (user: DbUser) => {
     if (!isAnyTest && verifyEmailsSetting.get()) {
-      void sendVerificationEmail(user);
+      backgroundTask(sendVerificationEmail(user));
       await bellNotifyEmailVerificationRequired(user);
     }
   },
@@ -228,9 +229,10 @@ export function createRecombeeUser({ document }: {document: DbUser}) {
   if (!document.email)
     return;
 
-  void recombeeApi.createUser(document)
+  backgroundTask(recombeeApi.createUser(document)
     // eslint-disable-next-line no-console
-    .catch(e => console.log('Error when sending created user to recombee', { e }));
+    .catch(e => console.log('Error when sending created user to recombee', { e }))
+  );
 }
 
 /* NEW ASYNC */
@@ -262,7 +264,7 @@ export async function subscribeToEAForumAudience(user: DbUser) {
     return;
   }
   const { lat: latitude, lng: longitude, known } = userGetLocation(user);
-  void fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
+  backgroundTask((fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
     method: 'POST',
     body: JSON.stringify({
       email_address: user.email,
@@ -277,11 +279,11 @@ export async function subscribeToEAForumAudience(user: DbUser) {
       'Content-Type': 'application/json',
       Authorization: `API_KEY ${mailchimpAPIKey}`,
     },
-  }).catch(e => {
+  })).catch(e => {
     captureException(e);
     // eslint-disable-next-line no-console
     console.log(e);
-  });
+  }));
 }
 
 export async function sendWelcomingPM(user: DbUser) {
@@ -413,10 +415,10 @@ export async function updateDisplayName(data: UpdateUserDataInput, { oldDocument
       throw new Error("This display name is already taken");
     }
     if (data.shortformFeedId && !isLWorAF) {
-      void updatePost({
+      backgroundTask(updatePost({
         data: {title: userShortformPostTitle(newDocument)},
         selector: { _id: data.shortformFeedId }
-      }, createAnonymousContext());
+      }, createAnonymousContext()));
     }
   }
   return data;
@@ -432,7 +434,7 @@ export function maybeSendVerificationEmail(modifier: MongoModifier, user: DbUser
   const lastSent = user.whenConfirmationEmailSent;
 
   if (!lastSent || (lastSent.getTime() !== whenConfirmationEmailSent.getTime())) {
-    void utils.sendVerificationEmailConditional(user);
+    backgroundTask(utils.sendVerificationEmailConditional(user));
   }
 }
 
@@ -509,7 +511,7 @@ export function syncProfileUpdatedAt(modifier: MongoModifier, user: DbUser) {
 export function updateUserMayTriggerReview({newDocument, data, context}: UpdateCallbackProperties<"Users">) {
   const reviewTriggerFields: (keyof DbUser)[] = ['voteCount', 'mapLocation', 'postCount', 'commentCount', 'biography', 'profileImageId'];
   if (reviewTriggerFields.some(field => field in data)) {
-    void triggerReviewIfNeeded(newDocument._id, context);
+    backgroundTask(triggerReviewIfNeeded(newDocument._id, context));
   }
 }
 
@@ -518,7 +520,7 @@ export async function userEditDeleteContentCallbacksAsync({ newDocument, oldDocu
     await nullifyVotesForUser(newDocument);
   }
   if (newDocument.deleteContent && !oldDocument.deleteContent && currentUser) {
-    void userDeleteContent(newDocument, currentUser, context);
+    backgroundTask(userDeleteContent(newDocument, currentUser, context));
   }
 }
 
@@ -631,7 +633,7 @@ export function userEditBannedCallbacksAsync(user: DbUser, oldUser: DbUser) {
   const previousUserWasBanned = !!(previousBanDate && new Date(previousBanDate) > now)
   
   if (updatedUserIsBanned && !previousUserWasBanned) {
-    void userIPBanAndResetLoginTokens(user);
+    backgroundTask(userIPBanAndResetLoginTokens(user));
   }
 }
 
@@ -671,7 +673,7 @@ export async function newAlignmentUserSendPMAsync(newUser: DbUser, oldUser: DbUs
       conversationId: conversation._id
     };
 
-    void createMessage({ data: firstMessageData }, lwAccountContext);
+    backgroundTask(createMessage({ data: firstMessageData }, lwAccountContext));
   }
 }
 

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -21,6 +21,7 @@ import { updatePostDenormalizedTags } from '../tagging/helpers';
 import { recomputeContributorScoresFor } from '../utils/contributorsUtil';
 import { createModeratorAction } from '../collections/moderatorActions/mutations';
 import { userGetGroups } from '@/lib/vulcan-users/permissions';
+import { backgroundTask } from '../utils/backgroundTask';
 
 const MODERATE_OWN_PERSONAL_THRESHOLD = 50;
 const TRUSTLEVEL1_THRESHOLD = 2000;
@@ -89,14 +90,14 @@ function voteUpdatePostDenormalizedTags({newDocument}: {newDocument: VoteableTyp
   } else {
     return;
   }
-  void updatePostDenormalizedTags(postId);
+  backgroundTask(updatePostDenormalizedTags(postId));
 }
 
 export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, collection: CollectionBase<VoteableCollectionName>, user: DbUser, context: ResolverContext): Promise<void> {
   voteUpdatePostDenormalizedTags({newDocument});
   cancelVoteKarma({newDocument, vote}, collection, user);
-  void cancelVoteCount({newDocument, vote});
-  void revokeUserAFKarmaForCancelledVote({newDocument, vote});
+  backgroundTask(cancelVoteCount({newDocument, vote}));
+  backgroundTask(revokeUserAFKarmaForCancelledVote({newDocument, vote}));
   
   
   if (vote.collectionName === "Revisions") {
@@ -108,11 +109,11 @@ export async function onVoteCancel(newDocument: DbVoteableType, vote: DbVote, co
 }
 
 export async function onCastVoteAsync(voteDocTuple: VoteDocTuple, collection: CollectionBase<VoteableCollectionName>, user: DbUser, context: ResolverContext): Promise<void> {
-  void grantUserAFKarmaForVote(voteDocTuple);
-  void updateTrustedStatus(voteDocTuple, context);
-  void updateModerateOwnPersonal(voteDocTuple, context);
-  void increaseMaxBaseScore(voteDocTuple);
-  void voteUpdatePostDenormalizedTags(voteDocTuple);
+  backgroundTask(grantUserAFKarmaForVote(voteDocTuple));
+  backgroundTask(updateTrustedStatus(voteDocTuple, context));
+  backgroundTask(updateModerateOwnPersonal(voteDocTuple, context));
+  backgroundTask(increaseMaxBaseScore(voteDocTuple));
+  voteUpdatePostDenormalizedTags(voteDocTuple);
 
   const { vote, newDocument } = voteDocTuple;
   if (vote.collectionName === "Revisions") {
@@ -122,9 +123,9 @@ export async function onCastVoteAsync(voteDocTuple: VoteDocTuple, collection: Co
     }
   }
 
-  void updateKarma(voteDocTuple, collection, user, context);
-  void incVoteCount(voteDocTuple);
-  void checkAutomod(voteDocTuple, collection, user, context);
+  backgroundTask(updateKarma(voteDocTuple, collection, user, context));
+  backgroundTask(incVoteCount(voteDocTuple));
+  backgroundTask(checkAutomod(voteDocTuple, collection, user, context));
   await maybeCreateReviewMarket(voteDocTuple, collection, user, context);
   await maybeCreateModeratorAlertsAfterVote(voteDocTuple, collection, user, context);
 }
@@ -156,14 +157,14 @@ async function updateKarma({newDocument, vote}: VoteDocTuple, collection: Collec
       for (let user of users) {
         const oldKarma = user.karma;
         const newKarma = oldKarma + vote.power;
-        void userKarmaChangedFrom(newDocument.userId, oldKarma, newKarma, context);
-      }  
+        backgroundTask(userKarmaChangedFrom(newDocument.userId, oldKarma, newKarma, context));
+      }
     }
   }
 
   
   if (!!newDocument.userId && isLWorAF && ['Posts', 'Comments'].includes(vote.collectionName) && votesCanTriggerReview(newDocument as DbPost | DbComment)) {
-    void checkForStricterRateLimits(newDocument.userId, context);
+    backgroundTask(checkForStricterRateLimits(newDocument.userId, context));
   }
 }
 
@@ -187,7 +188,7 @@ function cancelVoteKarma({newDocument, vote}: VoteDocTuple, collection: Collecti
   // Only update user karma if the operation isn't done by one of the item's authors at the time of the original vote.
   // We expect vote.authorIds here to be the same as the authorIds of the original vote.
   if (vote.authorIds && !vote.authorIds.includes(vote.userId) && collectionsThatAffectKarma.includes(vote.collectionName)) {
-    void Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {karma: -vote.power}});
+    backgroundTask(Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {karma: -vote.power}}));
   }
 }
 
@@ -201,7 +202,7 @@ async function incVoteCount ({newDocument, vote}: VoteDocTuple) {
   const casterField = `${vote.voteType}Count`
 
   if (newDocument.userId !== vote.userId) {
-    void Users.rawUpdateOne({_id: vote.userId}, {$inc: {[casterField]: 1, voteCount: 1}});
+    backgroundTask(Users.rawUpdateOne({_id: vote.userId}, {$inc: {[casterField]: 1, voteCount: 1}}));
   }
 
   // Increment the count for the person receiving the vote
@@ -209,7 +210,7 @@ async function incVoteCount ({newDocument, vote}: VoteDocTuple) {
 
   if (newDocument.userId !== vote.userId) {
     // update all users in vote.authorIds
-    void Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {[receiverField]: 1, voteReceivedCount: 1}});
+    backgroundTask(Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {[receiverField]: 1, voteReceivedCount: 1}}));
   }
 }
 
@@ -221,7 +222,7 @@ async function cancelVoteCount ({newDocument, vote}: VoteDocTuple) {
   const casterField = `${vote.voteType}Count`
 
   if (newDocument.userId !== vote.userId) {
-    void Users.rawUpdateOne({_id: vote.userId}, {$inc: {[casterField]: -1, voteCount: -1}});
+    backgroundTask(Users.rawUpdateOne({_id: vote.userId}, {$inc: {[casterField]: -1, voteCount: -1}}));
   }
 
   // Increment the count for the person receiving the vote
@@ -229,13 +230,13 @@ async function cancelVoteCount ({newDocument, vote}: VoteDocTuple) {
 
   if (newDocument.userId !== vote.userId) {
     // update all users in vote.authorIds
-    void Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {[receiverField]: -1, voteReceivedCount: -1}});
+    backgroundTask(Users.rawUpdateMany({_id: {$in: vote.authorIds}}, {$inc: {[receiverField]: -1, voteReceivedCount: -1}}));
   }
 }
 
 async function checkAutomod ({newDocument, vote}: VoteDocTuple, collection: CollectionBase<VoteableCollectionName>, user: DbUser, context: ResolverContext) {
   if (vote.collectionName === 'Comments') {
-    void triggerCommentAutomodIfNeeded(newDocument, vote);
+    backgroundTask(triggerCommentAutomodIfNeeded(newDocument, vote));
   }
 }
 
@@ -349,13 +350,13 @@ async function maybeCreateModeratorAlertsAfterVote({ newDocument, vote }: VoteDo
     } = longtermDownvoteScore;
   
     if (commentCount > 20 && longtermSeniorDownvoterCount >= 3 && longtermScore < 0) {
-      void createModeratorAction({
+      backgroundTask(createModeratorAction({
         data: {
           type: RECEIVED_SENIOR_DOWNVOTES_ALERT,
           userId: userId,
           endedAt: new Date()
         },
-      }, adminContext);
+      }, adminContext));
     }
   } catch (err) {
     captureException(err);

--- a/packages/lesswrong/server/clientIdMiddleware.ts
+++ b/packages/lesswrong/server/clientIdMiddleware.ts
@@ -5,6 +5,7 @@ import { responseIsCacheable } from './cacheControlMiddleware';
 import ClientIdsRepo from './repos/ClientIdsRepo';
 import LRU from 'lru-cache';
 import { getUserFromReq } from './vulcan-lib/apollo-server/context';
+import { backgroundTask } from './utils/backgroundTask';
 
 // Cache of seen (clientId, userId) pairs
 const seenClientIds = new LRU<string, boolean>({ max: 10_000, maxAge: 1000 * 60 * 60 });
@@ -90,12 +91,12 @@ export function ensureClientId(req: express.Request, res: express.Response): voi
         });
         
         if (!hasSeen({ clientId: req.clientId, userId })) {
-          void clientIdsRepo.ensureClientId({
+          backgroundTask(clientIdsRepo.ensureClientId({
             clientId: req.clientId,
             userId,
             referrer,
             landingPage: url,
-          });
+          }));
         }
         setHasSeen({ clientId: req.clientId, userId: getUserFromReq(req)?._id });
       } catch (e) {

--- a/packages/lesswrong/server/collections/advisorRequests/mutations.ts
+++ b/packages/lesswrong/server/collections/advisorRequests/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/advisorRequests/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -81,7 +81,7 @@ export async function updateAdvisorRequest({ selector, data }: UpdateAdvisorRequ
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('AdvisorRequests', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: AdvisorRequests, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: AdvisorRequests, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/bans/mutations.ts
+++ b/packages/lesswrong/server/collections/bans/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/bans/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { assignUserIdToData, getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -49,7 +49,7 @@ export async function updateBan({ selector, data }: { selector: SelectorInput, d
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('Bans', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: Bans, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Bans, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/bookmarks/mutations.ts
+++ b/packages/lesswrong/server/collections/bookmarks/mutations.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import { BookmarkableCollectionName } from '@/lib/collections/bookmarks/constants';
+import { backgroundTask } from '@/server/utils/backgroundTask';
 
 export const bookmarkGqlTypeDefs = gql`
   input ToggleBookmarkInput {
@@ -34,7 +35,7 @@ async function toggleBookmarkResolver(root: void, { input }: { input: ToggleBook
   }
 
   const resultingBookmark = await context.repos.bookmarks.upsertBookmark(currentUser._id, documentId, collectionName);
-  void context.repos.bookmarks.updateBookmarkCountForUser(currentUser._id);
+  backgroundTask(context.repos.bookmarks.updateBookmarkCountForUser(currentUser._id));
   
   return { data: resultingBookmark };
 }

--- a/packages/lesswrong/server/collections/books/mutations.ts
+++ b/packages/lesswrong/server/collections/books/mutations.ts
@@ -1,4 +1,3 @@
-
 import schema from "@/lib/collections/books/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
@@ -6,6 +5,7 @@ import { updateCollectionLinks } from "@/server/callbacks/bookCallbacks";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds, notifyUsersOfPingbackMentions } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -102,7 +102,7 @@ export async function updateBook({ selector, data }: UpdateBookInput, context: R
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: Books, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Books, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/chapters/mutations.ts
+++ b/packages/lesswrong/server/collections/chapters/mutations.ts
@@ -1,4 +1,3 @@
-
 import schema from "@/lib/collections/chapters/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
@@ -6,6 +5,7 @@ import { canonizeChapterPostInfo, notifyUsersOfNewPosts, updateSequenceLastUpdat
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -112,7 +112,7 @@ export async function updateChapter({ selector, data }: UpdateChapterInput, cont
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: Chapters, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Chapters, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/ckEditorUserSessions/mutations.ts
+++ b/packages/lesswrong/server/collections/ckEditorUserSessions/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/ckEditorUserSessions/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -49,7 +49,7 @@ export async function updateCkEditorUserSession({ selector, data }: { selector: 
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('CkEditorUserSessions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: CkEditorUserSessions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: CkEditorUserSessions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/collections/mutations.ts
+++ b/packages/lesswrong/server/collections/collections/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/collections/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin, userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -115,7 +115,7 @@ export async function updateCollection({ selector, data }: UpdateCollectionInput
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: Collections, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Collections, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/commentModeratorActions/mutations.ts
+++ b/packages/lesswrong/server/collections/commentModeratorActions/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/commentModeratorActions/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -63,7 +63,7 @@ export async function updateCommentModeratorAction({ selector, data }: UpdateCom
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('CommentModeratorActions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: CommentModeratorActions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: CommentModeratorActions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/curationNotices/mutations.ts
+++ b/packages/lesswrong/server/collections/curationNotices/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/curationNotices/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdminOrMod } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -98,7 +98,7 @@ export async function updateCurationNotice({ selector, data }: UpdateCurationNot
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: CurationNotices, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: CurationNotices, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/dialogueChecks/mutations.ts
+++ b/packages/lesswrong/server/collections/dialogueChecks/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/dialogueChecks/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -49,7 +49,7 @@ export async function updateDialogueCheck({ selector, data }: { data: Partial<Db
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('DialogueChecks', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: DialogueChecks, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: DialogueChecks, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/dialogueMatchPreferences/mutations.ts
+++ b/packages/lesswrong/server/collections/dialogueMatchPreferences/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/dialogueMatchPreferences/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyUpdateCallbackProps, runFieldOnUpdateCallbacks, updateAndReturnDocument } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -26,7 +26,7 @@ export async function updateDialogueMatchPreference({ selector, data }: { select
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('DialogueMatchPreferences', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: DialogueMatchPreferences, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: DialogueMatchPreferences, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/digestPosts/mutations.ts
+++ b/packages/lesswrong/server/collections/digestPosts/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/digestPosts/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -63,7 +63,7 @@ export async function updateDigestPost({ selector, data }: UpdateDigestPostInput
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('DigestPosts', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: DigestPosts, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: DigestPosts, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/digests/mutations.ts
+++ b/packages/lesswrong/server/collections/digests/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/digests/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { backdatePreviousDigest, createNextDigestOnPublish } from "@/server/callbacks/digestCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -67,7 +67,7 @@ export async function updateDigest({ selector, data }: UpdateDigestInput, contex
   await createNextDigestOnPublish(updateCallbackProperties);
   await backdatePreviousDigest(updateCallbackProperties);
 
-  void logFieldChanges({ currentUser, collection: Digests, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Digests, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/electionCandidates/mutations.ts
+++ b/packages/lesswrong/server/collections/electionCandidates/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/electionCandidates/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { setDefaultVotingFields } from "@/server/callbacks/electionCandidateCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -68,7 +68,7 @@ export async function updateElectionCandidate({ selector, data }: UpdateElection
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ElectionCandidates', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ElectionCandidates, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ElectionCandidates, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/electionVotes/mutations.ts
+++ b/packages/lesswrong/server/collections/electionVotes/mutations.ts
@@ -1,10 +1,10 @@
-
 import { isPastVotingDeadline, userCanVoteInDonationElection } from "@/lib/collections/electionVotes/helpers";
 import schema from "@/lib/collections/electionVotes/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { isAdmin, userIsAdmin, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -83,7 +83,7 @@ export async function updateElectionVote({ selector, data }: UpdateElectionVoteI
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ElectionVotes', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ElectionVotes, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ElectionVotes, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/elicitQuestionPredictions/mutations.ts
+++ b/packages/lesswrong/server/collections/elicitQuestionPredictions/mutations.ts
@@ -1,10 +1,9 @@
-
 import schema from "@/lib/collections/elicitQuestionPredictions/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
-
 
 export async function createElicitQuestionPrediction({ data }: { data: Partial<DbElicitQuestionPrediction> }, context: ResolverContext) {
   const { currentUser } = context;
@@ -49,7 +48,7 @@ export async function updateElicitQuestionPrediction({ selector, data }: { selec
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ElicitQuestionPredictions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ElicitQuestionPredictions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ElicitQuestionPredictions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/elicitQuestions/mutations.ts
+++ b/packages/lesswrong/server/collections/elicitQuestions/mutations.ts
@@ -1,14 +1,15 @@
-
 import schema from "@/lib/collections/elicitQuestions/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdminOrMod } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
+
 
 function newCheck(user: DbUser | null) {
   if (!user) return false;
@@ -61,7 +62,7 @@ export async function updateElicitQuestion({ selector, data }: UpdateElicitQuest
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ElicitQuestions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ElicitQuestions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ElicitQuestions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/forumEvents/mutations.ts
+++ b/packages/lesswrong/server/collections/forumEvents/mutations.ts
@@ -1,4 +1,3 @@
-
 import schema from "@/lib/collections/forumEvents/newSchema";
 import { canUserEditPostMetadata, userIsPostGroupOrganizer } from "@/lib/collections/posts/helpers";
 import { userCanPost } from "@/lib/collections/users/helpers";
@@ -7,6 +6,7 @@ import { userIsAdmin, userIsPodcaster } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument } from "@/server/vulcan-lib/mutators";
@@ -112,7 +112,7 @@ export async function updateForumEvent({ selector, data }: UpdateForumEventInput
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: ForumEvents, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ForumEvents, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/jargonTerms/mutations.ts
+++ b/packages/lesswrong/server/collections/jargonTerms/mutations.ts
@@ -1,4 +1,3 @@
-
 import { userCanCreateAndEditJargonTerms } from "@/lib/betas";
 import schema from "@/lib/collections/jargonTerms/newSchema";
 import { userIsPostCoauthor } from "@/lib/collections/posts/helpers";
@@ -11,6 +10,7 @@ import { logFieldChanges } from "@/server/fieldChanges";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
+import { backgroundTask } from "@/stubs/server/utils/backgroundTask";
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -127,7 +127,7 @@ export async function updateJargonTerm({ selector, data }: UpdateJargonTermInput
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: JargonTerms, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: JargonTerms, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/llmConversations/mutations.ts
+++ b/packages/lesswrong/server/collections/llmConversations/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/llmConversations/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -59,7 +59,7 @@ export async function updateLlmConversation({ selector, data }: UpdateLlmConvers
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('LlmConversations', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: LlmConversations, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: LlmConversations, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/llmMessages/mutations.ts
+++ b/packages/lesswrong/server/collections/llmMessages/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/llmMessages/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -49,7 +49,7 @@ export async function updateLlmMessage({ selector, data }: { selector: SelectorI
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('LlmMessages', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: LlmMessages, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: LlmMessages, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/localgroups/mutations.ts
+++ b/packages/lesswrong/server/collections/localgroups/mutations.ts
@@ -1,4 +1,3 @@
-
 import schema from "@/lib/collections/localgroups/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo } from "@/lib/vulcan-users/permissions";
@@ -6,6 +5,7 @@ import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfRefe
 import { createGroupNotifications, handleOrganizerUpdates, validateGroupIsOnlineOrHasLocation } from "@/server/callbacks/localgroupCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -111,7 +111,7 @@ export async function updateLocalgroup({ selector, data }: UpdateLocalgroupInput
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: Localgroups, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Localgroups, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/moderationTemplates/mutations.ts
+++ b/packages/lesswrong/server/collections/moderationTemplates/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/moderationTemplates/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -100,7 +100,7 @@ export async function updateModerationTemplate({ selector, data }: UpdateModerat
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: ModerationTemplates, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ModerationTemplates, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/moderatorActions/mutations.ts
+++ b/packages/lesswrong/server/collections/moderatorActions/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/moderatorActions/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { triggerReviewAfterModeration } from "@/server/callbacks/moderatorActionCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -74,7 +74,7 @@ export async function updateModeratorAction({ selector, data }: UpdateModeratorA
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ModeratorActions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ModeratorActions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ModeratorActions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/multiDocuments/mutations.ts
+++ b/packages/lesswrong/server/collections/multiDocuments/mutations.ts
@@ -1,4 +1,3 @@
-
 import { getRootDocument } from "@/lib/collections/multiDocuments/helpers";
 import schema from "@/lib/collections/multiDocuments/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
@@ -14,6 +13,7 @@ import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndRe
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
 import { editCheck as editTagCheck, newCheck as newTagCheck } from "@/server/collections/tags/helpers";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 /**
  * The logic for validating whether a user can either create or update a multi-document is basically the same.
@@ -147,7 +147,7 @@ export async function updateMultiDocument({ selector, data }: UpdateMultiDocumen
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: MultiDocuments, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: MultiDocuments, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/postRelations/mutations.ts
+++ b/packages/lesswrong/server/collections/postRelations/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/postRelations/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -47,7 +47,7 @@ export async function updatePostRelation({ selector, data }: { selector: Selecto
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('PostRelations', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: PostRelations, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: PostRelations, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/posts/mutations.ts
+++ b/packages/lesswrong/server/collections/posts/mutations.ts
@@ -1,4 +1,3 @@
-
 import { canUserEditPostMetadata, userIsPostGroupOrganizer } from "@/lib/collections/posts/helpers";
 import schema from "@/lib/collections/posts/newSchema";
 import { userCanPost } from "@/lib/collections/users/helpers";
@@ -17,6 +16,7 @@ import { logFieldChanges } from "@/server/fieldChanges";
 import { handleCrosspostUpdate } from "@/server/fmCrosspost/crosspost";
 import { rehostPostMetaImages } from "@/server/scripts/convertImagesToCloudinary";
 import { elasticSyncDocument } from "@/server/search/elastic/elasticCallbacks";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { runSlugCreateBeforeCallback, runSlugUpdateBeforeCallback } from "@/server/utils/slugUtil";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
@@ -94,7 +94,7 @@ export async function createPost({ data }: { data: CreatePostDataInput & { _id?:
   // former createAfter callbacks
   await swrInvalidatePostRoute(documentWithId._id);
   if (!documentWithId.authorIsUnreviewed && !documentWithId.draft) {
-    void onPostPublished(documentWithId, context);
+    backgroundTask(onPostPublished(documentWithId, context));
   }
   documentWithId = await applyNewPostTags(documentWithId, afterCreateProperties);
   documentWithId = await createNewJargonTermsCallback(documentWithId, afterCreateProperties);
@@ -135,7 +135,7 @@ export async function createPost({ data }: { data: CreatePostDataInput & { _id?:
   await autoTagNewPost(asyncProperties);
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Posts', documentWithId._id);
+    backgroundTask(elasticSyncDocument('Posts', documentWithId._id));
   }
 
   // former newAsync callbacks
@@ -260,10 +260,10 @@ export async function updatePost({ selector, data }: { data: UpdatePostDataInput
   });
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Posts', updatedDocument._id);
+    backgroundTask(elasticSyncDocument('Posts', updatedDocument._id));
   }
 
-  void logFieldChanges({ currentUser, collection: Posts, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Posts, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/reports/mutations.ts
+++ b/packages/lesswrong/server/collections/reports/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/reports/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { maybeSendAkismetReport } from "@/server/akismet";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -84,7 +84,7 @@ export async function updateReport({ selector, data }: UpdateReportInput, contex
 
   await maybeSendAkismetReport(updatedDocument, oldDocument, context);
 
-  void logFieldChanges({ currentUser, collection: Reports, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Reports, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/reviewWinnerArts/mutations.ts
+++ b/packages/lesswrong/server/collections/reviewWinnerArts/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/reviewWinnerArts/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -47,9 +47,8 @@ export async function updateReviewWinnerArt({ selector, data }: { selector: Sele
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ReviewWinnerArts', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ReviewWinnerArts, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ReviewWinnerArts, oldDocument, data: origData }));
 
   return updatedDocument;
 }
-
 

--- a/packages/lesswrong/server/collections/reviewWinners/mutations.ts
+++ b/packages/lesswrong/server/collections/reviewWinners/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/reviewWinners/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import gql from "graphql-tag";
@@ -61,7 +61,7 @@ export async function updateReviewWinner({ selector, data }: { selector: Selecto
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('ReviewWinners', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: ReviewWinners, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: ReviewWinners, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/rssfeeds/mutations.ts
+++ b/packages/lesswrong/server/collections/rssfeeds/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/rssfeeds/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
 import { populateRawFeed } from "@/server/rss-integration/callbacks";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -68,7 +68,7 @@ export async function updateRSSFeed({ selector, data }: UpdateRSSFeedInput, cont
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('RSSFeeds', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: RSSFeeds, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: RSSFeeds, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/sequences/mutations.ts
+++ b/packages/lesswrong/server/collections/sequences/mutations.ts
@@ -1,4 +1,3 @@
-
 import schema from "@/lib/collections/sequences/newSchema";
 import { isElasticEnabled } from "@/lib/instanceSettings";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
@@ -8,6 +7,7 @@ import { createFirstChapter } from "@/server/callbacks/sequenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
 import { elasticSyncDocument } from "@/server/search/elastic/elasticCallbacks";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -67,7 +67,7 @@ export async function createSequence({ data }: CreateSequenceInput, context: Res
   };
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Sequences', documentWithId._id);
+    backgroundTask(elasticSyncDocument('Sequences', documentWithId._id));
   }
 
   createFirstChapter(documentWithId, context);
@@ -116,10 +116,10 @@ export async function updateSequence({ selector, data }: UpdateSequenceInput, co
   });
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Sequences', updatedDocument._id);
+    backgroundTask(elasticSyncDocument('Sequences', updatedDocument._id));
   }
 
-  void logFieldChanges({ currentUser, collection: Sequences, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Sequences, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/surveyQuestions/mutations.ts
+++ b/packages/lesswrong/server/collections/surveyQuestions/mutations.ts
@@ -4,6 +4,7 @@ import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -63,7 +64,7 @@ export async function updateSurveyQuestion({ selector, data }: UpdateSurveyQuest
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('SurveyQuestions', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: SurveyQuestions, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: SurveyQuestions, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/surveySchedules/mutations.ts
+++ b/packages/lesswrong/server/collections/surveySchedules/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/surveySchedules/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -63,7 +63,7 @@ export async function updateSurveySchedule({ selector, data }: UpdateSurveySched
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('SurveySchedules', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: SurveySchedules, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: SurveySchedules, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/surveys/mutations.ts
+++ b/packages/lesswrong/server/collections/surveys/mutations.ts
@@ -4,6 +4,7 @@ import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -63,7 +64,7 @@ export async function updateSurvey({ selector, data }: UpdateSurveyInput, contex
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('Surveys', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: Surveys, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Surveys, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/tagFlags/mutations.ts
+++ b/packages/lesswrong/server/collections/tagFlags/mutations.ts
@@ -1,10 +1,10 @@
-
 import schema from "@/lib/collections/tagFlags/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { runSlugCreateBeforeCallback, runSlugUpdateBeforeCallback } from "@/server/utils/slugUtil";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
@@ -103,7 +103,7 @@ export async function updateTagFlag({ selector, data }: UpdateTagFlagInput, cont
     props: updateCallbackProperties,
   });
 
-  void logFieldChanges({ currentUser, collection: TagFlags, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: TagFlags, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/tags/mutations.ts
+++ b/packages/lesswrong/server/collections/tags/mutations.ts
@@ -13,6 +13,7 @@ import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndRe
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
 import { newCheck, editCheck } from "./helpers";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 export async function createTag({ data }: CreateTagInput, context: ResolverContext) {
   const { currentUser } = context;
@@ -58,7 +59,7 @@ export async function createTag({ data }: CreateTagInput, context: ResolverConte
   };
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Tags', documentWithId._id);
+    backgroundTask(elasticSyncDocument('Tags', documentWithId._id));
   }
 
   await uploadImagesInEditableFields({
@@ -111,10 +112,10 @@ export async function updateTag({ selector, data }: UpdateTagInput, context: Res
   });
 
   if (isElasticEnabled) {
-    void elasticSyncDocument('Tags', updatedDocument._id);
+    backgroundTask(elasticSyncDocument('Tags', updatedDocument._id));
   }
 
-  void logFieldChanges({ currentUser, collection: Tags, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Tags, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/tweets/mutations.ts
+++ b/packages/lesswrong/server/collections/tweets/mutations.ts
@@ -1,7 +1,7 @@
-
 import schema from "@/lib/collections/tweets/newSchema";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -47,7 +47,7 @@ export async function updateTweet({ selector, data }: { selector: SelectorInput,
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('Tweets', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: Tweets, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: Tweets, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/ultraFeedEvents/mutations.ts
+++ b/packages/lesswrong/server/collections/ultraFeedEvents/mutations.ts
@@ -9,6 +9,7 @@ import gql from "graphql-tag";
 import { z } from "zod";
 import { logFieldChanges } from "@/server/fieldChanges";
 import { userOwns } from "@/lib/vulcan-users/permissions";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 const seeLessEventDataSchema = z.object({
   feedbackReasons: z.object({
@@ -77,7 +78,7 @@ export async function updateUltraFeedEvent(args: { selector: string, data: Updat
     }
   }
   
-  void logFieldChanges({ currentUser, collection: UltraFeedEvents, oldDocument: existingDoc, data: inputData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UltraFeedEvents, oldDocument: existingDoc, data: inputData }));
   
   const updatedDocument = await updateAndReturnDocument(inputData, UltraFeedEvents, { _id: selector }, context);
 

--- a/packages/lesswrong/server/collections/userEAGDetails/mutations.ts
+++ b/packages/lesswrong/server/collections/userEAGDetails/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/userEAGDetails/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -81,7 +81,7 @@ export async function updateUserEAGDetail({ selector, data }: UpdateUserEAGDetai
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('UserEAGDetails', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: UserEAGDetails, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UserEAGDetails, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/userJobAds/mutations.ts
+++ b/packages/lesswrong/server/collections/userJobAds/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/userJobAds/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -81,7 +81,7 @@ export async function updateUserJobAd({ selector, data }: UpdateUserJobAdInput, 
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('UserJobAds', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: UserJobAds, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UserJobAds, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/userMostValuablePosts/mutations.ts
+++ b/packages/lesswrong/server/collections/userMostValuablePosts/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/userMostValuablePosts/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -81,7 +81,7 @@ export async function updateUserMostValuablePost({ selector, data }: UpdateUserM
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('UserMostValuablePosts', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: UserMostValuablePosts, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UserMostValuablePosts, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/userRateLimits/mutations.ts
+++ b/packages/lesswrong/server/collections/userRateLimits/mutations.ts
@@ -1,9 +1,9 @@
-
 import schema from "@/lib/collections/userRateLimits/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -81,7 +81,7 @@ export async function updateUserRateLimit({ selector, data }: UpdateUserRateLimi
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('UserRateLimits', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: UserRateLimits, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UserRateLimits, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/collections/userTagRels/mutations.ts
+++ b/packages/lesswrong/server/collections/userTagRels/mutations.ts
@@ -1,9 +1,9 @@
-
 import { userCanUseTags } from "@/lib/betas";
 import schema from "@/lib/collections/userTagRels/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
@@ -61,7 +61,7 @@ export async function updateUserTagRel({ selector, data }: UpdateUserTagRelInput
 
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('UserTagRels', updatedDocument, oldDocument);
 
-  void logFieldChanges({ currentUser, collection: UserTagRels, oldDocument, data: origData });
+  backgroundTask(logFieldChanges({ currentUser, collection: UserTagRels, oldDocument, data: origData }));
 
   return updatedDocument;
 }

--- a/packages/lesswrong/server/cron/startCron.ts
+++ b/packages/lesswrong/server/cron/startCron.ts
@@ -11,6 +11,7 @@ export function startSyncedCron() {
   }
 
   // Defer starting of cronjobs until 20s after server startup
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   void (async () => {
     await sleep(20000);
   

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -5,6 +5,7 @@ import moment from '../lib/moment-timezone';
 import { addCronJob } from './cron/cronUtil';
 import DebouncerEventsRepo from './repos/DebouncerEventsRepo';
 import { isAnyTest } from '../lib/executionEnvironment';
+import { backgroundTask } from './utils/backgroundTask';
 
 let eventDebouncersByName: Partial<Record<string,EventDebouncer<any>>> = {};
 
@@ -314,7 +315,7 @@ export const cronDebouncedEventHandler = addCronJob({
   cronStyleSchedule: '* * * * *',
   disabled: testServerSetting.get(),
   job() {
-    void dispatchPendingEvents();
+    backgroundTask(dispatchPendingEvents());
   }
 });
 

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -28,6 +28,7 @@ import { ThemeOptions } from '@/themes/themeNames';
 import { EmailWrapper } from '../emailComponents/EmailWrapper';
 import CookiesProvider from '@/lib/vendor/react-cookie/CookiesProvider';
 import { utmifyForumBacklinks, UtmParam } from '../analytics/utm-tracking';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export interface RenderedEmail {
   user: DbUser | null,
@@ -293,7 +294,7 @@ export const wrapAndSendEmail = async ({
   try {
     const email = await wrapAndRenderEmail({ user, to: destinationAddress, from, subject, body, utmParams });
     const succeeded = await sendEmail(email);
-    void logSentEmail(email, user, {succeeded});
+    backgroundTask(logSentEmail(email, user, {succeeded}));
     return succeeded;
   } catch(e) {
     // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/eventReminders.tsx
+++ b/packages/lesswrong/server/eventReminders.tsx
@@ -10,6 +10,7 @@ import moment from '../lib/moment-timezone';
 import { createAnonymousContext } from "@/server/vulcan-lib/createContexts";
 import { updatePost } from './collections/posts/mutations';
 import { EventTomorrowReminder } from './emailComponents/EventTomorrowReminder';
+import { backgroundTask } from './utils/backgroundTask';
 
 async function checkAndSendUpcomingEventEmails() {
   const in24hours = moment(new Date()).add(24, 'hours').toDate();
@@ -64,6 +65,6 @@ export const cronCheckAndSendUpcomingEventEmails = addCronJob({
   cronStyleSchedule: '* * * * *',
   disabled: testServerSetting.get(),
   job() {
-    void checkAndSendUpcomingEventEmails();
+    backgroundTask(checkAndSendUpcomingEventEmails());
   }
 });

--- a/packages/lesswrong/server/gatherTownCron.ts
+++ b/packages/lesswrong/server/gatherTownCron.ts
@@ -8,6 +8,7 @@ import * as _ from 'underscore';
 import { isLW } from '../lib/instanceSettings';
 import { createLWEvent } from './collections/lwevents/mutations';
 import { createAdminContext } from './vulcan-lib/createContexts';
+import { backgroundTask } from './utils/backgroundTask';
 
 const gatherTownRoomPassword = new DatabaseServerSetting<string | null>("gatherTownRoomPassword", "the12thvirtue")
 
@@ -29,7 +30,7 @@ export function initGatherTownCron() {
         name: 'gatherTownBot'+currentGatherTownTrackerVersion,
         interval: "every 3 minutes",
         job() {
-          void pollGatherTownUsers();
+          backgroundTask(pollGatherTownUsers());
         }
       });
     }
@@ -48,7 +49,7 @@ const pollGatherTownUsers = async () => {
   const {gatherTownUsers, checkFailed, failureReason} = result;
   // eslint-disable-next-line no-console
   console.log(`GatherTown users: ${JSON.stringify(result)}`);
-  void createLWEvent({
+  backgroundTask(createLWEvent({
     data: {
       name: 'gatherTownUsersCheck',
       important: false,
@@ -58,7 +59,7 @@ const pollGatherTownUsers = async () => {
         gatherTownUsers, checkFailed, failureReason
       }
     }
-  }, createAdminContext());
+  }, createAdminContext()));
 }
 
 type GatherTownPlayerInfo = any;

--- a/packages/lesswrong/server/karmaInflation/cron.ts
+++ b/packages/lesswrong/server/karmaInflation/cron.ts
@@ -3,6 +3,7 @@ import { nullKarmaInflationSeries, setKarmaInflationSeries, TimeSeries } from '.
 import { addCronJob } from '../cron/cronUtil';
 import PostsRepo from '../repos/PostsRepo';
 import DatabaseMetadataRepo from '../repos/DatabaseMetadataRepo';
+import { backgroundTask } from "../utils/backgroundTask";
 
 const AVERAGING_WINDOW_MS = 1000 * 60 * 60 * 24 * 28; // 28 days
 
@@ -65,6 +66,6 @@ export const refreshKarmaInflationCron = addCronJob({
   name: 'refreshKarmaInflationCron',
   interval: 'every 24 hours',
   job() {
-    void refreshKarmaInflation();
+    backgroundTask(refreshKarmaInflation());
   }
 });

--- a/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
+++ b/packages/lesswrong/server/languageModels/autoTagCallbacks.ts
@@ -271,6 +271,7 @@ export async function getTagBotUserId(context: ResolverContext): Promise<string|
   if (tagBotUserId === undefined) {
     if (!tagBotUserIdPromise) {
       tagBotUserIdPromise = new Promise((resolve) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         void (async () => {
           const tagBotAccount = await getTagBotAccount(context);
           tagBotUserId = tagBotAccount?._id ?? null;

--- a/packages/lesswrong/server/lesswrongFundraiser/stripeIntentsCache.ts
+++ b/packages/lesswrong/server/lesswrongFundraiser/stripeIntentsCache.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import * as Sentry from '@sentry/node';
 import { lightconeFundraiserPaymentLinkId } from '@/lib/publicSettings';
 import { lightconeFundraiserStripeSecretKeySetting } from '../serverSettings';
+import { backgroundTask } from '../utils/backgroundTask';
 export type SucceededPaymentIntent = Stripe.PaymentIntent & { status: 'succeeded' };
 
 export const stripeIntentsCache: { intents: SucceededPaymentIntent[] } = { intents: [] };
@@ -57,7 +58,7 @@ export async function updateStripeIntentsCache() {
 
 export function getStripeIntentsCache(): SucceededPaymentIntent[] {
   if (new Date().getTime() - lastUpdatedAt.getTime() > 1000 * 60) {
-    void updateStripeIntentsCache();
+    backgroundTask(updateStripeIntentsCache());
   }
   return structuredClone(stripeIntentsCache.intents);
 }

--- a/packages/lesswrong/server/manualMigrations/2019-04-10-confirmLegacyEmails.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-04-10-confirmLegacyEmails.ts
@@ -1,6 +1,7 @@
 import { forEachDocumentBatchInCollection, registerMigration } from './migrationUtils';
 import Users from '../../server/collections/users/collection';
 import * as _ from 'underscore';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export default registerMigration({
   name: "confirmLegacyEmails",
@@ -57,7 +58,7 @@ export default registerMigration({
           }
         }
         
-        void Users.rawCollection().bulkWrite(updates, { ordered: false });
+        backgroundTask(Users.rawCollection().bulkWrite(updates, { ordered: false }));
       }
     });
   },

--- a/packages/lesswrong/server/manualMigrations/2019-04-24-migrateLinkPosts.ts
+++ b/packages/lesswrong/server/manualMigrations/2019-04-24-migrateLinkPosts.ts
@@ -1,6 +1,7 @@
 import { registerMigration } from './migrationUtils';
 import { Posts } from '../../server/collections/posts/collection'
 import * as _ from 'underscore';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export default registerMigration({
   name: "migrateLinkPosts",
@@ -41,7 +42,7 @@ export default registerMigration({
     }));
     
     if (updates.length > 0) {
-      void Posts.rawCollection().bulkWrite(updates, { ordered: false });
+      backgroundTask(Posts.rawCollection().bulkWrite(updates, { ordered: false }));
     }
   }
 });

--- a/packages/lesswrong/server/manualMigrations/2023-12-22-send_yourTurn_notifications.ts
+++ b/packages/lesswrong/server/manualMigrations/2023-12-22-send_yourTurn_notifications.ts
@@ -2,6 +2,7 @@ import { registerMigration } from "./migrationUtils";
 import { createAdminContext } from "../vulcan-lib/createContexts";
 import { createNotification } from "../notificationCallbacksHelpers";
 import { getSqlClientOrThrow } from "../../server/sql/sqlClient";
+import { backgroundTask } from "../utils/backgroundTask";
 
 interface DialogueCheckWithExtraData extends DbDialogueCheck {
   targetUserMatchPreferenceId: string;
@@ -39,14 +40,14 @@ export default registerMigration({
     const context = createAdminContext();
     const checksYourTurn = await getMatchFormYourTurn()
     checksYourTurn.forEach(check => {
-      void createNotification({
+      backgroundTask(createNotification({
         userId: check.userId,
         notificationType: 'yourTurnMatchForm',
         documentType: 'dialogueMatchPreference',
         documentId: check.targetUserMatchPreferenceId,
         context,
         extraData: {checkId: check._id}
-      });
+      }));
     })
   }
 })

--- a/packages/lesswrong/server/manualMigrations/2024-05-13-assignRecommendationABTestsGroups.ts
+++ b/packages/lesswrong/server/manualMigrations/2024-05-13-assignRecommendationABTestsGroups.ts
@@ -1,6 +1,7 @@
 import { registerMigration } from "./migrationUtils";
 import { createAdminContext } from "../vulcan-lib/createContexts";
 import { updateUser } from "../collections/users/mutations";
+import { backgroundTask } from "../utils/backgroundTask";
 
 const testGroupIds = [
   '22EP7kj9ea5vtQzX6',
@@ -932,11 +933,11 @@ export default registerMigration({
     const { Users } = adminContext;
 
     testGroupIds.forEach(async (userId: string) => {
-      void updateUser({
+      backgroundTask(updateUser({
         data: {
           frontpageSelectedTab: 'recombee-hybrid'
         }, selector: { _id: userId }
-      }, adminContext);
+      }, adminContext));
     });
   }
 });

--- a/packages/lesswrong/server/manualMigrations/2024-06-10-messageResumeReadingUsers.ts
+++ b/packages/lesswrong/server/manualMigrations/2024-06-10-messageResumeReadingUsers.ts
@@ -7,6 +7,7 @@ import { createAnonymousContext } from '../vulcan-lib/createContexts';
 import { createConversation } from '../collections/conversations/mutations';
 import { computeContextFromUser } from '../vulcan-lib/apollo-server/context';
 import { createMessage } from '../collections/messages/mutations';
+import { backgroundTask } from '../utils/backgroundTask';
 
 const messageResumeReadingUsers = async (user: DbUser) => {
   const context = createAnonymousContext();
@@ -46,7 +47,7 @@ const messageResumeReadingUsers = async (user: DbUser) => {
     conversationId: conversation._id
   }
 
-  void createMessage({ data: firstMessageData }, lwAccountContext);
+  backgroundTask(createMessage({ data: firstMessageData }, lwAccountContext));
 }
 
 
@@ -58,7 +59,7 @@ export default registerMigration({
     const users = await Users.find({frontpageSelectedTab: 'forum-continue-reading'}).fetch();
 
     for (let user of users) {
-      void messageResumeReadingUsers(user);
+      backgroundTask(messageResumeReadingUsers(user));
     }
   },
 });

--- a/packages/lesswrong/server/migrations/20240906T192038.lwevents_ip_index.ts
+++ b/packages/lesswrong/server/migrations/20240906T192038.lwevents_ip_index.ts
@@ -45,12 +45,13 @@
  */
 export const acceptsSchemaHash = "4478fe67319e5ebbe8327768fc26f5f4";
 
+import { backgroundTask } from "../utils/backgroundTask";
 import { updateCustomIndexes } from "./meta/utils"
 
 export const up = async ({dbOutsideTransaction}: MigrationContext) => {
   // `void` instead of `await` when using `dbOutsideTransaction` to avoid a
   // nasty deadlock
-  void updateCustomIndexes(dbOutsideTransaction);
+  backgroundTask(updateCustomIndexes(dbOutsideTransaction));
 }
 
 export const down = async ({db}: MigrationContext) => {

--- a/packages/lesswrong/server/migrations/20250110T003951.add_tag_pingbacks_index.ts
+++ b/packages/lesswrong/server/migrations/20250110T003951.add_tag_pingbacks_index.ts
@@ -1,7 +1,8 @@
+import { backgroundTask } from "../utils/backgroundTask";
 import { updateCustomIndexes } from "./meta/utils";
 
 export const up = async ({dbOutsideTransaction}: MigrationContext) => {
   // `void` instead of `await` when using `dbOutsideTransaction` to avoid a
   // nasty deadlock
-  void updateCustomIndexes(dbOutsideTransaction);
+  backgroundTask(updateCustomIndexes(dbOutsideTransaction));
 }

--- a/packages/lesswrong/server/migrations/20250116T232831.add_index_for_multidoc_pingbacks.ts
+++ b/packages/lesswrong/server/migrations/20250116T232831.add_index_for_multidoc_pingbacks.ts
@@ -1,7 +1,8 @@
+import { backgroundTask } from "../utils/backgroundTask";
 import { updateCustomIndexes } from "./meta/utils";
 
 export const up = async ({dbOutsideTransaction}: MigrationContext) => {
   // `void` instead of `await` when using `dbOutsideTransaction` to avoid a
   // nasty deadlock
-  void updateCustomIndexes(dbOutsideTransaction);
+  backgroundTask(updateCustomIndexes(dbOutsideTransaction));
 }

--- a/packages/lesswrong/server/migrations/20250514T192027.updateCustomIndexes.ts
+++ b/packages/lesswrong/server/migrations/20250514T192027.updateCustomIndexes.ts
@@ -1,8 +1,9 @@
+import { backgroundTask } from "../utils/backgroundTask";
 import { updateCustomIndexes } from "./meta/utils";
 
 export const up = async ({dbOutsideTransaction}: MigrationContext) => {
   // `void` instead of `await` to avoid a deadlock
-  void updateCustomIndexes(dbOutsideTransaction);
+  backgroundTask(updateCustomIndexes(dbOutsideTransaction));
 }
 
 export const down = async ({db}: MigrationContext) => {

--- a/packages/lesswrong/server/migrations/20250624T190405.addBookmarksCount.ts
+++ b/packages/lesswrong/server/migrations/20250624T190405.addBookmarksCount.ts
@@ -1,10 +1,11 @@
 import Users from "../collections/users/collection";
 import BookmarksRepo from "../repos/BookmarksRepo";
+import { backgroundTask } from "../utils/backgroundTask";
 import { addField } from "./meta/utils";
 
 export const up = async ({db, dbOutsideTransaction}: MigrationContext) => {
   await addField(db, Users, "bookmarksCount");
-  void new BookmarksRepo(dbOutsideTransaction).updateBookmarkCountForAllUsers();
+  backgroundTask(new BookmarksRepo(dbOutsideTransaction).updateBookmarkCountForAllUsers());
 }
 
 export const down = async ({db}: MigrationContext) => {

--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -13,6 +13,7 @@ import gql from 'graphql-tag';
 import { PostsEmail } from './emailComponents/PostsEmail';
 import { UtmParam } from './analytics/utm-tracking';
 import { isEAForum } from '@/lib/instanceSettings';
+import { backgroundTask } from './utils/backgroundTask';
 
 // string (notification type name) => Debouncer
 export const notificationDebouncers = toDictionary(getNotificationTypes(),
@@ -25,7 +26,7 @@ export const notificationDebouncers = toDictionary(getNotificationTypes(),
         delayMinutes: 15,
       },
       callback: ({ userId, notificationType }: {userId: string, notificationType: string}, notificationIds: Array<string>) => {
-        void sendNotificationBatch({userId, notificationIds, notificationType});
+        backgroundTask(sendNotificationBatch({userId, notificationIds, notificationType}));
       }
     });
   }

--- a/packages/lesswrong/server/posts/out.ts
+++ b/packages/lesswrong/server/posts/out.ts
@@ -1,10 +1,11 @@
 import { addStaticRoute } from '../vulcan-lib/staticRoutes';
 import { Posts } from '../../server/collections/posts/collection';
 import type { ServerResponse } from 'http';
+import { backgroundTask } from '../utils/backgroundTask';
 
 const redirect = (res: ServerResponse, url: string, post: DbPost | null) => {
   if (post) {
-    void Posts.rawUpdateOne({_id: post._id}, { $inc: { clickCount: 1 } });
+    backgroundTask(Posts.rawUpdateOne({_id: post._id}, { $inc: { clickCount: 1 } }));
     res.writeHead(301, {'Location': url});
     res.end();
   } else {

--- a/packages/lesswrong/server/rateLimitUtils.ts
+++ b/packages/lesswrong/server/rateLimitUtils.ts
@@ -10,6 +10,7 @@ import { triggerReview } from "./callbacks/helpers"
 import { appendToSunshineNotes } from "../lib/collections/users/helpers"
 import { isNonEmpty } from "fp-ts/Array"
 import type { NonEmptyArray } from "fp-ts/lib/NonEmptyArray"
+import { backgroundTask } from "./utils/backgroundTask"
 
 /**
  * Fetches the most recent, active rate limit affecting a user.
@@ -326,25 +327,25 @@ function triggerReviewForStricterRateLimits(
   if (commentRateLimitComparison.isStricter) {
     const { strictestNewRateLimit: { itemsPerTimeframe, timeframeUnit, timeframeLength } } = commentRateLimitComparison;
 
-    void triggerReview(userId, context);
-    void appendToSunshineNotes({
+    backgroundTask(triggerReview(userId, context));
+    backgroundTask(appendToSunshineNotes({
       moderatedUserId: userId,
       adminName: 'Automod',
       text: `User triggered a stricter ${itemsPerTimeframe} comment(s) per ${timeframeLength} ${timeframeUnit} rate limit`,
       context,
-    });
+    }));
   }
 
   if (postRateLimitComparison.isStricter) {
     const { strictestNewRateLimit: { itemsPerTimeframe, timeframeUnit, timeframeLength } } = postRateLimitComparison;
 
-    void triggerReview(userId, context);
-    void appendToSunshineNotes({
+    backgroundTask(triggerReview(userId, context));
+    backgroundTask(appendToSunshineNotes({
       moderatedUserId: userId,
       adminName: 'Automod',
       text: `User triggered a stricter ${itemsPerTimeframe} post(s) per ${timeframeLength} ${timeframeUnit} rate limit`,
       context,
-    });
+    }));
   }
 }
 

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -21,6 +21,7 @@ import { FilterSettings, getDefaultFilterSettings } from '@/lib/filterSettings';
 import { PostsViews } from '@/lib/collections/posts/views';
 import { RevisionHTML } from '@/lib/collections/revisions/fragments';
 import type { RecommendedPost, RecombeeRecommendedPost, NativeRecommendedPost } from '@/lib/recombee/types';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export const getRecombeeClientOrThrow = (() => {
   let client: ApiClient;
@@ -436,7 +437,7 @@ const helpers = {
       }
     }));
 
-    void context.RecommendationsCaches.rawCollection().bulkWrite(recsToInsert);
+    backgroundTask(context.RecommendationsCaches.rawCollection().bulkWrite(recsToInsert));
   },
 
   async getCachedRecommendations({ recRequest, scenario, batch, skipCache, context }: GetCachedRecommendationsArgs): Promise<RecResponse[]> {
@@ -474,9 +475,10 @@ const helpers = {
         }));
     }
 
-    void helpers
+    backgroundTask(helpers
       .sendRecRequestWithPerfMetrics(recRequest, batch, true)
-      .then((recResponse) => helpers.backfillRecommendationsCache(userId, scenario, recResponse, context));
+      .then((recResponse) => helpers.backfillRecommendationsCache(userId, scenario, recResponse, context))
+    );
 
     return formattedRecommendations;
   },

--- a/packages/lesswrong/server/recommendations/RecommendationService.ts
+++ b/packages/lesswrong/server/recommendations/RecommendationService.ts
@@ -13,6 +13,7 @@ import PostRecommendationsRepo from "../repos/PostRecommendationsRepo";
 import { loggerConstructor } from "../../lib/utils/logging";
 import FeatureStrategy from "./FeatureStrategy";
 import NewAndUpvotedInTagStrategy from "./NewAndUpvotedInTagStrategy";
+import { backgroundTask } from "../utils/backgroundTask";
 
 type ConstructableStrategy = {
   new(): RecommendationStrategy,
@@ -70,13 +71,13 @@ class RecommendationService {
       const time = Date.now() - start;
       this.logger("...found", newPosts.length, "posts in", time, "milliseconds");
 
-      void this.repo.recordRecommendations(
+      backgroundTask(this.repo.recordRecommendations(
         currentUser,
         clientId,
         strategies[0],
         {...result.settings, context: strategy.context},
         newPosts,
-      );
+      ));
 
       posts = posts.concat(newPosts);
       count -= newPosts.length;

--- a/packages/lesswrong/server/rendering/pageCache.ts
+++ b/packages/lesswrong/server/rendering/pageCache.ts
@@ -11,6 +11,7 @@ import { DatabaseServerSetting } from '@/server/databaseSettings';
 import { isDatadogEnabled } from '@/lib/instanceSettings';
 import stringify from 'json-stringify-deterministic';
 import { ResponseManager } from './ResponseManager';
+import { backgroundTask } from '../utils/backgroundTask';
 
 // Page cache. This applies only to logged-out requests, and exists primarily
 // to handle the baseload of traffic going to the front page and to pages that
@@ -257,7 +258,7 @@ const cacheStoreLocal = (cacheKey: string, abTestGroups: RelevantTestGroupAlloca
 }
 
 const cacheStoreDB = (cacheKey: string, abTestGroups: RelevantTestGroupAllocation, rendered: CachedRenderResult): void => {
-  void new PageCacheRepo().upsertPageCacheEntry(cacheKey, abTestGroups, rendered);
+  backgroundTask(new PageCacheRepo().upsertPageCacheEntry(cacheKey, abTestGroups, rendered));
 }
 
 const cacheStore = (cacheKey: string, abTestGroups: RelevantTestGroupAllocation, rendered: CachedRenderResult): void => {

--- a/packages/lesswrong/server/rendering/renderPage.tsx
+++ b/packages/lesswrong/server/rendering/renderPage.tsx
@@ -165,6 +165,7 @@ export async function handleRequest(request: Request, response: Response) {
   const resourcePrefetchOption = parsedRoute.currentRoute?.enableResourcePrefetch
   if (resourcePrefetchOption) {
     if (typeof resourcePrefetchOption === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       void (async () => {
         if (await resourcePrefetchOption(request, response, parsedRoute, createAnonymousContext())) {
           responseManager.setStatus(200);

--- a/packages/lesswrong/server/rendering/requestQueue.ts
+++ b/packages/lesswrong/server/rendering/requestQueue.ts
@@ -81,7 +81,8 @@ function maybeStartQueuedRequests() {
       });
 
       inFlightRenderCount++;
-      void request.callback();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      request.callback();
     }
   }
 }

--- a/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
+++ b/packages/lesswrong/server/resolvers/alignmentForumMutations.ts
@@ -4,6 +4,7 @@ import { userCanMakeAlignmentPost } from '../../lib/alignment-forum/users/helper
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
 import { moveToAFUpdatesUserAFKarma, postsMoveToAFAddsAlignmentVoting } from '../callbacks/alignment-forum/callbacks';
 import { commentsAlignmentEdit, recalculateAFCommentMetadata } from '../callbacks/commentCallbackFunctions';
+import { backgroundTask } from "../utils/backgroundTask";
 
 export const alignmentForumMutations = {
   async alignmentComment(root: void, {commentId, af}: {commentId: string, af: boolean}, context: ResolverContext) {
@@ -31,7 +32,7 @@ export const alignmentForumMutations = {
       await context.Posts.rawUpdateOne({_id: postId}, modifier);
       const updatedPost = (await context.Posts.findOne(postId))!
       await moveToAFUpdatesUserAFKarma(updatedPost, post);
-      void postsMoveToAFAddsAlignmentVoting(updatedPost, post);
+      backgroundTask(postsMoveToAFAddsAlignmentVoting(updatedPost, post));
       return await accessFilterSingle(context.currentUser, 'Posts', updatedPost, context);
     } else {
       throw new Error(`app.user_cannot_edit_post_alignment_forum_status`);

--- a/packages/lesswrong/server/resolvers/arbitalPageData.ts
+++ b/packages/lesswrong/server/resolvers/arbitalPageData.ts
@@ -4,6 +4,7 @@ import { ArbitalCaches } from '../collections/arbitalCache/collection';
 import { addCronJob } from '../cron/cronUtil';
 import gql from 'graphql-tag';
 import { getMarkdownItArbital } from '@/lib/utils/markdownItPlugins';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export const arbitalCacheExpirationMs = 2*60*60*1000;
 
@@ -118,12 +119,12 @@ async function getArbitalPageWithCache(pageAlias: string): Promise<{ html: strin
   
   const result =  await fetchArbitalPageAsHtml(pageAlias);
   if (!result) return null;
-  void ArbitalCaches.rawInsert({
+  backgroundTask(ArbitalCaches.rawInsert({
     pageAlias,
     title: result.title,
     fetchedAt: now,
     sanitizedHtml: result.html, //TODO: This came out of a markdown conversion; is it safe?
-  });
+  }));
   
   return result;
 }

--- a/packages/lesswrong/server/resolvers/conversationResolvers.ts
+++ b/packages/lesswrong/server/resolvers/conversationResolvers.ts
@@ -8,6 +8,7 @@ import { createMessage } from '../collections/messages/mutations';
 import { computeContextFromUser } from '../vulcan-lib/apollo-server/context';
 import { ACCESS_FILTERED, accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { isAF } from "@/lib/instanceSettings";
+import { backgroundTask } from "../utils/backgroundTask";
 
 export const dmTriggeringEvents = new TupleSet(['newFollowSubscription'] as const)
 export type DmTriggeringEvent = UnionOf<typeof dmTriggeringEvents>;
@@ -110,9 +111,9 @@ export const conversationGqlMutations = {
       conversationId: conversation._id
     }
 
-    void createMessage({
+    backgroundTask(createMessage({
       data: firstMessageData
-    }, lwContext);
+    }, lwContext));
 
     return true;
   },

--- a/packages/lesswrong/server/resolvers/googleVertexResolvers.ts
+++ b/packages/lesswrong/server/resolvers/googleVertexResolvers.ts
@@ -2,6 +2,7 @@ import gql from "graphql-tag";
 import { googleVertexApi, helpers as googleVertexHelpers } from "../google-vertex/client";
 import type { PostEvent } from "../google-vertex/types";
 import { captureException } from "@sentry/core";
+import { backgroundTask } from "../utils/backgroundTask";
 
 export const googleVertexGqlTypeDefs = gql`
   extend type Mutation {
@@ -26,8 +27,8 @@ export const googleVertexGqlMutations = {
       const viewItemEvent = googleVertexHelpers.createViewItemEvent('view-item', eventInfo);
       const mediaPlayEvent = googleVertexHelpers.createViewItemEvent('media-play', eventInfo);
   
-      void googleVertexApi.writeUserEvent(viewItemEvent);
-      void googleVertexApi.writeUserEvent(mediaPlayEvent);
+      backgroundTask(googleVertexApi.writeUserEvent(viewItemEvent));
+      backgroundTask(googleVertexApi.writeUserEvent(mediaPlayEvent));
       return true;
     } catch(e) {
       captureException(e);
@@ -45,7 +46,7 @@ export const googleVertexGqlMutations = {
       const now = new Date();
       const viewHomePageEvent = googleVertexHelpers.createViewHomePageEvent({ userId: currentUser._id, timestamp: now });
   
-      void googleVertexApi.writeUserEvent(viewHomePageEvent);
+      backgroundTask(googleVertexApi.writeUserEvent(viewHomePageEvent));
       return true;
     } catch(e) {
       captureException(e);
@@ -65,7 +66,7 @@ export const googleVertexGqlMutations = {
       const eventInfo: PostEvent = { userId: currentUser._id, postId, timestamp: now, attributionId };
       const mediaCompleteEvent = googleVertexHelpers.createMediaCompleteEvent(eventInfo);
   
-      void googleVertexApi.writeUserEvent(mediaCompleteEvent);
+      backgroundTask(googleVertexApi.writeUserEvent(mediaCompleteEvent));
       return true;
     } catch(e) {
       captureException(e);

--- a/packages/lesswrong/server/resolvers/reviewWinnerResolvers.ts
+++ b/packages/lesswrong/server/resolvers/reviewWinnerResolvers.ts
@@ -4,13 +4,14 @@ import { reviewWinnerCache, ReviewWinnerWithPost } from "@/server/review/reviewW
 import { isLWorAF } from "../../lib/instanceSettings";
 import gql from "graphql-tag";
 import { createAdminContext, createAnonymousContext } from "../vulcan-lib/createContexts";
+import { backgroundTask } from "../utils/backgroundTask";
 
 
 export async function initReviewWinnerCache() {
   if (isLWorAF) {
     const context = createAnonymousContext();
-    void reviewWinnerCache.get(context);
-    void splashArtCoordinateCache.get(context);
+    backgroundTask(reviewWinnerCache.get(context));
+    backgroundTask(splashArtCoordinateCache.get(context));
   }
 }
 

--- a/packages/lesswrong/server/resolvers/surveyResolvers.ts
+++ b/packages/lesswrong/server/resolvers/surveyResolvers.ts
@@ -5,6 +5,7 @@ import type { SurveyScheduleWithSurvey } from "../repos/SurveySchedulesRepo";
 import gql from "graphql-tag";
 import { createSurveyQuestion, updateSurveyQuestion } from "../collections/surveyQuestions/mutations";
 import { updateSurvey } from "../collections/surveys/mutations";
+import { backgroundTask } from "../utils/backgroundTask";
 
 type EditSurveyArgs = {
   surveyId: string,
@@ -46,7 +47,7 @@ export const surveyResolversGraphQLQueries = {
       clientId,
     );
     if (survey) {
-      void surveySchedules.assignClientToSurveySchedule(survey._id, clientId);
+      backgroundTask(surveySchedules.assignClientToSurveySchedule(survey._id, clientId));
       return survey;
     }
     return null;

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -39,6 +39,7 @@ import { updateTag } from '../collections/tags/mutations';
 import { WithDateFields } from '@/lib/utils/dateUtils';
 import { getDefaultViewSelector, mergeSelectors, mergeWithDefaultViewSelector } from '@/lib/utils/viewUtils';
 import { CommentsViews } from '@/lib/collections/comments/views';
+import { backgroundTask } from '../utils/backgroundTask';
 
 type SubforumFeedSort = {
   posts: SubquerySortField<DbPost, keyof DbPost>,
@@ -521,7 +522,7 @@ export const tagResolversGraphQLMutations = {
       }
     }
     // Don't await this, because it might cause a timeout
-    void updateDenormalizedTags();
+    backgroundTask(updateDenormalizedTags());
 
     //
     // Transfer sub-tags

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -24,6 +24,7 @@ import { captureEvent } from '@/lib/analyticsEvents';
 import union from 'lodash/union';
 import groupBy from 'lodash/groupBy';
 import mergeWith from 'lodash/mergeWith';
+import { backgroundTask } from "../utils/backgroundTask";
 
 interface UltraFeedDateCutoffs {
   latestPostsMaxAgeDays: number;
@@ -711,7 +712,7 @@ export const ultraFeedGraphQLQueries = {
         const currentOffset = offset ?? 0; 
         const eventsToCreate = createUltraFeedEvents(results, currentUser._id, sessionId, currentOffset);
         if (eventsToCreate.length > 0) {
-          void bulkRawInsert("UltraFeedEvents", eventsToCreate as DbUltraFeedEvent[]);
+          backgroundTask(bulkRawInsert("UltraFeedEvents", eventsToCreate as DbUltraFeedEvent[]));
         }
       }
 

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -12,6 +12,7 @@ import { getUnusedSlugByCollectionName } from '../utils/slugUtil';
 import gql from 'graphql-tag';
 import { updateUser } from '../collections/users/mutations';
 import { accessFilterSingle } from '@/lib/utils/schemaUtils';
+import { backgroundTask } from '../utils/backgroundTask';
 
 type NewUserUpdates = {
   username: string
@@ -248,7 +249,7 @@ export const graphqlQueries = {
 
       // Start a background refresh if data is stale and no fetch is in progress
       if (isStale && !inFlightPromise) {
-        void startAirtableFetch();
+        backgroundTask(startAirtableFetch());
       }
 
       // Always return cached data (stale-while-revalidate pattern)

--- a/packages/lesswrong/server/runServer.ts
+++ b/packages/lesswrong/server/runServer.ts
@@ -1,3 +1,4 @@
 import { serverStartup } from "./serverStartup";
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 void serverStartup();

--- a/packages/lesswrong/server/scripts/createKarmaAward.ts
+++ b/packages/lesswrong/server/scripts/createKarmaAward.ts
@@ -4,6 +4,7 @@ import { Posts } from "@/server/collections/posts/collection.ts";
 import { karmaRewarderId100, karmaRewarderId1000 } from "@/lib/voting/vote";
 import { createPost } from "../collections/posts/mutations";
 import { computeContextFromUser } from "../vulcan-lib/apollo-server/context";
+import { backgroundTask } from "../utils/backgroundTask";
 
 const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, reason: string) => {
   // eslint-disable-next-line no-console
@@ -37,12 +38,12 @@ const createKarmaAwardForUser = async (userId: string, karmaAmount: 100|1000, re
     data: { userId: user._id, draft: true, deletedDraft: true, title: postInfo, contents } as CreatePostDataInput // deletedDraft isn't allowed through the create API, so we need validation disabled and a type cast
   }, userContext);
 
-  void performVoteServer({documentId: post._id, voteType: "bigUpvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true});
+  backgroundTask(performVoteServer({documentId: post._id, voteType: "bigUpvote", user: karmaAwardGivingUser, collection: Posts, skipRateLimits: true}));
 }
 
 // Exported to allow running manually with "yarn repl"
 export const createKarmaAwards = async (userIds: string[], karmaAmount: 100|1000, reason: string) => {
   for (const userId of userIds) {
-    void createKarmaAwardForUser(userId, karmaAmount, reason);
+    backgroundTask(createKarmaAwardForUser(userId, karmaAmount, reason));
   }
 }

--- a/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
+++ b/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
@@ -1,5 +1,6 @@
 import { wrapVulcanAsyncScript } from './utils'
 import Users from '../../server/collections/users/collection'
+import { backgroundTask } from '../utils/backgroundTask';
 
 /*
  * This script attempts to ensure that all users with an "email" value
@@ -44,7 +45,7 @@ export const ensureEmailInEmails = wrapVulcanAsyncScript(
         // add email to emails
         const newEmail = {address: user.email, verified: true};
         const newEmails = user.emails ? [...user.emails, newEmail] : [newEmail]
-        void Users.rawUpdateOne(user._id, {$set: {'emails': newEmails}});
+        backgroundTask(Users.rawUpdateOne(user._id, {$set: {'emails': newEmails}}));
         // eslint-disable-next-line no-console
         console.log('updating user account:', user.email, user.emails, newEmails);
       }

--- a/packages/lesswrong/server/scripts/fixEmailField.ts
+++ b/packages/lesswrong/server/scripts/fixEmailField.ts
@@ -1,9 +1,7 @@
 import Users from '../../server/collections/users/collection';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
-const fixEmail = false;
-
-if (fixEmail) { void (async ()=>{
+export async function fixEmail() {
   let usersCount = 0;
   let duplicateCount = 0;
   //eslint-disable-next-line no-console
@@ -25,4 +23,4 @@ if (fixEmail) { void (async ()=>{
   })
   //eslint-disable-next-line no-console
   console.log("Found n duplicate emails: ", duplicateCount);
-})()}
+}

--- a/packages/lesswrong/server/scripts/fixFrontpageCount.ts
+++ b/packages/lesswrong/server/scripts/fixFrontpageCount.ts
@@ -1,9 +1,7 @@
 import { Posts } from '../../server/collections/posts/collection';
 import Users from '../../server/collections/users/collection';
 
-const fixFrontpageCounts = false
-
-async function fixFrontpagePostCount() {
+export async function fixFrontpagePostCount() {
   try {
     let frontpageCountsPromise = Posts.aggregate([
       {$match: {frontpage: true}},
@@ -29,8 +27,4 @@ async function fixFrontpagePostCount() {
      //eslint-disable-next-line no-console
      console.error(e);
    }
-}
-
-if (fixFrontpageCounts) {
-  void fixFrontpagePostCount()
 }

--- a/packages/lesswrong/server/scripts/fixKarmaField.ts
+++ b/packages/lesswrong/server/scripts/fixKarmaField.ts
@@ -1,7 +1,6 @@
 import Users from '../../server/collections/users/collection';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
-const fixKarma = false;
 const mainPostKarmaWeight = 10;
 const mainCommentKarmaWeight = 1;
 const discussionPostKarmaWeight = 1;
@@ -9,7 +8,7 @@ const discussionCommentKarmaWeight = 1;
 const upvoteWeight = 1;
 const downvoteWeight = 1;
 
-if (fixKarma) { void (async ()=>{
+export async function fixKarma() {
   let usersCount = 0;
   const allUsers = await Users.find().fetch();
   await asyncForeachSequential(allUsers, async (user) => {
@@ -50,4 +49,4 @@ if (fixKarma) { void (async ()=>{
       }
     }
   })
-})() }
+}

--- a/packages/lesswrong/server/scripts/generativeModels/autoSpotlight.ts
+++ b/packages/lesswrong/server/scripts/generativeModels/autoSpotlight.ts
@@ -7,6 +7,7 @@ import { createAdminContext } from "../../vulcan-lib/createContexts";
 import { createSpotlight as createSpotlightMutator } from "@/server/collections/spotlights/mutations";
 import { ReviewWinnerTopPostsPage } from "@/lib/collections/reviewWinners/fragments";
 import { PostsWithNavigation } from "@/lib/collections/posts/fragments";
+import { backgroundTask } from "@/server/utils/backgroundTask";
 
 async function queryClaudeJailbreak(prompt: PromptCachingBetaMessageParam[], maxTokens: number) {
   const client = getAnthropicPromptCachingClientOrThrow()
@@ -23,7 +24,7 @@ function createSpotlight (post: PostsWithNavigation, reviewWinner: ReviewWinnerW
   const postYear = new Date(post.postedAt).getFullYear()
   const cloudinaryImageUrl = reviewWinner?.reviewWinner.reviewWinnerArt?.splashArtImageUrl
 
-  void createSpotlightMutator({
+  backgroundTask(createSpotlightMutator({
     data: {
       documentId: post._id,
       documentType: "Post",
@@ -36,7 +37,7 @@ function createSpotlight (post: PostsWithNavigation, reviewWinner: ReviewWinnerW
       description: { originalContents: { type: 'ckEditorMarkup', data: summary } },
       lastPromotedAt: new Date(0),
     }
-  }, context);
+  }, context));
 }
 
 async function getPromptInfo(): Promise<{posts: PostsWithNavigation[], spotlights: DbSpotlight[]}> {

--- a/packages/lesswrong/server/scripts/hpmorImport.ts
+++ b/packages/lesswrong/server/scripts/hpmorImport.ts
@@ -7,6 +7,7 @@ import { createPost } from '../collections/posts/mutations';
 
 const hpmorImport = false;
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 if (hpmorImport) { void (async ()=>{
   let filepath = process.env["PWD"] + "/packages/lesswrong/assets/hpmor_data.json";
   let f = fs.readFileSync(filepath, 'utf8');
@@ -44,6 +45,7 @@ if (hpmorImport) { void (async ()=>{
 
     if (!oldPost){
       const lwContext = await computeContextFromUser({ user: lwUser, isSSR: false });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       void createPost({
         data: post
       }, lwContext);

--- a/packages/lesswrong/server/scripts/importEAGUserInterests.ts
+++ b/packages/lesswrong/server/scripts/importEAGUserInterests.ts
@@ -5,6 +5,7 @@ import Users from '../../server/collections/users/collection';
 import { wrapVulcanAsyncScript } from './utils';
 import UserEAGDetails from '../../server/collections/userEAGDetails/collection';
 import moment from 'moment';
+import { backgroundTask } from '../utils/backgroundTask';
 
 const csvSchema = z.object({
   email: z.string(),
@@ -77,7 +78,7 @@ export const importEAGUserDetails = wrapVulcanAsyncScript(
     
     // Upsert EAG data for all the users in the CSV
     // WARNING: Upserts will be deprecated at some point
-    void UserEAGDetails.rawCollection().bulkWrite(Object.values(records).map((record) => {
+    backgroundTask((UserEAGDetails.rawCollection().bulkWrite(Object.values(records).map((record) => {
       delete record.submissionDate
       return {
         updateOne: {
@@ -86,6 +87,6 @@ export const importEAGUserDetails = wrapVulcanAsyncScript(
           upsert: true,
         }
       }
-    }));
+    }))));
   }
 )

--- a/packages/lesswrong/server/scripts/importLocalgroups.ts
+++ b/packages/lesswrong/server/scripts/importLocalgroups.ts
@@ -5,6 +5,7 @@ import { GROUP_CATEGORIES } from "@/lib/collections/localgroups/groupTypes";
 import { wrapVulcanAsyncScript } from './utils';
 import { createLocalgroup, updateLocalgroup } from '../collections/localgroups/mutations';
 import { createAnonymousContext } from "@/server/vulcan-lib/createContexts";
+import { backgroundTask } from '../utils/backgroundTask';
 
 /**
  * Import data for localgroups
@@ -66,7 +67,7 @@ export const importLocalgroups = wrapVulcanAsyncScript(
         }
         // replace any existing data with the imported data
         else {
-          void updateLocalgroup({ data: { ...dataToSet }, selector: { _id: data._id } }, createAnonymousContext())
+          backgroundTask(updateLocalgroup({ data: { ...dataToSet }, selector: { _id: data._id } }, createAnonymousContext()))
         }
       })
   }

--- a/packages/lesswrong/server/scripts/nullifyVotes.ts
+++ b/packages/lesswrong/server/scripts/nullifyVotes.ts
@@ -5,12 +5,13 @@ import { Votes } from '../../server/collections/votes/collection';
 import { createAdminContext } from "../vulcan-lib/createContexts";
 import { silentlyReverseVote } from '../voteServer';
 import { nullifyVotesForUser } from '../nullifyVotesForUser';
+import { backgroundTask } from '../utils/backgroundTask';
 
 // Exported to allow running manually with "yarn repl"
 export const nullifyVotesForNullifiedUsers = async () => {
   const users = await Users.find({nullifyVotes: true}).fetch();
   users.forEach((user) => {
-    void nullifyVotesForUser(user);
+    backgroundTask(nullifyVotesForUser(user));
   })
   //eslint-disable-next-line no-console
   console.warn(`Nullified votes for ${users.length} users`);

--- a/packages/lesswrong/server/scripts/oneOffBanSpammers.ts
+++ b/packages/lesswrong/server/scripts/oneOffBanSpammers.ts
@@ -3,6 +3,7 @@ import { userIPBanAndResetLoginTokens, userDeleteContent } from '../users/modera
 import Users from '../../server/collections/users/collection'
 import moment from 'moment'
 import { createAdminContext } from '../vulcan-lib/createContexts'
+import { backgroundTask } from '../utils/backgroundTask'
 
 const banUser = async (user: DbUser, adminUser: DbUser) => {
   // this was not updated when we moved from the "bio" field to the "biography" field,
@@ -21,8 +22,8 @@ const banUser = async (user: DbUser, adminUser: DbUser) => {
       },
     }
   }])
-  void userIPBanAndResetLoginTokens(user);
-  void userDeleteContent(user, adminUser, createAdminContext());
+  backgroundTask(userIPBanAndResetLoginTokens(user));
+  backgroundTask(userDeleteContent(user, adminUser, createAdminContext()));
 }
 
 export const oneOffBanSpammers = wrapVulcanAsyncScript(

--- a/packages/lesswrong/server/scripts/slugDeduplication.ts
+++ b/packages/lesswrong/server/scripts/slugDeduplication.ts
@@ -1,9 +1,7 @@
 import { Posts } from '../../server/collections/posts/collection';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
-const runDeduplication = false;
-
-async function slugDeduplication() {
+export async function slugDeduplication() {
   try {
     //eslint-disable-next-line no-console
     console.log("Running slugDeduplication");
@@ -48,8 +46,4 @@ async function slugDeduplication() {
     //eslint-disable-next-line no-console
     console.error(e)
   }
-}
-
-if (runDeduplication) {
-  void slugDeduplication()
 }

--- a/packages/lesswrong/server/scripts/sscImport.ts
+++ b/packages/lesswrong/server/scripts/sscImport.ts
@@ -8,6 +8,7 @@ import { createRSSFeed } from '../collections/rssfeeds/mutations';
 import { createAnonymousContext } from '../vulcan-lib/createContexts';
 import { computeContextFromUser } from "@/server/vulcan-lib/apollo-server/context";
 import { createPost, updatePost } from '../collections/posts/mutations';
+import { backgroundTask } from '../utils/backgroundTask';
 
 async function rssImport(userId: string, rssURL: string, pages = 100, overwrite = false, feedName = "", feedLink = "") {
   try {
@@ -61,11 +62,11 @@ async function rssImport(userId: string, rssURL: string, pages = 100, overwrite 
         const userContext = await computeContextFromUser({ user: lwUser, isSSR: false });
 
         if (!oldPost){
-          void createPost({ data: post }, userContext);
+          backgroundTask(createPost({ data: post }, userContext));
         } else {
           if(overwrite) {
             const userContext = await computeContextFromUser({ user: lwUser, isSSR: false });
-            void updatePost({ data: {...post}, selector: { _id: oldPost._id } }, userContext)
+            backgroundTask(updatePost({ data: {...post}, selector: { _id: oldPost._id } }, userContext))
           }
           //eslint-disable-next-line no-console
           console.warn("Post already imported: ", oldPost.title);
@@ -83,7 +84,7 @@ let zviId = "N9zj5qpTfqmbn9dro"
 let zviImport = false;
 
 if (zviImport) {
-  void rssImport(zviId, zviRSS, 10, true);
+  backgroundTask(rssImport(zviId, zviRSS, 10, true));
 }
 
 let katjaRSS = "https://meteuphoric.wordpress.com/feed/?paged="
@@ -91,7 +92,7 @@ let katjaId = "jRRYAy2mQAHy2Mq3f"
 let katjaImport = false;
 
 if (katjaImport) {
-  void rssImport(katjaId, katjaRSS, 40, true);
+  backgroundTask(rssImport(katjaId, katjaRSS, 40, true));
 }
 
 let putanumonitRSS = "https://putanumonit.com/feed/?paged=";
@@ -99,5 +100,5 @@ let putanumonitId = "tzER8b2F9ofG5wq5p";
 let putanumonitImport = false;
 
 if (putanumonitImport) {
-  void rssImport(putanumonitId, putanumonitRSS, 4, false, "putanumonit", "https://putanumonit.com/feed/");
+  backgroundTask(rssImport(putanumonitId, putanumonitRSS, 4, false, "putanumonit", "https://putanumonit.com/feed/"));
 }

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -17,6 +17,7 @@ import { basename, join } from 'path';
 import type { CommandLineArguments } from './commandLine';
 import { captureEvent } from '@/lib/analyticsEvents';
 import { updateStripeIntentsCache } from './lesswrongFundraiser/stripeIntentsCache';
+import { backgroundTask } from './utils/backgroundTask';
 
 /**
  * Entry point for the server, assuming it's a webserver (ie not cluster mode,
@@ -47,12 +48,12 @@ export async function runServerOnStartupFunctions() {
   serverInitSentry();
   startMemoryUsageMonitor();
   initLegacyRoutes();
-  void startupSanityChecks();
-  void refreshKarmaInflationCache();
+  backgroundTask(startupSanityChecks());
+  backgroundTask(refreshKarmaInflationCache());
   initGoogleVertex();
   addLegacyRssRoutes();
-  void initReviewWinnerCache();
-  void updateStripeIntentsCache();
+  backgroundTask(initReviewWinnerCache());
+  backgroundTask(updateStripeIntentsCache());
 
   startSyncedCron();
   captureEvent("serverStarted", {});

--- a/packages/lesswrong/server/sql/PgCollection.ts
+++ b/packages/lesswrong/server/sql/PgCollection.ts
@@ -13,6 +13,7 @@ import util from "util";
 import { DatabaseIndexSet } from "../../lib/utils/databaseIndexSet";
 import TableIndex from "./TableIndex";
 import { getSchema } from "@/lib/schema/allSchemas";
+import { backgroundTask } from "../utils/backgroundTask";
 
 let executingQueries = 0;
 
@@ -261,7 +262,7 @@ class PgCollection<
         `as this would cause a deadlock. If your code relies on this index existing immediately ` +
         `you should deploy in two stages. This is the query in question: "${query.compile()?.sql}"`
       )
-      void this.executeQuery(query, {fieldOrSpec, options}, "noTransaction")
+      backgroundTask(this.executeQuery(query, {fieldOrSpec, options}, "noTransaction"))
     }
   }
 

--- a/packages/lesswrong/server/tagging/helpers.ts
+++ b/packages/lesswrong/server/tagging/helpers.ts
@@ -2,6 +2,7 @@ import { TagRels } from '../../server/collections/tagRels/collection';
 import { Posts } from '../../server/collections/posts/collection';
 import { elasticSyncDocument } from '../search/elastic/elasticCallbacks';
 import { isElasticEnabled } from '../../lib/instanceSettings';
+import { backgroundTask } from '../utils/backgroundTask';
 
 export async function updatePostDenormalizedTags(postId: string) {
   if (!postId) {
@@ -20,6 +21,6 @@ export async function updatePostDenormalizedTags(postId: string) {
 
   await Posts.rawUpdateOne({_id:postId}, {$set: {tagRelevance: tagRelDict}});
   if (isElasticEnabled) {
-    void elasticSyncDocument("Posts", postId);
+    backgroundTask(elasticSyncDocument("Posts", postId));
   }
 }

--- a/packages/lesswrong/server/userJobAdCron.tsx
+++ b/packages/lesswrong/server/userJobAdCron.tsx
@@ -9,6 +9,7 @@ import { wrapAndSendEmail } from './emails/renderEmail';
 import { loggerConstructor } from '../lib/utils/logging';
 import { isEAForum } from '../lib/instanceSettings';
 import { EmailJobAdReminder } from './emailComponents/EmailJobAdReminder';
+import { backgroundTask } from './utils/backgroundTask';
 
 // Exported to allow running with "yarn repl"
 export const sendJobAdReminderEmails = async () => {
@@ -52,12 +53,12 @@ export const sendJobAdReminderEmails = async () => {
     const recipient = users.find(u => u._id === userJobAd.userId)
     if (recipient) {
       const jobAdData = JOB_AD_DATA[userJobAd.jobName]
-      void wrapAndSendEmail({
+      backgroundTask(wrapAndSendEmail({
         user: recipient,
         subject: `Reminder: ${jobAdData.role} role at${jobAdData.insertThe ? ' the ' : ' '}${jobAdData.org}`,
         body: <EmailJobAdReminder jobName={userJobAd.jobName} />,
         force: true  // ignore the "unsubscribe to all" in this case, since the user initiated it
-      })
+      }))
     }
   }
   
@@ -69,7 +70,7 @@ export const sendJobAdReminderEmailsCron = addCronJob({
   interval: `every 1 day`,
   disabled: !isEAForum,
   job() {
-    void sendJobAdReminderEmails();
+    backgroundTask(sendJobAdReminderEmails());
   }
 });
 

--- a/packages/lesswrong/server/utils/backgroundTask.ts
+++ b/packages/lesswrong/server/utils/backgroundTask.ts
@@ -1,0 +1,11 @@
+
+/**
+ * Run a task (promise), without waiting for the result. If in a serverless
+ * context, this function is responsible for making sure the process doesn't
+ * exit until the background task is finished. In a non-serverless context,
+ * this has no effect.
+ */
+export const backgroundTask = <T>(promise: Promise<T>) => {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  void promise;
+}

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -29,6 +29,7 @@ import { capitalize } from '@/lib/vulcan-lib/utils';
 import { createVote as createVoteMutator } from '@/server/collections/votes/mutations';
 import { createModeratorAction } from './collections/moderatorActions/mutations';
 import { getSchema } from '@/lib/schema/allSchemas';
+import { backgroundTask } from './utils/backgroundTask';
 
 
 // Test if a user has voted on the server
@@ -82,10 +83,10 @@ const addVoteServer = async ({ document, collection, voteType, extendedVote, use
     {}
   );
   if (isElasticEnabled && collectionIsSearchIndexed(collection.collectionName)) {
-    void elasticSyncDocument(collection.collectionName, newDocument._id);
+    backgroundTask(elasticSyncDocument(collection.collectionName, newDocument._id));
   }
   if (collection.collectionName === "Posts") {
-    void swrInvalidatePostRoute(newDocument._id)
+    backgroundTask(swrInvalidatePostRoute(newDocument._id))
   }
   return {newDocument, vote};
 }
@@ -205,7 +206,7 @@ export const clearVotesServer = async ({ document, user, collection, excludeLate
     ...newScores,
   };
   if (isElasticEnabled && collectionIsSearchIndexed(collection.collectionName)) {
-    void elasticSyncDocument(collection.collectionName, newDocument._id);
+    backgroundTask(elasticSyncDocument(collection.collectionName, newDocument._id));
   }
   return newDocument;
 }
@@ -296,12 +297,12 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
       const { moderatorActionType } = await checkVotingRateLimits({ document, collection, voteType, user, context });
       if (moderatorActionType && !(await wasVotingPatternWarningDeliveredRecently(user, moderatorActionType))) {
         if (moderatorActionType === RECEIVED_VOTING_PATTERN_WARNING) showVotingPatternWarning = true;
-        void createModeratorAction({
+        backgroundTask(createModeratorAction({
           data: {
             userId: user._id,
             type: moderatorActionType,
           }
-        }, context);
+        }, context));
       }
     }
     
@@ -325,7 +326,7 @@ export const performVoteServer = async ({ documentId, document, voteType, extend
 
     voteDocTuple.newDocument = document
     
-    void onCastVoteAsync(voteDocTuple, collection, user, context);
+    backgroundTask(onCastVoteAsync(voteDocTuple, collection, user, context));
 
     return {
       vote: voteDocTuple.vote,

--- a/packages/lesswrong/server/votingCron.ts
+++ b/packages/lesswrong/server/votingCron.ts
@@ -1,6 +1,7 @@
 import { batchUpdateScore } from './updateScores';
 import { getVoteableCollections } from '@/server/collections/allCollections';
 import { addCronJob } from './cron/cronUtil';
+import { backgroundTask } from './utils/backgroundTask';
 
 // Setting voting.scoreUpdateInterval removed and replaced with a hard-coded
 // interval because the time-parsing library we use can't handle numbers of
@@ -14,7 +15,7 @@ export const updateScoreActiveDocumentsCron = addCronJob({
     getVoteableCollections().forEach(collection => {
       const options = collection.options.voteable!;
       if (options.timeDecayScoresCronjob) {
-        void batchUpdateScore({collection});
+        backgroundTask(batchUpdateScore({collection}));
       }
     });
   }
@@ -26,7 +27,7 @@ export const updateScoreInactiveDocumentsCron = addCronJob({
     getVoteableCollections().forEach(collection => {
       const options = collection.options.voteable!;
       if (options.timeDecayScoresCronjob) {
-        void batchUpdateScore({collection, inactive: true});
+        backgroundTask(batchUpdateScore({collection, inactive: true}));
       }
     });
   }

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -22,6 +22,7 @@ import { computeContextFromUser } from './context';
 import { createUser } from '@/server/collections/users/mutations';
 import { createDisplayName } from '@/lib/collections/users/newSchema';
 import { comparePasswords, createPasswordHash, validatePassword } from './passwordHelpers';
+import { backgroundTask } from '@/server/utils/backgroundTask';
 
 const passwordAuthStrategy = new GraphQLLocalStrategy(async function getUserPassport(username, password, done) {
   const user = await new UsersRepo().getUserByUsernameOrEmail(username);
@@ -303,9 +304,9 @@ function registerLoginEvent(user: DbUser, req: AnyBecauseTodo) {
       referrer: req.headers['referer']
     }
   }
-  void computeContextFromUser({ user, isSSR: false }).then(userContext => {
-    void createLWEvent({ data: document }, userContext);
-  });
+  backgroundTask(computeContextFromUser({ user, isSSR: false }).then(userContext => {
+    backgroundTask(createLWEvent({ data: document }, userContext));
+  }));
 }
 
 const reCaptchaSecretSetting = new DatabaseServerSetting<string | null>('reCaptcha.secret', null) // ReCaptcha Secret

--- a/packages/lesswrong/server/wrapped/sendWrappedNotifications.ts
+++ b/packages/lesswrong/server/wrapped/sendWrappedNotifications.ts
@@ -3,6 +3,7 @@ import ReadStatuses from "../../server/collections/readStatus/collection";
 import Users from "../../server/collections/users/collection";
 import { createNotifications } from "../notificationCallbacksHelpers";
 import { WrappedYear, isWrappedYear } from "@/components/ea-forum/wrapped/hooks";
+import { backgroundTask } from "../utils/backgroundTask";
 
 export const getWrappedUsers = async (
   year: WrappedYear,
@@ -39,7 +40,7 @@ export const sendWrappedNotifications = async (year: WrappedYear) => {
 
   // eslint-disable-next-line no-console
   console.log(`Sending onsite Wrapped ${year} notifications to ${users.length} users`);
-  void createNotifications({
+  backgroundTask(createNotifications({
     userIds: users.map(u => u._id),
     notificationType: 'wrapped',
     documentId: null,
@@ -59,11 +60,11 @@ export const sendWrappedNotifications = async (year: WrappedYear) => {
         dayOfWeekGMT: "Monday",
       }
     },
-  });
+  }));
 
   // eslint-disable-next-line no-console
   console.log(`Sending email Wrapped ${year} notifications to ${emailUsers.length} users`);
-  void createNotifications({
+  backgroundTask(createNotifications({
     userIds: emailUsers.map(u => u._id),
     notificationType: 'wrapped',
     documentId: null,
@@ -83,5 +84,5 @@ export const sendWrappedNotifications = async (year: WrappedYear) => {
         dayOfWeekGMT: "Monday",
       }
     },
-  });
+  }));
 }

--- a/packages/lesswrong/server/wrapped/triggerWrappedRefresh.ts
+++ b/packages/lesswrong/server/wrapped/triggerWrappedRefresh.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-useless-escape */
 import { isE2E } from "../../lib/executionEnvironment";
 import { getAnalyticsConnectionOrThrow } from "../analytics/postgresConnection";
+import { backgroundTask } from "../utils/backgroundTask";
 
 // Run the following SQL to check on the progress of this script:
 // SELECT
@@ -72,11 +73,11 @@ export const triggerWrappedRefresh = async (recreateViews = false) => {
   if (viewExists.to_regclass === USER_ENGAGEMENT_VIEW_NAME) {
     if (!recreateViews) {
       console.log(`Triggering a refresh for ${USER_ENGAGEMENT_VIEW_NAME}...`);
-      void analyticsDb.none(`REFRESH MATERIALIZED VIEW ${USER_ENGAGEMENT_VIEW_NAME};`);
+      backgroundTask(analyticsDb.none(`REFRESH MATERIALIZED VIEW ${USER_ENGAGEMENT_VIEW_NAME};`));
     } else {
       console.log(`Dropping and recreating ${USER_ENGAGEMENT_VIEW_NAME}...`);
       await analyticsDb.none(`DROP MATERIALIZED VIEW ${USER_ENGAGEMENT_VIEW_NAME};`);
-      void analyticsDb.none(`CREATE MATERIALIZED VIEW ${USER_ENGAGEMENT_VIEW_NAME} AS ${USER_ENGAGEMENT_VIEWDEF};`);
+      backgroundTask(analyticsDb.none(`CREATE MATERIALIZED VIEW ${USER_ENGAGEMENT_VIEW_NAME} AS ${USER_ENGAGEMENT_VIEWDEF};`));
     }
   } else {
     // If it doesn't, create the view

--- a/packages/lesswrong/stubs/server/utils/backgroundTask.ts
+++ b/packages/lesswrong/stubs/server/utils/backgroundTask.ts
@@ -1,0 +1,7 @@
+
+// Stub version for the client simply voids the promise (without any special
+// handling for serverless even if it might be)
+export const backgroundTask = <T>(promise: Promise<T>) => {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  void promise;
+}


### PR DESCRIPTION
In a serverless context, processes may (but don't necessarily) terminate when the corresponding request finishes, which means that background tasks need something to indicate that they're running. This PR adds a function `backgroundTask`, and replaces (most) voided promises with calls to it. The function doesn't currently do anything other than void the promise that it receives, but it provides a central place to add the keep-the-server-running behavior. Also changes the eslint config to prevent ignoring promises with `void`, to ensure that the `backgroundTask` wrapper is used.

Note that calls to backgroundTask replace existing voided promises, and it is _not_ always safe to change their timing, eg to defer them until the end of the request. In some cases, the background task is receiving a callback function and will rejoin the main thread. In some cases, there isn't a request involved at all, eg manual migrations.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210893738878626) by [Unito](https://www.unito.io)
