### PR TITLE
fix click target issue with feed items

### DIFF
--- a/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
+++ b/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
@@ -306,8 +306,6 @@ const FeedContentBody = ({
     
     e.preventDefault();
     
-    // If total content exceeds maxWordCount → navigate
-    // If total content fits within maxWordCount → expand in place
     if (wordCount > maxWordCount && continueReadingUrl) {
       navigate(continueReadingUrl);
     } else {


### PR DESCRIPTION
the demodalification PR introduced a bug where only the "read more" button would take action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clicking anywhere on truncated feed content (excluding links) now expands in place or navigates to the full post when over the max word limit.
> 
> - **Frontend**
>   - **`packages/lesswrong/components/ultraFeed/FeedContentBody.tsx`**:
>     - Clicking anywhere on truncated content (not just the read-more suffix) triggers action.
>     - If `wordCount > maxWordCount` and `continueReadingUrl` exists, navigate; otherwise expand in place.
>     - Ignore clicks on links; prevent action when not truncated, already expanded, or `wordCount` is undefined.
>     - Update `useCallback` deps to include `maxWordCount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 486dd3482fe6b80ebf1f95c427d7c5931aef5331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212254364107645) by [Unito](https://www.unito.io)
