### PR TITLE
Dm autoflag message count

### DIFF
--- a/packages/lesswrong/server/callbacks/conversationCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/conversationCallbacks.ts
@@ -1,92 +1,9 @@
-import { FLAGGED_FOR_N_DMS, getMaxAllowedContactsBeforeBlock, MAX_ALLOWED_CONTACTS_BEFORE_FLAG } from "@/lib/collections/moderatorActions/constants";
-import { loggerConstructor } from '../../lib/utils/logging';
 import { UpdateCallbackProperties } from '../mutationCallbacks';
 import { getAdminTeamAccount } from '../utils/adminTeamAccount';
 import { createNotifications } from '../notificationCallbacksHelpers';
 import difference from 'lodash/difference';
-import { filterNonnull } from '@/lib/utils/typeGuardUtils';
-import { createModeratorAction } from '../collections/moderatorActions/mutations';
 import { computeContextFromUser } from '../vulcan-lib/apollo-server/context';
-import { createAnonymousContext } from "@/server/vulcan-lib/createContexts";
 import { createMessage } from '../collections/messages/mutations';
-import { updateUser } from '../collections/users/mutations';
-import { backgroundTask } from "../utils/backgroundTask";
-
-/**
- * Before a user has been fully approved, keep track of the number of users
- * they've started a conversation with. If they've messaged more than N, flag
- * them for review. If they've messaged more than M, block them from messaging
- * anyone else.
- *
- * In the case where a user should be blocked, this will throw an error, so we
- * should make sure to handle that on the frontend.
- */
-export async function flagOrBlockUserOnManyDMs({
-  currentConversation,
-  oldConversation,
-  currentUser,
-  context,
-}: {
-  currentConversation: CreateConversationDataInput | UpdateConversationDataInput,
-  oldConversation?: DbConversation,
-  currentUser: DbUser|null,
-  context: ResolverContext,
-}): Promise<void> {
-  const { ModeratorActions, Users } = context;
-  const logger = loggerConstructor('callbacks-conversations');
-  logger('flagOrBlockUserOnManyDMs()')
-  if (!currentUser) {
-    throw new Error("You can't create a conversation without being logged in");
-  }
-  if (currentUser.reviewedByUserId && !currentUser.snoozedUntilContentCount) {
-    logger('User has been fully approved, ignoring')
-    return;
-  }
-  // if the participants didn't change, we can ignore it
-  if (!currentConversation.participantIds) {
-    logger('No change to participantIds, ignoring')
-    return;
-  }
-
-  // Old conversation *should* be completely redundant with
-  // currentUser.usersContactedBeforeReview, but we will try to be robust to
-  // the case where it's not
-  logger('previous usersContactedBeforeReview', currentUser.usersContactedBeforeReview)
-  const allUsersEverContacted = filterNonnull([...(new Set([
-    ...currentConversation.participantIds,
-    ...(oldConversation?.participantIds ?? []),
-    ...(currentUser.usersContactedBeforeReview ?? [])
-  ]))].filter(id => id !== currentUser._id))
-  logger(
-    'new allUsersEverContacted', allUsersEverContacted,
-    '(length: ', allUsersEverContacted.length, ')'
-  )
-  if (allUsersEverContacted.length > MAX_ALLOWED_CONTACTS_BEFORE_FLAG && !currentUser.reviewedAt) {
-    // Flag users that have sent N+ DMs if they've never been reviewed
-    logger('Flagging user')
-    backgroundTask(createModeratorAction({
-      data: {
-        userId: currentUser._id,
-        type: FLAGGED_FOR_N_DMS,
-      },
-    }, context));
-  }
-  
-  // Always update the numUsersContacted field, for denormalization
-  backgroundTask(updateUser({
-    data: {
-      usersContactedBeforeReview: allUsersEverContacted,
-    },
-    selector: { _id: currentUser._id }
-  }, createAnonymousContext()));
-  
-  if (allUsersEverContacted.length > getMaxAllowedContactsBeforeBlock() && !currentUser.reviewedAt) {
-    logger('Blocking user')
-    throw new Error(`You cannot message more than ${getMaxAllowedContactsBeforeBlock()} users before your account has been reviewed. Please contact us if you'd like to message more people.`)
-  }
-  
-  logger('flagOrBlockUserOnManyDMs() return')
-}
 
 export async function sendUserLeavingConversationNotication({newDocument, oldDocument, context}: UpdateCallbackProperties<'Conversations'>) {
   const { Messages, Users } = context;

--- a/packages/lesswrong/server/collections/conversations/mutations.ts
+++ b/packages/lesswrong/server/collections/conversations/mutations.ts
@@ -3,7 +3,7 @@ import { userCanStartConversations } from "@/lib/collections/conversations/helpe
 import schema from "@/lib/collections/conversations/newSchema";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo } from "@/lib/vulcan-users/permissions";
