### PR TITLE
Fix bug that made vote-buttons on posts (but not comments) sometimes fail to update state

### DIFF
--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useRef } from 'react';
+import React, { useEffect, useReducer, useRef } from 'react';
 import { isMobile } from '../../lib/utils/isMobile'
 import { defineStyles } from '../hooks/useStyles';
 import { JssStyles } from '@/lib/jssStyles';
@@ -132,8 +132,18 @@ export const VoteButtonAnimation = ({
   const animationState = useRef<VoteButtonAnimationState>({
     mode: "idle",
     vote: currentStrength
-    
   });
+  
+  useEffect(() => {
+    if (animationState.current.mode === "idle" && animationState.current.vote !== currentStrength) {
+      animationState.current = {
+        mode: "idle",
+        vote: currentStrength,
+      };
+      forceRerender();
+    }
+  }, [currentStrength]);
+
   const handleMouseDown = () => { // This handler is only used on desktop
     if(!isMobile()) {
       if (animationState.current.mode === "idle") {


### PR DESCRIPTION
This made it so that when switching a post-vote from up to down or vise versa, you could get into a state where both vote buttons are colored. Also made it so that when you vote using the buttons at the top of the post, it didn't update the buttons at the bottom, and vise versa.


