### PR TITLE
LW Deploy, 2025-12-02b

### DIFF
--- a/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
+++ b/packages/lesswrong/components/ultraFeed/FeedContentBody.tsx
@@ -299,24 +299,19 @@ const FeedContentBody = ({
       return;
     }
     
-    // If wordCount is undefined, don't handle clicks for expansion
-    if (wordCount === undefined) {
+    // Only handle clicks if content is truncated and not yet expanded
+    if (!wasTruncated || isExpanded || wordCount === undefined) {
       return;
     }
     
-    // Check if clicking on the read-more suffix
-    const readMoreElement = target.closest('.read-more-suffix');
-    if (wasTruncated && !isExpanded && readMoreElement) {
-      e.preventDefault();
-      
-      // Check if this should navigate, otherwise fall back to expanding in place
-      if (readMoreElement.classList.contains('read-more-navigate') && continueReadingUrl) {
-        navigate(continueReadingUrl);
-      } else {
-        handleExpand();
-      }
+    e.preventDefault();
+    
+    if (wordCount > maxWordCount && continueReadingUrl) {
+      navigate(continueReadingUrl);
+    } else {
+      handleExpand();
     }
-  }, [handleExpand, wasTruncated, isExpanded, wordCount, continueReadingUrl, navigate]);
+  }, [handleExpand, wasTruncated, isExpanded, wordCount, maxWordCount, continueReadingUrl, navigate]);
 
   const getLineClampClass = () => {
     if (!applyLineClamp || !clampOverride) return "";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies click behavior: clicking truncated content now prevents default and either navigates if over maxWordCount or expands in place, while link clicks pass through.
> 
> - **UltraFeed Feed Content** (`packages/lesswrong/components/ultraFeed/FeedContentBody.tsx`):
>   - **Click handling simplified**:
>     - Only handles clicks when content is truncated, not expanded, and `wordCount` is defined.
>     - Prevents default and either `navigate(continueReadingUrl)` if `wordCount > maxWordCount`, else calls `handleExpand()`.
>     - Removes reliance on `.read-more-suffix`/`read-more-navigate` element checks; link clicks still pass through.
>     - Updates `useCallback` deps to include `maxWordCount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3b996463ac3bcd94a672ec63e8f64762467df46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->