### PR TITLE
Fix Metaculus question preview embeds

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -469,7 +469,7 @@ export const MetaculusPreview = ({href, id, className, children}: {
   const classes = useStyles(linkStyles);
 
   const { anchorEl, hover, eventHandlers } = useHover();
-  const [match, www, questionNumber] = href.match(/^http(?:s?):\/\/(www\.)?metaculus\.com\/questions\/([a-zA-Z0-9]{1,6})?/) || []
+  const [match, www, questionNumber] = href.match(/^http(?:s?):\/\/(www\.)?metaculus\.com\/questions\/(\d+)/) || []
 
   if (!questionNumber) {
     return <a href={href} className={className}>
@@ -485,7 +485,7 @@ export const MetaculusPreview = ({href, id, className, children}: {
       
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
         <div className={classes.metaculusBackground}>
-          <iframe className={classes.metaculusIframe} src={`https://d3s0w6fek99l5b.cloudfront.net/s/1/questions/embed/${questionNumber}/?plot=pdf`} />
+          <iframe className={classes.metaculusIframe} src={`https://www.metaculus.com/questions/embed/${questionNumber}`} />
         </div>
       </LWPopper>
     </span>


### PR DESCRIPTION
## Problem

Metaculus question hover previews currently show a Cloudflare error page instead of displaying the question forecast.

## Root Cause

The `MetaculusPreview` component in `PostLinkPreview.tsx` uses an outdated CloudFront CDN URL that no longer works:
```
https://d3s0w6fek99l5b.cloudfront.net/s/1/questions/embed/${questionNumber}/?plot=pdf
```

Additionally, the regex pattern for extracting question IDs was overly restrictive (6-character limit with alphanumeric characters).

## Solution

This PR updates the embed URL to use the current Metaculus domain and fixes the regex pattern:

1. **Update embed URL**: Changed to `https://www.metaculus.com/questions/embed/${questionNumber}`
2. **Fix regex pattern**: Changed from `[a-zA-Z0-9]{1,6}?` to `\d+` (matches numeric IDs of any length)

## Changes

**File**: `packages/lesswrong/components/linkPreview/PostLinkPreview.tsx`

- Line 472: Updated regex to match numeric question IDs without length restriction
- Line 488: Updated iframe src to use current Metaculus embed URL

## Testing

✅ Verified new embed URL loads correctly via direct browser access  
✅ Tested iframe embedding with multiple question IDs  
✅ Confirmed old CloudFront URL returns errors  
✅ Validated regex works with question IDs of various lengths (3-7+ digits)  
✅ Verified behavior matches other working preview components (Manifold, Fatebook)

## Impact

- Fixes broken Metaculus preview hover functionality
- More robust ID matching (no arbitrary length limit)
- Cleaner URL (removed unnecessary query parameter)
- Minimal risk: same iframe embedding pattern used by other working previews

## Example

After this fix, hovering over a Metaculus question link like `https://www.metaculus.com/questions/578` will display a working forecast preview instead of a Cloudflare error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211734483560365) by [Unito](https://www.unito.io)
