### PR TITLE
LW Deploy, 2025-12-03 (fundraiser is unreviewable)

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -5,7 +5,7 @@ import { isAF, isEAForum, defaultVisibilityTags, openThreadTagIdSetting, startHe
 import { frontpageTimeDecayExpr, postScoreModifiers, timeDecayExpr } from '../../scoring';
 import { viewFieldAllowAny, viewFieldNullOrMissing, jsonArrayContainsSelector } from '@/lib/utils/viewConstants';
 import { filters, postStatuses } from './constants';
-import { getPositiveVoteThreshold, QUICK_REVIEW_SCORE_THRESHOLD, ReviewPhase, REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD, VOTING_PHASE_REVIEW_THRESHOLD, longformReviewTagId } from '../../reviewUtils';
+import { getPositiveVoteThreshold, QUICK_REVIEW_SCORE_THRESHOLD, reviewExcludedPostIds, ReviewPhase, REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD, VOTING_PHASE_REVIEW_THRESHOLD, longformReviewTagId } from '../../reviewUtils';
 import { EA_FORUM_COMMUNITY_TOPIC_ID } from '../tags/helpers';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
@@ -1215,8 +1215,6 @@ function nominatablePostsByVote(terms: PostsViewTerms, _: ApolloClient, context?
   }
 }
 
-// Exclude IDs that should not be included, e.g. were republished and postedAt date isn't actually in current review
-const reviewExcludedPostIds = ['MquvZCGWyYinsN49c', '5n2ZQcbc7r4R8mvqc'];
 
 // Nominations for the (≤)2020 review are determined by the number of votes
 function reviewVoting(terms: PostsViewTerms) {

--- a/packages/lesswrong/lib/reviewUtils.tsx
+++ b/packages/lesswrong/lib/reviewUtils.tsx
@@ -174,7 +174,11 @@ export function eligibleToNominate (currentUser: UsersCurrent|DbUser|null) {
   return true
 }
 
+// Exclude IDs that should not be included in the review, e.g. were republished and postedAt date isn't actually in current review, fundraising posts, etc.
+export const reviewExcludedPostIds = ['MquvZCGWyYinsN49c', '5n2ZQcbc7r4R8mvqc'];
+
 export function postEligibleForReview (post: PostsBase) {
+  if (reviewExcludedPostIds.includes(post._id)) return false
   if (moment.utc(post.postedAt) > moment.utc(`${REVIEW_YEAR+1}-01-01`)) return false
   if (isLWorAF() && moment.utc(post.postedAt) < moment.utc(`${REVIEW_YEAR}-01-01`)) return false
   if (post.shortform) return false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes review-excluded post IDs in reviewUtils and applies them to review eligibility and review views/selectors.
> 
> - **Review logic**:
>   - Centralize `reviewExcludedPostIds` in `packages/lesswrong/lib/reviewUtils.tsx` and remove local definition from `packages/lesswrong/lib/collections/posts/views.ts`.
>   - Enforce exclusions in `postEligibleForReview()`.
>   - Use shared `reviewExcludedPostIds` in review selectors: `reviewVoting`, `frontpageReviewWidget`, `reviewFinalVoting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bcbfa699bd08f73e279febebe71e60ad710a962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->