### PR TITLE
Fix black-on-black text in dark mode when an RSS-synced post contains style="color: initial"

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -591,6 +591,7 @@ const attributesNeedingTransform: Record<string,boolean> = {
   "background": true,
   "backgroundColor": true,
   "borderColor": true,
+  "color": true,
 };
 
 function transformStylesForDarkMode(styles: Record<string,string>, themeName: UserThemeSetting): Record<string,string> {

--- a/packages/lesswrong/themes/userThemes/darkMode.ts
+++ b/packages/lesswrong/themes/userThemes/darkMode.ts
@@ -63,6 +63,7 @@ const inverseGreyAlpha = (alpha: number) => {
 // colors below have dedicated color-mappings; all other colors use `parseColor`
 // and `invertColor` from `colorUtil.ts`.
 export const colorReplacements: Record<string,string> = {
+  "initial":            "rgba(255,255,255,.87)",
   "rgba(255,255,255,.5)": "rgba(0,0,0.5)",
   "hsl(0, 0%, 90%)":    "hsl(0, 0%, 10%)",
   "#F2F2F2":            invertHexColor("#f2f2f2"),


### PR DESCRIPTION
Affected this post: https://www.lesswrong.com/posts/FrBxFa3qMDvLypDEZ/ai-63-introducing-alpha-fold-3

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210970287317903) by [Unito](https://www.unito.io)
