### PR TITLE
fix the normalized editable field resolver function to properly handl…

### DIFF
--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -223,8 +223,7 @@ const schema = {
       // applying the limit, which can end up adding over
       // 100ms to some queries.  This is much worse than
       // just adding a round trip to fetch the revisions.
-      // TODO: removing this broke post editors???
-      sqlResolver: getNormalizedEditableSqlResolver("contents"),
+      // sqlResolver: getNormalizedEditableSqlResolver("contents"),
       validation: {
         simpleSchema: RevisionStorageType,
         optional: true,


### PR DESCRIPTION
Yesterday I commented out the sqlResolver for the post contents field as part of a larger batch of performance improvements.  This turned out to break post editors - any non-collaborative post editor ended up not having any contents when loaded.

[This commit](https://github.com/ForumMagnum/ForumMagnum/commit/9fba6b45692608552ac420fe139f5304b07e1d12) temporarily removed handling for the `version` resolver argument in the normalized editable field resolver, and the special-cased handling for the `version: 'draft'` case didn't get put back in [here](https://github.com/ForumMagnum/ForumMagnum/commit/1cdca610aacb8d2a9b7cf77e4f8f4f827e0060f0) when support for `version` was restored to the resolver more generally.

We pass in `version: 'draft'` by default in `PostsEditForm` if no version is specified, to get whatever the latest revision is.

This PR fixes the normalized editable field resolver to respect `version: 'draft'` and then comments out the sqlResolver for `Posts.contents` again.  (This time I've tested that it didn't break the post editor.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211400106678784) by [Unito](https://www.unito.io)
