### PR TITLE
Fix types for cron jobs and update `sendInactiveUserSummaryEmailsCron`

### DIFF
--- a/packages/lesswrong/server/cron/cronUtil.ts
+++ b/packages/lesswrong/server/cron/cronUtil.ts
@@ -7,7 +7,7 @@ export type CronJobSpec = {
   disabled?: boolean,
   // uses later.js parser, no seconds allowed though
   cronStyleSchedule?: string,
-  job: () => void,
+  job: (intendedAt: Date, name: string) => void,
 }
 
 export const cronJobsDefined: CronJobSpec[] = [];

--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -160,5 +160,5 @@ export const sendInactiveUserSummaryEmailsCron = addCronJob({
   name: "sendInactiveUserSummaryEmails",
   interval: "every 1 day",
   disabled: !hasInactiveSummaryEmail,
-  job: sendInactiveUserSummaryEmails,
+  job: () => sendInactiveUserSummaryEmails(),
 });


### PR DESCRIPTION
Cron jobs are currently typed as `() => void`, however, this is incorrect. They actually have arguments passed in and should be typed as `(intendedAt: Date, name: string) => void`. This broke the inactive user summary cron job because it takes a limit as an _optional_ first argument, which actually received the `intendedAt` date which broke everything.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211066035735956) by [Unito](https://www.unito.io)
