### PR TITLE
Allow coveralls upload to fail, without failing CI run

### DIFF
--- a/.github/workflows/runTests.yaml
+++ b/.github/workflows/runTests.yaml
@@ -207,6 +207,7 @@ jobs:
         name: Upload schema to accept
         path: schema/schema_to_accept.sql
     - name: Save coverage report
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         file: unit-coverage/lcov.info
@@ -244,6 +245,7 @@ jobs:
     - name: yarn run integration-ci
       run: yarn run integration-ci
     - name: Save coverage report
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         file: integration-coverage/lcov.info
@@ -286,6 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true


### PR DESCRIPTION
Coveralls has had a couple of outages recently (and is often generally a bit unreliable) which causes our CI runs to fail. Since uploading the coverage report isn't actually very important, this PR changes it so that these steps can fail without failing the entire CI run.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211089141585082) by [Unito](https://www.unito.io)
