### PR TITLE
Refactor forum gating

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -95,10 +95,10 @@ const styles = defineStyles("Layout", (theme: ThemeType) => ({
     minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
     gridArea: 'main',
     [theme.breakpoints.down('md')]: {
-      paddingTop: isFriendlyUI ? 0 : theme.spacing.mainLayoutPaddingTop,
+      paddingTop: theme.isFriendlyUI ? 0 : theme.spacing.mainLayoutPaddingTop,
     },
     [theme.breakpoints.down('sm')]: {
-      paddingTop: isFriendlyUI ? 0 : 10,
+      paddingTop: theme.isFriendlyUI ? 0 : 10,
       paddingLeft: 8,
       paddingRight: 8,
     },

--- a/packages/lesswrong/components/admin/CurationNoticesItem.tsx
+++ b/packages/lesswrong/components/admin/CurationNoticesItem.tsx
@@ -1,6 +1,5 @@
 import { postGetPageUrl } from '@/lib/collections/posts/helpers';
 import { Link } from '@/lib/reactRouterWrapper';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { registerComponent } from "../../lib/vulcan-lib/components";
@@ -45,7 +44,7 @@ const CommentsListMutation = gql(`
 const styles = (theme: ThemeType) => ({
   root: {
     border: theme.palette.border.commentBorder,
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : undefined,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : undefined,
     cursor: "default",
     marginBottom: 20,
     background: theme.palette.background.pageActiveAreaBackground,
@@ -92,10 +91,10 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 8,
     color: theme.palette.text.dim,
     paddingTop: "0.6em",
-    marginRight: isFriendlyUI ? 40 : 20,
+    marginRight: theme.isFriendlyUI ? 40 : 20,
     "& a:hover, & a:active": {
       textDecoration: "none",
-      color: isFriendlyUI ? undefined : `${theme.palette.linkHover.dim} !important`,
+      color: theme.isFriendlyUI ? undefined : `${theme.palette.linkHover.dim} !important`,
     },
   },
   postTitle: {

--- a/packages/lesswrong/components/analytics/AnalyticsDisclaimers.tsx
+++ b/packages/lesswrong/components/analytics/AnalyticsDisclaimers.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import moment from "moment";
 import { forumSelect } from "../../lib/forumTypeUtils";
-import { isFriendlyUI } from "@/themes/forumTheme";
 import { GRAPH_LEFT_MARGIN } from "./AnalyticsGraph";
 import { Typography } from "../common/Typography";
 
@@ -23,7 +22,7 @@ const dataCollectionFirstDay = forumSelect({
 });
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI
+  root: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
       margin: `0 ${GRAPH_LEFT_MARGIN}px`,

--- a/packages/lesswrong/components/bookmarks/BookmarksPage.tsx
+++ b/packages/lesswrong/components/bookmarks/BookmarksPage.tsx
@@ -19,9 +19,9 @@ type TabType = 'bookmarks' | 'readhistory' | 'votehistory';
 const styles = (theme: ThemeType) => ({
   headline: {
     color: theme.palette.grey[1000],
-    fontSize: isFriendlyUI ? 28 : undefined,
-    fontFamily: isFriendlyUI ? undefined : theme.palette.fonts.serifStack,
-    marginTop: isFriendlyUI ? 10 : 0,
+    fontSize: theme.isFriendlyUI ? 28 : undefined,
+    fontFamily: theme.isFriendlyUI ? undefined : theme.palette.fonts.serifStack,
+    marginTop: theme.isFriendlyUI ? 10 : 0,
     marginBottom: 20,
     [theme.breakpoints.down('sm')]: {
       marginTop: 20,
@@ -33,7 +33,7 @@ const styles = (theme: ThemeType) => ({
   },
   tab: {
     fontSize: 14,
-    fontWeight: isFriendlyUI ? '700' : undefined,
+    fontWeight: theme.isFriendlyUI ? '700' : undefined,
     [theme.breakpoints.down('xs')]: {
       fontSize: 13,
     }

--- a/packages/lesswrong/components/collections/BigCollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/BigCollectionsCard.tsx
@@ -2,7 +2,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import type { CoreReadingCollection } from '../sequences/LWCoreReading';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import CloudinaryImage from "../common/CloudinaryImage";
 import LinkCard from "../common/LinkCard";
 import UsersName from "../users/UsersName";
@@ -48,7 +47,7 @@ const styles = (theme: ThemeType) => ({
   author: {
     ...theme.typography.postStyle,
     marginBottom:theme.spacing.unit,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },

--- a/packages/lesswrong/components/collections/CollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/CollectionsCard.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import type { CoreReadingCollection } from '../sequences/LWCoreReading';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LinkCard from "../common/LinkCard";
 import CloudinaryImage from "../common/CloudinaryImage";
 import UsersName from "../users/UsersName";
@@ -40,7 +39,7 @@ const styles = (theme: ThemeType) => ({
     paddingTop: theme.spacing.unit*1.5
   },
   title: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   mergeTitle: {
     display: "inline",
@@ -53,7 +52,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     marginBottom:theme.spacing.unit,
     display: "inline-block",
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },

--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -88,14 +88,14 @@ const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType
     borderBottomLeftRadius: theme.borderRadius.quickTakesEntry,
     borderBottomRightRadius: theme.borderRadius.quickTakesEntry,
   },
-  submitQuickTakesButtonAtBottom: isFriendlyUI
+  submitQuickTakesButtonAtBottom: theme.isFriendlyUI
     ? {
       marginTop: 20,
       padding: 20,
       borderTop: `1px solid ${theme.palette.grey[300]}`,
     }
     : {},
-  formButton: isFriendlyUI ? {
+  formButton: theme.isFriendlyUI ? {
     fontSize: 14,
     textTransform: 'none',
     padding: '6px 12px',
@@ -112,9 +112,9 @@ const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType
     },
   },
   cancelButton: {
-    color: isFriendlyUI ? undefined : theme.palette.grey[400],
+    color: theme.isFriendlyUI ? undefined : theme.palette.grey[400],
   },
-  submitButton: isFriendlyUI ? {
+  submitButton: theme.isFriendlyUI ? {
     backgroundColor: theme.palette.buttons.alwaysPrimary,
     color: theme.palette.text.alwaysWhite,
     '&:disabled': {

--- a/packages/lesswrong/components/comments/CommentFrame.tsx
+++ b/packages/lesswrong/components/comments/CommentFrame.tsx
@@ -11,7 +11,7 @@ export const CONDENSED_MARGIN_BOTTOM = 4
 const styles = (theme: ThemeType) => ({
   node: {
     border: theme.palette.border.commentBorder,
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : undefined,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : undefined,
     cursor: "default",
     // Higher specificity to override child class (variant syntax)
     '&$deleted': {
@@ -28,15 +28,15 @@ const styles = (theme: ThemeType) => ({
     borderTop: theme.palette.border.commentBorder,
     borderBottom: theme.palette.border.commentBorder,
     borderRight: "none",
-    borderRadius: isFriendlyUI
+    borderRadius: theme.isFriendlyUI
       ? `${theme.borderRadius.small}px 0 0 ${theme.borderRadius.small}px`
       : "2px 0 0 2px",
   },
   new: {
     '&&': {
-      borderLeft: `solid 5px ${theme.palette.secondary.light}${isFriendlyUI ? '' : '8c'}`,
+      borderLeft: `solid 5px ${theme.palette.secondary.light}${theme.isFriendlyUI ? '' : '8c'}`,
       '&:hover': {
-        borderLeft: `solid 5px ${theme.palette.secondary.main}${isFriendlyUI ? '' : '8c'}`
+        borderLeft: `solid 5px ${theme.palette.secondary.main}${theme.isFriendlyUI ? '' : '8c'}`
       },
     }
   },
@@ -73,7 +73,7 @@ const styles = (theme: ThemeType) => ({
   },
   shortformTop: {
     '&&': {
-      marginTop: isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
+      marginTop: theme.isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
       marginBottom: 0,
     }
   },
@@ -120,7 +120,7 @@ const styles = (theme: ThemeType) => ({
       left: 1,
       boxSizing: "border-box",
       backgroundColor: theme.palette.panelBackground.default,
-      borderRadius: isFriendlyUI ? theme.borderRadius.small : 0,
+      borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : 0,
     },
     position: "relative",
     backgroundImage: `linear-gradient(to bottom right, ${theme.palette.border.secondaryHighlight}, ${theme.palette.border.primaryHighlight})`,

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -6,7 +6,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { isNotRandomId } from '@/lib/random';
 import { scrollFocusOnElement } from '@/lib/scrollUtils';
 import { commentPermalinkStyleSetting } from '@/lib/publicSettings';
-import { isBookUI } from '@/themes/forumTheme';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import Loading from "../vulcan-core/Loading";
@@ -30,7 +29,7 @@ const styles = (theme: ThemeType) => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
-    ...(isBookUI ? {
+    ...(theme.isBookUI ? {
       marginTop: 64
     } : {}),
   },

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -10,7 +10,6 @@ import type { CommentTreeOptions } from '../commentTree';
 import type { VotingSystem } from '../../../lib/voting/votingSystems';
 import type { ContentItemBodyImperative } from '../../contents/contentBodyUtil';
 import { userIsAllowedToComment } from '../../../lib/collections/users/helpers';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import CommentBottomCaveats from "./CommentBottomCaveats";
 import { commentGetPageUrlFromIds } from '@/lib/collections/comments/helpers';
 import { Link } from '@/lib/reactRouterWrapper';
@@ -19,10 +18,10 @@ const styles = (theme: ThemeType) => ({
   bottom: {
     display: "flex",
     alignItems: "center",
-    paddingBottom: isFriendlyUI ? 12 : 5,
-    paddingTop: isFriendlyUI ? 4 : undefined,
+    paddingBottom: theme.isFriendlyUI ? 12 : 5,
+    paddingTop: theme.isFriendlyUI ? 4 : undefined,
     minHeight: 12,
-    ...(isFriendlyUI ? {} : {fontSize: 12}),
+    ...(theme.isFriendlyUI ? {} : {fontSize: 12}),
   },
   bottomWithReacts: {
     justifyContent: "space-between"

--- a/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import { commentGetPageUrlFromIds } from "../../../lib/collections/comments/helpers";
 import { Link } from '../../../lib/reactRouterWrapper';
 import { isEAForum } from '../../../lib/instanceSettings';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import classNames from 'classnames';
 import LWTooltip from "../../common/LWTooltip";
 import ForumIcon from "../../common/ForumIcon";
 
 const styles = defineStyles("CommentShortformIcon", (theme: ThemeType) => ({
-  smallIcon: isFriendlyUI ? {
+  smallIcon: theme.isFriendlyUI ? {
     cursor: "pointer",
     color: theme.palette.grey[1000],
     height: 16,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -17,13 +17,13 @@ const styles = (theme: ThemeType) => ({
   author: {
     ...theme.typography.body2,
     fontWeight: 600,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       marginRight: 2,
     }),
   },
   authorAnswer: {
     ...theme.typography.body2,
-    fontFamily: isFriendlyUI
+    fontFamily: theme.isFriendlyUI
       ? theme.palette.fonts.sansSerifStack
       : theme.typography.postStyle.fontFamily,
     fontWeight: 600,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -16,7 +16,6 @@ import { metaNoticeStyles } from "./metaNoticeStyles";
 import { getVotingSystemByName } from '../../../lib/voting/getVotingSystem';
 import { useVote } from '../../votes/withVote';
 import { VotingProps } from '../../votes/votingProps';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import type { TagCommentType } from '@/lib/collections/comments/types';
 import type { ContentItemBodyImperative } from '../../contents/contentBodyUtil';
 import CommentsEditForm from "../CommentsEditForm";
@@ -73,9 +72,9 @@ const styles = defineStyles("CommentsItem", (theme: ThemeType) => ({
   replyLink: {
     marginRight: 8,
     display: "inline",
-    fontWeight: isFriendlyUI ? 600 : theme.typography.body1.fontWeight,
+    fontWeight: theme.isFriendlyUI ? 600 : theme.typography.body1.fontWeight,
     color: theme.palette.link.dim,
-    fontSize: isFriendlyUI ? "1.1rem" : undefined,
+    fontSize: theme.isFriendlyUI ? "1.1rem" : undefined,
     "@media print": {
       display: "none",
     },
@@ -88,7 +87,7 @@ const styles = defineStyles("CommentsItem", (theme: ThemeType) => ({
     marginTop: 2,
     marginBottom: 8,
     border: theme.palette.border.normal,
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : 0,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : 0,
   },
   replyFormMinimalist: {
     borderRadius: theme.borderRadius.small,
@@ -104,7 +103,7 @@ const styles = defineStyles("CommentsItem", (theme: ThemeType) => ({
     paddingTop: 10,
     marginBottom: '-3px',
   },
-  pinnedIcon: isFriendlyUI
+  pinnedIcon: theme.isFriendlyUI
     ? {
       width: 16,
       height: 16,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { useCommentLink, UseCommentLinkProps } from './useCommentLink';
 import classNames from 'classnames';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import { isLWorAF } from '../../../lib/instanceSettings';
 import DeferRender from '@/components/common/DeferRender';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
@@ -15,7 +14,7 @@ const EDIT_GRACE_PERIOD = 60*60*1000; //1hr
 
 const styles = defineStyles("CommentsItemDate", (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       marginLeft: 2,
       marginRight: 7,
     } : {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -40,11 +40,11 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
     marginBottom: 8,
     color: theme.palette.text.dim,
     paddingTop: "0.6em",
-    marginRight: isFriendlyUI ? 40 : 20,
+    marginRight: theme.isFriendlyUI ? 40 : 20,
 
     "& a:hover, & a:active": {
       textDecoration: "none",
-      color: isFriendlyUI ? undefined : `${theme.palette.linkHover.dim} !important`,
+      color: theme.isFriendlyUI ? undefined : `${theme.palette.linkHover.dim} !important`,
     },
   },
   sideCommentMeta: {
@@ -55,14 +55,14 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
     ...metaNoticeStyles(theme),
   },
   collapse: {
-    marginRight: isFriendlyUI ? 6 : 5,
+    marginRight: theme.isFriendlyUI ? 6 : 5,
     opacity: 0.8,
     fontSize: "0.8rem",
     lineHeight: "1rem",
-    paddingBottom: isFriendlyUI ? 4 : 2,
-    display: isFriendlyUI ? "inline-block" : "flex",
+    paddingBottom: theme.isFriendlyUI ? 4 : 2,
+    display: theme.isFriendlyUI ? "inline-block" : "flex",
     verticalAlign: "middle",
-    transform: isFriendlyUI ? "translateY(3px)" : undefined,
+    transform: theme.isFriendlyUI ? "translateY(3px)" : undefined,
 
     "& span": {
       fontFamily: "monospace",
@@ -79,7 +79,7 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
     transform: 'translateY(0.75px)',
   },
   username: {
-    marginRight: isFriendlyUI ? 0 : 6,
+    marginRight: theme.isFriendlyUI ? 0 : 6,
 
     "$sideCommentMeta &": {
       flexGrow: 1,
@@ -116,7 +116,7 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
   },
   rightSection: {
     position: "absolute",
-    right: isFriendlyUI ? -46 : -26,
+    right: theme.isFriendlyUI ? -46 : -26,
     top: 12,
     display: "flex",
   },
@@ -133,7 +133,7 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
     stroke: "currentColor",
     color: theme.palette.primary.main
   },
-  menu: isFriendlyUI
+  menu: theme.isFriendlyUI
     ? {
       color: theme.palette.icon.dim,
     }

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -91,7 +91,7 @@ const styles = defineStyles("CommentsListSection", (theme: ThemeType) => ({
     paddingLeft: theme.spacing.unit*1.5,
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
-    marginTop: isFriendlyUI ? 8 : 4,
+    marginTop: theme.isFriendlyUI ? 8 : 4,
     fontStyle: "italic",
   }
 }))

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -41,7 +41,7 @@ export type FormDisplayMode = "default" | "minimalist"
 
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI ? {
+  root: theme.isFriendlyUI ? {
     '& .form-component-EditorFormComponent': {
       marginTop: 0
     }
@@ -65,7 +65,7 @@ const styles = (theme: ThemeType) => ({
       borderTopRightRadius: theme.borderRadius.quickTakesEntry,
     },
   },
-  quickTakesSubmitButtonAtBottom: isFriendlyUI
+  quickTakesSubmitButtonAtBottom: theme.isFriendlyUI
     ? {
       "& .form-component-EditorFormComponent": {
         background: "transparent",

--- a/packages/lesswrong/components/comments/PopularCommentsList.tsx
+++ b/packages/lesswrong/components/comments/PopularCommentsList.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType) => ({
     flexDirection: "column",
     gap: "4px",
     fontFamily: theme.palette.fonts.sansSerifStack,
-    fontSize: isFriendlyUI ? 14 : '1.16rem',
+    fontSize: theme.isFriendlyUI ? 14 : '1.16rem',
     fontWeight: 500,
     color: theme.palette.grey[1000],
   },

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -8,7 +8,6 @@ import { isMobile } from '../../lib/utils/isMobile'
 import { CommentTreeOptions } from './commentTree';
 import CoreTagIcon, { coreTagIconMap } from '../tagging/CoreTagIcon';
 import { metaNoticeStyles } from "./CommentsItem/metaNoticeStyles";
-import { isFriendlyUI } from '../../themes/forumTheme';
 import FormatDate from "../common/FormatDate";
 import ShowParentComment from "./ShowParentComment";
 import CommentUserName from "./CommentsItem/CommentUserName";
@@ -33,7 +32,7 @@ export const singleLineStyles = (theme: ThemeType) => ({
   paddingRight: theme.spacing.unit,
   color: theme.palette.text.dim60,
   whiteSpace: "nowrap",
-  fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+  fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
 })
 
 const styles = defineStyles("SingleLineComment", (theme: ThemeType) => ({

--- a/packages/lesswrong/components/common/ContentStyles.tsx
+++ b/packages/lesswrong/components/common/ContentStyles.tsx
@@ -2,7 +2,6 @@ import React, { CSSProperties } from 'react';
 import { postBodyStyles, smallPostStyles, commentBodyStyles } from '../../themes/stylePiping'
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 
 const styles = defineStyles("ContentStyles", (theme: ThemeType) => ({
@@ -14,7 +13,7 @@ const styles = defineStyles("ContentStyles", (theme: ThemeType) => ({
   postHighlight: {
     ...smallPostStyles(theme),
     '& h1, & h2, & h3': {
-      fontSize: isFriendlyUI ? "1.1rem" : "1.6rem",
+      fontSize: theme.isFriendlyUI ? "1.1rem" : "1.6rem",
       // Cancel out a negative margin which would cause clipping
       marginBlockStart: "0 !important",
     },

--- a/packages/lesswrong/components/common/Error404.tsx
+++ b/packages/lesswrong/components/common/Error404.tsx
@@ -1,12 +1,11 @@
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import { useServerRequestStatus } from '../../lib/routeUtil'
-import { isFriendlyUI } from '../../themes/forumTheme';
 import SingleColumnSection from "./SingleColumnSection";
 
 const styles = (theme: ThemeType) => ({
   root: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : theme.palette.fonts.serifStack,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : theme.palette.fonts.serifStack,
   },
 });
 

--- a/packages/lesswrong/components/common/ErrorAccessDenied.tsx
+++ b/packages/lesswrong/components/common/ErrorAccessDenied.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useCurrentUser } from './withUser';
 import { useServerRequestStatus } from '../../lib/routeUtil'
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LoginForm from "../users/LoginForm";
 import SingleColumnSection from "./SingleColumnSection";
 import { Typography } from "./Typography";
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI
+  root: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 16,

--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -7,13 +7,12 @@ import classNames from "classnames";
 import SingleColumnSection from "./SingleColumnSection";
 import LWTooltip from "./LWTooltip";
 import ForumIcon from "./ForumIcon";
-import { isBookUI } from "@/themes/forumTheme";
 
 const styles = (theme: ThemeType) => ({
   title: {
     display: "flex",
     columnGap: 10,
-    ...(isBookUI && {
+    ...(theme.isBookUI && {
       color: theme.palette.text.bannerAdOverlay,
     }),
   },

--- a/packages/lesswrong/components/common/FlashMessages.tsx
+++ b/packages/lesswrong/components/common/FlashMessages.tsx
@@ -5,7 +5,6 @@ import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { Snackbar } from '../widgets/Snackbar';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { Paper } from '../widgets/Paper';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { Typography } from "./Typography";
 
 const styles = defineStyles("FlashMessages", (theme) => ({
@@ -29,7 +28,7 @@ const styles = defineStyles("FlashMessages", (theme) => ({
   message: {
     padding: '8px 0',
     color: theme.palette.text.maxIntensity,
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   action: {
     display: 'flex',

--- a/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
+++ b/packages/lesswrong/components/common/ForumDropdownMultiselect.tsx
@@ -16,7 +16,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
     textAlign: "center",
-    ...(!isFriendlyUI && {
+    ...(!theme.isFriendlyUI && {
       "& button:hover": {
         backgroundColor: "transparent",
       },
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType) => ({
     paddingLeft: 12,
     paddingRight: 6,
     backgroundColor: "transparent",
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       color: "inherit",
       "&:hover": {
         backgroundColor: theme.palette.grey[250],
@@ -43,7 +43,7 @@ const styles = (theme: ThemeType) => ({
     }),
   },
   openButton: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       backgroundColor: theme.palette.grey[250],
       color: theme.palette.grey[1000],
     }),
@@ -51,7 +51,7 @@ const styles = (theme: ThemeType) => ({
   dropdownIcon: {
     verticalAlign: "middle",
     position: "relative",
-    ...(isFriendlyUI && { width: 10, fontSize: "18px!important", height: 12, marginLeft: 4, padding: 1}),
+    ...(theme.isFriendlyUI && { width: 10, fontSize: "18px!important", height: 12, marginLeft: 4, padding: 1}),
   },
   selectedIcon: {
     verticalAlign: "middle",
@@ -64,7 +64,7 @@ const styles = (theme: ThemeType) => ({
   },
   menu: {
     marginTop: 28,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       "& .MuiPopover-paper": {
         backgroundColor: theme.palette.dropdown.background,
         border: `1px solid ${theme.palette.dropdown.border}`,
@@ -83,7 +83,7 @@ const styles = (theme: ThemeType) => ({
     marginTop: 46
   },
   menuItem: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       color: theme.palette.grey[1000],
       borderRadius: theme.borderRadius.small,
       padding: "6px 8px",

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -145,7 +145,7 @@ export const styles = (theme: ThemeType) => ({
     boxSizing: "border-box",
     flexShrink: 0,
     flexDirection: "column",
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       maxWidth: "100vw",
       overflow: "hidden",
       padding: '1px 20px',
@@ -203,7 +203,7 @@ export const styles = (theme: ThemeType) => ({
     },
     display: 'flex',
     alignItems: 'center',
-    fontWeight: isFriendlyUI ? 400 : undefined,
+    fontWeight: theme.isFriendlyUI ? 400 : undefined,
     height: isFriendlyUI ? undefined : '19px',
     
     ...(isAF && {
@@ -255,7 +255,7 @@ export const styles = (theme: ThemeType) => ({
     marginRight: -theme.spacing.unit,
     marginLeft: "auto",
     display: "flex",
-    alignItems: isFriendlyUI ? 'center' : undefined,
+    alignItems: theme.isFriendlyUI ? 'center' : undefined,
   },
   // Prevent rearranging of mobile header when search loads after SSR
   searchSSRStandin: {

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSubscribedLocation } from '../../lib/routeUtil';
 import { Link } from '../../lib/reactRouterWrapper';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { blackBarTitle } from '../../lib/publicSettings';
 import HeaderEventSubtitle from "./HeaderEventSubtitle";
 import { defineStyles, useStyles } from '../hooks/useStyles';
@@ -10,7 +9,7 @@ export const headerSubtitleStyles = defineStyles("HeaderSubtitle", (theme: Theme
   subtitle: {
     marginLeft: '1em',
     paddingLeft: '1em',
-    textTransform: isFriendlyUI ? undefined : 'uppercase',
+    textTransform: theme.isFriendlyUI ? undefined : 'uppercase',
     color: blackBarTitle.get() ? theme.palette.text.alwaysWhite : theme.palette.header.text,
     borderLeft: theme.palette.border.appBarSubtitleDivider,
   },

--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -5,8 +5,7 @@ import { queryIsUpdating } from './queryStatusUtils'
 import {useTracking} from "../../lib/analyticsEvents";
 import { LoadMoreCallback } from '../hooks/useQueryWithLoadMore';
 import { useIsFirstRender } from "../hooks/useFirstRender";
-import { isBookUI, isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
-import { isAF } from '@/lib/instanceSettings';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import Loading from "../vulcan-core/Loading";
 import type { WrappedFetchMore } from '../hooks/useQueryWithLoadMore';
 import { defineStyles, useStyles } from '../hooks/useStyles';
@@ -16,19 +15,19 @@ const styles = defineStyles("LoadMore", (theme: ThemeType) => ({
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
     color: theme.palette.lwTertiary.main,
-    ...(isBookUI && theme.dark && {
+    ...(theme.isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     display: "inline-block",
     minHeight: 20,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontSize: 14,
         fontWeight: 600,
         lineHeight: "24px",
       }
       : {}),
-    ...(isAF && {
+    ...(theme.isAF && {
       fontWeight: 500,
     }),
   },

--- a/packages/lesswrong/components/common/Menus.tsx
+++ b/packages/lesswrong/components/common/Menus.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import ButtonBase from '@/lib/vendor/@material-ui/core/src/ButtonBase';
-import { isLW } from '@/lib/instanceSettings';
-import { isFriendlyUI } from '@/themes/forumTheme';
 
 export const styles = defineStyles("MenuItem", theme => ({
   root: {
@@ -19,13 +16,13 @@ export const styles = defineStyles("MenuItem", theme => ({
     paddingLeft: 16,
     paddingRight: 16,
     
-    ...(isLW && {
+    ...(theme.isLW && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       color: theme.palette.grey[800],
       fontSize: 14.3,
       lineHeight: "1.1em",
     }),
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       color: theme.palette.grey[900],
       fontWeight: 500,
@@ -51,7 +48,7 @@ export const styles = defineStyles("MenuItem", theme => ({
         backgroundColor: 'transparent',
       },
     },
-    ...(isLW && {
+    ...(theme.isLW && {
       paddingTop: 8,
       paddingBottom: 8
     }),

--- a/packages/lesswrong/components/common/MetaInfo.tsx
+++ b/packages/lesswrong/components/common/MetaInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames'
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { Typography } from "./Typography";
 
 export const styles = (theme: ThemeType) => ({
@@ -11,7 +10,7 @@ export const styles = (theme: ThemeType) => ({
     marginRight: theme.spacing.unit,
     fontSize: "1rem",
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack
     }),
   },

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -11,7 +11,6 @@ import { isAF } from '../../lib/instanceSettings';
 import qs from 'qs'
 import { useSearchAnalytics } from '../search/useSearchAnalytics';
 import { useCurrentUser } from './withUser';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useNavigate } from '../../lib/routeUtil';
 import { InstantSearch } from '../../lib/utils/componentsWithChildren';
 import { createPortal } from 'react-dom';
@@ -57,7 +56,7 @@ const styles = (theme: ThemeType) => ({
 
       height: "100%",
       width: "100%",
-      paddingTop: isFriendlyUI ? 5 : undefined,
+      paddingTop: theme.isFriendlyUI ? 5 : undefined,
       paddingRight: 0,
       paddingLeft: 48,
       verticalAlign: "bottom",
@@ -76,16 +75,16 @@ const styles = (theme: ThemeType) => ({
       position: 'fixed',
     },
   },
-  searchInputAreaSmall: isFriendlyUI ? {
+  searchInputAreaSmall: theme.isFriendlyUI ? {
     minWidth: 34,
   } : {},
   searchIcon: {
     "--icon-size": "24px",
   },
   searchIconButton: {
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.header.text ,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.header.text ,
   },
-  searchIconButtonSmall: isFriendlyUI ? {
+  searchIconButtonSmall: theme.isFriendlyUI ? {
     padding: 6,
     marginTop: 6,
   } : {},
@@ -95,7 +94,7 @@ const styles = (theme: ThemeType) => ({
   searchBarClose: {
     display: "inline-block",
     position: "absolute",
-    top: isFriendlyUI ? 18 : 15,
+    top: theme.isFriendlyUI ? 18 : 15,
     right: 5,
     cursor: "pointer"
   },

--- a/packages/lesswrong/components/common/SectionButton.tsx
+++ b/packages/lesswrong/components/common/SectionButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames'
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { isAF } from '@/lib/instanceSettings';
 import { Typography } from "./Typography";
 
@@ -11,7 +10,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.lwTertiary.main,
     display: "flex",
     alignItems: "center",
-    ...(isFriendlyUI ? {fontWeight: 600} : {}),
+    ...(theme.isFriendlyUI ? {fontWeight: 600} : {}),
     '& svg': {
       marginRight: theme.spacing.unit
     },

--- a/packages/lesswrong/components/common/SectionFooter.tsx
+++ b/packages/lesswrong/components/common/SectionFooter.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { Typography } from "./Typography";
 import { isIfAnyoneBuildsItFrontPage } from '../seasonal/IfAnyoneBuildsItSplash';
 
@@ -38,7 +37,7 @@ const styles = (theme: ThemeType) => ({
     }),
     flexWrap: "wrap",
     ...separatorBulletStyles(theme),
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontSize: 14,
         fontWeight: 600,

--- a/packages/lesswrong/components/common/SettingsColumn.tsx
+++ b/packages/lesswrong/components/common/SettingsColumn.tsx
@@ -4,7 +4,6 @@ import { QueryLink } from '../../lib/reactRouterWrapper'
 import classNames from 'classnames'
 import * as _ from 'underscore';
 import { SettingsOption } from '../../lib/collections/posts/dropdownOptions';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { TooltipSpan } from './FMTooltip';
 import MetaInfo from "./MetaInfo";
 
@@ -21,8 +20,8 @@ const styles = (theme: ThemeType) => ({
     '&&': {
       // Increase specifity to remove import-order conflict with MetaInfo
       display: "block",
-      fontStyle: isFriendlyUI ? undefined : "italic",
-      fontWeight: isFriendlyUI ? undefined : 600,
+      fontStyle: theme.isFriendlyUI ? undefined : "italic",
+      fontWeight: theme.isFriendlyUI ? undefined : 600,
       marginBottom: theme.spacing.unit/2
     },
   },

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useTracking } from "../../lib/analyticsEvents";
 import { isEAForum } from '../../lib/instanceSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import TabNavigationSubItem from "./TabNavigationMenu/TabNavigationSubItem";
 import SubscribeDialog from "./SubscribeDialog";
@@ -9,8 +8,8 @@ import SubscribeDialog from "./SubscribeDialog";
 const styles = defineStyles('SubscribeWidget', (theme: ThemeType) => ({
   root: {
     "&:hover": {
-      opacity: isFriendlyUI ? 1 : undefined,
-      color: isFriendlyUI ? theme.palette.grey[800] : undefined,
+      opacity: theme.isFriendlyUI ? 1 : undefined,
+      color: theme.isFriendlyUI ? theme.palette.grey[800] : undefined,
     },
   },
 }));

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -30,7 +30,7 @@ const styles = (theme: ThemeType) => ({
     [theme.breakpoints.down('md')]: {
       display: "none"
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       top: 26,
     })
   },

--- a/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/SubforumsList.tsx
@@ -36,7 +36,7 @@ const styles = ((theme: ThemeType) => ({
     paddingLeft: 62,
     paddingBottom: 5,
     ...theme.typography.body2,
-    color: theme.palette.grey[isEAForum ? 600 : 800],
+    color: theme.palette.grey[theme.isEAForum ? 600 : 800],
   },
   subItem: {
     textTransform: 'capitalize',

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Link } from '../../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { MenuTabRegular } from './menuTabs';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import LWTooltip from "../LWTooltip";
 import { MenuItemLink } from "../Menus";
 
@@ -20,7 +19,7 @@ const styles = (theme: ThemeType) => ({
       width: compressedIconSize,
       height: compressedIconSize,
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       opacity: 1,
     }),
   },

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -4,7 +4,6 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { useLocation } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import { MenuTabRegular } from './menuTabs';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { TooltipRef } from '../FMTooltip';
 import TabNavigationSubItem from "./TabNavigationSubItem";
 
@@ -14,15 +13,15 @@ const styles = (theme: ThemeType) => ({
   selected: {
     '& $icon': {
       opacity: 1,
-      color: isFriendlyUI ? theme.palette.text.alwaysWhite : undefined,
+      color: theme.isFriendlyUI ? theme.palette.text.alwaysWhite : undefined,
     },
     '& $navText': {
-      color: isFriendlyUI ? theme.palette.text.alwaysWhite : theme.palette.grey[900],
+      color: theme.isFriendlyUI ? theme.palette.text.alwaysWhite : theme.palette.grey[900],
       fontWeight: 600,
     },
     backgroundColor: theme.palette.grey[400],
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       backgroundColor: theme.palette.secondary.main
     }),
   },
@@ -36,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     alignItems: "center",
     justifyContent: "space-around",
     flexDirection: "column",
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         color: theme.palette.grey[600],
         "&:hover": {
@@ -48,19 +47,19 @@ const styles = (theme: ThemeType) => ({
   },
   icon: {
     display: "block",
-    opacity: isFriendlyUI ? 1 : 0.45,
+    opacity: theme.isFriendlyUI ? 1 : 0.45,
     width: smallIconSize,
     height: smallIconSize,
     '& svg': {
       width: smallIconSize,
       height: smallIconSize,
-      fill: isFriendlyUI ? undefined : "currentColor",
-      color: isFriendlyUI ? "inherit" : undefined,
+      fill: theme.isFriendlyUI ? undefined : "currentColor",
+      color: theme.isFriendlyUI ? "inherit" : undefined,
     }
   },
   navText: {
     ...theme.typography.body2,
-    color: isFriendlyUI ? "inherit" : theme.palette.grey[700],
+    color: theme.isFriendlyUI ? "inherit" : theme.palette.grey[700],
     fontSize: '.8rem',
   },
   homeIcon: {

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { useLocation } from '../../../lib/routeUtil';
 import { MenuTabRegular } from './menuTabs';
 import { forumSelect } from '../../../lib/forumTypeUtils';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import { useCurrentUser } from '../withUser';
 import { useCookiesWithConsent } from '@/components/hooks/useCookiesWithConsent';
 import { NAV_MENU_FLAG_COOKIE_PREFIX } from '@/lib/cookies/cookies';
@@ -26,12 +25,12 @@ const styles = (theme: ThemeType) => ({
       opacity: 1,
     },
     '& $navText': {
-      color: theme.palette.grey[isFriendlyUI ? 1000 : 900],
+      color: theme.palette.grey[theme.isFriendlyUI ? 1000 : 900],
       fontWeight: 600,
     },
   },
   menuItem: {
-    width: isFriendlyUI ? 210 : 190,
+    width: theme.isFriendlyUI ? 210 : 190,
   },
   desktopOnly: {
     [theme.breakpoints.down("xs")]: {
@@ -40,16 +39,16 @@ const styles = (theme: ThemeType) => ({
   },
   navButton: {
     '&:hover': {
-      opacity: isFriendlyUI ? 1 : 0.6,
-      color: isFriendlyUI ? theme.palette.grey[800] : undefined,
+      opacity: theme.isFriendlyUI ? 1 : 0.6,
+      color: theme.isFriendlyUI ? theme.palette.grey[800] : undefined,
       backgroundColor: 'transparent', // Prevent MUI default behavior of rendering solid background on hover
       
-      ...(isFriendlyUI && {
+      ...(theme.isFriendlyUI && {
         paddingTop: 10,
         paddingBottom: 10,
       }),
     },
-    color: theme.palette.grey[isFriendlyUI ? 600 : 800],
+    color: theme.palette.grey[theme.isFriendlyUI ? 600 : 800],
     ...(theme.forumType === "LessWrong"
       ? {
         paddingTop: 7,
@@ -72,7 +71,7 @@ const styles = (theme: ThemeType) => ({
     paddingRight: 0,
     '&:hover': {
       backgroundColor: 'transparent', // Prevent MUI default behavior of rendering solid background on hover
-      opacity: isFriendlyUI ? 1 : undefined,
+      opacity: theme.isFriendlyUI ? 1 : undefined,
     }
   },
   icon: {
@@ -82,23 +81,23 @@ const styles = (theme: ThemeType) => ({
     marginRight: 16,
     display: "inline",
     "& svg": {
-      fill: isFriendlyUI ? undefined : "currentColor",
-      color: isFriendlyUI ? undefined : theme.palette.icon.navigationSidebarIcon,
+      fill: theme.isFriendlyUI ? undefined : "currentColor",
+      color: theme.isFriendlyUI ? undefined : theme.palette.icon.navigationSidebarIcon,
       transform: iconTransform,
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       opacity: 1,
     }),
   },
   selectedIcon: {
     "& svg": {
-      color: isFriendlyUI ? theme.palette.grey[1000] : undefined,
+      color: theme.isFriendlyUI ? theme.palette.grey[1000] : undefined,
     },
   },
   navText: {
     ...theme.typography.body2,
     color: "inherit",
-    ...(isBookUI && theme.dark && {
+    ...(theme.isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     textTransform: "none !important",
@@ -111,7 +110,7 @@ const styles = (theme: ThemeType) => ({
     }
   },
   tooltip: {
-    maxWidth: isFriendlyUI ? 190 : undefined,
+    maxWidth: theme.isFriendlyUI ? 190 : undefined,
   },
   flag: {
     padding: "2px 4px",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -8,7 +8,6 @@ import menuTabs from './menuTabs'
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import { forumSelect } from '../../../lib/forumTypeUtils';
 import classNames from 'classnames';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import EventsList from './EventsList';
 import { SubscribeWidget } from '../SubscribeWidget';
 
@@ -21,7 +20,7 @@ const styles = (theme: ThemeType) => {
       flexDirection: "column",
       maxWidth: TAB_NAVIGATION_MENU_WIDTH,
       paddingTop: 15,
-      ...(isFriendlyUI
+      ...(theme.isFriendlyUI
         ? {
           paddingLeft: 6,
           height: "100%",
@@ -41,12 +40,12 @@ const styles = (theme: ThemeType) => {
     divider: {
       width: 50,
       borderBottom: theme.palette.border.normal,
-      ...(isBookUI && theme.dark && {
+      ...(theme.isBookUI && theme.dark && {
         color: theme.palette.text.bannerAdOverlay,
         background: theme.palette.text.bannerAdOverlay,
       }),
       marginBottom: theme.spacing.unit * 2.5,
-      ...(isFriendlyUI
+      ...(theme.isFriendlyUI
         ? {
           marginLeft: theme.spacing.unit * 2.5,
           marginTop: theme.spacing.unit * 2.5,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -3,10 +3,9 @@ import { registerComponent } from '../../../lib/vulcan-lib/components';
 import classNames from 'classnames'
 import { iconWidth } from './TabNavigationItem'
 import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 
 const iconPadding = (theme: ThemeType) =>
-  isFriendlyUI ? theme.spacing.unit / 2 : iconWidth + (theme.spacing.unit * 2);
+  theme.isFriendlyUI ? theme.spacing.unit / 2 : iconWidth + (theme.spacing.unit * 2);
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -15,8 +14,8 @@ const styles = (theme: ThemeType) => ({
     paddingBottom: theme.spacing.unit,
     // padding reflects how large an icon+padding is
     paddingLeft: (theme.spacing.unit*2) + iconPadding(theme),
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.grey[700],
-    ...(isBookUI && theme.dark && {
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.grey[700],
+    ...(theme.isBookUI && theme.dark && {
       color: theme.palette.text.bannerAdOverlay,
     }),
     width:
@@ -27,8 +26,8 @@ const styles = (theme: ThemeType) => ({
     whiteSpace: "nowrap",
     overflow: "hidden",
     '&:hover': {
-      opacity: isFriendlyUI ? 1 : 0.6,
-      color: isFriendlyUI ? theme.palette.grey[800] : undefined,
+      opacity: theme.isFriendlyUI ? 1 : 0.6,
+      color: theme.isFriendlyUI ? theme.palette.grey[800] : undefined,
     },
     boxSizing: "content-box"
   }

--- a/packages/lesswrong/components/community/Community.tsx
+++ b/packages/lesswrong/components/community/Community.tsx
@@ -15,7 +15,6 @@ import OutlinedInput from '@/lib/vendor/@material-ui/core/src/OutlinedInput';
 import Tab from '@/lib/vendor/@material-ui/core/src/Tab';
 import Tabs from '@/lib/vendor/@material-ui/core/src/Tabs';
 import { Chip } from "@/components/widgets/Chip";
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { Link } from "../../lib/reactRouterWrapper";
 import { useLocation, useNavigate } from "../../lib/routeUtil";
 import EventNotificationsDialog from "../localGroups/EventNotificationsDialog";
@@ -57,14 +56,14 @@ const styles = (theme: ThemeType) => ({
       marginTop: 30,
     },
     [theme.breakpoints.up('sm')]: {
-      marginTop: isFriendlyUI ? 20 : undefined,
+      marginTop: theme.isFriendlyUI ? 20 : undefined,
     },
   },
   sectionHeading: {
     ...theme.typography.headline,
     fontSize: 34,
     margin: 0,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },
@@ -171,7 +170,7 @@ const styles = (theme: ThemeType) => ({
   },
   localGroupsBtn: {
     textTransform: 'none',
-    fontSize: isFriendlyUI ? 13 : 12,
+    fontSize: theme.isFriendlyUI ? 13 : 12,
   },
   localGroupsBtnIcon: {
     fontSize: 15,
@@ -203,7 +202,7 @@ const styles = (theme: ThemeType) => ({
   eventsPageLink: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.text.invertedBackgroundText,
-    fontSize: isFriendlyUI ? 14 : 13,
+    fontSize: theme.isFriendlyUI ? 14 : 13,
     padding: '8px 16px',
     borderRadius: 4,
     marginTop: 10

--- a/packages/lesswrong/components/community/modules/CommunityMembers.tsx
+++ b/packages/lesswrong/components/community/modules/CommunityMembers.tsx
@@ -7,7 +7,6 @@ import OutlinedInput from '@/lib/vendor/@material-ui/core/src/OutlinedInput';
 import { distance } from './LocalGroups';
 import { useTracking } from '../../../lib/analyticsEvents';
 import type { BasicDoc, SearchBoxProvided, StateResultsProvided } from 'react-instantsearch-core';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { InstantSearch } from '../../../lib/utils/componentsWithChildren';
 import CloudinaryImage2 from "../../common/CloudinaryImage2";
 import SearchResultsMap from "./SearchResultsMap";
@@ -51,7 +50,7 @@ const styles = (theme: ThemeType) => ({
   fullMapLink: {
     color: theme.palette.primary.main,
     ...theme.typography.commentStyle,
-    fontSize: isFriendlyUI ? 14 : 13,
+    fontSize: theme.isFriendlyUI ? 14 : 13,
     margin: '0 5px'
   },
   noResults: {

--- a/packages/lesswrong/components/community/modules/LocalGroups.tsx
+++ b/packages/lesswrong/components/community/modules/LocalGroups.tsx
@@ -4,7 +4,6 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { useThemeColor } from '@/components/themes/useTheme';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import CommunityMapWrapper from "../../localGroups/CommunityMapWrapper";
 import CloudinaryImage2 from "../../common/CloudinaryImage2";
 import { useQuery } from "@/lib/crud/useQuery";
@@ -99,9 +98,9 @@ const styles = (theme: ThemeType) => ({
     alignItems: 'baseline',
   },
   localGroupName: {
-    ...theme.typography[isFriendlyUI ? "headerStyle" : "headline"],
+    ...theme.typography[theme.isFriendlyUI ? "headerStyle" : "headline"],
     fontSize: 18,
-    fontWeight: isFriendlyUI ? 700 : undefined,
+    fontWeight: theme.isFriendlyUI ? 700 : undefined,
     display: '-webkit-box',
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',

--- a/packages/lesswrong/components/community/modules/OnlineGroups.tsx
+++ b/packages/lesswrong/components/community/modules/OnlineGroups.tsx
@@ -5,7 +5,7 @@ import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { useThemeColor } from '@/components/themes/useTheme';
 
-import { isFriendlyUI, preferredHeadingCase } from '../../../themes/forumTheme';
+import { preferredHeadingCase } from '../../../themes/forumTheme';
 import CloudinaryImage2 from "../../common/CloudinaryImage2";
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
@@ -103,7 +103,7 @@ const styles = (theme: ThemeType) => ({
       whiteSpace: 'normal'
     }
   },
-  onlineGroupName: isFriendlyUI ? {
+  onlineGroupName: theme.isFriendlyUI ? {
       ...theme.typography.headerStyle,
       fontWeight: 700,
       fontSize: 18,
@@ -145,7 +145,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.primary.main,
     padding: '10px 14px',
     borderRadius: 4,
-    fontSize: isFriendlyUI ? 14 : theme.typography.commentStyle.fontSize,
+    fontSize: theme.isFriendlyUI ? 14 : theme.typography.commentStyle.fontSize,
   },
   postGroupsCTA: {
     textAlign: 'center',

--- a/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
+++ b/packages/lesswrong/components/community/modules/SearchResultsMap.tsx
@@ -6,7 +6,6 @@ import PersonIcon from '@/lib/vendor/@material-ui/icons/src/PersonPin';
 import type { Hit } from 'react-instantsearch-core';
 import classNames from 'classnames';
 import { componentWithChildren } from '../../../lib/utils/componentsWithChildren';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import CloudinaryImage2 from "../../common/CloudinaryImage2";
 import StyledMapPopup from "../../localGroups/StyledMapPopup";
 import { WrappedReactMapGL } from '../WrappedReactMapGL';
@@ -29,7 +28,7 @@ const styles = defineStyles("SearchResultsMap", (theme: ThemeType) => ({
     display: 'flex',
     columnGap: 10,
     alignItems: 'center',
-    color: isFriendlyUI ? undefined : theme.palette.text.alwaysBlack,
+    color: theme.isFriendlyUI ? undefined : theme.palette.text.alwaysBlack,
   },
   profileImage: {
     'box-shadow': '3px 3px 1px ' + theme.palette.boxShadowColor(.25),

--- a/packages/lesswrong/components/dialogues/DialoguesSectionFrontpageSettings.tsx
+++ b/packages/lesswrong/components/dialogues/DialoguesSectionFrontpageSettings.tsx
@@ -4,7 +4,6 @@ import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import classNames from 'classnames'
 import Checkbox from '@/lib/vendor/@material-ui/core/src/Checkbox';
 import { useCurrentUser } from '../common/withUser';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { TooltipSpan } from '../common/FMTooltip';
 import MetaInfo from "../common/MetaInfo";
 
@@ -18,7 +17,7 @@ const USER_SETTING_NAMES = {
 const styles = (theme: ThemeType) => ({
   root: {
     display: "block",
-    marginTop: isFriendlyUI ? 10 : undefined,
+    marginTop: theme.isFriendlyUI ? 10 : undefined,
     marginBottom: theme.spacing.unit,
     flexWrap: "wrap",
     background: theme.palette.panelBackground.default,

--- a/packages/lesswrong/components/dropdowns/DropdownDivider.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownDivider.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import classNames from "classnames";
-import { isFriendlyUI } from "../../themes/forumTheme";
 import SimpleDivider from "../widgets/SimpleDivider";
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   root: {
-    margin: isFriendlyUI ? `6px 0 !important` : undefined,
+    margin: theme.isFriendlyUI ? `6px 0 !important` : undefined,
   },
 });
 

--- a/packages/lesswrong/components/dropdowns/DropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownItem.tsx
@@ -4,7 +4,6 @@ import ListItemIcon from "@/lib/vendor/@material-ui/core/src/ListItemIcon";
 import { Link } from "../../lib/reactRouterWrapper";
 import type { HashLinkProps } from "../common/HashLink";
 import classNames from "classnames";
-import { isFriendlyUI } from "../../themes/forumTheme";
 import { MenuItem } from "../common/Menus";
 import Loading from "../vulcan-core/Loading";
 import LWTooltip from "../common/LWTooltip";
@@ -12,14 +11,14 @@ import { defineStyles, useStyles } from "../hooks/useStyles";
 
 const styles = defineStyles("DropdownItem", (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       "&:hover": {
         opacity: 1,
       },
     }),
   },
   main: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       borderRadius: theme.borderRadius.default,
       padding: 8,
       "&:hover": {
@@ -29,12 +28,12 @@ const styles = defineStyles("DropdownItem", (theme: ThemeType) => ({
         },
       },
       "& .ForumIcon-root": {
-        fontSize: isFriendlyUI ? 20 : undefined,
+        fontSize: theme.isFriendlyUI ? 20 : undefined,
       },
     }),
   },
   noIcon: {
-    paddingLeft: isFriendlyUI ? 12 : undefined,
+    paddingLeft: theme.isFriendlyUI ? 12 : undefined,
   },
   title: {
     flexGrow: 1,

--- a/packages/lesswrong/components/dropdowns/DropdownMenu.tsx
+++ b/packages/lesswrong/components/dropdowns/DropdownMenu.tsx
@@ -1,11 +1,10 @@
 import React, { ReactNode } from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import classNames from "classnames";
-import { isFriendlyUI } from "../../themes/forumTheme";
 
 const styles = (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       padding: 6,
       borderRadius: theme.borderRadius.default,
       backgroundColor: theme.palette.dropdown.background,

--- a/packages/lesswrong/components/dropdowns/comments/CommentsMenu.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentsMenu.tsx
@@ -4,12 +4,11 @@ import MoreVertIcon from '@/lib/vendor/@material-ui/icons/src/MoreVert';
 import { Menu } from '@/components/widgets/Menu';
 import { useCurrentUserId } from '../../common/withUser';
 import { useTracking } from "../../../lib/analyticsEvents";
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import CommentActions from "./CommentActions";
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       "& .MuiList-padding": {
         padding: 0,
       },

--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDialog.tsx
@@ -7,12 +7,11 @@ import { DialogContent } from '../../widgets/DialogContent';
 import { DialogTitle } from '../../widgets/DialogTitle';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import TextField from '@/lib/vendor/@material-ui/core/src/TextField';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import LWDialog from "../../common/LWDialog";
 
 const styles = (theme: ThemeType) => ({
   subtitle: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   deleteWithoutTrace: {
     marginRight:"auto"

--- a/packages/lesswrong/components/dropdowns/comments/LockThreadDialog.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/LockThreadDialog.tsx
@@ -7,13 +7,12 @@ import { DialogTitle } from '@/components/widgets/DialogTitle';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { gql } from "@/lib/generated/gql-codegen";
 import moment from 'moment';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import LWDialog from "../../common/LWDialog";
 import { DatePicker } from "../../form-components/FormComponentDateTime";
 
 const styles = (theme: ThemeType) => ({
   message: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
 });
 

--- a/packages/lesswrong/components/dropdowns/comments/PinToProfileDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/PinToProfileDropdownItem.tsx
@@ -16,8 +16,8 @@ const CommentsListUpdateMutation = gql(`
   }
 `);
 
-const styles = (_: ThemeType) => ({
-  icon: isFriendlyUI
+const styles = (theme: ThemeType) => ({
+  icon: theme.isFriendlyUI
     ? {fontSize: "18px"}
     : {},
 });

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { useCurrentUser } from '../../common/withUser';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
+import { isBookUI } from '../../../themes/forumTheme';
 import { hasCuratedPostsSetting } from '../../../lib/instanceSettings';
 import MoveToDraftDropdownItem from "./MoveToDraftDropdownItem";
 import BookmarkDropdownItem from "./BookmarkDropdownItem";
@@ -35,9 +35,9 @@ export const AllowHidingFrontPagePostsContext = React.createContext<boolean>(fal
 // Same as above context provider but for whether a post is being served as a recommendation
 export const IsRecommendationContext = React.createContext<boolean>(false);
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   root: {
-    minWidth: isFriendlyUI ? undefined : 300,
+    minWidth: theme.isFriendlyUI ? undefined : 300,
     maxWidth: "calc(100vw - 100px)",
   },
 })

--- a/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
@@ -5,7 +5,6 @@ import MoreVertIcon from '@/lib/vendor/@material-ui/icons/src/MoreVert';
 import { useTracking } from '../../../lib/analyticsEvents';
 import type { Placement as PopperPlacementType } from "popper.js"
 import { useIsAboveBreakpoint } from '../../hooks/useScreenWidth';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import PopperCard from "../../common/PopperCard";
@@ -18,7 +17,7 @@ const styles = defineStyles("PostActionsButton", (theme: ThemeType) => ({
   },
   icon: {
     verticalAlign: 'middle',
-    color: isFriendlyUI ? theme.palette.grey[400] : undefined,
+    color: theme.isFriendlyUI ? theme.palette.grey[400] : undefined,
     cursor: "pointer",
   },
   popper: {

--- a/packages/lesswrong/components/ea-forum/SiteLogo.tsx
+++ b/packages/lesswrong/components/ea-forum/SiteLogo.tsx
@@ -11,9 +11,9 @@ import { lightbulbIcon } from '../icons/lightbulbIcon';
 
 const styles = (theme: ThemeType) => ({
   root: {
-    height: isEAForum ? 34 : 48,
+    height: theme.isEAForum ? 34 : 48,
     [theme.breakpoints.down('sm')]: {
-      height: isEAForum ? 30 : 48,
+      height: theme.isEAForum ? 30 : 48,
     },
   },
   icon: {

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { isFriendlyUI } from '../../themes/forumTheme';
-import { isEAForum } from '../../lib/instanceSettings';
 import SingleColumnSection from "../common/SingleColumnSection";
 import PostsList2 from "../posts/PostsList2";
 import TargetedJobAdSection from "./TargetedJobAdSection";
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI
+  root: theme.isFriendlyUI
     ? {
       margin: "8px 0",
     }

--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useState} from 'react';
 import Input from '@/lib/vendor/@material-ui/core/src/Input';
 import {useMessages} from "../common/withMessages";
 import type { EditablePost, PostCategory } from '../../lib/collections/posts/helpers';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { isE2E } from '../../lib/executionEnvironment';
 import { LW_POST_TITLE_FONT_SIZE } from '../posts/PostsPage/PostsPageTitle';
 import { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
@@ -24,7 +23,7 @@ const styles = defineStyles('EditTitle', (theme: ThemeType) => ({
   root: {
     ...theme.typography.display3,
     ...theme.typography.headerStyle,
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       fontWeight: 700,
       fontSize: "3rem",
       marginBottom: 12,

--- a/packages/lesswrong/components/editor/LocalStorageCheck.tsx
+++ b/packages/lesswrong/components/editor/LocalStorageCheck.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { SerializedEditorContents, deserializeEditorContents, EditorContents, nonAdminEditors, adminEditors } from './Editor';
 import { useCurrentUser } from '../common/withUser';
 import { htmlToTextDefault } from '@/lib/htmlToText';
-import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
+import { preferredHeadingCase } from '@/themes/forumTheme';
 import ForumIcon from "../common/ForumIcon";
 import { defineStyles, useStyles } from '../hooks/useStyles';
 
@@ -11,7 +11,7 @@ const styles = defineStyles("LocalStorageCheck", (theme: ThemeType) => ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    columnGap: isFriendlyUI ? 8 : 10,
+    columnGap: theme.isFriendlyUI ? 8 : 10,
     fontFamily: theme.typography.commentStyle.fontFamily,
     color: theme.palette.text.primaryAlert,
     fontSize: 14,
@@ -34,14 +34,14 @@ const styles = defineStyles("LocalStorageCheck", (theme: ThemeType) => ({
     whiteSpace: 'nowrap',
     paddingLeft: 6,
     paddingRight: 2,
-    fontWeight: isFriendlyUI ? 600 : undefined,
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
   },
   restoreBody: {
     maxHeight: '1.5em',
     lineHeight: '1.5em',
     fontSize: '1.1rem',
     overflow: 'hidden',
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         color: theme.palette.text.primaryAlert,
         fontWeight: 500,

--- a/packages/lesswrong/components/events/EventsHome.tsx
+++ b/packages/lesswrong/components/events/EventsHome.tsx
@@ -19,7 +19,7 @@ import Checkbox from '@/lib/vendor/@material-ui/core/src/Checkbox';
 import ListItemText from '@/lib/vendor/@material-ui/core/src/ListItemText';
 import classNames from 'classnames';
 
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import EventNotificationsDialog from "../localGroups/EventNotificationsDialog";
 import LoginPopup from "../users/LoginPopup";
 import HighlightedEventCard from "./modules/HighlightedEventCard";
@@ -74,7 +74,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.headline,
     fontSize: 34,
     margin: 0,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },

--- a/packages/lesswrong/components/events/modules/EventCards.tsx
+++ b/packages/lesswrong/components/events/modules/EventCards.tsx
@@ -10,7 +10,6 @@ import { getDefaultEventImg } from './HighlightedEventCard';
 import { useCurrentUser } from '../../common/withUser';
 import classNames from 'classnames';
 import { communityPath } from '@/lib/pathConstants';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { forumSelect } from '../../../lib/forumTypeUtils';
 import AddToCalendarButton from "../../posts/AddToCalendar/AddToCalendarButton";
 import PostsItemTooltipWrapper from "../../posts/PostsItemTooltipWrapper";
@@ -81,7 +80,7 @@ const styles = (theme: ThemeType) => ({
     overflow: 'hidden',
     marginTop: 8,
     marginBottom: 0,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },

--- a/packages/lesswrong/components/events/modules/HighlightedEventCard.tsx
+++ b/packages/lesswrong/components/events/modules/HighlightedEventCard.tsx
@@ -5,7 +5,6 @@ import { Card } from "@/components/widgets/Paper";
 import { useTimezone } from '../../common/withTimezone';
 import { cloudinaryCloudNameSetting } from '../../../lib/publicSettings';
 import { useTracking } from '../../../lib/analyticsEvents';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import Loading from "../../vulcan-core/Loading";
 import AddToCalendarButton from "../../posts/AddToCalendar/AddToCalendarButton";
 import PrettyEventDateTime from "./PrettyEventDateTime";
@@ -86,7 +85,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.text.alwaysWhite,
     marginTop: 0,
     marginBottom: 10,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/form-components/DummyFormGroup.tsx
+++ b/packages/lesswrong/components/form-components/DummyFormGroup.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import * as _ from 'underscore';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { FormGroupHeader } from "../vulcan-forms/FormGroup";
 
 const styles = (theme: ThemeType) => ({
@@ -11,7 +10,7 @@ const styles = (theme: ThemeType) => ({
     border: theme.palette.border.grey300,
     marginBottom: theme.spacing.unit,
     background: theme.palette.background.pageActiveAreaBackground,
-    ...(isFriendlyUI ? {borderRadius: 6} : {})
+    ...(theme.isFriendlyUI ? {borderRadius: 6} : {})
   },
   formSectionCollapsed: {
     display: "none",

--- a/packages/lesswrong/components/form-components/FormGroupLayout.tsx
+++ b/packages/lesswrong/components/form-components/FormGroupLayout.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import * as _ from 'underscore';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { slugify } from '@/lib/utils/slugify';
 
 const styles = (theme: ThemeType) => ({
@@ -11,7 +10,7 @@ const styles = (theme: ThemeType) => ({
     border: theme.palette.border.grey300,
     marginBottom: theme.spacing.unit,
     background: theme.palette.background.pageActiveAreaBackground,
-    ...(isFriendlyUI ? {borderRadius: 6} : {})
+    ...(theme.isFriendlyUI ? {borderRadius: 6} : {})
   },
   formSectionBody: {
     paddingTop: theme.spacing.unit,

--- a/packages/lesswrong/components/form-components/MultiSelectButtons.tsx
+++ b/packages/lesswrong/components/form-components/MultiSelectButtons.tsx
@@ -3,14 +3,13 @@ import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import classnames from 'classnames';
 import * as _ from 'underscore';
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import type { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
 
 const styles = defineStyles('MultiSelectButtons', (theme: ThemeType) => ({
   button: {
     // TODO: Pick typography for this button. (This is just the typography that
     // Material UI v0 happened to use.)
-    fontWeight: isFriendlyUI ? 600 : 500,
+    fontWeight: theme.isFriendlyUI ? 600 : 500,
     fontSize: "16px",
     fontFamily: theme.palette.fonts.sansSerifStack,
 
@@ -25,7 +24,7 @@ const styles = defineStyles('MultiSelectButtons', (theme: ThemeType) => ({
   selected: {
     color: theme.palette.buttons.primaryDarkText,
     textTransform: "none",
-    fontWeight: isFriendlyUI ? 500 : undefined,
+    fontWeight: theme.isFriendlyUI ? 500 : undefined,
     // TODO: This green is hardcoded, but it's k because it's only used for events
     backgroundColor: theme.palette.buttons.groupTypesMultiselect.background,
 

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import ForumIcon from "../common/ForumIcon";
 
 const styles = (theme: ThemeType) => ({
@@ -23,7 +22,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.body2,
     fontSize: 14,
     color: theme.palette.grey[600],
-    ...(isFriendlyUI ? {fontWeight: 600} : {}),
+    ...(theme.isFriendlyUI ? {fontWeight: 600} : {}),
   },
   blackLabel: {
     color: theme.palette.text.primary,

--- a/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
+++ b/packages/lesswrong/components/jargon/GlossaryEditForm.tsx
@@ -5,7 +5,6 @@ import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import classNames from 'classnames';
 import TextField from '@/lib/vendor/@material-ui/core/src/TextField';
 import JargonEditorRow, { formStyles } from './JargonEditorRow';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { useJargonCounts } from '@/components/hooks/useJargonCounts';
 import Checkbox from '@/lib/vendor/@material-ui/core/src/Checkbox';
 import { useLocalStorageState } from '../hooks/useLocalStorageState';
@@ -261,7 +260,7 @@ const styles = (theme: ThemeType) => ({
   formSectionHeadingTitle: {
     marginBottom: 5,
     fontSize: "1.25rem",
-    fontWeight: isFriendlyUI ? 600 : undefined,
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
   },
   promptEditorWarning: {
     color: theme.palette.error.main,

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -7,7 +7,6 @@ import * as _ from 'underscore';
 import PersonIcon from '@/lib/vendor/@material-ui/icons/src/Person';
 import classNames from 'classnames';
 import { componentWithChildren } from '../../lib/utils/componentsWithChildren';
-import {isFriendlyUI} from '../../themes/forumTheme'
 import { filterNonnull } from '../../lib/utils/typeGuardUtils';
 import { spreadMapMarkers } from '../../lib/utils/spreadMapMarkers';
 import { useMapStyle } from '../hooks/useMapStyle';
@@ -91,7 +90,7 @@ const styles = (theme: ThemeType) => ({
   mapButtons: {
     alignItems: "flex-end",
     position: "absolute",
-    top: isFriendlyUI ? 40 : 10,
+    top: theme.isFriendlyUI ? 40 : 10,
     right: 10,
     display: "flex",
     flexDirection: "column",

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -72,7 +72,7 @@ const styles = (theme: ThemeType) => ({
   },
   checkboxLabel: {
     ...theme.typography.body2,
-    fontWeight: isEAForum ? 600 : undefined,
+    fontWeight: theme.isEAForum ? 600 : undefined,
   },
   checkedLabel: {
     color: theme.palette.text.tooltipText,

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -217,7 +217,7 @@ const styles = (theme: ThemeType) => ({
   },
   contactUsHeadline: {
     marginBottom: 16,
-    ...(isEAForum && {
+    ...(theme.isEAForum && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontWeight: 500,
     }),
@@ -225,7 +225,7 @@ const styles = (theme: ThemeType) => ({
   eventsHeadline: {
     marginTop: 40,
     marginBottom: 16,
-    ...(isEAForum && {
+    ...(theme.isEAForum && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontWeight: 500,
     }),

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Popup as BadlyTypedPopup } from 'react-map-gl';
-import { isEAForum } from '../../lib/instanceSettings';
 import { componentWithChildren } from '../../lib/utils/componentsWithChildren';
 
 const Popup = componentWithChildren(BadlyTypedPopup);
@@ -30,11 +29,11 @@ export const styles = (theme: ThemeType) => ({
   contactInfo: {
     marginBottom: "10px",
     marginTop: "10px",
-    fontWeight: isEAForum ? 450 : 400,
+    fontWeight: theme.isEAForum ? 450 : 400,
     color: theme.palette.text.dim60,
   },
   markerPageLink: {
-    fontWeight: isEAForum ? 450 : 400,
+    fontWeight: theme.isEAForum ? 450 : 400,
     color: theme.palette.link.dim3,
     flex: 'none'
   },

--- a/packages/lesswrong/components/messaging/ConversationContents.tsx
+++ b/packages/lesswrong/components/messaging/ConversationContents.tsx
@@ -39,7 +39,7 @@ const styles = (theme: ThemeType) => ({
       // on mobile. This fixes that.
       display: "flex",
     },
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       padding: '18px 0px',
       marginTop: "auto",
     } : {

--- a/packages/lesswrong/components/messaging/MessagesNewForm.tsx
+++ b/packages/lesswrong/components/messaging/MessagesNewForm.tsx
@@ -4,7 +4,6 @@ import { getDraftMessageHtml } from "../../lib/collections/messages/helpers";
 import { TemplateQueryStrings } from "./NewConversationButton";
 import classNames from "classnames";
 import { FormDisplayMode } from "../comments/CommentsNewForm";
-import {isFriendlyUI} from '../../themes/forumTheme'
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useMutation } from "@apollo/client/react";
 import { useQuery } from "@/lib/crud/useQuery";
@@ -80,7 +79,7 @@ const formStyles = defineStyles('MessagesForm', (theme: ThemeType) => ({
   formButton: {
     fontFamily: theme.typography.fontFamily,
     marginLeft: "5px",
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
           fontSize: 14,
           fontWeight: 500,

--- a/packages/lesswrong/components/messaging/NewConversationDialog.tsx
+++ b/packages/lesswrong/components/messaging/NewConversationDialog.tsx
@@ -15,7 +15,6 @@ import ExpandedUsersConversationSearchHit from "../search/ExpandedUsersConversat
 import ForumIcon from "../common/ForumIcon";
 import { Typography } from "../common/Typography";
 import EAButton from "../ea-forum/EAButton";
-import { isFriendlyUI } from "@/themes/forumTheme";
 
 const styles = (theme: ThemeType) => ({
   paper: {
@@ -34,8 +33,8 @@ const styles = (theme: ThemeType) => ({
   titleRow: {
     fontFamily: theme.palette.fonts.sansSerifStack,
     color: theme.palette.grey[1000],
-    fontSize: isFriendlyUI ? 20 : 18,
-    fontWeight: isFriendlyUI ? 700 : 500,
+    fontSize: theme.isFriendlyUI ? 20 : 18,
+    fontWeight: theme.isFriendlyUI ? 700 : 500,
     padding: '20px 20px 14px 20px',
     display: "flex",
     justifyContent: "space-between",

--- a/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
+++ b/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/collections/users/notificationFieldHelpers";
 import { getNotificationTypeByUserSetting } from '../../lib/notificationTypes';
 import BatchTimePicker, { PickedTime } from '../common/BatchTimePicker';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import classNames from 'classnames';
 import type { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
 import type { EditableUser } from '@/lib/collections/users/helpers';
@@ -30,7 +29,7 @@ const styles = (theme: ThemeType) => ({
     gap: "8px"
   },
   label: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   channelLabel: {
     fontSize: 13

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -8,7 +8,6 @@ import PostsIcon from '@/lib/vendor/@material-ui/icons/src/Description';
 import CommentsIcon from '@/lib/vendor/@material-ui/icons/src/ModeComment';
 import MailIcon from '@/lib/vendor/@material-ui/icons/src/Mail';
 import { useCurrentUserId } from '../common/withUser';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { Drawer } from '@/components/material-ui/Drawer'
 import ForumIcon from "../common/ForumIcon";
@@ -36,7 +35,7 @@ const styles = defineStyles("NotificationsMenu", (theme: ThemeType) => ({
     backgroundColor: 'inherit',
     color: theme.palette.text.notificationCount,
     fontSize: "12px",
-    fontWeight: isFriendlyUI ? 450 : 500,
+    fontWeight: theme.isFriendlyUI ? 450 : 500,
     right: "-15px",
     top: 0,
     pointerEvents: "none",

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -38,13 +38,13 @@ export const styles = defineStyles("NotificationsMenuButton", (theme: ThemeType)
   badgeContainer: {
     padding: "none",
     verticalAlign: "inherit",
-    fontFamily: isFriendlyUI
+    fontFamily: theme.isFriendlyUI
       ? theme.palette.fonts.sansSerifStack
       : 'freight-sans-pro, sans-serif',
   },
   badge: {
     pointerEvents: "none",
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         top: 3,
         right: 6,
@@ -65,17 +65,17 @@ export const styles = defineStyles("NotificationsMenuButton", (theme: ThemeType)
       }),
   },
   badgeBackground: {
-    backgroundColor: isFriendlyUI
+    backgroundColor: theme.isFriendlyUI
       ? theme.palette.primary.main
       : "inherit",
   },
-  badge1Char: isFriendlyUI
+  badge1Char: theme.isFriendlyUI
     ? {
       width: 18,
       height: 18,
     }
     : {},
-  badge2Chars: isFriendlyUI
+  badge2Chars: theme.isFriendlyUI
     ? {
       width: 20,
       height: 20,
@@ -83,13 +83,13 @@ export const styles = defineStyles("NotificationsMenuButton", (theme: ThemeType)
     : {},
   buttonOpen: {
     backgroundColor: theme.palette.buttons.notificationsBellOpen.background,
-    color: isFriendlyUI
+    color: theme.isFriendlyUI
       ? theme.palette.grey[600]
       : theme.palette.buttons.notificationsBellOpen.icon,
   },
   buttonClosed: {
     backgroundColor: "transparent",
-    color: isFriendlyUI
+    color: theme.isFriendlyUI
       ? theme.palette.grey[600]
       : theme.palette.header.text,
   },

--- a/packages/lesswrong/components/notifications/NotifyMeButton.tsx
+++ b/packages/lesswrong/components/notifications/NotifyMeButton.tsx
@@ -23,7 +23,7 @@ const styles = (theme: ThemeType) => ({
       opacity: 0.5
     }
   },
-  icon: isFriendlyUI ? {
+  icon: theme.isFriendlyUI ? {
     color: theme.palette.grey[900],
     fontSize: 16,
     marginRight: 6,

--- a/packages/lesswrong/components/notifications/UserNotifyDropdown.tsx
+++ b/packages/lesswrong/components/notifications/UserNotifyDropdown.tsx
@@ -12,7 +12,7 @@ import LWClickAwayListener from "../common/LWClickAwayListener";
 import DropdownMenu from "../dropdowns/DropdownMenu";
 import NotifyMeToggleDropdownItem from "../dropdowns/NotifyMeToggleDropdownItem";
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   buttonContent: {
     display: "flex",
     gap: "4px",
@@ -26,7 +26,7 @@ const styles = (_theme: ThemeType) => ({
     marginTop: 6,
   },
   dropdown: {
-    width: isFriendlyUI ? 200 : 220,
+    width: theme.isFriendlyUI ? 200 : 220,
     maxWidth: "100vw",
   },
 });

--- a/packages/lesswrong/components/posts/AddToCalendar/AddToCalendarButton.tsx
+++ b/packages/lesswrong/components/posts/AddToCalendar/AddToCalendarButton.tsx
@@ -3,7 +3,6 @@ import moment from '../../../lib/moment-timezone';
 import { useTracking } from "../../../lib/analyticsEvents";
 import makeUrls from './makeUrls';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import LWTooltip from "../../common/LWTooltip";
@@ -30,18 +29,18 @@ const styles = defineStyles("AddToCalendarButton", (theme: ThemeType) => ({
     background: 'transparent',
     color: theme.palette.grey[600],
     font: 'inherit',
-    fontSize: isFriendlyUI ? undefined : 14,
+    fontSize: theme.isFriendlyUI ? undefined : 14,
     verticalAlign: 'text-bottom',
     '&:hover': {
       opacity: 0.5
     }
   },
   icon: {
-    height: isFriendlyUI ? 18 : 16,
+    height: theme.isFriendlyUI ? 18 : 16,
     fill: theme.palette.grey[600]
   },
   label: {
-    marginLeft: isFriendlyUI ? 7 : 8,
+    marginLeft: theme.isFriendlyUI ? 7 : 8,
   },
   dropdown: {
     background: theme.palette.panelBackground.default,

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -21,7 +21,7 @@ import AllPostsList from "./AllPostsList";
 const styles = (theme: ThemeType) => ({
   title: {
     cursor: "pointer",
-    "& .SectionTitle-title": isFriendlyUI
+    "& .SectionTitle-title": theme.isFriendlyUI
       ? {
         color: theme.palette.grey[1000],
         textTransform: "none",

--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -39,7 +39,6 @@ import PostMostValuableCheckbox from "./PostMostValuableCheckbox";
 import { ResponseIcon } from "./PostsPage/RSVPs";
 import { maybeDate } from '@/lib/utils/dateUtils';
 import { isIfAnyoneBuildsItFrontPage } from '../seasonal/IfAnyoneBuildsItSplash';
-import { isBookUI } from '@/themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 
 export const KARMA_WIDTH = 32;
@@ -81,7 +80,7 @@ export const styles = defineStyles("LWPostsItem", (theme: ThemeType) => ({
   background: {
     width: "100%",
     background: theme.palette.panelBackground.default,
-    ...(isBookUI && theme.dark && {
+    ...(theme.isBookUI && theme.dark && {
       background: theme.palette.panelBackground.bannerAdTranslucent,
       backdropFilter: theme.palette.filters.bannerAdBlur,
       ...isIfAnyoneBuildsItFrontPage({
@@ -114,7 +113,7 @@ export const styles = defineStyles("LWPostsItem", (theme: ThemeType) => ({
   withGrayHover: {
     '&:hover': {
       backgroundColor: theme.palette.panelBackground.postsItemHover,
-      ...(isBookUI && theme.dark && {
+      ...(theme.isBookUI && theme.dark && {
         backgroundColor: theme.palette.panelBackground.bannerAdTranslucentHeavy,
       }),
     },

--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -2,10 +2,9 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { postGetLink, postGetLinkTarget } from '../../lib/collections/posts/helpers';
 import React from 'react';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI ? {
+  root: theme.isFriendlyUI ? {
     fontFamily: theme.palette.fonts.sansSerifStack,
     wordBreak: 'break-word',
     width: '100%',

--- a/packages/lesswrong/components/posts/NewDialogueDialog.tsx
+++ b/packages/lesswrong/components/posts/NewDialogueDialog.tsx
@@ -26,11 +26,11 @@ const PostsEditMutation = gql(`
 const styles = (theme: ThemeType) => ({
   dialog: {
     padding: 24,
-    paddingBottom: isFriendlyUI ? undefined : 12,
+    paddingBottom: theme.isFriendlyUI ? undefined : 12,
     fontFamily: theme.typography.fontFamily,
     color: theme.palette.text.normal,
     "& .MuiDialogActions-root": {
-      margin: isFriendlyUI ? 0 : undefined,
+      margin: theme.isFriendlyUI ? 0 : undefined,
     },
   },
   inputRow: {

--- a/packages/lesswrong/components/posts/PingbacksList.tsx
+++ b/packages/lesswrong/components/posts/PingbacksList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useOnMountTracking } from "../../lib/analyticsEvents";
-import { isFriendlyUI } from '../../themes/forumTheme';
 import Pingback from "./Pingback";
 import LWTooltip from "../common/LWTooltip";
 import LoadMore from "../common/LoadMore";
@@ -36,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     display: "inline-block",
     lineHeight: "1rem",
     marginBottom: -4,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontWeight: 600,
         marginTop: 12,

--- a/packages/lesswrong/components/posts/PostReadCheckbox.tsx
+++ b/packages/lesswrong/components/posts/PostReadCheckbox.tsx
@@ -4,7 +4,6 @@ import CheckBoxOutlineBlankIcon from '@/lib/vendor/@material-ui/icons/src/CheckB
 import CheckBoxTwoToneIcon from '@/lib/vendor/@material-ui/icons/src/CheckBoxTwoTone';
 import { useItemsRead } from '../hooks/useRecordPostView';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LWTooltip from "../common/LWTooltip";
 import { useMutation } from "@apollo/client/react";
 import { gql } from '@/lib/generated/gql-codegen';
@@ -14,7 +13,7 @@ const styles = (theme: ThemeType) => ({
     cursor: "pointer",
   },
   read: {
-    color: isFriendlyUI
+    color: theme.isFriendlyUI
       ? theme.palette.primary.main
       : theme.palette.primary.light,
   },

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -15,9 +15,9 @@ import LWTooltip from "../common/LWTooltip";
 export const styles = defineStyles('PostSubmit', (theme: ThemeType) => ({
   formButton: {
     fontFamily: theme.typography.commentStyle.fontFamily,
-    fontSize: isFriendlyUI ? 14 : 16,
+    fontSize: theme.isFriendlyUI ? 14 : 16,
     marginLeft: 5,
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       textTransform: 'none',
     } : {
       paddingBottom: 4,
@@ -28,7 +28,7 @@ export const styles = defineStyles('PostSubmit', (theme: ThemeType) => ({
     })
   },
   secondaryButton: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       color: theme.palette.grey[680],
       padding: '8px 12px'
     } : {
@@ -39,7 +39,7 @@ export const styles = defineStyles('PostSubmit', (theme: ThemeType) => ({
     marginLeft: 'auto'
   },
   submitButton: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       backgroundColor: theme.palette.buttons.alwaysPrimary,
       color: theme.palette.text.alwaysWhite,
       boxShadow: 'none',

--- a/packages/lesswrong/components/posts/PostsAnnualReviewMarketTag.tsx
+++ b/packages/lesswrong/components/posts/PostsAnnualReviewMarketTag.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { useHover } from '../common/withHover';
 import { highlightReviewWinnerThresholdSetting } from '@/lib/instanceSettings';
 import { tagStyle } from '../tagging/FooterTag';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { Card } from "@/components/widgets/Paper";
 import { FRIENDLY_HOVER_OVER_WIDTH } from '../common/FriendlyHoverOver';
 import HoverOver from "../common/HoverOver";
@@ -19,12 +18,12 @@ const sharedStyles = (theme: ThemeType) => ({
   boxSizing: 'border-box',
   paddingLeft: 6,
   paddingRight: 6,
-  marginRight: isFriendlyUI ? 3 : undefined,
-  marginBottom: isFriendlyUI ? 8 : undefined,
+  marginRight: theme.isFriendlyUI ? 3 : undefined,
+  marginBottom: theme.isFriendlyUI ? 8 : undefined,
   fontWeight: theme.typography.body1.fontWeight,
   ...theme.typography.commentStyle,
   cursor: "pointer",
-  whiteSpace: isFriendlyUI ? "nowrap": undefined,
+  whiteSpace: theme.isFriendlyUI ? "nowrap": undefined,
 })
 
 const styles = (theme: ThemeType) => ({
@@ -44,7 +43,7 @@ const styles = (theme: ThemeType) => ({
   },
   card: {
     padding: 16,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         paddingTop: 12,
         width: FRIENDLY_HOVER_OVER_WIDTH,

--- a/packages/lesswrong/components/posts/PostsGroupDetails.tsx
+++ b/packages/lesswrong/components/posts/PostsGroupDetails.tsx
@@ -2,7 +2,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames'
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 
@@ -27,7 +26,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.smallCaps,
   },
   notRecentDiscussionTitle: {
-    fontFamily: isFriendlyUI
+    fontFamily: theme.isFriendlyUI
       ? theme.palette.fonts.sansSerifStack
       : theme.typography.body1.fontFamily,
   },
@@ -36,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     fontFamily: theme.typography.fontFamily
   },
   root: {
-    marginBottom: isFriendlyUI ? 5 : 12, 
+    marginBottom: theme.isFriendlyUI ? 5 : 12, 
     marginTop: 10
   }
 })

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -29,7 +29,7 @@ const PostsExpandedHighlightQuery = gql(`
 const styles = (theme: ThemeType) => ({
   highlightContinue: {
     marginTop:theme.spacing.unit*2,
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
     '&& a, && a:hover': {
       color: theme.palette.primary.main,
     },

--- a/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { Typography } from "../common/Typography";
 import { isIfAnyoneBuildsItFrontPage } from '../seasonal/IfAnyoneBuildsItSplash';
 
@@ -11,7 +10,7 @@ const styles = (theme: ThemeType) => ({
     ...isIfAnyoneBuildsItFrontPage({
       color: theme.palette.text.bannerAdOverlay,
     }),
-    fontSize: isFriendlyUI ? "13px" : "1.1rem",
+    fontSize: theme.isFriendlyUI ? "13px" : "1.1rem",
     textAlign: "center",
     flexShrink: 0,
     flexGrow: 0,

--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import FormatDate, { ExpandedDate } from '../common/FormatDate';
 import moment from '../../lib/moment-timezone';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import classNames from 'classnames';
 import { useCurrentTime } from '../../lib/utils/timeUtil';
 import { formatRelative } from '@/lib/utils/timeFormat';
@@ -15,7 +14,7 @@ export const POSTED_AT_WIDTH = 38
 export const START_TIME_WIDTH = 72
 const HOUR_IN_MS = 60*60*1000;
 
-const customStyles = (theme: ThemeType) => isFriendlyUI
+const customStyles = (theme: ThemeType) => theme.isFriendlyUI
   ? {}
   : {
     fontWeight: 300,
@@ -24,7 +23,7 @@ const customStyles = (theme: ThemeType) => isFriendlyUI
 
 const styles = (theme: ThemeType) => ({
   postedAt: {
-    ...(isFriendlyUI && {display: "flex"}),
+    ...(theme.isFriendlyUI && {display: "flex"}),
     '&&': {
       cursor: "pointer",
       width: POSTED_AT_WIDTH,

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -19,8 +19,8 @@ import { defineStyles, useStyles } from '../hooks/useStyles';
 
 const styles = defineStyles("PostsItemIcons", (theme: ThemeType) => ({
   iconSet: {
-    marginLeft: isFriendlyUI ? 6 : theme.spacing.unit,
-    marginRight: isFriendlyUI ? 2 : theme.spacing.unit,
+    marginLeft: theme.isFriendlyUI ? 6 : theme.spacing.unit,
+    marginRight: theme.isFriendlyUI ? 2 : theme.spacing.unit,
     lineHeight: "1.0rem",
     '&:empty': {
       display: 'none',
@@ -35,23 +35,23 @@ const styles = defineStyles("PostsItemIcons", (theme: ThemeType) => ({
     '&&': {
       "--icon-size": "15.6px",
       fontSize: "15.6px",
-      color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
+      color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
       position: "relative",
       top: 3,
     },
   },
   curatedIcon: {
     "--icon-size": "15.6px",
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
     position: "relative",
-    top: isFriendlyUI ? 2 : 3,
+    top: theme.isFriendlyUI ? 2 : 3,
   },
   curatedIconColor: {
-    color: isFriendlyUI ? theme.palette.icon.yellow : theme.palette.primary.main,
+    color: theme.isFriendlyUI ? theme.palette.icon.yellow : theme.palette.primary.main,
   },
   question: {
     "--icon-size": "15.6px",
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
     fontWeight: '600'
   },
   alignmentIcon: {
@@ -62,7 +62,7 @@ const styles = defineStyles("PostsItemIcons", (theme: ThemeType) => ({
   linkIcon: {
     position: "relative",
     "--icon-size": "15.6px",
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         top: 1,
         color: theme.palette.grey[600],
@@ -73,10 +73,10 @@ const styles = defineStyles("PostsItemIcons", (theme: ThemeType) => ({
       }),
   },
   dialogueIcon: {
-    strokeWidth: isFriendlyUI ? "2px" : undefined,
+    strokeWidth: theme.isFriendlyUI ? "2px" : undefined,
   },
   recommendationIcon: {
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.icon.dim4,
     '&:hover': {
       opacity: 0.5
     }

--- a/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
@@ -7,7 +7,6 @@ import { useRecordPostView } from '../hooks/useRecordPostView';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
 import { KARMA_WIDTH } from './LWPostsItem';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import KarmaDisplay from "../common/KarmaDisplay";
 import PostsTitle from "./PostsTitle";
 import PostsUserAndCoauthors from "./PostsUserAndCoauthors";
@@ -21,7 +20,7 @@ const IMAGE_HEIGHT = 96;
 export const styles = (theme: ThemeType)=> ({
   root: {
     position: "relative",
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : undefined,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : undefined,
     [theme.breakpoints.down('xs')]: {
       width: "100%",
     },

--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -12,11 +12,10 @@ import LWTooltip from "../common/LWTooltip";
 import AddToCalendarButton from "./AddToCalendar/AddToCalendarButton";
 import { maybeDate } from '@/lib/utils/dateUtils';
 import { useIsOnGrayBackground } from '../hooks/useIsOnGrayBackground';
-import { isBookUI } from '@/themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
   onGrayBackground: {
-    ...(isBookUI && theme.dark && {
+    ...(theme.isBookUI && theme.dark && {
       color: theme.palette.greyAlpha(1),
     }),
   },

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_LOW_KARMA_THRESHOLD, MAX_LOW_KARMA_THRESHOLD } from '../../lib/
 
 import { SORT_ORDER_OPTIONS, SettingsOption } from '../../lib/collections/posts/dropdownOptions';
 import { isEAForum } from '../../lib/instanceSettings';
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import { ForumOptions, forumSelect } from '../../lib/forumTypeUtils';
 import pick from 'lodash/pick';
 import { timeframeLabels, timeframeSettings as defaultTimeframes, TimeframeSettingType } from "./timeframeUtils";
@@ -104,11 +104,11 @@ const styles = (theme: ThemeType) => ({
     display: "flex",
     alignItems: "flex-start",
     justifyContent: "space-between",
-    marginTop: isFriendlyUI ? 10 : undefined,
+    marginTop: theme.isFriendlyUI ? 10 : undefined,
     marginBottom: theme.spacing.unit,
     flexWrap: "wrap",
     background: theme.palette.panelBackground.default,
-    padding: isFriendlyUI ? "16px 24px 16px 24px" : "12px 24px 8px 12px",
+    padding: theme.isFriendlyUI ? "16px 24px 16px 24px" : "12px 24px 8px 12px",
     borderRadius: theme.borderRadius.default,
     [theme.breakpoints.down('xs')]: {
       flexDirection: "column",
@@ -121,7 +121,7 @@ const styles = (theme: ThemeType) => ({
   },
   checkbox: {
     padding: "1px 12px 0 0",
-    paddingRight: isFriendlyUI ? 6 : undefined,
+    paddingRight: theme.isFriendlyUI ? 6 : undefined,
   },
   checkboxGroup: {
     display: "flex",

--- a/packages/lesswrong/components/posts/PostsPage/AudioToggle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/AudioToggle.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import classNames from 'classnames';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { postHasAudioPlayer } from './PostsAudioPlayerWrapper';
 import LWTooltip from "../../common/LWTooltip";
 import ForumIcon from "../../common/ForumIcon";
 
-const PODCAST_ICON_SIZE = isFriendlyUI ? 22 : 24;
+const podcastIconSize = (theme: ThemeType) => theme.isFriendlyUI ? 22 : 24;
 // some padding around the icon to make it look like a stateful toggle button
-const PODCAST_ICON_PADDING = isFriendlyUI ? 4 : 2
+const podcastIconPadding = (theme: ThemeType) => theme.isFriendlyUI ? 4 : 2
 
 const styles = (theme: ThemeType) => ({
   togglePodcastContainer: {
     alignSelf: 'center',
     color: theme.palette.text.dim3,
-    height: PODCAST_ICON_SIZE,
+    height: podcastIconSize,
   },
   audioIcon: {
-    width: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2),
-    height: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2),
-    padding: PODCAST_ICON_PADDING,
-    transform: isFriendlyUI ? undefined : `translateY(-${PODCAST_ICON_PADDING}px)`,
+    width: podcastIconSize(theme) + (podcastIconPadding(theme) * 2),
+    height: podcastIconSize(theme) + (podcastIconPadding(theme) * 2),
+    padding: podcastIconPadding(theme),
+    transform: theme.isFriendlyUI ? undefined : `translateY(-${podcastIconPadding}px)`,
   },
   audioIconOn: {
     background: theme.palette.icon.dim05,

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -24,7 +24,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.text.dim2,
     whiteSpace: "no-wrap",
     fontSize: theme.typography.body2.fontSize,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       color: theme.palette.grey[800],
       fontWeight: 600
     }),
@@ -35,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     position: "relative",
     top: 3,
     marginRight: 4,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       color: theme.palette.grey[800]
     }),
   },

--- a/packages/lesswrong/components/posts/PostsPage/CrosspostHeaderIcon.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/CrosspostHeaderIcon.tsx
@@ -6,7 +6,6 @@ import {
 } from "../../../lib/instanceSettings";
 import { compassIcon } from "../../icons/compassIcon";
 import { lightbulbIcon } from "../../icons/lightbulbIcon";
-import { isFriendlyUI } from "../../../themes/forumTheme";
 import { registerComponent } from "../../../lib/vulcan-lib/components";
 import { combineUrls } from "../../../lib/vulcan-lib/utils";
 import LWTooltip from "../../common/LWTooltip";
@@ -19,7 +18,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.text.dim3,
     display: "inline-block",
     width: 20,
-    marginLeft: isFriendlyUI ? undefined : -6,
+    marginLeft: theme.isFriendlyUI ? undefined : -6,
     verticalAlign: "sub",
   },
 });

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -35,7 +35,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle,
     maxWidth: 600,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { registerComponent } from '../../../lib/vulcan-lib/components';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import UserNameDeleted from "../../users/UserNameDeleted";
 import UsersName from "../../users/UsersName";
 import UserCommentMarkers from "../../users/UserCommentMarkers";
@@ -15,13 +14,13 @@ export const AUTHOR_MARKER_STYLES = {
 
 const styles = (theme: ThemeType) => ({
   root: {
-    fontFamily: isFriendlyUI ? theme.typography.uiSecondary.fontFamily : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.typography.uiSecondary.fontFamily : undefined,
     textAlign: 'left',
     display: 'inline',
   },
   authorName: {
     fontWeight: 600,
-    marginLeft: isFriendlyUI ? 1 : 0,
+    marginLeft: theme.isFriendlyUI ? 1 : 0,
   },
   authorMarkers: AUTHOR_MARKER_STYLES,
 })

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -123,7 +123,7 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
     marginLeft: 'auto',
     marginRight: 'auto',
     maxWidth: CENTRAL_COLUMN_WIDTH, // this necessary in both friendly and non-friendly UI to prevent Comment Permalinks from overflowing the page
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       [theme.breakpoints.down('sm')]: {
         // This can only be used when display: "block" is applied, otherwise the 100% confuses the
         // grid layout into adding loads of left margin
@@ -132,7 +132,7 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
     }),
   },
   postBody: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       width: "100%",
     }),
   },
@@ -143,7 +143,7 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
     },
   },
   postContent: {
-    marginBottom: isFriendlyUI ? 40 : undefined
+    marginBottom: theme.isFriendlyUI ? 40 : undefined
   },
   betweenPostAndComments: {
     minHeight: 24,
@@ -161,7 +161,7 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
     // TODO: This is to prevent the Table of Contents from overlapping with the comments section. Could probably fine-tune the breakpoints and spacing to avoid needing this.
     background: theme.palette.background.pageActiveAreaBackground,
     position: "relative",
-    paddingTop: isFriendlyUI ? 16 : undefined
+    paddingTop: theme.isFriendlyUI ? 16 : undefined
   },
   noCommentsPlaceholder: {
     marginTop: 60,
@@ -259,7 +259,7 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
   },
   dateAtBottom: {
     color: theme.palette.text.dim3,
-    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    fontSize: theme.isFriendlyUI ? undefined : theme.typography.body2.fontSize,
     cursor: 'default'
   },
   reviewVoting: {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
@@ -10,7 +10,7 @@ import LWTooltip from "../../common/LWTooltip";
 const styles = (theme: ThemeType) => ({
   date: {
     color: theme.palette.text.dim3,
-    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    fontSize: theme.isFriendlyUI ? undefined : theme.typography.body2.fontSize,
     cursor: 'default'
   },
   mobileDate: {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -14,7 +14,6 @@ import moment from '../../../lib/moment-timezone';
 import React from 'react'
 import { useTracking } from '../../../lib/analyticsEvents';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { useCurrentTime } from '../../../lib/utils/timeUtil';
 import { Typography } from "../../common/Typography";
 import EventTime from "../../localGroups/EventTime";
@@ -37,7 +36,7 @@ const styles = (theme: ThemeType) => ({
     columnGap: 8,
   },
   iconWrapper: {
-    paddingTop: isFriendlyUI ? 3 : 2
+    paddingTop: theme.isFriendlyUI ? 3 : 2
   },
   icon: {
     fontSize: 16,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -23,10 +23,10 @@ const styles = (theme: ThemeType) => ({
     columnGap: 20,
     alignItems: 'center',
     fontSize: '1.4em',
-    paddingTop: isFriendlyUI ? 30 : undefined,
-    borderTop: isFriendlyUI ? theme.palette.border.grey300 : undefined,
-    marginTop: isFriendlyUI ? 40 : undefined,
-    marginBottom: isFriendlyUI ? 40 : undefined
+    paddingTop: theme.isFriendlyUI ? 30 : undefined,
+    borderTop: theme.isFriendlyUI ? theme.palette.border.grey300 : undefined,
+    marginTop: theme.isFriendlyUI ? 40 : undefined,
+    marginBottom: theme.isFriendlyUI ? 40 : undefined
   },
   bookmarkButton: {
     marginBottom: -5,
@@ -45,14 +45,14 @@ const styles = (theme: ThemeType) => ({
     },
   },
   voteBottom: {
-    flexGrow: isFriendlyUI ? 1 : undefined,
+    flexGrow: theme.isFriendlyUI ? 1 : undefined,
     position: 'relative',
     fontSize: 42,
     textAlign: 'center',
     display: 'inline-block',
-    marginLeft: isFriendlyUI ? undefined : 'auto',
-    marginRight: isFriendlyUI ? undefined : 'auto',
-    marginBottom: isFriendlyUI ? undefined : 40,
+    marginLeft: theme.isFriendlyUI ? undefined : 'auto',
+    marginRight: theme.isFriendlyUI ? undefined : 'auto',
+    marginBottom: theme.isFriendlyUI ? undefined : 40,
     "@media print": { display: "none" },
   },
   secondaryInfoRight: {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType) => ({
     display:"flex",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: isFriendlyUI ? 20 : theme.spacing.unit*2,
+    marginBottom: theme.isFriendlyUI ? 20 : theme.spacing.unit*2,
   },
   headerLeft: {
     width: "100%"
@@ -42,9 +42,9 @@ const styles = (theme: ThemeType) => ({
   headerVote: {
     textAlign: 'center',
     fontSize: 42,
-    position: isFriendlyUI ? 'absolute' : "relative",
-    top: isFriendlyUI ? 0 : undefined,
-    left: isFriendlyUI ? -93 : undefined,
+    position: theme.isFriendlyUI ? 'absolute' : "relative",
+    top: theme.isFriendlyUI ? 0 : undefined,
+    left: theme.isFriendlyUI ? -93 : undefined,
     [theme.breakpoints.down("sm")]: {
       position: 'relative',
       top: 'auto',
@@ -59,12 +59,12 @@ const styles = (theme: ThemeType) => ({
     alignItems: 'baseline',
     columnGap: SECONDARY_SPACING,
     flexWrap: 'wrap',
-    fontSize: isFriendlyUI ? theme.typography.body1.fontSize : '1.4rem',
-    fontWeight: isFriendlyUI ? 450 : undefined,
+    fontSize: theme.isFriendlyUI ? theme.typography.body1.fontSize : '1.4rem',
+    fontWeight: theme.isFriendlyUI ? 450 : undefined,
     fontFamily: theme.typography.uiSecondary.fontFamily,
     color: theme.palette.text.dim3,
-    paddingBottom: isFriendlyUI ? 12 : undefined,
-    borderBottom: isFriendlyUI ? theme.palette.border.grey300 : undefined
+    paddingBottom: theme.isFriendlyUI ? 12 : undefined,
+    borderBottom: theme.isFriendlyUI ? theme.palette.border.grey300 : undefined
   },
   secondaryInfo: {
     flexGrow: 1,
@@ -90,12 +90,12 @@ const styles = (theme: ThemeType) => ({
     columnGap: SECONDARY_SPACING
   },
   secondaryInfoLink: {
-    fontWeight: isFriendlyUI ? 450 : undefined,
-    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    fontWeight: theme.isFriendlyUI ? 450 : undefined,
+    fontSize: theme.isFriendlyUI ? undefined : theme.typography.body2.fontSize,
     "@media print": { display: "none" },
   },
   actions: {
-    color: isFriendlyUI ? undefined : theme.palette.grey[500],
+    color: theme.isFriendlyUI ? undefined : theme.palette.grey[500],
     "&:hover": {
       opacity: 0.5,
     },
@@ -149,7 +149,7 @@ const styles = (theme: ThemeType) => ({
   tagSection: {
     flex: 1,
     display: "flex",
-    flexDirection: isFriendlyUI ? "column" : "row",
+    flexDirection: theme.isFriendlyUI ? "column" : "row",
     height: "100%",
   }
 });

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../../lib/collections/posts/helpers';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
+import { isFriendlyUI } from '../../../themes/forumTheme';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import classNames from 'classnames';
 import { Typography } from "../../common/Typography";
@@ -15,12 +15,12 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
   ...theme.typography.display3,
   ...theme.typography.postStyle,
   ...theme.typography.headerStyle,
-  marginTop: isFriendlyUI ? 5 : 0,
+  marginTop: theme.isFriendlyUI ? 5 : 0,
   marginLeft: 0,
-  marginBottom: isFriendlyUI ? 12 : 0,
+  marginBottom: theme.isFriendlyUI ? 12 : 0,
   color: theme.palette.text.primary,
-  textWrap: isBookUI ? "balance" : undefined,
-  [theme.breakpoints.down('sm')]: isFriendlyUI
+  textWrap: theme.isBookUI ? "balance" : undefined,
+  [theme.breakpoints.down('sm')]: theme.isFriendlyUI
     ? {
       fontSize: '2.3rem',
       marginTop: 20,
@@ -28,7 +28,7 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
     : {
       fontSize: '3.5rem',
     },
-  ...(isFriendlyUI
+  ...(theme.isFriendlyUI
     ? {
       fontSize: '3rem',
     }
@@ -36,7 +36,7 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
       fontSize: LW_POST_TITLE_FONT_SIZE,
       lineHeight: '1.1',
   }),
-  [theme.breakpoints.down('xs')]: isFriendlyUI
+  [theme.breakpoints.down('xs')]: theme.isFriendlyUI
     ? {
       fontSize: '2.3rem',
     }
@@ -48,7 +48,7 @@ export const postPageTitleStyles = (theme: ThemeType) => ({
 const styles = defineStyles("PostsPageTitle", (theme: ThemeType) => ({
   root: {
     ...postPageTitleStyles(theme),
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       lineHeight: 1.25,
       fontWeight: 700
     }),

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -8,7 +8,6 @@ import { useCurrentUser } from '../../common/withUser';
 import { Link } from "../../../lib/reactRouterWrapper";
 import { useNavigate } from "../../../lib/routeUtil";
 import classNames from 'classnames';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import SequencesTooltip from "../../sequences/SequencesTooltip";
 import SequencesNavigationLink from "../../sequences/SequencesNavigationLink";
 
@@ -30,20 +29,20 @@ const styles = (theme: ThemeType) => ({
     display: "flex",
     alignItems: "center",
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       marginBottom: -8,
     }),
   },
   title: {
     ...titleStyles(theme),
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       textTransform: 'uppercase',
       fontSize: 18,
       color: theme.palette.greyAlpha(0.7),
       fontWeight: 500,
     }),
-    ...(isFriendlyUI && theme.dark && {
+    ...(theme.isFriendlyUI && theme.dark && {
       color: theme.palette.icon.dim,
     }),
   },

--- a/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPForm.tsx
@@ -8,7 +8,6 @@ import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { DialogActions } from '../../widgets/DialogActions';
 import { DialogTitle } from '../../widgets/DialogTitle';
 import { useCurrentUser } from '../../common/withUser';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { useNavigate } from '../../../lib/routeUtil';
 import { registerComponent } from "../../../lib/vulcan-lib/components";
 import LWDialog from "../../common/LWDialog";
@@ -22,7 +21,7 @@ export const responseToText: Record<RsvpResponse,string> = {
 }
 
 const styles = (theme: ThemeType) => ({
-  emailMessage: isFriendlyUI
+  emailMessage: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }

--- a/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/RSVPs.tsx
@@ -10,7 +10,6 @@ import HelpOutlineIcon from '@/lib/vendor/@material-ui/icons/src/HelpOutline';
 import HighlightOffIcon from '@/lib/vendor/@material-ui/icons/src/HighlightOff';
 import { useMutation } from "@apollo/client/react";
 import { gql } from '@/lib/generated/gql-codegen';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import groupBy from "lodash/groupBy";
 import mapValues from "lodash/mapValues";
 import { registerComponent } from "../../../lib/vulcan-lib/components";
@@ -21,7 +20,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 48
   },
   rsvpItem: {
-    width:  isFriendlyUI ? "33%" : "25%",
+    width:  theme.isFriendlyUI ? "33%" : "25%",
     display: "inline-block",
     marginRight: 16,
     paddingTop: 4,
@@ -97,7 +96,7 @@ const styles = (theme: ThemeType) => ({
       display: "block"
     },
   },
-  rsvpMessage: isFriendlyUI
+  rsvpMessage: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }

--- a/packages/lesswrong/components/posts/PostsPage/ReadTime.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ReadTime.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { registerComponent } from "@/lib/vulcan-lib/components";
 import LWTooltip from "../../common/LWTooltip";
 
 const styles = (theme: ThemeType) => ({
   root: {
-    fontWeight: isFriendlyUI ? 450 : undefined,
-    fontSize: isFriendlyUI ? undefined : theme.typography.body2.fontSize,
+    fontWeight: theme.isFriendlyUI ? 450 : undefined,
+    fontSize: theme.isFriendlyUI ? undefined : theme.typography.body2.fontSize,
     cursor: 'default',
     "@media print": { display: "none" },
   },

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -39,7 +39,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     position: "sticky",
     zIndex: 1,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontFamily: theme.palette.fonts.sansSerifStack,
         fontWeight: 600,
@@ -66,9 +66,9 @@ const styles = (theme: ThemeType) => ({
     marginTop: 6,
   },
   noPosts: {
-    marginLeft: isFriendlyUI ? 0 : 23,
+    marginLeft: theme.isFriendlyUI ? 0 : 23,
     color: theme.palette.text.dim,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         marginTop: 18,
         fontFamily: theme.palette.fonts.sansSerifStack,
@@ -77,20 +77,20 @@ const styles = (theme: ThemeType) => ({
   },
   posts: {
     boxShadow: theme.palette.boxShadow.default,
-    marginBottom: isFriendlyUI ? 8 : 0,
+    marginBottom: theme.isFriendlyUI ? 8 : 0,
   },
-  subtitle: isFriendlyUI ? {
+  subtitle: theme.isFriendlyUI ? {
     marginTop: 12,
   } : {},
   frontpageSubtitle: {
     marginBottom: 6
   },
   otherSubtitle: {
-    marginTop: isFriendlyUI ? 0 : 6,
+    marginTop: theme.isFriendlyUI ? 0 : 6,
     marginBottom: 6
   },
   divider: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       display: 'none'
     }),
   }

--- a/packages/lesswrong/components/posts/PostsTimeframeList.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeList.tsx
@@ -17,7 +17,7 @@ const styles = (theme: ThemeType) => ({
   loadMore: {
     ...theme.typography.postStyle,
     color: theme.palette.primary.main,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontFamily: theme.palette.fonts.sansSerifStack,
       }

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -8,7 +8,6 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { idSettingIcons, tagSettingIcons } from "../../lib/collections/posts/constants";
 import { communityPath } from '@/lib/pathConstants';
 import { InteractionWrapper } from '../common/useClickableCell';
-import { isBookUI, isFriendlyUI } from '../../themes/forumTheme';
 import { smallTagTextStyle, tagStyle } from '../tagging/FooterTag';
 import { useCurrentAndRecentForumEvents } from '../hooks/useCurrentForumEvent';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
@@ -23,8 +22,8 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.text.normal,
     position: "relative",
     lineHeight: "1.7rem",
-    fontWeight: isFriendlyUI ? 600 : undefined,
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : theme.typography.postStyle.fontFamily,
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : theme.typography.postStyle.fontFamily,
     zIndex: theme.zIndexes.postItemTitle,
     [theme.breakpoints.down('xs')]: {
       paddingLeft: 2,
@@ -41,7 +40,7 @@ const styles = (theme: ThemeType) => ({
     marginRight: theme.spacing.unit,
   },
   onGrayBackground: {
-    ...(isBookUI && theme.dark && {
+    ...(theme.isBookUI && theme.dark && {
       color: theme.palette.greyAlpha(1),
     }),
   },
@@ -49,13 +48,13 @@ const styles = (theme: ThemeType) => ({
     whiteSpace: "normal",
   },
   sticky: {
-    paddingLeft: isFriendlyUI ? 2 : undefined,
-    paddingRight: isFriendlyUI ? 8 : 10,
+    paddingLeft: theme.isFriendlyUI ? 2 : undefined,
+    paddingRight: theme.isFriendlyUI ? 8 : 10,
     position: "relative",
     top: 2,
     color: theme.palette.icon["dim4"],
   },
-  stickyIcon: isFriendlyUI
+  stickyIcon: theme.isFriendlyUI
     ? {
       width: 16,
       height: 16,
@@ -69,7 +68,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.icon.dim55,
     paddingRight: theme.spacing.unit,
     top: -2,
-    width: isFriendlyUI ? 26 : "auto",
+    width: theme.isFriendlyUI ? 26 : "auto",
     position: "relative",
     verticalAlign: "middle",
   },
@@ -79,7 +78,7 @@ const styles = (theme: ThemeType) => ({
       color: theme.palette.text.normal,
     }
   },
-  eaTitleDesktopEllipsis: isFriendlyUI ? {
+  eaTitleDesktopEllipsis: theme.isFriendlyUI ? {
     '&:hover': {
       opacity: 0.5
     },

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import classNames from 'classnames';
-import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
 import { fullHeightToCEnabled } from '../../../lib/betas';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import TableOfContentsDivider from "./TableOfContentsDivider";
@@ -25,7 +24,7 @@ const styles = defineStyles("TableOfContentsRow", (theme: ThemeType) => ({
       color: theme.palette.link.tocLinkHighlighted,
     },
     '& $highlightDot:after': {
-      content: isBookUI ? null : `"•"`,
+      content: theme.isBookUI ? null : `"•"`,
       marginLeft: 3,
       position: 'relative',
       top: 1
@@ -47,9 +46,9 @@ const styles = defineStyles("TableOfContentsRow", (theme: ThemeType) => ({
     lineHeight: fullHeightToCEnabled ? "1em" : "1.2em",
     '&:hover':{
       color: theme.palette.link.tocLinkHighlighted,
-      opacity: isFriendlyUI ? 1 : undefined
+      opacity: theme.isFriendlyUI ? 1 : undefined
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       lineHeight: "1.1rem",
       fontSize: "1rem",
     }),
@@ -60,7 +59,7 @@ const styles = defineStyles("TableOfContentsRow", (theme: ThemeType) => ({
     paddingTop: 3,
     paddingBottom: theme.spacing.unit*1.5,
     borderBottom: theme.palette.border.faint,
-    fontSize: isFriendlyUI ? "1em" : undefined,
+    fontSize: theme.isFriendlyUI ? "1em" : undefined,
     '&:hover': {
       opacity: "unset"
     }
@@ -85,19 +84,19 @@ const styles = defineStyles("TableOfContentsRow", (theme: ThemeType) => ({
   },
   level2: {
     fontSize:"1.1rem",
-    paddingLeft: isFriendlyUI ? 16 : 12,
+    paddingLeft: theme.isFriendlyUI ? 16 : 12,
     ...sectionOffsetStyling,
   },
   level3: {
     fontSize:"1.1rem",
     color: theme.palette.text.dim700,
-    paddingLeft: isFriendlyUI ? 32 : 24,
+    paddingLeft: theme.isFriendlyUI ? 32 : 24,
     ...sectionOffsetStyling,
   },
   level4: {
     fontSize:"1.1rem",
     color: theme.palette.text.dim700,
-    paddingLeft: isFriendlyUI ? 48 : 36,
+    paddingLeft: theme.isFriendlyUI ? 48 : 36,
     ...sectionOffsetStyling,
   },
   titleContainer: {

--- a/packages/lesswrong/components/posts/dialogues/DialogueEditorGuidelines.tsx
+++ b/packages/lesswrong/components/posts/dialogues/DialogueEditorGuidelines.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { commentBodyStyles } from '../../../themes/stylePiping';
-import { isFriendlyUI, preferredHeadingCase } from '../../../themes/forumTheme';
+import { preferredHeadingCase } from '../../../themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
   root: {
     backgroundColor: theme.palette.grey[60],
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         padding: "16px 16px 0",
         borderRadius: theme.borderRadius.default,
@@ -18,7 +18,7 @@ const styles = (theme: ThemeType) => ({
       paddingLeft: 20
     }
   },
-  title: isFriendlyUI
+  title: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontWeight: 600,

--- a/packages/lesswrong/components/posts/dialogues/DialogueSubmit.tsx
+++ b/packages/lesswrong/components/posts/dialogues/DialogueSubmit.tsx
@@ -26,9 +26,9 @@ const CommentEditMutation = gql(`
 export const styles = defineStyles('DialogueSubmit', (theme: ThemeType) => ({
   formButton: {
     fontFamily: theme.typography.commentStyle.fontFamily,
-    fontSize: isFriendlyUI ? 14 : 16,
+    fontSize: theme.isFriendlyUI ? 14 : 16,
     marginLeft: 5,
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       textTransform: 'none',
     } : {
       paddingBottom: 4,
@@ -39,7 +39,7 @@ export const styles = defineStyles('DialogueSubmit', (theme: ThemeType) => ({
     })
   },
   secondaryButton: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       color: theme.palette.grey[680],
       padding: '8px 12px'
     } : {
@@ -47,7 +47,7 @@ export const styles = defineStyles('DialogueSubmit', (theme: ThemeType) => ({
     })
   },
   submitButton: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       backgroundColor: theme.palette.buttons.alwaysPrimary,
       color: theme.palette.text.alwaysWhite,
       boxShadow: 'none',

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -51,7 +51,7 @@ const styles = (theme: ThemeType) => ({
     display: 'inline-block',
     fontWeight: 600,
     ...theme.typography.postStyle,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontFamily: theme.palette.fonts.sansSerifStack,
       }
@@ -71,7 +71,7 @@ const styles = (theme: ThemeType) => ({
     flexShrink: 0,
     flexGrow: 1,
     position: "relative",
-    top: isFriendlyUI ? 0 : -4,
+    top: theme.isFriendlyUI ? 0 : -4,
   },
   footer: {
     marginTop: 5,

--- a/packages/lesswrong/components/questions/AnswersList.tsx
+++ b/packages/lesswrong/components/questions/AnswersList.tsx
@@ -1,7 +1,6 @@
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import { useLocation } from '../../lib/routeUtil';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { CommentTreeNode } from '../../lib/utils/unflatten';
 import Answer from "./Answer";
 import SectionTitle from "../common/SectionTitle";
@@ -22,7 +21,7 @@ const styles = (theme: ThemeType) => ({
   answersSorting:{
     ...theme.typography.body1,
     color: theme.palette.text.secondary,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontFamily: theme.palette.fonts.sansSerifStack,
       }

--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -5,7 +5,7 @@ import CommentsNewForm, {
   CommentCancelCallback,
   CommentSuccessCallback } from "../comments/CommentsNewForm";
 import classNames from "classnames";
-import { isBookUI, isFriendlyUI } from "../../themes/forumTheme";
+import { isFriendlyUI } from "../../themes/forumTheme";
 import { useDialog } from "../common/withDialog";
 import { useLoginPopoverContext } from "../hooks/useLoginPopoverContext";
 import { COMMENTS_NEW_FORM_PADDING } from "@/lib/collections/comments/constants";
@@ -17,7 +17,7 @@ const styles = (theme: ThemeType) => ({
   root: {
     background: theme.palette.panelBackground.default,
     border: `1px solid ${theme.palette.grey[200]}`,
-    ...(isBookUI && {
+    ...(theme.isBookUI && {
       background: theme.palette.panelBackground.bannerAdTranslucentStrong,
       border: "none",
     }),
@@ -26,9 +26,9 @@ const styles = (theme: ThemeType) => ({
   },
   commentEditor: {
     "& .ck-placeholder": {
-      marginTop: isFriendlyUI ? "-3px !important" : undefined,
+      marginTop: theme.isFriendlyUI ? "-3px !important" : undefined,
       "&::before": {
-        color: isFriendlyUI ? theme.palette.grey[600] : undefined,
+        color: theme.isFriendlyUI ? theme.palette.grey[600] : undefined,
         fontFamily: theme.palette.fonts.sansSerifStack,
         fontSize: 14,
         fontWeight: 500,

--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -54,7 +54,7 @@ const styles = defineStyles("QuickTakesSection", (theme: ThemeType) => ({
   },
   list: {
     marginTop: 4,
-    ...(isFriendlyUI ? {} : {
+    ...(theme.isFriendlyUI ? {} : {
       display: "flex",
       flexDirection: "column",
       gap: "4px",  

--- a/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
+++ b/packages/lesswrong/components/recentDiscussion/FeedPostCommentsCard.tsx
@@ -9,7 +9,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
 import CommentsNode from "../comments/CommentsNode";
 import FeedPostsHighlight from "../posts/FeedPostsHighlight";
@@ -24,7 +23,7 @@ const styles = (theme: ThemeType) => ({
     position: "relative",
     minHeight: 58,
     boxShadow: theme.palette.boxShadow.default,
-    borderRadius: theme.borderRadius[isFriendlyUI ? "default" : "small"],
+    borderRadius: theme.borderRadius[theme.isFriendlyUI ? "default" : "small"],
     [theme.breakpoints.down('xs')]: {
       paddingTop: 16,
       paddingLeft: 16,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionFeed.tsx
@@ -4,8 +4,6 @@ import { useCurrentUser } from '../common/withUser';
 import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import { forumSelect } from '../../lib/forumTypeUtils';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
-import AddBoxIcon from '@/lib/vendor/@material-ui/icons/src/AddBox'
-import { isLWorAF } from '../../lib/instanceSettings';
 import {showSubscribeReminderInFeed} from '../../lib/publicSettings'
 import { ObservableQuery } from '@apollo/client';
 import RecentDiscussionThread from "./RecentDiscussionThread";
@@ -24,7 +22,6 @@ import AnalyticsInViewTracker from "../common/AnalyticsInViewTracker";
 import { RecentDiscussionFeedQuery } from '../common/feeds/feedQueries';
 import FeedSelectorDropdown from '../common/FeedSelectorCheckbox';
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { isBookUI } from '@/themes/forumTheme';
 import { randomId } from '../../lib/random';
 
 const styles = defineStyles("RecentDiscussionFeed", (theme: ThemeType) => ({
@@ -33,7 +30,7 @@ const styles = defineStyles("RecentDiscussionFeed", (theme: ThemeType) => ({
     columnGap: 10,
     alignItems: 'center',
     width: '100%',
-    ...(isBookUI && {
+    ...(theme.isBookUI && {
       color: theme.palette.text.bannerAdOverlay,
     }),
   },

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -15,7 +15,6 @@ import withErrorBoundary from '../common/withErrorBoundary'
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { forumTitleSetting, forumTypeSetting, isAF, isEAForum, isLW, isLWorAF } from '../../lib/instanceSettings';
 import TextField from '@/lib/vendor/@material-ui/core/src/TextField';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LoginForm from "../users/LoginForm";
 import SignupSubscribeToCurated from "../users/SignupSubscribeToCurated";
 import Loading from "../vulcan-core/Loading";
@@ -28,10 +27,10 @@ const styles = (theme: ThemeType) => ({
   root: {
     marginBottom: theme.spacing.unit*4,
     position: "relative",
-    backgroundColor: isFriendlyUI
+    backgroundColor: theme.isFriendlyUI
       ? theme.palette.grey[0]
       : theme.palette.panelBackground.recentDiscussionThread,
-    border: isFriendlyUI ? `1px solid ${theme.palette.grey[200]}` : undefined,
+    border: theme.isFriendlyUI ? `1px solid ${theme.palette.grey[200]}` : undefined,
 
     padding: 16,
     ...theme.typography.body2,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTagRevisionItem.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { isEAForum } from "../../lib/instanceSettings"
 import { registerComponent } from "../../lib/vulcan-lib/components"
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import TagRevisionItem from "../tagging/TagRevisionItem";
 
 const styles = defineStyles("RecentDiscussionTagRevisionItem", (theme) => ({
   root: {
     backgroundColor: theme.palette.panelBackground.recentDiscussionThread,
-    marginBottom: isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
+    marginBottom: theme.isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
     position: "relative",
     boxShadow: theme.palette.boxShadow.default,
-    borderRadius: theme.borderRadius[isFriendlyUI ? "default" : "small"],
+    borderRadius: theme.borderRadius[theme.isFriendlyUI ? "default" : "small"],
 
     paddingLeft: 16,
     paddingRight: 16,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -12,7 +12,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import type { CommentTreeOptions } from '../comments/commentTree';
 import { useCurrentUser } from '../common/withUser';
-import { isFriendlyUI } from '../../themes/forumTheme';
+import { isFriendlyUI } from '@/themes/forumTheme';
 import { useRecentDiscussionThread } from './useRecentDiscussionThread';
 import { useRecentDiscussionViewTracking } from './useRecentDiscussionViewTracking';
 import PostsGroupDetails from "../posts/PostsGroupDetails";
@@ -23,11 +23,11 @@ import PostActionsButton from "../dropdowns/posts/PostActionsButton";
 
 const styles = (theme: ThemeType) => ({
   root: {
-    marginBottom: isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
+    marginBottom: theme.isFriendlyUI ? theme.spacing.unit*2 : theme.spacing.unit*4,
     position: "relative",
     minHeight: 58,
     boxShadow: theme.palette.boxShadow.default,
-    borderRadius: theme.borderRadius[isFriendlyUI ? "default" : "small"],
+    borderRadius: theme.borderRadius[theme.isFriendlyUI ? "default" : "small"],
   },
   plainBackground: {
     backgroundColor: theme.palette.panelBackground.recentDiscussionThread,
@@ -91,10 +91,10 @@ const styles = (theme: ThemeType) => ({
     }
   },
   post: {
-    paddingTop: isFriendlyUI ? 12 : 18,
+    paddingTop: theme.isFriendlyUI ? 12 : 18,
     paddingLeft: 16,
     paddingRight: 16,
-    borderRadius: theme.borderRadius[isFriendlyUI ? "default" : "small"],
+    borderRadius: theme.borderRadius[theme.isFriendlyUI ? "default" : "small"],
     marginBottom: 4,
     
     [theme.breakpoints.down('xs')]: {
@@ -114,7 +114,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 8,
     display: "block",
     fontSize: "2rem",
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       fontSize: 22,
       fontWeight: 600,
       lineHeight: 1.25,

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThreadsList.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThreadsList.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useCurrentUser } from '../common/withUser';
 import AddBoxIcon from '@/lib/vendor/@material-ui/icons/src/AddBox';
 import { useGlobalKeydown } from '../common/withGlobalKeydown';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import RecentDiscussionThread from "./RecentDiscussionThread";
 import SingleColumnSection from "../common/SingleColumnSection";
 import SectionTitle from "../common/SectionTitle";

--- a/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
+++ b/packages/lesswrong/components/recommendations/PostBottomRecommendations.tsx
@@ -19,7 +19,7 @@ import { defineStyles, useStyles } from "../hooks/useStyles";
 
 const styles = defineStyles("PostBottomRecommendations", (theme: ThemeType) => ({
   root: {
-    background: isFriendlyUI ? theme.palette.grey[55] : 'transparent',
+    background: theme.isFriendlyUI ? theme.palette.grey[55] : 'transparent',
     padding: "60px 0 80px 0",
     marginTop: 60,
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -23,7 +23,7 @@ import CuratedPostsList from "./CuratedPostsList";
 import ForumIcon from "../common/ForumIcon";
 
 const styles = (theme: ThemeType) => ({
-  section: isFriendlyUI ? {} : {
+  section: theme.isFriendlyUI ? {} : {
     marginTop: -12,
   },
   continueReadingList: {
@@ -91,7 +91,7 @@ const styles = (theme: ThemeType) => ({
     '@media (max-width: 350px)': {
       display: 'none'
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       "&:hover": {
         color: theme.palette.grey[1000],
         opacity: 1,

--- a/packages/lesswrong/components/recommendations/RecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.tsx
@@ -2,7 +2,6 @@ import React, { ComponentType } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useRecommendations } from './withRecommendations';
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import PostsItem from "../posts/PostsItem";
 import PostsLoading from "../posts/PostsLoading";
 import { Typography } from "../common/Typography";
@@ -14,7 +13,7 @@ export type RecommendationsListItem = ComponentType<{
 
 const styles = (theme: ThemeType) => ({
   noMoreMessage: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
 });
 

--- a/packages/lesswrong/components/review/PostsItemReviewVote.tsx
+++ b/packages/lesswrong/components/review/PostsItemReviewVote.tsx
@@ -5,7 +5,6 @@ import { useCurrentUser } from '../common/withUser';
 import { forumTitleSetting } from '../../lib/instanceSettings';
 import { canNominate, getCostData, getReviewPhase, REVIEW_YEAR, VoteIndex } from '../../lib/reviewUtils';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import ReviewVotingWidget from "./ReviewVotingWidget";
 import LWPopper from "../common/LWPopper";
 import LWTooltip from "../common/LWTooltip";
@@ -65,7 +64,7 @@ const styles = (theme: ThemeType) => ({
     display: "inline-block"
   },
   card: {
-    padding: isFriendlyUI ? "8px 24px" : 8,
+    padding: theme.isFriendlyUI ? "8px 24px" : 8,
     textAlign: "center",
   },
   reviewButton: {

--- a/packages/lesswrong/components/review/ReviewVotingButtons.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingButtons.tsx
@@ -6,12 +6,11 @@ import { AnalyticsContext } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { eligibleToNominate, getCostData, reviewIsActive } from '../../lib/reviewUtils';
 import { SyntheticQualitativeVote } from './ReviewVotingPage';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LWTooltip from "../common/LWTooltip";
 
 const styles = (theme: ThemeType) => {
   const downvoteColor = theme.palette.text.reviewDownvote;
-  const upvoteColor = isFriendlyUI ? theme.palette.primary.main : theme.palette.text.reviewUpvote;
+  const upvoteColor = theme.isFriendlyUI ? theme.palette.primary.main : theme.palette.text.reviewUpvote;
   
   return {
     root: { 

--- a/packages/lesswrong/components/search/PostMentionHit.tsx
+++ b/packages/lesswrong/components/search/PostMentionHit.tsx
@@ -3,9 +3,9 @@ import { registerComponent } from "../../lib/vulcan-lib/components";
 import { isFriendlyUI } from "@/themes/forumTheme";
 import ForumIcon from "../common/ForumIcon";
 
-const styles = () => ({
+const styles = (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       display: "block",
       maxWidth: 500,
       overflow: "hidden",

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import type { Hit } from 'react-instantsearch-core';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import PostsTitle from "../posts/PostsTitle";
 import MetaInfo from "../common/MetaInfo";
@@ -21,7 +20,7 @@ const styles = (theme: ThemeType) => ({
   postLink: {
     float:"right",
     marginRight: theme.spacing.unit,
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   titleRow: {
     textOverflow: "ellipsis",

--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -5,7 +5,6 @@ import type { Hit } from 'react-instantsearch-core';
 import LocalLibraryIcon from '@/lib/vendor/@material-ui/icons/src/LocalLibrary';
 import { Snippet } from 'react-instantsearch-dom';
 import { SearchHitComponentProps } from './types';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import FormatDate from "../common/FormatDate";
 import LWTooltip from "../common/LWTooltip";
 import MetaInfo from "../common/MetaInfo";
@@ -23,7 +22,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     fontSize: "1.25rem",
     ...theme.typography.smallCaps,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
     marginRight: 8,

--- a/packages/lesswrong/components/search/TagMentionHit.tsx
+++ b/packages/lesswrong/components/search/TagMentionHit.tsx
@@ -3,9 +3,9 @@ import { registerComponent } from "../../lib/vulcan-lib/components";
 import { isFriendlyUI } from "@/themes/forumTheme";
 import ForumIcon from "../common/ForumIcon";
 
-const styles = () => ({
+const styles = (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       display: "block",
       maxWidth: 500,
       overflow: "hidden",

--- a/packages/lesswrong/components/search/UserMentionHit.tsx
+++ b/packages/lesswrong/components/search/UserMentionHit.tsx
@@ -8,7 +8,7 @@ import ForumIcon from "../common/ForumIcon";
 const styles = (theme: ThemeType) => ({
   root: {
     color: "inherit",
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       display: "block",
       maxWidth: 500,
       overflow: "hidden",

--- a/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
+++ b/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
@@ -1,6 +1,5 @@
 import Input from '@/lib/vendor/@material-ui/core/src/Input';
 import React from 'react';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { sequencesImageScrim } from '../sequences/SequencesPage';
 import type { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
@@ -47,8 +46,8 @@ const styles = defineStyles('EditSequenceTitle', (theme: ThemeType) => ({
   },
   input: {
     width: '100%',
-    fontSize: isFriendlyUI ? '2.4rem' : 36,
-    fontWeight: isFriendlyUI ? 600 : 400,
+    fontSize: theme.isFriendlyUI ? '2.4rem' : 36,
+    fontWeight: theme.isFriendlyUI ? 600 : 400,
     ...theme.typography.smallCaps,
     height: '1em',
     '&::placeholder': {

--- a/packages/lesswrong/components/sequences/BooksProgressBar.tsx
+++ b/packages/lesswrong/components/sequences/BooksProgressBar.tsx
@@ -4,7 +4,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import classNames from 'classnames';
 import { useItemsRead } from '../hooks/useRecordPostView';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LWTooltip from "../common/LWTooltip";
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import LoginToTrack from "./LoginToTrack";
@@ -27,7 +26,7 @@ const styles = (theme: ThemeType) => ({
   },
   read: {
     ...(
-      isFriendlyUI
+      theme.isFriendlyUI
         ? {
           backgroundColor: theme.palette.primary.main,
           border: theme.palette.primary.dark,

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -6,7 +6,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser';
 import SingleColumnSection, { SECTION_WIDTH } from '../common/SingleColumnSection';
 import { makeCloudinaryImageUrl } from '../common/CloudinaryImage2';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import { BooksForm } from './BooksForm';
@@ -81,7 +80,7 @@ const styles = (theme: ThemeType) => ({
   title: {
     ...theme.typography.headerStyle,
     fontWeight: "bold",
-    textTransform: isFriendlyUI ? undefined : "uppercase",
+    textTransform: theme.isFriendlyUI ? undefined : "uppercase",
     borderTopStyle: "solid",
     borderTopWidth: 4,
     paddingTop: 10,
@@ -90,7 +89,7 @@ const styles = (theme: ThemeType) => ({
   },
   description: {
     marginTop: 30,
-    marginBottom: isFriendlyUI ? 0 : 25,
+    marginBottom: theme.isFriendlyUI ? 0 : 25,
     lineHeight: 1.25,
     maxWidth: 700,
   },

--- a/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
+++ b/packages/lesswrong/components/sequences/LargeSequencesItem.tsx
@@ -96,7 +96,7 @@ const styles = (theme: ThemeType) => ({
     objectFit: "cover"
   },
   chapterTitle: {
-    fontSize: `${isFriendlyUI ? "1.2rem" : "1.25rem"} !important`,
+    fontSize: `${theme.isFriendlyUI ? "1.2rem" : "1.25rem"} !important`,
     margin: "8px 0 -8px 0 !important",
   },
   postIcon: {
@@ -119,7 +119,7 @@ const styles = (theme: ThemeType) => ({
     width: "45%",
     display: "flex",
     flexDirection: "column",
-    justifyContent: isFriendlyUI ? "flex-start" : "center",
+    justifyContent: theme.isFriendlyUI ? "flex-start" : "center",
     maxHeight: 600,
     [theme.breakpoints.down('xs')]: {
       width: "100%",

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
 import { getCollectionOrSequenceUrl } from '../../lib/collections/sequences/helpers';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defaultSequenceBannerIdSetting } from './SequencesPage';
 import { isLWorAF } from '../../lib/instanceSettings';
 import DeferRender from '../common/DeferRender';
@@ -36,7 +35,7 @@ const styles = (theme: ThemeType) => ({
 
   title: {
     fontSize: 16,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         lineHeight: 1.25,
         maxHeight: 42,
@@ -79,7 +78,7 @@ const styles = (theme: ThemeType) => ({
     flexDirection: "column",
     justifyContent: "center",
     background: theme.palette.panelBackground.default,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         borderRadius: `0 0 ${theme.borderRadius.small}px ${theme.borderRadius.small}px`,
         fontFamily: theme.palette.fonts.sansSerifStack,
@@ -104,7 +103,7 @@ const styles = (theme: ThemeType) => ({
     backgroundColor: theme.palette.grey[200],
     display: 'block',
     height: 95,
-    borderRadius: isFriendlyUI
+    borderRadius: theme.isFriendlyUI
       ? `${theme.borderRadius.small}px ${theme.borderRadius.small}px 0 0`
       : undefined,
     [legacyBreakpoints.maxSmall]: {
@@ -113,7 +112,7 @@ const styles = (theme: ThemeType) => ({
     "& img": {
       width: "100%",
       height: 95,
-      borderRadius: isFriendlyUI
+      borderRadius: theme.isFriendlyUI
         ? `${theme.borderRadius.small}px ${theme.borderRadius.small}px 0 0`
         : undefined,
       [legacyBreakpoints.maxSmall]: {

--- a/packages/lesswrong/components/sequences/SequencesNewForm.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNewForm.tsx
@@ -1,7 +1,6 @@
 import { useMessages } from '../common/withMessages';
 import React from 'react';
 import { useCurrentUser } from '../common/withUser';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useNavigate } from '../../lib/routeUtil';
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { SequencesForm } from './SequencesForm';
@@ -113,7 +112,7 @@ export const styles = defineStyles("SequencesNewForm", (theme: ThemeType) => ({
         },
         "& .form-input-errors": {
           position: "absolute",
-          top: isFriendlyUI ? 84 : 45,
+          top: theme.isFriendlyUI ? 84 : 45,
           left: 7,
           textAlign: "left",
         }

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -65,7 +65,7 @@ export const defaultSequenceBannerIdSetting = new DatabasePublicSetting<string|n
 
 const styles = (theme: ThemeType) => ({
   root: {
-    paddingTop: isFriendlyUI ? (270 + HEADER_HEIGHT) : 380,
+    paddingTop: theme.isFriendlyUI ? (270 + HEADER_HEIGHT) : 380,
   },
   deletedText: {
     paddingTop: 20,
@@ -105,7 +105,7 @@ const styles = (theme: ThemeType) => ({
   description: {
     marginTop: theme.spacing.unit * 2,
     marginLeft: theme.spacing.unit/2,
-    marginBottom: isFriendlyUI ? 40 : theme.spacing.unit * 2,
+    marginBottom: theme.isFriendlyUI ? 40 : theme.spacing.unit * 2,
   },
   banner: {
     position: "absolute",
@@ -144,8 +144,8 @@ const styles = (theme: ThemeType) => ({
       marginTop: -100,
     },
     [theme.breakpoints.down('xs')]: {
-      marginTop: isFriendlyUI ? undefined : theme.spacing.unit,
-      padding: isFriendlyUI ? 16 : theme.spacing.unit
+      marginTop: theme.isFriendlyUI ? undefined : theme.spacing.unit,
+      padding: theme.isFriendlyUI ? 16 : theme.spacing.unit
     },
   },
   leftAction: {

--- a/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSmallPostLink.tsx
@@ -17,10 +17,10 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     color: theme.palette.grey[900],
     display: "flex",
-    alignItems: isFriendlyUI ? "flex-start" : "center",
+    alignItems: theme.isFriendlyUI ? "flex-start" : "center",
     marginBottom: 6,
     marginTop: 6,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 14,
       fontWeight: 500,
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType) => ({
   },
   checkbox: {
     position: "relative",
-    top: isFriendlyUI ? -1 : 1,
+    top: theme.isFriendlyUI ? -1 : 1,
     marginRight: 10
   }
 });

--- a/packages/lesswrong/components/sequences/SequencesSummary.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSummary.tsx
@@ -29,13 +29,13 @@ const ChaptersFragmentMultiQuery = gql(`
 const styles = (theme: ThemeType) => ({
   root: {
     padding: 16,
-    width: isFriendlyUI ? FRIENDLY_HOVER_OVER_WIDTH : 450,
+    width: theme.isFriendlyUI ? FRIENDLY_HOVER_OVER_WIDTH : 450,
   },
   title: {
     ...theme.typography.body1,
     ...theme.typography.postStyle,
     ...theme.typography.smallCaps,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: "1.3rem",
       fontWeight: 700,
@@ -50,7 +50,7 @@ const styles = (theme: ThemeType) => ({
   },
   author: {
     color: theme.palette.text.dim,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 13,
       fontWeight: 500,
@@ -58,7 +58,7 @@ const styles = (theme: ThemeType) => ({
       marginBottom: 14,
     }),
   },
-  wordcount: isFriendlyUI
+  wordcount: theme.isFriendlyUI
     ? {}
     : {
       ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/shortform/NewShortformDialog.tsx
+++ b/packages/lesswrong/components/shortform/NewShortformDialog.tsx
@@ -6,16 +6,16 @@ import { useNavigate } from '../../lib/routeUtil';
 import ShortformSubmitForm from "./ShortformSubmitForm";
 import LWDialog from "../common/LWDialog";
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   content: {
     // This subselector is needed to beat the specificity of the default
     // MUI styles
     "&:first-child": {
-      padding: isFriendlyUI ? 0 : "0 20px 20px",
+      padding: theme.isFriendlyUI ? 0 : "0 20px 20px",
     },
   },
   dialogPaper: {
-    maxWidth: isFriendlyUI ? 750 : undefined,
+    maxWidth: theme.isFriendlyUI ? 750 : undefined,
   },
 });
 

--- a/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
+++ b/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
@@ -27,10 +27,10 @@ const styles = (theme: ThemeType) => ({
   },
   newQuickTake: {
     fontFamily: theme.palette.fonts.sansSerifStack,
-    fontWeight: isFriendlyUI ? 700 : 500,
+    fontWeight: theme.isFriendlyUI ? 700 : 500,
     fontSize: 20,
     color: theme.palette.grey[1000],
-    margin: isFriendlyUI ? 20 : '16px 20px 16px 0px',
+    margin: theme.isFriendlyUI ? 20 : '16px 20px 16px 0px',
   },
   quickTakesRoot: {
     background: "transparent",

--- a/packages/lesswrong/components/shortform/ShortformThreadList.tsx
+++ b/packages/lesswrong/components/shortform/ShortformThreadList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useCurrentUser } from '../common/withUser';
 import { userCanQuickTake } from '../../lib/vulcan-users/permissions';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LoadMore from "../common/LoadMore";
 import CommentOnPostWithReplies from "../comments/CommentOnPostWithReplies";
 import QuickTakesEntry from "../quickTakes/QuickTakesEntry";
@@ -22,7 +21,7 @@ const CommentWithRepliesFragmentMultiQuery = gql(`
 
 const styles = (theme: ThemeType) => ({
   shortformItem: {
-    marginTop: theme.spacing.unit * (isFriendlyUI ? 2 : 4),
+    marginTop: theme.spacing.unit * (theme.isFriendlyUI ? 2 : 4),
   }
 })
 

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -19,9 +19,9 @@ const ShortformCommentsMultiQuery = gql(`
   }
 `);
 
-const styles = (_: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   shortformGroup: {
-    marginTop: isFriendlyUI ? 20 : 12,
+    marginTop: theme.isFriendlyUI ? 20 : 12,
   },
   subtitle: {
     marginTop: 6,

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -60,7 +60,7 @@ const TEXT_WIDTH = 350;
 
 export const descriptionStyles = (theme: ThemeType) => ({
   ...postBodyStyles(theme),
-  ...(isBookUI ? theme.typography.body2 : {}),
+  ...(theme.isBookUI ? theme.typography.body2 : {}),
   lineHeight: '1.65rem',
   '& p': {
     marginTop: ".5em",
@@ -104,7 +104,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
       opacity: .2
     },
     '&:hover $closeButton': {
-      ...(isFriendlyUI ? {
+      ...(theme.isFriendlyUI ? {
         color: theme.palette.grey[100],
         background: theme.palette.panelBackground.default,
       } : {
@@ -131,7 +131,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
     padding: '.5em',
     minHeight: '.75em',
     minWidth: '.75em',
-    color: isFriendlyUI ? theme.palette.text.alwaysWhite : theme.palette.grey[300],
+    color: theme.isFriendlyUI ? theme.palette.text.alwaysWhite : theme.palette.grey[300],
     zIndex: theme.zIndexes.spotlightItemCloseButton,
   },
   hideButton: {
@@ -156,7 +156,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
     position: "relative",
     zIndex: theme.zIndexes.spotlightItem,
     // Drop shadow that helps the text stand out from the background image
-    textShadow: isFriendlyUI ? undefined : `
+    textShadow: theme.isFriendlyUI ? undefined : `
       0px 0px 10px ${theme.palette.background.default},
       0px 0px 20px ${theme.palette.background.default}
     `,
@@ -183,7 +183,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
     [theme.breakpoints.down('xs')]: {
       display: "none"
     },
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       fontSize: 13,
       fontWeight: 500,
       fontFamily: theme.palette.fonts.sansSerifStack,
@@ -205,7 +205,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
   },
   title: {
     ...theme.typography.postStyle,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontSize: 22,
         fontWeight: 700,
@@ -223,7 +223,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
   subtitle: {
     ...theme.typography.postStyle,
     ...theme.typography.italic,
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       fontSize: 13,
       fontWeight: 500,
       fontFamily: theme.palette.fonts.sansSerifStack,
@@ -236,7 +236,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
       marginTop: -1,
     }),
   },
-  startOrContinue: isFriendlyUI
+  startOrContinue: theme.isFriendlyUI
     ? {
       marginTop: 0,
       [theme.breakpoints.down("xs")]: {
@@ -251,7 +251,7 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
     position: "absolute",
     top: 0,
     right: 0,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
           borderRadius: theme.borderRadius.default,
           width: "100%",

--- a/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightStartOrContinueReading.tsx
@@ -4,7 +4,7 @@ import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useItemsRead } from '../hooks/useRecordPostView';
 import { postProgressBoxStyles } from '../sequences/BooksProgressBar';
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import { forumSelect } from '../../lib/forumTypeUtils';
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import { defineStyles, useStyles } from '../hooks/useStyles';
@@ -16,7 +16,7 @@ const styles = defineStyles("SpotlightStartOrContinueReading", (theme: ThemeType
   },
   firstPost: {
     ...theme.typography.body2,
-    fontSize: isFriendlyUI ? 13 : "1.1rem",
+    fontSize: theme.isFriendlyUI ? 13 : "1.1rem",
     ...theme.typography.commentStyle,
     position: "relative",
     zIndex: theme.zIndexes.spotlightItemCloseButton,
@@ -27,11 +27,11 @@ const styles = defineStyles("SpotlightStartOrContinueReading", (theme: ThemeType
   },
   postProgressBox: {
     ...postProgressBoxStyles(theme),
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       borderColor: theme.palette.text.alwaysWhite,
     }),
   },
-  read: isFriendlyUI
+  read: theme.isFriendlyUI
     ? {
       backgroundColor: theme.palette.text.alwaysWhite,
       border: theme.palette.text.alwaysWhite,

--- a/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorActions.tsx
@@ -17,7 +17,6 @@ import { getCurrentContentCount, UserContentCountPartial } from '../../lib/colle
 import { hideScrollBars } from '../../themes/styleUtils';
 import { getSignature, getSignatureWithNote } from '../../lib/collections/users/helpers';
 import { hideUnreviewedAuthorCommentsSettings } from '../../lib/publicSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useDialog } from '../common/withDialog';
 import NewModeratorActionDialog from "./NewModeratorActionDialog";
 import LWTooltip from "../common/LWTooltip";

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -8,7 +8,6 @@ import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import * as _ from 'underscore';
 import classNames from 'classnames';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import CurationNoticesItem from "../admin/CurationNoticesItem";
 import SunshineListItem from "./SunshineListItem";
 import SidebarHoverOver from "./SidebarHoverOver";
@@ -41,13 +40,13 @@ const styles = (theme: ThemeType) => ({
     position: "relative",
     top: 2
   },
-  postTitle: isFriendlyUI ? {} : {
+  postTitle: theme.isFriendlyUI ? {} : {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
     fontSize: "1rem",
     fontWeight: 500,
   },
-  titleWithCurationNotice: isFriendlyUI ? {} : {
+  titleWithCurationNotice: theme.isFriendlyUI ? {} : {
     color: 'green',
     fontWeight: 600,
   },

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
@@ -1,7 +1,6 @@
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -16,7 +15,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     overflow: "hidden",
     lineHeight: "1.2rem",
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   hover: {
     backgroundColor: theme.palette.grey[50]

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -12,7 +12,6 @@ import HomeIcon from '@/lib/vendor/@material-ui/icons/src/Home';
 import ClearIcon from '@/lib/vendor/@material-ui/icons/src/Clear';
 import VisibilityOutlinedIcon from '@/lib/vendor/@material-ui/icons/src/VisibilityOutlined';
 import { MANUAL_FLAG_ALERT } from "@/lib/collections/moderatorActions/constants";
-import { isFriendlyUI } from '../../themes/forumTheme';
 import MetaInfo from "../common/MetaInfo";
 import LinkPostMessage from "../posts/LinkPostMessage";
 import { ContentItemBody } from "../contents/ContentItemBody";
@@ -72,7 +71,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 8,
     display: "flex",
     alignItems: "center",
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   vote: {
     marginRight: 8

--- a/packages/lesswrong/components/tagging/AllPostsPageTagRevisionItem.tsx
+++ b/packages/lesswrong/components/tagging/AllPostsPageTagRevisionItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import Loading from "../vulcan-core/Loading";
@@ -22,7 +21,7 @@ const styles = (theme: ThemeType) => ({
     background: theme.palette.panelBackground.commentNodeEven,
     border: theme.palette.border.commentBorder,
     borderRight: "none",
-    borderRadius: isFriendlyUI
+    borderRadius: theme.isFriendlyUI
       ? `${theme.borderRadius.default}px 0 0 ${theme.borderRadius.default}px`
       : "2px 0 0 2px",
     padding: 12,

--- a/packages/lesswrong/components/tagging/CoreTagCard.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagCard.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { siteImageSetting } from '@/lib/publicSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import CloudinaryImage2 from "../common/CloudinaryImage2";
 import SubscribeButton from "./SubscribeButton";
 
@@ -38,10 +37,10 @@ const styles = (theme: ThemeType) => ({
     minWidth: 0, // required for text-overflow to work
   },
   title: {
-    ...theme.typography[isFriendlyUI ? "headerStyle" : "headline"],
+    ...theme.typography[theme.isFriendlyUI ? "headerStyle" : "headline"],
     fontSize: 16,
     lineHeight: "20px",
-    fontWeight: isFriendlyUI ? 600 : 700,
+    fontWeight: theme.isFriendlyUI ? 600 : 700,
     whiteSpace: "nowrap",
     overflow: "hidden",
   },

--- a/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/EAAllTagsPage.tsx
@@ -10,7 +10,6 @@ import AddBoxIcon from '@/lib/vendor/@material-ui/icons/src/AddBox';
 import { useDialog } from '../common/withDialog';
 import { taggingNameCapitalSetting, taggingNamePluralCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import { tagCreateUrl, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import LoginPopup from "../users/LoginPopup";
 import AllTagsAlphabetical from "./AllTagsAlphabetical";
 import SectionButton from "../common/SectionButton";
@@ -61,7 +60,7 @@ const styles = (theme: ThemeType) => ({
         height: 'inherit !important'
       }
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       background: theme.palette.grey[0],
       marginTop: 'unset',
       marginBottom: 'unset',

--- a/packages/lesswrong/components/tagging/EATagPage.tsx
+++ b/packages/lesswrong/components/tagging/EATagPage.tsx
@@ -124,10 +124,10 @@ const styles = (theme: ThemeType) => ({
     }
   },
   title: {
-    ...theme.typography[isFriendlyUI ? "display2" : "display3"],
-    ...theme.typography[isFriendlyUI ? "headerStyle" : "commentStyle"],
+    ...theme.typography[theme.isFriendlyUI ? "display2" : "display3"],
+    ...theme.typography[theme.isFriendlyUI ? "headerStyle" : "commentStyle"],
     marginTop: 0,
-    fontWeight: isFriendlyUI ? 700 : 600,
+    fontWeight: theme.isFriendlyUI ? 700 : 600,
     ...theme.typography.smallCaps,
   },
   notifyMeButton: {
@@ -179,7 +179,7 @@ const styles = (theme: ThemeType) => ({
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',
     overflow: 'hidden',
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   relatedTagLink : {
     color: theme.palette.lwTertiary.dark

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -60,9 +60,9 @@ const styles = (theme: ThemeType) => ({
     flexGrow: 1,
     textAlign: "center",
     fontWeight: theme.typography.body1.fontWeight,
-    color: isFriendlyUI ? theme.palette.lwTertiary.main : theme.palette.primary.main,
+    color: theme.isFriendlyUI ? theme.palette.lwTertiary.main : theme.palette.primary.main,
     boxShadow: theme.palette.boxShadow.default,
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       marginBottom: 4,
       marginRight: 4,
     } : {
@@ -78,7 +78,7 @@ const styles = (theme: ThemeType) => ({
     alignItems: 'center',
     justifyContent: 'center',
     fontWeight: theme.typography.body1.fontWeight,
-    overflow: isFriendlyUI ? undefined : 'hidden',
+    overflow: theme.isFriendlyUI ? undefined : 'hidden',
   },
   filterScore: {
     color: theme.palette.primary.main,
@@ -135,7 +135,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: -4,
     borderRadius: 2,
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       color: theme.palette.primary.main
     }),
   },

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { useCurrentUser } from '../common/withUser';
 import CoreTagIcon, { coreTagIconMap } from './CoreTagIcon';
-import { isBookUI, isFriendlyUI } from '../../themes/forumTheme';
+import { isFriendlyUI } from '../../themes/forumTheme';
 import TagsTooltip, { TagsTooltipPreviewWrapper } from './TagsTooltip';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import ForumIcon from "../common/ForumIcon";
@@ -15,11 +15,11 @@ import ForumIcon from "../common/ForumIcon";
 const useExperimentalTagStyleSetting = new DatabasePublicSetting<boolean>('useExperimentalTagStyle', false)
 
 export const tagStyle = (theme: ThemeType) => ({
-  marginRight: isFriendlyUI ? 3 : undefined,
+  marginRight: theme.isFriendlyUI ? 3 : undefined,
   padding: 5,
   paddingLeft: 6,
   paddingRight: 6,
-  marginBottom: isFriendlyUI ? 8 : undefined,
+  marginBottom: theme.isFriendlyUI ? 8 : undefined,
   fontWeight: theme.typography.body1.fontWeight,
   backgroundColor: theme.palette.tag.background,
   border: theme.palette.tag.border,
@@ -27,7 +27,7 @@ export const tagStyle = (theme: ThemeType) => ({
   borderRadius: 3,
   ...theme.typography.commentStyle,
   cursor: "pointer",
-  whiteSpace: isFriendlyUI ? "nowrap": undefined,
+  whiteSpace: theme.isFriendlyUI ? "nowrap": undefined,
 })
 
 const newTagStyle = (theme: ThemeType) => ({
@@ -69,14 +69,14 @@ const styles = defineStyles("FooterTag", (theme: ThemeType) => ({
       opacity: 1,
       backgroundColor: theme.palette.tag.backgroundHover,
     },
-    "& a:hover": isFriendlyUI ? {opacity: 1} : {},
-    ...(useExperimentalTagStyleSetting.get() && isBookUI
+    "& a:hover": theme.isFriendlyUI ? {opacity: 1} : {},
+    ...(useExperimentalTagStyleSetting.get() && theme.isBookUI
       ? newTagStyle(theme)
       : tagStyle(theme)
     )
   },
   tooltip: {
-    marginTop: isFriendlyUI ? 6 : undefined,
+    marginTop: theme.isFriendlyUI ? 6 : undefined,
   },
   core: {
     ...coreTagStyle(theme),
@@ -85,7 +85,7 @@ const styles = defineStyles("FooterTag", (theme: ThemeType) => ({
     position: "relative",
     display: "inline-block",
     minWidth: 20,
-    margin: isFriendlyUI ? "0 3px 0 6px" : undefined,
+    margin: theme.isFriendlyUI ? "0 3px 0 6px" : undefined,
     "& svg": {
       position: "absolute",
       top: -13,

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -14,7 +14,6 @@ import { forumSelect } from '../../lib/forumTypeUtils';
 import { useMessages } from '../common/withMessages';
 import { isLWorAF, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import stringify from 'json-stringify-deterministic';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { FRIENDLY_HOVER_OVER_WIDTH } from '../common/FriendlyHoverOver';
 import { AnnualReviewMarketInfo } from '../../lib/collections/posts/annualReviewMarkets';
 import { stableSortTags } from '../../lib/collections/tags/helpers';
@@ -28,7 +27,7 @@ import PostsAnnualReviewMarketTag from "../posts/PostsAnnualReviewMarketTag";
 import { apolloSSRFlag } from "@/lib/helpers";
 
 const styles = (theme: ThemeType) => ({
-  root: isFriendlyUI ? {
+  root: theme.isFriendlyUI ? {
     marginTop: 8,
     marginBottom: 8,
   } : {
@@ -42,7 +41,7 @@ const styles = (theme: ThemeType) => ({
     justifyContent: 'flex-end'
   },
   allowTruncate: {
-    display: isFriendlyUI ? "block" : "inline-flex",
+    display: theme.isFriendlyUI ? "block" : "inline-flex",
     // Truncate to 1 row (webkit-line-clamp would be ideal here but it adds an ellipsis
     // which can't be removed)
     maxHeight: 33,
@@ -53,12 +52,12 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 0,
   },
   postTypeLink: {
-    "&:hover": isFriendlyUI ? {opacity: 1} : {},
+    "&:hover": theme.isFriendlyUI ? {opacity: 1} : {},
   },
   frontpageOrPersonal: {
     ...tagStyle(theme),
     backgroundColor: theme.palette.tag.hollowTagBackground,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         marginBottom: 0,
         "&:hover": {
@@ -87,7 +86,7 @@ const styles = (theme: ThemeType) => ({
   },
   card: {
     padding: 16,
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         paddingTop: 12,
         width: FRIENDLY_HOVER_OVER_WIDTH,

--- a/packages/lesswrong/components/tagging/LWTagPage.tsx
+++ b/packages/lesswrong/components/tagging/LWTagPage.tsx
@@ -153,11 +153,11 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     }
   },
   title: {
-    ...theme.typography[isFriendlyUI ? "display2" : "display3"],
-    ...theme.typography[isFriendlyUI ? "headerStyle" : "commentStyle"],
+    ...theme.typography[theme.isFriendlyUI ? "display2" : "display3"],
+    ...theme.typography[theme.isFriendlyUI ? "headerStyle" : "commentStyle"],
     marginTop: 4,
     marginBottom: 12,
-    fontWeight: isFriendlyUI ? 700 : 600,
+    fontWeight: theme.isFriendlyUI ? 700 : 600,
     lineHeight: 1.05,
     [theme.breakpoints.down('sm')]: {
       fontSize: '27px',
@@ -211,7 +211,7 @@ const styles = defineStyles("LWTagPage", (theme: ThemeType) => ({
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": 'vertical',
     overflow: 'hidden',
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   relatedTagLink : {
     color: theme.palette.lwTertiary.dark

--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useVote } from '../votes/withVote';
 import { useVoteButtonsDisabled } from '../votes/useVoteButtonsDisabled';
 import classNames from 'classnames';
-import { isBookUI, isFriendlyUI } from '../../themes/forumTheme';
+import { isBookUI } from '../../themes/forumTheme';
 import { forumSelect } from '@/lib/forumTypeUtils';
 import { TooltipSpan } from '../common/FMTooltip';
 import OverallVoteButton from "../votes/OverallVoteButton";
@@ -24,7 +24,7 @@ const styles = (theme: ThemeType) => ({
   // these interact with whether the vote icons are solid or hollow (i.e. different components). Not ideally set up, so nb. 
   vertLayoutVoteUp: {
     position: "absolute",
-    left: isFriendlyUI ? 9 : 10,
+    left: theme.isFriendlyUI ? 9 : 10,
     top: forumSelect({
       LessWrong: -17,
       AlignmentForum: -15,
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType) => ({
   // these interact with whether the vote icons are solid or hollow (i.e. different components). Not ideally set up, so nb. 
   vertLayoutVoteDown: {
     position: "absolute",
-    left: isFriendlyUI ? 9 : 10,
+    left: theme.isFriendlyUI ? 9 : 10,
     top: forumSelect({
       LessWrong: 8,
       AlignmentForum: 10,

--- a/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
+++ b/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
@@ -6,7 +6,6 @@ import { tagGetUrl, tagGetDiscussionUrl, tagGetHistoryUrl } from '../../lib/coll
 import { Link } from '../../lib/reactRouterWrapper';
 import { ExpandedDate } from '../common/FormatDate';
 import moment from 'moment';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { tagUrlBaseSetting } from '@/lib/instanceSettings';
 import AllPostsPageTagDocDeletionItem, { DocumentDeletion } from './AllPostsPageTagDocDeletionItem';
 import ChangeMetricsDisplay from "./ChangeMetricsDisplay";
@@ -21,7 +20,7 @@ export const POSTED_AT_WIDTH = 38
 
 const styles = (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         background: theme.palette.grey[0],
         border: `1px solid ${theme.palette.grey[100]}`,
@@ -52,10 +51,10 @@ const styles = (theme: ThemeType) => ({
     cursor: "pointer",
     padding: 4,
     fontFamily: theme.typography.fontFamily,
-    fontSize: isFriendlyUI ? 14 : 17,
-    fontWeight: isFriendlyUI ? 600 : undefined,
+    fontSize: theme.isFriendlyUI ? 14 : 17,
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
     ...theme.typography.smallCaps,
-    marginLeft: isFriendlyUI ? 2 : undefined,
+    marginLeft: theme.isFriendlyUI ? 2 : undefined,
   },
   expandedBody: {
     marginTop: 8,
@@ -69,11 +68,11 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 8,
   },
   commentBubble: {
-    margin: `-5px ${isFriendlyUI ? 6 : 0}px 0 11px`,
+    margin: `-5px ${theme.isFriendlyUI ? 6 : 0}px 0 11px`,
   },
   changeMetrics: {
     cursor: "pointer",
-    margin: isFriendlyUI ? "0 4px -2px 2px" : undefined,
+    margin: theme.isFriendlyUI ? "0 4px -2px 2px" : undefined,
   },
   postedAt: {
     '&&': {
@@ -96,7 +95,7 @@ const styles = (theme: ThemeType) => ({
     fontSize: "1rem",
     fontFamily: theme.typography.fontFamily,
     color: theme.palette.link.dim3,
-    margin: `${isFriendlyUI ? -4 : -8}px 0 8px 8px`,
+    margin: `${theme.isFriendlyUI ? -4 : -8}px 0 8px 8px`,
   },
   usernames: {
     marginRight: 16,

--- a/packages/lesswrong/components/tagging/TagCompareRevisions.tsx
+++ b/packages/lesswrong/components/tagging/TagCompareRevisions.tsx
@@ -5,7 +5,6 @@ import { useLocation } from '../../lib/routeUtil';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import SingleColumnSection from "../common/SingleColumnSection";
 import CompareRevisions from "../revisions/CompareRevisions";
 import RevisionComparisonNotice from "../revisions/RevisionComparisonNotice";
@@ -26,10 +25,10 @@ const RevisionHistoryEntryMultiQuery = gql(`
 
 const styles = defineStyles('TagCompareRevisions', (theme) => ({
   title: {
-    ...theme.typography[isFriendlyUI ? "display2" : "display3"],
-    ...theme.typography[isFriendlyUI ? "headerStyle" : "commentStyle"],
+    ...theme.typography[theme.isFriendlyUI ? "display2" : "display3"],
+    ...theme.typography[theme.isFriendlyUI ? "headerStyle" : "commentStyle"],
     marginTop: 0,
-    fontWeight: isFriendlyUI ? 700 : 600,
+    fontWeight: theme.isFriendlyUI ? 700 : 600,
     ...theme.typography.smallCaps,
   },
   description: {},

--- a/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionButton.tsx
@@ -5,7 +5,6 @@ import CommentOutlinedIcon from "@/lib/vendor/@material-ui/icons/src/ModeComment
 import { useHover } from "../common/withHover";
 import { tagGetDiscussionUrl } from "../../lib/collections/tags/helpers";
 import classNames from "classnames";
-import { isFriendlyUI } from "@/themes/forumTheme";
 import TagDiscussion from "./TagDiscussion";
 import PopperCard from "../common/PopperCard";
 import { useQuery } from "@/lib/crud/useQuery";
@@ -41,7 +40,7 @@ const styles = (theme: ThemeType) => ({
   discussionCount: {
     [theme.breakpoints.down('sm')]: {
       alignSelf: "flex-start", //appears too low when there's no label
-      marginTop: isFriendlyUI ? undefined : -2,
+      marginTop: theme.isFriendlyUI ? undefined : -2,
     }
   },
   discussionCountWithoutLabel: {

--- a/packages/lesswrong/components/tagging/TagDiscussionPage.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussionPage.tsx
@@ -5,7 +5,6 @@ import { useTagBySlug } from './useTag';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { taggingNameIsSet, taggingNameSetting } from '../../lib/instanceSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import SingleColumnSection from "../common/SingleColumnSection";
 import TagDiscussionSection from "./TagDiscussionSection";
 import ContentStyles from "../common/ContentStyles";
@@ -15,7 +14,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.display3,
     ...theme.typography.commentStyle,
     marginTop: 0,
-    fontWeight: isFriendlyUI ? 700 : 600,
+    fontWeight: theme.isFriendlyUI ? 700 : 600,
     ...theme.typography.smallCaps,
   },
   description: {

--- a/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
+++ b/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
@@ -4,7 +4,6 @@ import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from '@/lib/generated/gql-codegen';
 import withErrorBoundary from '../common/withErrorBoundary'
 import { taggingNameCapitalSetting, taggingNameIsSet } from '../../lib/instanceSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import ContentType from "../posts/PostsPage/ContentType";
 import SingleLineTagUpdates from "./SingleLineTagUpdates";
 import LoadMore from "../common/LoadMore";
@@ -12,9 +11,9 @@ import { withDateFields } from '@/lib/utils/dateUtils';
 
 const INITIAL_LIMIT = 5
 
-const styles = (_: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   subtitle: {
-    marginTop: isFriendlyUI ? 20 : 6,
+    marginTop: theme.isFriendlyUI ? 20 : 6,
     marginBottom: 6
   },
 });

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -5,7 +5,6 @@ import { tagStyle } from './FooterTag';
 import { usePersonalBlogpostInfo } from './usePersonalBlogpostInfo';
 import { userHasNewTagSubscriptions } from '../../lib/betas';
 import { taggingNameCapitalSetting } from '../../lib/instanceSettings';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import AddTagButton from "./AddTagButton";
 import LWTooltip from "../common/LWTooltip";
 import FilterMode, { filteringStyles } from './FilterMode';
@@ -21,7 +20,7 @@ const styles = defineStyles("TagFilterSettings", (theme: ThemeType) => ({
     display: "flex",
     flexWrap: "wrap",
     alignItems: "center",
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         marginTop: 8,
       } : {
@@ -48,7 +47,7 @@ const styles = defineStyles("TagFilterSettings", (theme: ThemeType) => ({
     ...filteringStyles(theme),
   },
   personalAndPlus: {
-    ...(isFriendlyUI ? {} : {
+    ...(theme.isFriendlyUI ? {} : {
       gap: "4px",
       display: "flex",
       alignItems: "center"

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -13,7 +13,6 @@ import { useTagBySlug } from './useTag';
 import { tagGetHistoryUrl, tagMinimumKarmaPermissions, tagUserHasSufficientKarma, isTagAllowedType3Audio } from '../../lib/collections/tags/helpers';
 import { isLWorAF } from '@/lib/instanceSettings';
 import type { TagLens } from '@/lib/arbital/useTagLenses';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { AnalyticsContext, useTracking } from '@/lib/analyticsEvents';
 import LoginPopup from "../users/LoginPopup";
 import NewLensDialog from "./lenses/NewLensDialog";
@@ -31,14 +30,14 @@ const PODCAST_ICON_PADDING = 3;
 const styles = (theme: ThemeType) => ({
   buttonsRow: {
     ...theme.typography.body2,
-    marginTop: isFriendlyUI ? 2 : undefined,
-    marginBottom: isFriendlyUI ? 16 : undefined,
+    marginTop: theme.isFriendlyUI ? 2 : undefined,
+    marginBottom: theme.isFriendlyUI ? 16 : undefined,
     color: theme.palette.grey[700],
     display: "flex",
     flexWrap: "wrap",
     columnGap: 16,
     [theme.breakpoints.down('xs')]: {
-      marginTop: isFriendlyUI ? 8 : undefined,
+      marginTop: theme.isFriendlyUI ? 8 : undefined,
     },
     '& svg': {
       height: 20,
@@ -87,7 +86,7 @@ const styles = (theme: ThemeType) => ({
   },
   subscribeToWrapper: {
     display: "flex !important",
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
     } : {
       marginLeft: -2,
       marginRight: -5,
@@ -116,7 +115,7 @@ const styles = (theme: ThemeType) => ({
     width: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2) + "px !important",
     height: PODCAST_ICON_SIZE + (PODCAST_ICON_PADDING * 2) + "px !important",
     padding: PODCAST_ICON_PADDING,
-    transform: isFriendlyUI ? undefined : `translateY(-3px)`,
+    transform: theme.isFriendlyUI ? undefined : `translateY(-3px)`,
     marginRight: -3
   },
   audioIconOn: {

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -30,7 +30,7 @@ const PostsListMultiQuery = gql(`
 
 const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI ? {
+    ...(theme.isFriendlyUI ? {
       paddingTop: 8,
       paddingLeft: 16,
       paddingRight: 16,
@@ -46,7 +46,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
     width: FRIENDLY_HOVER_OVER_WIDTH,
   },
   mainContent: {
-    ...(!isFriendlyUI && {
+    ...(!theme.isFriendlyUI && {
       paddingLeft: 16,
       paddingRight: 16,
       maxHeight: 600,
@@ -65,7 +65,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
   relatedTagWrapper: {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
     fontSize: "1.1rem",
     color: theme.palette.grey[900],
     display: '-webkit-box',
@@ -139,7 +139,7 @@ const styles = defineStyles('TagPreview', (theme: ThemeType) => ({
     },
   },
   description: {
-    ...(!isFriendlyUI && { marginTop: 16 }),
+    ...(!theme.isFriendlyUI && { marginTop: 16 }),
   },
 }));
 

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { taggingNameCapitalSetting, taggingNameSetting } from '../../lib/instanceSettings';
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import { useVoteButtonsDisabled } from '../votes/useVoteButtonsDisabled';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useVote } from '../votes/withVote';
@@ -11,7 +11,7 @@ import LWTooltip from "../common/LWTooltip";
 
 const styles = (theme: ThemeType) => ({
   relevance: {
-    marginTop: isFriendlyUI ? undefined : 2,
+    marginTop: theme.isFriendlyUI ? undefined : 2,
     marginLeft: 16,
     ...theme.typography.commentStyle,
   },
@@ -22,7 +22,7 @@ const styles = (theme: ThemeType) => ({
   voteButton: {
     display: "inline-block",
     fontSize: 25,
-    transform: isFriendlyUI ? "translateY(2px)" : undefined,
+    transform: theme.isFriendlyUI ? "translateY(2px)" : undefined,
   },
   score: {
     marginLeft: 4,
@@ -30,7 +30,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[1000],
   },
   removeButton: {
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         float: "right",
         marginTop: 10,
@@ -43,7 +43,7 @@ const styles = (theme: ThemeType) => ({
       }),
   },
   removed: {
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         float: "right",
         marginTop: 12,

--- a/packages/lesswrong/components/tagging/TagRevisionItemFullMetadata.tsx
+++ b/packages/lesswrong/components/tagging/TagRevisionItemFullMetadata.tsx
@@ -10,9 +10,9 @@ import SmallSideVote from "../votes/SmallSideVote";
 
 const styles = (theme: ThemeType) => ({
   root: {
-    marginBottom: isFriendlyUI ? 12 : undefined,
+    marginBottom: theme.isFriendlyUI ? 12 : undefined,
   },
-  tagName: isFriendlyUI
+  tagName: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 16,
@@ -28,7 +28,7 @@ const styles = (theme: ThemeType) => ({
       display: "block",
       fontSize: "1.75rem",
     },
-  metadata: isFriendlyUI
+  metadata: theme.isFriendlyUI
     ? {
       fontFamily: theme.palette.fonts.sansSerifStack,
       fontSize: 14,
@@ -43,14 +43,14 @@ const styles = (theme: ThemeType) => ({
       ...theme.typography.commentStyle
     },
   metadataText: {
-    fontStyle: isFriendlyUI ? "italic" : undefined,
+    fontStyle: theme.isFriendlyUI ? "italic" : undefined,
   },
   username: {
     ...theme.typography.commentStyle,
     color: theme.palette.text.normal,
   },
   changeMetrics: {
-    marginRight: isFriendlyUI ? 8 : undefined,
+    marginRight: theme.isFriendlyUI ? 8 : undefined,
   },
 });
 

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import UsersName from "../users/UsersName";
 import MetaInfo from "../common/MetaInfo";
@@ -32,7 +31,7 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 2,
   },
   title: {
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         fontFamily: theme.palette.fonts.sansSerifStack,
         fontWeight: 600,
@@ -51,7 +50,7 @@ const styles = (theme: ThemeType) => ({
     whiteSpace: "unset",
     lineHeight: "1.1em",
     marginBottom: 4,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       lineHeight: '1.2em'
     }),
   },

--- a/packages/lesswrong/components/tagging/TagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/TagsChecklist.tsx
@@ -3,7 +3,6 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import { tagStyle, coreTagStyle, smallTagTextStyle } from './FooterTag';
 import { taggingNameSetting } from '../../lib/instanceSettings';
 import classNames from 'classnames';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LWTooltip from "../common/LWTooltip";
 import LoadMore from "../common/LoadMore";
 import ForumIcon from "../common/ForumIcon";
@@ -30,7 +29,7 @@ const styles = (theme: ThemeType) => ({
       border: theme.palette.border.grey300,
       color: theme.palette.grey[800]
     },
-    ...(isFriendlyUI
+    ...(theme.isFriendlyUI
       ? {
         ...coreTagStyle(theme),
         opacity: 0.6,
@@ -43,7 +42,7 @@ const styles = (theme: ThemeType) => ({
     position: 'relative',
     columnGap: 4,
     ...tagStyle(theme),
-    ...(isFriendlyUI ? coreTagStyle(theme) : {}),
+    ...(theme.isFriendlyUI ? coreTagStyle(theme) : {}),
     cursor: 'default'
   },
   smallTag: {

--- a/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
@@ -6,7 +6,6 @@ import { useCurrentUser } from '../common/withUser';
 import { EditTagForm } from './EditTagPage';
 import { useLocation } from '../../lib/routeUtil';
 import classNames from 'classnames'
-import { isFriendlyUI } from '@/themes/forumTheme';
 import LinkCard from "../common/LinkCard";
 import TagPreviewDescription from "./TagPreviewDescription";
 import TagSmallPostLink from "./TagSmallPostLink";
@@ -56,7 +55,7 @@ const styles = (theme: ThemeType) => ({
       width: "100%",
       maxWidth: "unset"
     },
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       maxWidth: 490,
     }),
   },

--- a/packages/lesswrong/components/tagging/TagsTooltip.tsx
+++ b/packages/lesswrong/components/tagging/TagsTooltip.tsx
@@ -1,7 +1,6 @@
 import React, { FC, ReactNode, useCallback, useState } from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useTagPreview } from "./useTag";
-import { isFriendlyUI } from "../../themes/forumTheme";
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from "classnames";
 import type { Placement as PopperPlacementType } from "popper.js"
@@ -20,14 +19,14 @@ import TagPreview from "./TagPreview";
 import LWClickAwayListener from "../common/LWClickAwayListener";
 
 const styles = defineStyles("TagsTooltip", theme => ({
-  tooltip: isFriendlyUI
+  tooltip: theme.isFriendlyUI
     ? {}
     : {
       padding: 0,
       background: theme.palette.panelBackground.default,
       boxShadow: theme.palette.boxShadow.lwTagHoverOver,
     },
-  tooltipTitle: isFriendlyUI
+  tooltipTitle: theme.isFriendlyUI
     ? {}
     : {
       maxWidth: "unset",

--- a/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
+++ b/packages/lesswrong/components/tagging/history/TagHistoryPage.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react'
 import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { useTagBySlug } from '../useTag';
 import { useLocation } from '../../../lib/routeUtil';
-import { isFriendlyUI } from '../../../themes/forumTheme';
 import { addDefaultLensToLenses, TagLens } from '@/lib/arbital/useTagLenses';
 import keyBy from 'lodash/keyBy';
 import { RevealHiddenBlocks, RevealHiddenBlocksContext } from '@/components/editor/conditionalVisibilityBlock/ConditionalVisibilityBlockDisplay';
@@ -34,7 +33,7 @@ import { TagHistoryFeedQuery } from '@/components/common/feeds/feedQueries';
 
 export const tagHistoryStyles = defineStyles("TagHistoryPage", (theme: ThemeType) => ({
   title: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   feed: {
     ...theme.typography.body2,

--- a/packages/lesswrong/components/tanstack-form-components/TanStackSubmit.tsx
+++ b/packages/lesswrong/components/tanstack-form-components/TanStackSubmit.tsx
@@ -1,9 +1,7 @@
-import { isFriendlyUI } from '../../themes/forumTheme';
-
 export const submitButtonStyles = (theme: ThemeType) => ({
   fontFamily: theme.typography.fontFamily,
   marginLeft: "5px",
-  ...(isFriendlyUI
+  ...(theme.isFriendlyUI
     ? {
       fontSize: 14,
       fontWeight: 500,
@@ -31,7 +29,7 @@ export const cancelButtonStyles = (theme: ThemeType) => ({
   "&:hover": {
     background: theme.palette.panelBackground.darken05,
   },
-  ...(isFriendlyUI
+  ...(theme.isFriendlyUI
     ? {
       fontSize: 14,
       fontWeight: 500,

--- a/packages/lesswrong/components/themes/ThemePickerMenu.tsx
+++ b/packages/lesswrong/components/themes/ThemePickerMenu.tsx
@@ -8,7 +8,6 @@ import { useCurrentUser } from '../common/withUser';
 import { isMobile } from '../../lib/utils/isMobile'
 import { Paper }from '@/components/widgets/Paper';
 import Info from '@/lib/vendor/@material-ui/icons/src/Info';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import LWTooltip from "../common/LWTooltip";
 import { Typography } from "../common/Typography";
 import DropdownMenu from "../dropdowns/DropdownMenu";
@@ -16,7 +15,7 @@ import DropdownItem from "../dropdowns/DropdownItem";
 import DropdownDivider from "../dropdowns/DropdownDivider";
 import ForumIcon from "../common/ForumIcon";
 
-const styles = (_theme: ThemeType) => ({
+const styles = (theme: ThemeType) => ({
   check: {
     width: 20,
     marginRight: 8,
@@ -30,7 +29,7 @@ const styles = (_theme: ThemeType) => ({
   },
   infoIcon: {
     fontSize: 14,
-    marginLeft: isFriendlyUI ? 6 : 0,
+    marginLeft: theme.isFriendlyUI ? 6 : 0,
   },
 })
 

--- a/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
@@ -14,7 +14,7 @@ import { TagCommentType } from '../../lib/collections/comments/types';
 import { tagGetHistoryUrl } from '../../lib/collections/tags/helpers';
 import type { ReactionChange } from '../../server/collections/users/karmaChangesGraphQL';
 import { getKarmaNotificationTimingChoices } from './KarmaChangeNotifierSettings';
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import { isEAForum } from '../../lib/instanceSettings';
 import { eaAnonymousEmojiPalette, eaEmojiPalette } from '../../lib/voting/eaEmojiPalette';
 import classNames from 'classnames';
@@ -57,7 +57,7 @@ const styles = defineStyles("KarmaChangeNotifier", (theme: ThemeType) => ({
     zIndex: theme.zIndexes.karmaChangeNotifier,
   },
   starIcon: {
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.header.text,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.header.text,
     ...isIfAnyoneBuildsItFrontPage({
       color: theme.palette.text.bannerAdOverlay,
     }),
@@ -80,12 +80,12 @@ const styles = defineStyles("KarmaChangeNotifier", (theme: ThemeType) => ({
     textAlign: "right",
   },
   votedItemReacts: {
-    marginLeft: isEAForum ? 12 : 6,
+    marginLeft: theme.isEAForum ? 12 : 6,
   },
   individualAddedReact: {
-    color: isEAForum ? theme.palette.primary.main : undefined,
+    color: theme.isEAForum ? theme.palette.primary.main : undefined,
     marginLeft: 2,
-    marginRight: isEAForum ? 6 : undefined,
+    marginRight: theme.isEAForum ? 6 : undefined,
   },
   votedItemDescription: {
     display: "inline-block",

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -10,7 +10,7 @@ import moment from '../../lib/moment-timezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
 import { karmaChangeNotifierDefaultSettings, KarmaChangeUpdateFrequency, type KarmaChangeSettingsType } from '../../lib/collections/users/helpers';
 import * as _ from 'underscore';
-import { isFriendlyUI, preferredHeadingCase } from '../../themes/forumTheme';
+import { preferredHeadingCase } from '../../themes/forumTheme';
 import { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { Typography } from "../common/Typography";
@@ -22,7 +22,7 @@ const styles = defineStyles('KarmaChangeNotifierSettings', (theme: ThemeType) =>
     paddingRight: 8,
   },
   heading: {
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
   },
   radioGroup: {
     display: "flex",

--- a/packages/lesswrong/components/users/UserTooltip.tsx
+++ b/packages/lesswrong/components/users/UserTooltip.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode } from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import type { Placement as PopperPlacementType } from "popper.js"
-import { isFriendlyUI } from "../../themes/forumTheme";
 import HoverOver from "../common/HoverOver";
 import EAUserTooltipContent from "./EAUserTooltipContent";
 import LWUserTooltipContent from "./LWUserTooltipContent";
+import { isFriendlyUI } from "@/themes/forumTheme";
 
-const styles = () => ({
-  root: isFriendlyUI
+const styles = (theme: ThemeType) => ({
+  root: theme.isFriendlyUI
     ? {
       padding: 12,
       top: 2,
@@ -16,7 +16,7 @@ const styles = () => ({
       padding: 0,
       background: "unset",
     },
-  overrideTooltip: isFriendlyUI
+  overrideTooltip: theme.isFriendlyUI
   ? {}
   : {
     padding: 0,
@@ -34,7 +34,7 @@ const UserTooltip = ({user, placement, inlineBlock, hideFollowButton, disabled, 
   children: ReactNode,
   classes: ClassesType<typeof styles>,
 }) => {
-  const content = isFriendlyUI 
+  const content = isFriendlyUI
     ? <EAUserTooltipContent user={user} />
     : <LWUserTooltipContent user={user} hideFollowButton={hideFollowButton} />;
   return (

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -14,11 +14,11 @@ import { Paper } from '../widgets/Paper';
 
 const styles = (theme: ThemeType) => ({
   root: {
-    marginTop: isFriendlyUI ? undefined : 5,
+    marginTop: theme.isFriendlyUI ? undefined : 5,
   },
   userButton: {
     fontSize: '14px',
-    fontWeight: isFriendlyUI ? undefined : 400,
+    fontWeight: theme.isFriendlyUI ? undefined : 400,
     opacity: .8,
     color: blackBarTitle.get() ? theme.palette.text.alwaysWhite : theme.palette.header.text,
   },

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -40,21 +40,21 @@ import { isIfAnyoneBuildsItFrontPage } from '../seasonal/IfAnyoneBuildsItSplash'
 
 const styles = (theme: ThemeType) => ({
   root: {
-    marginTop: isFriendlyUI ? undefined : 5,
+    marginTop: theme.isFriendlyUI ? undefined : 5,
     wordBreak: 'break-all',
     position: "relative"
   },
   userButtonRoot: {
     // Mui default is 16px, so we're halving it to bring it into line with the
     // rest of the header components
-    paddingLeft: isFriendlyUI ? 12 : theme.spacing.unit,
+    paddingLeft: theme.isFriendlyUI ? 12 : theme.spacing.unit,
     paddingRight: theme.spacing.unit,
-    borderRadius: isFriendlyUI ? theme.borderRadius.default : undefined
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.default : undefined
   },
   userButtonContents: {
     textTransform: 'none',
     fontSize: '16px',
-    fontWeight: isFriendlyUI ? undefined : 400,
+    fontWeight: theme.isFriendlyUI ? undefined : 400,
     color: blackBarTitle.get() ? theme.palette.text.alwaysWhite : theme.palette.header.text,
     ...isIfAnyoneBuildsItFrontPage({
       color: theme.palette.text.bannerAdOverlay,
@@ -75,7 +75,7 @@ const styles = (theme: ThemeType) => ({
     opacity: 0.9
   },
   icon: {
-    color: isFriendlyUI ? undefined : theme.palette.grey[500]
+    color: theme.isFriendlyUI ? undefined : theme.palette.grey[500]
   },
   deactivatedTooltip: {
     maxWidth: 230
@@ -84,7 +84,7 @@ const styles = (theme: ThemeType) => ({
     color: theme.palette.grey[600],
     marginLeft: 20
   },
-  adminToggleItem: isFriendlyUI ? {
+  adminToggleItem: theme.isFriendlyUI ? {
     display: 'none',
     [theme.breakpoints.down('xs')]: {
       display: 'block'

--- a/packages/lesswrong/components/users/UsersViewABTests.tsx
+++ b/packages/lesswrong/components/users/UsersViewABTests.tsx
@@ -5,7 +5,6 @@ import { useCurrentUser } from '../common/withUser';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import Select from '@/lib/vendor/@material-ui/core/src/Select';
 import * as _ from 'underscore';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import SingleColumnSection from "../common/SingleColumnSection";
 import SectionTitle from "../common/SectionTitle";
 import { MenuItem } from "../common/Menus";
@@ -13,13 +12,13 @@ import { MenuItem } from "../common/Menus";
 const styles = (theme: ThemeType) => ({
   explanatoryText: {
     ...theme.typography.body1,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
   },
   abTestsTable: {
     ...theme.typography.body1,
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       fontFamily: theme.palette.fonts.sansSerifStack,
     }),
     marginTop: 24,

--- a/packages/lesswrong/components/users/account/UsersAccount.tsx
+++ b/packages/lesswrong/components/users/account/UsersAccount.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '@/lib/vulcan-lib/components';
 import React from 'react';
 import { useLocation } from '@/lib/routeUtil';
 import { userCanEditUser } from '@/lib/collections/users/helpers';
-import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
+import { preferredHeadingCase } from '@/themes/forumTheme';
 import { useCurrentUser } from '@/components/common/withUser';
 import { hasAccountDeletionFlow } from '@/lib/betas';
 import UsersEditForm from "./UsersEditForm";
@@ -22,9 +22,9 @@ const styles = (theme: ThemeType) => ({
   },
   header: {
     margin: 0,
-    paddingTop: isFriendlyUI ? '32px' : '16px',
-    paddingBottom: isFriendlyUI ? '16px' : '32px',
-    paddingLeft: isFriendlyUI ? '4px' : '16px',
+    paddingTop: theme.isFriendlyUI ? '32px' : '16px',
+    paddingBottom: theme.isFriendlyUI ? '16px' : '32px',
+    paddingLeft: theme.isFriendlyUI ? '4px' : '16px',
     paddingRight: '16px',
     [theme.breakpoints.down('xs')]: {
       paddingLeft: "4px",

--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -68,7 +68,7 @@ const GetUserBySlugQuery = gql(`
 
 const styles = defineStyles('UsersEditForm', (theme: ThemeType) => ({
   root: {
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       "& .form-submit": {
         display: "flex",
         flexDirection: "column",

--- a/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/AgreementVoteAxis.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { useVoteButtonsDisabled } from './useVoteButtonsDisabled';
 import { VotingProps } from './votingProps';
-import { isFriendlyUI } from '../../themes/forumTheme';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import classNames from 'classnames';
 import VoteAgreementIcon from "./VoteAgreementIcon";
@@ -19,7 +18,7 @@ const styles = defineStyles('AgreementVoteAxis', (theme: ThemeType) => ({
     lineHeight: 0.6,
     height: 24,
     minWidth: 60,
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : 2,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : 2,
     textAlign: 'center',
     whiteSpace: "nowrap",
   },

--- a/packages/lesswrong/components/votes/LWPostsPageTopHeaderVote.tsx
+++ b/packages/lesswrong/components/votes/LWPostsPageTopHeaderVote.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 import { useVote } from './withVote';
-import { isAF, isLW } from '../../lib/instanceSettings';
+import { isAF } from '../../lib/instanceSettings';
 import { useVoteButtonsDisabled } from './useVoteButtonsDisabled';
 import { VotingSystem } from '../../lib/voting/votingSystems';
 import { TooltipSpan } from '../common/FMTooltip';
@@ -29,7 +29,7 @@ const styles = (theme: ThemeType) => ({
     },
   },
   voteScoresHorizontal: {
-    margin: isLW ? '-2px 8px' : '-4px 8px'
+    margin: theme.isLW ? '-2px 8px' : '-4px 8px'
   },
   voteScore: {
     color: theme.palette.grey[600],

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -16,12 +16,12 @@ const styles = defineStyles('OverallVoteAxis', theme => ({
   overallSection: {
     display: 'inline-block',
     height: 24,
-    paddingTop: isFriendlyUI ? 2.5 : 0
+    paddingTop: theme.isFriendlyUI ? 2.5 : 0
   },
   overallSectionBox: {
     marginLeft: 8,
     outline: theme.palette.border.commentBorder,
-    borderRadius: isFriendlyUI ? theme.borderRadius.small : 2,
+    borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : 2,
     textAlign: 'center',
     minWidth: 60
   },

--- a/packages/lesswrong/components/votes/PostsVoteDefault.tsx
+++ b/packages/lesswrong/components/votes/PostsVoteDefault.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '../../lib/vulcan-lib/components';
 import React, { Ref } from 'react';
 import classNames from 'classnames';
 import { useVote } from './withVote';
-import { isAF, isLW } from '../../lib/instanceSettings';
+import { isAF } from '../../lib/instanceSettings';
 import { useVoteButtonsDisabled } from './useVoteButtonsDisabled';
 import { VotingSystem } from '../../lib/voting/votingSystems';
 import { isFriendlyUI } from '../../themes/forumTheme';
@@ -35,10 +35,10 @@ const styles = (theme: ThemeType) => ({
   voteScores: {
     margin:"15%",
     
-    ...(isLW && {
+    ...(theme.isLW && {
       margin: "25% 15% 15% 15%"
     }),
-    ...(isAF && {
+    ...(theme.isAF && {
       fontVariantNumeric: "lining-nums",
     }),
   },
@@ -46,13 +46,13 @@ const styles = (theme: ThemeType) => ({
     margin: '0 12px'
   },
   voteScore: {
-    color: isFriendlyUI ? theme.palette.grey[600] : theme.palette.grey[500],
-    fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+    color: theme.isFriendlyUI ? theme.palette.grey[600] : theme.palette.grey[500],
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
     position: 'relative',
     zIndex: theme.zIndexes.postsVote,
-    fontSize: isFriendlyUI ? '50%' : '55%',
+    fontSize: theme.isFriendlyUI ? '50%' : '55%',
     
-    ...(isFriendlyUI && {
+    ...(theme.isFriendlyUI && {
       paddingTop:4,
       paddingBottom:2,
       paddingLeft:1,
@@ -81,7 +81,7 @@ const styles = (theme: ThemeType) => ({
     backgroundColor: theme.palette.panelBackground.default,
     transition: 'opacity 150ms cubic-bezier(0.4, 0, 1, 1) 0ms',
     marginLeft: 0,
-    paddingTop: isFriendlyUI ? 12 : 0
+    paddingTop: theme.isFriendlyUI ? 12 : 0
   },
 });
 

--- a/packages/lesswrong/components/votes/VoteArrowIconHollow.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIconHollow.tsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 import classNames from 'classnames';
 import UpArrowIcon from '@/lib/vendor/@material-ui/icons/src/KeyboardArrowUp';
 import Transition from 'react-transition-group/Transition';
-import { isEAForum } from '../../lib/instanceSettings';
 import type { VoteArrowIconProps } from './VoteArrowIcon';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { getVoteButtonColor, voteButtonSharedStyles } from './VoteButton';
@@ -13,7 +12,7 @@ const styles = defineStyles("VoteArrowIconHollow", (theme: ThemeType) => ({
   },
   smallArrow: {
     fontSize: '50%',
-    opacity: isEAForum ? 0.7 : 0.6,
+    opacity: theme.isEAForum ? 0.7 : 0.6,
   },
   up: {
   },

--- a/packages/lesswrong/components/votes/VoteArrowIconSolid.tsx
+++ b/packages/lesswrong/components/votes/VoteArrowIconSolid.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { SoftUpArrowIcon } from '../icons/softUpArrowIcon';
 import { SoftUpArrowIconCap } from '../icons/softUpArrowIconCap';
-import { isEAForum } from '../../lib/instanceSettings';
 import type { BaseVoteArrowIconProps } from './VoteArrowIcon';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import { getVoteButtonColor, voteButtonSharedStyles } from './VoteButton';
@@ -15,11 +14,11 @@ const styles = defineStyles("VoteArrowIconSolid", (theme: ThemeType) => ({
     cursor: 'not-allowed',
   },
   smallArrow: {
-    opacity: isEAForum ? 0.7 : 0.6,
+    opacity: theme.isEAForum ? 0.7 : 0.6,
     pointerEvents: 'none',
   },
   smallArrowLarge: {
-    opacity: isEAForum ? 0.7 : 0.6,
+    opacity: theme.isEAForum ? 0.7 : 0.6,
     pointerEvents: 'none',
   },
   up: {

--- a/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormGroup.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import * as _ from 'underscore';
-import { isFriendlyUI } from '../../themes/forumTheme';
 
 const headerStyles = (theme: ThemeType) => ({
   formSectionHeading: {
@@ -20,7 +19,7 @@ const headerStyles = (theme: ThemeType) => ({
   formSectionHeadingTitle: {
     marginBottom: 5,
     fontSize: "1.25rem",
-    fontWeight: isFriendlyUI ? 600 : undefined,
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
   },
 });
 

--- a/packages/lesswrong/components/widgets/SnackbarContent.tsx
+++ b/packages/lesswrong/components/widgets/SnackbarContent.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '../hooks/useStyles';
-import { isFriendlyUI } from '@/themes/forumTheme';
 import { Paper } from './Paper';
 import { Typography } from "../common/Typography";
 
@@ -27,7 +26,7 @@ export const styles = defineStyles("MuiSnackbarContent", theme => {
     message: {
       padding: '8px 0',
       color: theme.palette.text.maxIntensity,
-      fontFamily: isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
+      fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : undefined,
     },
     /* Styles applied to the action wrapper element if `action` is provided. */
     action: {

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -1,6 +1,8 @@
 import transitions from '@/lib/vendor/@material-ui/core/src/styles/transitions';
 import { defaultShadePalette, defaultComponentPalette } from './defaultPalette';
 import { defaultZIndexes } from "./zIndexes";
+import { isBookUI, isFriendlyUI } from './forumTheme';
+import { isAF, isEAForum, isLW, isLWorAF } from '@/lib/instanceSettings';
 
 const monoStack = [
   '"Liberation Mono"',
@@ -313,6 +315,12 @@ export const baseTheme: BaseThemeSpecification = {
           initial-value: 36%;
         }`
       ],
-    }
+      isBookUI,
+      isFriendlyUI,
+      isLW,
+      isAF,
+      isLWorAF,
+      isEAForum,
+    };
   }
 };

--- a/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/alignmentForumTheme.ts
@@ -98,7 +98,14 @@ export const alignmentForumTheme: SiteThemeSpecification = {
       },
     },
     overrides: {
-    }
+    },
+
+    isBookUI: true,
+    isFriendlyUI: false,
+    isLW: false,
+    isAF: true,
+    isLWorAF: true,
+    isEAForum: false,
   }),
 };
 

--- a/packages/lesswrong/themes/siteThemes/eaTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/eaTheme.ts
@@ -251,7 +251,14 @@ export const eaForumTheme: SiteThemeSpecification = {
             borderRadius: defaultBorderRadius
           }
         }
-      }
+      },
+
+      isBookUI: false,
+      isFriendlyUI: true,
+      isLW: false,
+      isAF: false,
+      isLWorAF: false,
+      isEAForum: true,
     }
   }
 };

--- a/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/lesswrongTheme.ts
@@ -129,6 +129,13 @@ export const lessWrongTheme: SiteThemeSpecification = {
           paddingBottom: 8
         }
       },
-    }
+    },
+
+    isBookUI: true,
+    isFriendlyUI: false,
+    isLW: true,
+    isAF: false,
+    isLWorAF: true,
+    isEAForum: false,
   }),
 };

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -728,6 +728,13 @@ declare global {
     },
     transitions: MuiTransitions,
     direction: "ltr"|"rtl",
+    
+    isBookUI: boolean,
+    isFriendlyUI: boolean,
+    isLW: boolean,
+    isAF: boolean,
+    isLWorAF: boolean,
+    isEAForum: boolean,
   };
 
   type NativeThemeType = Omit<ThemeType,"palette"|"forumType"|"themeOptions"|"breakpoints"> & { breakpoints: Omit<ThemeType["breakpoints"], "up"|"down"> };

--- a/packages/lesswrong/themes/themeType.ts
+++ b/packages/lesswrong/themes/themeType.ts
@@ -642,6 +642,15 @@ declare global {
     shadePalette: ThemeShadePalette
   }
   
+  type ForumTypeFlags = {
+    isBookUI: boolean,
+    isFriendlyUI: boolean,
+    isLW: boolean,
+    isAF: boolean,
+    isLWorAF: boolean,
+    isEAForum: boolean,
+  }
+  
   type ThemeType = {
     forumType: ForumTypeString,
     themeOptions: ThemeOptions,
@@ -728,14 +737,7 @@ declare global {
     },
     transitions: MuiTransitions,
     direction: "ltr"|"rtl",
-    
-    isBookUI: boolean,
-    isFriendlyUI: boolean,
-    isLW: boolean,
-    isAF: boolean,
-    isLWorAF: boolean,
-    isEAForum: boolean,
-  };
+  } & ForumTypeFlags;
 
   type NativeThemeType = Omit<ThemeType,"palette"|"forumType"|"themeOptions"|"breakpoints"> & { breakpoints: Omit<ThemeType["breakpoints"], "up"|"down"> };
   


### PR DESCRIPTION
Adds forum-gating flags (`isBookUI`, `isLWorAF`, etc) to the theme, the modifies style blocks that contain forum gating to get information from the theme, rather than importing global flags. This makes it so that the site-theme-override debug option in the user menu will be able to change styles that are forum-gated this way, and also makes it so that, if we do decide to host LW and AF out of the same server processes, the number of forum-gating-lines that will need handling will be much lower.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211127877551675) by [Unito](https://www.unito.io)
