### PR TITLE
Disable SQL resolvers

### DIFF
--- a/packages/lesswrong/server/sql/ProjectionContext.ts
+++ b/packages/lesswrong/server/sql/ProjectionContext.ts
@@ -98,7 +98,7 @@ class ProjectionContext<N extends CollectionNameString = CollectionNameString> {
         const customResolver: CustomResolver<N> = {
           type: outputType,
           resolver,
-          ...(enableCustomSqlResolvers ? {sqlResolver} : {}),
+          ...(enableSqlResolver ? {sqlResolver} : {}),
           sqlPostProcess,
           arguments: resolverArgs,
           fieldName,


### PR DESCRIPTION
See Slack thread: https://lworg.slack.com/archives/C75BWSNBH/p1763420030662909

Compiled joins aren't strictly necessary (if they don't happen the graphql layer will do another fetch), and may be interacting badly with postgres query planning and have other issues. Try turning them off, to see what effect that has on response-time/etc metrics.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211974517557564) by [Unito](https://www.unito.io)
