### PR TITLE
Prevent link-circles from wrapping separately from the last word of the link

### DIFF
--- a/packages/lesswrong/components/linkPreview/LinkToPost.tsx
+++ b/packages/lesswrong/components/linkPreview/LinkToPost.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { linkStyles } from './linkStyles';
+import { linkStyles, VisitedIndicator } from './linkStyles';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
@@ -29,6 +29,7 @@ const LinkToPost = ({post}: {
     <PostsTooltip post={post} placement="bottom-start" clickable>
       <Link className={classNames(linkClasses.link, classes.linkColor, visited && "visited")} to={postGetPageUrl(post)}>
         {post.title}
+        <VisitedIndicator/>
       </Link>
     </PostsTooltip>
   );

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -19,7 +19,7 @@ import LWPopper from "../common/LWPopper";
 import ContentStyles from "../common/ContentStyles";
 import { apolloSSRFlag } from '@/lib/helpers';
 import type { RouterLocation } from '@/lib/vulcan-lib/routes';
-import { linkStyles } from './linkStyles';
+import { linkStyles, VisitedIndicator } from './linkStyles';
 
 
 const SequencesPageFragmentQuery = gql(`
@@ -289,6 +289,7 @@ const PostLinkPreviewWithPost = ({href, post, id, className, children}: {
   if (!post) {
     return <Link to={href} className={classNames(classes.link, className)}>
       {children}
+      <VisitedIndicator/>
     </Link>
   }
 
@@ -304,6 +305,7 @@ const PostLinkPreviewWithPost = ({href, post, id, className, children}: {
     >
       <Link className={classNames(classes.link, visited && "visited", className)} to={href} id={id} smooth>
         {children}
+        <VisitedIndicator/>
       </Link>
     </PostsTooltip>
   );
@@ -323,6 +325,7 @@ const CommentLinkPreviewWithComment = ({href, comment, post, id, className, chil
   if (!comment) {
     return <Link to={href} className={classNames(classes.link, className)}>
       {children}
+      <VisitedIndicator/>
     </Link>
   }
   return (
@@ -335,6 +338,7 @@ const CommentLinkPreviewWithComment = ({href, comment, post, id, className, chil
     >
       <Link className={classNames(classes.link, className)} to={href} id={id}>
         {children}
+        <VisitedIndicator/>
       </Link>
     </PostsTooltip>
   );
@@ -369,6 +373,7 @@ export const SequencePreview = ({targetLocation, href, className, children}: {
     >
       <Link className={classNames(classes.link, className)} to={href} id={sequenceId}>
         {children}
+        <VisitedIndicator/>
       </Link>
     </SequencesTooltip>
   );
@@ -449,6 +454,7 @@ export const OWIDPreview = ({href, id, className, children}: {
     <span {...eventHandlers}>
       <a className={classNames(classes.link, className)} href={href} id={id}>
         {children}
+        <VisitedIndicator/>
       </a>
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -481,6 +487,7 @@ export const MetaculusPreview = ({href, id, className, children}: {
     <span {...eventHandlers}>
       <a className={classNames(classes.link, className)} href={href} id={id}>
         {children}
+        <VisitedIndicator/>
       </a>
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -521,6 +528,7 @@ export const FatebookPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -561,6 +569,7 @@ export const ManifoldPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -602,6 +611,7 @@ export const NeuronpediaPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -642,6 +652,7 @@ export const MetaforecastPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
@@ -758,6 +769,7 @@ export const EstimakerPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
           <iframe className={classes.estimakerIframe} src={href} />
@@ -797,6 +809,7 @@ export const ViewpointsPreview = ({href, id, className, children}: {
       <span {...eventHandlers}>
         <a className={classNames(classes.link, className)} href={href} id={id}>
           {children}
+          <VisitedIndicator/>
         </a>
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
           <iframe className={classes.viewpointsIframe} src={url} />

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useTagPreview } from './useTag';
-import { linkStyles } from '../linkPreview/linkStyles';
+import { linkStyles, VisitedIndicator } from '../linkPreview/linkStyles';
 import { removeUrlParameters } from '../../lib/routeUtil';
 import classNames from 'classnames';
 import { hasWikiLenses } from '@/lib/betas';
@@ -73,6 +73,7 @@ export const TagHoverPreview = ({
         to={linkTarget}
       >
         {tagName ?? children}
+        <VisitedIndicator/>
       </Link>
       {!!(showPostCount && tag?.postCount) &&
         <span className={classes.count}>({tag?.postCount})</span>


### PR DESCRIPTION
Links have a small circle after them to indicate hoverability, and to indicate (via styling) whether the link is visited/read. However if the link lines up with the right edge, it could wrap separately, leaving it dangling at the start of a line, which looks awkward.

Fix that by giving the link right padding equal to the size of the link indicator, then giving the link indicator a zero-width wrapper span so that it will never line wrap. Since the link indicator is now two nested spans instead of a single element, it can't be represented by a :after alone, so it has an explicit span/component, <VisitedIndicator/>.


