### PR TITLE
Fix compression of requests to /graphql by changing the accept: headers on requests

### DIFF
--- a/packages/lesswrong/lib/apollo/links.ts
+++ b/packages/lesswrong/lib/apollo/links.ts
@@ -66,6 +66,9 @@ export const createHttpLink = (baseUrl: string, loginToken: string|null) => {
     uri,
     credentials: isSameSiteRequest ? 'same-origin' : 'omit',
     batchMax: isServer ? 1 : graphqlBatchMaxSetting.get(),
+    headers: {
+      'accept': 'application/json',
+    },
     fetch,
     batchKey,
   });


### PR DESCRIPTION
By default, apollo-client sends requests with an Accept header of "application/graphql-response+json,application/json;q=0.9" which means it will either accept a graphql-specific MIME type, or will accept generic JSON as a MIME type (the actual response body will be the same). Then in apollo-server, it has a prioritized list of MIME types, and chooses the graphql-specific one for its response.

Then, Vercel (or maybe the internals of nextjs) has a whitelist of MIME types that it's allowed to compress. Presumably this is to avoid trying to compress already-compressed formats like JPG or AVI, but in this case, the result is tragic.

Knowing this, the fix is simple: Explicitly set the `accept` header when constructing `BatchHTTPLink`, so that it will use `application/json` (which is on the compression whitelist).

(I verified that this works and makes responses be compressed in a preview deploy.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212627026066779) by [Unito](https://www.unito.io)
