### PR TITLE
Fix link hover popper dead space on wrapped inline links (preview)

### DIFF
--- a/packages/lesswrong/components/common/withHover.tsx
+++ b/packages/lesswrong/components/common/withHover.tsx
@@ -12,6 +12,74 @@ export interface UseHoverEventHandlers {
 };
 
 /**
+ * A Popper-compatible virtual element that positions a popper relative to one
+ * specific line segment of an inline element, rather than that element's
+ * overall bounding box. Used to avoid dead space when hovering an inline link
+ * whose text wraps across multiple lines: getBoundingClientRect() returns the
+ * rect containing the mouse position when the hover started, so the popper
+ * card is placed directly beneath the hovered line segment instead of below
+ * the combined bounding box of all segments.
+ */
+type LineAnchorVirtualElement = {
+  __lineAnchorTarget: HTMLElement,
+  contextElement: HTMLElement,
+  readonly isConnected: boolean,
+  getBoundingClientRect: () => DOMRect,
+};
+
+const makeLineAnchorVirtualElement = (
+  target: HTMLElement,
+  mouseX: number,
+  mouseY: number,
+): LineAnchorVirtualElement => ({
+  __lineAnchorTarget: target,
+  contextElement: target,
+  get isConnected() { return target.isConnected; },
+  getBoundingClientRect() {
+    // If getClientRects isn't available (very old browsers / jsdom), fall back.
+    if (typeof target.getClientRects !== 'function') {
+      return target.getBoundingClientRect();
+    }
+    const rects = Array.from(target.getClientRects());
+    if (rects.length <= 1) {
+      return rects[0] ?? target.getBoundingClientRect();
+    }
+    // Pick the line segment that actually contained the mouse when the hover
+    // started. This is what the user visually associates the popper with.
+    for (const rect of rects) {
+      if (
+        mouseX >= rect.left && mouseX <= rect.right &&
+        mouseY >= rect.top && mouseY <= rect.bottom
+      ) {
+        return rect;
+      }
+    }
+    // Fallback: nearest segment by vertical distance to the mouse. Matches
+    // the rect the mouse just left if the user moved between lines during
+    // the brief window before the popper opens.
+    let bestRect = rects[0];
+    let bestDistance = Infinity;
+    for (const rect of rects) {
+      const midY = (rect.top + rect.bottom) / 2;
+      const distance = Math.abs(mouseY - midY);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestRect = rect;
+      }
+    }
+    return bestRect;
+  },
+});
+
+const isLineAnchorVirtualElement = (
+  value: unknown,
+): value is LineAnchorVirtualElement => (
+  !!value
+  && typeof value === 'object'
+  && '__lineAnchorTarget' in (value as object)
+);
+
+/**
  * Returns a set of event handlers for implementing a hover effect. Spread
  * eventHandlers into the props of a DOM element; the component that used this
  * hook will rerender whenever that element is hovered or unhovered.
@@ -36,17 +104,26 @@ export const useHover = (options?: {
    * passing getIsEnabled={() => !isMobile()}.
    */
   disabledOnMobile?: boolean,
