### PR TITLE
Don't send curation emails for posts if they were un-curated during the admin preview window

### DIFF
--- a/packages/lesswrong/server/curationEmails/cron.tsx
+++ b/packages/lesswrong/server/curationEmails/cron.tsx
@@ -49,6 +49,7 @@ export async function sendCurationEmail({users, postId, reason, subject}: {
   // ...but it might actually be better to not, since this allows us to e.g. edit the post after the job has started if there's some egregious issue
   const post = await Posts.findOne(postId);
   if (!post) throw Error(`Can't find post to send by email: ${postId}`)
+  if (!post.curatedDate) throw Error(`Post is not curated`);
 
   for (const user of users) {
     await wrapAndSendEmail({


### PR DESCRIPTION
This used to be checked, but was broken when we introduced a curation-emails queue in 95d4a135a23a7bbcb004795ae4d7b539095e1c9f.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211127923554327) by [Unito](https://www.unito.io)
