### PR TITLE
Fix image aspect ratios in EA card view list items

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -7,7 +7,7 @@ import { SECTION_WIDTH } from "../common/SingleColumnSection";
 import withErrorBoundary from "../common/withErrorBoundary";
 import classNames from "classnames";
 import { InteractionWrapper, useClickableCell } from "../common/useClickableCell";
-import { cloudinaryCloudNameSetting } from "../../lib/publicSettings";
+import { SOCIAL_PREVIEW_IMAGE_WIDTH } from "@/lib/collections/posts/helpers";
 import { usePostsListView } from "../hooks/usePostsListView";
 import PostsTitle from "./PostsTitle";
 import ForumIcon from "../common/ForumIcon";
@@ -259,10 +259,8 @@ export const styles = (theme: ThemeType) => ({
   },
 });
 
-const cloudinaryBase = `${cloudinaryCloudNameSetting.get()}/image/upload/`;
-
 const formatImageUrl = (url: string) =>
-  url.replace(cloudinaryBase, `${cloudinaryBase}c_fill,w_${CARD_IMG_WIDTH},h_${CARD_IMG_HEIGHT},dpr_2,q_auto,f_auto,`);
+  url.replace(`w_${SOCIAL_PREVIEW_IMAGE_WIDTH}`, `w_${CARD_IMG_WIDTH},dpr_2`);
 
 export type EAPostsItemProps = PostsItemConfig & {
   openInNewTab?: boolean,

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -86,6 +86,8 @@ ${postGetLink(post, true, false)}
   return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 
+export const SOCIAL_PREVIEW_IMAGE_WIDTH = 1200;
+
 /**
  * Get the Cloudinary prefix for a social media preview image - this can be
  * concatenated with a Cloudinary ID to form a valid URL. We apply auto-quality
@@ -96,7 +98,7 @@ ${postGetLink(post, true, false)}
  * size, it won't be scaled up.
  */
 const getSocialImagePreviewPrefix = () =>
-  `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/q_auto,f_auto,c_lfill,w_1200,ar_1.91,g_auto/`;
+  `https://res.cloudinary.com/${cloudinaryCloudNameSetting.get()}/image/upload/q_auto,f_auto,c_lfill,w_${SOCIAL_PREVIEW_IMAGE_WIDTH},ar_1.9,g_auto/`;
 
 // Select the social preview image for the post.
 // For events, we use their event image if that is set.


### PR DESCRIPTION
Fixes a regression from #11806 where images in card view list items have absurd aspect ratios (eg; https://res.cloudinary.com/cea/image/upload/c_fill,w_160,h_80,dpr_2,q_auto,f_auto,q_auto,f_auto,c_lfill,w_1200,ar_1.91,g_auto/SocialPreview/w6fa5igfgfsvidd896or).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212351123357817) by [Unito](https://www.unito.io)
