### PR TITLE
[EA] Fix /search filter modal not being dismissible

### DIFF
--- a/packages/lesswrong/components/common/LWDialog.tsx
+++ b/packages/lesswrong/components/common/LWDialog.tsx
@@ -50,7 +50,7 @@ const styles = defineStyles("LWDialog", theme => ({
     maxWidth: theme.breakpoints.values.md,
   },
   hidden: {
-    display: "none",
+    display: "none !important",
   },
 }), {stylePriority: -1});
 
@@ -94,9 +94,9 @@ const LWDialog = ({open, fullScreen, title, maxWidth='sm', fullWidth, disableBac
     {everOpened && (open || keepMounted) && createPortal(
       <div>
         <ClickAwayListener onClickAway={() => {
-          if (!disableBackdropClick)
+            if (!open || disableBackdropClick) return;
             onClose?.();
-        }}>
+          }}>
           <div className={classNames(
             classes.dialogWrapper, className, {
               [classes.hidden]: !open,

--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -38,6 +38,7 @@ import LWTooltip from "../common/LWTooltip";
 import ForumIcon from "../common/ForumIcon";
 import LWDialog from '../common/LWDialog';
 import HeadTags from '../common/HeadTags';
+import { InteractionWrapper } from '../common/useClickableCell';
 
 const hitsPerPage = 10
 
@@ -398,11 +399,13 @@ const SearchPageTabbed = ({classes}: {
               * null is the only option that actually suppresses the extra X button.
             // @ts-ignore */}
             <SearchBox defaultRefinement={query.query} reset={null} focusShortcuts={[]} autoFocus={true} />
-            <div onClick={() => setModalOpen(true)}>
-              <IconButton className={classes.funnelIconButton}>
-                <ForumIcon icon="Funnel" className={classNames({[classes.funnelIconLW]: !isEAForum, [classes.funnelIconEA]: isEAForum})}/>
-              </IconButton>
-            </div>
+            <InteractionWrapper>
+              <div onClick={() => setModalOpen(true)}>
+                <IconButton className={classes.funnelIconButton}>
+                  <ForumIcon icon="Funnel" className={classNames({[classes.funnelIconLW]: !isEAForum, [classes.funnelIconEA]: isEAForum})}/>
+                </IconButton>
+              </div>
+            </InteractionWrapper>
           </div>
           <LWTooltip
             title={`"Quotes" and -minus signs are supported. Use user:"Jane Doe" or ${taggingNameSetting.get()}:"Expected value" to filter by user or ${taggingNameSetting.get()}.`}


### PR DESCRIPTION
Fixes two problems:
1. `display: "none"` was being overidden by a higher priority class, which caused the modal to not disappear when you close it. Fixed by adding `!important`
2. Clicking the filter icon after the modal had already been opened once would trigger the clickaway in the same click, closing the modal as soon as it opened. Fixed by adding an InteractionWrapper (stops even propogation)