### PR TITLE
Fix horiz-scroll and clipping on horizontally-large tables

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -267,7 +267,7 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
         );
       }
 
-      if (root && ['p','div','table'].includes(TagName)) {
+      if (root && ['p','div','table','figure'].includes(TagName)) {
         return <MaybeScrollableBlock TagName={TagName} attribs={attribs} bodyRef={passedThroughProps.bodyRef}>
           {result}
         </MaybeScrollableBlock>

--- a/packages/lesswrong/components/contents/HorizScrollBlock.tsx
+++ b/packages/lesswrong/components/contents/HorizScrollBlock.tsx
@@ -87,9 +87,8 @@ export const HorizScrollBlock = ({children, className, contentsClassName}: {
     if (scrollableContentsRef.current) {
       const scrollLeft = scrollableContentsRef.current.scrollLeft;
       setIsScrolledAllTheWayLeft((scrollLeft===0));
-      setIsScrolledAllTheWayRight((
-        scrollLeft === scrollableContentsRef.current.scrollWidth - scrollableContentsRef.current.clientWidth
-      ));
+      const scrollRight = (scrollableContentsRef.current.scrollWidth - scrollableContentsRef.current.clientWidth) - scrollLeft;
+      setIsScrolledAllTheWayRight(scrollRight < 1.0);
     }
   }, []);
   

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -559,15 +559,6 @@ const baseBodyStyles = (theme: ThemeType) => ({
     width: 'fit-content',
     height: 'fit-content',
   },
-  // Many column tables should overflow instead of squishing
-  //  - NB: As of Jan 2023, this does not work on firefox, so ff users will have
-  //    squishy tables (which is the default behavior above)
-  '& figure.table:has(> table > tbody > tr > td + td + td + td)': {
-    overflowX: 'auto',
-    '& table': {
-      width: 700,
-    },
-  },
   '& td, & th': {
     ...tableCellStyles(theme)
   },


### PR DESCRIPTION
Removed a special-case width rule that had the wrong width, causing tables to be 18px oversized and get clipped. Include tables in horiz-scroller handling when they're wrapped in <figure>. Fix a floating point precision issue in the horiz scroller that made the right arrow appear when it shouldn't.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213224332655868) by [Unito](https://www.unito.io)
