### PR TITLE
Prototype fix for error due to aborted fetches on refresh

### DIFF
--- a/packages/lesswrong/components/common/ApolloWrapper.tsx
+++ b/packages/lesswrong/components/common/ApolloWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { use, useCallback } from 'react';
-import { headerLink, createErrorLink, createHttpLink } from "@/lib/apollo/links";
+import { headerLink, createErrorLink, createHttpLink, markPageAsUnloading } from "@/lib/apollo/links";
 import { isServer } from "@/lib/executionEnvironment";
 import { getSiteUrl } from "@/lib/vulcan-lib/utils";
 import { ApolloLink } from "@apollo/client";
@@ -9,6 +9,7 @@ import {
 } from "@apollo/client-integration-nextjs";
 import { ApolloNextAppProvider } from "@/lib/vendor/@apollo/client-integration-nextjs/ApolloNextAppProvider";
 import { disableFragmentWarnings } from "graphql-tag";
+import { useEventListener } from '../hooks/useEventListener';
 
 // In the internals of apollo client, they do two round-trips that look like `gql(print(gql(options.query)))`
 // This causes graphql-tag to emit warnings that look like "Warning: fragment with name PostsMinimumInfo already exists",
@@ -68,6 +69,9 @@ export function ApolloWrapper({ loginToken, searchParams, children }: React.Prop
   loginToken: string|null,
   searchParams: Record<string, string>,
 }>) {
+  useEventListener("beforeunload", () => {
+    markPageAsUnloading();
+  });
   // Either this is an SSR context, in which case constructing an apollo client
   // involves an async function call because of dynamic imports, or this is in
   // a client context, in which case construting an apollo client can be done


### PR DESCRIPTION
In Firefox, if you navigate (or initiate some other operation that involves network fetches) and refresh before those network fetches finish, then the browser will abort the fetches, this causes a visible error. This is because refreshing immediately cancels any outstanding network requests, and JS handles the abort as an error, updating the page.

This proof-of-concept adds a beforeunload listener and a wrapper around `fetch()`, which makes it so that once the page starts unloading, any in-progress fetches remain as unresolved promises.

This is a proof-of-concept and not produciton ready because `beforeunload` is not the right event; an unload can be aborted, since other event handlers on the same event can stop the navigation (by warning about unsaved data and the user clicking cancel). Additionally, interaction with the back-forward cache is untested.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211841573018651) by [Unito](https://www.unito.io)
