### PR TITLE
Fix a subtlety of the `loading` flag in SSR with suspense which cause…

### DIFF
--- a/packages/lesswrong/components/tagging/useTag.ts
+++ b/packages/lesswrong/components/tagging/useTag.ts
@@ -146,6 +146,7 @@ export const useTagPreview = (
       ...hashVariables,
     },
     skip: skip || hasWikiLenses,
+    ssr: false,
   });
 
   if (hasWikiLenses) {

--- a/packages/lesswrong/lib/crud/useQuery.ts
+++ b/packages/lesswrong/lib/crud/useQuery.ts
@@ -27,7 +27,8 @@ type UseQueryOptions = {
 export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryOptions) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   if (bundleIsServer && useContext(EnableSuspenseContext)) {
-    const isSkipped = options?.skip || (options && 'ssr' in options && !options.ssr);
+    const isNoSSR = (options && 'ssr' in options && !options.ssr)
+    const isSkipped = options?.skip || isNoSSR;
 
     if (debugSuspenseBoundaries) {
       // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -49,7 +50,10 @@ export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryO
       // eslint-disable-next-line no-console
       console.log(`    ...returned query from cache`);
     }
-    return result;
+    return {
+      ...result,
+      loading: !options?.skip && isNoSSR,
+    };
   } else {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const result = useQueryApollo(query, options);


### PR DESCRIPTION
…d an SSR mismatch which led to wiki links looking like redlinks when they weren't

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210972317547965) by [Unito](https://www.unito.io)
