### PR TITLE
[EA] Fix user report slack forwarding

### DIFF
--- a/packages/lesswrong/lib/collections/reports/fragments.ts
+++ b/packages/lesswrong/lib/collections/reports/fragments.ts
@@ -21,6 +21,7 @@ export const UnclaimedReportsList = () => frag`
     post {
       ...PostsList
     }
+    reportedUserId
     reportedUser {
       ...SunshineUsersList
     }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -3768,6 +3768,7 @@ interface UnclaimedReportsList { // fragment on Reports
   readonly comment: UnclaimedReportsList_comment|null,
   readonly postId: string|null,
   readonly post: PostsList|null,
+  readonly reportedUserId: string|null,
   readonly reportedUser: SunshineUsersList|null,
   readonly closedAt: Date|null,
   readonly createdAt: Date,

--- a/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
+++ b/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
@@ -11699,6 +11699,7 @@ fragment UnclaimedReportsList on Report {
   post {
     ...PostsList
   }
+  reportedUserId
   reportedUser {
     ...SunshineUsersList
   }


### PR DESCRIPTION
Forwarding reports to mod Slack currently only for for reported posts and reported comments. This PR expands this to also include reports directly of users.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210936586459273) by [Unito](https://www.unito.io)
