### PR TITLE
Unbreak and improve printing on post pages

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -300,7 +300,7 @@ const CommentsNodeInner = ({
     handleExpand({ event, scroll: scrollOnExpand });
   }, [handleExpand, scrollOnExpand]);
 
-  return <div className={comment.gapIndicator ? classes.gapIndicator : undefined}>
+  const result = (
     <CommentFrame
       comment={comment}
       treeOptions={treeOptions}
@@ -364,7 +364,15 @@ const CommentsNodeInner = ({
         </div>
       }
     </CommentFrame>
-  </div>
+  );
+  
+  if (comment.gapIndicator) {
+    return <div className={classes.gapIndicator}>
+      {result}
+    </div>
+  } else {
+    return result;
+  }
 }
 
 const CommentsNode = registerComponent('CommentsNode', CommentsNodeInner, {

--- a/packages/lesswrong/components/common/Footer.tsx
+++ b/packages/lesswrong/components/common/Footer.tsx
@@ -4,6 +4,9 @@ import React from 'react';
 const styles = (theme: ThemeType) => ({
   root: {
     height: 150,
+    "@media print": {
+      height: 0,
+    },
   }
 });
 

--- a/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
@@ -14,6 +14,9 @@ import LWClickAwayListener from "../../common/LWClickAwayListener";
 const styles = defineStyles("PostActionsButton", (theme: ThemeType) => ({
   root: {
     cursor: "pointer",
+    "@media print": {
+      display: "none",
+    },
   },
   icon: {
     verticalAlign: 'middle',

--- a/packages/lesswrong/components/posts/PostsItemComments.tsx
+++ b/packages/lesswrong/components/posts/PostsItemComments.tsx
@@ -37,7 +37,10 @@ const styles = (theme: ThemeType) => ({
     transform:"translate(50%, -50%)",
     color: theme.palette.icon.commentsBubble.commentCount,
     fontVariantNumeric:"lining-nums",
-    ...theme.typography.commentStyle
+    ...theme.typography.commentStyle,
+    "@media print": {
+      color: theme.palette.text.normal,
+    },
   },
   noUnreadComments: {
     color: theme.palette.icon.commentsBubble.noUnread,

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeader.tsx
@@ -142,7 +142,10 @@ const styles = (theme: ThemeType) => ({
   audioToggle: {
     marginRight: 12,
     display: "flex",
-    opacity: 0.75
+    opacity: 0.75,
+    "@media print": {
+      display: "none",
+    },
   },
   readTime: {
     marginRight: 20,
@@ -210,10 +213,12 @@ const styles = (theme: ThemeType) => ({
     marginBottom: 0,
   },
   rootWithSplashPageHeader: {
-    paddingTop: '44vh',
-    [theme.breakpoints.down('xs')]: {
-      marginTop: '44vh',
-      paddingTop: 0,
+    "@media screen": {
+      paddingTop: '44vh',
+      [theme.breakpoints.down('xs')]: {
+        marginTop: '44vh',
+        paddingTop: 0,
+      },
     },
   }
 }); 

--- a/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/LWPostsPageHeaderTopRight.tsx
@@ -52,6 +52,9 @@ const styles = (theme: ThemeType) => ({
   audioToggle: {
     opacity: 0.55,
     display: 'flex',
+    "@media print": {
+      display: "none",
+    },
   },
   darkerOpacity: {
     opacity: 0.7

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -234,6 +234,10 @@ export const styles = defineStyles("PostsPage", (theme: ThemeType) => ({
     bottom: 0,
     height: '100vh',
     width: '100vw',
+    
+    "@media print": {
+      display: "none",
+    },
   },
   reserveSpaceForSidenotes: {
     width: RIGHT_COLUMN_WIDTH_WITH_SIDENOTES,

--- a/packages/lesswrong/components/posts/PostsPage/WelcomeBox.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/WelcomeBox.tsx
@@ -15,6 +15,9 @@ import { Typography } from "../../common/Typography";
 
 const styles = (theme: ThemeType) => ({
   wrapper: {
+    "@media print": {
+      display: "none",
+    },
     [theme.breakpoints.down('md')]: {
       display: 'none'
     }

--- a/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/NamesAttachedReactionsVoteOnComment.tsx
@@ -107,6 +107,9 @@ const styles = defineStyles("NamesAttachedReactionsVoteOnComment", (theme: Theme
     "&:hover": {
       filter: "opacity(0.8)",
     },
+    "@media print": {
+      display: "none",
+    },
   },
   hoverBallot: {
     fontFamily: theme.typography.commentStyle.fontFamily,


### PR DESCRIPTION
Fixes issue where if a post page had a splash image (eg for Best of LessWrong), every page of the printout would be mostly covered up by a white box. Remove various UI elements from printouts that don't belong there. Fix sometimes missing padding in between comments in printouts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211250804989706) by [Unito](https://www.unito.io)
