### PR TITLE
Fix a bug that made draft comments appear in the replies to a comment-permalink for admins

### DIFF
--- a/app/api/notificationCount/route.ts
+++ b/app/api/notificationCount/route.ts
@@ -1,5 +1,4 @@
-import { NotificationsViews } from "@/lib/collections/notifications/views";
-import { getDefaultViewSelector } from "@/lib/utils/viewUtils";
+import { defaultNotificationsView } from "@/lib/collections/notifications/views";
 import Notifications from "@/server/collections/notifications/collection";
 import { getUserFromReq } from "@/server/vulcan-lib/apollo-server/getUserFromReq";
 import { isFriendlyUI } from "@/themes/forumTheme";
@@ -12,7 +11,7 @@ export async function GET(req: NextRequest) {
   }
 
   const selector = {
-    ...getDefaultViewSelector(NotificationsViews),
+    ...defaultNotificationsView({view: "default"}).selector,
     userId: currentUser._id,
   };
 

--- a/packages/lesswrong/lib/collections/comments/newSchema.ts
+++ b/packages/lesswrong/lib/collections/comments/newSchema.ts
@@ -506,7 +506,7 @@ const schema = {
         const params = viewTermsToQuery(CommentsViews, {
           view: "shortformLatestChildren",
           topLevelCommentId: comment._id,
-        });
+        }, undefined, context);
         const comments = await Comments.find(params.selector, params.options).fetch();
         return await accessFilterMultiple(currentUser, "Comments", comments, context);
       },

--- a/packages/lesswrong/lib/collections/notifications/views.ts
+++ b/packages/lesswrong/lib/collections/notifications/views.ts
@@ -10,7 +10,7 @@ declare global {
   }
 }
 
