### PR TITLE
refactor cron apis

### DIFF
--- a/.github/actions/runLWMigrations/action.yaml
+++ b/.github/actions/runLWMigrations/action.yaml
@@ -10,10 +10,6 @@ runs:
     - name: Setup Environment
       uses: ./.github/actions/setupEnvironment
 
-    - name: Type check
-      shell: bash
-      run: yarn tsc
-
     - name: Run migrations
       shell: bash
       env:

--- a/app/api/cron/every-midnight/route.ts
+++ b/app/api/cron/every-midnight/route.ts
@@ -1,12 +1,10 @@
 import type { NextRequest } from 'next/server';
 import { clearOldCronHistories } from '@/server/cron/cronUtil';
 import { maintainAnalyticsViews } from '@/server/analytics/analyticsViews';
-import { updateMissingPostEmbeddings, hasEmbeddingsForRecommendations } from '@/server/embeddings';
 import { sendInactiveUserSurveyEmails } from '@/server/inactiveUserSurveyCron';
 import { refreshKarmaInflation } from '@/server/karmaInflation/cron';
 import { pruneOldPerfMetrics } from '@/server/analytics/serverAnalyticsWriter';
 import PostRecommendationsRepo from '@/server/repos/PostRecommendationsRepo';
-import { clearOldUltraFeedServedEvents } from '@/server/ultraFeed/cron';
 import { sendJobAdReminderEmails } from '@/server/userJobAdCron';
 import { expiredRateLimitsReturnToReviewQueue } from '@/server/users/cron';
 import { updateScoreInactiveDocuments } from '@/server/votingCron';
@@ -18,55 +16,33 @@ export async function GET(request: NextRequest) {
     return new Response('Unauthorized', { status: 401 });
   }
 
-  // Run all daily midnight tasks in parallel
-  const tasks: Promise<void>[] = [];
+  await clearOldCronHistories();
 
-  // Clear old cron histories
-  tasks.push(clearOldCronHistories());
+  await refreshKarmaInflation();
 
-  // Maintain analytics views (EA Forum only)
-  if (isEAForum()) {
-    tasks.push(maintainAnalyticsViews());
-  }
-
-  // Update missing embeddings
-  if (hasEmbeddingsForRecommendations()) {
-    tasks.push(updateMissingPostEmbeddings());
-  }
-
-  // Send inactive user survey emails (EA Forum only)
-  if (isEAForum()) {
-    tasks.push(sendInactiveUserSurveyEmails());
-  }
-
-  // Refresh karma inflation
-  tasks.push(refreshKarmaInflation());
-
-  // Prune old performance metrics
-  if (performanceMetricLoggingEnabled.get()) {
-    tasks.push(pruneOldPerfMetrics());
-  }
-
-  // Clear stale recommendations
   const postRecommendationsRepo = new PostRecommendationsRepo();
-  tasks.push(postRecommendationsRepo.clearStaleRecommendations());
+  await postRecommendationsRepo.clearStaleRecommendations();
 
-  // Clear old ultrafeed served events
-  tasks.push(clearOldUltraFeedServedEvents());
+  await expiredRateLimitsReturnToReviewQueue();
 
-  // Send job ad reminder emails (EA Forum only)
-  if (isEAForum()) {
-    tasks.push(sendJobAdReminderEmails());
+  await updateScoreInactiveDocuments();
+
+  // This one's probably the longest-running, so do it last
+  if (performanceMetricLoggingEnabled.get()) {
+    await pruneOldPerfMetrics();
   }
 
-  // Handle expired rate limits
-  tasks.push(expiredRateLimitsReturnToReviewQueue());
+  // Send some emails and maintain analytics views (EA Forum only)
+  if (isEAForum()) {
+    // Run all daily midnight tasks in parallel
+    const tasks: Promise<void>[] = [];
+    tasks.push(sendInactiveUserSurveyEmails());
+    tasks.push(sendJobAdReminderEmails());
+    await Promise.all(tasks);
 
-  // Update score for inactive documents
-  tasks.push(updateScoreInactiveDocuments());
-
-  // Execute all tasks in parallel
-  await Promise.all(tasks);
+    // This is a fire-and-forget since the db queries take forever
+    maintainAnalyticsViews();
+  }
   
   return new Response('OK', { status: 200 });
 }

