### PR TITLE
Remove one quicktake

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -73,7 +73,7 @@ const QuickTakesSectionLoaded = ({showCommunity}: {
   const { data, loading, refetch, loadMoreProps } = useQueryWithLoadMore(ShortformCommentsMultiQuery, {
     variables: {
       selector: { shortformFrontpage: { showCommunity, maxAgeDays } },
-      limit: 8,
+      limit: 7,
       enableTotal: true,
     },
   });


### PR DESCRIPTION
Sets quicktake count from "8" to "7."

If it still feels like too much might go down to 6.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211539053984085) by [Unito](https://www.unito.io)
