### PR TITLE
Fix donation celebration 2025

### DIFF
--- a/packages/lesswrong/lib/givingSeason/index.tsx
+++ b/packages/lesswrong/lib/givingSeason/index.tsx
@@ -172,7 +172,6 @@ export const givingSeasonEvents: GivingSeasonEvent[] = [
 ];
 
 export const useCurrentGivingSeasonEvent = (): GivingSeasonEvent | null => {
-  return givingSeasonEvents[4];
   const currentTime = useCurrentTime();
   if (!isEAForum) {
     return null;


### PR DESCRIPTION
The banner isn't showing. This line was accidentally committed as test code. This line isn't actually causing the problem (verified to be true on dev), but it looks like the previous deploy failed for some reason(?), so I'm just fixing this for the sake of triggering a new deploy...