### PR TITLE
Migration to delete invalid read statuses

### DIFF
--- a/packages/lesswrong/server/migrations/20250812T114600.cleanup_invalid_ReadStatuses_2025_08.ts
+++ b/packages/lesswrong/server/migrations/20250812T114600.cleanup_invalid_ReadStatuses_2025_08.ts
@@ -1,0 +1,78 @@
+// Set to true to test the counts without actually deleting anything
+const DRY_RUN = false;
+
+export const up = async ({db}: MigrationContext) => {
+  // List of collections where there were any matching ReadStatuses based on a query
+  // of the EAF prod database
+  const collectionsToClean = [
+    'Users',
+    'Comments',
+    'Tags',
+    'AdvisorRequests',
+    'Reports',
+    'Localgroups',
+    'DigestPosts',
+    'Sequences',
+    'Chapters',
+    'ElectionVotes',
+    'UserMostValuablePosts',
+    'UserTagRels',
+    'Digests',
+    'ElectionCandidates',
+    'CommentModeratorActions',
+    'TagFlags',
+    'Collections',
+    'UserRateLimits',
+    'Books'
+  ];
+
+  console.log(`Starting ${DRY_RUN ? 'DRY RUN' : 'LIVE'} cleanup of invalid ReadStatuses...`);
+
+  let totalToDelete = 0;
+
+  for (const collectionName of collectionsToClean) {
+    const countResult = await db.one(`
+      SELECT COUNT(*) as count
+      FROM "ReadStatuses" rs
+      LEFT JOIN "${collectionName}" t ON rs."postId" = t._id
+      WHERE t._id IS NOT NULL
+    `);
+
+    const count = parseInt(countResult.count);
+
+    if (count > 0) {
+      console.log(`Found ${count} invalid ReadStatuses pointing to ${collectionName}`);
+      totalToDelete += count;
+
+      if (DRY_RUN) {
+        console.log(`DRY RUN: Would delete ${count} ReadStatuses pointing to ${collectionName}`);
+      } else {
+        const deleteResult = await db.result(`
+          DELETE FROM "ReadStatuses"
+          WHERE _id IN (
+            SELECT rs._id
+            FROM "ReadStatuses" rs
+            LEFT JOIN "${collectionName}" t ON rs."postId" = t._id
+            WHERE t._id IS NOT NULL
+          )
+        `);
+
+        const deletedCount = deleteResult.rowCount;
+        console.log(`Deleted ${deletedCount} invalid ReadStatuses pointing to ${collectionName}`);
+      }
+    } else {
+      console.log(`No invalid ReadStatuses found pointing to ${collectionName}`);
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log(`DRY RUN complete. Would delete ${totalToDelete} invalid ReadStatuses total`);
+    console.log('Set DRY_RUN = false in the migration file to actually perform the deletion');
+  } else {
+    console.log(`Cleanup complete. Total deleted: ${totalToDelete} invalid ReadStatuses`);
+  }
+}
+
+export const down = async ({db}: MigrationContext) => {
+  console.log('This migration cannot be reversed - invalid ReadStatuses have been permanently deleted');
+}

--- a/packages/lesswrong/server/migrations/20250812T114600.cleanup_invalid_ReadStatuses_2025_08.ts
+++ b/packages/lesswrong/server/migrations/20250812T114600.cleanup_invalid_ReadStatuses_2025_08.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Set to true to test the counts without actually deleting anything
 const DRY_RUN = false;
 


### PR DESCRIPTION
Prior to [this change](https://github.com/ForumMagnum/ForumMagnum/pull/8463#discussion_r2235789525), ReadStatuses could sometimes wrongly point to objects other than posts. This caused a discontinuity in our data, so we want to clean up these rows to make analytics based on ReadStatuses more consistent.

I ran a query on our prod database to find all the collections where there are examples of ReadStatuses pointing to them. This PR then adds a migration to delete these.

The reasons I'm deleting just these specific ones, rather than e.g. rows that don't point to a post are:
1. Posts may be deleted somehow (although I don't think we actually hard-delete them anywhere currently), which we still want to count for analytics purposes
2. There were other discrepancies in ReadStatuses, such as rows with a null postId. I don't know what caused these, so I'd rather leave them as they are

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211033634724815) by [Unito](https://www.unito.io)
