### PR TITLE
Patch yjs corruption bug

### DIFF
--- a/packages/lesswrong/components/lexical/collaboration.ts
+++ b/packages/lesswrong/components/lexical/collaboration.ts
@@ -12,6 +12,7 @@ import {HocuspocusProvider} from '@hocuspocus/provider';
 import {Doc, encodeStateAsUpdate, XmlText} from 'yjs';
 import {IndexeddbPersistence} from 'y-indexeddb';
 import { type CollaborativeEditingAccessLevel, accessLevelCan } from '@/lib/collections/posts/collabEditingPermissions';
+import { captureException } from '@/lib/sentryWrapper';
 
 /**
  * Removes "orphan" XmlText embeds from the main doc's root — live children of
@@ -300,9 +301,10 @@ export function createWebsocketProviderWithDoc(id: string, doc: Doc): Provider &
         const removed = repairOrphanXmlTextsInRoot(doc);
         if (removed.length > 0) {
           // eslint-disable-next-line no-console
-          console.warn(
-            `[Collaboration] Repaired ${removed.length} orphan XmlText(s) in post ${config.postId}: ${removed.join(', ')}`,
-          );
+          const errorMessage = `[Collaboration] Repaired ${removed.length} orphan XmlText(s) in post ${config.postId}: ${removed.join(', ')}`;
+          // eslint-disable-next-line no-console
+          console.warn(errorMessage);
+          captureException(new Error(errorMessage));
         }
       }
       config.onSynced?.(doc, isFirstSync, id);

--- a/packages/lesswrong/components/lexical/collaboration.ts
+++ b/packages/lesswrong/components/lexical/collaboration.ts
@@ -9,9 +9,64 @@
 import React, { createContext, useCallback, useContext } from 'react';
 import {Provider} from '@lexical/yjs';
 import {HocuspocusProvider} from '@hocuspocus/provider';
-import {Doc, encodeStateAsUpdate} from 'yjs';
+import {Doc, encodeStateAsUpdate, XmlText} from 'yjs';
 import {IndexeddbPersistence} from 'y-indexeddb';
 import { type CollaborativeEditingAccessLevel, accessLevelCan } from '@/lib/collections/posts/collabEditingPermissions';
+
+/**
+ * Removes "orphan" XmlText embeds from the main doc's root — live children of
+ * root that have no `__type` attribute and whose own `_map` is empty. These
+ * are an artifact of yjs/yjs#534: undoing a tracked cascade-delete of an
+ * XmlText whose attribute items had already been tombstoned via an untracked
+ * origin. `redoItem` rebuilds the XmlText via `content.copy()`, which for
+ * YXmlText returns a fresh empty instance, and the missing attr items never
+ * get redone — producing a root embed that Lexical's
+ * `$getOrInitCollabNodeFromSharedType` then rejects at load time with
+ * "Expected shared type to include type attribute".
+ *
+ * The orphan carries no recoverable data (no attrs, no children), so removing
+ * it is non-destructive; doing so via `root.delete` at the right offset emits
+ * a normal Yjs update that propagates to peers and the Hocuspocus server,
+ * self-healing the document. Returns the ids of items removed so the caller
+ * can log.
+ */
+function repairOrphanXmlTextsInRoot(doc: Doc): string[] {
+  const root = doc.get('root', XmlText);
+  const removed: string[] = [];
+  doc.transact(() => {
+    const delta = root.toDelta();
+    // Walk the delta to find orphan embeds and record their offsets. Embeds
+    // contribute length 1 to the parent XmlText; string inserts contribute
+    // their character length.
+    let offset = 0;
+    const orphanOffsets: number[] = [];
+    for (const entry of delta as Array<{ insert: unknown }>) {
+      const ins = entry.insert;
+      if (typeof ins === 'string') {
+        offset += ins.length;
+        continue;
+      }
+      if (ins instanceof XmlText) {
+        const hasType = ins.getAttribute('__type') !== undefined;
+        const mapSize = (ins as unknown as { _map: Map<string, unknown> })._map.size;
+        // Only remove items matching the exact yjs#534 shape: no __type and
+        // no entries in _map (i.e. the fresh `new YXmlText()` from _copy).
+        // Anything else might carry recoverable state and deserves inspection.
+        if (!hasType && mapSize === 0) {
+          orphanOffsets.push(offset);
+          const item = (ins as unknown as { _item?: { id: { client: number; clock: number } } })._item;
+          if (item) removed.push(`${item.id.client}@${item.id.clock}`);
+        }
+      }
+      offset += 1;
+    }
+    // Delete from the right so earlier offsets stay valid.
+    for (let i = orphanOffsets.length - 1; i >= 0; i--) {
+      root.delete(orphanOffsets[i], 1);
+    }
+  }, 'orphan-repair');
+  return removed;
+}
 
 export interface CollaborationConfig {
   postId: string;
@@ -238,6 +293,18 @@ export function createWebsocketProviderWithDoc(id: string, doc: Doc): Provider &
     onSynced: () => {
       const isFirstSync = !hasReceivedFirstSync;
       hasReceivedFirstSync = true;
+      // Repair yjs#534 orphan XmlTexts before handing the doc off to Lexical.
+      // No-op on healthy docs; fixes broken docs in place and syncs the
+      // repair back to the server / peers.
+      if (id === 'main') {
+        const removed = repairOrphanXmlTextsInRoot(doc);
+        if (removed.length > 0) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[Collaboration] Repaired ${removed.length} orphan XmlText(s) in post ${config.postId}: ${removed.join(', ')}`,
+          );
+        }
+      }
       config.onSynced?.(doc, isFirstSync, id);
     },
 

--- a/packages/lesswrong/components/lexical/collaboration.ts
+++ b/packages/lesswrong/components/lexical/collaboration.ts
@@ -298,13 +298,21 @@ export function createWebsocketProviderWithDoc(id: string, doc: Doc): Provider &
       // No-op on healthy docs; fixes broken docs in place and syncs the
       // repair back to the server / peers.
       if (id === 'main') {
-        const removed = repairOrphanXmlTextsInRoot(doc);
-        if (removed.length > 0) {
+        try {
+          const removed = repairOrphanXmlTextsInRoot(doc);
+          if (removed.length > 0) {
+            const errorMessage = `[Collaboration] Repaired ${removed.length} orphan XmlText(s) in post ${config.postId}: ${removed.join(', ')}`;
+            // eslint-disable-next-line no-console
+            console.warn(errorMessage);
+            captureException(new Error(errorMessage));
+          }
+        } catch (e) {
+          // Guard against unexpected throws from Yjs so a failed repair can't
+          // prevent config.onSynced below from running (that callback drives
+          // Lexical's bootstrap + first-sync tracking).
           // eslint-disable-next-line no-console
-          const errorMessage = `[Collaboration] Repaired ${removed.length} orphan XmlText(s) in post ${config.postId}: ${removed.join(', ')}`;
-          // eslint-disable-next-line no-console
-          console.warn(errorMessage);
-          captureException(new Error(errorMessage));
+          console.error('[Collaboration] repairOrphanXmlTextsInRoot threw:', e);
+          captureException(e instanceof Error ? e : new Error(String(e)));
         }
       }
       config.onSynced?.(doc, isFirstSync, id);


### PR DESCRIPTION
Per Claude:

> Some collaborative posts were failing to load with Expected shared type to include type attribute, leaving users with an empty editor. The underlying cause is yjs/yjs#534: under certain interleavings of untracked-origin writes (e.g. IndexedDB replay, peer updates) with tracked undo history, undoing a cascaded XmlText deletion rebuilds it via _copy() — which returns a bare new YXmlText() with no __type attribute — and the original attribute items are never re-integrated, leaving a live-but-malformed embed in the root that Lexical refuses to load.

> The fix adds repairOrphanXmlTextsInRoot(doc) to collaboration.ts, called from the HocuspocusProvider's onSynced: it walks the root's delta, identifies any embed matching the exact yjs#534 shape (no __type, empty _map), and deletes it inside a transaction. The orphan carries no recoverable data, so removal is non-destructive, and because it goes through a normal Yjs update it propagates to Hocuspocus, peers, and IndexedDB — the doc self-heals across all storage tiers. On first load of an already-broken post the user may briefly see the error before the repair runs, but a reload (or just waiting for sync) fixes it permanently.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214142887160207) by [Unito](https://www.unito.io)
