### PR TITLE
Remove EmojisPlugin from Lexical config

### DIFF
--- a/packages/lesswrong/components/lexical/Editor.tsx
+++ b/packages/lesswrong/components/lexical/Editor.tsx
@@ -67,7 +67,6 @@ import DateTimePlugin from './plugins/DateTimePlugin';
 import DragDropPaste from './plugins/DragDropPastePlugin';
 import DraggableBlockPlugin from './plugins/DraggableBlockPlugin';
 // import EmojiPickerPlugin from './plugins/EmojiPickerPlugin';
-import EmojisPlugin from './plugins/EmojisPlugin';
 import { MathPlugin } from '../editor/lexicalPlugins/math/MathPlugin';
 // import ExcalidrawPlugin from './plugins/ExcalidrawPlugin';
 import FigmaPlugin from './plugins/FigmaPlugin';
@@ -823,7 +822,6 @@ export default function Editor({
         <ComponentPickerPlugin />
         {/* <EmojiPickerPlugin /> */}
         <AutoEmbedPlugin />
-        <EmojisPlugin />
         <HashtagPlugin />
         {/* <KeywordsPlugin /> */}
         {/* <SpeechToTextPlugin /> */}


### PR DESCRIPTION
This plugin came as part of a copy-pasted default config. It converts strings like ":)" into Unicode emojis. Including doing so in code blocks, which, in at least one case, broke an iframe embedded visualization.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214055661985638) by [Unito](https://www.unito.io)
