### PR TITLE
Fix Airtable pagination in fundraiser thermometer

### DIFF
--- a/packages/lesswrong/server/resolvers/lightcone2024FundraiserResolvers.ts
+++ b/packages/lesswrong/server/resolvers/lightcone2024FundraiserResolvers.ts
@@ -21,19 +21,33 @@ async function fetchAirtableDonationRecords(): Promise<number> {
     throw new Error("Can't fetch Airtable records without an API key");
   }
 
-  const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}?view=${encodeURIComponent(viewName)}`;
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  // Fetch all pages of records from Airtable (API returns max 100 per request)
+  const allRecords: AnyBecauseIsInput[] = [];
+  let offset: string | undefined;
 
-  if (!response.ok) {
-    throw new Error(`Airtable API responded with status ${response.status} - ${response.statusText}`);
-  }
+  do {
+    const url = new URL(`https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}`);
+    url.searchParams.set('view', viewName);
+    if (offset) {
+      url.searchParams.set('offset', offset);
+    }
 
-  const data = await response.json();
-  const records: AnyBecauseIsInput[] = data.records ?? [];
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Airtable API responded with status ${response.status} - ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    allRecords.push(...(data.records ?? []));
+    offset = data.offset; // Will be undefined when there are no more pages
+  } while (offset);
+
+  const records: AnyBecauseIsInput[] = allRecords;
 
   const recordsWithAmount = records.map((record: AnyBecauseIsInput) => ({...record, amount: parseInt(record.fields["Amount"] ?? 0)}));
 


### PR DESCRIPTION
[Claude]

The Airtable API returns at most 100 records per request. This adds pagination handling to fetch all records from the view, which may fix the issue where new donations take a long time to appear in the thermometer.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212572978406619) by [Unito](https://www.unito.io)
