### PR TITLE
Fix issue that caused comment-permalink headers appearing on posts that don't match the comment after navigation

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -97,6 +97,15 @@ const CommentPermalink = ({
     forceUnCollapsed: true,
     noAutoScroll: true
   };
+  
+  // If there's a `?commentId=...` in the URL for a comment but the comment is
+  // on a different post, don't show it. This mostly mitigates the effect when
+  // a bug makes a link that fails to clear the ?commentId query term from a
+  // URL, and also makes it so you can't construct tricky links that make a
+  // comment look like a reply to a post that it isn't a reply to.
+  if (post && (comment.postId !== post._id)) {
+    return null;
+  }
 
   // NB: classes.root is not in the above styles, but is used by eaTheme
   return (

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -91,16 +91,6 @@ export const useNavigate = () => {
         } else {
           window.history.pushState(null, '', normalizedLocation);
         }
-
-        const hashChanged = updatedLocationDescriptor.hash !== window.location.hash;
-
-        if (hashChanged) {
-          const base = new URL(window.location.href).origin;
-          const oldURL = new URL(createPath(window.location), base).toString();
-          const newURL = new URL(normalizedLocation, base).toString();
-          const hashChangeEvent = new HashChangeEvent('hashchange', { oldURL, newURL });
-          window.dispatchEvent(hashChangeEvent);
-        }
       } else if (options?.replace) {
         if (normalizedLocation !== normalizedOldLocation) {
           history.replace(normalizedLocation);


### PR DESCRIPTION
After enabling `cacheComponents` in our nextjs config, a bug appeared where after navigating from a comment-hash URL on a post page to another post page, the destination post page would show the comment whose hash was in the URL at the top of the page as if it was a permalink. This happens because when `LocationContextProvider` rerenders during a navigation and looks at `window.location.hash`, due to some wonky changes inside nextjs, instead of seeing the new URL in `window.location`, it now sees the old URL (and it doesn't ever rerender with the new URL). Bits of the path that come from `usePathname` and `useParams` were not affected (the hash has to come from `window.location` because it isn't available during SSR, and there is no nextjs API to get it).

This PR adds two fixes. First, it rewrites the hash handling in `LocationContextProvider`, to use a different hack than the previous hack. Maybe this one will last for another major versoin. Second, it adds a check in `CommentPermalink` which hides the comment if it has a mismatched post ID, which catches this case and also catches the case where someone manually assembles a URL with a mismatched post ID and comment ID in it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212124835569805) by [Unito](https://www.unito.io)
