### PR TITLE
Fix a bug that hid all inline reactions from the sidebar

### DIFF
--- a/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactHoverableHighlight.tsx
@@ -30,13 +30,12 @@ const styles = defineStyles("InlineReactHoverableHighlight", (theme: ThemeType) 
     marginLeft: 4,
     paddingLeft: 4,
     paddingRight: 4,
-    
+  },
+  sidebarInlineReactIconsNonInbox: {
+    display: "none",
     [theme.breakpoints.up('sm')]: {
       display: "inline-block",
     },
-  },
-  hideInlineReactsDefault: {
-    display: "none",
   },
   inlineReactSidebarLine: {
     background: theme.palette.sideItemIndicator.inlineReaction,
@@ -138,7 +137,10 @@ const SidebarInlineReact = ({quote,reactions, voteProps, hoverEventHandlers}: {
   
   return <>
     {!isInbox && <SideItemLine colorClass={classes.inlineReactSidebarLine}/>}
-    <span {...hoverEventHandlers} className={classNames(classes.sidebarInlineReactIcons, !isInbox && classes.hideInlineReactsDefault)}>
+    <span {...hoverEventHandlers} className={classNames(
+      classes.sidebarInlineReactIcons,
+      !isInbox && classes.sidebarInlineReactIconsNonInbox,
+    )}>
       {reactionsUsed.map(r => <span key={r}>
         <LWTooltip
           title={<InlineReactHoverInfo


### PR DESCRIPTION
Fix a bug that hid all inline reactions from the sidebar. Introduced in [this commit](https://github.com/ForumMagnum/ForumMagnum/commit/855a61314fefd2c08c1062a1bc12ed2f81aaac76#diff-c3fc9c1bd604d70ffaee0b341705525237e8e32f9b91f8e7762bc9d4db250dadR141), the intent of that change was to prevent breakpoints from hiding inline reactions in the inbox, but it messed up CSS precedence and wound up hiding all inline reactions outside the inbox in non-mobile views.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211830223548135) by [Unito](https://www.unito.io)
