### PR TITLE
Ultrafeed fix modal links

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -12,6 +12,7 @@ import UsersNameWithModal from "../../ultraFeed/UsersNameWithModal";
 import UsersProfileImage from "../../users/UsersProfileImage";
 import UserTooltip from "../../users/UserTooltip";
 import type { Placement as PopperPlacementType } from "popper.js";
+import { useUltraFeedContext } from '../../ultraFeed/UltraFeedContextProvider';
 
 const PROFILE_IMAGE_SIZE = 20;
 
@@ -83,8 +84,11 @@ const CommentUserName = ({
 }) => {
   const currentUserHasProfileImages = useFilteredCurrentUser(u => userHasCommentProfileImages(u));
   const author = comment.user;
-
-  const UserNameComponent = useUltraFeedModal ? UsersNameWithModal : UsersName;
+  const { openInNewTab } = useUltraFeedContext();
+  
+  // Use modal version if explicitly requested or if we're in a context where links should open in new tabs
+  const shouldUseModal = useUltraFeedModal || openInNewTab;
+  const UserNameComponent = shouldUseModal ? UsersNameWithModal : UsersName;
 
   if (comment.deleted) {
     return <span className={className}>[comment deleted]</span>

--- a/packages/lesswrong/components/hooks/useOpenLinksInNewTab.ts
+++ b/packages/lesswrong/components/hooks/useOpenLinksInNewTab.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+
+/**
+ * Hook that intercepts link clicks within a container and opens them in new tabs
+ * @param containerRef - Optional ref to limit the scope of interception
+ * @param currentPath - Optional current path to determine if a link is same-page with hash
+ */
+export const useOpenLinksInNewTab = (
+  containerRef?: React.RefObject<HTMLElement | null>,
+  currentPath?: string
+) => {
+  useEffect(() => {
+
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      
+      // If containerRef is provided, check if click is within it
+      if (containerRef?.current && !containerRef.current.contains(target)) {
+        return;
+      }
+      
+      // Find the closest <a> tag
+      const link = target.closest('a') as HTMLAnchorElement | null;
+      const href = link?.getAttribute('href');
+      
+      // Skip if no link, no href, or should be handled normally
+      if (!link || !href || 
+          link.target === '_blank' || 
+          e.button !== 0 ||            
+          e.ctrlKey || e.shiftKey || e.metaKey || 
+          href.startsWith('#') ||      
+          (currentPath && href.startsWith(currentPath + '#'))) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+      window.open(href, '_blank');
+    };
+
+    // Use capture phase to intercept clicks before React Router
+    // TODO: Something better. I don't love this but interim solution while figure out if sticking with modals anyway.
+    document.addEventListener('click', handler, true);
+    return () => {
+      document.removeEventListener('click', handler, true);
+    };
+  }, [containerRef, currentPath]);
+};

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostDialog.tsx
@@ -55,6 +55,8 @@ import { commentIsHiddenPendingReview } from '../../lib/collections/comments/hel
 import { ItemsReadContextWrapper } from '../hooks/useRecordPostView';
 import Divider from '../common/Divider';
 import CommentOnPostWithReplies from '../comments/CommentOnPostWithReplies';
+import { UltraFeedContextProvider } from './UltraFeedContextProvider';
+import { useOpenLinksInNewTab } from '../hooks/useOpenLinksInNewTab';
 
 const styles = defineStyles("UltraFeedPostDialog", (theme: ThemeType) => ({
   dialogContent: {
@@ -416,6 +418,7 @@ const ModalContextWrapper = ({ children, postId, recommId }: {
   postId: string;
   recommId?: string;
 }) => (
+  <UltraFeedContextProvider openInNewTab={true}>
   <RecombeeRecommendationsContextWrapper postId={postId} recommId={recommId}>
     <ItemsReadContextWrapper>
       <AnalyticsContext pageModalContext="ultraFeedPostModal" postId={postId}>
@@ -423,6 +426,7 @@ const ModalContextWrapper = ({ children, postId, recommId }: {
       </AnalyticsContext>
     </ItemsReadContextWrapper>
   </RecombeeRecommendationsContextWrapper>
+  </UltraFeedContextProvider>
 );
 
 const CommentPermalinkSection = ({ 
@@ -662,6 +666,10 @@ const UltraFeedPostDialog = ({
   useModalHashLinkScroll(scrollableContentRef, true, true, (footnoteHTML: string) => {
     setFootnoteDialogHTML(footnoteHTML);
   });
+  
+  const postPath = postGetPageUrl(displayPost).split('?')[0];
+  useOpenLinksInNewTab(scrollableContentRef, postPath);
+
 
   const toggleEmbeddedPlayer = displayPost && postHasAudioPlayer(displayPost) ? (e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
UltraFeed modal had the issue (possibly a regression) that clicking internal links would navigate the underlying page but not close the modal*. This PR makes it so links within the modal open in a new tab (this is consistent with behavior in the UsersProfileModal) and the Comments in the modal use the UltraFeed user hover (that opens in a new tab)

*for some reason maybe changed the "closeOnNavigate" behavior.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211458815822703) by [Unito](https://www.unito.io)
