### PR TITLE
[1-liner] Add collapse buttons to shortform comment replies

### DIFF
--- a/packages/lesswrong/components/shortform/RepliesToCommentList.tsx
+++ b/packages/lesswrong/components/shortform/RepliesToCommentList.tsx
@@ -49,6 +49,7 @@ const RepliesToCommentList = ({ post, parentCommentId, directReplies = false }: 
   return <CommentsList
     treeOptions={{
       post,
+      showCollapseButtons: true,
     }}
     totalComments={results.length}
     comments={nestedComments}


### PR DESCRIPTION
## Feature Description

Sorry, I don't know whether you accept PRs. I couldn't really find much about contributions, but this is a missing feature that really bothers me on lesswrong.com - I often like to fold comments and enjoy doing that on normal posts, but the same functionality seems to be missing from short-form posts. 

longform: https://www.lesswrong.com/posts/byiLDrbj8MNzoHZkL/daycare-illnesses
<img width="500" alt="Screenshot 2026-04-13 at 11 08 22 PM" src="https://github.com/user-attachments/assets/25d64064-d315-4aee-8436-f5ff5da15862" />


shortform: https://www.lesswrong.com/posts/NsQgB6zAfjZnxwFZG/jay-bailey-s-shortform?commentId=xzzRY6bgiekJAWJe8
<img width="500"  alt="Screenshot 2026-04-13 at 11 09 11 PM" src="https://github.com/user-attachments/assets/034af5f8-6dc1-4356-bd71-8acab39e5dcc" />

## Fix

- Shortform/quick-takes comment replies were missing the [-] collapse button that regular post comments have
- The root cause is that `RepliesToCommentList` did not pass `showCollapseButtons: true` in its `treeOptions`, while `CommentsListSection` (used for regular posts) does
- This adds the flag so shortform replies can be collapsed like any other comment thread
