### PR TITLE
Rename content -> document in RejectContentParams

### DIFF
--- a/packages/lesswrong/components/hooks/useRejectContent.tsx
+++ b/packages/lesswrong/components/hooks/useRejectContent.tsx
@@ -25,32 +25,32 @@ const rejectCommentMutation = gql(`
 
 export type RejectContentParams = {
   collectionName: "Posts",
-  content: SunshinePostsList
+  document: SunshinePostsList
 } | {
   collectionName: "Comments",
-  content: CommentsList | CommentsListWithParentMetadata
+  document: CommentsList | CommentsListWithParentMetadata
 }
 
-export function useRejectContent ({collectionName, content}: RejectContentParams) {
+export function useRejectContent ({collectionName, document}: RejectContentParams) {
   const [updateContent] = useMutation(collectionName === "Posts" ? rejectPostMutation : rejectCommentMutation);
   
   const rejectContent = useCallback((reason: string) => {
     void updateContent({
       variables: {
-        selector: { _id: content._id },
+        selector: { _id: document._id },
         data: { rejected: true, rejectedReason: reason }
       }
     });
-  }, [updateContent, content._id]);
+  }, [updateContent, document._id]);
   
   const unrejectContent = useCallback(() => {
     void updateContent({
       variables: {
-        selector: { _id: content._id },
+        selector: { _id: document._id },
         data: { rejected: false }
       }
     });
-  }, [updateContent, content._id])
+  }, [updateContent, document._id])
   
   return {rejectContent, unrejectContent} 
 }

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
@@ -37,7 +37,7 @@ export const RejectContentButton = ({contentWrapper, classes}: {
   const { eventHandlers, anchorEl } = useHover();
   const { rejectContent, unrejectContent } = useRejectContent(contentWrapper);
   const [showRejectionDialog, setShowRejectionDialog] = useState(false);
-  const { content } = contentWrapper;
+  const { document } = contentWrapper;
 
   const handleRejectContent = (reason: string) => {
     setShowRejectionDialog(false);
@@ -45,12 +45,12 @@ export const RejectContentButton = ({contentWrapper, classes}: {
   };
 
   return <span {...eventHandlers}>
-    {content.rejected && <span >
+    {document.rejected && <span >
         <LWTooltip title="Undo rejection">
           <ReplayIcon className={classes.icon} onClick={unrejectContent}/>
         </LWTooltip>
     </span>}
-    {!content.rejected && content.authorIsUnreviewed && <span className={classes.button} onClick={() => setShowRejectionDialog(true)}>
+    {!document.rejected && document.authorIsUnreviewed && <span className={classes.button} onClick={() => setShowRejectionDialog(true)}>
       <RejectedIcon className={classes.icon}/> <MetaInfo>Reject</MetaInfo>
     </span>}
     <LWPopper

--- a/packages/lesswrong/components/sunshineDashboard/RejectedContentControls.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectedContentControls.tsx
@@ -41,7 +41,7 @@ const styles = defineStyles("RejectedContentControls", (theme: ThemeType) => ({
 export const RejectedContentControls = ({ contentWrapper }: {
   contentWrapper: RejectContentParams
 }) => {
-  const { collectionName, content } = contentWrapper;
+  const { collectionName, document } = contentWrapper;
   const classes = useStyles(styles);
 
   const { openDialog } = useDialog();
@@ -50,12 +50,12 @@ export const RejectedContentControls = ({ contentWrapper }: {
   if (collectionName === 'Posts' && !hasRejectedContentSectionSetting.get()) return null;
   if (collectionName === 'Comments' && !isLWorAF) return null;
 
-  const automatedContentEvaluations = content?.contents && 'automatedContentEvaluations' in content.contents && content.contents?.automatedContentEvaluations;
+  const automatedContentEvaluations = document?.contents && 'automatedContentEvaluations' in document.contents && document.contents?.automatedContentEvaluations;
 
   function handleLLMScoreClick() {
     if (!automatedContentEvaluations) return;
     const highlightedHtml = highlightHtmlWithLlmDetectionScores(
-      content.contents?.html || '',
+      document.contents?.html || '',
       automatedContentEvaluations.sentenceScores || []
     );
 
@@ -96,7 +96,7 @@ export const RejectedContentControls = ({ contentWrapper }: {
   return (
     <span className={classes.root}>
       <div className={classes.row}>
-        {content.rejected && <RejectedReasonDisplay reason={content.rejectedReason} />}
+        {document.rejected && <RejectedReasonDisplay reason={document.rejectedReason} />}
         {automatedContentEvaluations && (
           <div className={classes.automatedContentEvaluations}>
             <span className={classes.llmScore} onClick={handleLLMScoreClick}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentItem.tsx
@@ -35,7 +35,7 @@ export const SunshineNewUserCommentItem = ({comment}: {
   return <div className={classes?.comment}>
     <div className={classes?.rejection}>
       <ForumIcon className={classes?.expandCollapseButton} icon={isCollapsed ? "ThickChevronRight" : "ThickChevronDown"} onClick={() => setIsCollapsed(!isCollapsed)} />
-      <RejectedContentControls contentWrapper={{collectionName:"Comments", content:comment}}/>
+      <RejectedContentControls contentWrapper={{collectionName:"Comments", document:comment}}/>
     </div>
     {!isCollapsed && <CommentsNode 
       treeOptions={{

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostItem.tsx
@@ -65,7 +65,7 @@ export const SunshineNewUserPostItem = ({post}: {
   return <div className={classes.post}>
     <div className={classes.rejection}>
       <ForumIcon className={classes.expandCollapseButton} icon={isCollapsed ? "ThickChevronRight" : "ThickChevronDown"} onClick={() => setIsCollapsed(!isCollapsed)} />
-      <RejectedContentControls contentWrapper={{ collectionName: 'Posts', content: post }} />
+      <RejectedContentControls contentWrapper={{ collectionName: 'Posts', document: post }} />
     </div>
     <div className={classes.row}>
       <div className={classes.row}>


### PR DESCRIPTION
(this as originally part of https://github.com/ForumMagnum/ForumMagnum/pull/11167/files but it was cluttering up the file-diff and seemed nice to put in a simple standalone PR)

Currently the RejectContentParams has a field called "content" which is either a post or comment. Basically everywhere else we call this sort of thing "document", and it's confusing because "contents" is a field on posts or comments.

This just changes the name.