### PR TITLE
Restore bullet styling

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -736,15 +736,6 @@ export const ckEditorStyles = (theme: ThemeType) => {
         '& hr': {
           ...hrStyles(theme)
         },
-        '& ol, & ul': {
-          listStyleType: "revert !important",
-        },
-        '& ol > li > ol': {
-          listStyle: 'lower-alpha !important',
-        },
-        '& ol > li > ol > li > ol': {
-          listStyle: 'lower-roman !important',
-        },
         '& .footnote-reference': {
           scrollMarginTop: '100px',
         },


### PR DESCRIPTION
[This](https://github.com/ForumMagnum/ForumMagnum/pull/5805) PR removed custom bullet styles. This was to fix some relatively obscure bug in Google Doc copy-paste. We still have editor UI for custom bullet styles. Also, it seems that either Google or CKEditor has changed something underlying so that the original listed reproduction no longer produces the bug. 

I declare the cost of this isn't worth it. 

Beware, this might cause some historical posts to now change bullet list typing. I think this is worth the cost. I don't think it's worth running a whole big migration to fix all historical posts at their current bullet styling, but it might be worth it if we find some high-profile errors somewhere.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211486905595627) by [Unito](https://www.unito.io)
