### PR TITLE
[EA] Extend getVoteCounts cache timeout

### DIFF
--- a/packages/lesswrong/server/givingSeason/givingSeasonResolvers.ts
+++ b/packages/lesswrong/server/givingSeason/givingSeasonResolvers.ts
@@ -13,7 +13,7 @@ const getVoteCounts = async () => {
   return instantRunoffAllPossibleResults(votes as IRVote[]);
 };
 
-const voteCountsWithCache = memoizeWithExpiration(getVoteCounts, 60 * 1000);
+const voteCountsWithCache = memoizeWithExpiration(getVoteCounts, 24 * 60 * 60 * 1000);
 
 export const givingSeasonGraphQLTypeDefs = gql`
   type GivingSeasonTagFeedQueryResults {


### PR DESCRIPTION
We have a problem with front-page performance at the moment that causes it to be very slow on about half of requests.

I think this function is almost certainly the cause and it happens about half the time due to the combination of the cache lifetime and the fact that we have 16 worker processes in total so they each get ~2 frontpage SSRs per minute.

This is a performance profile from a production worker which shows the function taking about 4 seconds:
<img width="2534" height="1274" alt="Screenshot 2026-01-07 at 14 15 11" src="https://github.com/user-attachments/assets/139a5cc6-9379-4bea-bb12-42a998f8054c" />

This code already shouldn't be firing because it's related to Giving Season. I will come back and remove it more properly, but first I just wanted to deploy this change to extend the cache lifetime to test if this fully fixes our performance problem. 


