### PR TITLE
Fix nested link hover previews not working inside footnote hover previews when the "disable sidenotes" option is checked

### DIFF
--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -261,7 +261,7 @@ const FootnotePreview = ({classes, href, id, rel, contentStyleType="postHighligh
           <InteractionWrapper>
             <Card>
               <ContentStyles contentType={contentStyleType} className={classes.hovercard}>
-                <div dangerouslySetInnerHTML={{__html: footnoteHTML || ""}} />
+                <ContentItemBody dangerouslySetInnerHTML={{__html: footnoteHTML || ""}} />
               </ContentStyles>
             </Card>
           </InteractionWrapper>


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212562798044597) by [Unito](https://www.unito.io)
