### PR TITLE
Fix agent endpoint rejecting converted markdown-to-Lexical posts

### DIFF
--- a/app/api/agent/editorAgentUtil.ts
+++ b/app/api/agent/editorAgentUtil.ts
@@ -14,6 +14,7 @@ import { randomId } from "@/lib/random";
 import { sleep } from "@/lib/utils/asyncUtils";
 import { getLatestRev } from "@/server/editor/utils";
 import { captureException } from "@/lib/sentryWrapper";
+import YjsDocuments from "@/server/collections/yjsDocuments/collection";
 
 const HOCUSPOCUS_SYNC_TIMEOUT_MS = 15_000;
 const INITIAL_SYNC_SETTLE_MS = 25;
@@ -97,11 +98,30 @@ interface EditorTypeCheckResult {
  * Check whether a post uses the Lexical editor. The agent editing API surface
  * only works with Lexical collaborative documents; legacy CKEditor posts must
  * be read via /editPost or /api/editPost instead.
+ *
+ * When a user converts a post from markdown to Lexical in the editor UI, the
+ * Lexical editor opens and syncs to Hocuspocus, but no new revision is saved
+ * until the user actually edits the document. During that window the latest
+ * revision still says "markdown", even though the live document is Lexical.
+ * To handle this, we also check for a YjsDocuments entry -- its existence
+ * means the Lexical collaborative editor has synced state for this post.
  */
 export async function isSupportedEditorType(postId: string, context: ResolverContext): Promise<EditorTypeCheckResult> {
   const rev = await getLatestRev(postId, "contents", context);
   const editorType = rev?.originalContents?.type ?? "unknown";
-  return { supported: editorType === "lexical", editorType };
+  if (editorType === "lexical") {
+    return { supported: true, editorType };
+  }
+
+  // The latest revision isn't Lexical, but the post may have been converted
+  // and opened in the collaborative editor without saving a revision yet.
+  // A YjsDocuments row means Hocuspocus has synced Lexical state for this post.
+  const yjsDoc = await YjsDocuments.findOne({ documentId: postId });
+  if (yjsDoc) {
+    return { supported: true, editorType: "lexical" };
+  }
+
+  return { supported: false, editorType };
 }
 
 export function unsupportedEditorMessage(editorType: string): string {


### PR DESCRIPTION
> When a user creates a markdown post, enables sharing, and converts to Lexical, the agent API endpoints (replaceText, insertBlock, etc.) return an "unsupported editor" error because `isSupportedEditorType` only checks the latest revision's `originalContents.type`, which still says "markdown" -- no new revision is saved until the user actually edits the document after conversion.
> 
> Fix: after checking the latest revision, also check for a YjsDocuments entry for the post. A YjsDocuments row means the Lexical collaborative editor has synced state for this post (created when Hocuspocus opens the document), so the post is effectively a Lexical post even if the revision hasn't caught up yet.
> 
> Bug thread: https://lworg.slack.com/archives/CJUN2UAFN/p1776290047320079
> Preview: https://baserates-test-git-fix-agent-md-to-lex-perm-lesswrong.vercel.app

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214089348642485) by [Unito](https://www.unito.io)
