### PR TITLE
Improvements to noindexing in sitemap

### DIFF
--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1327,7 +1327,11 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       -- PostsRepo.getSitemapPosts
       SELECT "_id", "slug", "isEvent", "groupId", "modifiedAt"
       FROM "Posts"
-      WHERE ${getViewablePostsSelector()}
+      WHERE
+        NOT "noIndex"
+        AND NOT "rejected"
+        AND "baseScore" > 0
+        AND ${getViewablePostsSelector()}
       ORDER BY "postedAt" DESC
     `);
   }

--- a/packages/lesswrong/server/repos/SequencesRepo.ts
+++ b/packages/lesswrong/server/repos/SequencesRepo.ts
@@ -142,7 +142,7 @@ class SequencesRepo extends AbstractRepo<"Sequences"> {
       -- SequencesRepo.getSitemapSequences
       SELECT "_id"
       FROM "Sequences"
-      WHERE ${getViewableSequencesSelector()}
+      WHERE NOT "noindex" AND ${getViewableSequencesSelector()}
       ORDER BY "createdAt" DESC
     `);
   }

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -694,7 +694,12 @@ class UsersRepo extends AbstractRepo<"Users"> {
       -- UsersRepo.getSitemapUsers
       SELECT "slug"
       FROM "Users"
-      WHERE NOT "noindex" AND NOT "deleted" AND "banned" IS NULL
+      WHERE
+        NOT "noindex"
+        AND "karma" > 0
+        AND ("commentCount" > 0 OR "postCount" > 0)
+        AND NOT "deleted"
+        AND "banned" IS NULL
       ORDER BY "createdAt" DESC
     `);
   }

--- a/packages/lesswrong/server/sitemap.ts
+++ b/packages/lesswrong/server/sitemap.ts
@@ -1,4 +1,5 @@
 import { Routes } from "@/lib/vulcan-lib/routes";
+import { noIndexSetting } from "@/lib/instanceSettings";
 import { combineUrls, getSiteUrl } from "@/lib/vulcan-lib/utils";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { userGetProfileUrlFromSlug } from "@/lib/collections/users/helpers";
@@ -123,6 +124,9 @@ const generateSitemapIndex = (sitemapCount: number) => {
 }
 
 export const generateSitemaps = async (): Promise<string[]> => {
+  if (noIndexSetting.get()) {
+    return [compileEntries([])];
+  }
   const [
     postEntries,
     userEntries,


### PR DESCRIPTION
Various improvements to noindexing in the sitemap:
 - If the site-wide noindex database setting is set then return an empty sitemap
 - Exclude sequences marked as "noindex" (we currently don't have any, but it's still good for correctness)
 - Copy the noindex criteria from the posts page for posts: exclude posts marked as noindex, rejected, or with less than 1 karma (reduces the number in prod from 20598 to 19553)
 - Copy the noindex criteria from the user profile page for users: exclude users marked as noindex, with karma less than 1, or with no posts and no comments (reduces the number in prod from 37274 to 7454)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1210985187552595) by [Unito](https://www.unito.io)