--- a/app/api/cron/every-minute/route.ts
+++ b/app/api/cron/every-minute/route.ts
@@ -20,18 +20,12 @@ export async function GET(request: NextRequest) {
 
   // Send curation emails
   if (!isTestServer && usesCurationEmailsCron()) {
-    // This doesn't need an advisory lock because it runs a while loop that pulls emails off a queue one at at time,
-    // so we aren't going to get stuck with a very large number of heavy, concurrent queries if this job gets run again
-    // while the last batch is still going.
-    tasks.push(sendCurationEmails());
+    tasks.push(getCronLock('sendCurationEmails', sendCurationEmails));
   }
 
   // Debounced event handler
   if (!isTestServer) {
-    // This doesn't need an advisory lock because it runs a while loop that updates individual database records as it goes,
-    // so we aren't going to get stuck with a very large number of heavy, concurrent queries if this job gets run again
-    // while the last batch is still going.
-    tasks.push(dispatchPendingEvents());
+    tasks.push(getCronLock('dispatchPendingEvents', dispatchPendingEvents));
   }
 
   // Check upcoming event emails

--- a/app/api/cron/every-ten-minutes/route.ts
+++ b/app/api/cron/every-ten-minutes/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { checkScheduledPosts } from '@/server/posts/cron';
 import { runRSSImport } from '@/server/rss-integration/cron';
+import { getCronLock } from '@/server/cron/cronLock';
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -14,8 +15,8 @@ export async function GET(request: NextRequest) {
     checkScheduledPosts(),
     
     // Add new RSS posts
-    runRSSImport()
+    await getCronLock('runRSSImport', runRSSImport)
   ]);
-  
+
   return new Response('OK', { status: 200 });
 }

--- a/app/api/cron/update-missing-post-embeddings/route.ts
+++ b/app/api/cron/update-missing-post-embeddings/route.ts
@@ -1,0 +1,15 @@
+import { hasEmbeddingsForRecommendations, updateMissingPostEmbeddings } from "@/server/embeddings";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (hasEmbeddingsForRecommendations()) {
+    await updateMissingPostEmbeddings();
+  }
+
+  return new Response('OK', { status: 200 });
+}

