### PR TITLE
Comment scroll position persistence

### DIFF
--- a/packages/lesswrong/components/comments/CommentsSortBySelector.tsx
+++ b/packages/lesswrong/components/comments/CommentsSortBySelector.tsx
@@ -25,7 +25,7 @@ export const CommentsSortBySelector = ({setRestoreScrollPos}: {
     const currentQuery = isEmpty(query) ? {} : query
     const newQuery = {...currentQuery, commentsSortBy: sortBy}
     setRestoreScrollPos?.(window.scrollY);
-    navigate({...location.location, search: `?${qs.stringify(newQuery)}`})
+    navigate({...location.location, search: `?${qs.stringify(newQuery)}`}, { scroll: false })
   };
 
   const currentSortBy: string = query?.commentsSortBy || "new"

--- a/packages/lesswrong/components/comments/CommentsViews.tsx
+++ b/packages/lesswrong/components/comments/CommentsViews.tsx
@@ -35,7 +35,7 @@ const CommentsViews = ({post, setRestoreScrollPos}: {post?: PostsDetails, setRes
     const currentQuery = isEmpty(query) ? {view: 'postCommentsTop'} : query
     const newQuery = {...currentQuery, view: view, commentId: undefined}
     setRestoreScrollPos?.(window.scrollY - permalinkedCommentHeight());
-    navigate({...location.location, search: `?${qs.stringify(newQuery)}`})
+    navigate({...location.location, search: `?${qs.stringify(newQuery)}`}, { scroll: false })
   };
 
   const currentView: string = query?.view || commentGetDefaultView(post||null, currentUser)

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -65,7 +65,7 @@ export type NavigateFunction = ReturnType<typeof useNavigate>
  */
 export const useNavigate = () => {
   const { history } = useContext(NavigationContext)!;
-  return useCallback((locationDescriptor: LocationDescriptor | -1 | 1, options?: {replace?: boolean, openInNewTab?: boolean, skipRouter?: boolean}) => {
+  return useCallback((locationDescriptor: LocationDescriptor | -1 | 1, options?: {replace?: boolean, openInNewTab?: boolean, skipRouter?: boolean, scroll?: boolean}) => {
     if (locationDescriptor === -1) {
       history.back();
     } else if (locationDescriptor === 1) {
@@ -74,6 +74,7 @@ export const useNavigate = () => {
       const updatedLocationDescriptor = getUpdatedLocationDescriptor(window.location, locationDescriptor);
       const normalizedLocation = createPath(updatedLocationDescriptor);
       const normalizedOldLocation = createPath(window.location);
+      const scrollOptions = options?.scroll === false ? { scroll: false } : undefined;
 
       if (options?.openInNewTab) {
         window.open(normalizedLocation, '_blank')?.focus();
@@ -93,11 +94,11 @@ export const useNavigate = () => {
         }
       } else if (options?.replace) {
         if (normalizedLocation !== normalizedOldLocation) {
-          history.replace(normalizedLocation);
+          history.replace(normalizedLocation, scrollOptions);
         }
       } else {
         if (normalizedLocation !== normalizedOldLocation) {
-          history.push(normalizedLocation);
+          history.push(normalizedLocation, scrollOptions);
         }
       }
     }


### PR DESCRIPTION
Prevent scroll position from changing when updating comment sort order or view by disabling Next.js's default scroll-to-top behavior on these navigations.

The `navigate` function, which uses Next.js's router, was causing the page to scroll to the top by default on certain navigation events (like changing comment sort or view). This fix explicitly passes `scroll: false` to the router to override this default behavior, ensuring the user's scroll position is maintained.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1765848913022809?thread_ts=1765848913.022809&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-ef30be95-9b8c-41e0-9672-a8c0f6ff1cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef30be95-9b8c-41e0-9672-a8c0f6ff1cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212469180643593) by [Unito](https://www.unito.io)
