### PR TITLE
remove incorrect font size and padding for the lexical comment editor ContentEditable

### DIFF
--- a/packages/lesswrong/components/editor/LexicalPostEditor.tsx
+++ b/packages/lesswrong/components/editor/LexicalPostEditor.tsx
@@ -259,7 +259,7 @@ const lexicalStyles = defineStyles('LexicalPostEditor', (theme: ThemeType) => ({
     display: 'inline-block',
     pointerEvents: 'none',
   },
-}), { allowNonThemeColors: true });
+}));
 
 interface LexicalPostEditorProps {
   data?: string;

--- a/packages/lesswrong/components/lexical/ui/ContentEditable.tsx
+++ b/packages/lesswrong/components/lexical/ui/ContentEditable.tsx
@@ -27,8 +27,6 @@ const styles = defineStyles('LexicalContentEditable', (theme: ThemeType) => ({
     },
   },
   rootComment: {
-    fontSize: 14,
-    padding: '8px 12px',
     minHeight: 'var(--lexical-comment-min-height, 60px)',
   },
   placeholder: {


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212951040738291) by [Unito](https://www.unito.io)
