### PR TITLE
Fix image in edit profile form

### DIFF
--- a/packages/lesswrong/components/users/EditProfileForm.tsx
+++ b/packages/lesswrong/components/users/EditProfileForm.tsx
@@ -244,6 +244,7 @@ const UserProfileForm = ({
               <ImageUpload
                 field={field}
                 label="Profile Image"
+                document={{ _id: initialData._id }}
                 horizontal
               />
             )}


### PR DESCRIPTION
Before:
<img width="423" height="297" alt="Screenshot 2025-09-23 at 12 08 50" src="https://github.com/user-attachments/assets/e2c21500-83de-4359-8690-837e68131889" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211438193208589) by [Unito](https://www.unito.io)
