### PR TITLE
stop dropping display equation containers

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -208,11 +208,15 @@ export function renderMathInHtml(html: string): string {
     // RSS feeds, external scrapers, etc. (same rationale as the old
     // trimLatexAndAddCSS callback used with mathjax-node-page).
     const $ = cheerioParse(renderedHtml);
-    // Parity with old trimLatexAndAddCSS(): drop empty display equations.
-    // These can occasionally arise from malformed/empty TeX blocks.
+    // Drop only truly empty display equations.
+    // In MathJax v3, valid display equations can have empty text() while still
+    // containing rendered child nodes (<mjx-math>...), so text().trim()===""
+    // alone is not a safe emptiness check.
     $('mjx-container[display="true"]').each((_, elem) => {
       const node = $(elem);
-      if (node.text().trim() === '') {
+      const hasRenderedChildren = node.children().length > 0;
+      const hasMeaningfulText = node.text().trim() !== '';
+      if (!hasRenderedChildren && !hasMeaningfulText) {
         node.remove();
       }
     });


### PR DESCRIPTION
Fixing an oopsie introduced in https://github.com/ForumMagnum/ForumMagnum/commit/b02c15d3830cd1e147c4f922c0408c20f07fbb05 where we started dropping all "display" latex because of the new MathJax 3 output format.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213383989638239) by [Unito](https://www.unito.io)
