### PR TITLE
Gracefully handle TagUpdatesInTimeBlock too-wide windows

### DIFF
--- a/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
+++ b/packages/lesswrong/components/tagging/TagEditsTimeBlock.tsx
@@ -19,12 +19,21 @@ const styles = defineStyles('TagEditsTimeBlock', (theme: ThemeType) => ({
   },
 }));
 
+// The server-side TagUpdatesInTimeBlock resolver enforces a one-day cap on
+// the (before - after) window. We mirror that here so we can skip the query
+// entirely if a wider range somehow gets passed in, instead of firing a request
+// the server will just refuse / no-op.
+const MAX_TAG_UPDATES_WINDOW_HOURS = 30;
+
 const TagEditsTimeBlock = ({before, after, reportEmpty}: {
   before: Date,
   after: Date,
   reportEmpty: () => void,
 }) => {
   const classes = useStyles(styles);
+
+  const windowHours = (before.getTime() - after.getTime()) / (60 * 60 * 1000);
+  const windowTooWide = windowHours > MAX_TAG_UPDATES_WINDOW_HOURS;
 
   // TODO: see if we can use a fragment other than TagHistoryFragment to avoid fetching the ToC or other expensive stuff
   const { data, loading } = useQuery(gql(`
@@ -63,15 +72,20 @@ const TagEditsTimeBlock = ({before, after, reportEmpty}: {
       before, after,
     },
     ssr: true,
+    skip: windowTooWide,
   });
-  
+
   useEffect(() => {
-    if (!loading && !data?.TagUpdatesInTimeBlock?.length) {
+    if (windowTooWide || (!loading && !data?.TagUpdatesInTimeBlock?.length)) {
       reportEmpty();
     }
-  }, [loading, data, reportEmpty]);
+  }, [windowTooWide, loading, data, reportEmpty]);
   const [expanded, setExpanded] = useState(false)
-  
+
+  if (windowTooWide) {
+    return null;
+  }
+
   let tagUpdatesInTimeBlock = [...(data?.TagUpdatesInTimeBlock || [])]
     .sort((update1, update2) => {
       if ((update1.added ?? 0) > (update2.added ?? 0)) return -1

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -538,8 +538,17 @@ export const tagResolversGraphQLQueries = {
   async TagUpdatesInTimeBlock(root: void, {before,after}: {before: Date, after: Date}, context: ResolverContext) {
     if (!before) throw new Error("Missing graphql parameter: before");
     if (!after) throw new Error("Missing graphql parameter: after");
-    if(moment.duration(moment(before).diff(after)).as('hours') > 30)
-      throw new Error("TagUpdatesInTimeBlock limited to a one-day interval");
+    // The wikitag-updates section is only meant to render under the daily
+    // grouping on /allPosts (see PostsTimeBlock). If something asks for a
+    // wider window (e.g. weekly/monthly grouping leaking through, or stale
+    // before/after query params), gracefully return [] instead of throwing
+    // a noisy error into Sentry. Reported in #m_bugs-channel:
+    // https://lworg.slack.com/archives/CJUN2UAFN/p1775779693508829
+    if (moment.duration(moment(before).diff(after)).as('hours') > 30) {
+      // eslint-disable-next-line no-console
+      console.warn(`TagUpdatesInTimeBlock called with a window wider than one day (${after.toISOString?.() ?? after} -> ${before.toISOString?.() ?? before}); returning empty result.`);
+      return [];
+    }
     
     const rootCommentsSelector = getRootCommentsInTimeBlockSelector(before, after, context);
 


### PR DESCRIPTION
https://lworg.slack.com/archives/CJUN2UAFN/p1775779693508829

> On the All Posts page there's a "tag updates" section; when grouping
> is set to daily, it shows wikitag edits on that day. When grouping is
> set to weekly/monthly/etc, it tries to load this section, but the
> server-side resolver rejects the query.
>
> I believe we limited it to the daily view for query-performance
> reasons, but we should omit the section/skip the query rather than
> let the query fail and show up in error logs.

The wikitag-updates section is only meant to render under the daily grouping (PostsTimeBlock gates `<TagEditsTimeBlock>` on `timeframe === "daily"`). The server resolver enforces that with a 30-hour window cap and currently throws if asked for a wider range, which produces noisy error reports whenever something slips through (stale before/after query params, SSR prefetch from a different grouping, etc.).

Fixes:
- Server: replace the throw with a `console.warn` + `return []` so spurious calls degrade gracefully instead of polluting Sentry.
- Client: defensively skip the GraphQL query in `TagEditsTimeBlock` when the window is wider than 30 hours, and report-empty so the parent block can hide itself if there's nothing else to show.

Behavior under the normal daily grouping is unchanged.

Preview: https://baserates-test-git-fix-tag-updates-graceful-lesswrong.vercel.app

[Claude, automated]


