### PR TITLE
Treat arbital links as onsite for rendering and hover preview purposes

### DIFF
--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -160,6 +160,7 @@ const LwAfDomainWhitelist: DomainList = {
     "baserates.org",
     "alignmentforum.org",
     "alignment-forum.com",
+    "arbital.com",
     // TODO: fix this to not use `getCommandLineArguments` anymore
     // `localhost:${getCommandLineArguments().localhostUrlPort}`,
   ],


### PR DESCRIPTION
Treat arbital links as onsite so they point to imported arbital entries on the LW wiki when rendered in ContentItemBody and have appropriate hover preview links.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211444592576970) by [Unito](https://www.unito.io)
