### PR TITLE
Ultrafeed mobile is desktop

### DIFF
--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -100,7 +100,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     },
   },
   contentWrapperWithReadStyles: {
-    opacity: 1,
+    opacity: 0.9,
     [theme.breakpoints.down('sm')]: {
       opacity: 0.7,
     },

--- a/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedCommentItem.tsx
@@ -24,6 +24,7 @@ const commentHeaderPaddingDesktop = 12;
 
 const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
   root: {
+    borderBottom: theme.palette.border.itemSeparatorBottomStrong,
     position: 'relative',
     paddingTop: commentHeaderPaddingDesktop,
     backgroundColor: 'transparent',
@@ -33,9 +34,11 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     [theme.breakpoints.down('sm')]: {
       paddingLeft: 20,
       paddingRight: 20,
+      borderBottom: 'none',
     },
   },
   rootWithReadStyles: {
+    backgroundColor: theme.palette.grey[300],
     [theme.breakpoints.down('sm')]: {
       backgroundColor: theme.palette.grey[100],
     },
@@ -55,14 +58,16 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
   compressedRoot: {
     display: 'flex',
     flexDirection: 'row',
-    paddingLeft: 20,
-    paddingRight: 16,
+    // paddingLeft: 20,
+    // paddingRight: 16,
     [theme.breakpoints.down('sm')]: {
       paddingLeft: 20,
       paddingRight: 20,
     },
   },
   compressedRootWithReadStyles: {
+    backgroundColor: theme.palette.grey[300],
+    borderBottom: theme.palette.border.itemSeparatorBottomStrong,
     [theme.breakpoints.down('sm')]: {
       backgroundColor: theme.palette.grey[100],
     },
@@ -75,7 +80,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     overflow: 'visible',
   },
   commentContentWrapperWithBorder: {
-    borderBottom: theme.palette.border.itemSeparatorBottom,
+    // borderBottom: theme.palette.border.itemSeparatorBottom,
     [theme.breakpoints.down('sm')]: {
       borderBottom: 'none',
     },
@@ -95,6 +100,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     },
   },
   contentWrapperWithReadStyles: {
+    opacity: 1,
     [theme.breakpoints.down('sm')]: {
       opacity: 0.7,
     },
@@ -118,6 +124,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
     },
   },
   numCommentsWithReadStyles: {
+    opacity: 0.6,
     [theme.breakpoints.down('sm')]: {
       opacity: 0.7,
     },
@@ -125,7 +132,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
   verticalLineContainer: {
     fontStyle: 'italic',
     width: 0,
-    display: 'flex',
+    display: 'none',
     justifyContent: 'center',
     marginRight: 6,
     marginTop: -commentHeaderPaddingDesktop,
@@ -136,7 +143,7 @@ const styles = defineStyles("UltraFeedCommentItem", (theme: ThemeType) => ({
   },
   verticalLineContainerCompressed: {
     width: 0,
-    display: 'flex',
+    display: 'none',
     justifyContent: 'center',
     marginRight: 6,
     marginTop: 0,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -79,6 +79,7 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   },
   rootWithReadStyles: {
     backgroundColor: theme.palette.grey[300],
+    opacity: 0.9,
     [theme.breakpoints.down('sm')]: {
       backgroundColor: theme.palette.grey[100],
       borderTop: theme.palette.border.itemSeparatorBottom,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -78,6 +78,7 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
     },
   },
   rootWithReadStyles: {
+    backgroundColor: theme.palette.grey[300],
     [theme.breakpoints.down('sm')]: {
       backgroundColor: theme.palette.grey[100],
       borderTop: theme.palette.border.itemSeparatorBottom,
@@ -87,7 +88,7 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
   },
   verticalLineContainer: {
     width: 0,
-    display: 'flex',
+    display: 'none',
     justifyContent: 'center',
     marginRight: 6,
     marginTop: -12,


### PR DESCRIPTION
Trying out the mobile styles for desktop too:

<img width="662" height="873" alt="LessWrong 2025-08-04 18-30-10" src="https://github.com/user-attachments/assets/c2d3ef30-40e0-4c75-b198-3a2c0003a2aa" />
<img width="639" height="938" alt="LessWrong 2025-08-04 18-30-50" src="https://github.com/user-attachments/assets/dcbc5d1b-eac8-4360-94bf-1079b5c5085c" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210971271298617) by [Unito](https://www.unito.io)
