### PR TITLE
Make supermod postDetail not cover so many columns

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -94,7 +94,7 @@ const styles = defineStyles('ModerationInbox', (theme: ThemeType) => ({
     minWidth: 0,
   },
   postDetailPanel: {
-    flex: 2,
+    flex: 1,
     overflow: 'hidden',
   },
   loading: {


### PR DESCRIPTION
This still isn't quite the way I'd like it to be but is an improvement. (During my refactor, I accidentally made it so when you're viewing a post, you can't see all the columns. This UI tweak makes it so you can see them all while on a full-sized 16" laptop)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212870322813646) by [Unito](https://www.unito.io)
