### PR TITLE
[EA Forum only] separate out our commenting auto rate limits, adjust the 1 per day rate limit

### DIFF
--- a/packages/lesswrong/lib/rateLimits/constants.ts
+++ b/packages/lesswrong/lib/rateLimits/constants.ts
@@ -200,7 +200,91 @@ const EA = {
     ALL.POSTS.FIVE_PER_DAY
   ],
   COMMENTS: [
-    ...LW.COMMENTS
+    {
+      ...timeframe('1 Comments per 1 hours'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerHourNegativeKarma",
+      isActive: (user, features) => (
+        features.last20Karma < 0 &&
+        features.downvoterCount >= 3
+      ),
+      rateLimitMessage: `Users with less than 0 karma on recent posts/comments can comment once per hour. ${defaultRateLimitMessage}`
+    },
+  // 3 comments per day rate limits
+    {
+      ...timeframe('3 Comments per 1 days'),
+      appliesToOwnPosts: false,
+      rateLimitType: "newUserDefault",
+      rateLimitName: "threeCommentsPerDayNewUsers",
+      isActive: user => (user.karma < 5),
+      rateLimitMessage: `Users with less than 5 karma can write up to 3 comments per day. ${defaultRateLimitMessage}`,
+    },
+    {
+      ...timeframe('3 Comments per 1 days'), // semi-established users can make up to 20 posts/comments without getting upvoted, before hitting a 3/day comment rate limit
+      appliesToOwnPosts: false,
+      rateLimitName: "threeCommentsPerDayNoUpvotes",
+      isActive: (user, features) => (
+        user.karma < 1000 &&
+        features.last20Karma < 1
+      ),  // requires 1 weak upvote from a 1000+ karma user, or two new user upvotes, but at 1000+ karma I trust you more to go on long conversations
+      rateLimitMessage: `You've recently posted a lot without getting upvoted. Users are limited to 3 comments/day unless their last ${RECENT_CONTENT_COUNT} posts/comments have at least 2+ net-karma. ${defaultRateLimitMessage}`,
+    },
+  // 1 comment per day rate limits
+    {
+      ...timeframe('1 Comments per 1 days'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerDayLowKarma",
+      isActive: user => (user.karma < -2),
+      rateLimitMessage: `Users with less than -2 karma can write up to 1 comment per day. ${defaultRateLimitMessage}`
+    },
+    {
+      ...timeframe('1 Comments per 1 days'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerDayNegativeKarma5",
+      isActive: (user, features) => (
+        user.karma < 1000 &&
+        features.last20Karma < -5 &&
+        features.downvoterCount >= 4
+      ),
+      rateLimitMessage: `Users with less than -5 karma on recent posts/comments can write up to 1 comment per day. ${defaultRateLimitMessage}`
+    },
+    {
+      ...timeframe('1 Comments per 1 days'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerDayNegativeKarma25",
+      isActive: (user, features) => (
+        features.last20Karma < -25 &&
+        features.downvoterCount >= 7
+      ),
+      rateLimitMessage: `Users with less than -25 karma on recent posts/comments can write up to 1 comment per day. ${defaultRateLimitMessage}`
+    },
+  // 1 comment per 3 days rate limits
+    {
+      ...timeframe('1 Comments per 3 days'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerThreeDaysNegativeKarma15",
+      isActive: (user, features) => (
+        user.karma < 500 &&
+        features.last20Karma < -15 &&
+        features.downvoterCount >= 5
+      ),
+      rateLimitMessage: `Users with less than -15 karma on recent posts/comments can write up to 1 comment every 3 days. ${defaultRateLimitMessage}`
+    },
+  // 1 comment per week rate limits
+    {
+      ...timeframe('1 Comments per 1 weeks'),
+      appliesToOwnPosts: false,
+      rateLimitName: "oneCommentPerWeekNegativeMonthlyKarma30",
+      isActive: (user, features) => (
+        user.karma < 0 &&
+        features.last20Karma < -1 &&
+        features.lastMonthDownvoterCount >= 5 &&
+        features.lastMonthKarma <= -30
+      ),
+      // Added as a hedge against someone with positive karma coming back after some period of inactivity and immediately getting into an argument
+      rateLimitMessage: `Users with -30 or less karma on recent posts/comments can write up to one comment per week. ${defaultRateLimitMessage}`
+    },
+    ALL.COMMENTS.ONE_PER_EIGHT_SECONDS
   ]
 }
 


### PR DESCRIPTION
Based on a suggestion from mods, related to [this smalls issue](https://cea-core.slack.com/archives/C038J512SD8/p1755176984159719):

1. Separate out EA Forum comment auto rate limits from LW
2. Update ours to use the karma threshold of 1000 where LW used 2000
3. Update `oneCommentPerDayNegativeKarma5` to only apply for users < 1000 karma, add a similar rate limit for all users that kicks in at -25 karma instead

