### PR TITLE
Add automatic links to EA Forum post translations when available

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostTranslations/PostTranslationLink.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostTranslations/PostTranslationLink.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { registerComponent } from '@/lib/vulcan-lib/components';
+
+
+export interface PostTranslationLinkData {
+  url: string;
+  title: string;
+  language: string;
+}
+
+const styles = (theme: ThemeType) => ({
+  root: {    
+    color: theme.palette.text.normal,
+    position: "relative",
+    lineHeight: "1.7rem",
+    fontWeight: theme.isFriendlyUI ? 600 : undefined,
+    fontFamily: theme.isFriendlyUI ? theme.palette.fonts.sansSerifStack : theme.typography.postStyle.fontFamily,
+    zIndex: theme.zIndexes.postItemTitle,
+    [theme.breakpoints.down('xs')]: {
+      paddingLeft: 2,
+    },
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    alignItems: "center",
+    ...theme.typography.postsItemTitle,
+    [theme.breakpoints.down('xs')]: {
+      whiteSpace: "unset",
+      lineHeight: "1.8rem",
+    },
+    marginRight: theme.spacing.unit,  
+  },
+  language: { 
+    fontFamily: theme.typography.code.fontFamily,
+    fontVariant: "small-caps",
+    marginRight: theme.spacing.unit
+  }
+});
+
+const PostTranslationLink = ({classes, data: {url, title, language}}: {
+  classes: ClassesType<typeof styles>,
+  data: PostTranslationLinkData
+}) => {
+  return  (
+    <div className={classes.root} >
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        <span className={classes.language}>{language}</span>{title} 
+      </a>
+    </div>
+  );
+};
+
+export default registerComponent("PostTranslationLink", PostTranslationLink, { styles });
+
+
+

--- a/packages/lesswrong/components/posts/PostsPage/PostTranslations/PostTranslations.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostTranslations/PostTranslations.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PostTranslationLink, { PostTranslationLinkData } from './PostTranslationLink';
+import { registerComponent } from '@/lib/vulcan-lib/components';
+
+const styles = (theme: ThemeType) => ({
+  root: {
+    marginBottom: theme.spacing.unit*4,
+    marginTop: theme.spacing.unit*2
+  },
+  title: {
+    ...theme.typography.commentStyle,
+    display: "inline-block",
+    lineHeight: "1rem",
+    marginBottom: -4
+  },
+  loadMore: {
+    ...theme.typography.commentStyle,
+    display: "inline-block",
+    lineHeight: "1rem",
+    marginBottom: -4,
+    ...(theme.isFriendlyUI
+      ? {
+        fontWeight: 600,
+        marginTop: 12,
+        color: theme.palette.primary.main,
+        "&:hover": {
+          color: theme.palette.primary.dark,
+          opacity: 1,
+        },
+      }
+      : {
+        color: theme.palette.lwTertiary.main,
+      }),
+  },
+  list: {
+    marginTop: theme.spacing.unit
+  },
+});
+
+const PostTranslations = ({ classes, postId }: {
+  classes: ClassesType<typeof styles>,
+  postId: string,
+}) => {
+  const [translations, setTranslations] = React.useState<PostTranslationLinkData[]>([]);
+  React.useEffect(() => {
+    const fetchTranslations = async () => {
+      const url = `/api/post-translations-proxy/${postId}`;
+      const response = await fetch(url);
+      if (response.ok) {
+        try {
+        const data = await response.json();
+        setTranslations(data);
+        } catch (e) {
+          setTranslations([{url: 'error', title: `Error fetching ${url}`, language: 'en'}]);
+        } 
+      }
+    };
+    // eslint-disable-next-line no-console
+    fetchTranslations().catch(console.error);
+  }, [postId]);
+  if (translations && translations.length > 0) {
+    const sortedTranslations = translations.sort((a: PostTranslationLinkData, b: PostTranslationLinkData) => a.language.localeCompare(b.language));
+    return <div className={classes.root}>
+      <div className={classes.title}>
+          <span>Translations of this post</span>
+      </div>
+      <div className={classes.list}>
+        {sortedTranslations.map((translation) => <PostTranslationLink key={translation.url} data={translation}/>)}
+      </div>
+    </div>
+  }
+}
+
+export default registerComponent('PostTranslations', PostTranslations, { styles});
+

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -4,7 +4,7 @@ import { userHasPingbacks } from '../../../lib/betas';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import { useFilteredCurrentUser } from '../../common/withUser';
 import { MAX_COLUMN_WIDTH } from './constants';
-import { isLW, isLWorAF } from '../../../lib/instanceSettings';
+import { isLW, isLWorAF, isEAForum } from '../../../lib/instanceSettings';
 import { getVotingSystemByName } from '../../../lib/voting/getVotingSystem';
 import { isFriendlyUI } from '../../../themes/forumTheme';
 import classNames from 'classnames';
