### PR TITLE
allow shortforms removed from frontpage to be shown to users who have Personal Blog non-hidden for frontpage posts

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -540,7 +540,7 @@ function shortformFrontpage(terms: CommentsViewTerms, _: ApolloClient, context?:
   const twoHoursAgo = moment().subtract(2, 'hours').toDate();
   const maxAgeDays = terms.maxAgeDays ?? 5;
   const currentUserId = context?.currentUser?._id;
-  const hidePersonalShortforms = !context?.currentUser || context.currentUser.frontpageFilterSettings.personalBlog === "Hidden";
+  const hidePersonalShortforms = !context?.currentUser || context.currentUser.frontpageFilterSettings?.personalBlog === "Hidden";
   return {
     selector: {
       shortform: true,


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211885672073953) by [Unito](https://www.unito.io)
