### PR TITLE
Don't crash in computeAttributions when no revs exist up to the specified version

### DIFF
--- a/packages/lesswrong/server/attributeEdits.ts
+++ b/packages/lesswrong/server/attributeEdits.ts
@@ -33,13 +33,19 @@ export async function computeAttributions(
     documentId, collectionName, fieldName,
     skipAttributions: false,
   }).fetch();
-  if (!revs.length) return { finalHtml: "", attributions: [] };
+  if (!revs.length) {
+    return { finalHtml: "", attributions: [] };
+  }
 
   let filteredRevs = orderBy(revs, r=>r.editedAt);
   
   // If upToVersion is provided, ignore revs after that
   if (upToVersion) {
     filteredRevs = filter(filteredRevs, r=>compareVersionNumbers(upToVersion, r.version)>=0);
+  }
+
+  if (!filteredRevs.length) {
+    return { finalHtml: "", attributions: [] };
   }
   
   // Cluster commits by author. In any sequential run of commits by the same


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211505678558883) by [Unito](https://www.unito.io)
