### PR TITLE
Auto-save toggles and option controls in account settings

### DIFF
--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -1,8 +1,8 @@
 import { useMessages } from '@/components/common/withMessages';
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { EditableUser, getUserEmail, userCanEditUser, userGetDisplayName, userGetProfileUrl } from '@/lib/collections/users/helpers';
 import Button from '@/lib/vendor/@material-ui/core/src/Button';
-import { useCurrentUser } from '@/components/common/withUser';
+import { useCurrentUser, useRefetchCurrentUser } from '@/components/common/withUser';
 import { useMutation, useApolloClient } from '@apollo/client/react';
 import { useQuery } from "@/lib/crud/useQuery"
 import { useLocation, useNavigate } from '@/lib/routeUtil.tsx';
@@ -27,6 +27,7 @@ import NotificationsSettingsTab from './NotificationsSettingsTab';
 import ModerationSettingsTab from './ModerationSettingsTab';
 import AdminSettingsTab from './AdminSettingsTab';
 import type { SettingsFormApi } from './settingsTabTypes';
+import { useAutoSaveUserSettingsFields } from './useAutoSaveUserSettingsFields';
 
 const UsersEditUpdateMutation = gql(`
   mutation updateUserUsersEditForm($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -202,6 +203,7 @@ const UsersForm = ({
   isCurrentUser,
   requestPasswordReset,
   accountManagement,
+  profileSlug,
 }: {
   initialData: EditableUser;
   currentUser: UsersCurrent;
@@ -209,8 +211,11 @@ const UsersForm = ({
   isCurrentUser: boolean;
   requestPasswordReset: () => void;
   accountManagement: React.ReactNode | null;
+  profileSlug: string;
 }) => {
   const classes = useStyles(styles);
+  const client = useApolloClient();
+  const refetchCurrentUser = useRefetchCurrentUser();
   const { query } = useLocation();
   const navigate = useNavigate();
 
@@ -240,9 +245,13 @@ const UsersForm = ({
     onSuccessCallback: onSuccessModerationGuidelinesCallback,
   } = useEditorFormCallbacks<UsersEdit>();
 
-  const [mutate] = useMutation(UsersEditUpdateMutation);
+  const [mutate] = useMutation(UsersEditUpdateMutation, {
+    refetchQueries: [{ query: GetUserBySlugQuery, variables: { slug: profileSlug } }],
+  });
 
   const { setCaughtError, displayedErrorComponent } = useFormErrors();
+
+  const awaitPendingUserSettingsSavesRef = useRef<() => Promise<void>>(async () => {});
 
   const form = useForm({
     defaultValues: {
@@ -260,6 +269,8 @@ const UsersForm = ({
         onSubmitBiographyCallback.current?.(),
         onSubmitModerationGuidelinesCallback.current?.(),
       ]);
+
+      await awaitPendingUserSettingsSavesRef.current();
 
       try {
         let result: UsersEdit;
@@ -285,6 +296,20 @@ const UsersForm = ({
       }
     },
   });
+
+  const onPersistedUserSettings = useCallback(async () => {
+    await client.resetStore();
+    await refetchCurrentUser();
+  }, [client, refetchCurrentUser]);
+
+  const settingsFormForHook = form as unknown as SettingsFormApi;
+  const { awaitPendingSaves } = useAutoSaveUserSettingsFields(
+    settingsFormForHook,
+    initialData?._id,
+    mutate,
+    onPersistedUserSettings,
+  );
+  awaitPendingUserSettingsSavesRef.current = awaitPendingSaves;
 
   if (!initialData) {
     return <Error404 />;
@@ -436,6 +461,7 @@ const UsersEditForm = ({ terms, accountManagement }: {
           isCurrentUser={isCurrentUser}
           requestPasswordReset={requestPasswordReset}
           accountManagement={accountManagement ?? null}
+          profileSlug={terms.slug}
         />
       )}
     </div>

--- a/packages/lesswrong/components/users/account/useAutoSaveUserSettingsFields.ts
+++ b/packages/lesswrong/components/users/account/useAutoSaveUserSettingsFields.ts
@@ -1,0 +1,197 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import pick from "lodash/pick";
+import isEqual from "lodash/isEqual";
+import { useMessages } from "@/components/common/withMessages";
+import { recursivelyRemoveTypenameFrom } from "@/components/tanstack-form-components/helpers";
+import type { EditableUser } from "@/lib/collections/users/helpers";
+import type { SettingsFormApi } from "./settingsTabTypes";
+import type { useMutation } from "@apollo/client/react";
+
+/**
+ * User settings fields that are toggles, notification channel controls, karma
+ * notifier options, or other immediate controls — not free text, editors,
+ * locations, or multiselects (those still use Save Changes).
+ */
+const AUTO_IMMEDIATE_SAVE_FIELD_NAMES = [
+  "deleted",
+  "hideProfileTopPosts",
+  "commentSorting",
+  "noSingleLineComments",
+  "noCollapseCommentsPosts",
+  "noCollapseCommentsFrontpage",
+  "noKibitz",
+  "sortDraftsBy",
+  "hideCommunitySection",
+  "showCommunityInRecentDiscussion",
+  "postGlossariesPinned",
+  "hideElicitPredictions",
+  "hideFrontpageMap",
+  "hideFrontpageBook2020Ad",
+  "hideAFNonMemberInitialWarning",
+  "markDownPostEditor",
+  "beta",
+  "hideIntercom",
+  "showHideKarmaOption",
+  "hideFromPeopleDirectory",
+  "allowDatadogSessionReplay",
+  "auto_subscribe_to_my_posts",
+  "auto_subscribe_to_my_comments",
+  "autoSubscribeAsOrganizer",
+  "notificationSubscribedUserPost",
+  "notificationSubscribedUserComment",
+  "notificationCommentsOnSubscribedPost",
+  "notificationSubscribedTagPost",
+  "notificationSubscribedSequencePost",
+  "notificationPostsInGroups",
+  "notificationShortformContent",
+  "notificationRepliesToMyComments",
+  "notificationRepliesToSubscribedComments",
+  "notificationNewMention",
+  "notificationPrivateMessage",
+  "notificationSharedWithMe",
+  "notificationCommentsOnDraft",
+  "notificationAddedAsCoauthor",
+  "notificationDialogueMessages",
+  "notificationPublishedDialogueMessages",
+  "notificationSubforumUnread",
+  "notificationAlignmentSubmissionApproved",
+  "notificationEventInRadius",
+  "notificationRSVPs",
+  "notificationGroupAdministration",
+  "karmaChangeNotifierSettings",
+  "emailSubscribedToCurated",
+  "unsubscribeFromAll",
+  "moderationStyle",
+  "moderatorAssistance",
+  "collapseModerationGuidelines",
+  "sunshineFlagged",
+  "needsReview",
+  "sunshineSnoozed",
+  "noindex",
+  "defaultToCKEditor",
+  "hideSunshineSidebar",
+  "viewUnreviewedComments",
+  "postingDisabled",
+  "allCommentingDisabled",
+  "commentingOnOtherUsersDisabled",
+  "conversationsDisabled",
+  "nullifyVotes",
+  "deleteContent",
+  "isAdmin",
+  "groups",
+] as const satisfies ReadonlyArray<keyof EditableUser & string>;
+
+const AUTO_IMMEDIATE_SAVE_FIELDS = new Set<string>(AUTO_IMMEDIATE_SAVE_FIELD_NAMES);
+
+type UpdateUserMutateFn = useMutation.MutationFunction<
+  updateUserUsersEditFormMutation,
+  updateUserUsersEditFormMutationVariables
+>;
+
+function pickAutoSaveSubset(values: EditableUser): Partial<EditableUser> {
+  return pick(values, AUTO_IMMEDIATE_SAVE_FIELD_NAMES);
+}
+
+function clearSavedFieldsDirtyMeta(form: SettingsFormApi, fieldKeys: string[]) {
+  for (const fieldKey of fieldKeys) {
+    form.setFieldMeta(fieldKey as keyof EditableUser, (prev) => ({
+      ...prev,
+      isDirty: false,
+    }));
+  }
+}
+
+/**
+ * Persists toggle / select / notification-style fields as soon as they change.
+ * Sequential queue: one mutation in flight; coalesces further edits after it.
+ */
+export function useAutoSaveUserSettingsFields(
+  form: SettingsFormApi,
+  userId: string | undefined,
+  mutate: UpdateUserMutateFn,
+  onPersisted: () => void | Promise<void>,
+) {
+  const { flash } = useMessages();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const lastEnqueuedRef = useRef<Partial<EditableUser>>(pickAutoSaveSubset(form.state.values));
+
+  const pendingSaveRef = useRef<Partial<EditableUser> | null>(null);
+  const savingRef = useRef(false);
+  const drainResolversRef = useRef<Array<() => void>>([]);
+
+  const processQueue = useCallback(async () => {
+    if (savingRef.current || !pendingSaveRef.current || !userId) return;
+
+    const fields = pendingSaveRef.current;
+    pendingSaveRef.current = null;
+    savingRef.current = true;
+    setIsSaving(true);
+
+    const savedKeys = Object.keys(fields);
+
+    try {
+      const cleanedFields = recursivelyRemoveTypenameFrom(fields);
+      const { data } = await mutate({
+        variables: {
+          selector: { _id: userId },
+          data: cleanedFields,
+        },
+      });
+      if (!data?.updateUser?.data) {
+        throw new Error("Failed to update user");
+      }
+      clearSavedFieldsDirtyMeta(form, savedKeys);
+      await onPersisted();
+    } catch {
+      flash({ messageString: "Failed to save changes", type: "error" });
+      for (const key of savedKeys) {
+        delete lastEnqueuedRef.current[key as keyof EditableUser];
+      }
+    } finally {
+      savingRef.current = false;
+      if (pendingSaveRef.current) {
+        void processQueue();
+      } else {
+        setIsSaving(false);
+        for (const resolve of drainResolversRef.current) resolve();
+        drainResolversRef.current = [];
+      }
+    }
+  }, [mutate, userId, flash, form, onPersisted]);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const unsubscribe = form.store.subscribe(() => {
+      const values = form.state.values;
+      const fieldMeta = form.state.fieldMeta;
+
+      const changedKeys = Object.entries(fieldMeta)
+        .filter(([key, meta]) => {
+          if (!meta.isDirty || !AUTO_IMMEDIATE_SAVE_FIELDS.has(key)) return false;
+          const typedKey = key as keyof EditableUser;
+          return !isEqual(values[typedKey], lastEnqueuedRef.current[typedKey]);
+        })
+        .map(([key]) => key);
+
+      if (changedKeys.length > 0) {
+        const changedFields = pick(values, changedKeys) as Partial<EditableUser>;
+        Object.assign(lastEnqueuedRef.current, changedFields);
+        pendingSaveRef.current = { ...(pendingSaveRef.current ?? {}), ...changedFields };
+        void processQueue();
+      }
+    });
+
+    return unsubscribe;
+  }, [form, userId, processQueue]);
+
+  const awaitPendingSaves = useCallback(async () => {
+    if (!savingRef.current && !pendingSaveRef.current) return;
+    return new Promise<void>((resolve) => {
+      drainResolversRef.current.push(resolve);
+    });
+  }, []);
+
+  return { isSaving, awaitPendingSaves };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Account settings used a single **Save Changes** submit for the whole TanStack form. This adds an autosave path (same pattern as `useAutoSavePostFields`) for **toggles, dropdowns, per-notification channel controls, karma notifier settings, admin checkbox groups**, etc., so those persist as soon as they change.

## What still uses Save Changes
Free-text fields, rich-text editors (bio, moderation guidelines), location pickers, pinned-post manager, user multiselects (banned users), and other non-toggle inputs are unchanged and still require **Save Changes**.

## Implementation notes
- New hook `useAutoSaveUserSettingsFields` subscribes to the form store, queues `updateUser` mutations (one in flight, coalesces pending edits), clears `isDirty` on saved keys via `setFieldMeta`, then `resetStore` + `refetchCurrentUser` so Apollo and the current user stay in sync.
- Full-form submit awaits pending autosaves first to avoid racing two mutations.
- `useMutation` for the settings form refetches `GetUserBySlug` after each update.

## Testing
Not run in this environment (Node engine / full `yarn tsc` constraints). CI should exercise typecheck and tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1485439-9ab6-412b-82d0-a0ac0eb74d73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1485439-9ab6-412b-82d0-a0ac0eb74d73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214057410807814) by [Unito](https://www.unito.io)
