### PR TITLE
Remove unnecessary pending events design to fix server analytics

### DIFF
--- a/packages/lesswrong/server/analytics/serverAnalyticsWriter.ts
+++ b/packages/lesswrong/server/analytics/serverAnalyticsWriter.ts
@@ -174,10 +174,6 @@ export async function pruneOldPerfMetrics() {
  */
 export function serverWriteEvent(event: AnyBecauseTodo) {
   const { type, timestamp, props } = event;
-  if (pendingEvents) {
-    pendingEvents.push(event);
-    return;
-  }
   backgroundTask(writeEventsToAnalyticsDB([{
     type, timestamp,
     props: {
@@ -218,19 +214,5 @@ export function serverCaptureEvent(eventType: string, eventProps?: EventProps, s
   } catch(e) {
     // eslint-disable-next-line no-console
     console.error("Error while capturing analytics event: ", e);
-  }
-}
-
-// Analytics events that were recorded during startup before we were ready
-// to write them to the analytics DB.
-let pendingEvents: any[]|null = [];
-
-export function startAnalyticsWriter() {
-  const deferredEvents = pendingEvents;
-  pendingEvents = null;
-  if (deferredEvents) {
-    for (let event of deferredEvents) {
-      serverWriteEvent(event);
-    }
   }
 }

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -7,7 +7,7 @@ import { startupSanityChecks } from './startupSanityChecks';
 import { refreshKarmaInflationCache } from './karmaInflation/cron';
 // import { addLegacyRssRoutes } from './legacy-redirects/routes';
 // import { initReviewWinnerCache } from './resolvers/reviewWinnerResolvers';
-import { startAnalyticsWriter, serverCaptureEvent as captureEvent } from '@/server/analytics/serverAnalyticsWriter';
+import { serverCaptureEvent as captureEvent } from '@/server/analytics/serverAnalyticsWriter';
 import { startSyncedCron } from './cron/startCron';
 import { isAnyTest, isMigrations } from '@/lib/executionEnvironment';
 import chokidar from 'chokidar';
@@ -40,7 +40,6 @@ import { backgroundTask } from './utils/backgroundTask';
 // }
 
 export async function runServerOnStartupFunctions() {
-  startAnalyticsWriter();
   scheduleQueueProcessing();
   initRenderQueueLogging();
   startMemoryUsageMonitor();


### PR DESCRIPTION
## Fix broken analytics in NextJS

Removes the `pendingEvents` buffering mechanism from the analytics writer, which was broken after the NextJS migration.

**The Problem:**
- `pendingEvents` was designed for the old server architecture where `startAnalyticsWriter()` would be called during a startup phase to flush buffered events
- In NextJS, `startAnalyticsWriter()` was never called, so `pendingEvents` remained an empty array forever
- All analytics events were buffered but never written to the database

**The Fix:**
- Removed `pendingEvents` variable and `startAnalyticsWriter()` function
- Analytics events now write directly to the database via background tasks
- This is the correct pattern for NextJS's serverless architecture

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211957260564642) by [Unito](https://www.unito.io)
