### PR TITLE
Allow crosspost graphql requests from eaforum

### DIFF
--- a/app/api/v2/crosspost/connectCrossposter/route.ts
+++ b/app/api/v2/crosspost/connectCrossposter/route.ts
@@ -1,4 +1,5 @@
-import { connectCrossposterCrosspostHandler, crosspostOptionsHandler } from "@/server/crossposting/handlers";
+import { connectCrossposterCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/createCrosspost/route.ts
+++ b/app/api/v2/crosspost/createCrosspost/route.ts
@@ -1,4 +1,5 @@
-import { createCrosspostCrosspostHandler, crosspostOptionsHandler } from "@/server/crossposting/handlers";
+import { createCrosspostCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/crosspostDetails/route.ts
+++ b/app/api/v2/crosspost/crosspostDetails/route.ts
@@ -1,4 +1,5 @@
-import { crosspostDetailsCrosspostHandler, crosspostOptionsHandler } from "@/server/crossposting/handlers";
+import { crosspostDetailsCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/crossposterDetails/route.ts
+++ b/app/api/v2/crosspost/crossposterDetails/route.ts
@@ -1,4 +1,5 @@
-import { crossposterDetailsCrosspostHandler, crosspostOptionsHandler } from "@/server/crossposting/handlers";
+import { crossposterDetailsCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/generateToken/route.ts
+++ b/app/api/v2/crosspost/generateToken/route.ts
@@ -1,4 +1,5 @@
-import { crosspostOptionsHandler, generateTokenCrosspostHandler } from "@/server/crossposting/handlers";
+import { generateTokenCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/unlinkCrossposter/route.ts
+++ b/app/api/v2/crosspost/unlinkCrossposter/route.ts
@@ -1,4 +1,5 @@
-import { crosspostOptionsHandler, unlinkCrossposterCrosspostHandler } from "@/server/crossposting/handlers";
+import { unlinkCrossposterCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/api/v2/crosspost/updateCrosspost/route.ts
+++ b/app/api/v2/crosspost/updateCrosspost/route.ts
@@ -1,4 +1,5 @@
-import { crosspostOptionsHandler, updateCrosspostCrosspostHandler } from "@/server/crossposting/handlers";
+import { updateCrosspostCrosspostHandler } from "@/server/crossposting/handlers";
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 import type { NextRequest } from "next/server";
 
 export function POST(req: NextRequest) {

--- a/app/graphql/route.ts
+++ b/app/graphql/route.ts
@@ -10,6 +10,7 @@ import { performanceMetricLoggingEnabled } from '@/lib/instanceSettings';
 import { GraphQLFormattedError } from 'graphql';
 import { inspect } from 'util';
 import { formatError } from 'apollo-errors';
+import { crosspostOptionsHandler } from "@/server/crossposting/cors";
 
 class ApolloServerLogging implements ApolloServerPlugin<ResolverContext> {
   async requestDidStart({ request, contextValue: context }: GraphQLRequestContext<ResolverContext>) {
@@ -137,4 +138,8 @@ export function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   return sharedHandler(request);
+}
+
+export function OPTIONS(req: NextRequest) {
+  return crosspostOptionsHandler(req);
 }

--- a/packages/lesswrong/server/crossposting/cors.ts
+++ b/packages/lesswrong/server/crossposting/cors.ts
@@ -1,0 +1,21 @@
+import { fmCrosspostBaseUrlSetting } from "@/lib/instanceSettings";
+import { NextRequest, NextResponse } from "next/server";
+
+
+export const setCorsHeaders = (res: NextResponse) => {
+  const foreignBaseUrl = fmCrosspostBaseUrlSetting.get()?.replace(/\/$/, "");
+  if (foreignBaseUrl) {
+    res.headers.set("Access-Control-Allow-Origin", foreignBaseUrl);
+    res.headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.headers.set("Access-Control-Allow-Headers", "Content-Type");
+    res.headers.set("Access-Control-Max-Age", "86400");
+  }
+};
+
+export const crosspostOptionsHandler = (req: NextRequest) => {
+  const res = new NextResponse(null, { status: 204 });
+  setCorsHeaders(res);
+  res.headers.set("Connection", "Keep-Alive");
+  res.headers.set("Keep-Alive", "timeout=2, max=100");
+  return res;
+};

--- a/packages/lesswrong/server/crossposting/handlers.ts
+++ b/packages/lesswrong/server/crossposting/handlers.ts
@@ -27,18 +27,8 @@ import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { createPost, updatePost } from "../collections/posts/mutations";
 import Posts from "@/server/collections/posts/collection";
 import Users from "@/server/collections/users/collection";
-import { fmCrosspostBaseUrlSetting } from "@/lib/instanceSettings";
 import { NextRequest, NextResponse } from "next/server";
-
-const setCorsHeaders = (res: NextResponse) => {
-  const foreignBaseUrl = fmCrosspostBaseUrlSetting.get()?.replace(/\/$/, "");
-  if (foreignBaseUrl) {
-    res.headers.set("Access-Control-Allow-Origin", foreignBaseUrl);
-    res.headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.headers.set("Access-Control-Allow-Headers", "Content-Type");
-    res.headers.set("Access-Control-Max-Age", "86400");
-  }
-};
+import { setCorsHeaders } from "./cors";
 
 const onNextRequestError = (
   req: NextRequest,
@@ -60,14 +50,6 @@ const onNextRequestError = (
   const res = NextResponse.json({ error: message, errorCode }, { status });
   setCorsHeaders(res);
   
-  return res;
-};
-
-export const crosspostOptionsHandler = (req: NextRequest) => {
-  const res = new NextResponse(null, { status: 204 });
-  setCorsHeaders(res);
-  res.headers.set("Connection", "Keep-Alive");
-  res.headers.set("Keep-Alive", "timeout=2, max=100");
   return res;
 };
 


### PR DESCRIPTION
Adds cors response headers to /graphql to hopefully fix account linking being broken from the EA Forum side.  Also shuffled around some imports to try to avoid blowing up the /graphql build size any more than its already substantial state.