### PR TITLE
Ckeditor comment styling

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -812,9 +812,7 @@ export const ckEditorStyles = (theme: ThemeType) => {
       "--ck-color-comment-marker": theme.palette.editor.commentMarker,
       "--ck-color-comment-marker-active": theme.palette.editor.commentMarkerActive,
       '--ck-color-widget-editable-focus-background': theme.palette.panelBackground.default,
-      // Text colors for CKEditor sidebar comments (ensures readability in dark mode)
-      "--ck-color-text": theme.palette.text.maxIntensity,
-      "--ck-color-input-text": theme.palette.text.maxIntensity,
+      "--ck-comment-content-font-color": theme.palette.text.maxIntensity,
     }
   }
 }


### PR DESCRIPTION
Add CKEditor text color CSS variable to fix unreadable comment text in dark mode.

In dark mode, the CKEditor comment sidebar had a dark background but no explicit text color, causing text to default to dark and become unreadable. 

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1765223307727229?thread_ts=1765223307.727229&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-6c0d4e6d-9b82-4c4f-8311-3294b99febc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c0d4e6d-9b82-4c4f-8311-3294b99febc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212525981992662) by [Unito](https://www.unito.io)
