### PR TITLE
Fix incorrect paragrph spacing remover

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -721,7 +721,7 @@ export const ckEditorStyles = (theme: ThemeType) => {
         '& p': {
           marginTop: "1em",
           marginBottom: "1em",
-          '&:first-of-type': {
+          '&:first-child': {
             marginTop: 0,
           }
         },


### PR DESCRIPTION
For a long time paragraphs after blockquotes had their top spacing removed in the editor view (not the rendered view). This fixed that bug.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212698035774204) by [Unito](https://www.unito.io)
