### PR TITLE
fix various minor issues on mobile

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -7,7 +7,7 @@ import { defineStyles, useStyles } from "../hooks/useStyles";
 import { getUpdatedFieldValues } from "@/components/tanstack-form-components/helpers";
 import { useEditorFormCallbacks, EditorFormComponent } from "../editor/EditorFormComponent";
 import { MuiTextField } from "@/components/form-components/MuiTextField";
-import { getDefaultEditorPlaceholder } from '@/lib/editor/defaultEditorPlaceholder';
+import { getCommentEditorPlaceholder } from '@/lib/editor/defaultEditorPlaceholder';
 import { FormComponentDatePicker } from "../form-components/FormComponentDateTime";
 import { LegacyFormGroupLayout } from "@/components/tanstack-form-components/LegacyFormGroupLayout";
 import { EditCommentTitle } from "@/components/editor/EditCommentTitle";
@@ -502,7 +502,7 @@ export const CommentForm = ({
                     verify: false,
                   };
                 }}
-                hintText={isFriendlyUI() ? "Write a new comment..." : getDefaultEditorPlaceholder()}
+                hintText={getCommentEditorPlaceholder()}
                 fieldName="contents"
                 collectionName="Comments"
                 commentEditor={true}

--- a/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
@@ -51,7 +51,7 @@ const SequencesNavigationLink = ({ post, direction, classes }: {
       </Link>
     )
     if (post.title) {
-      return <TooltipSpan title={post.title} placement="top">{button}</TooltipSpan>
+      return <TooltipSpan title={post.title} placement="top" hideOnTouchScreens>{button}</TooltipSpan>
     } else {
       return button;
     }

--- a/packages/lesswrong/components/votes/PostsVoteDefault.tsx
+++ b/packages/lesswrong/components/votes/PostsVoteDefault.tsx
@@ -140,6 +140,7 @@ const PostsVoteDefault = ({
           title={`${voteProps.voteCount} ${voteProps.voteCount === 1 ? "Vote" : "Votes"}`}
           placement={tooltipPlacement}
           popperClassName={classes.tooltip}
+          hideOnTouchScreens
         >
           <Typography
             variant="headline"

--- a/packages/lesswrong/lib/editor/defaultEditorPlaceholder.ts
+++ b/packages/lesswrong/lib/editor/defaultEditorPlaceholder.ts
@@ -8,6 +8,9 @@ export const getDefaultEditorPlaceholder = () => isFriendlyUI() ?
 
 lesswrong.com/editor covers formatting, draft-sharing, co-authoring, LaTeX, footnotes, tagging users and posts, spoiler tags, Markdown, tables, crossposting, and more.`;
 
+export const getCommentEditorPlaceholder = () => isFriendlyUI() ?
+  `Write a new comment...` :
+  `Text goes here! See lesswrong.com/editor for info about everything the editor can do.`;
 
 export const debateEditorPlaceholder = `Enter your first dialogue comment here, add other participants as co-authors, then save this as a draft.
 


### PR DESCRIPTION
Fixes various small issues on mobile:
- a tooltip showing up to the right (offscreen) if you clicked on a post's karma at the top of the post page
- tooltips showing up when you clicked on the top-of-page sequence navigation left/right buttons (and sometimes stuck around post-navigation)
- new comment forms having internal scrolling because of their helper/placeholder text being too long

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212576114257635) by [Unito](https://www.unito.io)
