### PR TITLE
Allow native context menu in editor

### DIFF
--- a/packages/lesswrong/components/editor/editorAugmentations.ts
+++ b/packages/lesswrong/components/editor/editorAugmentations.ts
@@ -86,7 +86,7 @@ function convertKeystrokeToKeystrokeInfo(keystroke: string): KeystrokeInfo {
 }
 
 /**
- * Ensure we always open the editor toolbar on right-click.
+ * Ensure we always open the editor toolbar on right-click, along with the native context menu.
  */
 function improveEditorContextMenu(
   editorElementRef: RefObject<CKEditor<AnyBecauseHard> | null>,


### PR DESCRIPTION
Turns out people were using the native context menu for e.g. spellchecking.  Alas!

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211745089941544) by [Unito](https://www.unito.io)
