### PR TITLE
LW Deploy, 2025-11-11b

### DIFF
--- a/packages/lesswrong/components/ultraFeed/UltraFeedSettings.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedSettings.tsx
@@ -654,12 +654,19 @@ const UltraFeedSettings = ({
   }, [formValues, simpleViewTruncationLevels, updateSettings, captureEvent, settings, viewMode, flash, truncationMaps]);
   
   const handleReset = useCallback(() => {
+    // Preserve the current algorithm choice when resetting
+    const currentAlgorithm = formValues.algorithm;
+    
     // Reset local form state to defaults without persisting
-    setFormValues(deriveFormValuesFromSettings(DEFAULT_SETTINGS));
+    const resetFormValues = deriveFormValuesFromSettings(DEFAULT_SETTINGS);
+    setFormValues({
+      ...resetFormValues,
+      algorithm: currentAlgorithm,
+    });
     setSimpleViewTruncationLevels(deriveSimpleViewTruncationLevelsFromSettings(DEFAULT_SETTINGS, truncationMaps));
     setZodErrors(null);
     captureEvent("ultraFeedSettingsReset");
-  }, [captureEvent, truncationMaps]);
+  }, [captureEvent, truncationMaps, formValues.algorithm]);
 
   const truncationGridProps = {
     levels: simpleViewTruncationLevels,

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -693,7 +693,7 @@ export const ultraFeedGraphQLQueries = {
       );
 
       const algorithmName = parsedSettings.algorithm as UltraFeedAlgorithmName;
-      const algorithm = getAlgorithm(algorithmName);
+      const algorithm = getAlgorithm(algorithmName, currentUser);
       
       const rankedItemsWithMetadata = algorithm.rankItems(
         rankableItems, 

--- a/packages/lesswrong/server/ultraFeed/algorithms/algorithmRegistry.ts
+++ b/packages/lesswrong/server/ultraFeed/algorithms/algorithmRegistry.ts
@@ -7,6 +7,7 @@
 import type { UltraFeedAlgorithm } from '../ultraFeedAlgorithmInterface';
 import { scoringAlgorithm } from './scoringAlgorithm';
 import { samplingAlgorithm } from './samplingAlgorithm';
+import { userIsAdmin } from '@/lib/vulcan-users/permissions';
 
 export type UltraFeedAlgorithmName = 'scoring' | 'sampling';
 
@@ -15,9 +16,9 @@ const algorithms: Record<UltraFeedAlgorithmName, UltraFeedAlgorithm> = {
   sampling: samplingAlgorithm,
 };
 
-export function getAlgorithm(name: UltraFeedAlgorithmName | undefined | null): UltraFeedAlgorithm {
+export function getAlgorithm(name: UltraFeedAlgorithmName | undefined | null, currentUser?: DbUser | null): UltraFeedAlgorithm {
   if (!name || !algorithms[name]) {
-    return algorithms.sampling;
+    return userIsAdmin(currentUser ?? null) ? algorithms.scoring : algorithms.sampling;
   }
   return algorithms[name];
 }

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
@@ -61,9 +61,9 @@ export function toThreadRankable(
   const perComment: CommentRankableItem[] = thread.comments.map((c): CommentRankableItem => {
     const postedAt = c.metaInfo?.postedAt ?? null;
     const ageHrs = postedAt ? moment(now).diff(postedAt, 'hours') : 0;
-    const isRead = Boolean(c.metaInfo?.lastViewed || c.metaInfo?.lastInteracted);
+    const isRead = !!(c.metaInfo?.lastViewed || c.metaInfo?.lastInteracted);
     const primarySource = (c.metaInfo?.sources?.[0] as FeedItemSourceType | undefined);
-    const userSubscribedToAuthor = Boolean(c.metaInfo?.sources?.includes('subscriptionsComments' as const));
+    const userSubscribedToAuthor = !!c.metaInfo?.fromSubscribedUser;
     return {
       commentId: c.commentId,
       ageHrs,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Preserves selected algorithm on settings reset, defaults algorithm to scoring for admins (sampling otherwise), and refines thread ranking booleans.
> 
> - **UltraFeed Settings (UI)**
>   - Preserve current `algorithm` when `handleReset` resets local form state; update dependencies accordingly.
> - **Backend / Algorithm Selection**
>   - `getAlgorithm(name, currentUser)` now considers user role: defaults to `scoring` for admins, `sampling` for others; resolver updated to pass `currentUser`.
> - **Ranking Logic**
>   - Simplify boolean casts for `isRead` and derive `userSubscribedToAuthor` from `fromSubscribedUser` in `toThreadRankable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56586e80a3d59000c63c5ed96c4f2f13b8d5997b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211918782474434) by [Unito](https://www.unito.io)
