### PR TITLE
Regenerate Type3 audio on posts when edited

### DIFF
--- a/packages/lesswrong/server/type3.ts
+++ b/packages/lesswrong/server/type3.ts
@@ -14,6 +14,13 @@ const type3SourceUrlSetting = new DatabaseServerSetting<string>("type3.sourceUrl
 
 export const hasType3ApiAccess = () => !!type3ApiTokenSetting.get();
 
+type Type3RegenerateOptions = {
+  immediate?: boolean,
+};
+const defaultType3RegenerationOptions = {
+  immediate: true
+};
+
 const type3ApiRequest = async (
   endpoint: string,
   method: "POST" | "DELETE",
@@ -67,10 +74,12 @@ const getDocumentUrl = (document: DocumentWithAudio, collectionName: 'Posts' | '
 }
 
 
-export const regenerateType3Audio = async (document: DbPost | DbTag, collectionName: 'Posts' | 'Tags') => {
+export const regenerateType3Audio = async (document: DbPost | DbTag, collectionName: 'Posts'|'Tags', options?: Type3RegenerateOptions) => {
+  const optionsWithDefaults = {...defaultType3RegenerationOptions, ...options};
+
   const body = {
     source_url: getDocumentUrl(document, collectionName),
-    priority: "immediate",
+    ...(optionsWithDefaults.immediate ? {priority: "immediate"} : {}),
   };
 
   if (!isDocumentAllowedType3Audio(document, collectionName)) return;
@@ -80,7 +89,7 @@ export const regenerateType3Audio = async (document: DbPost | DbTag, collectionN
 }
 
 // Exported to allow running with "yarn repl"
-export const regenerateType3AudioForDocumentId = async (documentId: string, collectionName: 'Posts' | 'Tags') => {
+export const regenerateType3AudioForDocumentId = async (documentId: string, collectionName: 'Posts'|'Tags', options?: Type3RegenerateOptions) => {
   const document = await (collectionName === 'Posts' 
     ? Posts.findOne({_id: documentId})
 
@@ -89,7 +98,7 @@ export const regenerateType3AudioForDocumentId = async (documentId: string, coll
     throw new Error("Document not found");
   }
   if (isDocumentAllowedType3Audio(document, collectionName)) {
-    await regenerateType3Audio(document, collectionName);
+    await regenerateType3Audio(document, collectionName, options);
   }
 }
 


### PR DESCRIPTION
See Slack thread: https://lworg.slack.com/archives/C046C24H3LP/p1753843245656289

A few API notes:
* The discussion in Slack had the request providing a `url` field in the body, but preexisting code in `packages/lesswrong/server/type3.ts` has the field named `source_url` instead. I left it as-is so the requests will say `source-field`.
* Manually-triggered requests have `"priority": "immedate"` (preexisting). Automatically triggered requests do not.
* This triggers on edit. Since posts are initially created as blank drafts, this should cover all cases where posts should have audio generated. I haven't tested what happens with EA-forum-to-LW crossposts or with RSS crossposts; I see no obvious reason for them not to work.
* When I tested, editing a post generated exactly one API request. However, we _do not_ guarantee that no duplicate requests will be sent; Type3 should check whether the content is actually different before doing anything too expensive.
* We _do not_ guarantee that we will never trigger a change in every post in the database at once; for example if we do a migration to change how we handle LaTeX, or to drop support for draftjs and convert everything to ckeditor, this could wind up counting as an edit to every post at once. We won't send these to type3 on purpose if we remember, but there's a high probability that this happens at least once. Type3 should have some sort of rate limit. It is okay to not-regenerate posts beyond the rate limit, since if this does happen, it probably doesn't correspond to a change in the actual narration.