### PR TITLE
prevent closing supermod with unprocessed items in undo queue

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUndoHistory.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUndoHistory.tsx
@@ -158,8 +158,8 @@ const ModerationUndoHistory = ({
       event.preventDefault();
       // Legacy browsers may still be relying on returnValue to be set
       // https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent/returnValue
-      event.returnValue = true;
-      return true;
+      event.returnValue = 'Pending undo queue entries!';
+      return 'Pending undo queue entries!';
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);


### PR DESCRIPTION
This triggers when you try to close the tab if there's anything left in the undo queue.  It generally won't trigger on navigations, if Activity preserves the supermod state for you, but in that case the undo queue timer will stick around and get handled correctly (at least as tested in dev).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212546336682491) by [Unito](https://www.unito.io)
