### PR TITLE
Remove star icon curate button from curation suggestions

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.tsx
@@ -55,27 +55,14 @@ const styles = (theme: ThemeType) => ({
   },
 });
 
-const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost, timeForCuration}: {
+const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost}: {
   classes: ClassesType<typeof styles>,
   post: SunshineCurationPostsList,
   setCurationPost?: (post: SunshineCurationPostsList) => void,
-  timeForCuration?: boolean,
 }) => {
   const currentUser = useCurrentUser();
   const { hover, anchorEl, eventHandlers } = useHover();
   const [updatePost] = useMutation(SunshineCurationPostsListUpdateMutation);
-
-  const handleCurate = () => {
-    void updatePost({
-      variables: {
-        selector: { _id: post._id },
-        data: {
-          reviewForCuratedUserId: currentUser!._id,
-          curatedDate: new Date(),
-        }
-      }
-    })
-  }
 
   const handleDisregardForCurated = () => {
     void updatePost({
@@ -174,11 +161,6 @@ const SunshineCuratedSuggestionsItem = ({classes, post, setCurationPost, timeFor
             :
             <SidebarAction title="Unendorse Curation" onClick={handleUnsuggestCurated}>
               <ForumIcon icon="Undo"/>
-            </SidebarAction>
-          }
-          { timeForCuration && canCurate &&
-            <SidebarAction title="Curate Post" onClick={handleCurate}>
-              <ForumIcon icon="Star" />
             </SidebarAction>
           }
           { canCurate && <SidebarAction title="Remove from Curation Suggestions" onClick={handleDisregardForCurated}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -167,7 +167,7 @@ const SunshineCuratedSuggestionsList = ({ limit = 7, atBottom, classes, setCurat
       </SunshineListTitle>
       {results?.map(post =>
         <div key={post._id} >
-          <SunshineCuratedSuggestionsItem post={post} setCurationPost={setCurationPost} timeForCuration={timeForCuration}/>
+          <SunshineCuratedSuggestionsItem post={post} setCurationPost={setCurationPost}/>
         </div>
       )}
       {showLoadMore && <div className={classes.loadMorePadding}>


### PR DESCRIPTION
## Summary
- Removes the one-click "Curate Post" star icon button from the sidebar hover menu in the Suggestions for Curated panel
- Removes the now-unused `handleCurate` function and `timeForCuration` prop from `SunshineCuratedSuggestionsItem`
- Curation can still be done via the /admin/curation page

## Test plan
- [ ] Verify the curation suggestions panel still renders correctly for admins
- [ ] Verify hover menu still shows Write Curation Notice, Endorse/Unendorse, and Remove buttons
- [ ] Verify the star curate button no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213235392349977) by [Unito](https://www.unito.io)
