### PR TITLE
Fix comment count not being shown on post page mobile bottom bar when there are zero comments

### DIFF
--- a/packages/lesswrong/components/posts/PostsBottomBar.tsx
+++ b/packages/lesswrong/components/posts/PostsBottomBar.tsx
@@ -8,6 +8,7 @@ import Headroom from '@/lib/react-headroom';
 import PostActionsButton from '../dropdowns/posts/PostActionsButton';
 import { usePostsPageContext } from './PostsPage/PostsPageContext';
 import CommentIcon from '@/lib/vendor/@material-ui/icons/src/ModeComment';
+import isNumber from 'lodash/isNumber';
 
 const styles = defineStyles("PostsBottomBar", (theme: ThemeType) => ({
   headroom: {
@@ -163,7 +164,7 @@ const PostsBottomBar = () => {
             <div className={classes.button} onClick={handleCommentsClick}>
               <div className={classes.commentsButton}>
                 <CommentIcon className={classes.commentIcon} />
-                {!!post?.commentCount && (
+                {isNumber(post?.commentCount) && (
                   <div className={classes.commentCount}>
                     {post.commentCount}
                   </div>


### PR DESCRIPTION
There was a check that hid the number for the sake of loading states, but it was also catching `0` because it's falsy.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212561929406820) by [Unito](https://www.unito.io)
