### PR TITLE
Update review start date to December

### DIFF
--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -97,7 +97,7 @@ export function getReviewPeriodEnd(reviewYear: ReviewYear = REVIEW_YEAR) {
   return moment.utc(`${reviewYear+1}-01-01`).add(TIMEZONE_OFFSET, 'hours')
 }
 
-export const getReviewStart = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-11-24`).add(TIMEZONE_OFFSET, 'hours')
+export const getReviewStart = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-01`).add(TIMEZONE_OFFSET, 'hours')
 export const getNominationPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+1}-12-16`).add(TIMEZONE_OFFSET, 'hours')
 export const getReviewPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-01-16`).add(TIMEZONE_OFFSET, 'hours')
 export const getVotingPhaseEnd = (reviewYear: ReviewYear) => moment.utc(`${reviewYear+2}-02-06`).add(TIMEZONE_OFFSET, 'hours')


### PR DESCRIPTION
Update the review start date to December 1st to align with the actual start of the nominations phase.

This fixes an issue where the progress bar was incorrectly showing as "halfway done" when the review had just started on December 1st.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1764640893055129?thread_ts=1764640893.055129&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-ee76a2b4-d465-4fbf-910a-05a64f1462fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee76a2b4-d465-4fbf-910a-05a64f1462fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212247731429717) by [Unito](https://www.unito.io)
