### PR TITLE
Restore supermod rate limits

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserAutoRateLimitsDisplay.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModeratorUserInfo/UserAutoRateLimitsDisplay.tsx
@@ -58,6 +58,7 @@ const styles = (theme: ThemeType) => ({
   },
   strictestRateLimits: {
     margin: 0,
+    paddingLeft: 16,
   },
   absoluteRoot: {
     position: 'relative',
@@ -163,5 +164,3 @@ export const UserAutoRateLimitsDisplay = ({user, showKarmaMeta = false, absolute
 }
 
 export default registerComponent('UserAutoRateLimitsDisplay', UserAutoRateLimitsDisplay, {styles});
-
-

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserInfoColumn.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserInfoColumn.tsx
@@ -7,6 +7,7 @@ import ModerationUserStatsColumn from './ModerationUserStatsColumn';
 import ModerationUserBioColumn from './ModerationUserBioColumn';
 import ModeratorNotes from './ModeratorNotes';
 import { getPrimaryDisplayedModeratorAction, partitionModeratorActions } from './groupings';
+import UserAutoRateLimitsDisplay from '../ModeratorUserInfo/UserAutoRateLimitsDisplay';
 
 const styles = defineStyles('ModerationUserInfoColumn', (theme: ThemeType) => ({
   header: {
@@ -48,6 +49,7 @@ const ModerationUserInfoColumn = ({
       <ModeratorNotes user={user} currentUser={currentUser} />
 
       <ModerationUserStatsColumn user={user} posts={posts} comments={comments} />
+      <UserAutoRateLimitsDisplay user={user} showKarmaMeta={true} />
       <ModerationUserBioColumn user={user} />
     </div>
   );


### PR DESCRIPTION
These were accidentally removed. I am a bit confused why their padding was janky, I updated it to be less janky in this context which probably makes it more janky in an older context but we're not using the old context anymore.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213058741517065) by [Unito](https://www.unito.io)
