### PR TITLE
No dialog clickaway on ckeditor popovers

### DIFF
--- a/packages/lesswrong/components/common/LWDialog.tsx
+++ b/packages/lesswrong/components/common/LWDialog.tsx
@@ -94,10 +94,19 @@ const LWDialog = ({open, fullScreen, title, maxWidth='sm', fullWidth, disableBac
     {backdrop!=="none" && openRecently && <Backdrop visible={open} style={backdrop}/>}
     {everOpened && (open || keepMounted) && createPortal(
       <div>
-        <ClickAwayListener onClickAway={() => {
-          if (!disableBackdropClick)
-            onClose?.();
-        }}>
+        <ClickAwayListener
+          onClickAway={() => {
+            if (!disableBackdropClick)
+              onClose?.();
+          }}
+          // ckEditor renders things like its toolbar and link insertion form
+          // directly into document.body, so trying to click on one of them
+          // while in the context of having an open dialog with clickaway handling
+          // will cause the dialog to immediately close, which is not what we want.
+          // So ignore clicks on these classes for the purpose of deciding whether
+          // to close the dialog.
+          ignoreClasses=".ck-body-wrapper, .ck-balloon-panel"
+        >
           <div className={classNames(
             classes.dialogWrapper, className, {
               [classes.hidden]: !open,

--- a/packages/lesswrong/lib/vendor/react-click-away-listener.ts
+++ b/packages/lesswrong/lib/vendor/react-click-away-listener.ts
@@ -44,6 +44,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
   mouseEvent?: MouseEvents;
   touchEvent?: TouchEvents;
   children: ReactElement<any>;
+  ignoreClasses?: string;
 }
 
 const eventTypeMapping = {
@@ -60,7 +61,8 @@ const ClickAwayListener: FunctionComponent<Props> = ({
   children,
   onClickAway,
   mouseEvent = 'click',
-  touchEvent = 'touchend'
+  touchEvent = 'touchend',
+  ignoreClasses
 }) => {
   const node = useRef<HTMLElement | null>(null);
   const bubbledEventTarget = useRef<EventTarget | null>(null);
@@ -117,7 +119,16 @@ const ClickAwayListener: FunctionComponent<Props> = ({
       const isBubbledEventTarget = bubbledEventTarget.current === event.target;
       const notContainedInDocument = !nodeDocument.contains(event.target as Node);
 
-      if (isContainedByNode || isBubbledEventTarget || notContainedInDocument) {
+      let isIgnored = false;
+      if (ignoreClasses) {
+        const target = event.target;
+        const element = target instanceof Element ? target : (target as Node)?.parentElement;
+        if (element?.closest(ignoreClasses)) {
+          isIgnored = true;
+        }
+      }
+
+      if (isContainedByNode || isBubbledEventTarget || notContainedInDocument || isIgnored) {
         return;
       }
 
@@ -131,7 +142,7 @@ const ClickAwayListener: FunctionComponent<Props> = ({
       nodeDocument.removeEventListener(mouseEvent, handleEvents);
       nodeDocument.removeEventListener(touchEvent, handleEvents);
     };
-  }, [mouseEvent, onClickAway, touchEvent]);
+  }, [mouseEvent, onClickAway, touchEvent, ignoreClasses]);
 
   const mappedMouseEvent = eventTypeMapping[mouseEvent];
   const mappedTouchEvent = eventTypeMapping[touchEvent];


### PR DESCRIPTION
Don't close parent dialogs when clicking on popovers opened by ckeditor, like the toolbar and link editor form.  (This was causing problems in the Localgroup edit form, which is inside of a dialog.)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212956281566548) by [Unito](https://www.unito.io)
