### PR TITLE
Fix HoverPreviewLink in the case where href is nullish

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -39,7 +39,7 @@ const HoverPreviewLink = ({ href, id, rel, noPrefetch, contentStyleType, classNa
 }) => {
   const URLClass = getUrlClass()
   const location = useLocation();
-  href = href.trim();
+  href = href ? href.trim() : href;
 
   // Invalid link with no href? Don't transform it.
   if (!href) {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211737665106890) by [Unito](https://www.unito.io)
