### PR TITLE
[EA Forum only] expand the audience of the inactive summary email

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -581,7 +581,7 @@ class UsersRepo extends AbstractRepo<"Users"> {
         GROUP BY "userId"
       ) AS rs ON u._id = rs."userId"
       WHERE
-        rs."max_last_updated" > CURRENT_TIMESTAMP - INTERVAL '1 year'
+        rs."max_last_updated" is not null
         AND (
           (
             -- User has never received a summary email, or they read a post since the last summary email:


### PR DESCRIPTION
Following up from https://github.com/ForumMagnum/ForumMagnum/pull/11349, expanding the audience more since we've almost emptied the queue now