### PR TITLE
[EA] Add padding to PostsTopSequencesNav for when text wraps

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -22,6 +22,8 @@ export const titleStyles = (theme: ThemeType) => ({
   fontFamily: theme.typography.uiSecondary.fontFamily,
   lineHeight: '24px',
   color: theme.palette.text.dim,
+  paddingTop: 12,
+  paddingBottom: 12,
   ...theme.typography.smallCaps,
 })
 
@@ -37,7 +39,6 @@ const styles = (theme: ThemeType) => ({
   },
   title: {
     ...titleStyles(theme),
-    
     ...(isFriendlyUI && {
       textTransform: 'uppercase',
       fontSize: 18,


### PR DESCRIPTION
Before/after:
<img width="916" height="690" alt="Screenshot 2025-11-18 at 11 52 10" src="https://github.com/user-attachments/assets/dd408fe9-d30d-43f7-9799-a40927ec036f" />

<img width="916" height="690" alt="Screenshot 2025-11-18 at 11 50 13" src="https://github.com/user-attachments/assets/89b8eb01-1419-4a86-a5d3-29e7e009dd4d" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1211978857733539) by [Unito](https://www.unito.io)
