### PR TITLE
Fix extra semicolon in ProfilePage

### DIFF
--- a/app/users/[slug]/ProfilePage.tsx
+++ b/app/users/[slug]/ProfilePage.tsx
@@ -340,7 +340,7 @@ export default function ProfilePage({slug}: {
 
   return <>
     <StatusCodeSetter status={200}/>
-    <ProfilePageInner user={user} />;
+    <ProfilePageInner user={user} />
   </>
 }
 


### PR DESCRIPTION
<img width="2032" height="673" alt="image" src="https://github.com/user-attachments/assets/1be1c6cb-1f6e-4913-b77f-66f996c225da" />

Found by https://www.lesswrong.com/posts/qRQi9yzji8Ddzbzff/joanna-s-shortform?commentId=bcA62CD4AaPYJvz4p

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213403469119447) by [Unito](https://www.unito.io)
