### PR TITLE
[EA] Fix refreshing Google Docs service account

### DIFF
--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -212,6 +212,7 @@ const addGoogleDriveLinkMiddleware = (addConnectHandler: AddMiddlewareType) => {
 
     const url = oauth2Client.generateAuthUrl({
       access_type: 'offline', // offline => get a refresh token that persists for 6 months
+      prompt: 'consent',
       scope: [
         'https://www.googleapis.com/auth/drive.readonly',
         'https://www.googleapis.com/auth/userinfo.profile',


### PR DESCRIPTION
Previously it would fail to refresh if the previous login hadn't been revoked. I think we never noticed this before because we happened to always revoke the old one before refreshing the login.

The issue was that Google only returns an access token and not a refresh token, unless you re-prompt for consent for the services being used. This PR makes it always do this prompt.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212166545300604) by [Unito](https://www.unito.io)
