### PR TITLE
fix element ordering in Layout to restore correct fullscreen behavior in conversations page

### DIFF
--- a/packages/lesswrong/components/layout/Layout.tsx
+++ b/packages/lesswrong/components/layout/Layout.tsx
@@ -316,8 +316,8 @@ const Layout = ({children}: {
       <CommentOnSelectionPageWrapper>
       <CurrentAndRecentForumEventsProvider>
       <LlmSidebarWrapper>
-        <PageBackgroundWrapper>
         <HeaderHeightProvider>
+        <PageBackgroundWrapper>
           {buttonBurstSetting.get() && <GlobalButtonBurst />}
           <DialogManager>
             <CommentBoxManager>
@@ -406,8 +406,8 @@ const Layout = ({children}: {
             </CommentBoxManager>
           </DialogManager>
           <NavigationEventSender />
-        </HeaderHeightProvider>
         </PageBackgroundWrapper>
+        </HeaderHeightProvider>
       </LlmSidebarWrapper>
       </CurrentAndRecentForumEventsProvider>
       </CommentOnSelectionPageWrapper>


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212312949631931) by [Unito](https://www.unito.io)
