### PR TITLE
[EA] Include `fmCrosspostUserId` in the response for `crossposterDetailsRoute`

### DIFF
--- a/packages/lesswrong/lib/fmCrosspost/routes.ts
+++ b/packages/lesswrong/lib/fmCrosspost/routes.ts
@@ -59,6 +59,7 @@ export const crossposterDetailsRoute = new FMCrosspostRoute({
   responseSchema: z.object({
     displayName: z.string().nonempty(),
     slug: z.string().nonempty(),
+    fmCrosspostUserId: z.string().nullable().optional(),
   }),
 });
 

--- a/packages/lesswrong/server/crossposting/handlers.ts
+++ b/packages/lesswrong/server/crossposting/handlers.ts
@@ -132,6 +132,7 @@ export const addV2CrosspostHandlers = (app: Application) => {
       return {
         displayName: user.displayName ?? user.username ?? "",
         slug: user.slug ?? "",
+        fmCrosspostUserId: user.fmCrosspostUserId,
       };
     },
   );


### PR DESCRIPTION
https://cea-core.slack.com/archives/C75BWSNBH/p1758643850403319

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211508825562087) by [Unito](https://www.unito.io)
