### PR TITLE
Trim URLs before deciding how to hover-preview them

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -39,6 +39,7 @@ const HoverPreviewLink = ({ href, id, rel, noPrefetch, contentStyleType, classNa
 }) => {
   const URLClass = getUrlClass()
   const location = useLocation();
+  href = href.trim();
 
   // Invalid link with no href? Don't transform it.
   if (!href) {


### PR DESCRIPTION
Post https://www.lesswrong.com/posts/BkKHMYp3cmphLZgKd/eating-honey-is-probably-fine-actually contains a link with a leading space in it: ` https://linch.substack.com/p/eating-honey-is-probably-fine-actually`. This caused a surprising symptom: the link was parsed as if it was an onsite link, the `/p/` URL format made it interpreted as a wiki page, and it rendered as a broken redlink. Fix by trimming URLs before deciding how to hover-preview them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211712971148880) by [Unito](https://www.unito.io)
