### PR TITLE
Remove max score capping

### DIFF
--- a/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
@@ -423,7 +423,6 @@ function selectWithDiversityConstraints(
 
 /**
  * Score items without applying constraints or ordering.
- * Applies a global score cap (config.maxScore) to all items.
  * Returns items with their score breakdowns for display/analysis.
  */
 export function scoreItems(
@@ -453,12 +452,9 @@ export function scoreItems(
       };
     }
     
-    // Apply global cap
-    const cappedScore = Math.min(scoreResult.score, config.maxScore);
-    
     return { 
       id: item.id, 
-      score: cappedScore, 
+      score: scoreResult.score, 
       item,
       breakdown: scoreResult.breakdown,
     };


### PR DESCRIPTION
The score of items in the UltraFeed new algorithm had a max value of 100 applied (though not where it's displayed which was confusing). I don't think it makes sense and removed it.