--- a/packages/lesswrong/lib/generated/routeManifest.ts
+++ b/packages/lesswrong/lib/generated/routeManifest.ts
@@ -127,6 +127,9 @@ export const routeTrie = {
             "update-analytics-collections": {
               "hasRoute": true
             },
+            "update-missing-post-embeddings": {
+              "hasRoute": true
+            },
             "update-promoted-spotlight-item": {
               "hasRoute": true
             },
@@ -142,6 +145,7 @@ export const routeTrie = {
             "every-ten-minutes": "every-ten-minutes",
             "run-twitter-bot": "run-twitter-bot",
             "update-analytics-collections": "update-analytics-collections",
+            "update-missing-post-embeddings": "update-missing-post-embeddings",
             "update-promoted-spotlight-item": "update-promoted-spotlight-item",
             "update-user-activities": "update-user-activities"
           }

--- a/packages/lesswrong/server/analytics/analyticsViews.ts
+++ b/packages/lesswrong/server/analytics/analyticsViews.ts
@@ -9,7 +9,7 @@ const getMaintenanceQueries = () => forumSelect({
   default: [],
 });
 
-export const maintainAnalyticsViews = async () => {
+export const maintainAnalyticsViews = () => {
   if (!getMaintenanceQueries().length) return;
 
   const db = getAnalyticsConnection()
@@ -18,6 +18,8 @@ export const maintainAnalyticsViews = async () => {
 
   for (const query of getMaintenanceQueries()) {
     // Run these concurrently and don't wait, as they can take ~hours
+    // Explicit not running them in a background task given their runtime
+    // would be longer than a function lifetime and there's no reason to pay that cost.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     void db.none(query)
   }

--- a/packages/lesswrong/server/cron/cronLock.ts
+++ b/packages/lesswrong/server/cron/cronLock.ts
@@ -5,7 +5,7 @@ export function getCronLock(cronName: string, callback: () => Promise<void>) {
   const db = getSqlClientOrThrow();
   return db.task(async (task) => {
     try {
-      // Set an hour-long lock on whatever cron job is being passed in.
+      // Set an 800-second-long lock on whatever cron job is being passed in.
       // We don't have any cron jobs that should take that long to run
       // in the database, but we've had a couple of incidents of downtime
       // where we suspect that the situation was made worse by the cron

--- a/packages/lesswrong/server/cron/cronLock.ts
+++ b/packages/lesswrong/server/cron/cronLock.ts
@@ -1,0 +1,31 @@
+import { captureException } from "@/lib/sentryWrapper";
+import { getSqlClientOrThrow } from "../sql/sqlClient";
+
+export function getCronLock(cronName: string, callback: () => Promise<void>) {
+  const db = getSqlClientOrThrow();
+  return db.task(async (task) => {
+    try {
+      // Set an hour-long lock on whatever cron job is being passed in.
+      // We don't have any cron jobs that should take that long to run
+      // in the database, but we've had a couple of incidents of downtime
+      // where we suspect that the situation was made worse by the cron
+      // scheduler firing off additional cron jobs while the database
+      // was already under too much load.
+      // If we have such an incident again, the worst-case scenario
+      // is that the lock gets held for an 800s (around the duration of
+      // the maximum Vercel function lifetime).  This should be fine
+      // for basically all cron jobs that we might lock like this.
+      await task.none(`SET LOCAL lock_timeout = '800s'`);
+      const lockResult = await task.any<{ pg_try_advisory_lock: boolean }>(`SELECT pg_try_advisory_lock($1)`, [cronName]);
+      if (!lockResult[0].pg_try_advisory_lock) {
+        // eslint-disable-next-line no-console
+        console.error(`Lock could not be acquired for cron job ${cronName}`);
+        captureException(new Error(`Lock could not be acquired for cron job ${cronName}`));
+        return;
+      }
+      return await callback();
+    } finally {
+      await task.none(`SELECT pg_advisory_unlock($1)`, [cronName]);
+    }
+  });
+}

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -436,7 +436,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       WHERE
         ${getViewablePostsSelector('p')} AND
         pe."embeddings" IS NULL AND
-        COALESCE((r."wordCount")::INTEGER, 0) > 0 AND
+        COALESCE((r."wordCount")::INTEGER, 0) > 1 AND
         r.html NOT LIKE '%|endoftext|%'
     `);
     return results.map(({_id}) => _id);

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -434,8 +434,10 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
       LEFT JOIN "PostEmbeddings" pe ON p."_id" = pe."postId"
       WHERE
+        ${getViewablePostsSelector('p')} AND
         pe."embeddings" IS NULL AND
-        COALESCE((r."wordCount")::INTEGER, 0) > 0
+        COALESCE((r."wordCount")::INTEGER, 0) > 0 AND
+        r.html NOT LIKE '%|endoftext|%'
     `);
     return results.map(({_id}) => _id);
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -436,8 +436,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       WHERE
         ${getViewablePostsSelector('p')} AND
         pe."embeddings" IS NULL AND
-        COALESCE((r."wordCount")::INTEGER, 0) > 1 AND
-        r.html NOT LIKE '%|endoftext|%'
+        COALESCE((r."wordCount")::INTEGER, 0) > 1
     `);
     return results.map(({_id}) => _id);
   }

--- a/packages/lesswrong/server/ultraFeed/cron.ts
+++ b/packages/lesswrong/server/ultraFeed/cron.ts
@@ -11,8 +11,8 @@ export async function clearOldUltraFeedServedEvents() {
     createdAt: { $lt: cutoffDate },
   };
 
-    await UltraFeedEvents.rawRemove(selector);
-  }
+  await UltraFeedEvents.rawRemove(selector);
+}
 
 export async function clearLoggedOutServedSessionsWithNoViews() {
     const db = getSqlClientOrThrow('write');

--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,7 @@
     "path": "/api/cron/every-midnight",
     "schedule": "0 0 * * *"
   }, {
-    "path": "/",
-    "schedule": "* * * * *"
+    "path": "/api/cron/update-missing-post-embeddings",
+    "schedule": "0 1 * * *"
   }]
 }


### PR DESCRIPTION
…to run heavier operations sequentially, and implement advisory locks for the heavier ones that are on a fast schedule to prevent pileups if the db is nonresponsive.

Also fix the query for fetching posts without embeddings; it was previously returning ~2800 posts (and then fetching them in batches of 50, uselessly, since they were all posts that couldn't get embeddings for one reason or another).  Now it returns 4.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211549917832611) by [Unito](https://www.unito.io)
