### PR TITLE
fix multiple quote matching bugs and improve agent guidance

### DIFF
--- a/app/api/(markdown)/SKILL.md/route.tsx
+++ b/app/api/(markdown)/SKILL.md/route.tsx
@@ -165,9 +165,28 @@ and the conversation. You can use the thread ID to reply to existing threads.
 To add Google Docs-style comments to the draft, make a request to:
     POST /api/agent/commentOnDraft
     with JSON body: { postId, key, agentName?, quote?, comment }
-If a quote is provided, the comment will be attached to matching quoted text. The
-quote should be long enough to be unambiguous. If no quote is provided, the
-comment will be top-level. Both the quote and your comment should be in markdown.
+If a quote is provided, the comment will be attached to matching quoted text.
+The quote should be long enough to be unambiguous. If no quote is provided, the
+comment will be top-level.
+
+The comment body is markdown. The quote, however, should be the visible rendered
+text as a reader would see it — not the markdown source of the surrounding paragraph.
+A few things to watch out for:
+ * If the text you want to anchor to contains a link, quote the visible link text,
+   not the URL. URLs inside link targets are not part of the anchorable body text
+   and will never match.
+ * Only the post body is anchorable. The post title and other metadata fields are
+   not part of the anchorable region — a quote matching those will always fail.
+ * Quote verbatim from what the markdown API returned to you. The server handles
+   typographic punctuation folding (smart quotes vs. ASCII, en/em dashes, etc.)
+   and markdown emphasis markers (**, _, \`, ~) automatically, so you do not need
+   to strip or normalize them yourself. But rephrasing, "cleaning up" the text,
+   or quoting from memory rather than from the markdown you just read will miss.
+ * If the call returns a "no match" error, the one possible cause is that the user
+   has edited the draft since you read it. Fetch the current state of the post
+   via /api/editPost and re-derive your quote from the fresh read before retrying.
+   Drafts are a live collaboration surface; text you read a few minutes ago may
+   no longer be present.
 
 To reply to an existing comment thread on the draft:
     POST /api/agent/replyToComment
@@ -178,10 +197,17 @@ This adds a reply to the specified thread, visible in the editor's comment panel
 To replace text inside the draft, make a POST request to:
     POST /api/agent/replaceText
     with JSON body: { postId, key, agentName?, quote, replacement, mode?: "edit"|"suggest" }
-The quote and replacement should be in markdown. If the mode is "edit", the
-change will be applied immediately; if the mode is "suggest", the change will be
-displayed as a suggestion in the post editor. If the user hasn't said whether to
-use edit mode or suggest mode, use suggest mode.
+Note the asymmetry between the two string fields: the replacement should be in
+markdown (it's inserted into the draft and rendered through the editor's markdown
+pipeline), while the quote should be the visible rendered text as a reader would
+see it, not the markdown source. The same quote-matching rules as commentOnDraft
+apply — see that section above for details (visible link text rather than URLs,
+no need to include emphasis markers, quote verbatim from the markdown API,
+re-read the draft before retrying on "no match" errors).
+
+If the mode is "edit", the change will be applied immediately; if the mode is
+"suggest", the change will be displayed as a suggestion in the post editor. If
+the user hasn't said whether to use edit mode or suggest mode, use suggest mode.
 
 To insert new blocks of text into the draft, make a POST request to:
     POST /api/agent/insertBlock
@@ -214,7 +240,7 @@ specific AI model) into the draft, make a POST request to:
       markdown: string,
       location: "start"|"end"|{ before: string }|{ after: string }
     }
-The modelName is displayed in the block header (e.g. "Claude Opus 4.6"). If
+The modelName is displayed in the block header (e.g. "Claude Opus 4.7"). If
 omitted, it defaults to "AI Agent". The markdown is the content
 that will appear inside the block. The location works the same as insertBlock.
 LLM content blocks are always inserted directly (no suggest mode) because they
@@ -222,7 +248,7 @@ are explicitly labeled as AI-generated content.
 
 LLM content blocks (visually distinct blocks attributed to a specific AI model) are
 represented in the markdown output as:
-    %%% llm-output model="Claude Opus 4.6"
+    %%% llm-output model="Claude Opus 4.7"
 
     The markdown content of the block...
 

--- a/app/api/agent/captureAgentAnalytics.ts
+++ b/app/api/agent/captureAgentAnalytics.ts
@@ -12,6 +12,7 @@ interface AgentApiEventProps {
   // Set on success to describe what actually happened, especially partial failures
   // e.g. "inserted", "not_inserted", "replaced", "quote_not_found", "anchor_top_level_no_match"
   operationResult?: string;
+  threadId?: string;
 }
 
 function categorizeError(error: unknown): string {

--- a/app/api/agent/commentOnDraft/route.ts
+++ b/app/api/agent/commentOnDraft/route.ts
@@ -250,7 +250,7 @@ export async function POST(req: NextRequest) {
       authorId,
     });
 
-    captureAgentApiEvent({ route: "commentOnDraft", postId, userId: context.currentUser?._id, agentName, status: "success", operationResult: anchorStatus });
+    captureAgentApiEvent({ route: "commentOnDraft", postId, userId: context.currentUser?._id, agentName, status: "success", operationResult: anchorStatus, threadId });
     return NextResponse.json({
       ok: true,
       postId,

--- a/app/api/agent/editorAgentUtil.ts
+++ b/app/api/agent/editorAgentUtil.ts
@@ -43,18 +43,40 @@ export async function waitForProviderFlush(provider: HocuspocusProvider): Promis
   }
 }
 
+// 1:1 fold of typographic punctuation onto ASCII equivalents. Restricted to
+// length-preserving substitutions so that callers which map positions between
+// pre- and post-normalized strings (e.g. `mapNormalizedIndexToRaw`) remain
+// correct. Intentionally excludes ellipsis (U+2026 → `...`), NFKC, and other
+// length-changing transforms.
+const PUNCTUATION_FOLD_MAP: Record<string, string> = {
+  "\u2018": "'", "\u2019": "'", "\u201A": "'", "\u201B": "'",
+  "\u2032": "'", "\u02B9": "'", "\u02BC": "'",
+  "\u201C": '"', "\u201D": '"', "\u201E": '"', "\u201F": '"',
+  "\u2033": '"', "\u00AB": '"', "\u00BB": '"',
+  "\u2010": "-", "\u2011": "-", "\u2013": "-", "\u2014": "-",
+  "\u2015": "-", "\u2212": "-",
+};
+const PUNCTUATION_FOLD_REGEX = new RegExp(
+  `[${Object.keys(PUNCTUATION_FOLD_MAP).join("")}]`,
+  "g",
+);
+
+export function foldPunctuation(value: string): string {
+  return value.replace(PUNCTUATION_FOLD_REGEX, (ch) => PUNCTUATION_FOLD_MAP[ch]);
+}
+
 export function normalizeText(value: string): string {
-  return value.replace(/\s+/g, " ").trim().toLowerCase();
+  return foldPunctuation(value).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 export function paragraphMarkdownStartsWith(paragraphMarkdown: string, prefix: string): boolean {
-  const normalizedParagraph = paragraphMarkdown.trimStart().replace(/\s+/g, " ").toLowerCase();
-  const normalizedPrefix = prefix.trim().replace(/\s+/g, " ").toLowerCase();
+  const normalizedParagraph = foldPunctuation(paragraphMarkdown).trimStart().replace(/\s+/g, " ").toLowerCase();
+  const normalizedPrefix = foldPunctuation(prefix).trim().replace(/\s+/g, " ").toLowerCase();
   return normalizedParagraph.startsWith(normalizedPrefix);
 }
 
 export function plainTextStartsWith(nodeTextContent: string, prefix: string): boolean {
-  const prefixPlainText = prefix
+  const prefixPlainText = foldPunctuation(prefix)
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
     .replace(/\$\$([\s\S]*?)\$\$/g, "$1")
     .replace(/\$([^$]+)\$/g, "$1")
@@ -63,7 +85,7 @@ export function plainTextStartsWith(nodeTextContent: string, prefix: string): bo
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();
-  const normalizedTextContent = nodeTextContent
+  const normalizedTextContent = foldPunctuation(nodeTextContent)
     .replace(/\s+/g, " ")
     .trimStart()
     .toLowerCase();

--- a/app/api/agent/mapMarkdownToLexical.ts
+++ b/app/api/agent/mapMarkdownToLexical.ts
@@ -76,11 +76,34 @@ function normalizeForSemanticMatch(value: string): string {
   return normalizeText(normalizeMathDelimiters(normalizeEmphasisMarkerStyle(value)));
 }
 
+// The plaintext returned here preserves a character-by-character ordering
+// correspondence with the markdown source: each output character appears in
+// the input in the same order, so callers can align plaintext positions back
+// to markdown positions via a two-pointer walk (see `buildPlainToMarkdownMapping`
+// in replaceText). Keep this regex-based — do not swap to a markdown-it render,
+// which adds trailing whitespace and trims input whitespace in ways that break
+// position alignment. For the quote-matching projection (which needs CommonMark
+// semantics for intraword `_`, literal `$`, etc.), use
+// `markdownQuoteToRenderedPlainText` instead.
+export function markdownQuoteToPlainText(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/\$\$([\s\S]*?)\$\$/g, "$1")
+    .replace(/\$([^$]+)\$/g, "$1")
+    .replace(/\\([A-Za-z]+)/g, "$1")
+    .replace(/[*_`~]/g, "");
+}
+
+// Project an agent-supplied markdown quote to the rendered plaintext it
+// represents, via markdown-it's CommonMark implementation. Preserves literal
+// punctuation in content (e.g. `snake_case`, `2*3`, `` `code` ``) while
+// stripping genuine emphasis/code wrappers.
+//
 // Uses the no-mathjax markdown-it variant so `$...$` and `\(...\)` survive as
 // literal text, matching the `$equation$` form that `appendSegments` emits for
 // MathNode segments on the document side. Math delimiters are normalized up
 // front so `\(...\)` and `\[...\]` quotes fold onto the `$...$` shape.
