### PR TITLE
Make positioning of Petrov ceremony indicator "scroll down"

### DIFF
--- a/packages/lesswrong/components/seasonal/petrovDay/petrov-day-story/PetrovDayStory.tsx
+++ b/packages/lesswrong/components/seasonal/petrovDay/petrov-day-story/PetrovDayStory.tsx
@@ -136,20 +136,21 @@ const styles = defineStyles("PetrovDayStory", (theme: ThemeType) => ({
     zIndex: 15,
     marginLeft: 'auto',
   },
+  // note: it's important for the height here to be set such
+  // that it reliably puts the opening paragraphs slightly-intersecting
+  // with the bottom of the page, so readers know to scroll down.
   storyBuffer: {
-    height: 920,
+    height: "calc(100vh - 267px)",
     [theme.breakpoints.down(1800)]: {
-      height: 700,
     },
     [theme.breakpoints.down('xs')]: {
-      height: 300,
     },
     width: "100vw",
     zIndex: 1,
     position: "relative", 
   },
   storyBufferPage: {
-    maxHeight: '50vh'
+    height: "calc(100vh - 443px)"
   },
   storySection: {
     position: "relative",


### PR DESCRIPTION
Previously, the standalone Petrov Page looked like this:
<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/dc45657b-7c14-4084-ba0e-182a2d2fc2af" />

This makes it look ~reliably like this, where it's more obvious that there's more content if you scroll down:
<img width="1728" height="961" alt="image" src="https://github.com/user-attachments/assets/018e2d7f-4871-4226-8270-3b2e649c10cf" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211483837332565) by [Unito](https://www.unito.io)
