### PR TITLE
Truncate long display names in LW post preview tooltip metadata line

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip/LWPostsPreviewTooltip.tsx
@@ -102,6 +102,13 @@ const styles = defineStyles('LWPostsPreviewTooltip', (theme: ThemeType) => ({
     padding: 12,
     paddingBottom: 0,
   },
+  headerMain: {
+    // Flex item holding title + metadata line. Needs explicit minWidth: 0
+    // so descendants are allowed to shrink below their intrinsic width --
+    // otherwise the ellipsis truncation on the username never triggers.
+    minWidth: 0,
+    flex: 1,
+  },
   title: {
     marginBottom: -6,
   },
@@ -111,7 +118,20 @@ const styles = defineStyles('LWPostsPreviewTooltip', (theme: ThemeType) => ({
     fontSize: "1.1rem",
     color: theme.palette.grey[600],
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    // Allow the username child to shrink below its intrinsic width so the
+    // ellipsis truncation below actually kicks in instead of overflowing.
+    minWidth: 0,
+  },
+  userAndCoauthors: {
+    // Long display names previously wrapped mid-word, pushing the karma /
+    // comments / date metadata onto a second line (sometimes in the middle of
+    // the username itself). Constrain this wrapper to a single line with
+    // ellipsis truncation so unusually long names stay clipped inline.
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   highlight: {
     ...highlightStyles(theme)
@@ -133,7 +153,11 @@ const styles = defineStyles('LWPostsPreviewTooltip', (theme: ThemeType) => ({
   },
   metadata: {
     marginLeft: 12,
-    paddingTop: 2
+    paddingTop: 2,
+    // Keep "N karma / N comments / Nd" on a single line even when the
+    // sibling username takes up most of the available width.
+    whiteSpace: "nowrap",
+    flexShrink: 0,
   },
   smallText: {
     fontSize: ".9rem",
@@ -192,7 +216,7 @@ const LWPostsPreviewTooltip = ({postsList, post, hash, comment, dialogueMessageI
   return <AnalyticsContext pageElementContext={POST_PREVIEW_ELEMENT_CONTEXT}>
       <Card className={classes.root}>
         <div className={classes.header}>
-          <div>
+          <div className={classes.headerMain}>
             <div className={classes.title}>
               <PostsTitle post={post} wrap showIcons={false} />
             </div>
@@ -204,7 +228,7 @@ const LWPostsPreviewTooltip = ({postsList, post, hash, comment, dialogueMessageI
                 {renderWordCount && <span>{" "}<span className={classes.wordCount}>({wordCount} words)</span></span>}
               </span>}
               { !postsList && <>
-                {post.user && <PostsUserAndCoauthors post={post}/>}
+                {post.user && <div className={classes.userAndCoauthors}><PostsUserAndCoauthors post={post}/></div>}
                 <div className={classes.metadata}>
                   <span className={classes.smallText}>{postGetKarma(post)} karma</span>
                   <span className={classes.smallText}>{postGetCommentCountStr(post)}</span>


### PR DESCRIPTION
> Bug: https://lworg.slack.com/archives/CJUN2UAFN/p1776069042338179 Jim reported that when a post author has an unusually long display name, the "[name] [N karma] [N comments] [1d]" metadata line inside the LWPostsPreviewTooltip wraps mid-word in the username, and the "N comments" / "1d" items wrap to a second line as well. He suggested giving the username ellipsis overflow rather than wrapping.
> 
> Root cause: the metadata line is a flex row with PostsUserAndCoauthors and a metadata <div> as its two items. Neither had a minWidth: 0, so the username element's min-content width (dictated by its longest unbreakable token) could expand the container past the tooltip width and push the whole row into wrap-mode -- the flex container's default flex-wrap is nowrap, but the text inside each flex item was wrapping according to its own white-space rules. At the same time the metadata <div> had no whiteSpace: nowrap, so the karma/comments/date spans could break across lines whenever there wasn't enough horizontal room.
> 
> Fix (three small CSS changes in LWPostsPreviewTooltip.tsx, no behavior change for normal-length names):
> 
> 1. New headerMain class on the outer flex item inside .header: adds minWidth: 0 + flex: 1 so descendants are allowed to shrink below their intrinsic width. Without this the truncation in (2) never triggers because the chain of flex ancestors was sized to content.
> 
> 2. New userAndCoauthors wrapper around <PostsUserAndCoauthors>: minWidth: 0, whiteSpace: nowrap, overflow: hidden, textOverflow: ellipsis -- the username clips with an ellipsis on a single line.
> 
> 3. metadata: whiteSpace: nowrap + flexShrink: 0 so karma/comments/date stay together on one line even when the username consumes most of the width. tooltipInfo also gets minWidth: 0 so the flex container itself participates in the shrink chain.
> 
> Chose wrapping PostsUserAndCoauthors in a tooltip-local div rather than passing abbreviateIfLong to it, because abbreviateIfLong applies text-align: right and a 310px max-width that's tuned for other call sites (post list rows, etc.), and the tooltip wants the opposite: text-align: left (default) and a width bounded by the tooltip itself.
> 
> Preview: https://baserates-test-git-fix-tooltip-long-name-wrap-lesswrong.vercel.app
