### PR TITLE
[EA] Revert getRateLimitName to more descriptive version

### DIFF
--- a/packages/lesswrong/lib/rateLimits/utils.ts
+++ b/packages/lesswrong/lib/rateLimits/utils.ts
@@ -122,7 +122,7 @@ export function calculateRecentKarmaInfo(userId: string, allVotes: RecentVoteInf
 }
 
 function getRateLimitName (rateLimit: AutoRateLimit) {
-  return rateLimit.rateLimitName
+  return `${rateLimit.itemsPerTimeframe} ${rateLimit.actionType} per ${rateLimit.timeframeLength} ${rateLimit.timeframeUnit}`;
 }
 
 function getActiveRateLimits<T extends AutoRateLimit>(user: UserKarmaInfo & { recentKarmaInfo: RecentKarmaInfo }, autoRateLimits: T[]) {


### PR DESCRIPTION
Reverting due to @s-cheng's comment [here](https://github.com/ForumMagnum/ForumMagnum/pull/11197#discussion_r2255344250) pointing out that this is used in the moderator dashboard, and the old version gave more useful context:

> It looks like this is moderator-facing (for example you can see them on the right-hand side of each card [here](https://forum.effectivealtruism.org/admin/moderation)), so it's not just used for analytics. And this makes it such that when a mod rate-limits a user, that will appear as like moderatorRateLimit instead of the actual rate limit.