### PR TITLE
LW Meetups

### DIFF
--- a/packages/lesswrong/components/seasonal/meetupMonth/MeetupMonthBanner.tsx
+++ b/packages/lesswrong/components/seasonal/meetupMonth/MeetupMonthBanner.tsx
@@ -25,7 +25,7 @@ function getCarouselSections(classes: JssStyles) {
       minorTitle: "ACX Everywhere",
       subtitle: <div>Many cities have regular Astral Codex Ten meetup groups. Twice a year, we  advertise their upcoming meetup so that irregular attendees can attend and new readers can learn about them. <Link 
       to="/posts/6umEbXvotXicRPvGs/meetups-everywhere-2025-times-and-places">Learn more here.</Link></div>,
-      buttonText: "ACX",
+      buttonText: "ACX"
     },
     {
       minorTitle: "If Anyone Builds It",


### PR DESCRIPTION
This adds LessWrong meetups as a filter option to the Meetup Month.

It took up a bit too much space on smaller screens so it also comes with optional Shorter Button Name Options for "If Anyone" and "Petrov"

<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/e5585bbf-5fbb-4633-aa19-3d8b2c6d3559" />
<img width="1495" height="958" alt="image" src="https://github.com/user-attachments/assets/8ea0f79f-fc6d-4549-8e7f-3961b28b8d34" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211391558464156) by [Unito](https://www.unito.io)