+  /**
+   * If true, the returned anchorEl is a Popper virtual element that positions
+   * the popper against the specific text-line segment of the hovered element
+   * that contains the mouse. Use this for hover popovers on inline links: if
+   * the link text wraps across lines, the popper will appear beneath the
+   * actually-hovered line rather than beneath the overall bounding box (which
+   * leaves unreachable dead space between the first line and the popper card).
+   */
+  useLineAnchor?: boolean,
 }): {
   eventHandlers: UseHoverEventHandlers,
   hover: boolean,
   everHovered: boolean,
-  anchorEl: HTMLElement | null,
+  anchorEl: HTMLElement | LineAnchorVirtualElement | null,
   forceUnHover: () => void,
 } => {
-  const {eventProps, onEnter, onLeave, disabledOnMobile, getIsEnabled} = options ?? {};
+  const {eventProps, onEnter, onLeave, disabledOnMobile, getIsEnabled, useLineAnchor} = options ?? {};
   const [hover, setHover] = useState(false)
   const [everHovered, setEverHovered] = useState(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | LineAnchorVirtualElement | null>(null)
   const delayTimer = useRef<any>(null)
   const mouseOverStart = useRef<Date|null>(null)
 
@@ -89,11 +166,26 @@ export const useHover = (options?: {
       return true;
     });
     setEverHovered(true);
-    setAnchorEl(event.currentTarget as HTMLElement);
+    const target = event.currentTarget as HTMLElement;
+    if (useLineAnchor) {
+      const mouseX = (event as React.MouseEvent).clientX;
+      const mouseY = (event as React.MouseEvent).clientY;
+      setAnchorEl((prev) => {
+        // Keep the existing virtual element stable if we're still hovering the
+        // same target. mouseOver can retrigger when moving between child
+        // elements, and we don't want the popper to jitter between lines.
+        if (isLineAnchorVirtualElement(prev) && prev.__lineAnchorTarget === target) {
+          return prev;
+        }
+        return makeLineAnchorVirtualElement(target, mouseX, mouseY);
+      });
+    } else {
+      setAnchorEl(target);
+    }
     mouseOverStart.current = new Date()
     clearTimeout(delayTimer.current)
     delayTimer.current = setTimeout(captureHoverEvent,500)
-  }, [captureHoverEvent, onEnter, disabledOnMobile, getIsEnabled])
+  }, [captureHoverEvent, onEnter, disabledOnMobile, getIsEnabled, useLineAnchor])
 
   const handleMouseLeave = useCallback(() => {
     setHover((currentValue) => {

--- a/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
@@ -216,6 +216,7 @@ export const CrossSiteLinkPreview = ({
       href,
       onsite: false,
     },
+    useLineAnchor: true,
   });
 
   const queryResult = useQuery(CrossSiteLinkPreviewQuery, {

--- a/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
+++ b/packages/lesswrong/components/linkPreview/FootnotePreview.tsx
@@ -165,6 +165,7 @@ const FootnotePreview = ({href, id, rel, contentStyleType="postHighlight", child
     getIsEnabled: () => {
       return !isMobile() && window.innerWidth >= minScreenWidthForTooltips;
     },
+    useLineAnchor: true,
   });
   const { eventHandlers: sidenoteEventHandlers, hover: sidenoteHovered } = useHover();
   const eitherHovered = anchorHovered || sidenoteHovered;

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -463,6 +463,7 @@ export const DefaultPreview = ({href, onsite=false, id, rel, className, children
       href,
       onsite,
     },
+    useLineAnchor: true,
   });
   return (
     <span {...eventHandlers}>
@@ -492,7 +493,7 @@ export const OWIDPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
   const [match] = href.match(/^http(?:s?):\/\/ourworldindata\.org\/grapher\/.*/) || []
 
   if (!match) {
@@ -524,7 +525,7 @@ export const MetaculusPreview = ({href, id, className, children}: {
 }) => {
   const classes = useStyles(linkStyles);
 
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
   const [match, www, questionNumber] = href.match(/^http(?:s?):\/\/(www\.)?metaculus\.com\/questions\/(\d+)/) || []
 
   if (!questionNumber) {
@@ -556,7 +557,7 @@ export const FatebookPreview = ({href, id, className, children}: {
 }) => {
   const classes = useStyles(linkStyles);
   
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   const isEmbed = /^https?:\/\/fatebook\.io\/embed\/q\/[\w-]+$/.test(href);
 
@@ -594,7 +595,7 @@ export const ManifoldPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   // test if fits https://manifold.markets/embed/[...]
   const isEmbed = /^https?:\/\/manifold\.markets\/embed\/.+$/.test(href);
@@ -634,7 +635,7 @@ export const NeuronpediaPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   // test if it's already an embed url https://[www.]neuronpedia.org/[model]/[layer]/[index]?embed=true[...]
   const isEmbed = /https:\/\/(www\.)?neuronpedia\.org\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/\d+\?embed=true/.test(href);
@@ -675,7 +676,7 @@ export const MetaforecastPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   // test if fits https://metaforecast.org/questions/embed/[...]
   const isEmbed = /^https?:\/\/metaforecast\.org\/questions\/embed\/.+$/.test(href);
@@ -744,7 +745,7 @@ export const ArbitalPreview = ({href, id, className, children}: {
   const classes = useStyles(arbitalStyles);
   const linkClasses = useStyles(linkStyles);
 
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
   const [match, www, arbitalSlug] = href.match(/^http(?:s?):\/\/(www\.)?arbital\.com\/p\/([a-zA-Z0-9_]+)+/) || []
 
   const { data: rawData, loading } = useQuery(gql(`
@@ -796,7 +797,7 @@ export const EstimakerPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   // test if fits https://estimaker.app/_/$user/$slug
   const isEmbed = /^https?:\/\/estimaker\.app\/_\/.+$/.test(href);
@@ -830,7 +831,7 @@ export const ViewpointsPreview = ({href, id, className, children}: {
   children: ReactNode,
 }) => {
   const classes = useStyles(linkStyles);
-  const { anchorEl, hover, eventHandlers } = useHover();
+  const { anchorEl, hover, eventHandlers } = useHover({ useLineAnchor: true });
 
   // test if fits https://viewpoints.xyz/embed/polls/$slug
   const isEmbed = /^https?:\/\/viewpoints\.xyz\/embed\/polls\/.+$/.test(href);


### PR DESCRIPTION
Bugs-channel prompt:
> When hovering over a link (I think all link types), the popper is positioned bottom-start relative to the bounding box of the link text. If the link text is on a wrapped line, that means that if your mouse is over the pre-wrap segment, you can't move it onto the card to click on things inside the card, without passing over dead space that'll close the hover.
> 
> I think the ideal behavior here would be for it to use a slightly more sophisticated browser API to get a list of segment bounding boxes, rather than a single bounding box, and position the popper relative to the one that's actually hovered.

Claude:
> When an inline link wraps across multiple lines, hovering it used to place the hover card below the link's overall getBoundingClientRect(), which spans all line segments. If the mouse was hovering a pre-wrap segment (i.e. the first line), there was unreachable dead space between that line and the popper card -- moving the mouse toward the card passed through that space and closed the hover.
> 
> Fix: add a `useLineAnchor` option to `useHover` that, on mouseOver, builds a Popper virtual element whose `getBoundingClientRect()` returns the specific line-segment rect that contained the mouse. Internally this uses `Range.getClientRects()` via `element.getClientRects()`, which returns one DOMRect per wrapped line. The popper is then positioned beneath the actual hovered line, with no dead space above it.
> 
> The virtual element also:
>   - Caches across mouseOver retriggers on child elements (so the popper does not jitter between lines when the pointer crosses inner spans).
>   - Falls back to the plain bounding rect on browsers / test envs that do not implement `getClientRects`.
>   - Falls back to the vertically-nearest segment if no segment actually contains the recorded mouse position (e.g. pointer moved between lines in the brief window before the hover opens).
> 
> Turned on for inline link hover previews:
>   - `DefaultPreview` and all the external-preview variants in `PostLinkPreview.tsx` (Metaculus, Manifold, Fatebook, Neuronpedia, Metaforecast, OWID, Arbital, Estimaker, Viewpoints)
>   - `CrossSiteLinkPreview`
>   - `FootnotePreview`
> 
> These are the surfaces the bug report in #m_bugs-channel was about; other hovers (LWTooltip, PostsTooltip, etc.) can opt in later if needed.
> 
> Bug report: https://lworg.slack.com/archives/CJUN2UAFN/p1775777887405619
> Preview: https://baserates-test-git-fix-link-hover-line-rect-lesswrong.vercel.app
> 
> Authored by Claude (automated feature-development cron run). Picks up in-progress WIP left by the previous cron run on 2026-04-09 that added `useLineAnchor` support but never committed or pushed it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214055952423768) by [Unito](https://www.unito.io)
