### PR TITLE
add temporary client-side redirect to baserates-prod-test for admins

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -360,7 +360,7 @@ const Layout = ({currentUser, children}: {
   useEffect(() => {
     const redirectUrl = new URL(window.location.href);
     if (query.disableRedirect) {
-      setCookie(NO_ADMIN_NEXT_REDIRECT_COOKIE, true);
+      setCookie(NO_ADMIN_NEXT_REDIRECT_COOKIE, true, { path: '/' });
     } else if (isLW && userIsAdmin(currentUser) && !cookies[NO_ADMIN_NEXT_REDIRECT_COOKIE] && redirectUrl.host === 'wwww.lesswrong.com') {
       redirectUrl.host = 'baserates-prod-test.vercel.app';
       // These two are necessary when testing this on localhost

--- a/packages/lesswrong/lib/cookies/cookies.ts
+++ b/packages/lesswrong/lib/cookies/cookies.ts
@@ -218,6 +218,18 @@ export const ULTRA_FEED_PAGE_VISITED_COOKIE = registerCookie({
   description: "Whether the user has ever visited the ultra feed page",
 })
 
+export const PINNED_GLOSSARY_COOKIE = registerCookie({
+  name: 'pinnedGlossary',
+  type: 'functional',
+  description: 'Whether the glossary is pinned',
+});
+
+export const NO_ADMIN_NEXT_REDIRECT_COOKIE = registerCookie({
+  name: 'no_admin_next_redirect',
+  type: 'functional',
+  description: `If set, admins won't be redirected to the baserates-prod-test.vercel.app domain`,
+});
+
 
 // Third party cookies
 
@@ -350,12 +362,5 @@ registerCookie({
   description: "Google ReCaptcha may set a number of cookies under the 'google.com' domain in order to check for suspicious activity. " +
                "The full list of known possible cookies are: __Secure-3PSIDCC, __Secure-1PSIDCC, SIDCC, __Secure-3PAPISID, SSID, " +
                "__Secure-1PAPISID, HSID, __Secure-3PSID, __Secure-1PSID, SID, SAPISID, APISID, NID, OTZ, 1P_JAR, AEC, DV, __Secure-ENID",
-});
-
-// Pinned glossary
-export const PINNED_GLOSSARY_COOKIE = registerCookie({
-  name: 'pinnedGlossary',
-  type: 'functional',
-  description: 'Whether the glossary is pinned',
 });
 


### PR DESCRIPTION
Adds a client-side redirect to baserates-prod-test for admins, so that we can more reliably shake out loose bugs.  Can be disabled by appending `?disableRedirect=true` to any lesswrong.com url, which leaves a cookie preventing the redirect.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211051506890193) by [Unito](https://www.unito.io)
