### PR TITLE
Fix editing sequences

### DIFF
--- a/packages/lesswrong/components/editor/CKPostEditor.tsx
+++ b/packages/lesswrong/components/editor/CKPostEditor.tsx
@@ -379,6 +379,9 @@ const postEditorToolbarConfig = {
   },
 };
 
+/**
+ * This is called `PostEditor`, but note that it is also used for sequences
+ */
 const CKPostEditor = ({
   data,
   collectionName,
@@ -418,8 +421,10 @@ const CKPostEditor = ({
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
   const { openDialog } = useDialog();
-  const post = (document as PostsEdit);
-  const isBlockOwnershipMode = isCollaborative && post.collabEditorDialogue;
+  const postOrSequence = (document as PostsEdit | SequencesEdit);
+  const isBlockOwnershipMode = isCollaborative &&
+    "collabEditorDialogue" in postOrSequence &&
+    postOrSequence.collabEditorDialogue;
   const portalContext = useContext(CkEditorPortalContext);
   
   const getInitialCollaborationMode = () => {
@@ -464,7 +469,7 @@ const CKPostEditor = ({
 
     await sendNewDialogueMessageNotification({
       variables: {
-        postId: post._id,
+        postId: postOrSequence._id,
         dialogueHtml: editorContents
       }
     });
@@ -596,7 +601,7 @@ const CKPostEditor = ({
       accessLevel={accessLevel||"none"}
       collaborationMode={collaborationMode}
       setCollaborationMode={changeCollaborationMode}
-      post={post}
+      post={postOrSequence as PostsEdit}
       connectedUsers={connectedUsers}
     />}
     
@@ -634,9 +639,28 @@ const CKPostEditor = ({
           setEditor(editor);
         }
 
-        const userIds = formType === 'new' ? [userId] : [post.userId, ...post.coauthorUserIds];
-        if (post.collabEditorDialogue && accessLevel && accessLevelCan(accessLevel, 'edit')) {
-          const rawAuthors = formType === 'new' ? [currentUser!] : filterNonnull([post.user, ...(post.coauthors ?? [])])
+        const userIds = formType === 'new'
+          ? [userId]
+          : [
+            postOrSequence.userId,
+            ...(
+              "coauthorUserIds" in postOrSequence
+                ? postOrSequence.coauthorUserIds
+                : []
+            ),
+          ];
+        if (
+          "collabEditorDialogue" in postOrSequence &&
+          postOrSequence.collabEditorDialogue &&
+          accessLevel &&
+          accessLevelCan(accessLevel, 'edit')
+        ) {
+          const rawAuthors = formType === 'new'
+            ? [currentUser!]
+            : filterNonnull([
+              postOrSequence.user,
+              ...(postOrSequence.coauthors ?? [])
+            ]);
           const coauthors = uniqBy(
             rawAuthors.filter(coauthor => userIds.includes(coauthor._id)),
             (user) => user._id,
@@ -731,7 +755,10 @@ const CKPostEditor = ({
       }}
       config={editorConfig}
     />}
-    {post.collabEditorDialogue && !isFriendlyUI ? <DialogueEditorFeedback post={post} /> : null}
+    {"collabEditorDialogue" in postOrSequence && postOrSequence.collabEditorDialogue && !isFriendlyUI
+      ? <DialogueEditorFeedback post={postOrSequence} /> 
+      : null
+    }
   </div>
 }
 


### PR DESCRIPTION
Editing the description of a sequence confusingly uses the `CkPostEditor` component. Unfortunately that component (reasonably, given its name) always assumes that the document it's given is a post. This accidentally worked fine up until the recent change to coauthor handling, but it now throws an error when we try to spread `coauthorUserIds` which only exists on posts, not sequences. This PR changes `CkPostEditor` to be aware the it's document may be either a post or a sequence. This probably warrants a more thorough refactor in the future, but this will do for now.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211198257600507) by [Unito](https://www.unito.io)
