### PR TITLE
Enable draft comments for LessWrong

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -68,12 +68,6 @@ const formStyles = defineStyles('CommentForm', (theme: ThemeType) => ({
       color: theme.palette.text.bannerAdOverlay,
     }),
   },
-  submitButton: submitButtonStyles(theme),
-  cancelButton: cancelButtonStyles(theme),
-  submitSegmented: {
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
-  },
 }));
 
 const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType) => ({
@@ -107,7 +101,6 @@ const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType
     marginLeft: "5px",
     "&:hover": {
       opacity: .5,
-      backgroundColor: "none",
     },
   },
   cancelButton: {
@@ -121,7 +114,9 @@ const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType
       color: theme.palette.text.alwaysWhite,
       opacity: .5,
     }
-  } : {},
+  } : {
+    padding: '8px',
+  },
   submitMinimalist: {
     height: 'fit-content',
     marginTop: "auto",

--- a/packages/lesswrong/components/comments/CommentsDraftList.tsx
+++ b/packages/lesswrong/components/comments/CommentsDraftList.tsx
@@ -9,6 +9,7 @@ import { useCommentLinkState } from './CommentsItem/useCommentLink';
 import { gql } from '@/lib/generated/gql-codegen';
 import { useQuery } from "@/lib/crud/useQuery";
 import { useQueryWithLoadMore } from '../hooks/useQueryWithLoadMore';
+import SectionTitle from '../common/SectionTitle';
 
 const LinkedDraftCommentQuery = gql(`
   query LinkedDraftCommentQuery($documentId: String!) {
@@ -39,19 +40,24 @@ const styles = (theme: ThemeType) => ({
     fontWeight: 600,
     fontFamily: theme.palette.fonts.sansSerifStack,
   },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 500,
+  },
   noResults: {
     marginLeft: 8,
     color: theme.palette.text.dim4,
   }
 });
 
-const CommentsDraftList = ({userId, postId, initialLimit, itemsPerPage, showTotal, silentIfEmpty, classes}: {
+const CommentsDraftList = ({userId, postId, initialLimit, itemsPerPage, showTotal, silentIfEmpty, sectionTitleStyle, classes}: {
   userId: string,
   postId?: string,
   initialLimit?: number,
   itemsPerPage?: number,
   showTotal?: boolean,
   silentIfEmpty?: boolean,
+  sectionTitleStyle?: boolean
   classes: ClassesType<typeof styles>,
 }) => {
   const { linkedCommentId } = useCommentLinkState();
@@ -88,13 +94,14 @@ const CommentsDraftList = ({userId, postId, initialLimit, itemsPerPage, showTota
 
   // Move the linked comment up to the top if given
   const results = ([linkedComment, ...(rawResults ?? [])]
-    .filter(v => v?.draft) as DraftComments[])
-    .reduce((acc, comment) => {
-      if (!acc.some(existingComment => existingComment._id === comment._id)) {
+    .filter(v => !!v)
+    .filter(v => v.draft))
+    .reduce<DraftComments[]>((acc, comment) => {
+      if (!acc.some(existingComment => existingComment._id === comment?._id)) {
         acc.push(comment);
       }
       return acc;
-    }, [] as DraftComments[]);
+    }, []);
   const loading = draftCommentsLoading || (!linkedComment && linkedCommentLoading);
   const count = results.length;
 
@@ -105,7 +112,10 @@ const CommentsDraftList = ({userId, postId, initialLimit, itemsPerPage, showTota
   const showLoadMore = !loading && (count === undefined || totalCount === undefined || count < totalCount)
 
   return <AnalyticsContext pageElementContext="commentsDraftList">
-    {(!silentIfEmpty || !!results?.length) && <Typography variant="headline" className={classes.heading}>Draft comments</Typography>}
+    {(!silentIfEmpty || !!results?.length) && (sectionTitleStyle
+      ? <SectionTitle titleClassName={classes.sectionTitle} title='Draft comments'/>
+      : <Typography variant="headline" className={classes.heading}>Draft comments</Typography>
+    )}
     {(!silentIfEmpty && !loading && results?.length === 0) && (
       <Typography variant="body2" className={classes.noResults}>
         No comments to display.

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -85,7 +85,7 @@ const CommentBottom = ({comment, treeOptions, votingSystem, voteProps, commentBo
     )}>
       <CommentBottomCaveats comment={comment} />
       {showReplyButton && replyButton}
-      {VoteBottomComponent && <VoteBottomComponent
+      {VoteBottomComponent && !treeOptions.hideVoteBottom && <VoteBottomComponent
         document={comment}
         hideKarma={treeOptions.post?.hideCommentKarma}
         collectionName="Comments"

--- a/packages/lesswrong/components/comments/CommentsSubmitDropdown.tsx
+++ b/packages/lesswrong/components/comments/CommentsSubmitDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import { AnalyticsContext, useTracking } from '@/lib/analyticsEvents';
-import { preferredHeadingCase } from '@/themes/forumTheme';
+import { isFriendlyUI, preferredHeadingCase } from '@/themes/forumTheme';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import ForumIcon from '../common/ForumIcon';
 import LWPopper from '../common/LWPopper';
@@ -15,33 +15,54 @@ import LoginPopup from '../users/LoginPopup';
 
 const styles = (theme: ThemeType) => ({
   buttonWrapper: {
-    backgroundColor: theme.palette.primary.main,
+    ...(theme.isFriendlyUI ? {
+      backgroundColor: theme.palette.primary.main,
+    } : {}),
     borderTopRightRadius: theme.borderRadius.default,
     borderBottomRightRadius: theme.borderRadius.default,
     display: 'flex',
   },
   divider: {
-    width: 1,
     opacity: 0.9,
     flex: 1,
     marginTop: 'auto',
     marginBottom: 'auto',
     height: "calc(100% - 12px)",
-    backgroundColor: theme.palette.text.alwaysWhite,
+    ...(theme.isFriendlyUI ? {
+      width: 1,
+      backgroundColor: theme.palette.text.alwaysWhite,
+    } : {}),
   },
   button: {
     borderRadius: theme.borderRadius.default,
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
-    padding: '6px 4px',
+    padding: '6px 2px',
     minWidth: 0,
     boxShadow: 'none',
+    ...(!theme.isFriendlyUI ? {
+      color: theme.palette.lwTertiary.main,
+      "&:hover": {
+        opacity: 0.5,
+      },
+    } : {}),
   },
   dropdownIcon: {
     transform: 'translateY(1px)'
   },
   popper: {
     marginTop: 6
+  },
+  dropdownMenu: {
+    ...(!theme.isFriendlyUI && {
+      backgroundColor: theme.palette.dropdown.background,
+      borderRadius: theme.borderRadius.small,
+    }),
+  },
+  dropdownItem: {
+    ...(!theme.isFriendlyUI && {
+      padding: '4px 8px'
+    })
   }
 });
 
@@ -66,8 +87,8 @@ export const CommentsSubmitDropdown = ({ handleSubmit, classes }: {
       <div ref={dropdownRef} className={classes.buttonWrapper}>
         <div className={classes.divider} />
         <Button
-          variant="contained"
-          color="primary"
+          variant={isFriendlyUI() ? "contained" : undefined}
+          color={isFriendlyUI() ? "primary" : undefined}
           className={classes.button}
           onClick={() => setMenuOpen(!menuOpen)}
         >
@@ -82,9 +103,10 @@ export const CommentsSubmitDropdown = ({ handleSubmit, classes }: {
       >
         <LWClickAwayListener onClickAway={() => setMenuOpen(false)}>
           <Paper>
-            <DropdownMenu>
+            <DropdownMenu className={classes.dropdownMenu}>
               <DropdownItem
                 title={preferredHeadingCase("Save As Draft")}
+                menuItemClassName={classes.dropdownItem}
                 onClick={() => {
                   if (!currentUser) {
                     openDialog({

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -251,6 +251,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
               treeOptions={{
                 ...treeOptions,
                 hideReply: true,
+                hideVoteBottom: true,
                 initialShowEdit: false,
                 forceSingleLine: false,
                 forceNotSingleLine: true,

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -89,6 +89,12 @@ export interface CommentTreeOptions {
    * comments.
    */
   hideReply?: boolean,
+
+  /**
+   * If passed, the VoteBottom component will be hidden from the bottom of
+   * comments.
+   */
+  hideVoteBottom?: boolean,
   
   /**
    * If passed, the comment will have a link to the post or tag it

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -58,6 +58,7 @@ import { StructuredData } from '../common/StructuredData';
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import { StatusCodeSetter } from '../next/StatusCodeSetter';
+import CommentsDraftList from '../comments/CommentsDraftList';
 
 const UsersProfileMultiQuery = gql(`
   query multiUserUsersProfileQuery($selector: UserSelector, $limit: Int, $enableTotal: Boolean) {
@@ -393,6 +394,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
             <AnalyticsContext listContext={"userPageDrafts"}>
               <DraftsList limit={5}/>
               <PostsList2 hideAuthor showDraftTag={false} terms={unlistedTerms} showNoResults={false} showLoading={false} showLoadMore={false}/>
+              <CommentsDraftList userId={user._id} initialLimit={5} sectionTitleStyle />
             </AnalyticsContext>
             {hasEventsSetting.get() && <LocalGroupsList
               view='userInactiveGroups'

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -99,7 +99,7 @@ export const visitedLinksHaveFilledInCircle = () => isLWorAF();
 export const hasWikiLenses = () => isLWorAF();
 export const hasSubforums = () => isEAForum();
 export const hasPolls = () => isEAForum();
-export const hasDraftComments = () => isEAForum();
+export const hasDraftComments = () => true;
 
 // EA Forum disabled the author's ability to moderate posts. We disregard this
 // check in tests as the tests run in EA Forum mode, but we want to be able to

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -667,6 +667,13 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     const threadCandidateLimit = 200; // Hardcoded
     const lookbackInterval = `${threadEngagementLookbackDays} days`;
 
+    const getViewableCommentsFilter = (alias: string) => `
+      ${alias}."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
+      AND ${alias}.deleted IS NOT TRUE
+      AND ${alias}.retracted IS NOT TRUE
+      AND ${getViewableCommentsSelector(alias)}
+    `;
+
     const engagementStats = await this.getRawDb().manyOrNone<ThreadEngagementStats>(`
       -- CommentsRepo.getThreadEngagementStatsForRecentlyActiveThreads
       SELECT
@@ -683,8 +690,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           FROM (
             SELECT COALESCE(c."topLevelCommentId", c._id) AS "threadTopLevelId", MAX(c."postedAt") as "lastCommentActivity"
             FROM "Comments" c
-            WHERE c."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-              AND c.deleted IS NOT TRUE AND c.retracted IS NOT TRUE AND c."authorIsUnreviewed" IS NOT TRUE
+            WHERE ${getViewableCommentsFilter('c')}
             GROUP BY COALESCE(c."topLevelCommentId", c._id)
             ORDER BY "lastCommentActivity" DESC
             LIMIT $(threadCandidateLimit)
@@ -707,8 +713,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
                 SELECT "threadTopLevelId_inner_rat" FROM (
                     SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
                     FROM "Comments" c_inner
-                    WHERE c_inner."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-                      AND c_inner.deleted IS NOT TRUE AND c_inner.retracted IS NOT TRUE AND c_inner."authorIsUnreviewed" IS NOT TRUE
+                    WHERE ${getViewableCommentsFilter('c_inner')}
                     GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
                     ORDER BY "lastCommentActivity_inner" DESC
                     LIMIT $(threadCandidateLimit)
@@ -729,8 +734,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
                 SELECT "threadTopLevelId_inner_rat" FROM (
                     SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
                     FROM "Comments" c_inner
-                    WHERE c_inner."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-                      AND c_inner.deleted IS NOT TRUE AND c_inner.retracted IS NOT TRUE AND c_inner."authorIsUnreviewed" IS NOT TRUE
+                    WHERE ${getViewableCommentsFilter('c_inner')}
                     GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
                     ORDER BY "lastCommentActivity_inner" DESC
                     LIMIT $(threadCandidateLimit)
@@ -757,8 +761,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
                 SELECT "threadTopLevelId_inner_rat" FROM (
                     SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
                     FROM "Comments" c_inner
-                    WHERE c_inner."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-                      AND c_inner.deleted IS NOT TRUE AND c_inner.retracted IS NOT TRUE AND c_inner."authorIsUnreviewed" IS NOT TRUE
+                    WHERE ${getViewableCommentsFilter('c_inner')}
                     GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
                     ORDER BY "lastCommentActivity_inner" DESC
                     LIMIT $(threadCandidateLimit)
@@ -789,8 +792,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
                 SELECT "threadTopLevelId_inner_rat" FROM (
                     SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
                     FROM "Comments" c_inner
-                    WHERE c_inner."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-                      AND c_inner.deleted IS NOT TRUE AND c_inner.retracted IS NOT TRUE AND c_inner."authorIsUnreviewed" IS NOT TRUE
+                    WHERE ${getViewableCommentsFilter('c_inner')}
                     GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
                     ORDER BY "lastCommentActivity_inner" DESC
                     LIMIT $(threadCandidateLimit)
@@ -816,8 +818,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
                 SELECT "threadTopLevelId_inner_rat" FROM (
                     SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
                     FROM "Comments" c_inner
-                    WHERE c_inner."postedAt" > (NOW() - INTERVAL $(lookbackInterval))
-                      AND c_inner.deleted IS NOT TRUE AND c_inner.retracted IS NOT TRUE AND c_inner."authorIsUnreviewed" IS NOT TRUE
+                    WHERE ${getViewableCommentsFilter('c_inner')}
                     GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
                     ORDER BY "lastCommentActivity_inner" DESC
                     LIMIT $(threadCandidateLimit)

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -2,7 +2,7 @@ import Posts from "../../server/collections/posts/collection";
 import AbstractRepo from "./AbstractRepo";
 import { eaPublicEmojiNames } from "../../lib/voting/eaEmojiPalette";
 import LRU from "lru-cache";
-import { getViewableEventsSelector, getViewablePostsSelector } from "./helpers";
+import { getViewableCommentsSelector, getViewableEventsSelector, getViewablePostsSelector } from "./helpers";
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from "../../lib/collections/tags/helpers";
 import { recordPerfMetrics } from "./perfMetricWrapper";
 import { isAF } from "../../lib/instanceSettings";
@@ -1000,8 +1000,8 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         WHERE c."postedAt" > CURRENT_TIMESTAMP - INTERVAL $(maxAgeDays)
           AND c."postId" IS NOT NULL
           AND c.deleted IS NOT TRUE
-          AND c."authorIsUnreviewed" IS NOT TRUE
           AND c.retracted IS NOT TRUE
+          AND ${getViewableCommentsSelector('c')}
         GROUP BY "postId"
       ),
       posts_with_comments_from_subscribees AS (

--- a/packages/lesswrong/server/repos/VotesRepo.ts
+++ b/packages/lesswrong/server/repos/VotesRepo.ts
@@ -448,8 +448,7 @@ class VotesRepo extends AbstractRepo<"Votes"> {
             SELECT _id FROM "Posts" 
             WHERE
               "Posts"."userId" = $1
-              AND
-              "Posts"."draft" IS NOT true
+              AND "Posts"."draft" IS NOT TRUE
             ORDER BY "Posts"."postedAt" DESC
             LIMIT ${RECENT_CONTENT_COUNT}
           )
@@ -465,8 +464,8 @@ class VotesRepo extends AbstractRepo<"Votes"> {
             SELECT _id FROM "Comments" 
             WHERE
               "Comments"."userId" = $1
-              AND
-              "Comments"."debateResponse" IS NOT true
+              AND "Comments"."debateResponse" IS NOT TRUE
+              AND "Comments"."draft" IS NOT TRUE
             ORDER by "Comments"."postedAt" DESC
             LIMIT ${RECENT_CONTENT_COUNT}
           )
@@ -486,12 +485,9 @@ class VotesRepo extends AbstractRepo<"Votes"> {
         WHERE
           "Votes"."documentId" in (
             SELECT _id FROM "Posts" 
-            WHERE
-              "Posts"."userId" = $1
-            AND
-              "Posts"."draft" IS NOT true
-            AND
-              "Posts"."postedAt" < $2
+            WHERE "Posts"."userId" = $1
+            AND "Posts"."draft" IS NOT TRUE
+            AND "Posts"."postedAt" < $2
             ORDER BY "Posts"."postedAt" DESC
             LIMIT 1
           )
@@ -506,10 +502,9 @@ class VotesRepo extends AbstractRepo<"Votes"> {
         WHERE
           "Votes"."documentId" in (
             SELECT _id FROM "Comments" 
-            WHERE
-              "Comments"."userId" = $1
-            AND
-              "Comments"."postedAt" < $2
+            WHERE "Comments"."userId" = $1
+            AND "Comments"."postedAt" < $2
+            AND "Comments"."draft" IS NOT TRUE
             ORDER by "Comments"."postedAt" DESC
             LIMIT 1
           )

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -61,6 +61,7 @@ export const getViewableCommentsSelector = (commentsTableAlias?: string) => {
   const aliasPrefix = commentsTableAlias ? `${commentsTableAlias}.` : "";
   return `
     ${aliasPrefix}"rejected" IS NOT TRUE AND
+    ${aliasPrefix}"draft" IS NOT TRUE AND
     ${aliasPrefix}"debateResponse" IS NOT TRUE AND
     ${aliasPrefix}"authorIsUnreviewed" IS NOT TRUE
   `;


### PR DESCRIPTION
On a profile page:
<img width="787" height="615" alt="image" src="https://github.com/user-attachments/assets/0931e17f-15e3-4b30-89a4-52d3eb5f4633" />
<img width="798" height="604" alt="image" src="https://github.com/user-attachments/assets/bb4a4b90-7b99-41c7-aadc-573f71e1c877" />

On a post page:
<img width="806" height="862" alt="image" src="https://github.com/user-attachments/assets/8dbcc334-3a7f-494f-8d44-8675ee609259" />
<img width="829" height="861" alt="image" src="https://github.com/user-attachments/assets/4e1393f5-bfc1-45d2-8076-671adf2303a4" />

Relevant button differences with the EA forum:
- got rid of the divider
- reduced left-right padding on both the original submit button and the drop-down icon button push them closer together, since otherwise they looked too far apart without the divider (and with the same background color as the surrounding form)
- made the menu item padding much smaller to match the smaller combined width of our submit + drop-down
- kept our existing no-border and consistent background color between the submit button and the form its on

Other difference is that I implemented a different style on the profile page for the section title, to match our existing section titles (though smaller font size).

Go play around with it on the preview deployment.

Oh, also, I got rid of the existing reaction icon on single-line comment hover-previews, since it's just visual noise in that context (you can't click on those hover previews).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211540836011230) by [Unito](https://www.unito.io)
