### PR TITLE
Remove allowOverflow from PostActions, to make it not go off the screen on mobile

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActionsButton.tsx
@@ -82,7 +82,6 @@ const PostActionsButton = ({post, vertical, popperGap, autoPlace, flip, includeB
       open={isOpen}
       anchorEl={anchorEl.current}
       placement={popperPlacement}
-      allowOverflow
       flip={flip}
       style={gapStyle}
     >


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211438221071205) by [Unito](https://www.unito.io)
