### PR TITLE
Fix cursor position resetting to the end after you type a character in the middle on /search

### DIFF
--- a/packages/lesswrong/components/search/SearchPageTabbed.tsx
+++ b/packages/lesswrong/components/search/SearchPageTabbed.tsx
@@ -329,6 +329,7 @@ const SearchPageTabbed = () => {
       
     updateUrl(updatedSearchState, clearTagFilters ? [] : tagsFilter)
     setSearchState(updatedSearchState)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateUrl])
 
   useEffect(() => {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211868871805024) by [Unito](https://www.unito.io)
