### PR TITLE
Refactor exported/imported styles to use defineStyles rather than registerComponent

### DIFF
--- a/packages/lesswrong/components/admin/AdminHome.tsx
+++ b/packages/lesswrong/components/admin/AdminHome.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import { userIsAdmin } from '../../lib/vulcan-users/permissions';
 import { useCurrentUser } from '../common/withUser';
@@ -11,9 +10,11 @@ import { useRefreshDbSettings } from '../hooks/useRefreshDbSettings';
 import SingleColumnSection from "../common/SingleColumnSection";
 import AdminMetadata from "./AdminMetadata";
 import Loading from "../vulcan-core/Loading";
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
 // Also used in ModerationLog
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("AdminHome", (theme: ThemeType) => ({
   adminHomeOrModerationLogPage: {
     fontFamily: theme.typography.fontFamily,
   
@@ -38,11 +39,10 @@ export const styles = (theme: ThemeType) => ({
       opacity: 0.8,
     },
   },
-});
+}));
 
-const AdminHome = ({ classes }: {
-  classes: ClassesType<typeof styles>
-}) => {
+const AdminHome = () => {
+  const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const {refreshDbSettings, isRefreshingDbSettings} = useRefreshDbSettings();
   
@@ -105,6 +105,4 @@ const AdminHome = ({ classes }: {
   </SingleColumnSection>
 }
 
-export default registerComponent('AdminHome', AdminHome, {styles});
-
-
+export default AdminHome;

--- a/packages/lesswrong/components/analytics/AnalyticsGraph.tsx
+++ b/packages/lesswrong/components/analytics/AnalyticsGraph.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import type { TooltipProps } from "recharts";
 import { useThemeColor } from "../themes/useTheme";
@@ -14,6 +13,8 @@ import ForumDropdown from "../common/ForumDropdown";
 import LWTooltip from "../common/LWTooltip";
 import AnalyticsGraphSkeleton from "./AnalyticsGraphSkeleton";
 import AnalyticsDisclaimers from "./AnalyticsDisclaimers";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 const CONTROLS_BREAKPOINT = 650;
 
@@ -26,7 +27,7 @@ export const GRAPH_HEIGHT = 300;
  */
 export const GRAPH_LEFT_MARGIN = 14;
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("AnalyticsGraph", (theme: ThemeType) => ({
   root: {
     overflow: "auto hidden",
     display: "flex",
@@ -163,7 +164,7 @@ export const styles = (theme: ThemeType) => ({
     fontSize: 12,
     fontWeight: 500,
   },
-});
+}));
 
 const dateOptions = {
   last7Days: {
@@ -221,10 +222,10 @@ const startEndDateFromOption = (option: string) => {
 
 interface ColoredCheckboxProps extends CheckboxProps {
   fillColor: string;
-  classes: ClassesType<typeof styles>;
 }
 
-const ColoredCheckbox: React.FC<ColoredCheckboxProps> = ({ fillColor, classes, ...props }: ColoredCheckboxProps) => {
+const ColoredCheckbox: React.FC<ColoredCheckboxProps> = ({ fillColor, ...props }: ColoredCheckboxProps) => {
+  const classes = useStyles(styles);
   return (
     <Checkbox
       className={classes.checkbox}
@@ -244,14 +245,13 @@ export const AnalyticsGraph = ({
   postIds,
   initialDisplayFields = ["views", "reads"],
   disclaimerEarliestDate,
-  classes,
 }: {
   initialDisplayFields?: AnalyticsField[];
   userId?: string;
   postIds?: string[];
   disclaimerEarliestDate?: Date,
-  classes: ClassesType<typeof styles>;
 }) => {
+  const classes = useStyles(styles);
   const LINE_COLORS: Record<AnalyticsField, string> = {
     reads: useThemeColor(theme => theme.palette.graph.analyticsReads),
     views: useThemeColor(theme => theme.palette.primary.main),
@@ -404,7 +404,6 @@ export const AnalyticsGraph = ({
               <ColoredCheckbox
                 checked={displayFields.includes(field)}
                 onChange={() => toggleField(field as AnalyticsField)}
-                classes={classes}
                 fillColor={LINE_COLORS[field]}
               />
               {startCase(field)}
@@ -434,10 +433,4 @@ export const AnalyticsGraph = ({
   );
 };
 
-export default registerComponent(
-  "AnalyticsGraph",
-  AnalyticsGraph,
-  {styles},
-);
-
-
+export default AnalyticsGraph;

--- a/packages/lesswrong/components/analytics/AnalyticsGraphSkeleton.tsx
+++ b/packages/lesswrong/components/analytics/AnalyticsGraphSkeleton.tsx
@@ -6,9 +6,9 @@ import {
   styles as analyticsGraphStyles,
 } from "./AnalyticsGraph";
 import classNames from "classnames";
+import { defineStyles, useStyles } from "../hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
-  ...analyticsGraphStyles(theme),
+const styles = defineStyles("AnalyticsGraphSkeleton", (theme: ThemeType) => ({
   rootSkeleton: {
     overflow: "hidden !important",
   },
@@ -41,14 +41,16 @@ const styles = (theme: ThemeType) => ({
     marginTop: 20,
     marginBottom: 2,
   },
-});
+}));
 
-export const AnalyticsGraphSkeleton = ({dateOptionDropdown, classes}: {
+export const AnalyticsGraphSkeleton = ({dateOptionDropdown}: {
   dateOptionDropdown?: ReactNode,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const baseClasses = useStyles(analyticsGraphStyles);
+  const classes = useStyles(styles);
+
   const overallStat = (
-    <div className={classes.overallStat}>
+    <div className={baseClasses.overallStat}>
       <div className={classNames(classes.overallStatCount, classes.placeholder)} />
       <div className={classNames(classes.overallStatDescription, classes.placeholder)} />
     </div>
@@ -59,16 +61,16 @@ export const AnalyticsGraphSkeleton = ({dateOptionDropdown, classes}: {
   );
 
   return (
-    <div className={classNames(classes.root, classes.rootSkeleton)}>
+    <div className={classNames(baseClasses.root, classes.rootSkeleton)}>
       <div className={classes.dateDropdownWrapper}>
         {dateOptionDropdown}
       </div>
-      <div className={classes.controls}>
-        <div className={classes.overallStatContainer}>
+      <div className={baseClasses.controls}>
+        <div className={baseClasses.overallStatContainer}>
           {overallStat}
           {overallStat}
         </div>
-        <div className={classes.controlFields}>
+        <div className={baseClasses.controlFields}>
           {fieldLabel}
           {fieldLabel}
           {fieldLabel}
@@ -80,10 +82,6 @@ export const AnalyticsGraphSkeleton = ({dateOptionDropdown, classes}: {
   );
 }
 
-export default registerComponent(
-  "AnalyticsGraphSkeleton",
-  AnalyticsGraphSkeleton,
-  {styles},
-);
+export default AnalyticsGraphSkeleton;
 
 

--- a/packages/lesswrong/components/common/FriendlyHoverOver.tsx
+++ b/packages/lesswrong/components/common/FriendlyHoverOver.tsx
@@ -1,20 +1,27 @@
 import React, { ReactNode } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import type { Placement as PopperPlacementType } from "popper.js"
 import type { AnalyticsProps } from "../../lib/analyticsEvents";
 import classNames from "classnames";
 import LWTooltip from "./LWTooltip";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 export const FRIENDLY_THIN_HOVER_OVER_WIDTH = 270;
 export const FRIENDLY_HOVER_OVER_WIDTH = 340;
 
-export const styles = (theme: ThemeType) => ({
+export const friendlyHoverOverRootStyles = (theme: ThemeType) => ({
+  background: theme.palette.grey[0],
+  borderRadius: theme.borderRadius.default,
+  border: `1px solid ${theme.palette.grey[120]}`,
+  boxShadow: theme.palette.boxShadow.eaCard,
+});
+
+const styles = defineStyles("FriendlyHoverOver", (theme: ThemeType) => ({
   root: {
-    background: theme.palette.grey[0],
-    borderRadius: theme.borderRadius.default,
-    border: `1px solid ${theme.palette.grey[120]}`,
-    boxShadow: theme.palette.boxShadow.eaCard,
+    ...friendlyHoverOverRootStyles(theme),
   },
+}), {
+  stylePriority: -1,
 });
 
 export type FriendlyHoverOverProps = {
@@ -35,7 +42,6 @@ export type FriendlyHoverOverProps = {
   onHide?: () => void,
   children: ReactNode,
   forceOpen?: boolean,
-  classes: ClassesType<typeof styles>,
 }
 
 /**
@@ -57,8 +63,8 @@ const FriendlyHoverOver = ({
   onHide,
   children,
   forceOpen,
-  classes,
 }: FriendlyHoverOverProps) => {
+  const classes = useStyles(styles);
   return (
     <LWTooltip
       title={title}
@@ -81,10 +87,4 @@ const FriendlyHoverOver = ({
   );
 }
 
-export default registerComponent(
-  "FriendlyHoverOver",
-  FriendlyHoverOver,
-  {styles, stylePriority: -1},
-);
-
-
+export default FriendlyHoverOver;

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState, useCallback, useEffect, CSSProperties } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import Headroom from '../../lib/react-headroom'
 import Toolbar from '@/lib/vendor/@material-ui/core/src/Toolbar';
@@ -33,6 +32,8 @@ import { isHomeRoute } from '@/lib/routeChecks';
 import { useRouteMetadata } from '../ClientRouteMetadataContext';
 import { forumSelect } from '@/lib/forumTypeUtils';
 import NotificationsMenu from "../notifications/NotificationsMenu";
+import { defineStyles, useStyles } from '../hooks/useStyles';
+import { registerComponent } from '@/lib/vulcan-lib/components';
 
 /** Height of top header. On Book UI sites, this is for desktop only */
 export const getHeaderHeight = () => isBookUI() ? 64 : 66;
@@ -111,7 +112,7 @@ const textColorOverrideStyles = ({
   },
 });
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("Header", (theme: ThemeType) => ({
   appBar: {
     boxShadow: theme.palette.boxShadow.appBar,
     color: theme.palette.text.bannerAdOverlay,
@@ -308,7 +309,7 @@ export const styles = (theme: ThemeType) => ({
     marginLeft: theme.spacing.unit,
     marginBottom: 1.5,
   },
-});
+}));
 
 const Header = ({
   standaloneNavigationPresent,
@@ -317,7 +318,6 @@ const Header = ({
   stayAtTop=false,
   searchResultsArea,
   backgroundColor,
-  classes,
 }: {
   standaloneNavigationPresent: boolean,
   sidebarHidden: boolean,
@@ -326,8 +326,8 @@ const Header = ({
   searchResultsArea: React.RefObject<HTMLDivElement|null>,
   // CSS var corresponding to the background color you want to apply (see also appBarDarkBackground above)
   backgroundColor?: string,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const [navigationOpen, setNavigationOpenState] = useState(false);
   const [notificationOpen, setNotificationOpen] = useState(false);
   const [notificationHasOpened, setNotificationHasOpened] = useState(false);
@@ -588,7 +588,6 @@ const Header = ({
 }
 
 export default registerComponent('Header', Header, {
-  styles,
   areEqual: "auto",
   hocs: [withErrorBoundary]
 });

--- a/packages/lesswrong/components/common/MetaInfo.tsx
+++ b/packages/lesswrong/components/common/MetaInfo.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames'
 import { Typography } from "./Typography";
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
-export const styles = (theme: ThemeType) => ({
+export const metaInfoRootStyles = (theme: ThemeType) => ({
+  display: "inline",
+  color: theme.palette.grey[600],
+  marginRight: theme.spacing.unit,
+  fontSize: "1rem",
+  
+  ...(theme.isFriendlyUI && {
+    fontFamily: theme.palette.fonts.sansSerifStack
+  }),
+});
+
+const styles = defineStyles("MetaInfo", (theme: ThemeType) => ({
   root: {
-    display: "inline",
-    color: theme.palette.grey[600],
-    marginRight: theme.spacing.unit,
-    fontSize: "1rem",
-    
-    ...(theme.isFriendlyUI && {
-      fontFamily: theme.palette.fonts.sansSerifStack
-    }),
+    ...metaInfoRootStyles(theme),
   },
   button: {
     cursor: "pointer",
@@ -20,15 +25,15 @@ export const styles = (theme: ThemeType) => ({
       color: theme.palette.grey[400],
     },
   }
-})
+}))
 
-const MetaInfo = ({children, classes, button, className}: {
+const MetaInfo = ({children, button, className}: {
   children: React.ReactNode,
-  classes: ClassesType<typeof styles>,
   button?: boolean,
   className?: string
   title?: string,
 }) => {
+  const classes = useStyles(styles);
   return <Typography
     component='span'
     className={classNames(classes.root, button && classes.button, className)}
@@ -37,6 +42,6 @@ const MetaInfo = ({children, classes, button, className}: {
   </Typography>
 }
 
-export default registerComponent('MetaInfo', MetaInfo, {styles});
+export default MetaInfo;
 
 

--- a/packages/lesswrong/components/contents/HorizScrollBlock.tsx
+++ b/packages/lesswrong/components/contents/HorizScrollBlock.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 

--- a/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
+++ b/packages/lesswrong/components/ea-forum/digestAd/StickyDigestAd.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { AnalyticsContext } from '../../../lib/analyticsEvents';
 import { useCurrentUser } from '../../common/withUser';
 import { eaForumDigestSubscribeURL } from '../../recentDiscussion/RecentDiscussionSubscribeReminder';

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingInput.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingInput.tsx
@@ -1,26 +1,33 @@
 import React, { useCallback, ChangeEvent, RefObject } from "react";
-import { registerComponent } from "../../../lib/vulcan-lib/components";
 import classNames from "classnames";
+import { defineStyles } from "@/components/hooks/defineStyles";
+import { useStyles } from "@/components/hooks/useStyles";
+
+export const onboardingInputRootStyles = (theme: ThemeType) => ({
+  width: "100%",
+  padding: "16px",
+  borderRadius: theme.borderRadius.default,
+  background: theme.palette.panelBackground.loginInput,
+  color: `${theme.palette.grey[1000]} !important`,
+  fontSize: 14,
+  fontWeight: 500,
+  border: "none",
+  resize: "none",
+  "&::placeholder": {
+    color: theme.palette.grey[600],
+  },
+  "&:hover, &:focus": {
+    background: theme.palette.panelBackground.loginInputHovered,
+  },
+});
 
 // These styles are also used by `EAOnboardingSelect`
-export const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EAOnboardingInput", (theme: ThemeType) => ({
   root: {
-    width: "100%",
-    padding: "16px",
-    borderRadius: theme.borderRadius.default,
-    background: theme.palette.panelBackground.loginInput,
-    color: `${theme.palette.grey[1000]} !important`,
-    fontSize: 14,
-    fontWeight: 500,
-    border: "none",
-    resize: "none",
-    "&::placeholder": {
-      color: theme.palette.grey[600],
-    },
-    "&:hover, &:focus": {
-      background: theme.palette.panelBackground.loginInputHovered,
-    },
+    ...onboardingInputRootStyles(theme),
   },
+}), {
+  stylePriority: -1
 });
 
 const EAOnboardingInput = ({
@@ -32,7 +39,6 @@ const EAOnboardingInput = ({
   inputRef,
   disabled,
   className,
-  classes,
 }: {
   value: string,
   setValue: (value: string) => void,
@@ -42,8 +48,8 @@ const EAOnboardingInput = ({
   inputRef?: RefObject<HTMLInputElement|null> | RefObject<HTMLTextAreaElement|null>,
   disabled?: boolean,
   className?: string,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const onChange = useCallback((
     ev: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
   ) => {
@@ -63,10 +69,4 @@ const EAOnboardingInput = ({
   );
 }
 
-export default registerComponent(
-  "EAOnboardingInput",
-  EAOnboardingInput,
-  {styles, stylePriority: -1},
-);
-
-
+export default EAOnboardingInput;

--- a/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingSelect.tsx
+++ b/packages/lesswrong/components/ea-forum/onboarding/EAOnboardingSelect.tsx
@@ -1,14 +1,15 @@
 import React, { ChangeEvent, useCallback } from "react";
-import { registerComponent } from "../../../lib/vulcan-lib/components";
-import { styles as inputStyles } from "./EAOnboardingInput";
+import { onboardingInputRootStyles } from "./EAOnboardingInput";
 import ForumIcon from "../../common/ForumIcon";
+import { defineStyles } from "@/components/hooks/defineStyles";
+import { useStyles } from "@/components/hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("EAOnboardingSelect", (theme: ThemeType) => ({
   root: {
     position: "relative",
   },
   select: {
-    ...inputStyles(theme).root,
+    ...onboardingInputRootStyles(theme),
     appearance: "none",
   },
   icon: {
@@ -17,19 +18,18 @@ const styles = (theme: ThemeType) => ({
     height: "100%",
     color: theme.palette.grey[600],
   },
-});
+}));
 
 export const EAOnboardingSelect = ({
   value,
   setValue,
   options,
-  classes,
 }: {
   value?: string,
   setValue: (value: string) => void,
   options: {value: string, label: string}[],
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const onChange = useCallback((ev: ChangeEvent<HTMLSelectElement>) => {
     setValue(ev.target.value ?? "");
   }, [setValue]);
@@ -52,10 +52,4 @@ export const EAOnboardingSelect = ({
   );
 }
 
-export default registerComponent(
-  "EAOnboardingSelect",
-  EAOnboardingSelect,
-  {styles},
-);
-
-
+export default EAOnboardingSelect;

--- a/packages/lesswrong/components/editor/Editor.tsx
+++ b/packages/lesswrong/components/editor/Editor.tsx
@@ -8,7 +8,7 @@ import debounce from 'lodash/debounce';
 import { isClient } from '../../lib/executionEnvironment';
 import { isEAForum } from '../../lib/instanceSettings';
 import type { CollaborativeEditingAccessLevel } from '../../lib/collections/posts/collabEditingPermissions';
-import { styles as greyEditorStyles } from "../ea-forum/onboarding/EAOnboardingInput";
+import { onboardingInputRootStyles } from "../ea-forum/onboarding/EAOnboardingInput";
 import FormLabel from '@/lib/vendor/@material-ui/core/src/FormLabel';
 import {checkEditorValid} from './validation'
 import ContentStyles from "../common/ContentStyles";
@@ -89,7 +89,7 @@ export const styles = (theme: ThemeType) => ({
     ...ckEditorStyles(theme),
   },
   ckEditorGrey: {
-    ...greyEditorStyles(theme).root,
+    ...onboardingInputRootStyles(theme),
   },
   questionWidth: {
     width: 640,

--- a/packages/lesswrong/components/form-components/FormComponentFriendlyTextInput.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentFriendlyTextInput.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
-import { styles as friendlyInputStyles } from "../ea-forum/onboarding/EAOnboardingInput";
+import { onboardingInputRootStyles } from "../ea-forum/onboarding/EAOnboardingInput";
 import TextField from "@/lib/vendor/@material-ui/core/src/TextField";
 import classNames from "classnames";
 import { defineStyles, useStyles } from "../hooks/useStyles";
@@ -11,7 +10,7 @@ const styles = defineStyles('FormComponentFriendlyTextInput', (theme: ThemeType)
     fontSize: 12,
   },
   textField: {
-    ...friendlyInputStyles(theme).root,
+    ...onboardingInputRootStyles(theme),
     "& .MuiInputBase-input": {
       padding: 0,
       fontSize: 14,

--- a/packages/lesswrong/components/form-components/LocationFormComponent.tsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.tsx
@@ -5,7 +5,7 @@ import Geosuggest from 'react-geosuggest'
 import type { Suggest, QueryType } from 'react-geosuggest';
 import { isClient } from '../../lib/executionEnvironment';
 import { mapsAPIKeySetting } from '@/lib/instanceSettings';
-import { styles as greyInputStyles } from "../ea-forum/onboarding/EAOnboardingInput";
+import { onboardingInputRootStyles } from "../ea-forum/onboarding/EAOnboardingInput";
 import FormLabel from '@/lib/vendor/@material-ui/core/src/FormLabel';
 import classNames from 'classnames';
 import type { TypedFieldApi } from '@/components/tanstack-form-components/BaseAppForm';
@@ -99,7 +99,7 @@ const styles = defineStyles('LocationFormComponent', (theme: ThemeType) => ({
   },
   greyRoot: {
     "& .geosuggest__input": {
-      ...greyInputStyles(theme).root,
+      ...onboardingInputRootStyles(theme),
       padding: "16px !important",
       "&:focus": {
         border: "none",

--- a/packages/lesswrong/components/form-components/TagMultiselect.tsx
+++ b/packages/lesswrong/components/form-components/TagMultiselect.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useState } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
-import { styles as inputStyles } from "../ea-forum/onboarding/EAOnboardingInput";
+import { onboardingInputRootStyles } from "../ea-forum/onboarding/EAOnboardingInput";
 import FormLabel from '@/lib/vendor/@material-ui/core/src/FormLabel';
 import classNames from 'classnames';
 import SingleTagItem from "./SingleTagItem";
 import TagsSearchAutoComplete from "../search/TagsSearchAutoComplete";
 import ErrorBoundary from "../common/ErrorBoundary";
 import SectionTitle from "../common/SectionTitle";
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("TagMultiselect", (theme: ThemeType) => ({
   label: {
     display: 'block',
     fontSize: 10,
@@ -18,7 +19,7 @@ const styles = (theme: ThemeType) => ({
     fontSize: 12,
   },
   greyContainer: {
-    ...inputStyles(theme).root,
+    ...onboardingInputRootStyles(theme),
     "&:hover, &:focus": {}, // Overwrite styles from above
     padding: 8,
     display: "flex",
@@ -67,7 +68,7 @@ const styles = (theme: ThemeType) => ({
       cursor: "text"
     }
   },
-});
+}));
 
 const TagMultiselect = ({
   value,
@@ -78,7 +79,6 @@ const TagMultiselect = ({
   isVotingContext,
   updateCurrentValues,
   variant,
-  classes,
 }: {
   value: Array<string>,
   label?: React.ReactNode,
@@ -88,8 +88,8 @@ const TagMultiselect = ({
   isVotingContext?: boolean,
   updateCurrentValues(values: Array<string>): void,
   variant?: "default" | "grey",
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const [focused, setFocused] = useState(startWithBorder)
 
   const onFocus = useCallback(() => setFocused(true), []);
@@ -147,6 +147,6 @@ const TagMultiselect = ({
   )
 }
 
-export default registerComponent('TagMultiselect', TagMultiselect, {styles});
+export default TagMultiselect;
 
 

--- a/packages/lesswrong/components/icons/Dictionary.tsx
+++ b/packages/lesswrong/components/icons/Dictionary.tsx
@@ -1,4 +1,3 @@
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import React from 'react';
 
 export const DictionaryIcon = (props: React.HTMLAttributes<SVGElement>) => {

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -1,14 +1,15 @@
 import React, { ReactNode } from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Popup as BadlyTypedPopup } from 'react-map-gl';
 import { componentWithChildren } from '../../lib/utils/componentsWithChildren';
 import ContentStyles from '../common/ContentStyles';
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
 const Popup = componentWithChildren(BadlyTypedPopup);
 
 // Shared with LocalEventMarker
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("StyledMapPopup", (theme: ThemeType) => ({
   root: {
     ...theme.typography.body2,
     width: 250,
@@ -60,15 +61,14 @@ export const styles = (theme: ThemeType) => ({
     display: 'flex',
     justifyContent: 'space-between'
   },
-});
+}));
 
 const StyledMapPopup = ({
-  children, classes, link, title,
+  children, link, title,
   metaInfo, cornerLinks, lat, lng,
   onClose, offsetTop=-20, offsetLeft, hideBottomLinks
 }: {
   children?: ReactNode,
-  classes: ClassesType<typeof styles>,
   link: string,
   title: string|ReactNode,
   metaInfo?: any,
@@ -80,6 +80,7 @@ const StyledMapPopup = ({
   offsetLeft?: number,
   hideBottomLinks?: boolean
 }) => {
+  const classes = useStyles(styles);
   return <Popup
     latitude={lat}
     longitude={lng}
@@ -106,7 +107,7 @@ const StyledMapPopup = ({
   </Popup>
 }
 
-export default registerComponent("StyledMapPopup", StyledMapPopup, {styles});
+export default StyledMapPopup;
 
 
 

--- a/packages/lesswrong/components/notifications/NotificationsPopover.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPopover.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { getHeaderHeight } from "../common/Header";
 import { useCurrentUser } from "../common/withUser";
-import { styles as popoverStyles } from "../common/FriendlyHoverOver";
+import { friendlyHoverOverRootStyles } from "../common/FriendlyHoverOver";
 import { useNotificationDisplays } from "./NotificationsPage/useNotificationDisplays";
 import { karmaSettingsLink } from "./NotificationsPage/NotificationsPageFeed";
 import type { NotificationDisplay } from "@/lib/notificationTypes";
@@ -23,12 +22,14 @@ import PopperCard from "../common/PopperCard";
 import DropdownMenu from "../dropdowns/DropdownMenu";
 import DropdownItem from "../dropdowns/DropdownItem";
 import Loading from "../vulcan-core/Loading";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 const notificationsSettingsLink = "/account?highlightField=auto_subscribe_to_my_posts";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("NotificationsPopover", (theme: ThemeType) => ({
   root: {
-    ...popoverStyles(theme).root,
+    ...friendlyHoverOverRootStyles(theme),
     fontFamily: theme.palette.fonts.sansSerifStack,
     position: "relative",
     padding: 16,
@@ -98,7 +99,7 @@ const styles = (theme: ThemeType) => ({
     alignItems: "center",
     height: 350,
   },
-});
+}));
 
 const getSettingsNudge = (batchingFrequency: KarmaChangeUpdateFrequency) => {
   switch (batchingFrequency) {
@@ -115,13 +116,12 @@ const NotificationsPopover = ({
   karmaChanges,
   onOpenNotificationsPopover,
   closePopover,
-  classes,
 }: {
   karmaChanges?: UserKarmaChanges['karmaChanges'] | null,
   onOpenNotificationsPopover?: () => void,
   closePopover?: () => void,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const [markingAsRead, setMarkingAsRead] = useState(false);
   const [limit, setLimit] = useState(defaultLimit);
@@ -323,10 +323,4 @@ const NotificationsPopover = ({
   );
 }
 
-export default registerComponent(
-  "NotificationsPopover",
-  NotificationsPopover,
-  {styles},
-);
-
-
+export default NotificationsPopover;

--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -22,12 +22,14 @@ import PostReadCheckbox from "./PostReadCheckbox";
 import PostsItemNewCommentsWrapper from "./PostsItemNewCommentsWrapper";
 import PostMostValuableCheckbox from "./PostMostValuableCheckbox";
 import { maybeDate } from "@/lib/utils/dateUtils";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 const KARMA_WIDTH = 50;
 const CARD_IMG_HEIGHT = 80;
 const CARD_IMG_WIDTH = 160;
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("EAPostsItem", (theme: ThemeType) => ({
   root: {
     display: "flex",
     alignItems: "center",
@@ -258,6 +260,8 @@ export const styles = (theme: ThemeType) => ({
   cardMeta: {
     maxWidth: `calc(100% - ${CARD_IMG_WIDTH}px)`,
   },
+}), {
+  stylePriority: 1,
 });
 
 
@@ -270,16 +274,15 @@ export type EAPostsItemProps = PostsItemConfig & {
   openInNewTab?: boolean,
   hideSecondaryInfo?: boolean,
   secondaryInfoNode?: React.ReactNode,
-  classes: ClassesType<typeof styles>,
 };
 
 const EAPostsItem = ({
   openInNewTab,
   hideSecondaryInfo,
   secondaryInfoNode,
-  classes,
   ...props
 }: EAPostsItemProps) => {
+  const classes = useStyles(styles);
   const {
     post,
     postLink,
@@ -524,8 +527,6 @@ export default registerComponent(
   "EAPostsItem",
   EAPostsItem,
   {
-    styles,
-    stylePriority: 1,
     hocs: [withErrorBoundary],
     areEqual: {
       terms: "deep",

--- a/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
+++ b/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Link } from "../../lib/reactRouterWrapper";
 import ForumIcon, { ForumIconName } from "../common/ForumIcon";
 import { useDismissable } from "../hooks/useDismissable";
 import { HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE } from "../../lib/cookies/cookies";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 /**
  * Styles are shared with `NewTagInfoBox`
  */
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("NewPostHowToGuides", (theme: ThemeType) => ({
   root: {
     width: 280,
     margin: "60px 20px 0 -60px",
@@ -55,7 +56,7 @@ export const styles = (theme: ThemeType) => ({
       textDecoration: 'underline',
     },
   },
-});
+}));
 
 type HowToGuide = {
   icon: ForumIconName,
@@ -76,9 +77,8 @@ const guides: HowToGuide[] = [
   },
 ];
 
-export const NewPostHowToGuides = ({classes}: {
-  classes: ClassesType<typeof styles>,
-}) => {
+export const NewPostHowToGuides = () => {
+  const classes = useStyles(styles);
   const {dismissed, dismiss} = useDismissable(HIDE_NEW_POST_HOW_TO_GUIDE_COOKIE);
   if (dismissed) {
     return null;
@@ -104,10 +104,4 @@ export const NewPostHowToGuides = ({classes}: {
   );
 }
 
-export default registerComponent(
-  "NewPostHowToGuides",
-  NewPostHowToGuides,
-  {styles},
-);
-
-
+export default NewPostHowToGuides;

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import classNames from 'classnames';
 import { isRecombeeRecommendablePost, postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { curatedUrl } from '../recommendations/constants';

--- a/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIntroSequence.tsx
@@ -13,11 +13,12 @@ import PostsUserAndCoauthors from "./PostsUserAndCoauthors";
 import PostsItem2MetaInfo from "./PostsItem2MetaInfo";
 import PostsItemTooltipWrapper from "./PostsItemTooltipWrapper";
 import AnalyticsTracker from "../common/AnalyticsTracker";
+import { defineStyles, useStyles } from '../hooks/useStyles';
 
 const IMAGE_WIDTH = 292;
 const IMAGE_HEIGHT = 96;
 
-export const styles = (theme: ThemeType)=> ({
+export const styles = defineStyles("PostsItemIntroSequence", (theme: ThemeType)=> ({
   root: {
     position: "relative",
     borderRadius: theme.isFriendlyUI ? theme.borderRadius.small : undefined,
@@ -127,14 +128,13 @@ export const styles = (theme: ThemeType)=> ({
     paddingTop: 7,
     paddingBottom:8,
   },
-})
+}));
 
 const PostsItemIntroSequence = ({
   post,
   sequence,
   showBottomBorder=true,
   hideAuthor=false,
-  classes,
   curatedIconLeft=false,
   translucentBackground=false,
   withImage,
@@ -147,11 +147,11 @@ const PostsItemIntroSequence = ({
   defaultToShowUnreadComments?: boolean,
   dense?: boolean,
   hideAuthor?: boolean,
-  classes: ClassesType<typeof styles>,
   curatedIconLeft?: boolean,
   translucentBackground?: boolean,
   withImage?: boolean,
 }) => {
+  const classes = useStyles(styles);
   const { isRead } = useRecordPostView(post);
   const postLink = postGetPageUrl(post, false, sequence?._id);
 
@@ -212,8 +212,5 @@ const PostsItemIntroSequence = ({
 };
 
 export default registerComponent('PostsItemIntroSequence', PostsItemIntroSequence, {
-  styles,
   hocs: [withErrorBoundary],
 });
-
-

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -7,6 +7,8 @@ import { isClient } from '../../../lib/executionEnvironment';
 import classNames from 'classnames';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 import ForumIcon from "../../common/ForumIcon";
+import { defineStyles } from '@/components/hooks/defineStyles';
+import { useStyles } from '@/components/hooks/useStyles';
 
 const DEFAULT_TOC_MARGIN = 100
 const MAX_TOC_WIDTH = 270
@@ -15,7 +17,7 @@ export const MAX_CONTENT_WIDTH = 720;
 const TOC_OFFSET_TOP = 92
 const TOC_OFFSET_BOTTOM = 64
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("ToCColumn", (theme: ThemeType) => ({
   root: {
     position: "relative",
     [theme.breakpoints.down('sm')]: {
@@ -128,7 +130,7 @@ export const styles = (theme: ThemeType) => ({
   hideTocButtonHidden: {
     display: "none",
   },
-});
+}));
 
 const shouldHideToggleContentsButton = () => {
   if (!isClient) {
@@ -151,15 +153,14 @@ export const ToCColumn = ({
   rightColumnChildren,
   notHideable,
   children,
-  classes,
 }: {
   tableOfContents: React.ReactNode|null,
   header?: React.ReactNode,
   rightColumnChildren?: React.ReactNode,
   notHideable?: boolean,
   children: React.ReactNode,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const {captureEvent} = useTracking();
   const {sideCommentsActive} = useContext(SidebarsContext)!;
   const [hideTocButtonHidden, setHideTocButtonHidden] = useState(
@@ -229,6 +230,6 @@ export const ToCColumn = ({
   );
 }
 
-export default registerComponent("ToCColumn", ToCColumn, {styles});
+export default ToCColumn;
 
 

--- a/packages/lesswrong/components/search/UserMentionHit.tsx
+++ b/packages/lesswrong/components/search/UserMentionHit.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { registerComponent } from "../../lib/vulcan-lib/components"
-import MetaInfo, { styles as metaInfoStyles } from "../common/MetaInfo"
+import MetaInfo, { metaInfoRootStyles } from "../common/MetaInfo"
 import { isFriendlyUI } from "@/themes/forumTheme";
 import FormatDate from "../common/FormatDate";
 import ForumIcon from "../common/ForumIcon";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
-const styles = (theme: ThemeType) => ({
+const styles = defineStyles("UserMentionHit", (theme: ThemeType) => ({
   root: {
     color: "inherit",
     ...(theme.isFriendlyUI && {
@@ -23,7 +24,7 @@ const styles = (theme: ThemeType) => ({
   },
   userHitLabel: {
     ...theme.typography.body2,
-    ...metaInfoStyles(theme).root,
+    ...metaInfoRootStyles(theme),
     marginLeft: theme.spacing.unit,
 
     // To properly switch color on item being selected
@@ -31,12 +32,12 @@ const styles = (theme: ThemeType) => ({
       color: "inherit",
     },
   },
-});
+}));
 
-const UserMentionHit = ({hit, classes}: {
+const UserMentionHit = ({hit}: {
   hit: SearchUser,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const icon = isFriendlyUI()
     ? <ForumIcon icon="UserOutline" className={classes.icon} />
     : "👤";
@@ -51,10 +52,6 @@ const UserMentionHit = ({hit, classes}: {
   </span>
 }
 
-export default registerComponent(
-  "UserMentionHit",
-  UserMentionHit,
-  {styles},
-);
+export default UserMentionHit;
 
 

--- a/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
@@ -1,4 +1,3 @@
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import IconButton from '@/lib/vendor/@material-ui/core/src/IconButton'
 import NavigateBefore from '@/lib/vendor/@material-ui/icons/src/NavigateBefore'
@@ -8,9 +7,11 @@ import { useUpdateContinueReading } from './useUpdateContinueReading';
 import classnames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 import { TooltipSpan } from '../common/FMTooltip';
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
 // Shared with SequencesNavigationLinkDisabled
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("SequencesNavigationLink", (theme: ThemeType) => ({
   root: {
     padding: 0,
     margin: 12,
@@ -25,13 +26,13 @@ export const styles = (theme: ThemeType) => ({
       color: `${theme.palette.icon.dim6} !important`,
     }
   },
-});
+}));
 
-const SequencesNavigationLink = ({ post, direction, classes }: {
+const SequencesNavigationLink = ({ post, direction }: {
   post: PostSequenceNavigation['nextPost'] | PostSequenceNavigation['prevPost'] | null,
   direction: "left"|"right",
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const updateContinueReading = useUpdateContinueReading(post?._id, post?.sequence?._id);
   
   const icon = (
@@ -60,7 +61,4 @@ const SequencesNavigationLink = ({ post, direction, classes }: {
   }
 };
 
-export default registerComponent('SequencesNavigationLink', SequencesNavigationLink, {styles});
-
-
-
+export default SequencesNavigationLink;

--- a/packages/lesswrong/components/tagging/EAPostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/EAPostsItemTagRelevance.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useTracking } from "../../lib/analyticsEvents";
 import { useVoteButtonsDisabled } from "../votes/useVoteButtonsDisabled";
 import { useDialog } from "../common/withDialog";
@@ -10,8 +9,10 @@ import classNames from "classnames";
 import LoginPopup from "../users/LoginPopup";
 import LWTooltip from "../common/LWTooltip";
 import ForumIcon from "../common/ForumIcon";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("EAPostsItemTagRelevance", (theme: ThemeType) => ({
   root: {
     display: "flex",
     alignItems: "center",
@@ -36,7 +37,7 @@ export const styles = (theme: ThemeType) => ({
   downvoted: {
     color: theme.palette.error.main,
   },
-});
+}));
 
 /**
  * This component contains a new redesign of the posts item tag relevance vote.
@@ -44,10 +45,10 @@ export const styles = (theme: ThemeType) => ({
  * votes yet, but most of the logic is in place. Once the design is finished, this
  * is a drop-in replacement for `PostsItemTagRelevance` in `EAPostsItem`.
  */
-const EAPostsItemTagRelevance = ({tagRel, classes}: {
+const EAPostsItemTagRelevance = ({tagRel}: {
   tagRel: WithVoteTagRel,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   const {openDialog} = useDialog();
   const {flash} = useMessages();
   const {captureEvent} = useTracking();
@@ -114,10 +115,6 @@ const EAPostsItemTagRelevance = ({tagRel, classes}: {
   );
 }
 
-export default registerComponent(
-  "EAPostsItemTagRelevance",
-  EAPostsItemTagRelevance,
-  {styles},
-);
+export default EAPostsItemTagRelevance;
 
 

--- a/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
+++ b/packages/lesswrong/components/tagging/NewTagInfoBox.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { styles as postInfoStyles } from "../posts/NewPostHowToGuides";
 import { AnalyticsContext } from "@/lib/analyticsEvents";
 import { taggingNameSetting } from "@/lib/instanceSettings";
 import { Link } from "@/lib/reactRouterWrapper";
 import classNames from "classnames";
+import { defineStyles } from "../hooks/defineStyles";
+import { useStyles } from "../hooks/useStyles";
 
 const wikiFaqLink = "/topics/ea-wiki-faq";
 
-const styles = (theme: ThemeType) => ({
-  ...postInfoStyles(theme),
+const styles = defineStyles("NewTagInfoBox", (theme: ThemeType) => ({
   width: {
     marginRight: 0,
     "@media (max-width: 1400px)": {
@@ -36,14 +36,17 @@ const styles = (theme: ThemeType) => ({
       },
     },
   },
-});
+}));
 
-const NewTagInfoBox = ({classes}: {classes: ClassesType<typeof styles>}) => {
+const NewTagInfoBox = () => {
+  const classes = useStyles(styles);
+  const postInfoClasses = useStyles(postInfoStyles);
+
   const tag = taggingNameSetting.get();
   return (
     <AnalyticsContext pageElementContext="newTagInfoBox">
-      <div className={classNames(classes.root, classes.width)}>
-        <div className={classes.title}>
+      <div className={classNames(postInfoClasses.root, classes.width)}>
+        <div className={postInfoClasses.title}>
           Your {tag} may be rejected if:
         </div>
         <div className={classes.content}>
@@ -69,10 +72,6 @@ const NewTagInfoBox = ({classes}: {classes: ClassesType<typeof styles>}) => {
   );
 }
 
-export default registerComponent(
-  "NewTagInfoBox",
-  NewTagInfoBox,
-  {styles},
-);
+export default NewTagInfoBox;
 
 

--- a/packages/lesswrong/components/tagging/NewTagPage.tsx
+++ b/packages/lesswrong/components/tagging/NewTagPage.tsx
@@ -5,7 +5,6 @@ import { useCurrentUser } from '../common/withUser';
 import { tagGetUrl, getTagMinimumKarmaPermissions, tagUserHasSufficientKarma } from '../../lib/collections/tags/helpers';
 import { isEAForum, taggingNameCapitalSetting, taggingNamePluralSetting } from '../../lib/instanceSettings';
 import { slugify } from '@/lib/utils/slugify';
-import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useLocation, useNavigate } from "@/lib/routeUtil";
 import { useTagBySlug } from './useTag';
 import { TagForm } from './TagForm';
@@ -15,6 +14,8 @@ import NewTagInfoBox from "./NewTagInfoBox";
 import Loading from "../vulcan-core/Loading";
 import { useMutation } from "@apollo/client/react";
 import { gql } from "@/lib/generated/gql-codegen";
+import { defineStyles } from '../hooks/defineStyles';
+import { useStyles } from '../hooks/useStyles';
 
 const TagEditFragmentUpdateMutation = gql(`
   mutation updateTagNewTagPage($selector: SelectorInput!, $data: UpdateTagDataInput!) {
@@ -26,7 +27,7 @@ const TagEditFragmentUpdateMutation = gql(`
   }
 `);
 
-export const styles = (_theme: ThemeType) => ({
+export const styles = defineStyles("NewTagPage", (_theme: ThemeType) => ({
   root: {
     position: "relative",
   },
@@ -38,9 +39,10 @@ export const styles = (_theme: ThemeType) => ({
       right: -240,
     },
   },
-});
+}));
 
-const NewTagPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
+const NewTagPage = () => {
+  const classes = useStyles(styles);
   const navigate = useNavigate();
   const currentUser = useCurrentUser();
   const [updateTag] = useMutation(TagEditFragmentUpdateMutation);
@@ -119,6 +121,6 @@ const NewTagPage = ({classes}: {classes: ClassesType<typeof styles>}) => {
   );
 }
 
-export default registerComponent('NewTagPage', NewTagPage, {styles});
+export default NewTagPage;
 
 

--- a/packages/lesswrong/components/tagging/TagTableOfContents.tsx
+++ b/packages/lesswrong/components/tagging/TagTableOfContents.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { registerComponent } from '../../lib/vulcan-lib/components';
 import { Link } from '../../lib/reactRouterWrapper';
 import { tagUrlBaseSetting, taggingNameCapitalSetting } from '../../lib/instanceSettings';
 import type { ToCDisplayOptions } from '../posts/TableOfContents/TableOfContentsList';
 import TableOfContents from "../posts/TableOfContents/TableOfContents";
 import TableOfContentsRow from "../posts/TableOfContents/TableOfContentsRow";
 import TagContributorsList from "./TagContributorsList";
+import { defineStyles, useStyles } from '../hooks/useStyles';
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("TagTableOfContents", (theme: ThemeType) => ({
   tableOfContentsWrapper: {
     position: "relative",
     top: 12,
@@ -23,17 +23,17 @@ export const styles = (theme: ThemeType) => ({
   unreadCount: {
     color: theme.palette.primary.main,
   }
-});
+}));
 
 
-const TagTableOfContents = ({tag, expandAll, showContributors, onHoverContributor, displayOptions, classes}: {
+const TagTableOfContents = ({tag, expandAll, showContributors, onHoverContributor, displayOptions}: {
   tag: TagPageFragment|AllTagsPageFragment
   expandAll?: () => void,
   showContributors: boolean,
   onHoverContributor?: (contributorId: string) => void,
   displayOptions?: ToCDisplayOptions,
-  classes: ClassesType<typeof styles>,
 }) => {
+  const classes = useStyles(styles);
   if (!tag.tableOfContents) {
     return null;
   }
@@ -58,6 +58,6 @@ const TagTableOfContents = ({tag, expandAll, showContributors, onHoverContributo
   );
 }
 
-export default registerComponent("TagTableOfContents", TagTableOfContents, {styles});
+export default TagTableOfContents;
 
 

--- a/packages/lesswrong/components/tagging/subforums/SubforumLayout.tsx
+++ b/packages/lesswrong/components/tagging/subforums/SubforumLayout.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MAX_COLUMN_WIDTH } from '@/components/posts/PostsPage/constants';
 import { TAB_NAVIGATION_MENU_WIDTH } from '../../common/TabNavigationMenu/TabNavigationMenu';
-import { registerComponent } from '../../../lib/vulcan-lib/components';
 import CloudinaryImage2 from "../../common/CloudinaryImage2";
+import { defineStyles } from '@/components/hooks/defineStyles';
+import { useStyles } from '@/components/hooks/useStyles';
 
 const MIN_SIDEBAR_WIDTH = 250
 const MAX_SIDEBAR_WIDTH = 370
@@ -25,7 +26,7 @@ const gridTemplateColumns = `
   1fr
 `
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("SubforumLayout", (theme: ThemeType) => ({
   titleWrapper: {
     overflow: 'hidden',
     [theme.breakpoints.down('md')]: {
@@ -116,16 +117,16 @@ export const styles = (theme: ThemeType) => ({
     }
   },
   gap2: { gridArea: 'gap2' }
-});
+}));
 
-export const SubforumLayout = ({titleComponent, bannerImageId, headerComponent, sidebarComponents = [], children, classes}: {
+export const SubforumLayout = ({titleComponent, bannerImageId, headerComponent, sidebarComponents = [], children}: {
   titleComponent: React.ReactNode,
   bannerImageId: string,
   headerComponent: React.ReactNode,
   children: React.ReactNode,
-  classes: ClassesType<typeof styles>,
   sidebarComponents?: React.ReactNode[],
 }) => {
+  const classes = useStyles(styles);
   const nonEmptySidebarComponents = sidebarComponents.filter(x => x) // filter out nulls to avoid extra spacing
   /*
    * The logic for rendering the banner image has turned out more complicated than I would
@@ -202,6 +203,4 @@ export const SubforumLayout = ({titleComponent, bannerImageId, headerComponent, 
   );
 }
 
-export default registerComponent("SubforumLayout", SubforumLayout, {styles});
-
-
+export default SubforumLayout;

--- a/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
+++ b/packages/lesswrong/components/tagging/subforums/TagSubforumPage2.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { tagGetUrl } from '../../../lib/collections/tags/helpers';
-import { registerComponent } from '../../../lib/vulcan-lib/components';
 import { useCurrentUser } from '../../common/withUser';
 import { MAX_COLUMN_WIDTH } from '@/components/posts/PostsPage/constants';
 import { useTagBySlug } from '../useTag';
@@ -32,6 +31,7 @@ import { StructuredData } from '@/components/common/StructuredData';
 import { useMutation } from "@apollo/client/react";
 import { useQuery } from "@/lib/crud/useQuery"
 import { gql } from "@/lib/generated/gql-codegen";
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 
 const UserTagRelDetailsMultiQuery = gql(`
   query multiUserTagRelTagSubforumPage2Query($selector: UserTagRelSelector, $limit: Int, $enableTotal: Boolean) {
@@ -65,7 +65,7 @@ const UserTagRelDetailsMutation = gql(`
   }
 `);
 
-export const styles = (theme: ThemeType) => ({
+export const styles = defineStyles("TagSubforumPage2", (theme: ThemeType) => ({
   tabRow: {
     display: 'flex',
     alignItems: 'center',
@@ -151,15 +151,14 @@ export const styles = (theme: ThemeType) => ({
   tableOfContentsWrapper: {
     padding: 24,
   },
-});
+}));
 
 const subforumTabs = ["posts", "wiki"] as const
 type SubforumTab = typeof subforumTabs[number]
 const defaultTab: SubforumTab = "posts"
 
-const TagSubforumPage2 = ({classes}: {
-  classes: ClassesType<typeof styles>
-}) => {
+const TagSubforumPage2 = () => {
+  const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const navigate = useNavigate();
@@ -406,6 +405,6 @@ const TagSubforumPage2 = ({classes}: {
   );
 }
 
-export default registerComponent("TagSubforumPage2", TagSubforumPage2, {styles});
+export default TagSubforumPage2;
 
 


### PR DESCRIPTION
Refactors all of the places where I found `export const styles = (theme) => ...` to instead use `defineStyles` (with a corresponding refactor on the other side of the import when necessary). This removes a corner case that would've been hard to handle with a codemod, making it more possible to remove `registerComponent` programmatically.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211556617396222) by [Unito](https://www.unito.io)
