### PR TITLE
Fix missing vertical scroll in the post version history dialog (and presumably some other dialogs as well)

### DIFF
--- a/packages/lesswrong/components/common/LWDialog.tsx
+++ b/packages/lesswrong/components/common/LWDialog.tsx
@@ -29,6 +29,7 @@ const styles = defineStyles("LWDialog", theme => ({
     flexDirection: 'column',
     margin: '48px auto',
     pointerEvents: "auto",
+    overflowY: "auto",
   },
   paperFullScreen: {
     margin: 0,


### PR DESCRIPTION
Introduced in the material-UI refactor, when switching from MUI's <Paper> component to our own <Paper>.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211083290080769) by [Unito](https://www.unito.io)
