### PR TITLE
Remove "Published at" line from RSS entries

### DIFF
--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -2,9 +2,7 @@ import RSS from 'rss';
 import { Comments } from '../server/collections/comments/collection';
 import { commentGetPageUrlFromDB } from '../lib/collections/comments/helpers';
 import { postGetPageUrl } from '../lib/collections/posts/helpers';
-import { userGetDisplayNameById } from '../lib/vulcan-users/helpers';
 import { forumTitleSetting, siteUrlSetting, taglineSetting } from '../lib/instanceSettings';
-import moment from '../lib/moment-timezone';
 import { rssTermsToUrl, RSSTerms } from '../lib/rss_urls';
 import { accessFilterMultiple } from '../lib/utils/schemaUtils';
 import { getCommentParentTitle } from '@/lib/notificationDataHelpers';
@@ -86,10 +84,9 @@ export const servePostRSS = async (terms: RSSTerms,) => {
     let date = (viewDate > thresholdDate) ? viewDate : thresholdDate;
 
     const postLink = `<a href="${postGetPageUrl(post, true)}#comments">Discuss</a>`;
-    const formattedTime = moment(post.postedAt).tz(moment.tz.guess()).format('LLL z');
     const feedItem: any = {
       title: post.title,
-      description: `Published on ${formattedTime}<br/><br/>${(post.contents && post.contents.html) || ""}<br/><br/>${postLink}`,
+      description: `${(post.contents && post.contents.html) || ""}<br/><br/>${postLink}`,
       // LESSWRONG - changed how author is set for RSS because
       // LessWrong posts don't reliably have post.author defined.
       //author: post.author,


### PR DESCRIPTION
The RSS feed already includes a published date in a separate field, so starting every entry with Published at is duplicate content.

For example, in Feedbin, notice how the summaries in the entry list all start with the published line even though the time is displayed more nicely by the app, and in the entry view we display the publish time twice (once under the headline and a second time as the first line of the article):

<img width="3183" height="1298" alt="Screenshot From 2026-01-07 11-11-49" src="https://github.com/user-attachments/assets/52acf639-2ab4-4ebb-a6d6-49b2d3bcaafc" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212699785400418) by [Unito](https://www.unito.io)
