### PR TITLE
Add "tabStart" event to client

### DIFF
--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -4,8 +4,8 @@ import { clientContextVars, flushClientEvents, captureEvent } from '../../lib/an
 import { useCurrentUser } from './withUser';
 import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '@/components/common/sharedContexts';
-import { CLIENT_ID_COOKIE, CLIENT_ID_NEW_COOKIE, TIMEZONE_COOKIE, THEME_COOKIE, LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
-import { useCookiesWithConsent, useCookiePreferences } from '../hooks/useCookiesWithConsent';
+import { CLIENT_ID_COOKIE, LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
+import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { isLWorAF } from '../../lib/instanceSettings';
 import { getAllUserABTestGroups } from '@/lib/abTestImpl';
 

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -50,9 +50,9 @@ export const AnalyticsClient = () => {
     });
     sessionStorage.setItem(firedKey, "1");
     flushClientEvents(true);
-  // Intentionally run once per mount/tab, not on user or cookie changes
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Depend on clientId and currentUserId to ensure clientContextVars are set before firing
+  // sessionStorage check ensures this still only fires once per tab
+  }, [clientId, currentUserId, currentUser, cookies]);
   
   return <></>;
 }

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -4,7 +4,7 @@ import { clientContextVars, flushClientEvents, captureEvent } from '../../lib/an
 import { useCurrentUser } from './withUser';
 import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '@/components/common/sharedContexts';
