### PR TITLE
Fix missing relevance scores and relevance vote buttons on tag pages, and also slow queries elsewhere

### DIFF
--- a/packages/lesswrong/components/posts/usePostsList.ts
+++ b/packages/lesswrong/components/posts/usePostsList.ts
@@ -156,7 +156,7 @@ export const usePostsList = <TagId extends string | undefined = undefined>({
     } as const
     : {};
 
-  const query = !!tagId ? postsListWithVotesQuery : postsListTagWithVotesQuery;
+  const query = !!tagId ? postsListTagWithVotesQuery : postsListWithVotesQuery ;
   const { view = 'default', limit = 10, ...selectorTerms } = terms ?? {};
 
   const { data, error, loading, loadMoreProps } = useQueryWithLoadMore(query, {


### PR DESCRIPTION
This condition was accidentally flipped in [this commit](https://github.com/ForumMagnum/ForumMagnum/commit/2b82e650a349136773f4bceccead54e3c0e184ac#diff-1ac3bc795a78a272815118bcc638503df347a66404c83b966bbf36a0e6e3d80fR158) while refactoring away useMulti.

This also created some slow-query/indexing issues elsewhere; fetching the user's votes on tag-relations on posts can be slow because the user's votes are likely to not be in memory (and in this case there was also an issue where it fetched votes before applying the limit, rather than after, but it didn't need to be fetching them at all)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211933682807481) by [Unito](https://www.unito.io)
