### PR TITLE
switch recombee scenarios used for ultrafeed to avoid deadlocks

### DIFF
--- a/packages/lesswrong/components/ultraFeed/ScoreBreakdownContent.tsx
+++ b/packages/lesswrong/components/ultraFeed/ScoreBreakdownContent.tsx
@@ -133,7 +133,7 @@ const splitZeroAndNonZeroTerms = (terms: Array<{ name: string; value: number }>)
 const sourceLabels: Record<FeedItemSourceType, string> = {
   'subscriptionsPosts': 'you follow the author',
   'subscriptionsComments': 'comments by authors you follow',
-  'recombee-lesswrong-custom': 'personalized AI-recommendation based on your reads and votes',
+  'recombee-lesswrong-ultrafeed': 'personalized AI-recommendation based on your reads and votes',
   'hacker-news': 'recently published post',
   'bookmarks': 'you bookmarked this',
   'quicktakes': 'recent Quick Take',
@@ -142,7 +142,7 @@ const sourceLabels: Record<FeedItemSourceType, string> = {
 };
 
 const sourceTooltips: Partial<Record<FeedItemSourceType, string>> = {
-  'recombee-lesswrong-custom': 'LessWrong uses Recombee, trained on your reads and votes',
+  'recombee-lesswrong-ultrafeed': 'LessWrong uses Recombee, trained on your reads and votes',
   'bookmarks': 'Bookmarks are inserted periodically into your feed to remind you about them, you can turn this off in the settings',
 };
 
@@ -346,7 +346,7 @@ export const PostScoreBreakdownContent = ({ breakdown, sources, metaInfo }: { br
   const { settings } = useUltraFeedSettings();
   const { terms, typeMultiplier, total } = breakdown;
   
-  const isRecombeeOrSubscription = sources?.includes('recombee-lesswrong-custom') || sources?.includes('subscriptionsPosts');
+  const isRecombeeOrSubscription = sources?.includes('recombee-lesswrong-ultrafeed') || sources?.includes('subscriptionsPosts');
   const karmaBonusLabel = isRecombeeOrSubscription ? "Karma Bonus (timeless)" : "Karma Bonus (time-decaying)";
   
   const allTerms = [

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -285,7 +285,7 @@ const styles = defineStyles("UltraFeedPostItem", (theme: ThemeType) => ({
 const sourceIconMap: Array<{ source: FeedItemSourceType, icon: any, tooltip: string }> = [
   { source: 'bookmarks' as FeedItemSourceType, icon: BookmarksIcon, tooltip: "From your bookmarks" },
   { source: 'subscriptionsPosts' as FeedItemSourceType, icon: SubscriptionsIcon, tooltip: "From users you follow" },
-  { source: 'recombee-lesswrong-custom' as FeedItemSourceType, icon: SparkleIcon, tooltip: "Recommended for you" },
+  { source: 'recombee-lesswrong-ultrafeed' as FeedItemSourceType, icon: SparkleIcon, tooltip: "Recommended for you" },
   { source: 'hacker-news' as FeedItemSourceType, icon: ClockIcon, tooltip: "Latest posts" },
 ];
 

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -106,7 +106,7 @@ export const DEFAULT_SOURCE_WEIGHTS: Record<FeedItemSourceType, number> = {
   'recentComments': 20,
   'quicktakes': 15,
   'subscriptionsComments': 15,
-  'recombee-lesswrong-custom': 30,
+  'recombee-lesswrong-ultrafeed': 30,
   'hacker-news': 20,
   'subscriptionsPosts': 15,
   'spotlights': 5,
@@ -225,7 +225,7 @@ export const sourceWeightConfigs: SourceWeightConfig[] = [
     description: "Recent comments, prioritized karma and previous engagement with the threads or posts they're on"
   },
   {
-    key: 'recombee-lesswrong-custom',
+    key: 'recombee-lesswrong-ultrafeed',
     label: "Personalized Post Recs",
     description: "Tailored for you based on your reading and voting history."
   },

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -49,7 +49,7 @@ export type RankedItemMetadata =
       position: number;
     };
 
-export const feedPostSourceTypesArray = [ 'hacker-news', 'recombee-lesswrong-custom', 'bookmarks', 'subscriptionsPosts' ] as const;
+export const feedPostSourceTypesArray = [ 'hacker-news', 'recombee-lesswrong-ultrafeed', 'bookmarks', 'subscriptionsPosts' ] as const;
 export const feedCommentSourceTypesArray = ['quicktakes', 'recentComments', 'subscriptionsComments', 'bookmarks'] as const;
 export const feedSpotlightSourceTypesArray = ['spotlights'] as const;
 export const allFeedItemSourceTypes = [

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -568,7 +568,7 @@ const calculateFetchLimits = (
 } => {
   const totalWeight = Object.values(sourceWeights).reduce((sum: number, weight) => sum + weight, 0);
   
-  const recombeePostWeight = sourceWeights['recombee-lesswrong-custom'] ?? 0;
+  const recombeePostWeight = sourceWeights['recombee-lesswrong-ultrafeed'] ?? 0;
   const hackerNewsPostWeight = sourceWeights['hacker-news'] ?? 0;
   const subscribedPostWeight = sourceWeights['subscriptionsPosts'] ?? 0;
   const bookmarkWeight = sourceWeights['bookmarks'] ?? 0;

--- a/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
@@ -18,7 +18,7 @@ const UNVIEWED_RECOMBEE_CONFIG = {
 export async function getRecommendedPostsForUltraFeed(
   context: ResolverContext,
   limit: number,
-  scenarioId = 'recombee-lesswrong-custom',
+  scenarioId = 'recombee-lesswrong-ultrafeed',
   additionalExcludedIds: string[] = []
 ): Promise<FeedFullPost[]> {
   const { currentUser, repos } = context;
@@ -176,7 +176,7 @@ export async function getUltraFeedPostThreads(
   maxAgeDays: number
 ): Promise<FeedFullPost[]> {
 
-  const recombeeScenario = 'recombee-lesswrong-custom';
+  const recombeeScenario = 'recombee-lesswrong-ultrafeed';
 
   const [recommendedPostItems, latestAndSubscribedPostItems] = await Promise.all([
     (recommendedPostsLimit > 0)

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
@@ -138,7 +138,7 @@ function scorePost(
   // TODO: Not yet implemented - will be calculated from user's tag reading history when available
   const topicAffinityBonus = 0;
 
-  const isRecombeePost = post.sources.includes('recombee-lesswrong-custom');
+  const isRecombeePost = post.sources.includes('recombee-lesswrong-ultrafeed');
   const isSubscriptionPost = post.sources.includes('subscriptionsPosts');
   
   let karmaBonus = 0;


### PR DESCRIPTION
We were still getting deadlocks even after [the previous PR](https://github.com/ForumMagnum/ForumMagnum/pull/11966), probably because the enriched tab & ultrafeed were using the same recombee scenario and attempting to backfill the recommendations cache at about the same time, and sometimes getting overlapping post ids but in different orders.  I've duplicated the existing scenario in recombee under a different name and switched everything in ultrafeed over to it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212729324779036) by [Unito](https://www.unito.io)
