### PR TITLE
Fix offsite link preview cards going translucent on hover (preview)

### DIFF
--- a/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
@@ -112,6 +112,16 @@ const styles = defineStyles("CrossSiteLinkPreview", (theme: ThemeType) => ({
     ...theme.typography.body2,
     color: theme.palette.text.dim45,
   },
+  // The popper card content is wrapped in a `<Link>` (an `<a>` tag) so the
+  // whole card is clickable. The global `a:hover` rule applies
+  // `opacity: 0.5`, which makes the entire card translucent when hovered
+  // (except where `a:has(img):hover` happens to exempt it). Reset opacity
+  // here so the card stays fully opaque on hover.
+  cardLink: {
+    "&:hover, &:active": {
+      opacity: 1,
+    },
+  },
 }));
 
 function getDisplayTitle(title: string | null | undefined, href: string): string {
@@ -291,7 +301,7 @@ export const CrossSiteLinkPreview = ({
         </a>
 
         <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-          <Link to={href} id={id} rel={rel} className={className}>
+          <Link to={href} id={id} rel={rel} className={classNames(className, classes.cardLink)}>
             {previewData && !hasImage && <NoImageStyleCardContent href={href} previewData={previewData} debugMenu={debugMenu} />}
             {previewData && hasImage && imageLayout === "banner" && !useTopRightFloatImageLayout && (
               <BannerStyleCardContent href={href} previewData={previewData} debugMenu={debugMenu} />


### PR DESCRIPTION
> The popper card content is wrapped in a `<Link>` (an `<a>` tag) so the whole card is clickable. The global `a:hover` rule applies `opacity: 0.5`, which makes the entire card translucent when the cursor is over the card rather than over the link. Cards that contain an `<img>` were exempted by the `a:has(img):hover` rule, which is why only some formats (notably the no-image card) were affected -- matching the bug report's "not every format" wording.
> 
> Fix: add a `cardLink` class on the popper `<Link>` wrapper that resets
`opacity: 1` on hover/active.
> 
> Bug report: https://lworg.slack.com/archives/CJUN2UAFN/p1775776320743439
> Likely-introducing commit: 36953cdc4c2648bdcc02819f79365c2b3dd6bdf4
> Preview: https://baserates-test-git-fix-link-preview-opacity-lesswrong.vercel.app


