### PR TITLE
Side comment horizontal scroll

### DIFF
--- a/packages/lesswrong/components/layout/RouteRoot.tsx
+++ b/packages/lesswrong/components/layout/RouteRoot.tsx
@@ -4,7 +4,6 @@ import { RouteMetadataSetter } from '@/components/layout/RouteMetadataContext';
 import { StatusCodeSetter } from '@/components/next/StatusCodeSetter';
 import Footer from '@/components/layout/Footer';
 import { RouteRootClient } from './RouteRootClient';
-import { PopperPortalProvider } from '../common/LWPopper';
 
 const RouteRoot = ({delayedStatusCode=false, metadata, fullscreen, children}: {
   delayedStatusCode?: boolean
@@ -19,9 +18,7 @@ const RouteRoot = ({delayedStatusCode=false, metadata, fullscreen, children}: {
     <RouteRootClient
       fullscreen={!!fullscreen}
     >
-      <PopperPortalProvider>
-        {children}
-      </PopperPortalProvider>
+      {children}
     </RouteRootClient>
     
     {!metadata?.noFooter && <Footer/>}


### PR DESCRIPTION
Remove nested `PopperPortalProvider` from `RouteRoot.tsx` to fix side-comments being clipped instead of enabling horizontal scrolling.

The `PageBackgroundWrapper` has `overflowX: 'clip'`. A nested `PopperPortalProvider` in `RouteRoot.tsx` caused poppers to render inside this clipped area. By removing it, poppers now use the outer `PopperPortalProvider` (in `Layout.tsx`), whose container is a sibling to the clipped wrapper, allowing them to trigger horizontal scrollbars.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1765832649124499?thread_ts=1765832649.124499&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-608b9020-5545-47f5-b4d8-e750ed82fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-608b9020-5545-47f5-b4d8-e750ed82fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212469556624532) by [Unito](https://www.unito.io)
