### PR TITLE
set up scheduled ecs task for dumping prod db contents into dev each night, with associated infrastructure

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.20
+RUN apk add --no-cache postgresql15-client bash ca-certificates tzdata
+WORKDIR /app
+COPY refresh_dev.sh /app/refresh_dev.sh
+RUN chmod +x /app/refresh_dev.sh
+ENTRYPOINT ["/app/refresh_dev.sh"]

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -1,0 +1,4 @@
+If you need to update the nightly prod > dev database dump, the logic is in the refresh_dev.sh script.  Instructions:
+1. Update the script.
+2. (Pre-reqs: make sure you have the `aws` cli installed, with an access token sufficient to do ~all the things.  Also make sure you have `docker` installed.)
+3. Run `./ecs/push_refresh_script_update.sh` (if you're in the repo root directory).  This will rebuild the container with the script and push it to ECR, where it'll get picked up on the next scheduled nightly run.

--- a/ecs/fargate-dev-refresh.yml
+++ b/ecs/fargate-dev-refresh.yml
@@ -1,0 +1,205 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Daily Fargate Scheduled Task to refresh dev DB from prod via pg_dump | pg_restore
+
+Parameters:
+  AppName:
+    Type: String
+    Default: dev-refresh
+    Description: Logical app name prefix for created resources
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC where the task will run
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Private subnet IDs (in the same VPC) where the Fargate task will run
+  ContainerImage:
+    Type: String
+    Description: Full ECR image URI (e.g. 123456789012.dkr.ecr.us-east-1.amazonaws.com/dev-refresh:latest)
+  Cpu:
+    Type: String
+    Default: '1024' # 1 vCPU
+    AllowedValues: ['256','512','1024','2048','4096']
+  Memory:
+    Type: String
+    Default: '2048' # 2 GiB
+    AllowedValues: ['512','1024','2048','3072','4096','5120','6144','7168','8192','16384','30720']
+  EphemeralStorageGiB:
+    Type: Number
+    Default: 50
+    MinValue: 21
+    MaxValue: 200
+    Description: Ephemeral storage for the task (GiB). For pure streaming, you can lower this.
+  LogRetentionDays:
+    Type: Number
+    Default: 14
+  ScheduleExpression:
+    Type: String
+    Default: cron(15 9 * * ? *)
+    Description: EventBridge schedule in UTC (e.g., 09:15 UTC daily)
+  AssignPublicIp:
+    Type: String
+    Default: DISABLED
+    AllowedValues: [ENABLED, DISABLED]
+    Description: Usually DISABLED for private subnets
+  # If you want us to add ingress to your existing RDS SG, pass it here; otherwise leave blank.
+  RdsSecurityGroupId:
+    Type: String
+    Default: ''
+    Description: OPTIONAL existing RDS Security Group ID to open 5432 from the task SG (leave empty to skip)
+
+  # Secrets (entire connection strings)
+  ProdConnectionSecretArn:
+    Type: String
+    Description: ARN of Secrets Manager secret containing entire prod connection string
+  DevConnectionSecretArn:
+    Type: String
+    Description: ARN of Secrets Manager secret containing entire dev connection string
+
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /ecs/${AppName}
+      RetentionInDays: !Ref LogRetentionDays
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub ${AppName}-cluster
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AppName}-task-exec-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ecs-tasks.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # Pull from ECR + push logs
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: !Sub ${AppName}-secrets
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref ProdConnectionSecretArn
+                  - !Ref DevConnectionSecretArn
+
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub SG for ${AppName} Fargate task to reach RDS
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+  # OPTIONAL: open port 5432 on your existing RDS SG for this task SG
+  OptionalIngressToRds:
+    Condition: HasRdsSg
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref RdsSecurityGroupId
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref TaskSecurityGroup
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub ${AppName}-task
+      RequiresCompatibilities: [FARGATE]
+      NetworkMode: awsvpc
+      Cpu: !Ref Cpu
+      Memory: !Ref Memory
+      EphemeralStorage:
+        SizeInGiB: !Ref EphemeralStorageGiB
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      ContainerDefinitions:
+        - Name: !Ref AppName
+          Image: !Ref ContainerImage
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+          # Inject entire connection strings as env vars from two secrets
+          Secrets:
+            - Name: PROD_CONNECTION_STRING
+              ValueFrom: !Ref ProdConnectionSecretArn
+            - Name: DEV_CONNECTION_STRING
+              ValueFrom: !Ref DevConnectionSecretArn
+          Environment:
+            # If you want to tune pg_dump/pg_restore, add env here (optional)
+            - Name: TZ
+              Value: UTC
+
+  EventsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AppName}-events-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: events.amazonaws.com }
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub ${AppName}-events-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: RunFargateTask
+                Effect: Allow
+                Action: ecs:RunTask
+                Resource: '*'
+                Condition:
+                  ArnLike:
+                    ecs:cluster: !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${AppName}-cluster
+              - Sid: PassExecRole
+                Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt TaskExecutionRole.Arn
+
+  ScheduleRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub ${AppName}-daily
+      Description: !Sub Daily refresh dev from prod
+      ScheduleExpression: !Ref ScheduleExpression
+      State: ENABLED
+      Targets:
+        - Id: EcsTarget
+          Arn: !GetAtt Cluster.Arn
+          RoleArn: !GetAtt EventsRole.Arn
+          EcsParameters:
+            TaskDefinitionArn: !Ref TaskDefinition
+            LaunchType: FARGATE
+            NetworkConfiguration:
+              AwsVpcConfiguration:
+                AssignPublicIp: !Ref AssignPublicIp
+                SecurityGroups: [ !Ref TaskSecurityGroup ]
+                Subnets: !Ref SubnetIds
+
+Conditions:
+  HasRdsSg: !Not [ !Equals [ !Ref RdsSecurityGroupId, '' ] ]
+
+Outputs:
+  ClusterName:
+    Value: !Ref Cluster
+  TaskDefinitionArn:
+    Value: !Ref TaskDefinition
+  TaskSecurityGroupId:
+    Value: !Ref TaskSecurityGroup
+    Description: If you didn't pass RdsSecurityGroupId, add this SG to your RDS inbound 5432 allowlist.
+  LogGroupName:
+    Value: !Ref LogGroup

