### PR TITLE
Don't collapse posts-item comments when clicking in a reply box

### DIFF
--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -667,7 +667,7 @@ const LWPostsItem = (props: PostsItemConfig) => {
             }}
           />
 
-          {renderComments && <div className={classes.newCommentsSection} onClick={toggleComments}>
+          {renderComments && <div className={classes.newCommentsSection}>
             <PostsItemNewCommentsWrapper
               terms={commentTerms}
               post={post}
@@ -678,7 +678,7 @@ const LWPostsItem = (props: PostsItemConfig) => {
             />
           </div>}
 
-          {renderDialogueMessages && <div className={classes.newCommentsSection} onClick={toggleDialogueMessages}>
+          {renderDialogueMessages && <div className={classes.newCommentsSection}>
             <PostsItemNewDialogueResponses postId={post._id} unreadCount={post.unreadDebateResponseCount} />
           </div>}
         </div>


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214004915600620) by [Unito](https://www.unito.io)
