### PR TITLE
fix fullscreen inbox layout

### DIFF
--- a/packages/lesswrong/components/layout/RouteRootClient.tsx
+++ b/packages/lesswrong/components/layout/RouteRootClient.tsx
@@ -25,6 +25,12 @@ const styles = defineStyles("RouteRootClient", (theme: ThemeType) => ({
     overflowX: 'clip',
     maxWidth: "100%",
   },
+  mainFullscreen: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+  },
   centralColumn: {
     paddingTop: theme.spacing.mainLayoutPaddingTop,
     marginLeft: "auto",
@@ -74,11 +80,13 @@ export const RouteRootClient = ({hasLeftNavigationColumn, fullscreen, children}:
   
   const hideNavigationSidebar = !!use(HideNavigationSidebarContext)?.hideNavigationSidebar;
 
+  const isFullscreen = isFullscreenRoute(pathname);
+
   return <PopperPortalProvider>
-    <div className={classes.main}>
+    <div className={classNames(classes.main, {[classes.mainFullscreen]: isFullscreen})}>
     <LeftAndRightSidebarsWrapper
       sidebarsEnabled={shouldUseGridLayout}
-      fullscreen={isFullscreenRoute(pathname)}
+      fullscreen={isFullscreen}
       leftSidebar={
         standaloneNavigation && <SuspenseWrapper fallback={<span/>} name="NavigationStandalone" >
           <MaybeStickyWrapper sticky={friendlyHomeLayout}>


### PR DESCRIPTION
Fixing a regression from some recent layout refactoring.  Not actually confident this is correct, but it does locally fix the problem and doesn't introduce obvious new issues on the big pages I tested (homepage, posts page, allPosts, inbox) on desktop or mobile sizes.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212542337732114) by [Unito](https://www.unito.io)
