### PR TITLE
Make SunshineCuratedSuggestionsList show properly on /admin/curation and /recommendations

### DIFF
--- a/packages/lesswrong/components/admin/CurationPage.tsx
+++ b/packages/lesswrong/components/admin/CurationPage.tsx
@@ -96,7 +96,7 @@ export const CurationPage = ({classes}: {
           </div>
     </SingleColumnSection>
     {<div className={classes.curated}>
-        <SunshineCuratedSuggestionsList limit={50} atBottom setCurationPost={setPost}/>
+        <SunshineCuratedSuggestionsList limit={50} setCurationPost={setPost}/>
     </div>}
   </div>;
 }

--- a/packages/lesswrong/components/recommendations/RecommendationsPageCuratedList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPageCuratedList.tsx
@@ -40,7 +40,7 @@ const RecommendationsPageCuratedList = ({classes}: {
           </AnalyticsContext>
         </SingleColumnSection>}
         {hasCuratedPostsSetting.get() && currentUser?.isAdmin && <div className={classes.curated}>
-          <SunshineCuratedSuggestionsList limit={50} atBottom/>
+          <SunshineCuratedSuggestionsList limit={50}/>
         </div>}
       </AnalyticsContext>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -127,6 +127,10 @@ const SunshineCuratedSuggestionsList = ({ limit = 7, atBottom, classes, setCurat
     setHasDrafts(hasDrafts);
   }
 
+  if (currentUser?.hideSunshineSidebar) {
+    return null
+  }
+
   if (!shouldShow(!!atBottom, timeForCuration, currentUser, hasDrafts)) {
     return null
   }


### PR DESCRIPTION
They were only showing when no curation drafts or when it's curation time. But we need it always


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes curated suggestions visible where expected and respects a user hide-setting.
> 
> - Remove `atBottom` when rendering `SunshineCuratedSuggestionsList` in `CurationPage` and `RecommendationsPageCuratedList` to ensure the list appears
> - `SunshineCuratedSuggestionsList` now returns `null` when `currentUser.hideSunshineSidebar` is true
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca1cc753d49af891ede04648aaca2a851878976b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->