### PR TITLE
Make OWID iframe bigger

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -284,7 +284,7 @@ export const linkStyles = defineStyles("LinkStyles", (theme: ThemeType) => ({
   
   owidIframe: {
     width: 600,
-    height: 375,
+    height: 600,
     border: "none",
     maxWidth: "100vw",
   },


### PR DESCRIPTION
A graph on [this post](https://forum.effectivealtruism.org/posts/TLbctDQJEZtZhAAur/global-economic-inequality) was too squashed when using a height of 375px.

Before/after:
<img width="1285" height="724" alt="Screenshot 2025-09-04 at 11 48 58" src="https://github.com/user-attachments/assets/82131d4c-a809-478c-92d9-3420ff03befa" />
<img width="1285" height="724" alt="Screenshot 2025-09-04 at 11 49 56" src="https://github.com/user-attachments/assets/cdcd5025-5203-466b-a960-5c7db4d0f2a6" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211244602014923) by [Unito](https://www.unito.io)
