### PR TITLE
[EA] Fix 'Cannot read properties of undefined (reading 'setTag')' log spam

### DIFF
--- a/packages/lesswrong/server/datadog/datadogMiddleware.ts
+++ b/packages/lesswrong/server/datadog/datadogMiddleware.ts
@@ -19,16 +19,18 @@ export const datadogMiddleware = (req: AnyBecauseTodo, res: AnyBecauseTodo, next
   const span = tracer.scope().active()
   if (span !== null) {
     // @ts-ignore - there is currently no public API for getting the root span, this is the accepted way (see https://github.com/DataDog/dd-trace-js/issues/725#issuecomment-805277510)
-    const rootSpan = span.context()._trace.started[0]
-    const user = req.user
-    if (user) {
-      rootSpan.setTag('usr', getDatadogUser(user))
+    const rootSpan = span.context()._trace?.started?.[0]
+    if (rootSpan) {
+      const user = req.user
+      if (user) {
+        rootSpan.setTag('usr', getDatadogUser(user))
+      }
+
+      const ip = getIpFromRequest(req)
+
+      // Set the IP address as a tag on the root span
+      rootSpan.setTag('client.ip', ip)
     }
-
-    const ip = getIpFromRequest(req)
-
-    // Set the IP address as a tag on the root span
-    rootSpan.setTag('client.ip', ip)
   }
 
   res.setHeader( 'Access-Control-Allow-Headers', 'x-datadog-trace-id, x-datadog-parent-id, x-datadog-origin, x-datadog-sampling-priority, traceparent' );


### PR DESCRIPTION
In some requests we can't get a rootSpan. This was generating a lot of log spam, this PR skips those cases to prevent this.

It's about one in ten requests where we can't get a rootSpan. I didn't look too much into what the problem is as everything seems to be working fine functionality wise (including being tagged correctly in datadog). I expect it's just WebSockets or static assets or something

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212680535738881) by [Unito](https://www.unito.io)
