### PR TITLE
add ngram filter to enable search firstlast users by either name and prioritize older over newer users

### DIFF
--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -354,7 +354,7 @@ export const elasticPasswordSetting = new PublicInstanceSetting<string | null>(
 );
 
 export const searchOriginDate = new PublicInstanceSetting<string>(
-  "searchOriginDate",
+  "elasticsearch.searchOriginDate",
   "2014-06-01T01:00:00Z",
   "optional"
 );

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -133,6 +133,22 @@ const shingleTextMapping: MappingProperty = {
   },
 };
 
+// Dedicated mapping for names, using fm_name_analyzer (adds ngrams)
+const nameTextMapping: MappingProperty = {
+  type: "text",
+  analyzer: "fm_name_analyzer",
+  fields: {
+    exact: {
+      type: "text",
+      analyzer: "fm_exact_analyzer",
+    },
+    sort: {
+      type: "keyword",
+      normalizer: "fm_sortable_keyword",
+    },
+  },
+};
+
 const geopointMapping: MappingProperty = {
   type: "geo_point",
 };
@@ -259,7 +275,7 @@ const elasticSearchConfig: () => Record<SearchIndexCollectionName, IndexConfig> 
   },
   Users: {
     fields: [
-      "displayName^10000",
+      "displayName^10",
       "bio",
       "mapLocationAddress",
       "jobTitle",
@@ -295,7 +311,7 @@ const elasticSearchConfig: () => Record<SearchIndexCollectionName, IndexConfig> 
       },
       {
         field: "createdAt",
-        order: "desc",
+        order: "asc",
         weight: 0.5,
         scoring: {type: "date"},
       },
@@ -308,7 +324,7 @@ const elasticSearchConfig: () => Record<SearchIndexCollectionName, IndexConfig> 
       //{term: {isReviewed: true}},
     ],
     mappings: {
-      displayName: shingleTextMapping,
+      displayName: nameTextMapping,
       bio: fullTextMapping,
       mapLocationAddress: fullTextMapping,
       jobTitle: fullTextMapping,

--- a/packages/lesswrong/server/search/elastic/ElasticExporter.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticExporter.ts
@@ -292,6 +292,7 @@ export class ElasticExporter {
       body: {
         settings: {
           index: {
+            max_ngram_diff: 16,
             analysis: {
               filter: {
                 fm_english_stopwords: {
@@ -316,6 +317,11 @@ export class ElasticExporter {
                   type: "pattern_replace",
                   pattern: " ",
                   replacement: "",
+                },
+                fm_ngram_filter: {
+                  type: "ngram",
+                  min_gram: 4,
+                  max_gram: 20,
                 },
               },
               char_filter: {
@@ -370,6 +376,19 @@ export class ElasticExporter {
                     "fm_synonym_filter",
                     "fm_shingle_filter",
                     "fm_whitespace_filter",
+                  ],
+                  char_filter: [
+                    "fm_punctuation_filter",
+                  ],
+                },
+                fm_name_analyzer: {
+                  type: "custom",
+                  tokenizer: "standard",
+                  filter: [
+                    "lowercase",
+                    "fm_synonym_filter",
+                    "fm_shingle_filter",
+                    "fm_ngram_filter",
                   ],
                   char_filter: [
                     "fm_punctuation_filter",

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -263,6 +263,8 @@ class ElasticQuery {
     const {fields, snippet, highlight} = this.config;
     const {search} = this.queryData;
     const mainField = this.textFieldToExactField(fields[0], false);
+    const exactFields = fields.map(field => this.textFieldToExactField(field, true));
+    
     return {
       tokens,
       searchQuery: {
@@ -279,7 +281,7 @@ class ElasticQuery {
             {
               multi_match: {
                 query: search,
-                fields,
+                fields: this.collectionName === 'Users' ? exactFields : fields,
                 type: "phrase",
                 slop: 2,
                 boost: this.collectionName === 'Users' ? 10 : 100,

--- a/packages/lesswrong/server/search/elastic/ElasticQuery.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticQuery.ts
@@ -282,7 +282,7 @@ class ElasticQuery {
                 fields,
                 type: "phrase",
                 slop: 2,
-                boost: 100,
+                boost: this.collectionName === 'Users' ? 10 : 100,
               },
             },
             {


### PR DESCRIPTION
This fixes totally pathological cases like being unable to find any users that have display names structured like `firstmlast` with search queries like `first`, `last`, or `first last`, and otherwise mitigates the huge search penalty that users receive for having no spacing or punctuation in their display names.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211582637332572) by [Unito](https://www.unito.io)
