### PR TITLE
redo admin-gating lexical in the post collaboration page and ungate reviews page for logged out users

### DIFF
--- a/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/editor/PostCollaborationEditor.tsx
@@ -128,7 +128,7 @@ const PostCollaborationEditor = ({ classes }: {
       </div>*/}
       <ContentStyles className={classes.editor} contentType="post">
         <DeferRender ssr={false}>
-          {/* {isAdmin ? ( */}
+          {isAdmin ? (
             <LexicalEditor
               data={''}
               placeholder="Start writing..."
@@ -139,7 +139,7 @@ const PostCollaborationEditor = ({ classes }: {
               collectionName="Posts"
               accessLevel={post.myEditorAccess as CollaborativeEditingAccessLevel}
             />
-          {/* ) : (
+          ) : (
             <CKPostEditor
               data={''}
               documentId={postId}
@@ -152,7 +152,7 @@ const PostCollaborationEditor = ({ classes }: {
               document={post}
               onReady={()=>{}}
             />
-          )} */}
+          )}
           <PostVersionHistoryButton
             post={post}
             postId={postId}

--- a/packages/lesswrong/components/review/AnnualReviewPage.tsx
+++ b/packages/lesswrong/components/review/AnnualReviewPage.tsx
@@ -183,7 +183,7 @@ export const AnnualReviewPage = ({classes}: {
     </SingleColumnSection>
   }
 
-  if (!currentUser) {
+  if (!currentUser && activeTab !== 'reviews') {
     return <SingleColumnSection>
       You must be logged in to view the annual review.
     </SingleColumnSection>


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213162367230883) by [Unito](https://www.unito.io)