-export function markdownQuoteToPlainText(value: string): string {
+export function markdownQuoteToRenderedPlainText(value: string): string {
   const html = markdownToHtmlNoMath(normalizeMathDelimiters(value));
   const dom = new JSDOM(html);
   return dom.window.document.body.textContent ?? "";
@@ -135,7 +158,7 @@ function findTextRangeInNodeByPlainQuote(
   node: LexicalNode,
   markdownQuote: string
 ): { anchor: MarkdownSelectionPoint, focus: MarkdownSelectionPoint } | null {
-  const plainQuoteRaw = markdownQuoteToPlainText(markdownQuote).trim();
+  const plainQuoteRaw = markdownQuoteToRenderedPlainText(markdownQuote).trim();
   const plainQuote = normalizeText(plainQuoteRaw);
   if (!plainQuoteRaw || !plainQuote) {
     return null;

--- a/app/api/agent/mapMarkdownToLexical.ts
+++ b/app/api/agent/mapMarkdownToLexical.ts
@@ -8,10 +8,11 @@ import {
   type LexicalNode,
   type SerializedLexicalNode,
 } from "lexical";
-import { htmlToMarkdown, markdownToHtml } from "@/server/editor/conversionUtils";
+import { htmlToMarkdown, markdownToHtml, markdownToHtmlNoMath } from "@/server/editor/conversionUtils";
 import { JSDOM } from "jsdom";
 import { withDomGlobals } from "@/server/editor/withDomGlobals";
 import { createHeadlessEditor, normalizeText } from "./editorAgentUtil";
+import { FOOTNOTE_ELEMENT_TYPES } from "@/components/editor/lexicalPlugins/footnotes/constants";
 
 /**
  * Recursively serialize a Lexical node and its children to JSON.
@@ -75,13 +76,14 @@ function normalizeForSemanticMatch(value: string): string {
   return normalizeText(normalizeMathDelimiters(normalizeEmphasisMarkerStyle(value)));
 }
 
+// Uses the no-mathjax markdown-it variant so `$...$` and `\(...\)` survive as
+// literal text, matching the `$equation$` form that `appendSegments` emits for
+// MathNode segments on the document side. Math delimiters are normalized up
+// front so `\(...\)` and `\[...\]` quotes fold onto the `$...$` shape.
 export function markdownQuoteToPlainText(value: string): string {
-  return value
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
-    .replace(/\$\$([\s\S]*?)\$\$/g, "$1")
-    .replace(/\$([^$]+)\$/g, "$1")
-    .replace(/\\([A-Za-z]+)/g, "$1")
-    .replace(/[*_`~]/g, "");
+  const html = markdownToHtmlNoMath(normalizeMathDelimiters(value));
+  const dom = new JSDOM(html);
+  return dom.window.document.body.textContent ?? "";
 }
 
 /**
@@ -146,6 +148,13 @@ function findTextRangeInNodeByPlainQuote(
   }> = [];
 
   const appendSegments = (currentNode: LexicalNode) => {
+    // Must precede the $isTextNode branch: FootnoteReferenceNode extends
+    // TextNode with content `[N]`, but agents reading via the markdown API
+    // see footnotes as `[^id]` and naturally omit them when quoting.
+    if (currentNode.getType() === FOOTNOTE_ELEMENT_TYPES.footnoteReference) {
+      return;
+    }
+
     if ($isTextNode(currentNode)) {
       segments.push({
         kind: "text",
@@ -314,6 +323,23 @@ function serializeNodeSubtreeToMarkdown(node: LexicalNode, editor: LexicalEditor
   return htmlToMarkdown(html);
 }
 
+// Must mirror the exclusions in `appendSegments` so the filter stage of
+// `buildNodeMarkdownMapForSubtree` sees the same text that the per-paragraph
+// matcher will later search against. Otherwise a paragraph containing a
+// footnote reference gets filtered out before ever reaching the matcher.
+function getTextContentForQuoteMatching(node: LexicalNode): string {
+  if (node.getType() === FOOTNOTE_ELEMENT_TYPES.footnoteReference) {
+    return "";
+  }
+  if ($isTextNode(node)) {
+    return node.getTextContent();
+  }
+  if ($isElementNode(node)) {
+    return node.getChildren().map(getTextContentForQuoteMatching).join("");
+  }
+  return node.getTextContent();
+}
+
 function collectSubtreeNodes(rootNode: LexicalNode): Array<{ node: LexicalNode, depth: number }> {
   const collected: Array<{ node: LexicalNode, depth: number }> = [];
 
@@ -349,7 +375,7 @@ export function buildNodeMarkdownMapForSubtree(rootNodeKey: string, textFilter?:
   const byKey = new Map<string, NodeMarkdownEntry>();
   for (const { node, depth } of collectSubtreeNodes(rootNode)) {
     if (textFilter) {
-      const textContent = normalizeText(node.getTextContent());
+      const textContent = normalizeText(getTextContentForQuoteMatching(node));
       // Skip nodes whose text content is non-empty and clearly doesn't contain
       // the filter. Nodes with empty text content (e.g. decorator/math nodes)
       // are kept to avoid false negatives.

--- a/app/api/agent/toolSchemas.ts
+++ b/app/api/agent/toolSchemas.ts
@@ -72,7 +72,7 @@ export const insertBlockToolSchema = z.object({
 export const insertLLMBlockToolSchema = z.object({
   postId: z.string().describe("The ID of the post"),
   key: z.string().optional().describe("Optional link-sharing key for collaborative draft access"),
-  modelName: z.string().default("AI Agent").describe("The model name to display on the LLM content block (e.g. 'Claude Opus 4.6')"),
+  modelName: z.string().default("AI Agent").describe("The model name to display on the LLM content block (e.g. 'Claude Opus 4.7')"),
   markdown: z.string().describe("The markdown content for the LLM content block"),
   location: insertLocationSchema,
 });

--- a/app/api/homeDesigns/SKILL.md/route.ts
+++ b/app/api/homeDesigns/SKILL.md/route.ts
@@ -192,7 +192,7 @@ print(f"Access token: {access_token}")
     {
       "html": "<style>...</style><div id='root'></div><script type='text/babel' data-presets='react'>...</script>",
       "title": "My Custom Home Page",
-      "modelName": "claude-opus-4.6",
+      "modelName": "claude-opus-4.7",
       "publicId": null
     }
 
@@ -202,7 +202,7 @@ print(f"Access token: {access_token}")
 |-------|------|----------|-------------|
 | \`html\` | string | yes | Body content only — styles, HTML elements, and Babel script tags. See design reference below. |
 | \`title\` | string | no | Name for the design. Defaults to "Untitled Design". |
-| \`modelName\` | string | no | The model that generated this design (e.g. "claude-opus-4.6", "gpt-5.4"). |
+| \`modelName\` | string | no | The model that generated this design (e.g. "claude-opus-4.7", "gpt-5.4"). |
 | \`publicId\` | string | no | To update an existing design, pass its publicId. Omit or pass null to create a new one. |
 
 ### Response

--- a/packages/lesswrong/components/editor/lexicalPlugins/llmContentOutput/LLMContentBlockHeaderComponent.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/llmContentOutput/LLMContentBlockHeaderComponent.tsx
@@ -16,6 +16,7 @@ const headerStyles = defineStyles('LLMContentBlockHeader', () => ({
 }));
 
 const LLM_MODEL_OPTIONS = [
+  'Claude Opus 4.7',
   'Claude Opus 4.6',
   'Claude Opus 4.5',
   'Claude Opus 3',

--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -7,7 +7,7 @@ import { isAnyTest } from '../../lib/executionEnvironment';
 import { cheerioParse } from '../utils/htmlUtil';
 import { sanitize } from "@/lib/utils/sanitize";
 import { filterWhereFieldsNotNull } from '../../lib/utils/typeGuardUtils';
-import { getMarkdownIt } from '@/lib/utils/markdownItPlugins';
+import { getMarkdownIt, getMarkdownItNoMathjax } from '@/lib/utils/markdownItPlugins';
 import type { Cheerio, CheerioAPI, Element as CheerioElement } from 'cheerio';
 import type { DataNode } from 'domhandler';
 import { mathjax } from 'mathjax-full/js/mathjax.js';
@@ -427,6 +427,17 @@ export function ckEditorMarkupToMarkdown(markup: string): string {
 export function markdownToHtmlNoLaTeX(markdown: string): string {
   const id = randomId()
   const renderedMarkdown = getMarkdownIt().render(markdown, {docId: id})
+  return trimLeadingAndTrailingWhiteSpace(renderedMarkdown)
+}
+
+// Unlike `markdownToHtmlNoLaTeX`, this skips the `markdownItMathjax` markdown-it
+// plugin entirely, so `$...$` and `\(...\)` are treated as literal text rather
+// than parsed into math tokens. Used by the agent quote-matching path, where
+// we want the LaTeX delimiters preserved verbatim in the extracted plaintext
+// so they line up with MathNode segments on the document side.
+export function markdownToHtmlNoMath(markdown: string): string {
+  const id = randomId()
+  const renderedMarkdown = getMarkdownItNoMathjax().render(markdown, {docId: id})
   return trimLeadingAndTrailingWhiteSpace(renderedMarkdown)
 }
 

--- a/packages/lesswrong/server/scripts/generativeModels/coverImageGeneration.ts
+++ b/packages/lesswrong/server/scripts/generativeModels/coverImageGeneration.ts
@@ -39,13 +39,13 @@ import { executePromiseQueue } from '@/lib/utils/asyncUtils';
 const IMAGE_PROVIDER: 'fal' | 'midjourney' = 'midjourney';
 
 type OpenAiModel = 'gpt-5.2' | 'gpt-5-mini';
-type AnthropicModel = 'claude-opus-4-6' | 'claude-sonnet-4-6';
+type AnthropicModel = 'claude-opus-4-7' | 'claude-sonnet-4-6';
 type SupportedLlmModel = OpenAiModel | AnthropicModel;
 type LlmProvider = 'openai' | 'anthropic';
 
 // The LLM model to use for generating illustration descriptions.
 // Change this to experiment with different models.
-export const DEFAULT_ILLUSTRATION_MODEL: SupportedLlmModel = "claude-opus-4-6";
+export const DEFAULT_ILLUSTRATION_MODEL: SupportedLlmModel = "claude-opus-4-7";
 
 // ── Queries ──────────────────────────────────────────────────────────
 
@@ -117,7 +117,7 @@ const MODEL_PRICING: Record<UsageTracker['model'], { input: number; cachedInput:
   "gpt-5.2":      { input: 1.75,  cachedInput: 0.175, output: 14.0 },
   "gpt-5-mini":   { input: 0.25,  cachedInput: 0.025, output: 2.0 },
   "claude-sonnet-4-6": { input: 3.0, cachedInput: 0.3, output: 15.0 },
-  "claude-opus-4-6": { input: 5.0, cachedInput: 0.5, output: 25.0 },
+  "claude-opus-4-7": { input: 5.0, cachedInput: 0.5, output: 25.0 },
 };
 
 // Fal.ai per-request pricing (approximate).

--- a/packages/lesswrong/unitTests/commentOnDraftQuoteMatch.tests.ts
+++ b/packages/lesswrong/unitTests/commentOnDraftQuoteMatch.tests.ts
@@ -6,7 +6,8 @@ import {
 } from "lexical";
 import { $isMarkNode } from "@lexical/mark";
 import { $attachMarkToQuote, type QuoteMarkResult } from "../../../app/api/agent/commentOnDraft/route";
-import { runEditorUpdate, setupEditorWithContent } from "./lexicalTestHelpers";
+import { htmlToMarkdown } from "@/server/editor/conversionUtils";
+import { runEditorUpdate, setupEditorWithContent, setupEditorWithHtml } from "./lexicalTestHelpers";
 import { randomId } from "@/lib/random";
 
 async function attachCommentMark(
@@ -79,8 +80,8 @@ describe("commentOnDraft quote matching", () => {
   });
 
   it("attaches a mark when quote spans a link boundary", async () => {
-    // This simulates a common pattern in the Zvi post: plain text followed
-    // by link text, e.g. "Charles's frame of 'Anthropic stopped pretending..."
+    // Quote starts in plain text, crosses into a link's visible text, and
+    // exits back into plain text.
     const editor = await setupEditorWithContent(
       "I approve of Charles's frame of '[Anthropic stopped pretending](https://example.com)' as accurate."
     );
@@ -113,8 +114,8 @@ describe("commentOnDraft quote matching", () => {
   });
 
   it("attaches a mark when quote includes markdown formatting markers", async () => {
-    // Agents may include markdown syntax in their quotes, e.g. **bold**.
-    // The function should strip those and match on the plain text.
+    // Emphasis markers in the quote should be projected away before matching,
+    // since they aren't present as literal characters in the document's text.
     const editor = await setupEditorWithContent(
       "This has **bold text** in the middle of the sentence."
     );
@@ -144,5 +145,189 @@ describe("commentOnDraft quote matching", () => {
     expect(quoteFoundInDocument).toBe(true);
     expect(markCreated).toBe(true);
     expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // ASCII apostrophe (U+0027) in the quote must match typographic
+  // right-single-quote (U+2019) in the document, and vice versa.
+  it("attaches a mark when quote uses ASCII apostrophe and document uses U+2019", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum dolor sit amet, it\u2019s a placeholder sentence with the typographic apostrophe."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "it's a placeholder sentence",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // ASCII double quote (U+0022) in the quote must match typographic
+  // U+201C / U+201D in the document.
+  it("attaches a mark when quote uses ASCII double quotes and document uses U+201C/U+201D", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum \u201cdolor sit amet\u201d consectetur adipiscing elit."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      'ipsum "dolor sit amet" consectetur',
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Literal underscores in identifiers (variable names, file paths, etc.)
+  // must survive matching. The inline **bold** in the document forces the
+  // quote to cross a formatting boundary, which splits it across multiple
+  // text nodes and exercises the per-paragraph matcher path.
+  it("attaches a mark when the quote contains a literal underscore and crosses a formatting boundary", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum **bold phrase** with dolor_sit amet consectetur adipiscing elit."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "bold phrase with dolor_sit amet consectetur",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Unmatched literal `*` (no closing delimiter, so CommonMark won't parse
+  // it as emphasis) must survive the projection.
+  it("attaches a mark when the quote contains a literal asterisk and crosses a formatting boundary", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum **bold phrase** with foo*bar baz consectetur adipiscing elit."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "bold phrase with foo*bar baz consectetur",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Unmatched literal backtick (no closing backtick, so CommonMark won't
+  // start a code span) must survive the projection.
+  it("attaches a mark when the quote contains a literal backtick and crosses a formatting boundary", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum **bold phrase** with the ` character in the middle of the paragraph."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "bold phrase with the ` character in the middle",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Unmatched literal `~` (markdown-it-sub needs a closing `~` for
+  // subscript, so a lone tilde stays literal) must survive the projection.
+  it("attaches a mark when the quote contains a literal tilde and crosses a formatting boundary", async () => {
+    const editor = await setupEditorWithContent(
+      "Lorem ipsum **bold phrase** with approximately ~5 years of data in the set."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "bold phrase with approximately ~5 years of data",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Inline LaTeX `$...$` in the quote must match MathNode segments in the
+  // document — both sides canonicalize to the `$equation$` form, and the
+  // `_` and `$` inside the equation must not be stripped as markdown.
+  it("attaches a mark when the quote contains inline LaTeX that becomes a MathNode", async () => {
+    const editor = await setupEditorWithHtml(
+      '<p><span style="white-space: pre-wrap;">Dolor sit amet </span>' +
+      '<span class="math-tex">\\(g_2(x,y)\\)</span>' +
+      '<span style="white-space: pre-wrap;"> consectetur adipiscing elit.</span></p>'
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "amet $g_2(x,y)$ consectetur",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
+  // Quote must match across a footnote reference the agent omitted. The
+  // markdown API renders footnotes as `[^id]` markers, which agents naturally
+  // skip when quoting the surrounding prose, so the matcher has to ignore the
+  // footnote node rather than splicing its `[N]` text into the search string.
+  it("attaches a mark when the quote spans a footnote reference that the agent omitted", async () => {
+    const editor = await setupEditorWithHtml(
+      '<p>' +
+      '<span style="white-space: pre-wrap;">Lorem ipsum</span>' +
+      '<span class="footnote-reference" data-footnote-reference="" data-footnote-id="abc123" data-footnote-index="3" role="doc-noteref" id="fnrefabc123">' +
+        '<sup><a href="#fnabc123">[3]</a></sup>' +
+      '</span>' +
+      '<span style="white-space: pre-wrap;"> dolor sit amet consectetur.</span>' +
+      '</p>'
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "Lorem ipsum dolor sit amet",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+});
+
+// This describe block covers htmlToMarkdown (Turndown) behavior rather than
+// the commentOnDraft quote-matching logic itself. Could move to a dedicated
+// htmlToMarkdown test file.
+describe("htmlToMarkdown inter-word spacing", () => {
+  // When inter-word spacing is encoded as `&nbsp;` inside a bold/italic
+  // formatting wrapper (e.g. `word1<b><strong>&nbsp;</strong></b>word2`),
+  // Turndown's default emphasis rules drop the whitespace-only wrapper
+  // entirely, producing "word1word2" in the markdown output.
+  //
+  // Skipped: a fix requires overriding Turndown's default `strong`/`em`
+  // rules, which has a wider blast radius on other `htmlToMarkdown` callers
+  // and only triggers on the rare `&nbsp;`-as-word-separator-inside-bold
+  // pattern. Kept as `.skip` so the regression case stays documented for
+  // whoever picks up the Turndown work.
+  it.skip("preserves space between words when nbsp is inside a bold wrapper between spans", () => {
+    const html =
+      '<p><span style="white-space: pre-wrap;">Lorem ipsum dolor sit amet, with</span>' +
+      '<b><strong class="text-bold" style="white-space: pre-wrap;">&nbsp;</strong></b>' +
+      '<span style="white-space: pre-wrap;">the consectetur adipiscing elit.</span></p>';
+
+    const md = htmlToMarkdown(html);
+
+    expect(md).toContain("with the");
+    expect(md).not.toMatch(/withthe/);
   });
 });

--- a/packages/lesswrong/unitTests/lexicalTestHelpers.ts
+++ b/packages/lesswrong/unitTests/lexicalTestHelpers.ts
@@ -12,9 +12,8 @@ export async function runEditorUpdate(editor: LexicalEditor, updater: () => void
   });
 }
 
-export async function setupEditorWithContent(markdownContent: string, label = "LexicalTestHelper"): Promise<LexicalEditor> {
+export async function setupEditorWithHtml(html: string, label = "LexicalTestHelper"): Promise<LexicalEditor> {
   const editor = createHeadlessEditor(label);
-  const html = markdownToHtml(markdownContent);
 
   await runEditorUpdate(editor, () => {
     const dom = new JSDOM(html);
@@ -25,6 +24,11 @@ export async function setupEditorWithContent(markdownContent: string, label = "L
   });
 
   return editor;
+}
+
+export async function setupEditorWithContent(markdownContent: string, label = "LexicalTestHelper"): Promise<LexicalEditor> {
+  const html = markdownToHtml(markdownContent);
+  return setupEditorWithHtml(html, label);
 }
 
 export interface SuggestionInfo {

--- a/packages/lesswrong/unitTests/mapMarkdownToLexical.tests.ts
+++ b/packages/lesswrong/unitTests/mapMarkdownToLexical.tests.ts
@@ -14,7 +14,7 @@ import { markdownToHtml, htmlToMarkdown } from "@/server/editor/conversionUtils"
 import { withDomGlobals } from "@/server/editor/withDomGlobals";
 import { createHeadlessEditor } from "../../../app/api/agent/editorAgentUtil";
 import { buildNodeMarkdownMapForSubtree, locateMarkdownQuoteSelectionInSubtree } from "../../../app/api/agent/mapMarkdownToLexical";
-import { runEditorUpdate, setupEditorWithContent } from "./lexicalTestHelpers";
+import { runEditorUpdate, setupEditorWithContent, setupEditorWithHtml } from "./lexicalTestHelpers";
 import { normalizeImportedTopLevelNodes } from "../../../app/api/(markdown)/editorMarkdownUtils";
 
 async function selectMarkdownQuoteInEditor(
@@ -263,14 +263,26 @@ describe("mapMarkdownToLexical quote selection", () => {
   });
 
   it("selects and round-trips quote containing inline LaTeX", async () => {
-    const markdownDocument = [
-      "This paragraph contains inline math written as $\\LaTeX$ for testing.",
-      "",
-      "Another paragraph follows.",
-    ].join("\n");
+    // Set up via explicit HTML with a `<span class="math-tex">` wrapper so
+    // that Lexical's DOM importer creates a real MathNode. The markdown→HTML
+    // path (used by `setupEditorWithContent`) can't produce that structure
+    // in a test env because `renderMathInHtml` short-circuits, leaving the
+    // math-it-mathjax output as literal `\(...\)` text.
+    const editor = await setupEditorWithHtml(
+      '<p><span style="white-space: pre-wrap;">This paragraph contains inline math written as </span>' +
+      '<span class="math-tex">\\(\\LaTeX\\)</span>' +
+      '<span style="white-space: pre-wrap;"> for testing.</span></p>' +
+      '<p>Another paragraph follows.</p>'
+    );
     const markdownQuote = "$\\LaTeX$";
 
-    await expectQuoteRoundTripsFromMarkdownDocument({ markdownDocument, markdownQuote });
+    await selectMarkdownQuoteInEditor(editor, markdownQuote);
+    const extractedMarkdown = await deleteEverythingOutsideSelectionAndRoundTripToMarkdown(editor);
+    const toPlainText = (markdown: string): string => markdown
+      .replace(/\$([^$]+)\$/g, "$1")
+      .replace(/\\\(([\s\S]*?)\\\)/g, "$1")
+      .trim();
+    expect(toPlainText(extractedMarkdown)).toBe(toPlainText(markdownQuote));
   });
 
   it("finds a heading when quoted with markdown # prefix", async () => {


### PR DESCRIPTION
Per Claude:


> This PR ships four quote-matching fixes for the agent commentOnDraft / replaceText API, plus updated agent-facing documentation:
> 1. Smart-punctuation folding — ASCII quotes/dashes now match their typographic equivalents (U+2018/19, U+201C/D, en/em dashes, etc.) on both sides.
> 2. Literal markdown markers preserved — _, *, `, ~ in content (e.g. snake_case, 2*3, backticks and tildes in prose) no longer get blanket-stripped; the quote goes through markdown-it's CommonMark parser, which respects emphasis rules.
> 3. Inline LaTeX math — $...$ and \(...\) in the quote now match MathNode segments on the document side, via a new no-mathjax markdown-it pipeline.
> 4. Footnote references — quotes spanning a footnote reference (that the agent omitted because the markdown API shows it as [^id]) now match; the matcher and its pre-filter both skip footnote-reference nodes.
> Also: updated SKILL.md guidance on commentOnDraft/replaceText (quote visible rendered text not markdown source, only body is anchorable, quote verbatim, re-read on "no match"). The Turndown &nbsp;-inside-bold case is documented as a .skip'd test for a deferred follow-up.
