### PR TITLE
Fix tab selection not working on first click in incognito

### DIFF
--- a/packages/lesswrong/components/common/TabPicker.tsx
+++ b/packages/lesswrong/components/common/TabPicker.tsx
@@ -160,6 +160,13 @@ const TabPicker = <T extends TabRecord[]>(
 ) => {
   const [activeTab, setActiveTab] = useState<T[number]['name']>(defaultTab ?? sortedTabs[0].name);
 
+  // Sync activeTab with defaultTab when the prop changes (e.g., from parent state updates)
+  useEffect(() => {
+    if (defaultTab !== undefined && defaultTab !== activeTab) {
+      setActiveTab(defaultTab);
+    }
+  }, [defaultTab, activeTab]);
+
   // we use the widths of the tab list container when calculating how far to scroll left and right
   const tabsListRef = useRef<HTMLDivElement | null>(null);
 


### PR DESCRIPTION
TabPicker was managing its own activeTab state but not syncing it when the defaultTab prop changed from the parent component. This caused a desync where clicking a tab would update the parent's state but TabPicker's internal state wouldn't reflect the change, making the first click appear to do nothing and causing multiple tabs to appear selected.

Added a useEffect to sync activeTab with defaultTab prop changes.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212611810422274) by [Unito](https://www.unito.io)
