### PR TITLE
[EA] Show markdown dropdown in quick takes editor

### DIFF
--- a/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesEntry.tsx
@@ -43,9 +43,6 @@ const styles = (theme: ThemeType) => ({
     '& .ck.ck-editor__editable_inline': {
       border: "none !important",
     },
-    '& .EditorTypeSelect-select': {
-      display: 'none',
-    },
   },
   commentFormCollapsed: {
     '& .form-input': {


### PR DESCRIPTION
Requested by a user. It is a bit ugly but IMO it's better to have the functionality there so people are actually able to use the editor they want.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211947306916896) by [Unito](https://www.unito.io)
