### PR TITLE
Fix Review Voting Phase

### DIFF
--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -128,7 +128,7 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
   const { view, limit, ...selectorTerms } = {
     view: reviewPhase === "VOTING" ? "reviewFinalVoting" : "reviewVoting",
     before: `${reviewYear + 1}-01-01`,
-    reviewPhase: reviewPhase,
+    ...(reviewPhase === "VOTING" ? {} : {reviewPhase}),
     after: `${reviewYear}-01-01`,
     limit: 600,
   };
@@ -454,5 +454,3 @@ const ReviewVotingPage = ({classes, reviewYear, expandedPost, setExpandedPost}: 
 }
 
 export default registerComponent('ReviewVotingPage', ReviewVotingPage, {styles});
-
-


### PR DESCRIPTION
Once we switched to the voting phase, we started getting this error. 

This fix works and I'm merging it since it's currently broken, but I'm not sure if this is fixing it the correct way.

[GraphQLError: Variable "$selector" got invalid value { before: "2025-01-01", reviewPhase: "VOTING", after: "2024-01-01" } at "selector.reviewFinalVoting"; Field "reviewPhase" is not defined by type "PostsReviewFinalVotingInput".] { locations: [ { line: 1, column: 38 } ] } GraphQLError: Variable "$selector" got invalid value { before: "2025-01-01", reviewPhase: "VOTING", after: "2024-01-01" } at "selector.reviewFinalVoting"; Field "reviewPhase" is not defined by type "PostsReviewFinalVotingInput".
    at new Promise (<anonymous>)
    at executeGraphqlOperation (app/api/streamGraphql/route.ts:96:31)
    at <unknown> (app/api/streamGraphql/route.ts:172:38)
    at <unknown> (app/api/streamGraphql/route.ts:188:14)
  94 | }): Promise<any> {
  95 |   const schema = getExecutableSchema();
> 96 |   const result = await graphql({
     |                               ^
  97 |     schema,
  98 |     source: op.query,
  99 |     rootValue: {}, {
  path: undefined,
  locations: [Array],
  extensions: [Object: null prototype] {}