### PR TITLE
Fix broken editor when editing summaries on wiki pages

### DIFF
--- a/packages/lesswrong/components/tagging/SummariesEditForm.tsx
+++ b/packages/lesswrong/components/tagging/SummariesEditForm.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
+import { MouseSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 import classNames from "classnames";
 import { makeSortableListComponent } from "../form-components/sortableList";
@@ -276,6 +277,9 @@ const SummariesEditForm = ({ parentDocumentId, collectionName }: SummariesEditFo
   const classes = useStyles(styles);
   const [newSummaryEditorOpen, setNewSummaryEditorOpen] = useState(false);
   const [reorderedSummaries, setReorderedSummaries] = useState<string[]>();
+  const mouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: 5 } });
+  const pointerSensor = useSensor(PointerSensor, { activationConstraint: { distance: 5 } });
+  const sortableSensors = useSensors(mouseSensor, pointerSensor);
 
   const { data, loading, refetch } = useQuery(MultiDocumentContentDisplayMultiQuery, {
     variables: {
@@ -350,6 +354,7 @@ const SummariesEditForm = ({ parentDocumentId, collectionName }: SummariesEditFo
       value={displayedSummaries.map((summary) => summary._id)}
       axis="xy"
       className={classes.list}
+      sensors={sortableSensors}
       setValue={(newValue: string[]) => {
         void reorderSummaries({
           variables: {


### PR DESCRIPTION
SummariesEditForm now opts out of the sortable list’s `KeyboardSensor`, so editing an existing summary no longer lets the list capture the spacebar and enter drag mode. Reordering still works with mouse/pointer drag as before.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214112790188764) by [Unito](https://www.unito.io)
