### PR TITLE
mobile styling + tooltip for comment email subscribe

### DIFF
--- a/packages/lesswrong/components/comments/AutoEmailSubscribeCheckbox.tsx
+++ b/packages/lesswrong/components/comments/AutoEmailSubscribeCheckbox.tsx
@@ -22,16 +22,17 @@ const styles = defineStyles("AutoEmailSubscribeCheckbox", (theme) => ({
     display: "flex",
     alignItems: "center",
     "& .ToggleSwitch-root": {
-      width: `24px !important`,
+      width: `26px !important`,
       height: `16px !important`,
-      minWidth: `24px !important`,
+      minWidth: `26px !important`,
     },
     "& .ToggleSwitch-switchOn": {
-      left: -6,
+      left: -4,
     }
   },
   switch: {
     marginRight: 8,
+    opacity: 0.75,
     "& .ToggleSwitch-handle": {
       width: 12,
       height: 12,
@@ -39,10 +40,10 @@ const styles = defineStyles("AutoEmailSubscribeCheckbox", (theme) => ({
   },
   label: {
     ...theme.typography.commentStyle,
-    color: theme.palette.lwTertiary.main
+    color: theme.palette.lwTertiary.main,
   },
   disabled: {
-    opacity: 0.8,
+    opacity: 0.7,
     filter: "grayscale(100%)",
   },
   hideOnMobile: {

--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -146,7 +146,8 @@ const customSubmitButtonStyles = defineStyles('CommentSubmit', (theme: ThemeType
     display: "flex",
   },
   autoEmailSubscribe: {
-    marginRight: "auto"
+    marginRight: "auto",
+    marginLeft: 4
   },
 }), { stylePriority: 1 });
 


### PR DESCRIPTION
This makes the mobile version of the "email me replies to my comments" shorter. It also adds a tooltip that explains it a bit more thoroughly.

<img width="773" height="319" alt="image" src="https://github.com/user-attachments/assets/dab118db-95fc-483c-adb0-4219f702396b" />

<img width="489" height="257" alt="image" src="https://github.com/user-attachments/assets/108ee514-b129-49ba-8ff0-12b3b623fe3e" />

I considered updating the label to say something like "email me all replies to all my comments" but a) it's noticeably clunkier and b) I just really don't buy that this will be confusing in practice in a way anyone cares about, esp. with the tooltip that automatically shows up when you go to click on it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211574676532696) by [Unito](https://www.unito.io)
