### PR TITLE
style the visible-text-hack content so that it doesn't cause scrollbars

### DIFF
--- a/packages/lesswrong/components/layout/PageBackgroundWrapper.tsx
+++ b/packages/lesswrong/components/layout/PageBackgroundWrapper.tsx
@@ -63,8 +63,11 @@ export function BodyWithBackgroundColor({children}: {
       color paint by 500ms, which is pretty significant. As a workaround, add
       a div containing "visible" (but not really visible) text, which makes the
       background color get painted significantly sooner.
+      
+      Using position: absolute to avoid contributing to document height
+      (which would cause unwanted scrollbars on some fullscreen routes).
     */}
-    <div style={{opacity: 0.001}}>x</div>
+    <div style={{opacity: 0.001, position: 'absolute', top: 0, left: 0}}>x</div>
   </body>
 }
 


### PR DESCRIPTION
The original change caused a full-page vertical scroll on e.g. the supermod page, which had fixed page content.  Tested that the fix seems harmless on the home page, on /allPosts, and on the /inbox page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212167472455355) by [Unito](https://www.unito.io)
