### PR TITLE
Fix inconsistent comment date font size across contexts

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -25,6 +25,12 @@ const styles = defineStyles("CommentsItemDate", (theme: ThemeType) => ({
     // narrow/flexbox contexts
     whiteSpace: "nowrap",
 
+    // Pin the font size so the date renders consistently regardless of which
+    // context wraps the comment (post page, /allPosts quick takes, frontpage
+    // quick takes, comment permalink, etc., were inheriting different sizes
+    // from their containers — 13px in some places, 15.08px in others).
+    fontSize: 15.08,
+
     zIndex: theme.zIndexes.commentPermalinkIcon,
     color: theme.palette.text.dim,
   },


### PR DESCRIPTION
The font size of the date field on comments was inconsistent between the Quick Takes section on the front page vs other contexts (quick takes on /allPosts, comments on post pages). Make it consistently 15.08px.

Bug report: https://lworg.slack.com/archives/CJUN2UAFN/p1775778805157719
Preview: https://baserates-test-git-fix-comment-date-font-size-lesswrong.vercel.app
