### PR TITLE
Fix server-side debugging

### DIFF
--- a/scripts/runDevInstance.sh
+++ b/scripts/runDevInstance.sh
@@ -55,10 +55,10 @@ pull_envvars () {
 }
 
 run_dev_server () {
-	# We use node directly rather than going through yarn so that we can use some
-	# flags to silence spammy console logs on start.
-	#
-	# Node flags used:
+  # We use node directly rather than going through yarn so that we can use some
+  # flags to silence spammy console logs on start.
+  #
+  # Node flags used:
   #   --inspect: Enable debugging
   #   --inspect-publish-uid=http: Suppress message about how to connect to the debugger
   #   --no-deprecation: Suppress deprecation warnings about punycode
@@ -68,7 +68,7 @@ run_dev_server () {
   #        ~2x faster, at the expense of bugs that, as far as we know, don't
   #        impact development.
   #    "$@": Pass through exra arguments that were passed to the script, eg --port
-  node --inspect --inspect-publish-uid=http --no-deprecation ./node_modules/.bin/next dev --turbopack "$@"
+  node --no-deprecation ./node_modules/.bin/next dev --inspect --turbopack "$@"
 }
 
 pull_envvars && \


### PR DESCRIPTION
Our scripts/runDevInstance.sh was passing --inspect to turn on debugging, but this was opening a debugger port to the wrong process. Move the --inspect to the arguments of next rather than the arguments of node, which appears to work. (This might have worked under nextjs 15 and broken under 16, I'm not sure.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212522166192912) by [Unito](https://www.unito.io)
