### PR TITLE
stop clipping post action buttons on homepage

### DIFF
--- a/packages/lesswrong/components/layout/RouteRootClient.tsx
+++ b/packages/lesswrong/components/layout/RouteRootClient.tsx
@@ -6,6 +6,8 @@ import { DelayedLoading } from '../common/DelayedLoading';
 import ErrorBoundary from '../common/ErrorBoundary';
 import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import { PopperPortalProvider } from '../common/LWPopper';
+import { usePrerenderablePathname } from '../next/usePrerenderablePathname';
+import { isHomeRoute } from '@/lib/routeChecks';
 
 const styles = defineStyles("RouteRootClient", (theme: ThemeType) => ({
   main: {
@@ -27,6 +29,9 @@ const styles = defineStyles("RouteRootClient", (theme: ThemeType) => ({
       paddingRight: 8,
     },
   },
+  mainFrontPage: {
+    overflowX: 'visible',
+  },
   mainFullscreen: {
     height: "100%",
     padding: 0,
@@ -38,10 +43,13 @@ export const RouteRootClient = ({children, fullscreen}: {
   fullscreen: boolean
 }) => {
   const classes = useStyles(styles);
+  const pathname = usePrerenderablePathname();
+  const isFrontPage = isHomeRoute(pathname);
 
   return <PopperPortalProvider>
     <div className={classNames(classes.main, {
       [classes.mainFullscreen]: fullscreen,
+      [classes.mainFrontPage]: isFrontPage,
     })}>
       <ErrorBoundary>
         <SuspenseWrapper name="Route" fallback={<DelayedLoading/>}>


### PR DESCRIPTION
TODO: `isHomeRoute` apparently checks `!isAF()`, which we don't want here.  Do something else.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212509371165153) by [Unito](https://www.unito.io)
