### PR TITLE
Fix apollo-client batching

### DIFF
--- a/packages/lesswrong/lib/apollo/links.ts
+++ b/packages/lesswrong/lib/apollo/links.ts
@@ -38,7 +38,6 @@ export const createHttpLink = (baseUrl: string, loginToken: string|null) => {
       http: context.http,
       options: context.fetchOptions,
       credentials: context.credentials,
-      headers: context.headers,
     };
 
     const defaultBatchKey = selectURI(operation, uri) + JSON.stringify(contextConfig);


### PR DESCRIPTION
Commit 30b9961765278e6af3615154ae1a3596fb51c5fe added a header x-apollo-operation-name to apollo-client http requests, which mostly broke batching because the headers were serialized and used as part of the batch-key. This made it so that requests with different graphql operation names could no longer be grouped.

Since the breakage only prevented batching  of queries of different types, but didn't prevent all batching, we incorrectly thought that the loss of batching was somehow related to React concurrent rendering or Suspense, which were introduced at about the same time.

The fix here is just to remove the headers from the batch key. I believe this was originally added for the benefit of a crossposting API that no longer exists.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211632186292197) by [Unito](https://www.unito.io)
