### PR TITLE
Stop rotating carousel, set to Petrov

### DIFF
--- a/packages/lesswrong/components/seasonal/meetupMonth/MeetupMonthBanner.tsx
+++ b/packages/lesswrong/components/seasonal/meetupMonth/MeetupMonthBanner.tsx
@@ -429,7 +429,7 @@ export default function MeetupMonthBannerInner() {
 
   const [isTransitioning, setIsTransitioning] = useState(false)
   const [isSettingUp, setIsSettingUp] = useState(false)
-  const [currentCarouselIndex, setCurrentCarouselIndex] = useState(0)
+  const [currentCarouselIndex, setCurrentCarouselIndex] = useState(3)
   const [nextCarouselIndex, setNextCarouselIndex] = useState<number | null>(null)
 
   
@@ -483,14 +483,14 @@ export default function MeetupMonthBannerInner() {
   }, [currentCarouselIndex])
 
   // Automatically rotate carousel unless the user has clicked on the map
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      if (everClickedMap) return
-      const nextIndex = (currentCarouselIndex + 1) % carouselSections.length
-      handleMeetupTypeClick(nextIndex)
-    }, 30 * 1000)
-    return () => clearInterval(intervalId)
-  }, [currentCarouselIndex, handleMeetupTypeClick, carouselSections.length, everClickedMap])
+  // useEffect(() => {
+  //   const intervalId = setInterval(() => {
+  //     if (everClickedMap) return
+  //     const nextIndex = (currentCarouselIndex + 1) % carouselSections.length
+  //     handleMeetupTypeClick(nextIndex)
+  //   }, 30 * 1000)
+  //   return () => clearInterval(intervalId)
+  // }, [currentCarouselIndex, handleMeetupTypeClick, carouselSections.length, everClickedMap])
 
   if (isLoading) {
     return <div className={classes.root}>


### PR DESCRIPTION
Leaves the MeetupMonth carousel set to Petrov day with no auto-rotation

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211462364941518) by [Unito](https://www.unito.io)