-function defaultView(terms: NotificationsViewTerms) {
+export const defaultNotificationsView: ViewFunction<"Notifications"> = (terms: NotificationsViewTerms) => {
   // const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
   return {
     selector: {
@@ -62,4 +62,4 @@ export const NotificationsViews = new CollectionViewSet('Notifications', {
   userNotifications,
   unreadUserNotifications,
   adminAlertNotifications
-}, defaultView);
+}, defaultNotificationsView);

--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -3538,7 +3538,7 @@ const schema = {
           Partial<Pick<DbComment, "contents">>;
 
         const comments: CommentForSideComments[] = await Comments.find({
-          ...getDefaultViewSelector(CommentsViews),
+          ...getDefaultViewSelector(CommentsViews, context),
           postId: post._id,
           ...(cacheIsValid && {
             _id: {
@@ -3845,7 +3845,7 @@ const schema = {
         const timeCutoff = new Date(lastCommentedOrNow.getTime() - (maxAgeHours * oneHourInMs));
         const loaderName = af ? "recentCommentsAf" : "recentComments";
         const filter = {
-          ...getDefaultViewSelector(CommentsViews),
+          ...getDefaultViewSelector(CommentsViews, context),
           score: { $gt: 0 },
           draft: false,
           deletedPublic: false,
@@ -4071,7 +4071,7 @@ const schema = {
         const { Comments } = context;
         const firstComment = await Comments.findOne(
           {
-            ...getDefaultViewSelector(CommentsViews),
+            ...getDefaultViewSelector(CommentsViews, context),
             postId: post._id,
             // This actually forces `deleted: false` by combining with the default view selector
             deletedPublic: false,

--- a/packages/lesswrong/lib/collections/tags/newSchema.ts
+++ b/packages/lesswrong/lib/collections/tags/newSchema.ts
@@ -529,7 +529,7 @@ const schema = {
         const lastCommentTime = (tagCommentType === "SUBFORUM" ? tag.lastSubforumCommentAt : tag.lastCommentedAt) ?? undefined;
         const timeCutoff = moment(lastCommentTime).subtract(maxAgeHours, "hours").toDate();
         const comments = await Comments.find({
-          ...getDefaultViewSelector(CommentsViews),
+          ...getDefaultViewSelector(CommentsViews, context),
           tagId: tag._id,
           score: { $gt: 0 },
           draft: false,

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -27,7 +27,12 @@ export function describeTerms(collectionName: CollectionNameString, terms: ViewT
  * Given a set of terms describing a view, translate them into a mongodb selector
  * and options, which is ready to execute (but don't execute it yet).
  */
-export function viewTermsToQuery<N extends CollectionNameString>(viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>, terms: ViewTermsByCollectionName[N], apolloClient?: any, resolverContext?: ResolverContext) {
+export function viewTermsToQuery<N extends CollectionNameString>(
+  viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
+  terms: ViewTermsByCollectionName[N],
+  apolloClient: any,
+  resolverContext: ResolverContext
+) {
   return getParameters(viewSet, terms, apolloClient, resolverContext);
 }
 
@@ -37,14 +42,21 @@ export function viewTermsToQuery<N extends CollectionNameString>(viewSet: Collec
  * a query that doesn't pass through the views system, you probably want to use
  * this selector as a starting point.
  */
-export function getDefaultViewSelector<N extends CollectionNameString>(viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>) {
+export function getDefaultViewSelector<N extends CollectionNameString>(
+  viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
+  resolverContext: ResolverContext
+) {
   // Downcast the generic to avoid a very expensive but useless type inference that indexes over all view terms by collection
-  const viewQuery = viewTermsToQuery<CollectionNameString>(viewSet, {})
+  const viewQuery = viewTermsToQuery<CollectionNameString>(viewSet, {}, undefined, resolverContext)
   return replaceSpecialFieldSelectors(viewQuery.selector);
 }
 
-export function mergeWithDefaultViewSelector<N extends CollectionNameString>(viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>, selector: MongoSelector<ObjectsByCollectionName[N]>) {
-  return mergeSelectors(getDefaultViewSelector(viewSet), selector);
+export function mergeWithDefaultViewSelector<N extends CollectionNameString>(
+  viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
+  selector: MongoSelector<ObjectsByCollectionName[N]>,
+  resolverContext: ResolverContext
+) {
+  return mergeSelectors(getDefaultViewSelector(viewSet, resolverContext), selector);
 }
 
 /**

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -40,8 +40,7 @@ import { getExecutableSchema } from './vulcan-lib/apollo-server/initGraphQL';
 import express from 'express';
 import { getSiteUrl } from '@/lib/vulcan-lib/utils';
 import { requestToNextRequest } from './utils/requestToNextRequest';
-import { getDefaultViewSelector } from '@/lib/utils/viewUtils';
-import { NotificationsViews } from '@/lib/collections/notifications/views';
+import { defaultNotificationsView, NotificationsViews } from '@/lib/collections/notifications/views';
 import Notifications from './collections/notifications/collection';
 import { isFriendlyUI } from '@/themes/forumTheme';
 
@@ -322,7 +321,7 @@ export async function startWebserver() {
     }
 
     const selector = {
-      ...getDefaultViewSelector(NotificationsViews),
+      ...defaultNotificationsView({view: "default"}).selector,
       userId: currentUser._id,
     };
   

--- a/packages/lesswrong/server/resolvers/notificationResolvers.ts
+++ b/packages/lesswrong/server/resolvers/notificationResolvers.ts
@@ -1,5 +1,4 @@
 import { Notifications } from '../../server/collections/notifications/collection';
-import { getDefaultViewSelector } from '../../lib/utils/viewUtils';
 import { NotificationDisplay } from '../../lib/notificationTypes';
 import type { NotificationCountsResult } from '@/components/hooks/useUnreadNotifications';
 import { isDialogueParticipant } from '../../lib/collections/posts/helpers';
@@ -10,7 +9,7 @@ import { handleDialogueHtml } from '../editor/conversionUtils';
 import { createPaginatedResolver } from './paginatedResolver';
 import { isFriendlyUI } from '../../themes/forumTheme';
 import gql from "graphql-tag"
-import { NotificationsViews } from '@/lib/collections/notifications/views';
+import { defaultNotificationsView, NotificationsViews } from '@/lib/collections/notifications/views';
 
 const {Query: NotificationDisplaysQuery, typeDefs: NotificationDisplaysTypeDefs} = createPaginatedResolver({
   name: "NotificationDisplays",
@@ -102,8 +101,12 @@ export const notificationResolversGqlQueries = {
       }
     }
 
+    // Combine a user filter with the default notifications view. We call the
+    // default-view function directly rather than going through
+    // `getDefaultViewSelector` because views may require a ResolverContext,
+    // and we are relying on the fact that this particular view doesn't.
     const selector = {
-      ...getDefaultViewSelector(NotificationsViews),
+      ...defaultNotificationsView({view: "default"}).selector,
       userId: currentUser._id,
     };
     const lastNotificationsCheck = currentUser.lastNotificationsCheck;

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -286,7 +286,7 @@ export const postGqlQueries = {
   },
   async HomepageCommunityEventPosts(root: void, { eventType }: { eventType: string }, context: ResolverContext) {
     const { Posts, currentUser } = context
-    const defaultPostSelector = getDefaultViewSelector(PostsViews)
+    const defaultPostSelector = getDefaultViewSelector(PostsViews, context)
 
     const timeRange = 5 * 30 * 24 * 60 * 60 * 1000 // 5 months
     const posts = await Posts.find({

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -233,14 +233,14 @@ interface TagUpdates {
   documentDeletions: CategorizedDeletionEvent[];
 }
 
-function getRootCommentsInTimeBlockSelector(before: Date, after: Date): MongoSelector<DbComment> {
+function getRootCommentsInTimeBlockSelector(before: Date, after: Date, context: ResolverContext): MongoSelector<DbComment> {
   return mergeWithDefaultViewSelector(CommentsViews, {
     deleted: false,
     postedAt: {$lt: before, $gt: after},
     topLevelCommentId: null,
     tagId: {$exists: true, $ne: null},
     tagCommentType: "DISCUSSION",
-  });
+  }, context);
 }
 
 function getDocumentDeletionsInTimeBlockSelector(documentIds: string[], before: Date, after: Date) {
@@ -678,7 +678,7 @@ export const tagResolversGraphQLQueries = {
     if(moment.duration(moment(before).diff(after)).as('hours') > 30)
       throw new Error("TagUpdatesInTimeBlock limited to a one-day interval");
     
-    const rootCommentsSelector = getRootCommentsInTimeBlockSelector(before, after);
+    const rootCommentsSelector = getRootCommentsInTimeBlockSelector(before, after, context);
 
     // Get
     // - revisions to tags, lenses, and summaries in the given time interval

--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -112,7 +112,7 @@ export const serveCommentRSS = async (terms: RSSTerms, req: NextRequest) => {
   const feed = new RSS(getMeta(url));
   const context = await getContextFromReqAndRes({req, isSSR: false});
 
-  let parameters = viewTermsToQuery(CommentsViews, terms);
+  let parameters = viewTermsToQuery(CommentsViews, terms, undefined, context);
   parameters.options.limit = 50;
   const commentsCursor = await Comments.find(parameters.selector, parameters.options).fetch();
   const restrictedComments = await accessFilterMultiple(null, 'Comments', commentsCursor, context) as DbComment[];

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -32,7 +32,7 @@ async function getTocCommentsServer(document: DbPost, context: ResolverContext) 
   const { Comments } = context;
 
   const commentSelector: any = {
-    ...getDefaultViewSelector(CommentsViews),
+    ...getDefaultViewSelector(CommentsViews, context),
     answer: false,
     draft: false,
     parentAnswerId: null,

--- a/packages/lesswrong/server/utils/feedUtil.ts
+++ b/packages/lesswrong/server/utils/feedUtil.ts
@@ -4,7 +4,6 @@ import { accessFilterMultiple } from '../../lib/utils/schemaUtils';
 import { getDefaultViewSelector, mergeSelectors, mergeWithDefaultViewSelector, replaceSpecialFieldSelectors } from '../../lib/utils/viewUtils';
 import { filterNonnull } from '@/lib/utils/typeGuardUtils';
 import { FieldChanges } from '@/server/collections/fieldChanges/collection';
-import gql from 'graphql-tag';
 import { allViews } from '@/lib/views/allViews';
 import { CollectionViewSet } from '@/lib/views/collectionViewSet';
 
@@ -49,7 +48,7 @@ export function viewBasedSubquery<
     doQuery: async (limit: number, cutoff: SortKeyType): Promise<Partial<ObjectsByCollectionName[N]>[]> => {
       const viewSet = allViews[collection.collectionName] as CollectionViewSet<N, Record<string, ViewFunction<N>>>;
       const selectorWithDefaults = includeDefaultSelector
-        ? mergeWithDefaultViewSelector(viewSet, selector)
+        ? mergeWithDefaultViewSelector(viewSet, selector, context)
         : selector;
       const results = await queryWithCutoff({context, collection, selector, limit, cutoffField: sortField, cutoff, sortDirection});
       return await accessFilterMultiple(context.currentUser, collection.collectionName, results, context);
@@ -228,7 +227,7 @@ async function queryWithCutoff<N extends CollectionNameString>({
   // TODO: figure out how to get the appropriate collection's default view piped through here without going through allViews, if possible
   const viewSet: CollectionViewSet<CollectionNameString, any> = allViews[collectionName];
   const mergedSelector = mergeSelectors(
-    getDefaultViewSelector(viewSet),
+    getDefaultViewSelector(viewSet, context),
     selector,
     cutoffSelector
   )


### PR DESCRIPTION
A bug caused draft comments to appear for admins in a place where they shouldn't (in folded up single-line format, labelled [Draft], so not likely to be read by accident past the first few words).

Views (including default views) previously took an optional ResolverContext, which would be available on the server, but not on the client (because of mingo). We no longer use mingo, so view functions only run on the server, so we can make the resolver context required.

The comments default view includes `getDraftSelector` with a default of `include-my-draft-replies`. When a ResolverContext is provided, that filters out draft comments, except draft comments by the current user, as expected. When a ResolverContext is _not_ provided, however, it includes all draft comments (which then get filtered out for non-admins by permissions checks further down the line). The view gets used in the `latestChildren` resolver on `Comments`, which didn't pass a ResolverContext. Fix by passing a ResolverContext there, then modify `viewTermsToQuery` and related functions to all treat a context as required rather than optional, to prevent similar issues.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212562586908486) by [Unito](https://www.unito.io)