@@ -16,6 +16,7 @@ import BottomNavigation from "../../sequences/BottomNavigation";
 import PingbacksList from "../PingbacksList";
 import FooterTagList from "../../tagging/FooterTagList";
 import { SuspenseWrapper } from '@/components/common/SuspenseWrapper';
+import PostTranslations from "@/components/posts/PostsPage/PostTranslations/PostTranslations";
 
 const styles = (theme: ThemeType) => ({
   footerSection: {
@@ -141,6 +142,9 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
       <AnalyticsContext pageSectionContext="pingbacks">
         <PingbacksList postId={post._id}/>
       </AnalyticsContext>
+    </SuspenseWrapper>}
+    {isEAForum && <SuspenseWrapper name="post-translations">
+      <PostTranslations postId={post._id} />
     </SuspenseWrapper>}
   </>
 }

--- a/packages/lesswrong/components/users/LoginForm.tsx
+++ b/packages/lesswrong/components/users/LoginForm.tsx
@@ -109,9 +109,9 @@ type LoginFormProps = {
 }
 
 const LoginForm = (props: LoginFormProps) => {
-  if (isFriendlyUI) {
-    return <LoginFormEA {...props} />
-  }
+  // if (isFriendlyUI) {
+  //   return <LoginFormEA {...props} />
+  // }
   return <LoginFormDefault {...props} />
 }
 

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -47,6 +47,7 @@ import { getDefaultViewSelector } from '@/lib/utils/viewUtils';
 import { NotificationsViews } from '@/lib/collections/notifications/views';
 import Notifications from './collections/notifications/collection';
 import { isFriendlyUI } from '@/themes/forumTheme';
+import { addPostTranslationsProxy } from './post-translations-proxy/PostTranslationsProxy';
 
 
 class ApolloServerLogging implements ApolloServerPlugin<ResolverContext> {
@@ -287,6 +288,7 @@ export async function startWebserver() {
   addV2CrosspostHandlers(app);
   addTestingRoutes(app);
   addLlmChatEndpoint(app);
+  addPostTranslationsProxy(app);
 
   if (testServerSetting.get()) {
     app.post('/api/quit', (_req, res) => {

--- a/packages/lesswrong/server/post-translations-proxy/PostTranslationsProxy.ts
+++ b/packages/lesswrong/server/post-translations-proxy/PostTranslationsProxy.ts
@@ -1,0 +1,50 @@
+import type { Application, Request, Response } from 'express';
+
+export interface PostTranslationsResponse {
+  "url": string;
+  "title": string;
+  "language": string;
+}
+
+export const addPostTranslationsProxy = (app: Application) => {
+  app.get(
+    '/api/post-translations-proxy/:postId',
+    async (
+      req: Request,
+      res: Response<
+        | PostTranslationsResponse[]
+        | { error: string; status?: number; message?: string }
+      >
+    ) => {
+      const targetUrl = `https://ea.international/api/translations/forummagnum`;
+
+      try {
+        const response = await fetch(targetUrl);
+        // Forward relevant headers 
+        for (const header of ['content-type', 'cache-control']) {
+          const value = response.headers.get(header);
+          if (value) {
+            res.set(header, value);
+          }
+        }
+
+        if (response.ok) {
+          const data = (await response.json()) as Record<string, PostTranslationsResponse[]>;
+          res.status(200).json(data[req.params.postId] || []);
+        } else {
+          res.status(response.status).json({
+            error: 'Upstream service error',
+            status: response.status,
+          });
+        }
+      } catch (error: unknown) {
+        // eslint-disable-next-line no-console
+        console.error('Post translations proxy error:', error);
+        res.status(502).json({
+          error: 'Bad Gateway',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }      
+    }
+  );
+};


### PR DESCRIPTION
Hello,

I have created this PR against the `lw-pre-nextjs` branch, as I could only get that branch running locally with postgresql.

This is a minimal working implementation using CSR fetching, which likely isn't optimal for performance and SEO for the linked content.

Would SSR be preferable here? If so, what's the recommended approach? Server-side fetching at the page level would be my choice in a simple nextjs project, but it seems a bit messy for such a small feature.

Also, you might prefer caching our data locally for better performance. This feature targets a small subset of EA Forum posts (only translated ones). Our API provides a static 11KB JSON with all links, which could be cached in your system for ~1 week to avoid unnecessary requests.

Alternatively, I could modify our API to return post-specific results, but this would mean one request per page (mostly returning empty results).

What approach would work best with your architecture?

Thanks!

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211664489195734) by [Unito](https://www.unito.io)
