### PR TITLE
Fix thermometer image hiding on to-homepage navigation

### DIFF
--- a/packages/lesswrong/lib/lightconeFundraiser.ts
+++ b/packages/lesswrong/lib/lightconeFundraiser.ts
@@ -27,7 +27,7 @@ export const useFundraiserAirtableTotal = () => {
     ssr: true,
   });
 
-  const airtableTotal = data?.Lightcone2025FundraiserAirtableAmounts ?? 0;
+  const airtableTotal = data?.Lightcone2025FundraiserAirtableAmounts ?? 0.01;
   return airtableTotal;
 }
 


### PR DESCRIPTION
Set fundraiser default value before query finishes above zero to prevent thermometer image from being fully revealed when navigating to the home page after SSRing another page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212471830864644) by [Unito](https://www.unito.io)
