### PR TITLE
Add tags to sitemap and add canonical tag to `PermanentRedirect`

### DIFF
--- a/packages/lesswrong/components/common/PermanentRedirect.tsx
+++ b/packages/lesswrong/components/common/PermanentRedirect.tsx
@@ -2,6 +2,8 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import React, { useEffect } from 'react';
 import { useServerRequestStatus } from '../../lib/routeUtil'
 import { Redirect } from '../../lib/reactRouterWrapper';
+import { Helmet } from '../../lib/utils/componentsWithChildren';
+import { combineUrls, getSiteUrl } from '@/lib/vulcan-lib/utils';
 
 /**
  * If this component appears in the DOM, this page is a redirect to the given
@@ -38,7 +40,14 @@ const PermanentRedirect = ({url, status}: {
   if(urlIsAbsolute(url)) {
     return <></>;
   } else {
-    return <Redirect to={url}/>;
+    return (
+      <>
+        <Helmet>
+          <link rel="canonical" href={combineUrls(getSiteUrl(), url)} />
+        </Helmet>
+        <Redirect to={url}/>
+      </>
+    );
   }
 };
 
@@ -47,5 +56,3 @@ function urlIsAbsolute(url: string): boolean {
 }
 
 export default registerComponent('PermanentRedirect', PermanentRedirect);
-
-

--- a/packages/lesswrong/server/repos/TagsRepo.ts
+++ b/packages/lesswrong/server/repos/TagsRepo.ts
@@ -269,6 +269,18 @@ class TagsRepo extends AbstractRepo<"Tags"> {
 
     return { tags, totalCount };
   }
+
+  async getSitemapTags(): Promise<Pick<DbTag, "slug">[]> {
+    return this.getRawDb().any(`
+      -- TagsRepo.getSitemapTags
+      SELECT "slug"
+      FROM "Tags"
+      WHERE
+        NOT "noindex" AND
+        ${getViewableTagsSelector()}
+      ORDER BY "createdAt" DESC
+    `);
+  }
 }
 
 recordPerfMetrics(TagsRepo);

--- a/packages/lesswrong/server/sitemap.ts
+++ b/packages/lesswrong/server/sitemap.ts
@@ -2,10 +2,12 @@ import { Routes } from "@/lib/vulcan-lib/routes";
 import { combineUrls, getSiteUrl } from "@/lib/vulcan-lib/utils";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { userGetProfileUrlFromSlug } from "@/lib/collections/users/helpers";
+import { tagGetUrl } from "@/lib/collections/tags/helpers";
 import { sequenceGetPageUrl } from "@/lib/collections/sequences/helpers";
 import { localgroupGetUrl } from "@/lib/collections/localgroups/helpers";
 import PostsRepo from "./repos/PostsRepo";
 import UsersRepo from "./repos/UsersRepo";
+import TagsRepo from "./repos/TagsRepo";
 import SequencesRepo from "./repos/SequencesRepo";
 import LocalgroupsRepo from "./repos/LocalgroupsRepo";
 import chunk from "lodash/chunk";
@@ -81,6 +83,14 @@ const generateUserEntries = async (): Promise<SitemapEntry[]> => {
   }));
 }
 
+const generateTagEntries = async (): Promise<SitemapEntry[]> => {
+  const tags = await new TagsRepo().getSitemapTags();
+  return tags.map((tag) => ({
+    path: tagGetUrl(tag),
+    changefreq: "monthly",
+  }));
+}
+
 const generateSequencesEntries = async (): Promise<SitemapEntry[]> => {
   const sequences = await new SequencesRepo().getSitemapSequences();
   return sequences.map((sequence) => ({
@@ -116,11 +126,13 @@ export const generateSitemaps = async (): Promise<string[]> => {
   const [
     postEntries,
     userEntries,
+    tagEntries,
     sequenceEntries,
     localgroupEntries,
   ] = await Promise.all([
     generatePostEntries(),
     generateUserEntries(),
+    generateTagEntries(),
     generateSequencesEntries(),
     generateLocalgroupsEntries(),
   ]);
@@ -128,6 +140,7 @@ export const generateSitemaps = async (): Promise<string[]> => {
     ...generateStaticEntries(),
     ...postEntries,
     ...userEntries,
+    ...tagEntries,
     ...sequenceEntries,
     ...localgroupEntries,
   ];


### PR DESCRIPTION
More updates from looking at google search console:

- I forgot to include tag pages in the sitemap 🤦
- Google recently discovered a bunch of `/tag/${slug}` pages which just redirect to `/topics/${redirect}`, but the redirect happens client side and there's no canonical tag so google is complaining about duplicate content. This PR adds a canonical tag to `PermanentRedirect` to fix this (you can check that the tag makes it to the statically rendered HTML using curl).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210962130009381) by [Unito](https://www.unito.io)
