### PR TITLE
Fix spacing in ultrafeed comments

### DIFF
--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -77,19 +77,13 @@ export const styles = defineStyles("ContentStyles", (theme: ThemeType) => ({
     '& p:last-child': {
       marginBottom: '0 !important',
     },
-    // Hide a single leading br in the first paragraph, but preserve pairs that some users use to create paragraph breaks
-    '& p:first-child > br:first-child': {
+    // Hide a single leading br in first paragraph, unless it's a br pair
+    '& p:first-child:not(:has(> br:first-child + br)) > br:first-child': {
       display: 'none !important',
     },
-    '& p:first-child:has(> br:first-child + br) > br:first-child': {
-      display: 'inline !important',
-    },
-    // Hide a single trailing br in the last paragraph, but preserve pairs that some users use to create paragraph breaks
-    '& p:last-child > br:last-child': {
+    // Hide a single trailing br in last paragraph, unless it's a br pair
+    '& p:last-child:not(:has(> br + br:last-child)) > br:last-child': {
       display: 'none !important',
-    },
-    '& p:last-child:has(> br + br:last-child) > br:last-child': {
-      display: 'inline !important',
     },
     [theme.breakpoints.down('sm')]: {
       '& h1, & h2, & h3, & h4': {
@@ -113,19 +107,13 @@ export const styles = defineStyles("ContentStyles", (theme: ThemeType) => ({
     '& p:last-child': {
       marginBottom: '0 !important',
     },
-    // Hide a single leading br in the first paragraph, but preserve pairs
-    '& p:first-child > br:first-child': {
+    // Hide a single leading br in first paragraph, unless it's a br pair
+    '& p:first-child:not(:has(> br:first-child + br)) > br:first-child': {
       display: 'none !important',
     },
-    '& p:first-child:has(> br:first-child + br) > br:first-child': {
-      display: 'inline !important',
-    },
-    // Hide a single trailing br in the last paragraph, but preserve pairs
-    '& p:last-child > br:last-child': {
+    // Hide a single trailing br in last paragraph, unless it's a br pair
+    '& p:last-child:not(:has(> br + br:last-child)) > br:last-child': {
       display: 'none !important',
-    },
-    '& p:last-child:has(> br + br:last-child) > br:last-child': {
-      display: 'inline !important',
     },
     [theme.breakpoints.down('sm')]: {
       '& h1, & h2, & h3, & h4': {


### PR DESCRIPTION
The challenge here is trimming leading and trailing \<br> without also eliminating \<br> used within a paragraph to create paragraph breaks.

<img width="639" height="91" alt="tmp" src="https://github.com/user-attachments/assets/ae4c68f5-b377-491d-9678-d83bc0bd87e9" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `ultraFeed` and `ultraFeedPost` styles to hide only single leading/trailing line breaks, preserving intentional double breaks.
> 
> - **Styles**:
>   - **`packages/lesswrong/components/common/ContentStylesValues.ts`**:
>     - `ultraFeed`, `ultraFeedPost`: Update selectors to hide a single leading/trailing `br` in first/last paragraph only when not part of a `br` pair (using `:has`), retaining intentional double line breaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14f06e3b666069f648a421e6a9902e997624f5c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211488542270104) by [Unito](https://www.unito.io)
