### PR TITLE
Clean up confused usage of deletedDrafts flag

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -463,7 +463,6 @@ const PostsPage = ({fullPost, postPreload, refetch, embedded}: {
     !currentUser?.hidePostsRecommendations &&
     !post.shortform &&
     !post.draft &&
-    !post.deletedDraft &&
     !post.question &&
     !post.debate &&
     !post.isEvent &&

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -632,7 +632,9 @@ function drafts(terms: PostsViewTerms) {
       groupId: null, // TODO: fix vulcan so it doesn't do deep merges on viewFieldAllowAny
       authorIsUnreviewed: viewFieldAllowAny,
       hiddenRelatedQuestion: viewFieldAllowAny,
-      deletedDraft: false,
+      ...(!terms.includeArchived && {
+        deletedDraft: false,
+      }),
     },
     options: {
       sort: {}
@@ -641,9 +643,6 @@ function drafts(terms: PostsViewTerms) {
   
   if (terms.includeDraftEvents) {
     query.selector.isEvent = viewFieldAllowAny
-  }
-  if (terms.includeArchived) {
-    query.selector.deletedDraft = viewFieldAllowAny
   }
   if (!terms.includeShared) {
     query.selector.userId = terms.userId

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -116,7 +116,7 @@ export const documentIsNotDeleted = (
   // to represent "deleted-ness"
   return !(
     (document as unknown as DbComment).deleted ||
-    (document as unknown as DbPost).deletedDraft ||
+    ((document as unknown as DbPost).draft && (document as unknown as DbPost).deletedDraft) ||
     (document as unknown as DbSequence).isDeleted
   );
 }

--- a/packages/lesswrong/server/callbacks/chapterCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/chapterCallbacks.ts
@@ -72,7 +72,6 @@ export async function notifyUsersOfNewPosts({oldDocument, newDocument, context}:
   const posts = await Posts.find({
     _id: {$in: newPostIds},
     draft: {$ne: true},
-    deletedDraft: {$ne: true},
   }).fetch()
   if (!posts.length) {
     return

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -461,7 +461,6 @@ export async function checkRecentRepost<T extends CreatePostDataInput | Partial<
       title: post.title,
       userId: post.userId,
       draft: {$ne: true},
-      deletedDraft: {$ne: true},
       createdAt: {$gt: oneHourAgo},
     });
     if (existing) {
@@ -847,11 +846,10 @@ export async function autoTagUndraftedPost({oldDocument, newDocument, context}: 
   }
 }
 
-export async function updatePostEmbeddingsOnChange(newPost: Pick<DbPost, '_id' | 'contents_latest' | 'draft' | 'deletedDraft' | 'status'>, oldPost?: DbPost) {
+export async function updatePostEmbeddingsOnChange(newPost: Pick<DbPost, '_id' | 'contents_latest' | 'draft' | 'status'>, oldPost?: DbPost) {
   const hasChanged = !oldPost || oldPost.contents_latest !== newPost.contents_latest;
   if (hasChanged &&
     !newPost.draft &&
-    !newPost.deletedDraft &&
     newPost.status === postStatuses.STATUS_APPROVED &&
     !isAnyTest
   ) {

--- a/packages/lesswrong/server/callbacks/votingCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/votingCallbacks.ts
@@ -301,7 +301,7 @@ async function maybeCreateReviewMarket({newDocument, vote}: VoteDocTuple, collec
   if (vote.power <= 0 || vote.cancelled) return; // In principle it would be fine to make a market here, but it should never be first created here
   if ((newDocument.baseScore ?? 0) < reviewMarketCreationMinimumKarmaSetting.get()) return;
   const post = await Posts.findOne({_id: newDocument._id})
-  if (!post || post.draft || post.deletedDraft) return;
+  if (!post || post.draft) return;
   if (post.postedAt.getFullYear() < (new Date()).getFullYear() - 1) return; // only make markets for posts that haven't had a chance to be reviewed
   if (post.manifoldReviewMarketId) return;
 

--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -196,7 +196,6 @@ export const NewSequencePostsNotification = createServerNotificationType({
     const posts = await Posts.find({
       _id: {$in: extraData.postIds},
       draft: {$ne: true},
-      deletedDraft: {$ne: true},
     }).fetch()
     
     if (!posts.length) throw Error(`No valid new posts for notification: ${notifications[0]}`)

--- a/packages/lesswrong/server/permissions/accessFilters.ts
+++ b/packages/lesswrong/server/permissions/accessFilters.ts
@@ -180,7 +180,7 @@ const postCheckAccess: CheckAccessFunction<'Posts'> = async (currentUser, post, 
     return true;
   } else if (!currentUser && !!canonicalLinkSharingKey && constantTimeCompare({ correctValue: canonicalLinkSharingKey, unknownValue: unvalidatedLinkSharingKey })) {
     return true;
-  } else if (post.isFuture || post.draft || post.deletedDraft) {
+  } else if (post.isFuture || post.draft) {
     return false;
     // TODO: consider getting rid of this clause entirely and instead just relying on default view filter, 
     // since LW is now allowing people to see rejected content and preventing them from seeing 'not-yet-rejected

--- a/packages/lesswrong/server/recommendations/RecommendationStrategy.ts
+++ b/packages/lesswrong/server/recommendations/RecommendationStrategy.ts
@@ -124,7 +124,6 @@ abstract class RecommendationStrategy {
       filter: `
         p."status" = $(postStatus) AND
         p."draft" IS NOT TRUE AND
-        p."deletedDraft" IS NOT TRUE AND
         p."isFuture" IS NOT TRUE AND
         p."shortform" IS NOT TRUE AND
         p."hiddenRelatedQuestion" IS NOT TRUE AND

--- a/packages/lesswrong/server/repos/NotificationsRepo.ts
+++ b/packages/lesswrong/server/repos/NotificationsRepo.ts
@@ -193,12 +193,10 @@ export default class NotificationsRepo extends AbstractRepo<"Notifications"> {
         n."waitingForBatch" IS NOT TRUE AND
         ${type ? `n."type" = $(type) AND` : ""}
         ${includeMessages ? "": `COALESCE(n."documentType", '') <> 'message' AND`}
-        NOT COALESCE(p."deletedDraft", FALSE) AND
         NOT COALESCE(pu."deleted", FALSE) AND
         NOT COALESCE(pl."deleted", FALSE) AND
         NOT COALESCE(c."deleted", FALSE) AND
         NOT COALESCE(cu."deleted", FALSE) AND
-        NOT COALESCE(cp."deletedDraft", FALSE) AND
         NOT COALESCE(cpu."deleted", FALSE) AND
         NOT COALESCE(cpl."deleted", FALSE) AND
         NOT COALESCE(t."deleted", FALSE) AND

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -273,8 +273,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         p."shortform" is not true AND
         p."isFuture" is not true AND
         p."authorIsUnreviewed" is not true AND
-        p."draft" is not true AND
-        p."deletedDraft" is not true
+        p."draft" is not true
       ORDER BY p."baseScore" desc
       LIMIT 200
     `, [digestId, startDate, end], "getEligiblePostsForDigest");
@@ -288,8 +287,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       JOIN "DigestPosts" dp ON dp."postId" = p."_id" AND dp."onsiteDigestStatus" = 'yes'
       JOIN "Digests" d ON d.num = $1 AND dp."digestId" = d._id
       WHERE
-        p."draft" is not true AND
-        p."deletedDraft" is not true
+        p."draft" is not true
       ORDER BY p."curatedDate" DESC NULLS LAST, p."suggestForCuratedUserIds" DESC NULLS LAST, p."baseScore" desc
       LIMIT 50
     `, [num]);

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -18,7 +18,6 @@ export const getViewablePostsSelector = (postsTableAlias?: string) => {
   return `
     ${aliasPrefix}"status" = ${postStatuses.STATUS_APPROVED} AND
     ${aliasPrefix}"draft" = FALSE AND
-    ${aliasPrefix}"deletedDraft" = FALSE AND
     ${aliasPrefix}"isFuture" = FALSE AND
     ${aliasPrefix}"unlisted" = FALSE AND
     ${aliasPrefix}"shortform" = FALSE AND
@@ -35,7 +34,6 @@ export const getViewableEventsSelector = (postsTableAlias?: string) => {
     ${aliasPrefix}"isEvent" IS TRUE AND
     ${aliasPrefix}"status" = ${postStatuses.STATUS_APPROVED} AND
     ${aliasPrefix}"draft" IS FALSE AND
-    ${aliasPrefix}"deletedDraft" IS FALSE AND
     ${aliasPrefix}"isFuture" IS FALSE AND
     ${aliasPrefix}"unlisted" IS FALSE AND
     ${aliasPrefix}"shortform" IS FALSE AND

--- a/packages/lesswrong/server/scripts/randomRecommendationSamples.ts
+++ b/packages/lesswrong/server/scripts/randomRecommendationSamples.ts
@@ -15,7 +15,6 @@ export const randomRecommendationSamples = async () => {
     WHERE "createdAt" > $1 AND
       "status" = 2 AND
       "draft" IS NOT TRUE AND
-      "deletedDraft" IS NOT TRUE AND
       "isFuture" IS NOT TRUE AND
       "shortform" IS NOT TRUE AND
       "hiddenRelatedQuestion" IS NOT TRUE AND


### PR DESCRIPTION
The `deletedDraft` field was introduced way back in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/1436) in a way that was correct but misleadingly named; its sole effect was to hide old drafts from the user's drafts list. Later, [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/7124) misinterpreted that field as something to check for permissions purposes, making it possible for posts to be in a state where they have `draft: false` and `deletedDraft: true`, which made them kind of broken.

Fix that by remove most references to `deletedDraft`, which were checking it when they shouldn't be. Also removes an incorrect permissions check that said non-admins can't unarchive drafts (even though there's a button in the UI for them to do so), and made it so that publishing clears the flag automatically.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211830676819463) by [Unito](https://www.unito.io)
