### PR TITLE
Query improvements

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -216,7 +216,14 @@ const schema = {
       editableFieldOptions: { pingbacks: true, normalized: true },
       arguments: "version: String",
       resolver: getNormalizedEditableResolver("contents"),
-      sqlResolver: getNormalizedEditableSqlResolver("contents"),
+      // Testing out removing the sql resolver.
+      // There are a bunch of compiled fragment queries
+      // which end up being very expensive because they
+      // call TO_JSONB on the joined revisions _before_
+      // applying the limit, which can end up adding over
+      // 100ms to some queries.  This is much worse than
+      // just adding a round trip to fetch the revisions.
+      // sqlResolver: getNormalizedEditableSqlResolver("contents"),
       validation: {
         simpleSchema: RevisionStorageType,
         optional: true,

--- a/packages/lesswrong/lib/collections/reviewWinners/newSchema.ts
+++ b/packages/lesswrong/lib/collections/reviewWinners/newSchema.ts
@@ -38,7 +38,7 @@ const schema = {
       canRead: ["guests"],
       resolver: async (reviewWinner, args, context) => {
         return getWithCustomLoader(context, "activeReviewWinnerArt", reviewWinner.postId, (postIds) =>
-          context.repos.reviewWinnerArts.getAllActiveReviewWinnerArt(postIds)
+          context.repos.reviewWinnerArts.getActiveReviewWinnerArt(postIds)
         );
       },
     },

--- a/packages/lesswrong/server/manualMigrations/2024-03-01-updateReviewWinnerSocialPreviewImages.ts
+++ b/packages/lesswrong/server/manualMigrations/2024-03-01-updateReviewWinnerSocialPreviewImages.ts
@@ -11,7 +11,7 @@ export default registerMigration({
     const { Posts, ReviewWinners, repos: { reviewWinnerArts } } = adminContext;
     const reviewWinners = await ReviewWinners.find().fetch();
     const reviewWinnerPostIds = reviewWinners.map(rw => rw.postId);
-    const activeArt = await reviewWinnerArts.getAllActiveReviewWinnerArt(reviewWinnerPostIds);
+    const activeArt = await reviewWinnerArts.getActiveReviewWinnerArt(reviewWinnerPostIds);
 
     for (let [idx, art] of Object.entries(activeArt)) {
       const postId = reviewWinnerPostIds[parseInt(idx)];

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -490,7 +490,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       FROM "Posts" p
       ${readFilter.join}
       WHERE
-        NOW() - p."curatedDate" < ($1 || ' days')::INTERVAL AND
+        p."curatedDate" > NOW() - ($1 || ' days')::INTERVAL AND
         p."disableRecommendation" IS NOT TRUE AND
         ${readFilter.filter}
         ${postFilter}
@@ -501,7 +501,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       ${readFilter.join}
       WHERE
         p."curatedDate" IS NULL AND
-        NOW() - p."frontpageDate" < ($1 || ' days')::INTERVAL AND
+        p."frontpageDate" > NOW() - ($1 || ' days')::INTERVAL AND
         COALESCE(
           (p."tagRelevance"->'${EA_FORUM_COMMUNITY_TOPIC_ID}')::INTEGER,
           0


### PR DESCRIPTION
Improves an unknown number of post queries by removing the sql resolver for `contents` (but certainly at least the compiled `curated` view query), because having that join in the query means that postgres sometimes marshalls hundreds of revisions via `TO_JSONB` before applying the limit (which can take >100ms).  Also improves two repo queries.  `getCuratedAndPopularPosts` in particular had flipped date comparisons which meant it was just doing table scans instead of using indexes.