### PR TITLE
preserve old query params when handling redirected routes

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -180,7 +180,7 @@ export function parseRoute<Patterns extends string[]>({ location, onError = null
   // so we extract the pathname to match against and use the rest for
   // constructing the RouterLocation later.
   const parsedPath = parsePath(pathWithRedirects);
-  
+
   // However, for reconstructing the "location" (and other details),
   // we need to use the search params from both the original location
   // and the post-redirect location, since the redirect-following logic
@@ -226,7 +226,7 @@ export function parseRoute<Patterns extends string[]>({ location, onError = null
 
   const result = {
     routePattern,
-    location: parsedPath,
+    location: { ...parsedPath, search, hash },
     params,
     pathname,
     url: pathname + search + hash,

--- a/packages/lesswrong/unitTests/parseRoute.tests.ts
+++ b/packages/lesswrong/unitTests/parseRoute.tests.ts
@@ -1,0 +1,20 @@
+import { parsePath, parseRoute } from '@/lib/vulcan-lib/routes';
+
+describe('parseRoute', () => {
+  it('preserves query parameters from the original URL when applying redirects', () => {
+    const result = parseRoute({
+      location: parsePath('/inbox/fakeconversationid?utm_source=twitter'),
+      routePatterns: ['/inbox/:conversationId', '/inbox'],
+    });
+
+    const expectedSearch = '?utm_source=twitter&conversation=fakeconversationid';
+
+    expect(result.query).toEqual({ conversation: 'fakeconversationid', utm_source: 'twitter' });
+    expect(result.url).toBe('/inbox' + expectedSearch);
+    expect(result.pathname).toBe('/inbox');
+    expect(result.hash).toBe('');
+    expect(result.routePattern).toBe('/inbox');
+    expect(result.params).toEqual({});
+    expect(result.location).toEqual({ pathname: '/inbox', search: expectedSearch, hash: '' });
+  });
+});


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211737229005820) by [Unito](https://www.unito.io)
