### PR TITLE
fix default post titles coalescing

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -211,7 +211,7 @@ const PostsNewForm = () => {
     activateRSVPs: true,
     onlineEvent: groupData?.isOnline,
     globalEvent: groupData?.isOnline,
-    title: title ?? "Untitled Draft",
+    title: title || "Untitled Draft",
     types,
     meta: query && !!query.meta,
     groupId: query && query.groupId,


### PR DESCRIPTION
Fixes a bug introduced in [https://github.com/ForumMagnum/ForumMagnum/commit/f0feaf7f6e534fa2b361c0d76799f54f9b2670b9#diff-27384fbe44c0624313dff2[…]f92c2e1ffa67fa9e9bc4d94R217](https://github.com/ForumMagnum/FOrumMagnum/commit/f0feaf7f6e534fa2b361c0d76799f54f9b2670b9#diff-27384fbe44c0624313dff2dea6eea929ca03cd424f92c2e1ffa67fa9e9bc4d94R217) where we lost the default `Untitled Draft` post title.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211857622968839) by [Unito](https://www.unito.io)
