### PR TITLE
Fix inline side comments rendering at the top of page when inside collapsed sections

### DIFF
--- a/packages/lesswrong/components/contents/SideItems.tsx
+++ b/packages/lesswrong/components/contents/SideItems.tsx
@@ -195,8 +195,25 @@ export const SideItemsSidebar = () => {
     // reflow if layout is invalidated.)
     for (let i=0; i<displayContext.sideItems.length; i++) {
       const sideItem = displayContext.sideItems[i];
-      sideItem.anchorTop = getOffsetChainTop(sideItem.anchorEl) - sidebarColumnTop + sideItem.options.offsetTop;
-      sideItem.anchorLeft = sideItem.anchorEl.offsetLeft;
+      let anchorEl = sideItem.anchorEl;
+
+      // If the anchor is inside hidden content (e.g. a collapsed section with
+      // display:none), offsetParent is null and getOffsetChainTop returns 0,
+      // which would place the side comment at the top of the page. Walk up to
+      // find the nearest visible ancestor so the comment appears next to the
+      // collapsed section instead.
+      if (anchorEl.offsetParent === null && anchorEl !== document.body && anchorEl.isConnected) {
+        let ancestor = anchorEl.parentElement;
+        while (ancestor && ancestor.offsetParent === null && ancestor !== document.body) {
+          ancestor = ancestor.parentElement;
+        }
+        if (ancestor) {
+          anchorEl = ancestor;
+        }
+      }
+
+      sideItem.anchorTop = getOffsetChainTop(anchorEl) - sidebarColumnTop + sideItem.options.offsetTop;
+      sideItem.anchorLeft = anchorEl.offsetLeft;
       sideItem.sideItemHeight = sideItem.options.measuredElement?.current?.clientHeight ?? sideItem.container.clientHeight;
     }
     


### PR DESCRIPTION
(Generated by Claude: https://lworg.slack.com/archives/CJUN2UAFN/p1775628816206499?thread_ts=1775614781.828419&cid=CJUN2UAFN)

When a side comment's anchor text is inside a collapsed (display:none) collapsible section, `offsetParent` is null and `getOffsetChainTop()` returns 0, placing the comment at the top of the page.

Fix: before measuring, detect hidden anchors (offsetParent === null) and walk up the DOM to the nearest visible ancestor. The comment now appears next to the collapsed section header instead of the page top. When the section is expanded, normal positioning resumes via the existing ResizeObserver.

Bug report: https://lworg.slack.com/archives/CJUN2UAFN/p1775614781828419
Preview: https://baserates-test-claude-fix-side-comment-position-in-collapsed-sections.vercel.app

---

This seems like a plausible fix; worth a quick check.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1213985840752050) by [Unito](https://www.unito.io)
