### PR TITLE
Admin curation sidebar

### DIFF
--- a/packages/lesswrong/lib/routeChecks/index.ts
+++ b/packages/lesswrong/lib/routeChecks/index.ts
@@ -12,7 +12,9 @@ function pathnameMatchesRoutePath(pathname: string, routePath: string) {
 
 export const isHomeRoute = (pathname: string) => pathnameMatchesRoutePath(pathname, '/') && !isAF();
 
-export const isSunshineSidebarRoute = (pathname: string) => pathnameMatchesRoutePath(pathname, '/');
+export const isSunshineSidebarRoute = (pathname: string) => {
+  return pathnameMatchesRoutePath(pathname, '/') || pathname.startsWith('/admin');
+};
 
 export const isStandaloneRoute = (pathname: string) => ['/crosspostLogin', '/groups-map'].some(route => pathnameMatchesRoutePath(pathname, route));
 


### PR DESCRIPTION
Enable the Sunshine sidebar on admin routes (e.g., `/admin/curation`) by updating `isSunshineSidebarRoute` to include paths starting with `/admin`.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1768356774632079?thread_ts=1768356774.632079&cid=CJUN2UAFN)

<a href="https://cursor.com/background-agent?bcId=bc-8bb567dc-9af8-482a-8622-c43e183f1f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bb567dc-9af8-482a-8622-c43e183f1f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212751356284993) by [Unito](https://www.unito.io)
