### PR TITLE
unbreak older safari versions, i.e. on ipad mini 2021 with safari 15

### DIFF
--- a/app/api/getLlmFeedback/route.ts
+++ b/app/api/getLlmFeedback/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
   const anthropic = createAnthropic({ apiKey });
 
   const result = await generateText({
-    model: anthropic('claude-sonnet-4.5'),
+    model: anthropic('claude-sonnet-4-5'),
     prompt: `${prompt}\n\n<Post>${markdown}</Post>`,
     tools: {
       suggestedEdits: tool({

--- a/package.json
+++ b/package.json
@@ -379,5 +379,6 @@
   "graphql": {
     "schema": "packages/lesswrong/lib/generated/gqlSchema.gql",
     "documents": "packages/lesswrong/**/*.{graphql,ts,tsx}"
-  }
+  },
+  "browserslist": ["chrome 111", "edge 111", "firefox 111", "safari 12"]
 }


### PR DESCRIPTION
NextJS has apparently always had a concept of "supported" browser versions (https://nextjs.org/docs/architecture/supported-browsers#browserslist).  With Next 16, they pulled these versions up pretty dramatically - the defaults are all for browser versions from early 2023.  Something about this broke JS execution on the site for e.g. ipad minis from 2021, which might be locked to Safari 15.

I've left the supported chrome/edge/firefox versions unchanged from the Next 16 defaults, under the theory that people who have non-Apple hardware probably have an easier time upgrading their browser versions.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211918776565122) by [Unito](https://www.unito.io)