-import { CLIENT_ID_COOKIE, LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
+import { CLIENT_ID_COOKIE } from '../../lib/cookies/cookies';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { isLWorAF } from '../../lib/instanceSettings';
 import { getAllUserABTestGroups } from '@/lib/abTestImpl';
@@ -13,7 +13,7 @@ export const AnalyticsClient = () => {
   const currentUser = useCurrentUser();
   const [cookies] = useCookiesWithConsent([
     CLIENT_ID_COOKIE,
-    LAST_VISITED_FRONTPAGE_COOKIE,
+    // LAST_VISITED_FRONTPAGE_COOKIE,
   ]);
   const abTestGroupsUsed = useContext(ABTestGroupsUsedContext);
   
@@ -44,15 +44,13 @@ export const AnalyticsClient = () => {
       tabId,
       userAgent,
       abTestGroups,
-      cookies: {
-        isReturningVisitor: !!cookies[LAST_VISITED_FRONTPAGE_COOKIE],
-      },
     });
     sessionStorage.setItem(firedKey, "1");
     flushClientEvents(true);
   // Depend on clientId and currentUserId to ensure clientContextVars are set before firing
   // sessionStorage check ensures this still only fires once per tab
-  }, [clientId, currentUserId, currentUser, cookies]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId, currentUserId]);
   
   return <></>;
 }

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -11,8 +11,8 @@ import { getAllUserABTestGroups } from '@/lib/abTestImpl';
 
 export const AnalyticsClient = () => {
   const currentUser = useCurrentUser();
+  const [cookies] = useCookiesWithConsent([CLIENT_ID_COOKIE]);
   const currentUserLoading = useCurrentUserLoading();
-  const [cookies] = useCookiesWithConsent([ CLIENT_ID_COOKIE, ]);
   const abTestGroupsUsed = useContext(ABTestGroupsUsedContext);
   
   const currentUserId = currentUser?._id;
@@ -37,6 +37,7 @@ export const AnalyticsClient = () => {
     if (!tabId) return;
     const firedKey = `tabStartedFired:${tabId}`;
     if (sessionStorage.getItem(firedKey)) return;
+    sessionStorage.setItem(firedKey, "1");
 
     const userAgent = navigator.userAgent ?? null;
     const abTestGroups = getAllUserABTestGroups(currentUser ? { user: currentUser } : { clientId });
@@ -46,7 +47,6 @@ export const AnalyticsClient = () => {
       userAgent,
       abTestGroups,
     });
-    sessionStorage.setItem(firedKey, "1");
     flushClientEvents(true);
   // Depend on currentUserLoading to ensure we wait for user data before firing
   // sessionStorage check ensures this still only fires once per tab

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -1,16 +1,20 @@
 import React, {useContext, useEffect} from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { clientContextVars, flushClientEvents } from '../../lib/analyticsEvents';
+import { clientContextVars, flushClientEvents, captureEvent } from '../../lib/analyticsEvents';
 import { useCurrentUser } from './withUser';
 import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '@/components/common/sharedContexts';
-import { CLIENT_ID_COOKIE } from '../../lib/cookies/cookies';
-import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
+import { CLIENT_ID_COOKIE, CLIENT_ID_NEW_COOKIE, TIMEZONE_COOKIE, THEME_COOKIE, LAST_VISITED_FRONTPAGE_COOKIE } from '../../lib/cookies/cookies';
+import { useCookiesWithConsent, useCookiePreferences } from '../hooks/useCookiesWithConsent';
 import { isLWorAF } from '../../lib/instanceSettings';
+import { getAllUserABTestGroups } from '@/lib/abTestImpl';
 
 export const AnalyticsClient = () => {
   const currentUser = useCurrentUser();
-  const [cookies] = useCookiesWithConsent([CLIENT_ID_COOKIE]);
+  const [cookies] = useCookiesWithConsent([
+    CLIENT_ID_COOKIE,
+    LAST_VISITED_FRONTPAGE_COOKIE,
+  ]);
   const abTestGroupsUsed = useContext(ABTestGroupsUsedContext);
   
   const currentUserId = currentUser?._id;
@@ -25,6 +29,30 @@ export const AnalyticsClient = () => {
     // There may be events waiting for the client context vars to be set, so flush them now
     flushClientEvents(true);
   }, [currentUserId, clientId, currentUser, abTestGroupsUsed]);
+
+  // Fire a one-time per-tab lifecycle event when a new tab/app instance starts
+  useEffect(() => {
+    const tabId = window.tabId;
+    if (!tabId) return;
+    const firedKey = `tabStartedFired:${tabId}`;
+    if (sessionStorage.getItem(firedKey)) return;
+
+    const userAgent = navigator.userAgent ?? null;
+    const abTestGroups = getAllUserABTestGroups(currentUser ? { user: currentUser } : { clientId });
+
+    captureEvent("tabStarted", {
+      tabId,
+      userAgent,
+      abTestGroups,
+      cookies: {
+        isReturningVisitor: !!cookies[LAST_VISITED_FRONTPAGE_COOKIE],
+      },
+    });
+    sessionStorage.setItem(firedKey, "1");
+    flushClientEvents(true);
+  // Intentionally run once per mount/tab, not on user or cookie changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   return <></>;
 }

--- a/packages/lesswrong/components/common/withUser.tsx
+++ b/packages/lesswrong/components/common/withUser.tsx
@@ -7,6 +7,7 @@ import { localeSetting } from '@/lib/instanceSettings';
 import moment from 'moment';
 
 export const GetUserContext = createContext<()=>(UsersCurrent|null)>(() => null);
+export const CurrentUserLoadingContext = createContext<boolean>(false);
 
 export const UserContextProvider = ({children}: {
   children: React.ReactNode
@@ -31,11 +32,13 @@ export const UserContextProvider = ({children}: {
 
   return (
     <RefetchCurrentUserContext.Provider value={refetchCurrentUser}>
+    <CurrentUserLoadingContext.Provider value={currentUserLoading}>
     <UserContext.Provider value={currentUser}>
     <GetUserContext.Provider value={getCurrentUser}>
       {children}
     </GetUserContext.Provider>
     </UserContext.Provider>
+    </CurrentUserLoadingContext.Provider>
     </RefetchCurrentUserContext.Provider>
   );
 }
@@ -57,6 +60,8 @@ export const useGetCurrentUser = () => {
 };
 
 export const useCurrentUserId = () => useFilteredCurrentUser(u => u?._id);
+
+export const useCurrentUserLoading = () => useContext(CurrentUserLoadingContext);
 
 interface WithUserProps {
   currentUser: UsersCurrent | null;


### PR DESCRIPTION
We used to have analytics SSR events that crucially tied the abTestGroup info and user agent info to a given tab. With the loss of SSRs since the refactor, this PR introduces a substitute event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a per-tab startup analytics event that includes AB test groups and user agent, and introduces a context/hook to access current user loading state.
> 
> - **Analytics**:
>   - Fire one-time per-tab `tabStarted` event in `components/common/AnalyticsClient.tsx` after user loading completes; includes `tabId`, `userAgent`, and `abTestGroups`, then flushes.
>   - Integrate `captureEvent` and `getAllUserABTestGroups` for event payload.
> - **User Context**:
>   - Add `CurrentUserLoadingContext` and `useCurrentUserLoading` in `components/common/withUser.tsx`; provide `currentUserLoading` via context provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b21ef4e0f2a1e934ebcb7066bd208b75af664d7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211517263339958) by [Unito](https://www.unito.io)
