### PR TITLE
Don't filter unreviewed users out of search

### DIFF
--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -304,7 +304,8 @@ const elasticSearchConfig: Record<SearchIndexCollectionName, IndexConfig> = {
     filters: [
       {term: {deleted: false}},
       {term: {deleteContent: false}},
-      ...(isEAForum ? [] : [{term: {isReviewed: true}}]),
+      //Removed because it turns out you do need to be able to find unreviewed users in search sometimes, in order to add coauthors
+      //{term: {isReviewed: true}},
     ],
     mappings: {
       displayName: shingleTextMapping,


### PR DESCRIPTION
It turns out you do need to be able to find unreviewed users in search sometimes, in order to add coauthors.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210953605837844) by [Unito](https://www.unito.io)
