### PR TITLE
Fix input bug and new tab

### DIFF
--- a/packages/lesswrong/components/messaging/ConversationContents.tsx
+++ b/packages/lesswrong/components/messaging/ConversationContents.tsx
@@ -174,7 +174,7 @@ const ConversationContents = ({
         {renderMessages()}
         <div className={classes.editor}>
           <MessagesNewForm
-            key={`sendMessage-${messageSentCount}`}
+            key={`sendMessage-${conversation._id}-${messageSentCount}`}
             conversationId={conversation._id}
             templateQueries={{ templateId: query.templateId, displayName: query.displayName }}
             formStyle="minimalist"

--- a/packages/lesswrong/components/messaging/FriendlyConversationItem.tsx
+++ b/packages/lesswrong/components/messaging/FriendlyConversationItem.tsx
@@ -1,12 +1,13 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { truncate } from "../../lib/editor/ellipsize";
-import { useClickableCell } from "../common/useClickableCell";
 import classNames from "classnames";
 import { conversationGetFriendlyTitle } from "../../lib/collections/conversations/helpers";
 import UsersProfileImage from "../users/UsersProfileImage";
 import FormatDate from "../common/FormatDate";
 import { isFriendlyUI } from "@/themes/forumTheme";
+import { useLocation } from "../../lib/routeUtil";
+import qs from "qs";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -94,8 +95,22 @@ const FriendlyConversationItem = ({
   setSelectedConversationId: React.Dispatch<React.SetStateAction<string | undefined>>;
 }) => {
   const isSelected = selectedConversationId === conversation._id;
+  const { location, query } = useLocation();
 
-  const { onClick } = useClickableCell({ onClick: () => setSelectedConversationId(conversation._id) });
+  const onClick = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Handle ctrl/cmd+click to open in new tab
+    if (e.metaKey || e.ctrlKey) {
+      const newQuery = { ...query, conversation: conversation._id };
+      const search = qs.stringify(newQuery);
+      const url = `${location.pathname}?${search}`;
+      window.open(url, "_blank");
+    } else {
+      setSelectedConversationId(conversation._id);
+    }
+  }, [query, location.pathname, conversation._id, setSelectedConversationId]);
 
   if (!conversation) return null;
 


### PR DESCRIPTION
Fixes two bugs: message input text no longer persists when switching conversations, and Ctrl/Cmd+click now opens conversations in a new tab.

The message input form's key was updated to include the `conversation._id`, ensuring the component remounts and resets its state when the conversation changes. For new tab functionality, a custom `onClick` handler was implemented to detect modifier keys and open the conversation URL in a new tab, as the `useClickableCell` hook's new tab logic requires an `href`.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1764884302562859?thread_ts=1764884302.562859&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-241b907a-424f-4310-9d08-d16b0d948bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-241b907a-424f-4310-9d08-d16b0d948bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212329015886596) by [Unito](https://www.unito.io)
