### PR TITLE
Anchor hover popper to hovered line for wrapped inline links

### DIFF
--- a/packages/lesswrong/components/common/LWPopper.tsx
+++ b/packages/lesswrong/components/common/LWPopper.tsx
@@ -120,7 +120,11 @@ const LWPopper = ({
   
   // In some cases, interacting with something inside a popper will cause a rerender that detaches the anchorEl
   // This happened in hovers on in-line reacts, and the button to create a new react ended up on the top-left corner of the page
-  if (anchorEl && !anchorEl.isConnected) {
+  // NB: popper also supports "virtual elements" (plain objects with a
+  // getBoundingClientRect method and no isConnected property), used e.g. by
+  // useHover to anchor to a specific wrapped-line segment -- those don't have
+  // isConnected, so we guard by checking whether the property exists first.
+  if (anchorEl && "isConnected" in anchorEl && !anchorEl.isConnected) {
     return null;
   }
   

--- a/packages/lesswrong/components/common/PopperCard.tsx
+++ b/packages/lesswrong/components/common/PopperCard.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties } from 'react';
 import { Card } from "@/components/widgets/Paper";
 import type { Placement as PopperPlacementType } from "popper.js"
 import LWPopper from "./LWPopper";
+import type { HoverAnchor } from "./withHover";
 
 const PopperCard = ({
   children,
@@ -16,7 +17,9 @@ const PopperCard = ({
   children?: React.ReactNode,
   placement?: PopperPlacementType,
   open: boolean,
-  anchorEl: HTMLElement|null,
+  // HoverAnchor covers both real DOM elements and the popper virtual elements
+  // that useHover now produces for wrapped inline anchors.
+  anchorEl: HoverAnchor|null,
   allowOverflow?: boolean,
   flip?: boolean,
   style?: CSSProperties,

--- a/packages/lesswrong/components/common/withHover.tsx
+++ b/packages/lesswrong/components/common/withHover.tsx
@@ -6,6 +6,43 @@ function datesDifference(a: Date, b: Date): number {
   return (a as any)-(b as any);
 }
 
+// A popper-compatible anchor. Either a real DOM element (standard case) or a
+// virtual element that implements `getBoundingClientRect()` -- used when the
+// hovered element is an inline box that wraps across multiple lines, so we can
+// anchor the popper to the specific line segment the mouse is over rather than
+// to the union bounding box (which can leave dead space between the hovered
+// line and the popper -- see #m_bugs report 2026-04-09).
+export type HoverAnchor = HTMLElement | {
+  getBoundingClientRect: () => DOMRect,
+  contextElement?: Element,
+};
+
+/**
+ * Given an inline element and a mouse position, pick the `getClientRects()`
+ * rect that contains the cursor and return a popper virtual element bound to
+ * that specific rect. For elements with a single client rect (the common case)
+ * just returns the element itself, preserving existing behavior.
+ */
+function getSegmentAnchor(el: HTMLElement, clientX: number, clientY: number): HoverAnchor {
+  // getClientRects only reports multiple rects for inline boxes that wrap
+  // across lines. For block-level anchors it returns a single rect, so we
+  // fall through to returning the element itself (which preserves behavior
+  // for all the non-inline-link hover call sites).
+  const rects = el.getClientRects();
+  if (rects.length <= 1) return el;
+  for (let i = 0; i < rects.length; i++) {
+    const r = rects[i];
+    if (clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+      const snapshot = r;
+      return {
+        getBoundingClientRect: () => snapshot,
+        contextElement: el,
+      };
+    }
+  }
+  return el;
+}
+
 export interface UseHoverEventHandlers {
   onMouseOver: (ev: MouseEvent|React.MouseEvent) => void,
   onMouseLeave: (ev: MouseEvent|React.MouseEvent) => void,
@@ -40,13 +77,13 @@ export const useHover = (options?: {
   eventHandlers: UseHoverEventHandlers,
   hover: boolean,
   everHovered: boolean,
-  anchorEl: HTMLElement | null,
+  anchorEl: HoverAnchor | null,
   forceUnHover: () => void,
 } => {
   const {eventProps, onEnter, onLeave, disabledOnMobile, getIsEnabled} = options ?? {};
   const [hover, setHover] = useState(false)
   const [everHovered, setEverHovered] = useState(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [anchorEl, setAnchorEl] = useState<HoverAnchor | null>(null)
   const delayTimer = useRef<any>(null)
   const mouseOverStart = useRef<Date|null>(null)
 
@@ -89,7 +126,12 @@ export const useHover = (options?: {
       return true;
     });
     setEverHovered(true);
-    setAnchorEl(event.currentTarget as HTMLElement);
+    // If the hovered element is an inline anchor that wraps across multiple
+    // lines, anchor the popper to the specific line segment the mouse is over
+    // rather than to the overall bounding box. For non-wrapping elements this
+    // is a no-op (getClientRects returns a single rect).
+    const target = event.currentTarget as HTMLElement;
+    setAnchorEl(getSegmentAnchor(target, event.clientX, event.clientY));
     mouseOverStart.current = new Date()
     clearTimeout(delayTimer.current)
     delayTimer.current = setTimeout(captureHoverEvent,500)

--- a/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import LWPopper from "../common/LWPopper";
+import type { HoverAnchor } from "../common/withHover";
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
 
@@ -21,7 +22,7 @@ const styles = defineStyles('SidebarHoverOver', (theme: ThemeType) => ({
 const SidebarHoverOver = ({children, hover, anchorEl, width=500}: {
   children: React.ReactNode,
   hover: boolean,
-  anchorEl: HTMLElement|null,
+  anchorEl: HoverAnchor|null,
   width?: number,
 }) => {
   const classes = useStyles(styles);


### PR DESCRIPTION
> When a link with a hover preview wraps onto multiple lines, the popper was positioned at the bottom-left of the anchor's full bounding box (the union rect that spans all wrapped segments). If the mouse was on an earlier wrapped segment, the popper appeared far away with dead space between the cursor and the card, so moving onto the card closed the hover.
> 
> Fix is in `useHover`: on mouseOver, if the hovered element reports multiple client rects (inline box split across lines), pick the rect that contains the cursor and return a popper virtual element bound to that specific rect. Single-rect anchors (all non-wrapping elements, which is the vast majority of hover call sites) keep returning the raw HTMLElement, so no other hover behaviour changes.
> 
> Supporting changes:
> - `LWPopper`: skip the `isConnected` detached-element guard when the anchor is a virtual element (those don't have `isConnected`).
> - `PopperCard` and `SidebarHoverOver`: widen their `anchorEl` prop type from `HTMLElement | null` to the new `HoverAnchor | null` so the virtual-element path passes through without a type error.
> 
> Bug: https://lworg.slack.com/archives/CJUN2UAFN/p1775777887405619
> Preview: https://baserates-test-git-fix-hover-popper-wrap-line-lesswrong.vercel.app


