### PR TITLE
[EA] Fix duplicate notifications being sent for newComment and (indirect) newReplyToYou

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -233,7 +233,7 @@ const utils = {
         createNotifications({userIds: newReplyToYouIndirectUserIds, notificationType: 'newReplyToYou', documentType: 'comment', documentId: comment._id, extraData: {direct: false}})
       ]);
   
-      notifiedUsers = [...notifiedUsers, ...newReplyUserIds, ...newReplyToYouDirectUserIds];
+      notifiedUsers = [...notifiedUsers, ...newReplyUserIds, ...newReplyToYouDirectUserIds, ...newReplyToYouIndirectUserIds];
     }
   
     // 2. If this comment is a debate comment, notify users who are subscribed to the post as a debate (`newDebateComments`)


### PR DESCRIPTION
This is bug introduced when we added notification for indirect replies. For _direct_ replies, it would not create a 'newComment' notification if a 'newReplyToYou' had already been sent. but this did not apply to indirect replies. This PR adds that case.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211946882833134) by [Unito](https://www.unito.io)
