### PR TITLE
Lexical dollar trigger space

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/MarkdownTransformers/index.ts
+++ b/packages/lesswrong/components/lexical/plugins/MarkdownTransformers/index.ts
@@ -150,13 +150,14 @@ export const EQUATION: TextMatchTransformer = {
     return `$${node.getEquation()}$`;
   },
   importRegExp: /\$([^$]+?)\$/,
-  regExp: /\$([^$]+?)\$$/,
+  regExp: /\$([^$]+?)\$ $/,
   replace: (textNode, match) => {
     const [, equation] = match;
     const equationNode = $createMathNode(equation, true);
     textNode.replace(equationNode);
+    equationNode.insertAfter($createTextNode(' '));
   },
-  trigger: '$',
+  trigger: ' ',
   type: 'text-match',
 };
 


### PR DESCRIPTION
Fix the inline math (EQUATION) lexical markdown transformer to only trigger on a space typed after the closing `$`.

This prevents false positives where text like "$5 or $10" was incorrectly treated as LaTeX, by requiring a trailing space after the closing `$` for the transformer to activate.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1771538886215999?thread_ts=1771538886.215999&cid=CJUN2UAFN)

<p><a href="https://cursor.com/agents?id=bc-8c8de267-28cd-545e-810d-bcb3633a973e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c8de267-28cd-545e-810d-bcb3633a973e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213368103021445) by [Unito](https://www.unito.io)
