### PR TITLE
Fix /allPosts main section staying dimmed after opening settings panel

### DIFF
--- a/packages/lesswrong/components/posts/PostsTimeframeList.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeList.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
+import isEqual from 'lodash/isEqual';
 import moment from '../../lib/moment-timezone';
 import classNames from 'classnames';
 import { getDateRange, loadMoreTimeframeMessages, timeframeToRange, timeframeToTimeBlock, TimeframeType } from './timeframeUtils'
@@ -20,6 +21,17 @@ const styles = defineStyles('PostsTimeframeList', (theme: ThemeType) => ({
   }
 }))
 
+// Returns a reference-stable copy of `value` that only changes when `value`
+// changes by deep equality, so it can be used as a hook dependency without
+// firing on every render when parents pass freshly-built object literals.
+function useDeepMemo<T>(value: T): T {
+  const ref = useRef(value);
+  if (!isEqual(ref.current, value)) {
+    ref.current = value;
+  }
+  return ref.current;
+}
+
 const PostsTimeframeList = ({after, before, timeframe, numTimeBlocks, postListParameters, dimWhenLoading, reverse, shortform, includeTags=true}: {
   after: Date|string,
   before: Date|string,
@@ -38,12 +50,19 @@ const PostsTimeframeList = ({after, before, timeframe, numTimeBlocks, postListPa
   const [beforeState,setBeforeState] = useState(before);
   const [afterState,setAfterState] = useState(after);
 
+  // `postListParameters` is re-created as a fresh object on every parent
+  // render (e.g. opening the settings panel), so depending on it directly
+  // with reference equality would make the effect below fire spuriously,
+  // re-dimming the list with no actual reload in progress. Stabilize the
+  // reference via deep equality so we only react to real changes.
+  const stablePostListParameters = useDeepMemo(postListParameters);
+
   useOnPropsChanged(() => {
     setBeforeState(before);
     setAfterState(after);
     setDim(!!dimWhenLoading);
     setDisplayedNumTimeBlocks(numTimeBlocks);
-  }, [before, after, timeframe, postListParameters]);
+  }, [before, after, timeframe, stablePostListParameters]);
   
   const loadMoreTimeBlocks = (e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
> On the timeframe views of /allPosts, opening the settings panel caused the post list to become permanently dimmed even though no reload was in progress.
> 
> Root cause: PostsTimeframeList tracks a local `dim` state that gets reset via useOnPropsChanged whenever any of [before, after, timeframe, postListParameters] changes. `postListParameters` is rebuilt as a fresh object on every render of AllPostsList, and useOnPropsChanged compares deps with reference equality (it is backed by a plain useEffect), so the effect fired on every parent render. Opening the settings panel flipped `dimWhenLoading` to true and then the spurious effect kept re-dimming the list, with no subsequent load to clear it via timeBlockLoadComplete. The old class-based implementation used _.isEqual(postListParameters) to compare; the hook refactor dropped that.
> 
> Fix: add a small useDeepMemo helper that returns a reference-stable copy of its input until the value changes by deep equality, and route postListParameters through it before using it as a hook dep. Real settings changes (sort, filter, karma threshold, etc.) still propagate because their serialized content differs; merely toggling the settings panel no longer invalidates the dep.
> 
> Bug report: https://lworg.slack.com/archives/CJUN2UAFN/p1775778478530449
> Preview: https://baserates-test-git-fix-allposts-dim-stuck-lesswrong.vercel.app
