### PR TITLE
Fix missing user-activity falloff in Recent posts list during SSR

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/createContexts.ts
+++ b/packages/lesswrong/server/vulcan-lib/createContexts.ts
@@ -7,7 +7,6 @@ export const createAnonymousContext = (options?: Partial<ResolverContext>): Reso
   return {
     userId: null,
     clientId: null,
-    visitorActivity: null,
     currentUser: null,
     headers: undefined,
     locale: localeSetting.get(),


### PR DESCRIPTION
The visitorActivity field on context is a weird hack, where defaultResolver fills in a field that some views need but can't get because they're not async. It also has a distinction between "field not present" and "present with value null": the former means not fetched yet, the latter means it was already fetched and not found.

`runQuery` has a weird hack where it constructs a context, then spreads the provided context over it, rather than using the provided context directly. And in the process, it fills in `visitorActivity` with null, which it should have been leaving as field-not-present. This was a latent bug ever since the user-activity code was introduced. When we refactored to call `runQuery` during SSR rather than going through apollo-client, this switched us between two otherwise-identical ResovlerContext constructors, and exposed the bug.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213089225586251) by [Unito](https://www.unito.io)
