### PR TITLE
Remove broken sunshineNotes field from account-settings Admin tab

### DIFF
--- a/packages/lesswrong/components/users/account/AdminSettingsTab.tsx
+++ b/packages/lesswrong/components/users/account/AdminSettingsTab.tsx
@@ -83,15 +83,6 @@ const AdminSettingsTab = ({
       </SettingsSection>
 
       <SettingsSection title="Sunshine Review">
-        <form.Field name="sunshineNotes">
-          {(field) => (
-            <SettingsTextRow
-              field={field}
-              label="Sunshine notes"
-            />
-          )}
-        </form.Field>
-
         <form.Field name="sunshineFlagged">
           {(field) => (
             <SettingsToggleRow

--- a/packages/lesswrong/components/users/account/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/account/UsersEditForm.tsx
@@ -113,7 +113,6 @@ const FIELD_TO_TAB: Record<string, SettingsTabId> = {
   slug: 'admin',
   twitterProfileURLAdmin: 'admin',
   noindex: 'admin',
-  sunshineNotes: 'admin',
   sunshineFlagged: 'admin',
   needsReview: 'admin',
   sunshineSnoozed: 'admin',


### PR DESCRIPTION
> Jim reported (https://lworg.slack.com/archives/CJUN2UAFN/p1775938390300909) that the Admin tab of the account-settings page has a sunshineNotes field that's the wrong type (single-line input instead of multiline) and isn't correctly wired up. That field is already properly edited via the supermod page (see ModeratorNotes.tsx and useUserContentPermissions.ts in the sunshineDashboard/supermod directory, which provide a proper textarea with signing/dating helpers), so the duplicate in AdminSettingsTab is dead UI.
> 
> Removes the form.Field for sunshineNotes from AdminSettingsTab.tsx and the 'sunshineNotes: admin' entry from FIELD_TO_TAB in UsersEditForm.tsx (the only other place where having it as a form field mattered, for the highlight-on-deep-link flow). The database column and the supermod editing path are untouched.
> 
> Preview: https://baserates-test-git-fix-admin-sunshine-notes-lesswrong.vercel.app
> 
> Automated commit by Claude, not Oliver.
