### PR TITLE
Fix Session Id  Management

### DIFF
--- a/packages/lesswrong/components/hooks/useSessionManagement.ts
+++ b/packages/lesswrong/components/hooks/useSessionManagement.ts
@@ -72,6 +72,14 @@ export function useSessionManagement() {
     const session = getOrCreateSession();
     clientContextVars.sessionId = session.sessionId;
 
+    // Check session validity on ANY visibility change
+    const handleVisibilityChange = () => {
+      const currentSession = getOrCreateSession();
+      clientContextVars.sessionId = currentSession.sessionId;
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     // Listen for cross-tab session updates
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === SESSION_STORAGE_KEY && e.newValue) {
@@ -86,7 +94,10 @@ export function useSessionManagement() {
     };
 
     window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('storage', handleStorageChange);
+    };
   }, [getOrCreateSession]);
 
   return { updateLastActivity };


### PR DESCRIPTION
without this fix, a tab waking after > 30 min delay will resume sending with the same sessionId because there's nothing causing a check.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210893827830920) by [Unito](https://www.unito.io)
