### PR TITLE
Fix a bug that sometimes made strong-agree-voting not work

### DIFF
--- a/packages/lesswrong/components/votes/VoteAgreementIcon.tsx
+++ b/packages/lesswrong/components/votes/VoteAgreementIcon.tsx
@@ -35,7 +35,8 @@ const styles = defineStyles("VoteAgreementIcon", (theme: ThemeType) => ({
     opacity: 0.6,
     position: 'absolute',
     height: 14,
-    transform: 'translate(-4.5px, -2px)'
+    transform: 'translate(-4.5px, -2px)',
+    pointerEvents: "none",
   },
   clear: {
     fontSize: '45%',


### PR DESCRIPTION
When strong agree voting, sometimes you'd click and hold and it would abort the strong vote leaving a weak agree vote. This only happened on desktop, only for strong-agree, and only for part but not all of the clickable area.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211556770156841) by [Unito](https://www.unito.io)
