### PR TITLE
Karma change notifier bugfixes

### DIFF
--- a/packages/lesswrong/components/users/karmaChanges/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/karmaChanges/KarmaChangeNotifier.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import { useUpdateCurrentUser } from '../../hooks/useUpdateCurrentUser';
 import { Paper }from '@/components/widgets/Paper';
 import IconButton from '@/lib/vendor/@material-ui/core/src/IconButton';
 import { Badge } from "@/components/widgets/Badge";
@@ -20,6 +19,7 @@ import LWPopper from '../../common/LWPopper';
 import DeferRender from '@/components/common/DeferRender';
 import { useLocation } from '@/lib/routeUtil';
 import { canonicalizePath } from '@/lib/generated/routeManifest';
+import { useMutationNoCache } from '@/lib/crud/useMutationNoCache';
 
 const UserKarmaChangesQuery = gql(`
   query KarmaChangeNotifier($documentId: String) {
@@ -31,12 +31,18 @@ const UserKarmaChangesQuery = gql(`
   }
 `);
 
+const KarmaChangesCheckedMutation = gql(`
+  mutation karmaChangesCheckedKarmaChangeNotifier($startDate: Date, $endDate: Date) {
+    karmaChangesChecked(startDate: $startDate, endDate: $endDate)
+  }
+`);
+
 const KarmaChangeNotifierLoaded = ({className}: {
   className?: string,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser()!;
-  const updateCurrentUser = useUpdateCurrentUser();
+  const [karmaChangesChecked] = useMutationNoCache(KarmaChangesCheckedMutation);
   const [cleared,setCleared] = useState(false);
   const [open, setOpen] = useState(false);
   const anchorEl = useRef<HTMLDivElement|null>(null)
@@ -59,9 +65,11 @@ const KarmaChangeNotifierLoaded = ({className}: {
     setOpen(false);
     if (!currentUser) return;
     if (document?.karmaChanges) {
-      void updateCurrentUser({
-        ...(document.karmaChanges.endDate && { karmaChangeLastOpened: new Date(document.karmaChanges.endDate) }),
-        ...(document.karmaChanges.startDate && { karmaChangeBatchStart: new Date(document.karmaChanges.startDate) })
+      void karmaChangesChecked({
+        variables: {
+          startDate: document.karmaChanges.startDate,
+          endDate: document.karmaChanges.endDate,
+        },
       });
 
       if (document.karmaChanges.updateFrequency === "realtime") {

--- a/packages/lesswrong/lib/generated/gql-codegen/gql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/gql.ts
@@ -679,6 +679,7 @@ type Documents = {
     "\n  mutation updateUserUsersEditForm($selector: SelectorInput!, $data: UpdateUserDataInput!) {\n    updateUser(selector: $selector, data: $data) {\n      data {\n        ...UsersEdit\n      }\n    }\n  }\n": typeof types.updateUserUsersEditFormDocument,
     "\n  query UsersEditFormGetUserBySlug($slug: String!) {\n    GetUserBySlug(slug: $slug) {\n      ...UsersEdit\n    }\n  }\n": typeof types.UsersEditFormGetUserBySlugDocument,
     "\n  query KarmaChangeNotifier($documentId: String) {\n    user(input: { selector: { documentId: $documentId } }) {\n      result {\n        ...UserKarmaChanges\n      }\n    }\n  }\n": typeof types.KarmaChangeNotifierDocument,
+    "\n  mutation karmaChangesCheckedKarmaChangeNotifier($startDate: Date, $endDate: Date) {\n    karmaChangesChecked(startDate: $startDate, endDate: $endDate)\n  }\n": typeof types.karmaChangesCheckedKarmaChangeNotifierDocument,
     "\n  query SubscribedUser($documentId: String!) {\n    user(input: { selector: { _id: $documentId } }) {\n      result {\n        ...UsersMinimumInfo\n      }\n    }\n  }\n": typeof types.SubscribedUserDocument,
     "\n  query SubscribedPost($documentId: String!) {\n    post(input: { selector: { _id: $documentId } }) {\n      result {\n        ...PostsList\n      }\n    }\n  }\n": typeof types.SubscribedPostDocument,
     "\n  query SubscribedComment($documentId: String!) {\n    comment(input: { selector: { _id: $documentId } }) {\n      result {\n        ...CommentsListWithParentMetadata\n      }\n    }\n  }\n": typeof types.SubscribedCommentDocument,
@@ -1628,6 +1629,7 @@ const documents: Documents = {
     "\n  mutation updateUserUsersEditForm($selector: SelectorInput!, $data: UpdateUserDataInput!) {\n    updateUser(selector: $selector, data: $data) {\n      data {\n        ...UsersEdit\n      }\n    }\n  }\n": types.updateUserUsersEditFormDocument,
     "\n  query UsersEditFormGetUserBySlug($slug: String!) {\n    GetUserBySlug(slug: $slug) {\n      ...UsersEdit\n    }\n  }\n": types.UsersEditFormGetUserBySlugDocument,
     "\n  query KarmaChangeNotifier($documentId: String) {\n    user(input: { selector: { documentId: $documentId } }) {\n      result {\n        ...UserKarmaChanges\n      }\n    }\n  }\n": types.KarmaChangeNotifierDocument,
+    "\n  mutation karmaChangesCheckedKarmaChangeNotifier($startDate: Date, $endDate: Date) {\n    karmaChangesChecked(startDate: $startDate, endDate: $endDate)\n  }\n": types.karmaChangesCheckedKarmaChangeNotifierDocument,
     "\n  query SubscribedUser($documentId: String!) {\n    user(input: { selector: { _id: $documentId } }) {\n      result {\n        ...UsersMinimumInfo\n      }\n    }\n  }\n": types.SubscribedUserDocument,
     "\n  query SubscribedPost($documentId: String!) {\n    post(input: { selector: { _id: $documentId } }) {\n      result {\n        ...PostsList\n      }\n    }\n  }\n": types.SubscribedPostDocument,
     "\n  query SubscribedComment($documentId: String!) {\n    comment(input: { selector: { _id: $documentId } }) {\n      result {\n        ...CommentsListWithParentMetadata\n      }\n    }\n  }\n": types.SubscribedCommentDocument,
@@ -4586,6 +4588,10 @@ export function gql(source: "\n  query UsersEditFormGetUserBySlug($slug: String!
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(source: "\n  query KarmaChangeNotifier($documentId: String) {\n    user(input: { selector: { documentId: $documentId } }) {\n      result {\n        ...UserKarmaChanges\n      }\n    }\n  }\n"): (typeof documents)["\n  query KarmaChangeNotifier($documentId: String) {\n    user(input: { selector: { documentId: $documentId } }) {\n      result {\n        ...UserKarmaChanges\n      }\n    }\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  mutation karmaChangesCheckedKarmaChangeNotifier($startDate: Date, $endDate: Date) {\n    karmaChangesChecked(startDate: $startDate, endDate: $endDate)\n  }\n"): (typeof documents)["\n  mutation karmaChangesCheckedKarmaChangeNotifier($startDate: Date, $endDate: Date) {\n    karmaChangesChecked(startDate: $startDate, endDate: $endDate)\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -4466,6 +4466,7 @@ export type Mutation = {
   importUrlAsDraftPost: ExternalPostImportData;
   increasePostViewCount: Maybe<Scalars['Float']['output']>;
   initiateConversation: Maybe<Conversation>;
+  karmaChangesChecked: Scalars['Boolean']['output'];
   lockThread: Scalars['Boolean']['output'];
   login: Maybe<LoginReturnData>;
   logout: Maybe<LoginReturnData>;
@@ -4971,6 +4972,12 @@ export type MutationinitiateConversationArgs = {
   af?: InputMaybe<Scalars['Boolean']['input']>;
   moderator?: InputMaybe<Scalars['Boolean']['input']>;
   participantIds: Array<Scalars['String']['input']>;
+};
+
+
+export type MutationkarmaChangesCheckedArgs = {
+  endDate?: InputMaybe<Scalars['Date']['input']>;
+  startDate?: InputMaybe<Scalars['Date']['input']>;
 };
 
 
@@ -20471,6 +20478,14 @@ export type KarmaChangeNotifierQuery = { __typename?: 'Query', user: { __typenam
       & UserKarmaChanges
     ) | null } | null };
 
+export type karmaChangesCheckedKarmaChangeNotifierMutationVariables = Exact<{
+  startDate?: InputMaybe<Scalars['Date']['input']>;
+  endDate?: InputMaybe<Scalars['Date']['input']>;
+}>;
+
+
+export type karmaChangesCheckedKarmaChangeNotifierMutation = { __typename?: 'Mutation', karmaChangesChecked: boolean };
+
 export type SubscribedUserQueryVariables = Exact<{
   documentId: Scalars['String']['input'];
 }>;
@@ -23253,6 +23268,7 @@ export const importUrlAsDraftPostDocument = {"kind":"Document","definitions":[{"
 export const increasePostViewCountMutationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"increasePostViewCountMutation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"postId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"increasePostViewCount"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"postId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"postId"}}}]}]}}]} as unknown as DocumentNode<increasePostViewCountMutationMutation, increasePostViewCountMutationMutationVariables>;
 export const initiateConversationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"initiateConversation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"participantIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"af"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"moderator"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"initiateConversation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"participantIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"participantIds"}}},{"kind":"Argument","name":{"kind":"Name","value":"af"},"value":{"kind":"Variable","name":{"kind":"Name","value":"af"}}},{"kind":"Argument","name":{"kind":"Name","value":"moderator"},"value":{"kind":"Variable","name":{"kind":"Name","value":"moderator"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ConversationsMinimumInfo"}}]}}]}},ConversationsMinimumInfoFragmentDef]} as unknown as DocumentNode<initiateConversationMutation, initiateConversationMutationVariables>;
 export const isDisplayNameTakenDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"isDisplayNameTaken"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"displayName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"IsDisplayNameTaken"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"displayName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"displayName"}}}]}]}}]} as unknown as DocumentNode<isDisplayNameTakenQuery, isDisplayNameTakenQueryVariables>;
+export const karmaChangesCheckedKarmaChangeNotifierDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"karmaChangesCheckedKarmaChangeNotifier"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Date"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Date"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"karmaChangesChecked"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"startDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"startDate"}}},{"kind":"Argument","name":{"kind":"Name","value":"endDate"},"value":{"kind":"Variable","name":{"kind":"Name","value":"endDate"}}}]}]}}]} as unknown as DocumentNode<karmaChangesCheckedKarmaChangeNotifierMutation, karmaChangesCheckedKarmaChangeNotifierMutationVariables>;
 export const lastEventFragmentDoc = {"kind":"Document","definitions":[lastEventFragmentFragmentDef]} as unknown as DocumentNode<lastEventFragment, unknown>;
 export const latestGoogleDocMetadataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"latestGoogleDocMetadata"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"postId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"version"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"latestGoogleDocMetadata"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"postId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"postId"}}},{"kind":"Argument","name":{"kind":"Name","value":"version"},"value":{"kind":"Variable","name":{"kind":"Name","value":"version"}}}]}]}}]} as unknown as DocumentNode<latestGoogleDocMetadataQuery, latestGoogleDocMetadataQueryVariables>;
 export const launchPetrovMissileDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"launchPetrovMissile"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"launchCode"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"PetrovDayLaunchMissile"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"launchCode"},"value":{"kind":"Variable","name":{"kind":"Name","value":"launchCode"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"launchCode"}}]}}]}}]} as unknown as DocumentNode<launchPetrovMissileMutation, launchPetrovMissileMutationVariables>;

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -259,6 +259,7 @@ extend type Mutation {
   NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!, email: String, acceptedTos: Boolean): NewUserCompletedProfile
   UserExpandFrontpageSection(section: String!, expanded: Boolean!): Boolean
   UserUpdateSubforumMembership(tagId: String!, member: Boolean!): User
+  karmaChangesChecked(startDate: Date, endDate: Date): Boolean!
 }
 
 extend type Query {

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -4463,6 +4463,7 @@ type Mutation = {
   importUrlAsDraftPost: ExternalPostImportData;
   increasePostViewCount?: Maybe<Scalars['Float']['output']>;
   initiateConversation?: Maybe<Conversation>;
+  karmaChangesChecked: Scalars['Boolean']['output'];
   lockThread: Scalars['Boolean']['output'];
   login?: Maybe<LoginReturnData>;
   logout?: Maybe<LoginReturnData>;
@@ -4968,6 +4969,12 @@ type MutationinitiateConversationArgs = {
   af?: InputMaybe<Scalars['Boolean']['input']>;
   moderator?: InputMaybe<Scalars['Boolean']['input']>;
   participantIds: Array<Scalars['String']['input']>;
+};
+
+
+type MutationkarmaChangesCheckedArgs = {
+  endDate?: InputMaybe<Scalars['Date']['input']>;
+  startDate?: InputMaybe<Scalars['Date']['input']>;
 };
 
 
@@ -25064,6 +25071,17 @@ type KarmaChangeNotifierQueryVariables = Exact<{
 
 
 type KarmaChangeNotifierQuery = KarmaChangeNotifierQuery_Query;
+
+type karmaChangesCheckedKarmaChangeNotifierMutation_Mutation = { __typename?: 'Mutation', karmaChangesChecked: boolean };
+
+
+type karmaChangesCheckedKarmaChangeNotifierMutationVariables = Exact<{
+  startDate: InputMaybe<Scalars['Date']['input']>;
+  endDate: InputMaybe<Scalars['Date']['input']>;
+}>;
+
+
+type karmaChangesCheckedKarmaChangeNotifierMutation = karmaChangesCheckedKarmaChangeNotifierMutation_Mutation;
 
 type SubscribedUserQuery_user_SingleUserOutput_result_User = (
   { __typename?: 'User' }

--- a/packages/lesswrong/lib/generated/inputTypes.d.ts
+++ b/packages/lesswrong/lib/generated/inputTypes.d.ts
@@ -226,6 +226,7 @@ interface Mutation {
   NewUserCompleteProfile: NewUserCompletedProfile | null;
   UserExpandFrontpageSection: boolean | null;
   UserUpdateSubforumMembership: User | null;
+  karmaChangesChecked: boolean;
   setVotePost: Post | null;
   performVotePost: VoteResultPost | null;
   setVoteComment: Comment | null;

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -140,6 +140,25 @@ class UsersRepo extends AbstractRepo<"Users"> {
     `, [userId, section, String(expanded)]);
   }
 
