### PR TITLE
Add migration to make `Chapters.createdAt` non-nullable

### DIFF
--- a/packages/lesswrong/server/migrations/20250926T140606.make_chapters_createdAt_not_null.ts
+++ b/packages/lesswrong/server/migrations/20250926T140606.make_chapters_createdAt_not_null.ts
@@ -1,0 +1,44 @@
+export const up = async ({db}: MigrationContext) => {
+  const result = await db.one<{ exists: boolean }>(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_name = 'Chapters'
+        AND column_name = 'createdAt'
+        AND is_nullable = 'YES'
+    ) AS exists;
+  `);
+  if (!result.exists) {
+    console.log(`"Chapters.createdAt" is already NOT NULL. Skipping migration.`);
+    return;
+  }
+
+  // Fill missing createdAt dates from the relevant sequence
+  await db.none(`
+    UPDATE "Chapters" c
+    SET "createdAt" = COALESCE(s."createdAt", TIMESTAMP '1970-01-01 00:00:00')
+    FROM "Sequences" s
+    WHERE c."createdAt" IS NULL
+      AND c."sequenceId" = s."_id"
+  `);
+
+  // Set the date to the unix epoch if the sequence is missing
+  await db.none(`
+    UPDATE "Chapters" c
+    SET "createdAt" = TIMESTAMP '1970-01-01 00:00:00'
+    WHERE c."createdAt" IS NULL
+  `);
+
+  // Make the field non-nullable
+  await db.none(`
+    ALTER TABLE "Chapters"
+    ALTER COLUMN "createdAt" SET NOT NULL
+  `);
+}
+
+export const down = async ({db}: MigrationContext) => {
+  await db.none(`
+    ALTER TABLE "Chapters"
+    ALTER COLUMN "createdAt" DROP NOT NULL
+  `);
+}

--- a/packages/lesswrong/server/migrations/20250926T140606.make_chapters_createdAt_not_null.ts
+++ b/packages/lesswrong/server/migrations/20250926T140606.make_chapters_createdAt_not_null.ts
@@ -9,6 +9,7 @@ export const up = async ({db}: MigrationContext) => {
     ) AS exists;
   `);
   if (!result.exists) {
+    // eslint-disable-next-line no-console
     console.log(`"Chapters.createdAt" is already NOT NULL. Skipping migration.`);
     return;
   }


### PR DESCRIPTION
Our schema says that the `createdAt` field in `Chapters` should be non-nullable, but in all of our databases it _is_ nullable, and there are old records without a date. This causes graphql errors in unexpected places. No change should be needed except this migration.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211478474039043) by [Unito](https://www.unito.io)
