### PR TITLE
Remove Curate Post button from admin sidebar

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -9,7 +9,6 @@ import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import PlusOneIcon from '@material-ui/icons/PlusOne';
 import UndoIcon from '@material-ui/icons/Undo';
-import StarIcon from '@material-ui/icons/Star';
 import ClearIcon from '@material-ui/icons/Clear';
 import * as _ from 'underscore';
 
@@ -23,16 +22,6 @@ const SunshineCuratedSuggestionsItem = ({post}: {
     fragmentName: 'PostsList',
   });
   
-  const handleCurate = () => {
-    void updatePost({
-      selector: {_id: post._id},
-      data: {
-        reviewForCuratedUserId: currentUser!._id,
-        curatedDate: new Date(),
-      }
-    })
-  }
-
   const handleDisregardForCurated = () => {
     void updatePost({
       selector: {_id: post._id},
@@ -106,9 +95,6 @@ const SunshineCuratedSuggestionsItem = ({post}: {
               <UndoIcon/>
             </Components.SidebarAction>
           }
-          <Components.SidebarAction title="Curate Post" onClick={handleCurate}>
-            <StarIcon/>
-          </Components.SidebarAction>
           <Components.SidebarAction title="Remove from Curation Suggestions" onClick={handleDisregardForCurated}>
             <ClearIcon/>
           </Components.SidebarAction>


### PR DESCRIPTION
## Summary
- Removes the "Curate Post" (star icon) button from the Suggestions for Curated section in the admin sunshine sidebar
- Also removes the now-unused `handleCurate` function and `StarIcon` import
- Endorse/Unendorse Curation and Remove from Curation Suggestions buttons remain unchanged

## Test plan
- [ ] Verify the admin sidebar's curation suggestions section still renders correctly on the front page
- [ ] Confirm hovering over a suggestion shows only Endorse/Unendorse and Remove buttons
- [ ] Confirm no TypeScript or lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213234858968962) by [Unito](https://www.unito.io)
