### PR TITLE
Improve handling of footnote previews on small screens

### DIFF
--- a/packages/lesswrong/components/common/FMTooltip.tsx
+++ b/packages/lesswrong/components/common/FMTooltip.tsx
@@ -69,7 +69,7 @@ export const TooltipRef = <T extends HTMLElement>({
     }
   }, []);
 
-  const { eventHandlers, hover, everHovered, anchorEl } = useHover<any>({
+  const { eventHandlers, hover, everHovered, anchorEl } = useHover({
     eventProps: {
       pageElementContext: "tooltipHovered", // Can be overwritten by analyticsProps
       title: typeof title === "string" ? title : undefined,

--- a/packages/lesswrong/components/common/withHover.tsx
+++ b/packages/lesswrong/components/common/withHover.tsx
@@ -6,13 +6,17 @@ function datesDifference(a: Date, b: Date): number {
   return (a as any)-(b as any);
 }
 
+export interface UseHoverEventHandlers {
+  onMouseOver: (ev: MouseEvent|React.MouseEvent) => void,
+  onMouseLeave: (ev: MouseEvent|React.MouseEvent) => void,
+};
 
 /**
  * Returns a set of event handlers for implementing a hover effect. Spread
  * eventHandlers into the props of a DOM element; the component that used this
  * hook will rerender whenever that element is hovered or unhovered.
  */
-export const useHover = <EventType extends {currentTarget: HTMLElement}=React.MouseEvent<HTMLElement>>(options?: {
+export const useHover = (options?: {
   /**
    * Information attached to analytics events for this hover
    */
@@ -33,10 +37,7 @@ export const useHover = <EventType extends {currentTarget: HTMLElement}=React.Mo
    */
   disabledOnMobile?: boolean,
 }): {
-  eventHandlers: {
-    onMouseOver: (ev: EventType) => void,
-    onMouseLeave: (ev: EventType) => void,
-  }
+  eventHandlers: UseHoverEventHandlers,
   hover: boolean,
   everHovered: boolean,
   anchorEl: HTMLElement | null,
@@ -72,7 +73,7 @@ export const useHover = <EventType extends {currentTarget: HTMLElement}=React.Mo
     clearTimeout(delayTimer.current)
   }, [captureEvent])
 
-  const handleMouseOver = useCallback((event: EventType) => {
+  const handleMouseOver = useCallback((event: MouseEvent|React.MouseEvent) => {
     if ((disabledOnMobile && isMobile()) || (getIsEnabled && !getIsEnabled())) {
       return;
     }
@@ -88,11 +89,11 @@ export const useHover = <EventType extends {currentTarget: HTMLElement}=React.Mo
       return true;
     });
     setEverHovered(true);
-    setAnchorEl(event.currentTarget);
+    setAnchorEl(event.currentTarget as HTMLElement);
     mouseOverStart.current = new Date()
     clearTimeout(delayTimer.current)
     delayTimer.current = setTimeout(captureHoverEvent,500)
-  }, [captureHoverEvent, onEnter, disabledOnMobile])
+  }, [captureHoverEvent, onEnter, disabledOnMobile, getIsEnabled])
 
   const handleMouseLeave = useCallback(() => {
     setHover((currentValue) => {

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -206,7 +206,7 @@ const FootnotePreview = ({classes, href, id, rel, contentStyleType="postHighligh
     } else {
       window.dispatchEvent(new CustomEvent(EXPAND_FOOTNOTES_EVENT, {detail: href}));
     }
-  }, [href, footnoteHTML, openDialog]);
+  }, [href, footnoteHTML, openDialog, minScreenWidthForTooltips]);
   
   const postPageContext = usePostsPageContext();
   const post = postPageContext?.fullPost ?? postPageContext?.postPreload;


### PR DESCRIPTION
Footnote tooltips now flip, preventing scenarios where they get crammed into a tiny column. Tooltips now switch to having a clickable modal rather than a hover tooltip if _either_ it's a touch device _or_ the breakpoint is smaller than sm, rather than based on touch-device status alone.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212372122431617) by [Unito](https://www.unito.io)
