### PR TITLE
Less annoying CI

### DIFF
--- a/.github/workflows/runTests.yaml
+++ b/.github/workflows/runTests.yaml
@@ -105,8 +105,9 @@ jobs:
       PG_URL: postgres://postgres:password@localhost:5433/postgres
       E2E: true
     steps:
-      - name: Fail while broken
-        run: exit 1
+      - name: Skip while broken
+        if: ${{ false }}
+        run: exit 0
     # - name: Checkout code
     #   uses: actions/checkout@v4
     # - name: Setup Environment
@@ -175,8 +176,9 @@ jobs:
       FORUM_TYPE: LessWrong
       E2E: true
     steps:
-      - name: Fail while broken
-        run: exit 1
+      - name: Skip while broken
+        if: ${{ false }}
+        run: exit 0
     # - name: Checkout code
     #   uses: actions/checkout@v4
     # - name: Setup Environment


### PR DESCRIPTION
I don't want us to use CI errors to track a todo

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212614484231678) by [Unito](https://www.unito.io)
