### PR TITLE
Fix Pangram badge on comments and auto-dispatch for unreviewed posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,12 @@ Implications:
   [make_editable_callbacks.ts](packages/lesswrong/server/editor/make_editable_callbacks.ts)
   (one for new-document creation, one for edits). Missing this produces a
   non-obvious `tsc` error far from the schema change.
+- `Posts.contents` uses `getNormalizedEditableResolver` (SQL-joins to the
+  `Revisions` table), while `Comments.contents` uses
+  `getDenormalizedEditableResolver` (builds a Revision-shaped object from the
+  JSONB `contents` column on the Comment, which does **not** mirror every
+  `Revisions` column). A new column added to `Revisions` surfaces on
+  `Post.contents` but returns `null` on `Comment.contents` by default.
 
 ## Component And Styling Model
 

--- a/packages/lesswrong/lib/collections/revisions/newSchema.ts
+++ b/packages/lesswrong/lib/collections/revisions/newSchema.ts
@@ -18,6 +18,22 @@ import gql from "graphql-tag";
 import { getOriginalContents } from "./helpers";
 import { userIsPostGroupOrganizer } from "../posts/helpers";
 import { isLWorAF } from "@/lib/instanceSettings";
+import { LATEST_REVISION_ID_KEY } from "@/lib/editor/make_editable";
+
+// Pangram columns live only on the `Revisions` row. Posts' `contents` resolver
+// SQL-joins to Revisions so the columns surface on the root. Comments'
+// `contents` resolver is denormalized from JSONB, which doesn't mirror them;
+// for that path `getDenormalizedEditableResolver` stashes the real Revision id
+// as `LATEST_REVISION_ID_KEY` on the root so we can load it here.
+type PangramFieldKey = "pangramAiScore" | "pangramCheckedAt" | "pangramStatus" | "pangramRawResponse";
+const pangramFieldResolver = <K extends PangramFieldKey>(field: K) =>
+  async (root: AnyBecauseHard, _args: AnyBecauseHard, context: ResolverContext): Promise<DbRevision[K] | null> => {
+    if (!(LATEST_REVISION_ID_KEY in root)) return root[field] ?? null;
+    const latestRevisionId: string | null = root[LATEST_REVISION_ID_KEY];
+    if (!latestRevisionId) return null;
+    const revision = await context.loaders.Revisions.load(latestRevisionId);
+    return revision?.[field] ?? null;
+  };
 
 // I _think_ this is a server-side only library, but it doesn't seem to be causing problems living at the top level (yet)
 // TODO: consider moving it to a server-side helper file with a stub, if so
