### PR TITLE
Fix post-edit form showing stale data due to nextjs 16/cacheComponents/apollo-client bug

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -28,6 +28,7 @@ import NewPostHowToGuides from "./NewPostHowToGuides";
 import { withDateFields } from '@/lib/utils/dateUtils';
 import { PostsEditFormQuery } from './queries';
 import { StatusCodeSetter } from '../next/StatusCodeSetter';
+import { usePathname } from 'next/navigation';
 
 const UsersCurrentPostRateLimitQuery = gql(`
   query PostsEditFormUser($documentId: String, $eventForm: Boolean) {
@@ -130,11 +131,10 @@ const styles = defineStyles("PostsEditForm", (theme: ThemeType) => ({
   },
 }))
 
-const PostsEditForm = ({ documentId, version }: {
+const PostsEditFormInner = ({ documentId, version }: {
   documentId: string,
   version?: string | null,
 }) => {
-  // return <></>;
   const classes = useStyles(styles);
   const { query } = useLocation();
   const navigate = useNavigate();
@@ -169,7 +169,7 @@ const PostsEditForm = ({ documentId, version }: {
     }
   }, [isDraft]);
   
-  if (!document && loading) {
+  if (!document || loading) {
     return <Loading/>
   }
 
@@ -248,6 +248,22 @@ const PostsEditForm = ({ documentId, version }: {
   </>);
 }
 
-export default registerComponent('PostsEditForm', PostsEditForm);
+const PostsEditForm = ({ documentId, version }: {
+  documentId: string,
+  version?: string | null,
+}) => {
+  // HACK: key PostsEditForm with usePathname, so that when you navigate off of
+  // /editPost and then return, no state belonging to PostsEditFormInner will be
+  // preserved. Without this, if you save a post and then return to the edit
+  // page, nextjs (starting in next 16 with cacheComponents:true) will keep a
+  // copy of the editor's state variables inside an inactive <Activity>, and
+  // when resurrected, the useQuery(..., fetchPolicy: "network-only") will
+  // return a stale value on its first render. (This is a bug in the interaction
+  // between apollo-client and nextjs 16.)
+  const pathname = usePathname();
+  return <PostsEditFormInner documentId={documentId} version={version} key={pathname}/>
+}
+
+export default PostsEditForm;
 
 


### PR DESCRIPTION
When the `cacheComponents` flag is turned on in `next.config.ts`, this changes the behavior of `useQuery` with `fetchPolicy: "network-only"` so that it can return stale data. This created an issue where if you are on the Edit Post page, you click Save Draft, and then you click Edit from the post post triple-dot menu, the editor would load with a stale revision. If you edited from there, this would be data loss.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212121715597927) by [Unito](https://www.unito.io)
