### PR TITLE
fix bug where we were priming the loader cache with non-db-shaped records

### DIFF
--- a/packages/lesswrong/server/resolvers/defaultResolvers.ts
+++ b/packages/lesswrong/server/resolvers/defaultResolvers.ts
@@ -65,6 +65,11 @@ const getFragmentInfo = ({ fieldName, fieldNodes, fragments }: GraphQLResolveInf
   };
 };
 
+const stripNonDbFields = <N extends CollectionNameString>(doc: ObjectsByCollectionName[N], collectionName: N, context: ResolverContext) => {
+  const schema = context[collectionName].schema;
+  return Object.fromEntries(Object.entries(doc).filter(([fieldName]) => !!schema[fieldName]?.database));
+};
+
 type DefaultSingleResolverHandler<N extends CollectionNameString> = {
   [k in N as `${CamelCaseify<typeof collectionNameToTypeName[k]>}`]: (_root: void, { input }: { input: AnyBecauseTodo; }, context: ResolverContext, info: GraphQLResolveInfo) => Promise<{ result: Partial<ObjectsByCollectionName[N]> | null; }>
 };
@@ -208,6 +213,10 @@ export const getDefaultResolvers = <N extends CollectionNameString>(
       );
     }
     let docs = await fetchDocs();
+    
+    // strip out any non-db fields from the docs so we can prime the loader cache with them
+    const sanitizedDocs = docs.map(doc => stripNonDbFields(doc, collectionName, context));
+    sanitizedDocs.forEach((doc: AnyBecauseTodo) => context.loaders[collectionName].prime(doc._id, doc));
 
     // Were there enough results to reach the limit specified in the query?
     const saturated = parameters.options.limit && docs.length>=parameters.options.limit;
@@ -220,9 +229,6 @@ export const getDefaultResolvers = <N extends CollectionNameString>(
 
     // take the remaining documents and remove any fields that shouldn't be accessible
     const restrictedDocs = await restrictViewableFieldsMultiple(currentUser, collection, viewableDocs);
-
-    // prime the cache
-    restrictedDocs.forEach((doc: AnyBecauseTodo) => context.loaders[collectionName].prime(doc._id, doc));
 
     const data: { results: Partial<T>[]; totalCount?: number } = { results: restrictedDocs };
 


### PR DESCRIPTION
The previous behavior ran field-level permission checks on documents before priming the loader cache with them, which sometimes caused the types to lie when fetching them from the loader cache later (the caller would be expecting a full db-shaped object, and would get something where some non-nullable fields were missing).

Separately, we were also putting documents that had resolver fields on them in the cases where those resolver fields had sqlResolvers into the loader cache, since those sqlResolvers would've gotten compiled into the executed SelectFragmentQuery.  I don't know that it ever caused any problems, but it was definitely wrong.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211808327362660) by [Unito](https://www.unito.io)
