### PR TITLE
clean up a bunch of edge cases in the url regex

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/AutoLinkPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/AutoLinkPlugin/index.tsx
@@ -15,8 +15,46 @@ import {
 import { normalizeUrl } from '../../utils/url';
 
 
-const URL_REGEX =
-  /((https?:\/\/)?(www\.)?)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/;
+// One hostname label: 1-63 chars, unicode letters/numbers, no leading/trailing - or _
+const HOST_LABEL = '[\\p{L}\\p{N}](?:[\\p{L}\\p{N}_-]{0,61}[\\p{L}\\p{N}])?';
+
+// One or more labels + alphabetic TLD (2-63 chars)
+const DOMAIN_NAME = `${HOST_LABEL}(?:\\.${HOST_LABEL})*\\.\\p{L}{2,63}`;
+
+// IPv4 octet 0-255
+const IPV4_OCTET = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)';
+
+// IPv4 address, excluding 0.0.0.0
+const IPV4_ADDRESS = `(?!0\\.0\\.0\\.0)(?:${IPV4_OCTET}\\.){3}${IPV4_OCTET}`;
+
+// Host can be localhost, domain, or IPv4
+const HOSTNAME = `(?:localhost|${DOMAIN_NAME}|${IPV4_ADDRESS})`;
+
+const URL_REGEX = new RegExp(
+  // Require start or whitespace before URL
+  '(?<!\\S)(?:' +
+    // Scheme URLs (http/https), optional userinfo, full hostname, optional port
+    `https?:\\/\\/(?:[^\\s/@]+@)?${HOSTNAME}(?::\\d{1,5})?` +
+    '|' +
+    // Short-form domains only if www. or user@ prefix is present
+    `(?:www\\.|[^\\s/@]+@)${DOMAIN_NAME}(?::\\d{1,5})?` +
+    '|' +
+    // Allow localhost without scheme
+    'localhost(?::\\d{1,5})?' +
+    '|' +
+    // Allow bare IPv4 addresses
+    `${IPV4_ADDRESS}(?::\\d{1,5})?` +
+  ')' +
+  // Optional path/query/hash
+  // Note: We intentionally do not exclude trailing punctuation here because
+  // Lexical's boundary checks only treat ".,;" and whitespace as separators.
+  // Excluding punctuation in the regex would cause many valid URLs to fail
+  // (e.g. "https://example.com)").
+  '(?:[/?#][^\\s]*)?' +
+  // Anchor to end
+  '$',
+  'iu'
+);
 
 const EMAIL_REGEX =
   /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;


### PR DESCRIPTION
Lexical was doing things like auto-converting `2.0` into links (`https://2.0.0.0`).  This fixes that plus a bunch of the other obvious edge cases.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1212991561281182) by [Unito](https://www.unito.io)