--- a/ecs/push_refresh_script_update.sh
+++ b/ecs/push_refresh_script_update.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ------------------------------------------------------------
+# Build & push dev-refresh image to ECR as :latest (and optional :vYYYYmmdd-HHMMSS)
+# - Forces linux/amd64 to avoid M1/ARM runtime mismatches on Fargate x86_64
+# - Uses an ephemeral buildx builder and restores previous builder afterward
+# - Requires: aws cli, docker, docker buildx
+# ------------------------------------------------------------
+
+# --- Config (override with env vars or flags) ---
+REGION="${REGION:-us-east-1}"
+REPO_NAME="${REPO_NAME:-dev-refresh}"           # ECR repository name
+IMAGE_TAG="${IMAGE_TAG:-latest}"                # default tag to push (task def should point to this)
+PUSH_VERSION_TAG="${PUSH_VERSION_TAG:-false}"   # true/false to also push a versioned tag
+CONTEXT_DIR="${CONTEXT_DIR:-.}"                 # docker build context (default current dir)
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"          # Dockerfile path
+PLATFORMS="${PLATFORMS:-linux/amd64}"           # you can set linux/amd64,linux/arm64 to push multi-arch
+NO_CACHE="${NO_CACHE:-true}"                    # build with --no-cache by default
+
+# --- Flags parsing (optional) ---
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--region us-east-1] [--repo dev-refresh] [--tag latest]
+                       [--with-version-tag] [--context .] [--dockerfile Dockerfile]
+                       [--platforms linux/amd64] [--no-cache=false]
+
+Examples:
+  $(basename "$0") --with-version-tag
+  REGION=us-east-1 REPO_NAME=dev-refresh $(basename "$0") --platforms linux/amd64,linux/arm64
+EOF
+}
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region) REGION="$2"; shift 2;;
+    --repo|--repository) REPO_NAME="$2"; shift 2;;
+    --tag) IMAGE_TAG="$2"; shift 2;;
+    --with-version-tag) PUSH_VERSION_TAG=true; shift 1;;
+    --context) CONTEXT_DIR="$2"; shift 2;;
+    --dockerfile) DOCKERFILE="$2"; shift 2;;
+    --platforms) PLATFORMS="$2"; shift 2;;
+    --no-cache) NO_CACHE="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown arg: $1"; usage; exit 1;;
+  esac
+done
+
+echo "Region:          $REGION"
+echo "Repository:      $REPO_NAME"
+echo "Tag:             $IMAGE_TAG"
+echo "Platforms:       $PLATFORMS"
+echo "Context:         $CONTEXT_DIR"
+echo "Dockerfile:      $DOCKERFILE"
+echo "No cache:        $NO_CACHE"
+echo "Version tag too: $PUSH_VERSION_TAG"
+echo
+
+# --- AWS / ECR setup ---
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+REPO_URI="${ECR_URI}/${REPO_NAME}"
+
+# Create repo if missing
+if ! aws ecr describe-repositories --region "$REGION" --repository-names "$REPO_NAME" >/dev/null 2>&1; then
+  echo "ECR repo $REPO_NAME not found; creating..."
+  aws ecr create-repository --region "$REGION" --repository-name "$REPO_NAME" >/dev/null
+fi
+
+# Make sure tags are mutable so :latest can be overwritten
+aws ecr put-image-tag-mutability --region "$REGION" \
+  --repository-name "$REPO_NAME" \
+  --image-tag-mutability MUTABLE >/dev/null
+
+# ECR login
+aws ecr get-login-password --region "$REGION" \
+  | docker login --username AWS --password-stdin "$ECR_URI"
+
+# --- Prepare an ephemeral buildx builder (and remember the current one) ---
+CURRENT_BUILDER="$(docker buildx ls | awk '/\*/{print $1}' || true)"
+TMP_BUILDER="tmp-builder-$(date +%s)"
+
+cleanup() {
+  # Restore previous builder if it existed
+  if [[ -n "${CURRENT_BUILDER:-}" && "$CURRENT_BUILDER" != "$TMP_BUILDER" && -n "$(docker buildx ls | grep -E "^${CURRENT_BUILDER}\b" || true)" ]]; then
+    docker buildx use "$CURRENT_BUILDER" >/dev/null 2>&1 || true
+  fi
+  # Remove the ephemeral builder
+  docker buildx rm "$TMP_BUILDER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker buildx create --use --name "$TMP_BUILDER" >/dev/null
+
+# --- Build & push ---
+DATE_TAG="v$(date +%Y%m%d-%H%M%S)"
+CACHE_FLAG=""; [[ "$NO_CACHE" == "true" ]] && CACHE_FLAG="--no-cache"
+
+echo "Building and pushing ${REPO_URI}:${IMAGE_TAG} for platforms: ${PLATFORMS}"
+docker buildx build \
+  --platform "$PLATFORMS" \
+  -t "${REPO_URI}:${IMAGE_TAG}" \
+  -f "$DOCKERFILE" \
+  $CACHE_FLAG \
+  --push \
+  "$CONTEXT_DIR"
+
+if [[ "$PUSH_VERSION_TAG" == "true" ]]; then
+  echo "Also tagging and pushing ${REPO_URI}:${DATE_TAG}"
+  docker buildx build \
+    --platform "$PLATFORMS" \
+    -t "${REPO_URI}:${DATE_TAG}" \
+    -f "$DOCKERFILE" \
+    $CACHE_FLAG \
+    --push \
+    "$CONTEXT_DIR"
+fi
+
+# --- Show digests for confirmation ---
+echo
+echo "ECR images for ${REPO_NAME}:"
+aws ecr describe-images --region "$REGION" --repository-name "$REPO_NAME" \
+  --image-ids imageTag="$IMAGE_TAG" \
+  --query 'imageDetails[0].{Tag: imageTags[0], Digest: imageDigest, PushedAt: imagePushedAt}' --output table
+
+if [[ "$PUSH_VERSION_TAG" == "true" ]]; then
+  aws ecr describe-images --region "$REGION" --repository-name "$REPO_NAME" \
+    --image-ids imageTag="$DATE_TAG" \
+    --query 'imageDetails[0].{Tag: imageTags[0], Digest: imageDigest, PushedAt: imagePushedAt}' --output table
+  echo "Version tag pushed: ${DATE_TAG}"
+fi
+
+echo "Done. The scheduled/task-run will pull ${REPO_URI}:${IMAGE_TAG} on next start."

--- a/ecs/refresh_dev.sh
+++ b/ecs/refresh_dev.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PROD_CONNECTION_STRING:?}"
+: "${DEV_CONNECTION_STRING:?}"
+
+pg_dump -w -Fc -d "$PROD_CONNECTION_STRING" \
+  -T '"ClientIds"' -T '"LWEvents"' -T '"FieldChanges"' -T '"PostEmbeddings"' -T '"DebouncerEvents"' \
+  -x --no-owner \
+| pg_restore -w -c -n public -d "$DEV_CONNECTION_STRING" -x --no-owner


### PR DESCRIPTION
Also provides a script for updating the... script... which does the dump, if we ever want to e.g. exclude some more tables, or try parallelizing it, or something.  It does require you to have the aws cli (with some specific permissions) and docker installed locally.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211481878249472) by [Unito](https://www.unito.io)
