### PR TITLE
Flip Lexical link editor above link when it overflows

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -31,7 +31,7 @@ import {
   LexicalEditor,
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
-import {Dispatch, useCallback, useEffect, useRef, useState} from 'react';
+import {Dispatch, useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 
 import {createPortal} from 'react-dom';
 
@@ -183,6 +183,12 @@ function FloatingLinkEditor({
   const classes = useStyles(styles);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Last DOMRect used to position the floating editor. Stored in a ref so we
+  // can re-run positioning when the editor's own height changes (e.g. when
+  // toggling into edit mode, which adds the URL input row) without needing
+  // the Lexical selection to be live -- at that point focus has moved into
+  // our own <input>, so the usual $updateLinkEditor path can't recompute it.
+  const lastTargetRectRef = useRef<DOMRect | null>(null);
   const [linkUrl, setLinkUrl] = useState('');
   const [editedLinkUrl, setEditedLinkUrl] = useState('');
   const [linkText, setLinkText] = useState('');
@@ -263,6 +269,7 @@ function FloatingLinkEditor({
       }
 
       if (domRect) {
+        lastTargetRectRef.current = domRect;
         setFloatingElemPositionForLinkEditor(domRect, editorElem, anchorElem);
       }
       setLastSelection(selection);
@@ -270,6 +277,7 @@ function FloatingLinkEditor({
       if (rootElement !== null) {
         setFloatingElemPositionForLinkEditor(null, editorElem, anchorElem);
       }
+      lastTargetRectRef.current = null;
       setLastSelection(null);
       setIsLinkEditMode(false);
       setLinkUrl('');
@@ -344,6 +352,18 @@ function FloatingLinkEditor({
       inputRef.current.focus();
     }
   }, [isLinkEditMode, isLink]);
+
+  // Toggling into edit mode adds the URL input row, which makes the floating
+  // editor taller. Re-run positioning against the last target rect so the
+  // flip-above logic in setFloatingElemPositionForLinkEditor has a chance to
+  // kick in if the taller editor no longer fits below the link.
+  useLayoutEffect(() => {
+    const editorElem = editorRef.current;
+    const targetRect = lastTargetRectRef.current;
+    if (editorElem && targetRect) {
+      setFloatingElemPositionForLinkEditor(targetRect, editorElem, anchorElem);
+    }
+  }, [isLinkEditMode, anchorElem]);
 
   useEffect(() => {
     const editorElement = editorRef.current;

--- a/packages/lesswrong/components/lexical/utils/setFloatingElemPositionForLinkEditor.ts
+++ b/packages/lesswrong/components/lexical/utils/setFloatingElemPositionForLinkEditor.ts
@@ -34,6 +34,20 @@ export function setFloatingElemPositionForLinkEditor(
     left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
   }
 
+  // Flip the floating editor above the link when there isn't enough vertical
+  // room below it inside the editor's scroller. Without this, editing a link
+  // near the bottom of a comment causes the URL input row (which only appears
+  // in edit mode, so it wasn't accounted for when the editor was first
+  // positioned) to be hidden behind the comment form's cancel/submit row.
+  // Only flip if there's actually enough space above; otherwise leave it
+  // below and let whatever clipping happens be the least-bad option.
+  if (top + floatingElemRect.height > editorScrollerRect.bottom) {
+    const flippedTop = targetRect.top - floatingElemRect.height - verticalGap;
+    if (flippedTop >= editorScrollerRect.top) {
+      top = flippedTop;
+    }
+  }
+
   top -= anchorElementRect.top;
   left -= anchorElementRect.left;
 


### PR DESCRIPTION
> When editing a link near the bottom of a comment editor, clicking the pencil icon grew the floating link editor taller by adding the URL input row, but the positioning code had already placed it below the link based on the shorter linkView height. The new URL row ended up hidden behind the comment form's cancel/submit row -- as reported by Rafe: https://lworg.slack.com/archives/CJUN2UAFN/p1775852153050769
> 
> Two small changes:
> 
> 1. setFloatingElemPositionForLinkEditor now flips the editor above the link when it would otherwise extend past the editor scroller's bottom, as long as there's room for it above. Parallel to the existing horizontal-overflow adjustment.
> 
> 2. FloatingLinkEditor stores the last target DOMRect in a ref and re-runs positioning via useLayoutEffect whenever isLinkEditMode toggles. This is necessary because by the time the user has clicked the pencil, focus has moved into our own input, so the normal $updateLinkEditor path can't recompute a DOMRect from the Lexical selection. Without this, the flip logic in #1 wouldn't see the taller edit-mode height and wouldn't flip.
> 
> Preview: https://baserates-test-git-fix-link-editor-flip-above-lesswrong.vercel.app
> 
> Sent using Claude (not Oliver -- automated bug-triage cron).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214107960984510) by [Unito](https://www.unito.io)
