### PR TITLE
Fix alignment of reaction icon in comment hovers when there is no Reply link

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottom.tsx
@@ -24,8 +24,17 @@ const styles = (theme: ThemeType) => ({
     minHeight: 12,
     ...(theme.isFriendlyUI ? {} : {fontSize: 12}),
   },
-  bottomWithReacts: {
-    justifyContent: "space-between"
+  leftSection: {
+    display: "flex",
+    alignItems: "center",
+    columnGap: theme.spacing.unit,
+    flexWrap: "wrap",
+  },
+  rightSection: {
+    display: "flex",
+    alignItems: "center",
+    columnGap: theme.spacing.unit,
+    marginLeft: "auto",
   },
   answer: {
     display: "flex",
@@ -35,7 +44,7 @@ const styles = (theme: ThemeType) => ({
     ...theme.typography.body2,
     fontWeight: 450,
     color: theme.palette.lwTertiary.main,
-    marginLeft: "auto"
+    marginLeft: theme.spacing.unit,
   },
 })
 
@@ -77,28 +86,36 @@ const CommentBottom = ({comment, treeOptions, votingSystem, voteProps, commentBo
   )
   const showEditInContext = treeOptions.showEditInContext;
 
+  const showVoteBottom = !!VoteBottomComponent && !treeOptions.hideVoteBottom;
+  const showRightSection = showVoteBottom || showEditInContext;
+
   return (
     <div className={classNames(
       classes.bottom,
       comment.answer && classes.answer,
-      !!VoteBottomComponent && classes.bottomWithReacts,
     )}>
-      <CommentBottomCaveats comment={comment} />
-      {showReplyButton && replyButton}
-      {VoteBottomComponent && !treeOptions.hideVoteBottom && <VoteBottomComponent
-        document={comment}
-        hideKarma={treeOptions.post?.hideCommentKarma}
-        collectionName="Comments"
-        votingSystem={votingSystem}
-        commentBodyRef={commentBodyRef}
-        voteProps={voteProps}
-      />}
-      {showEditInContext && <Link
-        to={commentGetPageUrlFromIds({commentId: comment._id, postId: comment.postId})}
-        target="_blank" rel="noopener noreferrer"
-        className={classes.editInContext}>
-          Edit in context
-      </Link>}
+      <div className={classes.leftSection}>
+        <CommentBottomCaveats comment={comment} />
+        {showReplyButton && replyButton}
+      </div>
+      {showRightSection && (
+        <div className={classes.rightSection}>
+          {showVoteBottom && <VoteBottomComponent
+            document={comment}
+            hideKarma={treeOptions.post?.hideCommentKarma}
+            collectionName="Comments"
+            votingSystem={votingSystem}
+            commentBodyRef={commentBodyRef}
+            voteProps={voteProps}
+          />}
+          {showEditInContext && <Link
+            to={commentGetPageUrlFromIds({commentId: comment._id, postId: comment.postId})}
+            target="_blank" rel="noopener noreferrer"
+            className={classes.editInContext}>
+              Edit in context
+          </Link>}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Rework `CommentBottom` flex layout to ensure reaction icons remain right-aligned when the Reply link is hidden.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1764141219960209?thread_ts=1764141219.960209&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-1c812dbe-61ae-4a6e-b8cc-f5da2b153c34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c812dbe-61ae-4a6e-b8cc-f5da2b153c34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212167499200245) by [Unito](https://www.unito.io)
