### PR TITLE
[EA Forum only] a couple small fixes for the inactive user summary email

### DIFF
--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -140,7 +140,7 @@ const sendInactiveUserSummaryEmail = async (
 }
 
 export const sendInactiveUserSummaryEmails = async (
-  limit = 20,
+  limit = 60,
   dryRun = false,
 ) => {
   if (!hasInactiveSummaryEmail) {

--- a/packages/lesswrong/server/recommendations/FeatureStrategy.ts
+++ b/packages/lesswrong/server/recommendations/FeatureStrategy.ts
@@ -60,7 +60,7 @@ class FeatureStrategy extends RecommendationStrategy {
       -- FeatureStrategy
       SELECT p.*
       FROM (
-        SELECT p.*
+        SELECT p."_id", MAX(${score}) as max_score
         FROM "Posts" p
         ${readFilter.join}
         ${postFilter.join}
@@ -71,11 +71,14 @@ class FeatureStrategy extends RecommendationStrategy {
           ${readFilter.filter}
           ${postFilter.filter}
           ${tagFilter.filter}
-        ORDER BY 0 ${score} DESC
+        GROUP BY p."_id"
+        ORDER BY max_score DESC
         LIMIT $(count) * 10
-      ) p
+      ) ranked_posts
+      JOIN "Posts" p ON p."_id" = ranked_posts."_id"
       ${recommendedFilter.join}
       WHERE ${recommendedFilter.filter} 1=1
+      ORDER BY ranked_posts.max_score DESC
       LIMIT $(count)
     `, {
       ...readFilter.args,


### PR DESCRIPTION
Fixed a couple issues I noticed:
1. Posts in the email were not ordered by score desc
2. One person got an email with 3 posts, which is because some posts were recommended more than once

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211087412075252) by [Unito](https://www.unito.io)
