### PR TITLE
Fix stale answer displayNames

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -214,14 +214,25 @@ function elementToToCTitle(element: HTMLElement): string {
 }
 
 type CommentType = CommentsList | DbComment
-export function getTocAnswers({ post, answers }: { post: { question: boolean }; answers: CommentType[] }) {
-  if (!post.question) return []
+export function getTocAnswers({
+  post,
+  answers,
+  userMap,
+}: {
+  post: { question: boolean };
+  answers: CommentType[];
+  userMap?: Record<string, { displayName: string }>;
+}) {
+  if (!post.question) return [];
 
   const answerSections: ToCSection[] = answers.map((answer: CommentType): ToCSection => {
     const { html } = answer.contents || {};
     const highlight = truncate(html, 900);
     let shortHighlight = htmlToTextDefault(answerTocExcerptFromHTML(html ?? ""));
-    const author = ("user" in answer ? answer.user?.displayName : answer.author) ?? null;
+    const author =
+      ("user" in answer ? answer.user?.displayName : null) ??
+      (answer.userId ? userMap?.[answer.userId]?.displayName : null) ??
+      ("author" in answer ? answer.author : null) ?? "[anonymous]";
 
     return {
       title: `${answer.baseScore} ${author}`,


### PR DESCRIPTION
The `author` field on answers can be stale if someone changes their displayName. This adds an optional `userMap` to `getTocAnswers` to use before falling back to the denormalised `author` field.

An ideal solution here would fix `author` being stale, but this is just a quick workaround to fix the case that was reported.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211257937927292) by [Unito](https://www.unito.io)
