### PR TITLE
Don't scroll to the top of the page if hovering over a side comment…

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -207,7 +207,7 @@ const CommentsNodeInner = ({
 
   // If not using in-context comments, scroll to top when the `commentId` query changes
   useEffect(() => {
-    if (!hasInContextLinks && !noAutoScroll && comment && linkedCommentId === comment._id) {
+    if (!hasInContextLinks && !noAutoScroll && !treeOptions.isSideComment && comment && linkedCommentId === comment._id) {
       window.scrollTo({top: 0})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
…when the post page has that commentId in the query params.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212585147067533) by [Unito](https://www.unito.io)
