### PR TITLE
Reduce number of requests, increase reliability of, and prevent spurious errors for /analyticsEvent

### DIFF
--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect} from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { clientContextVars, flushClientEvents, captureEvent } from '../../lib/analyticsEvents';
+import { clientContextVars, throttledFlushClientEvents, captureEvent } from '../../lib/analyticsEvents';
 import { useCurrentUser, useCurrentUserLoading } from './withUser';
 import withErrorBoundary from './withErrorBoundary';
 import { ABTestGroupsUsedContext } from '@/components/common/sharedContexts';
@@ -25,8 +25,8 @@ export const AnalyticsClient = () => {
       clientContextVars.abTestGroupsUsed = abTestGroupsUsed;
     }
     // There may be events waiting for the client context vars to be set, so flush them now
-    flushClientEvents(true);
-  }, [currentUserId, clientId, currentUser, abTestGroupsUsed]);
+    throttledFlushClientEvents(true);
+  }, [currentUserId, clientId, abTestGroupsUsed]);
 
   // Fire a one-time per-tab lifecycle event when a new tab/app instance starts
   useEffect(() => {
@@ -47,7 +47,7 @@ export const AnalyticsClient = () => {
       userAgent,
       abTestGroups,
     });
-    flushClientEvents(true);
+    throttledFlushClientEvents(true);
   // Depend on currentUserLoading to ensure we wait for user data before firing
   // sessionStorage check ensures this still only fires once per tab
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/lesswrong/components/hooks/useIsMounted.ts
+++ b/packages/lesswrong/components/hooks/useIsMounted.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Returns a function that checks whether the component that called the hook is
+ * still mounted. Used with components that set timers.
+ */
+export const useIsMounted = (): {
+  getIsMounted: () => boolean
+} => {
+  const isMounted = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    }
+  }, []);
+  
+  return {
+    getIsMounted: useCallback(() => isMounted.current, [])
+  };
+}

--- a/packages/lesswrong/components/hooks/usePageVisibility.ts
+++ b/packages/lesswrong/components/hooks/usePageVisibility.ts
@@ -1,36 +1,40 @@
-import { useState, useCallback, useEffect } from 'react';
-import { useTracking } from '../../lib/analyticsEvents';
+import { useCallback, useRef } from 'react';
 import { isClient } from '../../lib/executionEnvironment';
 import { useEventListener } from './useEventListener';
 
 /**
  * Hook to track page visibility state.
- * Returns whether the page is currently visible and the visibility state.
+ * When page visibility changes, calls onChange. This does not
+ * return a value and does not trigger rerenders; React rerendering is
+ * suspended when the tab is not visible, so naively trying to do
+ * things with page visibility and React state will fail.
  */
-export function usePageVisibility() {
-  const { captureEvent } = useTracking();
-  const doc = isClient ? document : null;
-  const [pageIsVisible, setPageIsVisible] = useState(!doc?.hidden);
-  const [pageVisibilityState, setPageVisibilityState] = useState(doc?.visibilityState);
+export function usePageVisibility(onChange: (isVisible: boolean, visibilityState: DocumentVisibilityState) => void) {
+  const initialVisibility = getPageVisibility();
+  const visibilityRef = useRef(initialVisibility.isVisible);
 
   const handleVisibilityChange = useCallback(() => {
-    const isVisible = !doc?.hidden;
-    const visibilityState = doc?.visibilityState;
-    setPageIsVisible(isVisible);
-    setPageVisibilityState(visibilityState);
-    captureEvent("pageVisibilityChange", { isVisible, visibilityState });
-  }, [doc, captureEvent]);
-
-  useEffect(() => {
-    captureEvent("pageVisibilityChange", { 
-      isVisible: pageIsVisible, 
-      visibilityState: pageVisibilityState 
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const { isVisible, visibilityState } = getPageVisibility();
+    if (visibilityRef.current !== isVisible) {
+      visibilityRef.current = isVisible;
+      onChange?.(isVisible, visibilityState);
+    }
+  }, [onChange]);
 
   // visibilitychange seems to be missing from Typescript's list of window events?
   useEventListener('visibilitychange' as keyof WindowEventMap, handleVisibilityChange);
+}
 
-  return { pageIsVisible, pageVisibilityState };
+export function getPageVisibility(): {
+  isVisible: boolean,
+  visibilityState: DocumentVisibilityState
+}{
+  if (isClient) {
+    return {
+      isVisible: !document.hidden,
+      visibilityState: document.visibilityState
+    };
+  } else {
+    return { isVisible: false, visibilityState: "hidden" };
+  }
 }

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -586,7 +586,6 @@ export const postModerationWarningCommentIdSetting = new PublicInstanceSetting<s
 export const useExperimentalTagStyleSetting = new PublicInstanceSetting<boolean>('useExperimentalTagStyle', false, "optional");
 
 export const showAnalyticsDebug = new PublicInstanceSetting<"never" | "dev" | "always">("showAnalyticsDebug", "dev", "optional");
-export const flushIntervalSetting = new PublicInstanceSetting<number>("analyticsFlushInterval", 1000, "optional");
 
 type ReasonNoReviewNeeded = "alreadyApproved" | "noReview";
 type ReasonReviewIsNeeded = "mapLocation" | "firstPost" | "firstComment" | "contactedTooManyUsers" | "bio" | "profileImage" | "newContent";


### PR DESCRIPTION
Switches client-side posts to /analyticsEvent from using fetch to using sendBeacon, so that they're more likely to succeed when run from beforeUnloadFired. Increase the flush interval from 1s to 5s, make the flush timer throttling not trigger on leading edge, and don't bypass the flush timer during startup. The combined effect of these should be a greatly reduced number of POST requests to /analyticsEvent (but the same set of events received), which is better for Vercel hosting costs.

When you switch away from the site's browser tab, this triggers a `visibilitychange` event. We intended for that to cause notification checking and timer anaytics events to stop, but it didn't, because the event was used to trigger state changes and react rerendering, with the actual stopping-of-timers linked to useEffects in the rendered components. This doesn't work because React stops all rendering when the page is hidden (it might have worked in a past React version, I'm not sure).

Rewrite AnalyticsPageInitializer, NotificationsEffects, and associated hooks so that they avoid using React state (using only refs and callback functions). This makes them able to handle backgrounding correctly.