### PR TITLE
[EA] Support showing multiple topic tabs if there are multiple active events

### DIFF
--- a/packages/lesswrong/components/common/HomeTagBar.tsx
+++ b/packages/lesswrong/components/common/HomeTagBar.tsx
@@ -204,7 +204,7 @@ const HomeTagBar = (
     showDescriptionOnHover?: boolean,
   },
 ) => {
-  const {currentForumEvent} = useCurrentAndRecentForumEvents();
+  const {currentForumEvent, activeForumEvents} = useCurrentAndRecentForumEvents();
 
   // we use the widths of the tabs window and the underlying topics bar
   // when calculating how far to scroll left and right
@@ -240,11 +240,12 @@ const HomeTagBar = (
 
   const allTabs: TopicsBarTab[] = useMemo(() => {
     const mainTabs = [frontpageTab];
-    if (currentForumEvent?.tag) {
-      mainTabs.push(currentForumEvent?.tag);
-    }
+    const eventTags = activeForumEvents
+      .map(event => event.tag)
+      .filter(tag => tag != null);
+    mainTabs.push(...eventTags);
     return [...mainTabs, ...(sortTopics(coreTopics ?? []))];
-  }, [coreTopics, sortTopics, frontpageTab, currentForumEvent?.tag]);
+  }, [coreTopics, sortTopics, frontpageTab, activeForumEvents]);
 
   const [activeTab, setActiveTab] = useState<TopicsBarTab>(frontpageTab)
   const [leftArrowVisible, setLeftArrowVisible] = useState(false)
@@ -347,7 +348,8 @@ const HomeTagBar = (
                   {allTabs.map(tab => {
                     const tabName = tab.shortName || tab.name
                     const isActive = tab._id === activeTab._id;
-                    const isEventTab = tab._id === currentForumEvent?.tag?._id;
+                    const matchingEvent = activeForumEvents.find(event => event.tag?._id === tab._id);
+                    const isEventTab = !!matchingEvent;
                     return <LWTooltip
                       title={showDescriptionOnHover ? tab.description?.plaintextDescription : null}
                       popperClassName={classes.tagDescriptionTooltip}
@@ -361,8 +363,8 @@ const HomeTagBar = (
                           [classes.activeEventTab]: isActive && isEventTab,
                         })}
                         style={
-                          isEventTab
-                            ? eventTabProperties(currentForumEvent)
+                          matchingEvent
+                            ? eventTabProperties(matchingEvent)
                             : undefined
                         }
                       >

--- a/packages/lesswrong/lib/collections/forumEvents/views.ts
+++ b/packages/lesswrong/lib/collections/forumEvents/views.ts
@@ -56,7 +56,7 @@ function currentAndRecentForumEvents(terms: ForumEventsViewTerms) {
       isGlobal: true,
     },
     options: {
-      sort: {endDate: 1},
+      sort: {hideBanner: 1, endDate: 1},
       limit: terms.limit ?? 20,
     },
   };


### PR DESCRIPTION
Requested by Sarah because we will soon have multiple events running at the same time:
>The week after EAG (Oct 13-17), we will have two Forum events active at the same time (Draft Amnesty Week plus the Essays on Longtermism competition). Could someone double check if the code supports this case, and if not, make any necessary updates before Oct 10?
>Basically we want to have all the normal things (banner, topic labels, and topic tab) for DAW, while also having the essay competition topic labels & topic tab visible.

This PR adds the concept of `activeForumEvents` in addition to the `currentForumEvent`. All `activeForumEvents` get a topic tab and topic labels on the post item, only the `currentForumEvent` gets a banner (and, incidentally, for poll events only the `currentForumEvent` will have the poll appear in posts. I left this as is because I don't know what behaviour we want there).

<img width="3022" height="1650" alt="Screenshot 2025-10-06 at 14 26 13" src="https://github.com/user-attachments/assets/d15f1966-b3c8-4950-a453-cbeddb0509c3" />
