### PR TITLE
fix route parsing for redirected routes that go from path params to query params

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -20,6 +20,8 @@ import ContentStyles from "../common/ContentStyles";
 import { apolloSSRFlag } from '@/lib/helpers';
 import type { RouterLocation } from '@/lib/vulcan-lib/routes';
 import { linkStyles } from './linkStyles';
+import LWTooltip from '../common/LWTooltip';
+import ConversationPreview from '../messaging/ConversationPreview';
 
 
 const SequencesPageFragmentQuery = gql(`
@@ -371,6 +373,29 @@ export const SequencePreview = ({targetLocation, href, className, children}: {
         {children}
       </Link>
     </SequencesTooltip>
+  );
+}
+
+export const MessagePreview = ({href, targetLocation, id, className, children}: {
+  href: string,
+  targetLocation: RouterLocation,
+  id?: string,
+  className?: string,
+  children: ReactNode,
+}) => {
+  return (
+    <LWTooltip
+      tooltip={false}
+      title={
+        <span>
+          <Card>
+            <ConversationPreview conversationId={targetLocation?.query?.conversation} />
+          </Card>
+        </span>
+      }
+    >
+      {children}
+  </LWTooltip>
   );
 }
 

--- a/packages/lesswrong/components/linkPreview/parseRouteWithErrors.tsx
+++ b/packages/lesswrong/components/linkPreview/parseRouteWithErrors.tsx
@@ -1,5 +1,5 @@
 import { parseRoute, parsePath } from '@/lib/vulcan-lib/routes';
-import { CommentLinkPreviewLegacy, PostCommentLinkPreviewGreaterWrong, PostLinkPreview, PostLinkPreviewLegacy, PostLinkPreviewSequencePost, PostLinkPreviewSlug, SequencePreview } from './PostLinkPreview';
+import { CommentLinkPreviewLegacy, MessagePreview, PostCommentLinkPreviewGreaterWrong, PostLinkPreview, PostLinkPreviewLegacy, PostLinkPreviewSequencePost, PostLinkPreviewSlug, SequencePreview } from './PostLinkPreview';
 import { TagHoverPreview } from '../tagging/TagHoverPreview';
 
 // ea-forum-look-here
@@ -24,6 +24,8 @@ export const routePreviewComponentMapping = {
   [`/${legacyRouteAcronym}/:id/:slug?`]: PostLinkPreviewLegacy,
     // TODO: Pingback with getPostPingbackByLegacyId
   [`/${legacyRouteAcronym}/:id/:slug/:commentId`]: CommentLinkPreviewLegacy,
+  '/inbox/:conversationId': MessagePreview,
+  '/inbox': MessagePreview,
 }
 
 export const parseRouteWithErrors = <const T extends string[] | [] = []>(onsiteUrl: string, extraRoutePatterns?: T) => {

--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -148,7 +148,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, classes}: {
       )
     }
 
-    const parsedPath = parseRouteWithErrors(notificationLink, ['/inbox/:_id']);
+    const parsedPath = parseRouteWithErrors(notificationLink);
     switch (notification.documentType) {
       case "tagRel":
         return (
@@ -180,7 +180,7 @@ const NotificationsItem = ({notification, lastNotificationsCheck, classes}: {
       case "message":
         return (
           <TooltipWrapper
-            title={<ConversationPreview conversationId={parsedPath?.params?._id} />}
+            title={<ConversationPreview conversationId={parsedPath?.query?.conversation} />}
             classes={classes}
           >
             {children}

--- a/packages/lesswrong/lib/vendor/react-router/matchPath.ts
+++ b/packages/lesswrong/lib/vendor/react-router/matchPath.ts
@@ -97,7 +97,8 @@ export function matchPath<Params extends { [K in keyof Params]?: string; }>(path
 }
 
 export function applyParamsToPathname(pathnamePattern: string, params: {}): string {
-  return compile(pathnamePattern, {validate: false})(params);
+  const escapedPattern = pathnamePattern.replaceAll('?', '\\?');
+  return compile(escapedPattern, {validate: false})(params);
 }
 
 


### PR DESCRIPTION
The most recent deploy, with the conversation inbox refactor, uncovered some latent bugs in our route parsing logic when handling redirects. Particularly: redirects with a destination that had a query parameter, mapped from e.g. what was previously a path parameter.

The first bug was that `path-to-regexp` treats `?` as a special character indicating an optional path param, so passing in e.g. `/inbox?conversation=:conversationId` blows up because it probably expects the character that follows `?` (if any) to be a `/`.  This is fixed by escaping the `?`.

The second bug was that, after calling `applyRedirectsTo`, we were calling `getPatternMatchingPathname`, which didn't blow up when passed a destination path that included a `?`, but did fail to match on it.  So we need to parse the desination path to get the pathname to find the (final) matching route pattern, and then recombine with query/hash afterwards.

This PR also creates a link hover preview component for messages, so that we don't need to pass in the two paths as "extras" when parsing the route for the notification preview.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211736437030716) by [Unito](https://www.unito.io)
