### PR TITLE
Fix FixedToC title navigation bug

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -394,7 +394,11 @@ const FixedPositionToc = ({tocSections, title, heading, onClickSection, displayO
             onClick={ev => {
               if (isRegularClick(ev)) {
                 void handleClick(ev, () => {
-                  navigate("#", {
+                  const { commentId, ...restQuery } = query;
+                  navigate({
+                    search: isEmpty(restQuery) ? '' : `?${qs.stringify(restQuery)}`,
+                    hash: `#`,
+                  }, {
                     skipRouter: true,
                   });
                   const container = scrollContainerRef?.current;

--- a/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/FixedPositionToC.tsx
@@ -238,6 +238,11 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
+function getNewSearchParams(query: Record<string, string>) {
+  const { commentId, ...restQuery } = query;
+  return isEmpty(restQuery) ? '' : `?${qs.stringify(restQuery)}`;
+}
+
 const FixedPositionToc = ({tocSections, title, heading, onClickSection, displayOptions, classes, hover, scrollContainerRef}: {
   tocSections: ToCSection[],
   title: string|null,
@@ -292,10 +297,8 @@ const FixedPositionToc = ({tocSections, title, heading, onClickSection, displayO
         behavior: 'smooth',
       });
 
-      // Update URL hash for consistency
-      const { commentId, ...restQuery } = query;
       navigate({
-        search: isEmpty(restQuery) ? '' : `?${qs.stringify(restQuery)}`,
+        search: getNewSearchParams(query),
         hash: `#${anchor}`,
       }, {
         skipRouter: true,
@@ -306,9 +309,8 @@ const FixedPositionToc = ({tocSections, title, heading, onClickSection, displayO
     // Fallback to original window-scrolling behaviour
     const anchorY = getAnchorY(anchor);
     if (anchorY !== null) {
-      const { commentId, ...restQuery } = query;
       navigate({
-        search: isEmpty(restQuery) ? '' : `?${qs.stringify(restQuery)}`,
+        search: getNewSearchParams(query),
         hash: `#${anchor}`,
       }, {
         skipRouter: true,
@@ -394,9 +396,8 @@ const FixedPositionToc = ({tocSections, title, heading, onClickSection, displayO
             onClick={ev => {
               if (isRegularClick(ev)) {
                 void handleClick(ev, () => {
-                  const { commentId, ...restQuery } = query;
                   navigate({
-                    search: isEmpty(restQuery) ? '' : `?${qs.stringify(restQuery)}`,
+                    search: getNewSearchParams(query),
                     hash: `#`,
                   }, {
                     skipRouter: true,


### PR DESCRIPTION
Previously, clicking the title at the top of a postPage table of contents, would update your url to "https://lesswrong.com" instead of resetting the #hashtag of the post page url.

I'm not 100% sure why this is necessary, but I updated it to use the same query-preservation-formatting that we use for the rest of the anchor-clicking in the toc (which makes sense to want to use, to preserve the query, I just don't get why not-having-that would reset the whole url)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211462264653891) by [Unito](https://www.unito.io)