+  markKarmaChangesChecked(userId: string, startDate: Date | null | undefined, endDate: Date | null | undefined): Promise<null> {
+    return this.none(`
+      -- UsersRepo.markKarmaChangesChecked
+      UPDATE "Users"
+      SET
+        "karmaChangeBatchStart" = CASE
+          WHEN $2::TIMESTAMPTZ IS NULL THEN "karmaChangeBatchStart"
+          WHEN "karmaChangeBatchStart" IS NULL OR "karmaChangeBatchStart" < $2::TIMESTAMPTZ THEN $2::TIMESTAMPTZ
+          ELSE "karmaChangeBatchStart"
+        END,
+        "karmaChangeLastOpened" = CASE
+          WHEN $3::TIMESTAMPTZ IS NULL THEN "karmaChangeLastOpened"
+          WHEN "karmaChangeLastOpened" IS NULL OR "karmaChangeLastOpened" < $3::TIMESTAMPTZ THEN $3::TIMESTAMPTZ
+          ELSE "karmaChangeLastOpened"
+        END
+      WHERE "_id" = $1
+    `, [userId, startDate ?? null, endDate ?? null]);
+  }
+
   removeAlignmentGroupAndKarma(userId: string, reduceAFKarma: number): Promise<null> {
     return this.none(`
       -- UsersRepo.removeAlignmentGroupAndKarma

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -94,10 +94,11 @@ export const graphqlTypeDefs = gql`
     userReadCount: Int!
   }
 
-  extend type Mutation{
+  extend type Mutation {
     NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!, email: String, acceptedTos: Boolean): NewUserCompletedProfile
     UserExpandFrontpageSection(section: String!, expanded: Boolean!): Boolean
     UserUpdateSubforumMembership(tagId: String!, member: Boolean!): User
+    karmaChangesChecked(startDate: Date, endDate: Date): Boolean!
   }
 
   extend type Query {
@@ -199,6 +200,18 @@ export const graphqlMutations = {
     }, context)
     
     return updatedUser
+  },
+  async karmaChangesChecked(
+    _root: void,
+    {startDate, endDate}: {startDate?: Date | null, endDate?: Date | null},
+    {currentUser, repos}: ResolverContext,
+  ) {
+    if (!currentUser) {
+      throw new Error("You must login to do this");
+    }
+
+    await repos.users.markKarmaChangesChecked(currentUser._id, startDate, endDate);
+    return true;
   },
 }
 


### PR DESCRIPTION
 * Fix the page-header being replaced with an error on route-404 pages

Caused by a subtle hydration-ordering issue involving the interaction of
DeferRender with Suspense, which might be a React bug. The crash goes
away if the Suspense boundary is outside the DeferRender rather than
inside.

 * Fix an issue that could cause double-delivery of karma change notifications

If you check karma-changes on an old tab, you set the last-checked-date
to reflect when karma-changes were loaded into that tab, which means
that if you had checked them on a newer tab the last-checked date will
move backwards, potentially causing double-notification.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213387015742372) by [Unito](https://www.unito.io)
