### PR TITLE
Add users to queue if they set a website on their profile

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/helpers.ts
@@ -73,7 +73,15 @@ export function getCurrentContentCount(user: UserContentCountPartial) {
 }
 
 type ReasonNoReviewNeeded = "alreadyApproved"|"noReview";
-type ReasonReviewIsNeeded = "mapLocation"|"firstPost"|"firstComment"|"contactedTooManyUsers"|"bio"|"profileImage"|"newContent";
+type ReasonReviewIsNeeded =
+  | "mapLocation"
+  | "firstPost"
+  | "firstComment"
+  | "contactedTooManyUsers"
+  | "bio"
+  | "website"
+  | "profileImage"
+  | "newContent";
 type GetReasonForReviewResult =
     { needsReview: false, reason: ReasonNoReviewNeeded }
   | { needsReview: true, reason: ReasonReviewIsNeeded }
@@ -98,10 +106,10 @@ export function getReasonForReview(user: DbUser|SunshineUsersList): GetReasonFor
   if (fullyReviewed) {
     return {needsReview: false, reason: 'alreadyApproved'};
   }
-  
+
   const unreviewed = !user.reviewedByUserId;
   const snoozed = user.reviewedByUserId && user.snoozedUntilContentCount;
-  
+
   const reviewReasonMap: Record<ReasonForInitialReview, () => boolean> = {
     mapLocation: () => !!user.mapLocation,
     firstPost: () => !!user.postCount,
@@ -109,6 +117,7 @@ export function getReasonForReview(user: DbUser|SunshineUsersList): GetReasonFor
     contactedTooManyUsers: () => (user.usersContactedBeforeReview?.length ?? 0) > MAX_ALLOWED_CONTACTS_BEFORE_FLAG,
     // Depends on whether this is DbUser or SunshineUsersList
     bio: () => !!('htmlBio' in user ? user.htmlBio : user.biography?.html),
+    website: () => !!user.website,
     profileImage: () => !!user.profileImageId,
   }
 

--- a/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
@@ -509,7 +509,15 @@ export function syncProfileUpdatedAt(modifier: MongoModifier, user: DbUser) {
 
 /* UPDATE ASYNC */
 export function updateUserMayTriggerReview({newDocument, data, context}: UpdateCallbackProperties<"Users">) {
-  const reviewTriggerFields: (keyof DbUser)[] = ['voteCount', 'mapLocation', 'postCount', 'commentCount', 'biography', 'profileImageId'];
+  const reviewTriggerFields: (keyof DbUser)[] = [
+    'voteCount',
+    'mapLocation',
+    'postCount',
+    'commentCount',
+    'biography',
+    'website',
+    'profileImageId',
+  ];
   if (reviewTriggerFields.some(field => field in data)) {
     void triggerReviewIfNeeded(newDocument._id, context);
   }


### PR DESCRIPTION
Note that this also requires adding "website" to the `reasonsForInitialReview` database setting. I've already done this on the dev DB, but it's not safe to do so on prod until the new code is deployed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211467316758346) by [Unito](https://www.unito.io)
