### PR TITLE
don't scroll to the top of the page if a user hovers over a single-li…

### DIFF
--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -258,6 +258,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
                 showEditInContext: false
               }}
               hoverPreview
+              noAutoScroll
             />
           </div>
       </LWPopper>


### PR DESCRIPTION
Don't scroll to the top of the page if a user hovers over a single-line comment when the page has that comment as the current permalink at the top of the page (via the commentId parameter).

(Hovering over a single-line comment brings up a hover-preview that uses CommentsNode, which triggers a useEffect inside of CommentsNode that's meant to scroll to the top of the page if a CommentsNode is mounted representing the currently-permalinked comment.  That behavior makes sense for the "main" CommentsNode on the page; not so much for an instance of it inside of a hover preview.)


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211447539531504) by [Unito](https://www.unito.io)
