### PR TITLE
update queries and add indexes to improve /moderation page performance

### DIFF
--- a/app/moderation/page.tsx
+++ b/app/moderation/page.tsx
@@ -315,8 +315,7 @@ async function fetchModeratorPosts(db: SqlClient) {
 }
 
 async function fetchActiveRateLimits(db: SqlClient, limit: number, offset: number, showExpiredRateLimits: boolean, showNewUserRateLimits: boolean) {
-  const [activeRateLimitsData, activeRateLimitsCountResult] = await Promise.all([
-    db.manyOrNone<RateLimitRow>(`
+  const activeRateLimitsQuery = `
       WITH latest_events AS (
         SELECT DISTINCT ON (e."userId", e.properties->>'rateLimitType', e.properties->>'actionType')
           e."userId",
@@ -359,24 +358,52 @@ async function fetchActiveRateLimits(db: SqlClient, limit: number, offset: numbe
           ) as "rateLimits"
         FROM filtered_limits fl
         GROUP BY fl."userId"
+      ),
+      users_with_profile AS (
+        SELECT
+          uwl."userId",
+          uwl."rateLimits",
+          uwl."mostRecentActivation",
+          u._id as "user__id",
+          u."displayName" as "user_displayName",
+          u.slug as "user_slug",
+          u."createdAt" as "user_createdAt",
+          u.karma as "user_karma",
+          u."postCount" as "user_postCount",
+          u."commentCount" as "user_commentCount"
+        FROM users_with_limits uwl
+        LEFT JOIN "Users" u ON uwl."userId" = u._id
+      ),
+      eligible_users AS (
+        SELECT
+          uwp.*
+        FROM users_with_profile uwp
+        WHERE $3 OR COALESCE(uwp."user_postCount", 0) + COALESCE(uwp."user_commentCount", 0) >= 5
+      ),
+      paginated_users AS (
+        SELECT
+          eu.*
+        FROM eligible_users eu
+        ORDER BY eu."mostRecentActivation" DESC
+        LIMIT $1 OFFSET $2
       )
       SELECT
         uwl."userId",
         uwl."rateLimits"::text as "rateLimits",
         uwl."mostRecentActivation",
-        u._id as "user__id",
-        u."displayName" as "user_displayName",
-        u.slug as "user_slug",
-        u."createdAt" as "user_createdAt",
-        u.karma as "user_karma",
-        u."postCount" as "user_postCount",
-        u."commentCount" as "user_commentCount"
-      FROM users_with_limits uwl
-      LEFT JOIN "Users" u ON uwl."userId" = u._id
-      ${!showNewUserRateLimits ? `WHERE COALESCE(u."postCount", 0) + COALESCE(u."commentCount", 0) >= 5` : ''}
+        uwl."user__id",
+        uwl."user_displayName",
+        uwl."user_slug",
+        uwl."user_createdAt",
+        uwl."user_karma",
+        uwl."user_postCount",
+        uwl."user_commentCount"
+      FROM paginated_users uwl
       ORDER BY uwl."mostRecentActivation" DESC
-      LIMIT $1 OFFSET $2
-    `, [limit, offset]),
+    `;
+
+  const [activeRateLimitsData, activeRateLimitsCountResult] = await Promise.all([
+    db.manyOrNone<RateLimitRow>(activeRateLimitsQuery, [limit, offset, showNewUserRateLimits]),
     db.one<{count: number}>(`
       WITH latest_events AS (
         SELECT DISTINCT ON (e."userId", e.properties->>'rateLimitType', e.properties->>'actionType')
@@ -427,19 +454,26 @@ async function fetchActiveRateLimits(db: SqlClient, limit: number, offset: numbe
 async function fetchDeletedComments(db: SqlClient, limit: number, offset: number) {
   const [deletedCommentsData, deletedCommentsCountResult] = await Promise.all([
     db.manyOrNone<DeletedCommentRow>(`
+      WITH paginated_comments AS (
+        SELECT
+          c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
+          c."deletedPublic", c.contents, c."deletedByUserId"
+        FROM "Comments" c
+        WHERE c.deleted = TRUE AND c."deletedPublic" = TRUE
+        ORDER BY c."deletedDate" DESC NULLS LAST
+        LIMIT $1 OFFSET $2
+      )
       SELECT
         c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
         c."deletedPublic", c.contents,
         u._id as "user__id", u."displayName" as "user_displayName", u.slug as "user_slug",
         du._id as "deletedByUser__id", du."displayName" as "deletedByUser_displayName", du.slug as "deletedByUser_slug",
         p._id as "post__id", p.title as "post_title", p.slug as "post_slug"
-      FROM "Comments" c
+      FROM paginated_comments c
       LEFT JOIN "Users" u ON c."userId" = u._id
       LEFT JOIN "Users" du ON c."deletedByUserId" = du._id
       LEFT JOIN "Posts" p ON c."postId" = p._id
-      WHERE c.deleted = TRUE AND c."deletedPublic" = TRUE
       ORDER BY c."deletedDate" DESC NULLS LAST
-      LIMIT $1 OFFSET $2
     `, [limit, offset]),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
@@ -467,16 +501,22 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
 async function fetchRejectedPosts(db: SqlClient, limit: number, offset: number) {
   const [rejectedPostsData, rejectedPostsCountResult] = await Promise.all([
     db.manyOrNone<RejectedPostRow>(`
+      WITH paginated_posts AS (
+        SELECT
+          p._id, p.title, p.slug, p."userId", p."postedAt", p."rejectedReason", p."reviewedByUserId"
+        FROM "Posts" p
+        WHERE p.rejected = TRUE
+        ORDER BY p."postedAt" DESC NULLS LAST
+        LIMIT $1 OFFSET $2
+      )
       SELECT
         p._id, p.title, p.slug, p."userId", p."postedAt", p."rejectedReason",
         u._id as "user__id", u."displayName" as "user_displayName", u.slug as "user_slug",
         ru._id as "reviewedByUser__id", ru."displayName" as "reviewedByUser_displayName", ru.slug as "reviewedByUser_slug"
-      FROM "Posts" p
+      FROM paginated_posts p
       LEFT JOIN "Users" u ON p."userId" = u._id
       LEFT JOIN "Users" ru ON p."reviewedByUserId" = ru._id
-      WHERE p.rejected = TRUE
       ORDER BY p."postedAt" DESC NULLS LAST
-      LIMIT $1 OFFSET $2
     `, [limit, offset]),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
@@ -502,18 +542,24 @@ async function fetchRejectedPosts(db: SqlClient, limit: number, offset: number) 
 async function fetchRejectedComments(db: SqlClient, limit: number, offset: number) {
   const [rejectedCommentsData, rejectedCommentsCountResult] = await Promise.all([
     db.manyOrNone<RejectedCommentRow>(`
+      WITH paginated_comments AS (
+        SELECT
+          c._id, c."userId", c."postId", c."postedAt", c."rejectedReason", c.contents, c."reviewedByUserId"
+        FROM "Comments" c
+        WHERE c.rejected = TRUE
+        ORDER BY c."postedAt" DESC NULLS LAST
+        LIMIT $1 OFFSET $2
+      )
       SELECT
         c._id, c."userId", c."postId", c."postedAt", c."rejectedReason", c.contents,
         u._id as "user__id", u."displayName" as "user_displayName", u.slug as "user_slug",
         ru._id as "reviewedByUser__id", ru."displayName" as "reviewedByUser_displayName", ru.slug as "reviewedByUser_slug",
         p._id as "post__id", p.title as "post_title", p.slug as "post_slug"
-      FROM "Comments" c
+      FROM paginated_comments c
       LEFT JOIN "Users" u ON c."userId" = u._id
       LEFT JOIN "Users" ru ON c."reviewedByUserId" = ru._id
       LEFT JOIN "Posts" p ON c."postId" = p._id
-      WHERE c.rejected = TRUE
       ORDER BY c."postedAt" DESC NULLS LAST
-      LIMIT $1 OFFSET $2
     `, [limit, offset]),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
@@ -540,6 +586,14 @@ async function fetchRejectedComments(db: SqlClient, limit: number, offset: numbe
 async function fetchPostsWithBannedUsers(db: SqlClient, limit: number, offset: number) {
   const [postsWithBannedUsersData, postsWithBannedUsersCountResult] = await Promise.all([
     db.manyOrNone<PostWithBannedUsersRow>(`
+      WITH paginated_posts AS (
+        SELECT
+          p._id, p.title, p.slug, p."userId", p."createdAt", p."bannedUserIds"
+        FROM "Posts" p
+        WHERE p."bannedUserIds" IS NOT NULL AND array_length(p."bannedUserIds", 1) > 0
+        ORDER BY p."createdAt" DESC
+        LIMIT $1 OFFSET $2
+      )
       SELECT
         p._id, p.title, p.slug, p."userId", p."createdAt", p."bannedUserIds",
         u._id as "user__id", u."displayName" as "user_displayName", u.slug as "user_slug",
@@ -548,11 +602,9 @@ async function fetchPostsWithBannedUsers(db: SqlClient, limit: number, offset: n
           FROM unnest(p."bannedUserIds") AS banned_id
           JOIN "Users" bu ON bu._id = banned_id
         ) as "bannedUsers"
-      FROM "Posts" p
+      FROM paginated_posts p
       LEFT JOIN "Users" u ON p."userId" = u._id
-      WHERE p."bannedUserIds" IS NOT NULL AND array_length(p."bannedUserIds", 1) > 0
       ORDER BY p."createdAt" DESC
-      LIMIT $1 OFFSET $2
     `, [limit, offset]),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
@@ -577,6 +629,15 @@ async function fetchPostsWithBannedUsers(db: SqlClient, limit: number, offset: n
 async function fetchUsersWithBannedUsers(db: SqlClient, limit: number, offset: number) {
   const [usersWithBannedUsersData, usersWithBannedUsersCountResult] = await Promise.all([
     db.manyOrNone<UserWithBannedUsersRow>(`
+      WITH paginated_users AS (
+        SELECT
+          u._id, u."displayName", u.slug, u."bannedUserIds", u."bannedPersonalUserIds", u."createdAt"
+        FROM "Users" u
+        WHERE (u."bannedUserIds" IS NOT NULL AND array_length(u."bannedUserIds", 1) > 0)
+           OR (u."bannedPersonalUserIds" IS NOT NULL AND array_length(u."bannedPersonalUserIds", 1) > 0)
+        ORDER BY u."createdAt" DESC
+        LIMIT $1 OFFSET $2
+      )
       SELECT
         u._id, u."displayName", u.slug, u."bannedUserIds", u."bannedPersonalUserIds",
         (
@@ -589,11 +650,8 @@ async function fetchUsersWithBannedUsers(db: SqlClient, limit: number, offset: n
           FROM unnest(u."bannedPersonalUserIds") AS personal_id
           JOIN "Users" bpu ON bpu._id = personal_id
         ) as "bannedPersonalUsers"
-      FROM "Users" u
-      WHERE (u."bannedUserIds" IS NOT NULL AND array_length(u."bannedUserIds", 1) > 0)
-         OR (u."bannedPersonalUserIds" IS NOT NULL AND array_length(u."bannedPersonalUserIds", 1) > 0)
+      FROM paginated_users u
       ORDER BY u."createdAt" DESC
-      LIMIT $1 OFFSET $2
     `, [limit, offset]),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count

--- a/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
@@ -136,5 +136,19 @@ export function getDbIndexesOnComments() {
     WHERE "deleted" IS TRUE;
   `);
 
+  // Speeds up moderation log rejected-comments pagination and avoids explicit sort work.
+  indexSet.addCustomPgIndex(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Comments_rejected_postedAt"
+    ON "Comments" ("postedAt" DESC NULLS LAST)
+    WHERE "rejected" IS TRUE;
+  `);
+
+  // Speeds up moderation log public-deleted-comments pagination with matching filter + sort.
+  indexSet.addCustomPgIndex(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Comments_deletedPublic_deletedDate"
+    ON "Comments" ("deletedDate" DESC NULLS LAST)
+    WHERE "deleted" IS TRUE AND "deletedPublic" IS TRUE;
+  `);
+
   return indexSet;
 }

--- a/packages/lesswrong/server/databaseIndexes/postsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/postsDbIndexes.ts
@@ -306,5 +306,12 @@ export function getDbIndexesOnPosts() {
 
   indexSet.addIndex("Posts", { coauthorUserIds: 1 });
 
+  // Speeds up moderation log rejected-posts pagination with matching filter + sort.
+  indexSet.addCustomPgIndex(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Posts_rejected_postedAt"
+    ON "Posts" ("postedAt" DESC NULLS LAST)
+    WHERE "rejected" IS TRUE;
+  `);
+
   return indexSet;
 }

--- a/packages/lesswrong/server/databaseIndexes/usersDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/usersDbIndexes.ts
@@ -85,6 +85,14 @@ export function getDbIndexesOnUsers() {
   indexSet.addIndex("Users", { afSubmittedApplication:1, reviewForAlignmentForumUserId:1, groups:1, createdAt:1 });
   indexSet.addIndex("Users", {nearbyEventsNotificationsMongoLocation: "2dsphere"}, {name: "users.nearbyEventsNotifications"})
 
+
+  // Speeds up moderation log globally banned users list ordering and filtering.
+  indexSet.addCustomPgIndex(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_Users_banned_karma"
+    ON "Users" ("karma" DESC NULLS LAST, "banned")
+    WHERE "banned" IS NOT NULL;
+  `);
+
   return mergeDatabaseIndexSets([ 
     indexSet,
     getFacetFieldIndexes(),

--- a/packages/lesswrong/server/migrations/20260220T211734.moderationLogIndexOptimizations.ts
+++ b/packages/lesswrong/server/migrations/20260220T211734.moderationLogIndexOptimizations.ts
@@ -1,0 +1,9 @@
+import { queueMigrationTask } from "./meta/migrationTaskQueue";
+import { updateCustomIndexes } from "./meta/utils";
+
+export const up = async ({ dbOutsideTransaction }: MigrationContext) => {
+  queueMigrationTask(() => updateCustomIndexes(dbOutsideTransaction));
+};
+
+export const down = async (_: MigrationContext) => {
+};

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -3552,6 +3552,17 @@ CREATE INDEX IF NOT EXISTS "idx_Comments_deletedDate" ON "Comments" ("deletedDat
 WHERE
   "deleted" IS TRUE;
 
+-- CustomIndex "idx_Comments_rejected_postedAt"
+CREATE INDEX IF NOT EXISTS "idx_Comments_rejected_postedAt" ON "Comments" ("postedAt" DESC NULLS LAST)
+WHERE
+  "rejected" IS TRUE;
+
+-- CustomIndex "idx_Comments_deletedPublic_deletedDate"
+CREATE INDEX IF NOT EXISTS "idx_Comments_deletedPublic_deletedDate" ON "Comments" ("deletedDate" DESC NULLS LAST)
+WHERE
+  "deleted" IS TRUE AND
+  "deletedPublic" IS TRUE;
+
 -- CustomIndex "idx_posts_pingbacks"
 CREATE INDEX IF NOT EXISTS idx_posts_pingbacks ON "Posts" USING gin (pingbacks);
 
@@ -3564,6 +3575,11 @@ CREATE INDEX IF NOT EXISTS "idx_Posts_max_postedAt_mostRecentPublishedDialogueRe
 )
 WHERE
   "collabEditorDialogue" IS TRUE;
+
+-- CustomIndex "idx_Posts_rejected_postedAt"
+CREATE INDEX IF NOT EXISTS "idx_Posts_rejected_postedAt" ON "Posts" ("postedAt" DESC NULLS LAST)
+WHERE
+  "rejected" IS TRUE;
 
 -- CustomIndex "idx_tags_pingbacks"
 CREATE INDEX IF NOT EXISTS idx_tags_pingbacks ON "Tags" USING gin (pingbacks);
@@ -3613,6 +3629,11 @@ WHERE
   "unsubscribeFromAll" IS NOT TRUE AND
   "deleted" IS NOT TRUE AND
   "email" IS NOT NULL;
+
+-- CustomIndex "idx_Users_banned_karma"
+CREATE INDEX IF NOT EXISTS "idx_Users_banned_karma" ON "Users" ("karma" DESC NULLS LAST, "banned")
+WHERE
+  "banned" IS NOT NULL;
 
 -- CustomIndex "idx_Users_tsvector_jobTitle"
 CREATE INDEX IF NOT EXISTS "idx_Users_tsvector_jobTitle" ON "Users" (TO_TSVECTOR('english', "jobTitle"))


### PR DESCRIPTION
Improve `/moderation` page query performance by refactoring various queries to ensure they do late-row-lookups; as-is they were joining early and causing way more page reads than necessary.  Also adds some very narrow partial indexes.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213327617018282) by [Unito](https://www.unito.io)
