### PR TITLE
[EA] Disable Giving Season via GIVING_SEASON_ENABLED flag

### DIFF
--- a/packages/lesswrong/lib/givingSeason/index.tsx
+++ b/packages/lesswrong/lib/givingSeason/index.tsx
@@ -18,6 +18,13 @@ import { userIsAdmin } from "../vulcan-users/permissions";
 import { IRPossibleVoteCounts } from "./instantRunoff";
 import { userIsBanned } from "../collections/users/helpers";
 
+
+/**
+ * Master switch to disable all Giving Season code paths.
+ * Note: You'll need to update dates, event definitions, and other constants to fully bring it back online.
+ */
+export const GIVING_SEASON_ENABLED = false;
+
 export const GIVING_SEASON_INFO_HREF = "/posts/RzdKnBYe3jumrZxkB/giving-season-2025-announcement";
 export const ELECTION_INFO_HREF = "/posts/RzdKnBYe3jumrZxkB/giving-season-2025-announcement#November_24th_to_December_7th_";
 export const ELECTION_LEARN_MORE_HREF = "/posts/93KvQDDQfaZEBTP7t/donation-election-fund-rewards-and-matching";
@@ -208,6 +215,9 @@ export const GivingSeasonContext = ({children}: {children: ReactNode}) => {
   }, [defaultEvent]);
   useOnNavigate(onNavigate);
 
+  // Skip all queries when giving season is disabled
+  const skipQueries = !GIVING_SEASON_ENABLED;
+
   const {data: donationTotalData} = useQuery(gql`
     query GivingSeason2025DonationTotal {
       GivingSeason2025DonationTotal
@@ -215,7 +225,7 @@ export const GivingSeasonContext = ({children}: {children: ReactNode}) => {
   `, {
     pollInterval: 60 * 1000, // Poll once per minute
     ssr: true,
-    skip: !isEAForum || (!isHomePage && !isVotingPortalPage),
+    skip: skipQueries || !isEAForum || (!isHomePage && !isVotingPortalPage),
   });
   const amountRaised = Math.round(donationTotalData?.GivingSeason2025DonationTotal ?? 0);
 
@@ -225,7 +235,7 @@ export const GivingSeasonContext = ({children}: {children: ReactNode}) => {
     }
   `, {
     ssr: true,
-    skip: !isEAForum || !isHomePage,
+    skip: skipQueries || !isEAForum || !isHomePage,
   });
 
   const value = useMemo(() => ({

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -174,6 +174,7 @@ import MarginalFundingPage from '@/components/forumEvents/givingSeason/MarginalF
 import VotingPortalPage from '@/components/forumEvents/givingSeason/VotingPortalPage';
 import AdminElectionCandidates from '@/components/forumEvents/givingSeason/AdminElectionCandidates';
 import EditElectionCandidate from '@/components/forumEvents/givingSeason/EditElectionCandidate';
+import { GIVING_SEASON_ENABLED } from '@/lib/givingSeason';
 
 const communitySubtitle = { subtitleLink: communityPath, subtitle: isEAForum ? 'Groups' : 'Community' };
 
@@ -1068,13 +1069,13 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       fullscreen: true,
       noFooter: true,
     },
-    {
+    ...(GIVING_SEASON_ENABLED ? [{
       name: 'VotingPortal',
       path: '/voting-portal',
       component: VotingPortalPage,
       title: 'Vote in the Donation Election',
       noFooter: true,
-    },
+    }] : []),
     {
       name: 'ElectionCandidates',
       path: '/admin/election-candidates',

--- a/packages/lesswrong/server/givingSeason/webhook.ts
+++ b/packages/lesswrong/server/givingSeason/webhook.ts
@@ -3,6 +3,7 @@ import { PublicInstanceSetting } from "@/lib/instanceSettings";
 import { captureEvent } from "@/lib/analyticsEvents";
 import { getExchangeRate } from "./currencies";
 import DatabaseMetadataRepo from "../repos/DatabaseMetadataRepo";
+import { GIVING_SEASON_ENABLED } from "@/lib/givingSeason";
 
 export const addToGivingSeasonTotal = async (usdAmount: number) => {
   if (Number.isFinite(usdAmount) && usdAmount > 0) {
@@ -71,6 +72,10 @@ type WebhookPayload = {
 }
 
 export const addGivingSeasonEndpoints = (app: Express) => {
+  if (!GIVING_SEASON_ENABLED) {
+    return;
+  }
+
   const webhook = "/api/donation-election-2025-webhook";
   app.use(webhook, json({limit: "10mb"}));
   app.post(webhook, async (req, res) => {


### PR DESCRIPTION
Last year it was quite laborious to bring back the code from 2024, this time we're leaving the bulk of the code in place and just disabling the code paths. Note that if we have migrated to a new codebase by next year, this won't be very helpful but we can cross that bridge when we come to it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212706624847756) by [Unito](https://www.unito.io)
