### PR TITLE
Remove nextjs prefetching that wasn't doing anything except wasting bandwidth

### DIFF
--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -47,7 +47,6 @@ const getLinkPrefetch = (to: string, everHovered: boolean) => {
 }
 
 export const Link = ({eventProps, ...props}: LinkProps) => {
-  const [hovered, setHovered] = useState(false);
   
   const { captureEvent } = useTracking({
     eventType: "linkClicked",
@@ -71,9 +70,7 @@ export const Link = ({eventProps, ...props}: LinkProps) => {
   if (to && typeof to === 'string' && isOffsiteLink(to)) {
     return <a href={to} {...otherProps} onMouseDown={handleClick}/>
   } else {
-    const prefetch = getLinkPrefetch(to, hovered);
-    const propsWithPrefetch = { ...props, prefetch };
-    return <HashLink {...propsWithPrefetch} onMouseDown={handleClick} onMouseEnter={() => setHovered(true)}/>
+    return <HashLink {...props} prefetch={false} onMouseDown={handleClick} />
   }
 }
 


### PR DESCRIPTION
We observed lots of prefetching in browser devtools. Previously, these prefetches were small, containing only a scaffold, but currently (likely ever since we enabled the cacheComponents flag in nextjs), they were as large as the full size of the destination page. Moreover, looking at page-load timings, they appeared to do nothing at all for performance; when clicking on a link, an effectively-identical request to the immediately-preceding prefetch would be made, and nothing would appear on the client until that finished.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214008253023978) by [Unito](https://www.unito.io)
