### PR TITLE
don't trigger review for non-publishing updates to posts or edits to comments

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -1072,8 +1072,10 @@ export async function updatedCommentMaybeTriggerReview({ currentUser, context }:
     currentUser.snoozedUntilContentCount && await updateUser({ data: {
       snoozedUntilContentCount: currentUser.snoozedUntilContentCount - 1,
     }, selector: { _id: currentUser._id } }, createAnonymousContext());
+    // This might create multiple redundant moderator actions if the user is in a state where they'd trigger review
+    // and then update a comment multiple times.
+    await triggerReviewIfNeeded(currentUser._id, context)
   }
-  await triggerReviewIfNeeded(currentUser._id, context)
 }
 
 export async function updateUserNotesOnCommentRejection({ newDocument, oldDocument, currentUser, context }: UpdateCallbackProperties<"Comments">) {

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -166,6 +166,7 @@ export async function onPostPublished(post: DbPost, context: ResolverContext) {
   const { updateScoreOnPostPublish } = await import("./votingCallbacks");
   await updateScoreOnPostPublish(post, context);
   await onPublishUtils.ensureNonzeroRevisionVersionsAfterUndraft(post, context);
+  await triggerReviewIfNeeded(post.userId, context)
 }
 
 const utils = {
@@ -874,8 +875,6 @@ export async function updatePostEmbeddingsOnChange(newPost: Pick<DbPost, '_id' |
 
 export async function updatedPostMaybeTriggerReview({newDocument, oldDocument, context}: UpdateCallbackProperties<'Posts'>) {
   if (newDocument.draft || newDocument.rejected) return
-
-  await triggerReviewIfNeeded(oldDocument.userId, context)
   
   // if the post author is already approved and the post is getting undrafted,
   // or the post author is getting approved,


### PR DESCRIPTION
Right now we're creating a large number of redundant moderator actions if a user updates their first post after publishing it (but before approval), which is slightly annoying.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211665995199467) by [Unito](https://www.unito.io)
