### PR TITLE
Fix default sorting to use Magic during review phase

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -195,7 +195,7 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
       defaultSort = "needsPreliminaryVote";
       break;
     case 'REVIEWS':
-      defaultSort = "reviewVoteScoreHighKarma"
+      defaultSort = "needsReview"
       break;
     case 'VOTING':
       defaultSort = "needsFinalVote";


### PR DESCRIPTION
During the REVIEWS phase, the default sort was incorrectly set to "reviewVoteScoreHighKarma" (Nomination Vote Total) instead of "needsReview" (Magic - Needs Review). This fix makes the default sorting prioritize posts the user voted on that haven't had a review written yet.

Slack: https://lightconeteam.slack.com/archives/C01GXLMPU2C/p1766953696709719?thread_ts=1766953644.554909&cid=C01GXLMPU2C

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212601208019400) by [Unito](https://www.unito.io)
