### PR TITLE
remove probably-unnecessary check when updating the apollo cache after creating a draft comment that prevented it from being displayed inline without refreshing

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -341,8 +341,6 @@ export const CommentForm = ({
             const newComment = data?.createComment?.data;
             if (!newComment) {
               return existingComments;
-            } else if (newComment.draft && !storeFieldName.includes('"drafts"')) {
-              return existingComments;
             } else if (!newComment.postId && !newComment.tagId) {
               return existingComments;
             } else if (newComment.postId && !storeFieldName.includes(newComment.postId)) {


### PR DESCRIPTION
I don't _really_ remember why I added that conditional in the first place, but I've at least checked that removing it doesn't cause e.g. writing a draft quick take on the home page, while having some other comments open (like the recent comments for a post in the recent posts list) doesn't accidentally add it to those comments.