### PR TITLE
add duplex option to fix fetch call with a request stream

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -30,7 +30,8 @@ function urlIsAbsolute(url: string): boolean {
  * that <StatusCodeSetter> appears in the DOM (ideally after the smallest-
  * possible amount of loading).
  */
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
+  console.log(`Proxying ${request.nextUrl}`);
   // Before NextJS, we were using react-router, which wasn't case-sensitive by default.
   // To solve the problem of any existing links going to non-canonically-capitalized paths,
   // we have a codegen step that generates a trie which we use to find a matching canonical
@@ -244,7 +245,11 @@ export const config: MiddlewareConfig = {
      */
     {
       source: '/((?!api|auth|graphql|analyticsEvent|public|ckeditor-token|feed.xml|reactionImages|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
-      missing: [{ type: 'header', key: 'next-router-state-tree' }]
+      missing: [
+        { type: 'header', key: 'next-router-state-tree' },
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'x-forwarded-for-status-codes' },
+      ],
     }
   ]
 }


### PR DESCRIPTION
Upgrading NextJS to v16 apparently pulled in https://github.com/whatwg/fetch/pull/1457, which causes the `fetch` call to fail if `duplex` isn't included.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211831453327064) by [Unito](https://www.unito.io)
