### PR TITLE
[EA] Include match in donation election total

### DIFF
--- a/packages/lesswrong/components/forumEvents/givingSeason/GivingSeason2025Banner.tsx
+++ b/packages/lesswrong/components/forumEvents/givingSeason/GivingSeason2025Banner.tsx
@@ -499,7 +499,7 @@ export const GivingSeason2025Banner: FC = () => {
               />
             </div>
             <div className={classes.match}>
-              We&apos;re matching the first $5000
+              Includes our match on the first $5000
             </div>
           </div>
           <div className={classes.electionButtons}>

--- a/packages/lesswrong/lib/givingSeason.tsx
+++ b/packages/lesswrong/lib/givingSeason.tsx
@@ -19,6 +19,7 @@ export const GIVING_SEASON_INFO_HREF = "/posts/RzdKnBYe3jumrZxkB/giving-season-2
 export const ELECTION_INFO_HREF = "/posts/RzdKnBYe3jumrZxkB/giving-season-2025-announcement#November_24th_to_December_7th_";
 export const ELECTION_LEARN_MORE_HREF = "/posts/93KvQDDQfaZEBTP7t/donation-election-fund-rewards-and-matching";
 export const ELECTION_DONATE_HREF = "https://www.every.org/ea-forum-donation-election-2025";
+export const ELECTION_2025_MATCHED_AMOUNT = 5000;
 const ELECTION_TARGET_AMOUNT = 30000;
 
 type GivingSeasonEvent = {


### PR DESCRIPTION
At the request of Toby, updates the donation election thermometer to include the match on the first $5k

<img width="2292" height="1244" alt="Screenshot 2025-11-11 at 11 25 57" src="https://github.com/user-attachments/assets/321e7468-cf09-41e3-917f-94a7fa309833" />


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211909973816429) by [Unito](https://www.unito.io)
