### PR TITLE
[EA Forum only] send more inactive user summary emails

### DIFF
--- a/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
+++ b/packages/lesswrong/server/emails/inactiveUserSummaryCron.tsx
@@ -141,7 +141,7 @@ const sendInactiveUserSummaryEmail = async (
 }
 
 export const sendInactiveUserSummaryEmails = async (
-  limit = 60,
+  limit = 250,
   dryRun = false,
 ) => {
   if (!hasInactiveSummaryEmail) {

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -560,7 +560,8 @@ class UsersRepo extends AbstractRepo<"Users"> {
         GROUP BY "userId"
       ) AS rs ON u._id = rs."userId"
       WHERE
-        (
+        rs."max_last_updated" > CURRENT_TIMESTAMP - INTERVAL '1 year'
+        AND (
           (
             -- User has never received a summary email, or they read a post since the last summary email:
             -- Send a summary email if it's been 21+ days since they last visited


### PR DESCRIPTION
We've made some improvements to the inactive user summary email, so based on @Will-Howard's comment [here](https://github.com/ForumMagnum/ForumMagnum/pull/11165#discussion_r2218844524) I'm increasing the number sent per day and prioritizing sending them to the ~5k users who qualify for the email who have read a post in the past year.

I'll plan to revisit this in a couple weeks and update it again.