### PR TITLE
LW Deploy, 2025-12-03c

### DIFF
--- a/app/api/cron/update-review-vote-totals/route.ts
+++ b/app/api/cron/update-review-vote-totals/route.ts
@@ -1,0 +1,63 @@
+import type { NextRequest } from 'next/server';
+import { updateReviewVoteTotals } from '@/server/reviewVoteUpdate';
+import { 
+  REVIEW_YEAR, 
+  getNominationPhaseEnd, 
+  getReviewPhaseEnd
+} from '@/lib/reviewUtils';
+import moment from 'moment';
+
+/**
+ * Checks if today is one of the target dates for updating review vote totals:
+ * - 24 hours before the review phase starts (end of nominations)
+ * - 24 hours before the voting phase starts (end of reviews)
+ * - Halfway between those two dates
+ * 
+ * Returns the vote phase to update, or null if today is not a target date.
+ */
+function getVotePhaseToUpdate(): 'nominationVote' | 'finalVote' | null {
+  const now = moment.utc();
+  const today = now.startOf('day');
+  
+  const nominationsEnd = getNominationPhaseEnd(REVIEW_YEAR);
+  const reviewsEnd = getReviewPhaseEnd(REVIEW_YEAR);
+  
+  const beforeReviewPhase = nominationsEnd.clone().subtract(24, 'hours').startOf('day');
+  const beforeVotingPhase = reviewsEnd.clone().subtract(24, 'hours').startOf('day');
+  const midpoint = moment.utc(
+    nominationsEnd.valueOf() + ((reviewsEnd.valueOf() - nominationsEnd.valueOf()) / 2)
+  ).startOf('day');
+  
+  if (today.isSame(beforeReviewPhase, 'day') || today.isSame(midpoint, 'day')) {
+    return 'nominationVote';
+  }
+  
+  if (today.isSame(beforeVotingPhase, 'day')) {
+    return 'finalVote';
+  }
+  
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const votePhase = getVotePhaseToUpdate();
+  
+  if (votePhase) {
+    // eslint-disable-next-line no-console
+    console.log(`Running updateReviewVoteTotals for ${votePhase}`);
+    await updateReviewVoteTotals(votePhase);
+    // eslint-disable-next-line no-console
+    console.log(`Completed updateReviewVoteTotals for ${votePhase}`);
+    return new Response(`Updated ${votePhase}`, { status: 200 });
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('updateReviewVoteTotals cron: not a target date, skipping');
+  return new Response('Not a target date, skipping', { status: 200 });
+}
+

--- a/packages/lesswrong/components/posts/AllPostsList.tsx
+++ b/packages/lesswrong/components/posts/AllPostsList.tsx
@@ -53,6 +53,8 @@ const AllPostsList = ({
     sortedBy: currentSorting,
     after: query.after,
     before: query.before,
+    requiredUnnominated: query.unnominated === 'true',
+    requiredFrontpage: query.frontpage === 'true',
   };
   if (currentTimeframe === "allTime") {
     return (

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -385,7 +385,7 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
       <div className={classes.votingPageHeader}>
         {/* <p>This page shows all posts that passed the nomination round. <br/>Use it to help prioritize your reviewing and update your votes.</p> */}
         <p>Currently sorted by: <b>{sortingInfo[sortPosts].title}</b><em>.<br/>{sortingInfo[sortPosts].description}</em></p> 
-        <p>If this page is intimidating, just go to the <Link to={`/quickReview/${reviewYear}`}>Quick Review</Link> page.</p>
+        {reviewPhase !== 'NOMINATIONS' && <p>If this page is intimidating, just go to the <Link to={`/quickReview/${reviewYear}`}>Quick Review</Link> page.</p>}
       </div>
         <div className={classes.tagListContainer}>
           <PostsTagsList

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -203,6 +203,13 @@ function defaultView(terms: PostsViewTerms, _: ApolloClient, context?: ResolverC
     }
   }
   
+  if (terms.requiredUnnominated) {
+    params.selector.positiveReviewVoteCount = { $lt: REVIEW_AND_VOTING_PHASE_VOTECOUNT_THRESHOLD }
+  }
+  if (terms.requiredFrontpage) {
+    params.selector.frontpageDate = {$exists: true}
+  }
+
   if (terms.after || terms.before) {
     let postedAt: any = {};
 

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -5939,6 +5939,8 @@ export type PostDefaultViewInput = {
   notPostIds?: InputMaybe<Array<Scalars['String']['input']>>;
   postIds?: InputMaybe<Array<Scalars['String']['input']>>;
   question?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredFrontpage?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredUnnominated?: InputMaybe<Scalars['Boolean']['input']>;
   sortedBy?: InputMaybe<Scalars['String']['input']>;
   timeField?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
@@ -7355,6 +7357,8 @@ export type PostsTimeframeInput = {
   notPostIds?: InputMaybe<Array<Scalars['String']['input']>>;
   postIds?: InputMaybe<Array<Scalars['String']['input']>>;
   question?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredFrontpage?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredUnnominated?: InputMaybe<Scalars['Boolean']['input']>;
   sortedBy?: InputMaybe<Scalars['String']['input']>;
   timeField?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -4696,6 +4696,8 @@ input PostDefaultViewInput {
   before: String
   timeField: String
   curatedAfter: String
+  requiredUnnominated: Boolean
+  requiredFrontpage: Boolean
 }
 
 input PostsUserPostsInput {
@@ -4865,6 +4867,8 @@ input PostsTimeframeInput {
   timeField: String
   curatedAfter: String
   limit: Int
+  requiredUnnominated: Boolean
+  requiredFrontpage: Boolean
 }
 
 input PostsDailyInput {

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -5936,6 +5936,8 @@ type PostDefaultViewInput = {
   notPostIds?: InputMaybe<Array<Scalars['String']['input']>>;
   postIds?: InputMaybe<Array<Scalars['String']['input']>>;
   question?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredFrontpage?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredUnnominated?: InputMaybe<Scalars['Boolean']['input']>;
   sortedBy?: InputMaybe<Scalars['String']['input']>;
   timeField?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
@@ -7352,6 +7354,8 @@ type PostsTimeframeInput = {
   notPostIds?: InputMaybe<Array<Scalars['String']['input']>>;
   postIds?: InputMaybe<Array<Scalars['String']['input']>>;
   question?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredFrontpage?: InputMaybe<Scalars['Boolean']['input']>;
+  requiredUnnominated?: InputMaybe<Scalars['Boolean']['input']>;
   sortedBy?: InputMaybe<Scalars['String']['input']>;
   timeField?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -4237,6 +4237,8 @@ interface PostDefaultViewInput {
   before?: string | null;
   timeField?: string | null;
   curatedAfter?: string | null;
+  requiredUnnominated?: boolean | null;
+  requiredFrontpage?: boolean | null;
 }
 
 interface PostsUserPostsInput {
@@ -4406,6 +4408,8 @@ interface PostsTimeframeInput {
   timeField?: string | null;
   curatedAfter?: string | null;
   limit?: number | null;
+  requiredUnnominated?: boolean | null;
+  requiredFrontpage?: boolean | null;
 }
 
 interface PostsDailyInput {

--- a/packages/lesswrong/lib/generated/routeManifest.ts
+++ b/packages/lesswrong/lib/generated/routeManifest.ts
@@ -137,6 +137,9 @@ export const routeTrie = {
             "update-promoted-spotlight-item": {
               "hasRoute": true
             },
+            "update-review-vote-totals": {
+              "hasRoute": true
+            },
             "update-user-activities": {
               "hasRoute": true
             }
@@ -151,6 +154,7 @@ export const routeTrie = {
             "update-analytics-collections": "update-analytics-collections",
             "update-missing-post-embeddings": "update-missing-post-embeddings",
             "update-promoted-spotlight-item": "update-promoted-spotlight-item",
+            "update-review-vote-totals": "update-review-vote-totals",
             "update-user-activities": "update-user-activities"
           }
         },

--- a/packages/lesswrong/server/collections/posts/queries.ts
+++ b/packages/lesswrong/server/collections/posts/queries.ts
@@ -50,6 +50,8 @@ export const graphqlPostQueryTypeDefs = gql`
     before: String
     timeField: String
     curatedAfter: String
+    requiredUnnominated: Boolean
+    requiredFrontpage: Boolean
   }
   
   input PostsUserPostsInput {
@@ -219,6 +221,8 @@ export const graphqlPostQueryTypeDefs = gql`
     timeField: String
     curatedAfter: String
     limit: Int
+    requiredUnnominated: Boolean
+    requiredFrontpage: Boolean
   }
   
   input PostsDailyInput {

--- a/vercel.json
+++ b/vercel.json
@@ -35,5 +35,8 @@
   }, {
     "path": "/api/cron/update-missing-post-embeddings",
     "schedule": "0 1 * * *"
+  }, {
+    "path": "/api/cron/update-review-vote-totals",
+    "schedule": "0 2 * * *"
   }]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a secured cron route scheduled nightly to update review vote totals and introduces `requiredUnnominated`/`requiredFrontpage` post filters, plus a small Review Voting UI tweak.
> 
> - **Backend/Cron**:
>   - Adds `GET /api/cron/update-review-vote-totals` with auth check; determines target phase (`nominationVote`/`finalVote`) by dates and runs `updateReviewVoteTotals`.
>   - Registers route in `routeManifest` and schedules it in `vercel.json` (daily at 02:00 UTC).
> - **Posts querying/filtering**:
>   - `AllPostsList`: forwards query params `unnominated` and `frontpage` as `requiredUnnominated`/`requiredFrontpage` in `PostsViewTerms`.
>   - `views.defaultView`: supports `terms.requiredUnnominated` and `terms.requiredFrontpage` (filters by `positiveReviewVoteCount` threshold and `frontpageDate` existence).
>   - GraphQL schema/types/codegen: adds `requiredUnnominated` and `requiredFrontpage` to relevant `Posts*Input` types.
> - **UI**:
>   - `ReviewVotingPage`: only shows Quick Review link when `reviewPhase !== 'NOMINATIONS'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8e1041fb2a2337c0635fe6838abcfc2a26fea3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212254512032908) by [Unito](https://www.unito.io)