-import { conversationEditNotification, flagOrBlockUserOnManyDMs, sendUserLeavingConversationNotication } from "@/server/callbacks/conversationCallbacks";
+import { conversationEditNotification, sendUserLeavingConversationNotication } from "@/server/callbacks/conversationCallbacks";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
@@ -37,8 +37,6 @@ export async function createConversation({ data }: CreateConversationInput, cont
 
   data = await runFieldOnCreateCallbacks(schema, data, callbackProps);
 
-  await flagOrBlockUserOnManyDMs({ currentConversation: data, currentUser, context });
-
   const afterCreateProperties = await insertAndReturnCreateAfterProps(data, 'Conversations', callbackProps);
   let documentWithId = afterCreateProperties.document;
 
@@ -58,8 +56,6 @@ export async function updateConversation({ selector, data }: { data: UpdateConve
   const { oldDocument } = updateCallbackProperties;
 
   data = await runFieldOnUpdateCallbacks(schema, data, updateCallbackProperties);
-
-  await flagOrBlockUserOnManyDMs({ currentConversation: data, oldConversation: oldDocument, currentUser, context });
 
   let updatedDocument = await updateAndReturnDocument(data, Conversations, conversationSelector, context);
 

--- a/packages/lesswrong/server/collections/messages/mutations.ts
+++ b/packages/lesswrong/server/collections/messages/mutations.ts
@@ -8,6 +8,7 @@ import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFields
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
 import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndReturnCreateAfterProps, runFieldOnCreateCallbacks, runFieldOnUpdateCallbacks, updateAndReturnDocument, assignUserIdToData } from "@/server/vulcan-lib/mutators";
+import { flagOrBlockUserOnManyDMs } from "@/server/utils/dmMessagingModeration";
 import gql from "graphql-tag";
 
 async function newCheck(user: DbUser | null, document: DbMessage | null, context: ResolverContext) {
@@ -29,7 +30,7 @@ async function editCheck(user: DbUser | null, document: DbMessage | null, contex
 }
 
 export async function createMessage({ data }: CreateMessageInput, context: ResolverContext) {
-  const { currentUser } = context;
+  const { currentUser, Conversations } = context;
 
   const callbackProps = await getLegacyCreateCallbackProps('Messages', {
     context,
@@ -40,6 +41,17 @@ export async function createMessage({ data }: CreateMessageInput, context: Resol
   assignUserIdToData(data, currentUser, schema);
 
   data = callbackProps.document;
+
+  if (!data.conversationId) {
+    throw new Error("Messages must belong to a conversation");
+  }
+
+  const conversation = await Conversations.findOne({ _id: data.conversationId });
+  if (!conversation) {
+    throw new Error(`Conversation ${data.conversationId} does not exist`);
+  }
+
+  await flagOrBlockUserOnManyDMs({ conversation, currentUser, context });
 
   checkIfNewMessageIsEmpty(data);
 

--- a/packages/lesswrong/server/utils/dmMessagingModeration.ts
+++ b/packages/lesswrong/server/utils/dmMessagingModeration.ts
@@ -1,0 +1,135 @@
+import { FLAGGED_FOR_N_DMS, getMaxAllowedContactsBeforeBlock, MAX_ALLOWED_CONTACTS_BEFORE_FLAG } from "@/lib/collections/moderatorActions/constants";
+import { loggerConstructor } from "@/lib/utils/logging";
+import { filterNonnull } from "@/lib/utils/typeGuardUtils";
+import { createModeratorAction } from "@/server/collections/moderatorActions/mutations";
+import { updateUser } from "@/server/collections/users/mutations";
+import { backgroundTask } from "@/server/utils/backgroundTask";
+import { createAnonymousContext } from "@/server/vulcan-lib/createContexts";
+
+type ConversationForDmModeration = {
+  participantIds?: string[] | null;
+  moderator?: boolean | null;
+};
+
+type FlagOrBlockUserOnManyDMsArgs = {
+  conversation: ConversationForDmModeration | null | undefined;
+  currentUser: DbUser | null;
+  context: ResolverContext;
+};
+
+type ComputeUpdatedContactsArgs = {
+  participantIds: string[];
+  currentUserId: string;
+  previousContacts: string[];
+};
+
+const logger = loggerConstructor("callbacks-conversations");
+
+export function computeUpdatedUsersContactedBeforeReview({
+  participantIds,
+  currentUserId,
+  previousContacts,
+}: ComputeUpdatedContactsArgs): string[] | null {
+  const otherParticipantIds = filterNonnull(
+    participantIds.filter((id) => id !== currentUserId)
+  );
+  if (!otherParticipantIds.length) {
+    return null;
+  }
+
+  const contactSet = new Set([...previousContacts, ...otherParticipantIds]);
+
+  if (contactSet.size === previousContacts.length) {
+    return null;
+  }
+
+  return [...contactSet];
+}
+
+/**
+ * Before a user has been fully approved, keep track of the number of users
+ * they've started a conversation with. If they've messaged more than N, flag
+ * them for review. If they've messaged more than M, block them from messaging
+ * anyone else.
+ *
+ * This helper should be called whenever a user successfully sends a DM (ie.
+ * from the message creation flow) so that conversations with zero messages do
+ * not increment the counter.
+ */
+export async function flagOrBlockUserOnManyDMs({
+  conversation,
+  currentUser,
+  context,
+}: FlagOrBlockUserOnManyDMsArgs): Promise<void> {
+  logger("flagOrBlockUserOnManyDMs()");
+
+  if (!currentUser) {
+    throw new Error("You can't send a message without being logged in");
+  }
+
+  if (conversation?.moderator) {
+    logger("Moderator conversation, ignoring");
+    return;
+  }
+
+  if (currentUser.reviewedByUserId && !currentUser.snoozedUntilContentCount) {
+    logger("User has been fully approved, ignoring");
+    return;
+  }
+
+  const participantIds = conversation?.participantIds ?? [];
+  const previousContacts = currentUser.usersContactedBeforeReview ?? [];
+  const allUsersEverContacted = computeUpdatedUsersContactedBeforeReview({
+    participantIds,
+    currentUserId: currentUser._id,
+    previousContacts,
+  });
+
+  if (!allUsersEverContacted) {
+    logger("No new contacts added, ignoring");
+    return;
+  }
+  logger(
+    "new allUsersEverContacted",
+    allUsersEverContacted,
+    "(length: ",
+    allUsersEverContacted.length,
+    ")"
+  );
+
+  if (allUsersEverContacted.length > MAX_ALLOWED_CONTACTS_BEFORE_FLAG && !currentUser.reviewedAt) {
+    logger("Flagging user");
+    backgroundTask(
+      createModeratorAction(
+        {
+          data: {
+            userId: currentUser._id,
+            type: FLAGGED_FOR_N_DMS,
+          },
+        },
+        context
+      )
+    );
+  }
+
+  backgroundTask(
+    updateUser(
+      {
+        data: {
+          usersContactedBeforeReview: allUsersEverContacted,
+        },
+        selector: { _id: currentUser._id },
+      },
+      createAnonymousContext()
+    )
+  );
+
+  if (allUsersEverContacted.length > getMaxAllowedContactsBeforeBlock() && !currentUser.reviewedAt) {
+    logger("Blocking user");
+    throw new Error(
+      `You cannot message more than ${getMaxAllowedContactsBeforeBlock()} users before your account has been reviewed. Please contact us if you'd like to message more people.`
+    );
+  }
+
+  logger("flagOrBlockUserOnManyDMs() return");
+}

--- a/packages/lesswrong/unitTests/dmMessagingModeration.tests.ts
+++ b/packages/lesswrong/unitTests/dmMessagingModeration.tests.ts
@@ -1,0 +1,33 @@
+import { computeUpdatedUsersContactedBeforeReview } from "@/server/utils/dmMessagingModeration";
+
+describe("computeUpdatedUsersContactedBeforeReview", () => {
+  it("returns null when no other participants exist", () => {
+    const result = computeUpdatedUsersContactedBeforeReview({
+      participantIds: ["userA"],
+      currentUserId: "userA",
+      previousContacts: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("collects new participants that have not been contacted yet", () => {
+    const result = computeUpdatedUsersContactedBeforeReview({
+      participantIds: ["userA", "userB", "userC"],
+      currentUserId: "userA",
+      previousContacts: [],
+    });
+
+    expect(result).toEqual(["userB", "userC"]);
+  });
+
+  it("ignores duplicates and already-contacted users", () => {
+    const result = computeUpdatedUsersContactedBeforeReview({
+      participantIds: ["userA", "userB", "userC", "userC"],
+      currentUserId: "userA",
+      previousContacts: ["userB"],
+    });
+
+    expect(result).toEqual(["userB", "userC"]);
+  });
+});


### PR DESCRIPTION
Refactor DM moderation to count contacts only upon message sending, preventing autoflags for empty conversations.

The previous moderation logic incremented the pre-review contact counter when a conversation was created, leading to false positives when users opened a DM composer but didn't send a message. This change moves the contact counting to the message creation flow and explicitly ignores moderator conversations.

---
[Slack Thread](https://lworg.slack.com/archives/CJUN2UAFN/p1771549820855569?thread_ts=1771549820.855569&cid=CJUN2UAFN)

<p><a href="https://cursor.com/agents?id=bc-667cb65e-fd54-5bb8-b8ee-d27daad8ddc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-667cb65e-fd54-5bb8-b8ee-d27daad8ddc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213369051062822) by [Unito](https://www.unito.io)
