### PR TITLE
[EA Forum only] update the annual survey reminder email

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailAnnualForumUserSurvey.tsx
@@ -19,7 +19,7 @@ export const EmailAnnualForumUserSurvey = ({ user }: {
   user: DbUser;
 }) => {
   const classes = useStyles(styles);
-  const surveyLink = 'https://forms.cea.community/forum-survey-2024?utm_source=ea_forum&utm_medium=email&utm_campaign=survey_reminder'
+  const surveyLink = 'https://forms.cea.community/forum-survey-2025?utm_source=ea_forum&utm_medium=email&utm_campaign=survey_reminder'
 
   return (
     <div className={classes.root}>
@@ -27,18 +27,17 @@ export const EmailAnnualForumUserSurvey = ({ user }: {
         Hi {user.displayName},
       </p>
       <p>
-        I work on the <a href="https://forum.effectivealtruism.org/" className={classes.link}>EA Forum</a>,
-        and would be grateful if you took 7-15 minutes to <strong><a href={surveyLink} className={classes.link}>fill out our 2024 EA Forum user survey</a></strong>.
+        I work on the <a href="https://forum.effectivealtruism.org/" className={classes.link}>Effective Altruism Forum</a>,
+        and would be grateful if you took 10-20 minutes to <strong><a href={surveyLink} className={classes.link}>fill out our 2025 EA Forum user survey</a></strong>.
         Your response is important for guiding our team’s priorities for the next 12 months.
         (If you've already filled it out, thank you!)
       </p>
       <p>
-        Even if you have not used the Forum in a long time, your response is helpful for us to compare
-        different populations (and you will see a significantly shorter survey).
+        <strong>All questions are optional.</strong> Your answers will be saved in your browser, so you
+        can pause and return to it later. We plan to close the survey <strong>this Thursday</strong>, August 21, at 11:45 PM Eastern Time.
       </p>
       <p>
-        <strong>All questions are optional.</strong> Your answers will be saved in your browser, so you
-        can pause and return to it later. We plan to close the survey <strong>this Friday</strong>, August 23, at <a href="https://everytimezone.com/s/3be11109?t=66c7d100,c12" className={classes.link}>11:59 PM EDT</a>.
+        There is also an optional section at the end about other CEA programs. If you haven’t used the Forum in the past 12 months, you’ll see a significantly shorter survey, and your input on other CEA programs is still helpful.
       </p>
       <p>
         We appreciate you taking the time to fill out the survey, and we read every response.

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -513,7 +513,10 @@ class UsersRepo extends AbstractRepo<"Users"> {
         GROUP BY "userId"
       ) AS rs ON u._id = rs."userId"
       WHERE
-        u."userSurveyEmailSentAt" IS NULL
+        (
+          u."userSurveyEmailSentAt" IS NULL
+          OR u."userSurveyEmailSentAt" < CURRENT_TIMESTAMP - INTERVAL '10 months'
+        )
         AND u."unsubscribeFromAll" IS NOT TRUE
         AND u.deleted IS NOT TRUE
         AND u."deleteContent" IS NOT TRUE

--- a/packages/lesswrong/server/scripts/sendAnnualForumUserSurveyEmails.tsx
+++ b/packages/lesswrong/server/scripts/sendAnnualForumUserSurveyEmails.tsx
@@ -37,7 +37,7 @@ export const sendUserSurveyEmails = async (limit=10) => {
       await wrapAndSendEmail({
         user,
         from: 'EA Forum Team <eaforum@centreforeffectivealtruism.org>',
-        subject: `We’d love to hear from you! Fill out the 2024 EA Forum user survey`,
+        subject: `We’d love to hear from you! Fill out the 2025 EA Forum user survey`,
         body: <EmailAnnualForumUserSurvey user={user} />,
         tag: "annual-forum-survey",
       })


### PR DESCRIPTION
Updated for 2025, example email:

<img width="572" height="413" alt="Screenshot 2025-08-18 at 5 15 56 PM" src="https://github.com/user-attachments/assets/ac028ac5-a01a-4b5c-b456-c73f7f3c01cb" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211085702006899) by [Unito](https://www.unito.io)
