### PR TITLE
[FriendlyUI only] popular comments timestamp goes to permalink, reduce karma threshold

### DIFF
--- a/packages/lesswrong/components/comments/FriendlyPopularComment.tsx
+++ b/packages/lesswrong/components/comments/FriendlyPopularComment.tsx
@@ -16,6 +16,7 @@ import UsersName from "../users/UsersName";
 import LWTooltip from "../common/LWTooltip";
 import SmallSideVote from "../votes/SmallSideVote";
 import CommentBody from "./CommentsItem/CommentBody";
+import CommentsItemDate from "./CommentsItem/CommentsItemDate";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -158,14 +159,7 @@ const FriendlyPopularComment = ({comment, classes}: {
         }
         <InteractionWrapper className={classNames(classes.row, classes.wrap)}>
           <UsersName user={comment.user} className={classes.username} />
-          <div className={classes.date}>
-            <LWTooltip
-              placement="right"
-              title={<ExpandedDate date={comment.postedAt} />}
-            >
-              {moment(new Date(comment.postedAt)).fromNow()}
-            </LWTooltip>
-          </div>
+          <CommentsItemDate comment={comment} post={comment.post} className={classes.date} preventDateFormatting />
           {!comment.debateResponse && !comment.rejected &&
             <SmallSideVote
               document={comment}

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -104,7 +104,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
   }
 
   async getPopularComments({
-    minScore = 15,
+    minScore = 12,
     offset = 0,
     limit = 3,
     recencyFactor = 250000,

--- a/packages/lesswrong/server/resolvers/commentResolvers.ts
+++ b/packages/lesswrong/server/resolvers/commentResolvers.ts
@@ -25,8 +25,9 @@ const { Query: popularCommentsQuery, typeDefs: popularCommentsTypeDefs } = creat
     context: ResolverContext,
     limit: number,
   ): Promise<DbComment[]> => {
+    const minScore = isLWorAF ? 15 : 12;
     const recencyFactor = isLWorAF ? 175_000 : 250_000;
-    return context.repos.comments.getPopularComments({limit, recencyFactor});
+    return context.repos.comments.getPopularComments({limit, minScore, recencyFactor});
   },
   cacheMaxAgeMs: 300000, // 5 mins
 });


### PR DESCRIPTION
1. I noticed that we're sometimes below 3 popular comments now, so I reduced the karma threshold for friendly UI.
2. Since I was here I also made the timestamp in popular comments link to the comment in context. (Bonus: now this also shows when the comment was last edited)

<img width="546" height="382" alt="Screenshot 2025-08-21 at 5 22 21 PM" src="https://github.com/user-attachments/assets/bf2bc684-8f53-4135-84c0-5d64db0bb57a" />


