### PR TITLE
Add headers indicating whether robots.txt should tell crawlers they'r…

### DIFF
--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -2,13 +2,27 @@ import { robotsTxtSetting } from "@/server/databaseSettings";
 import type { NextRequest } from "next/server";
 
 // ea-forum-look-here
-const ALLOWED_HOSTS = new Set([
+// We only want robots.txt to make the site crawlable if it's one of our site's primary domains,
+// rather than a test/debug server like baserates.org.  We have this domain whitelist, but when
+// forwarding through cloudfront, the domain in nextUrl.host will be the forwarding destination
+// (i.e. *.vercel.app) rather than the origin.  So, while we're having cloudfront forward traffic,
+// we also have it add headers that mark where it was forwarded from.
+const CRAWLABLE_HOSTS = new Set([
   'www.lesswrong.com',
   'www.alignmentforum.org',
 ]);
 
+const CRAWLABLE_HEADERS = [
+  'X-Is-LessWrongCom',
+  'X-Is-AlignmentForumOrg',
+];
+
+function isCrawlable(req: NextRequest) {
+  return CRAWLABLE_HOSTS.has(req.nextUrl.host) || CRAWLABLE_HEADERS.some(header => req.headers.get(header));
+}
+
 export async function GET(req: NextRequest) {
-  if (!ALLOWED_HOSTS.has(req.nextUrl.host)) {
+  if (!isCrawlable(req)) {
     return new Response("User-agent: *\nDisallow: /", {status: 200});
   } else if (robotsTxtSetting.get()) {
     return new Response(robotsTxtSetting.get(), {status: 200});


### PR DESCRIPTION
Make sure that robots.txt is available on our production domains while cloudfront is redirecting traffic to them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211414345398299) by [Unito](https://www.unito.io)
