### PR TITLE
[EA] Cleanup for "Simplify Google Docs import to use public URLs only"

### DIFF
--- a/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
+++ b/packages/lesswrong/lib/generated/gqlSchemaAndFragments.gql
@@ -593,7 +593,6 @@ extend type Query {
   PostIsCriticism(args: JSON): Boolean
   DigestPlannerData(digestId: String, startDate: Date, endDate: Date): [DigestPlannerPost]
   DigestPosts(num: Int): [Post]
-  CanAccessGoogleDoc(fileUrl: String!): Boolean
 }
 
 extend type Mutation {

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -300,20 +300,6 @@ export const postGqlQueries = {
       }
     })
   },
-  /**
-   * Legacy query for old client bundles during switchover to new public-docs-only approach.
-   * Returns true if a valid Google Doc ID can be extracted from the URL. If the doc is not
-   * actually public is will fail when they try to import, but it at least won't throw an unhandled error.
-   */
-  async CanAccessGoogleDoc(root: void, { fileUrl }: { fileUrl: string }, context: ResolverContext) {
-    const { currentUser } = context
-    if (!currentUser) {
-      return null;
-    }
-
-    const fileId = extractGoogleDocId(fileUrl);
-    return !!fileId;
-  },
   ...DigestHighlightsQuery,
   ...DigestPostsThisWeekQuery,
   ...CuratedAndPopularThisWeekQuery,
@@ -488,8 +474,6 @@ export const postGqlTypeDefs = gql`
     PostIsCriticism(args: JSON): Boolean
     DigestPlannerData(digestId: String, startDate: Date, endDate: Date): [DigestPlannerPost]
     DigestPosts(num: Int): [Post]
-
-    CanAccessGoogleDoc(fileUrl: String!): Boolean
   }
 
   extend type Mutation {


### PR DESCRIPTION
#11829 included a stub of the `CanAccessGoogleDoc` api route, to continue to support stale client bundles. We can merge this PR to remove that once #11829 has been out for a few days.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212380818077948) by [Unito](https://www.unito.io)
