### PR TITLE
Avoid restoring a suspended mapbox from inside of Activity boundaries on nagivation

### DIFF
--- a/packages/lesswrong/components/community/WrappedReactMapGL.tsx
+++ b/packages/lesswrong/components/community/WrappedReactMapGL.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { componentWithChildren } from '@/lib/utils/componentsWithChildren';
 import { Helmet } from "@/components/layout/Helmet";


### PR DESCRIPTION
Not super clear what the actual underlying bug was, but when navigating back to a page that rendered mapbox after navigating away from it, mapbox would break and bubble up a `TypeError: can't redefine non-configurable property "offsetWidth"` error.  Fixed by a similar mechanism to the one we use in `PostsEditForm` to avoid accidentally preserving editor state after navigating away from the `/editPost` page.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212990370046458) by [Unito](https://www.unito.io)
