### PR TITLE
Fix conversation message text color

### DIFF
--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -71,8 +71,24 @@ const styles = (theme: ThemeType) => ({
   backgroundIsCurrent: {
     backgroundColor: theme.palette.grey[700],
     color: theme.palette.inverseGreyAlpha(.87),
-    '& *, & li::marker': {
+    // Use && to increase specificity and override messageBody styles
+    '&& p, && li, && li::marker, && blockquote, && h1, && h2, && h3, && h4, && h5, && h6, && a, && div, && td, && th, && span': {
       color: theme.palette.inverseGreyAlpha(.87),
+    },
+    '&& a:visited': {
+      color: theme.palette.inverseGreyAlpha(.7),
+    },
+    '&& code': {
+      color: theme.palette.text.normal,
+      backgroundColor: theme.palette.grey[100],
+    },
+    '&& pre': {
+      color: theme.palette.text.normal,
+      backgroundColor: theme.palette.grey[100],
+    },
+    '&& pre code': {
+      // Code inside pre blocks shouldn't have double background
+      backgroundColor: 'transparent',
     },
     marginLeft:theme.spacing.unit*1.5,
   },


### PR DESCRIPTION
Fix text color inconsistencies in conversation messages and resolve the 'white on white' code block issue for current user messages.

The previous styling for current user messages (dark background) had issues with various elements (like list items, headers, and especially code blocks) not correctly inheriting the intended light text color, leading to unreadable text or "white on white" code blocks in light mode. This PR introduces more specific CSS rules to ensure consistent text readability across all content types within conversation messages.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1762119181225449?thread_ts=1762119181.225449&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-936b3809-1ebd-436c-af7f-990e2acd7ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-936b3809-1ebd-436c-af7f-990e2acd7ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211884326997020) by [Unito](https://www.unito.io)
