### PR TITLE
Lexical: fix backspace/delete across image deleting only image (preview)

### DIFF
--- a/packages/lesswrong/components/lexical/nodes/ImageComponent.tsx
+++ b/packages/lesswrong/components/lexical/nodes/ImageComponent.tsx
@@ -467,7 +467,15 @@ export default function ImageComponent({
           }
           if ($isRangeSelection(selection) && !selection.isCollapsed()) {
             const selectedNodes = selection.getNodes();
-            if (selectedNodes.some((selected) => $isImageNode(selected))) {
+            // Only intercept when this image is the ONLY thing selected.
+            // If the range also covers paragraphs or other nodes, let
+            // Lexical's default deletion handle the full range so we don't
+            // leave the surrounding text behind.
+            const onlyThisImageSelected =
+              selectedNodes.length === 1 &&
+              $isImageNode(selectedNodes[0]) &&
+              selectedNodes[0].getKey() === imageNodeKey;
+            if (onlyThisImageSelected) {
               event.preventDefault();
               node.remove();
               return true;
@@ -524,7 +532,14 @@ export default function ImageComponent({
             return false;
           }
           const selectedNodes = selection.getNodes();
-          if (selectedNodes.some((selected) => $isImageNode(selected))) {
+          // Only intercept when this image is the ONLY thing selected.
+          // Broader range selections should fall through to default
+          // deletion so the surrounding text also goes away.
+          const onlyThisImageSelected =
+            selectedNodes.length === 1 &&
+            $isImageNode(selectedNodes[0]) &&
+            selectedNodes[0].getKey() === imageNodeKey;
+          if (onlyThisImageSelected) {
             event.preventDefault();
             node.remove();
             return true;


### PR DESCRIPTION
Tested and confirmed that the fix works. While the bug is in a vendored file, the file was significantly modified after we vendored it, and the bug doesn't repro in Lexical Playground, so not reporting upstream.

> Bug: https://lworg.slack.com/archives/CJUN2UAFN/p1774486537037819
> 
> Reported behavior: in Lexical, if you select a range that crosses an image (with text paragraphs on either side) and press backspace, the image is deleted but the surrounding text is left intact. Same happens with delete.
> 
> Root cause: the KEY_BACKSPACE_COMMAND and KEY_DELETE_COMMAND handlers in ImageComponent.tsx intercept any non-collapsed range selection whose getNodes() list contains *any* image node, and react by deleting this image and returning true. That stops Lexical's default deletion from running, so the paragraphs on either side of the image survive.
> 
> Fix: only intercept when the range selection resolves to exactly this one image (length === 1, is an ImageNode, key matches). For broader selections that also cover text or other content, fall through to Lexical's default deletion so the full range is removed. The caption handling (delete the image when its entire caption text is selected) is preserved.
> 
> Preview: https://baserates-test-git-fix-image-range-backspace-lesswrong.vercel.app
> 
> Posted by Claude (Oliver's bug-fix automation), not Oliver.