@@ -505,6 +521,7 @@ const schema = {
       inputType: "Float",
       canRead: ["sunshineRegiment", "admins"],
       canUpdate: ["sunshineRegiment", "admins"],
+      resolver: pangramFieldResolver("pangramAiScore"),
       validation: {
         optional: true,
       },
@@ -520,6 +537,7 @@ const schema = {
       inputType: "Date",
       canRead: ["sunshineRegiment", "admins"],
       canUpdate: ["sunshineRegiment", "admins"],
+      resolver: pangramFieldResolver("pangramCheckedAt"),
       validation: {
         optional: true,
       },
@@ -535,6 +553,7 @@ const schema = {
       inputType: "String",
       canRead: ["sunshineRegiment", "admins"],
       canUpdate: ["sunshineRegiment", "admins"],
+      resolver: pangramFieldResolver("pangramStatus"),
       validation: {
         optional: true,
       },
@@ -550,6 +569,7 @@ const schema = {
       inputType: "JSON",
       canRead: ["sunshineRegiment", "admins"],
       canUpdate: ["sunshineRegiment", "admins"],
+      resolver: pangramFieldResolver("pangramRawResponse"),
       validation: {
         optional: true,
         blackbox: true,

--- a/packages/lesswrong/lib/editor/make_editable.ts
+++ b/packages/lesswrong/lib/editor/make_editable.ts
@@ -167,11 +167,16 @@ export function getDenormalizedEditableResolver<N extends CollectionNameString>(
         context,
       ),
     } as DbRevision;
+    // Stash the real Revisions._id so field-level resolvers on Revision can
+    // fetch columns the JSONB mirror doesn't carry (see pangramFieldResolver).
+    (result as AnyBecauseHard)[LATEST_REVISION_ID_KEY] = (doc as AnyBecauseHard)[`${fieldName}_latest`] ?? null;
     // HACK: Pretend that this denormalized field is a DbRevision (even though
     // it's missing an _id and some other fields)
     return result
   }
 }
+
+export const LATEST_REVISION_ID_KEY = "_latestRevisionId";
 
 export function getDefaultLocalStorageIdGenerator<N extends CollectionNameString>(collectionName: N) {
   return function defaultLocalStorageIdGenerator(doc: any, name: string): {id: string, verify: boolean} {

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -6,6 +6,7 @@ import { postStatuses } from "@/lib/collections/posts/constants";
 import { TOS_NOT_ACCEPTED_ERROR } from "../fmCrosspost/errors";
 import { isRecombeeRecommendablePost, postIsApproved, postIsPublic } from "@/lib/collections/posts/helpers";
 import { getLatestContentsRevision } from "@/server/collections/revisions/helpers";
+import { isBeingUndrafted } from "@/server/editor/utils";
 import { subscriptionTypes } from "@/lib/collections/subscriptions/helpers";
 import { isAnyTest, isE2E } from "@/lib/executionEnvironment";
 import { eaFrontpageDateDefault, isEAForum, requireReviewToFrontpagePostsSetting } from "@/lib/instanceSettings";
@@ -144,12 +145,24 @@ export async function onPostPublished(post: DbPost, context: ResolverContext) {
   const { updateScoreOnPostPublish } = require("./votingCallbacks");
   await updateScoreOnPostPublish(post, context);
   await onPublishUtils.ensureNonzeroRevisionVersionsAfterUndraft(post, context);
-  // Deliberately fire-and-forget: Pangram latency (seconds) must not block publish.
-  void maybeRunPangramOnPost(post, context).catch(captureException);
+}
+
+export async function newPostTriggerPangram({document, context}: AfterCreateCallbackProperties<'Posts'>) {
+  void maybeRunPangramOnPost(document, context).catch(captureException);
+}
+
+export async function undraftedPostTriggerPangram({oldDocument, newDocument, context}: UpdateCallbackProperties<'Posts'>) {
+  if (!isBeingUndrafted(oldDocument, newDocument)) return;
+  void maybeRunPangramOnPost(newDocument, context).catch(captureException);
 }
 
 async function maybeRunPangramOnPost(post: DbPost, context: ResolverContext) {
   if (!pangramIsConfigured()) return;
+
+  const eligibility = documentIsEligibleForPangram(post);
+  // Short-circuit reversible ineligible states (draft, rejected) before the
+  // DataLoader roundtrips — hot path for draft-post creation.
+  if (!eligibility.eligible && !eligibility.skipStatus) return;
 
   const [author, revision] = await Promise.all([
     context.loaders.Users.load(post.userId),
@@ -160,7 +173,6 @@ async function maybeRunPangramOnPost(post: DbPost, context: ResolverContext) {
   // Avoid re-scoring the same revision when a draft is re-published. Manual rerun still overwrites.
   if (revision.pangramCheckedAt) return;
 
-  const eligibility = documentIsEligibleForPangram(post);
   if (!eligibility.eligible) {
     if (eligibility.skipStatus) {
       await recordPangramSkip(revision._id, eligibility.skipStatus, context);

--- a/packages/lesswrong/server/collections/posts/mutations.ts
+++ b/packages/lesswrong/server/collections/posts/mutations.ts
@@ -9,7 +9,7 @@ import { swrInvalidatePostRoute } from "@/server/cache/swr";
 import { moveToAFUpdatesUserAFKarma } from "@/server/callbacks/alignment-forum/callbacks";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { upsertPolls } from "@/server/callbacks/forumEventCallbacks";
-import { addLinkSharingKey, addReferrerToPost, applyNewPostTags, assertPostTitleHasNoEmojis, autoTagNewPost, autoTagUndraftedPost, checkRecentRepost, checkTosAccepted, clearCourseEndTime, createNewJargonTermsCallback, eventUpdatedNotifications, extractSocialPreviewImage, fixEventStartAndEndTimes, lwPostsNewUpvoteOwnPost, notifyUsersAddedAsCoauthors, notifyUsersAddedAsPostCoauthors, oldPostsLastCommentedAt, onEditAddLinkSharingKey, onPostPublished, postsNewDefaultLocation, postsNewDefaultTypes, postsNewPostRelation, postsNewRateLimit, postsNewUserApprovedStatus, postsUndraftRateLimit, removeFrontpageDate, removeRedraftNotifications, resetDialogueMatches, resetPostApprovedDate, sendEAFCuratedAuthorsNotification, sendLWAFPostCurationEmails, sendNewPublishedDialogueMessageNotifications, sendPostApprovalNotifications, sendPostSharedWithUserNotifications, sendRejectionPM, sendUsersSharedOnPostNotifications, setPostUndraftedFields, syncTagRelevance, triggerReviewForNewPostIfNeeded, updateCommentHideKarma, updatedPostMaybeTriggerReview, updatePostEmbeddingsOnChange, updatePostShortform, updateRecombeePost, updateUserNotesOnPostDraft, updateUserNotesOnPostRejection } from "@/server/callbacks/postCallbackFunctions";
+import { addLinkSharingKey, addReferrerToPost, applyNewPostTags, assertPostTitleHasNoEmojis, autoTagNewPost, autoTagUndraftedPost, checkRecentRepost, checkTosAccepted, clearCourseEndTime, createNewJargonTermsCallback, eventUpdatedNotifications, extractSocialPreviewImage, fixEventStartAndEndTimes, lwPostsNewUpvoteOwnPost, newPostTriggerPangram, notifyUsersAddedAsCoauthors, notifyUsersAddedAsPostCoauthors, oldPostsLastCommentedAt, onEditAddLinkSharingKey, onPostPublished, postsNewDefaultLocation, postsNewDefaultTypes, postsNewPostRelation, postsNewRateLimit, postsNewUserApprovedStatus, postsUndraftRateLimit, removeFrontpageDate, removeRedraftNotifications, resetDialogueMatches, resetPostApprovedDate, sendEAFCuratedAuthorsNotification, sendLWAFPostCurationEmails, sendNewPublishedDialogueMessageNotifications, sendPostApprovalNotifications, sendPostSharedWithUserNotifications, sendRejectionPM, sendUsersSharedOnPostNotifications, setPostUndraftedFields, syncTagRelevance, triggerReviewForNewPostIfNeeded, undraftedPostTriggerPangram, updateCommentHideKarma, updatedPostMaybeTriggerReview, updatePostEmbeddingsOnChange, updatePostShortform, updateRecombeePost, updateUserNotesOnPostDraft, updateUserNotesOnPostRejection } from "@/server/callbacks/postCallbackFunctions";
 import { sendAlignmentSubmissionApprovalNotifications } from "@/server/callbacks/sharedCallbackFunctions";
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds, notifyUsersOfPingbackMentions } from "@/server/editor/make_editable_callbacks";
 import { HAS_EMBEDDINGS_FOR_RECOMMENDATIONS } from "@/server/embeddings";
@@ -130,6 +130,7 @@ export async function createPost({ data }: { data: CreatePostDataInput & { _id?:
   // former createAsync callbacks
   await notifyUsersAddedAsPostCoauthors(asyncProperties);
   await triggerReviewForNewPostIfNeeded(asyncProperties);
+  await newPostTriggerPangram(asyncProperties);
   await autoTagNewPost(asyncProperties);
 
   if (isElasticEnabled) {
@@ -223,6 +224,7 @@ export async function updatePost({ selector, data }: { data: UpdatePostDataInput
   await notifyUsersAddedAsCoauthors(updateCallbackProperties);
   await updatePostEmbeddingsOnChange(updateCallbackProperties.newDocument, updateCallbackProperties.oldDocument);
   await updatedPostMaybeTriggerReview(updateCallbackProperties);
+  await undraftedPostTriggerPangram(updateCallbackProperties);
   await sendRejectionPM(updateCallbackProperties);
   await updateUserNotesOnPostDraft(updateCallbackProperties);
   await updateUserNotesOnPostRejection(updateCallbackProperties);


### PR DESCRIPTION
## Summary

Two bugs in the recently-merged Pangram AI-detection integration:

- **Bug A — Pangram fields return `null` on `Comment.contents`.** `Posts.contents` uses `getNormalizedEditableResolver` (SQL-joins to `Revisions`), so new Revisions columns surface automatically. `Comments.contents` uses `getDenormalizedEditableResolver`, which builds a Revision-shaped object from the JSONB `contents` column — and that JSONB mirror does not carry `pangramAiScore` / `pangramStatus` / `pangramCheckedAt` / `pangramRawResponse`. Fix: add field-level resolvers on the 4 pangram fields that load the real Revision via `context.loaders.Revisions` when needed. The denormalized resolver now stashes the real `Revisions._id` on its returned shape as `_latestRevisionId` so the field resolver can pick it up.
- **Bug B — Pangram never auto-dispatched for unreviewed authors.** `onPostPublished` was gated such that it didn't fire for unreviewed-author posts (the target population). Moved dispatch off `onPostPublished` onto dedicated `newPostTriggerPangram` (AfterCreate) and `undraftedPostTriggerPangram` (update gated by `isBeingUndrafted`) callbacks wired into the Posts mutation chain. Added an early eligibility short-circuit in `maybeRunPangramOnPost` so draft creation stays cheap.

Also documents the `Posts.contents` (normalized) vs `Comments.contents` (denormalized) resolver asymmetry in AGENTS.md so the next schema change on `Revisions` doesn't hit the same gap.

## Test plan

- [ ] As sunshine/admin, open the moderation sidebar on a user with a Pangram-scored Comment — badge shows the score on SSR and still shows after a browser refresh.
- [ ] Same check on a Post user — confirm no regression.
- [ ] As an unreviewed user, create a new (non-draft) post with >200 words; ~10s later, verify `pangramStatus` transitions `pending` → `scored` / `error`.
- [ ] As an unreviewed user, undraft a post (`draft: true` → `false`); verify pangram dispatches exactly once.
- [ ] Verify draft-post creation by an unreviewed user does not trigger DataLoader fetches for author/revision (short-circuit fires first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214173982313096) by [Unito](https://www.unito.io)
