### PR TITLE
Remove workaround for an apollo-client issue that's no longer present/relevant

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, useState, useEffect, useRef, useMemo} from 'react';
+import React, {ComponentProps, useState, useEffect, useRef, useMemo, Suspense} from 'react';
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser'
 import withErrorBoundary from '../common/withErrorBoundary'

--- a/packages/lesswrong/components/ea-forum/wrapped/hooks.tsx
+++ b/packages/lesswrong/components/ea-forum/wrapped/hooks.tsx
@@ -31,7 +31,6 @@ import WrappedRecommendationsSection from "./WrappedRecommendationsSection";
 import WrappedMostValuablePostsSection from "./WrappedMostValuablePostsSection";
 import WrappedThankYouSection from "./WrappedThankYouSection";
 import { useQueryWithLoadMore, LoadMoreProps } from "@/components/hooks/useQueryWithLoadMore";
-import { apolloSSRFlag } from "@/lib/helpers";
 import { WrappedYear } from "./constants";
 
 const PostsListWithVotesMultiQuery = gql(`
@@ -328,7 +327,7 @@ const useVotes = (year: WrappedYear, voteType: VoteType) => {
       limit: 100,
       enableTotal: false,
     },
-    ssr: apolloSSRFlag(false),
+    ssr: false,
     notifyOnNetworkStatusChange: true,
   });
 

--- a/packages/lesswrong/components/hooks/useQueryWithLoadMore.ts
+++ b/packages/lesswrong/components/hooks/useQueryWithLoadMore.ts
@@ -3,7 +3,6 @@ import { type OperationVariables } from "@apollo/client";
 import { useQuery } from "@/lib/crud/useQuery";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { Kind } from "graphql";
-import { apolloSSRFlag } from "@/lib/helpers";
 import isEqual from "lodash/isEqual";
 import { useStabilizedCallbackAsync } from "./useDebouncedCallback";
 
@@ -75,7 +74,7 @@ export function useQueryWithLoadMore<
 
   const queryOutput = useQuery(query, {
     ...remainingOptions,
-    ssr: apolloSSRFlag(ssr),
+    ssr,
     notifyOnNetworkStatusChange,
     variables: {
       ...({ selector, ...remainingVariables }) as TVariables,

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -17,7 +17,6 @@ import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import SequencesTooltip from "../sequences/SequencesTooltip";
 import LWPopper from "../common/LWPopper";
 import ContentStyles from "../common/ContentStyles";
-import { apolloSSRFlag } from '@/lib/helpers';
 import type { RouterLocation } from '@/lib/vulcan-lib/routes';
 import { linkStyles } from './linkStyles';
 import LWTooltip from '../common/LWTooltip';
@@ -94,7 +93,7 @@ export const PostLinkPreview = ({href, originalHref, targetLocation, id, classNa
       allowNull: true,
     },
     fetchPolicy: 'cache-first',
-    ssr: apolloSSRFlag(false),
+    ssr: false,
   });
   const post = data?.post?.result;
   

--- a/packages/lesswrong/components/recommendations/withRecommendations.ts
+++ b/packages/lesswrong/components/recommendations/withRecommendations.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from '@/lib/generated/gql-codegen';
-import { apolloSSRFlag } from '../../lib/helpers';
 import { defaultAlgorithmSettings, RecommendationsAlgorithm } from "../../lib/collections/users/recommendationSettings";
 
 export const useRecommendations = ({
@@ -27,9 +26,7 @@ export const useRecommendations = ({
         algorithm: algorithm || defaultAlgorithmSettings,
       },
       context: { batchKey: "recommendations" },
-      // This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
-      // the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
-      ssr: apolloSSRFlag(ssr),
+      ssr: ssr,
     }
   );
   return {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -23,7 +23,6 @@ import Loading from "../vulcan-core/Loading";
 import AddTagButton from "./AddTagButton";
 import CoreTagsChecklist from "./CoreTagsChecklist";
 import PostsAnnualReviewMarketTag from "../posts/PostsAnnualReviewMarketTag";
-import { apolloSSRFlag } from "@/lib/helpers";
 import ForumIcon from '../common/ForumIcon';
 import { defineStyles } from '../hooks/defineStyles';
 import { useStyles } from '../hooks/useStyles';
@@ -221,7 +220,7 @@ const FooterTagList = ({
     },
     fetchPolicy: 'cache-and-network',
     // Only fetch this as a follow-up query on the client
-    ssr: apolloSSRFlag(false),
+    ssr: false,
     notifyOnNetworkStatusChange: true,
   });
 

--- a/packages/lesswrong/lib/helpers.ts
+++ b/packages/lesswrong/lib/helpers.ts
@@ -111,9 +111,3 @@ export const setAtPath = <T extends {}, V extends AnyBecauseHard>(
   }
   return value;
 }
-
-/**
- * This is a workaround for a bug in apollo where setting `ssr: false` makes it not fetch
- * the query on the client (see https://github.com/apollographql/apollo-client/issues/5918)
- */
-export const apolloSSRFlag = (ssr: boolean) => ssr || !isServer;


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213133654964369) by [Unito](https://www.unito.io)
