### PR TITLE
Fix app.validation_error when AF non-members submit comments (preview)

### DIFF
--- a/packages/lesswrong/components/comments/CommentForm.tsx
+++ b/packages/lesswrong/components/comments/CommentForm.tsx
@@ -279,7 +279,8 @@ export const CommentForm = ({
 
   const formType = initialData ? 'edit' : 'new';
 
-  const showAfCheckbox = !hideAlignmentForumCheckbox && !isAF() && alignmentForumPost && (userIsMemberOf(currentUser, 'alignmentForum') || userIsAdmin(currentUser));
+  const canSetAfField = userIsMemberOf(currentUser, 'alignmentForum') || userIsAdmin(currentUser);
+  const showAfCheckbox = !hideAlignmentForumCheckbox && !isAF() && alignmentForumPost && canSetAfField;
 
   const DefaultFormGroupLayout = FormGroupNoStyling;
 
@@ -317,7 +318,15 @@ export const CommentForm = ({
 
         if (formType === 'new') {
           const { af, ...rest } = formApi.state.values;
-          const submitData = (showAfCheckbox || isAF()) ? { ...rest, af } : rest;
+          // Only include `af` in the submitted data when the user is allowed to
+          // set it. Otherwise server-side validation rejects the mutation with
+          // a cryptic `app.validation_error` because the `af` field has
+          // `canCreate: ["alignmentForum", "admins"]`. On AF this shows up when
+          // a non-AF-member tries to comment (Ruby/Jim in #m_bugs-channel,
+          // 2026-04-12 and 2026-04-14); we drop `af` so the comment submits as
+          // a regular LW comment and the existing non-member success-popup
+          // flow (`useAfNonMemberSuccessHandling`) queues it for AF review.
+          const submitData = ((showAfCheckbox || isAF()) && canSetAfField) ? { ...rest, af } : rest;
 
           const { data } = await create({ variables: { data: { ...submitData, draft } } });
           if (!data?.createComment?.data) {


### PR DESCRIPTION
> Non-AF-member users submitting a comment on alignmentforum.org got a cryptic red "app.validation_error" on submit. Root cause: on AF, commentDefaultToAlignment returns true unconditionally, so prefilledProps.af is true regardless of permissions. CommentForm's onSubmit then always included `af` in the submitData on AF (`isAF()` branch), but the comment schema has `canCreate: ["alignmentForum", "admins"]` on the `af` field, so server-side validateDocument rejects the whole mutation with `errors.disallowed_property_detected` -> `app.validation_error`. The existing useAfNonMemberSuccessHandling flow (which queues non-member comments for AF review) never got to run because submission failed first.
> 
> Fix: only include `af` in submitData when the user is actually allowed to set it (AF member or admin). Non-members on AF fall through to the default (`af: false`), the mutation succeeds, and the success callback runs useAfNonMemberSuccessHandling which adds the user to suggestForAlignmentUserIds and shows AFNonMemberSuccessPopup explaining moderator review -- the intended flow.
> 
> Reused the same `canSetAfField` condition for `showAfCheckbox` (which already checked alignmentForum/admin membership), so no UI behaviour change for the LW side of the AF-checkbox case.
> 
> Bug threads:
>   https://lworg.slack.com/archives/CJUN2UAFN/p1776039625268199 (2026-04-12)
>   https://lworg.slack.com/archives/CJUN2UAFN/p1776217162803809 (2026-04-14)
> 
> Preview: https://baserates-test-git-fix-af-nonmember-comment-lesswrong.vercel.app
